### PR TITLE
Path: Fix reference to cutting edge angle in OCL_Tool() class

### DIFF
--- a/src/Mod/Path/PathScripts/PathSurfaceSupport.py
+++ b/src/Mod/Path/PathScripts/PathSurfaceSupport.py
@@ -2578,11 +2578,11 @@ class OCL_Tool():
         # Engraver or V-bit cutter
         # OCL -> ConeCutter::ConeCutter(diameter, angle, length)
         if (self.diameter == -1.0 or
-            self.cuttingEdgeAngle == -1.0 or self.cutEdgeHeight == -1.0):
+            self.cutEdgeAngle == -1.0 or self.cutEdgeHeight == -1.0):
             return
         self.oclTool = self.ocl.ConeCutter(
                             self.diameter,
-                            self.cuttingEdgeAngle,
+                            self.cutEdgeAngle,
                             self.cutEdgeHeight + self.lengthOffset
                         )
 


### PR DESCRIPTION
Fixes erroneous reference to cutting edge angle identified in forum thread: [Tool controller breakage: 'cuttingEdgeAngle'](https://forum.freecadweb.org/viewtopic.php?f=15&t=53365).

The class variable name was not corrected with previously committed changes.
The correct cutting edge variable name is located in the __init__() constructor method.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
