### PR TITLE
[part] remove a now misleading comment

### DIFF
--- a/src/Mod/Part/Gui/DlgPrimitives.cpp
+++ b/src/Mod/Part/Gui/DlgPrimitives.cpp
@@ -848,9 +848,6 @@ void DlgPrimitives::accept(const QString& placement)
                          .arg(QString::fromLatin1(doc->getName()))
                          .arg(QString::fromLatin1(featurePtr->getNameInDocument()));
 
-    // the combox with the primitive type is fixed
-    // therefore by reading its state we know what we need to change
-
     // read values from the properties
     if (type == Part::Plane::getClassTypeId()) {
         command = QString::fromLatin1(


### PR DESCRIPTION
I added this comment when I read the dialog state fro the index of the type combobox, now we read the primitive's TypeID so the comment is misleading