### PR TITLE
Replace SVG icons of six Std View commands

### DIFF
--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -1145,7 +1145,7 @@ StdCmdSetAppearance::StdCmdSetAppearance()
     sToolTipText  = QT_TR_NOOP("Sets the display properties of the selected object");
     sWhatsThis    = "Std_SetAppearance";
     sStatusTip    = QT_TR_NOOP("Sets the display properties of the selected object");
-    sPixmap       = "Std_Tool1";
+    sPixmap       = "Std_SetAppearance";
     sAccel        = "Ctrl+D";
     eType         = Alter3DView;
 }
@@ -2289,7 +2289,7 @@ StdCmdViewIvStereoOff::StdCmdViewIvStereoOff()
     sToolTipText  = QT_TR_NOOP("Switch stereo viewing off");
     sWhatsThis    = "Std_ViewIvStereoOff";
     sStatusTip    = QT_TR_NOOP("Switch stereo viewing off");
-    sPixmap       = "Std_Tool6";
+    sPixmap       = "Std_ViewIvStereoOff";
     eType         = Alter3DView;
 }
 
@@ -2318,7 +2318,7 @@ StdCmdViewIvStereoRedGreen::StdCmdViewIvStereoRedGreen()
     sToolTipText  = QT_TR_NOOP("Switch stereo viewing to red/cyan");
     sWhatsThis    = "Std_ViewIvStereoRedGreen";
     sStatusTip    = QT_TR_NOOP("Switch stereo viewing to red/cyan");
-    sPixmap       = "Std_Tool7";
+    sPixmap       = "Std_ViewIvStereoRedGreen";
     eType         = Alter3DView;
 }
 
@@ -2346,7 +2346,7 @@ StdCmdViewIvStereoQuadBuff::StdCmdViewIvStereoQuadBuff()
     sToolTipText  = QT_TR_NOOP("Switch stereo viewing to quad buffer");
     sWhatsThis    = "Std_ViewIvStereoQuadBuff";
     sStatusTip    = QT_TR_NOOP("Switch stereo viewing to quad buffer");
-    sPixmap       = "Std_Tool7";
+    sPixmap       = "Std_ViewIvStereoQuadBuff";
     eType         = Alter3DView;
 }
 
@@ -2374,7 +2374,7 @@ StdCmdViewIvStereoInterleavedRows::StdCmdViewIvStereoInterleavedRows()
     sToolTipText  = QT_TR_NOOP("Switch stereo viewing to Interleaved Rows");
     sWhatsThis    = "Std_ViewIvStereoInterleavedRows";
     sStatusTip    = QT_TR_NOOP("Switch stereo viewing to Interleaved Rows");
-    sPixmap       = "Std_Tool7";
+    sPixmap       = "Std_ViewIvStereoInterleavedRows";
     eType         = Alter3DView;
 }
 
@@ -2402,7 +2402,7 @@ StdCmdViewIvStereoInterleavedColumns::StdCmdViewIvStereoInterleavedColumns()
     sToolTipText  = QT_TR_NOOP("Switch stereo viewing to Interleaved Columns");
     sWhatsThis    = "Std_ViewIvStereoInterleavedColumns";
     sStatusTip    = QT_TR_NOOP("Switch stereo viewing to Interleaved Columns");
-    sPixmap       = "Std_Tool7";
+    sPixmap       = "Std_ViewIvStereoInterleavedColumns";
     eType         = Alter3DView;
 }
 

--- a/src/Gui/Icons/Std_SetAppearance.svg
+++ b/src/Gui/Icons/Std_SetAppearance.svg
@@ -1,0 +1,233 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   width="64px"
+   height="64px"
+   id="svg3188"
+   version="1.1">
+  <title
+     id="title866">Std_SetAppearance</title>
+  <defs
+     id="defs3190">
+    <linearGradient
+       id="linearGradient3895">
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1;"
+         offset="0"
+         id="stop3897" />
+      <stop
+         style="stop-color:#204a87;stop-opacity:1;"
+         offset="1"
+         id="stop3899" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3354">
+      <stop
+         style="stop-color:#2157c7;stop-opacity:1;"
+         offset="0"
+         id="stop3356" />
+      <stop
+         style="stop-color:#6daaff;stop-opacity:1;"
+         offset="1"
+         id="stop3358" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3354"
+       id="linearGradient3599"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0083598,0,0,0.712664,-29.601181,398.25477)"
+       x1="2392.2313"
+       y1="1162.2943"
+       x2="2638.95"
+       y2="1162.2943" />
+    <linearGradient
+       xlink:href="#linearGradient3354-6"
+       id="linearGradient2996-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.15768287,0,0,0.15089213,-357.22613,-145.08225)"
+       x1="2392.2312"
+       y1="1162.2943"
+       x2="2638.95"
+       y2="1162.2943" />
+    <linearGradient
+       id="linearGradient3354-6">
+      <stop
+         style="stop-color:#2157c7;stop-opacity:1;"
+         offset="0"
+         id="stop3356-0" />
+      <stop
+         style="stop-color:#6daaff;stop-opacity:1;"
+         offset="1"
+         id="stop3358-6" />
+    </linearGradient>
+  </defs>
+  <g
+     id="layer1">
+    <rect
+       style="display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:2.08138;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="rect2364"
+       width="28"
+       height="58"
+       x="3"
+       y="3" />
+    <rect
+       style="display:inline;overflow:visible;visibility:visible;fill:none;stroke:#172a04;stroke-width:2;stroke-linejoin:round;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="rect3341"
+       width="20"
+       height="8.0000019"
+       x="7"
+       y="49" />
+    <rect
+       style="display:inline;overflow:visible;visibility:visible;fill:#73d216;stroke:#8ae234;stroke-width:2;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="rect3341-3"
+       width="16"
+       height="3.9999986"
+       x="9"
+       y="51" />
+    <rect
+       style="display:inline;overflow:visible;visibility:visible;fill:none;stroke:#0b1521;stroke-width:2;stroke-linejoin:round;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="rect3341-9"
+       width="20"
+       height="8.0000019"
+       x="7"
+       y="35" />
+    <rect
+       style="display:inline;overflow:visible;visibility:visible;fill:#3465a4;stroke:#729fcf;stroke-width:2;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="rect3341-3-1"
+       width="16"
+       height="3.9999986"
+       x="9"
+       y="37" />
+    <rect
+       style="display:inline;overflow:visible;visibility:visible;fill:none;stroke:#302b00;stroke-width:2;stroke-linejoin:round;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="rect3341-2"
+       width="20"
+       height="8.0000019"
+       x="7"
+       y="21" />
+    <rect
+       style="display:inline;overflow:visible;visibility:visible;fill:#edd400;stroke:#fce94f;stroke-width:2;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="rect3341-3-7"
+       width="16"
+       height="3.9999986"
+       x="9"
+       y="23" />
+    <rect
+       style="display:inline;overflow:visible;visibility:visible;fill:none;stroke:#280000;stroke-width:2;stroke-linejoin:round;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="rect3341-0"
+       width="20"
+       height="8.0000019"
+       x="7"
+       y="7" />
+    <rect
+       style="display:inline;overflow:visible;visibility:visible;fill:#cc0000;stroke:#ef2929;stroke-width:2;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="rect3341-3-9"
+       width="16"
+       height="3.9999986"
+       x="9"
+       y="9" />
+    <g
+       style="stroke-width:3.5;stroke-miterlimit:4;stroke-dasharray:none"
+       id="g3060"
+       transform="matrix(0.55090896,0,0,0.45218287,-39.418502,3.7972689)">
+      <path
+         id="path3150-7"
+         d="M 181.76846,74.564006 V 110.8957 l -17.89251,14.53268 v -36.3317 z"
+         style="fill:#204a87;stroke:none" />
+      <path
+         id="path3930"
+         d="m 163.87595,121.79521 17.89251,-14.53268"
+         style="fill:none;stroke:#3465a4;stroke-width:3.29157;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         id="path3932"
+         d="M 178.78637,114.52887 V 78.197173"
+         style="fill:none;stroke:#3465a4;stroke-width:3.29157;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         id="path3934"
+         d="m 181.76846,78.197173 -17.89251,14.53268"
+         style="fill:none;stroke:#3465a4;stroke-width:3.29157;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         id="path3936"
+         d="M 166.85803,85.463513 V 121.79521"
+         style="fill:none;stroke:#3465a4;stroke-width:3.29157;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         id="path3152-1"
+         d="M 163.87595,125.42838 140.01927,110.8957 V 74.564003 l 23.85668,14.532677 z"
+         style="fill:#3465a4;stroke:none" />
+      <path
+         id="path3938"
+         d="M 160.89386,89.096683 V 121.79521"
+         style="fill:none;stroke:#729fcf;stroke-width:3.29157;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         id="path3940"
+         d="m 140.01927,107.26253 23.85668,14.53268"
+         style="fill:none;stroke:#729fcf;stroke-width:3.29157;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         id="path3942"
+         d="M 143.00136,110.8957 V 78.197173"
+         style="fill:none;stroke:#729fcf;stroke-width:3.29157;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         id="path3150"
+         d="M 181.76846,74.564003 V 110.8957 l -17.89251,14.53268 V 89.096683 Z"
+         style="fill:none;stroke:#0b1521;stroke-width:3.29157;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+      <path
+         id="path3944"
+         d="M 163.87595,92.729853 140.01927,78.197173"
+         style="fill:none;stroke:#729fcf;stroke-width:3.29157;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         id="path3152"
+         d="M 163.87595,125.42838 140.01927,110.8957 V 74.564003 l 23.85668,14.53268 z"
+         style="fill:none;stroke:#0b1521;stroke-width:3.29157;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+      <path
+         id="path3156"
+         d="m 181.76846,74.564003 -17.89251,14.53268 -23.85668,-14.53268 17.89251,-14.53268 23.85668,14.53268"
+         style="fill:#729fcf;stroke:#0b1521;stroke-width:3.29157;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+    </g>
+  </g>
+  <metadata
+     id="metadata3231">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Std_SetAppearance</dc:title>
+        <cc:license
+           rdf:resource="" />
+        <dc:date>2020/12/20</dc:date>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[bitacovir]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier></dc:identifier>
+        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title></dc:title>
+          </cc:Agent>
+        </dc:contributor>
+        <dc:subject>
+          <rdf:Bag />
+        </dc:subject>
+        <dc:description></dc:description>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+</svg>

--- a/src/Gui/Icons/Std_ViewIvStereoInterleavedColumns.svg
+++ b/src/Gui/Icons/Std_ViewIvStereoInterleavedColumns.svg
@@ -1,0 +1,254 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   width="64px"
+   height="64px"
+   id="svg2980"
+   version="1.1">
+  <title
+     id="title1117">Std_ViewIvStereoInterleavedColumns</title>
+  <defs
+     id="defs2982">
+    <linearGradient
+       id="linearGradient952">
+      <stop
+         style="stop-color:#204a87;stop-opacity:1"
+         offset="0"
+         id="stop948" />
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1"
+         offset="1"
+         id="stop950" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient944">
+      <stop
+         style="stop-color:#a40000;stop-opacity:1"
+         offset="0"
+         id="stop940" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1"
+         offset="1"
+         id="stop942" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1078">
+      <stop
+         id="stop1074"
+         offset="0"
+         style="stop-color:#2e3436;stop-opacity:1" />
+      <stop
+         id="stop1076"
+         offset="1"
+         style="stop-color:#babdb6;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3794">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3796" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3798" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3864">
+      <stop
+         id="stop3866"
+         offset="0"
+         style="stop-color:#71b2f8;stop-opacity:1;" />
+      <stop
+         id="stop3868"
+         offset="1"
+         style="stop-color:#002795;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(0,-4)"
+       xlink:href="#linearGradient3767"
+       id="linearGradient3773"
+       x1="22.116516"
+       y1="55.717518"
+       x2="17.328547"
+       y2="21.31134"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3767">
+      <stop
+         style="stop-color:#3465a4;stop-opacity:1"
+         offset="0"
+         id="stop3769" />
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1"
+         offset="1"
+         id="stop3771" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(0,-4)"
+       xlink:href="#linearGradient3777"
+       id="linearGradient3783"
+       x1="53.896763"
+       y1="51.179787"
+       x2="47.502235"
+       y2="21.83742"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3777">
+      <stop
+         style="stop-color:#204a87;stop-opacity:1"
+         offset="0"
+         id="stop3779" />
+      <stop
+         style="stop-color:#3465a4;stop-opacity:1"
+         offset="1"
+         id="stop3781" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient3794"
+       id="radialGradient3800"
+       cx="1"
+       cy="45"
+       fx="1"
+       fy="45"
+       r="41"
+       gradientTransform="matrix(0.93348213,-2.2905276e-8,0,0.28687573,0.06651751,32.090592)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="24"
+       x2="7"
+       y1="43"
+       x1="56"
+       id="linearGradient1080"
+       xlink:href="#linearGradient1078"
+       gradientTransform="translate(0,-4)" />
+    <linearGradient
+       xlink:href="#linearGradient944"
+       id="linearGradient946"
+       x1="24.323317"
+       y1="38.115891"
+       x2="9.806756"
+       y2="27.753984"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-4)" />
+    <linearGradient
+       xlink:href="#linearGradient952"
+       id="linearGradient954"
+       x1="51.042877"
+       y1="39.422012"
+       x2="35.269917"
+       y2="27.405685"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-4)" />
+  </defs>
+  <metadata
+     id="metadata2985">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[bitacovir]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:title>Std_ViewIvStereoInterleavedColumns</dc:title>
+        <dc:date>2020/12/20</dc:date>
+        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier></dc:identifier>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title></dc:title>
+          </cc:Agent>
+        </dc:contributor>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     id="path1020"
+     d="M 3,16 H 61 V 46 H 42 C 35.259065,30.714814 27.983716,31.963913 22,46 H 3 Z"
+     style="fill:url(#linearGradient1080);fill-opacity:1;stroke:#555753;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     style="fill:url(#linearGradient946);fill-opacity:1;stroke:#280000;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none"
+     d="M 31.401313,21.859905 H 8.1273987 V 38.360987 H 23.397057 l 6.834934,-7.827763 z"
+     id="path921" />
+  <path
+     id="path921-8"
+     d="M 32.632737,21.859905 H 55.906651 V 38.360987 H 40.636993 l -6.834934,-6.652253 z"
+     style="fill:url(#linearGradient954);fill-opacity:1;stroke:#0b1521;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none" />
+  <path
+     style="fill:none;stroke:#babdb6;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 32.017025,33.189006 V 17.857777"
+     id="path919" />
+  <path
+     style="fill:none;stroke:#babdb6;stroke-width:1.808;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 5.051724,17.655172 H 59 V 44 L 43.235996,43.938429 C 36.666589,28.519738 26.039445,30.454028 20.661358,44.030786 L 5.051724,44 Z"
+     id="path1020-3" />
+  <path
+     style="fill:none;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 35.004082,21.643537 0.06531,10.144218 c 3.212544,1.029984 5.005244,3.076287 7.22721,6.160544"
+     id="path956" />
+  <path
+     id="path956-0"
+     d="M 29.15557,21.542552 29.09026,31.68677 c -3.36274,1.130115 -5.441474,3.316313 -7.466666,6.269387"
+     style="fill:none;stroke:#280000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <rect
+     style="fill:#ffffff;fill-rule:evenodd;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="rect1068"
+     width="4.1252704"
+     height="3.8789856"
+     x="10.528675"
+     y="24.322754"
+     ry="0.43099841" />
+  <rect
+     ry="0.43099841"
+     y="24.476677"
+     x="37.527649"
+     height="3.8789856"
+     width="4.1252704"
+     id="rect1068-5"
+     style="fill:#ffffff;fill-rule:evenodd;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     id="path1119-9"
+     d="M 30.840343,58.827548 V 5.0143181"
+     style="fill:none;stroke:#000000;stroke-width:6;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 30.840343,58.827548 V 5.0143181"
+     id="path1119-5-5" />
+  <path
+     style="fill:none;stroke:#000000;stroke-width:6;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 58.970335,58.78566 V 4.9724299"
+     id="path1119-9-3" />
+  <path
+     id="path1119-5-5-4"
+     d="M 58.970335,58.78566 V 4.9724299"
+     style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     style="fill:none;stroke:#000000;stroke-width:6;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 5.0138194,58.799875 V 4.9866457"
+     id="path1119-9-8" />
+  <path
+     id="path1119-5-5-9"
+     d="M 5.0138194,58.799875 V 4.9866457"
+     style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+</svg>

--- a/src/Gui/Icons/Std_ViewIvStereoInterleavedRows.svg
+++ b/src/Gui/Icons/Std_ViewIvStereoInterleavedRows.svg
@@ -1,0 +1,254 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   width="64px"
+   height="64px"
+   id="svg2980"
+   version="1.1">
+  <title
+     id="title1117">Std_ViewIvStereoInterleavedRows</title>
+  <defs
+     id="defs2982">
+    <linearGradient
+       id="linearGradient952">
+      <stop
+         style="stop-color:#204a87;stop-opacity:1"
+         offset="0"
+         id="stop948" />
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1"
+         offset="1"
+         id="stop950" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient944">
+      <stop
+         style="stop-color:#a40000;stop-opacity:1"
+         offset="0"
+         id="stop940" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1"
+         offset="1"
+         id="stop942" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1078">
+      <stop
+         id="stop1074"
+         offset="0"
+         style="stop-color:#2e3436;stop-opacity:1" />
+      <stop
+         id="stop1076"
+         offset="1"
+         style="stop-color:#babdb6;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3794">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3796" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3798" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3864">
+      <stop
+         id="stop3866"
+         offset="0"
+         style="stop-color:#71b2f8;stop-opacity:1;" />
+      <stop
+         id="stop3868"
+         offset="1"
+         style="stop-color:#002795;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(0,-4)"
+       xlink:href="#linearGradient3767"
+       id="linearGradient3773"
+       x1="22.116516"
+       y1="55.717518"
+       x2="17.328547"
+       y2="21.31134"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3767">
+      <stop
+         style="stop-color:#3465a4;stop-opacity:1"
+         offset="0"
+         id="stop3769" />
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1"
+         offset="1"
+         id="stop3771" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(0,-4)"
+       xlink:href="#linearGradient3777"
+       id="linearGradient3783"
+       x1="53.896763"
+       y1="51.179787"
+       x2="47.502235"
+       y2="21.83742"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3777">
+      <stop
+         style="stop-color:#204a87;stop-opacity:1"
+         offset="0"
+         id="stop3779" />
+      <stop
+         style="stop-color:#3465a4;stop-opacity:1"
+         offset="1"
+         id="stop3781" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient3794"
+       id="radialGradient3800"
+       cx="1"
+       cy="45"
+       fx="1"
+       fy="45"
+       r="41"
+       gradientTransform="matrix(0.93348213,-2.2905276e-8,0,0.28687573,0.06651751,32.090592)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="24"
+       x2="7"
+       y1="43"
+       x1="56"
+       id="linearGradient1080"
+       xlink:href="#linearGradient1078"
+       gradientTransform="translate(0,-4)" />
+    <linearGradient
+       xlink:href="#linearGradient944"
+       id="linearGradient946"
+       x1="24.323317"
+       y1="38.115891"
+       x2="9.806756"
+       y2="27.753984"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-4)" />
+    <linearGradient
+       xlink:href="#linearGradient952"
+       id="linearGradient954"
+       x1="51.042877"
+       y1="39.422012"
+       x2="35.269917"
+       y2="27.405685"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-4)" />
+  </defs>
+  <metadata
+     id="metadata2985">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[bitacovir]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:title>Std_ViewIvStereoInterleavedRows</dc:title>
+        <dc:date>2020/12/20</dc:date>
+        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier></dc:identifier>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title></dc:title>
+          </cc:Agent>
+        </dc:contributor>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     id="path1020"
+     d="M 3,16 H 61 V 46 H 42 C 35.259065,30.714814 27.983716,31.963913 22,46 H 3 Z"
+     style="fill:url(#linearGradient1080);fill-opacity:1;stroke:#555753;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     style="fill:url(#linearGradient946);fill-opacity:1;stroke:#280000;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none"
+     d="M 31.401313,21.859905 H 8.1273987 V 38.360987 H 23.397057 l 6.834934,-7.827763 z"
+     id="path921" />
+  <path
+     id="path921-8"
+     d="M 32.632737,21.859905 H 55.906651 V 38.360987 H 40.636993 l -6.834934,-6.652253 z"
+     style="fill:url(#linearGradient954);fill-opacity:1;stroke:#0b1521;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none" />
+  <path
+     style="fill:none;stroke:#babdb6;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 32.017025,33.189006 V 17.857777"
+     id="path919" />
+  <path
+     style="fill:none;stroke:#babdb6;stroke-width:1.808;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 5.051724,17.655172 H 59 V 44 L 43.235996,43.938429 C 36.666589,28.519738 26.039445,30.454028 20.661358,44.030786 L 5.051724,44 Z"
+     id="path1020-3" />
+  <path
+     style="fill:none;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 35.004082,21.643537 0.06531,10.144218 c 3.212544,1.029984 5.005244,3.076287 7.22721,6.160544"
+     id="path956" />
+  <path
+     id="path956-0"
+     d="M 29.15557,21.542552 29.09026,31.68677 c -3.36274,1.130115 -5.441474,3.316313 -7.466666,6.269387"
+     style="fill:none;stroke:#280000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <rect
+     style="fill:#ffffff;fill-rule:evenodd;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="rect1068"
+     width="4.1252704"
+     height="3.8789856"
+     x="10.528675"
+     y="24.322754"
+     ry="0.43099841" />
+  <rect
+     ry="0.43099841"
+     y="24.476677"
+     x="37.527649"
+     height="3.8789856"
+     width="4.1252704"
+     id="rect1068-5"
+     style="fill:#ffffff;fill-rule:evenodd;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     style="fill:none;stroke:#000000;stroke-width:6;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 5.0488386,6.1571202 H 58.862069"
+     id="path1119" />
+  <path
+     id="path1119-5"
+     d="m 5.048839,6.1571202 h 53.81323"
+     style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     id="path1119-9"
+     d="M 4.9804392,56.703342 H 58.793669"
+     style="fill:none;stroke:#000000;stroke-width:6;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 4.9804392,56.703342 H 58.793669"
+     id="path1119-5-5" />
+  <path
+     id="path1119-6"
+     d="M 5.0026606,30.400781 H 58.81589"
+     style="fill:none;stroke:#000000;stroke-width:6;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 5.002661,30.400781 H 58.81589"
+     id="path1119-5-1" />
+</svg>

--- a/src/Gui/Icons/Std_ViewIvStereoOff.svg
+++ b/src/Gui/Icons/Std_ViewIvStereoOff.svg
@@ -1,0 +1,218 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   width="64px"
+   height="64px"
+   id="svg2980"
+   version="1.1">
+  <title
+     id="title1117">Std_ViewIvStereoOff</title>
+  <defs
+     id="defs2982">
+    <linearGradient
+       id="linearGradient944">
+      <stop
+         style="stop-color:#a40000;stop-opacity:1"
+         offset="0"
+         id="stop940" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1"
+         offset="1"
+         id="stop942" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1078">
+      <stop
+         id="stop1074"
+         offset="0"
+         style="stop-color:#2e3436;stop-opacity:1" />
+      <stop
+         id="stop1076"
+         offset="1"
+         style="stop-color:#babdb6;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3794">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3796" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3798" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3864">
+      <stop
+         id="stop3866"
+         offset="0"
+         style="stop-color:#71b2f8;stop-opacity:1;" />
+      <stop
+         id="stop3868"
+         offset="1"
+         style="stop-color:#002795;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(0,-4)"
+       xlink:href="#linearGradient3767"
+       id="linearGradient3773"
+       x1="22.116516"
+       y1="55.717518"
+       x2="17.328547"
+       y2="21.31134"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3767">
+      <stop
+         style="stop-color:#3465a4;stop-opacity:1"
+         offset="0"
+         id="stop3769" />
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1"
+         offset="1"
+         id="stop3771" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(0,-4)"
+       xlink:href="#linearGradient3777"
+       id="linearGradient3783"
+       x1="53.896763"
+       y1="51.179787"
+       x2="47.502235"
+       y2="21.83742"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3777">
+      <stop
+         style="stop-color:#204a87;stop-opacity:1"
+         offset="0"
+         id="stop3779" />
+      <stop
+         style="stop-color:#3465a4;stop-opacity:1"
+         offset="1"
+         id="stop3781" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient3794"
+       id="radialGradient3800"
+       cx="1"
+       cy="45"
+       fx="1"
+       fy="45"
+       r="41"
+       gradientTransform="matrix(0.93348213,-2.2905276e-8,0,0.28687573,0.06651751,32.090592)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="24"
+       x2="7"
+       y1="43"
+       x1="56"
+       id="linearGradient1080"
+       xlink:href="#linearGradient1078"
+       gradientTransform="translate(0,-4)" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="17"
+       x2="15"
+       y1="47"
+       x1="29"
+       id="linearGradient3799"
+       xlink:href="#linearGradient944"
+       gradientTransform="translate(-6.0020978,-11.974588)" />
+  </defs>
+  <metadata
+     id="metadata2985">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[bitacovir]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:title>Std_ViewIvStereoOff</dc:title>
+        <dc:date>2020/12/20</dc:date>
+        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier></dc:identifier>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title></dc:title>
+          </cc:Agent>
+        </dc:contributor>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     id="path1020"
+     d="M 3,16 H 61 V 46 H 42 C 35.259065,30.714814 27.983716,31.963913 22,46 H 3 Z"
+     style="fill:url(#linearGradient1080);fill-opacity:1;stroke:#555753;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     style="fill:#2e3436;fill-opacity:1;stroke:#2e3436;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none"
+     d="M 31.401313,21.859905 H 8.1273987 V 38.360987 H 23.397057 l 6.834934,-7.827763 z"
+     id="path921" />
+  <path
+     id="path921-8"
+     d="M 32.632737,21.859905 H 55.906651 V 38.360987 H 40.636993 l -6.834934,-6.652253 z"
+     style="fill:#2e3436;fill-opacity:1;stroke:#2e3436;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none" />
+  <path
+     style="fill:none;stroke:#babdb6;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 32.017025,33.189006 V 17.857777"
+     id="path919" />
+  <path
+     style="fill:none;stroke:#babdb6;stroke-width:1.808;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 5.051724,17.655172 H 59 V 44 L 43.235996,43.938429 C 36.666589,28.519738 26.039445,30.454028 20.661358,44.030786 L 5.051724,44 Z"
+     id="path1020-3" />
+  <path
+     style="fill:none;stroke:#2e3436;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 35.004082,21.643537 0.06531,10.144218 c 3.212544,1.029984 5.005244,3.076287 7.22721,6.160544"
+     id="path956" />
+  <path
+     id="path956-0"
+     d="M 29.15557,21.542552 29.09026,31.68677 c -3.36274,1.130115 -5.441474,3.316313 -7.466666,6.269387"
+     style="fill:none;stroke:#2e3436;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <rect
+     style="fill:#ffffff;fill-rule:evenodd;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="rect1068"
+     width="4.1252704"
+     height="3.8789856"
+     x="10.528675"
+     y="24.322754"
+     ry="0.43099841" />
+  <rect
+     ry="0.43099841"
+     y="24.476677"
+     x="37.527649"
+     height="3.8789856"
+     width="4.1252704"
+     id="rect1068-5"
+     style="fill:#ffffff;fill-rule:evenodd;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     id="rect3761"
+     d="m 8.9979027,3.0254115 -6.0000001,6 10.0000004,10.0000005 -10.0000004,10 6.0000001,6 10.0000003,-10 10,10 6,-6 -10,-10 10,-10.0000005 -6,-6 -10,10.0000005 z"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3799);fill-opacity:1;fill-rule:evenodd;stroke:#280000;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+  <path
+     id="rect3761-3"
+     d="m 8.9979027,6.0254115 -3,3 10.0000003,10.0000005 -10.0000003,10 3,3 10.0000003,-10 10,10 3,-3 -10,-10 10,-10.0000005 -3,-3 -10,10.0000005 z"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#ef2929;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+</svg>

--- a/src/Gui/Icons/Std_ViewIvStereoQuadBuff.svg
+++ b/src/Gui/Icons/Std_ViewIvStereoQuadBuff.svg
@@ -1,0 +1,262 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   width="64px"
+   height="64px"
+   id="svg2980"
+   version="1.1">
+  <title
+     id="title1117">Std_ViewIvStereoQuadBuff</title>
+  <defs
+     id="defs2982">
+    <linearGradient
+       id="linearGradient952">
+      <stop
+         style="stop-color:#204a87;stop-opacity:1"
+         offset="0"
+         id="stop948" />
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1"
+         offset="1"
+         id="stop950" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient944">
+      <stop
+         style="stop-color:#a40000;stop-opacity:1"
+         offset="0"
+         id="stop940" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1"
+         offset="1"
+         id="stop942" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1078">
+      <stop
+         id="stop1074"
+         offset="0"
+         style="stop-color:#2e3436;stop-opacity:1" />
+      <stop
+         id="stop1076"
+         offset="1"
+         style="stop-color:#babdb6;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3794">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3796" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3798" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3864">
+      <stop
+         id="stop3866"
+         offset="0"
+         style="stop-color:#71b2f8;stop-opacity:1;" />
+      <stop
+         id="stop3868"
+         offset="1"
+         style="stop-color:#002795;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(0,-4)"
+       xlink:href="#linearGradient3767"
+       id="linearGradient3773"
+       x1="22.116516"
+       y1="55.717518"
+       x2="17.328547"
+       y2="21.31134"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3767">
+      <stop
+         style="stop-color:#3465a4;stop-opacity:1"
+         offset="0"
+         id="stop3769" />
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1"
+         offset="1"
+         id="stop3771" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(0,-4)"
+       xlink:href="#linearGradient3777"
+       id="linearGradient3783"
+       x1="53.896763"
+       y1="51.179787"
+       x2="47.502235"
+       y2="21.83742"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3777">
+      <stop
+         style="stop-color:#204a87;stop-opacity:1"
+         offset="0"
+         id="stop3779" />
+      <stop
+         style="stop-color:#3465a4;stop-opacity:1"
+         offset="1"
+         id="stop3781" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient3794"
+       id="radialGradient3800"
+       cx="1"
+       cy="45"
+       fx="1"
+       fy="45"
+       r="41"
+       gradientTransform="matrix(0.93348213,-2.2905276e-8,0,0.28687573,0.06651751,32.090592)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="24"
+       x2="7"
+       y1="43"
+       x1="56"
+       id="linearGradient1080"
+       xlink:href="#linearGradient1078"
+       gradientTransform="translate(0,4)" />
+    <linearGradient
+       xlink:href="#linearGradient944"
+       id="linearGradient946"
+       x1="24.323317"
+       y1="38.115891"
+       x2="9.806756"
+       y2="27.753984"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,4)" />
+    <linearGradient
+       xlink:href="#linearGradient952"
+       id="linearGradient954"
+       x1="51.042877"
+       y1="39.422012"
+       x2="35.269917"
+       y2="27.405685"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,4)" />
+  </defs>
+  <metadata
+     id="metadata2985">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[bitacovir]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:title>Std_ViewIvStereoQuadBuff</dc:title>
+        <dc:date>2020/12/20</dc:date>
+        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier></dc:identifier>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title></dc:title>
+          </cc:Agent>
+        </dc:contributor>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     id="path1024"
+     d="M 5,25 19,10 c 3,-3 6.886274,-0.7693802 6,4"
+     style="fill:none;stroke:#555753;stroke-width:6;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     style="fill:none;stroke:#555753;stroke-width:6;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 59,25 45,10 C 42,7 38.113726,9.2306198 39,14"
+     id="path1024-4" />
+  <path
+     id="path1020"
+     d="M 3,24 H 61 V 54 H 42 C 35.259065,38.714814 27.983716,39.963913 22,54 H 3 Z"
+     style="fill:url(#linearGradient1080);fill-opacity:1;stroke:#555753;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     style="fill:url(#linearGradient946);fill-opacity:1;stroke:#280000;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none"
+     d="M 31.401313,29.859905 H 8.1273987 V 46.360987 H 23.397057 l 6.834934,-7.827763 z"
+     id="path921" />
+  <path
+     style="fill:none;stroke:#babdb6;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 5,25 19,10 c 3,-3 6.886274,-0.7693802 6,4"
+     id="path1024-6" />
+  <path
+     id="path1024-6-3"
+     d="M 59,25 45,10 C 42,7 38.113726,9.2306198 39,14"
+     style="fill:none;stroke:#babdb6;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     style="fill:#babdb6"
+     d="M 18.656075,11.573258 6.095549,24.99578 l 7.6964,0.123143 z"
+     id="path897" />
+  <path
+     style="fill:none;stroke:#555753;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 19.504761,12.185034 15.15102,24.201361"
+     id="path899" />
+  <path
+     id="path897-0"
+     d="m 45.102561,11.388544 12.560526,13.422522 -7.6964,0.123143 z"
+     style="fill:#babdb6" />
+  <path
+     id="path899-2"
+     d="m 44.253875,12.00032 4.353741,12.016327"
+     style="fill:none;stroke:#555753;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     id="path921-8"
+     d="M 32.632737,29.859905 H 55.906651 V 46.360987 H 40.636993 l -6.834934,-6.652253 z"
+     style="fill:url(#linearGradient954);fill-opacity:1;stroke:#0b1521;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none" />
+  <path
+     style="fill:none;stroke:#babdb6;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 32.017025,41.189006 V 25.857777"
+     id="path919" />
+  <path
+     style="fill:none;stroke:#babdb6;stroke-width:1.808;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 5.051724,25.655172 H 59 V 52 L 43.235996,51.938429 C 36.666589,36.519738 26.039445,38.454028 20.661358,52.030786 L 5.051724,52 Z"
+     id="path1020-3" />
+  <path
+     style="fill:none;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 35.004082,29.643537 0.06531,10.144218 c 3.212544,1.029984 5.005244,3.076287 7.22721,6.160544"
+     id="path956" />
+  <path
+     id="path956-0"
+     d="M 29.15557,29.542552 29.09026,39.68677 c -3.36274,1.130115 -5.441474,3.316313 -7.466666,6.269387"
+     style="fill:none;stroke:#280000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <rect
+     style="fill:#ffffff;fill-rule:evenodd;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="rect1068"
+     width="4.1252704"
+     height="3.8789856"
+     x="10.528675"
+     y="32.322754"
+     ry="0.43099841" />
+  <rect
+     ry="0.43099841"
+     y="32.476677"
+     x="37.527649"
+     height="3.8789856"
+     width="4.1252704"
+     id="rect1068-5"
+     style="fill:#ffffff;fill-rule:evenodd;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+</svg>

--- a/src/Gui/Icons/Std_ViewIvStereoRedGreen.svg
+++ b/src/Gui/Icons/Std_ViewIvStereoRedGreen.svg
@@ -1,0 +1,230 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   width="64px"
+   height="64px"
+   id="svg2980"
+   version="1.1">
+  <title
+     id="title1117">Std_ViewIvStereoRedGreen</title>
+  <defs
+     id="defs2982">
+    <linearGradient
+       id="linearGradient952">
+      <stop
+         style="stop-color:#204a87;stop-opacity:1"
+         offset="0"
+         id="stop948" />
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1"
+         offset="1"
+         id="stop950" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient944">
+      <stop
+         style="stop-color:#a40000;stop-opacity:1"
+         offset="0"
+         id="stop940" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1"
+         offset="1"
+         id="stop942" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1078">
+      <stop
+         id="stop1074"
+         offset="0"
+         style="stop-color:#2e3436;stop-opacity:1" />
+      <stop
+         id="stop1076"
+         offset="1"
+         style="stop-color:#babdb6;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3794">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3796" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3798" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3864">
+      <stop
+         id="stop3866"
+         offset="0"
+         style="stop-color:#71b2f8;stop-opacity:1;" />
+      <stop
+         id="stop3868"
+         offset="1"
+         style="stop-color:#002795;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(0,-4)"
+       xlink:href="#linearGradient3767"
+       id="linearGradient3773"
+       x1="22.116516"
+       y1="55.717518"
+       x2="17.328547"
+       y2="21.31134"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3767">
+      <stop
+         style="stop-color:#3465a4;stop-opacity:1"
+         offset="0"
+         id="stop3769" />
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1"
+         offset="1"
+         id="stop3771" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(0,-4)"
+       xlink:href="#linearGradient3777"
+       id="linearGradient3783"
+       x1="53.896763"
+       y1="51.179787"
+       x2="47.502235"
+       y2="21.83742"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3777">
+      <stop
+         style="stop-color:#204a87;stop-opacity:1"
+         offset="0"
+         id="stop3779" />
+      <stop
+         style="stop-color:#3465a4;stop-opacity:1"
+         offset="1"
+         id="stop3781" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient3794"
+       id="radialGradient3800"
+       cx="1"
+       cy="45"
+       fx="1"
+       fy="45"
+       r="41"
+       gradientTransform="matrix(0.93348213,-2.2905276e-8,0,0.28687573,0.06651751,32.090592)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="24"
+       x2="7"
+       y1="43"
+       x1="56"
+       id="linearGradient1080"
+       xlink:href="#linearGradient1078"
+       gradientTransform="translate(0,-4)" />
+    <linearGradient
+       xlink:href="#linearGradient944"
+       id="linearGradient946"
+       x1="24.323317"
+       y1="38.115891"
+       x2="9.806756"
+       y2="27.753984"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-4)" />
+    <linearGradient
+       xlink:href="#linearGradient952"
+       id="linearGradient954"
+       x1="51.042877"
+       y1="39.422012"
+       x2="35.269917"
+       y2="27.405685"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-4)" />
+  </defs>
+  <metadata
+     id="metadata2985">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[bitacovir]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:title>Std_ViewIvStereoRedGreen</dc:title>
+        <dc:date>2020/12/20</dc:date>
+        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier></dc:identifier>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title></dc:title>
+          </cc:Agent>
+        </dc:contributor>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     id="path1020"
+     d="M 3,16 H 61 V 46 H 42 C 35.259065,30.714814 27.983716,31.963913 22,46 H 3 Z"
+     style="fill:url(#linearGradient1080);fill-opacity:1;stroke:#555753;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     style="fill:url(#linearGradient946);fill-opacity:1;stroke:#280000;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none"
+     d="M 31.401313,21.859905 H 8.1273987 V 38.360987 H 23.397057 l 6.834934,-7.827763 z"
+     id="path921" />
+  <path
+     id="path921-8"
+     d="M 32.632737,21.859905 H 55.906651 V 38.360987 H 40.636993 l -6.834934,-6.652253 z"
+     style="fill:url(#linearGradient954);fill-opacity:1;stroke:#0b1521;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none" />
+  <path
+     style="fill:none;stroke:#babdb6;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 32.017025,33.189006 V 17.857777"
+     id="path919" />
+  <path
+     style="fill:none;stroke:#babdb6;stroke-width:1.808;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 5.051724,17.655172 H 59 V 44 L 43.235996,43.938429 C 36.666589,28.519738 26.039445,30.454028 20.661358,44.030786 L 5.051724,44 Z"
+     id="path1020-3" />
+  <path
+     style="fill:none;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 35.004082,21.643537 0.06531,10.144218 c 3.212544,1.029984 5.005244,3.076287 7.22721,6.160544"
+     id="path956" />
+  <path
+     id="path956-0"
+     d="M 29.15557,21.542552 29.09026,31.68677 c -3.36274,1.130115 -5.441474,3.316313 -7.466666,6.269387"
+     style="fill:none;stroke:#280000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <rect
+     style="fill:#ffffff;fill-rule:evenodd;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="rect1068"
+     width="4.1252704"
+     height="3.8789856"
+     x="10.528675"
+     y="24.322754"
+     ry="0.43099841" />
+  <rect
+     ry="0.43099841"
+     y="24.476677"
+     x="37.527649"
+     height="3.8789856"
+     width="4.1252704"
+     id="rect1068-5"
+     style="fill:#ffffff;fill-rule:evenodd;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+</svg>

--- a/src/Gui/Icons/resource.qrc
+++ b/src/Gui/Icons/resource.qrc
@@ -162,6 +162,7 @@
         <file>Std_Revert.svg</file>
         <file>Std_SaveAll.svg</file>
         <file>Std_SaveCopy.svg</file>
+        <file>Std_SetAppearance.svg</file>
         <file>Std_Tool1.svg</file>
         <file>Std_Tool2.svg</file>
         <file>Std_Tool3.svg</file>
@@ -174,7 +175,12 @@
         <file>Std_Tool10.svg</file>
         <file>Std_Tool11.svg</file>
         <file>Std_Tool12.svg</file>
-        <file>Std_WindowCascade.svg</file>
+        <file>Std_ViewIvStereoInterleavedColumns.svg</file>
+        <file>Std_ViewIvStereoInterleavedRows.svg</file>
+        <file>Std_ViewIvStereoInterleavedRows.svg</file>
+        <file>Std_ViewIvStereoOff.svg</file>
+        <file>Std_ViewIvStereoQuadBuff.svg</file>
+        <file>Std_ViewIvStereoRedGreen.svg</file>
         <file>Std_WindowNext.svg</file>
         <file>Std_WindowPrev.svg</file>
         <file>Std_WindowTileVer.svg</file>


### PR DESCRIPTION
Six Std View Menu commands have similar ad not representative icons in the FreeCAD UI (Menu View - Stereo ): Std SetAppearance, and the five ViewIvStereo tools. Using similar icons is confuse. 

This commit replaces these SVG files with more representative icons for these commands. Also, it makes the necessary changes on CommandView.cpp and resource.qrc files.

The new SVG icons follow the FreeCAD Artwork Guidelines and were saved as Plain SVG format.

Forum Discussion: https://forum.freecadweb.org/viewtopic.php?f=34&t=53119&start=20#p460992 https://forum.freecadweb.org/viewtopic.php?f=34&t=53119&start=30#p461058 