### PR TITLE
Fix various typos

### DIFF
--- a/src/Mod/Draft/draftgeoutils/edges.py
+++ b/src/Mod/Draft/draftgeoutils/edges.py
@@ -114,8 +114,8 @@ def isSameLine(e1, e2):
 def is_line(bspline):
     """Return True if the given BSpline curve is a straight line."""
 
-# previous implementation may fail for a multipole striaght spline due
-# a second order error in tolerance, wich introduce a difference of 1e-14
+# previous implementation may fail for a multipole straight spline due
+# a second order error in tolerance, which introduce a difference of 1e-14
 # in the values of the tangents. Also, may fail on a periodic spline.
 #    step = bspline.LastParameter/10
 #    b = bspline.tangent(0)

--- a/src/Mod/Draft/draftgeoutils/geometry.py
+++ b/src/Mod/Draft/draftgeoutils/geometry.py
@@ -297,7 +297,7 @@ def is_planar(shape, tol=-1):
 def is_straight_line(shape, tol=-1):
     """Return True if shape is a straight line.
     function used in other methods because Part.Shape.findPlane assign a
-    plane and normal to straight wires creating priviliged directions
+    plane and normal to straight wires creating privileged directions
     and to deal with straight wires with overlapped edges."""
 
     if len(shape.Faces) != 0:
@@ -319,7 +319,7 @@ def is_straight_line(shape, tol=-1):
             first_point = edge.firstVertex().Point
             last_point = edge.lastVertex().Point
             dir_edge = edge.tangentAt(edge.FirstParameter)
-            # chek if edge is curve or no parallel to start_edge
+            # check if edge is curve or no parallel to start_edge
             # because sin(x) = x + O(x**3), for small angular deflection it's
             # enough use the cross product of directions (or dot with a normal)
             if (abs(edge.Length - first_point.distanceToPoint(last_point)) > err
@@ -410,7 +410,7 @@ def get_spline_surface_normal(shape, tol=-1):
     u = (u0 + u1)/2
     v = (v0 + v1)/2
     first_normal = first_surf.normal(u, v)
-    # chek if all faces are planar and parallel
+    # check if all faces are planar and parallel
     for face in shape.Faces:
         surf = face.Surface
         if not surf.isPlanar(tol):

--- a/src/Mod/Draft/draftmake/make_sketch.py
+++ b/src/Mod/Draft/draftmake/make_sketch.py
@@ -127,7 +127,7 @@ def make_sketch(objects_list, autoconstraints=False, addTo=None,
         normal = DraftGeomUtils.get_normal(shapes_list[0], tol)
 
     else:
-        # supose all geometries are straight lines or points
+        # suppose all geometries are straight lines or points
         points = [vertex.Point for shape in shapes_list for vertex in shape.Vertexes]
         if len(points) >= 2:
             poly = Part.makePolygon(points)

--- a/src/Mod/Part/App/BRepFeat/MakePrismPyImp.cpp
+++ b/src/Mod/Part/App/BRepFeat/MakePrismPyImp.cpp
@@ -53,7 +53,7 @@ int MakePrismPy::PyInit(PyObject* args, PyObject* kwds)
     PyObject* Direction;
     int Fuse;
     PyObject* Modify;
-    static char* keywords[] = {"Sbase", "Pbase", "Skface", "Direction", "Fuse", "Modifiy", nullptr};
+    static char* keywords[] = {"Sbase", "Pbase", "Skface", "Direction", "Fuse", "Modify", nullptr};
     if (PyArg_ParseTupleAndKeywords(args, kwds, "O!O!O!O!iO!", keywords,
                                     &(TopoShapePy::Type), &Sbase,
                                     &(TopoShapePy::Type), &Pbase,
@@ -110,7 +110,7 @@ PyObject* MakePrismPy::init(PyObject *args,  PyObject* kwds)
     PyObject* Direction;
     int Fuse;
     PyObject* Modify;
-    static char* keywords[] = {"Sbase", "Pbase", "Skface", "Direction", "Fuse", "Modifiy", nullptr};
+    static char* keywords[] = {"Sbase", "Pbase", "Skface", "Direction", "Fuse", "Modify", nullptr};
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!O!O!O!iO!", keywords,
                                      &(TopoShapePy::Type), &Sbase,
                                      &(TopoShapePy::Type), &Pbase,


### PR DESCRIPTION
Found via `codespell v2.0.dev`  
```
codespell -q 3 -L aci,ake,aline,alle,alledges,alocation,als,ang,anid,ba,beginn,behaviour,bloaded,byteorder,calculater,cancelled,cancelling,cas,cascade,centimetre,childs,colour,colours,commen,connexion,currenty,dof,doubleclick,dum,eiter,elemente,ende,feld,finde,findf,freez,hist,iff,indicies,initialisation,initialise,initialised,initialises,initialisiert,ist,kilometre,lod,mantatory,methode,metres,millimetre,modell,nd,noe,normale,normaly,nto,numer,oder,orgin,orginx,orginy,ot,pard,pres,programm,que,recurrance,rougly,seperator,serie,sinc,strack,substraction,te,thist,thru,tread,uint,unter,vertexes,wallthickness,whitespaces -S ./.git,*.po,*.ts,./ChangeLog.txt,./src/3rdParty,./src/Mod/Assembly/App/opendcm,./src/CXX,./src/zipios++,./src/Base/swig*,./src/Mod/Robot/App/kdl_cp,./src/Mod/Import/App/SCL,./src/WindowsInstaller,./src/Doc/FreeCAD.uml
```