### PR TITLE
Fix various typos [skip-ci]

### DIFF
--- a/src/Mod/PartDesign/App/FeatureHole.cpp
+++ b/src/Mod/PartDesign/App/FeatureHole.cpp
@@ -1421,7 +1421,7 @@ void Hole::readCutDefinitions()
         ::App::Application::getUserAppDataDir() + subpath,
     };
 
-    std::cerr << "Looking for thread definitons in: ";
+    std::cerr << "Looking for thread definitions in: ";
     for (auto &i : dirs)
         std::cerr << i << " ";
     std::cerr << "\n";

--- a/src/Mod/PartDesign/App/json.hpp
+++ b/src/Mod/PartDesign/App/json.hpp
@@ -5142,7 +5142,7 @@ auto input_adapter(T (&array)[N]) -> decltype(input_adapter(array, array + N))
 }
 
 // This class only handles inputs of input_buffer_adapter type.
-// It's required so that expressions like {ptr, len} can be implicitely casted
+// It's required so that expressions like {ptr, len} can be implicitly casted
 // to the correct adapter.
 class span_input_adapter
 {
@@ -9916,7 +9916,7 @@ class binary_reader
 
     @return whether conversion completed
 
-    @note This function needs to respect the system's endianess, because
+    @note This function needs to respect the system's endianness, because
           bytes in CBOR, MessagePack, and UBJSON are stored in network order
           (big endian) and therefore need reordering on little endian systems.
     */
@@ -10088,7 +10088,7 @@ class binary_reader
     /// the number of characters read
     std::size_t chars_read = 0;
 
-    /// whether we can assume little endianess
+    /// whether we can assume little endianness
     const bool is_little_endian = little_endianess();
 
     /// the SAX parser
@@ -14227,7 +14227,7 @@ class binary_writer
     @tparam OutputIsLittleEndian Set to true if output data is
                                  required to be little endian
 
-    @note This function needs to respect the system's endianess, because bytes
+    @note This function needs to respect the system's endianness, because bytes
           in CBOR, MessagePack, and UBJSON are stored in network order (big
           endian) and therefore need reordering on little endian systems.
     */
@@ -14310,7 +14310,7 @@ class binary_writer
     }
 
   private:
-    /// whether we can assume little endianess
+    /// whether we can assume little endianness
     const bool is_little_endian = little_endianess();
 
     /// the output
@@ -17385,7 +17385,7 @@ class basic_json
        - If a subtype is given and the binary array contains exactly 1, 2, 4, 8,
          or 16 elements, the fixext family (fixext1, fixext2, fixext4, fixext8)
          is used. For other sizes, the ext family (ext8, ext16, ext32) is used.
-         The subtype is then added as singed 8-bit integer.
+         The subtype is then added as signed 8-bit integer.
        - If no subtype is given, the bin family (bin8, bin16, bin32) is used.
     - BSON
        - If a subtype is given, it is used and added as unsigned 8-bit integer.
@@ -21337,7 +21337,7 @@ class basic_json
           `key()` returns an empty string.
 
     @warning Using `items()` on temporary objects is dangerous. Make sure the
-             object's lifetime exeeds the iteration. See
+             object's lifetime exceeds the iteration. See
              <https://github.com/nlohmann/json/issues/2040> for more
              information.
 

--- a/src/Mod/Path/App/VoronoiEdgePyImp.cpp
+++ b/src/Mod/Path/App/VoronoiEdgePyImp.cpp
@@ -557,7 +557,7 @@ PyObject* VoronoiEdgePy::toShape(PyObject *args)
         // parabola: (x - p)^2 = 4*focal*(y - q)   |  (p,q) ... location of parabola
         focal = (flenX * flenX) / (4 * fabs(flenY));
         if (dbg) {
-          std::cerr << "segement" << segment << ", point" << point << std::endl;
+          std::cerr << "segment" << segment << ", point" << point << std::endl;
           std::cerr << "  loc" << loc << ", axis" << axis << std::endl;
           std::cerr << "  dist0(" << dist0 << " : " << flenX0 << ", dist1(" << dist1 << " : " << flenX1 << ")" << std::endl;
           std::cerr << "  z(" << z0 << ", " << zx << ", " << z1 << ")" << std::endl;

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -6177,7 +6177,7 @@ void SketchObject::rebuildExternalGeometry(void)
                                         P2 = ProjPointOnPlane_XYZ(pntL, sketchPlane);
                                         // P1 = P1, already defined
                                     } else {
-                                        // P1 = P1, alreday defined
+                                        // P1 = P1, already defined
                                         // P2 = P2, already defined
                                     }
                                 } else {

--- a/src/Mod/TechDraw/Gui/QGIFace.cpp
+++ b/src/Mod/TechDraw/Gui/QGIFace.cpp
@@ -223,7 +223,7 @@ void QGIFace::loadSvgHatch(std::string fileSpec)
     }
     m_svgXML = f.readAll();
 
-    // search in the file for the "stroke" specifiction in order to find out what declaration style is used
+    // search in the file for the "stroke" specification in order to find out what declaration style is used
     // this is necessary to apply a color set by the user to the SVG
     QByteArray pattern("stroke:");
     QByteArrayMatcher matcher(pattern);


### PR DESCRIPTION
Found via `codespell v2.0.dev`  
```
codespell -q 3 -L aci,ake,aline,alle,alledges,alocation,als,ang,anid,ba,beginn,behaviour,bloaded,byteorder,calculater,cancelled,cancelling,cas,cascade,centimetre,childs,colour,colours,commen,connexion,currenty,dof,doubleclick,dum,eiter,elemente,ende,feld,finde,findf,freez,hist,iff,indicies,initialisation,initialise,initialised,initialises,initialisiert,ist,kilometre,lod,mantatory,methode,metres,millimetre,modell,nd,noe,normale,normaly,nto,numer,oder,orgin,orginx,orginy,ot,pard,pres,programm,que,recurrance,rougly,seperator,serie,sinc,strack,substraction,te,thist,thru,tread,uint,unter,vertexes,wallthickness,whitespaces -S ./.git,*.po,*.ts,./ChangeLog.txt,./src/3rdParty,./src/Mod/Assembly/App/opendcm,./src/CXX,./src/zipios++,./src/Base/swig*,./src/Mod/Robot/App/kdl_cp,./src/Mod/Import/App/SCL,./src/WindowsInstaller,./src/Doc/FreeCAD.uml
```