### PR TITLE
Refactor code in DrawViewDimension::getRefType() shorter and simpler.…

### DIFF
--- a/src/Mod/TechDraw/App/DrawViewDimension.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDimension.cpp
@@ -252,7 +252,7 @@ App::DocumentObjectExecReturn *DrawViewDimension::execute(void)
          Type.isValue("DistanceY") )  {
         if (getRefType() == oneEdge) {
             m_linearPoints = getPointsOneEdge();
-        }else if (getRefType() == twoEdge) {
+        } else if (getRefType() == twoEdge) {
             m_linearPoints = getPointsTwoEdges();
         } else if (getRefType() == twoVertex) {
             m_linearPoints = getPointsTwoVerts();
@@ -916,63 +916,27 @@ DrawViewPart* DrawViewDimension::getViewPart() const
 
 int DrawViewDimension::getRefType() const
 {
-    int refType = invalidRef;
-    const std::vector<std::string> &subElements      = References2D.getSubValues();
-    if (subElements.size() == 1) {
-        refType = getRefType1(subElements[0]);
-    } else if (subElements.size() == 2) {
-        refType = getRefType2(subElements[0],subElements[1]);
-    } else if (subElements.size() == 3) {
-        refType = getRefType3(subElements[0],subElements[1],subElements[2]);
-    }
-    return refType;
+    return getRefTypeSubElements(References2D.getSubValues());
 }
 
-//static
-int DrawViewDimension::getRefType1(const std::string g1)
+int DrawViewDimension::getRefTypeSubElements(const std::vector<std::string> &subElements)
 {
     int refType = invalidRef;
-    if (DrawUtil::getGeomTypeFromName(g1) == "Edge") {
-        refType = oneEdge;
-    }
-    return refType;
-}
+    int refEdges = 0, refVertices = 0;
 
-//static
-int DrawViewDimension::getRefType2(const std::string g1, const std::string g2)
-{
-    int refType = invalidRef;
-    if ((DrawUtil::getGeomTypeFromName(g1) == "Edge") &&
-        (DrawUtil::getGeomTypeFromName(g2) == "Edge")) {
-        refType = twoEdge;
-    } else if ((DrawUtil::getGeomTypeFromName(g1) == "Vertex") &&
-               (DrawUtil::getGeomTypeFromName(g2) == "Vertex")) {
-        refType = twoVertex;
-    } else if (((DrawUtil::getGeomTypeFromName(g1) == "Vertex") &&
-                (DrawUtil::getGeomTypeFromName(g2) == "Edge"))   ||
-               ((DrawUtil::getGeomTypeFromName(g1) == "Edge") &&
-               (DrawUtil::getGeomTypeFromName(g2) == "Vertex")) ) {
-        refType = vertexEdge;
+    for (const auto& se: subElements) {
+        if (DrawUtil::getGeomTypeFromName(se) == "Vertex") { refVertices++; }
+        if (DrawUtil::getGeomTypeFromName(se) == "Edge") { refEdges++; }
     }
-    //} else add different types here - Vertex-Face, ...
+
+    if (refEdges == 0 && refVertices == 2) { refType = twoVertex; }
+    if (refEdges == 0 && refVertices == 3) { refType = threeVertex; }
+    if (refEdges == 1 && refVertices == 0) { refType = oneEdge; }
+    if (refEdges == 1 && refVertices == 1) { refType = vertexEdge; }
+    if (refEdges == 2 && refVertices == 0) { refType = twoEdge; }
 
     return refType;
 }
-
-int DrawViewDimension::getRefType3(const std::string g1,
-                                   const std::string g2,
-                                   const std::string g3)
-{
-    int refType = invalidRef;
-    if ((DrawUtil::getGeomTypeFromName(g1) == "Vertex") &&
-        (DrawUtil::getGeomTypeFromName(g2) == "Vertex") &&
-        (DrawUtil::getGeomTypeFromName(g3) == "Vertex") ) {
-        refType = threeVertex;
-    }
-
-    return refType;
-}
-
 
 //! validate 2D references - only checks if the target exists
 bool DrawViewDimension::checkReferences2D() const

--- a/src/Mod/TechDraw/App/DrawViewDimension.h
+++ b/src/Mod/TechDraw/App/DrawViewDimension.h
@@ -139,12 +139,8 @@ public:
 
     virtual DrawViewPart* getViewPart() const;
     virtual QRectF getRect() const override { return QRectF(0,0,1,1);}          //pretend dimensions always fit!
-    static int getRefType1(const std::string s);
-    static int getRefType2(const std::string s1, const std::string s2);
-    static int getRefType3(const std::string g1,
-                           const std::string g2,
-                           const std::string g3);
-    virtual int getRefType() const;                                   //Vertex-Vertex, Edge, Edge-Edge
+    virtual int getRefType() const;             //Vertex-Vertex, Edge, Edge-Edge
+    static int getRefTypeSubElements(const std::vector<std::string> &);             //Vertex-Vertex, Edge, Edge-Edge
     void setAll3DMeasurement();
     void clear3DMeasurements(void);
     virtual bool checkReferences2D(void) const;

--- a/src/Mod/TechDraw/Gui/TaskLinkDim.cpp
+++ b/src/Mod/TechDraw/Gui/TaskLinkDim.cpp
@@ -99,12 +99,7 @@ void TaskLinkDim::loadAvailDims()
     std::vector<App::DocumentObject*> pageViews = m_page->Views.getValues();
     std::vector<App::DocumentObject*>::iterator itView = pageViews.begin();
     std::string result;
-    int selRefType = 0;   //invalidRef;
-    if (m_subs.size() == 1) {
-        selRefType = TechDraw::DrawViewDimension::getRefType1(m_subs[0]);
-    } else {
-        selRefType = TechDraw::DrawViewDimension::getRefType2(m_subs[0],m_subs[1]);
-    }
+    int selRefType = TechDraw::DrawViewDimension::getRefTypeSubElements(m_subs);
     int found = 0;
     for (; itView != pageViews.end(); itView++) {
         if ((*itView)->isDerivedFrom(TechDraw::DrawViewDimension::getClassTypeId())) {


### PR DESCRIPTION
… No functional change except subelement sizes > 3 are supported, even though they are not supposed to happen.  These minor refactoring changes should not cause any functional differences to TechDraw, and I have shortly tested that the code works as before.  This pull request does not fix any bug, but when fixing an unrelated bug in the same source file, I also refactored this function to be cleaner and more readable.


Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
