### PR TITLE
App: fix ObjectIdentifier::relativeTo()

### DIFF
--- a/src/App/ObjectIdentifier.cpp
+++ b/src/App/ObjectIdentifier.cpp
@@ -1153,7 +1153,7 @@ std::vector<std::string> ObjectIdentifier::getStringList() const
 
 ObjectIdentifier ObjectIdentifier::relativeTo(const ObjectIdentifier &other) const
 {
-    ObjectIdentifier result(owner);
+    ObjectIdentifier result(other.getOwner());
     ResolveResults thisresult(*this);
     ResolveResults otherresult(other);
 


### PR DESCRIPTION
Reported from realthunder/FreeCAD_Assembly3#328

`ObjectIdentifier::relativeTo()` uses the wrong base owner object, causing the expression to display as local property reference. The expression can still evaluate to the correct result, but error will occur when the document is saved, restored, and the object is recomputed.