### PR TITLE
Draft: Improve makeWires in upgrade function

### DIFF
--- a/src/Mod/Draft/drafttests/test_modification.py
+++ b/src/Mod/Draft/drafttests/test_modification.py
@@ -232,7 +232,7 @@ class DraftModification(unittest.TestCase):
         self.assertTrue(obj, "'{}' failed".format(operation))
 
     def test_upgrade(self):
-        """Upgrade two Draft Lines into a closed Draft Wire."""
+        """Upgrade two Lines into a closed Wire, then draftify it."""
         operation = "Draft Upgrade"
         _msg("  Test '{}'".format(operation))
         a = Vector(0, 0, 0)
@@ -242,8 +242,12 @@ class DraftModification(unittest.TestCase):
         _msg("  a={0}, b={1}".format(a, b))
         _msg("  Line 2")
         _msg("  b={0}, c={1}".format(b, c))
-        line_1 = Draft.make_line(a, b)
-        line_2 = Draft.make_line(b, c)
+        shape_line_1 = Part.makeLine(a, b)
+        shape_line_2 = Part.makeLine(b, c)
+        line_1 = App.ActiveDocument.addObject("Part::Feature")
+        line_2 = App.ActiveDocument.addObject("Part::Feature")
+        line_1.Shape = shape_line_1
+        line_2.Shape = shape_line_2
         App.ActiveDocument.recompute()
 
         obj = Draft.upgrade([line_1, line_2], delete=True)
@@ -255,8 +259,7 @@ class DraftModification(unittest.TestCase):
         obj2 = Draft.upgrade(obj[0], delete=True)
         App.ActiveDocument.recompute()
         s2 = obj2[0][0]
-        _msg("  2: Result '{0}' ({1})".format(s2.Shape.ShapeType,
-                                              s2.TypeId))
+        _msg("  2: Result '{0}' ({1})".format(s2.Shape.ShapeType, s2.TypeId))
         self.assertTrue(bool(obj2[0]), "'{}' failed".format(operation))
 
         obj3 = Draft.upgrade(obj2[0], delete=True)
@@ -265,10 +268,15 @@ class DraftModification(unittest.TestCase):
         _msg("  3: Result '{0}' ({1})".format(s3.Shape.ShapeType, s3.TypeId))
         self.assertTrue(bool(obj3[0]), "'{}' failed".format(operation))
 
-        obj4 = Draft.upgrade(obj3[0], delete=True)
+        # when draftify, upgrade dont return a new object
+        Draft.upgrade(obj3[0], delete=True)
         App.ActiveDocument.recompute()
         wire = App.ActiveDocument.Wire
         _msg("  4: Result '{0}' ({1})".format(wire.Proxy.Type, wire.TypeId))
+        self.assertTrue(bool(wire), "'{}' failed".format(operation))
+
+        obj4 = Draft.upgrade(wire, delete=True)
+        App.ActiveDocument.recompute()
         _msg("  The last object cannot be upgraded further")
         self.assertFalse(bool(obj4[0]), "'{}' failed".format(operation))
 


### PR DESCRIPTION
With these changes, a list of objects conformed by edges (without faces) will be sorted and converted to wires.
Objects with dependencies will not be removed, only visibility will be changed to false.
For a eclectic example, see https://forum.freecadweb.org/viewtopic.php?f=8&t=52583

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
