### PR TITLE
Silence Qt/Windows setGeometry Warning

### DIFF
--- a/src/Gui/DlgMacroExecuteImp.cpp
+++ b/src/Gui/DlgMacroExecuteImp.cpp
@@ -351,7 +351,7 @@ void DlgMacroExecuteImp::on_createButton_clicked()
 {
     // query file name
     QString fn = QInputDialog::getText(this, tr("Macro file"), tr("Enter a file name, please:"),
-        QLineEdit::Normal, QString(), 0);
+        QLineEdit::Normal, QString(), nullptr, Qt::MSWindowsFixedSizeDialogHint);
     if (!fn.isEmpty())
     {
         QString suffix = QFileInfo(fn).suffix().toLower();
@@ -680,7 +680,7 @@ void DlgMacroExecuteImp::on_renameButton_clicked()
 
     // query new name
     QString fn = QInputDialog::getText(this, tr("Renaming Macro File"),
-        tr("Enter new name:"), QLineEdit::Normal, oldName, 0);
+        tr("Enter new name:"), QLineEdit::Normal, oldName, nullptr, Qt::MSWindowsFixedSizeDialogHint);
     if (!fn.isEmpty() && fn != oldName) {
         QString suffix = QFileInfo(fn).suffix().toLower();
         if (suffix != QLatin1String("fcmacro") && suffix != QLatin1String("py"))
@@ -767,7 +767,8 @@ void DlgMacroExecuteImp::on_duplicateButton_clicked()
 
     // give user a chance to pick a different name from digitized name suggested
     QString fn = QInputDialog::getText(this, tr("Duplicate Macro"),
-        tr("Enter new name:"), QLineEdit::Normal, oldNameDigitized, 0);
+        tr("Enter new name:"), QLineEdit::Normal, oldNameDigitized, 
+        nullptr, Qt::MSWindowsFixedSizeDialogHint);
     if (!fn.isEmpty() && fn != oldName) {
         QString suffix = QFileInfo(fn).suffix().toLower();
         if (suffix != QLatin1String("fcmacro") && suffix != QLatin1String("py")){

--- a/src/Gui/DlgParameterImp.cpp
+++ b/src/Gui/DlgParameterImp.cpp
@@ -554,7 +554,7 @@ void ParameterGroup::onCreateSubgroup()
 {
     bool ok;
     QString name = QInputDialog::getText(this, QObject::tr("New sub-group"), QObject::tr("Enter the name:"),
-                                         QLineEdit::Normal, QString(), &ok );
+                                         QLineEdit::Normal, QString(), &ok, Qt::MSWindowsFixedSizeDialogHint);
 
     if (ok && Gui::validateInput(this, name))
     {
@@ -782,7 +782,7 @@ void ParameterValue::onCreateTextItem()
 {
     bool ok;
     QString name = QInputDialog::getText(this, QObject::tr("New text item"), QObject::tr("Enter the name:"),
-                                         QLineEdit::Normal, QString(), &ok);
+                                         QLineEdit::Normal, QString(), &ok, Qt::MSWindowsFixedSizeDialogHint);
 
     if (!ok || !Gui::validateInput(this, name))
         return;
@@ -798,7 +798,7 @@ void ParameterValue::onCreateTextItem()
     }
 
     QString val = QInputDialog::getText(this, QObject::tr("New text item"), QObject::tr("Enter your text:"),
-                                        QLineEdit::Normal, QString(), &ok);
+                                        QLineEdit::Normal, QString(), &ok, Qt::MSWindowsFixedSizeDialogHint);
     if ( ok && !val.isEmpty() )
     {
         ParameterValueItem *pcItem;
@@ -811,7 +811,7 @@ void ParameterValue::onCreateIntItem()
 {
     bool ok;
     QString name = QInputDialog::getText(this, QObject::tr("New integer item"), QObject::tr("Enter the name:"),
-                                         QLineEdit::Normal, QString(), &ok);
+                                         QLineEdit::Normal, QString(), &ok, Qt::MSWindowsFixedSizeDialogHint);
 
     if (!ok || !Gui::validateInput(this, name))
         return;
@@ -827,7 +827,7 @@ void ParameterValue::onCreateIntItem()
     }
 
     int val = QInputDialog::getInt(this, QObject::tr("New integer item"), QObject::tr("Enter your number:"),
-                                   0, -2147483647, 2147483647, 1, &ok);
+                                   0, -2147483647, 2147483647, 1, &ok, Qt::MSWindowsFixedSizeDialogHint);
 
     if ( ok )
     {
@@ -841,7 +841,7 @@ void ParameterValue::onCreateUIntItem()
 {
     bool ok;
     QString name = QInputDialog::getText(this, QObject::tr("New unsigned item"), QObject::tr("Enter the name:"),
-                                         QLineEdit::Normal, QString(), &ok);
+                                         QLineEdit::Normal, QString(), &ok, Qt::MSWindowsFixedSizeDialogHint);
 
     if (!ok || !Gui::validateInput(this, name))
         return;
@@ -877,7 +877,7 @@ void ParameterValue::onCreateFloatItem()
 {
     bool ok;
     QString name = QInputDialog::getText(this, QObject::tr("New float item"), QObject::tr("Enter the name:"),
-                                         QLineEdit::Normal, QString(), &ok);
+                                         QLineEdit::Normal, QString(), &ok, Qt::MSWindowsFixedSizeDialogHint);
 
     if (!ok || !Gui::validateInput(this, name))
         return;
@@ -893,7 +893,7 @@ void ParameterValue::onCreateFloatItem()
     }
 
     double val = QInputDialog::getDouble(this, QObject::tr("New float item"), QObject::tr("Enter your number:"),
-                                         0, -2147483647, 2147483647, 12, &ok);
+                                         0, -2147483647, 2147483647, 12, &ok, Qt::MSWindowsFixedSizeDialogHint);
     if ( ok )
     {
         ParameterValueItem *pcItem;
@@ -906,7 +906,7 @@ void ParameterValue::onCreateBoolItem()
 {
     bool ok;
     QString name = QInputDialog::getText(this, QObject::tr("New Boolean item"), QObject::tr("Enter the name:"),
-                                         QLineEdit::Normal, QString(), &ok);
+                                         QLineEdit::Normal, QString(), &ok, Qt::MSWindowsFixedSizeDialogHint);
 
     if (!ok || !Gui::validateInput(this, name))
         return;
@@ -924,7 +924,7 @@ void ParameterValue::onCreateBoolItem()
     QStringList list; list << QString::fromLatin1("true")
                            << QString::fromLatin1("false");
     QString val = QInputDialog::getItem (this, QObject::tr("New boolean item"), QObject::tr("Choose an item:"),
-                                         list, 0, false, &ok);
+                                         list, 0, false, &ok, Qt::MSWindowsFixedSizeDialogHint);
     if ( ok )
     {
         ParameterValueItem *pcItem;
@@ -1065,7 +1065,7 @@ void ParameterText::changeValue()
 {
     bool ok;
     QString txt = QInputDialog::getText(treeWidget(), QObject::tr("Change value"), QObject::tr("Enter your text:"),
-                                        QLineEdit::Normal, text(2), &ok);
+                                        QLineEdit::Normal, text(2), &ok, Qt::MSWindowsFixedSizeDialogHint);
     if ( ok )
     {
         setText( 2, txt );
@@ -1109,7 +1109,7 @@ void ParameterInt::changeValue()
 {
     bool ok;
     int num = QInputDialog::getInt(treeWidget(), QObject::tr("Change value"), QObject::tr("Enter your number:"),
-                                   text(2).toInt(), -2147483647, 2147483647, 1, &ok);
+                                   text(2).toInt(), -2147483647, 2147483647, 1, &ok, Qt::MSWindowsFixedSizeDialogHint);
     if ( ok )
     {
         setText(2, QString::fromLatin1("%1").arg(num));
@@ -1206,7 +1206,7 @@ void ParameterFloat::changeValue()
 {
     bool ok;
     double num = QInputDialog::getDouble(treeWidget(), QObject::tr("Change value"), QObject::tr("Enter your number:"),
-                                         text(2).toDouble(), -2147483647, 2147483647, 12, &ok);
+                                         text(2).toDouble(), -2147483647, 2147483647, 12, &ok, Qt::MSWindowsFixedSizeDialogHint);
     if ( ok )
     {
         setText(2, QString::fromLatin1("%1").arg(num));
@@ -1254,7 +1254,7 @@ void ParameterBool::changeValue()
     int pos = (text(2) == list[0] ? 0 : 1);
 
     QString txt = QInputDialog::getItem (treeWidget(), QObject::tr("Change value"), QObject::tr("Choose an item:"),
-                                         list, pos, false, &ok);
+                                         list, pos, false, &ok, Qt::MSWindowsFixedSizeDialogHint);
     if ( ok )
     {
         setText( 2, txt );

--- a/src/Gui/DlgToolbarsImp.cpp
+++ b/src/Gui/DlgToolbarsImp.cpp
@@ -488,7 +488,7 @@ void DlgCustomToolbars::on_newButton_clicked()
 {
     bool ok;
     QString text = QString::fromLatin1("Custom%1").arg(ui->toolbarTreeWidget->topLevelItemCount()+1);
-    text = QInputDialog::getText(this, tr("New toolbar"), tr("Toolbar name:"), QLineEdit::Normal, text, &ok);
+    text = QInputDialog::getText(this, tr("New toolbar"), tr("Toolbar name:"), QLineEdit::Normal, text, &ok, Qt::MSWindowsFixedSizeDialogHint);
     if (ok) {
         // Check for duplicated name
         for (int i=0; i<ui->toolbarTreeWidget->topLevelItemCount(); i++) {
@@ -535,7 +535,7 @@ void DlgCustomToolbars::on_renameButton_clicked()
         bool ok;
         QString old_text = item->text(0);
         QString text = QInputDialog::getText(this, tr("Rename toolbar"), tr("Toolbar name:"),
-            QLineEdit::Normal, old_text, &ok);
+            QLineEdit::Normal, old_text, &ok, Qt::MSWindowsFixedSizeDialogHint);
         if (ok && text != old_text) {
             // Check for duplicated name
             for (int i=0; i<ui->toolbarTreeWidget->topLevelItemCount(); i++) {

--- a/src/Gui/DlgUnitsCalculator.ui
+++ b/src/Gui/DlgUnitsCalculator.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>424</width>
+    <width>537</width>
     <height>262</height>
    </rect>
   </property>

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -648,6 +648,7 @@ int MainWindow::confirmSave(const char *docName, QWidget *parent, bool addCheckb
     }
 
     int res = 0;
+    box.adjustSize(); // Silence warnings from Qt on Windows
     switch (box.exec())
     {
     case QMessageBox::Save:

--- a/src/Gui/TextDocumentEditorView.cpp
+++ b/src/Gui/TextDocumentEditorView.cpp
@@ -258,6 +258,7 @@ bool TextDocumentEditorView::canClose()
             discardBtn->setShortcut(QKeySequence::mnemonic(text));
         }
 
+        box.adjustSize();
         switch (box.exec())
         {
         case QMessageBox::Save:

--- a/src/Mod/Mesh/Gui/Command.cpp
+++ b/src/Mod/Mesh/Gui/Command.cpp
@@ -573,7 +573,7 @@ void CmdMeshFromGeometry::activated(int)
 {
     bool ok;
     double tol = QInputDialog::getDouble(Gui::getMainWindow(), QObject::tr("Meshing Tolerance"),
-        QObject::tr("Enter tolerance for meshing geometry:"), 0.1, 0.01,10.0,2,&ok);
+        QObject::tr("Enter tolerance for meshing geometry:"), 0.1, 0.01, 10.0, 2, &ok, Qt::MSWindowsFixedSizeDialogHint);
     if (!ok)
         return;
 
@@ -1645,7 +1645,7 @@ void CmdMeshFillupHoles::activated(int)
     std::vector<App::DocumentObject*> meshes = getSelection().getObjectsOfType(Mesh::Feature::getClassTypeId());
     bool ok;
     int FillupHolesOfLength = QInputDialog::getInt(Gui::getMainWindow(), QObject::tr("Fill holes"),
-                                QObject::tr("Fill holes with maximum number of edges:"), 3, 3, 10000, 1, &ok);
+                                QObject::tr("Fill holes with maximum number of edges:"), 3, 3, 10000, 1, &ok, Qt::MSWindowsFixedSizeDialogHint);
     if (!ok) return;
     openCommand(QT_TRANSLATE_NOOP("Command", "Fill up holes"));
     for (std::vector<App::DocumentObject*>::const_iterator it = meshes.begin(); it != meshes.end(); ++it) {
@@ -1889,7 +1889,7 @@ void CmdMeshScale::activated(int)
 
     bool ok;
     double factor = QInputDialog::getDouble(Gui::getMainWindow(), QObject::tr("Scaling"),
-        QObject::tr("Enter scaling factor:"), 1, 0, DBL_MAX, 5, &ok);
+        QObject::tr("Enter scaling factor:"), 1, 0, DBL_MAX, 5, &ok, Qt::MSWindowsFixedSizeDialogHint);
     if (!ok || factor == 0)
         return;
 

--- a/src/Mod/Part/Gui/CommandSimple.cpp
+++ b/src/Mod/Part/Gui/CommandSimple.cpp
@@ -126,7 +126,7 @@ void CmdPartShapeFromMesh::activated(int iMsg)
 
     bool ok;
     double tol = QInputDialog::getDouble(Gui::getMainWindow(), QObject::tr("Sewing Tolerance"),
-        QObject::tr("Enter tolerance for sewing shape:"), 0.1, minimal_tolerance, 10.0, decimals, &ok);
+        QObject::tr("Enter tolerance for sewing shape:"), 0.1, minimal_tolerance, 10.0, decimals, &ok, Qt::MSWindowsFixedSizeDialogHint);
     if (!ok)
         return;
     Base::Type meshid = Base::Type::fromName("Mesh::Feature");

--- a/src/Mod/PartDesign/Gui/CommandBody.cpp
+++ b/src/Mod/PartDesign/Gui/CommandBody.cpp
@@ -729,7 +729,7 @@ void CmdPartDesignMoveFeature::activated(int iMsg)
     QString text = QInputDialog::getItem(Gui::getMainWindow(),
         qApp->translate("PartDesign_MoveFeature", "Select body"),
         qApp->translate("PartDesign_MoveFeature", "Select a body from the list"),
-        items, 0, false, &ok);
+        items, 0, false, &ok, Qt::MSWindowsFixedSizeDialogHint);
     if (!ok) return;
     int index = items.indexOf(text);
     if (index < 0) return;
@@ -879,7 +879,7 @@ void CmdPartDesignMoveFeatureInTree::activated(int iMsg)
     QString text = QInputDialog::getItem(Gui::getMainWindow(),
         qApp->translate("PartDesign_MoveFeatureInTree", "Select feature"),
         qApp->translate("PartDesign_MoveFeatureInTree", "Select a feature from the list"),
-        items, 0, false, &ok);
+        items, 0, false, &ok, Qt::MSWindowsFixedSizeDialogHint);
     if (!ok) return;
     int index = items.indexOf(text);
     // first object is the beginning of the body

--- a/src/Mod/Points/Gui/Command.cpp
+++ b/src/Mod/Points/Gui/Command.cpp
@@ -200,7 +200,7 @@ void CmdPointsConvert::activated(int iMsg)
 
     bool ok;
     double tol = QInputDialog::getDouble(Gui::getMainWindow(), QObject::tr("Distance"),
-        QObject::tr("Enter maximum distance:"), 0.1, 0.05, 10.0, 2, &ok);
+        QObject::tr("Enter maximum distance:"), 0.1, 0.05, 10.0, 2, &ok, Qt::MSWindowsFixedSizeDialogHint);
     if (!ok)
         return;
 

--- a/src/Mod/Raytracing/Gui/ViewProvider.cpp
+++ b/src/Mod/Raytracing/Gui/ViewProvider.cpp
@@ -96,7 +96,7 @@ bool ViewProviderLux::setEdit(int ModNum)
         int current = items.indexOf(cfi.absoluteFilePath());
 
         bool ok;
-        QString file = QInputDialog::getItem(Gui::getMainWindow(), tr("LuxRender template"), tr("Select a LuxRender template"), items, current, false, &ok);
+        QString file = QInputDialog::getItem(Gui::getMainWindow(), tr("LuxRender template"), tr("Select a LuxRender template"), items, current, false, &ok, Qt::MSWindowsFixedSizeDialogHint);
         if (ok) {
             App::Document* doc  = getObject()->getDocument();
             doc->openTransaction("Edit LuxRender project");
@@ -175,7 +175,7 @@ bool ViewProviderPovray::setEdit(int ModNum)
         int current = items.indexOf(cfi.absoluteFilePath());
 
         bool ok;
-        QString file = QInputDialog::getItem(Gui::getMainWindow(), tr("Povray template"), tr("Select a Povray template"), items, current, false, &ok);
+        QString file = QInputDialog::getItem(Gui::getMainWindow(), tr("Povray template"), tr("Select a Povray template"), items, current, false, &ok, Qt::MSWindowsFixedSizeDialogHint);
         if (ok) {
             App::Document* doc  = getObject()->getDocument();
             doc->openTransaction("Edit Povray project");

--- a/src/Mod/Robot/Gui/CommandTrajectory.cpp
+++ b/src/Mod/Robot/Gui/CommandTrajectory.cpp
@@ -267,7 +267,7 @@ void CmdRobotSetDefaultValues::activated(int)
     bool ok;
     QString text = QInputDialog::getText(0, QObject::tr("Set default speed"),
                                           QObject::tr("speed: (e.g. 1 m/s or 3 cm/s)"), QLineEdit::Normal,
-                                          QString::fromLatin1("1 m/s"), &ok);
+                                          QString::fromLatin1("1 m/s"), &ok, Qt::MSWindowsFixedSizeDialogHint);
     if ( ok && !text.isEmpty() ) {
         doCommand(Doc,"_DefSpeed = '%s'",text.toLatin1().constData());
     }
@@ -276,7 +276,7 @@ void CmdRobotSetDefaultValues::activated(int)
     items  << QString::fromLatin1("False") << QString::fromLatin1("True");
 
     QString item = QInputDialog::getItem(0, QObject::tr("Set default continuity"),
-                                          QObject::tr("continuous ?"), items, 0, false, &ok);
+                                          QObject::tr("continuous ?"), items, 0, false, &ok, Qt::MSWindowsFixedSizeDialogHint);
     if (ok && !item.isEmpty())
         doCommand(Doc,"_DefCont = %s",item.toLatin1().constData());
 
@@ -284,7 +284,7 @@ void CmdRobotSetDefaultValues::activated(int)
 
     text = QInputDialog::getText(0, QObject::tr("Set default acceleration"),
                                           QObject::tr("acceleration: (e.g. 1 m/s^2 or 3 cm/s^2)"), QLineEdit::Normal,
-                                          QString::fromLatin1("1 m/s^2"), &ok);
+                                          QString::fromLatin1("1 m/s^2"), &ok, Qt::MSWindowsFixedSizeDialogHint);
     if ( ok && !text.isEmpty() ) {
         doCommand(Doc,"_DefAccelaration = '%s'",text.toLatin1().constData());
     }

--- a/src/Mod/Sketcher/Gui/Command.cpp
+++ b/src/Mod/Sketcher/Gui/Command.cpp
@@ -179,7 +179,7 @@ void CmdSketcherNewSketch::activated(int iMsg)
             QString text = QInputDialog::getItem(Gui::getMainWindow(),
                 qApp->translate("Sketcher_NewSketch", "Sketch attachment"),
                 qApp->translate("Sketcher_NewSketch", "Select the method to attach this sketch to selected object"),
-                items, iSugg, false, &ok);
+                items, iSugg, false, &ok, Qt::MSWindowsFixedSizeDialogHint);
             if (!ok) return;
             int index = items.indexOf(text);
             if (index == 0){
@@ -541,7 +541,7 @@ void CmdSketcherMapSketch::activated(int iMsg)
         QString text = QInputDialog::getItem(Gui::getMainWindow(),
             qApp->translate("Sketcher_MapSketch", "Select sketch"),
             qApp->translate("Sketcher_MapSketch", "Select a sketch from the list"),
-            items, 0, false, &ok);
+            items, 0, false, &ok, Qt::MSWindowsFixedSizeDialogHint);
         if (!ok)
             return;
         int index = items.indexOf(text);
@@ -620,7 +620,8 @@ void CmdSketcherMapSketch::activated(int iMsg)
                                      items,
                                      bCurIncompatible ? iSugg : iCurr,
                                      false,
-                                     &ok);
+                                     &ok, 
+                                     Qt::MSWindowsFixedSizeDialogHint);
         // * collect dialog result
         if (!ok)
             return;

--- a/src/Mod/TechDraw/Gui/mrichtextedit.cpp
+++ b/src/Mod/TechDraw/Gui/mrichtextedit.cpp
@@ -355,7 +355,8 @@ void MRichTextEdit::textLink(bool checked) {
         QString newUrl = QInputDialog::getText(this, tr("Create a link"),
                                         tr("Link URL:"), QLineEdit::Normal,
                                         url,
-                                        &ok);
+                                        &ok,
+                                        Qt::MSWindowsFixedSizeDialogHint);
         if (ok) {
             fmt.setAnchor(true);
             fmt.setAnchorHref(newUrl);


### PR DESCRIPTION
Add the optional `Qt::MSWindowsFixedSizeDialogHint` parameter to all uses of the `QInputDialog::getX` static functions to silence a Qt/Windows debug mode warning, "QWindowsWindow::setGeometry: Unable to set geometry." Increase the size of the unit calculator to eliminate the same warning. Finally, call `adjustSize()` on the "Unsaved Changes" dialogs to silence their warning.

Forums discussion topic here: https://forum.freecadweb.org/viewtopic.php?p=456437