### PR TITLE
[TD] Balloon fixes, change places of Properties in UI, fix refresh bugs

### DIFF
--- a/src/Mod/TechDraw/App/DrawViewBalloon.cpp
+++ b/src/Mod/TechDraw/App/DrawViewBalloon.cpp
@@ -99,13 +99,13 @@ DrawViewBalloon::DrawViewBalloon(void)
     EndType.setEnums(ArrowPropEnum::ArrowTypeEnums);
     ADD_PROPERTY(EndType,(prefEnd()));
 
+    ADD_PROPERTY_TYPE(EndTypeScale,(1.0),"",(App::PropertyType)(App::Prop_None),"EndType shape scale");
+    ShapeScale.setConstraints(&SymbolScaleRange);
+
     BubbleShape.setEnums(balloonTypeEnums);
     ADD_PROPERTY(BubbleShape,(prefShape()));
 
     ADD_PROPERTY_TYPE(ShapeScale,(1.0),"",(App::PropertyType)(App::Prop_None),"Balloon shape scale");
-    ShapeScale.setConstraints(&SymbolScaleRange);
-
-    ADD_PROPERTY_TYPE(EndTypeScale,(1.0),"",(App::PropertyType)(App::Prop_None),"EndType shape scale");
     ShapeScale.setConstraints(&SymbolScaleRange);
 
     ADD_PROPERTY_TYPE(TextWrapLen,(-1),"",(App::PropertyType)(App::Prop_None),"Text wrap length; -1 means no wrap");

--- a/src/Mod/TechDraw/App/DrawViewBalloon.cpp
+++ b/src/Mod/TechDraw/App/DrawViewBalloon.cpp
@@ -129,7 +129,8 @@ void DrawViewBalloon::onChanged(const App::Property* prop)
         if ( (prop == &EndType) ||
              (prop == &BubbleShape)  ||
              (prop == &Text)    ||
-             (prop == &KinkLength) ) {
+             (prop == &KinkLength)   ||
+             (prop == &EndTypeScale) ) {
             requestPaint();
         }
     }

--- a/src/Mod/TechDraw/App/DrawViewBalloon.cpp
+++ b/src/Mod/TechDraw/App/DrawViewBalloon.cpp
@@ -113,8 +113,6 @@ DrawViewBalloon::DrawViewBalloon(void)
     ADD_PROPERTY_TYPE(KinkLength,(prefKinkLength()),"",(App::PropertyType)(App::Prop_None),
                                   "Distance from symbol to leader kink");
 
-    ADD_PROPERTY_TYPE(LineVisible,(true),"",(App::PropertyType)(App::Prop_None),"Balloon line visible or hidden");
-
     SourceView.setScope(App::LinkScope::Global);
     Rotation.setStatus(App::Property::Hidden,true);
     Caption.setStatus(App::Property::Hidden,true);

--- a/src/Mod/TechDraw/App/DrawViewBalloon.cpp
+++ b/src/Mod/TechDraw/App/DrawViewBalloon.cpp
@@ -65,7 +65,7 @@ using namespace TechDraw;
 
 App::PropertyFloatConstraint::Constraints DrawViewBalloon::SymbolScaleRange = { Precision::Confusion(),
                                                                   std::numeric_limits<double>::max(),
-                                                                  (1.0) };
+                                                                  (0.1) };
 
 //===========================================================================
 // DrawViewBalloon
@@ -100,7 +100,7 @@ DrawViewBalloon::DrawViewBalloon(void)
     ADD_PROPERTY(EndType,(prefEnd()));
 
     ADD_PROPERTY_TYPE(EndTypeScale,(1.0),"",(App::PropertyType)(App::Prop_None),"EndType shape scale");
-    ShapeScale.setConstraints(&SymbolScaleRange);
+    EndTypeScale.setConstraints(&SymbolScaleRange);
 
     BubbleShape.setEnums(balloonTypeEnums);
     ADD_PROPERTY(BubbleShape,(prefShape()));
@@ -128,9 +128,12 @@ void DrawViewBalloon::onChanged(const App::Property* prop)
     if (!isRestoring()) {
         if ( (prop == &EndType) ||
              (prop == &BubbleShape)  ||
+             (prop == &ShapeScale)   ||
              (prop == &Text)    ||
              (prop == &KinkLength)   ||
-             (prop == &EndTypeScale) ) {
+             (prop == &EndTypeScale) ||
+             (prop == &OriginX) ||
+             (prop == &OriginY) ) {
             requestPaint();
         }
     }

--- a/src/Mod/TechDraw/App/DrawViewBalloon.h
+++ b/src/Mod/TechDraw/App/DrawViewBalloon.h
@@ -59,7 +59,6 @@ public:
     App::PropertyDistance        OriginY;
     App::PropertyFloat           TextWrapLen;
     App::PropertyDistance        KinkLength;
-    App::PropertyBool            LineVisible;
 
     short mustExecute() const override;
 

--- a/src/Mod/TechDraw/Gui/QGIViewBalloon.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewBalloon.cpp
@@ -766,7 +766,7 @@ void QGIViewBalloon::draw()
     balloonLines->setPath(dLinePath);
 
     // This overwrites the previously created QPainterPath with empty one, in case it should be hidden.  Should be refactored.
-    if (!balloon->LineVisible.getValue()) {
+    if (!vp->LineVisible.getValue()) {
         arrow->hide();
         balloonLines->setPath(QPainterPath());
     }

--- a/src/Mod/TechDraw/Gui/ViewProviderBalloon.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderBalloon.cpp
@@ -75,6 +75,7 @@ ViewProviderBalloon::ViewProviderBalloon()
     double weight = lg->getWeight("Thin");
     delete lg;                                   //Coverity CID 174670
     ADD_PROPERTY_TYPE(LineWidth,(weight),group,(App::PropertyType)(App::Prop_None),"Leader line width");
+    ADD_PROPERTY_TYPE(LineVisible,(true),group,(App::PropertyType)(App::Prop_None),"Balloon line visible or hidden");
 
     ADD_PROPERTY_TYPE(Color,(PreferencesGui::dimColor()),
                                               group,App::Prop_None,"Color of the balloon");
@@ -148,7 +149,8 @@ void ViewProviderBalloon::onChanged(const App::Property* p)
     if ((p == &Font)  ||
         (p == &Fontsize) ||
         (p == &Color) ||
-        (p == &LineWidth)) {
+        (p == &LineWidth) ||
+        (p == &LineVisible)) {
         QGIView* qgiv = getQView();
         if (qgiv) {
             qgiv->updateView(true);

--- a/src/Mod/TechDraw/Gui/ViewProviderBalloon.h
+++ b/src/Mod/TechDraw/Gui/ViewProviderBalloon.h
@@ -48,6 +48,7 @@ public:
     App::PropertyFont   Font;
     App::PropertyLength Fontsize;
     App::PropertyLength LineWidth;
+    App::PropertyBool   LineVisible;
     App::PropertyColor  Color;
 
     virtual void attach(App::DocumentObject *);


### PR DESCRIPTION
This pull request fixes minor refresh bugs in TechDraw Balloon, and changes the order of the Properties in UI.  This fixes problems discussed in a FreeCAD [Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=35&t=51869).



Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
