### PR TITLE
Increase Travis timeout on OS X builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -339,7 +339,8 @@ script:
         cat $HOME/.ccache/ccache.conf
         ccache -z -s
         df -h
-        if [ "${TRAVIS_OS_NAME}" == "osx" ]; then export PATH="/usr/local/opt/ccacche/libexec:$PATH"; sudo gtimeout -s KILL 7200 make -j2; [ $? == 0 ] && echo "No timeout" || { ccache -s; return 0; }  fi 
+        # On OS X, give the make process 2hr 20min to complete, and kill after that to preserve the ccache
+        if [ "${TRAVIS_OS_NAME}" == "osx" ]; then export PATH="/usr/local/opt/ccacche/libexec:$PATH"; sudo gtimeout -s KILL 8400 make -j2; [ $? == 0 ] && echo "No timeout" || { ccache -s; return 0; }  fi 
         if [ "${TRAVIS_OS_NAME}" == "linux" ]; then sudo timeout -k 175m 170m make -j2 install || true; fi
         sudo make -j2 install
         ccache -s


### PR DESCRIPTION
Give the build 2h20m on OS X before killing it (this is an increase from the previous 2hr limit).