### PR TITLE
Path: fix unnecessary copy on read for Command.parameters dict

### DIFF
--- a/src/Mod/Path/App/CommandPy.xml
+++ b/src/Mod/Path/App/CommandPy.xml
@@ -43,7 +43,7 @@ pairs, or a placement, or a vector</UserDocu>
         </Methode>
         <Methode Name="setFromGCode">
             <Documentation>
-                <UserDocu>toGCode(): returns a GCode representation of the command</UserDocu>
+                <UserDocu>setFromGCode(): sets the path from the contents of the given GCode string</UserDocu>
             </Documentation>
         </Methode>
         <Methode Name="transform">
@@ -51,5 +51,8 @@ pairs, or a placement, or a vector</UserDocu>
                 <UserDocu>transform(Placement): returns a copy of this command transformed by the given placement</UserDocu>
             </Documentation>
         </Methode>
+        <ClassDeclarations>
+            mutable Py::Dict parameters_copy_dict;
+        </ClassDeclarations>
     </PythonExport>
 </GenerateModel>

--- a/src/Mod/Path/App/CommandPyImp.cpp
+++ b/src/Mod/Path/App/CommandPyImp.cpp
@@ -56,6 +56,11 @@ std::string CommandPy::representation(void) const
     return str.str();
 }
 
+// 
+// Py::Dict parameters_copy_dict is now a class member to avoid delete/create/copy on every read access from python code
+// Now the pre-filled Py::Dict is returned which is more consistent with normal python behaviour.
+// It should be cleared whenever the c++ Parameters object is changed eg setParameters() or other objects invalidate its content, eg setPlacement()
+// https://forum.freecadweb.org/viewtopic.php?f=15&t=50583
 
 PyObject *CommandPy::PyMake(struct _typeobject *, PyObject *, PyObject *)  // Python wrapper
 {
@@ -158,7 +163,7 @@ void CommandPy::setName(Py::String arg)
 
 Py::Dict CommandPy::getParameters(void) const
 {
-    // dict now a class member , https://forum.freecadweb.org/viewtopic.php?f=15&t=50583&
+    // dict now a class member , https://forum.freecadweb.org/viewtopic.php?f=15&t=50583
     if (parameters_copy_dict.length()==0) {    
       for(std::map<std::string,double>::iterator i = getCommandPtr()->Parameters.begin(); i != getCommandPtr()->Parameters.end(); ++i) {
           parameters_copy_dict.setItem(i->first, Py::Float(i->second));


### PR DESCRIPTION

Contents of underlying c++ std::map data is copied to a new PyDict on every read. This is contrary to expected python behaviour which would normally just return the pointer to a python object and increment the reference counter for it.  This was leading to massive redundant deletion and copying in all post processors which reference this variable in a nested loop. This PR adds a permanent dict member to the class and keeps track of changes to avoid unnecessary copying.

https://forum.freecadweb.org/viewtopic.php?f=15&t=50583&start=30#p457914

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [x] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
