### PR TITLE
Sketcher: InsertDatum.ui dialog is too small.

### DIFF
--- a/src/Mod/Sketcher/Gui/InsertDatum.ui
+++ b/src/Mod/Sketcher/Gui/InsertDatum.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>254</width>
-    <height>140</height>
+    <height>170</height>
    </rect>
   </property>
   <property name="sizePolicy">


### PR DESCRIPTION
https://tracker.freecadweb.org/view.php?id=4493

On Fedora 33 the input field is too small and the input text is clipped.
Increasing the dialog height solves it for Fedora and hopefully it still
looks nice on other platforms as well.
