### PR TITLE
[Part] allow to edit helices via dialog

### DIFF
--- a/src/Mod/Part/Gui/DlgPrimitives.h
+++ b/src/Mod/Part/Gui/DlgPrimitives.h
@@ -60,9 +60,16 @@ class DlgPrimitives : public QWidget
     Q_OBJECT
 
 public:
-    DlgPrimitives(QWidget* parent = 0);
+    enum PrimitiveType {
+        Plane, Box, Cylinder, Cone, Sphere, Ellipsoid, Torus, Prism, Wedge,
+        Helix, Spiral, Circle, Ellipse, Point, Line, RegPolygon
+    };
+
+    DlgPrimitives(QWidget* parent = 0, PrimitiveType type = PrimitiveType::Plane,
+        bool edit = false, const char* ObjectName = "");
     ~DlgPrimitives();
     void createPrimitive(const QString&);
+    void accept(const QString&);
 
 private Q_SLOTS:
     void on_buttonCircleFromThreePoints_clicked();
@@ -80,7 +87,7 @@ class Location : public QWidget
     Q_OBJECT
 
 public:
-    Location(QWidget* parent = 0);
+    Location(QWidget* parent = 0, bool edit = false, const char* ObjectName = "");
     ~Location();
     QString toPlacement() const;
 
@@ -105,13 +112,31 @@ public:
 public:
     bool accept();
     bool reject();
-
     QDialogButtonBox::StandardButtons getStandardButtons() const;
     void modifyStandardButtons(QDialogButtonBox*);
 
 private:
     DlgPrimitives* widget;
     Location* location;
+};
+
+class TaskPrimitivesEdit : public Gui::TaskView::TaskDialog
+{
+    Q_OBJECT
+
+public:
+    TaskPrimitivesEdit(DlgPrimitives::PrimitiveType type, const char* ObjectName);
+    ~TaskPrimitivesEdit();
+    
+public:
+    bool accept();
+    bool reject();
+    QDialogButtonBox::StandardButtons getStandardButtons() const;
+    void modifyStandardButtons(QDialogButtonBox*);
+
+private:
+    DlgPrimitives* widget;
+    Location* location; 
 };
 
 } // namespace PartGui

--- a/src/Mod/Part/Gui/Location.ui
+++ b/src/Mod/Part/Gui/Location.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>209</width>
-    <height>205</height>
+    <width>280</width>
+    <height>307</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -16,52 +16,229 @@
   <property name="sizeGripEnabled" stdset="0">
    <bool>true</bool>
   </property>
-  <layout class="QGridLayout" name="gridLayout_2">
-   <item row="0" column="0">
-    <widget class="QGroupBox" name="groupBox">
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QGroupBox" name="PositionGB">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="title">
       <string>Position</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
       <item row="0" column="0">
-       <widget class="Gui::LocationWidget" name="loc"/>
-      </item>
-      <item row="1" column="0">
-       <layout class="QHBoxLayout" name="horizontalLayout">
+       <layout class="QHBoxLayout" name="horizontalLayout_5">
         <item>
-         <spacer name="horizontalSpacer">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
+         <widget class="QLabel" name="labelLength2_2">
+          <property name="text">
+           <string>X</string>
           </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
+         </widget>
         </item>
         <item>
-         <widget class="QPushButton" name="viewPositionButton">
+         <widget class="Gui::QuantitySpinBox" name="XPositionQSB">
+          <property name="unit" stdset="0">
+           <string notr="true"/>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="1" column="0">
+       <layout class="QHBoxLayout" name="horizontalLayout_8">
+        <item>
+         <widget class="QLabel" name="labelLength2_3">
           <property name="text">
-           <string>3D View</string>
+           <string>Y</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="Gui::QuantitySpinBox" name="YPositionQSB">
+          <property name="unit" stdset="0">
+           <string notr="true"/>
           </property>
          </widget>
         </item>
        </layout>
       </item>
       <item row="2" column="0">
-       <spacer>
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
+       <layout class="QHBoxLayout" name="horizontalLayout_9">
+        <item>
+         <widget class="QLabel" name="labelLength2_4">
+          <property name="text">
+           <string>Z</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="Gui::QuantitySpinBox" name="ZPositionQSB">
+          <property name="unit" stdset="0">
+           <string notr="true"/>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="RotationGB">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="title">
+      <string>Rotation</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_2">
+      <item row="0" column="0">
+       <widget class="QGroupBox" name="RotationAxisGB">
+        <property name="enabled">
+         <bool>true</bool>
         </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
+        <property name="toolTip">
+         <string>Use custom vector for pad direction otherwise
+the sketch plane's normal vector will be used</string>
         </property>
-       </spacer>
+        <property name="title">
+         <string>Rotation axis direction</string>
+        </property>
+        <property name="checkable">
+         <bool>false</bool>
+        </property>
+        <layout class="QVBoxLayout" name="verticalLayout_3">
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout_6">
+           <item>
+            <widget class="QLabel" name="labelXSkew">
+             <property name="text">
+              <string>x</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="Gui::DoubleSpinBox" name="XDirectionEdit">
+             <property name="toolTip">
+              <string>x-component of direction vector</string>
+             </property>
+             <property name="keyboardTracking">
+              <bool>false</bool>
+             </property>
+             <property name="minimum">
+              <double>-100.000000000000000</double>
+             </property>
+             <property name="maximum">
+              <double>100.000000000000000</double>
+             </property>
+             <property name="singleStep">
+              <double>0.100000000000000</double>
+             </property>
+             <property name="unit" stdset="0">
+              <string notr="true"/>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout_7">
+           <item>
+            <widget class="QLabel" name="labelYSkew">
+             <property name="text">
+              <string>y</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="Gui::DoubleSpinBox" name="YDirectionEdit">
+             <property name="toolTip">
+              <string>y-component of direction vector</string>
+             </property>
+             <property name="keyboardTracking">
+              <bool>false</bool>
+             </property>
+             <property name="minimum">
+              <double>-100.000000000000000</double>
+             </property>
+             <property name="maximum">
+              <double>100.000000000000000</double>
+             </property>
+             <property name="singleStep">
+              <double>0.100000000000000</double>
+             </property>
+             <property name="unit" stdset="0">
+              <string notr="true"/>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout_18">
+           <item>
+            <widget class="QLabel" name="labelZSkew">
+             <property name="text">
+              <string>z</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="Gui::DoubleSpinBox" name="ZDirectionEdit">
+             <property name="toolTip">
+              <string>z-component of direction vector</string>
+             </property>
+             <property name="keyboardTracking">
+              <bool>false</bool>
+             </property>
+             <property name="minimum">
+              <double>-100.000000000000000</double>
+             </property>
+             <property name="maximum">
+              <double>100.000000000000000</double>
+             </property>
+             <property name="singleStep">
+              <double>0.100000000000000</double>
+             </property>
+             <property name="value">
+              <double>1.000000000000000</double>
+             </property>
+             <property name="unit" stdset="0">
+              <string notr="true"/>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <layout class="QHBoxLayout" name="horizontalLayout_4">
+        <item>
+         <widget class="QLabel" name="labelLength2">
+          <property name="text">
+           <string>Angle</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="Gui::QuantitySpinBox" name="AngleQSB">
+          <property name="unit" stdset="0">
+           <string notr="true"/>
+          </property>
+          <property name="singleStep">
+           <double>5.000000000000000</double>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
      </layout>
     </widget>
@@ -71,9 +248,14 @@
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
   <customwidget>
-   <class>Gui::LocationWidget</class>
+   <class>Gui::QuantitySpinBox</class>
    <extends>QWidget</extends>
-   <header>Gui/InputVector.h</header>
+   <header>Gui/QuantitySpinBox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>Gui::DoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>Gui/SpinBox.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/src/Mod/Part/Gui/ViewProviderHelixParametric.cpp
+++ b/src/Mod/Part/Gui/ViewProviderHelixParametric.cpp
@@ -27,6 +27,9 @@
 # include <Python.h>
 #endif
 
+#include <Gui/Application.h>
+#include <Gui/Control.h>
+#include "DlgPrimitives.h"
 #include "ViewProviderHelixParametric.h"
 
 using namespace PartGui;
@@ -53,6 +56,46 @@ std::vector<std::string> ViewProviderHelixParametric::getDisplayModes(void) cons
     StrList.push_back("Points");
 
     return StrList;
+}
+
+void ViewProviderHelixParametric::setupContextMenu(QMenu* menu, QObject* receiver, const char* member)
+{
+    QAction* act;
+    act = menu->addAction(QObject::tr("Edit helix"), receiver, member);
+    act->setData(QVariant((int)ViewProvider::Default));
+    ViewProviderSpline::setupContextMenu(menu, receiver, member);
+}
+
+void ViewProviderHelixParametric::updateData(const App::Property* prop)
+{
+    PartGui::ViewProviderSpline::updateData(prop);
+}
+
+bool ViewProviderHelixParametric::setEdit(int ModNum)
+{
+    if (ModNum == ViewProvider::Default) {
+        if (Gui::Control().activeDialog())
+            return false;
+        auto ObjectName = getObject()->getNameInDocument();
+        PartGui::TaskPrimitivesEdit* dlg
+            = new PartGui::TaskPrimitivesEdit(PartGui::DlgPrimitives::PrimitiveType::Helix, ObjectName);
+        Gui::Control().showDialog(dlg);
+        return true;
+    }
+    else {
+        ViewProviderSpline::setEdit(ModNum);
+        return true;
+    }
+}
+
+void ViewProviderHelixParametric::unsetEdit(int ModNum)
+{
+    if (ModNum == ViewProvider::Default) {
+        Gui::Control().closeDialog();
+    }
+    else {
+        ViewProviderSpline::unsetEdit(ModNum);
+    }
 }
 
 // ------------------------------------------------------------------

--- a/src/Mod/Part/Gui/ViewProviderHelixParametric.h
+++ b/src/Mod/Part/Gui/ViewProviderHelixParametric.h
@@ -39,6 +39,13 @@ public:
     /// destructor
     virtual ~ViewProviderHelixParametric();
     std::vector<std::string> getDisplayModes(void) const;
+    void setupContextMenu(QMenu*, QObject*, const char*);
+
+protected:
+    void updateData(const App::Property*);
+    bool setEdit(int ModNum);
+    void unsetEdit(int ModNum);
+
 };
 
 class PartGuiExport ViewProviderSpiralParametric : public ViewProviderSpline


### PR DESCRIPTION
fixes https://tracker.freecadweb.org/view.php?id=3857

Currently primitives of the Part WB can only be created suing a dialog. Editing is not possible that way.

This PR makes the first step in achieving this:

- Helices can now be edited using the same dialog ans when created

- New location dialog. The Gui::LocationWidget used there is not aware of the rotation angle and it treats the rotation axis as direction. To fix this, I set changed the dialog so that one can define every parameter as in the PartDesign attacher dialog (Placement, rotation axis and rotation angle separately). Another reason for this change was that one could not use the location dialog, fill it with the placement properties of the object, and close the dialog without any change. Because of the missing angle info the objects was then always rotated despite nothing was changed.

If this PR goes in, I will extend it for the other primitives.

Todo for the future: allow a preview of the changes made in the dialog. (I could not find out how this is done.)