### PR TITLE
Fix macro code processing

### DIFF
--- a/src/Mod/AddonManager/addonmanager_macro.py
+++ b/src/Mod/AddonManager/addonmanager_macro.py
@@ -143,19 +143,19 @@ class Macro(object):
         if not code:
             code = re.findall(r"<pre>(.*?)</pre>", p.replace("\n", "--endl--"))
             if code:
-                # code = code[0]
                 # take the biggest code block
                 code = sorted(code, key=len)[-1]
                 code = code.replace("--endl--", "\n")
+                # Clean HTML escape codes.
+                if sys.version_info.major < 3:
+                    code = code.decode("utf8")
+                code = unescape(code)
+                code = code.replace(b"\xc2\xa0".decode("utf-8"), " ")
+                if sys.version_info.major < 3:
+                    code = code.encode("utf8")
             else:
                 FreeCAD.Console.PrintWarning(translate("AddonsInstaller", "Unable to fetch the code of this macro."))
-            # Clean HTML escape codes.
-            if sys.version_info.major < 3:
-                code = code.decode("utf8")
-            code = unescape(code)
-            code = code.replace(b"\xc2\xa0".decode("utf-8"), " ")
-            if sys.version_info.major < 3:
-                code = code.encode("utf8")
+
         desc = re.findall(r"<td class=\"ctEven left macro-description\">(.*?)</td>", p.replace("\n", " "))
         if desc:
             desc = desc[0]


### PR DESCRIPTION
I believe this code is currently incorrect, as it makes references to code outside the "if code" block, where it can not be ensured that code is a string. Moving the code processing into this block avoids this issue.

I experienced a stuck Addon Manager, which was caused by an exception

```
  File "/usr/share/freecad/Mod/AddonManager/addonmanager_macro.py", line ..., in fill_details_from_wiki
    FreeCAD.Console.PrintWarning(translate("AddonsInstaller", "Unable to clean macro code: ") + code + '\n')
TypeError: can only concatenate str (not "list") to str
```
which is fixed by these changes.

OS: Ubuntu 20.04.1 LTS
Word size of OS: 64-bit
Word size of FreeCAD: 64-bit
Version: 0.18.4.
Build type: Release
Python version: 3.8.2
Qt version: 5.12.5
Coin version: 4.0.0
OCC version: 7.3.0
Locale: English/United States (en_US)

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
