### PR TITLE
[TD] Make Dimension label graphical layout more compact by making …

### DIFF
--- a/src/Mod/TechDraw/Gui/QGCustomText.cpp
+++ b/src/Mod/TechDraw/Gui/QGCustomText.cpp
@@ -195,13 +195,11 @@ QRectF QGCustomText::boundingRect() const
 {
     if (toPlainText().isEmpty()) {
         return QRectF();
-    }
-
-    if (tightBounding) {
+    } else if (tightBounding) {
         return tightBoundingRect();
+    } else {
+        return QGraphicsTextItem::boundingRect();
     }
-
-    return QGraphicsTextItem::boundingRect();
 }
 
 QRectF QGCustomText::tightBoundingRect() const
@@ -253,5 +251,4 @@ void QGCustomText::makeMark(Base::Vector3d v)
 {
     makeMark(v.x,v.y);
 }
-
 

--- a/src/Mod/TechDraw/Gui/QGCustomText.cpp
+++ b/src/Mod/TechDraw/Gui/QGCustomText.cpp
@@ -210,9 +210,20 @@ QRectF QGCustomText::tightBoundingRect() const
     qreal x_adj = (result.width() - tight.width())/4.0;
     qreal y_adj = (result.height() - tight.height())/4.0;
 
+    // Adjust the bounding box 50% towards the Qt tightBoundingRect(),
+    // except chomp some extra empty space above the font (2*y_adj)
     result.adjust(x_adj, 2*y_adj, -x_adj, -y_adj);
 
     return result;
+}
+
+// Calculate the amount of difference between tight and relaxed bounding boxes
+QPointF QGCustomText::tightBoundingAdjust() const
+{
+    QRectF original = QGraphicsTextItem::boundingRect();
+    QRectF tight = tightBoundingRect();
+
+    return QPointF(tight.x()-original.x(), tight.y()-original.y());
 }
 
 QColor QGCustomText::getNormalColor()    //preference!

--- a/src/Mod/TechDraw/Gui/QGCustomText.cpp
+++ b/src/Mod/TechDraw/Gui/QGCustomText.cpp
@@ -60,6 +60,7 @@ QGCustomText::QGCustomText(QGraphicsItem* parent) :
 
     m_colCurrent = getNormalColor();
     m_colNormal  = m_colCurrent;
+    tightBounding = false;
 }
 
 void QGCustomText::centerAt(QPointF centerPos)
@@ -173,7 +174,12 @@ void QGCustomText::setColor(QColor c)
     m_colNormal = c;
     m_colCurrent = c;
     QGraphicsTextItem::setDefaultTextColor(c);
- }
+}
+
+void QGCustomText::setTightBounding(bool tight)
+{
+    tightBounding = tight;
+}
 
 void QGCustomText::paint ( QPainter * painter, const QStyleOptionGraphicsItem * option, QWidget * widget) {
     QStyleOptionGraphicsItem myOption(*option);
@@ -183,6 +189,32 @@ void QGCustomText::paint ( QPainter * painter, const QStyleOptionGraphicsItem * 
 //    painter->drawRect(boundingRect());          //good for debugging
 
     QGraphicsTextItem::paint (painter, &myOption, widget);
+}
+
+QRectF QGCustomText::boundingRect() const
+{
+    if (toPlainText().isEmpty()) {
+        return QRectF();
+    }
+
+    if (tightBounding) {
+        return tightBoundingRect();
+    }
+
+    return QGraphicsTextItem::boundingRect();
+}
+
+QRectF QGCustomText::tightBoundingRect() const
+{
+    QFontMetrics qfm(font());
+    QRectF result = QGraphicsTextItem::boundingRect();
+    QRectF tight = qfm.tightBoundingRect(toPlainText());
+    qreal x_adj = (result.width() - tight.width())/4.0;
+    qreal y_adj = (result.height() - tight.height())/4.0;
+
+    result.adjust(x_adj, 2*y_adj, -x_adj, -y_adj);
+
+    return result;
 }
 
 QColor QGCustomText::getNormalColor()    //preference!

--- a/src/Mod/TechDraw/Gui/QGCustomText.h
+++ b/src/Mod/TechDraw/Gui/QGCustomText.h
@@ -49,6 +49,7 @@ public:
     virtual void paint(QPainter * painter, const QStyleOptionGraphicsItem * option, QWidget * widget = 0 );
     virtual QRectF boundingRect() const override;
     QRectF tightBoundingRect() const;
+    QPointF tightBoundingAdjust() const;
 
     void setHighlighted(bool state);
     virtual void setPrettyNormal();
@@ -83,7 +84,7 @@ protected:
     Base::Reference<ParameterGrp> getParmGroup(void);
 
     bool isHighlighted;
-    bool tightBounding;
+    bool tightBounding;  // Option to use tighter boundingRect(), works only for plaintext QGCustomText
     QColor m_colCurrent;
     QColor m_colNormal;
 

--- a/src/Mod/TechDraw/Gui/QGCustomText.h
+++ b/src/Mod/TechDraw/Gui/QGCustomText.h
@@ -47,6 +47,8 @@ public:
     enum {Type = QGraphicsItem::UserType + 130};
     int type() const { return Type;}
     virtual void paint(QPainter * painter, const QStyleOptionGraphicsItem * option, QWidget * widget = 0 );
+    virtual QRectF boundingRect() const override;
+    QRectF tightBoundingRect() const;
 
     void setHighlighted(bool state);
     virtual void setPrettyNormal();
@@ -68,6 +70,8 @@ public:
     virtual QColor getSelectColor(void);
     virtual void setColor(QColor c);
 
+    virtual void setTightBounding(bool tight);
+
     void makeMark(double x, double y);
     void makeMark(Base::Vector3d v);
 
@@ -79,6 +83,7 @@ protected:
     Base::Reference<ParameterGrp> getParmGroup(void);
 
     bool isHighlighted;
+    bool tightBounding;
     QColor m_colCurrent;
     QColor m_colNormal;
 

--- a/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
@@ -107,12 +107,16 @@ QGIDatumLabel::QGIDatumLabel()
     setFiltersChildEvents(true);
 
     m_dimText = new QGCustomText();
+    m_dimText->setTightBounding(true);
     m_dimText->setParentItem(this);
     m_tolTextOver = new QGCustomText();
+    m_tolTextOver->setTightBounding(true);
     m_tolTextOver->setParentItem(this);
     m_tolTextUnder = new QGCustomText();
+    m_tolTextUnder->setTightBounding(true);
     m_tolTextUnder->setParentItem(this);
     m_unitText = new QGCustomText();
+    m_unitText->setTightBounding(true);
     m_unitText->setParentItem(this);
 
     m_ctrl = false;
@@ -266,8 +270,8 @@ void QGIDatumLabel::setPosFromCenter(const double &xCenter, const double &yCente
     }
     double tolRight = unitRight + width;
 
-    m_tolTextOver->justifyRightAt(tolRight, middle, false);
-    m_tolTextUnder->justifyRightAt(tolRight, middle + underBox.height(), false);
+    m_tolTextOver->justifyRightAt(tolRight, middle - overBox.height() + underBox.height()/4, false);
+    m_tolTextUnder->justifyRightAt(tolRight, middle + underBox.height()/4, false);
 
 }
 

--- a/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
@@ -270,9 +270,11 @@ void QGIDatumLabel::setPosFromCenter(const double &xCenter, const double &yCente
     }
     double tolRight = unitRight + width;
 
-    m_tolTextOver->justifyRightAt(tolRight, middle - overBox.height() + underBox.height()/4, false);
-    m_tolTextUnder->justifyRightAt(tolRight, middle + underBox.height()/4, false);
-
+    // Adjust for difference in tight and original bounding box sizes, note the y-coord down system
+    QPointF tol_adj = m_tolTextOver->tightBoundingAdjust();
+    m_tolTextOver->justifyRightAt(tolRight + tol_adj.x(), middle - tol_adj.y(), false);
+    tol_adj = m_tolTextUnder->tightBoundingAdjust();
+    m_tolTextUnder->justifyRightAt(tolRight + tol_adj.x(), middle + overBox.height() - tol_adj.y(), false);
 }
 
 void QGIDatumLabel::setLabelCenter()


### PR DESCRIPTION
… boundingRect() tighter for dimension number labels.  This fixes a possible regression and rendering problem discussed in https://forum.freecadweb.org/viewtopic.php?f=35&t=52621&p=451898  The idea is to override the Qt boundingRect() in QGCustomText with a tighter one, but only if explicitly asked for.  The tighter bounding box is then used in DrawViewDimension labels.  The matter is under discussion in the thread, so maybe not merge this pull request right away; I published this in the hopes that it'd get some testing and comments.


Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [x] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
