### PR TITLE
Surface : prevent GeomFillSurface to produce C0-continuity surface

### DIFF
--- a/src/Mod/Surface/App/FeatureGeomFillSurface.cpp
+++ b/src/Mod/Surface/App/FeatureGeomFillSurface.cpp
@@ -338,6 +338,8 @@ void GeomFillSurface::createBSplineSurface(TopoDS_Wire& aWire)
         else {
             // try to convert it into a B-spline
             Handle(Geom_TrimmedCurve) trim = new Geom_TrimmedCurve(c_geom, u1, u2);
+            // Approximate the curve to non-rational polynomial BSpline
+            // to avoid C0 continuity in output surface
             GeomConvert conv;
             Convert_ParameterisationType paratype = Convert_Polynomial;
             Handle(Geom_BSplineCurve) bspline2 = conv.CurveToBSplineCurve(trim, paratype);
@@ -346,7 +348,7 @@ void GeomFillSurface::createBSplineSurface(TopoDS_Wire& aWire)
                 curves.push_back(bspline2);
             }
             else {
-                // BRepBuilderAPI_NurbsConvert failed, try ShapeConstruct_Curve now
+                // GeomConvert failed, try ShapeConstruct_Curve now
                 ShapeConstruct_Curve scc;
                 Handle(Geom_BSplineCurve) spline = scc.ConvertToBSpline(c_geom, u1, u2, Precision::Confusion());
                 if (spline.IsNull())
@@ -368,13 +370,6 @@ void GeomFillSurface::createBSplineSurface(TopoDS_Wire& aWire)
                 curves[i]->Reverse();
         }
     }
-//     for (std::size_t i=0; i<edgeCount; i++) {
-//         if (curves[i]->Continuity() == GeomAbs_Shape::GeomAbs_C0) {
-//             Handle(Geom_BSplineCurve) c1_curve = GeomConvert::CurveToBSplineCurve(curves[i], Convert_ParameterisationType::Convert_Polynomial);
-//             curves[i] = c1_curve;
-//         }
-//     }
-    
     if (edgeCount == 2) {
         aSurfBuilder.Init(curves[0], curves[1], fstyle);
     }


### PR DESCRIPTION
The conic input curves will be approximated to polynomial BSplines instead of exact rational ones.
This will avoid BOP-check "GeomAbs_C0" error.
The surface will work better for 3D offset.
The OCCT function used ([GeomFill_BSplineCurves](url=https://dev.opencascade.org/doc/refman/html/class_geom_fill___b_spline_curves.html)) have a warning for rational curves : 
"Warning Some problems may show up with rational curves. "

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
