### PR TITLE
[Sketch] improve wording for a color

### DIFF
--- a/src/Mod/Sketcher/Gui/SketcherSettingsColors.ui
+++ b/src/Mod/Sketcher/Gui/SketcherSettingsColors.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>438</width>
-    <height>474</height>
+    <height>711</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -574,14 +574,14 @@
            </size>
           </property>
           <property name="text">
-           <string>Datum color</string>
+           <string>Dimensional constraint color</string>
           </property>
          </widget>
         </item>
         <item row="17" column="1">
          <widget class="Gui::PrefColorButton" name="DatumColor">
           <property name="toolTip">
-           <string>Color of the datum portion of a driving constraint</string>
+           <string>Color of dimensional driving constraints</string>
           </property>
           <property name="color">
            <color>


### PR DESCRIPTION
- as discussed here: https://forum.freecadweb.org/viewtopic.php?f=10&t=53587&start=10#p460768
the wording "datum color" does not make clear what it is about. It is in fact the color for dimensional constraints, thus name it as such

- also fix the dialog height (found and automatically corrected by Qt Designer)