### PR TITLE
[Gui] get rid of MSCV compiler warning

### DIFF
--- a/src/Gui/DocumentObserverPython.h
+++ b/src/Gui/DocumentObserverPython.h
@@ -77,7 +77,7 @@ private:
     Py::Object inst;
     static std::vector<DocumentObserverPython*> _instances;
 
-    typedef struct {
+    typedef struct PythonObject {
        boost::signals2::scoped_connection slot;
        Py::Object py;
        PyObject* ptr() {


### PR DESCRIPTION
Since months I got this:
`>D:\FreeCADGit\src\Gui\DocumentObserverPython.h(80,20): warning C5208: unnamed class used in typedef name cannot declare members other than non-static data members, member enumerations, or member classes`

The reason is that since C++17 nameless typedefs are restricted, see for example here:
https://en.cppreference.com/w/cpp/language/typedef
, therefore the warning.
By naming it, the warning vanishes.