### PR TITLE
AddOn manager, use default branch instead of master branch

### DIFF
--- a/src/Mod/AddonManager/addonmanager_workers.py
+++ b/src/Mod/AddonManager/addonmanager_workers.py
@@ -768,7 +768,7 @@ class InstallWorker(QtCore.QThread):
                                                      str(self.repos[idx][0]) + "\n")
                     if have_git:
                         self.info_label.emit("Cloning module...")
-                        repo = git.Repo.clone_from(self.repos[idx][1], clonedir, branch="master")
+                        repo = git.Repo.clone_from(self.repos[idx][1], clonedir)
 
                         # Make sure to clone all the submodules as well
                         if repo.submodules:


### PR DESCRIPTION
see forum disscussion:

https://forum.freecadweb.org/viewtopic.php?f=8&t=52007

It worked for some AddOns, but I do not know if this will result in a regression in other AddOns.