### PR TITLE
[TD] GQIViedDimension.cpp, GQCustomText.cpp - Fix Dimension label …

### DIFF
--- a/src/Mod/TechDraw/Gui/QGCustomText.cpp
+++ b/src/Mod/TechDraw/Gui/QGCustomText.cpp
@@ -211,8 +211,8 @@ QRectF QGCustomText::tightBoundingRect() const
     qreal y_adj = (result.height() - tight.height())/4.0;
 
     // Adjust the bounding box 50% towards the Qt tightBoundingRect(),
-    // except chomp some extra empty space above the font (2*y_adj)
-    result.adjust(x_adj, 2*y_adj, -x_adj, -y_adj);
+    // except chomp some extra empty space above the font (1.75*y_adj)
+    result.adjust(x_adj, 1.75*y_adj, -x_adj, -y_adj);
 
     return result;
 }

--- a/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
@@ -257,7 +257,8 @@ void QGIDatumLabel::setPosFromCenter(const double &xCenter, const double &yCente
     QRectF unitBox = m_unitText->boundingRect();
     double unitWidth = unitBox.width();
     double unitRight = right + unitWidth;
-    m_unitText->setPos(right,top);
+    // Set the m_unitText font *baseline* at same height as the m_dimText font baseline
+    m_unitText->setPos(right, 0.0);
 
     //set tolerance position
     QRectF overBox = m_tolTextOver->boundingRect();


### PR DESCRIPTION
…unit positioning bug and too tight bounding rectangle.  In pull request #4082 I forgot to adjust for the label height change of the unit text tightBoundingRectangle(). Some characters could be chopped by slightly too aggressive tightBoundingRectF(), so there's a fix for that, too.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
