### PR TITLE
[Path WB] Removing the check for parallel edges

### DIFF
--- a/src/Mod/Path/PathScripts/PathSlot.py
+++ b/src/Mod/Path/PathScripts/PathSlot.py
@@ -1005,13 +1005,13 @@ class ObjectSlot(PathOp.ObjectOp):
             self.dYdX2 = dYdX2
 
         # Parallel check for twin face, and face-edge cases
-        if dYdX1 and dYdX2:
-            if not self._isParallel(dYdX1, dYdX2):
-                PathLog.debug('dYdX1, dYdX2: {}, {}'.format(dYdX1, dYdX2))
-                msg = translate('PathSlot',
-                    'Selected geometry not parallel.')
-                FreeCAD.Console.PrintError(msg + '\n')
-                return False
+        #if dYdX1 and dYdX2:
+        #    if not self._isParallel(dYdX1, dYdX2):
+        #        PathLog.debug('dYdX1, dYdX2: {}, {}'.format(dYdX1, dYdX2))
+        #        msg = translate('PathSlot',
+        #            'Selected geometry not parallel.')
+        #        FreeCAD.Console.PrintError(msg + '\n')
+        #        return False
 
         if p2:
             return (p1, p2)


### PR DESCRIPTION
In order to realise my project, I had to remove the check whether the two selected edges were parallel.

Could it be possible to remove this check?

I know, my commit is not the final solution. However, I use the pull request to point to the code that prevents my project from succeeding.

Regards,
Stefan

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
