### PR TITLE
[Sketcher] Eliminate Windows debug-mode warning

### DIFF
--- a/src/Mod/Sketcher/Gui/Command.cpp
+++ b/src/Mod/Sketcher/Gui/Command.cpp
@@ -228,6 +228,7 @@ void CmdSketcherNewSketch::activated(int iMsg)
         // ask user for orientation
         SketchOrientationDialog Dlg;
 
+        Dlg.adjustSize();
         if (Dlg.exec() != QDialog::Accepted)
             return; // canceled
         Base::Vector3d p = Dlg.Pos.getPosition();


### PR DESCRIPTION
Eliminate the Windows debug-mode warning on creating a new sketch by making `SketchOrientationDialog` adjust its size before displaying.