### PR TITLE
[Part] remove unnecessary vertical whitespace in dialogs

### DIFF
--- a/src/Mod/Part/Gui/DlgPrimitives.ui
+++ b/src/Mod/Part/Gui/DlgPrimitives.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>360</width>
-    <height>380</height>
+    <height>294</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -2152,19 +2152,6 @@
              </widget>
             </item>
            </layout>
-          </item>
-          <item row="1" column="0">
-           <spacer name="verticalSpacer_4">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>0</height>
-             </size>
-            </property>
-           </spacer>
           </item>
          </layout>
         </widget>

--- a/src/Mod/Part/Gui/Location.ui
+++ b/src/Mod/Part/Gui/Location.ui
@@ -50,19 +50,6 @@
         </item>
        </layout>
       </item>
-      <item row="2" column="0">
-       <spacer>
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
      </layout>
     </widget>
    </item>

--- a/src/Mod/Part/Gui/TaskShapeBuilder.ui
+++ b/src/Mod/Part/Gui/TaskShapeBuilder.ui
@@ -125,10 +125,13 @@
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Fixed</enum>
+     </property>
      <property name="sizeHint" stdset="0">
       <size>
        <width>20</width>
-       <height>127</height>
+       <height>20</height>
       </size>
      </property>
     </spacer>


### PR DESCRIPTION
on smaller screens it is very annoying that the Part dialogs have too much vertical whitespace.

This PR gets rid of some unnecessary whitespace.

New layouts:
![FreeCAD_lO3LD4QgE5](https://user-images.githubusercontent.com/1828501/97096005-75936000-1666-11eb-868e-39731152f4cc.png)

![FreeCAD_6ybBdUKUYN](https://user-images.githubusercontent.com/1828501/97096003-74623300-1666-11eb-9084-a6adc0aa5950.png)
![FreeCAD_RCG4YQcMgz](https://user-images.githubusercontent.com/1828501/97096004-74fac980-1666-11eb-8f8a-1e761e64e283.png)
