### PR TITLE
[Sketcher] SketchObject takes over r/w management of Sketch - Several fixes

### DIFF
--- a/src/Mod/Sketcher/App/Sketch.cpp
+++ b/src/Mod/Sketcher/App/Sketch.cpp
@@ -1427,6 +1427,13 @@ GCS::Curve* Sketch::getGCSCurveByGeoId(int geoId)
     };
 }
 
+const GCS::Curve* Sketch::getGCSCurveByGeoId(int geoId) const
+{
+    // I hereby guarantee that if I modify the non-const version, I will still
+    // never modify (this). I return const copy to enforce on my users.
+    return const_cast<Sketch *>(this)->getGCSCurveByGeoId(geoId);
+}
+
 // constraint adding ==========================================================
 
 int Sketch::addConstraint(const Constraint *constraint)
@@ -3177,7 +3184,7 @@ double Sketch::calculateAngleViaPoint(int geoId1, int geoId2, double px, double 
     return GCSsys.calculateAngleViaPoint(*crv1, *crv2, p);
 }
 
-Base::Vector3d Sketch::calculateNormalAtPoint(int geoIdCurve, double px, double py)
+Base::Vector3d Sketch::calculateNormalAtPoint(int geoIdCurve, double px, double py) const
 {
     geoIdCurve = checkGeoId(geoIdCurve);
 
@@ -3186,7 +3193,7 @@ Base::Vector3d Sketch::calculateNormalAtPoint(int geoIdCurve, double px, double 
     p.y = &py;
 
     //check pointers
-    GCS::Curve* crv = getGCSCurveByGeoId(geoIdCurve);
+    const GCS::Curve* crv = getGCSCurveByGeoId(geoIdCurve);
     if (!crv) {
         throw Base::ValueError("calculateNormalAtPoint: getGCSCurveByGeoId returned NULL!\n");
     }

--- a/src/Mod/Sketcher/App/Sketch.h
+++ b/src/Mod/Sketcher/App/Sketch.h
@@ -356,7 +356,7 @@ public:
     double calculateAngleViaPoint(int geoId1, int geoId2, double px, double py );
 
     //This is to be used for rendering of angle-via-point constraint.
-    Base::Vector3d calculateNormalAtPoint(int geoIdCurve, double px, double py);
+    Base::Vector3d calculateNormalAtPoint(int geoIdCurve, double px, double py) const;
 
     //icstr should be the value returned by addXXXXConstraint
     //see more info in respective function in GCS.
@@ -485,6 +485,7 @@ private:
     /// checks if the index bounds and converts negative indices to positive
     int checkGeoId(int geoId) const;
     GCS::Curve* getGCSCurveByGeoId(int geoId);
+    const GCS::Curve* getGCSCurveByGeoId(int geoId) const;
 };
 
 } //namespace Part

--- a/src/Mod/Sketcher/App/Sketch.h
+++ b/src/Mod/Sketcher/App/Sketch.h
@@ -104,6 +104,8 @@ public:
     inline bool hasRedundancies(void) const { return !Redundant.empty(); }
     inline const std::vector<int> &getRedundant(void) const { return Redundant; }
 
+    inline float getSolveTime() const { return SolveTime; }
+
     inline bool hasMalformedConstraints(void) const { return malformedConstraints; }
 public:
     std::set < std::pair< int, Sketcher::PointPos>> getDependencyGroup(int geoId, PointPos pos) const;
@@ -131,6 +133,16 @@ public:
       * The relative flag permits moving relatively to the current position
       */
     int movePoint(int geoId, PointPos pos, Base::Vector3d toPoint, bool relative=false);
+
+    /**
+     * Sets whether the initial solution should be recalculated while dragging after a certain distance from the previous drag point
+     * for smoother dragging operation.
+     */
+    bool getRecalculateInitialSolutionWhileMovingPoint() const
+        {return RecalculateInitialSolutionWhileMovingPoint;}
+
+    void setRecalculateInitialSolutionWhileMovingPoint(bool recalculateInitialSolutionWhileMovingPoint)
+        {RecalculateInitialSolutionWhileMovingPoint = recalculateInitialSolutionWhileMovingPoint;}
 
     /// add dedicated geometry
     //@{
@@ -378,6 +390,7 @@ public:
         BSpline = 9
     };
 
+protected:
     float SolveTime;
     bool RecalculateInitialSolutionWhileMovingPoint;
 

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -294,7 +294,7 @@ int SketchObject::solve(bool updateGeoAfterSolving/*=true*/)
         Base::Console().Error("Sketch %s has malformed constraints!\n",this->getNameInDocument());
     }
 
-    lastSolveTime=solvedSketch.SolveTime;
+    lastSolveTime=solvedSketch.getSolveTime();
 
     if (err == 0 && updateGeoAfterSolving) {
         // set the newly solved geometry

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -1155,12 +1155,10 @@ int SketchObject::toggleConstruction(int GeoId)
         }
     }
 
-    // There is not actual intertransaction going on here, however for a toggle neither the geometry indices nor the vertices need to be updated
-    // so this is a convenient way of preventing it.
-    {
-        Base::StateLocker lock(internaltransaction, true);
-        this->Geometry.setValues(std::move(newVals));
-    }
+    // While it may seem that there is not a need to trigger an update at this time, because the solver has its own copy of the geometry,
+    // and updateColors of the viewprovider may be triggered by the clearselection of the UI command, this won't update the elements widget,
+    // in the accumulative of actions it is judged that it is worth to trigger an update here.
+    this->Geometry.setValues(std::move(newVals));
 
     solverNeedsUpdate=true;
     return 0;
@@ -1188,12 +1186,10 @@ int SketchObject::setConstruction(int GeoId, bool on)
         }
     }
 
-    // There is not actual intertransaction going on here, however for a toggle neither the geometry indices nor the vertices need to be updated
-    // so this is a convenient way of preventing it.
-    {
-        Base::StateLocker lock(internaltransaction, true);
-        this->Geometry.setValues(std::move(newVals));
-    }
+    // While it may seem that there is not a need to trigger an update at this time, because the solver has its own copy of the geometry,
+    // and updateColors of the viewprovider may be triggered by the clearselection of the UI command, this won't update the elements widget,
+    // in the accumulative of actions it is judged that it is worth to trigger an update here.
+    this->Geometry.setValues(std::move(newVals));
 
     solverNeedsUpdate=true;
     return 0;

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -8002,6 +8002,27 @@ int SketchObject::autoRemoveRedundants(bool updategeo)
     return redundants.size();
 }
 
+int SketchObject::renameConstraint(int GeoId, std::string name)
+{
+    // only change the constraint item if the names are different
+    const Constraint* item = Constraints[GeoId];
+
+    if (item->Name != name) {
+        Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+
+        Constraint* copy = item->clone();
+        copy->Name = name;
+
+        Constraints.set1Value(GeoId, copy);
+        delete copy;
+
+        solverNeedsUpdate = true; // make sure any prospective solver access updates the constraint pointer that just got invalidated
+
+        return 0;
+    }
+    return -1;
+}
+
 std::vector<Base::Vector3d> SketchObject::getOpenVertices(void) const
 {
     std::vector<Base::Vector3d> points;

--- a/src/Mod/Sketcher/App/SketchObject.h
+++ b/src/Mod/Sketcher/App/SketchObject.h
@@ -361,11 +361,12 @@ public: /* Solver exposed interface */
     inline void setRecalculateInitialSolutionWhileMovingPoint(bool recalculateInitialSolutionWhileMovingPoint)
         {solvedSketch.setRecalculateInitialSolutionWhileMovingPoint(recalculateInitialSolutionWhileMovingPoint);}
     /// Forwards a request for a temporary initMove to the solver using the current sketch state as a reference (enables dragging)
-    inline int initTemporaryMove(int geoId, PointPos pos, bool fine=true)
-        { return solvedSketch.initMove(geoId,pos,fine);}
-    /// Forwards a request for point or curve temporary movement to the solver using the current state as a reference (enables dragging)
-    inline int moveTemporaryPoint(int geoId, PointPos pos, Base::Vector3d toPoint, bool relative=false)
-        { return solvedSketch.movePoint(geoId, pos, toPoint, relative);}
+    inline int initTemporaryMove(int geoId, PointPos pos, bool fine=true);
+    /** Forwards a request for point or curve temporary movement to the solver using the current state as a reference (enables dragging).
+     *  NOTE: A temporary move operation must always be preceded by a initTemporaryMove() operation.
+     */
+    inline int moveTemporaryPoint(int geoId, PointPos pos, Base::Vector3d toPoint, bool relative=false);
+    /// forwards a request to update an extension of a geometry of the solver to the solver.
     inline void updateSolverExtension(int geoId, std::unique_ptr<Part::GeometryExtension> && ext)
         { return solvedSketch.updateExtension(geoId, std::move(ext));}
 
@@ -435,6 +436,8 @@ public:
     // helper
     /// returns the number of redundant constraints detected
     int autoRemoveRedundants(bool updategeo = true);
+
+    int renameConstraint(int GeoId, std::string name);
 
     // Validation routines
     std::vector<Base::Vector3d> getOpenVertices(void) const;
@@ -526,6 +529,22 @@ private:
 
     bool managedoperation; // indicates whether changes to properties are the deed of SketchObject or not (for input validation)
 };
+
+inline int SketchObject::initTemporaryMove(int geoId, PointPos pos, bool fine/*=true*/)
+{
+    // if a previous operation did not update the geometry (including geometry extensions)
+    // or constraints (including any deleted pointer, as in renameConstraint) of the solver,
+    // here we update them before starting a temporary operation.
+    if(solverNeedsUpdate)
+        solve();
+
+    return solvedSketch.initMove(geoId,pos,fine);
+}
+
+inline int SketchObject::moveTemporaryPoint(int geoId, PointPos pos, Base::Vector3d toPoint, bool relative/*=false*/)
+{
+    return solvedSketch.movePoint(geoId, pos, toPoint, relative);
+}
 
 typedef App::FeaturePythonT<SketchObject> SketchObjectPython;
 

--- a/src/Mod/Sketcher/App/SketchObject.h
+++ b/src/Mod/Sketcher/App/SketchObject.h
@@ -353,9 +353,23 @@ public:
     inline const std::vector<int> &getLastConflicting(void) const { return lastConflicting; }
     /// gets the redundant constraints of last solver execution
     inline const std::vector<int> &getLastRedundant(void) const { return lastRedundant; }
-    /// gets the solved sketch as a reference
-    inline Sketch &getSolvedSketch(void) {return solvedSketch;}
 
+public: /* Solver exposed interface */
+    /// gets the solved sketch as a reference
+    inline const Sketch &getSolvedSketch(void) const {return solvedSketch;}
+    /// enables/disables solver initial solution recalculation when moving point mode (useful for dragging)
+    inline void setRecalculateInitialSolutionWhileMovingPoint(bool recalculateInitialSolutionWhileMovingPoint)
+        {solvedSketch.setRecalculateInitialSolutionWhileMovingPoint(recalculateInitialSolutionWhileMovingPoint);}
+    /// Forwards a request for a temporary initMove to the solver using the current sketch state as a reference (enables dragging)
+    inline int initTemporaryMove(int geoId, PointPos pos, bool fine=true)
+        { return solvedSketch.initMove(geoId,pos,fine);}
+    /// Forwards a request for point or curve temporary movement to the solver using the current state as a reference (enables dragging)
+    inline int moveTemporaryPoint(int geoId, PointPos pos, Base::Vector3d toPoint, bool relative=false)
+        { return solvedSketch.movePoint(geoId, pos, toPoint, relative);}
+    inline void updateSolverExtension(int geoId, std::unique_ptr<Part::GeometryExtension> && ext)
+        { return solvedSketch.updateExtension(geoId, std::move(ext));}
+
+public:
     /// returns the geometric elements/vertex which the solver detects as having dependent parameters.
     /// these parameters relate to not fully constraint edges/vertices.
     void getGeometryWithDependentParameters(std::vector<std::pair<int,PointPos>>& geometrymap);

--- a/src/Mod/Sketcher/App/SketchObjectPyImp.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectPyImp.cpp
@@ -417,14 +417,8 @@ PyObject* SketchObjectPy::renameConstraint(PyObject *args)
         }
     }
 
-    // only change the constraint item if the names are different
-    const Constraint* item = this->getSketchObjectPtr()->Constraints[Index];
-    if (item->Name != Name) {
-        Constraint* copy = item->clone();
-        copy->Name = Name;
-        this->getSketchObjectPtr()->Constraints.set1Value(Index, copy);
-        delete copy;
-    }
+    this->getSketchObjectPtr()->renameConstraint(Index, Name);
+
     Py_Return;
 }
 

--- a/src/Mod/Sketcher/App/planegcs/GCS.cpp
+++ b/src/Mod/Sketcher/App/planegcs/GCS.cpp
@@ -1298,19 +1298,19 @@ int System::addConstraintInternalAlignmentBSplineControlPoint(BSpline &b, Circle
 //points are supplied, p is used for first curve and p2 for second, yielding a
 //remote angle computation (this is useful when the endpoints haven't) been
 //made coincident yet
-double System::calculateAngleViaPoint(Curve &crv1, Curve &crv2, Point &p)
+double System::calculateAngleViaPoint(const Curve &crv1, const Curve &crv2, Point &p) const
 {
     return calculateAngleViaPoint(crv1, crv2, p, p);
 }
 
-double System::calculateAngleViaPoint(Curve &crv1, Curve &crv2, Point &p1, Point &p2)
+double System::calculateAngleViaPoint(const Curve &crv1, const Curve &crv2, Point &p1, Point &p2) const
 {
     GCS::DeriVector2 n1 = crv1.CalculateNormal(p1);
     GCS::DeriVector2 n2 = crv2.CalculateNormal(p2);
     return atan2(-n2.x*n1.y+n2.y*n1.x, n2.x*n1.x + n2.y*n1.y);
 }
 
-void System::calculateNormalAtPoint(Curve &crv, Point &p, double &rtnX, double &rtnY)
+void System::calculateNormalAtPoint(const Curve &crv, const Point &p, double &rtnX, double &rtnY) const
 {
     GCS::DeriVector2 n1 = crv.CalculateNormal(p);
     rtnX = n1.x;

--- a/src/Mod/Sketcher/App/planegcs/GCS.cpp
+++ b/src/Mod/Sketcher/App/planegcs/GCS.cpp
@@ -3822,6 +3822,9 @@ void System::makeReducedJacobian(Eigen::MatrixXd &J,
             jacobianconstraintmap[jacobianconstraintcount-1] = allcount-1;
         }
     }
+
+    if(jacobianconstraintcount == 0) // only driven constraints
+        J.resize(0,0);
 }
 
 int System::diagnose(Algorithm alg)

--- a/src/Mod/Sketcher/App/planegcs/GCS.h
+++ b/src/Mod/Sketcher/App/planegcs/GCS.h
@@ -325,9 +325,9 @@ namespace GCS
         int addConstraintInternalAlignmentParabolaFocus(Parabola &e, Point &p1, int tagId=0, bool driving = true);
         int addConstraintInternalAlignmentBSplineControlPoint(BSpline &b, Circle &c, int poleindex, int tag=0, bool driving = true);
 
-        double calculateAngleViaPoint(Curve &crv1, Curve &crv2, Point &p);
-        double calculateAngleViaPoint(Curve &crv1, Curve &crv2, Point &p1, Point &p2);
-        void calculateNormalAtPoint(Curve &crv, Point &p, double &rtnX, double &rtnY);
+        double calculateAngleViaPoint(const Curve &crv1, const Curve &crv2, Point &p) const;
+        double calculateAngleViaPoint(const Curve &crv1, const Curve &crv2, Point &p1, Point &p2) const;
+        void calculateNormalAtPoint(const Curve &crv, const Point &p, double &rtnX, double &rtnY) const;
 
         // Calculates errors of all constraints which have a tag equal to
         // the one supplied. Individual errors are summed up using RMS.

--- a/src/Mod/Sketcher/App/planegcs/Geo.cpp
+++ b/src/Mod/Sketcher/App/planegcs/Geo.cpp
@@ -30,7 +30,7 @@
 
 namespace GCS{
 
-DeriVector2::DeriVector2(const Point &p, double *derivparam)
+DeriVector2::DeriVector2(const Point &p, const double *derivparam)
 {
     x=*p.x; y=*p.y;
     dx=0.0; dy=0.0;
@@ -88,7 +88,7 @@ DeriVector2 DeriVector2::divD(double val, double dval) const
                        );
 }
 
-DeriVector2 Curve::Value(double /*u*/, double /*du*/, double* /*derivparam*/)
+DeriVector2 Curve::Value(double /*u*/, double /*du*/, const double* /*derivparam*/) const
 {
     assert(false /*Value() is not implemented*/);
     return DeriVector2();
@@ -96,15 +96,16 @@ DeriVector2 Curve::Value(double /*u*/, double /*du*/, double* /*derivparam*/)
 
 //----------------Line
 
-DeriVector2 Line::CalculateNormal(Point &/*p*/, double* derivparam)
+DeriVector2 Line::CalculateNormal(const Point &p, const double* derivparam) const
 {
+    (void) p;
     DeriVector2 p1v(p1, derivparam);
     DeriVector2 p2v(p2, derivparam);
 
     return p2v.subtr(p1v).rotate90ccw();
 }
 
-DeriVector2 Line::Value(double u, double du, double* derivparam)
+DeriVector2 Line::Value(double u, double du, const double* derivparam) const
 {
     DeriVector2 p1v(p1, derivparam);
     DeriVector2 p2v(p2, derivparam);
@@ -138,7 +139,7 @@ Line* Line::Copy()
 
 //---------------circle
 
-DeriVector2 Circle::CalculateNormal(Point &p, double* derivparam)
+DeriVector2 Circle::CalculateNormal(const Point &p, const double* derivparam) const
 {
     DeriVector2 cv (center, derivparam);
     DeriVector2 pv (p, derivparam);
@@ -146,7 +147,7 @@ DeriVector2 Circle::CalculateNormal(Point &p, double* derivparam)
     return cv.subtr(pv);
 }
 
-DeriVector2 Circle::Value(double u, double du, double* derivparam)
+DeriVector2 Circle::Value(double u, double du, const double* derivparam) const
 {
     //(x,y) = center + cos(u)*(r,0) + sin(u)*(0,r)
 
@@ -214,7 +215,7 @@ Arc* Arc::Copy()
 //--------------ellipse
 
 //this function is exposed to allow reusing pre-filled derivectors in constraints code
-double Ellipse::getRadMaj(const DeriVector2 &center, const DeriVector2 &f1, double b, double db, double &ret_dRadMaj)
+double Ellipse::getRadMaj(const DeriVector2 &center, const DeriVector2 &f1, double b, double db, double &ret_dRadMaj) const
 {
     double cf, dcf;
     cf = f1.subtr(center).length(dcf);
@@ -224,7 +225,7 @@ double Ellipse::getRadMaj(const DeriVector2 &center, const DeriVector2 &f1, doub
 }
 
 //returns major radius. The derivative by derivparam is returned into ret_dRadMaj argument.
-double Ellipse::getRadMaj(double *derivparam, double &ret_dRadMaj)
+double Ellipse::getRadMaj(double *derivparam, double &ret_dRadMaj) const
 {
     DeriVector2 c(center, derivparam);
     DeriVector2 f1(focus1, derivparam);
@@ -232,13 +233,13 @@ double Ellipse::getRadMaj(double *derivparam, double &ret_dRadMaj)
 }
 
 //returns the major radius (plain value, no derivatives)
-double Ellipse::getRadMaj()
+double Ellipse::getRadMaj() const
 {
     double dradmaj;//dummy
     return getRadMaj(0,dradmaj);
 }
 
-DeriVector2 Ellipse::CalculateNormal(Point &p, double* derivparam)
+DeriVector2 Ellipse::CalculateNormal(const Point &p, const double* derivparam) const
 {
     //fill some vectors in
     DeriVector2 cv (center, derivparam);
@@ -279,7 +280,7 @@ DeriVector2 Ellipse::CalculateNormal(Point &p, double* derivparam)
         return ret;
 }
 
-DeriVector2 Ellipse::Value(double u, double du, double* derivparam)
+DeriVector2 Ellipse::Value(double u, double du, const double* derivparam) const
 {
     //In local coordinate system, value() of ellipse is:
     //(a*cos(u), b*sin(u))
@@ -370,7 +371,7 @@ ArcOfEllipse* ArcOfEllipse::Copy()
 //---------------hyperbola
 
 //this function is exposed to allow reusing pre-filled derivectors in constraints code
-double Hyperbola::getRadMaj(const DeriVector2 &center, const DeriVector2 &f1, double b, double db, double &ret_dRadMaj)
+double Hyperbola::getRadMaj(const DeriVector2 &center, const DeriVector2 &f1, double b, double db, double &ret_dRadMaj) const
 {
     double cf, dcf;
     cf = f1.subtr(center).length(dcf);
@@ -382,7 +383,7 @@ double Hyperbola::getRadMaj(const DeriVector2 &center, const DeriVector2 &f1, do
 }
 
 //returns major radius. The derivative by derivparam is returned into ret_dRadMaj argument.
-double Hyperbola::getRadMaj(double *derivparam, double &ret_dRadMaj)
+double Hyperbola::getRadMaj(double *derivparam, double &ret_dRadMaj) const
 {
     DeriVector2 c(center, derivparam);
     DeriVector2 f1(focus1, derivparam);
@@ -390,13 +391,13 @@ double Hyperbola::getRadMaj(double *derivparam, double &ret_dRadMaj)
 }
 
 //returns the major radius (plain value, no derivatives)
-double Hyperbola::getRadMaj()
+double Hyperbola::getRadMaj() const
 {
     double dradmaj;//dummy
     return getRadMaj(0,dradmaj);
 }
 
-DeriVector2 Hyperbola::CalculateNormal(Point &p, double* derivparam)
+DeriVector2 Hyperbola::CalculateNormal(const Point &p, const double* derivparam) const
 {
     //fill some vectors in
     DeriVector2 cv (center, derivparam);
@@ -416,7 +417,7 @@ DeriVector2 Hyperbola::CalculateNormal(Point &p, double* derivparam)
     return ret;
 }
 
-DeriVector2 Hyperbola::Value(double u, double du, double* derivparam)
+DeriVector2 Hyperbola::Value(double u, double du, const double* derivparam) const
 {
 
     //In local coordinate system, value() of hyperbola is:
@@ -505,7 +506,7 @@ ArcOfHyperbola* ArcOfHyperbola::Copy()
 
 //---------------parabola
 
-DeriVector2 Parabola::CalculateNormal(Point &p, double* derivparam)
+DeriVector2 Parabola::CalculateNormal(const Point &p, const double* derivparam) const
 {
     //fill some vectors in
     DeriVector2 cv (vertex, derivparam);
@@ -522,7 +523,7 @@ DeriVector2 Parabola::CalculateNormal(Point &p, double* derivparam)
     return ret;
 }
 
-DeriVector2 Parabola::Value(double u, double du, double* derivparam)
+DeriVector2 Parabola::Value(double u, double du, const double* derivparam) const
 {
 
     //In local coordinate system, value() of parabola is:
@@ -607,7 +608,7 @@ ArcOfParabola* ArcOfParabola::Copy()
 }
 
 // bspline
-DeriVector2 BSpline::CalculateNormal(Point& p, double* derivparam)
+DeriVector2 BSpline::CalculateNormal(const Point &p, const double* derivparam) const
 {
     // place holder
     DeriVector2 ret;
@@ -651,7 +652,7 @@ DeriVector2 BSpline::CalculateNormal(Point& p, double* derivparam)
     return ret;
 }
 
-DeriVector2 BSpline::Value(double /*u*/, double /*du*/, double* /*derivparam*/)
+DeriVector2 BSpline::Value(double /*u*/, double /*du*/, const double* /*derivparam*/) const
 {
     // place holder
     DeriVector2 ret = DeriVector2();

--- a/src/Mod/Sketcher/App/planegcs/Geo.h
+++ b/src/Mod/Sketcher/App/planegcs/Geo.h
@@ -55,7 +55,7 @@ namespace GCS
         DeriVector2(){x=0; y=0; dx=0; dy=0;}
         DeriVector2(double x, double y) {this->x = x; this->y = y; this->dx = 0; this->dy = 0;}
         DeriVector2(double x, double y, double dx, double dy) {this->x = x; this->y = y; this->dx = dx; this->dy = dy;}
-        DeriVector2(const Point &p, double* derivparam);
+        DeriVector2(const Point &p, const double* derivparam);
         double x, dx;
         double y, dy;
 
@@ -100,7 +100,7 @@ namespace GCS
         //derivparam is a pointer to a curve parameter (or point coordinate) to
         // compute the derivative for. The derivative is returned through dx,dy
         // fields of DeriVector2.
-        virtual DeriVector2 CalculateNormal(Point &p, double* derivparam = 0) = 0;
+        virtual DeriVector2 CalculateNormal(const Point &p, const double* derivparam = 0) const = 0;
 
         /**
          * @brief Value: returns point (vector) given the value of parameter
@@ -109,7 +109,7 @@ namespace GCS
          * @param derivparam: pointer to sketch parameter to calculate the derivative for
          * @return
          */
-        virtual DeriVector2 Value(double u, double du, double* derivparam = 0);
+        virtual DeriVector2 Value(double u, double du, const double* derivparam = 0) const;
 
         //adds curve's parameters to pvec (used by constraints)
         virtual int PushOwnParams(VEC_pD &pvec) = 0;
@@ -126,11 +126,11 @@ namespace GCS
         virtual ~Line(){}
         Point p1;
         Point p2;
-        DeriVector2 CalculateNormal(Point &p, double* derivparam = 0);
-        DeriVector2 Value(double u, double du, double* derivparam = 0);
-        virtual int PushOwnParams(VEC_pD &pvec);
-        virtual void ReconstructOnNewPvec (VEC_pD &pvec, int &cnt);
-        virtual Line* Copy();
+        DeriVector2 CalculateNormal(const Point &p, const double* derivparam = 0) const override;
+        DeriVector2 Value(double u, double du, const double* derivparam = 0) const override;
+        virtual int PushOwnParams(VEC_pD &pvec) override;
+        virtual void ReconstructOnNewPvec (VEC_pD &pvec, int &cnt) override;
+        virtual Line* Copy() override;
     };
 
     class Circle: public Curve
@@ -140,11 +140,11 @@ namespace GCS
         virtual ~Circle(){}
         Point center;
         double *rad;
-        DeriVector2 CalculateNormal(Point &p, double* derivparam = 0);
-        DeriVector2 Value(double u, double du, double* derivparam = 0);
-        virtual int PushOwnParams(VEC_pD &pvec);
-        virtual void ReconstructOnNewPvec (VEC_pD &pvec, int &cnt);
-        virtual Circle* Copy();
+        DeriVector2 CalculateNormal(const Point &p, const double* derivparam = 0) const override;
+        DeriVector2 Value(double u, double du, const double* derivparam = 0) const override;
+        virtual int PushOwnParams(VEC_pD &pvec) override;
+        virtual void ReconstructOnNewPvec (VEC_pD &pvec, int &cnt) override;
+        virtual Circle* Copy() override;
     };
 
     class Arc: public Circle
@@ -158,19 +158,19 @@ namespace GCS
         Point start;
         Point end;
         //Point center; //inherited
-        virtual int PushOwnParams(VEC_pD &pvec);
-        virtual void ReconstructOnNewPvec (VEC_pD &pvec, int &cnt);
-        virtual Arc* Copy();
+        virtual int PushOwnParams(VEC_pD &pvec) override;
+        virtual void ReconstructOnNewPvec (VEC_pD &pvec, int &cnt) override;
+        virtual Arc* Copy() override;
     };
 
     class MajorRadiusConic: public Curve
     {
     public:
         virtual ~MajorRadiusConic(){}
-        virtual double getRadMaj(const DeriVector2 &center, const DeriVector2 &f1, double b, double db, double &ret_dRadMaj) = 0;
-        virtual double getRadMaj(double* derivparam, double &ret_dRadMaj) = 0;
-        virtual double getRadMaj() = 0;
-        DeriVector2 CalculateNormal(Point &p, double* derivparam = 0) = 0;
+        virtual double getRadMaj(const DeriVector2 &center, const DeriVector2 &f1, double b, double db, double &ret_dRadMaj) const = 0;
+        virtual double getRadMaj(double* derivparam, double &ret_dRadMaj) const = 0;
+        virtual double getRadMaj() const = 0;
+        //DeriVector2 CalculateNormal(Point &p, double* derivparam = 0) = 0;
     };
 
     class Ellipse: public MajorRadiusConic
@@ -181,14 +181,14 @@ namespace GCS
         Point center;
         Point focus1;
         double *radmin;
-        virtual double getRadMaj(const DeriVector2 &center, const DeriVector2 &f1, double b, double db, double &ret_dRadMaj);
-        virtual double getRadMaj(double* derivparam, double &ret_dRadMaj);
-        virtual double getRadMaj();
-        DeriVector2 CalculateNormal(Point &p, double* derivparam = 0);
-        DeriVector2 Value(double u, double du, double* derivparam = 0);
-        virtual int PushOwnParams(VEC_pD &pvec);
-        virtual void ReconstructOnNewPvec (VEC_pD &pvec, int &cnt);
-        virtual Ellipse* Copy();
+        virtual double getRadMaj(const DeriVector2 &center, const DeriVector2 &f1, double b, double db, double &ret_dRadMaj) const override;
+        virtual double getRadMaj(double* derivparam, double &ret_dRadMaj) const override;
+        virtual double getRadMaj() const override;
+        DeriVector2 CalculateNormal(const Point &p, const double* derivparam = 0) const override;
+        DeriVector2 Value(double u, double du, const double* derivparam = 0) const override;
+        virtual int PushOwnParams(VEC_pD &pvec) override;
+        virtual void ReconstructOnNewPvec (VEC_pD &pvec, int &cnt) override;
+        virtual Ellipse* Copy() override;
     };
 
     class ArcOfEllipse: public Ellipse
@@ -204,9 +204,9 @@ namespace GCS
         //Point center;  //inherited
         //double *focus1.x; //inherited
         //double *focus1.y; //inherited
-        virtual int PushOwnParams(VEC_pD &pvec);
-        virtual void ReconstructOnNewPvec (VEC_pD &pvec, int &cnt);
-        virtual ArcOfEllipse* Copy();
+        virtual int PushOwnParams(VEC_pD &pvec) override;
+        virtual void ReconstructOnNewPvec (VEC_pD &pvec, int &cnt) override;
+        virtual ArcOfEllipse* Copy() override;
     };
 
     class Hyperbola: public MajorRadiusConic
@@ -217,14 +217,14 @@ namespace GCS
         Point center;
         Point focus1;
         double *radmin;
-        virtual double getRadMaj(const DeriVector2 &center, const DeriVector2 &f1, double b, double db, double &ret_dRadMaj);
-        virtual double getRadMaj(double* derivparam, double &ret_dRadMaj);
-        virtual double getRadMaj();
-        DeriVector2 CalculateNormal(Point &p, double* derivparam = 0);
-        virtual DeriVector2 Value(double u, double du, double* derivparam = 0);
-        virtual int PushOwnParams(VEC_pD &pvec);
-        virtual void ReconstructOnNewPvec (VEC_pD &pvec, int &cnt);
-        virtual Hyperbola* Copy();
+        virtual double getRadMaj(const DeriVector2 &center, const DeriVector2 &f1, double b, double db, double &ret_dRadMaj) const override;
+        virtual double getRadMaj(double* derivparam, double &ret_dRadMaj) const override;
+        virtual double getRadMaj() const override;
+        DeriVector2 CalculateNormal(const Point &p, const double* derivparam = 0) const override;;
+        virtual DeriVector2 Value(double u, double du, const double* derivparam = 0) const override;
+        virtual int PushOwnParams(VEC_pD &pvec) override;
+        virtual void ReconstructOnNewPvec (VEC_pD &pvec, int &cnt) override;
+        virtual Hyperbola* Copy() override;
     };
 
     class ArcOfHyperbola: public Hyperbola
@@ -238,9 +238,9 @@ namespace GCS
         Point start;
         Point end;
         // interface helpers
-        virtual int PushOwnParams(VEC_pD &pvec);
-        virtual void ReconstructOnNewPvec (VEC_pD &pvec, int &cnt);
-        virtual ArcOfHyperbola* Copy();
+        virtual int PushOwnParams(VEC_pD &pvec) override;
+        virtual void ReconstructOnNewPvec (VEC_pD &pvec, int &cnt) override;
+        virtual ArcOfHyperbola* Copy() override;
     };
 
     class Parabola: public Curve
@@ -250,11 +250,11 @@ namespace GCS
         virtual ~Parabola(){}
         Point vertex;
         Point focus1;
-        DeriVector2 CalculateNormal(Point &p, double* derivparam = 0);
-        virtual DeriVector2 Value(double u, double du, double* derivparam = 0);
-        virtual int PushOwnParams(VEC_pD &pvec);
-        virtual void ReconstructOnNewPvec (VEC_pD &pvec, int &cnt);
-        virtual Parabola* Copy();
+        DeriVector2 CalculateNormal(const Point &p, const double* derivparam = 0) const override;
+        virtual DeriVector2 Value(double u, double du, const double* derivparam = 0) const override;
+        virtual int PushOwnParams(VEC_pD &pvec) override;
+        virtual void ReconstructOnNewPvec (VEC_pD &pvec, int &cnt) override;
+        virtual Parabola* Copy() override;
     };
 
     class ArcOfParabola: public Parabola
@@ -268,9 +268,9 @@ namespace GCS
         Point start;
         Point end;
         // interface helpers
-        virtual int PushOwnParams(VEC_pD &pvec);
-        virtual void ReconstructOnNewPvec (VEC_pD &pvec, int &cnt);
-        virtual ArcOfParabola* Copy();
+        virtual int PushOwnParams(VEC_pD &pvec) override;
+        virtual void ReconstructOnNewPvec (VEC_pD &pvec, int &cnt) override;
+        virtual ArcOfParabola* Copy() override;
     };
 
     class BSpline: public Curve
@@ -293,11 +293,11 @@ namespace GCS
         bool periodic;
         VEC_I knotpointGeoids; // geoids of knotpoints as to index Geom array
         // interface helpers
-        DeriVector2 CalculateNormal(Point &p, double* derivparam = 0);
-        virtual DeriVector2 Value(double u, double du, double* derivparam = 0);
-        virtual int PushOwnParams(VEC_pD &pvec);
-        virtual void ReconstructOnNewPvec (VEC_pD &pvec, int &cnt);
-        virtual BSpline* Copy();
+        DeriVector2 CalculateNormal(const Point &p, const double* derivparam = 0) const override;;
+        virtual DeriVector2 Value(double u, double du, const double* derivparam = 0) const override;
+        virtual int PushOwnParams(VEC_pD &pvec) override;
+        virtual void ReconstructOnNewPvec (VEC_pD &pvec, int &cnt) override;
+        virtual BSpline* Copy() override;
     };
 
 } //namespace GCS

--- a/src/Mod/Sketcher/Gui/TaskSketcherSolverAdvanced.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherSolverAdvanced.cpp
@@ -132,9 +132,12 @@ void TaskSketcherSolverAdvanced::updateDefaultMethodParameters(void)
             ui->lineEditSolverParam1->setText(QString::number(eps).remove(QString::fromLatin1("+").replace(QString::fromLatin1("e0"),QString::fromLatin1("E")).toUpper()));
             ui->lineEditSolverParam2->setText(QString::number(eps1).remove(QString::fromLatin1("+").replace(QString::fromLatin1("e0"),QString::fromLatin1("E")).toUpper()));
             ui->lineEditSolverParam3->setText(QString::number(tau).remove(QString::fromLatin1("+").replace(QString::fromLatin1("e0"),QString::fromLatin1("E")).toUpper()));
-            sketchView->getSketchObject()->getSolvedSketch().setLM_eps(eps);
-            sketchView->getSketchObject()->getSolvedSketch().setLM_eps1(eps1);
-            sketchView->getSketchObject()->getSolvedSketch().setLM_tau(tau);
+            // SketchObject has encapsulated write-access. The current use of const_cast just for configuration is
+            // deemed acceptable. Eventually this dialog should be rewritten to include only useful information and the configuration
+            // centralised in an individual configuration object, possibly compatible with several solvers (e.g. DeepSOIC's ConstraintSolver)
+            const_cast<Sketcher::Sketch &>(sketchView->getSketchObject()->getSolvedSketch()).setLM_eps(eps);
+            const_cast<Sketcher::Sketch &>(sketchView->getSketchObject()->getSolvedSketch()).setLM_eps1(eps1);
+            const_cast<Sketcher::Sketch &>(sketchView->getSketchObject()->getSolvedSketch()).setLM_tau(tau);
             break;
         }
         case 2: // DogLeg
@@ -151,9 +154,9 @@ void TaskSketcherSolverAdvanced::updateDefaultMethodParameters(void)
             ui->lineEditSolverParam1->setText(QString::number(tolg).remove(QString::fromLatin1("+").replace(QString::fromLatin1("e0"),QString::fromLatin1("E")).toUpper()));
             ui->lineEditSolverParam2->setText(QString::number(tolx).remove(QString::fromLatin1("+").replace(QString::fromLatin1("e0"),QString::fromLatin1("E")).toUpper()));
             ui->lineEditSolverParam3->setText(QString::number(tolf).remove(QString::fromLatin1("+").replace(QString::fromLatin1("e0"),QString::fromLatin1("E")).toUpper()));
-            sketchView->getSketchObject()->getSolvedSketch().setDL_tolg(tolg);
-            sketchView->getSketchObject()->getSolvedSketch().setDL_tolf(tolf);
-            sketchView->getSketchObject()->getSolvedSketch().setDL_tolx(tolx);
+            const_cast<Sketcher::Sketch &>(sketchView->getSketchObject()->getSolvedSketch()).setDL_tolg(tolg);
+            const_cast<Sketcher::Sketch &>(sketchView->getSketchObject()->getSolvedSketch()).setDL_tolf(tolf);
+            const_cast<Sketcher::Sketch &>(sketchView->getSketchObject()->getSolvedSketch()).setDL_tolx(tolx);
             break;
         }
     }
@@ -198,9 +201,9 @@ void TaskSketcherSolverAdvanced::updateRedundantMethodParameters(void)
             ui->lineEditRedundantSolverParam1->setText(QString::number(eps).remove(QString::fromLatin1("+").replace(QString::fromLatin1("e0"),QString::fromLatin1("E")).toUpper()));
             ui->lineEditRedundantSolverParam2->setText(QString::number(eps1).remove(QString::fromLatin1("+").replace(QString::fromLatin1("e0"),QString::fromLatin1("E")).toUpper()));
             ui->lineEditRedundantSolverParam3->setText(QString::number(tau).remove(QString::fromLatin1("+").replace(QString::fromLatin1("e0"),QString::fromLatin1("E")).toUpper()));
-            sketchView->getSketchObject()->getSolvedSketch().setLM_epsRedundant(eps);
-            sketchView->getSketchObject()->getSolvedSketch().setLM_eps1Redundant(eps1);
-            sketchView->getSketchObject()->getSolvedSketch().setLM_tauRedundant(eps1);
+            const_cast<Sketcher::Sketch &>(sketchView->getSketchObject()->getSolvedSketch()).setLM_epsRedundant(eps);
+            const_cast<Sketcher::Sketch &>(sketchView->getSketchObject()->getSolvedSketch()).setLM_eps1Redundant(eps1);
+            const_cast<Sketcher::Sketch &>(sketchView->getSketchObject()->getSolvedSketch()).setLM_tauRedundant(eps1);
             break;
         }
         case 2: // DogLeg
@@ -217,9 +220,9 @@ void TaskSketcherSolverAdvanced::updateRedundantMethodParameters(void)
             ui->lineEditRedundantSolverParam1->setText(QString::number(tolg).remove(QString::fromLatin1("+").replace(QString::fromLatin1("e0"),QString::fromLatin1("E")).toUpper()));
             ui->lineEditRedundantSolverParam2->setText(QString::number(tolx).remove(QString::fromLatin1("+").replace(QString::fromLatin1("e0"),QString::fromLatin1("E")).toUpper()));
             ui->lineEditRedundantSolverParam3->setText(QString::number(tolf).remove(QString::fromLatin1("+").replace(QString::fromLatin1("e0"),QString::fromLatin1("E")).toUpper()));
-            sketchView->getSketchObject()->getSolvedSketch().setDL_tolgRedundant(tolg);
-            sketchView->getSketchObject()->getSolvedSketch().setDL_tolfRedundant(tolf);
-            sketchView->getSketchObject()->getSolvedSketch().setDL_tolxRedundant(tolx);
+            const_cast<Sketcher::Sketch &>(sketchView->getSketchObject()->getSolvedSketch()).setDL_tolgRedundant(tolg);
+            const_cast<Sketcher::Sketch &>(sketchView->getSketchObject()->getSolvedSketch()).setDL_tolfRedundant(tolf);
+            const_cast<Sketcher::Sketch &>(sketchView->getSketchObject()->getSolvedSketch()).setDL_tolxRedundant(tolx);
             break;
         }
     }
@@ -238,14 +241,14 @@ void TaskSketcherSolverAdvanced::on_lineEditSolverParam1_editingFinished()
     {
         case 1: // LM
         {
-            sketchView->getSketchObject()->getSolvedSketch().setLM_eps(val);
+            const_cast<Sketcher::Sketch &>(sketchView->getSketchObject()->getSolvedSketch()).setLM_eps(val);
             ui->lineEditSolverParam1->setEntryName("LM_eps");
             ui->lineEditSolverParam1->onSave();
             break;
         }
         case 2: // DogLeg
         {
-            sketchView->getSketchObject()->getSolvedSketch().setDL_tolg(val);
+            const_cast<Sketcher::Sketch &>(sketchView->getSketchObject()->getSolvedSketch()).setDL_tolg(val);
             ui->lineEditSolverParam1->setEntryName("DL_tolg");
             ui->lineEditSolverParam1->onSave();
             break;
@@ -266,14 +269,14 @@ void TaskSketcherSolverAdvanced::on_lineEditRedundantSolverParam1_editingFinishe
     {
         case 1: // LM
         {
-            sketchView->getSketchObject()->getSolvedSketch().setLM_epsRedundant(val);
+            const_cast<Sketcher::Sketch &>(sketchView->getSketchObject()->getSolvedSketch()).setLM_epsRedundant(val);
             ui->lineEditRedundantSolverParam1->setEntryName("Redundant_LM_eps");
             ui->lineEditRedundantSolverParam1->onSave();
             break;
         }
         case 2: // DogLeg
         {
-            sketchView->getSketchObject()->getSolvedSketch().setDL_tolgRedundant(val);
+            const_cast<Sketcher::Sketch &>(sketchView->getSketchObject()->getSolvedSketch()).setDL_tolgRedundant(val);
             ui->lineEditRedundantSolverParam1->setEntryName("Redundant_DL_tolg");
             ui->lineEditRedundantSolverParam1->onSave();
             break;
@@ -294,14 +297,14 @@ void TaskSketcherSolverAdvanced::on_lineEditSolverParam2_editingFinished()
     {
         case 1: // LM
         {
-            sketchView->getSketchObject()->getSolvedSketch().setLM_eps1(val);
+            const_cast<Sketcher::Sketch &>(sketchView->getSketchObject()->getSolvedSketch()).setLM_eps1(val);
             ui->lineEditSolverParam2->setEntryName("LM_eps1");
             ui->lineEditSolverParam2->onSave();
             break;
         }
         case 2: // DogLeg
         {
-            sketchView->getSketchObject()->getSolvedSketch().setDL_tolx(val);
+            const_cast<Sketcher::Sketch &>(sketchView->getSketchObject()->getSolvedSketch()).setDL_tolx(val);
             ui->lineEditSolverParam2->setEntryName("DL_tolx");
             ui->lineEditSolverParam2->onSave();
             break;
@@ -322,14 +325,14 @@ void TaskSketcherSolverAdvanced::on_lineEditRedundantSolverParam2_editingFinishe
     {
         case 1: // LM
         {
-            sketchView->getSketchObject()->getSolvedSketch().setLM_eps1Redundant(val);
+            const_cast<Sketcher::Sketch &>(sketchView->getSketchObject()->getSolvedSketch()).setLM_eps1Redundant(val);
             ui->lineEditRedundantSolverParam2->setEntryName("Redundant_LM_eps1");
             ui->lineEditRedundantSolverParam2->onSave();
             break;
         }
         case 2: // DogLeg
         {
-            sketchView->getSketchObject()->getSolvedSketch().setDL_tolxRedundant(val);
+            const_cast<Sketcher::Sketch &>(sketchView->getSketchObject()->getSolvedSketch()).setDL_tolxRedundant(val);
             ui->lineEditRedundantSolverParam2->setEntryName("Redundant_DL_tolx");
             ui->lineEditRedundantSolverParam2->onSave();
             break;
@@ -350,14 +353,14 @@ void TaskSketcherSolverAdvanced::on_lineEditSolverParam3_editingFinished()
     {
         case 1: // LM
         {
-            sketchView->getSketchObject()->getSolvedSketch().setLM_tau(val);
+            const_cast<Sketcher::Sketch &>(sketchView->getSketchObject()->getSolvedSketch()).setLM_tau(val);
             ui->lineEditSolverParam3->setEntryName("LM_tau");
             ui->lineEditSolverParam3->onSave();
             break;
         }
         case 2: // DogLeg
         {
-            sketchView->getSketchObject()->getSolvedSketch().setDL_tolf(val);
+            const_cast<Sketcher::Sketch &>(sketchView->getSketchObject()->getSolvedSketch()).setDL_tolf(val);
             ui->lineEditSolverParam3->setEntryName("DL_tolf");
             ui->lineEditSolverParam3->onSave();
             break;
@@ -378,14 +381,14 @@ void TaskSketcherSolverAdvanced::on_lineEditRedundantSolverParam3_editingFinishe
     {
         case 1: // LM
         {
-            sketchView->getSketchObject()->getSolvedSketch().setLM_tauRedundant(val);
+            const_cast<Sketcher::Sketch &>(sketchView->getSketchObject()->getSolvedSketch()).setLM_tauRedundant(val);
             ui->lineEditRedundantSolverParam3->setEntryName("Redundant_LM_tau");
             ui->lineEditRedundantSolverParam3->onSave();
             break;
         }
         case 2: // DogLeg
         {
-            sketchView->getSketchObject()->getSolvedSketch().setDL_tolfRedundant(val);
+            const_cast<Sketcher::Sketch &>(sketchView->getSketchObject()->getSolvedSketch()).setDL_tolfRedundant(val);
             ui->lineEditRedundantSolverParam3->setEntryName("Redundant_DL_tolf");
             ui->lineEditRedundantSolverParam3->onSave();
             break;
@@ -396,32 +399,32 @@ void TaskSketcherSolverAdvanced::on_lineEditRedundantSolverParam3_editingFinishe
 void TaskSketcherSolverAdvanced::on_comboBoxDefaultSolver_currentIndexChanged(int index)
 {
     ui->comboBoxDefaultSolver->onSave();
-    sketchView->getSketchObject()->getSolvedSketch().defaultSolver=(GCS::Algorithm) index;
+    const_cast<Sketcher::Sketch &>(sketchView->getSketchObject()->getSolvedSketch()).defaultSolver=(GCS::Algorithm) index;
     updateDefaultMethodParameters();
 }
 
 void TaskSketcherSolverAdvanced::on_comboBoxDogLegGaussStep_currentIndexChanged(int index)
 {
     ui->comboBoxDogLegGaussStep->onSave();
-    sketchView->getSketchObject()->getSolvedSketch().setDogLegGaussStep((GCS::DogLegGaussStep) index);
+    const_cast<Sketcher::Sketch &>(sketchView->getSketchObject()->getSolvedSketch()).setDogLegGaussStep((GCS::DogLegGaussStep) index);
     updateDefaultMethodParameters();
 }
 
 void TaskSketcherSolverAdvanced::on_spinBoxMaxIter_valueChanged(int i)
 {
     ui->spinBoxMaxIter->onSave();
-    sketchView->getSketchObject()->getSolvedSketch().setMaxIter(i);
+    const_cast<Sketcher::Sketch &>(sketchView->getSketchObject()->getSolvedSketch()).setMaxIter(i);
 }
 
 void TaskSketcherSolverAdvanced::on_checkBoxSketchSizeMultiplier_stateChanged(int state)
 {
     if(state==Qt::Checked) {
         ui->checkBoxSketchSizeMultiplier->onSave();
-        sketchView->getSketchObject()->getSolvedSketch().setSketchSizeMultiplier(true);
+        const_cast<Sketcher::Sketch &>(sketchView->getSketchObject()->getSolvedSketch()).setSketchSizeMultiplier(true);
     }
     else if (state==Qt::Unchecked) {
         ui->checkBoxSketchSizeMultiplier->onSave();
-        sketchView->getSketchObject()->getSolvedSketch().setSketchSizeMultiplier(false);
+        const_cast<Sketcher::Sketch &>(sketchView->getSketchObject()->getSolvedSketch()).setSketchSizeMultiplier(false);
     }
 }
 
@@ -436,7 +439,7 @@ void TaskSketcherSolverAdvanced::on_lineEditQRPivotThreshold_editingFinished()
 
     ui->lineEditQRPivotThreshold->onSave();
 
-    sketchView->getSketchObject()->getSolvedSketch().setQRPivotThreshold(val);
+    const_cast<Sketcher::Sketch &>(sketchView->getSketchObject()->getSolvedSketch()).setQRPivotThreshold(val);
 }
 
 void TaskSketcherSolverAdvanced::on_lineEditConvergence_editingFinished()
@@ -450,7 +453,7 @@ void TaskSketcherSolverAdvanced::on_lineEditConvergence_editingFinished()
 
     ui->lineEditConvergence->onSave();
 
-    sketchView->getSketchObject()->getSolvedSketch().setConvergence(val);
+    const_cast<Sketcher::Sketch &>(sketchView->getSketchObject()->getSolvedSketch()).setConvergence(val);
 }
 
 void TaskSketcherSolverAdvanced::on_lineEditRedundantConvergence_editingFinished()
@@ -464,44 +467,44 @@ void TaskSketcherSolverAdvanced::on_lineEditRedundantConvergence_editingFinished
 
     ui->lineEditRedundantConvergence->onSave();
 
-    sketchView->getSketchObject()->getSolvedSketch().setConvergenceRedundant(val);
+    const_cast<Sketcher::Sketch &>(sketchView->getSketchObject()->getSolvedSketch()).setConvergenceRedundant(val);
 }
 
 void TaskSketcherSolverAdvanced::on_comboBoxQRMethod_currentIndexChanged(int index)
 {
-    sketchView->getSketchObject()->getSolvedSketch().setQRAlgorithm((GCS::QRAlgorithm) index);
+    const_cast<Sketcher::Sketch &>(sketchView->getSketchObject()->getSolvedSketch()).setQRAlgorithm((GCS::QRAlgorithm) index);
     ui->comboBoxQRMethod->onSave();
 }
 
 void TaskSketcherSolverAdvanced::on_comboBoxRedundantDefaultSolver_currentIndexChanged(int index)
 {
     ui->comboBoxRedundantDefaultSolver->onSave();
-    sketchView->getSketchObject()->getSolvedSketch().defaultSolverRedundant=(GCS::Algorithm) index;
+    const_cast<Sketcher::Sketch &>(sketchView->getSketchObject()->getSolvedSketch()).defaultSolverRedundant=(GCS::Algorithm) index;
     updateRedundantMethodParameters();
 }
 
 void TaskSketcherSolverAdvanced::on_spinBoxRedundantSolverMaxIterations_valueChanged(int i)
 {
     ui->spinBoxRedundantSolverMaxIterations->onSave();
-    sketchView->getSketchObject()->getSolvedSketch().setMaxIterRedundant(i);
+    const_cast<Sketcher::Sketch &>(sketchView->getSketchObject()->getSolvedSketch()).setMaxIterRedundant(i);
 }
 
 void TaskSketcherSolverAdvanced::on_checkBoxRedundantSketchSizeMultiplier_stateChanged(int state)
 {
     if(state==Qt::Checked) {
         ui->checkBoxRedundantSketchSizeMultiplier->onSave();
-        sketchView->getSketchObject()->getSolvedSketch().setSketchSizeMultiplierRedundant(true);
+        const_cast<Sketcher::Sketch &>(sketchView->getSketchObject()->getSolvedSketch()).setSketchSizeMultiplierRedundant(true);
     }
     else if (state==Qt::Unchecked) {
         ui->checkBoxRedundantSketchSizeMultiplier->onSave();
-        sketchView->getSketchObject()->getSolvedSketch().setSketchSizeMultiplierRedundant(true);
+        const_cast<Sketcher::Sketch &>(sketchView->getSketchObject()->getSolvedSketch()).setSketchSizeMultiplierRedundant(true);
     }
 }
 
 void TaskSketcherSolverAdvanced::on_comboBoxDebugMode_currentIndexChanged(int index)
 {
     ui->comboBoxDebugMode->onSave();
-    sketchView->getSketchObject()->getSolvedSketch().setDebugMode((GCS::DebugMode) index);
+    const_cast<Sketcher::Sketch &>(sketchView->getSketchObject()->getSolvedSketch()).setDebugMode((GCS::DebugMode) index);
 }
 
 void TaskSketcherSolverAdvanced::on_pushButtonSolve_clicked(bool checked/* = false*/)
@@ -560,18 +563,18 @@ void TaskSketcherSolverAdvanced::on_pushButtonDefaults_clicked(bool checked/* = 
 
 void TaskSketcherSolverAdvanced::updateSketchObject(void)
 {
-    sketchView->getSketchObject()->getSolvedSketch().setDebugMode((GCS::DebugMode) ui->comboBoxDebugMode->currentIndex());
-    sketchView->getSketchObject()->getSolvedSketch().setSketchSizeMultiplierRedundant(ui->checkBoxRedundantSketchSizeMultiplier->isChecked());
-    sketchView->getSketchObject()->getSolvedSketch().setMaxIterRedundant(ui->spinBoxRedundantSolverMaxIterations->value());
-    sketchView->getSketchObject()->getSolvedSketch().defaultSolverRedundant=(GCS::Algorithm) ui->comboBoxRedundantDefaultSolver->currentIndex();
-    sketchView->getSketchObject()->getSolvedSketch().setQRAlgorithm((GCS::QRAlgorithm) ui->comboBoxQRMethod->currentIndex());
-    sketchView->getSketchObject()->getSolvedSketch().setQRPivotThreshold(ui->lineEditQRPivotThreshold->text().toDouble());
-    sketchView->getSketchObject()->getSolvedSketch().setConvergenceRedundant(ui->lineEditRedundantConvergence->text().toDouble());
-    sketchView->getSketchObject()->getSolvedSketch().setConvergence(ui->lineEditConvergence->text().toDouble());
-    sketchView->getSketchObject()->getSolvedSketch().setSketchSizeMultiplier(ui->checkBoxSketchSizeMultiplier->isChecked());
-    sketchView->getSketchObject()->getSolvedSketch().setMaxIter(ui->spinBoxMaxIter->value());
-    sketchView->getSketchObject()->getSolvedSketch().defaultSolver=(GCS::Algorithm) ui->comboBoxDefaultSolver->currentIndex();
-    sketchView->getSketchObject()->getSolvedSketch().setDogLegGaussStep((GCS::DogLegGaussStep) ui->comboBoxDogLegGaussStep->currentIndex());
+    const_cast<Sketcher::Sketch &>(sketchView->getSketchObject()->getSolvedSketch()).setDebugMode((GCS::DebugMode) ui->comboBoxDebugMode->currentIndex());
+    const_cast<Sketcher::Sketch &>(sketchView->getSketchObject()->getSolvedSketch()).setSketchSizeMultiplierRedundant(ui->checkBoxRedundantSketchSizeMultiplier->isChecked());
+    const_cast<Sketcher::Sketch &>(sketchView->getSketchObject()->getSolvedSketch()).setMaxIterRedundant(ui->spinBoxRedundantSolverMaxIterations->value());
+    const_cast<Sketcher::Sketch &>(sketchView->getSketchObject()->getSolvedSketch()).defaultSolverRedundant=(GCS::Algorithm) ui->comboBoxRedundantDefaultSolver->currentIndex();
+    const_cast<Sketcher::Sketch &>(sketchView->getSketchObject()->getSolvedSketch()).setQRAlgorithm((GCS::QRAlgorithm) ui->comboBoxQRMethod->currentIndex());
+    const_cast<Sketcher::Sketch &>(sketchView->getSketchObject()->getSolvedSketch()).setQRPivotThreshold(ui->lineEditQRPivotThreshold->text().toDouble());
+    const_cast<Sketcher::Sketch &>(sketchView->getSketchObject()->getSolvedSketch()).setConvergenceRedundant(ui->lineEditRedundantConvergence->text().toDouble());
+    const_cast<Sketcher::Sketch &>(sketchView->getSketchObject()->getSolvedSketch()).setConvergence(ui->lineEditConvergence->text().toDouble());
+    const_cast<Sketcher::Sketch &>(sketchView->getSketchObject()->getSolvedSketch()).setSketchSizeMultiplier(ui->checkBoxSketchSizeMultiplier->isChecked());
+    const_cast<Sketcher::Sketch &>(sketchView->getSketchObject()->getSolvedSketch()).setMaxIter(ui->spinBoxMaxIter->value());
+    const_cast<Sketcher::Sketch &>(sketchView->getSketchObject()->getSolvedSketch()).defaultSolver=(GCS::Algorithm) ui->comboBoxDefaultSolver->currentIndex();
+    const_cast<Sketcher::Sketch &>(sketchView->getSketchObject()->getSolvedSketch()).setDogLegGaussStep((GCS::DogLegGaussStep) ui->comboBoxDogLegGaussStep->currentIndex());
 
     updateDefaultMethodParameters();
     updateRedundantMethodParameters();

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -1276,9 +1276,9 @@ bool ViewProviderSketch::mouseMove(const SbVec2s &cursorPos, Gui::View3DInventor
                     if (getSketchObject()->getSolvedSketch().movePoint(GeoId, PosId, vec, false) == 0) {
                         setPositionText(Base::Vector2d(x,y));
                         draw(true,false);
-                        signalSolved(QString::fromLatin1("Solved in %1 sec").arg(getSketchObject()->getSolvedSketch().SolveTime));
+                        signalSolved(QString::fromLatin1("Solved in %1 sec").arg(getSketchObject()->getSolvedSketch().getSolveTime()));
                     } else {
-                        signalSolved(QString::fromLatin1("Unsolved (%1 sec)").arg(getSketchObject()->getSolvedSketch().SolveTime));
+                        signalSolved(QString::fromLatin1("Unsolved (%1 sec)").arg(getSketchObject()->getSolvedSketch().getSolveTime()));
                         //Base::Console().Log("Error solving:%d\n",ret);
                     }
                 }
@@ -1317,9 +1317,9 @@ bool ViewProviderSketch::mouseMove(const SbVec2s &cursorPos, Gui::View3DInventor
                 if (getSketchObject()->getSolvedSketch().movePoint(edit->DragCurve, Sketcher::none, vec, relative) == 0) {
                     setPositionText(Base::Vector2d(x,y));
                     draw(true,false);
-                    signalSolved(QString::fromLatin1("Solved in %1 sec").arg(getSketchObject()->getSolvedSketch().SolveTime));
+                    signalSolved(QString::fromLatin1("Solved in %1 sec").arg(getSketchObject()->getSolvedSketch().getSolveTime()));
                 } else {
-                    signalSolved(QString::fromLatin1("Unsolved (%1 sec)").arg(getSketchObject()->getSolvedSketch().SolveTime));
+                    signalSolved(QString::fromLatin1("Unsolved (%1 sec)").arg(getSketchObject()->getSolvedSketch().getSolveTime()));
                 }
             }
             return true;
@@ -6255,7 +6255,7 @@ bool ViewProviderSketch::setEdit(int ModNum)
     // Enable solver initial solution update while dragging.
     ParameterGrp::handle hGrp2 = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher");
 
-    getSketchObject()->getSolvedSketch().RecalculateInitialSolutionWhileMovingPoint = hGrp2->GetBool("RecalculateInitialSolutionWhileDragging",true);
+    getSketchObject()->getSolvedSketch().setRecalculateInitialSolutionWhileMovingPoint(hGrp2->GetBool("RecalculateInitialSolutionWhileDragging",true));
 
 
     // intercept del key press from main app

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -1231,8 +1231,6 @@ bool ViewProviderSketch::mouseMove(const SbVec2s &cursorPos, Gui::View3DInventor
 
                 }
 
-                getSketchObject()->initTemporaryMove(edit->DragCurve, Sketcher::none, false);
-
                 if (geo->getTypeId() == Part::GeomLineSegment::getClassTypeId() ||
                     geo->getTypeId() == Part::GeomBSplineCurve::getClassTypeId()) {
                     relative = true;
@@ -1249,6 +1247,9 @@ bool ViewProviderSketch::mouseMove(const SbVec2s &cursorPos, Gui::View3DInventor
                     xInit = 0;
                     yInit = 0;
                 }
+
+                getSketchObject()->initTemporaryMove(edit->DragCurve, Sketcher::none, false);
+
             } else {
                 Mode = STATUS_NONE;
             }

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -189,7 +189,7 @@ struct EditData {
     MarkerSize(7),
     blockedPreselection(false),
     FullyConstrained(false),
-    //ActSketch(0), // if you are wondering, it went to SketchObject, accessible via getSketchObject()->getSolvedSketch()
+    //ActSketch(0), // if you are wondering, it went to SketchObject, accessible via getSolvedSketch() and via SketchObject interface as appropriate
     EditRoot(0),
     PointsMaterials(0),
     CurvesMaterials(0),
@@ -1139,7 +1139,7 @@ bool ViewProviderSketch::mouseMove(const SbVec2s &cursorPos, Gui::View3DInventor
             }
             return false;
         case STATUS_SELECT_Point:
-            if (!getSketchObject()->getSolvedSketch().hasConflicts() &&
+            if (!getSolvedSketch().hasConflicts() &&
                 edit->PreselectPoint != -1 && edit->DragPoint != edit->PreselectPoint) {
                 Mode = STATUS_SKETCH_DragPoint;
                 edit->DragPoint = edit->PreselectPoint;
@@ -1147,7 +1147,7 @@ bool ViewProviderSketch::mouseMove(const SbVec2s &cursorPos, Gui::View3DInventor
                 Sketcher::PointPos PosId;
                 getSketchObject()->getGeoVertexIndex(edit->DragPoint, GeoId, PosId);
                 if (GeoId != Sketcher::Constraint::GeoUndef && PosId != Sketcher::none) {
-                    getSketchObject()->getSolvedSketch().initMove(GeoId, PosId, false);
+                    getSketchObject()->initTemporaryMove(GeoId, PosId, false);
                     relative = false;
                     xInit = 0;
                     yInit = 0;
@@ -1161,7 +1161,7 @@ bool ViewProviderSketch::mouseMove(const SbVec2s &cursorPos, Gui::View3DInventor
             edit->PreselectConstraintSet.clear();
             return true;
         case STATUS_SELECT_Edge:
-            if (!getSketchObject()->getSolvedSketch().hasConflicts() &&
+            if (!getSolvedSketch().hasConflicts() &&
                 edit->PreselectCurve != -1 && edit->DragCurve != edit->PreselectCurve) {
                 Mode = STATUS_SKETCH_DragCurve;
                 edit->DragCurve = edit->PreselectCurve;
@@ -1183,7 +1183,7 @@ bool ViewProviderSketch::mouseMove(const SbVec2s &cursorPos, Gui::View3DInventor
 
                         // The B-Spline is constrained to be non-rational (equal weights), moving produces a bad effect
                         // because OCCT will normalize the values of the weights.
-                        auto grp = getSketchObject()->getSolvedSketch().getDependencyGroup(edit->DragCurve, Sketcher::none);
+                        auto grp = getSolvedSketch().getDependencyGroup(edit->DragCurve, Sketcher::none);
 
                         int bsplinegeoid = -1;
 
@@ -1231,7 +1231,7 @@ bool ViewProviderSketch::mouseMove(const SbVec2s &cursorPos, Gui::View3DInventor
 
                 }
 
-                getSketchObject()->getSolvedSketch().initMove(edit->DragCurve, Sketcher::none, false);
+                getSketchObject()->initTemporaryMove(edit->DragCurve, Sketcher::none, false);
 
                 if (geo->getTypeId() == Part::GeomLineSegment::getClassTypeId() ||
                     geo->getTypeId() == Part::GeomBSplineCurve::getClassTypeId()) {
@@ -1273,12 +1273,12 @@ bool ViewProviderSketch::mouseMove(const SbVec2s &cursorPos, Gui::View3DInventor
                 getSketchObject()->getGeoVertexIndex(edit->DragPoint, GeoId, PosId);
                 Base::Vector3d vec(x,y,0);
                 if (GeoId != Sketcher::Constraint::GeoUndef && PosId != Sketcher::none) {
-                    if (getSketchObject()->getSolvedSketch().movePoint(GeoId, PosId, vec, false) == 0) {
+                    if (getSketchObject()->moveTemporaryPoint(GeoId, PosId, vec, false) == 0) {
                         setPositionText(Base::Vector2d(x,y));
                         draw(true,false);
-                        signalSolved(QString::fromLatin1("Solved in %1 sec").arg(getSketchObject()->getSolvedSketch().getSolveTime()));
+                        signalSolved(QString::fromLatin1("Solved in %1 sec").arg(getSolvedSketch().getSolveTime()));
                     } else {
-                        signalSolved(QString::fromLatin1("Unsolved (%1 sec)").arg(getSketchObject()->getSolvedSketch().getSolveTime()));
+                        signalSolved(QString::fromLatin1("Unsolved (%1 sec)").arg(getSolvedSketch().getSolveTime()));
                         //Base::Console().Log("Error solving:%d\n",ret);
                     }
                 }
@@ -1314,12 +1314,12 @@ bool ViewProviderSketch::mouseMove(const SbVec2s &cursorPos, Gui::View3DInventor
                     vec = center + dir / scalefactor;
                 }
 
-                if (getSketchObject()->getSolvedSketch().movePoint(edit->DragCurve, Sketcher::none, vec, relative) == 0) {
+                if (getSketchObject()->moveTemporaryPoint(edit->DragCurve, Sketcher::none, vec, relative) == 0) {
                     setPositionText(Base::Vector2d(x,y));
                     draw(true,false);
-                    signalSolved(QString::fromLatin1("Solved in %1 sec").arg(getSketchObject()->getSolvedSketch().getSolveTime()));
+                    signalSolved(QString::fromLatin1("Solved in %1 sec").arg(getSolvedSketch().getSolveTime()));
                 } else {
-                    signalSolved(QString::fromLatin1("Unsolved (%1 sec)").arg(getSketchObject()->getSolvedSketch().getSolveTime()));
+                    signalSolved(QString::fromLatin1("Unsolved (%1 sec)").arg(getSolvedSketch().getSolveTime()));
                 }
             }
             return true;
@@ -1380,7 +1380,7 @@ void ViewProviderSketch::moveConstraint(int constNum, const Base::Vector2d &toPo
 #endif
 
     // with memory allocation
-    const std::vector<Part::Geometry *> geomlist = getSketchObject()->getSolvedSketch().extractGeometry(true, true);
+    const std::vector<Part::Geometry *> geomlist = getSolvedSketch().extractGeometry(true, true);
 
 #ifdef _DEBUG
     assert(int(geomlist.size()) == extGeoCount + intGeoCount);
@@ -1393,10 +1393,10 @@ void ViewProviderSketch::moveConstraint(int constNum, const Base::Vector2d &toPo
 
         Base::Vector3d p1(0.,0.,0.), p2(0.,0.,0.);
         if (Constr->SecondPos != Sketcher::none) { // point to point distance
-            p1 = getSketchObject()->getSolvedSketch().getPoint(Constr->First, Constr->FirstPos);
-            p2 = getSketchObject()->getSolvedSketch().getPoint(Constr->Second, Constr->SecondPos);
+            p1 = getSolvedSketch().getPoint(Constr->First, Constr->FirstPos);
+            p2 = getSolvedSketch().getPoint(Constr->Second, Constr->SecondPos);
         } else if (Constr->Second != Constraint::GeoUndef) { // point to line distance
-            p1 = getSketchObject()->getSolvedSketch().getPoint(Constr->First, Constr->FirstPos);
+            p1 = getSolvedSketch().getPoint(Constr->First, Constr->FirstPos);
             const Part::Geometry *geo = GeoById(geomlist, Constr->Second);
             if (geo->getTypeId() == Part::GeomLineSegment::getClassTypeId()) {
                 const Part::GeomLineSegment *lineSeg = static_cast<const Part::GeomLineSegment *>(geo);
@@ -1408,7 +1408,7 @@ void ViewProviderSketch::moveConstraint(int constNum, const Base::Vector2d &toPo
             } else
                 return;
         } else if (Constr->FirstPos != Sketcher::none) {
-            p2 = getSketchObject()->getSolvedSketch().getPoint(Constr->First, Constr->FirstPos);
+            p2 = getSolvedSketch().getPoint(Constr->First, Constr->FirstPos);
         } else if (Constr->First != Constraint::GeoUndef) {
             const Part::Geometry *geo = GeoById(geomlist, Constr->First);
             if (geo->getTypeId() == Part::GeomLineSegment::getClassTypeId()) {
@@ -1534,11 +1534,11 @@ void ViewProviderSketch::moveConstraint(int constNum, const Base::Vector2d &toPo
                     factor = factor * Base::sgn<double>((dir1+dir2) * vec);
                 }
             } else {//angle-via-point
-                Base::Vector3d p = getSketchObject()->getSolvedSketch().getPoint(Constr->Third, Constr->ThirdPos);
+                Base::Vector3d p = getSolvedSketch().getPoint(Constr->Third, Constr->ThirdPos);
                 p0 = Base::Vector3d(p.x, p.y, 0);
-                dir1 = getSketchObject()->getSolvedSketch().calculateNormalAtPoint(Constr->First, p.x, p.y);
+                dir1 = getSolvedSketch().calculateNormalAtPoint(Constr->First, p.x, p.y);
                 dir1.RotateZ(-M_PI/2);//convert to vector of tangency by rotating
-                dir2 = getSketchObject()->getSolvedSketch().calculateNormalAtPoint(Constr->Second, p.x, p.y);
+                dir2 = getSolvedSketch().calculateNormalAtPoint(Constr->Second, p.x, p.y);
                 dir2.RotateZ(-M_PI/2);
 
                 Base::Vector3d vec = Base::Vector3d(toPos.x, toPos.y, 0) - p0;
@@ -3032,7 +3032,7 @@ void ViewProviderSketch::updateColor(void)
             } else if (type == Sketcher::Coincident) {
                 auto selectpoint = [this, pcolor, PtNum](int geoid, Sketcher::PointPos pos){
                     if(geoid >= 0) {
-                        int index = getSketchObject()->getSolvedSketch().getPointId(geoid, pos) + 1;
+                        int index = getSolvedSketch().getPointId(geoid, pos) + 1;
                         if (index >= 0 && index < PtNum)
                             pcolor[index] = SelectColor;
                     }
@@ -3060,7 +3060,7 @@ void ViewProviderSketch::updateColor(void)
                     case EllipseFocus1:
                     case EllipseFocus2:
                     {
-                        int index = getSketchObject()->getSolvedSketch().getPointId(constraint->First, constraint->FirstPos) + 1;
+                        int index = getSolvedSketch().getPointId(constraint->First, constraint->FirstPos) + 1;
                         if (index >= 0 && index < PtNum) pcolor[index] = SelectColor;
                     }
                     break;
@@ -3760,7 +3760,7 @@ void ViewProviderSketch::draw(bool temp /*=false*/, bool rebuildinformationlayer
     const std::vector<Part::Geometry *> *geomlist;
     std::vector<Part::Geometry *> tempGeo;
     if (temp)
-        tempGeo = getSketchObject()->getSolvedSketch().extractGeometry(true, true); // with memory allocation
+        tempGeo = getSolvedSketch().extractGeometry(true, true); // with memory allocation
     else
         tempGeo = getSketchObject()->getCompleteGeometry(); // without memory allocation
     geomlist = &tempGeo;
@@ -3880,7 +3880,7 @@ void ViewProviderSketch::draw(bool temp /*=false*/, bool rebuildinformationlayer
                                 auto vpext = std::make_unique<SketcherGui::ViewProviderSketchGeometryExtension>();
                                 vpext->setRepresentationFactor(scalefactor);
 
-                                getSketchObject()->getSolvedSketch().updateExtension(GeoId, std::move(vpext));
+                                getSketchObject()->updateSolverExtension(GeoId, std::move(vpext));
                             }
 
                             if(!circle->hasExtension(SketcherGui::ViewProviderSketchGeometryExtension::getClassTypeId()))
@@ -4881,12 +4881,12 @@ Restart:
                             Base::Vector3d midpos2, dir2, norm2;
 
                             if (temp)
-                                midpos1 = getSketchObject()->getSolvedSketch().getPoint(Constr->First, Constr->FirstPos);
+                                midpos1 = getSolvedSketch().getPoint(Constr->First, Constr->FirstPos);
                             else
                                 midpos1 = getSketchObject()->getPoint(Constr->First, Constr->FirstPos);
 
                             if (temp)
-                                midpos2 = getSketchObject()->getSolvedSketch().getPoint(Constr->Second, Constr->SecondPos);
+                                midpos2 = getSolvedSketch().getPoint(Constr->Second, Constr->SecondPos);
                             else
                                 midpos2 = getSketchObject()->getPoint(Constr->Second, Constr->SecondPos);
 
@@ -4938,11 +4938,11 @@ Restart:
                                 assert(0);//no point found!
                             } while (false);
                             if (temp)
-                                midpos1 = getSketchObject()->getSolvedSketch().getPoint(ptGeoId, ptPosId);
+                                midpos1 = getSolvedSketch().getPoint(ptGeoId, ptPosId);
                             else
                                 midpos1 = getSketchObject()->getPoint(ptGeoId, ptPosId);
 
-                            norm1 = getSketchObject()->getSolvedSketch().calculateNormalAtPoint(Constr->Second, midpos1.x, midpos1.y);
+                            norm1 = getSolvedSketch().calculateNormalAtPoint(Constr->Second, midpos1.x, midpos1.y);
                             norm1.Normalize();
                             dir1 = norm1; dir1.RotateZ(-M_PI/2.0);
 
@@ -5206,15 +5206,15 @@ Restart:
                         Base::Vector3d pnt1(0.,0.,0.), pnt2(0.,0.,0.);
                         if (Constr->SecondPos != Sketcher::none) { // point to point distance
                             if (temp) {
-                                pnt1 = getSketchObject()->getSolvedSketch().getPoint(Constr->First, Constr->FirstPos);
-                                pnt2 = getSketchObject()->getSolvedSketch().getPoint(Constr->Second, Constr->SecondPos);
+                                pnt1 = getSolvedSketch().getPoint(Constr->First, Constr->FirstPos);
+                                pnt2 = getSolvedSketch().getPoint(Constr->Second, Constr->SecondPos);
                             } else {
                                 pnt1 = getSketchObject()->getPoint(Constr->First, Constr->FirstPos);
                                 pnt2 = getSketchObject()->getPoint(Constr->Second, Constr->SecondPos);
                             }
                         } else if (Constr->Second != Constraint::GeoUndef) { // point to line distance
                             if (temp) {
-                                pnt1 = getSketchObject()->getSolvedSketch().getPoint(Constr->First, Constr->FirstPos);
+                                pnt1 = getSolvedSketch().getPoint(Constr->First, Constr->FirstPos);
                             } else {
                                 pnt1 = getSketchObject()->getPoint(Constr->First, Constr->FirstPos);
                             }
@@ -5230,7 +5230,7 @@ Restart:
                                 break;
                         } else if (Constr->FirstPos != Sketcher::none) {
                             if (temp) {
-                                pnt2 = getSketchObject()->getSolvedSketch().getPoint(Constr->First, Constr->FirstPos);
+                                pnt2 = getSolvedSketch().getPoint(Constr->First, Constr->FirstPos);
                             } else {
                                 pnt2 = getSketchObject()->getPoint(Constr->First, Constr->FirstPos);
                             }
@@ -5301,9 +5301,9 @@ Restart:
                                 if (ptPosId != Sketcher::none) break;
                                 assert(0);//no point found!
                             } while (false);
-                            pos = getSketchObject()->getSolvedSketch().getPoint(ptGeoId, ptPosId);
+                            pos = getSolvedSketch().getPoint(ptGeoId, ptPosId);
 
-                            Base::Vector3d norm = getSketchObject()->getSolvedSketch().calculateNormalAtPoint(Constr->Second, pos.x, pos.y);
+                            Base::Vector3d norm = getSolvedSketch().calculateNormalAtPoint(Constr->Second, pos.x, pos.y);
                             norm.Normalize();
                             Base::Vector3d dir = norm; dir.RotateZ(-M_PI/2.0);
 
@@ -5429,8 +5429,8 @@ Restart:
                         assert(Constr->First >= -extGeoCount && Constr->First < intGeoCount);
                         assert(Constr->Second >= -extGeoCount && Constr->Second < intGeoCount);
 
-                        Base::Vector3d pnt1 = getSketchObject()->getSolvedSketch().getPoint(Constr->First, Constr->FirstPos);
-                        Base::Vector3d pnt2 = getSketchObject()->getSolvedSketch().getPoint(Constr->Second, Constr->SecondPos);
+                        Base::Vector3d pnt1 = getSolvedSketch().getPoint(Constr->First, Constr->FirstPos);
+                        Base::Vector3d pnt2 = getSolvedSketch().getPoint(Constr->Second, Constr->SecondPos);
 
                         SbVec3f p1(pnt1.x,pnt1.y,zConstr);
                         SbVec3f p2(pnt2.x,pnt2.y,zConstr);
@@ -5513,11 +5513,11 @@ Restart:
                                 startangle = atan2(dir1.y,dir1.x);
                             }
                             else {//angle-via-point
-                                Base::Vector3d p = getSketchObject()->getSolvedSketch().getPoint(Constr->Third, Constr->ThirdPos);
+                                Base::Vector3d p = getSolvedSketch().getPoint(Constr->Third, Constr->ThirdPos);
                                 p0 = SbVec3f(p.x, p.y, 0);
-                                dir1 = getSketchObject()->getSolvedSketch().calculateNormalAtPoint(Constr->First, p.x, p.y);
+                                dir1 = getSolvedSketch().calculateNormalAtPoint(Constr->First, p.x, p.y);
                                 dir1.RotateZ(-M_PI/2);//convert to vector of tangency by rotating
-                                dir2 = getSketchObject()->getSolvedSketch().calculateNormalAtPoint(Constr->Second, p.x, p.y);
+                                dir2 = getSolvedSketch().calculateNormalAtPoint(Constr->Second, p.x, p.y);
                                 dir2.RotateZ(-M_PI/2);
 
                                 startangle = atan2(dir1.y,dir1.x);
@@ -6001,7 +6001,7 @@ void ViewProviderSketch::updateData(const App::Property *prop)
         UpdateSolverInformation(); // just update the solver window with the last SketchObject solving information
 
         if(getSketchObject()->getExternalGeometryCount()+getSketchObject()->getHighestCurveIndex() + 1 ==
-            getSketchObject()->getSolvedSketch().getGeometrySize()) {
+            getSolvedSketch().getGeometrySize()) {
             Gui::MDIView *mdi = Gui::Application::Instance->editDocument()->getActiveView();
             if (mdi->isDerivedFrom(Gui::View3DInventor::getClassTypeId()))
                 draw(false,true);
@@ -6255,8 +6255,7 @@ bool ViewProviderSketch::setEdit(int ModNum)
     // Enable solver initial solution update while dragging.
     ParameterGrp::handle hGrp2 = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher");
 
-    getSketchObject()->getSolvedSketch().setRecalculateInitialSolutionWhileMovingPoint(hGrp2->GetBool("RecalculateInitialSolutionWhileDragging",true));
-
+    getSketchObject()->setRecalculateInitialSolutionWhileMovingPoint(hGrp2->GetBool("RecalculateInitialSolutionWhileDragging",true));
 
     // intercept del key press from main app
     listener = new ShortcutListener(this);
@@ -6340,7 +6339,7 @@ void ViewProviderSketch::UpdateSolverInformation()
         if (getSketchObject()->getLastSolverStatus() == 0) {
             if (dofs == 0) {
                 // color the sketch as fully constrained if it has geometry (other than the axes)
-                if(getSketchObject()->getSolvedSketch().getGeometrySize()>2)
+                if(getSolvedSketch().getGeometrySize()>2)
                     edit->FullyConstrained = true;
 
                 if (!hasRedundancies) {
@@ -6824,6 +6823,11 @@ int ViewProviderSketch::getPreselectCross(void) const
 Sketcher::SketchObject *ViewProviderSketch::getSketchObject(void) const
 {
     return dynamic_cast<Sketcher::SketchObject *>(pcObject);
+}
+
+const Sketcher::Sketch &ViewProviderSketch::getSolvedSketch(void) const
+{
+    return const_cast<const Sketcher::SketchObject *>(getSketchObject())->getSolvedSketch();
 }
 
 void ViewProviderSketch::deleteSelected()

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.h
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.h
@@ -194,6 +194,18 @@ public:
     /// get the pointer to the sketch document object
     Sketcher::SketchObject *getSketchObject(void) const;
 
+    /** returns a const reference to the last solved sketch object. It guarantees that
+     *  the solver object does not lose synchronisation with the SketchObject properties.
+     *
+     * NOTE: Operations requiring write access to the solver must be done via SketchObject
+     * interface. See for example functions:
+     * -> inline void setRecalculateInitialSolutionWhileMovingPoint(bool recalculateInitialSolutionWhileMovingPoint)
+     * -> inline int initTemporaryMove(int geoId, PointPos pos, bool fine=true)
+     * -> inline int moveTemporaryPoint(int geoId, PointPos pos, Base::Vector3d toPoint, bool relative=false)
+     * -> inline void updateSolverExtension(int geoId, std::unique_ptr<Part::GeometryExtension> && ext)
+     */
+    const Sketcher::Sketch &getSolvedSketch(void) const;
+
     /// snap points x,y (mouse coordinates) onto grid if enabled
     void snapToGrid(double &x, double &y);
 


### PR DESCRIPTION

Basically:
- ViewProviderSketch no longer has r/w access to the solver. It has r/o access and has to go through SketchObject for r/w operations.
- GCS uses const correctness to increase the r/o interface (also uses override).
- Fixes bug that a line with a single reference constraint would be detected as fully-constraint sketch.
- Fixes a bug that on toggling construction the Element's widget is not updated.
- Fixes a crash on renaming a constraint: https://github.com/FreeCAD/FreeCAD/pull/4183

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
