### PR TITLE
[TD] handle equal tolerances correctly

### DIFF
--- a/src/Mod/TechDraw/App/DrawViewDimension.h
+++ b/src/Mod/TechDraw/App/DrawViewDimension.h
@@ -102,10 +102,10 @@ public:
     App::PropertyBool              TheoreticalExact;
     App::PropertyBool              Inverted;
     App::PropertyString            FormatSpec;
-    App::PropertyString            FormatSpecUnderTolerance;
-    App::PropertyString            FormatSpecOverTolerance;
+    App::PropertyString            FormatSpecTolerance;
     App::PropertyBool              Arbitrary;
     App::PropertyBool              ArbitraryTolerances;
+    App::PropertyBool              EqualTolerance;
     App::PropertyQuantity          OverTolerance;
     App::PropertyQuantity          UnderTolerance;
 
@@ -122,7 +122,7 @@ public:
     short mustExecute() const override;
     virtual bool has2DReferences(void) const;
     virtual bool has3DReferences(void) const;
-    bool hasTolerance(void) const;
+    bool hasOverUnderTolerance(void) const;
 
     /** @name methods override Feature */
     //@{
@@ -137,6 +137,7 @@ public:
     //return PyObject as DrawViewDimensionPy
     virtual PyObject *getPyObject(void) override;
 
+    virtual std::string getFormattedToleranceValue(int partial);
     virtual std::pair<std::string, std::string> getFormattedToleranceValues(int partial = 0);
     virtual std::string getFormattedDimensionValue(int partial = 0);
     virtual std::string formatValue(qreal value, QString qFormatSpec, int partial = 0);
@@ -168,6 +169,7 @@ public:
 
 protected:
     virtual void handleChangedPropertyType(Base::XMLReader &, const char * , App::Property * ) override;
+    virtual void Restore(Base::XMLReader& reader);
     virtual void onChanged(const App::Property* prop) override;
     virtual void onDocumentRestored() override;
     std::string getPrefix() const;

--- a/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
@@ -59,7 +59,6 @@
 #include <Mod/TechDraw/App/DrawViewPart.h>
 #include <Mod/TechDraw/App/DrawUtil.h>
 #include <Mod/TechDraw/App/Geometry.h>
-//#include <Mod/TechDraw/App/Preferences.h>
 
 #include "Rez.h"
 #include "ZVALUE.h"
@@ -311,19 +310,20 @@ void QGIDatumLabel::setDimString(QString t, qreal maxWidth)
     m_dimText->setTextWidth(maxWidth);
 }
 
-void QGIDatumLabel::setTolString()
+void QGIDatumLabel::setToleranceString()
 {
     prepareGeometryChange();
     QGIViewDimension* qgivd = dynamic_cast<QGIViewDimension*>(parentItem());
     if( qgivd == nullptr ) {
-        return;                  //tarfu
+        return;
     }
     const auto dim( dynamic_cast<TechDraw::DrawViewDimension *>(qgivd->getViewObject()) );
     if( dim == nullptr ) {
         return;
-    } else if (!dim->hasTolerance()) {
+        // don't show if both are zero or if EqualTolerance is true
+    } else if (!dim->hasOverUnderTolerance() || dim->EqualTolerance.getValue()) {
         m_tolTextOver->hide();
-        m_tolTextUnder->hide();        // don't show if both zero
+        m_tolTextUnder->hide();
         return;
     }
     m_tolTextOver->show();
@@ -611,8 +611,6 @@ void QGIViewDimension::updateDim()
         return;
     }
  
-//    QString labelText = QString::fromUtf8(dim->getFormattedDimensionValue().c_str());
-    //want this split into value and unit
     QString labelText;
     QString unitText;
     if (dim->Arbitrary.getValue()) {
@@ -624,6 +622,16 @@ void QGIViewDimension::updateDim()
             labelText = QString::fromUtf8(dim->getFormattedDimensionValue(1).c_str()); //just the number pref/spec/suf
             unitText  = QString::fromUtf8(dim->getFormattedDimensionValue(2).c_str()); //just the unit
         }
+        // if there is an equal over-/undertolerance, add the tolerance to dimension
+        if (dim->EqualTolerance.getValue() && !DrawUtil::fpCompare(dim->OverTolerance.getValue(), 0.0)) {
+            std::pair<std::string, std::string> ToleranceText, ToleranceUnit;
+            QString tolerance = QString::fromStdString(dim->getFormattedToleranceValue(1).c_str());
+            // tolerance might start with a plus sign that we don't want, so cut it off
+            if (tolerance.at(0) == QChar::fromLatin1('+'))
+                tolerance.remove(0, 1);
+            // add the tolerance to the dimension using the ± sign
+            labelText = labelText + QString::fromUtf8(" \xC2\xB1 ") + tolerance;
+        }
     }
     QFont font = datumLabel->getFont();
     font.setFamily(QString::fromUtf8(vp->Font.getValue()));
@@ -632,7 +640,7 @@ void QGIViewDimension::updateDim()
 
     prepareGeometryChange();
     datumLabel->setDimString(labelText);
-    datumLabel->setTolString();
+    datumLabel->setToleranceString();
     datumLabel->setUnitString(unitText);
     datumLabel->setPosFromCenter(datumLabel->X(),datumLabel->Y());
 

--- a/src/Mod/TechDraw/Gui/QGIViewDimension.h
+++ b/src/Mod/TechDraw/Gui/QGIViewDimension.h
@@ -77,7 +77,7 @@ public:
     void setDimString(QString t);
     void setDimString(QString t, qreal maxWidth);
     void setUnitString(QString t);
-    void setTolString();
+    void setToleranceString();
     void setPrettySel(void);
     void setPrettyPre(void);
     void setPrettyNormal(void);


### PR DESCRIPTION
the common rule is that if a dimension has equal over- and undertolerance, they are output on the same line as the dimension concatenated using the ± character.

This PR does this.
(It also uses a more self-explaining function name.)

Note that this is not just cosmetics, it is even standardized in the GD&T norms. The issue is also described in the Wiki: https://wiki.freecadweb.org/TechDraw_Geometric_dimensioning_and_tolerancing#Formatting_2

The implementation allows the user to choose
- if he uses the same value for over- undertolerance, he gets the common ± output
- if he enters the negated overtolerance for the undertolerance, he gets the double line output that is common for non-equal tolerances

