### PR TITLE
[Sketcher] Fix #4478 - Release handler in commands where not needed

### DIFF
--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -255,6 +255,22 @@ bool SketcherGui::IsPointAlreadyOnCurve(int GeoIdCurve, int GeoIdPoint, Sketcher
     return Obj->isPointOnCurve(GeoIdCurve, p.x, p.y);
 }
 
+bool SketcherGui::ReleaseHandler(Gui::Document* doc) {
+    if (doc) {
+        if (doc->getInEdit() && doc->getInEdit()->isDerivedFrom(SketcherGui::ViewProviderSketch::getClassTypeId())) {
+            SketcherGui::ViewProviderSketch* vp = static_cast<SketcherGui::ViewProviderSketch*> (doc->getInEdit());
+
+            if (static_cast<SketcherGui::ViewProviderSketch*>(doc->getInEdit())
+                ->getSketchMode() == ViewProviderSketch::STATUS_SKETCH_UseHandler) {
+
+                vp->purgeHandler();
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 /// Makes a simple tangency constraint using extra point + tangent via point
 /// ellipse => an ellipse
 /// geom2 => any of an ellipse, an arc of ellipse, a circle, or an arc (of circle)

--- a/src/Mod/Sketcher/Gui/CommandConstraints.h
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.h
@@ -51,6 +51,9 @@ bool isConstructionPoint(const Sketcher::SketchObject* Obj, int GeoId);
 
 bool IsPointAlreadyOnCurve(int GeoIdCurve, int GeoIdPoint, Sketcher::PointPos PosIdPoint, Sketcher::SketchObject* Obj);
 
+/// Release any currently-active handler for the document.
+/// Returns true if a handler was released, and false if not
+bool ReleaseHandler(Gui::Document* doc);
 
 // These functions are declared here to promote code reuse from other modules
 

--- a/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp
+++ b/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp
@@ -62,8 +62,10 @@ bool isSketcherAcceleratorActive(Gui::Document *doc, bool actsOnSelection)
     if (doc) {
         // checks if a Sketch Viewprovider is in Edit and is in no special mode
         if (doc->getInEdit() && doc->getInEdit()->isDerivedFrom(SketcherGui::ViewProviderSketch::getClassTypeId())) {
-            if (static_cast<SketcherGui::ViewProviderSketch*>(doc->getInEdit())
-                ->getSketchMode() == ViewProviderSketch::STATUS_NONE) {
+            auto mode = static_cast<SketcherGui::ViewProviderSketch*>(doc->getInEdit())
+                ->getSketchMode();
+            if (mode == ViewProviderSketch::STATUS_NONE ||
+                mode == ViewProviderSketch::STATUS_SKETCH_UseHandler) {
                 if (!actsOnSelection)
                     return true;
                 else if (Gui::Selection().countObjectsOfType(Sketcher::SketchObject::getClassTypeId()) > 0)
@@ -108,6 +110,11 @@ CmdSketcherCloseShape::CmdSketcherCloseShape()
 void CmdSketcherCloseShape::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
+
+    // Cancel any in-progress operation
+    Gui::Document* doc = Gui::Application::Instance->activeDocument();
+    SketcherGui::ReleaseHandler(doc);
+
     // get the selection
     std::vector<Gui::SelectionObject> selection;
     selection = getSelection().getSelectionEx(0, Sketcher::SketchObject::getClassTypeId());
@@ -213,6 +220,11 @@ CmdSketcherConnect::CmdSketcherConnect()
 void CmdSketcherConnect::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
+
+    // Cancel any in-progress operation
+    Gui::Document* doc = Gui::Application::Instance->activeDocument();
+    SketcherGui::ReleaseHandler(doc);
+
     // get the selection
     std::vector<Gui::SelectionObject> selection;
     selection = getSelection().getSelectionEx(0, Sketcher::SketchObject::getClassTypeId());
@@ -293,6 +305,11 @@ CmdSketcherSelectConstraints::CmdSketcherSelectConstraints()
 void CmdSketcherSelectConstraints::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
+
+    // Cancel any in-progress operation
+    Gui::Document* doc = Gui::Application::Instance->activeDocument();
+    SketcherGui::ReleaseHandler(doc);
+
     // get the selection
     std::vector<Gui::SelectionObject> selection;
     selection = getSelection().getSelectionEx(0, Sketcher::SketchObject::getClassTypeId());
@@ -361,6 +378,7 @@ void CmdSketcherSelectOrigin::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
     Gui::Document * doc= getActiveGuiDocument();
+    ReleaseHandler(doc);
     SketcherGui::ViewProviderSketch* vp = static_cast<SketcherGui::ViewProviderSketch*>(doc->getInEdit());
     Sketcher::SketchObject* Obj= vp->getSketchObject();
 //    ViewProviderSketch * vp = static_cast<ViewProviderSketch *>(Gui::Application::Instance->getViewProvider(docobj));
@@ -404,6 +422,7 @@ void CmdSketcherSelectVerticalAxis::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
     Gui::Document * doc= getActiveGuiDocument();
+    ReleaseHandler(doc);
     SketcherGui::ViewProviderSketch* vp = static_cast<SketcherGui::ViewProviderSketch*>(doc->getInEdit());
     Sketcher::SketchObject* Obj= vp->getSketchObject();
 
@@ -445,6 +464,7 @@ void CmdSketcherSelectHorizontalAxis::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
     Gui::Document * doc= getActiveGuiDocument();
+    ReleaseHandler(doc);
     SketcherGui::ViewProviderSketch* vp = static_cast<SketcherGui::ViewProviderSketch*>(doc->getInEdit());
     Sketcher::SketchObject* Obj= vp->getSketchObject();
 
@@ -485,6 +505,7 @@ void CmdSketcherSelectRedundantConstraints::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
     Gui::Document * doc= getActiveGuiDocument();
+    ReleaseHandler(doc);
     SketcherGui::ViewProviderSketch* vp = static_cast<SketcherGui::ViewProviderSketch*>(doc->getInEdit());
     Sketcher::SketchObject* Obj= vp->getSketchObject();
 
@@ -536,6 +557,7 @@ void CmdSketcherSelectConflictingConstraints::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
     Gui::Document * doc= getActiveGuiDocument();
+    ReleaseHandler(doc);
     SketcherGui::ViewProviderSketch* vp = static_cast<SketcherGui::ViewProviderSketch*>(doc->getInEdit());
     Sketcher::SketchObject* Obj= vp->getSketchObject();
     std::string doc_name = Obj->getDocument()->getName();
@@ -587,6 +609,7 @@ void CmdSketcherSelectElementsAssociatedWithConstraints::activated(int iMsg)
     Q_UNUSED(iMsg);
     std::vector<Gui::SelectionObject> selection = Gui::Selection().getSelectionEx();
     Gui::Document * doc= getActiveGuiDocument();
+    ReleaseHandler(doc);
     SketcherGui::ViewProviderSketch* vp = static_cast<SketcherGui::ViewProviderSketch*>(doc->getInEdit());
     Sketcher::SketchObject* Obj= vp->getSketchObject();
 
@@ -706,6 +729,7 @@ void CmdSketcherSelectElementsWithDoFs::activated(int iMsg)
     Q_UNUSED(iMsg);
     getSelection().clearSelection();
     Gui::Document * doc= getActiveGuiDocument();
+    ReleaseHandler(doc);
     SketcherGui::ViewProviderSketch* vp = static_cast<SketcherGui::ViewProviderSketch*>(doc->getInEdit());
     Sketcher::SketchObject* Obj= vp->getSketchObject();
 
@@ -804,6 +828,11 @@ CmdSketcherRestoreInternalAlignmentGeometry::CmdSketcherRestoreInternalAlignment
 void CmdSketcherRestoreInternalAlignmentGeometry::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
+
+    // Cancel any in-progress operation
+    Gui::Document* doc = Gui::Application::Instance->activeDocument();
+    SketcherGui::ReleaseHandler(doc);
+
     // get the selection
     std::vector<Gui::SelectionObject> selection;
     selection = getSelection().getSelectionEx(0, Sketcher::SketchObject::getClassTypeId());
@@ -893,6 +922,11 @@ CmdSketcherSymmetry::CmdSketcherSymmetry()
 void CmdSketcherSymmetry::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
+
+    // Cancel any in-progress operation
+    Gui::Document* doc = Gui::Application::Instance->activeDocument();
+    SketcherGui::ReleaseHandler(doc);
+
     // get the selection
     std::vector<Gui::SelectionObject> selection;
     selection = getSelection().getSelectionEx(0, Sketcher::SketchObject::getClassTypeId());
@@ -1930,6 +1964,7 @@ void CmdSketcherDeleteAllGeometry::activated(int iMsg)
     if (ret == QMessageBox::Yes) {
         getSelection().clearSelection();
         Gui::Document * doc= getActiveGuiDocument();
+        ReleaseHandler(doc);
         SketcherGui::ViewProviderSketch* vp = static_cast<SketcherGui::ViewProviderSketch*>(doc->getInEdit());
         Sketcher::SketchObject* Obj= vp->getSketchObject();
 
@@ -1989,6 +2024,7 @@ void CmdSketcherDeleteAllConstraints::activated(int iMsg)
     if (ret == QMessageBox::Yes) {
         getSelection().clearSelection();
         Gui::Document * doc= getActiveGuiDocument();
+        ReleaseHandler(doc);
         SketcherGui::ViewProviderSketch* vp = static_cast<SketcherGui::ViewProviderSketch*>(doc->getInEdit());
         Sketcher::SketchObject* Obj= vp->getSketchObject();
 

--- a/src/Mod/Sketcher/Gui/TaskSketcherConstrains.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstrains.cpp
@@ -42,6 +42,7 @@
 #include "ViewProviderSketch.h"
 
 #include <Mod/Sketcher/App/SketchObject.h>
+#include <Mod/Sketcher/Gui/CommandConstraints.h>
 
 #include <Base/Tools.h>
 #include <App/Application.h>
@@ -442,6 +443,22 @@ void ConstraintView::contextMenuEvent (QContextMenuEvent* event)
     QMenu menu;
     QListWidgetItem* item = currentItem();
     QList<QListWidgetItem *> items = selectedItems();
+
+    // Cancel any in-progress operation
+    Gui::Document* doc = Gui::Application::Instance->activeDocument();
+    bool didRelease = SketcherGui::ReleaseHandler(doc);
+
+    // Sync the FreeCAD selection with the selection in the ConstraintView widget
+    if (didRelease) {
+        Gui::Selection().clearSelection();
+        for (auto&& it : items) {
+            auto ci = static_cast<ConstraintItem*>(it);
+            std::string constraint_name = Sketcher::PropertyConstraintList::getConstraintName(ci->ConstraintNbr);
+            std::string doc_name = ci->sketchView->getSketchObject()->getDocument()->getName();
+            std::string obj_name = ci->sketchView->getSketchObject()->getNameInDocument();
+            Gui::Selection().addSelection(doc_name.c_str(), obj_name.c_str(), constraint_name.c_str());
+        }
+    }
 
     bool isQuantity = false;
     bool isToggleDriving = false;


### PR DESCRIPTION
Fixes #4478: Active constraint tool blocks sidebar tasks from working.

Many Sketcher commands are interrupted by the existence of a handler. Rather than having these commands silently cancel, purge the handler if a command executes that does not need it. Forums discussion [here](https://forum.freecadweb.org/viewtopic.php?f=10&t=51833).

This fix is in three parts: first, `isSketcherAcceleratorActive()` is modified to allow `Mode==STATUS_SKETCH_UseHandler` in addition to `Mode==STATUS_NONE`.

Second, each Sketcher command that depends on isSketcherAcceleratorActive() to determine its availability, but that does not ever use `ActivateAcceleratorHandler()` is modified to call a new `ReleaseHandler()` function prior to that command's execution. This new function determines whether there is an active handler, and releases it if so. It returns a boolean indicating whether or not it released a handler.

Finally, to address a related problem when right-clicking on a constraint in the TaskSketcherConstrains sidebar during an active operation, if `ReleaseHandler()` actually does release a handler when right-clicking, the `Gui::Selection()` is updated to match the constraints selected in the Qt widget listing the constraints.
