### PR TITLE
[TD] update balloon dialog

### DIFF
--- a/src/Mod/TechDraw/App/DrawViewBalloon.cpp
+++ b/src/Mod/TechDraw/App/DrawViewBalloon.cpp
@@ -91,26 +91,26 @@ const char* DrawViewBalloon::balloonTypeEnums[]= {"Circular",
 
 DrawViewBalloon::DrawViewBalloon(void)
 {
-    ADD_PROPERTY_TYPE(Text ,     (""),"",App::Prop_None,"The text to be displayed");
-    ADD_PROPERTY_TYPE(SourceView,(0),"",(App::PropertyType)(App::Prop_None),"Source view for balloon");
-    ADD_PROPERTY_TYPE(OriginX,(0),"",(App::PropertyType)(App::Prop_None),"Balloon origin x");
-    ADD_PROPERTY_TYPE(OriginY,(0),"",(App::PropertyType)(App::Prop_None),"Balloon origin y");
+    ADD_PROPERTY_TYPE(Text, (""), "", App::Prop_None, "The text to be displayed");
+    ADD_PROPERTY_TYPE(SourceView, (0), "", (App::PropertyType)(App::Prop_None), "Source view for balloon");
+    ADD_PROPERTY_TYPE(OriginX, (0), "", (App::PropertyType)(App::Prop_None), "Balloon origin x");
+    ADD_PROPERTY_TYPE(OriginY, (0), "", (App::PropertyType)(App::Prop_None), "Balloon origin y");
 
     EndType.setEnums(ArrowPropEnum::ArrowTypeEnums);
-    ADD_PROPERTY(EndType,(prefEnd()));
+    ADD_PROPERTY_TYPE(EndType, (prefEnd()), "", (App::PropertyType)(App::Prop_None), "End symbol for the balloon line");
 
-    ADD_PROPERTY_TYPE(EndTypeScale,(1.0),"",(App::PropertyType)(App::Prop_None),"EndType shape scale");
+    ADD_PROPERTY_TYPE(EndTypeScale, (1.0), "", (App::PropertyType)(App::Prop_None),"End symbol scale factor");
     EndTypeScale.setConstraints(&SymbolScaleRange);
 
     BubbleShape.setEnums(balloonTypeEnums);
-    ADD_PROPERTY(BubbleShape,(prefShape()));
+    ADD_PROPERTY_TYPE(BubbleShape, (prefShape()), "", (App::PropertyType)(App::Prop_None), "Shape of the balloon bubble");
 
-    ADD_PROPERTY_TYPE(ShapeScale,(1.0),"",(App::PropertyType)(App::Prop_None),"Balloon shape scale");
+    ADD_PROPERTY_TYPE(ShapeScale, (1.0), "", (App::PropertyType)(App::Prop_None), "Balloon shape scale");
     ShapeScale.setConstraints(&SymbolScaleRange);
 
-    ADD_PROPERTY_TYPE(TextWrapLen,(-1),"",(App::PropertyType)(App::Prop_None),"Text wrap length; -1 means no wrap");
+    ADD_PROPERTY_TYPE(TextWrapLen, (-1), "", (App::PropertyType)(App::Prop_None), "Text wrap length; -1 means no wrap");
 
-    ADD_PROPERTY_TYPE(KinkLength,(prefKinkLength()),"",(App::PropertyType)(App::Prop_None),
+    ADD_PROPERTY_TYPE(KinkLength, (prefKinkLength()), "", (App::PropertyType)(App::Prop_None),
                                   "Distance from symbol to leader kink");
 
     SourceView.setScope(App::LinkScope::Global);

--- a/src/Mod/TechDraw/Gui/TaskBalloon.cpp
+++ b/src/Mod/TechDraw/Gui/TaskBalloon.cpp
@@ -68,44 +68,49 @@ TaskBalloon::TaskBalloon(QGIViewBalloon *parent, ViewProviderBalloon *balloonVP)
 
     ui->setupUi(this);
 
-    ui->inputScale->setValue(parent->dvBalloon->ShapeScale.getValue());
-    connect(ui->inputScale, SIGNAL(valueChanged(double)), this, SLOT(onShapeScaleChanged()));
+    ui->qsbShapeScale->setValue(parent->dvBalloon->ShapeScale.getValue());
+    connect(ui->qsbShapeScale, SIGNAL(valueChanged(double)), this, SLOT(onShapeScaleChanged()));
+
+    ui->qsbSymbolScale->setValue(parent->dvBalloon->EndTypeScale.getValue());
+    connect(ui->qsbSymbolScale, SIGNAL(valueChanged(double)), this, SLOT(onEndSymbolScaleChanged()));
 
     std::string value = parent->dvBalloon->Text.getValue();
     QString qs = QString::fromUtf8(value.data(), value.size());
-    ui->inputValue->setText(qs);
-    ui->inputValue->selectAll();
-    connect(ui->inputValue, SIGNAL(textChanged(QString)), this, SLOT(onTextChanged()));
-    QTimer::singleShot(0, ui->inputValue, SLOT(setFocus()));
+    ui->leText->setText(qs);
+    ui->leText->selectAll();
+    connect(ui->leText, SIGNAL(textChanged(QString)), this, SLOT(onTextChanged()));
+    QTimer::singleShot(0, ui->leText, SLOT(setFocus()));
 
-    DrawGuiUtil::loadArrowBox(ui->comboEndType);
+    DrawGuiUtil::loadArrowBox(ui->comboEndSymbol);
     i = parent->dvBalloon->EndType.getValue();
-    ui->comboEndType->setCurrentIndex(i);
-    connect(ui->comboEndType, SIGNAL(currentIndexChanged(int)), this, SLOT(onEndTypeChanged()));
+    ui->comboEndSymbol->setCurrentIndex(i);
+    connect(ui->comboEndSymbol, SIGNAL(currentIndexChanged(int)), this, SLOT(onEndSymbolChanged()));
 
     i = parent->dvBalloon->BubbleShape.getValue();
-    ui->comboSymbol->setCurrentIndex(i);
-    connect(ui->comboSymbol, SIGNAL(currentIndexChanged(int)), this, SLOT(onShapeChanged()));
+    ui->comboBubbleShape->setCurrentIndex(i);
+    connect(ui->comboBubbleShape, SIGNAL(currentIndexChanged(int)), this, SLOT(onBubbleShapeChanged()));
 
     ui->qsbFontSize->setUnit(Base::Unit::Length);
     ui->qsbFontSize->setMinimum(0);
     connect(ui->qsbFontSize, SIGNAL(valueChanged(double)), this, SLOT(onFontsizeChanged()));
+    connect(ui->comboLineVisible, SIGNAL(currentIndexChanged(int)), this, SLOT(onLineVisibleChanged()));
     ui->qsbLineWidth->setUnit(Base::Unit::Length);
     ui->qsbLineWidth->setSingleStep(0.100);
     ui->qsbLineWidth->setMinimum(0);
     connect(ui->qsbLineWidth, SIGNAL(valueChanged(double)), this, SLOT(onLineWidthChanged()));
-    ui->qsbBalloonKink->setUnit(Base::Unit::Length);
+    ui->qsbKinkLength->setUnit(Base::Unit::Length);
     // negative kink length is allowed, thus no minimum
-    connect(ui->qsbBalloonKink, SIGNAL(valueChanged(double)), this, SLOT(onBalloonKinkChanged()));
+    connect(ui->qsbKinkLength, SIGNAL(valueChanged(double)), this, SLOT(onKinkLengthChanged()));
 
     if (balloonVP != nullptr) {
         ui->textColor->setColor(balloonVP->Color.getValue().asValue<QColor>());
         connect(ui->textColor, SIGNAL(changed()), this, SLOT(onColorChanged()));
         ui->qsbFontSize->setValue(balloonVP->Fontsize.getValue());
+        ui->comboLineVisible->setCurrentIndex(balloonVP->LineVisible.getValue());
         ui->qsbLineWidth->setValue(balloonVP->LineWidth.getValue());
     }
     // new balloons have already the preferences BalloonKink length
-    ui->qsbBalloonKink->setValue(parent->dvBalloon->KinkLength.getValue());
+    ui->qsbKinkLength->setValue(parent->dvBalloon->KinkLength.getValue());
 }
 
 TaskBalloon::~TaskBalloon()
@@ -115,16 +120,18 @@ TaskBalloon::~TaskBalloon()
 
 bool TaskBalloon::accept()
 {
-    m_parent->dvBalloon->Text.setValue(ui->inputValue->text().toUtf8().constData());
+    m_parent->dvBalloon->Text.setValue(ui->leText->text().toUtf8().constData());
     App::Color ac;
     ac.setValue<QColor>(ui->textColor->color());
     m_balloonVP->Color.setValue(ac);
     m_balloonVP->Fontsize.setValue(ui->qsbFontSize->value().getValue());
-    m_parent->dvBalloon->ShapeScale.setValue(ui->inputScale->value().getValue());
-    m_parent->dvBalloon->EndType.setValue(ui->comboEndType->currentIndex());
-    m_parent->dvBalloon->BubbleShape.setValue(ui->comboSymbol->currentIndex());
+    m_parent->dvBalloon->ShapeScale.setValue(ui->qsbShapeScale->value().getValue());
+    m_parent->dvBalloon->EndType.setValue(ui->comboEndSymbol->currentIndex());
+    m_parent->dvBalloon->EndTypeScale.setValue(ui->qsbSymbolScale->value().getValue());
+    m_parent->dvBalloon->BubbleShape.setValue(ui->comboBubbleShape->currentIndex());
+    m_balloonVP->LineVisible.setValue(ui->comboLineVisible->currentIndex());
     m_balloonVP->LineWidth.setValue(ui->qsbLineWidth->value().getValue());
-    m_parent->dvBalloon->KinkLength.setValue(ui->qsbBalloonKink->value().getValue());
+    m_parent->dvBalloon->KinkLength.setValue(ui->qsbKinkLength->value().getValue());
     m_parent->updateView(true);
 
     return true;
@@ -144,7 +151,7 @@ void TaskBalloon::recomputeFeature()
 
 void TaskBalloon::onTextChanged()
 {
-    m_parent->dvBalloon->Text.setValue(ui->inputValue->text().toUtf8().constData());
+    m_parent->dvBalloon->Text.setValue(ui->leText->text().toUtf8().constData());
     recomputeFeature();
 }
 
@@ -162,21 +169,33 @@ void TaskBalloon::onFontsizeChanged()
     recomputeFeature();
 }
 
-void TaskBalloon::onShapeChanged()
+void TaskBalloon::onBubbleShapeChanged()
 {
-    m_parent->dvBalloon->BubbleShape.setValue(ui->comboSymbol->currentIndex());
+    m_parent->dvBalloon->BubbleShape.setValue(ui->comboBubbleShape->currentIndex());
     recomputeFeature();
 }
 
 void TaskBalloon::onShapeScaleChanged()
 {
-    m_parent->dvBalloon->ShapeScale.setValue(ui->inputScale->value().getValue());
+    m_parent->dvBalloon->ShapeScale.setValue(ui->qsbShapeScale->value().getValue());
     recomputeFeature();
 }
 
-void TaskBalloon::onEndTypeChanged()
+void TaskBalloon::onEndSymbolChanged()
 {
-    m_parent->dvBalloon->EndType.setValue(ui->comboEndType->currentIndex());
+    m_parent->dvBalloon->EndType.setValue(ui->comboEndSymbol->currentIndex());
+    recomputeFeature();
+}
+
+void TaskBalloon::onEndSymbolScaleChanged()
+{
+    m_parent->dvBalloon->EndTypeScale.setValue(ui->qsbSymbolScale->value().getValue());
+    recomputeFeature();
+}
+
+void TaskBalloon::onLineVisibleChanged()
+{
+    m_balloonVP->LineVisible.setValue(ui->comboLineVisible->currentIndex());
     recomputeFeature();
 }
 
@@ -186,9 +205,9 @@ void TaskBalloon::onLineWidthChanged()
     recomputeFeature();
 }
 
-void TaskBalloon::onBalloonKinkChanged()
+void TaskBalloon::onKinkLengthChanged()
 {
-    m_parent->dvBalloon->KinkLength.setValue(ui->qsbBalloonKink->value().getValue());
+    m_parent->dvBalloon->KinkLength.setValue(ui->qsbKinkLength->value().getValue());
     recomputeFeature();
 }
 

--- a/src/Mod/TechDraw/Gui/TaskBalloon.h
+++ b/src/Mod/TechDraw/Gui/TaskBalloon.h
@@ -56,11 +56,13 @@ private Q_SLOTS:
     void onTextChanged();
     void onColorChanged();
     void onFontsizeChanged();
-    void onShapeChanged();
+    void onBubbleShapeChanged();
     void onShapeScaleChanged();
-    void onEndTypeChanged();
+    void onEndSymbolChanged();
+    void onEndSymbolScaleChanged();
+    void onLineVisibleChanged();
     void onLineWidthChanged();
-    void onBalloonKinkChanged();  
+    void onKinkLengthChanged();
 
 private:
     Ui_TaskBalloon *ui;

--- a/src/Mod/TechDraw/Gui/TaskBalloon.ui
+++ b/src/Mod/TechDraw/Gui/TaskBalloon.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>307</width>
-    <height>229</height>
+    <height>279</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -16,27 +16,6 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <layout class="QGridLayout" name="gridLayout">
-     <item row="0" column="0">
-      <widget class="QLabel" name="label">
-       <property name="text">
-        <string>Text:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="QLineEdit" name="inputValue">
-       <property name="toolTip">
-        <string>Text to be displayed</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="label_5">
-       <property name="text">
-        <string>Text Color:</string>
-       </property>
-      </widget>
-     </item>
      <item row="1" column="1">
       <widget class="Gui::ColorButton" name="textColor">
        <property name="toolTip">
@@ -51,10 +30,10 @@
        </property>
       </widget>
      </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="label_7">
+     <item row="7" column="0">
+      <widget class="QLabel" name="label_9">
        <property name="text">
-        <string>Fontsize:</string>
+        <string>Line Visible:</string>
        </property>
       </widget>
      </item>
@@ -89,15 +68,171 @@
        </property>
       </widget>
      </item>
+     <item row="5" column="1">
+      <widget class="QComboBox" name="comboEndSymbol">
+       <property name="toolTip">
+        <string>End symbol for the balloon line</string>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="1">
+      <widget class="Gui::QuantitySpinBox" name="qsbLineWidth">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>20</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string>Leader line width</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+       <property name="value">
+        <double>0.350000000000000</double>
+       </property>
+       <property name="prefEntry" stdset="0">
+        <cstring>BalloonKink</cstring>
+       </property>
+       <property name="prefPath" stdset="0">
+        <cstring>Mod/TechDraw/Dimensions</cstring>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="0">
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>Shape Scale:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="0">
+      <widget class="QLabel" name="label_8">
+       <property name="text">
+        <string>Line Width:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="10" column="0">
+      <widget class="QLabel" name="label_6">
+       <property name="text">
+        <string>Leader Kink Length:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Text:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="0">
+      <widget class="QLabel" name="label_4">
+       <property name="text">
+        <string>End Symbol:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <widget class="Gui::QuantitySpinBox" name="qsbShapeScale">
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>20</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string>Bubble shape scale factor</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+       <property name="minimum">
+        <double>0.000000000000000</double>
+       </property>
+       <property name="singleStep">
+        <double>0.100000000000000</double>
+       </property>
+       <property name="value">
+        <double>1.000000000000000</double>
+       </property>
+      </widget>
+     </item>
      <item row="3" column="0">
       <widget class="QLabel" name="label_3">
        <property name="text">
-        <string>Shape:</string>
+        <string>Bubble Shape:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="label_7">
+       <property name="text">
+        <string>Font Size:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="1">
+      <widget class="QComboBox" name="comboLineVisible">
+       <property name="toolTip">
+        <string>Whether the leader line is visible or not</string>
+       </property>
+       <property name="currentIndex">
+        <number>0</number>
+       </property>
+       <item>
+        <property name="text">
+         <string>False</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>True</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item row="10" column="1">
+      <widget class="Gui::QuantitySpinBox" name="qsbKinkLength">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>20</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string>Length of balloon leader line kink</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+       <property name="value">
+        <double>5.000000000000000</double>
+       </property>
+       <property name="prefEntry" stdset="0">
+        <cstring>BalloonKink</cstring>
+       </property>
+       <property name="prefPath" stdset="0">
+        <cstring>Mod/TechDraw/Dimensions</cstring>
        </property>
       </widget>
      </item>
      <item row="3" column="1">
-      <widget class="QComboBox" name="comboSymbol">
+      <widget class="QComboBox" name="comboBubbleShape">
        <property name="toolTip">
         <string>Shape of the balloon bubble</string>
        </property>
@@ -166,15 +301,22 @@
        </item>
       </widget>
      </item>
-     <item row="4" column="0">
-      <widget class="QLabel" name="label_2">
-       <property name="text">
-        <string>Shape Scale:</string>
+     <item row="0" column="1">
+      <widget class="QLineEdit" name="leText">
+       <property name="toolTip">
+        <string>Text to be displayed</string>
        </property>
       </widget>
      </item>
-     <item row="4" column="1">
-      <widget class="Gui::QuantitySpinBox" name="inputScale">
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_5">
+       <property name="text">
+        <string>Text Color:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="1">
+      <widget class="Gui::QuantitySpinBox" name="qsbSymbolScale">
        <property name="minimumSize">
         <size>
          <width>0</width>
@@ -182,7 +324,7 @@
         </size>
        </property>
        <property name="toolTip">
-        <string>Scale factor for the 'Shape'</string>
+        <string>End symbol scale factor</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -198,93 +340,10 @@
        </property>
       </widget>
      </item>
-     <item row="5" column="0">
-      <widget class="QLabel" name="label_4">
-       <property name="text">
-        <string>End Symbol:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="1">
-      <widget class="QComboBox" name="comboEndType">
-       <property name="toolTip">
-        <string>End symbol for the balloon line</string>
-       </property>
-      </widget>
-     </item>
      <item row="6" column="0">
-      <widget class="QLabel" name="label_8">
+      <widget class="QLabel" name="label_10">
        <property name="text">
-        <string>Line Width:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="6" column="1">
-      <widget class="Gui::QuantitySpinBox" name="qsbLineWidth">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>20</height>
-        </size>
-       </property>
-       <property name="toolTip">
-        <string>Leader line width</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-       <property name="value">
-        <double>0.350000000000000</double>
-       </property>
-       <property name="prefEntry" stdset="0">
-        <cstring>BalloonKink</cstring>
-       </property>
-       <property name="prefPath" stdset="0">
-        <cstring>Mod/TechDraw/Dimensions</cstring>
-       </property>
-      </widget>
-     </item>
-     <item row="7" column="0">
-      <widget class="QLabel" name="label_6">
-       <property name="text">
-        <string>Leader Kink Length:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="7" column="1">
-      <widget class="Gui::QuantitySpinBox" name="qsbBalloonKink">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>20</height>
-        </size>
-       </property>
-       <property name="toolTip">
-        <string>Length of balloon leader line kink</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-       <property name="value">
-        <double>5.000000000000000</double>
-       </property>
-       <property name="prefEntry" stdset="0">
-        <cstring>BalloonKink</cstring>
-       </property>
-       <property name="prefPath" stdset="0">
-        <cstring>Mod/TechDraw/Dimensions</cstring>
+        <string>End Symbol Scale:</string>
        </property>
       </widget>
      </item>

--- a/src/Mod/TechDraw/Gui/ViewProviderBalloon.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderBalloon.cpp
@@ -47,7 +47,6 @@
 #include <Gui/ViewProviderDocumentObject.h>
 
 #include <Mod/TechDraw/App/LineGroup.h>
-//#include <Mod/TechDraw/App/Preferences.h>
 
 #include "PreferencesGui.h"
 #include "TaskBalloon.h"
@@ -67,18 +66,16 @@ ViewProviderBalloon::ViewProviderBalloon()
 
     static const char *group = "Balloon Format";
 
-    ADD_PROPERTY_TYPE(Font,(Preferences::labelFont().c_str()),group,App::Prop_None, "The name of the font to use");
-    ADD_PROPERTY_TYPE(Fontsize,(Preferences::dimFontSizeMM()),
-                                group,(App::PropertyType)(App::Prop_None),"Balloon text size in units");
+    ADD_PROPERTY_TYPE(Font, (Preferences::labelFont().c_str()), group, App::Prop_None, "The name of the font to use");
+    ADD_PROPERTY_TYPE(Fontsize, (Preferences::dimFontSizeMM()),
+                                group, (App::PropertyType)(App::Prop_None), "Balloon text size in units");
     int lgNumber = Preferences::lineGroup();
     auto lg = TechDraw::LineGroup::lineGroupFactory(lgNumber);
     double weight = lg->getWeight("Thin");
     delete lg;                                   //Coverity CID 174670
-    ADD_PROPERTY_TYPE(LineWidth,(weight),group,(App::PropertyType)(App::Prop_None),"Leader line width");
-    ADD_PROPERTY_TYPE(LineVisible,(true),group,(App::PropertyType)(App::Prop_None),"Balloon line visible or hidden");
-
-    ADD_PROPERTY_TYPE(Color,(PreferencesGui::dimColor()),
-                                              group,App::Prop_None,"Color of the balloon");
+    ADD_PROPERTY_TYPE(LineWidth, (weight), group, (App::PropertyType)(App::Prop_None), "Leader line width");
+    ADD_PROPERTY_TYPE(LineVisible, (true), group, (App::PropertyType)(App::Prop_None), "Balloon line visible or hidden");
+    ADD_PROPERTY_TYPE(Color, (PreferencesGui::dimColor()), group, App::Prop_None, "Color of the balloon");
 }
 
 ViewProviderBalloon::~ViewProviderBalloon()


### PR DESCRIPTION
2 weeks ago the properties EndTypeScale and LineVisible were added by @aapo-aapo but not to the dialog.

This PR adds them to the balloon dialog.

I also took the opportunity to cleanup the code:
- add missing tooltips
- uniform tooltips in App and Gui
- uniform the UI element names

This is the updated dialog:
![FreeCAD_W0VWy5EpwJ](https://user-images.githubusercontent.com/1828501/103163988-af6b1900-4805-11eb-9093-b3c56a884f0f.png)