### PR TITLE
Draft: Fixes in gui_offset

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_offset.py
+++ b/src/Mod/Draft/draftguitools/gui_offset.py
@@ -181,7 +181,7 @@ class Offset(gui_base_original.Modifier):
                                                    self.point)
                     v2 = DraftGeomUtils.getTangent(self.shape.Edges[dist[1]],
                                                    self.point)
-                    a = -DraftVecUtils.angle(v1, v2)
+                    a = -DraftVecUtils.angle(v1, v2, plane.axis)
                     self.dvec = DraftVecUtils.rotate(d, a, plane.axis)
                     occmode = self.ui.occOffset.isChecked()
                     utils.param.SetBool("Offset_OCC", occmode)
@@ -196,7 +196,7 @@ class Offset(gui_base_original.Modifier):
                     self.npts = []
                     for p in self.sel.Points:
                         currtan = DraftGeomUtils.getTangent(e, p)
-                        a = -DraftVecUtils.angle(currtan, basetan)
+                        a = -DraftVecUtils.angle(currtan, basetan, plane.axis)
                         self.dvec = DraftVecUtils.rotate(d, a, plane.axis)
                         self.npts.append(p.add(self.dvec))
                     self.ghost.update(self.npts)
@@ -294,6 +294,13 @@ class Offset(gui_base_original.Modifier):
                     delta = str(rad)
                 else:
                     _err("Draft.Offset error: Unhandled case")
+            # to offset bspline
+            elif self.mode == "BSpline":
+                new_points = []
+                for old_point, new_point in zip(self.sel.Points, self.npts):
+                    diff_direction = new_point.sub(old_point).normalize()
+                    new_points.append(old_point.add(diff_direction*rad))
+                delta = DraftVecUtils.toString(new_points)
             else:
                 self.dvec.normalize()
                 self.dvec.multiply(rad)
@@ -301,6 +308,7 @@ class Offset(gui_base_original.Modifier):
             copymode = False
             occmode = self.ui.occOffset.isChecked()
             utils.param.SetBool("Offset_OCC", occmode)
+
             if self.ui.isCopy.isChecked():
                 copymode = True
             Gui.addModule("Draft")


### PR DESCRIPTION
The offset operation for polylines and b-splines in planes other than XY usually produces erroneous results. This is solved by specifying the normal of the WorkingPlane.
The distance input field in the offset dialog for bsplines is fixed. (Previously it didn't work).


Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [*] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
