### PR TITLE
Path: 3D Surface fix to apply `CutMode` when `CutPattern = Offset`; and LGTM cleanup

### DIFF
--- a/src/Mod/Path/PathScripts/PathSurface.py
+++ b/src/Mod/Path/PathScripts/PathSurface.py
@@ -496,8 +496,8 @@ class ObjectSurface(PathOp.ObjectOp):
         # set cut mode; reverse as needed
         if obj.CutMode == 'Climb':
             self.CutClimb = True
-        if obj.CutPatternReversed is True:
-            if self.CutClimb is True:
+        if obj.CutPatternReversed:
+            if self.CutClimb:
                 self.CutClimb = False
             else:
                 self.CutClimb = True
@@ -919,9 +919,11 @@ class ObjectSurface(PathOp.ObjectOp):
         elif obj.CutPattern in ['Line', 'Spiral', 'ZigZag']:
             stpOvr = list()
             if obj.CutPattern == 'Line':
-                PNTSET = PathSurfaceSupport.pathGeomToLinesPointSet(obj, pathGeom, self.CutClimb, self.toolDiam, self.closedGap, self.gaps)
+                # PNTSET = PathSurfaceSupport.pathGeomToLinesPointSet(obj, pathGeom, self.CutClimb, self.toolDiam, self.closedGap, self.gaps)
+                PNTSET = PathSurfaceSupport.pathGeomToLinesPointSet(self, obj, pathGeom)
             elif obj.CutPattern == 'ZigZag':
-                PNTSET = PathSurfaceSupport.pathGeomToZigzagPointSet(obj, pathGeom, self.CutClimb, self.toolDiam, self.closedGap, self.gaps)
+                # PNTSET = PathSurfaceSupport.pathGeomToZigzagPointSet(obj, pathGeom, self.CutClimb, self.toolDiam, self.closedGap, self.gaps)
+                PNTSET = PathSurfaceSupport.pathGeomToZigzagPointSet(self, obj, pathGeom)
             elif obj.CutPattern == 'Spiral':
                 PNTSET = PathSurfaceSupport.pathGeomToSpiralPointSet(obj, pathGeom)
 
@@ -938,7 +940,8 @@ class ObjectSurface(PathOp.ObjectOp):
         elif obj.CutPattern in ['Circular', 'CircularZigZag']:
             # PNTSET is list, by stepover.
             # Each stepover is a list containing arc/loop descriptions, (sp, ep, cp)
-            PNTSET = PathSurfaceSupport.pathGeomToCircularPointSet(obj, pathGeom, self.CutClimb, self.toolDiam, self.closedGap, self.gaps, self.tmpCOM)
+            # PNTSET = PathSurfaceSupport.pathGeomToCircularPointSet(obj, pathGeom, self.CutClimb, self.toolDiam, self.closedGap, self.gaps, self.tmpCOM)
+            PNTSET = PathSurfaceSupport.pathGeomToCircularPointSet(self, obj, pathGeom)
 
             for so in range(0, len(PNTSET)):
                 stpOvr = list()

--- a/src/Mod/Path/PathScripts/PathSurface.py
+++ b/src/Mod/Path/PathScripts/PathSurface.py
@@ -1806,6 +1806,9 @@ class ObjectSurface(PathOp.ObjectOp):
                         lo = ocl.Line(p2, p1)
                     else:
                         lo = ocl.Line(p1, p2)
+                else:
+                    # default to line-object
+                    lo = ocl.Line(p1, p2)
             else:
                 lo = ocl.Line(p1, p2)   # line-object
 

--- a/src/Mod/Path/PathScripts/PathSurfaceSupport.py
+++ b/src/Mod/Path/PathScripts/PathSurfaceSupport.py
@@ -1488,6 +1488,12 @@ def pathGeomToCircularPointSet(self, obj, compGeoShp):
         Y = (ep[1] - sp[1])**2
         return math.sqrt(X + Y)  # the 'z' value is zero in both points
 
+    if obj.CutPatternReversed:
+        if self.CutClimb:
+            self.CutClimb = False
+        else:
+            self.CutClimb = True
+
     # Separate arc data into Loops and Arcs
     for ei in range(0, ec):
         edg = compGeoShp.Edges[ei]

--- a/src/Mod/Path/PathScripts/PathSurfaceSupport.py
+++ b/src/Mod/Path/PathScripts/PathSurfaceSupport.py
@@ -226,7 +226,6 @@ class PathGeometryGenerator:
     def _Line(self):
         GeoSet = list()
         centRot = FreeCAD.Vector(0.0, 0.0, 0.0)  # Bottom left corner of face/selection/model
-        cAng = math.atan(self.deltaX / self.deltaY)  # BoundaryBox angle
 
         # Create end points for set of lines to intersect with cross-section face
         pntTuples = list()
@@ -474,7 +473,6 @@ class ProcessSelectedFaces:
 
         # Setup STL, model type, and bound box containers for each model in Job
         for m in range(0, len(JOB.Model.Group)):
-            M = JOB.Model.Group[m]
             self.modelSTLs.append(False)
             self.profileShapes.append(False)
 
@@ -797,8 +795,6 @@ class ProcessSelectedFaces:
             PathLog.debug('Processing avoid faces.')
             cont = True
             isHole = False
-            outFCS = list()
-            intFEAT = list()
 
             outFCS, intFEAT = self.findUnifiedRegions(VDS)
             if self.obj.InternalFeaturesCut:
@@ -1318,11 +1314,10 @@ def pathGeomToLinesPointSet(obj, compGeoShp, cutClimb, toolDiam, closedGap, gaps
 
         if chkGap is True:
             if gap < obj.GapThreshold.Value:
-                b = inLine.pop()  # pop off 'BRK' marker
+                inLine.pop()  # pop off 'BRK' marker
                 (vA, vB) = inLine.pop()  # pop off previous line segment for combining with current
                 tup = (vA, tup[1])
                 closedGap = True
-                True if closedGap else False  # used closedGap for LGTM
             else:
                 gap = round(gap, 6)
                 if gap < gaps[0]:
@@ -1417,7 +1412,7 @@ def pathGeomToZigzagPointSet(obj, compGeoShp, cutClimb, toolDiam, closedGap, gap
 
         if chkGap:
             if gap < obj.GapThreshold.Value:
-                b = inLine.pop()  # pop off 'BRK' marker
+                inLine.pop()  # pop off 'BRK' marker
                 (vA, vB) = inLine.pop()  # pop off previous line segment for combining with current
                 if dirFlg == 1:
                     tup = (vA, tup[1])
@@ -1887,7 +1882,6 @@ class FindUnifiedRegions:
 
     def _groupEdgesByLength(self):
         PathLog.debug('_groupEdgesByLength()')
-        cont = True
         threshold = self.geomToler
         grp = list()
         processLast = False
@@ -1909,7 +1903,6 @@ class FindUnifiedRegions:
             actvItem = DATA[actvIdx][0]  # 0 index is length
             grp.append(actvIdx)
             idxCnt -= 1
-            noMatch = True
 
             while idxCnt > 0:
                 tstIdx = indexes[0]
@@ -1922,7 +1915,6 @@ class FindUnifiedRegions:
                     indexes.pop(0)
                     idxCnt -= 1
                     grp.append(tstIdx)
-                    noMatch = False
                 else:
                     if len(grp) > 1:
                         # grp.sort()
@@ -1939,7 +1931,6 @@ class FindUnifiedRegions:
     def _identifySharedEdgesByLength(self, grp):
         PathLog.debug('_identifySharedEdgesByLength()')
         holds = list()
-        cont = True
         specialIndexes = []
         threshold = self.geomToler
 
@@ -1949,7 +1940,6 @@ class FindUnifiedRegions:
         # Sort edgeData data
         self.edgeData.sort(key=keyFirst)
         DATA = self.edgeData
-        lenDATA = len(DATA)
         lenGrp = len(grp)
 
         while lenGrp > 0:
@@ -2000,10 +1990,7 @@ class FindUnifiedRegions:
         PathLog.debug('_extractWiresFromEdges()')
         DATA = self.edgeData
         holds = list()
-        lastEdge = None
-        lastIdx = None
         firstEdge = None
-        isWire = False
         cont = True
         connectedEdges = []
         connectedIndexes = []
@@ -2086,8 +2073,6 @@ class FindUnifiedRegions:
             # Put holds indexes back in search stack
             if notConnected:
                 holds.append(actvIdx)
-                if idxCnt == 0:
-                    lastLoop = True
             holds.extend(indexes)
             indexes = holds
             idxCnt = len(indexes)
@@ -2101,7 +2086,6 @@ class FindUnifiedRegions:
         numLoops = len(LOOPS)
         PathLog.debug(' -numLoops: {}.'.format(numLoops))
         if numLoops > 0:
-            FACES = list()
             for li in range(0, numLoops):
                 Edges = LOOPS[li]
                 #for e in Edges:
@@ -2576,11 +2560,11 @@ class OCL_Tool():
         # Engraver or V-bit cutter
         # OCL -> ConeCutter::ConeCutter(diameter, angle, length)
         if (self.diameter == -1.0 or
-            self.cutEdgeAngle == -1.0 or self.cutEdgeHeight == -1.0):
+            self.cuttingEdgeAngle == -1.0 or self.cutEdgeHeight == -1.0):
             return
         self.oclTool = self.ocl.ConeCutter(
                             self.diameter,
-                            self.cutEdgeAngle/2.,
+                            self.cuttingEdgeAngle,
                             self.cutEdgeHeight + self.lengthOffset
                         )
 

--- a/src/Mod/Path/PathScripts/PathWaterline.py
+++ b/src/Mod/Path/PathScripts/PathWaterline.py
@@ -1441,11 +1441,14 @@ class ObjectWaterline(PathOp.ObjectOp):
             self.showDebugObject(pathGeom, 'PathGeom_{}'.format(round(csHght, 2)))
 
             if cutPattern == 'Line':
-                pntSet = PathSurfaceSupport.pathGeomToLinesPointSet(obj, pathGeom, self.CutClimb, self.toolDiam, self.closedGap, self.gaps)
+                # pntSet = PathSurfaceSupport.pathGeomToLinesPointSet(obj, pathGeom, self.CutClimb, self.toolDiam, self.closedGap, self.gaps)
+                pntSet = PathSurfaceSupport.pathGeomToLinesPointSet(self, obj, pathGeom)
             elif cutPattern == 'ZigZag':
-                pntSet = PathSurfaceSupport.pathGeomToZigzagPointSet(obj, pathGeom, self.CutClimb, self.toolDiam, self.closedGap, self.gaps)
+                # pntSet = PathSurfaceSupport.pathGeomToZigzagPointSet(obj, pathGeom, self.CutClimb, self.toolDiam, self.closedGap, self.gaps)
+                pntSet = PathSurfaceSupport.pathGeomToZigzagPointSet(self, obj, pathGeom)
             elif cutPattern in ['Circular', 'CircularZigZag']:
-                pntSet = PathSurfaceSupport.pathGeomToCircularPointSet(obj, pathGeom, self.CutClimb, self.toolDiam, self.closedGap, self.gaps, self.tmpCOM)
+                # pntSet = PathSurfaceSupport.pathGeomToCircularPointSet(obj, pathGeom, self.CutClimb, self.toolDiam, self.closedGap, self.gaps, self.tmpCOM)
+                pntSet = PathSurfaceSupport.pathGeomToCircularPointSet(self, obj, pathGeom)
             elif cutPattern == 'Spiral':
                 pntSet = PathSurfaceSupport.pathGeomToSpiralPointSet(obj, pathGeom)
 


### PR DESCRIPTION
Issue reported in forum at, [Re: Separate 3D Surface and Waterline (new feature) [Merged]](https://forum.freecadweb.org/viewtopic.php?f=15&t=44473&p=441615#p412303)


Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
