### PR TITLE
[TD] Dimension tolerance label string fixes, uses the same mechanism as main dimension value 

### DIFF
--- a/src/Mod/TechDraw/App/AppTechDrawPy.cpp
+++ b/src/Mod/TechDraw/App/AppTechDrawPy.cpp
@@ -639,7 +639,7 @@ private:
                         double parentX = dvp->X.getValue() + grandParentX;
                         double parentY = dvp->Y.getValue() + grandParentY;
                         Base::Vector3d parentPos(parentX,parentY,0.0);
-                        std::string sDimText = dvd->getFormatedValue();
+                        std::string sDimText = dvd->getFormattedDimensionValue();
                         char* dimText = &sDimText[0u];                  //hack for const-ness
                         float gap = 5.0;                                //hack. don't know font size here.
                         layerName = dvd->getNameInDocument();

--- a/src/Mod/TechDraw/App/DrawViewDimension.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDimension.cpp
@@ -213,7 +213,6 @@ short DrawViewDimension::mustExecute() const
 
 App::DocumentObjectExecReturn *DrawViewDimension::execute(void)
 {
-//    Base::Console().Message("DVD::execute() - %s\n", getNameInDocument());
     if (!keepUpdated()) {
         return App::DocumentObject::StdReturn;
     }
@@ -685,14 +684,13 @@ std::string DrawViewDimension::formatValue(qreal value, QString qFormatSpec, int
     }
 
     return result;
-
 }
 
-QStringList DrawViewDimension::getFormattedToleranceValues(int partial)
+std::pair<std::string, std::string> DrawViewDimension::getFormattedToleranceValues(int partial)
 {
     QString underFormatSpec = QString::fromUtf8(FormatSpecUnderTolerance.getStrValue().data());
     QString overFormatSpec = QString::fromUtf8(FormatSpecOverTolerance.getStrValue().data());
-    QStringList tolerances;
+    std::pair<std::string, std::string> tolerances;
     QString underTolerance, overTolerance;
 
     if (ArbitraryTolerances.getValue()) {
@@ -703,7 +701,8 @@ QStringList DrawViewDimension::getFormattedToleranceValues(int partial)
         overTolerance = QString::fromUtf8(formatValue(OverTolerance.getValue(), overFormatSpec, partial).c_str());
     }
 
-    tolerances << underTolerance << overTolerance;
+    tolerances.first = underTolerance.toStdString();
+    tolerances.second = overTolerance.toStdString();
 
     return tolerances;
 }
@@ -728,7 +727,7 @@ QStringList DrawViewDimension::getPrefixSuffixSpec(QString fSpec)
     QString formatSuffix;
     QString formatted;
     //find the %x.y tag in FormatSpec
-    QRegExp rxFormat(QString::fromUtf8("%[+-]*[0-9]*\\.*[0-9]*[aefgAEFG]"));     //printf double format spec
+    QRegExp rxFormat(QString::fromUtf8("%[+-]?[0-9]*\\.*[0-9]*[aefgAEFG]"));     //printf double format spec
     QString match;
     int pos = 0;
     if ((pos = rxFormat.indexIn(fSpec, 0)) != -1)  {

--- a/src/Mod/TechDraw/App/DrawViewDimension.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDimension.cpp
@@ -577,6 +577,7 @@ std::string DrawViewDimension::formatValue(qreal value, QString qFormatSpec, int
             //qUserString from Quantity includes units - prefix + R + nnn ft + suffix
             qMultiValueStr = formatPrefix + qGenPrefix + qUserString + formatSuffix;
         }
+        formattedValue = qMultiValueStr;
     } else if ((unitSystem == Base::UnitSystem::ImperialCivil) &&
                 angularMeasure) {
         QString dispMinute = QString::fromUtf8("\'");
@@ -591,6 +592,7 @@ std::string DrawViewDimension::formatValue(qreal value, QString qFormatSpec, int
             // prefix + 48*30'30" + suffix
             qMultiValueStr = formatPrefix + qGenPrefix + displaySub + formatSuffix;
         }
+        formattedValue = qMultiValueStr;
     } else {
     //handle single value schemes
         if (formatSpecifier.isEmpty()) {
@@ -702,7 +704,7 @@ QStringList DrawViewDimension::getPrefixSuffixSpec(QString fSpec)
     QString formatSuffix;
     QString formatted;
     //find the %x.y tag in FormatSpec
-    QRegExp rxFormat(QString::fromUtf8("%[0-9]*\\.*[0-9]*[aefgAEFG]"));     //printf double format spec
+    QRegExp rxFormat(QString::fromUtf8("%[+-]*[0-9]*\\.*[0-9]*[aefgAEFG]"));     //printf double format spec
     QString match;
     int pos = 0;
     if ((pos = rxFormat.indexIn(fSpec, 0)) != -1)  {

--- a/src/Mod/TechDraw/App/DrawViewDimension.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDimension.cpp
@@ -92,7 +92,10 @@ DrawViewDimension::DrawViewDimension(void)
     References3D.setScope(App::LinkScope::Global);
 
     ADD_PROPERTY_TYPE(FormatSpec,(getDefaultFormatSpec()) , "Format", App::Prop_Output,"Dimension Format");
+    ADD_PROPERTY_TYPE(FormatSpecOverTolerance,("%+g") , "Format", App::Prop_Output,"Dimension Overtolerance Format");
+    ADD_PROPERTY_TYPE(FormatSpecUnderTolerance,("%+g") , "Format", App::Prop_Output,"Dimension Undertolerance Format");
     ADD_PROPERTY_TYPE(Arbitrary,(false) ,"Format", App::Prop_Output,"Value overridden by user");
+    ADD_PROPERTY_TYPE(ArbitraryTolerances,(false) ,"Format", App::Prop_Output,"Tolerance values overridden by user");
 
     Type.setEnums(TypeEnums);                                          //dimension type: length, radius etc
     ADD_PROPERTY(Type,((long)0));
@@ -685,10 +688,31 @@ std::string DrawViewDimension::formatValue(qreal value, QString qFormatSpec, int
 
 }
 
+QStringList DrawViewDimension::getFormattedToleranceValues(int partial)
+{
+    QString underFormatSpec = QString::fromUtf8(FormatSpecUnderTolerance.getStrValue().data());
+    QString overFormatSpec = QString::fromUtf8(FormatSpecOverTolerance.getStrValue().data());
+    QStringList tolerances;
+    QString underTolerance, overTolerance;
+
+    if (ArbitraryTolerances.getValue()) {
+        underTolerance = underFormatSpec;
+        overTolerance = overFormatSpec;
+    } else {
+        underTolerance = QString::fromUtf8(formatValue(UnderTolerance.getValue(), underFormatSpec, partial).c_str());
+        overTolerance = QString::fromUtf8(formatValue(OverTolerance.getValue(), overFormatSpec, partial).c_str());
+    }
+
+    tolerances << underTolerance << overTolerance;
+
+    return tolerances;
+}
+
+
 std::string DrawViewDimension::getFormattedDimensionValue(int partial)
 {
 //    Base::Console().Message("DVD::getFormattedValue(%d)\n", partial);
-    QString qFormatSpec = QString::fromUtf8(FormatSpec.getStrValue().data(),FormatSpec.getStrValue().size());
+    QString qFormatSpec = QString::fromUtf8(FormatSpec.getStrValue().data());
 
     if (Arbitrary.getValue()) {
         return FormatSpec.getStrValue();

--- a/src/Mod/TechDraw/App/DrawViewDimension.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDimension.cpp
@@ -530,23 +530,17 @@ bool DrawViewDimension::isMultiValueSchema(void) const
     return result;
 }
 
-std::string  DrawViewDimension::getFormatedValue(int partial)
+std::string DrawViewDimension::formatValue(qreal value, QString qFormatSpec, int partial)
 {
-//    Base::Console().Message("DVD::getFormatedValue(%d)\n", partial);
     std::string result;
-    if (Arbitrary.getValue()) {
-        return FormatSpec.getStrValue();
-    }
     bool multiValueSchema = false;
 
-    QString qFormatSpec = QString::fromUtf8(FormatSpec.getStrValue().data(),FormatSpec.getStrValue().size());
-    double val = getDimValue();
     QString qUserStringUnits;
     QString formattedValue;
 
     bool angularMeasure = false;
     Base::Quantity asQuantity;
-    asQuantity.setValue(val);
+    asQuantity.setValue(value);
     if ( (Type.isValue("Angle")) ||
          (Type.isValue("Angle3Pt")) ) {
         angularMeasure = true;
@@ -686,8 +680,20 @@ std::string  DrawViewDimension::getFormatedValue(int partial)
     }
 
     return result;
+
 }
 
+std::string DrawViewDimension::getFormattedDimensionValue(int partial)
+{
+//    Base::Console().Message("DVD::getFormattedValue(%d)\n", partial);
+    QString qFormatSpec = QString::fromUtf8(FormatSpec.getStrValue().data(),FormatSpec.getStrValue().size());
+
+    if (Arbitrary.getValue()) {
+        return FormatSpec.getStrValue();
+    }
+
+    return formatValue(getDimValue(), qFormatSpec, partial);
+}
 
 QStringList DrawViewDimension::getPrefixSuffixSpec(QString fSpec)
 {

--- a/src/Mod/TechDraw/App/DrawViewDimension.h
+++ b/src/Mod/TechDraw/App/DrawViewDimension.h
@@ -133,7 +133,9 @@ public:
     //return PyObject as DrawViewDimensionPy
     virtual PyObject *getPyObject(void) override;
 
-    virtual std::string getFormatedValue(int partial = 0);
+    virtual std::string getFormattedDimensionValue(int partial = 0);
+    virtual std::string formatValue(qreal value, QString qFormatSpec, int partial = 0);
+
     virtual double getDimValue();
     QStringList getPrefixSuffixSpec(QString fSpec);
 

--- a/src/Mod/TechDraw/App/DrawViewDimension.h
+++ b/src/Mod/TechDraw/App/DrawViewDimension.h
@@ -101,7 +101,10 @@ public:
     App::PropertyBool              TheoreticalExact;
     App::PropertyBool              Inverted;
     App::PropertyString            FormatSpec;
+    App::PropertyString            FormatSpecUnderTolerance;
+    App::PropertyString            FormatSpecOverTolerance;
     App::PropertyBool              Arbitrary;
+    App::PropertyBool              ArbitraryTolerances;
     App::PropertyFloat             OverTolerance;
     App::PropertyFloat             UnderTolerance;
 
@@ -133,6 +136,7 @@ public:
     //return PyObject as DrawViewDimensionPy
     virtual PyObject *getPyObject(void) override;
 
+    virtual QStringList getFormattedToleranceValues(int partial = 0);
     virtual std::string getFormattedDimensionValue(int partial = 0);
     virtual std::string formatValue(qreal value, QString qFormatSpec, int partial = 0);
 

--- a/src/Mod/TechDraw/App/DrawViewDimension.h
+++ b/src/Mod/TechDraw/App/DrawViewDimension.h
@@ -136,7 +136,7 @@ public:
     //return PyObject as DrawViewDimensionPy
     virtual PyObject *getPyObject(void) override;
 
-    virtual QStringList getFormattedToleranceValues(int partial = 0);
+    virtual std::pair<std::string, std::string> getFormattedToleranceValues(int partial = 0);
     virtual std::string getFormattedDimensionValue(int partial = 0);
     virtual std::string formatValue(qreal value, QString qFormatSpec, int partial = 0);
 

--- a/src/Mod/TechDraw/App/DrawViewDimensionPyImp.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDimensionPyImp.cpp
@@ -61,7 +61,7 @@ PyObject* DrawViewDimensionPy::getText(PyObject* args)
 //        return 0;
 //    }
     DrawViewDimension* dvd = getDrawViewDimensionPtr();
-    std::string  textString = dvd->getFormatedValue();
+    std::string  textString = dvd->getFormattedDimensionValue();
 //TODO: check multiversion code!
 #if PY_MAJOR_VERSION >= 3
     PyObject* pyText = Base::PyAsUnicodeObject(textString);

--- a/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
@@ -357,14 +357,14 @@ void QGIDatumLabel::setTolString()
 
     QString overFormat;
     QString underFormat;
-    #if QT_VERSION >= 0x050000
-        overFormat = QString::asprintf(qsFormatOver.toStdString().c_str(), overTol);
-        underFormat = QString::asprintf(qsFormatUnder.toStdString().c_str(), underTol);
-    #else
-        QString qs2;
-        overFormat = qs2.sprintf(qsFormatOver.toStdString().c_str(), overTol);
-        underFormat = qs2.sprintf(qsFormatUnder.toStdString().c_str(), underTol);
-    #endif
+
+    if (dim->isMultiValueSchema()) {
+        overFormat = QString::fromUtf8(dim->formatValue(overTol, qsFormatOver, 0).c_str());
+        underFormat = QString::fromUtf8(dim->formatValue(underTol, qsFormatUnder, 0).c_str());
+    } else {
+        overFormat = QString::fromUtf8(dim->formatValue(overTol, qsFormatOver, 1).c_str());
+        underFormat = QString::fromUtf8(dim->formatValue(underTol, qsFormatUnder, 1).c_str());
+    }
 
     m_tolTextOver->setPlainText(overFormat + tolSuffix);
     m_tolTextUnder->setPlainText(underFormat + tolSuffix);

--- a/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
@@ -333,23 +333,25 @@ void QGIDatumLabel::setTolString()
         tolSuffix = QString::fromUtf8(dim->getFormattedDimensionValue(2).c_str()); //just the unit
     }
 
-    QStringList labelTexts, unitTexts;
+    std::pair<std::string, std::string> labelTexts, unitTexts;
 
     if (dim->ArbitraryTolerances.getValue()) {
         labelTexts = dim->getFormattedToleranceValues(1); //just the number pref/spec/suf
-        unitTexts << QString::fromLatin1("") << QString::fromLatin1("");
+        unitTexts.first = "";
+        unitTexts.second = "";
     } else {
         if (dim->isMultiValueSchema()) {
             labelTexts = dim->getFormattedToleranceValues(0); //don't format multis
-            unitTexts << QString::fromLatin1("") << QString::fromLatin1("");
+            unitTexts.first = "";
+            unitTexts.second = "";
         } else {
             labelTexts = dim->getFormattedToleranceValues(1); //just the number pref/spec/suf
             unitTexts  = dim->getFormattedToleranceValues(2); //just the unit
         }
     }
 
-    m_tolTextUnder->setPlainText(labelTexts[0] + unitTexts[0]);
-    m_tolTextOver->setPlainText(labelTexts[1] + unitTexts[1]);
+    m_tolTextUnder->setPlainText(QString::fromUtf8(labelTexts.first.c_str()) + QString::fromUtf8(unitTexts.first.c_str()));
+    m_tolTextOver->setPlainText(QString::fromUtf8(labelTexts.second.c_str()) + QString::fromUtf8(unitTexts.second.c_str()));
 
     return;
 } 

--- a/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
@@ -352,7 +352,7 @@ void QGIDatumLabel::setTolString()
     }
     QString tolSuffix;
     if ((dim->Type.isValue("Angle")) || (dim->Type.isValue("Angle3Pt"))) {
-        tolSuffix = QString::fromUtf8(dim->getFormatedValue(2).c_str()); //just the unit
+        tolSuffix = QString::fromUtf8(dim->getFormattedDimensionValue(2).c_str()); //just the unit
     }
 
     QString overFormat;
@@ -626,18 +626,18 @@ void QGIViewDimension::updateDim()
         return;
     }
  
-//    QString labelText = QString::fromUtf8(dim->getFormatedValue().c_str());
+//    QString labelText = QString::fromUtf8(dim->getFormattedDimensionValue().c_str());
     //want this split into value and unit
     QString labelText;
     QString unitText;
     if (dim->Arbitrary.getValue()) {
-        labelText = QString::fromUtf8(dim->getFormatedValue(1).c_str()); //just the number pref/spec/suf
+        labelText = QString::fromUtf8(dim->getFormattedDimensionValue(1).c_str()); //just the number pref/spec/suf
     } else {
         if (dim->isMultiValueSchema()) {
-            labelText = QString::fromUtf8(dim->getFormatedValue(0).c_str()); //don't format multis
+            labelText = QString::fromUtf8(dim->getFormattedDimensionValue(0).c_str()); //don't format multis
         } else {
-            labelText = QString::fromUtf8(dim->getFormatedValue(1).c_str()); //just the number pref/spec/suf
-            unitText  = QString::fromUtf8(dim->getFormatedValue(2).c_str()); //just the unit
+            labelText = QString::fromUtf8(dim->getFormattedDimensionValue(1).c_str()); //just the number pref/spec/suf
+            unitText  = QString::fromUtf8(dim->getFormattedDimensionValue(2).c_str()); //just the unit
         }
     }
     QFont font = datumLabel->getFont();

--- a/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
@@ -328,46 +328,28 @@ void QGIDatumLabel::setTolString()
     m_tolTextOver->show();
     m_tolTextUnder->show();
 
-    double overTol = dim->OverTolerance.getValue();
-    double underTol = dim->UnderTolerance.getValue();
-
-    int precision = getPrecision();
-    QString qsPrecision = QString::number(precision);
-    QString qsFormatOver = QString::fromUtf8("%+.") +            //show sign
-                           qsPrecision +
-                           QString::fromUtf8("g");               //trim trailing zeroes
-    if (DrawUtil::fpCompare(overTol, 0.0, pow(10.0, -precision))) {
-        qsFormatOver = QString::fromUtf8("%.") +            //no sign
-                           qsPrecision +
-                           QString::fromUtf8("g");
-    }
-    
-    QString qsFormatUnder = QString::fromUtf8("%+.") +            //show sign
-                              qsPrecision +
-                              QString::fromUtf8("g");               //trim trailing zeroes
-    if (DrawUtil::fpCompare(underTol, 0.0, pow(10.0, -precision))) {
-        qsFormatUnder = QString::fromUtf8("%.") +            //no sign
-                           qsPrecision +
-                           QString::fromUtf8("g");               //trim trailing zeroes
-    }
     QString tolSuffix;
     if ((dim->Type.isValue("Angle")) || (dim->Type.isValue("Angle3Pt"))) {
         tolSuffix = QString::fromUtf8(dim->getFormattedDimensionValue(2).c_str()); //just the unit
     }
 
-    QString overFormat;
-    QString underFormat;
+    QStringList labelTexts, unitTexts;
 
-    if (dim->isMultiValueSchema()) {
-        overFormat = QString::fromUtf8(dim->formatValue(overTol, qsFormatOver, 0).c_str());
-        underFormat = QString::fromUtf8(dim->formatValue(underTol, qsFormatUnder, 0).c_str());
+    if (dim->ArbitraryTolerances.getValue()) {
+        labelTexts = dim->getFormattedToleranceValues(1); //just the number pref/spec/suf
+        unitTexts << QString::fromLatin1("") << QString::fromLatin1("");
     } else {
-        overFormat = QString::fromUtf8(dim->formatValue(overTol, qsFormatOver, 1).c_str());
-        underFormat = QString::fromUtf8(dim->formatValue(underTol, qsFormatUnder, 1).c_str());
+        if (dim->isMultiValueSchema()) {
+            labelTexts = dim->getFormattedToleranceValues(0); //don't format multis
+            unitTexts << QString::fromLatin1("") << QString::fromLatin1("");
+        } else {
+            labelTexts = dim->getFormattedToleranceValues(1); //just the number pref/spec/suf
+            unitTexts  = dim->getFormattedToleranceValues(2); //just the unit
+        }
     }
 
-    m_tolTextOver->setPlainText(overFormat + tolSuffix);
-    m_tolTextUnder->setPlainText(underFormat + tolSuffix);
+    m_tolTextUnder->setPlainText(labelTexts[0] + unitTexts[0]);
+    m_tolTextOver->setPlainText(labelTexts[1] + unitTexts[1]);
 
     return;
 } 


### PR DESCRIPTION
This pull request fixes dimension tolerance label construction problems by combining the code with the construction of main dimension label construction code.  It contains three commits.  (1) Refactor dimension label string construction into generic value processing part and specific dimension-value processing part.  (2) Make tolerance label construction to use the same generic value processing part.  This solves problems with different unit schemas and different decimal separators, as these problems were already solved for main dimension value, but not for the tolerance values.  (3) Finally, add the same user-editable per-dimension formatting strings (e.g. "%.2g") for tolerance values that previously existed only for the main value.

This should fix several issues raised on the FC TechDraw forum:
Decimal separator problem issue:  https://forum.freecadweb.org/viewtopic.php?f=35&t=52630
Tolerance problem with imperial units:  https://forum.freecadweb.org/viewtopic.php?f=35&t=52621&start=10#p452049
Tolerance requests and problems (not all fixed by this):  https://forum.freecadweb.org/viewtopic.php?f=35&t=39268


Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [x] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
