### PR TITLE
[TD] DrawViewDimension Tolerances, print zero tolerances without plus…

### DIFF
--- a/src/Mod/TechDraw/App/DrawViewDimension.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDimension.cpp
@@ -779,8 +779,16 @@ std::pair<std::string, std::string> DrawViewDimension::getFormattedToleranceValu
         underTolerance = underFormatSpec;
         overTolerance = overFormatSpec;
     } else {
-        underTolerance = QString::fromUtf8(formatValue(UnderTolerance.getValue(), underFormatSpec, partial).c_str());
-        overTolerance = QString::fromUtf8(formatValue(OverTolerance.getValue(), overFormatSpec, partial).c_str());
+        if (DrawUtil::fpCompare(UnderTolerance.getValue(), 0.0)) {
+            underTolerance = QString::fromUtf8(formatValue(UnderTolerance.getValue(), QString::fromUtf8("%.0f"), partial).c_str());
+        } else {
+            underTolerance = QString::fromUtf8(formatValue(UnderTolerance.getValue(), underFormatSpec, partial).c_str());
+        }
+        if (DrawUtil::fpCompare(OverTolerance.getValue(), 0.0)) {
+            overTolerance = QString::fromUtf8(formatValue(OverTolerance.getValue(), QString::fromUtf8("%.0f"), partial).c_str());
+        } else {
+            overTolerance = QString::fromUtf8(formatValue(OverTolerance.getValue(), overFormatSpec, partial).c_str());
+        }
     }
 
     tolerances.first = underTolerance.toStdString();


### PR DESCRIPTION
… sign and decimals.  This was discussed in forums in [a thread](https://forum.freecadweb.org/viewtopic.php?f=35&t=53680) discussing norm-conforming tolerances.


Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
