### PR TITLE
[PD] Hole countersink angle work

### DIFF
--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.ui
@@ -127,6 +127,9 @@
      <property name="minimum">
       <double>0.000000000000000</double>
      </property>
+     <property name="singleStep">
+      <double>0.100000000000000</double>
+     </property>
     </widget>
    </item>
    <item row="11" column="6" colspan="2">
@@ -149,6 +152,9 @@
      </property>
      <property name="minimum">
       <double>0.000000000000000</double>
+     </property>
+     <property name="singleStep">
+      <double>0.100000000000000</double>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
- fix bug that custom angles were overwritten
- the norms only define screw heads, not the cut for them, so also a custom angle is possible to sink a metric screw
- use better step in UI since one changes the presets only in fractions of a millimeter (otherwise it would be a different hole size)
- handle case of no cut
- calculate change in diameter when adding depth to countersinks

Forum: https://forum.freecadweb.org/viewtopic.php?f=19&t=51491&p=447712#p447712