### PR TITLE
Fix various typos [skip ci]

### DIFF
--- a/src/App/MergeDocuments.cpp
+++ b/src/App/MergeDocuments.cpp
@@ -68,7 +68,7 @@ protected:
     // It is not safe to change potential object name reference at this level.
     // For example, a LinkSub with sub element name Face1 may also be some
     // object's name that may potentially be mapped. In addition, with the
-    // introduction of full quanlified SubName reference, the Sub value inside
+    // introduction of full qualified SubName reference, the Sub value inside
     // LinkSub may require customized mapping. So we move the mapping logic to
     // various link property's Restore() function.
 #if 0

--- a/src/Gui/CoinRiftWidget.cpp
+++ b/src/Gui/CoinRiftWidget.cpp
@@ -307,7 +307,7 @@ void CoinRiftWidget::initializeGL()
     glDisable(GL_TEXTURE_2D);
 
 #ifdef USE_FRAMEBUFFER
-    // Continue rendering to the orgiginal frame buffer (likely 0, the onscreen buffer).
+    // Continue rendering to the original frame buffer (likely 0, the onscreen buffer).
     OVR::CAPI::GL::glBindFramebuffer(GL_FRAMEBUFFER_EXT, oldfb);
 #endif
     doneCurrent();
@@ -319,7 +319,7 @@ void CoinRiftWidget::paintGL()
     const int ms(1000 / 75 /*fps*/);
     QTimer::singleShot(ms, this, SLOT(updateGL()));
 
-    // handling the sfety warning
+    // handling the safety warning
     handlingSafetyWarning();
 
     makeCurrent();
@@ -388,7 +388,7 @@ void CoinRiftWidget::paintGL()
 // m_sceneManager->setCamera(camera[eye]); // SoSceneManager does this implicitly.
         m_sceneManager->render();
 
-        // Continue rendering to the orgiginal frame buffer (likely 0, the onscreen buffer).
+        // Continue rendering to the original frame buffer (likely 0, the onscreen buffer).
         OVR::CAPI::GL::glBindFramebuffer(GL_FRAMEBUFFER_EXT, oldfb);
         Q_ASSERT(!glGetError());
 #endif

--- a/src/Gui/Icons/Std_DependencyGraph.svg
+++ b/src/Gui/Icons/Std_DependencyGraph.svg
@@ -186,7 +186,7 @@
         </dc:contributor>
         <dc:subject>
           <rdf:Bag>
-            <rdf:li>Arrows baloons</rdf:li>
+            <rdf:li>Arrow balloons</rdf:li>
           </rdf:Bag>
         </dc:subject>
         <dc:description></dc:description>

--- a/src/Gui/NavigationStyle.cpp
+++ b/src/Gui/NavigationStyle.cpp
@@ -1074,7 +1074,7 @@ void NavigationStyle::saveCursorPosition(const SoEvent * const ev)
         setRotationCenter(boundingBoxCenter);
 
         // To drag around the center point of the bbox we have to determine
-        // its projection on the screen becaue this information is used in
+        // its projection on the screen because this information is used in
         // NavigationStyle::spin() for the panning
         SbViewVolume vv = cam->getViewVolume(ratio);
         vv.projectToScreen(boundingBoxCenter, boundingBoxCenter);

--- a/src/Gui/Tree.h
+++ b/src/Gui/Tree.h
@@ -403,7 +403,7 @@ public:
     // check if a new item is required at root
     bool requiredAtRoot(bool excludeSelf=true) const;
 
-    // return the owner, and full quanlified subname
+    // return the owner, and full qualified subname
     App::DocumentObject *getFullSubName(std::ostringstream &str,
             DocumentObjectItem *parent = 0) const;
 

--- a/src/Gui/ViewProvider.h
+++ b/src/Gui/ViewProvider.h
@@ -276,7 +276,7 @@ public:
     virtual bool canDragAndDropObject(App::DocumentObject*) const;
     /** Add an object to the view provider by drag and drop */
     virtual void dropObject(App::DocumentObject*);
-    /** Query object dropping with full quanlified name
+    /** Query object dropping with full qualified name
      *
      * Tree view now calls this function instead of canDropObject(), and may
      * query for objects from other document. The default implementation
@@ -304,7 +304,7 @@ public:
     /// return a subname referencing the sub-object holding the dropped objects
     virtual std::string getDropPrefix() const { return std::string(); }
 
-    /** Add an object with full quanlified name to the view provider by drag and drop
+    /** Add an object with full qualified name to the view provider by drag and drop
      *
      * @param obj: the object being dropped
      *

--- a/src/Gui/ViewProviderPythonFeature.h
+++ b/src/Gui/ViewProviderPythonFeature.h
@@ -109,10 +109,10 @@ public:
     ValueT dropObject(App::DocumentObject*);
     /** Return false to force drop only operation for a give object*/
     ValueT canDragAndDropObject(App::DocumentObject*) const;
-    /** Query object dropping with full quanlified name */
+    /** Query object dropping with full qualified name */
     ValueT canDropObjectEx(App::DocumentObject *obj, App::DocumentObject *,
             const char *,const std::vector<std::string> &elements) const;
-    /** Add an object with full quanlified name to the view provider by drag and drop */
+    /** Add an object with full qualified name to the view provider by drag and drop */
     bool dropObjectEx(App::DocumentObject *obj, App::DocumentObject *,
             const char *, const std::vector<std::string> &elements, std::string &ret);
     ValueT replaceObject(App::DocumentObject *, App::DocumentObject *);
@@ -419,7 +419,7 @@ public:
             return ViewProviderT::canDropObjectEx(obj,owner,subname,elements);
         }
     }
-    /** Add an object with full quanlified name to the view provider by drag and drop */
+    /** Add an object with full qualified name to the view provider by drag and drop */
     virtual std::string dropObjectEx(App::DocumentObject *obj, App::DocumentObject *owner,
             const char *subname, const std::vector<std::string> &elements) override
     {

--- a/src/Mod/MeshPart/App/MeshFlattening.h
+++ b/src/Mod/MeshPart/App/MeshFlattening.h
@@ -74,7 +74,7 @@ public:
 	ColMat<long, 1> fixed_nodes; // input
 	ColMat<double, 3> xyz_nodes; // compute from uv_mesh (xyz = A * poles)
 	ColMat<double, 2> uv_nodes;  // input
-	ColMat<double, 2> ze_nodes;  // copute
+	ColMat<double, 2> ze_nodes;  // compute
 
 	// nurbs
 	ColMat<double, 2> ze_poles;   // compute
@@ -82,4 +82,4 @@ public:
 
 };
 
-#endif // MESHFLATTENING 
+#endif // MESHFLATTENING

--- a/src/Mod/Sketcher/App/ExternalGeometryFacadePy.xml
+++ b/src/Mod/Sketcher/App/ExternalGeometryFacadePy.xml
@@ -43,7 +43,7 @@
     </Attribute>
     <Attribute Name="Construction" ReadOnly="false">
       <Documentation>
-        <UserDocu>Sets/retuns this geometry as a construction one, which will not be part of a later built shape.</UserDocu>
+        <UserDocu>Sets/returns this geometry as a construction one, which will not be part of a later built shape.</UserDocu>
       </Documentation>
       <Parameter Name="Construction" Type="Boolean"/>
       </Attribute>

--- a/src/Mod/Sketcher/App/GeometryFacadePy.xml
+++ b/src/Mod/Sketcher/App/GeometryFacadePy.xml
@@ -51,7 +51,7 @@
     </Attribute>
     <Attribute Name="Construction" ReadOnly="false">
       <Documentation>
-        <UserDocu>Sets/retuns this geometry as a construction one, which will not be part of a later built shape.</UserDocu>
+        <UserDocu>Sets/returns this geometry as a construction one, which will not be part of a later built shape.</UserDocu>
       </Documentation>
       <Parameter Name="Construction" Type="Boolean"/>
     </Attribute>

--- a/src/Mod/Sketcher/App/SketchGeometryExtensionPy.xml
+++ b/src/Mod/Sketcher/App/SketchGeometryExtensionPy.xml
@@ -51,7 +51,7 @@
     </Attribute>
     <Attribute Name="Construction" ReadOnly="false">
       <Documentation>
-        <UserDocu>Sets/retuns this geometry as a construction one, which will not be part of a later built shape.</UserDocu>
+        <UserDocu>Sets/returns this geometry as a construction one, which will not be part of a later built shape.</UserDocu>
       </Documentation>
       <Parameter Name="Construction" Type="Boolean"/>
     </Attribute>

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -7509,7 +7509,7 @@ void SketchObject::migrateSketch(void)
 
             addGeometryState(c);
 
-            // Convert B-Spline controlpoints radius/diameter constraints to Weight cosntraints
+            // Convert B-Spline controlpoints radius/diameter constraints to Weight constraints
             if(c->Type == InternalAlignment && c->AlignmentType == BSplineControlPoint) {
                 int circlegeoid = c->First;
                 int bsplinegeoid = c->Second;

--- a/src/Mod/Sketcher/App/SketchObject.h
+++ b/src/Mod/Sketcher/App/SketchObject.h
@@ -502,7 +502,7 @@ private:
     // 1. Upon restore, any migration is handled to set the status for legacy files (backwards compatibility)
     // 2. Functionality adding constraints (of the relevant type) calls addGeometryState to set the status
     // 3. Functionality removing constraints (of the relevant type) calls removeGeometryState to remove the status
-    // 4. Save mechanism will ensure persistance.
+    // 4. Save mechanism will ensure persistence.
     void addGeometryState(const Constraint* cstr) const;
     void removeGeometryState(const Constraint* cstr) const;
 


### PR DESCRIPTION
Found via `codespell v2.1.dev0`  
```
codespell -q 3 -L aci,ake,aline,alle,alledges,alocation,als,ang,anid,apoints,ba,beginn,behaviour,bloaded,byteorder,calculater,cancelled,cancelling,cas,cascade,centimetre,childs,colour,colours,commen,connexion,currenty,dof,doubleclick,dum,eiter,elemente,ende,feld,finde,findf,freez,hist,iff,indicies,initialisation,initialise,initialised,initialises,initialisiert,ist,kilometre,lod,mantatory,methode,metres,millimetre,modell,nd,noe,normale,normaly,nto,numer,oder,orgin,orginx,orginy,ot,pard,pres,programm,que,recurrance,rougly,seperator,serie,sinc,strack,substraction,te,thist,thru,tread,uint,unter,vertexes,wallthickness,whitespaces -S ./.git,*.po,*.ts,./ChangeLog.txt,./src/3rdParty,./src/Mod/Assembly/App/opendcm,./src/CXX,./src/zipios++,./src/Base/swig*,./src/Mod/Robot/App/kdl_cp,./src/Mod/Import/App/SCL,./src/WindowsInstaller,./src/Doc/FreeCAD.uml
```