### PR TITLE
Fix typos [skip ci]

### DIFF
--- a/src/App/ApplicationPy.cpp
+++ b/src/App/ApplicationPy.cpp
@@ -104,7 +104,7 @@ PyMethodDef Application::Methods[] = {
      "loadFile(string=filename,[string=module]) -> None\n\n"
      "Loads an arbitrary file by delegating to the given Python module:\n"
      "* If no module is given it will be determined by the file extension.\n"
-     "* If more than one module can load a file the first one one will be taken.\n"
+     "* If more than one module can load a file the first one will be taken.\n"
      "* If no module exists to load the file an exception will be raised."},
     {"open",   reinterpret_cast<PyCFunction>(reinterpret_cast<void (*) (void)>( Application::sOpenDocument )), METH_VARARGS|METH_KEYWORDS,
      "See openDocument(string)"},

--- a/src/App/DocumentObject.h
+++ b/src/App/DocumentObject.h
@@ -407,7 +407,7 @@ public:
      *
      * @param newLabel: input as the new label, which can be modified by object itself
      *
-     * This function is is called before onBeforeChange()
+     * This function is called before onBeforeChange()
      */
     virtual void onBeforeChangeLabel(std::string &newLabel) {(void)newLabel;}
 

--- a/src/Gui/ApplicationPy.cpp
+++ b/src/Gui/ApplicationPy.cpp
@@ -214,7 +214,7 @@ PyMethodDef Application::Methods[] = {
    "loadFile(string=filename,[string=module]) -> None\n\n"
    "Loads an arbitrary file by delegating to the given Python module:\n"
    "* If no module is given it will be determined by the file extension.\n"
-   "* If more than one module can load a file the first one one will be taken.\n"
+   "* If more than one module can load a file the first one will be taken.\n"
    "* If no module exists to load the file an exception will be raised."},
 
   {"coinRemoveAllChildren",     (PyCFunction) Application::sCoinRemoveAllChildren, METH_VARARGS,

--- a/src/Mod/Assembly/App/Product.h
+++ b/src/Mod/Assembly/App/Product.h
@@ -44,7 +44,7 @@ public:
     App::PropertyLinkList   Items;
 
    /** @name base properties of all Assembly Items 
-     * This properties corospond mostly to the meta information
+     * This properties correspond mostly to the meta information
      * in the App::Document class
      */
     //@{

--- a/src/Mod/Assembly/Gui/ViewProviderProduct.cpp
+++ b/src/Mod/Assembly/Gui/ViewProviderProduct.cpp
@@ -130,7 +130,7 @@ void ViewProviderProduct::setupContextMenu(QMenu* menu, QObject* receiver, const
     //QAction* toggle = menu->addAction(QObject::tr("Rigid subassembly"), receiver, member);
     //toggle->setData(QVariant(1000)); // identifier
     //toggle->setCheckable(true);
-    //toggle->setToolTip(QObject::tr("Set if the subassembly shall be solved as on part (rigid) or if all parts of this assembly are solved for themselfe."));
+    //toggle->setToolTip(QObject::tr("Set if the subassembly shall be solved as on part (rigid) or if all parts of this assembly are solved for themself."));
     //toggle->setStatusTip(QObject::tr("Set if the subassembly shall be solved as on part (rigid) or if all parts of this assembly are solved for themself."));
     //bool prop = static_cast<Assembly::Product*>(getObject())->Rigid.getValue();
     //toggle->setChecked(prop);

--- a/src/Mod/Assembly/Gui/ViewProviderProductRef.cpp
+++ b/src/Mod/Assembly/Gui/ViewProviderProductRef.cpp
@@ -119,7 +119,7 @@ void ViewProviderProductRef::setupContextMenu(QMenu* menu, QObject* receiver, co
     //QAction* toggle = menu->addAction(QObject::tr("Rigid subassembly"), receiver, member);
     //toggle->setData(QVariant(1000)); // identifier
     //toggle->setCheckable(true);
-    //toggle->setToolTip(QObject::tr("Set if the subassembly shall be solved as on part (rigid) or if all parts of this assembly are solved for themselfe."));
+    //toggle->setToolTip(QObject::tr("Set if the subassembly shall be solved as on part (rigid) or if all parts of this assembly are solved for themself."));
     //toggle->setStatusTip(QObject::tr("Set if the subassembly shall be solved as on part (rigid) or if all parts of this assembly are solved for themself."));
     //bool prop = static_cast<Assembly::Product*>(getObject())->Rigid.getValue();
     //toggle->setChecked(prop);

--- a/src/Mod/Cam/App/ConvertDyna.cpp
+++ b/src/Mod/Cam/App/ConvertDyna.cpp
@@ -230,7 +230,7 @@ void ReadDyna::ReadConstraints(std::ifstream &inputfile)
 
         for (i = 0; i < 10; i++,j++)
             Info[j] = str[i];
-        First = atoi(Info);   //Constainted Point
+        First = atoi(Info);   //Constrained Point
 
         j = 0;
 
@@ -267,10 +267,10 @@ void ReadDyna::ReadConstraints(std::ifstream &inputfile)
 
 /*! \brief Triangulator
 
- This will triuangulate the squares, taking note of the constraining point that might come into play.
+ This will triangulate the squares, taking note of the constraining point that might come into play.
 
- To date, only three things are considered now:- No constrains in the edges, One Constrain in the edges, and Two
- Constrains next to each other (not opposite each other!) in the edges
+ To date, only three things are considered now: No constraints in the edges, One Constraint in the edges, and Two
+ Constraints next to each other (not opposite each other!) in the edges
 
  Sparing some commenting... I got lost inside of it too...
 */

--- a/src/Mod/Part/App/TopoShapeFacePy.xml
+++ b/src/Mod/Part/App/TopoShapeFacePy.xml
@@ -85,7 +85,7 @@ curveonSurface(Edge) -> None or tuple
 Returns the curve  associated to the  edge in  the
 parametric  space of  the  face.  Returns None if this
 curve  does not exist. If this curve exists then a tuple
-of curve and and parameter range is returned.
+of curve and parameter range is returned.
 				</UserDocu>
 			</Documentation>
 		</Methode>

--- a/src/Mod/PartDesign/App/json.hpp
+++ b/src/Mod/PartDesign/App/json.hpp
@@ -19870,7 +19870,7 @@ class basic_json
 
     @throw type_error.304 if the JSON value is not an object; in this case,
     calling `at` with a key makes no sense. See example below.
-    @throw out_of_range.403 if the key @a key is is not stored in the object;
+    @throw out_of_range.403 if the key @a key is not stored in the object;
     that is, `find(key) == end()`. See example below.
 
     @exceptionsafety Strong guarantee: if an exception is thrown, there are no
@@ -19921,7 +19921,7 @@ class basic_json
 
     @throw type_error.304 if the JSON value is not an object; in this case,
     calling `at` with a key makes no sense. See example below.
-    @throw out_of_range.403 if the key @a key is is not stored in the object;
+    @throw out_of_range.403 if the key @a key is not stored in the object;
     that is, `find(key) == end()`. See example below.
 
     @exceptionsafety Strong guarantee: if an exception is thrown, there are no

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -3412,7 +3412,7 @@ int SketchObject::addSymmetric(const std::vector<int> &geoIdList, int refGeoId, 
     std::map<int, bool> isStartEndInverted;
 
     // Find out if reference is aligned with V or H axis,
-    // if so we can keep Vertical and Horizontal constrants in the mirrored geometry.
+    // if so we can keep Vertical and Horizontal constraints in the mirrored geometry.
     bool refIsAxisAligned = false;
     if (refGeoId == Sketcher::GeoEnum::VAxis || refGeoId == Sketcher::GeoEnum::HAxis) {
         refIsAxisAligned = true;

--- a/src/XDGData/org.freecadweb.FreeCAD.appdata.xml.in
+++ b/src/XDGData/org.freecadweb.FreeCAD.appdata.xml.in
@@ -12,7 +12,7 @@
       primarily to design real-life objects of any size. 
       Parametric modeling allows you to easily modify your 
       design by going back into your model history and 
-      changing its parameters. It is is designed to fit a 
+      changing its parameters. It is designed to fit a 
       wide range of uses including product design, mechanical 
       engineering, architecture and 3D printing.
     </p>


### PR DESCRIPTION
Typos ffound via `codespell v2.1.dev0`  
Also includes fixes in deprecated code of `src/Mod/Assembly`