### PR TITLE
[PD] fix hole thread UI bugs

### DIFF
--- a/src/Mod/PartDesign/App/FeatureHole.cpp
+++ b/src/Mod/PartDesign/App/FeatureHole.cpp
@@ -632,8 +632,10 @@ void Hole::onChanged(const App::Property *prop)
             HoleCutType.setEnums(HoleCutType_ISOmetric_Enums);
             Threaded.setReadOnly(false);
             ThreadSize.setReadOnly(false);
-            ThreadFit.setReadOnly(false);
-            ThreadClass.setReadOnly(false);
+            // thread class and direction are only sensible if threaded
+            // fit only sensible if not threaded
+            ThreadFit.setReadOnly(Threaded.getValue());
+            ThreadClass.setReadOnly(!Threaded.getValue());
             Diameter.setReadOnly(true);
             HoleCutDiameter.setReadOnly(true);
             HoleCutDepth.setReadOnly(true);
@@ -645,8 +647,10 @@ void Hole::onChanged(const App::Property *prop)
             HoleCutType.setEnums(HoleCutType_ISOmetricfine_Enums);
             Threaded.setReadOnly(false);
             ThreadSize.setReadOnly(false);
-            ThreadFit.setReadOnly(false);
-            ThreadClass.setReadOnly(false);
+            // thread class and direction are only sensible if threaded
+            // fit only sensible if not threaded
+            ThreadFit.setReadOnly(Threaded.getValue());
+            ThreadClass.setReadOnly(!Threaded.getValue());
             Diameter.setReadOnly(true);
             HoleCutDiameter.setReadOnly(true);
             HoleCutDepth.setReadOnly(true);
@@ -658,8 +662,10 @@ void Hole::onChanged(const App::Property *prop)
             HoleCutType.setEnums(HoleCutType_UNC_Enums);
             Threaded.setReadOnly(false);
             ThreadSize.setReadOnly(false);
-            ThreadFit.setReadOnly(false);
-            ThreadClass.setReadOnly(false);
+            // thread class and direction are only sensible if threaded
+            // fit only sensible if not threaded
+            ThreadFit.setReadOnly(Threaded.getValue());
+            ThreadClass.setReadOnly(!Threaded.getValue());
             Diameter.setReadOnly(true);
 
             if (holeCutType == "None") {
@@ -685,8 +691,10 @@ void Hole::onChanged(const App::Property *prop)
             HoleCutType.setEnums(HoleCutType_UNF_Enums);
             Threaded.setReadOnly(false);
             ThreadSize.setReadOnly(false);
-            ThreadFit.setReadOnly(false);
-            ThreadClass.setReadOnly(false);
+            // thread class and direction are only sensible if threaded
+            // fit only sensible if not threaded
+            ThreadFit.setReadOnly(Threaded.getValue());
+            ThreadClass.setReadOnly(!Threaded.getValue());
             Diameter.setReadOnly(true);
 
             if (holeCutType == "None") {
@@ -712,8 +720,10 @@ void Hole::onChanged(const App::Property *prop)
             HoleCutType.setEnums(HoleCutType_UNEF_Enums);
             Threaded.setReadOnly(false);
             ThreadSize.setReadOnly(false);
-            ThreadFit.setReadOnly(false);
-            ThreadClass.setReadOnly(false);
+            // thread class and direction are only sensible if threaded
+            // fit only sensible if not threaded
+            ThreadFit.setReadOnly(Threaded.getValue());
+            ThreadClass.setReadOnly(!Threaded.getValue());;
             Diameter.setReadOnly(true);
 
             if (holeCutType == "None") {
@@ -758,12 +768,16 @@ void Hole::onChanged(const App::Property *prop)
     else if (prop == &Threaded) {
         std::string type(ThreadType.getValueAsString());
 
+        // thread class and direction are only sensible if threaded
+        // fit only sensible if not threaded
         if (Threaded.getValue()) {
+            ThreadClass.setReadOnly(false);
             ThreadDirection.setReadOnly(false);
             ThreadFit.setReadOnly(true);
             ModelActualThread.setReadOnly(true); // For now set this one to read only
         }
         else {
+            ThreadClass.setReadOnly(true);
             ThreadDirection.setReadOnly(true);
             if (type == "None")
                 ThreadFit.setReadOnly(true);

--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
@@ -99,7 +99,11 @@ TaskHoleParameters::TaskHoleParameters(ViewProviderHole *HoleView, QWidget *pare
         ++cursor;
     }
     ui->ThreadClass->setCurrentIndex(pcHole->ThreadClass.getValue());
+    // Class is only enabled (sensible) if threaded
+    ui->ThreadClass->setEnabled(pcHole->Threaded.getValue());
     ui->ThreadFit->setCurrentIndex(pcHole->ThreadFit.getValue());
+    // Fit is only enabled (sensible) if not threaded
+    ui->ThreadFit->setEnabled(!pcHole->Threaded.getValue());
     ui->Diameter->setValue(pcHole->Diameter.getValue());
     if (pcHole->ThreadDirection.getValue() == 0L)
         ui->directionRightHand->setChecked(true);


### PR DESCRIPTION
- initialization: if a threaded, the fit must not be enabled
- when changing the profile type setReadOnly for the fit and class according to if threaded or not
- when changing if threaded or not, setReadOnly accordingly for the fit and class