### PR TITLE
Sketcher: Delete Equal constraints on LineSegments in SketchObject::trim

### DIFF
--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -2288,7 +2288,7 @@ int SketchObject::trim(int GeoId, const Base::Vector3d& point)
 
     };
     
-    // this is a helper function to remove Equal constraints from Line segments. 
+    // Helper function to remove Equal constraints from a chosen edge (e.g Line segment). 
     auto delEqualConstraintsOnGeoId = [this] (int GeoId) {
             
         std::vector<int> delete_list;
@@ -2306,7 +2306,6 @@ int SketchObject::trim(int GeoId, const Base::Vector3d& point)
             index++;
         }
         delConstraints(delete_list);
-        return index-1;
     };
 
     auto creategeometryundopoint = [this, geomlist]() {

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -2330,7 +2330,7 @@ int SketchObject::trim(int GeoId, const Base::Vector3d& point)
                 std::swap(x1,x2);
             }
             if (x1 >= 0.001*length && x2 <= 0.999*length) {
-                if (x1 < x0 && x2 > x0) {  // trim a way a sement in the middle
+                if (x1 < x0 && x2 > x0) {  // trim away a segment in the middle
                     int newGeoId = addGeometry(geo);
                     // go through all constraints and replace the point (GeoId,end) with (newGeoId,end)
                     transferConstraints(GeoId, end, newGeoId, end);


### PR DESCRIPTION
This closes:
https://tracker.freecadweb.org/view.php?id=4510

Forum discussion:
https://forum.freecadweb.org/viewtopic.php?f=8&t=53240

After PR:
![fix](https://user-images.githubusercontent.com/1278189/102209374-f20d2700-3ed0-11eb-9371-bf9e25dc3009.gif)

Before PR:
![weird_sketcher_trim_behavior_simpliied](https://user-images.githubusercontent.com/1278189/102209427-06e9ba80-3ed1-11eb-9271-1879a0d20956.gif)
