### PR TITLE
[TD] cleanup preferences

### DIFF
--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawAdvanced.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawAdvanced.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>460</width>
-    <height>318</height>
+    <width>440</width>
+    <height>333</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -40,7 +40,95 @@
      <layout class="QVBoxLayout" name="verticalLayout">
       <item>
        <layout class="QGridLayout" name="gridLayout" columnstretch="1,0,1">
-        <item row="5" column="2">
+        <item row="3" column="0">
+         <widget class="Gui::PrefCheckBox" name="cbShowLoose">
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>20</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Include 2D Objects in projection</string>
+          </property>
+          <property name="text">
+           <string>Show Loose 2D Geom</string>
+          </property>
+          <property name="checked">
+           <bool>false</bool>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>ShowLoose2d</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/General</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="Gui::PrefCheckBox" name="cbCrazyEdges">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="toolTip">
+           <string>Include edges with unexpected geometry (zero length etc.) in results</string>
+          </property>
+          <property name="text">
+           <string>Allow Crazy Edges</string>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>allowCrazyEdge</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/debug</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="0">
+         <widget class="QLabel" name="label_5">
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="baseSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Edge Fuzz</string>
+          </property>
+         </widget>
+        </item>
+        <item row="6" column="2">
+         <widget class="Gui::PrefLineEdit" name="leFormatSpec">
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>20</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Override automatic dimension format</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>formatSpec</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>/Mod/TechDraw/Dimensions</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="7" column="2">
          <widget class="Gui::PrefComboBox" name="cbEndCap">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -86,7 +174,136 @@ Only change unless you know what you are doing!</string>
           </item>
          </widget>
         </item>
-        <item row="6" column="2">
+        <item row="2" column="2">
+         <widget class="Gui::PrefCheckBox" name="cbFuseBeforeSection">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>20</height>
+           </size>
+          </property>
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="toolTip">
+           <string>Perform a fuse operation on input shape(s) before Section view processing</string>
+          </property>
+          <property name="text">
+           <string>Fuse Before Section</string>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>SectionFuseFirst</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/General</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="6" column="0">
+         <widget class="QLabel" name="label_3">
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="text">
+           <string>Dimension Format</string>
+          </property>
+         </widget>
+        </item>
+        <item row="7" column="0">
+         <widget class="QLabel" name="label_7">
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="text">
+           <string>Line End Cap Shape</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item row="1" column="2">
+         <widget class="Gui::PrefCheckBox" name="cbDebugDetail">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>20</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Dump intermediate results during Detail view processing</string>
+          </property>
+          <property name="text">
+           <string>Debug Detail</string>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>debugDetail</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/debugDetail</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="2">
+         <widget class="Gui::PrefCheckBox" name="cbShowSectionEdges">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>20</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Highlights border of section cut in section views</string>
+          </property>
+          <property name="text">
+           <string>Show Section Edges</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>ShowSectionEdges</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>/Mod/TechDraw/General</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="8" column="2">
          <widget class="Gui::PrefSpinBox" name="sbMaxTiles">
           <property name="minimumSize">
            <size>
@@ -122,146 +339,21 @@ Then you need to increase the tile limit.</string>
           </property>
          </widget>
         </item>
-        <item row="1" column="2">
-         <widget class="Gui::PrefCheckBox" name="cbDebugDetail">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>20</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>Dump intermediate results during Detail view processing</string>
-          </property>
+        <item row="8" column="0">
+         <widget class="QLabel" name="label">
           <property name="text">
-           <string>Debug Detail</string>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>debugDetail</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/debugDetail</cstring>
+           <string>Max SVG Hatch Tiles</string>
           </property>
          </widget>
         </item>
-        <item row="3" column="0">
-         <widget class="Gui::PrefCheckBox" name="cbShowLoose">
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>20</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>Include 2D Objects in projection</string>
-          </property>
+        <item row="9" column="0">
+         <widget class="QLabel" name="label_2">
           <property name="text">
-           <string>Show Loose 2D Geom</string>
-          </property>
-          <property name="checked">
-           <bool>false</bool>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>ShowLoose2d</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/General</cstring>
+           <string>Max PAT Hatch Segments</string>
           </property>
          </widget>
         </item>
-        <item row="1" column="0">
-         <widget class="Gui::PrefCheckBox" name="cbDebugSection">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="toolTip">
-           <string>Dump intermediate results during Section view processing</string>
-          </property>
-          <property name="text">
-           <string>Debug Section</string>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>debugSection</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/debug</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="2">
-         <widget class="Gui::PrefCheckBox" name="cbFuseBeforeSection">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>20</height>
-           </size>
-          </property>
-          <property name="font">
-           <font>
-            <italic>true</italic>
-           </font>
-          </property>
-          <property name="toolTip">
-           <string>Perform a fuse operation on input shape(s) before Section view processing</string>
-          </property>
-          <property name="text">
-           <string>Fuse Before Section</string>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>SectionFuseFirst</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/General</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="2">
-         <widget class="Gui::PrefCheckBox" name="cbShowSectionEdges">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>20</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>Highlights border of section cut in section views</string>
-          </property>
-          <property name="text">
-           <string>Show Section Edges</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>ShowSectionEdges</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>/Mod/TechDraw/General</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="7" column="2">
+        <item row="9" column="2">
          <widget class="Gui::PrefSpinBox" name="sbMaxPat">
           <property name="minimumSize">
            <size>
@@ -296,15 +388,25 @@ when hatching a face with a PAT pattern</string>
           </property>
          </widget>
         </item>
-        <item row="5" column="0">
-         <widget class="QLabel" name="label_7">
-          <property name="font">
-           <font>
-            <italic>true</italic>
-           </font>
+        <item row="1" column="0">
+         <widget class="Gui::PrefCheckBox" name="cbDebugSection">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="toolTip">
+           <string>Dump intermediate results during Section view processing</string>
           </property>
           <property name="text">
-           <string>Line End Cap Shape</string>
+           <string>Debug Section</string>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>debugSection</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/debug</cstring>
           </property>
          </widget>
         </item>
@@ -336,86 +438,98 @@ can be a performance penalty in complex models.</string>
           </property>
          </widget>
         </item>
-        <item row="2" column="1">
-         <spacer name="horizontalSpacer">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
+        <item row="5" column="0">
+         <widget class="QLabel" name="label_4">
+          <property name="minimumSize">
            <size>
-            <width>40</width>
-            <height>20</height>
+            <width>0</width>
+            <height>0</height>
            </size>
           </property>
-         </spacer>
+          <property name="text">
+           <string>Mark Fuzz</string>
+          </property>
+         </widget>
         </item>
-        <item row="2" column="0">
-         <widget class="Gui::PrefCheckBox" name="cbCrazyEdges">
+        <item row="4" column="2">
+         <widget class="Gui::PrefDoubleSpinBox" name="pdsbEdgeFuzz">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
-          <property name="toolTip">
-           <string>Include edges with unexpected geometry (zero length etc.) in results</string>
-          </property>
-          <property name="text">
-           <string>Allow Crazy Edges</string>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>allowCrazyEdge</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/debug</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="0">
-         <widget class="QLabel" name="label">
-          <property name="text">
-           <string>Max SVG Hatch Tiles</string>
-          </property>
-         </widget>
-        </item>
-        <item row="7" column="0">
-         <widget class="QLabel" name="label_2">
-          <property name="text">
-           <string>Max PAT Hatch Segments</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="0">
-         <widget class="QLabel" name="label_3">
-          <property name="font">
-           <font>
-            <italic>true</italic>
-           </font>
-          </property>
-          <property name="text">
-           <string>Dimension Format</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="2">
-         <widget class="Gui::PrefLineEdit" name="leFormatSpec">
           <property name="minimumSize">
            <size>
+            <width>174</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="baseSize">
+           <size>
             <width>0</width>
-            <height>20</height>
+            <height>0</height>
            </size>
           </property>
           <property name="toolTip">
-           <string>Override automatic dimension format</string>
+           <string>Size of selection area around edges
+Each unit is approx. 0.1 mm wide</string>
+          </property>
+          <property name="statusTip">
+           <string/>
           </property>
           <property name="alignment">
            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
           </property>
+          <property name="value">
+           <double>10.000000000000000</double>
+          </property>
           <property name="prefEntry" stdset="0">
-           <cstring>formatSpec</cstring>
+           <cstring>EdgeFuzz</cstring>
           </property>
           <property name="prefPath" stdset="0">
-           <cstring>/Mod/TechDraw/Dimensions</cstring>
+           <cstring>Mod/TechDraw/General</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="2">
+         <widget class="Gui::PrefDoubleSpinBox" name="pdsbMarkFuzz">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>174</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="baseSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Selection area around center marks
+Each unit is approx. 0.1 mm wide</string>
+          </property>
+          <property name="statusTip">
+           <string/>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+          <property name="value">
+           <double>5.000000000000000</double>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>MarkFuzz</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/General</cstring>
           </property>
          </widget>
         </item>
@@ -450,8 +564,8 @@ can be a performance penalty in complex models.</string>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
-       <width>20</width>
-       <height>20</height>
+       <width>17</width>
+       <height>1</height>
       </size>
      </property>
     </spacer>
@@ -477,6 +591,11 @@ can be a performance penalty in complex models.</string>
   <customwidget>
    <class>Gui::PrefLineEdit</class>
    <extends>QLineEdit</extends>
+   <header>Gui/PrefWidgets.h</header>
+  </customwidget>
+  <customwidget>
+   <class>Gui::PrefDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
    <header>Gui/PrefWidgets.h</header>
   </customwidget>
  </customwidgets>

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawAdvancedImp.cpp
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawAdvancedImp.cpp
@@ -45,32 +45,36 @@ DlgPrefsTechDrawAdvancedImp::~DlgPrefsTechDrawAdvancedImp()
 
 void DlgPrefsTechDrawAdvancedImp::saveSettings()
 {
-    ui->cbEndCap->onSave();
-    ui->cbCrazyEdges->onSave();
-    ui->cbDebugSection->onSave();
-    ui->cbDetectFaces->onSave();
-    ui->cbDebugDetail->onSave();
+    ui->cbDetectFaces->onSave(); 
     ui->cbShowSectionEdges->onSave();
+    ui->cbDebugSection->onSave();
+    ui->cbDebugDetail->onSave();
+    ui->cbCrazyEdges->onSave();
     ui->cbFuseBeforeSection->onSave();
+    ui->cbShowLoose->onSave();
+    ui->pdsbEdgeFuzz->onSave();
+    ui->pdsbMarkFuzz->onSave();
+    ui->leFormatSpec->onSave();
+    ui->cbEndCap->onSave();
     ui->sbMaxTiles->onSave();
     ui->sbMaxPat->onSave();
-    ui->cbShowLoose->onSave();
-    ui->leFormatSpec->onSave();
 }
 
 void DlgPrefsTechDrawAdvancedImp::loadSettings()
 {
-    ui->cbEndCap->onRestore();
-    ui->cbCrazyEdges->onRestore();
-    ui->cbDebugSection->onRestore();
     ui->cbDetectFaces->onRestore();
-    ui->cbDebugDetail->onRestore();
     ui->cbShowSectionEdges->onRestore();
+    ui->cbDebugSection->onRestore();
+    ui->cbDebugDetail->onRestore();
+    ui->cbCrazyEdges->onRestore();
     ui->cbFuseBeforeSection->onRestore();
+    ui->cbShowLoose->onRestore();
+    ui->pdsbEdgeFuzz->onRestore();
+    ui->pdsbMarkFuzz->onRestore();
+    ui->leFormatSpec->onRestore();
+    ui->cbEndCap->onRestore();
     ui->sbMaxTiles->onRestore();
     ui->sbMaxPat->onRestore();
-    ui->cbShowLoose->onRestore();
-    ui->leFormatSpec->onRestore();
 }
 
 /**

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawAnnotation.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawAnnotation.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>415</width>
+    <width>440</width>
     <height>447</height>
    </rect>
   </property>

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawColors.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawColors.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>460</width>
-    <height>343</height>
+    <width>440</width>
+    <height>342</height>
    </rect>
   </property>
   <property name="sizePolicy">

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawDimensions.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawDimensions.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>460</width>
-    <height>403</height>
+    <width>440</width>
+    <height>336</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -46,19 +46,6 @@
      <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
        <layout class="QGridLayout" name="gridLayout">
-        <item row="0" column="0">
-         <widget class="QLabel" name="label_16">
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Standard and Style</string>
-          </property>
-         </widget>
-        </item>
         <item row="0" column="2">
          <widget class="Gui::PrefComboBox" name="pcbStandardAndStyle">
           <property name="sizePolicy">
@@ -104,30 +91,101 @@
           </item>
          </widget>
         </item>
-        <item row="1" column="0">
-         <widget class="Gui::PrefCheckBox" name="cbGlobalDecimals">
+        <item row="6" column="0">
+         <widget class="QLabel" name="label_9">
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="text">
+           <string>Arrow Style</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="0">
+         <widget class="QLabel" name="label_16">
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Standard and Style</string>
+          </property>
+         </widget>
+        </item>
+        <item row="6" column="2">
+         <widget class="Gui::PrefComboBox" name="pcbArrow">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>22</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Arrowhead style</string>
+          </property>
+          <property name="currentIndex">
+           <number>-1</number>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>ArrowStyle</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/Dimensions</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="7" column="0">
+         <widget class="QLabel" name="label_12">
           <property name="font">
            <font>
             <italic>true</italic>
            </font>
           </property>
+          <property name="text">
+           <string>Arrow Size</string>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="2">
+         <widget class="Gui::PrefLineEdit" name="leDiameter">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>22</height>
+           </size>
+          </property>
+          <property name="font">
+           <font>
+            <pointsize>12</pointsize>
+           </font>
+          </property>
           <property name="toolTip">
-           <string>Use system setting for number of decimals</string>
+           <string>Character used to indicate diameter dimensions</string>
           </property>
           <property name="text">
-           <string>Use Global Decimals</string>
+           <string>⌀</string>
           </property>
-          <property name="checked">
-           <bool>true</bool>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
           </property>
           <property name="prefEntry" stdset="0">
-           <cstring>UseGlobalDecimals</cstring>
+           <cstring>DiameterSymbol</cstring>
           </property>
           <property name="prefPath" stdset="0">
            <cstring>/Mod/TechDraw/Dimensions</cstring>
@@ -162,10 +220,40 @@
           </property>
          </widget>
         </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="label_11">
+        <item row="5" column="0">
+         <widget class="QLabel" name="label_8">
           <property name="text">
-           <string>Alternate Decimals</string>
+           <string>Diameter Symbol</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="Gui::PrefCheckBox" name="cbGlobalDecimals">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="toolTip">
+           <string>Use system setting for number of decimals</string>
+          </property>
+          <property name="text">
+           <string>Use Global Decimals</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>UseGlobalDecimals</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>/Mod/TechDraw/Dimensions</cstring>
           </property>
          </widget>
         </item>
@@ -200,18 +288,6 @@
           </property>
           <property name="prefPath" stdset="0">
            <cstring>/Mod/TechDraw/Dimensions</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="label_2">
-          <property name="font">
-           <font>
-            <italic>true</italic>
-           </font>
-          </property>
-          <property name="text">
-           <string>Font Size</string>
           </property>
          </widget>
         </item>
@@ -259,102 +335,7 @@
           </property>
          </widget>
         </item>
-        <item row="4" column="0">
-         <widget class="QLabel" name="label_8">
-          <property name="text">
-           <string>Diameter Symbol</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="2">
-         <widget class="Gui::PrefLineEdit" name="leDiameter">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>22</height>
-           </size>
-          </property>
-          <property name="font">
-           <font>
-            <pointsize>12</pointsize>
-           </font>
-          </property>
-          <property name="toolTip">
-           <string>Character used to indicate diameter dimensions</string>
-          </property>
-          <property name="text">
-           <string>⌀</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>DiameterSymbol</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>/Mod/TechDraw/Dimensions</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="0">
-         <widget class="QLabel" name="label_9">
-          <property name="font">
-           <font>
-            <italic>true</italic>
-           </font>
-          </property>
-          <property name="text">
-           <string>Arrow Style</string>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="2">
-         <widget class="Gui::PrefComboBox" name="pcbArrow">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>22</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>Arrowhead style</string>
-          </property>
-          <property name="currentIndex">
-           <number>-1</number>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>ArrowStyle</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/Dimensions</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="0">
-         <widget class="QLabel" name="label_12">
-          <property name="font">
-           <font>
-            <italic>true</italic>
-           </font>
-          </property>
-          <property name="text">
-           <string>Arrow Size</string>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="2">
+        <item row="7" column="2">
          <widget class="Gui::PrefUnitSpinBox" name="plsb_ArrowSize">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -385,151 +366,91 @@
           </property>
          </widget>
         </item>
-       </layout>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="groupBox_2">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>85</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
-       <height>500</height>
-      </size>
-     </property>
-     <property name="baseSize">
-      <size>
-       <width>0</width>
-       <height>500</height>
-      </size>
-     </property>
-     <property name="title">
-      <string>Conventions</string>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <item>
-       <layout class="QGridLayout" name="gridLayout_6" columnstretch="1,0,1">
-        <item row="0" column="1">
-         <spacer name="horizontalSpacer_3">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item row="0" column="0">
-         <widget class="QLabel" name="label_7">
+        <item row="2" column="0">
+         <widget class="QLabel" name="label_11">
           <property name="text">
-           <string>Projection Group Angle</string>
+           <string>Alternate Decimals</string>
           </property>
          </widget>
         </item>
-        <item row="0" column="2">
-         <widget class="Gui::PrefComboBox" name="cbProjAngle">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
+        <item row="3" column="0">
+         <widget class="QLabel" name="label_2">
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
           </property>
-          <property name="minimumSize">
-           <size>
-            <width>184</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>Use first- or third-angle multiview projection convention</string>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>ProjectionAngle</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/General</cstring>
-          </property>
-          <item>
-           <property name="text">
-            <string>First</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Third</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Page</string>
-           </property>
-          </item>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="label_14">
           <property name="text">
-           <string>Hidden Line Style</string>
+           <string>Font Size</string>
           </property>
          </widget>
         </item>
-        <item row="1" column="2">
-         <widget class="Gui::PrefComboBox" name="cbHiddenLineStyle">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
+        <item row="4" column="0">
+         <widget class="QLabel" name="lbl_LabelFont">
           <property name="minimumSize">
            <size>
             <width>0</width>
             <height>0</height>
            </size>
           </property>
+          <property name="baseSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="font">
+           <font>
+            <italic>false</italic>
+           </font>
+          </property>
+          <property name="text">
+           <string>Tolerance Text Scale</string>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="2">
+         <widget class="Gui::PrefDoubleSpinBox" name="pdsbToleranceScale">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>174</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="baseSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
           <property name="toolTip">
-           <string>Style for hidden lines</string>
+           <string>Tolerance text scale
+Multiplier of 'Font Size'</string>
+          </property>
+          <property name="accessibleName">
+           <string/>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+          <property name="singleStep">
+           <double>0.100000000000000</double>
+          </property>
+          <property name="value">
+           <double>0.800000000000000</double>
           </property>
           <property name="prefEntry" stdset="0">
-           <cstring>HiddenLine</cstring>
+           <cstring>TolSizeAdjust</cstring>
           </property>
           <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/General</cstring>
+           <cstring>Mod/TechDraw/Dimensions</cstring>
           </property>
-          <item>
-           <property name="text">
-            <string>Continuous</string>
-           </property>
-           <property name="icon">
-            <iconset resource="Resources/TechDraw.qrc">
-             <normaloff>:/icons/continuous-line.svg</normaloff>:/icons/continuous-line.svg</iconset>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Dashed</string>
-           </property>
-           <property name="icon">
-            <iconset resource="Resources/TechDraw.qrc">
-             <normaloff>:/icons/dash-line.svg</normaloff>:/icons/dash-line.svg</iconset>
-           </property>
-          </item>
          </widget>
         </item>
        </layout>
@@ -592,6 +513,11 @@
   <customwidget>
    <class>Gui::PrefLineEdit</class>
    <extends>QLineEdit</extends>
+   <header>Gui/PrefWidgets.h</header>
+  </customwidget>
+  <customwidget>
+   <class>Gui::PrefDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
    <header>Gui/PrefWidgets.h</header>
   </customwidget>
   <customwidget>

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawDimensionsImp.cpp
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawDimensionsImp.cpp
@@ -58,16 +58,15 @@ DlgPrefsTechDrawDimensionsImp::~DlgPrefsTechDrawDimensionsImp()
 
 void DlgPrefsTechDrawDimensionsImp::saveSettings()
 {
+    ui->pcbStandardAndStyle->onSave(); 
     ui->cbGlobalDecimals->onSave();
-    ui->cbHiddenLineStyle->onSave();
-    ui->cbProjAngle->onSave();
     ui->cbShowUnits->onSave();
+    ui->sbAltDecimals->onSave();
+    ui->plsb_FontSize->onSave();
+    ui->pdsbToleranceScale->onSave();
     ui->leDiameter->onSave();
     ui->pcbArrow->onSave();
-    ui->pcbStandardAndStyle->onSave();
     ui->plsb_ArrowSize->onSave();
-    ui->plsb_FontSize->onSave();
-    ui->sbAltDecimals->onSave();
 }
 
 void DlgPrefsTechDrawDimensionsImp::loadSettings()
@@ -81,16 +80,15 @@ void DlgPrefsTechDrawDimensionsImp::loadSettings()
 //    plsb_ArrowSize->setValue(arrowDefault);
     ui->plsb_ArrowSize->setValue(fontDefault);
 
+    ui->pcbStandardAndStyle->onRestore();
     ui->cbGlobalDecimals->onRestore();
-    ui->cbHiddenLineStyle->onRestore();
-    ui->cbProjAngle->onRestore();
     ui->cbShowUnits->onRestore();
+    ui->sbAltDecimals->onRestore();
+    ui->plsb_FontSize->onRestore();
+    ui->pdsbToleranceScale->onRestore();
     ui->leDiameter->onRestore();
     ui->pcbArrow->onRestore();
-    ui->pcbStandardAndStyle->onRestore();
     ui->plsb_ArrowSize->onRestore();
-    ui->plsb_FontSize->onRestore();
-    ui->sbAltDecimals->onRestore();
 
     DrawGuiUtil::loadArrowBox(ui->pcbArrow);
     ui->pcbArrow->setCurrentIndex(prefArrowStyle());

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawGeneral.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawGeneral.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>496</width>
-    <height>495</height>
+    <width>440</width>
+    <height>581</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -229,8 +229,12 @@ for ProjectionGroups</string>
             <height>0</height>
            </size>
           </property>
+          <property name="toolTip">
+           <string>* this font is also used for dimensions
+   Changes have no effect on existing dimensions.</string>
+          </property>
           <property name="text">
-           <string>Label Font</string>
+           <string>Label Font*</string>
           </property>
          </widget>
         </item>
@@ -319,6 +323,153 @@ for ProjectionGroups</string>
           <property name="prefPath" stdset="0">
            <cstring>/Mod/TechDraw/Labels</cstring>
           </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="groupBox_2">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>85</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>500</height>
+      </size>
+     </property>
+     <property name="baseSize">
+      <size>
+       <width>0</width>
+       <height>500</height>
+      </size>
+     </property>
+     <property name="title">
+      <string>Conventions</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <layout class="QGridLayout" name="gridLayout_6" columnstretch="1,0,1">
+        <item row="0" column="1">
+         <spacer name="horizontalSpacer_3">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item row="0" column="0">
+         <widget class="QLabel" name="label_7">
+          <property name="text">
+           <string>Projection Group Angle</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="2">
+         <widget class="Gui::PrefComboBox" name="cbProjAngle">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>184</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Use first- or third-angle multiview projection convention</string>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>ProjectionAngle</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/General</cstring>
+          </property>
+          <item>
+           <property name="text">
+            <string>First</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Third</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Page</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="label_14">
+          <property name="text">
+           <string>Hidden Line Style</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="2">
+         <widget class="Gui::PrefComboBox" name="cbHiddenLineStyle">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Style for hidden lines</string>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>HiddenLine</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/General</cstring>
+          </property>
+          <item>
+           <property name="text">
+            <string>Continuous</string>
+           </property>
+           <property name="icon">
+            <iconset resource="Resources/TechDraw.qrc">
+             <normaloff>:/icons/continuous-line.svg</normaloff>:/icons/continuous-line.svg</iconset>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Dashed</string>
+           </property>
+           <property name="icon">
+            <iconset resource="Resources/TechDraw.qrc">
+             <normaloff>:/icons/dash-line.svg</normaloff>:/icons/dash-line.svg</iconset>
+           </property>
+          </item>
          </widget>
         </item>
        </layout>
@@ -690,6 +841,11 @@ for ProjectionGroups</string>
    <header>Gui/PrefWidgets.h</header>
   </customwidget>
   <customwidget>
+   <class>Gui::PrefComboBox</class>
+   <extends>QComboBox</extends>
+   <header>Gui/PrefWidgets.h</header>
+  </customwidget>
+  <customwidget>
    <class>Gui::PrefLineEdit</class>
    <extends>QLineEdit</extends>
    <header>Gui/PrefWidgets.h</header>
@@ -705,6 +861,8 @@ for ProjectionGroups</string>
    <header>Gui/PrefWidgets.h</header>
   </customwidget>
  </customwidgets>
- <resources/>
+ <resources>
+  <include location="Resources/TechDraw.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawGeneralImp.cpp
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawGeneralImp.cpp
@@ -53,54 +53,59 @@ DlgPrefsTechDrawGeneralImp::~DlgPrefsTechDrawGeneralImp()
 
 void DlgPrefsTechDrawGeneralImp::saveSettings()
 {
-    ui->pfc_DefTemp->onSave();
-    ui->pfc_DefDir->onSave();
-    ui->pfc_HatchFile->onSave();
-    ui->pfc_FilePattern->onSave();
-    ui->pfc_LineGroup->onSave();
-    ui->pfc_Welding->onSave();
-    ui->le_NamePattern->onSave();
-
-    ui->pfb_LabelFont->onSave();
-    ui->plsb_LabelSize->onSave();
-
     ui->cb_Global->onSave();
     ui->cb_Override->onSave();
     ui->cb_PageUpdate->onSave();
     ui->cb_AutoDist->onSave();
+
+    ui->pfb_LabelFont->onSave();
+    ui->plsb_LabelSize->onSave();
+
+    ui->cbProjAngle->onSave();
+    ui->cbHiddenLineStyle->onSave();
+
+    ui->pfc_DefTemp->onSave();
+    ui->pfc_DefDir->onSave();
+    ui->pfc_HatchFile->onSave();
+    ui->pfc_LineGroup->onSave();
+    ui->pfc_Welding->onSave();
+    ui->pfc_FilePattern->onSave();
+    ui->le_NamePattern->onSave();
 }
 
 void DlgPrefsTechDrawGeneralImp::loadSettings()
 {
-//    double labelDefault = 8.0;
-    double labelDefault = Preferences::labelFontSizeMM();
-    ui->plsb_LabelSize->setValue(labelDefault);
-    QFont prefFont(Preferences::labelFontQString());
-    ui->pfb_LabelFont->setCurrentFont(prefFont);
-//    ui->pfb_LabelFont->setCurrentText(Preferences::labelFontQString());   //only works in Qt5
-
-    ui->pfc_DefTemp->setFileName(Preferences::defaultTemplate());
-    ui->pfc_DefDir->setFileName(Preferences::defaultTemplateDir());
-    ui->pfc_HatchFile->setFileName(QString::fromStdString(DrawHatch::prefSvgHatch()));
-    ui->pfc_FilePattern->setFileName(QString::fromStdString(DrawGeomHatch::prefGeomHatchFile()));
-    ui->pfc_Welding->setFileName(PreferencesGui::weldingDirectory());
-    ui->pfc_LineGroup->setFileName(QString::fromUtf8(Preferences::lineGroupFile().c_str()));
-
-    ui->pfc_DefTemp->onRestore();
-    ui->pfc_DefDir->onRestore();
-    ui->pfc_HatchFile->onRestore();
-    ui->pfc_FilePattern->onRestore();
-    ui->pfc_LineGroup->onRestore();
-    ui->pfc_Welding->onRestore();
-    ui->le_NamePattern->onRestore();
-
-    ui->pfb_LabelFont->onRestore();
-    ui->plsb_LabelSize->onRestore();
-
     ui->cb_Global->onRestore();
     ui->cb_Override->onRestore();
     ui->cb_PageUpdate->onRestore();
     ui->cb_AutoDist->onRestore();
+
+    double labelDefault = Preferences::labelFontSizeMM();
+    ui->plsb_LabelSize->setValue(labelDefault);
+    QFont prefFont(Preferences::labelFontQString());
+    ui->pfb_LabelFont->setCurrentFont(prefFont);
+    //    ui->pfb_LabelFont->setCurrentText(Preferences::labelFontQString());   //only works in Qt5
+
+    ui->pfb_LabelFont->onRestore();
+    ui->plsb_LabelSize->onRestore();
+
+    ui->cbProjAngle->onRestore();
+    ui->cbHiddenLineStyle->onRestore(); 
+    
+    ui->pfc_DefTemp->setFileName(Preferences::defaultTemplate());
+    ui->pfc_DefDir->setFileName(Preferences::defaultTemplateDir());
+    ui->pfc_HatchFile->setFileName(QString::fromStdString(DrawHatch::prefSvgHatch()));
+    ui->pfc_LineGroup->setFileName(QString::fromUtf8(Preferences::lineGroupFile().c_str()));
+    ui->pfc_Welding->setFileName(PreferencesGui::weldingDirectory());
+    ui->pfc_FilePattern->setFileName(QString::fromStdString(DrawGeomHatch::prefGeomHatchFile()));
+    
+    ui->pfc_DefTemp->onRestore();
+    ui->pfc_DefDir->onRestore();
+    ui->pfc_HatchFile->onRestore();
+    ui->pfc_LineGroup->onRestore();
+    ui->pfc_Welding->onRestore();
+    ui->pfc_FilePattern->onRestore();
+    ui->le_NamePattern->onRestore();
 }
 
 /**

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawHLR.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawHLR.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>441</width>
+    <width>440</width>
     <height>307</height>
    </rect>
   </property>
@@ -49,6 +49,41 @@
      <layout class="QVBoxLayout" name="verticalLayout">
       <item>
        <layout class="QGridLayout" name="gridLayout_6">
+        <item row="1" column="0">
+         <widget class="QLabel" name="label_17">
+          <property name="text">
+           <string>Visible</string>
+          </property>
+         </widget>
+        </item>
+        <item row="6" column="2">
+         <widget class="Gui::PrefSpinBox" name="psbIsoCount">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>140</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Number of ISO lines per face edge</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight</set>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>IsoCount</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/HLR</cstring>
+          </property>
+         </widget>
+        </item>
         <item row="4" column="0">
          <widget class="Gui::PrefCheckBox" name="pcbSeamViz">
           <property name="sizePolicy">
@@ -109,6 +144,88 @@
           </property>
          </widget>
         </item>
+        <item row="0" column="0">
+         <widget class="Gui::PrefCheckBox" name="pcbPolygon">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="toolTip">
+           <string>Use an approximation to find hidden lines.
+Fast, but result is a collection of short straight lines.</string>
+          </property>
+          <property name="text">
+           <string>Use Polygon Approximation</string>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>UsePolygon</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/HLR</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="2">
+         <widget class="Gui::PrefCheckBox" name="pcbSmoothHid">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="toolTip">
+           <string>Show hidden smooth edges</string>
+          </property>
+          <property name="text">
+           <string>Show Smooth Lines</string>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>SmoothHid</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/HLR</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="2">
+         <widget class="Gui::PrefCheckBox" name="pcbHardHid">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="toolTip">
+           <string>Show hidden hard and outline edges</string>
+          </property>
+          <property name="text">
+           <string>Show Hard Lines</string>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>HardHid</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/HLR</cstring>
+          </property>
+         </widget>
+        </item>
         <item row="2" column="0">
          <widget class="Gui::PrefCheckBox" name="pcbHardViz">
           <property name="enabled">
@@ -148,8 +265,8 @@
           </property>
          </widget>
         </item>
-        <item row="0" column="0">
-         <widget class="Gui::PrefCheckBox" name="pcbPolygon">
+        <item row="4" column="2">
+         <widget class="Gui::PrefCheckBox" name="pcbSeamHid">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
             <horstretch>0</horstretch>
@@ -162,17 +279,68 @@
            </font>
           </property>
           <property name="toolTip">
-           <string>Use an approximation to find hidden lines.
-Fast, but result is a collection of short straight lines.</string>
+           <string>Show hidden seam lines</string>
           </property>
           <property name="text">
-           <string>Use Polygon Approximation</string>
+           <string>Show Seam Lines</string>
           </property>
           <property name="prefEntry" stdset="0">
-           <cstring>UsePolygon</cstring>
+           <cstring>SeamHid</cstring>
           </property>
           <property name="prefPath" stdset="0">
            <cstring>Mod/TechDraw/HLR</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="2">
+         <widget class="Gui::PrefCheckBox" name="pcbIsoHid">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="toolTip">
+           <string>Show hidden equal parameterization lines</string>
+          </property>
+          <property name="text">
+           <string>Show UV ISO Lines</string>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>IsoHid</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/HLR</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="2">
+         <widget class="QLabel" name="label_18">
+          <property name="text">
+           <string>Hidden</string>
+          </property>
+         </widget>
+        </item>
+        <item row="6" column="0">
+         <widget class="QLabel" name="label_19">
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="text">
+           <string>ISO Count</string>
           </property>
          </widget>
         </item>
@@ -203,173 +371,31 @@ Fast, but result is a collection of short straight lines.</string>
           </property>
          </widget>
         </item>
-        <item row="3" column="1">
-         <widget class="Gui::PrefCheckBox" name="pcbSmoothHid">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
+        <item row="1" column="3">
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
           </property>
-          <property name="font">
-           <font>
-            <italic>true</italic>
-           </font>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
           </property>
-          <property name="toolTip">
-           <string>Show hidden smooth edges</string>
-          </property>
-          <property name="text">
-           <string>Show Smooth Lines</string>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>SmoothHid</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/HLR</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="1">
-         <widget class="Gui::PrefCheckBox" name="pcbSeamHid">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="font">
-           <font>
-            <italic>true</italic>
-           </font>
-          </property>
-          <property name="toolTip">
-           <string>Show hidden seam lines</string>
-          </property>
-          <property name="text">
-           <string>Show Seam Lines</string>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>SeamHid</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/HLR</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="1">
-         <widget class="Gui::PrefCheckBox" name="pcbIsoHid">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="font">
-           <font>
-            <italic>true</italic>
-           </font>
-          </property>
-          <property name="toolTip">
-           <string>Show hidden equal parameterization lines</string>
-          </property>
-          <property name="text">
-           <string>Show UV ISO Lines</string>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>IsoHid</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/HLR</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="label_17">
-          <property name="text">
-           <string>Visible</string>
-          </property>
-         </widget>
+         </spacer>
         </item>
         <item row="1" column="1">
-         <widget class="QLabel" name="label_18">
-          <property name="text">
-           <string>Hidden</string>
+         <spacer name="horizontalSpacer_2">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
           </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="Gui::PrefCheckBox" name="pcbHardHid">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="font">
-           <font>
-            <italic>true</italic>
-           </font>
-          </property>
-          <property name="toolTip">
-           <string>Show hidden hard and outline edges</string>
-          </property>
-          <property name="text">
-           <string>Show Hard Lines</string>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>HardHid</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/HLR</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="0">
-         <widget class="QLabel" name="label_19">
-          <property name="minimumSize">
+          <property name="sizeHint" stdset="0">
            <size>
-            <width>0</width>
-            <height>0</height>
+            <width>40</width>
+            <height>20</height>
            </size>
           </property>
-          <property name="font">
-           <font>
-            <italic>true</italic>
-           </font>
-          </property>
-          <property name="text">
-           <string>ISO Count</string>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="1">
-         <widget class="Gui::PrefSpinBox" name="psbIsoCount">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>140</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>Number of ISO lines per face edge</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight</set>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>IsoCount</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/HLR</cstring>
-          </property>
-         </widget>
+         </spacer>
         </item>
        </layout>
       </item>

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawScale.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawScale.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>440</width>
-    <height>447</height>
+    <height>342</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -221,164 +221,6 @@
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="gb_Selection">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>0</height>
-      </size>
-     </property>
-     <property name="baseSize">
-      <size>
-       <width>0</width>
-       <height>200</height>
-      </size>
-     </property>
-     <property name="title">
-      <string>Selection</string>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout_2">
-      <item>
-       <layout class="QGridLayout" name="gridLayout_2">
-        <item row="0" column="1">
-         <spacer name="horizontalSpacer_2">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item row="1" column="2">
-         <widget class="Gui::PrefDoubleSpinBox" name="pdsbMarkFuzz">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>174</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="baseSize">
-           <size>
-            <width>0</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>Selection area around center marks
-Each unit is approx. 0.1 mm wide</string>
-          </property>
-          <property name="statusTip">
-           <string/>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-          <property name="value">
-           <double>5.000000000000000</double>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>MarkFuzz</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/General</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="2">
-         <widget class="Gui::PrefDoubleSpinBox" name="pdsbEdgeFuzz">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>174</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="baseSize">
-           <size>
-            <width>0</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>Size of selection area around edges
-Each unit is approx. 0.1 mm wide</string>
-          </property>
-          <property name="statusTip">
-           <string/>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-          <property name="value">
-           <double>10.000000000000000</double>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>EdgeFuzz</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/General</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="label_4">
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Mark Fuzz</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="0">
-         <widget class="QLabel" name="label_3">
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="baseSize">
-           <size>
-            <width>0</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Edge Fuzz</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
     <widget class="QGroupBox" name="gb_SizeAdj">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -398,47 +240,14 @@ Each unit is approx. 0.1 mm wide</string>
      <layout class="QVBoxLayout" name="verticalLayout_3">
       <item>
        <layout class="QGridLayout" name="gridLayout_3">
-        <item row="2" column="2">
-         <widget class="Gui::PrefDoubleSpinBox" name="pdsbToleranceScale">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>174</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="baseSize">
-           <size>
-            <width>0</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>Tolerance font size adjustment. Multiplier of dimension font size.</string>
-          </property>
-          <property name="accessibleName">
-           <string/>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-          <property name="value">
-           <double>0.500000000000000</double>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>TolSizeAdjust</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/Dimensions</cstring>
+        <item row="0" column="0">
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>Vertex Scale</string>
           </property>
          </widget>
         </item>
-        <item row="3" column="2">
+        <item row="2" column="2">
          <widget class="Gui::PrefUnitSpinBox" name="pdsbTemplateMark">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -469,25 +278,17 @@ Each unit is approx. 0.1 mm wide</string>
           </property>
          </widget>
         </item>
-        <item row="0" column="0">
-         <widget class="QLabel" name="label">
+        <item row="1" column="0">
+         <widget class="QLabel" name="label_2">
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
+          </property>
           <property name="text">
-           <string>Vertex Scale</string>
+           <string>Center Mark Scale</string>
           </property>
          </widget>
-        </item>
-        <item row="1" column="1">
-         <spacer name="horizontalSpacer_3">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
         </item>
         <item row="1" column="2">
          <widget class="Gui::PrefDoubleSpinBox" name="pdsbCenterScale">
@@ -512,6 +313,9 @@ Each unit is approx. 0.1 mm wide</string>
           <property name="alignment">
            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
           </property>
+          <property name="singleStep">
+           <double>0.100000000000000</double>
+          </property>
           <property name="value">
            <double>0.500000000000000</double>
           </property>
@@ -520,6 +324,42 @@ Each unit is approx. 0.1 mm wide</string>
           </property>
           <property name="prefPath" stdset="0">
            <cstring>Mod/TechDraw/Decorations</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="label_7">
+          <property name="text">
+           <string>Template Edit Mark</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="2">
+         <widget class="Gui::PrefDoubleSpinBox" name="pdsbSymbolScale">
+          <property name="toolTip">
+           <string>Multiplier for size of welding symbols</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+          <property name="singleStep">
+           <double>0.100000000000000</double>
+          </property>
+          <property name="value">
+           <double>1.250000000000000</double>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>SymbolFactor</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/Decorations</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="0">
+         <widget class="QLabel" name="label_5">
+          <property name="text">
+           <string>Welding Symbol Scale</string>
           </property>
          </widget>
         </item>
@@ -557,74 +397,18 @@ Each unit is approx. 0.1 mm wide</string>
           </property>
          </widget>
         </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="label_2">
-          <property name="font">
-           <font>
-            <italic>true</italic>
-           </font>
+        <item row="1" column="1">
+         <spacer name="horizontalSpacer_3">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
           </property>
-          <property name="text">
-           <string>Center Mark Scale</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="lbl_LabelFont">
-          <property name="minimumSize">
+          <property name="sizeHint" stdset="0">
            <size>
-            <width>0</width>
-            <height>0</height>
+            <width>40</width>
+            <height>20</height>
            </size>
           </property>
-          <property name="baseSize">
-           <size>
-            <width>0</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="font">
-           <font>
-            <italic>true</italic>
-           </font>
-          </property>
-          <property name="text">
-           <string>Tolerance Text Scale</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="label_7">
-          <property name="text">
-           <string>Template Edit Mark</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="0">
-         <widget class="QLabel" name="label_5">
-          <property name="text">
-           <string>Welding Symbol Scale</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="2">
-         <widget class="Gui::PrefDoubleSpinBox" name="pdsbSymbolScale">
-          <property name="toolTip">
-           <string>Multiplier for size of welding symbols</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-          <property name="value">
-           <double>1.250000000000000</double>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>SymbolFactor</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/Decorations</cstring>
-          </property>
-         </widget>
+         </spacer>
         </item>
        </layout>
       </item>

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawScaleImp.cpp
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawScaleImp.cpp
@@ -61,32 +61,24 @@ void DlgPrefsTechDrawScaleImp::onScaleTypeChanged(int index)
 
 void DlgPrefsTechDrawScaleImp::saveSettings()
 {
-    ui->pdsbToleranceScale->onSave();
-    ui->pdsbTemplateMark->onSave();
-    ui->pdsbVertexScale->onSave();
-    ui->pdsbCenterScale->onSave();
     ui->pdsbPageScale->onSave();
     ui->cbViewScaleType->onSave();
     ui->pdsbViewScale->onSave();
-    ui->pdsbEdgeFuzz->onSave();
-    ui->pdsbMarkFuzz->onSave();
+    ui->pdsbVertexScale->onSave(); 
+    ui->pdsbCenterScale->onSave();
     ui->pdsbTemplateMark->onSave();
     ui->pdsbSymbolScale->onSave();
 }
 
 void DlgPrefsTechDrawScaleImp::loadSettings()
 {
-    double markDefault = 3.0;
-    ui->pdsbTemplateMark->setValue(markDefault);
-    ui->pdsbToleranceScale->onRestore();
-    ui->pdsbTemplateMark->onRestore();
-    ui->pdsbVertexScale->onRestore();
-    ui->pdsbCenterScale->onRestore();
     ui->pdsbPageScale->onRestore();
     ui->cbViewScaleType->onRestore();
     ui->pdsbViewScale->onRestore();
-    ui->pdsbEdgeFuzz->onRestore();
-    ui->pdsbMarkFuzz->onRestore();
+    ui->pdsbVertexScale->onRestore();
+    ui->pdsbCenterScale->onRestore();
+    double markDefault = 3.0;
+    ui->pdsbTemplateMark->setValue(markDefault);
     ui->pdsbTemplateMark->onRestore();
     ui->pdsbSymbolScale->onRestore();
 }


### PR DESCRIPTION
as discussed here: https://forum.freecadweb.org/viewtopic.php?f=35&t=53680&p=461356#p461349

* change default tolerance text scale to 0.8
* the tolerance scale is directly applied, thus it must have non-italic label
* move tolerance scale to "Dimensions" tab
* move Fuzz settings to "Advanced" tab
* add a note for the label font that this is also used for dimensions and that it there only has an effect for new ones
* use more useful step size of 0.1 for some scaling spinboxes
* sort UI fields in the C++ code to avoid doubled or missing entries (there were 2 doubled entries)