### PR TITLE
Path: Feature/path voronoi vcarve refactor

### DIFF
--- a/src/Mod/Path/App/Voronoi.h
+++ b/src/Mod/Path/App/Voronoi.h
@@ -58,6 +58,7 @@ namespace Path
 
     // types
     typedef double coordinate_type;
+    typedef boost::polygon::voronoi_vertex<double> vertex_type;
     typedef boost::polygon::point_data<coordinate_type> point_type;
     typedef boost::polygon::segment_data<coordinate_type> segment_type;
     typedef boost::polygon::voronoi_diagram<double> voronoi_diagram_type;

--- a/src/Mod/Path/App/VoronoiCellPy.xml
+++ b/src/Mod/Path/App/VoronoiCellPy.xml
@@ -5,7 +5,7 @@
         Name="VoronoiCellPy" 
         Twin="VoronoiCell" 
         TwinPointer="VoronoiCell" 
-        Include="Mod/Path/App/Voronoi.h" 
+        Include="Mod/Path/App/VoronoiCell.h" 
         FatherInclude="Base/BaseClassPy.h" 
         Namespace="Path" 
         FatherNamespace="Base"

--- a/src/Mod/Path/App/VoronoiCellPyImp.cpp
+++ b/src/Mod/Path/App/VoronoiCellPyImp.cpp
@@ -75,14 +75,14 @@ int VoronoiCellPy::PyInit(PyObject* args, PyObject* /*kwd*/)
 
 
 PyObject* VoronoiCellPy::richCompare(PyObject *lhs, PyObject *rhs, int op) {
-  PyObject *cmp = Py_False;
+  PyObject *cmp = (op == Py_EQ) ? Py_False : Py_True;
   if (   PyObject_TypeCheck(lhs, &VoronoiCellPy::Type)
       && PyObject_TypeCheck(rhs, &VoronoiCellPy::Type)
-      && op == Py_EQ) {
+      && (op == Py_EQ || op == Py_NE)) {
     const VoronoiCell *vl = static_cast<VoronoiCellPy*>(lhs)->getVoronoiCellPtr();
     const VoronoiCell *vr = static_cast<VoronoiCellPy*>(rhs)->getVoronoiCellPtr();
     if (vl->index == vr->index && vl->dia == vr->dia) {
-      cmp = Py_True;
+      cmp = (op == Py_EQ) ? Py_True : Py_False;
     }
   }
   Py_INCREF(cmp);

--- a/src/Mod/Path/App/VoronoiCellPyImp.cpp
+++ b/src/Mod/Path/App/VoronoiCellPyImp.cpp
@@ -27,19 +27,18 @@
 # include <boost/algorithm/string.hpp>
 #endif
 
+#include "Base/Exception.h"
+#include "Base/GeometryPyCXX.h"
+#include "Base/PlacementPy.h"
+#include "Base/Vector3D.h"
+#include "Base/VectorPy.h"
 #include "Mod/Path/App/Voronoi.h"
 #include "Mod/Path/App/VoronoiCell.h"
 #include "Mod/Path/App/VoronoiCellPy.h"
 #include "Mod/Path/App/VoronoiEdge.h"
 #include "Mod/Path/App/VoronoiEdgePy.h"
-#include <Base/Exception.h>
-#include <Base/GeometryPyCXX.h>
-#include <Base/PlacementPy.h>
-#include <Base/Vector3D.h>
-#include <Base/VectorPy.h>
 
-// files generated out of VoronoiCellPy.xml
-#include "VoronoiCellPy.cpp"
+#include "Mod/Path/App/VoronoiCellPy.cpp"
 
 using namespace Path;
 

--- a/src/Mod/Path/App/VoronoiEdgePy.xml
+++ b/src/Mod/Path/App/VoronoiEdgePy.xml
@@ -5,7 +5,7 @@
         Name="VoronoiEdgePy" 
         Twin="VoronoiEdge" 
         TwinPointer="VoronoiEdge" 
-        Include="Mod/Path/App/Voronoi.h" 
+        Include="Mod/Path/App/VoronoiEdge.h" 
         FatherInclude="Base/BaseClassPy.h" 
         Namespace="Path" 
         FatherNamespace="Base"

--- a/src/Mod/Path/App/VoronoiEdgePy.xml
+++ b/src/Mod/Path/App/VoronoiEdgePy.xml
@@ -100,9 +100,9 @@
                 <UserDocu>Returns true if edge goes through endpoint of the segment site</UserDocu>
             </Documentation>
         </Methode>
-        <Methode Name="toGeom" Const="true">
+        <Methode Name="toShape" Const="true">
             <Documentation>
-                <UserDocu>Returns a geom representation of the edge (line segment or arc of parabola)</UserDocu>
+                <UserDocu>Returns a shape for the edge</UserDocu>
             </Documentation>
         </Methode>
         <Methode Name="getDistances" Const="true">

--- a/src/Mod/Path/App/VoronoiEdgePyImp.cpp
+++ b/src/Mod/Path/App/VoronoiEdgePyImp.cpp
@@ -92,16 +92,14 @@ int VoronoiEdgePy::PyInit(PyObject* args, PyObject* /*kwd*/)
 
 
 PyObject* VoronoiEdgePy::richCompare(PyObject *lhs, PyObject *rhs, int op) {
-  PyObject *cmp = Py_False;
+  PyObject *cmp = (op == Py_EQ) ? Py_False : Py_True;
   if (   PyObject_TypeCheck(lhs, &VoronoiEdgePy::Type)
       && PyObject_TypeCheck(rhs, &VoronoiEdgePy::Type)
-      && op == Py_EQ) {
+      && (op == Py_EQ || op == Py_NE)) {
     const VoronoiEdge *vl = static_cast<VoronoiEdgePy*>(lhs)->getVoronoiEdgePtr();
     const VoronoiEdge *vr = static_cast<VoronoiEdgePy*>(rhs)->getVoronoiEdgePtr();
-    if (vl->index == vr->index && vl->dia == vr->dia) {
-      cmp = Py_True;
-    } else {
-      std::cerr << "VoronoiEdge==(" << vl->index << " != " << vr->index << " || " << (vl->dia == vr->dia) << ")" << std::endl;
+    if (vl->dia == vr->dia && vl->index == vr->index) {
+      cmp = (op == Py_EQ) ? Py_True : Py_False;
     }
   }
   Py_INCREF(cmp);

--- a/src/Mod/Path/App/VoronoiEdgePyImp.cpp
+++ b/src/Mod/Path/App/VoronoiEdgePyImp.cpp
@@ -25,25 +25,26 @@
 
 #ifndef _PreComp_
 #include <boost/algorithm/string.hpp>
-#include "BRepBuilderAPI_MakeEdge.hxx"
-#include "Mod/Path/App/Voronoi.h"
-#include "Mod/Path/App/Voronoi.h"
-#include "Mod/Path/App/VoronoiCell.h"
-#include "Mod/Path/App/VoronoiEdge.h"
-#include "Mod/Path/App/VoronoiVertex.h"
-#include <Base/Exception.h>
-#include <Base/Vector3D.h>
-#include <Base/VectorPy.h>
-#include <Mod/Part/App/ArcOfParabolaPy.h>
-#include <Mod/Part/App/LineSegmentPy.h>
-#include <Mod/Part/App/TopoShapeEdgePy.h>
+#include <BRepBuilderAPI_MakeEdge.hxx>
 #include <Geom_Parabola.hxx>
 #endif
 
+#include "Base/Exception.h"
+#include "Base/Vector3D.h"
+#include "Base/VectorPy.h"
+#include "Mod/Part/App/ArcOfParabolaPy.h"
+#include "Mod/Part/App/LineSegmentPy.h"
+#include "Mod/Part/App/TopoShapeEdgePy.h"
+#include "Mod/Path/App/Voronoi.h"
+#include "Mod/Path/App/Voronoi.h"
+#include "Mod/Path/App/VoronoiCell.h"
 #include "Mod/Path/App/VoronoiCellPy.h"
+#include "Mod/Path/App/VoronoiEdge.h"
 #include "Mod/Path/App/VoronoiEdgePy.h"
-#include "Mod/Path/App/VoronoiEdgePy.cpp"
+#include "Mod/Path/App/VoronoiVertex.h"
 #include "Mod/Path/App/VoronoiVertexPy.h"
+
+#include "Mod/Path/App/VoronoiEdgePy.cpp"
 
 using namespace Path;
 

--- a/src/Mod/Path/App/VoronoiEdgePyImp.cpp
+++ b/src/Mod/Path/App/VoronoiEdgePyImp.cpp
@@ -397,7 +397,8 @@ PyObject* VoronoiEdgePy::toShape(PyObject *args)
 {
   double z0 = 0.0;
   double z1 = DBL_MAX;
-  if (!PyArg_ParseTuple(args, "|dd", &z0, &z1)) {
+  int dbg   = 0;
+  if (!PyArg_ParseTuple(args, "|ddp", &z0, &z1, &dbg)) {
     throw Py::RuntimeError("no, one or two arguments of type double accepted");
   }
   if (z1 == DBL_MAX) {
@@ -545,7 +546,7 @@ PyObject* VoronoiEdgePy::toShape(PyObject *args)
         double flenX;
         double flenY;
         // if one of the points is the location, we have to use the other to get sensible values
-        if (fabs(dist0) > 0.001) {
+        if (fabs(dist0) > fabs(dist1)) {
           flenX = flenX0;
           flenY = distanceBetween(loc, pt0x, e->dia->getScale());
         } else {
@@ -554,6 +555,12 @@ PyObject* VoronoiEdgePy::toShape(PyObject *args)
         }
         // parabola: (x - p)^2 = 4*focal*(y - q)   |  (p,q) ... location of parabola
         focal = (flenX * flenX) / (4 * fabs(flenY));
+        if (dbg) {
+          std::cerr << "segement" << segment << ", point" << point << std::endl;
+          std::cerr << "  loc" << loc << ", axis" << axis << std::endl;
+          std::cerr << "  dist0(" << dist0 << " : " << flenX0 << ", dist1(" << dist1 << " : " << flenX1 << ")" << std::endl;
+          std::cerr << "  z(" << z0 << ", " << zx << ", " << z1 << ")" << std::endl;
+        }
         // use new X values to set the parameters
         dist0 = dist0 >= 0 ? flenX0 : -flenX0;
         dist1 = dist1 >= 0 ? flenX1 : -flenX1;

--- a/src/Mod/Path/App/VoronoiPyImp.cpp
+++ b/src/Mod/Path/App/VoronoiPyImp.cpp
@@ -27,21 +27,20 @@
 # include <boost/algorithm/string.hpp>
 #endif
 
+#include "Base/Exception.h"
+#include "Base/GeometryPyCXX.h"
+#include "Base/Vector3D.h"
+#include "Base/VectorPy.h"
 #include "Mod/Path/App/Voronoi.h"
 #include "Mod/Path/App/VoronoiCell.h"
+#include "Mod/Path/App/VoronoiCellPy.h"
 #include "Mod/Path/App/VoronoiEdge.h"
+#include "Mod/Path/App/VoronoiEdgePy.h"
+#include "Mod/Path/App/VoronoiPy.h"
 #include "Mod/Path/App/VoronoiVertex.h"
-#include <Base/Exception.h>
-#include <Base/GeometryPyCXX.h>
-#include <Base/Vector3D.h>
-#include <Base/VectorPy.h>
+#include "Mod/Path/App/VoronoiVertexPy.h"
 
-// files generated out of VoronoiPy.xml
-#include "VoronoiPy.h"
-#include "VoronoiPy.cpp"
-#include "VoronoiCellPy.h"
-#include "VoronoiEdgePy.h"
-#include "VoronoiVertexPy.h"
+#include "Mod/Path/App/VoronoiPy.cpp"
 
 using namespace Path;
 

--- a/src/Mod/Path/App/VoronoiVertexPy.xml
+++ b/src/Mod/Path/App/VoronoiVertexPy.xml
@@ -46,9 +46,9 @@
             </Documentation>
             <Parameter Name="IncidentEdge" Type="Object"/>
         </Attribute>
-        <Methode Name="toGeom" Const="true">
+        <Methode Name="toPoint" Const="true">
             <Documentation>
-                <UserDocu>Returns a Vertex - or None if not possible</UserDocu>
+                <UserDocu>Returns a Vector - or None if not possible</UserDocu>
             </Documentation>
         </Methode>
     </PythonExport>

--- a/src/Mod/Path/App/VoronoiVertexPy.xml
+++ b/src/Mod/Path/App/VoronoiVertexPy.xml
@@ -5,7 +5,7 @@
         Name="VoronoiVertexPy" 
         Twin="VoronoiVertex" 
         TwinPointer="VoronoiVertex" 
-        Include="Mod/Path/App/Voronoi.h" 
+        Include="Mod/Path/App/VoronoiVertex.h" 
         FatherInclude="Base/BaseClassPy.h" 
         Namespace="Path" 
         FatherNamespace="Base"

--- a/src/Mod/Path/App/VoronoiVertexPyImp.cpp
+++ b/src/Mod/Path/App/VoronoiVertexPyImp.cpp
@@ -151,7 +151,7 @@ Py::Object VoronoiVertexPy::getIncidentEdge() const {
   return Py::asObject(new VoronoiEdgePy(new VoronoiEdge(v->dia, v->ptr->incident_edge())));
 }
 
-PyObject* VoronoiVertexPy::toGeom(PyObject *args)
+PyObject* VoronoiVertexPy::toPoint(PyObject *args)
 {
   double z = 0.0;
   if (!PyArg_ParseTuple(args, "|d", &z)) {

--- a/src/Mod/Path/App/VoronoiVertexPyImp.cpp
+++ b/src/Mod/Path/App/VoronoiVertexPyImp.cpp
@@ -76,14 +76,14 @@ int VoronoiVertexPy::PyInit(PyObject* args, PyObject* /*kwd*/)
 
 
 PyObject* VoronoiVertexPy::richCompare(PyObject *lhs, PyObject *rhs, int op) {
-  PyObject *cmp = Py_False;
+  PyObject *cmp = (op == Py_EQ) ? Py_False : Py_True;
   if (   PyObject_TypeCheck(lhs, &VoronoiVertexPy::Type)
       && PyObject_TypeCheck(rhs, &VoronoiVertexPy::Type)
-      && op == Py_EQ) {
+      && (op == Py_EQ || op == Py_NE)) {
     const VoronoiVertex *vl = static_cast<VoronoiVertexPy*>(lhs)->getVoronoiVertexPtr();
     const VoronoiVertex *vr = static_cast<VoronoiVertexPy*>(rhs)->getVoronoiVertexPtr();
     if (vl->index == vr->index && vl->dia == vr->dia) {
-      cmp = Py_True;
+      cmp = (op == Py_EQ) ? Py_True : Py_False;
     }
   }
   Py_INCREF(cmp);

--- a/src/Mod/Path/App/VoronoiVertexPyImp.cpp
+++ b/src/Mod/Path/App/VoronoiVertexPyImp.cpp
@@ -27,20 +27,19 @@
 # include <boost/algorithm/string.hpp>
 #endif
 
-#include "Voronoi.h"
-#include "VoronoiPy.h"
-#include "VoronoiEdge.h"
-#include "VoronoiEdgePy.h"
-#include "VoronoiVertex.h"
-#include "VoronoiVertexPy.h"
-#include <Base/Exception.h>
-#include <Base/GeometryPyCXX.h>
-#include <Base/PlacementPy.h>
-#include <Base/Vector3D.h>
-#include <Base/VectorPy.h>
+#include "Base/Exception.h"
+#include "Base/GeometryPyCXX.h"
+#include "Base/PlacementPy.h"
+#include "Base/Vector3D.h"
+#include "Base/VectorPy.h"
+#include "Mod/Path/App/Voronoi.h"
+#include "Mod/Path/App/VoronoiEdge.h"
+#include "Mod/Path/App/VoronoiEdgePy.h"
+#include "Mod/Path/App/VoronoiPy.h"
+#include "Mod/Path/App/VoronoiVertex.h"
+#include "Mod/Path/App/VoronoiVertexPy.h"
 
-// files generated out of VoronoiVertexPy.xml
-#include "VoronoiVertexPy.cpp"
+#include "Mod/Path/App/VoronoiVertexPy.cpp"
 
 using namespace Path;
 

--- a/src/Mod/Path/CMakeLists.txt
+++ b/src/Mod/Path/CMakeLists.txt
@@ -198,6 +198,7 @@ SET(PathTests_SRCS
     PathTests/TestPathToolController.py
     PathTests/TestPathTooltable.py
     PathTests/TestPathUtil.py
+    PathTests/TestPathVoronoi.py
     PathTests/boxtest.fcstd
     PathTests/test_centroid_00.ngc
     PathTests/test_geomop.fcstd

--- a/src/Mod/Path/PathScripts/PathVcarve.py
+++ b/src/Mod/Path/PathScripts/PathVcarve.py
@@ -110,8 +110,6 @@ def _collectVoronoiWires(vd):
                 else:
                     vStart = None
             wires.append(we)
-            print("knots %s - (%s, %s)" % (knots, vFirst, vLast))
-            # The first and last edge are knots, check if they still have more edges attached
         if len(vertex[vFirst]) == 0:
             knots = [v for v in knots if v != vFirst]
         if len(vertex[vLast]) == 0:
@@ -126,7 +124,7 @@ def _sortVoronoiWires(wires, start = FreeCAD.Vector(0, 0, 0)):
             if l is None or l > start.distanceToPoint(point[i]):
                 l = start.distanceToPoint(point[i])
                 p = i
-        return p
+        return (p, l)
 
 
     begin = {}
@@ -136,14 +134,22 @@ def _sortVoronoiWires(wires, start = FreeCAD.Vector(0, 0, 0)):
         begin[i] = w[ 0].Vertices[0].toPoint()
         end[i]   = w[-1].Vertices[1].toPoint()
 
-    index = []
+    result = []
     while begin:
-        idx = closestTo(start, begin)
-        index.append(idx)
-        del   begin[idx]
-        start = end[idx]
+        (bIdx, bLen) = closestTo(start, begin)
+        (eIdx, eLen) = closestTo(start, end)
+        if bLen < eLen:
+            result.append(wires[bIdx])
+            start =   end[bIdx]
+            del     begin[bIdx]
+            del       end[bIdx]
+        else:
+            result.append([e.Twin for e in reversed(wires[eIdx])])
+            start = begin[eIdx]
+            del     begin[eIdx]
+            del       end[eIdx]
 
-    return [wires[i] for i in index]
+    return result
 
 class ObjectVcarve(PathEngraveBase.ObjectOp):
     '''Proxy class for Vcarve operation.'''

--- a/src/Mod/Path/PathTests/TestPathVoronoi.py
+++ b/src/Mod/Path/PathTests/TestPathVoronoi.py
@@ -23,7 +23,9 @@
 # ***************************************************************************
 
 import FreeCAD
+import Part
 import Path
+import PathScripts.PathGeom as PathGeom
 import PathTests.PathTestUtils as PathTestUtils
 
 vd = None
@@ -86,4 +88,85 @@ class TestPathVoronoi(PathTestUtils.PathTestBase):
         self.assertEqual(   vd.Cells[1], vd.Cells[1])
         self.assertNotEqual(vd.Cells[0], vd.Cells[1])
         self.assertNotEqual(vd.Cells[1], vd.Cells[0])
+
+    def test50(self):
+        '''Check toShape for linear edges'''
+
+        edges = [e for e in vd.Edges if e.Color == 0 and e.isLinear()]
+        self.assertNotEqual(len(edges), 0)
+        e0 = edges[0]
+
+        e = e0.toShape()
+        self.assertTrue(type(e.Curve) == Part.LineSegment or type(e.Curve) == Part.Line)
+        self.assertFalse(PathGeom.pointsCoincide(e.valueAt(e.FirstParameter), e.valueAt(e.LastParameter)))
+        self.assertEqual(e.valueAt(e.FirstParameter).z, 0)
+        self.assertEqual(e.valueAt(e.LastParameter).z,  0)
+
+    def test51(self):
+        '''Check toShape for linear edges with set z'''
+
+        edges = [e for e in vd.Edges if e.Color == 0 and e.isLinear()]
+        self.assertNotEqual(len(edges), 0)
+        e0 = edges[0]
+
+        e = e0.toShape(13.7)
+        self.assertTrue(type(e.Curve) == Part.LineSegment or type(e.Curve) == Part.Line)
+        self.assertFalse(PathGeom.pointsCoincide(e.valueAt(e.FirstParameter), e.valueAt(e.LastParameter)))
+        self.assertEqual(e.valueAt(e.FirstParameter).z, 13.7)
+        self.assertEqual(e.valueAt(e.LastParameter).z,  13.7)
+
+    def test52(self):
+        '''Check toShape for linear edges with varying z'''
+
+        edges = [e for e in vd.Edges if e.Color == 0 and e.isLinear()]
+        self.assertNotEqual(len(edges), 0)
+        e0 = edges[0]
+
+        e = e0.toShape(2.37, 5.14)
+        self.assertTrue(type(e.Curve) == Part.LineSegment or type(e.Curve) == Part.Line)
+        self.assertFalse(PathGeom.pointsCoincide(e.valueAt(e.FirstParameter), e.valueAt(e.LastParameter)))
+        self.assertEqual(e.valueAt(e.FirstParameter).z, 2.37)
+        self.assertEqual(e.valueAt(e.LastParameter).z,  5.14)
+
+    def test60(self):
+        '''Check toShape for curved edges'''
+
+        edges = [e for e in vd.Edges if e.Color == 0 and e.isCurved()]
+        self.assertNotEqual(len(edges), 0)
+        e0 = edges[0]
+
+        e = e0.toShape()
+        print(type(e.Curve))
+        self.assertTrue(type(e.Curve) == Part.Parabola or type(e.Curve) == Part.BSplineCurve)
+        self.assertFalse(PathGeom.pointsCoincide(e.valueAt(e.FirstParameter), e.valueAt(e.LastParameter)))
+        self.assertEqual(e.valueAt(e.FirstParameter).z, 0)
+        self.assertEqual(e.valueAt(e.LastParameter).z,  0)
+
+    def test61(self):
+        '''Check toShape for curved edges with set z'''
+
+        edges = [e for e in vd.Edges if e.Color == 0 and e.isCurved()]
+        self.assertNotEqual(len(edges), 0)
+        e0 = edges[0]
+
+        e = e0.toShape(13.7)
+        print(type(e.Curve))
+        self.assertTrue(type(e.Curve) == Part.Parabola or type(e.Curve) == Part.BSplineCurve)
+        self.assertFalse(PathGeom.pointsCoincide(e.valueAt(e.FirstParameter), e.valueAt(e.LastParameter)))
+        self.assertEqual(e.valueAt(e.FirstParameter).z, 13.7)
+        self.assertEqual(e.valueAt(e.LastParameter).z,  13.7)
+
+    def test62(self):
+        '''Check toShape for curved edges with varying z'''
+
+        edges = [e for e in vd.Edges if e.Color == 0 and e.isCurved()]
+        self.assertNotEqual(len(edges), 0)
+        e0 = edges[0]
+
+        e = e0.toShape(2.37, 5.14)
+        print(type(e.Curve))
+        self.assertTrue(type(e.Curve) == Part.Parabola or type(e.Curve) == Part.BSplineCurve)
+        self.assertFalse(PathGeom.pointsCoincide(e.valueAt(e.FirstParameter), e.valueAt(e.LastParameter)))
+        self.assertEqual(e.valueAt(e.FirstParameter).z, 2.37)
+        self.assertEqual(e.valueAt(e.LastParameter).z,  5.14)
 

--- a/src/Mod/Path/PathTests/TestPathVoronoi.py
+++ b/src/Mod/Path/PathTests/TestPathVoronoi.py
@@ -27,6 +27,7 @@ import Part
 import Path
 import PathScripts.PathGeom as PathGeom
 import PathTests.PathTestUtils as PathTestUtils
+import sys
 
 vd = None
 
@@ -44,7 +45,11 @@ def initVD():
         vd.construct()
 
         for e in vd.Edges:
-            e.Color = 0 if e.isPrimary() else 1;
+            if sys.version_info.major > 2:
+                e.Color = 0 if e.isPrimary() else 1
+            else:
+                e.Color = long(0) if e.isPrimary() else long(1)
+
         vd.colorExterior(2)
         vd.colorColinear(3)
         vd.colorTwins(4)

--- a/src/Mod/Path/PathTests/TestPathVoronoi.py
+++ b/src/Mod/Path/PathTests/TestPathVoronoi.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+
+# ***************************************************************************
+# *                                                                         *
+# *   Copyright (c) 2020 sliptonic <shopinthewoods@gmail.com>               *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   This program is distributed in the hope that it will be useful,       *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with this program; if not, write to the Free Software   *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+
+import FreeCAD
+import Path
+import PathTests.PathTestUtils as PathTestUtils
+
+vd = None
+
+def initVD():
+    global vd
+    if vd is None:
+        pts = [(0,0), (3.5,0), (3.5,1), (1,1), (1,2), (2.5,2), (2.5,3), (1,3), (1,4), (3.5, 4), (3.5,5), (0,5)]
+        ptv = [FreeCAD.Vector(p[0], p[1]) for p in pts]
+        ptv.append(ptv[0])
+
+        vd = Path.Voronoi()
+        for i in range(len(pts)):
+            vd.addSegment(ptv[i], ptv[i+1])
+
+        vd.construct()
+
+        for e in vd.Edges:
+            e.Color = 0 if e.isPrimary() else 1;
+        vd.colorExterior(2)
+        vd.colorColinear(3)
+        vd.colorTwins(4)
+
+
+class TestPathVoronoi(PathTestUtils.PathTestBase):
+
+    def setUp(self):
+        initVD()
+
+    def test00(self):
+        '''Check vertex comparison'''
+
+        self.assertTrue(    vd.Vertices[0] == vd.Vertices[0])
+        self.assertTrue(    vd.Vertices[1] == vd.Vertices[1])
+        self.assertTrue(    vd.Vertices[0] != vd.Vertices[1])
+        self.assertEqual(   vd.Vertices[0], vd.Vertices[0])
+        self.assertEqual(   vd.Vertices[1], vd.Vertices[1])
+        self.assertNotEqual(vd.Vertices[0], vd.Vertices[1])
+        self.assertNotEqual(vd.Vertices[1], vd.Vertices[0])
+
+    def test10(self):
+        '''Check edge comparison'''
+
+        self.assertTrue(    vd.Edges[0] == vd.Edges[0])
+        self.assertTrue(    vd.Edges[1] == vd.Edges[1])
+        self.assertTrue(    vd.Edges[0] != vd.Edges[1])
+        self.assertEqual(   vd.Edges[0], vd.Edges[0])
+        self.assertEqual(   vd.Edges[1], vd.Edges[1])
+        self.assertNotEqual(vd.Edges[0], vd.Edges[1])
+        self.assertNotEqual(vd.Edges[1], vd.Edges[0])
+
+
+    def test20(self):
+        '''Check cell comparison'''
+
+        self.assertTrue(    vd.Cells[0] == vd.Cells[0])
+        self.assertTrue(    vd.Cells[1] == vd.Cells[1])
+        self.assertTrue(    vd.Cells[0] != vd.Cells[1])
+        self.assertEqual(   vd.Cells[0], vd.Cells[0])
+        self.assertEqual(   vd.Cells[1], vd.Cells[1])
+        self.assertNotEqual(vd.Cells[0], vd.Cells[1])
+        self.assertNotEqual(vd.Cells[1], vd.Cells[0])
+

--- a/src/Mod/Path/PathTests/TestPathVoronoi.py
+++ b/src/Mod/Path/PathTests/TestPathVoronoi.py
@@ -99,8 +99,8 @@ class TestPathVoronoi(PathTestUtils.PathTestBase):
         e = e0.toShape()
         self.assertTrue(type(e.Curve) == Part.LineSegment or type(e.Curve) == Part.Line)
         self.assertFalse(PathGeom.pointsCoincide(e.valueAt(e.FirstParameter), e.valueAt(e.LastParameter)))
-        self.assertEqual(e.valueAt(e.FirstParameter).z, 0)
-        self.assertEqual(e.valueAt(e.LastParameter).z,  0)
+        self.assertRoughly(e.valueAt(e.FirstParameter).z, 0)
+        self.assertRoughly(e.valueAt(e.LastParameter).z,  0)
 
     def test51(self):
         '''Check toShape for linear edges with set z'''
@@ -112,8 +112,8 @@ class TestPathVoronoi(PathTestUtils.PathTestBase):
         e = e0.toShape(13.7)
         self.assertTrue(type(e.Curve) == Part.LineSegment or type(e.Curve) == Part.Line)
         self.assertFalse(PathGeom.pointsCoincide(e.valueAt(e.FirstParameter), e.valueAt(e.LastParameter)))
-        self.assertEqual(e.valueAt(e.FirstParameter).z, 13.7)
-        self.assertEqual(e.valueAt(e.LastParameter).z,  13.7)
+        self.assertRoughly(e.valueAt(e.FirstParameter).z, 13.7)
+        self.assertRoughly(e.valueAt(e.LastParameter).z,  13.7)
 
     def test52(self):
         '''Check toShape for linear edges with varying z'''
@@ -125,8 +125,8 @@ class TestPathVoronoi(PathTestUtils.PathTestBase):
         e = e0.toShape(2.37, 5.14)
         self.assertTrue(type(e.Curve) == Part.LineSegment or type(e.Curve) == Part.Line)
         self.assertFalse(PathGeom.pointsCoincide(e.valueAt(e.FirstParameter), e.valueAt(e.LastParameter)))
-        self.assertEqual(e.valueAt(e.FirstParameter).z, 2.37)
-        self.assertEqual(e.valueAt(e.LastParameter).z,  5.14)
+        self.assertRoughly(e.valueAt(e.FirstParameter).z, 2.37)
+        self.assertRoughly(e.valueAt(e.LastParameter).z,  5.14)
 
     def test60(self):
         '''Check toShape for curved edges'''
@@ -136,11 +136,10 @@ class TestPathVoronoi(PathTestUtils.PathTestBase):
         e0 = edges[0]
 
         e = e0.toShape()
-        print(type(e.Curve))
         self.assertTrue(type(e.Curve) == Part.Parabola or type(e.Curve) == Part.BSplineCurve)
         self.assertFalse(PathGeom.pointsCoincide(e.valueAt(e.FirstParameter), e.valueAt(e.LastParameter)))
-        self.assertEqual(e.valueAt(e.FirstParameter).z, 0)
-        self.assertEqual(e.valueAt(e.LastParameter).z,  0)
+        self.assertRoughly(e.valueAt(e.FirstParameter).z, 0)
+        self.assertRoughly(e.valueAt(e.LastParameter).z,  0)
 
     def test61(self):
         '''Check toShape for curved edges with set z'''
@@ -150,11 +149,10 @@ class TestPathVoronoi(PathTestUtils.PathTestBase):
         e0 = edges[0]
 
         e = e0.toShape(13.7)
-        print(type(e.Curve))
         self.assertTrue(type(e.Curve) == Part.Parabola or type(e.Curve) == Part.BSplineCurve)
         self.assertFalse(PathGeom.pointsCoincide(e.valueAt(e.FirstParameter), e.valueAt(e.LastParameter)))
-        self.assertEqual(e.valueAt(e.FirstParameter).z, 13.7)
-        self.assertEqual(e.valueAt(e.LastParameter).z,  13.7)
+        self.assertRoughly(e.valueAt(e.FirstParameter).z, 13.7)
+        self.assertRoughly(e.valueAt(e.LastParameter).z,  13.7)
 
     def test62(self):
         '''Check toShape for curved edges with varying z'''
@@ -164,9 +162,8 @@ class TestPathVoronoi(PathTestUtils.PathTestBase):
         e0 = edges[0]
 
         e = e0.toShape(2.37, 5.14)
-        print(type(e.Curve))
         self.assertTrue(type(e.Curve) == Part.Parabola or type(e.Curve) == Part.BSplineCurve)
         self.assertFalse(PathGeom.pointsCoincide(e.valueAt(e.FirstParameter), e.valueAt(e.LastParameter)))
-        self.assertEqual(e.valueAt(e.FirstParameter).z, 2.37)
-        self.assertEqual(e.valueAt(e.LastParameter).z,  5.14)
+        self.assertRoughly(e.valueAt(e.FirstParameter).z, 2.37)
+        self.assertRoughly(e.valueAt(e.LastParameter).z,  5.14)
 

--- a/src/Mod/Path/TestPathApp.py
+++ b/src/Mod/Path/TestPathApp.py
@@ -42,6 +42,7 @@ from PathTests.TestPathToolController import TestPathToolController
 from PathTests.TestPathSetupSheet import TestPathSetupSheet
 from PathTests.TestPathDeburr  import TestPathDeburr
 from PathTests.TestPathHelix  import TestPathHelix
+from PathTests.TestPathVoronoi  import TestPathVoronoi
 
 # dummy usage to get flake8 and lgtm quiet
 False if TestApp.__name__ else True
@@ -62,4 +63,5 @@ False if TestPathDeburr.__name__ else True
 False if TestPathHelix.__name__ else True
 False if TestPathPreferences.__name__ else True
 False if TestPathToolBit.__name__ else True
+False if TestPathVoronoi.__name__ else True
 


### PR DESCRIPTION
Voronoi changes:
* Changed `toGeom` api to `toPoint` for vertices and to `toShape` for edges in order to easier deal with segmenting an edge (although it was not required in the end).
* Added a second optional z-value to the `toShape(z0, z1)` call so that the voronoi implementation can return the correct edge with an in/decline.

Vcarve changes:
* Voronoi point based wire detection, easier to determine connected edges than using geometries or shapes.
* Added sorting algorithm for wires to connect an end point with the closest wire starting point
* Allow flipping a voronoi wire if its end point is closest to the end point of the previous wire.