### PR TITLE
[Path] Sort edges before splitting at selected vertex

### DIFF
--- a/src/Mod/Path/PathScripts/PathEngraveBase.py
+++ b/src/Mod/Path/PathScripts/PathEngraveBase.py
@@ -30,6 +30,7 @@ import copy
 # lazily loaded modules
 from lazy_loader.lazy_loader import LazyLoader
 DraftGeomUtils = LazyLoader('DraftGeomUtils', globals(), 'DraftGeomUtils')
+Part = LazyLoader('Part', globals(), 'Part')
 
 from PySide import QtCore
 
@@ -69,9 +70,11 @@ class ObjectOp(PathOp.ObjectOp):
 
             # reorder the wire
             if hasattr(obj, 'StartVertex'):
-                offset = DraftGeomUtils.rebaseWire(offset, obj.StartVertex)
+                start_idx = obj.StartVertex
 
             edges = copy.copy(PathOpTools.orientWire(offset, forward).Edges)
+            edges = Part.sortEdges(edges)[0];
+
             last = None
 
             for z in zValues:


### PR DESCRIPTION
Fixes #4458
This is intended to fix bug #4458. The problem is, that edges are not sorted after dividing and therefore two edges may follow after each other which do not have an equal point at all. Inserting an additional sorting line fixes the problem. I also removed the split by "rebaseWire"-Method, as an additional split already exits in the function. It is not clear to me what is the intended behavior if both StartVertex are given and parameter start_idx is given. Now StartVertex has a higher priority if set. Only PathDeburr is using start_idx, which has no StartVertex-feature. So, there should be no problem rising. I tested deburr and engrave. Both are working in a short test.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:
.
- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
