### PR TITLE
Path: Fix Drilling Op issues when using rotation feature

### DIFF
--- a/src/Mod/Path/PathScripts/PathCircularHoleBase.py
+++ b/src/Mod/Path/PathScripts/PathCircularHoleBase.py
@@ -734,12 +734,6 @@ class ObjectOp(PathOp.ObjectOp):
         elif axis == 'Y':
             vect = FreeCAD.Vector(0, 1, 0)
 
-        # Commented out to fix PocketShape InverseAngle rotation problem
-        # if obj.InverseAngle is True:
-        #    angle = -1 * angle
-        #    if math.fabs(angle) == 0.0:
-        #        angle = 0.0
-
         # Create a temporary clone of model for rotational use.
         (clnBase, clnStock, tag) = self.cloneBaseAndStock(obj, base, angle, axis, subCount)
 

--- a/src/Mod/Path/PathScripts/PathCircularHoleBase.py
+++ b/src/Mod/Path/PathScripts/PathCircularHoleBase.py
@@ -19,12 +19,6 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-# *                                                                         *
-# *   Additional modifications and contributions beginning 2019             *
-# *   Focus: 4th-axis integration                                           *
-# *   by Russell Johnson  <russ4262@gmail.com>                              *
-# *                                                                         *
-# ***************************************************************************
 
 import FreeCAD
 import PathScripts.PathLog as PathLog
@@ -50,9 +44,6 @@ __author__ = "sliptonic (Brad Collette)"
 __url__ = "https://www.freecadweb.org"
 __doc__ = "Base class an implementation for operations on circular holes."
 __contributors__ = "russ4262 (Russell Johnson)"
-__created__ = "2017"
-__scriptVersion__ = "2b"
-__lastModified__ = "2020-02-13 17:11 CST"
 
 
 # Qt translation handling
@@ -339,7 +330,8 @@ class ObjectOp(PathOp.ObjectOp):
                                      'angle': angle, 'axis': axis, 'trgtDep': obj.FinalDepth.Value,
                                       'stkTop': stock.Shape.BoundBox.ZMax})
 
-        # haveLocations are populated from Base Locations tab as (x,y) coordinates
+        # haveLocations are populated from user-provided (x, y) coordinates
+        # provided by the user in the Base Locations tab of the Task Editor window
         if haveLocations(self, obj):
             for location in obj.Locations:
                 # holes.append({'x': location.x, 'y': location.y, 'r': 0, 'angle': 0.0, 'axis': 'X', 'holeBtm': obj.FinalDepth.Value})

--- a/src/Mod/Path/PathScripts/PathCircularHoleBase.py
+++ b/src/Mod/Path/PathScripts/PathCircularHoleBase.py
@@ -605,7 +605,7 @@ class ObjectOp(PathOp.ObjectOp):
             xAx = 'xAxCyl'
             yAx = 'yAxCyl'
             # zAx = 'zAxCyl'
-            VA = fcad.addObject("App::DocumentObjectGroup", "visualAxis")
+            visual_axis_obj = fcad.addObject("App::DocumentObjectGroup", "visualAxis")
             if FreeCAD.GuiUp:
                 FreeCADGui.ActiveDocument.getObject('visualAxis').Visibility = False
             vaGrp = fcad.getObject("visualAxis")
@@ -637,7 +637,7 @@ class ObjectOp(PathOp.ObjectOp):
                 cylGui.Transparency = 85
                 cylGui.Visibility = False
             vaGrp.addObject(cyl)
-            VA.purgeTouched()
+            visual_axis_obj.purgeTouched()
 
     def useTempJobClones(self, cloneName):
         '''useTempJobClones(cloneName)

--- a/src/Mod/Path/PathScripts/PathCircularHoleBase.py
+++ b/src/Mod/Path/PathScripts/PathCircularHoleBase.py
@@ -330,20 +330,21 @@ class ObjectOp(PathOp.ObjectOp):
                             PathLog.warning(msg)
 
                         # Warn user if Final Depth set lower than bottom of hole
-                        if finDep < holeBtm:
+                        if obj.FinalDepth.Value < holeBtm:
                             msg = translate("Path", "Final Depth setting is below the hole bottom for {}.".format(sub)) + '  '
                             msg += translate("Path", "{} depth is calculated at {} mm".format(sub, round(holeBtm, 4)))
                             PathLog.warning(msg)
 
                         holes.append({'x': pos.x, 'y': pos.y, 'r': self.holeDiameter(obj, base, sub),
-                                     'angle': angle, 'axis': axis, 'trgtDep': finDep,
+                                     'angle': angle, 'axis': axis, 'trgtDep': obj.FinalDepth.Value,
                                       'stkTop': stock.Shape.BoundBox.ZMax})
 
+        # haveLocations are populated from Base Locations tab as (x,y) coordinates
         if haveLocations(self, obj):
             for location in obj.Locations:
                 # holes.append({'x': location.x, 'y': location.y, 'r': 0, 'angle': 0.0, 'axis': 'X', 'holeBtm': obj.FinalDepth.Value})
                 holes.append({'x': location.x, 'y': location.y, 'r': 0,
-                             'angle': 0.0, 'axis': 'X', 'trgtDep': finDep,
+                             'angle': 0.0, 'axis': 'X', 'trgtDep': obj.FinalDepth.Value,
                               'stkTop': PathUtils.findParentJob(obj).Stock.Shape.BoundBox.ZMax})
 
         if len(holes) > 0:

--- a/src/Mod/Path/PathScripts/PathCircularHoleBase.py
+++ b/src/Mod/Path/PathScripts/PathCircularHoleBase.py
@@ -599,18 +599,19 @@ class ObjectOp(PathOp.ObjectOp):
         '''visualAxis()
             Create visual X & Y axis for use in orientation of rotational operations
             Triggered only for PathLog.debug'''
+        fcad = FreeCAD.ActiveDocument
 
-        if not FreeCAD.ActiveDocument.getObject('xAxCyl'):
+        if not fcad.getObject('xAxCyl'):
             xAx = 'xAxCyl'
             yAx = 'yAxCyl'
             # zAx = 'zAxCyl'
-            VA = FreeCAD.ActiveDocument.addObject("App::DocumentObjectGroup", "visualAxis")
+            VA = fcad.addObject("App::DocumentObjectGroup", "visualAxis")
             if FreeCAD.GuiUp:
                 FreeCADGui.ActiveDocument.getObject('visualAxis').Visibility = False
-            vaGrp = FreeCAD.ActiveDocument.getObject("visualAxis")
+            vaGrp = fcad.getObject("visualAxis")
 
-            FreeCAD.ActiveDocument.addObject("Part::Cylinder", xAx)
-            cyl = FreeCAD.ActiveDocument.getObject(xAx)
+            fcad.addObject("Part::Cylinder", xAx)
+            cyl = fcad.getObject(xAx)
             cyl.Label = xAx
             cyl.Radius = self.xRotRad
             cyl.Height = 0.01
@@ -623,8 +624,8 @@ class ObjectOp(PathOp.ObjectOp):
                 cylGui.Visibility = False
             vaGrp.addObject(cyl)
 
-            FreeCAD.ActiveDocument.addObject("Part::Cylinder", yAx)
-            cyl = FreeCAD.ActiveDocument.getObject(yAx)
+            fcad.addObject("Part::Cylinder", yAx)
+            cyl = fcad.getObject(yAx)
             cyl.Label = yAx
             cyl.Radius = self.yRotRad
             cyl.Height = 0.01
@@ -642,25 +643,27 @@ class ObjectOp(PathOp.ObjectOp):
         '''useTempJobClones(cloneName)
             Manage use of temporary model clones for rotational operation calculations.
             Clones are stored in 'rotJobClones' group.'''
-        if FreeCAD.ActiveDocument.getObject('rotJobClones'):
+        fcad = FreeCAD.ActiveDocument
+
+        if fcad.getObject('rotJobClones'):
             if cloneName == 'Start':
                 if PathLog.getLevel(PathLog.thisModule()) < 4:
-                    for cln in FreeCAD.ActiveDocument.getObject('rotJobClones').Group:
-                        FreeCAD.ActiveDocument.removeObject(cln.Name)
+                    for cln in fcad.getObject('rotJobClones').Group:
+                        fcad.removeObject(cln.Name)
             elif cloneName == 'Delete':
                 if PathLog.getLevel(PathLog.thisModule()) < 4:
-                    for cln in FreeCAD.ActiveDocument.getObject('rotJobClones').Group:
-                        FreeCAD.ActiveDocument.removeObject(cln.Name)
-                    FreeCAD.ActiveDocument.removeObject('rotJobClones')
+                    for cln in fcad.getObject('rotJobClones').Group:
+                        fcad.removeObject(cln.Name)
+                    fcad.removeObject('rotJobClones')
                 else:
-                    FreeCAD.ActiveDocument.getObject('rotJobClones').purgeTouched()
+                    fcad.getObject('rotJobClones').purgeTouched()
         else:
-            FreeCAD.ActiveDocument.addObject("App::DocumentObjectGroup", "rotJobClones")
+            fcad.addObject("App::DocumentObjectGroup", "rotJobClones")
             if FreeCAD.GuiUp:
                 FreeCADGui.ActiveDocument.getObject('rotJobClones').Visibility = False
 
         if cloneName != 'Start' and cloneName != 'Delete':
-            FreeCAD.ActiveDocument.getObject('rotJobClones').addObject(FreeCAD.ActiveDocument.getObject(cloneName))
+            fcad.getObject('rotJobClones').addObject(fcad.getObject(cloneName))
             if FreeCAD.GuiUp:
                 FreeCADGui.ActiveDocument.getObject(cloneName).Visibility = False
 
@@ -669,6 +672,7 @@ class ObjectOp(PathOp.ObjectOp):
             Method called to create a temporary clone of the base and parent Job stock.
             Clones are destroyed after usage for calculations related to rotational operations.'''
         # Create a temporary clone and stock of model for rotational use.
+        fcad = FreeCAD.ActiveDocument
         rndAng = round(angle, 8)
         if rndAng < 0.0:  # neg sign is converted to underscore in clone name creation.
             tag = axis + '_' + axis + '_' + str(math.fabs(rndAng)).replace('.', '_')
@@ -679,21 +683,21 @@ class ObjectOp(PathOp.ObjectOp):
         if clnNm not in self.cloneNames:
             self.cloneNames.append(clnNm)
             self.cloneNames.append(stckClnNm)
-            if FreeCAD.ActiveDocument.getObject(clnNm):
-                FreeCAD.ActiveDocument.getObject(clnNm).Shape = base.Shape
+            if fcad.getObject(clnNm):
+                fcad.getObject(clnNm).Shape = base.Shape
             else:
-                FreeCAD.ActiveDocument.addObject('Part::Feature', clnNm).Shape = base.Shape
+                fcad.addObject('Part::Feature', clnNm).Shape = base.Shape
                 self.useTempJobClones(clnNm)
-            if FreeCAD.ActiveDocument.getObject(stckClnNm):
-                FreeCAD.ActiveDocument.getObject(stckClnNm).Shape = PathUtils.findParentJob(obj).Stock.Shape
+            if fcad.getObject(stckClnNm):
+                fcad.getObject(stckClnNm).Shape = PathUtils.findParentJob(obj).Stock.Shape
             else:
-                FreeCAD.ActiveDocument.addObject('Part::Feature', stckClnNm).Shape = PathUtils.findParentJob(obj).Stock.Shape
+                fcad.addObject('Part::Feature', stckClnNm).Shape = PathUtils.findParentJob(obj).Stock.Shape
                 self.useTempJobClones(stckClnNm)
             if FreeCAD.GuiUp:
                 FreeCADGui.ActiveDocument.getObject(stckClnNm).Transparency = 90
                 FreeCADGui.ActiveDocument.getObject(clnNm).ShapeColor = (1.000, 0.667, 0.000)
-        clnBase = FreeCAD.ActiveDocument.getObject(clnNm)
-        clnStock = FreeCAD.ActiveDocument.getObject(stckClnNm)
+        clnBase = fcad.getObject(clnNm)
+        clnStock = fcad.getObject(stckClnNm)
         tag = base.Name + '_' + tag
         return (clnBase, clnStock, tag)
 

--- a/src/Mod/Path/PathScripts/PathDrilling.py
+++ b/src/Mod/Path/PathScripts/PathDrilling.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # ***************************************************************************
 # *   Copyright (c) 2014 Yorik van Havre <yorik@uncreated.net>              *
-# *   Copyright (c) 2020 russ4262 (Russell Johnson)                         *
 # *   Copyright (c) 2020 Schildkroet                                        *
 # *                                                                         *
 # *   This program is free software; you can redistribute it and/or modify  *
@@ -21,12 +20,6 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-# *                                                                         *
-# *   Additional modifications and contributions beginning 2019             *
-# *   Focus: 4th-axis integration                                           *
-# *   by Russell Johnson  <russ4262@gmail.com>                              *
-# *                                                                         *
-# ***************************************************************************
 
 from __future__ import print_function
 
@@ -43,6 +36,8 @@ __title__ = "Path Drilling Operation"
 __author__ = "sliptonic (Brad Collette)"
 __url__ = "https://www.freecadweb.org"
 __doc__ = "Path Drilling operation."
+__contributors__ = "russ4262 (Russell Johnson)"
+
 
 PathLog.setLevel(PathLog.Level.INFO, PathLog.thisModule())
 # PathLog.trackModule(PathLog.thisModule())
@@ -198,8 +193,8 @@ class ObjectDrilling(PathCircularHoleBase.ObjectOp):
 
         # Initial setting for EnableRotation is taken from Job SetupSheet
         # User may override on per-operation basis as needed.
-        if hasattr(parentJob.SetupSheet, 'SetupEnableRotation'):
-            obj.EnableRotation = parentJob.SetupSheet.SetupEnableRotation
+        if hasattr(job.SetupSheet, 'SetupEnableRotation'):
+            obj.EnableRotation = job.SetupSheet.SetupEnableRotation
         else:
             obj.EnableRotation = 'Off'
 


### PR DESCRIPTION
This PR addresses numerous problems that existed in the rotational use of the Drilling Op.  The issues were brought to light in the forum, [4th axis tool orientation not right in G-Code](https://forum.freecadweb.org/viewtopic.php?style=3&f=15&t=52262).

There are many changes to the rotational-related code in this PR, but they are necessary to make the existing rotational feature more usable in 0.19 since the feature is available.  A large portion of the changes pertain to simplifying the rotational integration code to align it more with the integration found in the PocketShape module.

Some of the changes are simply to synchronize (update) existing rotational methods with identical methods that initiated in the PathAreaOp module.  Eventually (in the next release after 0.19), this set of methods could be removed and replaced with references to those in the PathAreaOp module as a means to consolidated the rotational code in use throughout Path WB.

The changes in this PR do not (or, at least are not intended or known to) affect standard, non-rotational use of the Drilling op.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
