### PR TITLE
Sketcher: fix crash on moving point with referencing constraint

### DIFF
--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -680,8 +680,10 @@ int SketchObject::setUpSketch()
     lastConflicting=solvedSketch.getConflicting();
     lastRedundant=solvedSketch.getRedundant();
 
-    if(lastHasRedundancies || lastDoF < 0 || lastHasConflict)
-        Constraints.touch();
+    if (!internaltransaction) {
+        if(lastHasRedundancies || lastDoF < 0 || lastHasConflict)
+            Constraints.touch();
+    }
 
     return lastDoF;
 
@@ -7504,6 +7506,8 @@ void SketchObject::onChanged(const App::Property* prop)
                             Base::Console().Error("SketchObject::onChanged(): Unmanaged change of Geometry Property results in invalid constraint indices\n");
                         }
                     }
+                    Base::StateLocker lock(internaltransaction, true);
+                    setUpSketch();
                 }
                 else { // Change is in Constraints
 
@@ -7525,6 +7529,8 @@ void SketchObject::onChanged(const App::Property* prop)
                         }
 
                     }
+                    Base::StateLocker lock(internaltransaction, true);
+                    setUpSketch();
                 }
             }
         }


### PR DESCRIPTION
See description at https://github.com/realthunder/FreeCAD_assembly3/issues/387

@abdullahtahiriyo This looks like a serious problem. Maybe you have a better way of fixing it?

Basically, the problem is that the `solvedSketch` inside a SketchObject contains raw constraint pointer. When any constraint of a `SketchObject` is changed, it is cloned before changing, and then got deleted. But the relevant constraint inside `solvedSketch` is not updated. It is usually not a problem, as the `solvedSketch` will be updated before accessing. But for this particular case, it is not. `ViewProviderSketch` directly [calls](https://github.com/FreeCAD/FreeCAD/blob/cbbbe942eac73163365d9698985bf57e4515a63e/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp#L1276) `Sketch::movePoint()` when dragging a point or curve, instead of `SketchObject::movePoint()`, for performance reason I presume.

I remember you have done some optimization on reducing sketch recompute on property change. Maybe the problem here is a side effect of that change?