### PR TITLE
[PD] cut-profiles with identical names for different threads

### DIFF
--- a/src/Mod/PartDesign/App/FeatureHole.h
+++ b/src/Mod/PartDesign/App/FeatureHole.h
@@ -169,11 +169,25 @@ private:
         double angle;
     };
 
-    std::map<std::string, CutDimensionSet> HoleCutTypeMap;
+    class CutDimensionKey {
+        std::string thread_type;
+        std::string cut_name;
+    public:
+        CutDimensionKey() {}
+        CutDimensionKey(const std::string &t, const std::string &c);
+        bool operator<(const CutDimensionKey &b) const;
+    };
 
-    void addCounterType(const CutDimensionSet& dimensions);
-    bool isDynamicCounterbore(const std::string &holeCutType);
-    bool isDynamicCountersink(const std::string &holeCutType);
+    std::map<CutDimensionKey, CutDimensionSet> HoleCutTypeMap;
+
+    const CutDimensionSet& find_cutDimensionSet(const std::string &t,
+          const std::string &c);
+
+    const CutDimensionSet& find_cutDimensionSet(const CutDimensionKey &k);
+
+    void addCutType(const CutDimensionSet& dimensions);
+    bool isDynamicCounterbore(const std::string &thread, const std::string &holeCutType);
+    bool isDynamicCountersink(const std::string &thread, const std::string &holeCutType);
     void updateHoleCutParams();
     void updateDiameterParam();
     void readCutDefinitions();


### PR DESCRIPTION
Allow cut-profiles with identical names for different threads.

see:
https://forum.freecadweb.org/viewtopic.php?f=19&t=51491&start=60#p446854
https://forum.freecadweb.org/viewtopic.php?f=19&t=51491&start=60#p446902

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
