### PR TITLE
[Sketch] add option to display spline weights

### DIFF
--- a/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp
+++ b/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp
@@ -214,6 +214,37 @@ bool CmdSketcherBSplineKnotMultiplicity::isActive(void)
     return isSketcherBSplineActive(getActiveGuiDocument(), false);
 }
 
+//
+DEF_STD_CMD_A(CmdSketcherBSplinePoleWeight)
+
+CmdSketcherBSplinePoleWeight::CmdSketcherBSplinePoleWeight()
+    : Command("Sketcher_BSplinePoleWeight")
+{
+    sAppModule = "Sketcher";
+    sGroup = QT_TR_NOOP("Sketcher");
+    sMenuText = QT_TR_NOOP("Show/hide B-spline control point weight");
+    sToolTipText = QT_TR_NOOP("Switches between showing and hiding the control point weight for all B-splines");
+    sWhatsThis = "Sketcher_BSplinePoleWeight";
+    sStatusTip = sToolTipText;
+    sPixmap = "Sketcher_BSplinePoleWeight";
+    sAccel = "";
+    eType = ForEdit;
+}
+
+void CmdSketcherBSplinePoleWeight::activated(int iMsg)
+{
+    Q_UNUSED(iMsg);
+
+    Gui::Document* doc = getActiveGuiDocument();
+    SketcherGui::ViewProviderSketch* vp = static_cast<SketcherGui::ViewProviderSketch*>(doc->getInEdit());
+    ShowRestoreInformationLayer(vp, "BSplinePoleWeightVisible");
+}
+
+bool CmdSketcherBSplinePoleWeight::isActive(void)
+{
+    return isSketcherBSplineActive(getActiveGuiDocument(), false);
+}
+
 // Composite drop down menu for show/hide geometry information layer
 DEF_STD_CMD_ACLU(CmdSketcherCompBSplineShowHideGeometryInformation)
 
@@ -223,7 +254,7 @@ CmdSketcherCompBSplineShowHideGeometryInformation::CmdSketcherCompBSplineShowHid
     sAppModule      = "Sketcher";
     sGroup          = QT_TR_NOOP("Sketcher");
     sMenuText       = QT_TR_NOOP("Show/hide B-spline information layer");
-    sToolTipText    = QT_TR_NOOP("Show/hide B-spline information layer");
+    sToolTipText    = sMenuText;
     sWhatsThis      = "Sketcher_CompBSplineShowHideGeometryInformation";
     sStatusTip      = sToolTipText;
     eType           = ForEdit;
@@ -242,6 +273,8 @@ void CmdSketcherCompBSplineShowHideGeometryInformation::activated(int iMsg)
         cmd = rcCmdMgr.getCommandByName("Sketcher_BSplineComb");
     else if (iMsg == 3)
         cmd = rcCmdMgr.getCommandByName("Sketcher_BSplineKnotMultiplicity");
+    else if (iMsg == 4)
+        cmd = rcCmdMgr.getCommandByName("Sketcher_BSplinePoleWeight");
     else
         return;
 
@@ -254,6 +287,8 @@ void CmdSketcherCompBSplineShowHideGeometryInformation::activated(int iMsg)
 
     assert(iMsg < a.size());
     pcAction->setIcon(a[iMsg]->icon());
+    // we must also set the tooltip of the used command
+    pcAction->setToolTip(a[iMsg]->toolTip());
 }
 
 Gui::Action * CmdSketcherCompBSplineShowHideGeometryInformation::createAction(void)
@@ -270,6 +305,8 @@ Gui::Action * CmdSketcherCompBSplineShowHideGeometryInformation::createAction(vo
     c3->setIcon(Gui::BitmapFactory().iconFromTheme("Sketcher_BSplineComb"));
     QAction* c4 = pcAction->addAction(QString());
     c4->setIcon(Gui::BitmapFactory().iconFromTheme("Sketcher_BSplineKnotMultiplicity"));
+    QAction* c5 = pcAction->addAction(QString());
+    c5->setIcon(Gui::BitmapFactory().iconFromTheme("Sketcher_BSplinePoleWeight"));
 
     _pcAction = pcAction;
     languageChange();
@@ -318,6 +355,14 @@ void CmdSketcherCompBSplineShowHideGeometryInformation::languageChange()
                                            "Switches between showing and hiding the knot multiplicity for all B-splines"));
     c4->setStatusTip(QApplication::translate("Sketcher_BSplineKnotMultiplicity",
                                              "Switches between showing and hiding the knot multiplicity for all B-splines"));
+
+    QAction* c5 = a[4];
+    c5->setText(QApplication::translate("CmdSketcherCompBSplineShowHideGeometryInformation",
+        "Show/hide B-spline control point weight"));
+    c5->setToolTip(QApplication::translate("Sketcher_BSplinePoleWeight",
+        "Switches between showing and hiding the control point weight for all B-splines"));
+    c5->setStatusTip(QApplication::translate("Sketcher_BSplinePoleWeight",
+        "Switches between showing and hiding the control point weight for all B-splines"));
 }
 
 void CmdSketcherCompBSplineShowHideGeometryInformation::updateAction(int /*mode*/)
@@ -945,6 +990,7 @@ void CreateSketcherCommandsBSpline(void)
     rcCmdMgr.addCommand(new CmdSketcherBSplinePolygon());
     rcCmdMgr.addCommand(new CmdSketcherBSplineComb());
     rcCmdMgr.addCommand(new CmdSketcherBSplineKnotMultiplicity());
+    rcCmdMgr.addCommand(new CmdSketcherBSplinePoleWeight());
     rcCmdMgr.addCommand(new CmdSketcherCompBSplineShowHideGeometryInformation());
     rcCmdMgr.addCommand(new CmdSketcherConvertToNURB());
     rcCmdMgr.addCommand(new CmdSketcherIncreaseDegree());

--- a/src/Mod/Sketcher/Gui/Resources/Sketcher.qrc
+++ b/src/Mod/Sketcher/Gui/Resources/Sketcher.qrc
@@ -232,6 +232,7 @@
         <file>icons/splines/Sketcher_BSplineIncreaseDegree.svg</file>
         <file>icons/splines/Sketcher_BSplineIncreaseKnotMultiplicity.svg</file>
         <file>icons/splines/Sketcher_BSplineKnotMultiplicity.svg</file>
+        <file>icons/splines/Sketcher_BSplinePoleWeight.svg</file>
         <file>icons/splines/Sketcher_BSplinePolygon.svg</file>
     </qresource>
     <qresource>

--- a/src/Mod/Sketcher/Gui/Resources/icons/splines/Sketcher_BSplinePoleWeight.svg
+++ b/src/Mod/Sketcher/Gui/Resources/icons/splines/Sketcher_BSplinePoleWeight.svg
@@ -1,0 +1,186 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="64px" height="64px" id="svg2918" version="1.1">
+  <defs id="defs2920">
+    <marker style="overflow:visible" id="Arrow1Lend" refX="0.0" refY="0.0" orient="auto">
+      <path transform="scale(0.8) rotate(180) translate(12.5,0)" style="fill-rule:evenodd;stroke:black;stroke-width:1pt;stroke-opacity:1" d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z " id="path1006" />
+    </marker>
+    <marker style="overflow:visible" id="Arrow1Lstart" refX="0.0" refY="0.0" orient="auto">
+      <path transform="scale(0.8) translate(12.5,0)" style="fill-rule:evenodd;stroke:blue;stroke-width:1pt;stroke-opacity:1;fill:blue;fill-opacity:1" d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z " id="path1003" />
+    </marker>
+    <linearGradient id="linearGradient3144">
+      <stop style="stop-color:#ffffff;stop-opacity:1" offset="0" id="stop3146" />
+      <stop style="stop-color:#ffffff;stop-opacity:0" offset="1" id="stop3148" />
+    </linearGradient>
+    <linearGradient id="linearGradient3144-3">
+      <stop style="stop-color:#ffffff;stop-opacity:1" offset="0" id="stop3146-1" />
+      <stop style="stop-color:#ffffff;stop-opacity:0" offset="1" id="stop3148-5" />
+    </linearGradient>
+    <radialGradient xlink:href="#linearGradient3144" id="radialGradient3958" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)" cx="225.26402" cy="672.79736" fx="225.26402" fy="672.79736" r="34.345188" />
+    <radialGradient xlink:href="#linearGradient3144-3" id="radialGradient3960" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)" cx="225.26402" cy="672.79736" fx="225.26402" fy="672.79736" r="34.345188" />
+    <radialGradient xlink:href="#linearGradient3144" id="radialGradient3042" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)" cx="225.26402" cy="672.79736" fx="225.26402" fy="672.79736" r="34.345188" />
+    <radialGradient xlink:href="#linearGradient3144" id="radialGradient3068" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)" cx="225.26402" cy="672.79736" fx="225.26402" fy="672.79736" r="34.345188" />
+    <radialGradient xlink:href="#linearGradient3144" id="radialGradient3880" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)" cx="225.26402" cy="672.79736" fx="225.26402" fy="672.79736" r="34.345188" />
+    <radialGradient xlink:href="#linearGradient3144" id="radialGradient4654" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)" cx="225.26402" cy="672.79736" fx="225.26402" fy="672.79736" r="34.345188" />
+    <radialGradient xlink:href="#linearGradient3144" id="radialGradient4693" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)" cx="225.26402" cy="672.79736" fx="225.26402" fy="672.79736" r="34.345188" />
+    <linearGradient y2="5" x2="-22" y1="18" x1="-18" gradientUnits="userSpaceOnUse" id="linearGradient3131-2" xlink:href="#linearGradient3836-9-3-9" />
+    <linearGradient id="linearGradient3836-9-3-9">
+      <stop style="stop-color:#a40000;stop-opacity:1" offset="0" id="stop3838-8-5-1" />
+      <stop style="stop-color:#ef2929;stop-opacity:1" offset="1" id="stop3840-1-6-2" />
+    </linearGradient>
+    <linearGradient y2="5" x2="-22" y1="18" x1="-18" gradientUnits="userSpaceOnUse" id="linearGradient3171-7" xlink:href="#linearGradient3836-9-3-6-0" />
+    <linearGradient id="linearGradient3836-9-3-6-0">
+      <stop style="stop-color:#a40000;stop-opacity:1" offset="0" id="stop3838-8-5-7-9" />
+      <stop style="stop-color:#ef2929;stop-opacity:1" offset="1" id="stop3840-1-6-5-3" />
+    </linearGradient>
+    <linearGradient xlink:href="#linearGradient3836-9-3" id="linearGradient3262" gradientUnits="userSpaceOnUse" x1="-18" y1="18" x2="-22" y2="5" />
+    <linearGradient id="linearGradient3836-9-3">
+      <stop style="stop-color:#a40000;stop-opacity:1" offset="0" id="stop3838-8-5" />
+      <stop style="stop-color:#ef2929;stop-opacity:1" offset="1" id="stop3840-1-6" />
+    </linearGradient>
+    <linearGradient id="linearGradient3836-9-3-6">
+      <stop style="stop-color:#a40000;stop-opacity:1" offset="0" id="stop3838-8-5-7" />
+      <stop style="stop-color:#ef2929;stop-opacity:1" offset="1" id="stop3840-1-6-5" />
+    </linearGradient>
+    <linearGradient xlink:href="#linearGradient3836-9-3-6-7" id="linearGradient3264-1" gradientUnits="userSpaceOnUse" x1="-18" y1="18" x2="-22" y2="5" gradientTransform="matrix(0.93724177,0,0,0.93725692,-1.2227671,0.70650014)" />
+    <linearGradient id="linearGradient3836-9-3-6-7">
+      <stop style="stop-color:#a40000;stop-opacity:1" offset="0" id="stop3838-8-5-7-4" />
+      <stop style="stop-color:#ef2929;stop-opacity:1" offset="1" id="stop3840-1-6-5-0" />
+    </linearGradient>
+    <linearGradient xlink:href="#linearGradient3836-9-3-6-4" id="linearGradient3264-9" gradientUnits="userSpaceOnUse" x1="-18" y1="18" x2="-22" y2="5" gradientTransform="matrix(0.93724177,0,0,0.93725692,-1.2227671,0.70650014)" />
+    <linearGradient id="linearGradient3836-9-3-6-4">
+      <stop style="stop-color:#a40000;stop-opacity:1" offset="0" id="stop3838-8-5-7-8" />
+      <stop style="stop-color:#ef2929;stop-opacity:1" offset="1" id="stop3840-1-6-5-8" />
+    </linearGradient>
+    <linearGradient xlink:href="#linearGradient3836-9-3-6-1" id="linearGradient3264-17" gradientUnits="userSpaceOnUse" x1="-18" y1="18" x2="-22" y2="5" gradientTransform="matrix(0.93724177,0,0,0.93725692,-1.2227671,0.70650014)" />
+    <linearGradient id="linearGradient3836-9-3-6-1">
+      <stop style="stop-color:#a40000;stop-opacity:1" offset="0" id="stop3838-8-5-7-1" />
+      <stop style="stop-color:#ef2929;stop-opacity:1" offset="1" id="stop3840-1-6-5-5" />
+    </linearGradient>
+    <linearGradient xlink:href="#linearGradient3836-9-3-6-2" id="linearGradient3264-3" gradientUnits="userSpaceOnUse" x1="-18" y1="18" x2="-22" y2="5" gradientTransform="matrix(0.93724177,0,0,0.93725692,-1.2227671,0.70650014)" />
+    <linearGradient id="linearGradient3836-9-3-6-2">
+      <stop style="stop-color:#a40000;stop-opacity:1" offset="0" id="stop3838-8-5-7-2" />
+      <stop style="stop-color:#ef2929;stop-opacity:1" offset="1" id="stop3840-1-6-5-1" />
+    </linearGradient>
+    <linearGradient xlink:href="#linearGradient3836-9-3-3" id="linearGradient3262-5" gradientUnits="userSpaceOnUse" x1="-18" y1="18" x2="-22" y2="5" />
+    <linearGradient id="linearGradient3836-9-3-3">
+      <stop style="stop-color:#a40000;stop-opacity:1" offset="0" id="stop3838-8-5-5" />
+      <stop style="stop-color:#ef2929;stop-opacity:1" offset="1" id="stop3840-1-6-6" />
+    </linearGradient>
+    <linearGradient xlink:href="#linearGradient3836-9-3-6-29" id="linearGradient3264" gradientUnits="userSpaceOnUse" x1="-18" y1="18" x2="-22" y2="5" />
+    <linearGradient id="linearGradient3836-9-3-6-29">
+      <stop style="stop-color:#a40000;stop-opacity:1" offset="0" id="stop3838-8-5-7-12" />
+      <stop style="stop-color:#ef2929;stop-opacity:1" offset="1" id="stop3840-1-6-5-7" />
+    </linearGradient>
+    <linearGradient y2="5" x2="-22" y1="18" x1="-18" gradientUnits="userSpaceOnUse" id="linearGradient3131-2-0" xlink:href="#linearGradient3836-9-3-9-9" />
+    <linearGradient id="linearGradient3836-9-3-9-9">
+      <stop style="stop-color:#a40000;stop-opacity:1" offset="0" id="stop3838-8-5-1-3" />
+      <stop style="stop-color:#ef2929;stop-opacity:1" offset="1" id="stop3840-1-6-2-6" />
+    </linearGradient>
+    <linearGradient y2="5" x2="-22" y1="18" x1="-18" gradientUnits="userSpaceOnUse" id="linearGradient3171-7-0" xlink:href="#linearGradient3836-9-3-6-0-6" />
+    <linearGradient id="linearGradient3836-9-3-6-0-6">
+      <stop style="stop-color:#a40000;stop-opacity:1" offset="0" id="stop3838-8-5-7-9-2" />
+      <stop style="stop-color:#ef2929;stop-opacity:1" offset="1" id="stop3840-1-6-5-3-6" />
+    </linearGradient>
+    <linearGradient xlink:href="#linearGradient3836-9-3-6-29" id="linearGradient3937" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.71441909,0,0,0.71408544,-5.531259,3.2604792)" x1="-18" y1="18" x2="-22" y2="5" />
+    <linearGradient xlink:href="#linearGradient3836-9-3-6-29-8" id="linearGradient3937-1" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.71441909,0,0,0.71408544,-5.531259,3.2604792)" x1="-18" y1="18" x2="-22" y2="5" />
+    <linearGradient id="linearGradient3836-9-3-6-29-8">
+      <stop style="stop-color:#a40000;stop-opacity:1" offset="0" id="stop3838-8-5-7-12-7" />
+      <stop style="stop-color:#ef2929;stop-opacity:1" offset="1" id="stop3840-1-6-5-7-9" />
+    </linearGradient>
+    <linearGradient y2="5" x2="-22" y1="18" x1="-18" gradientTransform="matrix(0.71441909,0,0,0.71408544,-5.531259,3.2604792)" gradientUnits="userSpaceOnUse" id="linearGradient3956" xlink:href="#linearGradient3836-9-3-6-29-8" />
+    <linearGradient xlink:href="#linearGradient3836-9-3-6-29-7" id="linearGradient3937-3" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.71441909,0,0,0.71408544,-5.531259,3.2604792)" x1="-18" y1="18" x2="-22" y2="5" />
+    <linearGradient id="linearGradient3836-9-3-6-29-7">
+      <stop style="stop-color:#a40000;stop-opacity:1" offset="0" id="stop3838-8-5-7-12-5" />
+      <stop style="stop-color:#ef2929;stop-opacity:1" offset="1" id="stop3840-1-6-5-7-92" />
+    </linearGradient>
+    <linearGradient xlink:href="#linearGradient3836-9-3-6-29-1" id="linearGradient3937-36" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.71441909,0,0,0.71408544,-5.531259,3.2604792)" x1="-18" y1="18" x2="-22" y2="5" />
+    <linearGradient id="linearGradient3836-9-3-6-29-1">
+      <stop style="stop-color:#a40000;stop-opacity:1" offset="0" id="stop3838-8-5-7-12-2" />
+      <stop style="stop-color:#ef2929;stop-opacity:1" offset="1" id="stop3840-1-6-5-7-93" />
+    </linearGradient>
+    <marker style="overflow:visible" id="Arrow1Lstart-2" refX="0" refY="0" orient="auto">
+      <path transform="matrix(0.8,0,0,0.8,10,0)" style="fill-rule:evenodd;stroke:black;stroke-width:1pt;stroke-opacity:1" d="M 0,0 L 5,-5 L -12.5,0 L 5,5 Z" id="path1003-7" />
+    </marker>
+    <marker style="overflow:visible" id="Arrow1Lend-6" refX="0" refY="0" orient="auto">
+      <path transform="matrix(-0.8,0,0,-0.8,-10,0)" style="fill-rule:evenodd;stroke:red;stroke-width:1pt;stroke-opacity:1;fill:red;fill-opacity:1" d="M 0,0 L 5,-5 L -12.5,0 L 5,5 Z" id="path1006-5" />
+    </marker>
+  </defs>
+  <metadata id="metadata2923">
+    <rdf:RDF>
+      <cc:Work rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[agryson] Alexander Gryson</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:title>Sketcher_Create_Periodic_BSpline</dc:title>
+        <dc:date>2017-02-15</dc:date>
+        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier>FreeCAD/src/Mod/Sketcher/Gui/Resources/icons/Sketcher_Toggle_BSpline_Information.svg</dc:identifier>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>[agryson] Alexander Gryson</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g id="layer1">
+    <g transform="matrix(-0.14137236,0.07774155,-0.01888492,-0.10633123,99.823869,75.569613)" id="g3177" />
+    <g transform="matrix(-0.14109247,0.07923086,-0.02087339,-0.10522619,77.138226,86.686164)" id="g3185" />
+    <g id="g960">
+      <path style="fill:none;stroke:#2e3436;stroke-width:8;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="M 55.999976,26.000003 C 58,48 32,32 29.999975,52.000002" id="path3266" />
+      <path style="fill:none;stroke:#d3d7cf;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="M 55.999976,26.000003 C 56,48 32,32 29.999975,52.000002" id="path3266-9" />
+      <path style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="M 54.999975,26.000003 C 56,47 32,31 28.999974,52.000002" id="path3266-9-2" />
+      <g transform="matrix(0.59988397,0,0,0.60016354,23.595637,49.138672)" id="g3797-7-2-3">
+        <g id="g3933" transform="translate(30.005802,0)">
+          <path d="m -25.658702,6.015909 a 8.3321309,8.3277776 0 1 1 12.65725,10.83369 8.3321309,8.3277776 0 1 1 -12.65725,-10.83369 z" id="path4250-6-9-5" style="fill:#ef2929;stroke:#280000;stroke-width:3.33320141;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+          <path d="m -23.129965,8.18309 a 5.0009335,4.9985982 0 1 1 7.596839,6.502756 5.0009335,4.9985982 0 0 1 -7.596839,-6.502756 z" id="path4250-7-0-1-6" style="fill:url(#linearGradient3937);fill-opacity:1;stroke:#ef2929;stroke-width:3.33320141;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        </g>
+      </g>
+      <g id="g3933-2" transform="matrix(0.59988397,0,0,0.60016354,67.595636,19.138672)">
+        <path d="m -25.658702,6.015909 a 8.3321309,8.3277776 0 1 1 12.65725,10.83369 8.3321309,8.3277776 0 1 1 -12.65725,-10.83369 z" id="path4250-6-9-5-0" style="fill:#ef2929;stroke:#280000;stroke-width:3.33320141;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path d="m -23.129965,8.18309 a 5.0009335,4.9985982 0 1 1 7.596839,6.502756 5.0009335,4.9985982 0 0 1 -7.596839,-6.502756 z" id="path4250-7-0-1-6-2" style="fill:url(#linearGradient3956);fill-opacity:1;stroke:#ef2929;stroke-width:3.33320141;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      </g>
+      <g transform="matrix(0.59988397,0,0,0.60016354,25.595637,25.138672)" id="g3797-7-2-3-2">
+        <g id="g3933-8" transform="translate(30.005802)">
+          <path d="M -25.658702,6.015909 A 8.3321309,8.3277776 0 1 1 -13.001452,16.849599 A 8.3321309,8.3277776 0 1 1 -25.658702,6.015909 Z" id="path4250-6-9-5-9" style="fill:#ef2929;stroke:#280000;stroke-width:3.3332;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <path d="M -23.129965,8.18309 A 5.0009335,4.9985982 0 1 1 -15.533126,14.685846 A 5.0009335,4.9985982 0 0 1 -23.129965,8.18309 Z" id="path4250-7-0-1-6-7" style="fill:url(#linearGradient3937-3);fill-opacity:1;stroke:#ef2929;stroke-width:3.3332;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        </g>
+      </g>
+      <g transform="matrix(0.59988397,0,0,0.60016354,49.595637,41.138672)" id="g3797-7-2-3-1">
+        <g id="g3933-9" transform="translate(30.005802,0)">
+          <path d="m -25.658702,6.015909 a 8.3321309,8.3277776 0 1 1 12.65725,10.83369 8.3321309,8.3277776 0 1 1 -12.65725,-10.83369 z" id="path4250-6-9-5-4" style="fill:#ef2929;stroke:#280000;stroke-width:3.33320141;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+          <path d="m -23.129965,8.18309 a 5.0009335,4.9985982 0 1 1 7.596839,6.502756 5.0009335,4.9985982 0 0 1 -7.596839,-6.502756 z" id="path4250-7-0-1-6-78" style="fill:url(#linearGradient3937-36);fill-opacity:1;stroke:#ef2929;stroke-width:3.33320141;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        </g>
+      </g>
+      <g id="g958" transform="translate(30.279658,-18.049864)">
+        <path style="fill:#ef2929;stroke:#280000;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="path4250-6-9-5-3" d="m 8.203393,54.749201 a 4.9983118,4.9980285 0 1 1 7.592881,6.501986 4.9983118,4.9980285 0 1 1 -7.592881,-6.501986 z" />
+        <path style="fill:#99cc33;fill-opacity:1;stroke:#669900;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="path4250-7-0-1-6-5" d="M 9.7203418,56.049864 A 2.9999798,2.9999764 0 1 1 14.277564,59.952581 2.9999798,2.9999764 0 0 1 9.7203418,56.049864 Z" />
+      </g>
+    </g>
+    <g id="g1490" style="stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none">
+      <g id="g958-8-1" transform="matrix(3.0331773,0,0,3.0331773,-17.021831,-157.70381)" style="fill:white;stroke:red;stroke-width:0.65937458;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none;fill-opacity:1">
+        <path style="fill:white;stroke:red;stroke-width:0.65937458;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;fill-opacity:1" id="path4250-6-9-5-3-3-1" d="M 8.203393,54.749201 A 4.9983118,4.9980285 0 1 1 15.796274,61.251187 A 4.9983118,4.9980285 0 1 1 8.203393,54.749201 Z" />
+      </g>
+      <g id="g958-8" transform="matrix(1.6589687,0,0,1.6589687,-0.53155661,-77.999445)" style="fill:none;stroke:blue;stroke-width:1.20557;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
+        <path style="fill:none;stroke:blue;stroke-width:1.20557;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="path4250-6-9-5-3-3" d="M 8.203393,54.749201 A 4.9983118,4.9980285 0 1 1 15.796274,61.251187 A 4.9983118,4.9980285 0 1 1 8.203393,54.749201 Z" />
+      </g>
+    </g>
+    <g id="g2122" />
+  </g>
+</svg>

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -3843,7 +3843,7 @@ void ViewProviderSketch::draw(bool temp /*=false*/, bool rebuildinformationlayer
             double maxcurv = 0;
             double maxdisttocenterofmass = 0;
 
-            for(int i = 0; i < ndiv; i++) {
+            for (int i = 0; i < ndiv; i++) {
                 paramlist[i] = firstparam + i * step;
                 pointatcurvelist[i] = spline->pointAtParameter(paramlist[i]);
 
@@ -3859,12 +3859,12 @@ void ViewProviderSketch::draw(bool temp /*=false*/, bool rebuildinformationlayer
                     curvaturelist[i] = 0;
                 }
 
-                if(curvaturelist[i] > maxcurv)
+                if (curvaturelist[i] > maxcurv)
                     maxcurv = curvaturelist[i];
 
                 double tempf = ( pointatcurvelist[i] - midp ).Length();
 
-                if( tempf > maxdisttocenterofmass )
+                if (tempf > maxdisttocenterofmass)
                     maxdisttocenterofmass = tempf;
 
             }
@@ -3903,7 +3903,7 @@ void ViewProviderSketch::draw(bool temp /*=false*/, bool rebuildinformationlayer
 
         midp /= poles.size();
 
-        if(rebuildinformationlayer) {
+        if (rebuildinformationlayer) {
             SoSwitch *sw = new SoSwitch();
 
             sw->whichChild = hGrpsk->GetBool("BSplineDegreeVisible", true)?SO_SWITCH_ALL:SO_SWITCH_NONE;
@@ -3943,7 +3943,7 @@ void ViewProviderSketch::draw(bool temp /*=false*/, bool rebuildinformationlayer
         else {
             SoSwitch *sw = static_cast<SoSwitch *>(edit->infoGroup->getChild(currentInfoNode));
 
-            if(visibleInformationChanged)
+            if (visibleInformationChanged)
                 sw->whichChild = hGrpsk->GetBool("BSplineDegreeVisible", true)?SO_SWITCH_ALL:SO_SWITCH_NONE;
 
             SoSeparator *sep = static_cast<SoSeparator *>(sw->getChild(0));
@@ -3956,7 +3956,7 @@ void ViewProviderSketch::draw(bool temp /*=false*/, bool rebuildinformationlayer
         currentInfoNode++; // switch to next node
 
         // control polygon --------------------------------------------------------
-        if(rebuildinformationlayer) {
+        if (rebuildinformationlayer) {
             SoSwitch *sw = new SoSwitch();
 
             sw->whichChild = hGrpsk->GetBool("BSplineControlPolygonVisible", true)?SO_SWITCH_ALL:SO_SWITCH_NONE;
@@ -3975,7 +3975,7 @@ void ViewProviderSketch::draw(bool temp /*=false*/, bool rebuildinformationlayer
 
             SoCoordinate3 *polygoncoords = new SoCoordinate3;
 
-            if(spline->isPeriodic()) {
+            if (spline->isPeriodic()) {
                 polygoncoords->point.setNum(poles.size()+1);
             }
             else {
@@ -3989,7 +3989,7 @@ void ViewProviderSketch::draw(bool temp /*=false*/, bool rebuildinformationlayer
                 vts[i].setValue((*it).x,(*it).y,zInfo);
             }
 
-            if(spline->isPeriodic()) {
+            if (spline->isPeriodic()) {
                 vts[poles.size()].setValue(poles[0].x,poles[0].y,zInfo);
             }
 
@@ -4086,7 +4086,7 @@ void ViewProviderSketch::draw(bool temp /*=false*/, bool rebuildinformationlayer
             pointatcomblist[i] = pointatcurvelist[i] - combrepscalehyst * curvaturelist[i] * normallist[i];
         }
 
-        if(rebuildinformationlayer) {
+        if (rebuildinformationlayer) {
             SoSwitch *sw = new SoSwitch();
 
             sw->whichChild = hGrpsk->GetBool("BSplineCombVisible", true)?SO_SWITCH_ALL:SO_SWITCH_NONE;
@@ -4177,7 +4177,7 @@ void ViewProviderSketch::draw(bool temp /*=false*/, bool rebuildinformationlayer
         std::vector<int>::const_iterator itm;
 
 
-        if(rebuildinformationlayer) {
+        if (rebuildinformationlayer) {
 
             for( itk = knots.begin(), itm = mult.begin(); itk != knots.end() && itm != mult.end(); ++itk, ++itm) {
 
@@ -4199,14 +4199,14 @@ void ViewProviderSketch::draw(bool temp /*=false*/, bool rebuildinformationlayer
 
                 Base::Vector3d knotposition = spline->pointAtParameter(*itk);
 
-                translate->translation.setValue(knotposition.x,knotposition.y,zInfo);
+                translate->translation.setValue(knotposition.x, knotposition.y, zInfo);
 
                 SoFont *font = new SoFont;
                 font->name.setValue("Helvetica");
                 font->size.setValue(fontSize);
 
                 SoText2 *degreetext = new SoText2;
-                degreetext->string = SbString("(")+SbString(*itm)+SbString(")");
+                degreetext->string = SbString("(") + SbString(*itm) + SbString(")");
 
                 sep->addChild(translate);
                 sep->addChild(mat);
@@ -4235,13 +4235,95 @@ void ViewProviderSketch::draw(bool temp /*=false*/, bool rebuildinformationlayer
 
                 static_cast<SoTranslation *>(sep->getChild(GEOINFO_BSPLINE_DEGREE_POS))->translation.setValue(knotposition.x,knotposition.y,zInfo);
 
-                static_cast<SoText2 *>(sep->getChild(GEOINFO_BSPLINE_DEGREE_TEXT))->string = SbString("(")+SbString(*itm)+SbString(")");
+                static_cast<SoText2 *>(sep->getChild(GEOINFO_BSPLINE_DEGREE_TEXT))->string = SbString("(") + SbString(*itm) + SbString(")");
 
                 currentInfoNode++; // switch to next node
             }
         }
 
         // End of knot multiplicity
+
+        // pole weights --------------------------------------------------------
+        std::vector<double> weights = spline->getWeights();
+        QString WeightString;
+        int itw;
+        // since the first and last control point of a spline is also treated as knot and thus
+        // can also have a displayed multiplicity, we must assure the multiplicity is not visibly overwritten
+        // we add spaces to show the weight behind the multiplicity
+        auto TextBegin = hGrpsk->GetBool("BSplineKnotMultiplicityVisible", true) ? "   [" : "[";
+
+        if (rebuildinformationlayer) {
+
+            for (itw = 0; itw != weights.size(); ++itw) {
+
+                SoSwitch* sw = new SoSwitch();
+
+                sw->whichChild = hGrpsk->GetBool("BSplinePoleWeightVisible", true) ? SO_SWITCH_ALL : SO_SWITCH_NONE;
+
+                SoSeparator* sep = new SoSeparator();
+                sep->ref();
+                // no caching for fluctuand data structures
+                sep->renderCaching = SoSeparator::OFF;
+
+                // every information visual node gets its own material for to-be-implemented preselection and selection
+                SoMaterial* mat = new SoMaterial;
+                mat->ref();
+                mat->diffuseColor = InformationColor;
+
+                SoTranslation* translate = new SoTranslation;
+
+                Base::Vector3d poleposition = poles[itw];
+
+                SoFont* font = new SoFont;
+                font->name.setValue("Helvetica");
+                font->size.setValue(fontSize);
+
+                translate->translation.setValue(poleposition.x, poleposition.y, zInfo);
+
+                // set up string with weight value and the user-defined number of decimals
+                WeightString  = QString::fromLatin1("%1").arg(weights[itw], 0, 'f', Base::UnitsApi::getDecimals());
+
+                SoText2* WeightText = new SoText2;
+                WeightText->string = SbString(TextBegin) + SbString(WeightString.toStdString().c_str()) + SbString("]");
+
+                sep->addChild(translate);
+                sep->addChild(mat);
+                sep->addChild(font);
+                sep->addChild(WeightText);
+
+                sw->addChild(sep);
+
+                edit->infoGroup->addChild(sw);
+                sep->unref();
+                mat->unref();
+
+                currentInfoNode++; // switch to next node
+            }
+        }
+        else {
+            for (itw = 0; itw != weights.size(); ++itw) {
+                SoSwitch* sw = static_cast<SoSwitch*>(edit->infoGroup->getChild(currentInfoNode));
+
+                if (visibleInformationChanged)
+                    sw->whichChild = hGrpsk->GetBool("BSplinePoleWeightVisible", true) ? SO_SWITCH_ALL : SO_SWITCH_NONE;
+
+                SoSeparator* sep = static_cast<SoSeparator*>(sw->getChild(0));
+
+                Base::Vector3d poleposition = poles[itw];
+
+                static_cast<SoTranslation*>(sep->getChild(GEOINFO_BSPLINE_DEGREE_POS))
+                    ->translation.setValue(poleposition.x, poleposition.y, zInfo);
+
+                WeightString = QString::fromLatin1("%1").arg(weights[itw], 0, 'f', Base::UnitsApi::getDecimals());
+
+                static_cast<SoText2*>(sep->getChild(GEOINFO_BSPLINE_DEGREE_TEXT))
+                                        ->string = SbString(TextBegin) + SbString(WeightString.toStdString().c_str()) + SbString("]");
+
+                currentInfoNode++; // switch to next node
+            }
+        }
+
+        // End of pole weights
     }
 
 


### PR DESCRIPTION
When working with weights, it is a huge improvement to see the weights immediately when changing the pole circle radius.
This PR adds an option to display the weights.

Here is how it works:
![dJju0GLiGZ](https://user-images.githubusercontent.com/1828501/98456515-fb42ff80-217e-11eb-83c3-9f523ac8cf32.gif)

Since the endpoints can have a displayed multiplicity, I placed the weight info behind it, but maybe one should then better display it right below the multiplicity.