### PR TITLE
[Path]: Fix Profile error with `HandleMultipleFeatures` when set to `Individually` with multiple features selected

### DIFF
--- a/src/Mod/Path/PathScripts/PathProfile.py
+++ b/src/Mod/Path/PathScripts/PathProfile.py
@@ -145,7 +145,7 @@ class ObjectProfile(PathAreaOp.ObjectOp):
         return {
             'AttemptInverseAngle': True,
             'Direction': 'CW',
-            'HandleMultipleFeatures': 'Individually',
+            'HandleMultipleFeatures': 'Collectively',
             'InverseAngle': False,
             'JoinType': 'Round',
             'LimitDepthToFace': True,


### PR DESCRIPTION
This PR addresses an error that occurs with default `HandleMultipleFeatures` value of `Individually` when the user selects multiple features, such as an edge loop or closed set of vertical faces.  Considering this is likely to be a common selection type for Base Geometry when using the Profile op, this PR also changes the default `HandleMultipleFeatures` value to `Collectively` so the expected behavior will occur from the onset.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
