### PR TITLE
[TD] fix regression for balloon text separators

### DIFF
--- a/src/Mod/TechDraw/Gui/QGIViewBalloon.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewBalloon.cpp
@@ -636,6 +636,7 @@ void QGIViewBalloon::draw()
     } else if (strcmp(balloonType, "Rectangle") == 0) {
         //Add some room
         textHeight = (textHeight * scale) + Rez::guiX(1.0);
+        // we add some textWidth later because we first need to handle the text separators 
         if (balloonLabel->verticalSep) {
             for (std::vector<int>::iterator it = balloonLabel->seps.begin() ; it != balloonLabel->seps.end(); ++it) {
                 balloonPath.moveTo(lblCenter.x - (textWidth / 2.0) + *it, lblCenter.y - (textHeight / 2.0));
@@ -643,8 +644,7 @@ void QGIViewBalloon::draw()
             }
         }
         textWidth = (textWidth * scale) + Rez::guiX(2.0);
-        textHeight = (textHeight * scale) + Rez::guiX(2.0);
-        balloonPath.addRect(lblCenter.x -(textWidth / 2.0), lblCenter.y - (textHeight / 2.0), textWidth, textHeight);
+        balloonPath.addRect(lblCenter.x - (textWidth / 2.0), lblCenter.y - (textHeight / 2.0), textWidth, textHeight);
         offsetLR     = (textWidth / 2.0);
     } else if (strcmp(balloonType, "Triangle") == 0) {
         double radius = sqrt(pow((textHeight / 2.0), 2) + pow((textWidth / 2.0), 2));


### PR DESCRIPTION
as reported here: https://forum.freecadweb.org/viewtopic.php?f=35&t=53664 the balloon text separation no longer works.

The regression was introduced by commit 05577c267 . The mistake thereby was that the textHeight is already handled before the separators and that rectangular balloons behave differently because of the separator feature.