### PR TITLE
Sketcher: clean up the tools in the workbench

### DIFF
--- a/src/Mod/Sketcher/Gui/Command.cpp
+++ b/src/Mod/Sketcher/Gui/Command.cpp
@@ -141,7 +141,7 @@ CmdSketcherNewSketch::CmdSketcherNewSketch()
     sAppModule      = "Sketcher";
     sGroup          = QT_TR_NOOP("Sketcher");
     sMenuText       = QT_TR_NOOP("Create sketch");
-    sToolTipText    = QT_TR_NOOP("Create a new sketch");
+    sToolTipText    = QT_TR_NOOP("Create a new sketch.");
     sWhatsThis      = "Sketcher_NewSketch";
     sStatusTip      = sToolTipText;
     sPixmap         = "Sketcher_NewSketch";
@@ -204,22 +204,23 @@ void CmdSketcherNewSketch::activated(int iMsg)
         // create Sketch on Face
         std::string FeatName = getUniqueObjectName("Sketch");
 
-        openCommand("Create a Sketch on Face");
-        doCommand(Doc,"App.activeDocument().addObject('Sketcher::SketchObject','%s')",FeatName.c_str());
+        openCommand("Create a new sketch on a face");
+        doCommand(Doc,"App.activeDocument().addObject('Sketcher::SketchObject', '%s')", FeatName.c_str());
         if (mapmode < Attacher::mmDummy_NumberOfModes)
             doCommand(Gui,"App.activeDocument().%s.MapMode = \"%s\"",FeatName.c_str(),AttachEngine::getModeName(mapmode).c_str());
         else
             assert(0 /* mapmode index out of range */);
-        doCommand(Gui,"App.activeDocument().%s.Support = %s",FeatName.c_str(),supportString.c_str());
+        doCommand(Gui,"App.activeDocument().%s.Support = %s", FeatName.c_str(), supportString.c_str());
         doCommand(Gui,"App.activeDocument().recompute()");  // recompute the sketch placement based on its support
-        doCommand(Gui,"Gui.activeDocument().setEdit('%s')",FeatName.c_str());
+        doCommand(Gui,"Gui.activeDocument().setEdit('%s')", FeatName.c_str());
 
-        Part::Feature *part = static_cast<Part::Feature*>(support.getValue());//if multi-part support, this will return 0
+        Part::Feature *part = static_cast<Part::Feature*>(support.getValue());  // if multi-part support, this will return 0
         if (part){
             App::DocumentObjectGroup* grp = part->getGroup();
             if (grp) {
-                doCommand(Doc,"App.activeDocument().%s.addObject(App.activeDocument().%s)"
-                             ,grp->getNameInDocument(),FeatName.c_str());
+                doCommand(Doc,
+                          "App.activeDocument().%s.addObject(App.activeDocument().%s)",
+                          grp->getNameInDocument(), FeatName.c_str());
             }
         }
     }
@@ -234,11 +235,14 @@ void CmdSketcherNewSketch::activated(int iMsg)
 
         std::string FeatName = getUniqueObjectName("Sketch");
 
-        openCommand("Create a new Sketch");
-        doCommand(Doc,"App.activeDocument().addObject('Sketcher::SketchObject','%s')",FeatName.c_str());
-        doCommand(Doc,"App.activeDocument().%s.Placement = App.Placement(App.Vector(%f,%f,%f),App.Rotation(%f,%f,%f,%f))",FeatName.c_str(),p.x,p.y,p.z,r[0],r[1],r[2],r[3]);
-        doCommand(Doc,"App.activeDocument().%s.MapMode = \"%s\"",FeatName.c_str(),AttachEngine::getModeName(Attacher::mmDeactivated).c_str());
-        doCommand(Gui,"Gui.activeDocument().setEdit('%s')",FeatName.c_str());
+        openCommand("Create a new sketch");
+        doCommand(Doc, "App.activeDocument().addObject('Sketcher::SketchObject', '%s')", FeatName.c_str());
+        doCommand(Doc,
+                  "App.activeDocument().%s.Placement = App.Placement(App.Vector(%f, %f, %f), App.Rotation(%f, %f, %f, %f))",
+                  FeatName.c_str(), p.x, p.y, p.z, r[0], r[1], r[2], r[3]);
+        doCommand(Doc,"App.activeDocument().%s.MapMode = \"%s\"",
+                  FeatName.c_str(), AttachEngine::getModeName(Attacher::mmDeactivated).c_str());
+        doCommand(Gui,"Gui.activeDocument().setEdit('%s')", FeatName.c_str());
     }
 
 }
@@ -259,7 +263,7 @@ CmdSketcherEditSketch::CmdSketcherEditSketch()
     sAppModule      = "Sketcher";
     sGroup          = QT_TR_NOOP("Sketcher");
     sMenuText       = QT_TR_NOOP("Edit sketch");
-    sToolTipText    = QT_TR_NOOP("Edit the selected sketch");
+    sToolTipText    = QT_TR_NOOP("Edit the selected sketch.");
     sWhatsThis      = "Sketcher_EditSketch";
     sStatusTip      = sToolTipText;
     sPixmap         = "Sketcher_EditSketch";
@@ -272,7 +276,7 @@ void CmdSketcherEditSketch::activated(int iMsg)
 
     if (SketchFilter.match()) {
         Sketcher::SketchObject *Sketch = static_cast<Sketcher::SketchObject*>(SketchFilter.Result[0][0].getObject());
-        openCommand("Edit Sketch");
+        openCommand("Edit sketch");
         doCommand(Gui,"Gui.activeDocument().setEdit('%s')",Sketch->getNameInDocument());
     }
 }
@@ -290,7 +294,7 @@ CmdSketcherLeaveSketch::CmdSketcherLeaveSketch()
     sAppModule      = "Sketcher";
     sGroup          = QT_TR_NOOP("Sketcher");
     sMenuText       = QT_TR_NOOP("Leave sketch");
-    sToolTipText    = QT_TR_NOOP("Close the editing of the sketch");
+    sToolTipText    = QT_TR_NOOP("Finish editing the active sketch.");
     sWhatsThis      = "Sketcher_LeaveSketch";
     sStatusTip      = sToolTipText;
     sPixmap         = "Sketcher_LeaveSketch";
@@ -309,11 +313,10 @@ void CmdSketcherLeaveSketch::activated(int iMsg)
             vp->purgeHandler();
     }
 
-    openCommand("Sketch changed");
+    openCommand("Finish editting sketch");
     doCommand(Gui,"Gui.activeDocument().resetEdit()");
     doCommand(Doc,"App.ActiveDocument.recompute()");
     commitCommand();
-
 }
 
 bool CmdSketcherLeaveSketch::isActive(void)
@@ -336,7 +339,9 @@ CmdSketcherStopOperation::CmdSketcherStopOperation()
     sAppModule      = "Sketcher";
     sGroup          = QT_TR_NOOP("Sketcher");
     sMenuText       = QT_TR_NOOP("Stop operation");
-    sToolTipText    = QT_TR_NOOP("Stop current operation");
+    sToolTipText    = QT_TR_NOOP("When in edit mode, "
+                                 "stop the active operation "
+                                 "(drawing, constraining, etc.).");
     sWhatsThis      = "Sketcher_StopOperation";
     sStatusTip      = sToolTipText;
     sPixmap         = "process-stop";
@@ -375,7 +380,8 @@ CmdSketcherReorientSketch::CmdSketcherReorientSketch()
     sAppModule      = "Sketcher";
     sGroup          = QT_TR_NOOP("Sketcher");
     sMenuText       = QT_TR_NOOP("Reorient sketch...");
-    sToolTipText    = QT_TR_NOOP("Reorient the selected sketch");
+    sToolTipText    = QT_TR_NOOP("Place the selected sketch on one of the global coordinate planes.\n"
+                                 "This will clear the 'Support' property, if any.");
     sWhatsThis      = "Sketcher_ReorientSketch";
     sStatusTip      = sToolTipText;
     sPixmap         = "Sketcher_ReorientSketch";
@@ -406,49 +412,91 @@ void CmdSketcherReorientSketch::activated(int iMsg)
 
     // do the right view direction
     std::string camstring;
-    switch(Dlg.DirType){
+    switch (Dlg.DirType) {
         case 0:
-            camstring = "#Inventor V2.1 ascii \\n OrthographicCamera {\\n viewportMapping ADJUST_CAMERA \\n "
-                "position 0 0 87 \\n orientation 0 0 1  0 \\n nearDistance -112.88701 \\n farDistance 287.28702 \\n "
-                "aspectRatio 1 \\n focalDistance 87 \\n height 143.52005 }";
+            camstring = "#Inventor V2.1 ascii\\n"
+                "OrthographicCamera {\\n"
+                " viewportMapping ADJUST_CAMERA\\n"
+                "  position 0 0 87\\n"
+                "  orientation 0 0 1  0\\n"
+                "  nearDistance -112.88701\\n"
+                "  farDistance 287.28702\\n"
+                "  aspectRatio 1\\n"
+                "  focalDistance 87\\n"
+                "  height 143.52005 }";
             break;
         case 1:
-            camstring = "#Inventor V2.1 ascii \\n OrthographicCamera {\\n viewportMapping ADJUST_CAMERA \\n "
-                "position 0 0 -87 \\n orientation -1 0 0  3.1415927 \\n nearDistance -112.88701 \\n farDistance 287.28702 \\n "
-                "aspectRatio 1 \\n focalDistance 87 \\n height 143.52005 }";
+            camstring = "#Inventor V2.1 ascii\\n"
+                "OrthographicCamera {\\n"
+                " viewportMapping ADJUST_CAMERA\\n"
+                "  position 0 0 -87\\n"
+                "  orientation -1 0 0  3.1415927\\n"
+                "  nearDistance -112.88701\\n"
+                "  farDistance 287.28702\\n "
+                "  aspectRatio 1\\n"
+                "  focalDistance 87\\n"
+                "  height 143.52005 }";
             break;
         case 2:
-            camstring = "#Inventor V2.1 ascii \\n OrthographicCamera {\\n viewportMapping ADJUST_CAMERA\\n "
-                "position 0 -87 0 \\n  orientation -1 0 0  4.712389\\n  nearDistance -112.88701\\n  farDistance 287.28702\\n "
-                "aspectRatio 1\\n  focalDistance 87\\n  height 143.52005\\n\\n}";
+            camstring = "#Inventor V2.1 ascii\\n"
+                "OrthographicCamera {\\n"
+                " viewportMapping ADJUST_CAMERA\\n"
+                "  position 0 -87 0\\n"
+                "  orientation -1 0 0  4.712389\\n"
+                "  nearDistance -112.88701\\n"
+                "  farDistance 287.28702\\n"
+                "  aspectRatio 1\\n"
+                "  focalDistance 87\\n"
+                "  height 143.52005\\n\\n}";
             break;
         case 3:
-            camstring = "#Inventor V2.1 ascii \\n OrthographicCamera {\\n viewportMapping ADJUST_CAMERA\\n "
-                "position 0 87 0 \\n  orientation 0 0.70710683 0.70710683  3.1415927\\n  nearDistance -112.88701\\n  farDistance 287.28702\\n "
-                "aspectRatio 1\\n  focalDistance 87\\n  height 143.52005\\n\\n}";
+            camstring = "#Inventor V2.1 ascii\\n"
+                "OrthographicCamera {\\n"
+                " viewportMapping ADJUST_CAMERA\\n"
+                "  position 0 87 0\\n"
+                "  orientation 0 0.70710683 0.70710683  3.1415927\\n"
+                "  nearDistance -112.88701\\n"
+                "  farDistance 287.28702\\n"
+                "  aspectRatio 1\\n"
+                "  focalDistance 87\\n"
+                "  height 143.52005\\n\\n}";
             break;
         case 4:
-            camstring = "#Inventor V2.1 ascii \\n OrthographicCamera {\\n viewportMapping ADJUST_CAMERA\\n "
-                "position 87 0 0 \\n  orientation 0.57735026 0.57735026 0.57735026  2.0943952 \\n  nearDistance -112.887\\n  farDistance 287.28699\\n "
-                "aspectRatio 1\\n  focalDistance 87\\n  height 143.52005\\n\\n}";
+            camstring = "#Inventor V2.1 ascii\\n"
+                "OrthographicCamera {\\n"
+                " viewportMapping ADJUST_CAMERA\\n"
+                "  position 87 0 0\\n"
+                "  orientation 0.57735026 0.57735026 0.57735026  2.0943952\\n"
+                "  nearDistance -112.887\\n"
+                "  farDistance 287.28699\\n"
+                "  aspectRatio 1\\n"
+                "  focalDistance 87\\n"
+                "  height 143.52005\\n\\n}";
             break;
         case 5:
-            camstring = "#Inventor V2.1 ascii \\n OrthographicCamera {\\n viewportMapping ADJUST_CAMERA\\n "
-                "position -87 0 0 \\n  orientation -0.57735026 0.57735026 0.57735026  4.1887903 \\n  nearDistance -112.887\\n  farDistance 287.28699\\n "
-                "aspectRatio 1\\n  focalDistance 87\\n  height 143.52005\\n\\n}";
+            camstring = "#Inventor V2.1 ascii\\n"
+                "OrthographicCamera {\\n"
+                " viewportMapping ADJUST_CAMERA\\n"
+                "  position -87 0 0\\n"
+                "  orientation -0.57735026 0.57735026 0.57735026  4.1887903\\n"
+                "  nearDistance -112.887\\n"
+                "  farDistance 287.28699\\n"
+                "  aspectRatio 1\\n"
+                "  focalDistance 87\\n"
+                "  height 143.52005\\n\\n}";
             break;
     }
 
-    openCommand("Reorient Sketch");
-    Gui::cmdAppObjectArgs(sketch, "Placement = App.Placement(App.Vector(%f,%f,%f),App.Rotation(%f,%f,%f,%f))"
-                                , p.x,p.y,p.z,r[0],r[1],r[2],r[3]);
-    doCommand(Gui,"Gui.ActiveDocument.setEdit('%s')",sketch->getNameInDocument());
+    openCommand("Reorient sketch");
+    Gui::cmdAppObjectArgs(sketch,
+                          "Placement = App.Placement(App.Vector(%f, %f, %f), App.Rotation(%f, %f, %f, %f))",
+                          p.x, p.y, p.z, r[0], r[1], r[2], r[3]);
+    doCommand(Gui,"Gui.ActiveDocument.setEdit('%s')", sketch->getNameInDocument());
 }
 
 bool CmdSketcherReorientSketch::isActive(void)
 {
-    return Gui::Selection().countObjectsOfType
-        (Sketcher::SketchObject::getClassTypeId()) == 1;
+    return Gui::Selection().countObjectsOfType(Sketcher::SketchObject::getClassTypeId()) == 1;
 }
 
 DEF_STD_CMD_A(CmdSketcherMapSketch)
@@ -459,7 +507,9 @@ CmdSketcherMapSketch::CmdSketcherMapSketch()
     sAppModule      = "Sketcher";
     sGroup          = QT_TR_NOOP("Sketcher");
     sMenuText       = QT_TR_NOOP("Map sketch to face...");
-    sToolTipText    = QT_TR_NOOP("Map a sketch to a face");
+    sToolTipText    = QT_TR_NOOP("Set the 'Support' of a sketch.\n"
+                                 "First select the supporting geometry, for example, a face or an edge of a solid object,\n"
+                                 "then call this command, then choose the desired sketch.");
     sWhatsThis      = "Sketcher_MapSketch";
     sStatusTip      = sToolTipText;
     sPixmap         = "Sketcher_MapSketch";
@@ -469,7 +519,7 @@ void CmdSketcherMapSketch::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
     QString msg_str;
-    try{
+    try {
         Attacher::eMapMode suggMapMode;
         std::vector<Attacher::eMapMode> validModes;
 
@@ -494,14 +544,14 @@ void CmdSketcherMapSketch::activated(int iMsg)
             qApp->translate("Sketcher_MapSketch", "Select sketch"),
             qApp->translate("Sketcher_MapSketch", "Select a sketch from the list"),
             items, 0, false, &ok);
-        if (!ok) return;
+        if (!ok)
+            return;
         int index = items.indexOf(text);
         Part2DObject* sketch = static_cast<Part2DObject*>(sketches[index]);
 
-
         // check circular dependency
         std::vector<Gui::SelectionObject> selobjs = Gui::Selection().getSelectionEx();
-        for (size_t i = 0  ;  i < selobjs.size()  ;  ++i){
+        for (size_t i = 0; i < selobjs.size(); ++i) {
             App::DocumentObject* part = static_cast<Part::Feature*>(selobjs[i].getObject());
             if (!part) {
                 assert(0);
@@ -509,7 +559,8 @@ void CmdSketcherMapSketch::activated(int iMsg)
             }
             std::vector<App::DocumentObject*> input = part->getOutList();
             if (std::find(input.begin(), input.end(), sketch) != input.end()) {
-                throw ExceptionWrongInput(QT_TR_NOOP("Some of the selected objects depend on the sketch to be mapped. Circular dependencies are not allowed!"));
+                throw ExceptionWrongInput(QT_TR_NOOP("Some of the selected objects depend on the sketch to be mapped. "
+                                                     "Circular dependencies are not allowed."));
             }
         }
 
@@ -538,41 +589,45 @@ void CmdSketcherMapSketch::activated(int iMsg)
         //QStringList items; //already defined
         items.clear();
         items.push_back(QObject::tr("Don't attach"));
-        int iSugg = 0;//index of the auto-suggested mode in the list of valid modes
-        int iCurr = 0;//index of current mode in the list of valid modes
-        for (size_t i = 0  ;  i < validModes.size()  ;  ++i){
+        int iSugg = 0; //index of the auto-suggested mode in the list of valid modes
+        int iCurr = 0; //index of current mode in the list of valid modes
+        for (size_t i = 0; i < validModes.size(); ++i) {
             items.push_back(QString::fromLatin1(AttachEngine::getModeName(validModes[i]).c_str()));
             if (validModes[i] == curMapMode) {
                 iCurr = items.size() - 1;
                 items.back().append(bCurIncompatible?
-                                        qApp->translate("Sketcher_MapSketch"," (incompatible with selection)")
+                                        qApp->translate("Sketcher_MapSketch", " (incompatible with selection)")
                                       :
-                                        qApp->translate("Sketcher_MapSketch"," (current)")  );
+                                        qApp->translate("Sketcher_MapSketch", " (current)"));
             }
-            if (validModes[i] == suggMapMode){
+            if (validModes[i] == suggMapMode) {
                 iSugg = items.size() - 1;
-                if(iSugg == 1){
-                    iSugg = 0;//redirect deactivate to detach
+                if(iSugg == 1) {
+                    iSugg = 0;  // redirect deactivate to detach
                 } else {
-                    items.back().append(qApp->translate("Sketcher_MapSketch"," (suggested)"));
+                    items.back().append(qApp->translate("Sketcher_MapSketch", " (suggested)"));
                 }
             }
         }
         // * execute the dialog
-        text = QInputDialog::getItem(Gui::getMainWindow()
-            ,qApp->translate("Sketcher_MapSketch", "Sketch attachment")
-            ,bCurIncompatible?
-              qApp->translate("Sketcher_MapSketch", "Current attachment mode is incompatible with the new selection. Select the method to attach this sketch to selected objects.")
-              :
-              qApp->translate("Sketcher_MapSketch", "Select the method to attach this sketch to selected objects.")
-            ,items
-            , bCurIncompatible ? iSugg : iCurr
-            , false
-            , &ok);
+        text = QInputDialog::getItem(Gui::getMainWindow(),
+                                     qApp->translate("Sketcher_MapSketch", "Sketch attachment"),
+                                     bCurIncompatible ?
+                                         qApp->translate("Sketcher_MapSketch",
+                                                         "Current attachment mode is incompatible with the new selection.\n"
+                                                         "Select the method to attach this sketch to selected objects.")
+                                         :
+                                         qApp->translate("Sketcher_MapSketch",
+                                                         "Select the method to attach this sketch to selected objects."),
+                                     items,
+                                     bCurIncompatible ? iSugg : iCurr,
+                                     false,
+                                     &ok);
         // * collect dialog result
-        if (!ok) return;
+        if (!ok)
+            return;
         index = items.indexOf(text);
-        if (index == 0){
+        if (index == 0) {
             bAttach = false;
             suggMapMode = Attacher::mmDeactivated;
         } else {
@@ -586,12 +641,12 @@ void CmdSketcherMapSketch::activated(int iMsg)
             Gui::Selection().getAsPropertyLinkSubList(support);
             std::string supportString = support.getPyReprString();
 
-            openCommand("Attach Sketch");
+            openCommand("Attach sketch");
             Gui::cmdAppObjectArgs(sketch, "MapMode = \"%s\"",AttachEngine::getModeName(suggMapMode).c_str());
             Gui::cmdAppObjectArgs(sketch, "Support = %s",supportString.c_str());
             commitCommand();
         } else {
-            openCommand("Detach Sketch");
+            openCommand("Detach sketch");
             Gui::cmdAppObjectArgs(sketch, "MapMode = \"%s\"",AttachEngine::getModeName(suggMapMode).c_str());
             Gui::cmdAppObjectArgs(sketch, "Support = None");
             commitCommand();
@@ -599,25 +654,32 @@ void CmdSketcherMapSketch::activated(int iMsg)
     } catch (ExceptionWrongInput &e) {
         QMessageBox::warning(Gui::getMainWindow(),
                              qApp->translate("Sketcher_MapSketch", "Map sketch"),
-                             qApp->translate("Sketcher_MapSketch", "Can't map a sketch to support:\n"
-                                         "%1").arg(e.ErrMsg.length() ? e.ErrMsg : msg_str));
+                             qApp->translate("Sketcher_MapSketch",
+                                             "Can't map a sketch to support:\n"
+                                             "%1").arg(e.ErrMsg.length() ? e.ErrMsg : msg_str));
     }
 }
 
 bool CmdSketcherMapSketch::isActive(void)
 {
-    return getActiveGuiDocument() != 0;
+    App::Document* doc = App::GetApplication().getActiveDocument();
+    Base::Type sketch_type = Base::Type::fromName("Sketcher::SketchObject");
+    if (doc && doc->countObjectsOfType(sketch_type) > 0)
+        return true;
+
+    return false;
 }
 
 DEF_STD_CMD_A(CmdSketcherViewSketch)
 
 CmdSketcherViewSketch::CmdSketcherViewSketch()
-  : Command("Sketcher_ViewSketch")
+    : Command("Sketcher_ViewSketch")
 {
     sAppModule      = "Sketcher";
     sGroup          = QT_TR_NOOP("Sketcher");
     sMenuText       = QT_TR_NOOP("View sketch");
-    sToolTipText    = QT_TR_NOOP("View sketch perpendicular to sketch plane");
+    sToolTipText    = QT_TR_NOOP("When in edit mode, "
+                                 "set the camera orientation perpendicular to the sketch plane.");
     sWhatsThis      = "Sketcher_ViewSketch";
     sStatusTip      = sToolTipText;
     sPixmap         = "Sketcher_ViewSketch";
@@ -655,7 +717,8 @@ CmdSketcherValidateSketch::CmdSketcherValidateSketch()
     sAppModule      = "Sketcher";
     sGroup          = QT_TR_NOOP("Sketcher");
     sMenuText       = QT_TR_NOOP("Validate sketch...");
-    sToolTipText    = QT_TR_NOOP("Validate sketch");
+    sToolTipText    = QT_TR_NOOP("Validate a sketch by looking at missing coincidences,\n"
+                                 "invalid constraints, degenerated geometry, etc.");
     sWhatsThis      = "Sketcher_ValidateSketch";
     sStatusTip      = sToolTipText;
     eType           = 0;
@@ -669,7 +732,7 @@ void CmdSketcherValidateSketch::activated(int iMsg)
     if (selection.size() != 1) {
         QMessageBox::warning(Gui::getMainWindow(),
             qApp->translate("CmdSketcherValidateSketch", "Wrong selection"),
-            qApp->translate("CmdSketcherValidateSketch", "Select one sketch, please."));
+            qApp->translate("CmdSketcherValidateSketch", "Select only one sketch."));
         return;
     }
 
@@ -679,18 +742,20 @@ void CmdSketcherValidateSketch::activated(int iMsg)
 
 bool CmdSketcherValidateSketch::isActive(void)
 {
-    return (hasActiveDocument() && !Gui::Control().activeDialog());
+    return Gui::Selection().countObjectsOfType(Sketcher::SketchObject::getClassTypeId()) == 1;
 }
 
 DEF_STD_CMD_A(CmdSketcherMirrorSketch)
 
 CmdSketcherMirrorSketch::CmdSketcherMirrorSketch()
-: Command("Sketcher_MirrorSketch")
+    : Command("Sketcher_MirrorSketch")
 {
     sAppModule      = "Sketcher";
     sGroup          = QT_TR_NOOP("Sketcher");
     sMenuText       = QT_TR_NOOP("Mirror sketch");
-    sToolTipText    = QT_TR_NOOP("Mirror sketch");
+    sToolTipText    = QT_TR_NOOP("Create a new mirrored sketch for each selected sketch\n"
+                                 "by using the X or Y axes, or the origin point,\n"
+                                 "as mirroring reference.");
     sWhatsThis      = "Sketcher_MirrorSketch";
     sStatusTip      = sToolTipText;
     eType           = 0;
@@ -704,20 +769,19 @@ void CmdSketcherMirrorSketch::activated(int iMsg)
     if (selection.size() < 1) {
         QMessageBox::warning(Gui::getMainWindow(),
             qApp->translate("CmdSketcherMirrorSketch", "Wrong selection"),
-            qApp->translate("CmdSketcherMirrorSketch", "Select one or more sketches, please."));
+            qApp->translate("CmdSketcherMirrorSketch", "Select one or more sketches."));
         return;
     }
 
-    // Ask the user which kind of mirroring he wants
+    // Ask the user the type of mirroring
     SketchMirrorDialog * smd = new SketchMirrorDialog();
 
-    int refgeoid=-1;
-    Sketcher::PointPos refposid=Sketcher::none;
+    int refgeoid = -1;
+    Sketcher::PointPos refposid = Sketcher::none;
 
-    if( smd->exec() == QDialog::Accepted ){
-        refgeoid=smd->RefGeoid;
-        refposid=smd->RefPosid;
-
+    if (smd->exec() == QDialog::Accepted) {
+        refgeoid = smd->RefGeoid;
+        refposid = smd->RefPosid;
         delete smd;
     }
     else {
@@ -726,37 +790,31 @@ void CmdSketcherMirrorSketch::activated(int iMsg)
     }
 
     App::Document* doc = App::GetApplication().getActiveDocument();
-
-    openCommand("Create a mirror Sketch for each sketch");
+    openCommand("Create a mirrored sketch for each selected sketch");
 
     for (std::vector<Gui::SelectionObject>::const_iterator it=selection.begin(); it != selection.end(); ++it) {
         // create Sketch
         std::string FeatName = getUniqueObjectName("MirroredSketch");
-
-        doCommand(Doc,"App.activeDocument().addObject('Sketcher::SketchObject','%s')",FeatName.c_str());
-
+        doCommand(Doc,"App.activeDocument().addObject('Sketcher::SketchObject', '%s')", FeatName.c_str());
         Sketcher::SketchObject* mirrorsketch = static_cast<Sketcher::SketchObject*>(doc->getObject(FeatName.c_str()));
 
         const Sketcher::SketchObject* Obj = static_cast<const Sketcher::SketchObject*>((*it).getObject());
-
         Base::Placement pl = Obj->Placement.getValue();
-
         Base::Vector3d p = pl.getPosition();
         Base::Rotation r = pl.getRotation();
 
-        doCommand(Doc,"App.activeDocument().%s.Placement = App.Placement(App.Vector(%f,%f,%f),App.Rotation(%f,%f,%f,%f))",
+        doCommand(Doc,
+                  "App.activeDocument().%s.Placement = App.Placement(App.Vector(%f, %f, %f), App.Rotation(%f, %f, %f, %f))",
                   FeatName.c_str(),
-                  p.x,p.y,p.z,r[0],r[1],r[2],r[3]);
+                  p.x, p.y, p.z, r[0], r[1], r[2], r[3]);
 
         Sketcher::SketchObject* tempsketch = new Sketcher::SketchObject();
-
-        int addedGeometries=tempsketch->addGeometry(Obj->getInternalGeometry());
-
-        int addedConstraints=tempsketch->addConstraints(Obj->Constraints.getValues());
+        int addedGeometries = tempsketch->addGeometry(Obj->getInternalGeometry());
+        int addedConstraints = tempsketch->addConstraints(Obj->Constraints.getValues());
 
         std::vector<int> geoIdList;
 
-        for(int i=0;i<=addedGeometries;i++)
+        for (int i=0; i<=addedGeometries; i++)
             geoIdList.push_back(i);
 
         tempsketch->addSymmetric(geoIdList, refgeoid, refposid);
@@ -770,27 +828,34 @@ void CmdSketcherMirrorSketch::activated(int iMsg)
 
         for (std::vector<Sketcher::Constraint *>::const_iterator itc=mirrorconstr.begin(); itc != mirrorconstr.end(); ++itc) {
 
-            if ((*itc)->First!=Sketcher::Constraint::GeoUndef || (*itc)->First==Sketcher::GeoEnum::HAxis || (*itc)->First==Sketcher::GeoEnum::VAxis) // not x, y axes or origin
-                (*itc)->First-=(addedGeometries+1);
-            if ((*itc)->Second!=Sketcher::Constraint::GeoUndef || (*itc)->Second==Sketcher::GeoEnum::HAxis || (*itc)->Second==Sketcher::GeoEnum::VAxis) // not x, y axes or origin
-                (*itc)->Second-=(addedGeometries+1);
-            if ((*itc)->Third!=Sketcher::Constraint::GeoUndef || (*itc)->Third==Sketcher::GeoEnum::HAxis || (*itc)->Third==Sketcher::GeoEnum::VAxis) // not x, y axes or origin
-                (*itc)->Third-=(addedGeometries+1);
+            if ((*itc)->First != Sketcher::Constraint::GeoUndef
+                    || (*itc)->First == Sketcher::GeoEnum::HAxis
+                    || (*itc)->First == Sketcher::GeoEnum::VAxis)
+                // not x, y axes or origin
+                (*itc)->First -= (addedGeometries + 1);
+            if ((*itc)->Second != Sketcher::Constraint::GeoUndef
+                    || (*itc)->Second == Sketcher::GeoEnum::HAxis
+                    || (*itc)->Second == Sketcher::GeoEnum::VAxis)
+                // not x, y axes or origin
+                (*itc)->Second -= (addedGeometries + 1);
+            if ((*itc)->Third != Sketcher::Constraint::GeoUndef
+                    || (*itc)->Third == Sketcher::GeoEnum::HAxis
+                    || (*itc)->Third == Sketcher::GeoEnum::VAxis)
+                // not x, y axes or origin
+                (*itc)->Third -= (addedGeometries + 1);
         }
 
         mirrorsketch->addGeometry(mirrorgeo);
         mirrorsketch->addConstraints(mirrorconstr);
-
         delete tempsketch;
     }
 
     doCommand(Gui,"App.activeDocument().recompute()");
-
 }
 
 bool CmdSketcherMirrorSketch::isActive(void)
 {
-    return (hasActiveDocument() && !Gui::Control().activeDialog());
+    return Gui::Selection().countObjectsOfType(Sketcher::SketchObject::getClassTypeId()) > 0;
 }
 
 DEF_STD_CMD_A(CmdSketcherMergeSketches)
@@ -801,7 +866,7 @@ CmdSketcherMergeSketches::CmdSketcherMergeSketches()
     sAppModule      = "Sketcher";
     sGroup          = QT_TR_NOOP("Sketcher");
     sMenuText       = QT_TR_NOOP("Merge sketches");
-    sToolTipText    = QT_TR_NOOP("Merge sketches");
+    sToolTipText    = QT_TR_NOOP("Create a new sketch from merging two or more selected sketches.");
     sWhatsThis      = "Sketcher_MergeSketches";
     sStatusTip      = sToolTipText;
     eType           = 0;
@@ -815,7 +880,7 @@ void CmdSketcherMergeSketches::activated(int iMsg)
     if (selection.size() < 2) {
         QMessageBox::warning(Gui::getMainWindow(),
                              qApp->translate("CmdSketcherMergeSketches", "Wrong selection"),
-                             qApp->translate("CmdSketcherMergeSketches", "Select at least two sketches, please."));
+                             qApp->translate("CmdSketcherMergeSketches", "Select at least two sketches."));
         return;
     }
 
@@ -824,13 +889,13 @@ void CmdSketcherMergeSketches::activated(int iMsg)
     // create Sketch
     std::string FeatName = getUniqueObjectName("Sketch");
 
-    openCommand("Create a merge Sketch");
-    doCommand(Doc,"App.activeDocument().addObject('Sketcher::SketchObject','%s')",FeatName.c_str());
+    openCommand("Merge sketches");
+    doCommand(Doc,"App.activeDocument().addObject('Sketcher::SketchObject', '%s')", FeatName.c_str());
 
     Sketcher::SketchObject* mergesketch = static_cast<Sketcher::SketchObject*>(doc->getObject(FeatName.c_str()));
 
-    int baseGeometry=0;
-    int baseConstraints=0;
+    int baseGeometry = 0;
+    int baseConstraints = 0;
 
     for (std::vector<Gui::SelectionObject>::const_iterator it=selection.begin(); it != selection.end(); ++it) {
         const Sketcher::SketchObject* Obj = static_cast<const Sketcher::SketchObject*>((*it).getObject());
@@ -841,18 +906,21 @@ void CmdSketcherMergeSketches::activated(int iMsg)
         for (int i=0; i<=(addedConstraints-baseConstraints); i++){
             Sketcher::Constraint * constraint= mergesketch->Constraints.getValues()[i+baseConstraints];
 
-            if (constraint->First!=Sketcher::Constraint::GeoUndef &&
-                constraint->First!=Sketcher::GeoEnum::HAxis &&
-                constraint->First!=Sketcher::GeoEnum::VAxis) // not x, y axes or origin
-                constraint->First+=baseGeometry;
-            if (constraint->Second!=Sketcher::Constraint::GeoUndef &&
-                constraint->Second!=Sketcher::GeoEnum::HAxis &&
-                constraint->Second!=Sketcher::GeoEnum::VAxis) // not x, y axes or origin
-                constraint->Second+=baseGeometry;
-            if (constraint->Third!=Sketcher::Constraint::GeoUndef &&
-                constraint->Third!=Sketcher::GeoEnum::HAxis &&
-                constraint->Third!=Sketcher::GeoEnum::VAxis) // not x, y axes or origin
-                constraint->Third+=baseGeometry;
+            if (constraint->First != Sketcher::Constraint::GeoUndef &&
+                    constraint->First != Sketcher::GeoEnum::HAxis &&
+                    constraint->First != Sketcher::GeoEnum::VAxis)
+                // not x, y axes or origin
+                constraint->First += baseGeometry;
+            if (constraint->Second != Sketcher::Constraint::GeoUndef &&
+                    constraint->Second != Sketcher::GeoEnum::HAxis &&
+                    constraint->Second != Sketcher::GeoEnum::VAxis)
+                // not x, y axes or origin
+                constraint->Second += baseGeometry;
+            if (constraint->Third != Sketcher::Constraint::GeoUndef &&
+                    constraint->Third != Sketcher::GeoEnum::HAxis &&
+                    constraint->Third != Sketcher::GeoEnum::VAxis)
+                // not x, y axes or origin
+                constraint->Third += baseGeometry;
         }
 
         baseGeometry=addedGeometries+1;
@@ -860,14 +928,15 @@ void CmdSketcherMergeSketches::activated(int iMsg)
     }
 
     // apply the placement of the first sketch in the list (#0002434)
-    doCommand(Doc,"App.activeDocument().ActiveObject.Placement=App.activeDocument().%s.Placement"
-                 ,selection.front().getFeatName());
-    doCommand(Doc,"App.activeDocument().recompute()");
+    doCommand(Doc,
+              "App.activeDocument().ActiveObject.Placement = App.activeDocument().%s.Placement",
+              selection.front().getFeatName());
+    doCommand(Doc, "App.activeDocument().recompute()");
 }
 
 bool CmdSketcherMergeSketches::isActive(void)
 {
-    return (hasActiveDocument() && !Gui::Control().activeDialog());
+    return Gui::Selection().countObjectsOfType(Sketcher::SketchObject::getClassTypeId()) > 1;
 }
 
 // Acknowledgement of idea and original python macro goes to SpritKopf:
@@ -881,7 +950,8 @@ CmdSketcherViewSection::CmdSketcherViewSection()
     sAppModule      = "Sketcher";
     sGroup          = QT_TR_NOOP("Sketcher");
     sMenuText       = QT_TR_NOOP("View section");
-    sToolTipText    = QT_TR_NOOP("Switches between section and full view");
+    sToolTipText    = QT_TR_NOOP("When in edit mode, "
+                                 "switch between section view and full view.");
     sWhatsThis      = "Sketcher_ViewSection";
     sStatusTip      = sToolTipText;
     sPixmap         = "Sketcher_ViewSection";

--- a/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp
+++ b/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp
@@ -475,15 +475,36 @@ bool CmdSketcherIncreaseDegree::isActive(void)
 }
 
 
-// TODO: implement this function to complement Sketcher_BSplineIncreaseDegree
-
 // Decrease degree of the spline
-// DEF_STD_CMD_A(CmdSketcherDecreaseDegree)
-// CmdSketcherDecreaseDegree::CmdSketcherDecreaseDegree()
-// : Command("Sketcher_BSplineDecreaseDegree")
-// {
-// ...
-// }
+DEF_STD_CMD_A(CmdSketcherDecreaseDegree)
+
+CmdSketcherDecreaseDegree::CmdSketcherDecreaseDegree()
+    : Command("Sketcher_BSplineDecreaseDegree")
+{
+    sAppModule      = "Sketcher";
+    sGroup          = QT_TR_NOOP("Sketcher");
+    sMenuText       = QT_TR_NOOP("Decrease B-spline degree");
+    sToolTipText    = QT_TR_NOOP("Decreases the degree of the B-spline.\n"
+                                 "This command is currently NOT IMPLEMENTED.");
+    sWhatsThis      = "Sketcher_BSplineDecreaseDegree";
+    sStatusTip      = sToolTipText;
+    sPixmap         = "Sketcher_BSplineDecreaseDegree";
+    sAccel          = "";
+    eType           = ForEdit;
+}
+
+// TODO: fully implement this function to complement Sketcher_BSplineIncreaseDegree
+void CmdSketcherDecreaseDegree::activated(int iMsg)
+{
+    Q_UNUSED(iMsg);
+    Base::Console().Message("Decrease degree of spline. "
+                            "This command is currently NOT IMPLEMENTED.\n");
+}
+
+bool CmdSketcherDecreaseDegree::isActive(void)
+{
+    return isSketcherBSplineActive(getActiveGuiDocument(), true);
+}
 
 
 DEF_STD_CMD_A(CmdSketcherIncreaseKnotMultiplicity)
@@ -889,8 +910,7 @@ void CreateSketcherCommandsBSpline(void)
     rcCmdMgr.addCommand(new CmdSketcherCompBSplineShowHideGeometryInformation());
     rcCmdMgr.addCommand(new CmdSketcherConvertToNURB());
     rcCmdMgr.addCommand(new CmdSketcherIncreaseDegree());
-    // TODO: implement this function to complement CmdSketcherIncreaseDegree
-    // rcCmdMgr.addCommand(new CmdSketcherDecreaseDegree());
+    rcCmdMgr.addCommand(new CmdSketcherDecreaseDegree());  // TODO: implement this function
     rcCmdMgr.addCommand(new CmdSketcherIncreaseKnotMultiplicity());
     rcCmdMgr.addCommand(new CmdSketcherDecreaseKnotMultiplicity());
     rcCmdMgr.addCommand(new CmdSketcherCompModifyKnotMultiplicity());

--- a/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp
+++ b/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp
@@ -55,13 +55,13 @@ using namespace std;
 using namespace SketcherGui;
 using namespace Sketcher;
 
-bool isSketcherBSplineActive(Gui::Document *doc, bool actsOnSelection )
+bool isSketcherBSplineActive(Gui::Document *doc, bool actsOnSelection)
 {
     if (doc) {
         // checks if a Sketch Viewprovider is in Edit and is in no special mode
         if (doc->getInEdit() && doc->getInEdit()->isDerivedFrom(SketcherGui::ViewProviderSketch::getClassTypeId())) {
-            if (static_cast<SketcherGui::ViewProviderSketch*>(doc->getInEdit())
-                ->getSketchMode() == ViewProviderSketch::STATUS_NONE) {
+            if (static_cast<SketcherGui::ViewProviderSketch*>(doc->getInEdit())->getSketchMode() == ViewProviderSketch::STATUS_NONE)
+            {
                 if (!actsOnSelection)
                     return true;
                 else if (Gui::Selection().countObjectsOfType(Sketcher::SketchObject::getClassTypeId()) > 0)
@@ -69,16 +69,14 @@ bool isSketcherBSplineActive(Gui::Document *doc, bool actsOnSelection )
             }
         }
     }
-
     return false;
 }
 
 void ActivateBSplineHandler(Gui::Document *doc,DrawSketchHandler *handler)
 {
     if (doc) {
-        if (doc->getInEdit() && doc->getInEdit()->isDerivedFrom
-           (SketcherGui::ViewProviderSketch::getClassTypeId())) {
-
+        if (doc->getInEdit() && doc->getInEdit()->isDerivedFrom(SketcherGui::ViewProviderSketch::getClassTypeId()))
+        {
             SketcherGui::ViewProviderSketch* vp = static_cast<SketcherGui::ViewProviderSketch*> (doc->getInEdit());
             vp->purgeHandler();
             vp->activateHandler(handler);
@@ -89,11 +87,8 @@ void ActivateBSplineHandler(Gui::Document *doc,DrawSketchHandler *handler)
 void ShowRestoreInformationLayer(SketcherGui::ViewProviderSketch* vp, char * visibleelementname)
 {
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher/General");
-
     bool status = hGrp->GetBool(visibleelementname, true);
-
     hGrp->SetBool(visibleelementname, !status);
-
     vp->showRestoreInformationLayer();
 }
 
@@ -101,11 +96,11 @@ void ShowRestoreInformationLayer(SketcherGui::ViewProviderSketch* vp, char * vis
 DEF_STD_CMD_A(CmdSketcherBSplineDegree)
 
 CmdSketcherBSplineDegree::CmdSketcherBSplineDegree()
-:Command("Sketcher_BSplineDegree")
+    : Command("Sketcher_BSplineDegree")
 {
     sAppModule      = "Sketcher";
     sGroup          = QT_TR_NOOP("Sketcher");
-    sMenuText       = QT_TR_NOOP("Show/Hide B-spline degree");
+    sMenuText       = QT_TR_NOOP("Show/hide B-spline degree");
     sToolTipText    = QT_TR_NOOP("Switches between showing and hiding the degree for all B-splines");
     sWhatsThis      = "Sketcher_BSplineDegree";
     sStatusTip      = sToolTipText;
@@ -118,28 +113,25 @@ void CmdSketcherBSplineDegree::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
 
-    Gui::Document * doc= getActiveGuiDocument();
-
+    Gui::Document * doc = getActiveGuiDocument();
     SketcherGui::ViewProviderSketch* vp = static_cast<SketcherGui::ViewProviderSketch*>(doc->getInEdit());
-
     ShowRestoreInformationLayer(vp, "BSplineDegreeVisible");
-
 }
 
 bool CmdSketcherBSplineDegree::isActive(void)
 {
-    return isSketcherBSplineActive( getActiveGuiDocument(), false );
+    return isSketcherBSplineActive(getActiveGuiDocument(), false);
 }
 
 // Show/Hide B-spline polygon
 DEF_STD_CMD_A(CmdSketcherBSplinePolygon)
 
 CmdSketcherBSplinePolygon::CmdSketcherBSplinePolygon()
-    :Command("Sketcher_BSplinePolygon")
+    : Command("Sketcher_BSplinePolygon")
 {
     sAppModule      = "Sketcher";
     sGroup          = QT_TR_NOOP("Sketcher");
-    sMenuText       = QT_TR_NOOP("Show/Hide B-spline control polygon");
+    sMenuText       = QT_TR_NOOP("Show/hide B-spline control polygon");
     sToolTipText    = QT_TR_NOOP("Switches between showing and hiding the control polygons for all B-splines");
     sWhatsThis      = "Sketcher_BSplinePolygon";
     sStatusTip      = sToolTipText;
@@ -152,28 +144,25 @@ void CmdSketcherBSplinePolygon::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
 
-    Gui::Document * doc= getActiveGuiDocument();
-
+    Gui::Document * doc = getActiveGuiDocument();
     SketcherGui::ViewProviderSketch* vp = static_cast<SketcherGui::ViewProviderSketch*>(doc->getInEdit());
-
     ShowRestoreInformationLayer(vp, "BSplineControlPolygonVisible");
-
 }
 
 bool CmdSketcherBSplinePolygon::isActive(void)
 {
-    return isSketcherBSplineActive( getActiveGuiDocument(), false );
+    return isSketcherBSplineActive(getActiveGuiDocument(), false);
 }
 
 // Show/Hide B-spline comb
 DEF_STD_CMD_A(CmdSketcherBSplineComb)
 
 CmdSketcherBSplineComb::CmdSketcherBSplineComb()
-:Command("Sketcher_BSplineComb")
+    : Command("Sketcher_BSplineComb")
 {
     sAppModule      = "Sketcher";
     sGroup          = QT_TR_NOOP("Sketcher");
-    sMenuText       = QT_TR_NOOP("Show/Hide B-spline curvature comb");
+    sMenuText       = QT_TR_NOOP("Show/hide B-spline curvature comb");
     sToolTipText    = QT_TR_NOOP("Switches between showing and hiding the curvature comb for all B-splines");
     sWhatsThis      = "Sketcher_BSplineComb";
     sStatusTip      = sToolTipText;
@@ -186,28 +175,25 @@ void CmdSketcherBSplineComb::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
 
-    Gui::Document * doc= getActiveGuiDocument();
-
+    Gui::Document * doc = getActiveGuiDocument();
     SketcherGui::ViewProviderSketch* vp = static_cast<SketcherGui::ViewProviderSketch*>(doc->getInEdit());
-
     ShowRestoreInformationLayer(vp, "BSplineCombVisible");
-
 }
 
 bool CmdSketcherBSplineComb::isActive(void)
 {
-    return isSketcherBSplineActive( getActiveGuiDocument(), false );
+    return isSketcherBSplineActive(getActiveGuiDocument(), false);
 }
 
 //
 DEF_STD_CMD_A(CmdSketcherBSplineKnotMultiplicity)
 
 CmdSketcherBSplineKnotMultiplicity::CmdSketcherBSplineKnotMultiplicity()
-:Command("Sketcher_BSplineKnotMultiplicity")
+    : Command("Sketcher_BSplineKnotMultiplicity")
 {
     sAppModule      = "Sketcher";
     sGroup          = QT_TR_NOOP("Sketcher");
-    sMenuText       = QT_TR_NOOP("Show/Hide B-spline knot multiplicity");
+    sMenuText       = QT_TR_NOOP("Show/hide B-spline knot multiplicity");
     sToolTipText    = QT_TR_NOOP("Switches between showing and hiding the knot multiplicity for all B-splines");
     sWhatsThis      = "Sketcher_BSplineKnotMultiplicity";
     sStatusTip      = sToolTipText;
@@ -220,24 +206,21 @@ void CmdSketcherBSplineKnotMultiplicity::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
 
-    Gui::Document * doc= getActiveGuiDocument();
-
+    Gui::Document * doc = getActiveGuiDocument();
     SketcherGui::ViewProviderSketch* vp = static_cast<SketcherGui::ViewProviderSketch*>(doc->getInEdit());
-
     ShowRestoreInformationLayer(vp, "BSplineKnotMultiplicityVisible");
-
 }
 
 bool CmdSketcherBSplineKnotMultiplicity::isActive(void)
 {
-    return isSketcherBSplineActive( getActiveGuiDocument(), false );
+    return isSketcherBSplineActive(getActiveGuiDocument(), false);
 }
 
 // Composite drop down menu for show/hide geometry information layer
 DEF_STD_CMD_ACLU(CmdSketcherCompBSplineShowHideGeometryInformation)
 
 CmdSketcherCompBSplineShowHideGeometryInformation::CmdSketcherCompBSplineShowHideGeometryInformation()
-: Command("Sketcher_CompBSplineShowHideGeometryInformation")
+    : Command("Sketcher_CompBSplineShowHideGeometryInformation")
 {
     sAppModule      = "Sketcher";
     sGroup          = QT_TR_NOOP("Sketcher");
@@ -251,16 +234,15 @@ CmdSketcherCompBSplineShowHideGeometryInformation::CmdSketcherCompBSplineShowHid
 void CmdSketcherCompBSplineShowHideGeometryInformation::activated(int iMsg)
 {
     Gui::CommandManager &rcCmdMgr = Gui::Application::Instance->commandManager();
-
     Gui::Command * cmd;
 
-    if (iMsg==0)
+    if (iMsg == 0)
         cmd = rcCmdMgr.getCommandByName("Sketcher_BSplineDegree");
-    else if (iMsg==1)
+    else if (iMsg == 1)
         cmd = rcCmdMgr.getCommandByName("Sketcher_BSplinePolygon");
-    else if (iMsg==2)
+    else if (iMsg == 2)
         cmd = rcCmdMgr.getCommandByName("Sketcher_BSplineComb");
-    else if (iMsg==3)
+    else if (iMsg == 3)
         cmd = rcCmdMgr.getCommandByName("Sketcher_BSplineKnotMultiplicity");
     else
         return;
@@ -311,21 +293,33 @@ void CmdSketcherCompBSplineShowHideGeometryInformation::languageChange()
     QList<QAction*> a = pcAction->actions();
 
     QAction* c1 = a[0];
-    c1->setText(QApplication::translate("CmdSketcherCompBSplineShowHideGeometryInformation","Show/Hide B-spline degree"));
-    c1->setToolTip(QApplication::translate("Sketcher_BSplineDegree","Switches between showing and hiding the degree for all B-splines"));
-    c1->setStatusTip(QApplication::translate("Sketcher_BSplineDegree","Switches between showing and hiding the degree for all B-splines"));
+    c1->setText(QApplication::translate("CmdSketcherCompBSplineShowHideGeometryInformation",
+                                        "Show/hide B-spline degree"));
+    c1->setToolTip(QApplication::translate("Sketcher_BSplineDegree",
+                                           "Switches between showing and hiding the degree for all B-splines"));
+    c1->setStatusTip(QApplication::translate("Sketcher_BSplineDegree",
+                                             "Switches between showing and hiding the degree for all B-splines"));
     QAction* c2 = a[1];
-    c2->setText(QApplication::translate("CmdSketcherCompBSplineShowHideGeometryInformation","Show/Hide B-spline control polygon"));
-    c2->setToolTip(QApplication::translate("Sketcher_BSplinePolygon","Switches between showing and hiding the control polygons for all B-splines"));
-    c2->setStatusTip(QApplication::translate("Sketcher_BSplinePolygon","Switches between showing and hiding the control polygons for all B-splines"));
+    c2->setText(QApplication::translate("CmdSketcherCompBSplineShowHideGeometryInformation",
+                                        "Show/hide B-spline control polygon"));
+    c2->setToolTip(QApplication::translate("Sketcher_BSplinePolygon",
+                                           "Switches between showing and hiding the control polygons for all B-splines"));
+    c2->setStatusTip(QApplication::translate("Sketcher_BSplinePolygon",
+                                             "Switches between showing and hiding the control polygons for all B-splines"));
     QAction* c3 = a[2];
-    c3->setText(QApplication::translate("CmdSketcherCompBSplineShowHideGeometryInformation","Show/Hide B-spline curvature comb"));
-    c3->setToolTip(QApplication::translate("Sketcher_BSplineComb","Switches between showing and hiding the curvature comb for all B-splines"));
-    c3->setStatusTip(QApplication::translate("Sketcher_BSplineComb","Switches between showing and hiding the curvature comb for all B-splines"));
+    c3->setText(QApplication::translate("CmdSketcherCompBSplineShowHideGeometryInformation",
+                                        "Show/hide B-spline curvature comb"));
+    c3->setToolTip(QApplication::translate("Sketcher_BSplineComb",
+                                           "Switches between showing and hiding the curvature comb for all B-splines"));
+    c3->setStatusTip(QApplication::translate("Sketcher_BSplineComb",
+                                             "Switches between showing and hiding the curvature comb for all B-splines"));
     QAction* c4 = a[3];
-    c4->setText(QApplication::translate("CmdSketcherCompBSplineShowHideGeometryInformation","Show/Hide B-spline knot multiplicity"));
-    c4->setToolTip(QApplication::translate("Sketcher_BSplineKnotMultiplicity","Switches between showing and hiding the knot multiplicity for all B-splines"));
-    c4->setStatusTip(QApplication::translate("Sketcher_BSplineKnotMultiplicity","Switches between showing and hiding the knot multiplicity for all B-splines"));
+    c4->setText(QApplication::translate("CmdSketcherCompBSplineShowHideGeometryInformation",
+                                        "Show/hide B-spline knot multiplicity"));
+    c4->setToolTip(QApplication::translate("Sketcher_BSplineKnotMultiplicity",
+                                           "Switches between showing and hiding the knot multiplicity for all B-splines"));
+    c4->setStatusTip(QApplication::translate("Sketcher_BSplineKnotMultiplicity",
+                                             "Switches between showing and hiding the knot multiplicity for all B-splines"));
 }
 
 void CmdSketcherCompBSplineShowHideGeometryInformation::updateAction(int /*mode*/)
@@ -334,19 +328,19 @@ void CmdSketcherCompBSplineShowHideGeometryInformation::updateAction(int /*mode*
 
 bool CmdSketcherCompBSplineShowHideGeometryInformation::isActive(void)
 {
-    return isSketcherBSplineActive( getActiveGuiDocument(), false );
+    return isSketcherBSplineActive(getActiveGuiDocument(), false);
 }
 
-// Convert to NURB
+// Convert to NURBS
 DEF_STD_CMD_A(CmdSketcherConvertToNURB)
 
 CmdSketcherConvertToNURB::CmdSketcherConvertToNURB()
-:Command("Sketcher_BSplineConvertToNURB")
+    : Command("Sketcher_BSplineConvertToNURB")
 {
     sAppModule      = "Sketcher";
     sGroup          = QT_TR_NOOP("Sketcher");
-    sMenuText       = QT_TR_NOOP("Convert Geometry to B-spline");
-    sToolTipText    = QT_TR_NOOP("Converts the given Geometry to a B-spline");
+    sMenuText       = QT_TR_NOOP("Convert geometry to B-spline");
+    sToolTipText    = QT_TR_NOOP("Converts the selected geometry to a B-spline");
     sWhatsThis      = "Sketcher_BSplineConvertToNURB";
     sStatusTip      = sToolTipText;
     sPixmap         = "Sketcher_BSplineApproximate";
@@ -375,25 +369,22 @@ void CmdSketcherConvertToNURB::activated(int iMsg)
 
     openCommand("Convert to NURBS");
 
-    for (unsigned int i=0; i<SubNames.size(); i++ ) {
+    for (unsigned int i=0; i < SubNames.size(); i++)
+    {
         // only handle edges
         if (SubNames[i].size() > 4 && SubNames[i].substr(0,4) == "Edge") {
-
             int GeoId = std::atoi(SubNames[i].substr(4,4000).c_str()) - 1;
             Gui::cmdAppObjectArgs(selection[0].getObject(), "convertToNURBS(%d) ", GeoId);
             nurbsized = true;
         }
         else if (SubNames[i].size() > 12 && SubNames[i].substr(0,12) == "ExternalEdge") {
-
             int GeoId = - (std::atoi(SubNames[i].substr(12,4000).c_str()) + 2);
             Gui::cmdAppObjectArgs(selection[0].getObject(), "convertToNURBS(%d) ", GeoId);
             nurbsized = true;
         }
-
-
     }
 
-    if(!nurbsized) {
+    if (!nurbsized) {
         abortCommand();
         QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
                              QObject::tr("None of the selected elements is an edge."));
@@ -401,24 +392,23 @@ void CmdSketcherConvertToNURB::activated(int iMsg)
     else {
         commitCommand();
     }
-
     tryAutoRecomputeIfNotSolve(Obj);
 }
 
 bool CmdSketcherConvertToNURB::isActive(void)
 {
-    return isSketcherBSplineActive( getActiveGuiDocument(), true );
+    return isSketcherBSplineActive(getActiveGuiDocument(), true);
 }
 
 // Increase degree of the spline
 DEF_STD_CMD_A(CmdSketcherIncreaseDegree)
 
 CmdSketcherIncreaseDegree::CmdSketcherIncreaseDegree()
-:Command("Sketcher_BSplineIncreaseDegree")
+    : Command("Sketcher_BSplineIncreaseDegree")
 {
     sAppModule      = "Sketcher";
     sGroup          = QT_TR_NOOP("Sketcher");
-    sMenuText       = QT_TR_NOOP("Increase degree");
+    sMenuText       = QT_TR_NOOP("Increase B-spline degree");
     sToolTipText    = QT_TR_NOOP("Increases the degree of the B-spline");
     sWhatsThis      = "Sketcher_BSplineIncreaseDegree";
     sStatusTip      = sToolTipText;
@@ -446,29 +436,28 @@ void CmdSketcherIncreaseDegree::activated(int iMsg)
 
     openCommand("Increase spline degree");
 
-    bool ignored=false;
+    bool ignored = false;
 
-    for (unsigned int i=0; i<SubNames.size(); i++ ) {
+    for (unsigned int i=0; i < SubNames.size(); i++)
+    {
         // only handle edges
-        if (SubNames[i].size() > 4 && SubNames[i].substr(0,4) == "Edge") {
-
+        if (SubNames[i].size() > 4 && SubNames[i].substr(0,4) == "Edge")
+        {
             int GeoId = std::atoi(SubNames[i].substr(4,4000).c_str()) - 1;
-
             const Part::Geometry * geo = Obj->getGeometry(GeoId);
 
             if (geo->getTypeId() == Part::GeomBSplineCurve::getClassTypeId()) {
                 Gui::cmdAppObjectArgs(selection[0].getObject(), "increaseBSplineDegree(%d) ", GeoId);
-                
                 // add new control points
                 Gui::cmdAppObjectArgs(selection[0].getObject(), "exposeInternalGeometry(%d)", GeoId);
             }
             else {
-                ignored=true;
+                ignored = true;
             }
         }
     }
 
-    if(ignored) {
+    if (ignored) {
         QMessageBox::warning(Gui::getMainWindow(),
                              QObject::tr("Wrong selection"),
                              QObject::tr("At least one of the selected "
@@ -476,15 +465,13 @@ void CmdSketcherIncreaseDegree::activated(int iMsg)
     }
 
     commitCommand();
-
     tryAutoRecomputeIfNotSolve(Obj);
-
     getSelection().clearSelection();
 }
 
 bool CmdSketcherIncreaseDegree::isActive(void)
 {
-    return isSketcherBSplineActive( getActiveGuiDocument(), true );
+    return isSketcherBSplineActive(getActiveGuiDocument(), true);
 }
 
 
@@ -493,7 +480,7 @@ bool CmdSketcherIncreaseDegree::isActive(void)
 // Decrease degree of the spline
 // DEF_STD_CMD_A(CmdSketcherDecreaseDegree)
 // CmdSketcherDecreaseDegree::CmdSketcherDecreaseDegree()
-// :Command("Sketcher_BSplineDecreaseDegree")
+// : Command("Sketcher_BSplineDecreaseDegree")
 // {
 // ...
 // }
@@ -502,7 +489,7 @@ bool CmdSketcherIncreaseDegree::isActive(void)
 DEF_STD_CMD_A(CmdSketcherIncreaseKnotMultiplicity)
 
 CmdSketcherIncreaseKnotMultiplicity::CmdSketcherIncreaseKnotMultiplicity()
-:Command("Sketcher_BSplineIncreaseKnotMultiplicity")
+    : Command("Sketcher_BSplineIncreaseKnotMultiplicity")
 {
     sAppModule      = "Sketcher";
     sGroup          = QT_TR_NOOP("Sketcher");
@@ -540,7 +527,7 @@ void CmdSketcherIncreaseKnotMultiplicity::activated(int iMsg)
     // get the needed lists and objects
     const std::vector<std::string> &SubNames = selection[0].getSubNames();
 
-    if(SubNames.size()>1) {
+    if (SubNames.size() > 1) {
         // Check that only one object is selected,
         // as we need only one object to get the new GeoId after multiplicity change
         QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
@@ -554,38 +541,38 @@ void CmdSketcherIncreaseKnotMultiplicity::activated(int iMsg)
 
     bool applied = false;
     bool notaknot = true;
-
     boost::uuids::uuid bsplinetag;
 
     int GeoId;
     Sketcher::PointPos PosId;
     getIdsFromName(SubNames[0], Obj, GeoId, PosId);
 
-    if(isSimpleVertex(Obj, GeoId, PosId)) {
+    if (isSimpleVertex(Obj, GeoId, PosId))
+    {
+        const std::vector<Sketcher::Constraint *> &vals = Obj->Constraints.getValues();
 
-        const std::vector< Sketcher::Constraint * > &vals = Obj->Constraints.getValues();
-
-        for (std::vector< Sketcher::Constraint * >::const_iterator it= vals.begin(); it != vals.end(); ++it) {
-            if((*it)->Type == Sketcher::InternalAlignment && (*it)->First == GeoId && (*it)->AlignmentType == Sketcher::BSplineKnotPoint)
+        for (std::vector<Sketcher::Constraint *>::const_iterator it= vals.begin(); it != vals.end(); ++it)
+        {
+            if ((*it)->Type == Sketcher::InternalAlignment
+                && (*it)->First == GeoId
+                && (*it)->AlignmentType == Sketcher::BSplineKnotPoint)
             {
                 bsplinetag = Obj->getGeometry((*it)->Second)->getTag();
-
                 notaknot = false;
 
                 try {
-                    Gui::cmdAppObjectArgs(selection[0].getObject(), "modifyBSplineKnotMultiplicity(%d,%d,%d) ",
-                        (*it)->Second, (*it)->InternalAlignmentIndex + 1, 1);
-
+                    Gui::cmdAppObjectArgs(selection[0].getObject(),
+                                          "modifyBSplineKnotMultiplicity(%d, %d, %d) ",
+                                          (*it)->Second, (*it)->InternalAlignmentIndex + 1, 1);
                     applied = true;
 
                     // Warning: GeoId list might have changed
                     // as the consequence of deleting pole circles and
                     // particularly B-spline GeoID might have changed.
-
                 }
                 catch (const Base::CADKernelError& e) {
                     e.ReportException();
-                    if(e.getTranslatable()) {
+                    if (e.getTranslatable()) {
                         QMessageBox::warning(Gui::getMainWindow(),
                                              QObject::tr("CAD Kernel Error"),
                                              QObject::tr(e.getMessage().c_str()));
@@ -594,30 +581,25 @@ void CmdSketcherIncreaseKnotMultiplicity::activated(int iMsg)
                 }
                 catch (const Base::Exception& e) {
                     e.ReportException();
-                    if(e.getTranslatable()) {
+                    if (e.getTranslatable()) {
                         QMessageBox::warning(Gui::getMainWindow(),
                                              QObject::tr("Input Error"),
                                              QObject::tr(e.getMessage().c_str()));
                     }
-
                     getSelection().clearSelection();
                 }
-
-                break; // we have already found our knot.
-
+                break;  // we have already found our knot.
             }
-
         }
-
     }
 
-    if(notaknot){
+    if (notaknot) {
         QMessageBox::warning(Gui::getMainWindow(),
                              QObject::tr("Wrong selection"),
                              QObject::tr("None of the selected elements is a knot of a B-spline"));
     }
 
-    if(applied)
+    if (applied)
     {
         // find new geoid for B-spline as GeoId might have changed
         const std::vector< Part::Geometry * > &gvals = Obj->getInternalGeometry();
@@ -632,8 +614,7 @@ void CmdSketcherIncreaseKnotMultiplicity::activated(int iMsg)
             }
         }
 
-
-        if(ngfound) {
+        if (ngfound) {
             try {
                 // add internalalignment for new pole
                 Gui::cmdAppObjectArgs(selection[0].getObject(), "exposeInternalGeometry(%d)", ngeoid);
@@ -642,11 +623,10 @@ void CmdSketcherIncreaseKnotMultiplicity::activated(int iMsg)
                 Base::Console().Error("%s\n", e.what());
                 getSelection().clearSelection();
             }
-
         }
     }
 
-    if(!applied) {
+    if (!applied) {
         abortCommand();
     }
     else {
@@ -654,24 +634,22 @@ void CmdSketcherIncreaseKnotMultiplicity::activated(int iMsg)
     }
 
     tryAutoRecomputeIfNotSolve(Obj);
-
     getSelection().clearSelection();
-
 }
 
 bool CmdSketcherIncreaseKnotMultiplicity::isActive(void)
 {
-    return isSketcherBSplineActive( getActiveGuiDocument(), true );
+    return isSketcherBSplineActive(getActiveGuiDocument(), true);
 }
 
 DEF_STD_CMD_A(CmdSketcherDecreaseKnotMultiplicity)
 
 CmdSketcherDecreaseKnotMultiplicity::CmdSketcherDecreaseKnotMultiplicity()
-:Command("Sketcher_BSplineDecreaseKnotMultiplicity")
+    : Command("Sketcher_BSplineDecreaseKnotMultiplicity")
 {
     sAppModule      = "Sketcher";
     sGroup          = QT_TR_NOOP("Sketcher");
-    sMenuText       = QT_TR_NOOP("Decrease multiplicity");
+    sMenuText       = QT_TR_NOOP("Decrease knot multiplicity");
     sToolTipText    = QT_TR_NOOP("Decreases the multiplicity of the selected knot of a B-spline");
     sWhatsThis      = "Sketcher_BSplineDecreaseKnotMultiplicity";
     sStatusTip      = sToolTipText;
@@ -705,7 +683,7 @@ void CmdSketcherDecreaseKnotMultiplicity::activated(int iMsg)
     // get the needed lists and objects
     const std::vector<std::string> &SubNames = selection[0].getSubNames();
 
-    if(SubNames.size()>1) {
+    if (SubNames.size() > 1) {
         // Check that only one object is selected,
         // as we need only one object to get the new GeoId after multiplicity change
         QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
@@ -719,53 +697,50 @@ void CmdSketcherDecreaseKnotMultiplicity::activated(int iMsg)
 
     bool applied = false;
     bool notaknot = true;
-
     boost::uuids::uuid bsplinetag;
 
     int GeoId;
     Sketcher::PointPos PosId;
     getIdsFromName(SubNames[0], Obj, GeoId, PosId);
 
-    if(isSimpleVertex(Obj, GeoId, PosId)) {
-
+    if (isSimpleVertex(Obj, GeoId, PosId))
+    {
         const std::vector< Sketcher::Constraint * > &vals = Obj->Constraints.getValues();
 
-        for (std::vector< Sketcher::Constraint * >::const_iterator it= vals.begin(); it != vals.end(); ++it) {
-            if((*it)->Type == Sketcher::InternalAlignment && (*it)->First == GeoId && (*it)->AlignmentType == Sketcher::BSplineKnotPoint)
+        for (std::vector< Sketcher::Constraint * >::const_iterator it= vals.begin(); it != vals.end(); ++it)
+        {
+            if ((*it)->Type == Sketcher::InternalAlignment
+                && (*it)->First == GeoId
+                && (*it)->AlignmentType == Sketcher::BSplineKnotPoint)
             {
                 bsplinetag = Obj->getGeometry((*it)->Second)->getTag();
-
                 notaknot = false;
 
                 try {
-                    Gui::cmdAppObjectArgs(selection[0].getObject(), "modifyBSplineKnotMultiplicity(%d,%d,%d) ",
+                    Gui::cmdAppObjectArgs(selection[0].getObject(),
+                                          "modifyBSplineKnotMultiplicity(%d, %d, %d) ",
                                           (*it)->Second, (*it)->InternalAlignmentIndex + 1, -1);
-                    
                     applied = true;
 
                     // Warning: GeoId list might have changed as the consequence of deleting pole circles and
                     // particularly B-spline GeoID might have changed.
-
                 }
                 catch (const Base::Exception& e) {
                     QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Error"),
                                          QObject::tr(getStrippedPythonExceptionString(e).c_str()));
                     getSelection().clearSelection();
                 }
-
-                break; // we have already found our knot.
-
+                break;  // we have already found our knot.
             }
         }
-
     }
 
-    if(notaknot){
+    if (notaknot) {
         QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
                              QObject::tr("None of the selected elements is a knot of a B-spline"));
     }
 
-    if(applied)
+    if (applied)
     {
         // find new geoid for B-spline as GeoId might have changed
         const std::vector< Part::Geometry * > &gvals = Obj->getInternalGeometry();
@@ -780,8 +755,7 @@ void CmdSketcherDecreaseKnotMultiplicity::activated(int iMsg)
             }
         }
 
-
-        if(ngfound) {
+        if (ngfound) {
             try {
                 // add internalalignment for new pole
                 Gui::cmdAppObjectArgs(selection[0].getObject(), "exposeInternalGeometry(%d)", ngeoid);
@@ -793,7 +767,7 @@ void CmdSketcherDecreaseKnotMultiplicity::activated(int iMsg)
         }
     }
 
-    if(!applied) {
+    if (!applied) {
         abortCommand();
     }
     else {
@@ -801,13 +775,12 @@ void CmdSketcherDecreaseKnotMultiplicity::activated(int iMsg)
     }
 
     tryAutoRecomputeIfNotSolve(Obj);
-
     getSelection().clearSelection();
 }
 
 bool CmdSketcherDecreaseKnotMultiplicity::isActive(void)
 {
-    return isSketcherBSplineActive( getActiveGuiDocument(), true );
+    return isSketcherBSplineActive(getActiveGuiDocument(), true);
 }
 
 
@@ -815,7 +788,7 @@ bool CmdSketcherDecreaseKnotMultiplicity::isActive(void)
 DEF_STD_CMD_ACLU(CmdSketcherCompModifyKnotMultiplicity)
 
 CmdSketcherCompModifyKnotMultiplicity::CmdSketcherCompModifyKnotMultiplicity()
-: Command("Sketcher_CompModifyKnotMultiplicity")
+    : Command("Sketcher_CompModifyKnotMultiplicity")
 {
     sAppModule      = "Sketcher";
     sGroup          = QT_TR_NOOP("Sketcher");
@@ -830,12 +803,11 @@ void CmdSketcherCompModifyKnotMultiplicity::activated(int iMsg)
 {
 
     Gui::CommandManager &rcCmdMgr = Gui::Application::Instance->commandManager();
-
     Gui::Command * cmd;
 
-    if (iMsg==0)
+    if (iMsg == 0)
         cmd = rcCmdMgr.getCommandByName("Sketcher_BSplineIncreaseKnotMultiplicity");
-    else if (iMsg==1)
+    else if (iMsg == 1)
         cmd = rcCmdMgr.getCommandByName("Sketcher_BSplineDecreaseKnotMultiplicity");
     else
         return;
@@ -882,14 +854,19 @@ void CmdSketcherCompModifyKnotMultiplicity::languageChange()
     QList<QAction*> a = pcAction->actions();
 
     QAction* c1 = a[0];
-    c1->setText(QApplication::translate("CmdSketcherCompModifyKnotMultiplicity","Increase knot multiplicity"));
-    c1->setToolTip(QApplication::translate("Sketcher_BSplineIncreaseKnotMultiplicity","Increases the multiplicity of the selected knot of a B-spline"));
-    c1->setStatusTip(QApplication::translate("Sketcher_BSplineIncreaseKnotMultiplicity","Increases the multiplicity of the selected knot of a B-spline"));
+    c1->setText(QApplication::translate("CmdSketcherCompModifyKnotMultiplicity",
+                                        "Increase knot multiplicity"));
+    c1->setToolTip(QApplication::translate("Sketcher_BSplineIncreaseKnotMultiplicity",
+                                           "Increases the multiplicity of the selected knot of a B-spline"));
+    c1->setStatusTip(QApplication::translate("Sketcher_BSplineIncreaseKnotMultiplicity",
+                                             "Increases the multiplicity of the selected knot of a B-spline"));
     QAction* c2 = a[1];
-    c2->setText(QApplication::translate("CmdSketcherCompModifyKnotMultiplicity","Decrease knot multiplicity"));
-    c2->setToolTip(QApplication::translate("Sketcher_BSplineDecreaseKnotMultiplicity","Decreases the multiplicity of the selected knot of a B-spline"));
-    c2->setStatusTip(QApplication::translate("Sketcher_BSplineDecreaseKnotMultiplicity","Decreases the multiplicity of the selected knot of a B-spline"));
-
+    c2->setText(QApplication::translate("CmdSketcherCompModifyKnotMultiplicity",
+                                        "Decrease knot multiplicity"));
+    c2->setToolTip(QApplication::translate("Sketcher_BSplineDecreaseKnotMultiplicity",
+                                           "Decreases the multiplicity of the selected knot of a B-spline"));
+    c2->setStatusTip(QApplication::translate("Sketcher_BSplineDecreaseKnotMultiplicity",
+                                             "Decreases the multiplicity of the selected knot of a B-spline"));
 }
 
 void CmdSketcherCompModifyKnotMultiplicity::updateAction(int /*mode*/)
@@ -898,7 +875,7 @@ void CmdSketcherCompModifyKnotMultiplicity::updateAction(int /*mode*/)
 
 bool CmdSketcherCompModifyKnotMultiplicity::isActive(void)
 {
-    return isSketcherBSplineActive( getActiveGuiDocument(), false );
+    return isSketcherBSplineActive(getActiveGuiDocument(), false);
 }
 
 void CreateSketcherCommandsBSpline(void)

--- a/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp
+++ b/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp
@@ -57,7 +57,7 @@ using namespace std;
 using namespace SketcherGui;
 using namespace Sketcher;
 
-bool isSketcherAcceleratorActive(Gui::Document *doc, bool actsOnSelection )
+bool isSketcherAcceleratorActive(Gui::Document *doc, bool actsOnSelection)
 {
     if (doc) {
         // checks if a Sketch Viewprovider is in Edit and is in no special mode
@@ -95,8 +95,9 @@ CmdSketcherCloseShape::CmdSketcherCloseShape()
 {
     sAppModule      = "Sketcher";
     sGroup          = QT_TR_NOOP("Sketcher");
-    sMenuText       = QT_TR_NOOP("Close Shape");
-    sToolTipText    = QT_TR_NOOP("Produce closed shape by Link end point of element with next elements' starting point");
+    sMenuText       = QT_TR_NOOP("Close shape");
+    sToolTipText    = QT_TR_NOOP("Produce a closed shape by tying the end point "
+                                 "of one element with the next element's starting point");
     sWhatsThis      = "Sketcher_CloseShape";
     sStatusTip      = sToolTipText;
     sPixmap         = "Sketcher_CloseShape";
@@ -128,13 +129,13 @@ void CmdSketcherCloseShape::activated(int iMsg)
 
     Sketcher::SketchObject* Obj = static_cast<Sketcher::SketchObject*>(selection[0].getObject());
 
-    int GeoIdFirst=-1;
-    int GeoIdLast=-1;
+    int GeoIdFirst = -1;
+    int GeoIdLast = -1;
 
     // undo command open
     openCommand("Add coincident constraint");
     // go through the selected subelements
-    for (unsigned int i=0; i<(SubNames.size()-1); i++ ) {
+    for (unsigned int i=0; i < (SubNames.size() - 1); i++) {
         // only handle edges
         if (SubNames[i].size() > 4 && SubNames[i].substr(0,4) == "Edge" &&
             SubNames[i+1].size() > 4 && SubNames[i+1].substr(0,4) == "Edge") {
@@ -142,10 +143,10 @@ void CmdSketcherCloseShape::activated(int iMsg)
             int GeoId1 = std::atoi(SubNames[i].substr(4,4000).c_str()) - 1;
             int GeoId2 = std::atoi(SubNames[i+1].substr(4,4000).c_str()) - 1;
 
-            if(GeoIdFirst==-1)
-              GeoIdFirst=GeoId1;
+            if (GeoIdFirst == -1)
+                GeoIdFirst = GeoId1;
 
-            GeoIdLast=GeoId2;
+            GeoIdLast = GeoId2;
 
             const Part::Geometry *geo1 = Obj->getGeometry(GeoId1);
             const Part::Geometry *geo2 = Obj->getGeometry(GeoId2);
@@ -169,27 +170,26 @@ void CmdSketcherCloseShape::activated(int iMsg)
                 return;
             }
 
-            Gui::cmdAppObjectArgs(selection[0].getObject(), "addConstraint(Sketcher.Constraint('Coincident',%d,%d,%d,%d)) ",
-                GeoId1,Sketcher::end,GeoId2,Sketcher::start);
+            Gui::cmdAppObjectArgs(selection[0].getObject(),
+                                  "addConstraint(Sketcher.Constraint('Coincident', %d, %d, %d, %d)) ",
+                                  GeoId1, Sketcher::end, GeoId2, Sketcher::start);
         }
     }
 
     // Close Last Edge with First Edge
-    Gui::cmdAppObjectArgs(selection[0].getObject(),"addConstraint(Sketcher.Constraint('Coincident',%d,%d,%d,%d)) ",
-        GeoIdLast,Sketcher::end,GeoIdFirst,Sketcher::start);
+    Gui::cmdAppObjectArgs(selection[0].getObject(),
+                          "addConstraint(Sketcher.Constraint('Coincident', %d, %d, %d, %d)) ",
+                          GeoIdLast, Sketcher::end, GeoIdFirst, Sketcher::start);
 
-    // finish the transaction and update
+    // finish the transaction and update, and clear the selection (convenience)
     commitCommand();
-
     tryAutoRecompute(Obj);
-
-    // clear the selection (convenience)
     getSelection().clearSelection();
 }
 
 bool CmdSketcherCloseShape::isActive(void)
 {
-    return isSketcherAcceleratorActive( getActiveGuiDocument(), true );
+    return isSketcherAcceleratorActive(getActiveGuiDocument(), true);
 }
 
 
@@ -201,8 +201,8 @@ CmdSketcherConnect::CmdSketcherConnect()
 {
     sAppModule      = "Sketcher";
     sGroup          = QT_TR_NOOP("Sketcher");
-    sMenuText       = QT_TR_NOOP("Connect Edges");
-    sToolTipText    = QT_TR_NOOP("Link end point of element with next elements' starting point");
+    sMenuText       = QT_TR_NOOP("Connect edges");
+    sToolTipText    = QT_TR_NOOP("Tie the end point of the element with next element's starting point");
     sWhatsThis      = "Sketcher_ConnectLines";
     sStatusTip      = sToolTipText;
     sPixmap         = "Sketcher_ConnectLines";
@@ -262,18 +262,15 @@ void CmdSketcherConnect::activated(int iMsg)
         }
     }
 
-    // finish the transaction and update
+    // finish the transaction and update, and clear the selection (convenience)
     commitCommand();
-
     tryAutoRecompute(Obj);
-
-    // clear the selection (convenience)
     getSelection().clearSelection();
 }
 
 bool CmdSketcherConnect::isActive(void)
 {
-    return isSketcherAcceleratorActive( getActiveGuiDocument(), true );
+    return isSketcherAcceleratorActive(getActiveGuiDocument(), true);
 }
 
 // Select Constraints of selected elements
@@ -284,8 +281,8 @@ CmdSketcherSelectConstraints::CmdSketcherSelectConstraints()
 {
     sAppModule      = "Sketcher";
     sGroup          = QT_TR_NOOP("Sketcher");
-    sMenuText       = QT_TR_NOOP("Select Constraints");
-    sToolTipText    = QT_TR_NOOP("Select the constraints associated to the selected elements");
+    sMenuText       = QT_TR_NOOP("Select associated constraints");
+    sToolTipText    = QT_TR_NOOP("Select the constraints associated with the selected geometrical elements");
     sWhatsThis      = "Sketcher_SelectConstraints";
     sStatusTip      = sToolTipText;
     sPixmap         = "Sketcher_SelectConstraints";
@@ -326,9 +323,12 @@ void CmdSketcherSelectConstraints::activated(int iMsg)
             // push all the constraints
             int i = 0;
             for (std::vector< Sketcher::Constraint * >::const_iterator it= vals.begin();
-                 it != vals.end(); ++it,++i) {
-                if ( (*it)->First == GeoId || (*it)->Second == GeoId || (*it)->Third == GeoId){
-                  Gui::Selection().addSelection(doc_name.c_str(), obj_name.c_str(), Sketcher::PropertyConstraintList::getConstraintName(i).c_str());
+                 it != vals.end(); ++it,++i)
+            {
+                if ((*it)->First == GeoId || (*it)->Second == GeoId || (*it)->Third == GeoId) {
+                    Gui::Selection().addSelection(doc_name.c_str(),
+                                                  obj_name.c_str(),
+                                                  Sketcher::PropertyConstraintList::getConstraintName(i).c_str());
                 }
             }
         }
@@ -337,7 +337,7 @@ void CmdSketcherSelectConstraints::activated(int iMsg)
 
 bool CmdSketcherSelectConstraints::isActive(void)
 {
-    return isSketcherAcceleratorActive( getActiveGuiDocument(), true );
+    return isSketcherAcceleratorActive(getActiveGuiDocument(), true);
 }
 
 // Select Origin
@@ -348,8 +348,8 @@ CmdSketcherSelectOrigin::CmdSketcherSelectOrigin()
 {
     sAppModule      = "Sketcher";
     sGroup          = QT_TR_NOOP("Sketcher");
-    sMenuText       = QT_TR_NOOP("Select Origin");
-    sToolTipText    = QT_TR_NOOP("Select the origin point");
+    sMenuText       = QT_TR_NOOP("Select origin");
+    sToolTipText    = QT_TR_NOOP("Select the local origin point of the sketch");
     sWhatsThis      = "Sketcher_SelectOrigin";
     sStatusTip      = sToolTipText;
     sPixmap         = "Sketcher_SelectOrigin";
@@ -361,13 +361,9 @@ void CmdSketcherSelectOrigin::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
     Gui::Document * doc= getActiveGuiDocument();
-
     SketcherGui::ViewProviderSketch* vp = static_cast<SketcherGui::ViewProviderSketch*>(doc->getInEdit());
-
     Sketcher::SketchObject* Obj= vp->getSketchObject();
-
 //    ViewProviderSketch * vp = static_cast<ViewProviderSketch *>(Gui::Application::Instance->getViewProvider(docobj));
-
 //    Sketcher::SketchObject* Obj = vp->getSketchObject();
 
     std::string doc_name = Obj->getDocument()->getName();
@@ -377,15 +373,14 @@ void CmdSketcherSelectOrigin::activated(int iMsg)
     ss << "RootPoint";
 
     if(Gui::Selection().isSelected(doc_name.c_str(), obj_name.c_str(), ss.str().c_str()))
-      Gui::Selection().rmvSelection(doc_name.c_str(), obj_name.c_str(), ss.str().c_str());
+        Gui::Selection().rmvSelection(doc_name.c_str(), obj_name.c_str(), ss.str().c_str());
     else
-      Gui::Selection().addSelection(doc_name.c_str(), obj_name.c_str(), ss.str().c_str());
-
+        Gui::Selection().addSelection(doc_name.c_str(), obj_name.c_str(), ss.str().c_str());
 }
 
 bool CmdSketcherSelectOrigin::isActive(void)
 {
-    return isSketcherAcceleratorActive( getActiveGuiDocument(), false );
+    return isSketcherAcceleratorActive(getActiveGuiDocument(), false);
 }
 
 // Select Vertical Axis
@@ -396,8 +391,8 @@ CmdSketcherSelectVerticalAxis::CmdSketcherSelectVerticalAxis()
 {
     sAppModule      = "Sketcher";
     sGroup          = QT_TR_NOOP("Sketcher");
-    sMenuText       = QT_TR_NOOP("Select Vertical Axis");
-    sToolTipText    = QT_TR_NOOP("Select the vertical axis");
+    sMenuText       = QT_TR_NOOP("Select vertical axis");
+    sToolTipText    = QT_TR_NOOP("Select the local vertical axis of the sketch");
     sWhatsThis      = "Sketcher_SelectVerticalAxis";
     sStatusTip      = sToolTipText;
     sPixmap         = "Sketcher_SelectVerticalAxis";
@@ -409,9 +404,7 @@ void CmdSketcherSelectVerticalAxis::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
     Gui::Document * doc= getActiveGuiDocument();
-
     SketcherGui::ViewProviderSketch* vp = static_cast<SketcherGui::ViewProviderSketch*>(doc->getInEdit());
-
     Sketcher::SketchObject* Obj= vp->getSketchObject();
 
     std::string doc_name = Obj->getDocument()->getName();
@@ -424,12 +417,11 @@ void CmdSketcherSelectVerticalAxis::activated(int iMsg)
       Gui::Selection().rmvSelection(doc_name.c_str(), obj_name.c_str(), ss.str().c_str());
     else
       Gui::Selection().addSelection(doc_name.c_str(), obj_name.c_str(), ss.str().c_str());
-
 }
 
 bool CmdSketcherSelectVerticalAxis::isActive(void)
 {
-    return isSketcherAcceleratorActive( getActiveGuiDocument(), false );
+    return isSketcherAcceleratorActive(getActiveGuiDocument(), false);
 }
 
 // Select Horizontal Axis
@@ -440,8 +432,8 @@ CmdSketcherSelectHorizontalAxis::CmdSketcherSelectHorizontalAxis()
 {
     sAppModule      = "Sketcher";
     sGroup          = QT_TR_NOOP("Sketcher");
-    sMenuText       = QT_TR_NOOP("Select Horizontal Axis");
-    sToolTipText    = QT_TR_NOOP("Select the horizontal axis");
+    sMenuText       = QT_TR_NOOP("Select horizontal axis");
+    sToolTipText    = QT_TR_NOOP("Select the local horizontal axis of the sketch");
     sWhatsThis      = "Sketcher_SelectHorizontalAxis";
     sStatusTip      = sToolTipText;
     sPixmap         = "Sketcher_SelectHorizontalAxis";
@@ -453,9 +445,7 @@ void CmdSketcherSelectHorizontalAxis::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
     Gui::Document * doc= getActiveGuiDocument();
-
     SketcherGui::ViewProviderSketch* vp = static_cast<SketcherGui::ViewProviderSketch*>(doc->getInEdit());
-
     Sketcher::SketchObject* Obj= vp->getSketchObject();
 
     std::string doc_name = Obj->getDocument()->getName();
@@ -468,12 +458,11 @@ void CmdSketcherSelectHorizontalAxis::activated(int iMsg)
       Gui::Selection().rmvSelection(doc_name.c_str(), obj_name.c_str(), ss.str().c_str());
     else
       Gui::Selection().addSelection(doc_name.c_str(), obj_name.c_str(), ss.str().c_str());
-
 }
 
 bool CmdSketcherSelectHorizontalAxis::isActive(void)
 {
-    return isSketcherAcceleratorActive( getActiveGuiDocument(), false );
+    return isSketcherAcceleratorActive(getActiveGuiDocument(), false);
 }
 
 DEF_STD_CMD_A(CmdSketcherSelectRedundantConstraints)
@@ -483,8 +472,8 @@ CmdSketcherSelectRedundantConstraints::CmdSketcherSelectRedundantConstraints()
 {
     sAppModule      = "Sketcher";
     sGroup          = QT_TR_NOOP("Sketcher");
-    sMenuText       = QT_TR_NOOP("Select Redundant Constraints");
-    sToolTipText    = QT_TR_NOOP("Select Redundant Constraints");
+    sMenuText       = QT_TR_NOOP("Select redundant constraints");
+    sToolTipText    = QT_TR_NOOP("Select redundant constraints");
     sWhatsThis      = "Sketcher_SelectRedundantConstraints";
     sStatusTip      = sToolTipText;
     sPixmap         = "Sketcher_SelectRedundantConstraints";
@@ -496,9 +485,7 @@ void CmdSketcherSelectRedundantConstraints::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
     Gui::Document * doc= getActiveGuiDocument();
-
     SketcherGui::ViewProviderSketch* vp = static_cast<SketcherGui::ViewProviderSketch*>(doc->getInEdit());
-
     Sketcher::SketchObject* Obj= vp->getSketchObject();
 
     std::string doc_name = Obj->getDocument()->getName();
@@ -513,20 +500,21 @@ void CmdSketcherSelectRedundantConstraints::activated(int iMsg)
     // push the constraints
     int i = 0;
     for (std::vector< Sketcher::Constraint * >::const_iterator it= vals.begin();it != vals.end(); ++it,++i) {
-        for(std::vector< int >::const_iterator itc= solverredundant.begin();itc != solverredundant.end(); ++itc) {
-            if ( (*itc) - 1 == i){
-                Gui::Selection().addSelection(doc_name.c_str(), obj_name.c_str(), Sketcher::PropertyConstraintList::getConstraintName(i).c_str());
+        for(std::vector< int >::const_iterator itc= solverredundant.begin();itc != solverredundant.end(); ++itc)
+        {
+            if ((*itc) - 1 == i) {
+                Gui::Selection().addSelection(doc_name.c_str(),
+                                              obj_name.c_str(),
+                                              Sketcher::PropertyConstraintList::getConstraintName(i).c_str());
                 break;
             }
         }
-
-
     }
 }
 
 bool CmdSketcherSelectRedundantConstraints::isActive(void)
 {
-    return isSketcherAcceleratorActive( getActiveGuiDocument(), false );
+    return isSketcherAcceleratorActive(getActiveGuiDocument(), false);
 }
 
 DEF_STD_CMD_A(CmdSketcherSelectConflictingConstraints)
@@ -536,8 +524,8 @@ CmdSketcherSelectConflictingConstraints::CmdSketcherSelectConflictingConstraints
 {
     sAppModule      = "Sketcher";
     sGroup          = QT_TR_NOOP("Sketcher");
-    sMenuText       = QT_TR_NOOP("Select Conflicting Constraints");
-    sToolTipText    = QT_TR_NOOP("Select Conflicting Constraints");
+    sMenuText       = QT_TR_NOOP("Select conflicting constraints");
+    sToolTipText    = QT_TR_NOOP("Select conflicting constraints");
     sWhatsThis      = "Sketcher_SelectConflictingConstraints";
     sStatusTip      = sToolTipText;
     sPixmap         = "Sketcher_SelectConflictingConstraints";
@@ -549,11 +537,8 @@ void CmdSketcherSelectConflictingConstraints::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
     Gui::Document * doc= getActiveGuiDocument();
-
     SketcherGui::ViewProviderSketch* vp = static_cast<SketcherGui::ViewProviderSketch*>(doc->getInEdit());
-
     Sketcher::SketchObject* Obj= vp->getSketchObject();
-
     std::string doc_name = Obj->getDocument()->getName();
     std::string obj_name = Obj->getNameInDocument();
 
@@ -567,8 +552,11 @@ void CmdSketcherSelectConflictingConstraints::activated(int iMsg)
     int i = 0;
     for (std::vector< Sketcher::Constraint * >::const_iterator it= vals.begin();it != vals.end(); ++it,++i) {
         for(std::vector< int >::const_iterator itc= solverconflicting.begin();itc != solverconflicting.end(); ++itc) {
-            if ( (*itc) - 1 == i){
-                Gui::Selection().addSelection(doc_name.c_str(), obj_name.c_str(), Sketcher::PropertyConstraintList::getConstraintName(i).c_str());
+            if ((*itc) - 1 == i)
+            {
+                Gui::Selection().addSelection(doc_name.c_str(),
+                                              obj_name.c_str(),
+                                              Sketcher::PropertyConstraintList::getConstraintName(i).c_str());
                 break;
             }
         }
@@ -577,7 +565,7 @@ void CmdSketcherSelectConflictingConstraints::activated(int iMsg)
 
 bool CmdSketcherSelectConflictingConstraints::isActive(void)
 {
-    return isSketcherAcceleratorActive( getActiveGuiDocument(), false );
+    return isSketcherAcceleratorActive(getActiveGuiDocument(), false);
 }
 
 DEF_STD_CMD_A(CmdSketcherSelectElementsAssociatedWithConstraints)
@@ -587,8 +575,8 @@ CmdSketcherSelectElementsAssociatedWithConstraints::CmdSketcherSelectElementsAss
 {
     sAppModule      = "Sketcher";
     sGroup          = QT_TR_NOOP("Sketcher");
-    sMenuText       = QT_TR_NOOP("Select Elements associated with constraints");
-    sToolTipText    = QT_TR_NOOP("Select Elements associated with constraints");
+    sMenuText       = QT_TR_NOOP("Select associated geometry");
+    sToolTipText    = QT_TR_NOOP("Select the geometrical elements associated with the selected constraints");
     sWhatsThis      = "Sketcher_SelectElementsAssociatedWithConstraints";
     sStatusTip      = sToolTipText;
     sPixmap         = "Sketcher_SelectElementsAssociatedWithConstraints";
@@ -600,11 +588,8 @@ void CmdSketcherSelectElementsAssociatedWithConstraints::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
     std::vector<Gui::SelectionObject> selection = Gui::Selection().getSelectionEx();
-
     Gui::Document * doc= getActiveGuiDocument();
-
     SketcherGui::ViewProviderSketch* vp = static_cast<SketcherGui::ViewProviderSketch*>(doc->getInEdit());
-
     Sketcher::SketchObject* Obj= vp->getSketchObject();
 
     const std::vector<std::string> &SubNames = selection[0].getSubNames();
@@ -616,7 +601,7 @@ void CmdSketcherSelectElementsAssociatedWithConstraints::activated(int iMsg)
     std::string obj_name = Obj->getNameInDocument();
     std::stringstream ss;
 
-    int selected=0;
+    int selected = 0;
 
     // go through the selected subelements
     for (std::vector<std::string>::const_iterator it=SubNames.begin(); it != SubNames.end(); ++it) {
@@ -691,15 +676,15 @@ void CmdSketcherSelectElementsAssociatedWithConstraints::activated(int iMsg)
         }
     }
 
-    if ( selected == 0 ) {
+    if (selected == 0) {
         QMessageBox::warning(Gui::getMainWindow(), QObject::tr("No constraint selected"),
-                                     QObject::tr("At least one constraint must be selected"));
+                             QObject::tr("At least one constraint must be selected"));
     }
 }
 
 bool CmdSketcherSelectElementsAssociatedWithConstraints::isActive(void)
 {
-    return isSketcherAcceleratorActive( getActiveGuiDocument(), true );
+    return isSketcherAcceleratorActive(getActiveGuiDocument(), true);
 }
 
 DEF_STD_CMD_A(CmdSketcherSelectElementsWithDoFs)
@@ -709,8 +694,8 @@ CmdSketcherSelectElementsWithDoFs::CmdSketcherSelectElementsWithDoFs()
 {
     sAppModule      = "Sketcher";
     sGroup          = QT_TR_NOOP("Sketcher");
-    sMenuText       = QT_TR_NOOP("Select solver DoFs");
-    sToolTipText    = QT_TR_NOOP("Select elements where the solver still detects unconstrained degrees of freedom.");
+    sMenuText       = QT_TR_NOOP("Select unconstrained DoF");
+    sToolTipText    = QT_TR_NOOP("Select geometrical elements where the solver still detects unconstrained degrees of freedom.");
     sWhatsThis      = "Sketcher_SelectElementsWithDoFs";
     sStatusTip      = sToolTipText;
     sPixmap         = "Sketcher_SelectElementsWithDoFs";
@@ -722,16 +707,12 @@ void CmdSketcherSelectElementsWithDoFs::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
     getSelection().clearSelection();
-
     Gui::Document * doc= getActiveGuiDocument();
-
     SketcherGui::ViewProviderSketch* vp = static_cast<SketcherGui::ViewProviderSketch*>(doc->getInEdit());
-
     Sketcher::SketchObject* Obj= vp->getSketchObject();
 
     std::string doc_name = Obj->getDocument()->getName();
     std::string obj_name = Obj->getNameInDocument();
-
     std::stringstream ss;
 
     auto geos = Obj->getInternalGeometry();
@@ -740,18 +721,17 @@ void CmdSketcherSelectElementsWithDoFs::activated(int iMsg)
     // have to re-solve using Dense QR.
     GCS::QRAlgorithm curQRAlg = Obj->getSolvedSketch().getQRAlgorithm();
 
-    if(curQRAlg == GCS::EigenSparseQR) {
+    if (curQRAlg == GCS::EigenSparseQR) {
         Obj->getSolvedSketch().setQRAlgorithm(GCS::EigenDenseQR);
         Obj->solve(false);
     }
 
-
-    auto testselectvertex = [&Obj,&ss,&doc_name,&obj_name](int geoId, PointPos pos){
+    auto testselectvertex = [&Obj, &ss, &doc_name, &obj_name](int geoId, PointPos pos) {
         ss.str(std::string());
 
-        if(Obj->getSolvedSketch().hasDependentParameters(geoId, pos)) {
+        if (Obj->getSolvedSketch().hasDependentParameters(geoId, pos)) {
             int vertex = Obj->getVertexIndexGeoPos(geoId, pos);
-            if(vertex>-1) {
+            if (vertex > -1) {
                 ss << "Vertex" <<  vertex + 1;
 
                 Gui::Selection().addSelection(doc_name.c_str(), obj_name.c_str(), ss.str().c_str());
@@ -759,7 +739,7 @@ void CmdSketcherSelectElementsWithDoFs::activated(int iMsg)
         }
     };
 
-    auto testselectedge = [&Obj,&ss,&doc_name,&obj_name](int geoId){
+    auto testselectedge = [&Obj, &ss, &doc_name, &obj_name](int geoId) {
         ss.str(std::string());
 
         if(Obj->getSolvedSketch().hasDependentParameters(geoId, Sketcher::none)) {
@@ -770,43 +750,41 @@ void CmdSketcherSelectElementsWithDoFs::activated(int iMsg)
 
     int geoid = 0;
 
-    for(auto geo : geos) {
-        if(geo->getTypeId() == Part::GeomPoint::getClassTypeId()) {
+    for (auto geo : geos) {
+        if (geo->getTypeId() == Part::GeomPoint::getClassTypeId()) {
             testselectvertex(geoid, Sketcher::start);
         }
-        else if(geo->getTypeId() == Part::GeomLineSegment::getClassTypeId() ||
-                geo->getTypeId() == Part::GeomBSplineCurve::getClassTypeId()) {
+        else if (geo->getTypeId() == Part::GeomLineSegment::getClassTypeId() ||
+                 geo->getTypeId() == Part::GeomBSplineCurve::getClassTypeId()) {
             testselectvertex(geoid, Sketcher::start);
             testselectvertex(geoid, Sketcher::end);
             testselectedge(geoid);
         }
-        else if(geo->getTypeId() == Part::GeomCircle::getClassTypeId() ||
-                geo->getTypeId() == Part::GeomEllipse::getClassTypeId() ) {
+        else if (geo->getTypeId() == Part::GeomCircle::getClassTypeId() ||
+                 geo->getTypeId() == Part::GeomEllipse::getClassTypeId()) {
             testselectvertex(geoid, Sketcher::mid);
             testselectedge(geoid);
         }
-        else if(geo->getTypeId() == Part::GeomArcOfCircle::getClassTypeId() ||
-                geo->getTypeId() == Part::GeomArcOfEllipse::getClassTypeId() ||
-                geo->getTypeId() == Part::GeomArcOfHyperbola::getClassTypeId() ||
-                geo->getTypeId() == Part::GeomArcOfParabola::getClassTypeId() ) {
+        else if (geo->getTypeId() == Part::GeomArcOfCircle::getClassTypeId() ||
+                 geo->getTypeId() == Part::GeomArcOfEllipse::getClassTypeId() ||
+                 geo->getTypeId() == Part::GeomArcOfHyperbola::getClassTypeId() ||
+                 geo->getTypeId() == Part::GeomArcOfParabola::getClassTypeId()) {
             testselectvertex(geoid, Sketcher::start);
             testselectvertex(geoid, Sketcher::end);
             testselectvertex(geoid, Sketcher::mid);
             testselectedge(geoid);
         }
-
         geoid++;
     }
 
-    if(curQRAlg == GCS::EigenSparseQR) {
+    if (curQRAlg == GCS::EigenSparseQR) {
         Obj->getSolvedSketch().setQRAlgorithm(GCS::EigenSparseQR);
     }
-
 }
 
 bool CmdSketcherSelectElementsWithDoFs::isActive(void)
 {
-    return isSketcherAcceleratorActive( getActiveGuiDocument(), false );
+    return isSketcherAcceleratorActive(getActiveGuiDocument(), false);
 }
 
 DEF_STD_CMD_A(CmdSketcherRestoreInternalAlignmentGeometry)
@@ -817,7 +795,7 @@ CmdSketcherRestoreInternalAlignmentGeometry::CmdSketcherRestoreInternalAlignment
     sAppModule      = "Sketcher";
     sGroup          = QT_TR_NOOP("Sketcher");
     sMenuText       = QT_TR_NOOP("Show/hide internal geometry");
-    sToolTipText    = QT_TR_NOOP("Show all internal geometry / hide unused internal geometry");
+    sToolTipText    = QT_TR_NOOP("Show all internal geometry or hide unused internal geometry");
     sWhatsThis      = "Sketcher_RestoreInternalAlignmentGeometry";
     sStatusTip      = sToolTipText;
     sPixmap         = "Sketcher_Element_Ellipse_All";
@@ -834,8 +812,9 @@ void CmdSketcherRestoreInternalAlignmentGeometry::activated(int iMsg)
 
     // only one sketch with its subelements are allowed to be selected
     if (selection.size() != 1) {
-        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-            QObject::tr("Select elements from a single sketch."));
+        QMessageBox::warning(Gui::getMainWindow(),
+                             QObject::tr("Wrong selection"),
+                             QObject::tr("Select elements from a single sketch."));
         return;
     }
 
@@ -852,10 +831,11 @@ void CmdSketcherRestoreInternalAlignmentGeometry::activated(int iMsg)
     // go through the selected subelements
     for (std::vector<std::string>::const_iterator it=SubNames.begin(); it != SubNames.end(); ++it) {
         // only handle edges
-        if ( (it->size() > 4 && it->substr(0,4) == "Edge") ||
-             (it->size() > 12 && it->substr(0,12) == "ExternalEdge")) {
+        if ((it->size() > 4 && it->substr(0,4) == "Edge") ||
+            (it->size() > 12 && it->substr(0,12) == "ExternalEdge"))
+        {
             int GeoId;
-            if(it->substr(0,4) == "Edge")
+            if (it->substr(0,4) == "Edge")
                GeoId = std::atoi(it->substr(4,4000).c_str()) - 1;
             else
                GeoId = -std::atoi(it->substr(12,4000).c_str()) - 2;
@@ -866,7 +846,8 @@ void CmdSketcherRestoreInternalAlignmentGeometry::activated(int iMsg)
                 geo->getTypeId() == Part::GeomArcOfEllipse::getClassTypeId() ||
                 geo->getTypeId() == Part::GeomArcOfHyperbola::getClassTypeId() ||
                 geo->getTypeId() == Part::GeomArcOfParabola::getClassTypeId() ||
-                geo->getTypeId() == Part::GeomBSplineCurve::getClassTypeId() ) {
+                geo->getTypeId() == Part::GeomBSplineCurve::getClassTypeId())
+            {
 
                 int currentgeoid = Obj->getHighestCurveIndex();
 
@@ -890,7 +871,6 @@ void CmdSketcherRestoreInternalAlignmentGeometry::activated(int iMsg)
                 }
 
                 Gui::Command::commitCommand();
-
                 tryAutoRecomputeIfNotSolve(static_cast<Sketcher::SketchObject *>(Obj));
             }
         }
@@ -899,7 +879,7 @@ void CmdSketcherRestoreInternalAlignmentGeometry::activated(int iMsg)
 
 bool CmdSketcherRestoreInternalAlignmentGeometry::isActive(void)
 {
-    return isSketcherAcceleratorActive( getActiveGuiDocument(), true );
+    return isSketcherAcceleratorActive(getActiveGuiDocument(), true);
 }
 
 DEF_STD_CMD_A(CmdSketcherSymmetry)
@@ -941,7 +921,6 @@ void CmdSketcherSymmetry::activated(int iMsg)
     }
 
     Sketcher::SketchObject* Obj = static_cast<Sketcher::SketchObject*>(selection[0].getObject());
-
     getSelection().clearSelection();
 
     int LastGeoId = 0;
@@ -955,10 +934,12 @@ void CmdSketcherSymmetry::activated(int iMsg)
     std::stringstream stream;
     int geoids = 0;
 
-    for (std::vector<std::string>::const_iterator it=SubNames.begin(); it != SubNames.end(); ++it) {
+    for (std::vector<std::string>::const_iterator it=SubNames.begin(); it != SubNames.end(); ++it)
+    {
         // only handle non-external edges
         if ((it->size() > 4 && it->substr(0,4) == "Edge") ||
-            (it->size() > 12 && it->substr(0,12) == "ExternalEdge")) {
+            (it->size() > 12 && it->substr(0,12) == "ExternalEdge"))
+        {
 
             if (it->substr(0,4) == "Edge") {
                 LastGeoId = std::atoi(it->substr(4,4000).c_str()) - 1;
@@ -972,31 +953,33 @@ void CmdSketcherSymmetry::activated(int iMsg)
             // reference can be external or non-external
             LastGeo = Obj->getGeometry(LastGeoId);
             // Only for supported types
-            if(LastGeo->getTypeId() == Part::GeomLineSegment::getClassTypeId())
+            if (LastGeo->getTypeId() == Part::GeomLineSegment::getClassTypeId())
                 lastgeotype = line;
             else
                 lastgeotype = invalid;
 
             // lines to make symmetric (only non-external)
-            if(LastGeoId>=0) {
+            if (LastGeoId >= 0) {
                 geoids++;
                 stream << LastGeoId << ",";
             }
         }
-        else if(it->size() > 6 && it->substr(0,6) == "Vertex"){
+        else if (it->size() > 6 && it->substr(0,6) == "Vertex")
+        {
             // only if it is a GeomPoint
             int VtId = std::atoi(it->substr(6,4000).c_str()) - 1;
             int GeoId;
             Sketcher::PointPos PosId;
             Obj->getGeoVertexIndex(VtId, GeoId, PosId);
 
-            if (Obj->getGeometry(GeoId)->getTypeId() == Part::GeomPoint::getClassTypeId()) {
+            if (Obj->getGeometry(GeoId)->getTypeId() == Part::GeomPoint::getClassTypeId())
+            {
                 LastGeoId = GeoId;
                 LastPointPos = Sketcher::start;
                 lastgeotype = point;
 
                 // points to make symmetric
-                if(LastGeoId>=0) {
+                if (LastGeoId >= 0) {
                     geoids++;
                     stream << LastGeoId << ",";
                 }
@@ -1004,9 +987,10 @@ void CmdSketcherSymmetry::activated(int iMsg)
         }
     }
 
-    bool lastvertexoraxis=false;
+    bool lastvertexoraxis = false;
     // check if last selected element is a Vertex, not being a GeomPoint
-    if(SubNames.rbegin()->size() > 6 && SubNames.rbegin()->substr(0,6) == "Vertex"){
+    if (SubNames.rbegin()->size() > 6 && SubNames.rbegin()->substr(0,6) == "Vertex")
+    {
         int VtId = std::atoi(SubNames.rbegin()->substr(6,4000).c_str()) - 1;
         int GeoId;
         Sketcher::PointPos PosId;
@@ -1015,32 +999,36 @@ void CmdSketcherSymmetry::activated(int iMsg)
             LastGeoId = GeoId;
             LastPointPos = PosId;
             lastgeotype = point;
-            lastvertexoraxis=true;
+            lastvertexoraxis = true;
         }
     }
     // check if last selected element is horizontal axis
-    else if(SubNames.rbegin()->size() == 6 && SubNames.rbegin()->substr(0,6) == "H_Axis"){
+    else if (SubNames.rbegin()->size() == 6 && SubNames.rbegin()->substr(0,6) == "H_Axis")
+    {
         LastGeoId = Sketcher::GeoEnum::HAxis;
         LastPointPos = Sketcher::none;
         lastgeotype = line;
-        lastvertexoraxis=true;
+        lastvertexoraxis = true;
     }
     // check if last selected element is vertical axis
-    else if(SubNames.rbegin()->size() == 6 && SubNames.rbegin()->substr(0,6) == "V_Axis"){
+    else if (SubNames.rbegin()->size() == 6 && SubNames.rbegin()->substr(0,6) == "V_Axis")
+    {
         LastGeoId = Sketcher::GeoEnum::VAxis;
         LastPointPos = Sketcher::none;
         lastgeotype = line;
-        lastvertexoraxis=true;
+        lastvertexoraxis = true;
     }
     // check if last selected element is the root point
-    else if(SubNames.rbegin()->size() == 9 && SubNames.rbegin()->substr(0,9) == "RootPoint"){
+    else if (SubNames.rbegin()->size() == 9 && SubNames.rbegin()->substr(0,9) == "RootPoint")
+    {
         LastGeoId = Sketcher::GeoEnum::RtPnt;
         LastPointPos = Sketcher::start;
         lastgeotype = point;
-        lastvertexoraxis=true;
+        lastvertexoraxis = true;
     }
 
-    if ( geoids == 0 || (geoids == 1 && LastGeoId>=0 && !lastvertexoraxis) ) {
+    if (geoids == 0 || (geoids == 1 && LastGeoId >= 0 && !lastvertexoraxis))
+    {
         QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
             QObject::tr("A symmetric construction requires "
                         "at least two geometric elements, "
@@ -1049,7 +1037,7 @@ void CmdSketcherSymmetry::activated(int iMsg)
         return;
     }
 
-    if ( lastgeotype == invalid ) {
+    if (lastgeotype == invalid) {
         QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
             QObject::tr("The last element must be a point "
                         "or a line serving as reference "
@@ -1064,10 +1052,10 @@ void CmdSketcherSymmetry::activated(int iMsg)
     // 2- Last element is a point GeomPoint
     // 3- Last element is a point (Vertex)
 
-    if(LastGeoId>=0 && !lastvertexoraxis) {
+    if (LastGeoId >= 0 && !lastvertexoraxis) {
         // if LastGeoId was added remove the last element
         int index = geoIdList.rfind(',');
-        index = geoIdList.rfind(',',index-1);
+        index = geoIdList.rfind(',', index-1);
         geoIdList.resize(index);
     }
     else {
@@ -1075,27 +1063,27 @@ void CmdSketcherSymmetry::activated(int iMsg)
         geoIdList.resize(index);
     }
 
-    geoIdList.insert(0,1,'[');
-    geoIdList.append(1,']');
+    geoIdList.insert(0, 1, '[');
+    geoIdList.append(1, ']');
 
-    Gui::Command::openCommand("Create Symmetric geometry");
+    Gui::Command::openCommand("Create symmetric geometry");
 
     try{
-        Gui::cmdAppObjectArgs(Obj, "addSymmetric(%s,%d,%d)", geoIdList.c_str(), LastGeoId, LastPointPos);
-
+        Gui::cmdAppObjectArgs(Obj,
+                              "addSymmetric(%s, %d, %d)",
+                              geoIdList.c_str(), LastGeoId, LastPointPos);
         Gui::Command::commitCommand();
     }
     catch (const Base::Exception& e) {
         Base::Console().Error("%s\n", e.what());
         Gui::Command::abortCommand();
     }
-
     tryAutoRecomputeIfNotSolve(Obj);
 }
 
 bool CmdSketcherSymmetry::isActive(void)
 {
-    return isSketcherAcceleratorActive( getActiveGuiDocument(), true );
+    return isSketcherAcceleratorActive(getActiveGuiDocument(), true);
 }
 
 
@@ -1150,132 +1138,131 @@ static const char *cursor_createcopy[]={
     "................................",
     "................................"};
 
-    class DrawSketchHandlerCopy: public DrawSketchHandler
+class DrawSketchHandlerCopy: public DrawSketchHandler
+{
+public:
+    DrawSketchHandlerCopy(string geoidlist, int origingeoid,
+                          Sketcher::PointPos originpos, int nelements,
+                          SketcherCopy::Op op)
+    : Mode(STATUS_SEEK_First)
+    , geoIdList(geoidlist)
+    , Origin()
+    , OriginGeoId(origingeoid)
+    , OriginPos(originpos)
+    , nElements(nelements)
+    , Op(op)
+    , EditCurve(2)
     {
-    public:
-        DrawSketchHandlerCopy(string geoidlist, int origingeoid, Sketcher::PointPos originpos, int nelements, SketcherCopy::Op op)
-        : Mode(STATUS_SEEK_First)
-        , geoIdList(geoidlist)
-        , Origin()
-        , OriginGeoId(origingeoid)
-        , OriginPos(originpos)
-        , nElements(nelements)
-        , Op(op)
-        , EditCurve(2)
-        {
-        }
+    }
 
-        virtual ~DrawSketchHandlerCopy(){}
-        /// mode table
-        enum SelectMode {
-            STATUS_SEEK_First,      /**< enum value ----. */
-            STATUS_End
-        };
+    virtual ~DrawSketchHandlerCopy(){}
+    /// mode table
+    enum SelectMode {
+        STATUS_SEEK_First,      /**< enum value ----. */
+        STATUS_End
+    };
 
-        virtual void activated(ViewProviderSketch *sketchgui)
-        {
-            setCursor(QPixmap(cursor_createcopy),7,7);
-            Origin = static_cast<Sketcher::SketchObject *>(sketchgui->getObject())->getPoint(OriginGeoId, OriginPos);
-            EditCurve[0] = Base::Vector2d(Origin.x,Origin.y);
-        }
+    virtual void activated(ViewProviderSketch *sketchgui)
+    {
+        setCursor(QPixmap(cursor_createcopy), 7, 7);
+        Origin = static_cast<Sketcher::SketchObject *>(sketchgui->getObject())->getPoint(OriginGeoId, OriginPos);
+        EditCurve[0] = Base::Vector2d(Origin.x, Origin.y);
+    }
 
-        virtual void mouseMove(Base::Vector2d onSketchPos)
-        {
-            if (Mode==STATUS_SEEK_First) {
-                float length = (onSketchPos - EditCurve[0]).Length();
-                float angle = (onSketchPos - EditCurve[0]).GetAngle(Base::Vector2d(1.f,0.f));
-                SbString text;
-                text.sprintf(" (%.1f,%.1fdeg)", length, angle * 180 / M_PI);
-                setPositionText(onSketchPos, text);
+    virtual void mouseMove(Base::Vector2d onSketchPos)
+    {
+        if (Mode == STATUS_SEEK_First) {
+            float length = (onSketchPos - EditCurve[0]).Length();
+            float angle = (onSketchPos - EditCurve[0]).GetAngle(Base::Vector2d(1.f,0.f));
+            SbString text;
+            text.sprintf(" (%.1f, %.1fdeg)", length, angle * 180 / M_PI);
+            setPositionText(onSketchPos, text);
 
-                EditCurve[1] = onSketchPos;
-                sketchgui->drawEdit(EditCurve);
-                if (seekAutoConstraint(sugConstr1, onSketchPos, Base::Vector2d(0.0,0.0),AutoConstraint::VERTEX)) {
-                    renderSuggestConstraintsCursor(sugConstr1);
-                    return;
-                }
-
+            EditCurve[1] = onSketchPos;
+            sketchgui->drawEdit(EditCurve);
+            if (seekAutoConstraint(sugConstr1, onSketchPos, Base::Vector2d(0.0, 0.0), AutoConstraint::VERTEX)) {
+                renderSuggestConstraintsCursor(sugConstr1);
+                return;
             }
-            applyCursor();
         }
+        applyCursor();
+    }
 
-        virtual bool pressButton(Base::Vector2d onSketchPos)
-        {
-            if (Mode==STATUS_SEEK_First){
-                EditCurve[1] = onSketchPos;
-                sketchgui->drawEdit(EditCurve);
-                Mode = STATUS_End;
-            }
-
-            return true;
+    virtual bool pressButton(Base::Vector2d onSketchPos)
+    {
+        if (Mode == STATUS_SEEK_First) {
+            EditCurve[1] = onSketchPos;
+            sketchgui->drawEdit(EditCurve);
+            Mode = STATUS_End;
         }
+        return true;
+    }
 
-        virtual bool releaseButton(Base::Vector2d onSketchPos)
+    virtual bool releaseButton(Base::Vector2d onSketchPos)
+    {
+        Q_UNUSED(onSketchPos);
+        if (Mode == STATUS_End)
         {
-            Q_UNUSED(onSketchPos);
-            if (Mode==STATUS_End){
+            Base::Vector2d vector = EditCurve[1] - EditCurve[0];
+            unsetCursor();
+            resetPositionText();
 
-                Base::Vector2d vector = EditCurve[1]-EditCurve[0];
+            int currentgeoid = static_cast<Sketcher::SketchObject *>(sketchgui->getObject())->getHighestCurveIndex();
+            Gui::Command::openCommand("Copy/clone/move geometry");
 
-                unsetCursor();
-                resetPositionText();
-
-                int currentgeoid = static_cast<Sketcher::SketchObject *>(sketchgui->getObject())->getHighestCurveIndex();
-
-                Gui::Command::openCommand("Copy/clone/move geometry");
-
-                try{
-                    if( Op != SketcherCopy::Move) {
-                        Gui::cmdAppObjectArgs(sketchgui->getObject(), "addCopy(%s,App.Vector(%f,%f,0),%s)",
-                                            geoIdList.c_str(), vector.x, vector.y,
-                                            (Op == SketcherCopy::Clone?"True":"False"));
-                    }
-                    else {
-                        Gui::cmdAppObjectArgs(sketchgui->getObject(), "addMove(%s,App.Vector(%f,%f,0))",
-                            geoIdList.c_str(), vector.x, vector.y);
-                    }
-
-                    Gui::Command::commitCommand();
-                }
-                catch (const Base::Exception& e) {
-                    Base::Console().Error("%s\n", e.what());
-                    Gui::Command::abortCommand();
-                }
-
-                if( Op != SketcherCopy::Move) {
-                    // add auto constraints for the destination copy
-                    if (sugConstr1.size() > 0) {
-                        createAutoConstraints(sugConstr1, currentgeoid+nElements, OriginPos);
-                        sugConstr1.clear();
-                    }
+            try{
+                if (Op != SketcherCopy::Move) {
+                    Gui::cmdAppObjectArgs(sketchgui->getObject(),
+                                          "addCopy(%s, App.Vector(%f, %f, 0), %s)",
+                                          geoIdList.c_str(), vector.x, vector.y,
+                                          (Op == SketcherCopy::Clone ? "True" : "False"));
                 }
                 else {
-                    if (sugConstr1.size() > 0) {
-                        createAutoConstraints(sugConstr1, OriginGeoId, OriginPos);
-                        sugConstr1.clear();
-                    }
+                    Gui::cmdAppObjectArgs(sketchgui->getObject(),
+                                          "addMove(%s, App.Vector(%f, %f, 0))",
+                                          geoIdList.c_str(), vector.x, vector.y);
                 }
-
-                tryAutoRecomputeIfNotSolve(static_cast<Sketcher::SketchObject *>(sketchgui->getObject()));
-
-                EditCurve.clear();
-                sketchgui->drawEdit(EditCurve);
-
-                sketchgui->purgeHandler(); // no code after this line, Handler get deleted in ViewProvider
+                Gui::Command::commitCommand();
             }
-            return true;
+            catch (const Base::Exception& e) {
+                Base::Console().Error("%s\n", e.what());
+                Gui::Command::abortCommand();
+            }
+
+            if (Op != SketcherCopy::Move) {
+                // add auto constraints for the destination copy
+                if (sugConstr1.size() > 0) {
+                    createAutoConstraints(sugConstr1, currentgeoid+nElements, OriginPos);
+                    sugConstr1.clear();
+                }
+            }
+            else {
+                if (sugConstr1.size() > 0) {
+                    createAutoConstraints(sugConstr1, OriginGeoId, OriginPos);
+                    sugConstr1.clear();
+                }
+            }
+
+            tryAutoRecomputeIfNotSolve(static_cast<Sketcher::SketchObject *>(sketchgui->getObject()));
+            EditCurve.clear();
+            sketchgui->drawEdit(EditCurve);
+
+            // no code after this line, Handler gets deleted in ViewProvider
+            sketchgui->purgeHandler();
         }
-    protected:
-        SelectMode Mode;
-        string geoIdList;
-        Base::Vector3d Origin;
-        int OriginGeoId;
-        Sketcher::PointPos OriginPos;
-        int nElements;
-        SketcherCopy::Op Op;
-        std::vector<Base::Vector2d> EditCurve;
-        std::vector<AutoConstraint> sugConstr1;
-    };
+        return true;
+    }
+protected:
+    SelectMode Mode;
+    string geoIdList;
+    Base::Vector3d Origin;
+    int OriginGeoId;
+    Sketcher::PointPos OriginPos;
+    int nElements;
+    SketcherCopy::Op Op;
+    std::vector<Base::Vector2d> EditCurve;
+    std::vector<AutoConstraint> sugConstr1;
+};
 
 /*---- SketcherCopy definition ----*/
 SketcherCopy::SketcherCopy(const char* name): Command(name)
@@ -1288,21 +1275,22 @@ void SketcherCopy::activate(SketcherCopy::Op op)
 
     // only one sketch with its subelements are allowed to be selected
     if (selection.size() != 1) {
-        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                                QObject::tr("Select elements from a single sketch."));
+        QMessageBox::warning(Gui::getMainWindow(),
+                             QObject::tr("Wrong selection"),
+                             QObject::tr("Select elements from a single sketch."));
         return;
     }
 
     // get the needed lists and objects
     const std::vector<std::string> &SubNames = selection[0].getSubNames();
     if (SubNames.empty()) {
-        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                                QObject::tr("Select elements from a single sketch."));
+        QMessageBox::warning(Gui::getMainWindow(),
+                             QObject::tr("Wrong selection"),
+                             QObject::tr("Select elements from a single sketch."));
         return;
     }
 
     Sketcher::SketchObject* Obj = static_cast<Sketcher::SketchObject*>(selection[0].getObject());
-
     getSelection().clearSelection();
 
     int LastGeoId = 0;
@@ -1312,14 +1300,15 @@ void SketcherCopy::activate(SketcherCopy::Op op)
     // create python command with list of elements
     std::stringstream stream;
     int geoids = 0;
-    for (std::vector<std::string>::const_iterator it=SubNames.begin(); it != SubNames.end(); ++it) {
+    for (std::vector<std::string>::const_iterator it=SubNames.begin(); it != SubNames.end(); ++it)
+    {
         // only handle non-external edges
         if (it->size() > 4 && it->substr(0,4) == "Edge") {
             LastGeoId = std::atoi(it->substr(4,4000).c_str()) - 1;
             LastPointPos = Sketcher::none;
             LastGeo = Obj->getGeometry(LastGeoId);
             // lines to copy
-            if (LastGeoId>=0) {
+            if (LastGeoId >= 0) {
                 geoids++;
                 stream << LastGeoId << ",";
             }
@@ -1330,11 +1319,12 @@ void SketcherCopy::activate(SketcherCopy::Op op)
             int GeoId;
             Sketcher::PointPos PosId;
             Obj->getGeoVertexIndex(VtId, GeoId, PosId);
-            if (Obj->getGeometry(GeoId)->getTypeId() == Part::GeomPoint::getClassTypeId()) {
+            if (Obj->getGeometry(GeoId)->getTypeId() == Part::GeomPoint::getClassTypeId())
+            {
                 LastGeoId = GeoId;
                 LastPointPos = Sketcher::start;
                 // points to copy
-                if (LastGeoId>=0) {
+                if (LastGeoId >= 0) {
                     geoids++;
                     stream << LastGeoId << ",";
                 }
@@ -1343,7 +1333,8 @@ void SketcherCopy::activate(SketcherCopy::Op op)
     }
 
     // check if last selected element is a Vertex, not being a GeomPoint
-    if (SubNames.rbegin()->size() > 6 && SubNames.rbegin()->substr(0,6) == "Vertex"){
+    if (SubNames.rbegin()->size() > 6 && SubNames.rbegin()->substr(0,6) == "Vertex")
+    {
         int VtId = std::atoi(SubNames.rbegin()->substr(6,4000).c_str()) - 1;
         int GeoId;
         Sketcher::PointPos PosId;
@@ -1355,7 +1346,8 @@ void SketcherCopy::activate(SketcherCopy::Op op)
     }
 
     if (geoids < 1) {
-        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
+        QMessageBox::warning(Gui::getMainWindow(),
+                             QObject::tr("Wrong selection"),
                              QObject::tr("A copy requires at least one selected non-external geometric element"));
         return;
     }
@@ -1365,19 +1357,20 @@ void SketcherCopy::activate(SketcherCopy::Op op)
     // remove the last added comma and brackets to make the python list
     int index = geoIdList.rfind(',');
     geoIdList.resize(index);
-    geoIdList.insert(0,1,'[');
-    geoIdList.append(1,']');
+    geoIdList.insert(0, 1, '[');
+    geoIdList.append(1, ']');
 
     // if the last element is not a point serving as a reference for the copy process
     // then make the start point of the last element the copy reference (if it exists, if not the center point)
     if (LastPointPos == Sketcher::none) {
         if (LastGeo->getTypeId() == Part::GeomCircle::getClassTypeId() ||
-            LastGeo->getTypeId() == Part::GeomEllipse::getClassTypeId()) {
+            LastGeo->getTypeId() == Part::GeomEllipse::getClassTypeId())
+        {
             LastPointPos = Sketcher::mid;
-            }
-            else {
-                LastPointPos = Sketcher::start;
-            }
+        }
+        else {
+            LastPointPos = Sketcher::start;
+        }
     }
 
     // Ask the user if he wants to clone or to simple copy
@@ -1395,7 +1388,8 @@ void SketcherCopy::activate(SketcherCopy::Op op)
     }
 */
 
-    ActivateAcceleratorHandler(getActiveGuiDocument(),new DrawSketchHandlerCopy(geoIdList, LastGeoId, LastPointPos, geoids, op));
+    ActivateAcceleratorHandler(getActiveGuiDocument(),
+                               new DrawSketchHandlerCopy(geoIdList, LastGeoId, LastPointPos, geoids, op));
 }
 
 
@@ -1413,7 +1407,7 @@ protected:
 };
 
 CmdSketcherCopy::CmdSketcherCopy()
-:SketcherCopy("Sketcher_Copy")
+    :SketcherCopy("Sketcher_Copy")
 {
     sAppModule      = "Sketcher";
     sGroup          = QT_TR_NOOP("Sketcher");
@@ -1440,7 +1434,7 @@ void CmdSketcherCopy::activate()
 
 bool CmdSketcherCopy::isActive(void)
 {
-    return isSketcherAcceleratorActive( getActiveGuiDocument(), true );
+    return isSketcherAcceleratorActive(getActiveGuiDocument(), true);
 }
 
 class CmdSketcherClone : public SketcherCopy
@@ -1449,7 +1443,7 @@ public:
     CmdSketcherClone();
     virtual ~CmdSketcherClone(){}
     virtual const char* className() const
-    { return "CmdSketcherClone"; }
+        { return "CmdSketcherClone"; }
     virtual void activate();
 protected:
     virtual void activated(int iMsg);
@@ -1457,7 +1451,7 @@ protected:
 };
 
 CmdSketcherClone::CmdSketcherClone()
-:SketcherCopy("Sketcher_Clone")
+    :SketcherCopy("Sketcher_Clone")
 {
     sAppModule      = "Sketcher";
     sGroup          = QT_TR_NOOP("Sketcher");
@@ -1483,7 +1477,7 @@ void CmdSketcherClone::activate()
 
 bool CmdSketcherClone::isActive(void)
 {
-    return isSketcherAcceleratorActive( getActiveGuiDocument(), true );
+    return isSketcherAcceleratorActive(getActiveGuiDocument(), true);
 }
 
 class CmdSketcherMove : public SketcherCopy
@@ -1492,7 +1486,7 @@ public:
     CmdSketcherMove();
     virtual ~CmdSketcherMove(){}
     virtual const char* className() const
-    { return "CmdSketcherMove"; }
+        { return "CmdSketcherMove"; }
     virtual void activate();
 protected:
     virtual void activated(int iMsg);
@@ -1500,7 +1494,7 @@ protected:
 };
 
 CmdSketcherMove::CmdSketcherMove()
-:SketcherCopy("Sketcher_Move")
+    :SketcherCopy("Sketcher_Move")
 {
     sAppModule      = "Sketcher";
     sGroup          = QT_TR_NOOP("Sketcher");
@@ -1524,16 +1518,15 @@ void CmdSketcherMove::activate()
     SketcherCopy::activate(SketcherCopy::Move);
 }
 
-
 bool CmdSketcherMove::isActive(void)
 {
-    return isSketcherAcceleratorActive( getActiveGuiDocument(), true );
+    return isSketcherAcceleratorActive(getActiveGuiDocument(), true);
 }
 
 DEF_STD_CMD_ACL(CmdSketcherCompCopy)
 
 CmdSketcherCompCopy::CmdSketcherCompCopy()
-: Command("Sketcher_CompCopy")
+    : Command("Sketcher_CompCopy")
 {
     sAppModule      = "Sketcher";
     sGroup          = QT_TR_NOOP("Sketcher");
@@ -1558,17 +1551,17 @@ void CmdSketcherCompCopy::activated(int iMsg)
     assert(iMsg < a.size());
     pcAction->setIcon(a[iMsg]->icon());
 
-    if (iMsg==0){
+    if (iMsg == 0){
         CmdSketcherClone sc;
         sc.activate();
         pcAction->setShortcut(QString::fromLatin1(this->sAccel));
     }
-    else if (iMsg==1) {
+    else if (iMsg == 1) {
         CmdSketcherCopy sc;
         sc.activate();
         pcAction->setShortcut(QString::fromLatin1(this->sAccel));
     }
-    else if (iMsg==2) {
+    else if (iMsg == 2) {
         CmdSketcherMove sc;
         sc.activate();
         pcAction->setShortcut(QString::fromLatin1(""));
@@ -1669,139 +1662,138 @@ static const char *cursor_createrectangulararray[]={
     "................................",
     "................................"};
 
-    class DrawSketchHandlerRectangularArray: public DrawSketchHandler
+class DrawSketchHandlerRectangularArray: public DrawSketchHandler
+{
+public:
+    DrawSketchHandlerRectangularArray(string geoidlist, int origingeoid,
+                                      Sketcher::PointPos originpos, int nelements, bool clone,
+                                      int rows, int cols, bool constraintSeparation,
+                                      bool equalVerticalHorizontalSpacing)
+        : Mode(STATUS_SEEK_First)
+        , geoIdList(geoidlist)
+        , OriginGeoId(origingeoid)
+        , OriginPos(originpos)
+        , nElements(nelements)
+        , Clone(clone)
+        , Rows(rows)
+        , Cols(cols)
+        , ConstraintSeparation(constraintSeparation)
+        , EqualVerticalHorizontalSpacing(equalVerticalHorizontalSpacing)
+        , EditCurve(2)
     {
-    public:
-        DrawSketchHandlerRectangularArray(string geoidlist, int origingeoid, Sketcher::PointPos originpos, int nelements, bool clone,
-                                          int rows, int cols, bool constraintSeparation,
-                                          bool equalVerticalHorizontalSpacing )
-            : Mode(STATUS_SEEK_First)
-            , geoIdList(geoidlist)
-            , OriginGeoId(origingeoid)
-            , OriginPos(originpos)
-            , nElements(nelements)
-            , Clone(clone)
-            , Rows(rows)
-            , Cols(cols)
-            , ConstraintSeparation(constraintSeparation)
-            , EqualVerticalHorizontalSpacing(equalVerticalHorizontalSpacing)
-            , EditCurve(2)
-        {
-        }
+    }
 
-        virtual ~DrawSketchHandlerRectangularArray(){}
-        /// mode table
-        enum SelectMode {
-            STATUS_SEEK_First,      /**< enum value ----. */
-            STATUS_End
-        };
-
-        virtual void activated(ViewProviderSketch *sketchgui)
-        {
-            setCursor(QPixmap(cursor_createrectangulararray),7,7);
-            Origin = static_cast<Sketcher::SketchObject *>(sketchgui->getObject())->getPoint(OriginGeoId, OriginPos);
-            EditCurve[0] = Base::Vector2d(Origin.x,Origin.y);
-        }
-
-        virtual void mouseMove(Base::Vector2d onSketchPos)
-        {
-            if (Mode==STATUS_SEEK_First) {
-                float length = (onSketchPos - EditCurve[0]).Length();
-                float angle = (onSketchPos - EditCurve[0]).GetAngle(Base::Vector2d(1.f,0.f));
-                SbString text;
-                text.sprintf(" (%.1f,%.1fdeg)", length, angle * 180 / M_PI);
-                setPositionText(onSketchPos, text);
-
-                EditCurve[1] = onSketchPos;
-                sketchgui->drawEdit(EditCurve);
-                if (seekAutoConstraint(sugConstr1, onSketchPos, Base::Vector2d(0.0,0.0),AutoConstraint::VERTEX)) {
-                    renderSuggestConstraintsCursor(sugConstr1);
-                    return;
-                }
-
-            }
-            applyCursor();
-        }
-
-        virtual bool pressButton(Base::Vector2d onSketchPos)
-        {
-            if (Mode==STATUS_SEEK_First){
-                EditCurve[1] = onSketchPos;
-                sketchgui->drawEdit(EditCurve);
-                Mode = STATUS_End;
-            }
-
-            return true;
-        }
-
-        virtual bool releaseButton(Base::Vector2d onSketchPos)
-        {
-            Q_UNUSED(onSketchPos);
-            if (Mode==STATUS_End){
-
-                Base::Vector2d vector = EditCurve[1]-EditCurve[0];
-
-                unsetCursor();
-                resetPositionText();
-
-                Gui::Command::openCommand("Create copy of geometry");
-
-                try {
-                    Gui::cmdAppObjectArgs(sketchgui->getObject(), "addRectangularArray(%s, App.Vector(%f,%f,0),%s,%d,%d,%s,%f)",
-                                          geoIdList.c_str(), vector.x, vector.y,
-                                          (Clone?"True":"False"),
-                                          Cols, Rows,
-                                          (ConstraintSeparation?"True":"False"),
-                                          (EqualVerticalHorizontalSpacing?1.0:0.5));
-
-                    Gui::Command::commitCommand();
-                }
-                catch (const Base::Exception& e) {
-                    Base::Console().Error("%s\n", e.what());
-                    Gui::Command::abortCommand();
-                }
-
-                // add auto constraints for the destination copy
-                if (sugConstr1.size() > 0) {
-                    createAutoConstraints(sugConstr1, OriginGeoId+nElements, OriginPos);
-                    sugConstr1.clear();
-                }
-
-                tryAutoRecomputeIfNotSolve(static_cast<Sketcher::SketchObject *>(sketchgui->getObject()));
-
-
-                EditCurve.clear();
-                sketchgui->drawEdit(EditCurve);
-
-                sketchgui->purgeHandler(); // no code after this line, Handler get deleted in ViewProvider
-            }
-            return true;
-        }
-    protected:
-        SelectMode Mode;
-        string geoIdList;
-        Base::Vector3d Origin;
-        int OriginGeoId;
-        Sketcher::PointPos OriginPos;
-        int nElements;
-        bool Clone;
-        int Rows;
-        int Cols;
-        bool ConstraintSeparation;
-        bool EqualVerticalHorizontalSpacing;
-        std::vector<Base::Vector2d> EditCurve;
-        std::vector<AutoConstraint> sugConstr1;
+    virtual ~DrawSketchHandlerRectangularArray(){}
+    /// mode table
+    enum SelectMode {
+        STATUS_SEEK_First,      /**< enum value ----. */
+        STATUS_End
     };
+
+    virtual void activated(ViewProviderSketch *sketchgui)
+    {
+        setCursor(QPixmap(cursor_createrectangulararray), 7, 7);
+        Origin = static_cast<Sketcher::SketchObject *>(sketchgui->getObject())->getPoint(OriginGeoId, OriginPos);
+        EditCurve[0] = Base::Vector2d(Origin.x, Origin.y);
+    }
+
+    virtual void mouseMove(Base::Vector2d onSketchPos)
+    {
+        if (Mode==STATUS_SEEK_First) {
+            float length = (onSketchPos - EditCurve[0]).Length();
+            float angle = (onSketchPos - EditCurve[0]).GetAngle(Base::Vector2d(1.f, 0.f));
+            SbString text;
+            text.sprintf(" (%.1f, %.1fdeg)", length, angle * 180 / M_PI);
+            setPositionText(onSketchPos, text);
+
+            EditCurve[1] = onSketchPos;
+            sketchgui->drawEdit(EditCurve);
+            if (seekAutoConstraint(sugConstr1, onSketchPos, Base::Vector2d(0.0, 0.0), AutoConstraint::VERTEX))
+            {
+                renderSuggestConstraintsCursor(sugConstr1);
+                return;
+            }
+
+        }
+        applyCursor();
+    }
+
+    virtual bool pressButton(Base::Vector2d onSketchPos)
+    {
+        if (Mode == STATUS_SEEK_First) {
+            EditCurve[1] = onSketchPos;
+            sketchgui->drawEdit(EditCurve);
+            Mode = STATUS_End;
+        }
+        return true;
+    }
+
+    virtual bool releaseButton(Base::Vector2d onSketchPos)
+    {
+        Q_UNUSED(onSketchPos);
+        if (Mode == STATUS_End)
+        {
+            Base::Vector2d vector = EditCurve[1] - EditCurve[0];
+            unsetCursor();
+            resetPositionText();
+
+            Gui::Command::openCommand("Create copy of geometry");
+
+            try {
+                Gui::cmdAppObjectArgs(sketchgui->getObject(),
+                                      "addRectangularArray(%s, App.Vector(%f, %f, 0), %s, %d, %d, %s, %f)",
+                                      geoIdList.c_str(), vector.x, vector.y,
+                                      (Clone ? "True" : "False"),
+                                      Cols, Rows,
+                                      (ConstraintSeparation ? "True" : "False"),
+                                      (EqualVerticalHorizontalSpacing ? 1.0 : 0.5));
+                Gui::Command::commitCommand();
+            }
+            catch (const Base::Exception& e) {
+                Base::Console().Error("%s\n", e.what());
+                Gui::Command::abortCommand();
+            }
+
+            // add auto constraints for the destination copy
+            if (sugConstr1.size() > 0) {
+                createAutoConstraints(sugConstr1, OriginGeoId+nElements, OriginPos);
+                sugConstr1.clear();
+            }
+            tryAutoRecomputeIfNotSolve(static_cast<Sketcher::SketchObject *>(sketchgui->getObject()));
+
+            EditCurve.clear();
+            sketchgui->drawEdit(EditCurve);
+
+            // no code after this line, Handler is deleted in ViewProvider
+            sketchgui->purgeHandler();
+        }
+        return true;
+    }
+protected:
+    SelectMode Mode;
+    string geoIdList;
+    Base::Vector3d Origin;
+    int OriginGeoId;
+    Sketcher::PointPos OriginPos;
+    int nElements;
+    bool Clone;
+    int Rows;
+    int Cols;
+    bool ConstraintSeparation;
+    bool EqualVerticalHorizontalSpacing;
+    std::vector<Base::Vector2d> EditCurve;
+    std::vector<AutoConstraint> sugConstr1;
+};
 
 
 DEF_STD_CMD_A(CmdSketcherRectangularArray)
 
 CmdSketcherRectangularArray::CmdSketcherRectangularArray()
-:Command("Sketcher_RectangularArray")
+    :Command("Sketcher_RectangularArray")
 {
     sAppModule      = "Sketcher";
     sGroup          = QT_TR_NOOP("Sketcher");
-    sMenuText       = QT_TR_NOOP("Rectangular Array");
+    sMenuText       = QT_TR_NOOP("Rectangular array");
     sToolTipText    = QT_TR_NOOP("Creates a rectangular array pattern of the geometry taking as reference the last selected point");
     sWhatsThis      = "Sketcher_RectangularArray";
     sStatusTip      = sToolTipText;
@@ -1819,7 +1811,8 @@ void CmdSketcherRectangularArray::activated(int iMsg)
 
     // only one sketch with its subelements are allowed to be selected
     if (selection.size() != 1) {
-        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
+        QMessageBox::warning(Gui::getMainWindow(),
+                             QObject::tr("Wrong selection"),
                              QObject::tr("Select elements from a single sketch."));
         return;
     }
@@ -1827,8 +1820,9 @@ void CmdSketcherRectangularArray::activated(int iMsg)
     // get the needed lists and objects
     const std::vector<std::string> &SubNames = selection[0].getSubNames();
     if (SubNames.empty()) {
-        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-            QObject::tr("Select elements from a single sketch."));
+        QMessageBox::warning(Gui::getMainWindow(),
+                             QObject::tr("Wrong selection"),
+                             QObject::tr("Select elements from a single sketch."));
         return;
     }
 
@@ -1849,16 +1843,16 @@ void CmdSketcherRectangularArray::activated(int iMsg)
         if (it->size() > 4 && it->substr(0,4) == "Edge") {
             LastGeoId = std::atoi(it->substr(4,4000).c_str()) - 1;
             LastPointPos = Sketcher::none;
-
             LastGeo = Obj->getGeometry(LastGeoId);
 
             // lines to copy
-            if (LastGeoId>=0) {
+            if (LastGeoId >= 0) {
                 geoids++;
                 stream << LastGeoId << ",";
             }
         }
-        else if (it->size() > 6 && it->substr(0,6) == "Vertex") {
+        else if (it->size() > 6 && it->substr(0,6) == "Vertex")
+        {
             // only if it is a GeomPoint
             int VtId = std::atoi(it->substr(6,4000).c_str()) - 1;
             int GeoId;
@@ -1868,7 +1862,7 @@ void CmdSketcherRectangularArray::activated(int iMsg)
                 LastGeoId = GeoId;
                 LastPointPos = Sketcher::start;
                 // points to copy
-                if(LastGeoId>=0) {
+                if (LastGeoId >= 0) {
                     geoids++;
                     stream << LastGeoId << ",";
                 }
@@ -1888,8 +1882,9 @@ void CmdSketcherRectangularArray::activated(int iMsg)
         }
     }
 
-    if ( geoids < 1 ) {
-        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
+    if (geoids < 1) {
+        QMessageBox::warning(Gui::getMainWindow(),
+                             QObject::tr("Wrong selection"),
                              QObject::tr("A copy requires at least one selected non-external geometric element"));
         return;
     }
@@ -1899,8 +1894,8 @@ void CmdSketcherRectangularArray::activated(int iMsg)
     // remove the last added comma and brackets to make the python list
     int index = geoIdList.rfind(',');
     geoIdList.resize(index);
-    geoIdList.insert(0,1,'[');
-    geoIdList.append(1,']');
+    geoIdList.insert(0, 1, '[');
+    geoIdList.append(1, ']');
 
     // if the last element is not a point serving as a reference for the copy process
     // then make the start point of the last element the copy reference (if it exists, if not the center point)
@@ -1923,25 +1918,24 @@ void CmdSketcherRectangularArray::activated(int iMsg)
                                                   slad->Rows, slad->Cols, slad->ConstraintSeparation,
                                                   slad->EqualVerticalHorizontalSpacing));
     }
-
     delete slad;
 }
 
 bool CmdSketcherRectangularArray::isActive(void)
 {
-    return isSketcherAcceleratorActive( getActiveGuiDocument(), true );
+    return isSketcherAcceleratorActive(getActiveGuiDocument(), true);
 }
 
-// Select Origin
 DEF_STD_CMD_A(CmdSketcherDeleteAllGeometry)
 
 CmdSketcherDeleteAllGeometry::CmdSketcherDeleteAllGeometry()
-:Command("Sketcher_DeleteAllGeometry")
+    :Command("Sketcher_DeleteAllGeometry")
 {
     sAppModule      = "Sketcher";
     sGroup          = QT_TR_NOOP("Sketcher");
-    sMenuText       = QT_TR_NOOP("Delete All Geometry");
-    sToolTipText    = QT_TR_NOOP("Deletes all the geometry and constraints but external geometry");
+    sMenuText       = QT_TR_NOOP("Delete all geometry");
+    sToolTipText    = QT_TR_NOOP("Delete all geometry and constraints in the current sketch, "
+                                 "with the exception of external geometry");
     sWhatsThis      = "Sketcher_DeleteAllGeometry";
     sStatusTip      = sToolTipText;
     sPixmap         = "Sketcher_DeleteGeometry";
@@ -1954,33 +1948,30 @@ void CmdSketcherDeleteAllGeometry::activated(int iMsg)
     Q_UNUSED(iMsg);
 
     int ret = QMessageBox::question(Gui::getMainWindow(), QObject::tr("Delete All Geometry"),
-                                    QObject::tr("Are you really sure you want to delete all the geometry and constraints?"),
+                                    QObject::tr("Are you really sure you want to delete all geometry and constraints?"),
                                     QMessageBox::Yes, QMessageBox::Cancel);
     // use an equality constraint
-    if (ret == QMessageBox::Yes) {
+    if (ret == QMessageBox::Yes)
+    {
         getSelection().clearSelection();
-
         Gui::Document * doc= getActiveGuiDocument();
-
         SketcherGui::ViewProviderSketch* vp = static_cast<SketcherGui::ViewProviderSketch*>(doc->getInEdit());
-
         Sketcher::SketchObject* Obj= vp->getSketchObject();
 
         try {
-            Gui::Command::openCommand("Delete All Geometry");
+            Gui::Command::openCommand("Delete all geometry");
             Gui::cmdAppObjectArgs(Obj, "deleteAllGeometry()");
-
             Gui::Command::commitCommand();
         }
         catch (const Base::Exception& e) {
-            Base::Console().Error("Failed to delete All Geometry: %s\n", e.what());
+            Base::Console().Error("Failed to delete all geometry: %s\n", e.what());
             Gui::Command::abortCommand();
         }
 
         ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher");
-        bool autoRecompute = hGrp->GetBool("AutoRecompute",false);
+        bool autoRecompute = hGrp->GetBool("AutoRecompute", false);
 
-        if(autoRecompute)
+        if (autoRecompute)
             Gui::Command::updateActive();
         else
             Obj->solve();
@@ -1993,18 +1984,18 @@ void CmdSketcherDeleteAllGeometry::activated(int iMsg)
 
 bool CmdSketcherDeleteAllGeometry::isActive(void)
 {
-    return isSketcherAcceleratorActive( getActiveGuiDocument(), false );
+    return isSketcherAcceleratorActive(getActiveGuiDocument(), false);
 }
 
 DEF_STD_CMD_A(CmdSketcherDeleteAllConstraints)
 
 CmdSketcherDeleteAllConstraints::CmdSketcherDeleteAllConstraints()
-:Command("Sketcher_DeleteAllConstraints")
+    :Command("Sketcher_DeleteAllConstraints")
 {
     sAppModule      = "Sketcher";
     sGroup          = QT_TR_NOOP("Sketcher");
-    sMenuText       = QT_TR_NOOP("Delete All Constraints");
-    sToolTipText    = QT_TR_NOOP("Deletes all the constraints");
+    sMenuText       = QT_TR_NOOP("Delete all constraints");
+    sToolTipText    = QT_TR_NOOP("Delete all constraints in the sketch");
     sWhatsThis      = "Sketcher_DeleteAllConstraints";
     sStatusTip      = sToolTipText;
     sPixmap         = "Sketcher_DeleteConstraints";
@@ -2020,19 +2011,16 @@ void CmdSketcherDeleteAllConstraints::activated(int iMsg)
                                     QObject::tr("Are you really sure you want to delete all the constraints?"),
                                     QMessageBox::Yes, QMessageBox::Cancel);
 
-    if (ret == QMessageBox::Yes) {
+    if (ret == QMessageBox::Yes)
+    {
         getSelection().clearSelection();
-
         Gui::Document * doc= getActiveGuiDocument();
-
         SketcherGui::ViewProviderSketch* vp = static_cast<SketcherGui::ViewProviderSketch*>(doc->getInEdit());
-
         Sketcher::SketchObject* Obj= vp->getSketchObject();
 
         try {
             Gui::Command::openCommand("Delete All Constraints");
             Gui::cmdAppObjectArgs(Obj, "deleteAllConstraints()");
-
             Gui::Command::commitCommand();
         }
         catch (const Base::Exception& e) {
@@ -2043,7 +2031,7 @@ void CmdSketcherDeleteAllConstraints::activated(int iMsg)
         ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher");
         bool autoRecompute = hGrp->GetBool("AutoRecompute",false);
 
-        if(autoRecompute)
+        if (autoRecompute)
             Gui::Command::updateActive();
         else
             Obj->solve();
@@ -2057,7 +2045,7 @@ void CmdSketcherDeleteAllConstraints::activated(int iMsg)
 
 bool CmdSketcherDeleteAllConstraints::isActive(void)
 {
-    return isSketcherAcceleratorActive( getActiveGuiDocument(), false );
+    return isSketcherAcceleratorActive(getActiveGuiDocument(), false);
 }
 
 void CreateSketcherCommandsConstraintAccel(void)

--- a/src/Mod/Sketcher/Gui/CommandSketcherVirtualSpace.cpp
+++ b/src/Mod/Sketcher/Gui/CommandSketcherVirtualSpace.cpp
@@ -60,8 +60,8 @@ bool isSketcherVirtualSpaceActive(Gui::Document *doc, bool actsOnSelection )
     if (doc) {
         // checks if a Sketch Viewprovider is in Edit and is in no special mode
         if (doc->getInEdit() && doc->getInEdit()->isDerivedFrom(SketcherGui::ViewProviderSketch::getClassTypeId())) {
-            if (static_cast<SketcherGui::ViewProviderSketch*>(doc->getInEdit())
-                ->getSketchMode() == ViewProviderSketch::STATUS_NONE) {
+            if (static_cast<SketcherGui::ViewProviderSketch*>(doc->getInEdit())->getSketchMode() == ViewProviderSketch::STATUS_NONE)
+            {
                 if (!actsOnSelection)
                     return true;
                 else if (Gui::Selection().countObjectsOfType(Sketcher::SketchObject::getClassTypeId()) > 0)
@@ -69,17 +69,15 @@ bool isSketcherVirtualSpaceActive(Gui::Document *doc, bool actsOnSelection )
             }
         }
     }
-
     return false;
 }
 
-void ActivateVirtualSpaceHandler(Gui::Document *doc,DrawSketchHandler *handler)
+void ActivateVirtualSpaceHandler(Gui::Document *doc, DrawSketchHandler *handler)
 {
     if (doc) {
-        if (doc->getInEdit() && doc->getInEdit()->isDerivedFrom
-           (SketcherGui::ViewProviderSketch::getClassTypeId())) {
-
-            SketcherGui::ViewProviderSketch* vp = static_cast<SketcherGui::ViewProviderSketch*> (doc->getInEdit());
+        if (doc->getInEdit() && doc->getInEdit()->isDerivedFrom(SketcherGui::ViewProviderSketch::getClassTypeId()))
+        {
+            SketcherGui::ViewProviderSketch* vp = static_cast<SketcherGui::ViewProviderSketch*>(doc->getInEdit());
             vp->purgeHandler();
             vp->activateHandler(handler);
         }
@@ -90,7 +88,7 @@ void ActivateVirtualSpaceHandler(Gui::Document *doc,DrawSketchHandler *handler)
 DEF_STD_CMD_A(CmdSketcherSwitchVirtualSpace)
 
 CmdSketcherSwitchVirtualSpace::CmdSketcherSwitchVirtualSpace()
-:Command("Sketcher_SwitchVirtualSpace")
+    : Command("Sketcher_SwitchVirtualSpace")
 {
     sAppModule      = "Sketcher";
     sGroup          = QT_TR_NOOP("Sketcher");
@@ -106,14 +104,13 @@ CmdSketcherSwitchVirtualSpace::CmdSketcherSwitchVirtualSpace()
 void CmdSketcherSwitchVirtualSpace::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-    bool modeChange=true;
+    bool modeChange = true;
 
     std::vector<Gui::SelectionObject> selection;
 
-    if (Gui::Selection().countObjectsOfType(Sketcher::SketchObject::getClassTypeId()) > 0){
+    if (Gui::Selection().countObjectsOfType(Sketcher::SketchObject::getClassTypeId()) > 0)
+    {
         // Now we check whether we have a constraint selected or not.
-
-        // get the selection
         selection = getSelection().getSelectionEx();
 
         // only one sketch with its subelements are allowed to be selected
@@ -131,18 +128,18 @@ void CmdSketcherSwitchVirtualSpace::activated(int iMsg)
             return;
         }
 
-        for (std::vector<std::string>::const_iterator it=SubNames.begin();it!=SubNames.end();++it){
+        for (std::vector<std::string>::const_iterator it=SubNames.begin(); it != SubNames.end(); ++it)
+        {
             // see if we have constraints, if we do it is not a mode change, but a toggle.
-            if (it->size() > 10 && it->substr(0,10) == "Constraint")
-                modeChange=false;
+            if (it->size() > 10 && it->substr(0, 10) == "Constraint")
+                modeChange = false;
         }
     }
 
     if (modeChange) {
-        Gui::Document * doc= getActiveGuiDocument();
+        Gui::Document * doc = getActiveGuiDocument();
 
         SketcherGui::ViewProviderSketch* vp = static_cast<SketcherGui::ViewProviderSketch*>(doc->getInEdit());
-
         vp->setIsShownVirtualSpace(!vp->getIsShownVirtualSpace());
     }
     else // toggle the selected constraint(s)
@@ -161,17 +158,19 @@ void CmdSketcherSwitchVirtualSpace::activated(int iMsg)
         // undo command open
         openCommand("Toggle constraints to the other virtual space");
 
-        int successful=SubNames.size();
+        int successful = SubNames.size();
         // go through the selected subelements
-        for (std::vector<std::string>::const_iterator it=SubNames.begin();it!=SubNames.end();++it){
+        for (std::vector<std::string>::const_iterator it=SubNames.begin(); it != SubNames.end(); ++it)
+        {
             // only handle constraints
-            if (it->size() > 10 && it->substr(0,10) == "Constraint") {
+            if (it->size() > 10 && it->substr(0,10) == "Constraint")
+            {
                 int ConstrId = Sketcher::PropertyConstraintList::getIndexFromConstraintName(*it);
                 Gui::Command::openCommand("Update constraint's virtual space");
                 try {
                     Gui::cmdAppObjectArgs(Obj, "toggleVirtualSpace(%d)", ConstrId);
                 }
-                catch(const Base::Exception&) {
+                catch (const Base::Exception&) {
                     successful--;
                 }
             }
@@ -182,16 +181,15 @@ void CmdSketcherSwitchVirtualSpace::activated(int iMsg)
         else
             abortCommand();
 
+        // recomputer and clear the selection (convenience)
         tryAutoRecompute(Obj);
-
-        // clear the selection (convenience)
         getSelection().clearSelection();
     }
 }
 
 bool CmdSketcherSwitchVirtualSpace::isActive(void)
 {
-    return isSketcherVirtualSpaceActive( getActiveGuiDocument(), false );
+    return isSketcherVirtualSpaceActive(getActiveGuiDocument(), false);
 }
 
 void CreateSketcherCommandsVirtualSpace(void)

--- a/src/Mod/Sketcher/Gui/Workbench.cpp
+++ b/src/Mod/Sketcher/Gui/Workbench.cpp
@@ -58,21 +58,19 @@ Gui::MenuItem* Workbench::setupMenuBar() const
     Gui::MenuItem* item = root->findItem("&Windows");
 
 // == Profile menu ==========================================
-/*    Gui::MenuItem* profile = new Gui::MenuItem;
+/* TODO: implement profile menu with different profiles
+    Gui::MenuItem* profile = new Gui::MenuItem;
     root->insertItem(item, profile);
     profile->setCommand("P&rofiles");
 
-    *profile << "Sketcher_ProfilesHexagon1";*/
+    *profile << "Sketcher_ProfilesHexagon1";
+*/
 
 // == Sketcher menu ==========================================
 
-    Gui::MenuItem* sketch = new Gui::MenuItem;
-//    root->insertItem(profile, sketch);
-    root->insertItem(item, sketch);
-    sketch->setCommand("S&ketch");
     Gui::MenuItem* geom = new Gui::MenuItem();
     geom->setCommand("Sketcher geometries");
-    addSketcherWorkbenchGeometries( *geom );
+    addSketcherWorkbenchGeometries(*geom);
 
     Gui::MenuItem* cons = new Gui::MenuItem();
     cons->setCommand("Sketcher constraints");
@@ -90,8 +88,10 @@ Gui::MenuItem* Workbench::setupMenuBar() const
     virtualspace->setCommand("Sketcher virtual space");
     addSketcherWorkbenchVirtualSpace(*virtualspace);
 
-    addSketcherWorkbenchSketchActions( *sketch );
-    *sketch << "Sketcher_StopOperation";
+    Gui::MenuItem* sketch = new Gui::MenuItem;
+    root->insertItem(item, sketch);
+    sketch->setCommand("S&ketch");
+    addSketcherWorkbenchSketchActions(*sketch);
     *sketch << geom
             << cons
             << consaccel
@@ -105,9 +105,9 @@ Gui::ToolBarItem* Workbench::setupToolBars() const
 {
     Gui::ToolBarItem* root = StdWorkbench::setupToolBars();
 
-    Gui::ToolBarItem* part = new Gui::ToolBarItem(root);
-    part->setCommand("Sketcher");
-    addSketcherWorkbenchSketchActions( *part );
+    Gui::ToolBarItem* sketcher = new Gui::ToolBarItem(root);
+    sketcher->setCommand("Sketcher");
+    addSketcherWorkbenchSketchActions(*sketcher);
 
     Gui::ToolBarItem* geom = new Gui::ToolBarItem(root);
     geom->setCommand("Sketcher geometries");
@@ -115,26 +115,26 @@ Gui::ToolBarItem* Workbench::setupToolBars() const
 
     Gui::ToolBarItem* cons = new Gui::ToolBarItem(root);
     cons->setCommand("Sketcher constraints");
-    addSketcherWorkbenchConstraints( *cons );
+    addSketcherWorkbenchConstraints(*cons);
 
     Gui::ToolBarItem* consaccel = new Gui::ToolBarItem(root);
     consaccel->setCommand("Sketcher tools");
-    addSketcherWorkbenchTools( *consaccel );
+    addSketcherWorkbenchTools(*consaccel);
 
     Gui::ToolBarItem* bspline = new Gui::ToolBarItem(root);
     bspline->setCommand("Sketcher B-spline tools");
-    addSketcherWorkbenchBSplines( *bspline );
+    addSketcherWorkbenchBSplines(*bspline);
 
     Gui::ToolBarItem* virtualspace = new Gui::ToolBarItem(root);
     virtualspace->setCommand("Sketcher virtual space");
-    addSketcherWorkbenchVirtualSpace( *virtualspace );
+    addSketcherWorkbenchVirtualSpace(*virtualspace);
 
      return root;
 }
 
 Gui::ToolBarItem* Workbench::setupCommandBars() const
 {
-    // Part tools
+    // Sketcher tools
     Gui::ToolBarItem* root = new Gui::ToolBarItem;
     return root;
 }
@@ -143,18 +143,52 @@ Gui::ToolBarItem* Workbench::setupCommandBars() const
 namespace SketcherGui {
 
 template <typename T>
-void SketcherAddWorkbenchConstraints( T& cons );
-template <typename T>
-void Sketcher_addWorkbenchSketchActions( T& sketch );
-template <typename T>
-void SketcherAddWorkbenchGeometries( T& geom );
+inline void SketcherAddWorkspaceSketchExtra(T& /*sketch*/) { }
 
+template <>
+inline void SketcherAddWorkspaceSketchExtra<Gui::MenuItem>(Gui::MenuItem& sketch)
+{
+    sketch  << "Sketcher_ReorientSketch"
+            << "Sketcher_ValidateSketch"
+            << "Sketcher_MergeSketches"
+            << "Sketcher_MirrorSketch"
+            << "Sketcher_StopOperation";
+}
 
+template <>
+inline void SketcherAddWorkspaceSketchExtra<Gui::ToolBarItem>(Gui::ToolBarItem& sketch)
+{
+    sketch  << "Sketcher_ReorientSketch"
+            << "Sketcher_ValidateSketch"
+            << "Sketcher_MergeSketches"
+            << "Sketcher_MirrorSketch"
+            << "Sketcher_StopOperation";
+}
+
+template <typename T>
+void SketcherAddWorkbenchSketchActions(T& sketch);
+
+template <typename T>
+inline void SketcherAddWorkbenchSketchActions(T& sketch)
+{
+    sketch  << "Sketcher_NewSketch"
+            << "Sketcher_EditSketch"
+            << "Sketcher_LeaveSketch"
+            << "Sketcher_ViewSketch"
+            << "Sketcher_ViewSection"
+            << "Sketcher_MapSketch";
+    SketcherAddWorkspaceSketchExtra(sketch);
+}
+
+template <typename T>
+void SketcherAddWorkbenchGeometries(T& geom);
 
 template <typename T>
 void SketcherAddWorkspaceArcs(T& geom);
+
 template <>
-inline void SketcherAddWorkspaceArcs<Gui::MenuItem>(Gui::MenuItem& geom){
+inline void SketcherAddWorkspaceArcs<Gui::MenuItem>(Gui::MenuItem& geom)
+{
     geom    << "Sketcher_CreateArc"
             << "Sketcher_Create3PointArc"
             << "Sketcher_CreateCircle"
@@ -167,17 +201,22 @@ inline void SketcherAddWorkspaceArcs<Gui::MenuItem>(Gui::MenuItem& geom){
             << "Sketcher_CreateBSpline"
             << "Sketcher_CreatePeriodicBSpline";
 }
+
 template <>
-inline void SketcherAddWorkspaceArcs<Gui::ToolBarItem>(Gui::ToolBarItem& geom){
+inline void SketcherAddWorkspaceArcs<Gui::ToolBarItem>(Gui::ToolBarItem& geom)
+{
     geom    << "Sketcher_CompCreateArc"
             << "Sketcher_CompCreateCircle"
             << "Sketcher_CompCreateConic"
             << "Sketcher_CompCreateBSpline";
 }
+
 template <typename T>
 void SketcherAddWorkspaceRegularPolygon(T& geom);
+
 template <>
-inline void SketcherAddWorkspaceRegularPolygon<Gui::MenuItem>(Gui::MenuItem& geom){
+inline void SketcherAddWorkspaceRegularPolygon<Gui::MenuItem>(Gui::MenuItem& geom)
+{
     geom    << "Sketcher_CreateTriangle"
             << "Sketcher_CreateSquare"
             << "Sketcher_CreatePentagon"
@@ -186,19 +225,23 @@ inline void SketcherAddWorkspaceRegularPolygon<Gui::MenuItem>(Gui::MenuItem& geo
             << "Sketcher_CreateOctagon"
             << "Sketcher_CreateRegularPolygon";
 }
+
 template <>
-inline void SketcherAddWorkspaceRegularPolygon<Gui::ToolBarItem>(Gui::ToolBarItem& geom){
+inline void SketcherAddWorkspaceRegularPolygon<Gui::ToolBarItem>(Gui::ToolBarItem& geom)
+{
     geom    << "Sketcher_CompCreateRegularPolygon";
 }
+
 template <typename T>
-inline void SketcherAddWorkbenchGeometries(T& geom){
+inline void SketcherAddWorkbenchGeometries(T& geom)
+{
     geom    << "Sketcher_CreatePoint"
             << "Sketcher_CreateLine";
-    SketcherAddWorkspaceArcs( geom );
+    SketcherAddWorkspaceArcs(geom);
     geom    << "Separator"
             << "Sketcher_CreatePolyline"
             << "Sketcher_CreateRectangle";
-    SketcherAddWorkspaceRegularPolygon( geom );
+    SketcherAddWorkspaceRegularPolygon(geom);
     geom    << "Sketcher_CreateSlot"
             << "Separator"
             << "Sketcher_CreateFillet"
@@ -211,11 +254,15 @@ inline void SketcherAddWorkbenchGeometries(T& geom){
             /*<< "Sketcher_CreateDraftLine"*/;
 }
 
+//template <typename T>
+//void SketcherAddWorkbenchConstraints(T& cons);
+
 template <typename T>
 inline void SketcherAddWorkbenchConstraints(T& cons);
 
 template <>
-inline void SketcherAddWorkbenchConstraints<Gui::MenuItem>(Gui::MenuItem& cons){
+inline void SketcherAddWorkbenchConstraints<Gui::MenuItem>(Gui::MenuItem& cons)
+{
     cons    << "Sketcher_ConstrainCoincident"
             << "Sketcher_ConstrainPointOnObject"
             << "Sketcher_ConstrainVertical"
@@ -242,7 +289,8 @@ inline void SketcherAddWorkbenchConstraints<Gui::MenuItem>(Gui::MenuItem& cons){
 }
 
 template <>
-inline void SketcherAddWorkbenchConstraints<Gui::ToolBarItem>(Gui::ToolBarItem& cons){
+inline void SketcherAddWorkbenchConstraints<Gui::ToolBarItem>(Gui::ToolBarItem& cons)
+{
     cons    << "Sketcher_ConstrainCoincident"
             << "Sketcher_ConstrainPointOnObject"
             << "Sketcher_ConstrainVertical"
@@ -271,44 +319,54 @@ template <typename T>
 inline void SketcherAddWorkbenchTools(T& consaccel);
 
 template <>
-inline void SketcherAddWorkbenchTools<Gui::MenuItem>(Gui::MenuItem& consaccel){
+inline void SketcherAddWorkbenchTools<Gui::MenuItem>(Gui::MenuItem& consaccel)
+{
     consaccel   << "Sketcher_SelectElementsWithDoFs"
                 << "Sketcher_CloseShape"
                 << "Sketcher_ConnectLines"
                 << "Sketcher_SelectConstraints"
+                << "Sketcher_SelectElementsAssociatedWithConstraints"
+                << "Sketcher_SelectRedundantConstraints"
+                << "Sketcher_SelectConflictingConstraints"
+                << "Sketcher_RestoreInternalAlignmentGeometry"
+                << "Separator"
                 << "Sketcher_SelectOrigin"
                 << "Sketcher_SelectVerticalAxis"
                 << "Sketcher_SelectHorizontalAxis"
-                << "Sketcher_SelectRedundantConstraints"
-                << "Sketcher_SelectConflictingConstraints"
-                << "Sketcher_SelectElementsAssociatedWithConstraints"
-                << "Sketcher_RestoreInternalAlignmentGeometry"
+                << "Separator"
                 << "Sketcher_Symmetry"
                 << "Sketcher_Clone"
                 << "Sketcher_Copy"
                 << "Sketcher_Move"
                 << "Sketcher_RectangularArray"
+                << "Separator"
                 << "Sketcher_DeleteAllGeometry"
                 << "Sketcher_DeleteAllConstraints";
 }
+
 template <>
-inline void SketcherAddWorkbenchTools<Gui::ToolBarItem>(Gui::ToolBarItem& consaccel){
+inline void SketcherAddWorkbenchTools<Gui::ToolBarItem>(Gui::ToolBarItem& consaccel)
+{
     consaccel   << "Sketcher_SelectElementsWithDoFs"
                 << "Sketcher_CloseShape"
                 << "Sketcher_ConnectLines"
                 << "Sketcher_SelectConstraints"
                 << "Sketcher_SelectElementsAssociatedWithConstraints"
+                << "Sketcher_SelectRedundantConstraints"
+                << "Sketcher_SelectConflictingConstraints"
                 << "Sketcher_RestoreInternalAlignmentGeometry"
                 << "Sketcher_Symmetry"
                 << "Sketcher_CompCopy"
-                << "Sketcher_RectangularArray";
+                << "Sketcher_RectangularArray"
+                << "Sketcher_DeleteAllConstraints";
 }
 
 template <typename T>
 inline void SketcherAddWorkbenchBSplines(T& bspline);
 
 template <>
-inline void SketcherAddWorkbenchBSplines<Gui::MenuItem>(Gui::MenuItem& bspline){
+inline void SketcherAddWorkbenchBSplines<Gui::MenuItem>(Gui::MenuItem& bspline)
+{
     bspline << "Sketcher_BSplineDegree"
         << "Sketcher_BSplinePolygon"
         << "Sketcher_BSplineComb"
@@ -321,7 +379,8 @@ inline void SketcherAddWorkbenchBSplines<Gui::MenuItem>(Gui::MenuItem& bspline){
 }
 
 template <>
-inline void SketcherAddWorkbenchBSplines<Gui::ToolBarItem>(Gui::ToolBarItem& bspline){
+inline void SketcherAddWorkbenchBSplines<Gui::ToolBarItem>(Gui::ToolBarItem& bspline)
+{
     bspline << "Sketcher_CompBSplineShowHideGeometryInformation"
     << "Sketcher_BSplineConvertToNURB"
     << "Sketcher_BSplineIncreaseDegree"
@@ -333,87 +392,75 @@ template <typename T>
 inline void SketcherAddWorkbenchVirtualSpace(T& virtualspace);
 
 template <>
-inline void SketcherAddWorkbenchVirtualSpace<Gui::MenuItem>(Gui::MenuItem& virtualspace){
+inline void SketcherAddWorkbenchVirtualSpace<Gui::MenuItem>(Gui::MenuItem& virtualspace)
+{
     virtualspace << "Sketcher_SwitchVirtualSpace";
 }
 
 template <>
-inline void SketcherAddWorkbenchVirtualSpace<Gui::ToolBarItem>(Gui::ToolBarItem& virtualspace){
+inline void SketcherAddWorkbenchVirtualSpace<Gui::ToolBarItem>(Gui::ToolBarItem& virtualspace)
+{
     virtualspace << "Sketcher_SwitchVirtualSpace";
 }
 
-template <typename T>
-inline void SketcherAddWorkspaceSketchExtra(T& /*sketch*/){
+void addSketcherWorkbenchSketchActions(Gui::MenuItem& sketch)
+{
+    SketcherAddWorkbenchSketchActions(sketch);
 }
 
-template <>
-inline void SketcherAddWorkspaceSketchExtra<Gui::MenuItem>(Gui::MenuItem& sketch){
-    sketch  << "Sketcher_ReorientSketch"
-            << "Sketcher_ValidateSketch"
-            << "Sketcher_MergeSketches"
-            << "Sketcher_MirrorSketch";
-}
-
-template <typename T>
-inline void Sketcher_addWorkbenchSketchActions(T& sketch){
-    sketch  << "Sketcher_NewSketch"
-            << "Sketcher_EditSketch"
-            << "Sketcher_LeaveSketch"
-            << "Sketcher_ViewSketch"
-            << "Sketcher_ViewSection"
-            << "Sketcher_MapSketch";
-    SketcherAddWorkspaceSketchExtra( sketch );
-}
-
-
-
-void addSketcherWorkbenchConstraints( Gui::MenuItem& cons ){
-    SketcherAddWorkbenchConstraints( cons );
-}
-
-void addSketcherWorkbenchTools( Gui::MenuItem& consaccel ){
-    SketcherAddWorkbenchTools( consaccel );
-}
-
-void addSketcherWorkbenchBSplines( Gui::MenuItem& bspline ){
-    SketcherAddWorkbenchBSplines( bspline );
-}
-
-void addSketcherWorkbenchVirtualSpace( Gui::MenuItem& virtualspace ){
-    SketcherAddWorkbenchVirtualSpace( virtualspace );
-}
-
-void addSketcherWorkbenchSketchActions( Gui::MenuItem& sketch ){
-    Sketcher_addWorkbenchSketchActions( sketch );
-}
-void addSketcherWorkbenchGeometries( Gui::MenuItem& geom ){
+void addSketcherWorkbenchGeometries(Gui::MenuItem& geom)
+{
     SketcherAddWorkbenchGeometries(geom);
 }
 
-void addSketcherWorkbenchConstraints( Gui::ToolBarItem& cons ){
-    SketcherAddWorkbenchConstraints( cons );
-}
-
-void addSketcherWorkbenchTools( Gui::ToolBarItem& consaccel )
+void addSketcherWorkbenchConstraints(Gui::MenuItem& cons)
 {
-    SketcherAddWorkbenchTools( consaccel );
+    SketcherAddWorkbenchConstraints(cons);
 }
 
-void addSketcherWorkbenchBSplines( Gui::ToolBarItem& bspline )
+void addSketcherWorkbenchTools(Gui::MenuItem& consaccel)
 {
-    SketcherAddWorkbenchBSplines( bspline );
+    SketcherAddWorkbenchTools(consaccel);
 }
 
-void addSketcherWorkbenchVirtualSpace( Gui::ToolBarItem& virtualspace )
+void addSketcherWorkbenchBSplines(Gui::MenuItem& bspline)
 {
-    SketcherAddWorkbenchVirtualSpace( virtualspace );
+    SketcherAddWorkbenchBSplines(bspline);
 }
 
-void addSketcherWorkbenchSketchActions( Gui::ToolBarItem& sketch ){
-    Sketcher_addWorkbenchSketchActions( sketch );
+void addSketcherWorkbenchVirtualSpace(Gui::MenuItem& virtualspace)
+{
+    SketcherAddWorkbenchVirtualSpace(virtualspace);
 }
-void addSketcherWorkbenchGeometries( Gui::ToolBarItem& geom ){
+
+void addSketcherWorkbenchSketchActions(Gui::ToolBarItem& sketch)
+{
+    SketcherAddWorkbenchSketchActions(sketch);
+}
+
+void addSketcherWorkbenchGeometries(Gui::ToolBarItem& geom)
+{
     SketcherAddWorkbenchGeometries(geom);
+}
+
+void addSketcherWorkbenchConstraints(Gui::ToolBarItem& cons)
+{
+    SketcherAddWorkbenchConstraints(cons);
+}
+
+void addSketcherWorkbenchTools(Gui::ToolBarItem& consaccel)
+{
+    SketcherAddWorkbenchTools(consaccel);
+}
+
+void addSketcherWorkbenchBSplines(Gui::ToolBarItem& bspline)
+{
+    SketcherAddWorkbenchBSplines(bspline);
+}
+
+void addSketcherWorkbenchVirtualSpace(Gui::ToolBarItem& virtualspace)
+{
+    SketcherAddWorkbenchVirtualSpace(virtualspace);
 }
 
 } /* namespace SketcherGui */

--- a/src/Mod/Sketcher/Gui/Workbench.cpp
+++ b/src/Mod/Sketcher/Gui/Workbench.cpp
@@ -373,7 +373,7 @@ inline void SketcherAddWorkbenchBSplines<Gui::MenuItem>(Gui::MenuItem& bspline)
         << "Sketcher_BSplineKnotMultiplicity"
         << "Sketcher_BSplineConvertToNURB"
         << "Sketcher_BSplineIncreaseDegree"
-        // << "Sketcher_BSplineDecreaseDegree" TODO: implement this
+        << "Sketcher_BSplineDecreaseDegree"  // TODO: implement this command
         << "Sketcher_BSplineIncreaseKnotMultiplicity"
         << "Sketcher_BSplineDecreaseKnotMultiplicity";
 }
@@ -384,7 +384,7 @@ inline void SketcherAddWorkbenchBSplines<Gui::ToolBarItem>(Gui::ToolBarItem& bsp
     bspline << "Sketcher_CompBSplineShowHideGeometryInformation"
     << "Sketcher_BSplineConvertToNURB"
     << "Sketcher_BSplineIncreaseDegree"
-    // << "Sketcher_BSplineDecreaseDegree" TODO: implement this
+    << "Sketcher_BSplineDecreaseDegree"  // TODO: implement this command
     << "Sketcher_CompModifyKnotMultiplicity";
 }
 

--- a/src/Mod/Sketcher/Gui/Workbench.h
+++ b/src/Mod/Sketcher/Gui/Workbench.h
@@ -21,8 +21,8 @@
  ***************************************************************************/
 
 
-#ifndef IMAGE_WORKBENCH_H
-#define IMAGE_WORKBENCH_H
+#ifndef SKETCHER_WORKBENCH_H
+#define SKETCHER_WORKBENCH_H
 
 #include <Gui/Workbench.h>
 #include <Gui/MenuManager.h>
@@ -47,24 +47,20 @@ protected:
     Gui::ToolBarItem* setupCommandBars() const;
 };
 
+SketcherGuiExport void addSketcherWorkbenchSketchActions(Gui::MenuItem& sketch);
+SketcherGuiExport void addSketcherWorkbenchGeometries(Gui::MenuItem& geom);
+SketcherGuiExport void addSketcherWorkbenchConstraints(Gui::MenuItem& cons);
+SketcherGuiExport void addSketcherWorkbenchTools(Gui::MenuItem& consaccel);
+SketcherGuiExport void addSketcherWorkbenchBSplines(Gui::MenuItem& bspline);
+SketcherGuiExport void addSketcherWorkbenchVirtualSpace(Gui::MenuItem& virtualspace);
 
-
-
-SketcherGuiExport void addSketcherWorkbenchConstraints( Gui::MenuItem& cons );
-SketcherGuiExport void addSketcherWorkbenchTools( Gui::MenuItem& consaccel );
-SketcherGuiExport void addSketcherWorkbenchBSplines( Gui::MenuItem& bspline );
-SketcherGuiExport void addSketcherWorkbenchVirtualSpace( Gui::MenuItem& virtualspace );
-SketcherGuiExport void addSketcherWorkbenchSketchActions( Gui::MenuItem& sketch );
-SketcherGuiExport void addSketcherWorkbenchGeometries( Gui::MenuItem& geom );
-
-SketcherGuiExport void addSketcherWorkbenchConstraints( Gui::ToolBarItem& cons );
-SketcherGuiExport void addSketcherWorkbenchTools( Gui::ToolBarItem& consaccel );
-SketcherGuiExport void addSketcherWorkbenchBSplines( Gui::ToolBarItem& bspline );
-SketcherGuiExport void addSketcherWorkbenchVirtualSpace( Gui::ToolBarItem& virtualspace );
-SketcherGuiExport void addSketcherWorkbenchSketchActions( Gui::ToolBarItem& sketch );
-SketcherGuiExport void addSketcherWorkbenchGeometries( Gui::ToolBarItem& geom );
+SketcherGuiExport void addSketcherWorkbenchSketchActions(Gui::ToolBarItem& sketch);
+SketcherGuiExport void addSketcherWorkbenchGeometries(Gui::ToolBarItem& geom);
+SketcherGuiExport void addSketcherWorkbenchConstraints(Gui::ToolBarItem& cons);
+SketcherGuiExport void addSketcherWorkbenchTools(Gui::ToolBarItem& consaccel);
+SketcherGuiExport void addSketcherWorkbenchBSplines(Gui::ToolBarItem& bspline);
+SketcherGuiExport void addSketcherWorkbenchVirtualSpace(Gui::ToolBarItem& virtualspace);
 
 } // namespace SketcherGui
 
-
-#endif // IMAGE_WORKBENCH_H 
+#endif // SKETCHER_WORKBENCH_H


### PR DESCRIPTION
Various cleanup tasks in the commands of the workbench.

* Five tools were in the menu, `ReorientSketch`, `ValidateSketch`, `MergeSketch`, `MirrorSketch`, `StopOperation`. Now they are also included in the general toolbar so that they are more accessible.
* Reorganize the order of the function declarations in `Workbench.{h, cpp}` so that they are in this order: actions (general), geometries, constraints, tools, B-spline, and virtual space.
* Add separators to the "tools" commands in the menu so that they look better.
* Correct the header guard `#ifndef SKETCHER_WORKBENCH_H`, instead of `IMAGE_WORKBENCH_H`.
* Clean up the tooltips of various commands in the general, tools, B-spline sections.
* Make sure certain commands are active with the right conditions:
  * `MapOnSketch` is active only when there is a sketch available in the document.
  * `ReorientSketch` and `ValidateSketch` are active only when one, and only one, sketch is selected.
  * `MergeSketch` is active only when there is at least two sketches selected.
  * `MirrorSketch` is active only when there is at least one sketch selected.
* Clean up the spacing of the code and add newlines to make the code more readable
  * Add spaces around operators like `=`, `==`, `<`, `<=`.
  * Long lines are broken to be 80 to 100 characters long when possible.
* `DrawSketchHandlerCopy` and `DrawSketchHandlerRectangularArray` are de-indented so that they start at column 1.
* Add `Sketcher_BSplineDecreaseDegree` command although with an empty implementation. Currently there is a command to increase the degree of a B-spline but the corresponding command to reduce the degree does not exist. So this command is a placeholder for when the full implementation is added in the future by somebody.

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists