### PR TITLE
Draft: Draft_Dimension_linked_geometry_fix

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_dimensions.py
+++ b/src/Mod/Draft/draftguitools/gui_dimensions.py
@@ -168,7 +168,7 @@ class Dimension(gui_base_original.Creator):
                     if v.Point == edge.Vertexes[1].Point:
                         v2 = i
 
-                if v1 and v2:
+                if v1 != None and v2 != None: # note that v1 or v2 can be zero
                     self.link = [sel_object.Object, v1, v2]
             elif DraftGeomUtils.geomType(edge) == "Circle":
                 self.node.extend([edge.Curve.Center,


### PR DESCRIPTION
Linked geometry was not handled if the selected edge started or ended at vertex zero.