### PR TITLE
Sketcher: Fix issue #4513 - SketchObject::addSymmetric

### DIFF
--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -3418,14 +3418,14 @@ int SketchObject::addSymmetric(const std::vector<int> &geoIdList, int refGeoId, 
     // Find out if reference is aligned with V or H axis,
     // if so we can keep Vertical and Horizontal constrants in the mirrored geometry.
     bool refIsAxisAligned = false;
-    if (refGeoId == Sketcher::GeoEnum::VAxis || refGeoId == Sketcher::GeoEnum::HAxis)
+    if (refGeoId == Sketcher::GeoEnum::VAxis || refGeoId == Sketcher::GeoEnum::HAxis) {
         refIsAxisAligned = true;
-    for (std::vector<Constraint *>::const_iterator it = constrvals.begin(); it != constrvals.end(); ++it) {
-        Constraint *constr = *(it);
-        if (constr->First != refGeoId)
-            continue;
-        if (constr->Type == Sketcher::Vertical || constr->Type == Sketcher::Horizontal)
-            refIsAxisAligned = true;
+    } else {
+        for (std::vector<Constraint *>::const_iterator it = constrvals.begin(); it != constrvals.end(); ++it) {
+            Constraint *constr = *(it);
+            if (constr->First == refGeoId && (constr->Type == Sketcher::Vertical || constr->Type == Sketcher::Horizontal))
+                refIsAxisAligned = true;
+        }
     }
 
     // reference is a line


### PR DESCRIPTION
This fixes issue
https://tracker.freecadweb.org/view.php?id=4513

Forum discussion:
https://forum.freecadweb.org/viewtopic.php?f=22&t=53346

addSymmetric will now only transfer Vertical and Horizontal constraints if the reference axis is either
 - the HAxis
 - the VAxis
 - a Vertical line
 - a Horizontal line

**Before:**
![mirror_broken](https://user-images.githubusercontent.com/1278189/102883594-8d157c00-4450-11eb-9d62-bf71d4dafd51.gif)

**After:**
![mirror_working](https://user-images.githubusercontent.com/1278189/102883614-94d52080-4450-11eb-9262-d32eebc70deb.gif)
