### PR TITLE
CXX, Objects.hxx: Python 3.9 Unicode compilation warning fixes …

### DIFF
--- a/src/CXX/Python3/Objects.hxx
+++ b/src/CXX/Python3/Objects.hxx
@@ -2135,13 +2135,20 @@ namespace Py
         // Queries
         virtual size_type size() const
         {
-            return PyUnicode_GET_SIZE( ptr() );
+            return PyUnicode_GetLength( ptr() );
+        }
+
+#if PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION < 9
+        const Py_UNICODE *unicode_data() const
+        {
+            return PyUnicode_AS_UNICODE( ptr() );
         }
 
         unicodestring as_unicodestring() const
         {
-            return unicodestring( PyUnicode_AS_UNICODE( ptr() ), PyUnicode_GET_SIZE( ptr() ) );
+            return unicodestring( unicode_data(), PyUnicode_GetLength( ptr() ) );
         }
+#endif
 
         operator std::string() const
         {
@@ -2153,11 +2160,6 @@ namespace Py
         {
             Bytes b( encode( encoding, error ) );
             return b.as_std_string();
-        }
-
-        const Py_UNICODE *unicode_data() const
-        {
-            return PyUnicode_AS_UNICODE( ptr() );
         }
     };
 

--- a/src/Mod/Part/App/AppPartPy.cpp
+++ b/src/Mod/Part/App/AppPartPy.cpp
@@ -1859,7 +1859,7 @@ private:
         double height;
         double track = 0;
 
-        Py_UNICODE *unichars;
+        Py_UNICODE *unichars = NULL;
         Py_ssize_t pysize;
 
         PyObject *CharList;
@@ -1900,7 +1900,11 @@ private:
 #else
             pysize = PyUnicode_GetSize(p);
 #endif
+#if PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION < 9
             unichars = PyUnicode_AS_UNICODE(p);
+#else
+            unichars = (Py_UNICODE *)PyUnicode_AsUCS4Copy(p);
+#endif
         }
         else if (PyUnicode_Check(intext)) {
 #if PY_VERSION_HEX >= 0x03030000
@@ -1908,7 +1912,11 @@ private:
 #else
             pysize = PyUnicode_GetSize(intext);
 #endif
+#if PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION < 9
             unichars = PyUnicode_AS_UNICODE(intext);
+#else
+            unichars = (Py_UNICODE *)PyUnicode_AsUCS4Copy(intext);
+#endif
         }
         else {
             throw Py::TypeError("** makeWireString bad text parameter");
@@ -1933,6 +1941,11 @@ private:
             else {
                 CharList = FT2FC(unichars,pysize,dir,fontfile,height,track);
             }
+#if PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION >= 9
+            if (unichars) {
+                PyMem_Free(unichars);
+            }
+#endif
         }
         catch (Standard_DomainError&) {                                      // Standard_DomainError is OCC error.
             throw Py::Exception(PartExceptionOCCDomainError, "makeWireString failed - Standard_DomainError");


### PR DESCRIPTION
… suggested by wmayer on the FC forum.  This fixes the rest of the annoying Python 3.9 compilation warnings, reported in the FC forum [thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=53471).


Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
