### PR TITLE
Path: Fix `Import` feature of Base Geometry

### DIFF
--- a/src/Mod/Path/PathScripts/PathOpGui.py
+++ b/src/Mod/Path/PathScripts/PathOpGui.py
@@ -601,12 +601,13 @@ class TaskPanelBaseGeometryPage(TaskPanelPage):
     def importBaseGeometry(self):
         opLabel = str(self.form.geometryImportList.currentText())
         ops = FreeCAD.ActiveDocument.getObjectsByLabel(opLabel)
-        if ops.__len__() > 1:
+        if len(ops) > 1:
             msg = translate('PathOpGui', 'Mulitiple operations are labeled as')
             msg += " {}\n".format(opLabel)
             FreeCAD.Console.PrintWarning(msg)
-        for (base, subList) in ops[0].Base:
-            FreeCADGui.Selection.addSelection(base, subList)
+        (base, subList) = ops[0].Base[0]
+        FreeCADGui.Selection.clearSelection()
+        FreeCADGui.Selection.addSelection(base, subList)
         self.addBase()
 
     def registerSignalHandlers(self, obj):


### PR DESCRIPTION
Error was thrown if FreeCADGui.Selection list had more than one item.  Solution is to clear selection before adding  selection from import operation.  I also removed the `for` loop since the selection should be singular.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
