### PR TITLE
[TD] TechDraw Balloon improvements with two new App::PropertyType properties

### DIFF
--- a/src/Mod/TechDraw/App/DrawViewBalloon.cpp
+++ b/src/Mod/TechDraw/App/DrawViewBalloon.cpp
@@ -113,6 +113,8 @@ DrawViewBalloon::DrawViewBalloon(void)
     ADD_PROPERTY_TYPE(KinkLength,(prefKinkLength()),"",(App::PropertyType)(App::Prop_None),
                                   "Distance from symbol to leader kink");
 
+    ADD_PROPERTY_TYPE(LineVisible,(true),"",(App::PropertyType)(App::Prop_None),"Balloon line visible or hidden");
+
     SourceView.setScope(App::LinkScope::Global);
     Rotation.setStatus(App::Property::Hidden,true);
     Caption.setStatus(App::Property::Hidden,true);

--- a/src/Mod/TechDraw/App/DrawViewBalloon.cpp
+++ b/src/Mod/TechDraw/App/DrawViewBalloon.cpp
@@ -105,6 +105,9 @@ DrawViewBalloon::DrawViewBalloon(void)
     ADD_PROPERTY_TYPE(ShapeScale,(1.0),"",(App::PropertyType)(App::Prop_None),"Balloon shape scale");
     ShapeScale.setConstraints(&SymbolScaleRange);
 
+    ADD_PROPERTY_TYPE(EndTypeScale,(1.0),"",(App::PropertyType)(App::Prop_None),"EndType shape scale");
+    ShapeScale.setConstraints(&SymbolScaleRange);
+
     ADD_PROPERTY_TYPE(TextWrapLen,(-1),"",(App::PropertyType)(App::Prop_None),"Text wrap length; -1 means no wrap");
 
     ADD_PROPERTY_TYPE(KinkLength,(prefKinkLength()),"",(App::PropertyType)(App::Prop_None),

--- a/src/Mod/TechDraw/App/DrawViewBalloon.h
+++ b/src/Mod/TechDraw/App/DrawViewBalloon.h
@@ -49,15 +49,16 @@ public:
     DrawViewBalloon();
     virtual ~DrawViewBalloon();
 
-    App::PropertyLink        SourceView;
-    App::PropertyString      Text;
-    App::PropertyEnumeration EndType;
-    App::PropertyEnumeration BubbleShape;
+    App::PropertyLink            SourceView;
+    App::PropertyString          Text;
+    App::PropertyEnumeration     EndType;
+    App::PropertyEnumeration     BubbleShape;
     App::PropertyFloatConstraint ShapeScale;
-    App::PropertyDistance    OriginX;
-    App::PropertyDistance    OriginY;
-    App::PropertyFloat       TextWrapLen;
-    App::PropertyDistance    KinkLength;
+    App::PropertyFloatConstraint EndTypeScale;
+    App::PropertyDistance        OriginX;
+    App::PropertyDistance        OriginY;
+    App::PropertyFloat           TextWrapLen;
+    App::PropertyDistance        KinkLength;
 
     short mustExecute() const override;
 

--- a/src/Mod/TechDraw/App/DrawViewBalloon.h
+++ b/src/Mod/TechDraw/App/DrawViewBalloon.h
@@ -59,6 +59,7 @@ public:
     App::PropertyDistance        OriginY;
     App::PropertyFloat           TextWrapLen;
     App::PropertyDistance        KinkLength;
+    App::PropertyBool            LineVisible;
 
     short mustExecute() const override;
 

--- a/src/Mod/TechDraw/Gui/QGIViewBalloon.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewBalloon.cpp
@@ -765,6 +765,7 @@ void QGIViewBalloon::draw()
     dLinePath.lineTo(arrowTipX - xAdj, arrowTipY - yAdj);
     balloonLines->setPath(dLinePath);
 
+    // This overwrites the previously created QPainterPath with empty one, in case it should be hidden.  Should be refactored.
     if (!balloon->LineVisible.getValue()) {
         arrow->hide();
         balloonLines->setPath(QPainterPath());

--- a/src/Mod/TechDraw/Gui/QGIViewBalloon.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewBalloon.cpp
@@ -738,7 +738,7 @@ void QGIViewBalloon::draw()
         float arAngle = atan2(dirballoonLinesLine.y, dirballoonLinesLine.x) * 180 / M_PI;
 
         arrow->setPos(arrowTipX, arrowTipY);
-        if ( (endType == ArrowType::FILLED_TRIANGLE) && 
+        if ( (endType == ArrowType::FILLED_TRIANGLE) &&
              (prefOrthoPyramid()) ) {
             if (arAngle < 0.0) {
                 arAngle += 360.0;
@@ -764,6 +764,11 @@ void QGIViewBalloon::draw()
     }
     dLinePath.lineTo(arrowTipX - xAdj, arrowTipY - yAdj);
     balloonLines->setPath(dLinePath);
+
+    if (!balloon->LineVisible.getValue()) {
+        arrow->hide();
+        balloonLines->setPath(QPainterPath());
+    }
 
     // redraw the Balloon and the parent View
     if (hasHover && !isSelected()) {

--- a/src/Mod/TechDraw/Gui/QGIViewBalloon.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewBalloon.cpp
@@ -717,14 +717,14 @@ void QGIViewBalloon::draw()
     double yAdj = 0.0;
     int endType = balloon->EndType.getValue();
     double arrowAdj = QGIArrow::getOverlapAdjust(endType,
-                                                 QGIArrow::getPrefArrowSize());
+                                                 balloon->EndTypeScale.getValue()*QGIArrow::getPrefArrowSize());
 
     if (endType == ArrowType::NONE) {
         arrow->hide();
     } else {
         arrow->setStyle(endType);
 
-        arrow->setSize(QGIArrow::getPrefArrowSize());
+        arrow->setSize(balloon->EndTypeScale.getValue()*QGIArrow::getPrefArrowSize());
         arrow->draw();
 
         Base::Vector3d arrowTipPos(arrowTipX, arrowTipY, 0.0);


### PR DESCRIPTION
There were 2 TechDraw Balloon feature requests made in https://forum.freecadweb.org/viewtopic.php?f=35&t=51869 requiring adding two App::PropertyType properties.  Since any new properties would be added to the FreeCAD file format, too, care should be taken to select the property names, in order to avoid future inconsistencies should the property names be later changed between FreeCAD versions.  The 1st proposed commit adds into Balloon an App::PropertyType property "EndTypeScale" with (default 1.0), which scales the existing property "EndType" of the Balloon (arrow, circle, etc.).  The 2nd proposed commit adds into Balloon an App::PropertyType property "LineVisible" (default true), which draws the Balloon with line if true, and the Balloon without line if false.

There is no changes in TechDraw Preferences for neither of the new properties.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [x] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586)
---
