### PR TITLE
Add SVG icons for five Std Tool commands

### DIFF
--- a/src/Gui/CommandDoc.cpp
+++ b/src/Gui/CommandDoc.cpp
@@ -384,6 +384,7 @@ StdCmdDependencyGraph::StdCmdDependencyGraph()
     sStatusTip    = QT_TR_NOOP("Show the dependency graph of the objects in the active document");
     sWhatsThis    = "Std_DependencyGraph";
     eType         = 0;
+    sPixmap       = "Std_DependencyGraph";
 }
 
 void StdCmdDependencyGraph::activated(int iMsg)
@@ -658,6 +659,7 @@ StdCmdProjectUtil::StdCmdProjectUtil()
     sMenuText     = QT_TR_NOOP("Project utility...");
     sToolTipText  = QT_TR_NOOP("Utility to extract or create project files");
     sStatusTip    = QT_TR_NOOP("Utility to extract or create project files");
+    sPixmap       = "Std_ProjectUtil";
 }
 
 void StdCmdProjectUtil::activated(int iMsg)

--- a/src/Gui/CommandStd.cpp
+++ b/src/Gui/CommandStd.cpp
@@ -343,7 +343,7 @@ StdCmdDlgParameter::StdCmdDlgParameter()
   sToolTipText  = QT_TR_NOOP("Opens a Dialog to edit the parameters");
   sWhatsThis    = "Std_DlgParameter";
   sStatusTip    = QT_TR_NOOP("Opens a Dialog to edit the parameters");
-  //sPixmap     = "settings";
+  sPixmap       = "Std_DlgParameter";
   eType         = 0;
 }
 

--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -3009,6 +3009,7 @@ StdCmdSceneInspector::StdCmdSceneInspector()
     sWhatsThis    = "Std_SceneInspector";
     sStatusTip    = QT_TR_NOOP("Scene inspector");
     eType         = Alter3DView;
+    sPixmap       = "Std_SceneInspector";
 }
 
 void StdCmdSceneInspector::activated(int iMsg)
@@ -3067,6 +3068,7 @@ StdCmdDemoMode::StdCmdDemoMode()
     sWhatsThis    = "Std_DemoMode";
     sStatusTip    = QT_TR_NOOP("View turntable");
     eType         = Alter3DView;
+    sPixmap       = "Std_DemoMode";
 }
 
 void StdCmdDemoMode::activated(int iMsg)

--- a/src/Gui/Icons/Std_DemoMode.svg
+++ b/src/Gui/Icons/Std_DemoMode.svg
@@ -1,0 +1,325 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   width="64px"
+   height="64px"
+   id="svg2985"
+   version="1.1">
+  <title
+     id="title889">Std_DemoMode</title>
+  <defs
+     id="defs2987">
+    <linearGradient
+       id="linearGradient2286">
+      <stop
+         id="stop2282"
+         offset="0"
+         style="stop-color:#d3d7cf;stop-opacity:1" />
+      <stop
+         id="stop2284"
+         offset="1"
+         style="stop-color:#888a85;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2278">
+      <stop
+         id="stop2274"
+         offset="0"
+         style="stop-color:#babdb6;stop-opacity:1" />
+      <stop
+         id="stop2276"
+         offset="1"
+         style="stop-color:#555753;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2270">
+      <stop
+         id="stop2266"
+         offset="0"
+         style="stop-color:#06989a;stop-opacity:1" />
+      <stop
+         id="stop2268"
+         offset="1"
+         style="stop-color:#34e0e2;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4387">
+      <stop
+         style="stop-color:#71b2f8;stop-opacity:1;"
+         offset="0"
+         id="stop4389" />
+      <stop
+         style="stop-color:#002795;stop-opacity:1;"
+         offset="1"
+         id="stop4391" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6321">
+      <stop
+         style="stop-color:#71b2f8;stop-opacity:1;"
+         offset="0"
+         id="stop6323" />
+      <stop
+         style="stop-color:#002795;stop-opacity:1;"
+         offset="1"
+         id="stop6325" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient3377"
+       id="radialGradient3692"
+       cx="45.883327"
+       cy="28.869568"
+       fx="45.883327"
+       fy="28.869568"
+       r="19.467436"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-0.23443224,0.23443198)" />
+    <linearGradient
+       id="linearGradient3377">
+      <stop
+         id="stop3379"
+         offset="0"
+         style="stop-color:#faff2b;stop-opacity:1;" />
+      <stop
+         id="stop3381"
+         offset="1"
+         style="stop-color:#ffaa00;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3377-3">
+      <stop
+         id="stop3379-8"
+         offset="0"
+         style="stop-color:#faff2b;stop-opacity:1;" />
+      <stop
+         id="stop3381-3"
+         offset="1"
+         style="stop-color:#ffaa00;stop-opacity:1;" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient3377-3"
+       id="radialGradient6412"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.67067175,0,0,0.64145918,-63.380792,0.83845403)"
+       cx="45.883327"
+       cy="28.869568"
+       fx="45.883327"
+       fy="28.869568"
+       r="19.467436" />
+    <linearGradient
+       id="linearGradient3036">
+      <stop
+         id="stop3038"
+         offset="0"
+         style="stop-color:#ef2929;stop-opacity:1" />
+      <stop
+         id="stop3040"
+         offset="1"
+         style="stop-color:#a40000;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="28"
+       x2="7"
+       y1="9"
+       x1="47"
+       id="linearGradient2095"
+       xlink:href="#linearGradient1189"
+       gradientTransform="matrix(0.96812402,0,0,0.96755864,-0.72057496,-2.6783592)" />
+    <linearGradient
+       id="linearGradient1189">
+      <stop
+         id="stop1185"
+         offset="0"
+         style="stop-color:#204a87;stop-opacity:1" />
+      <stop
+         id="stop1187"
+         offset="1"
+         style="stop-color:#729fcf;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="21.83742"
+       x2="47.502235"
+       y1="51.179787"
+       x1="53.896763"
+       gradientTransform="matrix(0.51495804,-0.30442335,0,0.49438794,16.927271,22.734089)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1141"
+       xlink:href="#linearGradient3777" />
+    <linearGradient
+       id="linearGradient3777">
+      <stop
+         style="stop-color:#204a87;stop-opacity:1"
+         offset="0"
+         id="stop3779" />
+      <stop
+         style="stop-color:#3465a4;stop-opacity:1"
+         offset="1"
+         id="stop3781" />
+    </linearGradient>
+    <linearGradient
+       y2="21.31134"
+       x2="17.328547"
+       y1="55.717518"
+       x1="22.116516"
+       gradientTransform="matrix(0.59371633,0.12271962,0,0.47927013,14.013224,6.2958988)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1148"
+       xlink:href="#linearGradient3767" />
+    <linearGradient
+       id="linearGradient3767">
+      <stop
+         style="stop-color:#3465a4;stop-opacity:1"
+         offset="0"
+         id="stop3769" />
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1"
+         offset="1"
+         id="stop3771" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-4.9088165,2.9980746)"
+       gradientUnits="userSpaceOnUse"
+       y2="30.552135"
+       x2="-33.344933"
+       y1="42.39082"
+       x1="-10.064023"
+       id="linearGradient2272"
+       xlink:href="#linearGradient2270" />
+    <linearGradient
+       gradientTransform="matrix(1.1029302,0,0,1.1029302,-2.6537934,-5.1993604)"
+       gradientUnits="userSpaceOnUse"
+       y2="48.889295"
+       x2="57.918649"
+       y1="48.889295"
+       x1="5.2031382"
+       id="linearGradient2280"
+       xlink:href="#linearGradient2278" />
+    <linearGradient
+       gradientTransform="matrix(1.1029302,0,0,1.1029302,-3.3029791,-6.3775123)"
+       gradientUnits="userSpaceOnUse"
+       y2="39.110054"
+       x2="56.349602"
+       y1="31.772533"
+       x1="9.3063459"
+       id="linearGradient2288"
+       xlink:href="#linearGradient2286" />
+    <linearGradient
+       y2="30.552135"
+       x2="-33.344933"
+       y1="42.39082"
+       x1="-10.064023"
+       gradientTransform="translate(-4.9088165,2.9980746)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient2299"
+       xlink:href="#linearGradient2270" />
+  </defs>
+  <metadata
+     id="metadata2990">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Std_DemoMode</dc:title>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[watsug]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:title>Part_Shape_from_Mesh</dc:title>
+        <dc:date>2020/10/29</dc:date>
+        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier />
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>watsug's design in collaboration with bitacovir</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>shapes</rdf:li>
+            <rdf:li>arrows</rdf:li>
+            <rdf:li>disc</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <dc:description>Shapes spining on a disc</dc:description>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1">
+    <path
+       d="m 4.2359229,37.043568 -0.048088,5.836239 c 2.207e-4,9.928292 12.5216101,17.976662 27.9676181,17.976852 15.446003,-1.9e-4 27.967392,-8.04856 27.967614,-17.976852 5.8e-4,-0.06649 5.8e-4,-0.133919 0,-0.200404 V 36.59644 Z"
+       style="display:inline;fill:url(#linearGradient2280);fill-opacity:1;stroke:#000000;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect964" />
+    <ellipse
+       ry="17.977093"
+       rx="27.968081"
+       cy="36.282097"
+       cx="32.15591"
+       id="ellipse968"
+       style="display:inline;fill:url(#linearGradient2288);fill-opacity:1;stroke:#000000;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path1129"
+       d="M 15.794367,14.751365 35.980723,22.194148 48.545698,10.409747 30.213193,3.1737008 Z"
+       style="fill:#729fcf;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path1131"
+       d="M 48.545698,10.409747 48.751683,28.396478 35.980723,41.62808 V 22.194148 Z"
+       style="fill:url(#linearGradient1141);fill-opacity:1;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1148);fill-opacity:1;fill-rule:evenodd;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="m 15.794367,14.751365 20.186356,7.442783 V 41.62808 L 15.794375,34.185298 Z"
+       id="path1133" />
+    <path
+       id="path1135"
+       d="m 17.737651,17.6036 0.05103,15.177868 16.195226,6.00843 -0.03083,-15.22289 z"
+       style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path1137"
+       d="m 37.980556,23.051925 0.01236,13.624019 8.742359,-9.065426 -0.06896,-12.689745 z"
+       style="fill:none;stroke:#3465a4;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <g
+       transform="translate(44.989669,-10.871767)"
+       id="g2297">
+      <path
+         id="path1674-1"
+         d="m -41.830525,26.376315 c 0.02083,-5.139299 6.656758,-7.017741 6.839516,-6.798432 l -0.259755,9.53058 c -1.012378,0.04821 -3.94483,2.973159 -3.608686,3.837823 1.465418,3.76949 -2.833321,2.543502 -2.833321,2.543502 z"
+         style="fill:#06989a;fill-opacity:1;stroke:#042a2a;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         id="path1672-4"
+         d="m -41.833104,26.222536 c 0.351761,3.541373 3.718483,6.23343 6.599585,7.801327 2.859442,1.556103 9.456615,4.114176 9.456615,4.114176 l 0.129872,-7.48733 15.6817765,13.677363 -16.2423545,7.278677 0.04107,-4.78595 c 0,0 -5.811947,-2.363939 -9.094348,-4.06471 -2.429894,-1.259057 -6.282395,-3.256954 -6.454927,-6.068292 -0.172673,-2.81368 -0.11731,-10.465261 -0.11731,-10.465261 z"
+         style="fill:url(#linearGradient2299);fill-opacity:1;stroke:#042a2a;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         style="fill:none;stroke:#34e0e2;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m -39.698628,37.06293 c 1.571404,2.479121 6.532674,4.525045 15.544469,8.592835 l -0.02522,2.87215 10.56882,-4.72646 -5.672703,-4.894247"
+         id="path2264" />
+    </g>
+    <path
+       id="path2290"
+       d="M 56.387208,30.566295 C 67.02078,50.4064 24.555796,60.864302 8.7975428,43.215151"
+       style="fill:none;stroke:#d3d7cf;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path2292"
+       d="m 8.4035692,49.307138 c 6.0508778,8.049476 19.6839998,10.880783 30.4609368,9"
+       style="fill:none;stroke:#babdb6;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  </g>
+</svg>

--- a/src/Gui/Icons/Std_DependencyGraph.svg
+++ b/src/Gui/Icons/Std_DependencyGraph.svg
@@ -1,0 +1,273 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.1"
+   id="svg2985"
+   height="64px"
+   width="64px">
+  <title
+     id="title889">Std_DependencyGraph</title>
+  <defs
+     id="defs2987">
+    <linearGradient
+       id="linearGradient3319">
+      <stop
+         id="stop3315"
+         offset="0"
+         style="stop-color:#729fcf;stop-opacity:1" />
+      <stop
+         id="stop3317"
+         offset="1"
+         style="stop-color:#204a87;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4387">
+      <stop
+         id="stop4389"
+         offset="0"
+         style="stop-color:#71b2f8;stop-opacity:1;" />
+      <stop
+         id="stop4391"
+         offset="1"
+         style="stop-color:#002795;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6321">
+      <stop
+         id="stop6323"
+         offset="0"
+         style="stop-color:#71b2f8;stop-opacity:1;" />
+      <stop
+         id="stop6325"
+         offset="1"
+         style="stop-color:#002795;stop-opacity:1;" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="translate(-0.23443224,0.23443198)"
+       gradientUnits="userSpaceOnUse"
+       r="19.467436"
+       fy="28.869568"
+       fx="45.883327"
+       cy="28.869568"
+       cx="45.883327"
+       id="radialGradient3692"
+       xlink:href="#linearGradient3377" />
+    <linearGradient
+       id="linearGradient3377">
+      <stop
+         style="stop-color:#faff2b;stop-opacity:1;"
+         offset="0"
+         id="stop3379" />
+      <stop
+         style="stop-color:#ffaa00;stop-opacity:1;"
+         offset="1"
+         id="stop3381" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3377-3">
+      <stop
+         style="stop-color:#faff2b;stop-opacity:1;"
+         offset="0"
+         id="stop3379-8" />
+      <stop
+         style="stop-color:#ffaa00;stop-opacity:1;"
+         offset="1"
+         id="stop3381-3" />
+    </linearGradient>
+    <radialGradient
+       r="19.467436"
+       fy="28.869568"
+       fx="45.883327"
+       cy="28.869568"
+       cx="45.883327"
+       gradientTransform="matrix(0.67067175,0,0,0.64145918,-63.380792,0.83845403)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient6412"
+       xlink:href="#linearGradient3377-3" />
+    <linearGradient
+       xlink:href="#linearGradient3036"
+       id="linearGradient3049"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="rotate(33.834399,20.280412,56.143946)"
+       x1="14.824193"
+       y1="50.468616"
+       x2="20.93985"
+       y2="56.000233" />
+    <linearGradient
+       id="linearGradient3036">
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1"
+         offset="0"
+         id="stop3038" />
+      <stop
+         style="stop-color:#a40000;stop-opacity:1"
+         offset="1"
+         id="stop3040" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3895-6">
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1;"
+         offset="0"
+         id="stop3897-7" />
+      <stop
+         style="stop-color:#204a87;stop-opacity:1;"
+         offset="1"
+         id="stop3899-5" />
+    </linearGradient>
+    <linearGradient
+       y2="56.000233"
+       x2="20.93985"
+       y1="50.468616"
+       x1="14.824193"
+       gradientTransform="rotate(33.834399,-6.8783909,90.878388)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3307"
+       xlink:href="#linearGradient3319" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="4"
+       x2="48"
+       y1="16"
+       x1="49"
+       id="linearGradient3848"
+       xlink:href="#linearGradient3842"
+       gradientTransform="matrix(1.6433254,0,0,0.97077226,-45.241374,0.95414569)" />
+    <linearGradient
+       id="linearGradient3842">
+      <stop
+         id="stop3844"
+         offset="0"
+         style="stop-color:#555753;stop-opacity:1" />
+      <stop
+         id="stop3846"
+         offset="1"
+         style="stop-color:#babdb6;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata2990">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Std_DependencyGraph</dc:title>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[bitacovir]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:title>Part_Shape_from_Mesh</dc:title>
+        <dc:date>2020/10/31</dc:date>
+        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier />
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title />
+          </cc:Agent>
+        </dc:contributor>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>Arrows baloons</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <dc:description></dc:description>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1">
+    <path
+       style="fill:none;stroke:#2e3436;stroke-width:6;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 36.878083,17.641312 11.974398,28.016"
+       id="path1713-8-4" />
+    <path
+       id="path1715-8"
+       d="m 51.643288,36.049439 c 0,0.1744 -0.780291,12.841008 -0.780291,12.841008 L 40.176469,41.848248 Z"
+       style="fill:#2e3436;stroke:#2e3436;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
+    <ellipse
+       style="fill:#babdb6;fill-rule:evenodd;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1690-0-7"
+       cx="51.404488"
+       cy="53.497292"
+       rx="9.6189308"
+       ry="7.5841575" />
+    <ellipse
+       ry="5.7666111"
+       rx="7.8213005"
+       cy="53.475906"
+       cx="51.441685"
+       id="path1690-2-8-9"
+       style="fill:none;fill-rule:evenodd;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none" />
+    <path
+       style="fill:#babdb6;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 49.715718,38.859318 c -0.616598,0 -6.227642,2.898011 -6.227642,2.898011 l 5.919343,3.576269 z"
+       id="path1801" />
+    <path
+       id="path1713-8"
+       d="M 36.878083,17.641312 47.002687,41.495274"
+       style="fill:none;stroke:#babdb6;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path1713-8-4-0"
+       d="m 27.957562,17.518003 -11.974398,28.016"
+       style="fill:none;stroke:#2e3436;stroke-width:6;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="fill:#2e3436;stroke:#2e3436;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
+       d="m 13.192357,35.92613 c 0,0.1744 0.780291,12.841008 0.780291,12.841008 l 10.686528,-7.042199 z"
+       id="path1715-8-0" />
+    <path
+       id="path1801-2"
+       d="m 15.119927,38.736009 c 0.616598,0 6.227642,2.898011 6.227642,2.898011 l -5.919343,3.576269 z"
+       style="fill:#babdb6;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       style="fill:none;stroke:#babdb6;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 27.957562,17.518003 17.832958,41.371965"
+       id="path1713-8-0" />
+    <ellipse
+       ry="7.5841575"
+       rx="9.6189308"
+       cy="53.410088"
+       cx="12.64402"
+       id="path1690-0"
+       style="fill:#babdb6;fill-rule:evenodd;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none" />
+    <ellipse
+       style="fill:none;fill-rule:evenodd;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1690-2-8"
+       cx="12.681218"
+       cy="53.388702"
+       rx="7.8213005"
+       ry="5.7666111" />
+    <ellipse
+       style="fill:#babdb6;fill-rule:evenodd;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1690"
+       cx="31.955387"
+       cy="10.600465"
+       rx="9.6189308"
+       ry="7.5841575" />
+    <ellipse
+       ry="5.7666111"
+       rx="7.8213005"
+       cy="10.579082"
+       cx="31.992584"
+       id="path1690-2"
+       style="fill:none;fill-rule:evenodd;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none" />
+  </g>
+</svg>

--- a/src/Gui/Icons/Std_DlgParameter.svg
+++ b/src/Gui/Icons/Std_DlgParameter.svg
@@ -1,0 +1,251 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.1"
+   id="svg2985"
+   height="64px"
+   width="64px">
+  <title
+     id="title889">Std_DlgParameter</title>
+  <defs
+     id="defs2987">
+    <linearGradient
+       id="linearGradient3319">
+      <stop
+         id="stop3315"
+         offset="0"
+         style="stop-color:#729fcf;stop-opacity:1" />
+      <stop
+         id="stop3317"
+         offset="1"
+         style="stop-color:#204a87;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4387">
+      <stop
+         id="stop4389"
+         offset="0"
+         style="stop-color:#71b2f8;stop-opacity:1;" />
+      <stop
+         id="stop4391"
+         offset="1"
+         style="stop-color:#002795;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6321">
+      <stop
+         id="stop6323"
+         offset="0"
+         style="stop-color:#71b2f8;stop-opacity:1;" />
+      <stop
+         id="stop6325"
+         offset="1"
+         style="stop-color:#002795;stop-opacity:1;" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="translate(-0.23443224,0.23443198)"
+       gradientUnits="userSpaceOnUse"
+       r="19.467436"
+       fy="28.869568"
+       fx="45.883327"
+       cy="28.869568"
+       cx="45.883327"
+       id="radialGradient3692"
+       xlink:href="#linearGradient3377" />
+    <linearGradient
+       id="linearGradient3377">
+      <stop
+         style="stop-color:#faff2b;stop-opacity:1;"
+         offset="0"
+         id="stop3379" />
+      <stop
+         style="stop-color:#ffaa00;stop-opacity:1;"
+         offset="1"
+         id="stop3381" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3377-3">
+      <stop
+         style="stop-color:#faff2b;stop-opacity:1;"
+         offset="0"
+         id="stop3379-8" />
+      <stop
+         style="stop-color:#ffaa00;stop-opacity:1;"
+         offset="1"
+         id="stop3381-3" />
+    </linearGradient>
+    <radialGradient
+       r="19.467436"
+       fy="28.869568"
+       fx="45.883327"
+       cy="28.869568"
+       cx="45.883327"
+       gradientTransform="matrix(0.67067175,0,0,0.64145918,-63.380792,0.83845403)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient6412"
+       xlink:href="#linearGradient3377-3" />
+    <linearGradient
+       xlink:href="#linearGradient3036"
+       id="linearGradient3049"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="rotate(33.834399,20.280412,56.143946)"
+       x1="14.824193"
+       y1="50.468616"
+       x2="20.93985"
+       y2="56.000233" />
+    <linearGradient
+       id="linearGradient3036">
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1"
+         offset="0"
+         id="stop3038" />
+      <stop
+         style="stop-color:#a40000;stop-opacity:1"
+         offset="1"
+         id="stop3040" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3895-6">
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1;"
+         offset="0"
+         id="stop3897-7" />
+      <stop
+         style="stop-color:#204a87;stop-opacity:1;"
+         offset="1"
+         id="stop3899-5" />
+    </linearGradient>
+    <linearGradient
+       y2="56.000233"
+       x2="20.93985"
+       y1="50.468616"
+       x1="14.824193"
+       gradientTransform="rotate(33.834399,-6.8783909,90.878388)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3307"
+       xlink:href="#linearGradient3319" />
+    <linearGradient
+       xlink:href="#linearGradient3864-9"
+       id="linearGradient3808"
+       x1="-146.74467"
+       y1="58.261547"
+       x2="-157.32494"
+       y2="26.520763"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.97668521,0.0547655,-0.0547655,0.97668512,182.70859,-2.2305154)" />
+    <linearGradient
+       id="linearGradient3864-9">
+      <stop
+         style="stop-color:#204a87;stop-opacity:1"
+         offset="0"
+         id="stop3866-1" />
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1"
+         offset="1"
+         id="stop3868-1" />
+    </linearGradient>
+    <linearGradient
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715"
+       gradientTransform="matrix(2.774389,0,0,1.969706,-1892.179,-872.8854)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6715-5"
+       xlink:href="#linearGradient5048" />
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         style="stop-color:black;stop-opacity:0;"
+         offset="0"
+         id="stop5050" />
+      <stop
+         id="stop5056"
+         offset="0.5"
+         style="stop-color:black;stop-opacity:1;" />
+      <stop
+         style="stop-color:black;stop-opacity:0;"
+         offset="1"
+         id="stop5052" />
+    </linearGradient>
+    <linearGradient
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715"
+       gradientTransform="matrix(2.774389,0,0,1.969706,-1892.179,-872.8854)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3242"
+       xlink:href="#linearGradient5048" />
+  </defs>
+  <metadata
+     id="metadata2990">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Std_DlgParameter</dc:title>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[bitacovir]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:title>Part_Shape_from_Mesh</dc:title>
+        <dc:date>2020/11/19</dc:date>
+        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier />
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>Based on Bejant's work</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>Gear</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <dc:description>Blue gear</dc:description>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1">
+    <g
+       transform="translate(0.17674686,0.06165982)"
+       id="g3353">
+      <path
+         id="path3659-5"
+         d="m 47.072047,13.49348 -7.25661,3.639384 -3.044172,-1.251456 -2.537552,-7.7361038 -4.673163,-0.016413 -2.564225,7.7086968 -3.054328,1.257622 -7.236841,-3.661338 -3.328762,3.30636 3.639401,7.256608 -1.275845,3.033674 -7.7361133,2.537561 0.00796,4.683643 7.7087123,2.564218 1.257621,3.054327 -3.685711,7.226363 3.306355,3.328755 7.256601,-3.639389 3.058066,1.286323 2.513177,7.725622 4.708019,0.0025 2.53984,-7.719179 3.054339,-1.257622 7.250725,3.696204 3.328762,-3.306361 -3.639392,-7.256605 1.261932,-3.068543 7.725633,-2.513183 0.02691,-4.697535 -7.719194,-2.539837 -1.25763,-3.054327 3.671825,-7.261229 z m -11.175912,10.938628 1.396243,0.918293 1.186806,1.203784 0.925177,1.409058 0.635757,1.544598 0.332462,1.645274 -0.02304,1.665726 -0.333176,1.647904 -0.636201,1.546466 -0.95316,1.410145 -1.168915,1.172904 -1.409065,0.925174 -1.544597,0.635755 -1.645274,0.332453 -1.676208,0.0014 -1.647918,-0.333161 -1.546458,-0.636213 -1.410137,-0.953159 -1.162439,-1.193302 -0.935639,-1.384673 -0.635777,-1.544598 -0.321962,-1.669654 -0.0013,-1.67621 0.333167,-1.647908 0.636221,-1.54646 0.942669,-1.385767 1.179415,-1.197283 1.409046,-0.925175 1.544597,-0.635759 1.66965,-0.321966 1.665725,0.02304 1.64791,0.333159 1.546466,0.636214 z"
+         style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3808);fill-opacity:1;fill-rule:evenodd;stroke:#000137;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+      <path
+         id="path3659-5-6"
+         d="m 46.665932,16.228758 -6.772715,3.391179 -4.847822,-2.056474 -2.489782,-7.138562 -1.396661,-0.0028 -2.415722,7.225884 -4.953349,1.931885 -6.673522,-3.356372 -0.974551,0.996986 3.405375,6.846867 -2.164816,4.741796 -7.058271,2.365929 -0.0036,1.486481 7.171516,2.4044 1.986735,4.956424 -3.396705,6.663018 0.96246,0.935939 6.696534,-3.340444 5.115268,2.120649 2.1773,7.07612 1.395792,0.06172 2.43718,-7.177917 4.87118,-2.101523 6.975472,3.459155 0.912547,-0.872108 -3.41459,-6.68235 1.907599,-4.988763 7.254984,-2.423995 0.03309,-1.462493 -7.096784,-2.249261 -2.111617,-5.018436 3.409598,-6.821492 z"
+         style="display:inline;overflow:visible;visibility:visible;fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+      <circle
+         r="10.932387"
+         cy="30.086609"
+         cx="33.553997"
+         id="path3898"
+         style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6;stroke-opacity:1"
+         transform="rotate(3.2093756)" />
+    </g>
+  </g>
+</svg>

--- a/src/Gui/Icons/Std_ProjectUtil.svg
+++ b/src/Gui/Icons/Std_ProjectUtil.svg
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   width="64"
+   height="64"
+   viewBox="0 0 63.999999 63.999998"
+   id="svg2"
+   version="1.1">
+  <title
+     id="title842">Std_ProjectUtil</title>
+  <metadata
+     id="metadata14">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Std_ProjectUtil</dc:title>
+        <dc:date>2020/10/31</dc:date>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[bitacovir]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:subject>
+          <rdf:Bag />
+        </dc:subject>
+        <dc:description>Green arrow and blue frame</dc:description>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs12">
+    <linearGradient
+       id="linearGradient3861">
+      <stop
+         style="stop-color:#3465a4;stop-opacity:1;"
+         offset="0"
+         id="stop3863" />
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1"
+         offset="1"
+         id="stop3865" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3861"
+       id="linearGradient4204"
+       x1="220.23199"
+       y1="452.43173"
+       x2="178.23227"
+       y2="89.727692"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       xlink:href="#linearGradient3806"
+       id="linearGradient3012"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.4500001,0,0,1.4705882,-27.45,-15.05882)"
+       x1="39.263832"
+       y1="20.978374"
+       x2="43.478561"
+       y2="42.076672" />
+    <linearGradient
+       id="linearGradient3806">
+      <stop
+         style="stop-color:#8ae234;stop-opacity:1"
+         offset="0"
+         id="stop3808" />
+      <stop
+         style="stop-color:#4e9a06;stop-opacity:1"
+         offset="1"
+         id="stop3810" />
+    </linearGradient>
+  </defs>
+  <g
+     id="g4"
+     style="fill:#205493;stroke:#0b1521;stroke-width:17.03064728;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     transform="matrix(0.11712934,0,0,0.12658345,6.3540226,-2.7048542)">
+    <path
+       style="fill:url(#linearGradient4204);fill-opacity:1;stroke:#0b1521;stroke-width:17.13426781;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 191.68535,68.991034 c -25.01113,0.825185 25.55018,0.03509 0.25466,0.363792 -43.36411,0.212557 -75.47638,-0.692241 -118.824699,0.06442 -43.079122,3.698128 -79.7652904,44.484054 -76.9336704,88.026064 -0.4439575,75.47002 -0.051566,150.94383 -0.1459621,226.41396 -0.5002276,16.57633 1.0512879,33.72441 9.3462972,48.45039 15.1024633,29.2002 47.5748333,49.03481 80.7098203,46.74393 81.071924,-0.21153 162.166794,0.57106 243.224554,-0.41015 43.22514,-3.74522 79.42489,-45.02726 76.62401,-88.51258 -0.22056,-30.91559 1.31867,-13.51025 0.0795,-44.36085 -2.34002,-8.22613 -12.14001,-10.33714 -19.54688,-8.83594 -7.75802,-0.46323 -18.74559,-1.78474 -22.87891,6.63477 -3.83588,9.4189 -0.29725,19.57848 -1.61914,29.34375 -0.40461,25.86461 0.59366,3.47835 -1.47293,29.2046 -4.3795,20.76154 -25.86566,35.21453 -46.75585,32.40721 -79.28903,-0.25751 -158.60963,0.5384 -237.878912,-0.41112 -21.612075,-2.81679 -38.071154,-24.76126 -35.322258,-46.2832 0.263584,-79.62158 -0.544254,-159.27571 0.416008,-238.87696 2.816182,-21.62523 24.76226,-38.04333 46.289061,-35.32265 66.459691,-0.23376 45.553841,0.63643 111.988081,-0.21561 8.31737,-1.76623 8.5373,-12.68319 9.56641,-18.996089 0.22106,-7.774814 2.06378,-18.411454 -5.84961,-23.224609 -3.44384,-1.838988 -7.42123,-2.284442 -11.26958,-2.203125 z"
+       id="path6" />
+  </g>
+  <g
+     style="display:inline"
+     id="layer1-3"
+     transform="matrix(0.49826057,-0.41559217,-0.33137144,-0.39728689,38.332558,50.381372)">
+    <path
+       id="path3343"
+       d="M 35.907323,8.8968626 V 23.000001 H 3 l 10e-8,23.505231 H 35.907323 V 60.60837 L 64.1136,34.752616 Z"
+       style="fill:url(#linearGradient3012);fill-opacity:1;fill-rule:evenodd;stroke:#172a04;stroke-width:4.31504;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path3343-2"
+       d="m 39.668159,17.515447 v 8.618585 H 7.0742394 V 43.371201 H 39.668159 v 8.618585 l 18.33408,-17.23717 z"
+       style="fill:none;stroke:#8ae234;stroke-width:3.74776;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  </g>
+</svg>

--- a/src/Gui/Icons/Std_SceneInspector.svg
+++ b/src/Gui/Icons/Std_SceneInspector.svg
@@ -1,0 +1,279 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.1"
+   id="svg2985"
+   height="64px"
+   width="64px">
+  <title
+     id="title889">Std_SceneInspector</title>
+  <defs
+     id="defs2987">
+    <linearGradient
+       id="linearGradient3319">
+      <stop
+         id="stop3315"
+         offset="0"
+         style="stop-color:#729fcf;stop-opacity:1" />
+      <stop
+         id="stop3317"
+         offset="1"
+         style="stop-color:#204a87;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4387">
+      <stop
+         id="stop4389"
+         offset="0"
+         style="stop-color:#71b2f8;stop-opacity:1;" />
+      <stop
+         id="stop4391"
+         offset="1"
+         style="stop-color:#002795;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6321">
+      <stop
+         id="stop6323"
+         offset="0"
+         style="stop-color:#71b2f8;stop-opacity:1;" />
+      <stop
+         id="stop6325"
+         offset="1"
+         style="stop-color:#002795;stop-opacity:1;" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="translate(-0.23443224,0.23443198)"
+       gradientUnits="userSpaceOnUse"
+       r="19.467436"
+       fy="28.869568"
+       fx="45.883327"
+       cy="28.869568"
+       cx="45.883327"
+       id="radialGradient3692"
+       xlink:href="#linearGradient3377" />
+    <linearGradient
+       id="linearGradient3377">
+      <stop
+         style="stop-color:#faff2b;stop-opacity:1;"
+         offset="0"
+         id="stop3379" />
+      <stop
+         style="stop-color:#ffaa00;stop-opacity:1;"
+         offset="1"
+         id="stop3381" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3377-3">
+      <stop
+         style="stop-color:#faff2b;stop-opacity:1;"
+         offset="0"
+         id="stop3379-8" />
+      <stop
+         style="stop-color:#ffaa00;stop-opacity:1;"
+         offset="1"
+         id="stop3381-3" />
+    </linearGradient>
+    <radialGradient
+       r="19.467436"
+       fy="28.869568"
+       fx="45.883327"
+       cy="28.869568"
+       cx="45.883327"
+       gradientTransform="matrix(0.67067175,0,0,0.64145918,-63.380792,0.83845403)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient6412"
+       xlink:href="#linearGradient3377-3" />
+    <linearGradient
+       xlink:href="#linearGradient3036"
+       id="linearGradient3049"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="rotate(33.834399,20.280412,56.143946)"
+       x1="14.824193"
+       y1="50.468616"
+       x2="20.93985"
+       y2="56.000233" />
+    <linearGradient
+       id="linearGradient3036">
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1"
+         offset="0"
+         id="stop3038" />
+      <stop
+         style="stop-color:#a40000;stop-opacity:1"
+         offset="1"
+         id="stop3040" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3895-6">
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1;"
+         offset="0"
+         id="stop3897-7" />
+      <stop
+         style="stop-color:#204a87;stop-opacity:1;"
+         offset="1"
+         id="stop3899-5" />
+    </linearGradient>
+    <linearGradient
+       y2="56.000233"
+       x2="20.93985"
+       y1="50.468616"
+       x1="14.824193"
+       gradientTransform="rotate(33.834399,-6.8783909,90.878388)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3307"
+       xlink:href="#linearGradient3319" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="4"
+       x2="48"
+       y1="16"
+       x1="49"
+       id="linearGradient3848"
+       xlink:href="#linearGradient3842"
+       gradientTransform="matrix(1.6433254,0,0,0.97077226,-45.241374,0.95414569)" />
+    <linearGradient
+       id="linearGradient3842">
+      <stop
+         id="stop3844"
+         offset="0"
+         style="stop-color:#555753;stop-opacity:1" />
+      <stop
+         id="stop3846"
+         offset="1"
+         style="stop-color:#babdb6;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.8263216,0,0,0.85134146,-53.899557,6.4014059)"
+       gradientUnits="userSpaceOnUse"
+       y2="14"
+       x2="43"
+       y1="54"
+       x1="49"
+       id="linearGradient3836"
+       xlink:href="#linearGradient3830" />
+    <linearGradient
+       id="linearGradient3830">
+      <stop
+         id="stop3832"
+         offset="0"
+         style="stop-color:#d3d7cf;stop-opacity:1;" />
+      <stop
+         id="stop3834"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata2990">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Std_SceneInspector</dc:title>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[bitacovir]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:title>Part_Shape_from_Mesh</dc:title>
+        <dc:date>2020/10/31</dc:date>
+        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier />
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title />
+          </cc:Agent>
+        </dc:contributor>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>window</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <dc:description>Window with list of elements</dc:description>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1">
+    <rect
+       y="5.8080096"
+       x="12.275028"
+       height="52.421707"
+       width="39.439812"
+       id="rect3020"
+       style="fill:none;stroke:#2e3436;stroke-width:7.5783;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6;stroke-opacity:1" />
+    <rect
+       y="5.8080096"
+       x="12.275028"
+       height="52.421707"
+       width="39.439812"
+       id="rect3020-6"
+       style="fill:none;stroke:#888a85;stroke-width:2.5261;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6;stroke-opacity:1" />
+    <rect
+       y="5.8080068"
+       x="12.275028"
+       height="7.7661781"
+       width="39.439812"
+       id="rect3826"
+       style="fill:url(#linearGradient3848);fill-opacity:1;stroke:#888a85;stroke-width:2.5261;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6;stroke-opacity:1" />
+    <rect
+       y="17.468843"
+       x="17.327002"
+       height="35.756344"
+       width="29.221146"
+       id="rect3828"
+       style="fill:url(#linearGradient3836);fill-opacity:1;stroke:#ffffff;stroke-width:2.62182;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6;stroke-opacity:1" />
+    <path
+       id="path3838"
+       d="M 13.532966,15.515748 H 50.426045"
+       style="fill:none;stroke:#2e3436;stroke-width:2.55182;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       id="path3840"
+       d="M 13.671701,9.691097 H 26.818305"
+       style="fill:none;stroke:#ffffff;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="fill:none;stroke:#555753;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 20.1011,19.97778 H 32.248084"
+       id="path1619" />
+    <path
+       id="path1619-0"
+       d="M 27.033986,25.862348 H 43.628164"
+       style="fill:none;stroke:#555753;stroke-width:2.33762;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="fill:none;stroke:#555753;stroke-width:2.33762;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 27.095645,31.623598 H 43.689823"
+       id="path1619-0-3" />
+    <path
+       style="fill:none;stroke:#555753;stroke-width:2.33762;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 27.157305,37.076547 H 43.751483"
+       id="path1619-0-9" />
+    <path
+       id="path1619-4"
+       d="M 20.19359,42.899455 H 32.340574"
+       style="fill:none;stroke:#555753;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path1619-0-9-2"
+       d="M 27.126476,47.928674 H 43.720654"
+       style="fill:none;stroke:#555753;stroke-width:2.33762;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  </g>
+</svg>

--- a/src/Gui/Icons/resource.qrc
+++ b/src/Gui/Icons/resource.qrc
@@ -168,6 +168,11 @@
         <file>Std_WindowNext.svg</file>
         <file>Std_WindowPrev.svg</file>
         <file>Std_WindowTileVer.svg</file>
+        <file>Std_DemoMode.svg</file>
+        <file>Std_DependencyGraph.svg</file>
+        <file>Std_DlgParameter.svg</file>
+        <file>Std_ProjectUtil.svg</file>
+        <file>Std_SceneInspector.svg</file>
         <file>WhatsThis.svg</file>
         <file>colors.svg</file>
         <file>px.svg</file>


### PR DESCRIPTION
Five Std Tool commands do not have icons for the FreeCAD UI (Menu Tools): Std SceneInspector, Std DependencyGraph, Std ProjectUtil, Std DemoMode, Std DlgParameter

This commit adds SVG files with icons for these commands. Also, it makes the necessary changes on CommandStd.cpp, CommandDoc.cpp, CommandView.cpp and resource.qrc files. 

The new SVG icons follow the FreeCAD Artwork Guidelines and were saved as Plain SVG format.

Forum Discussion: https://forum.freecadweb.org/viewtopic.php?f=34&t=51502