### PR TITLE
(Windows only) Improve the dpi handling with different dpi screens on…

### DIFF
--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -1904,6 +1904,10 @@ void Application::runApplication(void)
 #if QT_VERSION >= 0x050600
     //Enable automatic scaling based on pixel density of display (added in Qt 5.6)
     QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+#ifdef FC_OS_WIN32
+    SetProcessDPIAware(); // call before the main event loop
+    QApplication::setAttribute(Qt::AA_DisableHighDpiScaling);
+#endif
 #endif
 #if QT_VERSION >= 0x050100
     //Enable support for highres images (added in Qt 5.1, but off by default)


### PR DESCRIPTION
(Windows only) Improve the dpi handling with different dpi screens on Windows OS only.
--> If using screens with different dpi (e.g. HD, 4k) the font size is not handled well. It shows a little blurry. Also the icon size is not handled well. With this two settings this looks much better then without.
Found this solution according to this article:
https://vicrucann.github.io/tutorials/osg-qt-high-dpi/
