### PR TITLE
[Path] VoronoiPyImp.cpp: Fix deprecation warning for Python 3.9 and …

### DIFF
--- a/src/Mod/Path/App/VoronoiPyImp.cpp
+++ b/src/Mod/Path/App/VoronoiPyImp.cpp
@@ -185,7 +185,12 @@ static bool callbackWithVertex(Voronoi::diagram_type *dia, PyObject *callback, c
 #endif
       PyObject *vx = new VoronoiVertexPy(new VoronoiVertex(dia, v));
       PyObject *arglist = Py_BuildValue("(O)", vx);
+
+#if PY_VERSION_HEX < 0x03090000
       PyObject *result = PyEval_CallObject(callback, arglist);
+#else
+      PyObject *result = PyObject_CallObject(callback, arglist);
+#endif
       Py_DECREF(arglist);
       Py_DECREF(vx);
       if (result == NULL) {


### PR DESCRIPTION
…newer, as PyEval_CallObject() has been deprecated.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
