### PR TITLE
[TD] make LineGroup selectable

### DIFF
--- a/src/Mod/TechDraw/App/Cosmetic.cpp
+++ b/src/Mod/TechDraw/App/Cosmetic.cpp
@@ -107,8 +107,8 @@ std::string LineFormat::toString(void) const
 //static preference getters.
 double LineFormat::getDefEdgeWidth()
 {
-    std::string lgName = Preferences::lineGroup();
-    auto lg = TechDraw::LineGroup::lineGroupFactory(lgName);
+    int lgNumber = Preferences::lineGroup();
+    auto lg = TechDraw::LineGroup::lineGroupFactory(lgNumber);
 
     double width = lg->getWeight("Graphic");
     delete lg; 

--- a/src/Mod/TechDraw/App/DrawUtil.cpp
+++ b/src/Mod/TechDraw/App/DrawUtil.cpp
@@ -561,9 +561,8 @@ double DrawUtil::sensibleScale(double working_scale)
 
 double DrawUtil::getDefaultLineWeight(std::string lineType)
 {
-    std::string lgName = Preferences::lineGroup();
- 
-    auto lg = LineGroup::lineGroupFactory(lgName);
+    int lgNumber = Preferences::lineGroup();
+    auto lg = LineGroup::lineGroupFactory(lgNumber);
 
     double weight = lg->getWeight(lineType);
     delete lg;                                    //Coverity CID 174671

--- a/src/Mod/TechDraw/App/LineGroup.cpp
+++ b/src/Mod/TechDraw/App/LineGroup.cpp
@@ -125,62 +125,49 @@ std::vector<double> LineGroup::split(std::string line)
     return result;
 }
 
-//static support function: find group defn in file
-std::string LineGroup::getRecordFromFile(std::string parmFile, std::string groupName)
+//static support function: find group definition in file
+std::string LineGroup::getRecordFromFile(std::string parmFile, int groupNumber)
 {
     std::string record;
-    std::string lineSpec;
     std::ifstream inFile;
     inFile.open (parmFile, std::ifstream::in);
     if(!inFile.is_open()) {
         Base::Console().Message( "Cannot open LineGroup file: %s\n",parmFile.c_str());
         return record;
     }
-
-    bool groupFound = false;
+    // parse file to get the groupNumber'th line
+    int counter = 0; // the combobox enums begin with 0
     while ( inFile.good() ){
          std::string line;
-         std::getline(inFile,line);
-         std::string nameTag = line.substr(0,1);
-         std::string foundName;
-         unsigned long int commaPos;
-         if ((nameTag == ";")  ||
-             (nameTag == " ")  ||
-             (line.empty()) )  {           //is cr/lf empty?
-             continue;
-         } else if (nameTag == "*") {
-             commaPos = line.find(',',1);
-             if (commaPos != std::string::npos) {
-                  foundName = line.substr(1,commaPos-1);
-             } else {
-                  foundName = line.substr(1);
-             }
-             if (foundName == groupName) {
-                 //this is our group
+         std::getline(inFile, line);
+         std::string nameTag = line.substr(0, 1);
+         if (nameTag == "*") { // we found a definition line
+             if (counter == groupNumber) {
                  record = line;
-                 groupFound = true;
-                 break;
+                 return record;
              }
+             ++counter;
         }
     }  //endwhile
-    if (!groupFound) {
-        Base::Console().Message("LineGroup - group: %s is not found\n", groupName.c_str());
-    }
-    return record;
+    // nothing was found
+    Base::Console().Error("LineGroup: the LineGroup file has only %s entries but entry number %s is set\n"
+        , std::to_string(counter).c_str()
+        , std::to_string(groupNumber).c_str());
+    return std::string(); // return an empty string
 }
 
 //static LineGroup maker
-LineGroup* LineGroup::lineGroupFactory(std::string groupName)
+LineGroup* LineGroup::lineGroupFactory(int groupNumber)
 {
-    LineGroup* lg = new LineGroup(groupName);
+    LineGroup* lg = new LineGroup();
 
     std::string lgFileName = Preferences::lineGroupFile();
 
-    std::string lgRecord = LineGroup::getRecordFromFile(lgFileName, groupName);
+    std::string lgRecord = LineGroup::getRecordFromFile(lgFileName, groupNumber);
 
     std::vector<double> values = LineGroup::split(lgRecord);
     if (values.size() < 4) {
-        Base::Console().Message( "LineGroup::invalid entry in %s\n",groupName.c_str() );
+        Base::Console().Error( "LineGroup::invalid entry in %s\n", lgFileName.c_str() );
     } else {
         lg->setWeight("Thin",values[0]);
         lg->setWeight("Graphic",values[1]);
@@ -191,16 +178,47 @@ LineGroup* LineGroup::lineGroupFactory(std::string groupName)
 }
 
 //valid weight names: Thick, Thin, Graphic, Extra
-double LineGroup::getDefaultWidth(std::string weightName, std::string groupName)
+double LineGroup::getDefaultWidth(std::string weightName, int groupNumber)
 {
     //default line weights
-    std::string lgName = groupName;
-    if (groupName.empty()) {
-        lgName = Preferences::lineGroup();
+    int lgNumber = groupNumber;
+    if (lgNumber == -1) {
+        lgNumber = Preferences::lineGroup();
     }
-    auto lg = TechDraw::LineGroup::lineGroupFactory(lgName);
+    auto lg = TechDraw::LineGroup::lineGroupFactory(lgNumber);
 
     double weight = lg->getWeight(weightName);
     delete lg;
     return weight;
+}
+
+//static support function: find group definition in file
+std::string LineGroup::getGroupNamesFromFile(std::string FileName)
+{
+    std::string record;
+    std::ifstream inFile;
+    inFile.open(FileName, std::ifstream::in);
+    if (!inFile.is_open()) {
+        Base::Console().Message("Cannot open LineGroup file: %s\n", FileName.c_str());
+        return record;
+    }
+    // parse the file
+    while (inFile.good()) {
+        std::string line;
+        std::getline(inFile, line);
+        std::string nameTag = line.substr(0, 1);
+        std::string found;
+        unsigned long int commaPos;
+        if (nameTag == "*") {
+            commaPos = line.find(',', 1);
+            if (commaPos != std::string::npos) {
+                found = line.substr(1, commaPos - 1);
+                record = record + found + ',';
+            }
+        }
+    }  //endwhile
+    if (record.empty()) {
+        Base::Console().Message("LineGroup error: no group found in file %s\n", FileName.c_str());
+    }
+    return record;
 }

--- a/src/Mod/TechDraw/App/LineGroup.h
+++ b/src/Mod/TechDraw/App/LineGroup.h
@@ -47,13 +47,14 @@ public:
     static std::vector<double> split(std::string line);
 
     //static support function: find group defn in file
-    static std::string getRecordFromFile(std::string parmFile, std::string groupName);
+    static std::string getRecordFromFile(std::string parmFile, int groupNumber);
 
     //static LineGroup maker
-    static LineGroup* lineGroupFactory(std::string groupName);
+    static LineGroup* lineGroupFactory(int groupNumber);
 
-    static double getDefaultWidth(std::string weightName,
-                                  std::string groupName = std::string());
+    static double getDefaultWidth(std::string weightName, int groupNumber = -1);
+
+    static std::string getGroupNamesFromFile(std::string FileName);
 
 
 protected:

--- a/src/Mod/TechDraw/App/Preferences.cpp
+++ b/src/Mod/TechDraw/App/Preferences.cpp
@@ -167,13 +167,13 @@ int Preferences::projectionAngle()
     return projType;
 }
 
-std::string Preferences::lineGroup()
+int Preferences::lineGroup()
 {
     Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter().
                                          GetGroup("BaseApp")->GetGroup("Preferences")->
                                          GetGroup("Mod/TechDraw/Decorations");
-    std::string lgName = hGrp->GetASCII("LineGroup","FC 0.70mm");
-    return lgName;
+    int lgInt = hGrp->GetInt("LineGroup", 3); // FC 0.70mm
+    return lgInt;
 }
 
 int Preferences::balloonArrow()

--- a/src/Mod/TechDraw/App/Preferences.h
+++ b/src/Mod/TechDraw/App/Preferences.h
@@ -59,7 +59,7 @@ static bool        useGlobalDecimals();
 static bool        keepPagesUpToDate();
 
 static int         projectionAngle();
-static std::string lineGroup();
+static int         lineGroup();
 
 static int         balloonArrow();
 

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawAnnotation.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawAnnotation.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>460</width>
+    <width>415</width>
     <height>447</height>
    </rect>
   </property>
@@ -578,7 +578,7 @@
          </widget>
         </item>
         <item row="3" column="2">
-         <widget class="Gui::PrefLineEdit" name="leLineGroup">
+         <widget class="Gui::PrefComboBox" name="pcbLineGroup">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
             <horstretch>0</horstretch>
@@ -591,20 +591,14 @@
             <height>0</height>
            </size>
           </property>
-          <property name="toolTip">
-           <string>Default name in LineGroup CSV file</string>
-          </property>
-          <property name="text">
-           <string notr="true">FC 0.70mm</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
           <property name="prefEntry" stdset="0">
            <cstring>LineGroup</cstring>
           </property>
           <property name="prefPath" stdset="0">
            <cstring>/Mod/TechDraw/Decorations</cstring>
+          </property>
+          <property name="text" stdset="0">
+           <string/>
           </property>
          </widget>
         </item>
@@ -698,8 +692,11 @@
             <italic>true</italic>
            </font>
           </property>
+          <property name="toolTip">
+           <string>Line group used to set line widths</string>
+          </property>
           <property name="text">
-           <string>Line Group Name</string>
+           <string>Line Group</string>
           </property>
          </widget>
         </item>
@@ -881,11 +878,6 @@
   <customwidget>
    <class>Gui::PrefComboBox</class>
    <extends>QComboBox</extends>
-   <header>Gui/PrefWidgets.h</header>
-  </customwidget>
-  <customwidget>
-   <class>Gui::PrefLineEdit</class>
-   <extends>QLineEdit</extends>
    <header>Gui/PrefWidgets.h</header>
   </customwidget>
   <customwidget>

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawAnnotationImp.cpp
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawAnnotationImp.cpp
@@ -34,6 +34,7 @@
 #include "PreferencesGui.h"
 #include "DlgPrefsTechDrawAnnotationImp.h"
 #include "ui_DlgPrefsTechDrawAnnotation.h"
+#include <Mod/TechDraw/App/LineGroup.h>
 
 
 using namespace TechDrawGui;
@@ -47,6 +48,10 @@ DlgPrefsTechDrawAnnotationImp::DlgPrefsTechDrawAnnotationImp( QWidget* parent )
     ui->setupUi(this);
     ui->pdsbBalloonKink->setUnit(Base::Unit::Length);
     ui->pdsbBalloonKink->setMinimum(0);
+    
+    // connect the LineGroup the update the tooltip if index changed
+    connect(ui->pcbLineGroup, SIGNAL(currentIndexChanged(int)),
+        this, SLOT(onLineGroupChanged(int)));
 }
 
 DlgPrefsTechDrawAnnotationImp::~DlgPrefsTechDrawAnnotationImp()
@@ -61,7 +66,7 @@ void DlgPrefsTechDrawAnnotationImp::saveSettings()
     ui->cbPyramidOrtho->onSave();
     ui->cbSectionLineStd->onSave();
     ui->cbShowCenterMarks->onSave();
-    ui->leLineGroup->onSave();
+    ui->pcbLineGroup->onSave();
     ui->pcbBalloonArrow->onSave();
     ui->pcbBalloonShape->onSave();
     ui->pcbCenterStyle->onSave();
@@ -79,13 +84,27 @@ void DlgPrefsTechDrawAnnotationImp::loadSettings()
     //QAbstractSpinBox
     double kinkDefault = 5.0;
     ui->pdsbBalloonKink->setValue(kinkDefault);
-
+    // re-read the available LineGroup files
+    ui->pcbLineGroup->clear();
+    std::string lgFileName = Preferences::lineGroupFile();
+    std::string lgRecord = LineGroup::getGroupNamesFromFile(lgFileName);
+    // split collected groups
+    std::stringstream ss(lgRecord);
+    std::vector<std::string> lgNames;
+    while (std::getline(ss, lgRecord, ',')) {
+        lgNames.push_back(lgRecord);
+    }
+    // fill the combobox with the found names
+    for (auto it = lgNames.begin(); it < lgNames.end(); ++it) {
+        ui->pcbLineGroup->addItem(tr((*it).c_str()));
+    }
+ 
     ui->cbAutoHoriz->onRestore();
     ui->cbPrintCenterMarks->onRestore();
     ui->cbPyramidOrtho->onRestore();
     ui->cbSectionLineStd->onRestore();
     ui->cbShowCenterMarks->onRestore();
-    ui->leLineGroup->onRestore();
+    ui->pcbLineGroup->onRestore();
     ui->pcbBalloonArrow->onRestore();
     ui->pcbBalloonShape->onRestore();
     ui->pcbCenterStyle->onRestore();
@@ -117,6 +136,31 @@ void DlgPrefsTechDrawAnnotationImp::changeEvent(QEvent *e)
 int DlgPrefsTechDrawAnnotationImp::prefBalloonArrow(void) const
 {
     return Preferences::balloonArrow();
+}
+
+/**
+ * Updates the tooltip of the LineGroup combobox
+ */
+void DlgPrefsTechDrawAnnotationImp::onLineGroupChanged(int index)
+{
+    if (index == -1) { // there is no valid index yet
+        ui->pcbLineGroup->setToolTip(QString::fromStdString("Please select a Line Group"));
+        return;
+    }
+    // get the definition the the selected LineGroup (includes the name)
+    std::string lgRecord = LineGroup::getRecordFromFile(Preferences::lineGroupFile(), index);
+    std::stringstream ss(lgRecord);
+    std::vector<std::string> lgNames;
+    while (std::getline(ss, lgRecord, ',')) {
+        lgNames.push_back(lgRecord);
+    }
+    // format the tooltip
+    std::stringstream TooltipText;
+    TooltipText << lgNames.at(0).substr(1) << " defines these line thicknesses:\n"
+        << "thin: " << lgNames.at(1) << "\n"
+        << "graphic: " << lgNames.at(2) << "\n"
+        << "thick: " << lgNames.at(3);
+    ui->pcbLineGroup->setToolTip(QString::fromStdString(TooltipText.str()));
 }
 
 #include <Mod/TechDraw/Gui/moc_DlgPrefsTechDrawAnnotationImp.cpp>

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawAnnotationImp.h
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawAnnotationImp.h
@@ -39,6 +39,9 @@ public:
     DlgPrefsTechDrawAnnotationImp( QWidget* parent = 0 );
     ~DlgPrefsTechDrawAnnotationImp();
 
+public Q_SLOTS:
+    void onLineGroupChanged(int);
+
 protected:
     void saveSettings();
     void loadSettings();

--- a/src/Mod/TechDraw/Gui/TaskCenterLine.cpp
+++ b/src/Mod/TechDraw/Gui/TaskCenterLine.cpp
@@ -431,8 +431,8 @@ void TaskCenterLine::enableTaskButtons(bool b)
 
 double TaskCenterLine::getCenterWidth()
 {
-    std::string lgName = Preferences::lineGroup();
-    auto lg = TechDraw::LineGroup::lineGroupFactory(lgName);
+    int lgNumber = Preferences::lineGroup();
+    auto lg = TechDraw::LineGroup::lineGroupFactory(lgNumber);
 
     double width = lg->getWeight("Graphic");
     delete lg;

--- a/src/Mod/TechDraw/Gui/TaskLeaderLine.cpp
+++ b/src/Mod/TechDraw/Gui/TaskLeaderLine.cpp
@@ -789,8 +789,8 @@ int TaskLeaderLine::getPrefArrowStyle()
 
 double TaskLeaderLine::prefWeight() const
 {
-    std::string lgName = Preferences::lineGroup();
-    auto lg = TechDraw::LineGroup::lineGroupFactory(lgName);
+    int lgNumber = Preferences::lineGroup();
+    auto lg = TechDraw::LineGroup::lineGroupFactory(lgNumber);
     double weight = lg->getWeight("Thin");
     delete lg;                                   //Coverity CID 174670
     return weight;

--- a/src/Mod/TechDraw/Gui/TaskRichAnno.cpp
+++ b/src/Mod/TechDraw/Gui/TaskRichAnno.cpp
@@ -333,8 +333,8 @@ void TaskRichAnno::onEditorExit(void)
 
 double TaskRichAnno::prefWeight() const
 {
-    std::string lgName = Preferences::lineGroup();
-    auto lg = TechDraw::LineGroup::lineGroupFactory(lgName);
+    int lgNumber = Preferences::lineGroup();
+    auto lg = TechDraw::LineGroup::lineGroupFactory(lgNumber);
     double weight = lg->getWeight("Graphic");
     delete lg;                                   //Coverity CID 174670
     return weight;

--- a/src/Mod/TechDraw/Gui/ViewProviderBalloon.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderBalloon.cpp
@@ -70,8 +70,8 @@ ViewProviderBalloon::ViewProviderBalloon()
     ADD_PROPERTY_TYPE(Font,(Preferences::labelFont().c_str()),group,App::Prop_None, "The name of the font to use");
     ADD_PROPERTY_TYPE(Fontsize,(Preferences::dimFontSizeMM()),
                                 group,(App::PropertyType)(App::Prop_None),"Balloon text size in units");
-    std::string lgName = Preferences::lineGroup();
-    auto lg = TechDraw::LineGroup::lineGroupFactory(lgName);
+    int lgNumber = Preferences::lineGroup();
+    auto lg = TechDraw::LineGroup::lineGroupFactory(lgNumber);
     double weight = lg->getWeight("Thin");
     delete lg;                                   //Coverity CID 174670
     ADD_PROPERTY_TYPE(LineWidth,(weight),group,(App::PropertyType)(App::Prop_None),"Leader line width");

--- a/src/Mod/TechDraw/Gui/ViewProviderDimension.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderDimension.cpp
@@ -183,8 +183,8 @@ double ViewProviderDimension::prefFontSize() const
 
 double ViewProviderDimension::prefWeight() const
 {
-    std::string lgName = Preferences::lineGroup();
-    auto lg = TechDraw::LineGroup::lineGroupFactory(lgName);
+    int lgNumber = Preferences::lineGroup();
+    auto lg = TechDraw::LineGroup::lineGroupFactory(lgNumber);
     double weight = lg->getWeight("Thin");
     delete lg;                                   //Coverity CID 174670
     return weight;

--- a/src/Mod/TechDraw/Gui/ViewProviderGeomHatch.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderGeomHatch.cpp
@@ -186,8 +186,8 @@ void ViewProviderGeomHatch::updateGraphic(void)
 
 void ViewProviderGeomHatch::getParameters(void)
 {
-    std::string lgName = Preferences::lineGroup();
-    auto lg = TechDraw::LineGroup::lineGroupFactory(lgName);
+    int lgNumber = Preferences::lineGroup();
+    auto lg = TechDraw::LineGroup::lineGroupFactory(lgNumber);
     double weight = lg->getWeight("Graphic");
     delete lg;                                                    //Coverity CID 174667
     WeightPattern.setValue(weight);

--- a/src/Mod/TechDraw/Gui/ViewProviderLeader.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderLeader.cpp
@@ -200,8 +200,8 @@ TechDraw::DrawLeaderLine* ViewProviderLeader::getFeature() const
 double ViewProviderLeader::getDefLineWeight(void)
 {
     double result = 0.0;
-    std::string lgName = Preferences::lineGroup();
-    auto lg = TechDraw::LineGroup::lineGroupFactory(lgName);
+    int lgNumber = Preferences::lineGroup();
+    auto lg = TechDraw::LineGroup::lineGroupFactory(lgNumber);
     result = lg->getWeight("Thin");
     delete lg;                                   //Coverity CID 174670
     return result;

--- a/src/Mod/TechDraw/Gui/ViewProviderRichAnno.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderRichAnno.cpp
@@ -189,8 +189,8 @@ double ViewProviderRichAnno::getDefFontSize()
 double ViewProviderRichAnno::getDefLineWeight(void)
 {
     double result = 0.0;
-    std::string lgName = Preferences::lineGroup();
-    auto lg = TechDraw::LineGroup::lineGroupFactory(lgName);
+    int lgNumber = Preferences::lineGroup();
+    auto lg = TechDraw::LineGroup::lineGroupFactory(lgNumber);
     result = lg->getWeight("Graphics");
     delete lg;
     return result;

--- a/src/Mod/TechDraw/Gui/ViewProviderViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderViewPart.cpp
@@ -88,8 +88,8 @@ ViewProviderViewPart::ViewProviderViewPart()
     static const char *hgroup = "Highlight";
 
     //default line weights
-    std::string lgName = Preferences::lineGroup();
-    auto lg = TechDraw::LineGroup::lineGroupFactory(lgName);
+    int lgNumber = Preferences::lineGroup();
+    auto lg = TechDraw::LineGroup::lineGroupFactory(lgNumber);
 
     double weight = lg->getWeight("Thick");
     ADD_PROPERTY_TYPE(LineWidth,(weight),group,App::Prop_None,"The thickness of visible lines (line groups xx.2");


### PR DESCRIPTION
At the moment one has to specify the LineGroup as string. But one doesn't know what groups exist. So one has to check the Wiki, learn there where the groups are defined and then open the definition file with a text editor.

This PR simplifies this by reading the existing groups out of the definition file and fill the combobox accordingly.
It also give the user info what the selected LineGroup defines via the tooltip.

A nice side effect is that no typos can occur since you don't have to enter the LineGroup name as text.

Here is how the dialog looks now:
![XmC8xAZHeJ](https://user-images.githubusercontent.com/1828501/100526850-2b554f80-31cd-11eb-8a4f-d44dfac88b04.png)
