### PR TITLE
Add SVG icons for two Std commands

### DIFF
--- a/src/Gui/CommandDoc.cpp
+++ b/src/Gui/CommandDoc.cpp
@@ -995,6 +995,7 @@ StdCmdDuplicateSelection::StdCmdDuplicateSelection()
     sToolTipText  = QT_TR_NOOP("Put duplicates of the selected objects to the active document");
     sWhatsThis    = "Std_DuplicateSelection";
     sStatusTip    = QT_TR_NOOP("Put duplicates of the selected objects to the active document");
+    sPixmap       = "Std_DuplicateSelection";
 }
 
 void StdCmdDuplicateSelection::activated(int iMsg)
@@ -1437,6 +1438,7 @@ StdCmdAlignment::StdCmdAlignment()
     sToolTipText  = QT_TR_NOOP("Align the selected objects");
     sStatusTip    = QT_TR_NOOP("Align the selected objects");
     sWhatsThis    = "Std_Alignment";
+    sPixmap       = "Std_Alignment";
 }
 
 void StdCmdAlignment::activated(int iMsg)

--- a/src/Gui/Icons/Std_Alignment.svg
+++ b/src/Gui/Icons/Std_Alignment.svg
@@ -1,0 +1,308 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   viewBox="0 0 64 64"
+   version="1.1"
+   id="svg3559"
+   height="64"
+   width="64">
+  <title
+     id="title885">Std_Alignment</title>
+  <defs
+     id="defs3561">
+    <linearGradient
+       id="linearGradient4383-1">
+      <stop
+         style="stop-color:#c4a000;stop-opacity:1"
+         offset="0"
+         id="stop69725" />
+      <stop
+         style="stop-color:#fce94f;stop-opacity:1"
+         offset="1"
+         id="stop69727" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4393">
+      <stop
+         id="stop4395"
+         offset="0"
+         style="stop-color:#204a87;stop-opacity:1" />
+      <stop
+         id="stop4397"
+         offset="1"
+         style="stop-color:#3465a4;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4383">
+      <stop
+         id="stop4385"
+         offset="0"
+         style="stop-color:#3465a4;stop-opacity:1" />
+      <stop
+         id="stop4387"
+         offset="1"
+         style="stop-color:#729fcf;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-1.243533,-2.588112)"
+       gradientUnits="userSpaceOnUse"
+       y2="30.588112"
+       x2="21.243532"
+       y1="54.588112"
+       x1="27.243532"
+       id="linearGradient4389-0"
+       xlink:href="#linearGradient4383-3" />
+    <linearGradient
+       id="linearGradient4383-3">
+      <stop
+         id="stop4385-1"
+         offset="0"
+         style="stop-color:#3465a4;stop-opacity:1" />
+      <stop
+         id="stop4387-2"
+         offset="1"
+         style="stop-color:#729fcf;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(1.2856487,1.4142136)"
+       gradientUnits="userSpaceOnUse"
+       y2="24.585787"
+       x2="40.714352"
+       y1="45.585785"
+       x1="48.714352"
+       id="linearGradient4399-7"
+       xlink:href="#linearGradient4393-9" />
+    <linearGradient
+       id="linearGradient4393-9">
+      <stop
+         id="stop4395-8"
+         offset="0"
+         style="stop-color:#204a87;stop-opacity:1" />
+      <stop
+         id="stop4397-1"
+         offset="1"
+         style="stop-color:#3465a4;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="27.588112"
+       x2="17.243532"
+       y1="37.588112"
+       x1="20.243532"
+       gradientTransform="translate(10.250331,-12.567881)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1873"
+       xlink:href="#linearGradient4383-1" />
+    <linearGradient
+       y2="20.585787"
+       x2="48.714352"
+       y1="25.585787"
+       x1="50.714352"
+       gradientTransform="translate(-10.220487,-5.5655559)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1875"
+       xlink:href="#linearGradient4383-1" />
+    <linearGradient
+       y2="40.588112"
+       x2="22.243532"
+       y1="54.588112"
+       x1="27.243532"
+       gradientTransform="translate(-1.243533,-2.588112)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1877"
+       xlink:href="#linearGradient4383" />
+    <linearGradient
+       y2="34.585785"
+       x2="44.714352"
+       y1="45.585785"
+       x1="48.714352"
+       gradientTransform="translate(1.2856487,1.4142136)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1879"
+       xlink:href="#linearGradient4393" />
+  </defs>
+  <metadata
+     id="metadata3564">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Std_Alignment</dc:title>
+        <dc:title>Path-Stock</dc:title>
+        <dc:date>2020/10/04</dc:date>
+        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier></dc:identifier>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>Based on Alexander Gryson's work</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[bitacovir]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>shapes</rdf:li>
+            <rdf:li>arrow</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <dc:description>Alignment of shapes</dc:description>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     style="display:inline"
+     id="layer1">
+    <g
+       style="display:inline"
+       id="g903-4"
+       transform="translate(-0.57017084,1.9623157)">
+      <g
+         id="g895-3">
+        <path
+           style="fill:url(#linearGradient1877);fill-opacity:1;fill-rule:nonzero;stroke:#0b1521;stroke-width:2;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+           d="M 9,49 V 35 l 28,10 v 14 z"
+           id="path4381-0" />
+        <path
+           style="fill:url(#linearGradient1879);fill-opacity:1;fill-rule:nonzero;stroke:#0b1521;stroke-width:2;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+           d="M 37,59 V 45 L 55,28 v 13 z"
+           id="path4391-7" />
+        <path
+           style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none"
+           d="M 11.008035,47.60627 11,38 l 24,8 0.0081,10.184812 z"
+           id="path4381-7-4" />
+        <path
+           style="fill:none;stroke:#3465a4;stroke-width:2;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none"
+           d="M 39.005041,54.16825 39,46 53,33 l 0.0021,7.176847 z"
+           id="path4391-0-7" />
+      </g>
+      <path
+         style="fill:#729fcf;fill-opacity:1;fill-rule:nonzero;stroke:#0b1521;stroke-width:2;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+         d="M 9,35 28,20 55,28 37,45 Z"
+         id="path69038-9" />
+    </g>
+    <path
+       style="fill:url(#linearGradient1873);fill-opacity:1;fill-rule:nonzero;stroke:#302b00;stroke-width:2;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       d="M 7.5168515,21.814561 7.4254239,7.7231349 32.493864,17.02023 v 14.5 z"
+       id="path69705-0" />
+    <path
+       style="fill:none;stroke:#fce94f;stroke-width:2;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none"
+       d="m 9.7911342,20.448851 1.5542688,-8.994295 19.148461,6.565674 v 10.5 z"
+       id="path69707-2" />
+    <path
+       id="path69715-4"
+       d="m 32.493864,31.52023 v -14.5 l 6.668513,-5.379652 0.193947,14.048169 z"
+       style="fill:url(#linearGradient1875);fill-opacity:1;fill-rule:nonzero;stroke:#302b00;stroke-width:2;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none" />
+    <path
+       id="path69719-0"
+       d="M 34.493864,27.214177 V 18.02023 l 2.765487,-2.121055 0.129298,8.821897 z"
+       style="fill:none;stroke:#fce94f;stroke-width:2;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none" />
+    <path
+       id="path69721-4"
+       d="M 7.4254239,7.7231349 15.636883,2.9745167 39.162377,11.640578 32.493864,17.02023 Z"
+       style="fill:#fce94f;fill-opacity:1;fill-rule:nonzero;stroke:#302b00;stroke-width:2;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none" />
+    <path
+       id="path919-9"
+       d="m 8.2427554,23.33752 24.3726956,9.050869 6.044686,-4.913328"
+       style="display:inline;fill:none;stroke:#ef2929;stroke-width:4;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="fill:none;stroke:#a40000;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 7.2406947,21.916031 24.9545373,9.309465 7.305343,-5.624468"
+       id="path919" />
+    <g
+       id="g917"
+       transform="translate(-24.852502,8.3352804)">
+      <path
+         style="fill:#ef2929;stroke:#280000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
+         d="m 58.682913,34.173071 5.687233,-5.924856 -3.676748,-0.07165 0.02797,-15.999965 -3.999994,-0.007 -0.02797,15.999965 -3.999992,-0.007 z"
+         id="path3948-2-8" />
+    </g>
+    <path
+       style="display:inline;fill:none;stroke:#ef2929;stroke-width:4;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 9.6017314,38.471341 36.437588,47.921196 53.374296,32.37999"
+       id="path919-9-1" />
+    <path
+       id="path919-9-1-3"
+       d="M 8.6182125,39.252397 36.688342,49.15939 54.402184,32.932477"
+       style="display:inline;fill:none;stroke:#a40000;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  </g>
+  <g
+     style="display:none;opacity:0.58800001"
+     id="layer2">
+    <path
+       style="fill:#ef2929;fill-rule:evenodd;stroke:#ef2929;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 9,35 9,49"
+       id="path68967" />
+    <path
+       style="fill:#ef2929;fill-rule:evenodd;stroke:#ef2929;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 9,35 37,45"
+       id="path68971" />
+    <path
+       id="path68973"
+       d="m 55,28 0,13"
+       style="fill:#ef2929;fill-rule:evenodd;stroke:#ef2929;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       id="path68977"
+       d="M 37,45 55,28"
+       style="fill:#ef2929;fill-rule:evenodd;stroke:#ef2929;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       style="fill:#ef2929;fill-rule:evenodd;stroke:#ef2929;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 23,40 23,26"
+       id="path68983" />
+    <path
+       style="fill:#ef2929;fill-rule:evenodd;stroke:#ef2929;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 29,5 13,5"
+       id="path68985" />
+    <path
+       id="path68989"
+       d="M 23,26 42,10"
+       style="fill:#ef2929;fill-rule:evenodd;stroke:#ef2929;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       id="path68993"
+       d="M 19,13 29,5"
+       style="fill:#ef2929;fill-rule:evenodd;stroke:#ef2929;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       id="path68997"
+       d="m 55,15 -9,8"
+       style="fill:#ef2929;fill-rule:evenodd;stroke:#ef2929;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       style="fill:#ef2929;fill-rule:evenodd;stroke:#ef2929;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 42,23 42,10"
+       id="path69030" />
+    <path
+       id="path69034"
+       d="m 42,23 14,5"
+       style="fill:#ef2929;fill-rule:evenodd;stroke:#ef2929;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       style="fill:#ef2929;fill-rule:evenodd;stroke:#ef2929;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 23,40 42,23"
+       id="path69036" />
+    <path
+       style="fill:#ef2929;fill-rule:evenodd;stroke:#ef2929;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 23,10 19,0"
+       id="path69711" />
+    <path
+       id="path69713"
+       d="m 34,17 0,13"
+       style="fill:#ef2929;fill-rule:evenodd;stroke:#ef2929;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  </g>
+</svg>

--- a/src/Gui/Icons/Std_DuplicateSelection.svg
+++ b/src/Gui/Icons/Std_DuplicateSelection.svg
@@ -1,0 +1,257 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   width="64px"
+   height="64px"
+   id="svg2985"
+   version="1.1">
+  <title
+     id="title889">Std_DuplicateSelection</title>
+  <defs
+     id="defs2987">
+    <linearGradient
+       id="linearGradient4387">
+      <stop
+         style="stop-color:#71b2f8;stop-opacity:1;"
+         offset="0"
+         id="stop4389" />
+      <stop
+         style="stop-color:#002795;stop-opacity:1;"
+         offset="1"
+         id="stop4391" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6321">
+      <stop
+         style="stop-color:#71b2f8;stop-opacity:1;"
+         offset="0"
+         id="stop6323" />
+      <stop
+         style="stop-color:#002795;stop-opacity:1;"
+         offset="1"
+         id="stop6325" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient3377"
+       id="radialGradient3692"
+       cx="45.883327"
+       cy="28.869568"
+       fx="45.883327"
+       fy="28.869568"
+       r="19.467436"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-0.23443224,0.23443198)" />
+    <linearGradient
+       id="linearGradient3377">
+      <stop
+         id="stop3379"
+         offset="0"
+         style="stop-color:#faff2b;stop-opacity:1;" />
+      <stop
+         id="stop3381"
+         offset="1"
+         style="stop-color:#ffaa00;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3377-3">
+      <stop
+         id="stop3379-8"
+         offset="0"
+         style="stop-color:#faff2b;stop-opacity:1;" />
+      <stop
+         id="stop3381-3"
+         offset="1"
+         style="stop-color:#ffaa00;stop-opacity:1;" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient3377-3"
+       id="radialGradient6412"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.67067175,0,0,0.64145918,-63.380792,0.83845403)"
+       cx="45.883327"
+       cy="28.869568"
+       fx="45.883327"
+       fy="28.869568"
+       r="19.467436" />
+    <linearGradient
+       id="linearGradient3036">
+      <stop
+         id="stop3038"
+         offset="0"
+         style="stop-color:#ef2929;stop-opacity:1" />
+      <stop
+         id="stop3040"
+         offset="1"
+         style="stop-color:#a40000;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata2990">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Std_DuplicateSelection</dc:title>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[bitacovir]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:title>Part_Shape_from_Mesh</dc:title>
+        <dc:date>2020/10/03</dc:date>
+        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier />
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>Based on Alexander Gryson's work</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>shape</rdf:li>
+            <rdf:li>box</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <dc:description>Duplicated Shape </dc:description>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1">
+    <g
+       id="g1038">
+      <g
+         transform="matrix(0.67067175,0,0,0.55048347,-60.906953,-8.0462517)"
+         id="g3060"
+         style="stroke-width:3.5;stroke-miterlimit:4;stroke-dasharray:none">
+        <path
+           style="fill:#204a87;stroke:none"
+           d="M 181.76846,74.564006 V 110.8957 l -17.89251,14.53268 v -36.3317 z"
+           id="path3150-7" />
+        <path
+           style="fill:none;stroke:#3465a4;stroke-width:3.29157;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 163.87595,121.79521 17.89251,-14.53268"
+           id="path3930" />
+        <path
+           style="fill:none;stroke:#3465a4;stroke-width:3.29157;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="M 178.78637,114.52887 V 78.197173"
+           id="path3932" />
+        <path
+           style="fill:none;stroke:#3465a4;stroke-width:3.29157;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 181.76846,78.197173 -17.89251,14.53268"
+           id="path3934" />
+        <path
+           style="fill:none;stroke:#3465a4;stroke-width:3.29157;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="M 166.85803,85.463513 V 121.79521"
+           id="path3936" />
+        <path
+           style="fill:#3465a4;stroke:none"
+           d="M 163.87595,125.42838 140.01927,110.8957 V 74.564003 l 23.85668,14.532677 z"
+           id="path3152-1" />
+        <path
+           style="fill:none;stroke:#729fcf;stroke-width:3.29157;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="M 160.89386,89.096683 V 121.79521"
+           id="path3938" />
+        <path
+           style="fill:none;stroke:#729fcf;stroke-width:3.29157;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 140.01927,107.26253 23.85668,14.53268"
+           id="path3940" />
+        <path
+           style="fill:none;stroke:#729fcf;stroke-width:3.29157;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="M 143.00136,110.8957 V 78.197173"
+           id="path3942" />
+        <path
+           style="fill:none;stroke:#0b1521;stroke-width:3.29157;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+           d="M 181.76846,74.564003 V 110.8957 l -17.89251,14.53268 V 89.096683 Z"
+           id="path3150" />
+        <path
+           style="fill:none;stroke:#729fcf;stroke-width:3.29157;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="M 163.87595,92.729853 140.01927,78.197173"
+           id="path3944" />
+        <path
+           style="fill:none;stroke:#0b1521;stroke-width:3.29157;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+           d="M 163.87595,125.42838 140.01927,110.8957 V 74.564003 l 23.85668,14.53268 z"
+           id="path3152" />
+        <path
+           style="fill:#729fcf;stroke:#0b1521;stroke-width:3.29157;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+           d="m 181.76846,74.564003 -17.89251,14.53268 -23.85668,-14.53268 17.89251,-14.53268 23.85668,14.53268"
+           id="path3156" />
+      </g>
+      <g
+         style="stroke-width:3.5;stroke-miterlimit:4;stroke-dasharray:none"
+         id="g3060-2"
+         transform="matrix(0.67067175,0,0,0.55048347,-90.906967,-30.046251)">
+        <path
+           id="path3150-7-8"
+           d="M 181.76846,74.564006 V 110.8957 l -17.89251,14.53268 v -36.3317 z"
+           style="fill:#204a87;stroke:none" />
+        <path
+           id="path3930-1"
+           d="m 163.87595,121.79521 17.89251,-14.53268"
+           style="fill:none;stroke:#3465a4;stroke-width:3.29157;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+        <path
+           id="path3932-0"
+           d="M 178.78637,114.52887 V 78.197173"
+           style="fill:none;stroke:#3465a4;stroke-width:3.29157;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+        <path
+           id="path3934-2"
+           d="m 181.76846,78.197173 -17.89251,14.53268"
+           style="fill:none;stroke:#3465a4;stroke-width:3.29157;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+        <path
+           id="path3936-5"
+           d="M 166.85803,85.463513 V 121.79521"
+           style="fill:none;stroke:#3465a4;stroke-width:3.29157;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+        <path
+           id="path3152-1-3"
+           d="M 163.87595,125.42838 140.01927,110.8957 V 74.564003 l 23.85668,14.532677 z"
+           style="fill:#3465a4;stroke:none" />
+        <path
+           id="path3938-2"
+           d="M 160.89386,89.096683 V 121.79521"
+           style="fill:none;stroke:#729fcf;stroke-width:3.29157;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+        <path
+           id="path3940-4"
+           d="m 140.01927,107.26253 23.85668,14.53268"
+           style="fill:none;stroke:#729fcf;stroke-width:3.29157;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+        <path
+           id="path3942-2"
+           d="M 143.00136,110.8957 V 78.197173"
+           style="fill:none;stroke:#729fcf;stroke-width:3.29157;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+        <path
+           id="path3150-5"
+           d="M 181.76846,74.564003 V 110.8957 l -17.89251,14.53268 V 89.096683 Z"
+           style="fill:none;stroke:#0b1521;stroke-width:3.29157;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           id="path3944-9"
+           d="M 163.87595,92.729853 140.01927,78.197173"
+           style="fill:none;stroke:#729fcf;stroke-width:3.29157;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+        <path
+           id="path3152-9"
+           d="M 163.87595,125.42838 140.01927,110.8957 V 74.564003 l 23.85668,14.53268 z"
+           style="fill:none;stroke:#0b1521;stroke-width:3.29157;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           id="path3156-2"
+           d="m 181.76846,74.564003 -17.89251,14.53268 -23.85668,-14.53268 17.89251,-14.53268 23.85668,14.53268"
+           style="fill:#729fcf;stroke:#0b1521;stroke-width:3.29157;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/src/Gui/Icons/resource.qrc
+++ b/src/Gui/Icons/resource.qrc
@@ -196,6 +196,8 @@
         <file>folder.svg</file>
         <file>document-python.svg</file>
         <file>document-package.svg</file>
+        <file>Std_Alignment.svg</file>
+        <file>Std_DuplicateSelection.svg</file>
     </qresource>
     <!-- Demonstrating support for an embedded icon theme -->
     <!-- See also http://permalink.gmane.org/gmane.comp.lib.qt.general/26374 -->


### PR DESCRIPTION
Two Std commands do not have icons for the FreeCAD UI (Menu Edit): Std DuplicateSelection, Std_Alignment.

This commit adds SVG files with icons for these commands. Also, it makes the necessary changes on CommandDoc.cpp and resource.qrc files.

The new SVG icons follow the FreeCAD Artwork Guidelines and were saved as Plain SVG format.

The discussion with the proposal for SVG icons can be found in the UX/UI Design FreeCAD Forum:
Icon for Std Alignment
https://forum.freecadweb.org/viewtopic.php?f=34&t=50688
Icon for Std DuplicateSelection
https://forum.freecadweb.org/viewtopic.php?f=34&t=50791
