### PR TITLE
Gui: temporary fix of preference menu in MacOS

### DIFF
--- a/src/Gui/Action.cpp
+++ b/src/Gui/Action.cpp
@@ -252,8 +252,10 @@ void ActionGroup::addTo(QWidget *w)
     // and adding this action to the widget doesn't work.
     if (_dropDown) {
         if (w->inherits("QMenu")) {
-            QMenu* menu = qobject_cast<QMenu*>(w);
-            menu = menu->addMenu(_action->text());
+            QMenu *menu = new QMenu(w);
+            QAction* action = qobject_cast<QMenu*>(w)->addMenu(menu);
+            action->setMenuRole(_action->menuRole());
+            menu->setTitle(_action->text());
             menu->addActions(_group->actions());
         }
         else if (w->inherits("QToolBar")) {

--- a/src/Gui/Command.cpp
+++ b/src/Gui/Command.cpp
@@ -995,6 +995,7 @@ Command *GroupCommand::addCommand(const char *name) {
 
 Action * GroupCommand::createAction(void) {
     ActionGroup* pcAction = new ActionGroup(this, getMainWindow());
+    pcAction->setMenuRole(QAction::NoRole);
     pcAction->setDropDownMenu(true);
     pcAction->setExclusive(false);
     pcAction->setCheckable(true);

--- a/src/Gui/CommandStd.cpp
+++ b/src/Gui/CommandStd.cpp
@@ -377,6 +377,7 @@ Action * StdCmdDlgPreferences::createAction(void)
 {
     Action *pcAction = Command::createAction();
     pcAction->setMenuRole(QAction::PreferencesRole);
+
     return pcAction;
 }
 


### PR DESCRIPTION
See issue reported [here](https://github.com/realthunder/FreeCAD_assembly3/issues/388).

`QAction` defaults menu role to `TextHeuristicRole`, which causes qt to guess the menu role based on action title. And titles start with 'Config', 'Options', 'Settings', etc. will be considered as preference menu. It seems some non-english translation causes the wrong action be chosen as preference, such as 'Treeview actions'.

This commit just applied a temporary fix to default to `QAction::NoRole` for `GroupCommand`. If there is ever some `GroupCommand` need to be a system menu item on macos, we could add some command bit flag for that purpose.