### PR TITLE
[PD] more hole fixes

### DIFF
--- a/src/Mod/PartDesign/App/FeatureHole.cpp
+++ b/src/Mod/PartDesign/App/FeatureHole.cpp
@@ -637,9 +637,23 @@ void Hole::onChanged(const App::Property *prop)
             ThreadFit.setReadOnly(Threaded.getValue());
             ThreadClass.setReadOnly(!Threaded.getValue());
             Diameter.setReadOnly(true);
-            HoleCutDiameter.setReadOnly(true);
-            HoleCutDepth.setReadOnly(true);
-            HoleCutCountersinkAngle.setReadOnly(true);
+
+            if (holeCutType == "None") {
+                HoleCutDiameter.setReadOnly(true);
+                HoleCutDepth.setReadOnly(true);
+                HoleCutCountersinkAngle.setReadOnly(true);
+            }
+            else if (holeCutType == "Counterbore") {
+                HoleCutDiameter.setReadOnly(true);
+                HoleCutDepth.setReadOnly(false);
+                HoleCutCountersinkAngle.setReadOnly(true);
+
+            }
+            else if (holeCutType == "Countersink") {
+                HoleCutDiameter.setReadOnly(false);
+                HoleCutDepth.setReadOnly(true);
+                HoleCutCountersinkAngle.setReadOnly(true);
+            }
         }
         else if ( type == "ISOMetricFineProfile" ) {
             ThreadSize.setEnums(ThreadSize_ISOmetricfine_Enums);
@@ -652,9 +666,23 @@ void Hole::onChanged(const App::Property *prop)
             ThreadFit.setReadOnly(Threaded.getValue());
             ThreadClass.setReadOnly(!Threaded.getValue());
             Diameter.setReadOnly(true);
-            HoleCutDiameter.setReadOnly(true);
-            HoleCutDepth.setReadOnly(true);
-            HoleCutCountersinkAngle.setReadOnly(true);
+
+            if (holeCutType == "None") {
+                HoleCutDiameter.setReadOnly(true);
+                HoleCutDepth.setReadOnly(true);
+                HoleCutCountersinkAngle.setReadOnly(true);
+            }
+            else if (holeCutType == "Counterbore") {
+                HoleCutDiameter.setReadOnly(true);
+                HoleCutDepth.setReadOnly(false);
+                HoleCutCountersinkAngle.setReadOnly(true);
+
+            }
+            else if (holeCutType == "Countersink") {
+                HoleCutDiameter.setReadOnly(false);
+                HoleCutDepth.setReadOnly(true);
+                HoleCutCountersinkAngle.setReadOnly(true);
+            }
         }
         else if ( type == "UNC" ) {
             ThreadSize.setEnums(ThreadSize_UNC_Enums);
@@ -824,21 +852,28 @@ void Hole::onChanged(const App::Property *prop)
             threadType = ThreadType.getValueAsString();
         if (HoleCutType.isValid())
             holeCutType = HoleCutType.getValueAsString();
-        bool holeCutEnable = ( threadType != "ISOMetricProfile" &&
-                threadType !="ISOMetricFineProfile" &&
-                (holeCutType != "None"));
+        bool holeCutEnable = (holeCutType != "None");
+        
+        // HoleCutDiameter is only allowed for countersinks or counterbores with UTS or no profile
+        if (holeCutType == "None")
+            HoleCutDiameter.setReadOnly(true);
+        else if (threadType != "ISOMetricProfile" && threadType != "ISOMetricFineProfile")
+            HoleCutDiameter.setReadOnly(false);
+        else if (holeCutType == "Countersink" || holeCutType == "Countersink socket screw")
+            HoleCutDiameter.setReadOnly(false);
+        else
+            HoleCutDiameter.setReadOnly(true);
 
-        HoleCutDiameter.setReadOnly(!holeCutEnable);
-
+        // HoleCutDepth can always be changed if there is a cut
         if (holeCutType == "Countersink" || holeCutType == "Countersink socket screw")
             HoleCutDepth.setReadOnly(true);
         else
             HoleCutDepth.setReadOnly(!holeCutEnable);
-
-        if (holeCutType != "Countersink" && holeCutType != "Countersink socket screw")
-            HoleCutCountersinkAngle.setReadOnly(true);
-        else
-            HoleCutCountersinkAngle.setReadOnly(!holeCutEnable);
+        // HoleCutCountersinkAngle is only allowed for countersinks with UTS or no profile
+        HoleCutCountersinkAngle.setReadOnly(true);
+        if ((holeCutType == "Countersink" || holeCutType == "Countersink socket screw")
+            && (threadType != "ISOMetricProfile" && threadType != "ISOMetricFineProfile"))
+            HoleCutCountersinkAngle.setReadOnly(false);
 
         updateHoleCutParams();
     }

--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.ui
@@ -14,42 +14,54 @@
    <string>Task Hole Parameters</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="10" column="2" colspan="5">
-    <widget class="QComboBox" name="ThreadFit">
-     <item>
-      <property name="text">
-       <string>Standard fit</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Close fit</string>
-      </property>
-     </item>
-    </widget>
-   </item>
-   <item row="17" column="2" colspan="2">
-    <widget class="QLabel" name="label_10">
+   <item row="20" column="0" colspan="8">
+    <widget class="QLabel" name="label_16">
      <property name="text">
-      <string>Countersink angle</string>
+      <string>&lt;b&gt;Misc&lt;/b&gt;</string>
      </property>
     </widget>
    </item>
-   <item row="11" column="2">
-    <widget class="QComboBox" name="ThreadClass"/>
-   </item>
-   <item row="6" column="3" colspan="4">
-    <widget class="Gui::PrefQuantitySpinBox" name="ThreadCutOffInner">
+   <item row="5" column="4" colspan="4">
+    <widget class="Gui::PrefQuantitySpinBox" name="ThreadAngle">
      <property name="enabled">
       <bool>false</bool>
      </property>
      <property name="unit" stdset="0">
-      <string notr="true">mm</string>
+      <string notr="true">deg</string>
      </property>
     </widget>
    </item>
-   <item row="1" column="2" colspan="5">
+   <item row="14" column="0">
+    <widget class="QLabel" name="label">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Type</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="2" colspan="6">
     <widget class="QComboBox" name="ThreadType"/>
+   </item>
+   <item row="18" column="0" colspan="8">
+    <widget class="QLabel" name="label_9">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>&lt;b&gt;Drill point&lt;/b&gt;</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+     </property>
+    </widget>
    </item>
    <item row="10" column="0" colspan="2">
     <widget class="QLabel" name="label_3">
@@ -58,7 +70,7 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="3" colspan="4">
+   <item row="4" column="4" colspan="4">
     <widget class="Gui::PrefQuantitySpinBox" name="ThreadPitch">
      <property name="enabled">
       <bool>false</bool>
@@ -68,30 +80,61 @@
      </property>
     </widget>
    </item>
-   <item row="8" column="0" colspan="2">
-    <widget class="QLabel" name="label_8">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
+   <item row="7" column="2">
+    <widget class="QLabel" name="label_CutoffOuter">
+     <property name="enabled">
+      <bool>false</bool>
      </property>
      <property name="text">
-      <string>Direction</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+      <string>Cutoff outer</string>
      </property>
     </widget>
    </item>
-   <item row="2" column="2" colspan="5">
-    <widget class="QCheckBox" name="Threaded">
-     <property name="text">
-      <string>Threaded</string>
+   <item row="7" column="4" colspan="4">
+    <widget class="Gui::PrefQuantitySpinBox" name="ThreadCutOffOuter">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="unit" stdset="0">
+      <string notr="true">mm</string>
      </property>
     </widget>
    </item>
-   <item row="19" column="2" colspan="5">
+   <item row="6" column="2">
+    <widget class="QLabel" name="label_CutoffInner">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="text">
+      <string>Cutoff inner</string>
+     </property>
+    </widget>
+   </item>
+   <item row="16" column="5" colspan="3">
+    <widget class="Gui::PrefQuantitySpinBox" name="HoleCutDepth">
+     <property name="unit" stdset="0">
+      <string notr="true">mm</string>
+     </property>
+    </widget>
+   </item>
+   <item row="11" column="6" colspan="2">
+    <widget class="Gui::PrefQuantitySpinBox" name="Diameter">
+     <property name="unit" stdset="0">
+      <string notr="true">mm</string>
+     </property>
+    </widget>
+   </item>
+   <item row="15" column="5" colspan="3">
+    <widget class="Gui::PrefQuantitySpinBox" name="HoleCutDiameter">
+     <property name="contextMenuPolicy">
+      <enum>Qt::NoContextMenu</enum>
+     </property>
+     <property name="unit" stdset="0">
+      <string notr="true">mm</string>
+     </property>
+    </widget>
+   </item>
+   <item row="19" column="2" colspan="6">
     <widget class="QWidget" name="widget_2" native="true">
      <layout class="QVBoxLayout" name="verticalLayout_2">
       <property name="spacing">
@@ -149,11 +192,8 @@
      </layout>
     </widget>
    </item>
-   <item row="14" column="2" colspan="5">
-    <widget class="QComboBox" name="HoleCutType"/>
-   </item>
-   <item row="7" column="3" colspan="4">
-    <widget class="Gui::PrefQuantitySpinBox" name="ThreadCutOffOuter">
+   <item row="6" column="4" colspan="4">
+    <widget class="Gui::PrefQuantitySpinBox" name="ThreadCutOffInner">
      <property name="enabled">
       <bool>false</bool>
      </property>
@@ -162,10 +202,17 @@
      </property>
     </widget>
    </item>
-   <item row="20" column="0" colspan="7">
-    <widget class="QLabel" name="label_16">
+   <item row="12" column="6" colspan="2">
+    <widget class="Gui::PrefQuantitySpinBox" name="Depth">
+     <property name="unit" stdset="0">
+      <string notr="true">mm</string>
+     </property>
+    </widget>
+   </item>
+   <item row="21" column="6">
+    <widget class="QCheckBox" name="Reversed">
      <property name="text">
-      <string>&lt;b&gt;Misc&lt;/b&gt;</string>
+      <string>Reversed</string>
      </property>
     </widget>
    </item>
@@ -182,47 +229,7 @@
      </property>
     </widget>
    </item>
-   <item row="21" column="5">
-    <widget class="QCheckBox" name="Reversed">
-     <property name="text">
-      <string>Reversed</string>
-     </property>
-    </widget>
-   </item>
-   <item row="9" column="0">
-    <widget class="QLabel" name="label_4">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Size</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0" colspan="2">
-    <widget class="QLabel" name="label_2">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Profile</string>
-     </property>
-    </widget>
-   </item>
-   <item row="15" column="2" colspan="2">
-    <widget class="QLabel" name="label_11">
-     <property name="text">
-      <string>Diameter</string>
-     </property>
-    </widget>
-   </item>
-   <item row="11" column="3" colspan="2">
+   <item row="11" column="4" colspan="2">
     <widget class="QLabel" name="label_7">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
@@ -232,13 +239,6 @@
      </property>
      <property name="text">
       <string>Diameter</string>
-     </property>
-    </widget>
-   </item>
-   <item row="15" column="4" colspan="3">
-    <widget class="Gui::PrefQuantitySpinBox" name="HoleCutDiameter">
-     <property name="unit" stdset="0">
-      <string notr="true">mm</string>
      </property>
     </widget>
    </item>
@@ -255,10 +255,119 @@
      </property>
     </widget>
    </item>
-   <item row="16" column="4" colspan="3">
-    <widget class="Gui::PrefQuantitySpinBox" name="HoleCutDepth">
+   <item row="15" column="2" colspan="3">
+    <widget class="QLabel" name="label_11">
+     <property name="text">
+      <string>Diameter</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0" colspan="8">
+    <widget class="QLabel" name="label_13">
+     <property name="text">
+      <string>&lt;b&gt;Threading and size&lt;/b&gt;</string>
+     </property>
+    </widget>
+   </item>
+   <item row="17" column="5" colspan="3">
+    <widget class="Gui::PrefQuantitySpinBox" name="HoleCutCountersinkAngle">
      <property name="unit" stdset="0">
-      <string notr="true">mm</string>
+      <string notr="true">deg</string>
+     </property>
+    </widget>
+   </item>
+   <item row="11" column="2">
+    <widget class="QComboBox" name="ThreadClass">
+     <property name="toolTip">
+      <string>Tolerance class for threaded holes according to the hole profile</string>
+     </property>
+    </widget>
+   </item>
+   <item row="21" column="2" colspan="3">
+    <widget class="Gui::PrefQuantitySpinBox" name="TaperedAngle">
+     <property name="unit" stdset="0">
+      <string notr="true">deg</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="2" colspan="6">
+    <widget class="QCheckBox" name="Threaded">
+     <property name="text">
+      <string>Threaded</string>
+     </property>
+    </widget>
+   </item>
+   <item row="21" column="0" colspan="2">
+    <widget class="QCheckBox" name="Tapered">
+     <property name="text">
+      <string>Tapered</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="2">
+    <widget class="QLabel" name="label_Angle">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="text">
+      <string>Angle</string>
+     </property>
+    </widget>
+   </item>
+   <item row="12" column="2" colspan="3">
+    <widget class="QComboBox" name="DepthType">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <item>
+      <property name="text">
+       <string>Dimension</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Through all</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item row="14" column="2" colspan="6">
+    <widget class="QComboBox" name="HoleCutType"/>
+   </item>
+   <item row="9" column="2" colspan="6">
+    <widget class="QComboBox" name="ThreadSize"/>
+   </item>
+   <item row="19" column="0" colspan="2">
+    <widget class="QLabel" name="label_15">
+     <property name="text">
+      <string>Type</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+     </property>
+    </widget>
+   </item>
+   <item row="17" column="2" colspan="3">
+    <widget class="QLabel" name="label_10">
+     <property name="text">
+      <string>Countersink angle</string>
+     </property>
+    </widget>
+   </item>
+   <item row="16" column="2" colspan="3">
+    <widget class="QLabel" name="label_12">
+     <property name="text">
+      <string>Depth</string>
+     </property>
+    </widget>
+   </item>
+   <item row="13" column="0" colspan="8">
+    <widget class="QLabel" name="label_14">
+     <property name="text">
+      <string>&lt;b&gt;Hole cut&lt;/b&gt;</string>
      </property>
     </widget>
    </item>
@@ -272,14 +381,36 @@
      </property>
     </widget>
    </item>
-   <item row="13" column="0" colspan="7">
-    <widget class="QLabel" name="label_14">
+   <item row="1" column="0" colspan="2">
+    <widget class="QLabel" name="label_2">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="text">
-      <string>&lt;b&gt;Hole cut&lt;/b&gt;</string>
+      <string>Profile</string>
      </property>
     </widget>
    </item>
-   <item row="8" column="2" colspan="5">
+   <item row="8" column="0" colspan="2">
+    <widget class="QLabel" name="label_8">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Direction</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="2" colspan="6">
     <widget class="QWidget" name="widget" native="true">
      <layout class="QVBoxLayout" name="verticalLayout">
       <property name="spacing">
@@ -314,35 +445,25 @@
      </layout>
     </widget>
    </item>
-   <item row="16" column="2" colspan="2">
-    <widget class="QLabel" name="label_12">
-     <property name="text">
-      <string>Depth</string>
-     </property>
-    </widget>
-   </item>
-   <item row="12" column="2" colspan="2">
-    <widget class="QComboBox" name="DepthType">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
+   <item row="10" column="2" colspan="6">
+    <widget class="QComboBox" name="ThreadFit">
+     <property name="toolTip">
+      <string>Hole fit, only available for holes without thread</string>
      </property>
      <item>
       <property name="text">
-       <string>Dimension</string>
+       <string>Standard fit</string>
       </property>
      </item>
      <item>
       <property name="text">
-       <string>Through all</string>
+       <string>Close fit</string>
       </property>
      </item>
     </widget>
    </item>
-   <item row="18" column="0" colspan="7">
-    <widget class="QLabel" name="label_9">
+   <item row="9" column="0">
+    <widget class="QLabel" name="label_4">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
        <horstretch>0</horstretch>
@@ -350,81 +471,11 @@
       </sizepolicy>
      </property>
      <property name="text">
-      <string>&lt;b&gt;Drill point&lt;/b&gt;</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+      <string>Size</string>
      </property>
     </widget>
    </item>
-   <item row="6" column="2">
-    <widget class="QLabel" name="label_CutoffInner">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="text">
-      <string>Cutoff inner</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="2">
-    <widget class="QLabel" name="label_Angle">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="text">
-      <string>Angle</string>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="2">
-    <widget class="QLabel" name="label_CutoffOuter">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="text">
-      <string>Cutoff outer</string>
-     </property>
-    </widget>
-   </item>
-   <item row="9" column="2" colspan="5">
-    <widget class="QComboBox" name="ThreadSize"/>
-   </item>
-   <item row="21" column="0" colspan="2">
-    <widget class="QCheckBox" name="Tapered">
-     <property name="text">
-      <string>Tapered</string>
-     </property>
-    </widget>
-   </item>
-   <item row="11" column="5" colspan="2">
-    <widget class="Gui::PrefQuantitySpinBox" name="Diameter">
-     <property name="unit" stdset="0">
-      <string notr="true">mm</string>
-     </property>
-    </widget>
-   </item>
-   <item row="14" column="0">
-    <widget class="QLabel" name="label">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Type</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0" colspan="7">
-    <widget class="QLabel" name="label_13">
-     <property name="text">
-      <string>&lt;b&gt;Threading and size&lt;/b&gt;</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="2" colspan="5">
+   <item row="3" column="2" colspan="6">
     <widget class="QCheckBox" name="ModelActualThread">
      <property name="enabled">
       <bool>false</bool>
@@ -434,46 +485,18 @@
      </property>
     </widget>
    </item>
-   <item row="21" column="2" colspan="2">
-    <widget class="Gui::PrefQuantitySpinBox" name="TaperedAngle">
-     <property name="unit" stdset="0">
-      <string notr="true">deg</string>
+   <item row="11" column="3">
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
      </property>
-    </widget>
-   </item>
-   <item row="5" column="3" colspan="4">
-    <widget class="Gui::PrefQuantitySpinBox" name="ThreadAngle">
-     <property name="enabled">
-      <bool>false</bool>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
      </property>
-     <property name="unit" stdset="0">
-      <string notr="true">deg</string>
-     </property>
-    </widget>
-   </item>
-   <item row="19" column="0" colspan="2">
-    <widget class="QLabel" name="label_15">
-     <property name="text">
-      <string>Type</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-     </property>
-    </widget>
-   </item>
-   <item row="17" column="4" colspan="3">
-    <widget class="Gui::PrefQuantitySpinBox" name="HoleCutCountersinkAngle">
-     <property name="unit" stdset="0">
-      <string notr="true">deg</string>
-     </property>
-    </widget>
-   </item>
-   <item row="12" column="5" colspan="2">
-    <widget class="Gui::PrefQuantitySpinBox" name="Depth">
-     <property name="unit" stdset="0">
-      <string notr="true">mm</string>
-     </property>
-    </widget>
+    </spacer>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
- initialization: thread direction only sensible if there is a thread
- initialization: hole diameter can only be changed if there is no profile
- initialization: only enable allowed hole cut parameters
- also for the ISO profiles it is allowed to countersink/bore deeper/less deep
- UI file: add some tooltips (the other changes were done automatically by Qt's designer)