### PR TITLE
Path: Millface fix - Address rounding issue

### DIFF
--- a/src/Mod/Path/PathScripts/PathMillFace.py
+++ b/src/Mod/Path/PathScripts/PathMillFace.py
@@ -106,7 +106,7 @@ class ObjectFace(PathPocketBase.ObjectPocket):
 
         if obj.Base:
             PathLog.debug("obj.Base: {}".format(obj.Base))
-            self.removalshapes = list()
+            self.removalshapes = []
             faces = []
             holes = []
             holeEnvs = []
@@ -239,7 +239,7 @@ class ObjectFace(PathPocketBase.ObjectPocket):
             # If the operation has a geometry identified the Finaldepth
             # is the top of the boundbox which includes all features.
             if len(obj.Base) >= 1:
-                shapes = list()
+                shapes = []
                 for base, subs in obj.Base:
                     for s in subs:
                         shapes.append(getattr(base.Shape, s))

--- a/src/Mod/Path/PathScripts/PathMillFace.py
+++ b/src/Mod/Path/PathScripts/PathMillFace.py
@@ -203,9 +203,11 @@ class ObjectFace(PathPocketBase.ObjectPocket):
                                                 plane=planeshape)
             ofstShape.translate(FreeCAD.Vector(0.0, 0.0, psZMin - ofstShape.BoundBox.ZMin))
 
-            custDepthparams = self._customDepthParams(obj, obj.StartDepth.Value + 0.1, obj.FinalDepth.Value - 0.1)  # only an envelope
+            # Calculate custom depth params for removal shape envelope, with start and final depth buffers
+            custDepthparams = self._customDepthParams(obj, obj.StartDepth.Value + 0.2, obj.FinalDepth.Value - 0.1)  # only an envelope
             ofstShapeEnv = PathUtils.getEnvelope(partshape=ofstShape, depthparams=custDepthparams)
             env = ofstShapeEnv.cut(baseShape)
+            env.translate(FreeCAD.Vector(0.0, 0.0, -0.000001))  # lower removal shape into buffer zone
 
         if holeShape:
             PathLog.debug("Processing holes and face ...")

--- a/src/Mod/Path/PathScripts/PathMillFace.py
+++ b/src/Mod/Path/PathScripts/PathMillFace.py
@@ -106,6 +106,7 @@ class ObjectFace(PathPocketBase.ObjectPocket):
 
         if obj.Base:
             PathLog.debug("obj.Base: {}".format(obj.Base))
+            self.removalshapes = list()
             faces = []
             holes = []
             holeEnvs = []
@@ -217,7 +218,11 @@ class ObjectFace(PathPocketBase.ObjectPocket):
         else:
             PathLog.debug("Processing solid face ...")
             tup = env, False, 'pathMillFace', 0.0, 'X', obj.StartDepth.Value, obj.FinalDepth.Value
-        return [tup]
+
+        self.removalshapes.append(tup)
+        obj.removalshape = self.removalshapes[0][0]  # save removal shape
+
+        return self.removalshapes
 
     def areaOpSetDefaultValues(self, obj, job):
         '''areaOpSetDefaultValues(obj, job) ... initialize mill facing properties'''


### PR DESCRIPTION
Fix for rounding issue exposed in forum thread, [Face Milling Bug? ... Facing Rabbets](https://forum.freecadweb.org/viewtopic.php?style=3&f=15&t=52729).  This fix increases the vertical removal shape envelope buffer by 0.1 mm and then translates that envelope down by the same value.

Also instates usage of `obj.removalshape` for debugging purposes.


Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
