### PR TITLE
[PD] more hole fixes

### DIFF
--- a/src/Mod/PartDesign/App/FeatureHole.cpp
+++ b/src/Mod/PartDesign/App/FeatureHole.cpp
@@ -71,7 +71,7 @@ namespace PartDesign {
 
 const char* Hole::DepthTypeEnums[]                   = { "Dimension", "ThroughAll", /*, "UpToFirst", */ NULL };
 const char* Hole::ThreadTypeEnums[]                  = { "None", "ISOMetricProfile", "ISOMetricFineProfile", "UNC", "UNF", "UNEF", NULL};
-const char* Hole::ThreadFitEnums[]                   = { "Standard", "Close", NULL};
+const char* Hole::ThreadFitEnums[]                   = { "Standard", "Close", "Wide", NULL};
 const char* Hole::DrillPointEnums[]                  = { "Flat", "Angled", NULL};
 
 /* "None" profile */
@@ -95,34 +95,49 @@ const Hole::ThreadDescription Hole::threadDescription[][171] =
 
     /* ISO metric regular */
     {
-        { "M1.6", 	1.60,       0.35 },
-        { "M2", 	2.00,       0.40 },
-        { "M2.5", 	2.50,       0.45 },
-        { "M3", 	3.00,       0.50 },
-        { "M3.5", 	3.50,       0.60 },
-        { "M4", 	4.00,       0.70 },
-        { "M5", 	5.00,       0.80 },
-        { "M6", 	6.00,       1.00 },
-        { "M8", 	8.00,       1.25 },
-        { "M10", 	10.00,      1.50 },
-        { "M12", 	12.00,      1.75 },
-        { "M14", 	14.00,      2.00 },
-        { "M16", 	16.00,      2.00 },
-        { "M20", 	20.00,      2.50 },
-        { "M22", 	22.00,      2.50 },
-        { "M24", 	24.00,      3.00 },
-        { "M27", 	27.00,      3.00 },
-        { "M30", 	30.00,      3.50 },
-        { "M36", 	36.00,      4.00 },
-        { "M42", 	42.00,      4.50 },
-        { "M48", 	48.00,      5.00 },
-        { "M56", 	56.00,      5.50 },
-        { "M64", 	64.00,      6.00 },
-        { "M68", 	68.00,      6.00 },
+        { "M1", 	1.0,       0.25 },
+        { "M1.1", 	1.1,       0.25 },
+        { "M1.2", 	1.2,       0.25 },
+        { "M1.4", 	1.4,       0.30 },
+        { "M1.6", 	1.6,       0.35 },
+        { "M1.8", 	1.8,       0.35 },
+        { "M2", 	2.0,       0.40 },
+        { "M2.2", 	2.2,       0.45 },
+        { "M2.5", 	2.5,       0.45 },
+        { "M3", 	3.0,       0.50 },
+        { "M3.5", 	3.5,       0.60 },
+        { "M4", 	4.0,       0.70 },
+        { "M4.5", 	4.5,       0.75 },
+        { "M5", 	5.0,       0.80 },
+        { "M6", 	6.0,       1.00 },
+        { "M7", 	7.0,       1.00 },
+        { "M8", 	8.0,       1.25 },
+        { "M9", 	9.0,       1.25 },
+        { "M10", 	10.0,      1.50 },
+        { "M11", 	11.0,      1.50 },
+        { "M12", 	12.0,      1.75 },
+        { "M14", 	14.0,      2.00 },
+        { "M16", 	16.0,      2.00 },
+        { "M18", 	18.0,      2.50 },
+        { "M20", 	20.0,      2.50 },
+        { "M22", 	22.0,      2.50 },
+        { "M24", 	24.0,      3.00 },
+        { "M27", 	27.0,      3.00 },
+        { "M30", 	30.0,      3.50 },
+        { "M36", 	36.0,      4.00 },
+        { "M39", 	39.0,      4.00 },
+        { "M42", 	42.0,      4.50 },
+        { "M45", 	45.0,      4.50 },
+        { "M48", 	48.0,      5.00 },
+        { "M52", 	52.0,      5.00 },
+        { "M56", 	56.0,      5.50 },
+        { "M60", 	60.0,      5.50 },
+        { "M64", 	64.0,      6.00 },
+        { "M68", 	68.0,      6.00 },
      },
     /* ISO metric fine */
     {
-        { "M1.0x0.2", 	1.0,    0.20 },
+        { "M1x0.2", 	1.0,    0.20 },
         { "M1.1x0.2", 	1.1,    0.20 },
         { "M1.2x0.2", 	1.2,    0.20 },
         { "M1.4x0.2", 	1.4,    0.20 },
@@ -356,19 +371,62 @@ const Hole::ThreadDescription Hole::threadDescription[][171] =
 
 };
 
+const double Hole::metricHoleDiameters[35][4] =
+{
+    /* ISO metric according to ISO 273 */
+    // {screw diameter, close, standard, coarse}
+        { 1.0,      1.1,    1.2,    1.3},
+        { 1.2,      1.3,    1.4,    1.5},
+        { 1.4,      1.5,    1.6,    1.8},
+        { 1.6,      1.7,    1.8,    2.0},
+        { 1.8,      2.0,    2.1,    2.2},
+        { 2.0,      2.2,    2.4,    2.6},
+        { 2.5,      2.7,    2.9,    3.1},
+        { 3.0,      3.2,    3.4,    3.6},
+        { 3.5,      3.7,    3.9,    4.2},
+        { 4.0,      4.3,    4.5,    4.8},
+        { 4.5,      4.8,    5.0,    5.3},
+        { 5.0,      5.3,    5.5,    5.8},
+        { 6.0,      6.4,    6.6,    7.0},
+        { 7.0,      7.4,    7.6,    8.0},
+        { 8.0,      8.4,    9.0,    10.0},
+        { 10.0,     10.5,   11.0,   12.0},
+        { 12.0,     13.0,   13.5,   14.5},
+        { 14.0,     15.0,   15.5,   16.5},
+        { 16.0,     17.0,  	17.5,   18.5},
+        { 18.0,     19.0,  	20.0,   21.0},
+        { 20.0,     21.0,  	22.0,   24.0},
+        { 22.0,     23.0,  	24.0,   26.0},
+        { 24.0,     25.0,  	26.0,   28.0},
+        { 27.0,     28.0,  	30.0,   32.0},
+        { 30.0,     31.0,  	33.0,   35.0},
+        { 36.0,     37.0,  	39.0,   42.0},
+        { 39.0,     40.0,  	42.0,   45.0},
+        { 42.0,     43.0,  	45.0,   48.0},
+        { 45.0,     46.0,  	48.0,   52.0},
+        { 48.0,     50.0,  	52.0,   56.0},
+        { 52.0,     54.0,  	56.0,   62.0},
+        { 56.0,     58.0,  	62.0,   66.0},
+        { 60.0,     62.0,  	66.0,   70.0},
+        { 64.0,     66.0,  	70.0,   74.0},
+        { 68.0,     70.0,  	77.0,   78.0}
+};
+
 /* ISO coarse metric enums */
 std::vector<std::string> Hole::HoleCutType_ISOmetric_Enums  = { "None", "Counterbore", "Countersink", "Cheesehead (deprecated)", "Countersink socket screw (deprecated)", "Cap screw (deprecated)" };
-const char* Hole::ThreadSize_ISOmetric_Enums[]   = { "M1.6",  "M2",  "M2.5",  "M3",
-                                                     "M3.5",  "M4",  "M5",    "M6",
-                                                     "M8",    "M10", "M12",   "M14",
-                                                     "M16",   "M20", "M22",   "M24",
-                                                     "M27",   "M30", "M36",   "M42",
-                                                     "M48",   "M56", "M64",   "M68", NULL };
+const char* Hole::ThreadSize_ISOmetric_Enums[]   = { "M1",   "M1.1", "M1.2", "M1.4", "M1.6",
+                                                     "M1.8", "M2",   "M2.2", "M2.5", "M3",
+                                                     "M3.5", "M4",   "M4.5", "M5",   "M6",
+                                                     "M7",   "M8",   "M9",   "M10",  "M11",
+                                                     "M12",  "M14",  "M16",  "M18",  "M20",
+                                                     "M22",  "M24",  "M27",  "M30",  "M33",
+                                                     "M36",  "M39",  "M42",  "M45",  "M48",
+                                                     "M52",  "M56",  "M60",  "M64",  "M68",  NULL };
 const char* Hole::ThreadClass_ISOmetric_Enums[]  = { "4G", "4H", "5G", "5H", "6G", "6H", "7G", "7H","8G", "8H", NULL };
 
 std::vector<std::string> Hole::HoleCutType_ISOmetricfine_Enums  = { "None", "Counterbore", "Countersink", "Cheesehead (deprecated)", "Countersink socket screw (deprecated)", "Cap screw (deprecated)" };
 const char* Hole::ThreadSize_ISOmetricfine_Enums[]   = {
-    "M1.0x0.2",    "M1.1x0.2",    "M1.2x0.2",    "M1.4x0.2",
+    "M1x0.2",      "M1.1x0.2",    "M1.2x0.2",    "M1.4x0.2",
     "M1.6x0.2",    "M1.8x0.2",    "M2x0.25",     "M2.2x0.25",
     "M2.5x0.35",   "M3x0.35",     "M3.5x0.35",
     "M4x0.5",      "M4.5x0.5",    "M5x0.5",      "M5.5x0.5",
@@ -679,12 +737,50 @@ void Hole::updateDiameterParam()
         diameter = diameter - pitch;
     }
     else {
+        bool found = false;
+        int MatrixRowSize = sizeof(metricHoleDiameters) / sizeof(metricHoleDiameters[0]);
         switch ( ThreadFit.getValue() ) {
-        case 0: /* standard */
-            diameter = ( 5 * ( (int)( ( diameter * 110 ) / 5 ) ) ) / 100.0;
+        case 0: /* standard fit */
+            // read diameter out of matrix
+            for (int i = 0; i < MatrixRowSize; i++) {
+                if (metricHoleDiameters[i][0] == diameter) {
+                    diameter = metricHoleDiameters[i][2];
+                    found = true;
+                    break;
+                }
+            }
+            // if nothing was found, we must calculate
+            if (!found) {
+                diameter = (5 * ((int)((diameter * 110) / 5))) / 100.0;
+            }
             break;
-        case 1: /* close */
-            diameter = ( 5 * ( (int)( ( diameter * 105 ) / 5 ) ) ) / 100.0;
+        case 1: /* close fit */
+            // read diameter out of matrix
+            for (int i = 0; i < MatrixRowSize; i++) {
+                if (metricHoleDiameters[i][0] == diameter) {
+                    diameter = metricHoleDiameters[i][1];
+                    found = true;
+                    break;
+                }
+            }
+            // if nothing was found, we must calculate
+            if (!found) {
+                diameter = (5 * ((int)((diameter * 105) / 5))) / 100.0;
+            }
+            break;
+        case 2: /* wide fit */
+            // read diameter out of matrix
+            for (int i = 0; i < MatrixRowSize; i++) {
+                if (metricHoleDiameters[i][0] == diameter) {
+                    diameter = metricHoleDiameters[i][3];
+                    found = true;
+                    break;
+                }
+            }
+            // if nothing was found, we must calculate
+            if (!found) {
+                diameter = (5 * ((int)((diameter * 115) / 5))) / 100.0;
+            }
             break;
         default:
             assert( 0 );

--- a/src/Mod/PartDesign/App/FeatureHole.h
+++ b/src/Mod/PartDesign/App/FeatureHole.h
@@ -84,8 +84,9 @@ public:
         double diameter;
         double pitch;
     } ThreadDescription;
-
     static const ThreadDescription threadDescription[][171];
+
+    static const double metricHoleDiameters[35][4];
 
     virtual void Restore(Base::XMLReader & reader);
 

--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
@@ -167,7 +167,9 @@ TaskHoleParameters::TaskHoleParameters(ViewProviderHole *HoleView, QWidget *pare
     else
         ui->drillPointAngled->setChecked(true);
     ui->DrillPointAngle->setValue(pcHole->DrillPointAngle.getValue());
-    ui->Tapered->setChecked(pcHole->ModelActualThread.getValue());
+    ui->Tapered->setChecked(pcHole->Tapered.getValue());
+    // Angle is only enabled (sensible) if tapered
+    ui->TaperedAngle->setEnabled(pcHole->Tapered.getValue());
     ui->TaperedAngle->setValue(pcHole->TaperedAngle.getValue());
     ui->Reversed->setChecked(pcHole->Reversed.getValue());
 
@@ -793,7 +795,7 @@ long TaskHoleParameters::getThreadClass() const
 
 long TaskHoleParameters::getThreadFit() const
 {
-    // the fit is independent if the hole is threaded or not
+    // the fit (clearance) is independent if the hole is threaded or not
     // since an unthreaded hole for a screw can also have a close fit
     return ui->ThreadFit->currentIndex();
 }

--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.ui
@@ -6,97 +6,21 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>356</width>
-    <height>583</height>
+    <width>373</width>
+    <height>560</height>
    </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
   </property>
   <property name="windowTitle">
    <string>Task Hole Parameters</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="20" column="0" colspan="8">
-    <widget class="QLabel" name="label_16">
-     <property name="text">
-      <string>&lt;b&gt;Misc&lt;/b&gt;</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="4" colspan="4">
-    <widget class="Gui::PrefQuantitySpinBox" name="ThreadAngle">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="unit" stdset="0">
-      <string notr="true">deg</string>
-     </property>
-     <property name="minimum">
-      <double>0.000000000000000</double>
-     </property>
-    </widget>
-   </item>
-   <item row="14" column="0">
-    <widget class="QLabel" name="label">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Type</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="2" colspan="6">
-    <widget class="QComboBox" name="ThreadType"/>
-   </item>
-   <item row="18" column="0" colspan="8">
-    <widget class="QLabel" name="label_9">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>&lt;b&gt;Drill point&lt;/b&gt;</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-     </property>
-    </widget>
-   </item>
-   <item row="10" column="0" colspan="2">
-    <widget class="QLabel" name="label_3">
-     <property name="text">
-      <string>Fit</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="4" colspan="4">
-    <widget class="Gui::PrefQuantitySpinBox" name="ThreadPitch">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="unit" stdset="0">
-      <string notr="true">mm</string>
-     </property>
-     <property name="minimum">
-      <double>0.000000000000000</double>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="2">
-    <widget class="QLabel" name="label_CutoffOuter">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="text">
-      <string>Cutoff outer</string>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="4" colspan="4">
+   <item row="7" column="3">
     <widget class="Gui::PrefQuantitySpinBox" name="ThreadCutOffOuter">
      <property name="enabled">
       <bool>false</bool>
@@ -109,43 +33,192 @@
      </property>
     </widget>
    </item>
-   <item row="6" column="2">
-    <widget class="QLabel" name="label_CutoffInner">
+   <item row="11" column="1">
+    <widget class="QComboBox" name="DepthType">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>140</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <item>
+      <property name="text">
+       <string>Dimension</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Through all</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item row="10" column="5">
+    <widget class="Gui::PrefQuantitySpinBox" name="Diameter">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>110</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string>Hole diameter</string>
+     </property>
+     <property name="unit" stdset="0">
+      <string notr="true">mm</string>
+     </property>
+     <property name="minimum">
+      <double>0.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="5">
+    <widget class="QComboBox" name="ThreadFit">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>110</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string>Hole clearance
+Only available for holes without thread</string>
+     </property>
+     <item>
+      <property name="text">
+       <string>Standard</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Close</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Wide</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item row="5" column="1">
+    <widget class="QLabel" name="label_Angle">
      <property name="enabled">
       <bool>false</bool>
      </property>
      <property name="text">
-      <string>Cutoff inner</string>
+      <string>Angle</string>
      </property>
     </widget>
    </item>
-   <item row="16" column="5" colspan="3">
+   <item row="10" column="2">
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Fixed</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>13</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="12" column="0">
+    <widget class="QLabel" name="label_14">
+     <property name="text">
+      <string>&lt;b&gt;Hole cut&lt;/b&gt;</string>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="1">
+    <widget class="QWidget" name="widget" native="true">
+     <property name="toolTip">
+      <string>Thread direction</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <property name="spacing">
+       <number>0</number>
+      </property>
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QRadioButton" name="directionRightHand">
+        <property name="toolTip">
+         <string/>
+        </property>
+        <property name="text">
+         <string>Right hand</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="directionLeftHand">
+        <property name="text">
+         <string>Left hand</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="4" column="3">
+    <widget class="Gui::PrefQuantitySpinBox" name="ThreadPitch">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="unit" stdset="0">
+      <string notr="true">mm</string>
+     </property>
+     <property name="minimum">
+      <double>0.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="15" column="3" colspan="3">
     <widget class="Gui::PrefQuantitySpinBox" name="HoleCutDepth">
-     <property name="unit" stdset="0">
-      <string notr="true">mm</string>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
-     <property name="minimum">
-      <double>0.000000000000000</double>
-     </property>
-     <property name="singleStep">
-      <double>0.100000000000000</double>
-     </property>
-    </widget>
-   </item>
-   <item row="11" column="6" colspan="2">
-    <widget class="Gui::PrefQuantitySpinBox" name="Diameter">
-     <property name="unit" stdset="0">
-      <string notr="true">mm</string>
-     </property>
-     <property name="minimum">
-      <double>0.000000000000000</double>
-     </property>
-    </widget>
-   </item>
-   <item row="15" column="5" colspan="3">
-    <widget class="Gui::PrefQuantitySpinBox" name="HoleCutDiameter">
-     <property name="contextMenuPolicy">
-      <enum>Qt::NoContextMenu</enum>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>16777215</height>
+      </size>
      </property>
      <property name="unit" stdset="0">
       <string notr="true">mm</string>
@@ -158,8 +231,59 @@
      </property>
     </widget>
    </item>
-   <item row="19" column="2" colspan="6">
+   <item row="3" column="1">
+    <widget class="QCheckBox" name="ModelActualThread">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="text">
+      <string>Model actual thread</string>
+     </property>
+    </widget>
+   </item>
+   <item row="11" column="0">
+    <widget class="QLabel" name="label_6">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Depth</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Profile</string>
+     </property>
+    </widget>
+   </item>
+   <item row="18" column="1">
     <widget class="QWidget" name="widget_2" native="true">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>140</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string>Ending of the hole if 'Depth' is set to 'Dimension'</string>
+     </property>
      <layout class="QVBoxLayout" name="verticalLayout_2">
       <property name="spacing">
        <number>0</number>
@@ -179,7 +303,7 @@
       <item>
        <widget class="QRadioButton" name="drillPointFlat">
         <property name="sizePolicy">
-         <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
@@ -194,7 +318,7 @@
         <item>
          <widget class="QRadioButton" name="drillPointAngled">
           <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
@@ -206,6 +330,12 @@
         </item>
         <item>
          <widget class="Gui::PrefQuantitySpinBox" name="DrillPointAngle">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
           <property name="unit" stdset="0">
            <string notr="true">deg</string>
           </property>
@@ -219,34 +349,23 @@
      </layout>
     </widget>
    </item>
-   <item row="6" column="4" colspan="4">
-    <widget class="Gui::PrefQuantitySpinBox" name="ThreadCutOffInner">
-     <property name="enabled">
-      <bool>false</bool>
+   <item row="1" column="1" colspan="5">
+    <widget class="QComboBox" name="ThreadType">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
-     <property name="unit" stdset="0">
-      <string notr="true">mm</string>
-     </property>
-     <property name="minimum">
-      <double>0.000000000000000</double>
-     </property>
-    </widget>
-   </item>
-   <item row="12" column="6" colspan="2">
-    <widget class="Gui::PrefQuantitySpinBox" name="Depth">
-     <property name="unit" stdset="0">
-      <string notr="true">mm</string>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>16777215</height>
+      </size>
      </property>
     </widget>
    </item>
-   <item row="21" column="6">
-    <widget class="QCheckBox" name="Reversed">
-     <property name="text">
-      <string>Reversed</string>
-     </property>
-    </widget>
-   </item>
-   <item row="11" column="0" colspan="2">
+   <item row="10" column="0">
     <widget class="QLabel" name="label_5">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
@@ -259,243 +378,53 @@
      </property>
     </widget>
    </item>
-   <item row="11" column="4" colspan="2">
-    <widget class="QLabel" name="label_7">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Diameter</string>
-     </property>
-    </widget>
-   </item>
-   <item row="12" column="0" colspan="2">
-    <widget class="QLabel" name="label_6">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Depth</string>
-     </property>
-    </widget>
-   </item>
-   <item row="15" column="2" colspan="3">
-    <widget class="QLabel" name="label_11">
-     <property name="text">
-      <string>Diameter</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0" colspan="8">
-    <widget class="QLabel" name="label_13">
-     <property name="text">
-      <string>&lt;b&gt;Threading and size&lt;/b&gt;</string>
-     </property>
-    </widget>
-   </item>
-   <item row="17" column="5" colspan="3">
-    <widget class="Gui::PrefQuantitySpinBox" name="HoleCutCountersinkAngle">
-     <property name="unit" stdset="0">
-      <string notr="true">deg</string>
-     </property>
-     <property name="minimum">
-      <double>0.000000000000000</double>
-     </property>
-    </widget>
-   </item>
-   <item row="11" column="2">
-    <widget class="QComboBox" name="ThreadClass">
-     <property name="toolTip">
-      <string>Tolerance class for threaded holes according to the hole profile</string>
-     </property>
-    </widget>
-   </item>
-   <item row="21" column="2" colspan="3">
-    <widget class="Gui::PrefQuantitySpinBox" name="TaperedAngle">
-     <property name="unit" stdset="0">
-      <string notr="true">deg</string>
-     </property>
-     <property name="minimum">
-      <double>0.000000000000000</double>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="2" colspan="6">
-    <widget class="QCheckBox" name="Threaded">
-     <property name="text">
-      <string>Threaded</string>
-     </property>
-    </widget>
-   </item>
-   <item row="21" column="0" colspan="2">
+   <item row="20" column="0">
     <widget class="QCheckBox" name="Tapered">
      <property name="text">
       <string>Tapered</string>
      </property>
     </widget>
    </item>
-   <item row="5" column="2">
-    <widget class="QLabel" name="label_Angle">
+   <item row="6" column="1">
+    <widget class="QLabel" name="label_CutoffInner">
      <property name="enabled">
       <bool>false</bool>
      </property>
      <property name="text">
-      <string>Angle</string>
+      <string>Cutoff inner</string>
      </property>
     </widget>
    </item>
-   <item row="12" column="2" colspan="3">
-    <widget class="QComboBox" name="DepthType">
+   <item row="10" column="1">
+    <widget class="QComboBox" name="ThreadClass">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+      <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
-     <item>
-      <property name="text">
-       <string>Dimension</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Through all</string>
-      </property>
-     </item>
-    </widget>
-   </item>
-   <item row="14" column="2" colspan="6">
-    <widget class="QComboBox" name="HoleCutType"/>
-   </item>
-   <item row="9" column="2" colspan="6">
-    <widget class="QComboBox" name="ThreadSize"/>
-   </item>
-   <item row="19" column="0" colspan="2">
-    <widget class="QLabel" name="label_15">
-     <property name="text">
-      <string>Type</string>
+     <property name="maximumSize">
+      <size>
+       <width>140</width>
+       <height>16777215</height>
+      </size>
      </property>
-     <property name="alignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-     </property>
-    </widget>
-   </item>
-   <item row="17" column="2" colspan="3">
-    <widget class="QLabel" name="label_10">
-     <property name="text">
-      <string>Countersink angle</string>
-     </property>
-    </widget>
-   </item>
-   <item row="16" column="2" colspan="3">
-    <widget class="QLabel" name="label_12">
-     <property name="text">
-      <string>Depth</string>
-     </property>
-    </widget>
-   </item>
-   <item row="13" column="0" colspan="8">
-    <widget class="QLabel" name="label_14">
-     <property name="text">
-      <string>&lt;b&gt;Hole cut&lt;/b&gt;</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="2">
-    <widget class="QLabel" name="label_Pitch">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="text">
-      <string>Pitch</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0" colspan="2">
-    <widget class="QLabel" name="label_2">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Profile</string>
-     </property>
-    </widget>
-   </item>
-   <item row="8" column="0" colspan="2">
-    <widget class="QLabel" name="label_8">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Direction</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-     </property>
-    </widget>
-   </item>
-   <item row="8" column="2" colspan="6">
-    <widget class="QWidget" name="widget" native="true">
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <property name="spacing">
-       <number>0</number>
-      </property>
-      <property name="leftMargin">
-       <number>0</number>
-      </property>
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="rightMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>0</number>
-      </property>
-      <item>
-       <widget class="QRadioButton" name="directionRightHand">
-        <property name="text">
-         <string>Right hand</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QRadioButton" name="directionLeftHand">
-        <property name="text">
-         <string>Left hand</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="10" column="2" colspan="6">
-    <widget class="QComboBox" name="ThreadFit">
      <property name="toolTip">
-      <string>Hole fit, only available for holes without thread</string>
+      <string>Tolerance class for threaded holes according to hole profile</string>
      </property>
-     <item>
-      <property name="text">
-       <string>Standard fit</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Close fit</string>
-      </property>
-     </item>
+    </widget>
+   </item>
+   <item row="11" column="3" colspan="3">
+    <widget class="Gui::PrefQuantitySpinBox" name="Depth">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="unit" stdset="0">
+      <string notr="true">mm</string>
+     </property>
     </widget>
    </item>
    <item row="9" column="0">
@@ -511,28 +440,288 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="2" colspan="6">
-    <widget class="QCheckBox" name="ModelActualThread">
+   <item row="17" column="0">
+    <widget class="QLabel" name="label_9">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>&lt;b&gt;Drill point&lt;/b&gt;</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+     </property>
+    </widget>
+   </item>
+   <item row="18" column="0">
+    <widget class="QLabel" name="label_15">
+     <property name="text">
+      <string>Type</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="1">
+    <widget class="QLabel" name="label_CutoffOuter">
      <property name="enabled">
       <bool>false</bool>
      </property>
      <property name="text">
-      <string>Model actual thread</string>
+      <string>Cutoff outer</string>
      </property>
     </widget>
    </item>
-   <item row="11" column="3">
-    <spacer name="horizontalSpacer">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+   <item row="13" column="0">
+    <widget class="QLabel" name="label">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
-     <property name="sizeHint" stdset="0">
+     <property name="text">
+      <string>Type</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="3">
+    <widget class="Gui::PrefQuantitySpinBox" name="ThreadAngle">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="unit" stdset="0">
+      <string notr="true">deg</string>
+     </property>
+     <property name="minimum">
+      <double>0.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0" colspan="2">
+    <widget class="QLabel" name="label_13">
+     <property name="text">
+      <string>&lt;b&gt;Threading and size&lt;/b&gt;</string>
+     </property>
+    </widget>
+   </item>
+   <item row="13" column="1">
+    <widget class="QComboBox" name="HoleCutType">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="maximumSize">
       <size>
-       <width>40</width>
-       <height>20</height>
+       <width>140</width>
+       <height>16777215</height>
       </size>
      </property>
-    </spacer>
+     <property name="toolTip">
+      <string>Cuty type for screw heads</string>
+     </property>
+    </widget>
+   </item>
+   <item row="16" column="3" colspan="3">
+    <widget class="Gui::PrefQuantitySpinBox" name="HoleCutCountersinkAngle">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="unit" stdset="0">
+      <string notr="true">deg</string>
+     </property>
+     <property name="minimum">
+      <double>0.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="19" column="0">
+    <widget class="QLabel" name="label_16">
+     <property name="text">
+      <string>&lt;b&gt;Misc&lt;/b&gt;</string>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="0">
+    <widget class="QLabel" name="label_8">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Direction</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+     </property>
+    </widget>
+   </item>
+   <item row="10" column="3" colspan="2">
+    <widget class="QLabel" name="label_7">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Diameter</string>
+     </property>
+    </widget>
+   </item>
+   <item row="15" column="1">
+    <widget class="QLabel" name="label_12">
+     <property name="text">
+      <string>Depth</string>
+     </property>
+    </widget>
+   </item>
+   <item row="16" column="1">
+    <widget class="QLabel" name="label_10">
+     <property name="text">
+      <string>Countersink angle</string>
+     </property>
+    </widget>
+   </item>
+   <item row="14" column="1">
+    <widget class="QLabel" name="label_11">
+     <property name="text">
+      <string>Diameter</string>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="3">
+    <widget class="QLabel" name="label_3">
+     <property name="text">
+      <string>Clearance</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="3">
+    <widget class="Gui::PrefQuantitySpinBox" name="ThreadCutOffInner">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="unit" stdset="0">
+      <string notr="true">mm</string>
+     </property>
+     <property name="minimum">
+      <double>0.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QCheckBox" name="Threaded">
+     <property name="toolTip">
+      <string>Whether the hole gets a thread</string>
+     </property>
+     <property name="text">
+      <string>Threaded</string>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="1">
+    <widget class="QComboBox" name="ThreadSize">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>140</width>
+       <height>16777215</height>
+      </size>
+     </property>
+    </widget>
+   </item>
+   <item row="20" column="1">
+    <widget class="Gui::PrefQuantitySpinBox" name="TaperedAngle">
+     <property name="maximumSize">
+      <size>
+       <width>120</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string>Taper angle for the hole
+90 degree: straight hole
+under 90: smaller hole radius at the bottom
+over 90: larger hole radius at the bottom</string>
+     </property>
+     <property name="unit" stdset="0">
+      <string notr="true">deg</string>
+     </property>
+     <property name="minimum">
+      <double>0.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="QLabel" name="label_Pitch">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="text">
+      <string>Pitch</string>
+     </property>
+    </widget>
+   </item>
+   <item row="14" column="3" colspan="3">
+    <widget class="Gui::PrefQuantitySpinBox" name="HoleCutDiameter">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="contextMenuPolicy">
+      <enum>Qt::NoContextMenu</enum>
+     </property>
+     <property name="unit" stdset="0">
+      <string notr="true">mm</string>
+     </property>
+     <property name="minimum">
+      <double>0.000000000000000</double>
+     </property>
+     <property name="singleStep">
+      <double>0.100000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="20" column="4" colspan="2">
+    <widget class="QCheckBox" name="Reversed">
+     <property name="toolTip">
+      <string>Reverses the hole direction</string>
+     </property>
+     <property name="text">
+      <string>Reversed</string>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>
@@ -549,5 +738,54 @@
   </customwidget>
  </customwidgets>
  <resources/>
- <connections/>
+ <connections>
+  <connection>
+   <sender>Tapered</sender>
+   <signal>clicked(bool)</signal>
+   <receiver>TaperedAngle</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>40</x>
+     <y>540</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>136</x>
+     <y>540</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>Threaded</sender>
+   <signal>clicked(bool)</signal>
+   <receiver>ThreadFit</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>136</x>
+     <y>63</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>322</x>
+     <y>254</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>Threaded</sender>
+   <signal>clicked(bool)</signal>
+   <receiver>ThreadClass</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>136</x>
+     <y>63</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>136</x>
+     <y>280</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
 </ui>


### PR DESCRIPTION
- there is the ISO 273 describing clearance holes, so we need to take these values. Only if we have a size not defined in the norm, we calculate
- add the coarse (wide) type for clearance holes from ISO 273
- add all screw thread sizes defined in DIN 13/ISO 261
- change name "fit" to "clearance" as discussed
- add tooltips to the dialog
- fix issue with TaperedAngle dialog field
- rearrange thread dialog to make it more compact; result:
![FreeCAD_ftkteMXSnI](https://user-images.githubusercontent.com/1828501/99453983-10a9ed80-2926-11eb-8575-00e698bc7b08.png)

Forum threads:
https://forum.freecadweb.org/viewtopic.php?f=19&t=51491&p=448607#p448607
and
