### PR TITLE
Fix typos [skip ci]

### DIFF
--- a/src/Mod/Path/PathScripts/PathProfile.py
+++ b/src/Mod/Path/PathScripts/PathProfile.py
@@ -262,7 +262,7 @@ class ObjectProfile(PathAreaOp.ObjectOp):
         return params
 
     def areaOpAreaParamsExpandProfile(self, obj, isHole):
-        '''areaOpPathParamsExpandProfile(obj, isHole) ... return dictionary with area parameters for expaned profile'''
+        '''areaOpPathParamsExpandProfile(obj, isHole) ... return dictionary with area parameters for expanded profile'''
         params = {}
 
         params['Fill'] = 1

--- a/src/Mod/Sketcher/App/GeometryFacade.h
+++ b/src/Mod/Sketcher/App/GeometryFacade.h
@@ -83,7 +83,7 @@ class GeometryFacadePy;
 //  }
 //
 //
-// Note: The standard GeometryFacade stores Part::Geometry derived clases as a Part::Geometry *, while
+// Note: The standard GeometryFacade stores Part::Geometry derived classes as a Part::Geometry *, while
 // it has the ability to return a dynamic_cast-ed version to a provided type as follows:
 //
 // HLine->getGeometry<Part::GeomLineSegment>();

--- a/src/Mod/Sketcher/App/planegcs/GCS.cpp
+++ b/src/Mod/Sketcher/App/planegcs/GCS.cpp
@@ -3880,7 +3880,7 @@ SolverReportingManager::Manager().LogToFile("GCS::System::diagnose()\n");
 
     makeReducedJacobian(J, jacobianconstraintmap, pdiagnoselist, tagmultiplicity);
 
-    // this function will exit with a diagnosis and, unless overriden by functions below, with full DoFs
+    // this function will exit with a diagnosis and, unless overridden by functions below, with full DoFs
     hasDiagnosis = true;
     dofs = pdiagnoselist.size();
 


### PR DESCRIPTION
Found via `codespell v2.1.dev0`  
```
codespell -q 3 -L aci,ake,aline,alle,alledges,alocation,als,ang,anid,apoints,ba,beginn,behaviour,bloaded,byteorder,calculater,cancelled,cancelling,cas,cascade,click,dum,eiter,elemente,ende,feld,finde,findf,freez,hist,iff,indicies,initialisation,initialise,initialised,initialises,initialisiert,ist,kilometre,lod,mantatory,methode,metres,millim,ot,pard,pres,programm,que,recurrance,rougly,seperator,serie,sinc,strack,substraction,te,thist,thru,tread,uint,unter,vertexes,wallthickness,whitespaces -S ./.git,*.po,*.ts,./ChangeLogpios++,./src/Base/swig*,./src/Mod/Robot/App/kdl_cp,./src/Mod/Import/App/SCL,./src/WindowsInstaller,./src/Doc/FreeCAD.uml
```