### PR TITLE
Update fcinfo script for py3 compatibility

### DIFF
--- a/src/Tools/fcinfo
+++ b/src/Tools/fcinfo
@@ -174,7 +174,7 @@ class FreeCADFileHandler(xml.sax.ContentHandler):
 
             # Print all the contents of the document properties
             items = self.contents.items()
-            items.sort()
+            items = sorted(items)
             for key,value in items:
                 key = self.clean(key)
                 value = self.clean(value)
@@ -186,7 +186,7 @@ class FreeCADFileHandler(xml.sax.ContentHandler):
 
         if (tag == "Document") and (self.short != 2):
             items = self.contents.items()
-            items.sort()
+            items = sorted(items)
             for key,value in items:
                 key = self.clean(key)
                 if "00000000::" in key:


### PR DESCRIPTION
Small changes in the fcinfo script in order to run with both python2 and python3. Some systems now default the system `python` command to run as python3 so this script currently fails on those systems.
