### PR TITLE
[TD] Check return value of getMDIViewPage() a second time

### DIFF
--- a/src/Mod/TechDraw/Gui/AppTechDrawGuiPy.cpp
+++ b/src/Mod/TechDraw/Gui/AppTechDrawGuiPy.cpp
@@ -193,7 +193,11 @@ private:
                        } else {
                            vpp->showMDIViewPage();
                            mdi = vpp->getMDIViewPage();
-                           mdi->printPdf(filePath);
+                           if (mdi) {
+                               mdi->printPdf(filePath);
+                           } else {
+                               throw Py::TypeError("Page not available! Is it Hidden?");
+                           }
                        }
                    }
                }
@@ -234,7 +238,11 @@ private:
                        } else {
                            vpp->showMDIViewPage();
                            mdi = vpp->getMDIViewPage();
-                           mdi->saveSVG(filePath);
+                           if (mdi) {
+                               mdi->saveSVG(filePath);
+                           } else {
+                               throw Py::TypeError("Page not available! Is it Hidden?");
+                           }
                        }
                    }
                }


### PR DESCRIPTION
When exporting a hidden TechDraw::Page with exportPageAs[Pdf|SVG] a
Segmentation Fault occured.

The return value of getMDIViewPage() was only checked for the first call, but
not for the second call. showMDIViewPage() silently returns, when the
TechDraw::Page is hidden and does not load the page.

---
Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
   No new failures - all errors also happen with master branch:
   Run test, errors=3 - not regarding this change
   - ERROR: test_known_quantity_units (femtest.app.test_material.TestMaterialUnits)
   - ERROR: test_material_card_quantities (femtest.app.test_material.TestMaterialUnits)
   - ERROR: test_tetra10_yml (femtest.app.test_mesh.TestMeshEleTetra10)
   - FAIL: testApplyFiles (Document.DocumentFileIncludeCases)
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
