### PR TITLE
[TD] Datum object bug fix in ShapeExctractor.cpp, avoids drawing Datums …

### DIFF
--- a/src/Mod/TechDraw/App/ShapeExtractor.cpp
+++ b/src/Mod/TechDraw/App/ShapeExtractor.cpp
@@ -137,8 +137,8 @@ TopoDS_Shape ShapeExtractor::getShapes(const std::vector<App::DocumentObject*> l
     builder.MakeCompound(comp);
     bool found = false;
     for (auto& s:sourceShapes) {
-        if (s.IsNull()) {
-            continue;    //has no shape
+        if (s.IsNull() || Part::TopoShape(s).isInfinite()) {
+            continue;    // has no shape or the shape is infinite
         }
         found = true;
         BRepBuilderAPI_Copy BuilderCopy(s);
@@ -313,7 +313,7 @@ std::vector<TopoDS_Shape> ShapeExtractor::extractDrawableShapes(const TopoDS_Sha
         TopExp_Explorer expSolid(shapeIn, TopAbs_SOLID);
         for (int i = 1; expSolid.More(); expSolid.Next(), i++) {
             TopoDS_Solid s = TopoDS::Solid(expSolid.Current());
-            if (!s.IsNull()) {
+            if (!s.IsNull() && !Part::TopoShape(s).isInfinite()) {
                 extShapes.push_back(s);
             }
         }
@@ -322,7 +322,7 @@ std::vector<TopoDS_Shape> ShapeExtractor::extractDrawableShapes(const TopoDS_Sha
         TopExp_Explorer expEdge(shapeIn, TopAbs_EDGE, TopAbs_SOLID);
         for (int i = 1; expEdge.More(); expEdge.Next(), i++) {
             TopoDS_Shape s = expEdge.Current();
-            if (!s.IsNull()) {
+            if (!s.IsNull() && !Part::TopoShape(s).isInfinite()) {
                 extEdges.push_back(s);
             }
         }
@@ -331,7 +331,7 @@ std::vector<TopoDS_Shape> ShapeExtractor::extractDrawableShapes(const TopoDS_Sha
         TopExp_Explorer expSolid(shapeIn, TopAbs_SOLID);
         for (int i = 1; expSolid.More(); expSolid.Next(), i++) {
             TopoDS_Solid s = TopoDS::Solid(expSolid.Current());
-            if (!s.IsNull()) {
+            if (!s.IsNull() && !Part::TopoShape(s).isInfinite()) {
                 extShapes.push_back(s);
             }
         }
@@ -341,7 +341,7 @@ std::vector<TopoDS_Shape> ShapeExtractor::extractDrawableShapes(const TopoDS_Sha
         TopExp_Explorer expEdge(shapeIn, TopAbs_EDGE, TopAbs_SOLID);
         for (int i = 1; expEdge.More(); expEdge.Next(), i++) {
             TopoDS_Shape s = expEdge.Current();
-            if (!s.IsNull()) {
+            if (!s.IsNull() && !Part::TopoShape(s).isInfinite()) {
                 extEdges.push_back(s);
             }
         }


### PR DESCRIPTION
…inside App::Part objects.  Trying to draw Datum objects within TechDraw makes the whole DrawView fail.  This PR filters out Datum objects in TechDraw ShapeExtractor.  The bug was reported in a forum [thread](https://forum.freecadweb.org/viewtopic.php?f=35&t=52774).



Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
