### PR TITLE
PartDesign: New features AdditiveHelix and SubtractiveHelix

### DIFF
--- a/src/Mod/Part/App/TopoShape.cpp
+++ b/src/Mod/Part/App/TopoShape.cpp
@@ -2431,7 +2431,7 @@ TopoDS_Shape TopoShape::makeLongHelix(Standard_Real pitch, Standard_Real height,
     Handle(Geom_Surface) surf;
     Standard_Boolean isCylinder;
 
-    if (angle < Precision::Confusion()) {                                      // Cylindrical helix
+    if (std::fabs(angle) < Precision::Confusion()) {                           // Cylindrical helix
         if (radius < Precision::Confusion())
             Standard_Failure::Raise("Radius of helix too small");
         surf= new Geom_CylindricalSurface(cylAx2, radius);
@@ -2439,8 +2439,6 @@ TopoDS_Shape TopoShape::makeLongHelix(Standard_Real pitch, Standard_Real height,
     }
     else {                                                                     // Conical helix
         angle = Base::toRadians(angle);
-        if (angle < Precision::Confusion())
-            Standard_Failure::Raise("Angle of helix too small");
         surf = new Geom_ConicalSurface(gp_Ax3(cylAx2), angle, radius);
         isCylinder = false;
     }

--- a/src/Mod/PartDesign/App/AppPartDesign.cpp
+++ b/src/Mod/PartDesign/App/AppPartDesign.cpp
@@ -59,6 +59,7 @@
 #include "FeatureLoft.h"
 #include "ShapeBinder.h"
 #include "FeatureBase.h"
+#include "FeatureHelix.h"
 
 namespace PartDesign {
 extern PyObject* initModule();
@@ -116,6 +117,9 @@ PyMOD_INIT_FUNC(_PartDesign)
     PartDesign::Loft                        ::init();
     PartDesign::AdditiveLoft                ::init();
     PartDesign::SubtractiveLoft             ::init();
+    PartDesign::Helix                       ::init();
+    PartDesign::AdditiveHelix               ::init();
+    PartDesign::SubtractiveHelix            ::init();
     PartDesign::ShapeBinder                 ::init();
     PartDesign::SubShapeBinder              ::init();
     PartDesign::Plane                       ::init();

--- a/src/Mod/PartDesign/App/Body.cpp
+++ b/src/Mod/PartDesign/App/Body.cpp
@@ -140,7 +140,7 @@ App::DocumentObject* Body::getPrevSolidFeature(App::DocumentObject *start)
     if (rvIt != features.rend()) { // the solid found in model list
         return *rvIt;
     }
-    
+
     return nullptr;
 }
 
@@ -197,7 +197,7 @@ bool Body::isMemberOfMultiTransform(const App::DocumentObject* f)
     // This can be recognized because the Originals property is empty (it is contained
     // in the MultiTransform instead)
     // COMMENT ON THE COMMENT:
-    // This is wrong because at the creation (addObject) and before assigning the originals, that 
+    // This is wrong because at the creation (addObject) and before assigning the originals, that
     // is when this code is executed, the originals property is indeed empty.
     //
     // However, for the purpose of setting the base feature, the transform feature has been modified
@@ -244,7 +244,7 @@ Body* Body::findBodyOf(const App::DocumentObject* feature)
 {
     if(!feature)
         return nullptr;
-    
+
     return static_cast<Body*>(BodyBase::findBodyOf(feature));
 }
 
@@ -253,15 +253,15 @@ std::vector<App::DocumentObject*> Body::addObject(App::DocumentObject *feature)
 {
     if(!isAllowed(feature))
         throw Base::ValueError("Body: object is not allowed");
-    
+
     //TODO: features should not add all links
-    
+
     //only one group per object. If it is in a body the single feature will be removed
     auto *group = App::GroupExtension::getGroupOfObject(feature);
     if(group && group != getExtendedObject())
         group->getExtensionByType<GroupExtension>()->removeObject(feature);
-      
-    
+
+
     insertObject (feature, getNextSolidFeature (), /*after = */ false);
     // Move the Tip if we added a solid
     if (isSolidFeature(feature)) {
@@ -272,22 +272,22 @@ std::vector<App::DocumentObject*> Body::addObject(App::DocumentObject *feature)
         && feature->isDerivedFrom(PartDesign::Feature::getClassTypeId()))
     {
         for(auto obj : Group.getValues()) {
-            if(obj->Visibility.getValue() 
-                    && obj!=feature 
+            if(obj->Visibility.getValue()
+                    && obj!=feature
                     && obj->isDerivedFrom(PartDesign::Feature::getClassTypeId()))
                 obj->Visibility.setValue(false);
         }
     }
-    
+
     std::vector<App::DocumentObject*> result = {feature};
     return result;
 }
 
 std::vector< App::DocumentObject* > Body::addObjects(std::vector< App::DocumentObject* > objs) {
-    
+
     for(auto obj : objs)
         addObject(obj);
-    
+
     return objs;
 }
 
@@ -298,7 +298,7 @@ void Body::insertObject(App::DocumentObject* feature, App::DocumentObject* targe
     if (target && !hasObject (target)) {
         throw Base::ValueError("Body: the feature we should insert relative to is not part of that body");
     }
-    
+
     //ensure that all origin links are ok
     relinkToOrigin(feature);
 
@@ -445,7 +445,7 @@ void Body::onSettingDocument() {
 
 void Body::onChanged (const App::Property* prop) {
     // we neither load a project nor perform undo/redo
-    if (!this->isRestoring() 
+    if (!this->isRestoring()
             && this->getDocument()
             && !this->getDocument()->isPerformingTransaction()) {
         if (prop == &BaseFeature) {
@@ -506,7 +506,7 @@ std::vector<std::string> Body::getSubObjects(int reason) const {
     return {};
 }
 
-App::DocumentObject *Body::getSubObject(const char *subname, 
+App::DocumentObject *Body::getSubObject(const char *subname,
         PyObject **pyObj, Base::Matrix4D *pmat, bool transform, int depth) const
 {
 #if 1
@@ -525,8 +525,8 @@ App::DocumentObject *Body::getSubObject(const char *subname,
 
     // We return the shape only if there are feature visible inside
     for(auto obj : Group.getValues()) {
-        if(obj->Visibility.getValue() && 
-           obj->isDerivedFrom(PartDesign::Feature::getClassTypeId())) 
+        if(obj->Visibility.getValue() &&
+           obj->isDerivedFrom(PartDesign::Feature::getClassTypeId()))
         {
             return Part::BodyBase::getSubObject(subname,pyObj,pmat,transform,depth);
         }
@@ -545,4 +545,15 @@ void Body::onDocumentRestored()
     }
     _GroupTouched.setStatus(App::Property::Output,true);
     DocumentObject::onDocumentRestored();
+}
+
+// a body is solid if it has features that are solid
+bool Body::isSolid()
+{
+    std::vector<App::DocumentObject *> features = getFullModel();
+    for (auto it = features.begin(); it!=features.end(); ++it){
+        if (isSolidFeature((*it)))
+            return true;
+    }
+    return false;
 }

--- a/src/Mod/PartDesign/App/Body.h
+++ b/src/Mod/PartDesign/App/Body.h
@@ -118,7 +118,7 @@ public:
     PyObject *getPyObject(void) override;
 
     virtual std::vector<std::string> getSubObjects(int reason=0) const override;
-    virtual App::DocumentObject *getSubObject(const char *subname, 
+    virtual App::DocumentObject *getSubObject(const char *subname,
         PyObject **pyObj, Base::Matrix4D *pmat, bool transform, int depth) const override;
 
     void setShowTip(bool enable) {
@@ -136,6 +136,9 @@ public:
       * That is, sketches and datum features are skipped
       */
     App::DocumentObject *getNextSolidFeature(App::DocumentObject* start = NULL);
+
+    // a body is solid if it has features that are solid according to member isSolidFeature.
+    bool isSolid(void);
 
 protected:
     virtual void onSettingDocument() override;

--- a/src/Mod/PartDesign/App/CMakeLists.txt
+++ b/src/Mod/PartDesign/App/CMakeLists.txt
@@ -109,6 +109,8 @@ SET(FeaturesSketchBased_SRCS
     FeaturePipe.cpp
     FeatureLoft.h
     FeatureLoft.cpp
+    FeatureHelix.h
+    FeatureHelix.cpp
 )
 
 SOURCE_GROUP("SketchBasedFeatures" FILES ${FeaturesSketchBased_SRCS})

--- a/src/Mod/PartDesign/App/FeatureHelix.cpp
+++ b/src/Mod/PartDesign/App/FeatureHelix.cpp
@@ -1,0 +1,553 @@
+/***************************************************************************
+ *   Copyright (c) 2010 Juergen Riegel <FreeCAD@juergen-riegel.net>        *
+ *                 2020 David Österberg                                    *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#include "PreCompiled.h"
+#ifndef _PreComp_
+# include <BRep_Builder.hxx>
+# include <BRepBndLib.hxx>
+# include <BRepPrimAPI_MakeRevol.hxx>
+# include <BRepBuilderAPI_MakeFace.hxx>
+# include <BRepExtrema_DistShapeShape.hxx>
+# include <BRepBuilderAPI_MakeEdge.hxx>
+# include <BRepExtrema_DistShapeShape.hxx>
+# include <BRepAlgoAPI_Cut.hxx>
+# include <TopoDS.hxx>
+# include <TopoDS_Face.hxx>
+# include <TopoDS_Wire.hxx>
+# include <TopExp_Explorer.hxx>
+# include <BRepAlgoAPI_Fuse.hxx>
+# include <BRepAlgoAPI_Common.hxx>
+# include <Precision.hxx>
+# include <gp_Lin.hxx>
+# include <BRepBuilderAPI_MakeWire.hxx>
+# include <BRepAdaptor_Surface.hxx>
+# include <Law_Function.hxx>
+# include <BRepOffsetAPI_MakePipeShell.hxx>
+# include <BRepBuilderAPI_MakeSolid.hxx>
+# include <BRepBuilderAPI_Sewing.hxx>
+# include <BRepClass3d_SolidClassifier.hxx>
+# include <ShapeAnalysis.hxx>
+# include <gp_Ax1.hxx>
+# include <gp_Ax3.hxx>
+#endif
+
+# include <Standard_Version.hxx>
+# include <Base/Axis.h>
+# include <Base/Console.h>
+# include <Base/Exception.h>
+# include <Base/Placement.h>
+# include <Base/Tools.h>
+
+# include <Mod/Part/App/TopoShape.h>
+# include <Mod/Part/App/FaceMakerCheese.h>
+
+# include "FeatureHelix.h"
+
+const double PI = 3.14159265359;
+
+using namespace PartDesign;
+
+const char* Helix::ModeEnums[] = {"pitch-height", "pitch-turns", "height-turns", NULL};
+
+PROPERTY_SOURCE(PartDesign::Helix, PartDesign::ProfileBased)
+
+Helix::Helix()
+{
+    addSubType = FeatureAddSub::Additive;
+
+    ADD_PROPERTY_TYPE(Base,(Base::Vector3d(0.0,0.0,0.0)),"Helix", App::Prop_ReadOnly, "Base");
+    ADD_PROPERTY_TYPE(Axis,(Base::Vector3d(0.0,1.0,0.0)),"Helix", App::Prop_ReadOnly, "Axis");
+    ADD_PROPERTY_TYPE(Pitch,(10.),"Helix", App::Prop_None, "Pitch");
+    ADD_PROPERTY_TYPE(Height,(30.0),"Helix", App::Prop_None, "Height");
+    ADD_PROPERTY_TYPE(Turns,(3.0),"Helix", App::Prop_None, "Turns");
+    ADD_PROPERTY_TYPE(LeftHanded,(long(0)),"Helix", App::Prop_None, "LeftHanded");
+    ADD_PROPERTY_TYPE(Reversed,(long(0)),"Helix", App::Prop_None, "Reversed");
+    ADD_PROPERTY_TYPE(Angle,(0.0),"Helix", App::Prop_None, "Angle");
+    ADD_PROPERTY_TYPE(ReferenceAxis,(0),"Helix", App::Prop_None, "Reference axis of revolution");
+    ADD_PROPERTY_TYPE(Mode, (long(0)), "Helix", App::Prop_None, "Helix input mode");
+    ADD_PROPERTY_TYPE(Outside,(long(0)),"Helix", App::Prop_None, "Outside");
+    ADD_PROPERTY_TYPE(HasBeenEdited,(long(0)),"Helix", App::Prop_None, "HasBeenEdited");
+    Mode.setEnums(ModeEnums);
+
+}
+
+short Helix::mustExecute() const
+{
+    if (Placement.isTouched() ||
+        ReferenceAxis.isTouched() ||
+        Axis.isTouched() ||
+        Base.isTouched() ||
+        Angle.isTouched())
+        return 1;
+    return ProfileBased::mustExecute();
+}
+
+App::DocumentObjectExecReturn *Helix::execute(void)
+{
+     // Validate and normalize parameters
+    switch (Mode.getValue()) {
+        case 0:  // pitch - height
+            if (Pitch.getValue() < Precision::Confusion())
+                return new App::DocumentObjectExecReturn("Error: Pitch too small");
+            if (Height.getValue() < Precision::Confusion())
+                return new App::DocumentObjectExecReturn("Error: height too small!");
+            break;
+        case 1: // pitch - turns
+            if (Pitch.getValue() < Precision::Confusion())
+                return new App::DocumentObjectExecReturn("Error: pitch too small!");
+            if (Turns.getValue() < Precision::Confusion())
+                return new App::DocumentObjectExecReturn("Error: turns too small!");
+            Height.setValue(Turns.getValue()*Pitch.getValue());
+            break;
+        case 2: // height - turns
+            if (Height.getValue() < Precision::Confusion())
+                return new App::DocumentObjectExecReturn("Error: height too small!");
+            if (Turns.getValue() < Precision::Confusion())
+                return new App::DocumentObjectExecReturn("Error turns too small!");
+            Pitch.setValue(Height.getValue()/Turns.getValue());
+            break;
+        default:
+            return new App::DocumentObjectExecReturn("Error: unsupported mode");
+    }
+
+    TopoDS_Shape sketchshape;
+    try {
+        sketchshape = getVerifiedFace();
+    } catch (const Base::Exception& e) {
+        return new App::DocumentObjectExecReturn(e.what());
+    }
+
+    if (sketchshape.IsNull())
+        return new App::DocumentObjectExecReturn("Error: No valid sketch or face");
+    else {
+        //TODO: currently we only allow planar faces. the reason for this is that with other faces in front, we could
+        //not use the current simulate approach and build the start and end face from the wires. As the shell
+        //begins always at the spine and not the profile, the sketchshape cannot be used directly as front face.
+        //We would need a method to translate the front shape to match the shell starting position somehow...
+        TopoDS_Face face = TopoDS::Face(sketchshape);
+        BRepAdaptor_Surface adapt(face);
+        if(adapt.GetType() != GeomAbs_Plane)
+            return new App::DocumentObjectExecReturn("Error: Face must be planar");
+    }
+
+    // if the Base property has a valid shape, fuse the AddShape into it
+    TopoDS_Shape base;
+    try {
+        base = getBaseShape();
+    } catch (const Base::Exception&) {
+        // fall back to support (for legacy features)
+        base = TopoDS_Shape();
+    }
+
+
+    // update Axis from ReferenceAxis
+    try {
+        updateAxis();
+    } catch (const Base::Exception& e) {
+        return new App::DocumentObjectExecReturn(e.what());
+    }
+
+    // get revolve axis
+    Base::Vector3d b = Base.getValue();
+    gp_Pnt pnt(b.x,b.y,b.z);
+    Base::Vector3d v = Axis.getValue();
+    gp_Dir dir(v.x,v.y,v.z);
+
+    try {
+        this->positionByPrevious();
+        TopLoc_Location invObjLoc = this->getLocation().Inverted();
+
+        base.Move(invObjLoc);
+
+        // generate the helix path
+        TopoDS_Shape path = generateHelixPath();
+
+        // Below is basically a copy paste (with some simplification) from  FeaturePipe.cpp Pipe::execute
+        // TODO: find a way to reduce code repetition. E.g can I rip out this functionality of Pipe:execute to a static helper
+        // function and call from here?
+
+        std::vector<TopoDS_Wire> wires;
+        try {
+            wires = getProfileWires();
+        } catch (const Base::Exception& e) {
+            return new App::DocumentObjectExecReturn(e.what());
+        }
+
+        std::vector<std::vector<TopoDS_Wire>> wiresections;
+        for(TopoDS_Wire& wire : wires)
+            wiresections.emplace_back(1, wire);
+
+        //maybe we need a scaling law
+        Handle(Law_Function) scalinglaw;
+
+        //build all shells
+        std::vector<TopoDS_Shape> shells;
+        std::vector<TopoDS_Wire> frontwires, backwires;
+        for(std::vector<TopoDS_Wire>& wires : wiresections) {
+
+            BRepOffsetAPI_MakePipeShell mkPS(TopoDS::Wire(path));
+
+            mkPS.SetTolerance(Precision::Confusion());
+            mkPS.SetTransitionMode(BRepBuilderAPI_Transformed);
+
+            mkPS.SetMode(true);  //This is for frenet
+            //mkPipeShell.SetMode(TopoDS::Wire(auxpath), true);  // this is for two rails
+
+
+            if(!scalinglaw) {
+                for(TopoDS_Wire& wire : wires) {
+                    wire.Move(invObjLoc);
+                    mkPS.Add(wire);
+                }
+            }
+            else {
+                for(TopoDS_Wire& wire : wires)  {
+                    wire.Move(invObjLoc);
+                    mkPS.SetLaw(wire, scalinglaw);
+                }
+            }
+
+            if (!mkPS.IsReady())
+                return new App::DocumentObjectExecReturn("Error: Could not build");
+
+            shells.push_back(mkPS.Shape());
+
+
+            if (!mkPS.Shape().Closed()) {
+                // shell is not closed - use simulate to get the end wires
+                TopTools_ListOfShape sim;
+                mkPS.Simulate(2, sim);
+
+                frontwires.push_back(TopoDS::Wire(sim.First()));
+                backwires.push_back(TopoDS::Wire(sim.Last()));
+            }
+        }
+
+        BRepBuilderAPI_MakeSolid mkSolid;
+
+        if (!frontwires.empty()) {
+            // build the end faces, sew the shell and build the final solid
+            TopoDS_Shape front = Part::FaceMakerCheese::makeFace(frontwires);
+            TopoDS_Shape back  = Part::FaceMakerCheese::makeFace(backwires);
+
+            BRepBuilderAPI_Sewing sewer;
+            sewer.SetTolerance(Precision::Confusion());
+            sewer.Add(front);
+            sewer.Add(back);
+
+            for(TopoDS_Shape& s : shells)
+                sewer.Add(s);
+
+            sewer.Perform();
+            mkSolid.Add(TopoDS::Shell(sewer.SewedShape()));
+        } else {
+            // shells are already closed - add them directly
+            for (TopoDS_Shape& s : shells) {
+                mkSolid.Add(TopoDS::Shell(s));
+            }
+        }
+
+        if(!mkSolid.IsDone())
+            return new App::DocumentObjectExecReturn("Error: Result is not a solid");
+
+        TopoDS_Shape result = mkSolid.Shape();
+        BRepClass3d_SolidClassifier SC(result);
+        SC.PerformInfinitePoint(Precision::Confusion());
+        if (SC.State() == TopAbs_IN)
+            result.Reverse();
+
+        AddSubShape.setValue(result);
+
+
+        if(base.IsNull()) {
+
+            if (getAddSubType() == FeatureAddSub::Subtractive)
+                return new App::DocumentObjectExecReturn("Error: There is nothing to subtract\n");
+
+            int solidCount = countSolids(result);
+            if (solidCount > 1) {
+                return new App::DocumentObjectExecReturn("Error: Result has multiple solids");
+            }
+            Shape.setValue(getSolid(result));
+            return App::DocumentObject::StdReturn;
+        }
+
+        if(getAddSubType() == FeatureAddSub::Additive) {
+
+            BRepAlgoAPI_Fuse mkFuse(base, result);
+            if (!mkFuse.IsDone())
+                return new App::DocumentObjectExecReturn("Error: Adding the helix failed");
+            // we have to get the solids (fuse sometimes creates compounds)
+            TopoDS_Shape boolOp = this->getSolid(mkFuse.Shape());
+            // lets check if the result is a solid
+            if (boolOp.IsNull())
+                return new App::DocumentObjectExecReturn("Error: Result is not a solid");
+
+            int solidCount = countSolids(boolOp);
+            if (solidCount > 1) {
+                return new App::DocumentObjectExecReturn("Error: Result has multiple solids");
+            }
+
+            boolOp = refineShapeIfActive(boolOp);
+            Shape.setValue(getSolid(boolOp));
+        }
+        else if(getAddSubType() == FeatureAddSub::Subtractive) {
+
+            TopoDS_Shape boolOp;
+
+            if (Outside.getValue()) {  // are we subtracting the inside or the outside of the profile.
+                BRepAlgoAPI_Common mkCom(result, base);
+                if (!mkCom.IsDone())
+                    return new App::DocumentObjectExecReturn("Error: Intersecting the helix failed");
+                boolOp = this->getSolid(mkCom.Shape());
+
+            } else {
+                BRepAlgoAPI_Cut mkCut(base, result);
+                if (!mkCut.IsDone())
+                    return new App::DocumentObjectExecReturn("Error: Subtracting the helix failed");
+                boolOp = this->getSolid(mkCut.Shape());
+            }
+
+            // lets check if the result is a solid
+            if (boolOp.IsNull())
+                return new App::DocumentObjectExecReturn("Error: Result is not a solid");
+
+            int solidCount = countSolids(boolOp);
+            if (solidCount > 1) {
+                return new App::DocumentObjectExecReturn("Error: Result has multiple solids");
+            }
+
+            boolOp = refineShapeIfActive(boolOp);
+            Shape.setValue(getSolid(boolOp));
+        }
+
+        return App::DocumentObject::StdReturn;
+    }
+    catch (Standard_Failure& e) {
+
+        if (std::string(e.GetMessageString()) == "TopoDS::Face")
+            return new App::DocumentObjectExecReturn("Error: Could not create face from sketch");
+        else
+            return new App::DocumentObjectExecReturn(e.GetMessageString());
+    }
+    catch (Base::Exception& e) {
+        return new App::DocumentObjectExecReturn(e.what());
+    }
+}
+
+
+
+void Helix::updateAxis(void)
+{
+    App::DocumentObject *pcReferenceAxis = ReferenceAxis.getValue();
+    const std::vector<std::string> &subReferenceAxis = ReferenceAxis.getSubValues();
+    Base::Vector3d base;
+    Base::Vector3d dir;
+    getAxis(pcReferenceAxis, subReferenceAxis, base, dir, false);
+
+    Base.setValue(base.x,base.y,base.z);
+    Axis.setValue(dir.x,dir.y,dir.z);
+}
+
+
+TopoDS_Shape Helix::generateHelixPath(void)
+{
+    double pitch = Pitch.getValue();
+    double height = Height.getValue();
+    bool leftHanded = LeftHanded.getValue();
+    bool reversed = Reversed.getValue();
+    double angle = Angle.getValue();
+    if (angle < Precision::Confusion() && angle > -Precision::Confusion())
+        angle = 0.0;
+
+    // get revolve axis
+    Base::Vector3d b = Base.getValue();
+    gp_Pnt pnt(b.x,b.y,b.z);
+    Base::Vector3d v = Axis.getValue();
+    gp_Dir dir(v.x,v.y,v.z);
+
+    Base::Vector3d normal = getProfileNormal();
+    Base::Vector3d start = v.Cross(normal);  // pointing towards the desired helix start point.
+    gp_Dir dir_start(start.x, start.y, start.z);
+
+    // Determine radius as the minimum distance between sketchshape and axis.
+    // also find out in what quadrant relative to the axis the profile is located.
+    double radius = 1e99;
+    bool turned = false;
+    double startOffset = 1e99;
+    TopoDS_Shape sketchshape = getVerifiedFace();
+    BRepBuilderAPI_MakeEdge axisEdge(gp_Lin(pnt, dir));
+    BRepBuilderAPI_MakeEdge startEdge(gp_Lin(pnt, dir_start));
+    for (TopExp_Explorer xp(sketchshape, TopAbs_FACE); xp.More(); xp.Next()) {
+        const TopoDS_Face face =  TopoDS::Face(xp.Current());
+        TopoDS_Wire wire = ShapeAnalysis::OuterWire(face);
+        BRepExtrema_DistShapeShape distR(wire, axisEdge.Shape(), Precision::Confusion());
+        if (distR.IsDone()) {
+            if (distR.Value() < radius) {
+                radius = distR.Value();
+                const gp_Pnt p1 = distR.PointOnShape1(1);
+                const gp_Pnt p2 = distR.PointOnShape2(1);
+                double offsetProfile = p1.X()*dir_start.X() + p1.Y()*dir_start.Y() + p1.Z()*dir_start.Z();
+                double offsetAxis = p2.X()*dir_start.X() + p2.Y()*dir_start.Y() + p2.Z()*dir_start.Z();
+                turned = (offsetProfile < offsetAxis);
+            }
+        }
+        BRepExtrema_DistShapeShape distStart(wire, startEdge.Shape(), Precision::Confusion());
+        if (distStart.IsDone()) {
+            if (distStart.Value() < abs(startOffset)) {
+                const gp_Pnt p1 = distStart.PointOnShape1(1);
+                const gp_Pnt p2 = distStart.PointOnShape2(1);
+                double offsetProfile = p1.X()*dir.X() + p1.Y()*dir.Y() + p1.Z()*dir.Z();
+                double offsetAxis = p2.X()*dir.X() + p2.Y()*dir.Y() + p2.Z()*dir.Z();
+                startOffset = offsetProfile - offsetAxis;
+            }
+        }
+
+    }
+
+    if (radius <  Precision::Confusion()) {
+        // in this case ensure that axis is not in the sketch plane
+        if (v*normal < Precision::Confusion())
+            throw Base::ValueError("Error: Result is self intersecting");
+        radius = 1.0; //fallback to radius 1
+        startOffset = 0.0;
+    }
+
+    //build the helix path
+    TopoShape helix = TopoShape().makeLongHelix(pitch, height, radius, angle, leftHanded);
+    TopoDS_Shape path = helix.getShape();
+
+
+    /*
+     * The helix wire is created with the axis coinciding with z-axis and the start point at (radius, 0, 0)
+     * We want to move it so that the axis becomes aligned with "dir" and "pnt", we also want (radius,0,0) to
+     * map to the sketch plane.
+     */
+
+
+    gp_Pnt origo(0.0, 0.0, 0.0);
+    gp_Dir dir_axis1(0.0, 0.0, 1.0);  // pointing along the helix axis, as created.
+    gp_Dir dir_axis2(1.0, 0.0, 0.0);  // pointing towards the helix start point, as created.
+
+    gp_Trsf mov;
+
+
+    if (reversed) {
+        mov.SetRotation(gp_Ax1(origo, dir_axis2), PI);
+        TopLoc_Location loc(mov);
+        path.Move(loc);
+    }
+
+    if (abs(startOffset) > 0) {  // translate the helix so that the starting point aligns with the profile
+        mov.SetTranslation(startOffset*gp_Vec(dir_axis1));
+        TopLoc_Location loc(mov);
+        path.Move(loc);
+    }
+
+    if (turned) {  // turn the helix so that the starting point aligns with the profile
+        mov.SetRotation(gp_Ax1(origo, dir_axis1), PI);
+        TopLoc_Location loc(mov);
+        path.Move(loc);
+    }
+
+    gp_Ax3 sourceCS(origo, dir_axis1, dir_axis2);
+    gp_Ax3 targetCS(pnt, dir, dir_start);
+
+    mov.SetTransformation(sourceCS, targetCS);
+    TopLoc_Location loc(mov);
+    path.Move(loc.Inverted());
+
+
+# if OCC_VERSION_HEX < 0x70500
+    /* I initially tried using path.Move(invObjLoc) like usual. But it does not give the right result
+     * The starting point of the helix is not correct and I don't know why! With below hack it works.
+     */
+    Base::Vector3d placeAxis;
+    double placeAngle;
+    this->Placement.getValue().getRotation().getValue(placeAxis, placeAngle);
+    gp_Dir placeDir(placeAxis.x, placeAxis.y, placeAxis.z);
+    mov.SetRotation(gp_Ax1(origo, placeDir), placeAngle);
+    TopLoc_Location loc2(mov);
+    path.Move(loc2.Inverted());
+# else
+    TopLoc_Location invObjLoc = this->getLocation().Inverted();
+    path.Move(invObjLoc);
+# endif
+
+    return path;
+}
+
+// this function calculates self intersection safe pitch based on the profile bounding box.
+double Helix::safePitch()
+{
+    // Below is an approximation. It is possible to do the general way by solving for the pitch
+    // where the helix is self intersecting.
+
+    double angle = Angle.getValue()/180.0*PI;
+
+    TopoDS_Shape sketchshape = getVerifiedFace();
+    Bnd_Box bb;
+    BRepBndLib::Add(sketchshape, bb);
+
+    double Xmin, Ymin, Zmin, Xmax, Ymax, Zmax;
+    bb.Get(Xmin, Ymin, Zmin, Xmax, Ymax, Zmax);
+
+    double X = Xmax - Xmin, Y = Ymax - Ymin, Z = Zmax - Zmin;
+
+    Base::Vector3d v = Axis.getValue();
+    gp_Dir dir(v.x,v.y,v.z);
+    gp_Vec bbvec(X, Y, Z);
+
+    double p0 = bbvec*dir; // safe pitch if angle=0
+
+    Base::Vector3d n = getProfileNormal();
+    Base::Vector3d s = v.Cross(n);  // pointing towards the desired helix start point.
+    gp_Dir dir_s(s.x, s.y, s.z);
+
+    if (tan(abs(angle))*p0 > abs(bbvec*dir_s))
+        return abs(bbvec*dir_s)/tan(abs(angle));
+    else
+        return p0;
+}
+
+// this function proposes pitch and height
+void Helix::proposeParameters(bool force)
+{
+    if (force || !HasBeenEdited.getValue()) {
+        double pitch = 1.1*safePitch();
+        Pitch.setValue(pitch);
+        Height.setValue(pitch*3.0);
+        HasBeenEdited.setValue(1);
+    }
+}
+
+
+PROPERTY_SOURCE(PartDesign::AdditiveHelix, PartDesign::Helix)
+AdditiveHelix::AdditiveHelix() {
+    addSubType = Additive;
+}
+
+PROPERTY_SOURCE(PartDesign::SubtractiveHelix, PartDesign::Helix)
+SubtractiveHelix::SubtractiveHelix() {
+    addSubType = Subtractive;
+}

--- a/src/Mod/PartDesign/App/FeatureHelix.h
+++ b/src/Mod/PartDesign/App/FeatureHelix.h
@@ -1,0 +1,103 @@
+/***************************************************************************
+ *   Copyright (c) 2010 Juergen Riegel <FreeCAD@juergen-riegel.net>        *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#ifndef PARTDESIGN_Helix_H
+#define PARTDESIGN_Helix_H
+
+#include <App/PropertyUnits.h>
+#include "FeatureSketchBased.h"
+#include <TopoDS_Shape.hxx>
+
+namespace PartDesign
+{
+
+class PartDesignExport Helix : public ProfileBased
+{
+    PROPERTY_HEADER(PartDesign::Helix);
+
+public:
+    Helix();
+
+    App::PropertyVector      Base;
+    App::PropertyVector      Axis;
+    App::PropertyLength      Pitch;
+    App::PropertyLength      Height;
+    App::PropertyFloat       Turns;
+    App::PropertyBool        LeftHanded;
+    App::PropertyAngle       Angle;
+    App::PropertyEnumeration Mode;
+    App::PropertyBool        Outside;
+    App::PropertyBool        HasBeenEdited;
+
+    /** if this property is set to a valid link, both Axis and Base properties
+     *  are calculated according to the linked line
+    */
+    App::PropertyLinkSub ReferenceAxis;
+
+    /** @name methods override feature */
+    //@{
+    App::DocumentObjectExecReturn *execute(void);
+    short mustExecute() const;
+    /// returns the type name of the view provider
+    const char* getViewProviderName(void) const {
+        return "PartDesignGui::ViewProviderHelix";
+    }
+    //@}
+
+    void proposeParameters(bool force = false);
+    double safePitch(void);
+
+protected:
+    /// updates Axis from ReferenceAxis
+    void updateAxis(void);
+
+    /// generate helix and move it to the right location.
+    TopoDS_Shape generateHelixPath(void);
+
+    // project shape on plane. Used for detecting self intersection.
+    TopoDS_Shape projectShape(const TopoDS_Shape& input, const gp_Ax2& plane);
+
+private:
+    static const char* ModeEnums[];
+};
+
+
+class PartDesignExport AdditiveHelix : public Helix {
+
+    PROPERTY_HEADER(PartDesign::AdditiveHelix);
+public:
+    AdditiveHelix();
+};
+
+
+class PartDesignExport SubtractiveHelix : public Helix {
+
+    PROPERTY_HEADER(PartDesign::SubtractiveHelix);
+public:
+    SubtractiveHelix();
+};
+
+} //namespace PartDesign
+
+
+#endif // PART_Helix_H

--- a/src/Mod/PartDesign/App/FeatureSketchBased.cpp
+++ b/src/Mod/PartDesign/App/FeatureSketchBased.cpp
@@ -208,7 +208,7 @@ TopoDS_Shape ProfileBased::getVerifiedFace(bool silent) const {
                 if(faces.empty()) {
                     if(!shape.hasSubShape(TopAbs_WIRE))
                         shape = shape.makEWires();
-                    if(shape.hasSubShape(TopAbs_WIRE)) 
+                    if(shape.hasSubShape(TopAbs_WIRE))
                         shape = shape.makEFace(0,"Part::FaceMakerCheese");
                     else
                         err = "Cannot make face from profile";
@@ -1012,7 +1012,7 @@ double ProfileBased::getReversedAngle(const Base::Vector3d &b, const Base::Vecto
 }
 
 void ProfileBased::getAxis(const App::DocumentObject *pcReferenceAxis, const std::vector<std::string> &subReferenceAxis,
-                          Base::Vector3d& base, Base::Vector3d& dir)
+                          Base::Vector3d& base, Base::Vector3d& dir, bool checkPerpendicular)
 {
     dir = Base::Vector3d(0,0,0); // If unchanged signals that no valid axis was found
     if (pcReferenceAxis == NULL)
@@ -1071,7 +1071,7 @@ void ProfileBased::getAxis(const App::DocumentObject *pcReferenceAxis, const std
         dir = line->getDirection();
 
         // Check that axis is perpendicular with sketch plane!
-        if (sketchplane.Axis().Direction().IsParallel(gp_Dir(dir.x, dir.y, dir.z), Precision::Angular()))
+        if (checkPerpendicular && sketchplane.Axis().Direction().IsParallel(gp_Dir(dir.x, dir.y, dir.z), Precision::Angular()))
             throw Base::ValueError("Rotation axis must not be perpendicular with the sketch plane");
         return;
     }
@@ -1082,7 +1082,7 @@ void ProfileBased::getAxis(const App::DocumentObject *pcReferenceAxis, const std
         line->Placement.getValue().multVec(Base::Vector3d (1,0,0), dir);
 
         // Check that axis is perpendicular with sketch plane!
-        if (sketchplane.Axis().Direction().IsParallel(gp_Dir(dir.x, dir.y, dir.z), Precision::Angular()))
+        if (checkPerpendicular && sketchplane.Axis().Direction().IsParallel(gp_Dir(dir.x, dir.y, dir.z), Precision::Angular()))
             throw Base::ValueError("Rotation axis must not be perpendicular with the sketch plane");
         return;
     }

--- a/src/Mod/PartDesign/App/FeatureSketchBased.h
+++ b/src/Mod/PartDesign/App/FeatureSketchBased.h
@@ -78,7 +78,7 @@ public:
      *               Default is false.
      */
     Part::Part2DObject* getVerifiedSketch(bool silent=false) const;
-    
+
     /**
      * Verifies the linked Profile and returns it if it is a valid object
      * @param silent if profile property is malformed and the parameter is true
@@ -86,7 +86,7 @@ public:
      *               Default is false.
      */
     Part::Feature* getVerifiedObject(bool silent=false) const;
-    
+
     /**
      * Verifies the linked Object and returns the shape used as profile
      * @param silent if profirle property is malformed and the parameter is true
@@ -94,25 +94,25 @@ public:
      *               Default is false.
      */
     TopoDS_Shape getVerifiedFace(bool silent = false) const;
-    
+
     /// Returns the wires the sketch is composed of
     std::vector<TopoDS_Wire> getProfileWires() const;
-    
+
     /// Returns the face of the sketch support (if any)
     const TopoDS_Face getSupportFace() const;
-    
+
     Base::Vector3d getProfileNormal() const;
 
     Part::TopoShape getProfileShape() const;
 
     /// retrieves the number of axes in the linked sketch (defined as construction lines)
-    int getSketchAxisCount(void) const;    
+    int getSketchAxisCount(void) const;
 
     virtual Part::Feature* getBaseObject(bool silent=false) const;
-    
+
     //backwards compatibility: profile property was renamed and has different type now
     virtual void Restore(Base::XMLReader& reader);
-    
+
 protected:
     void remapSupportShape(const TopoDS_Shape&);
 
@@ -167,8 +167,8 @@ protected:
     double getReversedAngle(const Base::Vector3d& b, const Base::Vector3d& v);
     /// get Axis from ReferenceAxis
     void getAxis(const App::DocumentObject* pcReferenceAxis, const std::vector<std::string>& subReferenceAxis,
-                 Base::Vector3d& base, Base::Vector3d& dir);
-        
+                 Base::Vector3d& base, Base::Vector3d& dir, bool checkPerpendicular=true);
+
     void onChanged(const App::Property* prop);
 private:
     bool isParallelPlane(const TopoDS_Shape&, const TopoDS_Shape&) const;

--- a/src/Mod/PartDesign/Gui/AppPartDesignGui.cpp
+++ b/src/Mod/PartDesign/Gui/AppPartDesignGui.cpp
@@ -61,6 +61,7 @@
 #include "ViewProviderThickness.h"
 #include "ViewProviderPipe.h"
 #include "ViewProviderLoft.h"
+#include "ViewProviderHelix.h"
 #include "ViewProviderShapeBinder.h"
 #include "ViewProviderBase.h"
 
@@ -156,6 +157,7 @@ PyMOD_INIT_FUNC(PartDesignGui)
     PartDesignGui::ViewProviderPrimitive     ::init();
     PartDesignGui::ViewProviderPipe          ::init();
     PartDesignGui::ViewProviderLoft          ::init();
+    PartDesignGui::ViewProviderHelix         ::init();
     PartDesignGui::ViewProviderBase          ::init();
 
      // add resources and reloads the translators

--- a/src/Mod/PartDesign/Gui/CMakeLists.txt
+++ b/src/Mod/PartDesign/Gui/CMakeLists.txt
@@ -55,6 +55,7 @@ set(PartDesignGui_MOC_HDRS
     TaskPrimitiveParameters.h
     TaskPipeParameters.h
     TaskLoftParameters.h
+    TaskHelixParameters.h
 )
 fc_wrap_cpp(PartDesignGui_MOC_SRCS ${PartDesignGui_MOC_HDRS})
 SOURCE_GROUP("Moc" FILES ${PartDesignGui_MOC_SRCS})
@@ -89,6 +90,7 @@ set(PartDesignGui_UIC_SRCS
     TaskPipeScaling.ui
     TaskLoftParameters.ui
     DlgReference.ui
+    TaskHelixParameters.ui
 )
 
 if(BUILD_QT5)
@@ -158,7 +160,9 @@ SET(PartDesignGuiViewProvider_SRCS
     ViewProviderPipe.cpp
     ViewProviderLoft.h
     ViewProviderLoft.cpp
-    ViewProviderBase.h 
+    ViewProviderHelix.h
+    ViewProviderHelix.cpp
+    ViewProviderBase.h
     ViewProviderBase.cpp
 )
 SOURCE_GROUP("ViewProvider" FILES ${PartDesignGuiViewProvider_SRCS})
@@ -237,6 +241,9 @@ SET(PartDesignGuiTaskDlgs_SRCS
     TaskLoftParameters.ui
     TaskLoftParameters.h
     TaskLoftParameters.cpp
+    TaskHelixParameters.ui
+    TaskHelixParameters.h
+    TaskHelixParameters.cpp
 )
 SOURCE_GROUP("TaskDialogs" FILES ${PartDesignGuiTaskDlgs_SRCS})
 

--- a/src/Mod/PartDesign/Gui/Resources/PartDesign.qrc
+++ b/src/Mod/PartDesign/Gui/Resources/PartDesign.qrc
@@ -6,6 +6,7 @@
         <file>icons/PartDesign_Additive_Ellipsoid.svg</file>
         <file>icons/PartDesign_Additive_Loft.svg</file>
         <file>icons/PartDesign_Additive_Pipe.svg</file>
+        <file>icons/PartDesign_Additive_Helix.svg</file>
         <file>icons/PartDesign_Additive_Prism.svg</file>
         <file>icons/PartDesign_Additive_Sphere.svg</file>
         <file>icons/PartDesign_Additive_Torus.svg</file>
@@ -50,6 +51,7 @@
         <file>icons/PartDesign_Subtractive_Ellipsoid.svg</file>
         <file>icons/PartDesign_Subtractive_Loft.svg</file>
         <file>icons/PartDesign_Subtractive_Pipe.svg</file>
+        <file>icons/PartDesign_Subtractive_Helix.svg</file>
         <file>icons/PartDesign_Subtractive_Prism.svg</file>
         <file>icons/PartDesign_Subtractive_Sphere.svg</file>
         <file>icons/PartDesign_Subtractive_Torus.svg</file>

--- a/src/Mod/PartDesign/Gui/Resources/icons/PartDesign_Additive_Helix.svg
+++ b/src/Mod/PartDesign/Gui/Resources/icons/PartDesign_Additive_Helix.svg
@@ -1,0 +1,1456 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   width="64px"
+   height="64px"
+   id="svg2901"
+   version="1.1">
+  <title
+     id="title1085">PartDesign_Additive_Helix</title>
+  <defs
+     id="defs2903">
+    <linearGradient
+       id="linearGradient1942">
+      <stop
+         style="stop-color:#d5c035;stop-opacity:1;"
+         offset="0"
+         id="stop1938" />
+      <stop
+         style="stop-color:#fce94f;stop-opacity:1"
+         offset="1"
+         id="stop1940" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1930">
+      <stop
+         style="stop-color:#c4a000;stop-opacity:1"
+         offset="0"
+         id="stop1926" />
+      <stop
+         style="stop-color:#fce94f;stop-opacity:1"
+         offset="1"
+         id="stop1928" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1475">
+      <stop
+         style="stop-color:#fce94f;stop-opacity:1"
+         offset="0"
+         id="stop1471" />
+      <stop
+         style="stop-color:#836b00;stop-opacity:1"
+         offset="1"
+         id="stop1473" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4237">
+      <stop
+         id="stop4239"
+         offset="0"
+         style="stop-color:#f82b39;stop-opacity:1;" />
+      <stop
+         id="stop4241"
+         offset="1"
+         style="stop-color:#520001;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4052">
+      <stop
+         style="stop-color:#0090ff;stop-opacity:1;"
+         offset="0"
+         id="stop4054" />
+      <stop
+         id="stop4060"
+         offset="0.5"
+         style="stop-color:#f0f1f1;stop-opacity:1;" />
+      <stop
+         style="stop-color:#0046ff;stop-opacity:1;"
+         offset="1"
+         id="stop4056" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4044">
+      <stop
+         style="stop-color:#0090ff;stop-opacity:1;"
+         offset="0"
+         id="stop4046" />
+      <stop
+         style="stop-color:#061aff;stop-opacity:1;"
+         offset="1"
+         id="stop4048" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3273">
+      <stop
+         id="stop3275"
+         offset="0"
+         style="stop-color:#c8e0f9;stop-opacity:1;" />
+      <stop
+         id="stop3277"
+         offset="1"
+         style="stop-color:#f7f9fa;stop-opacity:0.09649123;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3377">
+      <stop
+         id="stop3379"
+         offset="0"
+         style="stop-color:#c8e0f9;stop-opacity:1;" />
+      <stop
+         id="stop3381"
+         offset="1"
+         style="stop-color:#002795;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient4044"
+       id="linearGradient4050"
+       x1="44.858215"
+       y1="14.016123"
+       x2="33.928684"
+       y2="33.216251"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.97680237,0,0,0.96003508,1.4694319,0.12765765)" />
+    <linearGradient
+       xlink:href="#linearGradient4052"
+       id="linearGradient4058"
+       x1="42.373707"
+       y1="5.7974987"
+       x2="52.323219"
+       y2="22.675821"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.97680237,0,0,0.96003508,1.4694319,0.12765765)" />
+    <linearGradient
+       xlink:href="#linearGradient4052-1"
+       id="linearGradient4058-6"
+       x1="42.373707"
+       y1="5.7974987"
+       x2="52.323219"
+       y2="22.675821"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.97680237,0,0,0.96003508,1.4694319,0.12765765)" />
+    <linearGradient
+       id="linearGradient4052-1">
+      <stop
+         style="stop-color:#1f5fe0;stop-opacity:1;"
+         offset="0"
+         id="stop4054-5" />
+      <stop
+         id="stop4060-8"
+         offset="0.5"
+         style="stop-color:#71b2f8;stop-opacity:1;" />
+      <stop
+         style="stop-color:#002795;stop-opacity:1;"
+         offset="1"
+         id="stop4056-4" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-30.295225,-2.9287147)"
+       y2="22.675821"
+       x2="52.323219"
+       y1="5.7974987"
+       x1="42.373707"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4078"
+       xlink:href="#linearGradient4052-1" />
+    <linearGradient
+       xlink:href="#linearGradient4044"
+       id="linearGradient3885"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.97680237,0,0,0.96003508,107.10579,-22.235978)"
+       x1="44.858215"
+       y1="14.016123"
+       x2="33.928684"
+       y2="33.216251" />
+    <linearGradient
+       xlink:href="#linearGradient4052-1"
+       id="linearGradient3890"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.97680237,0,0,0.96003508,107.10579,-22.235978)"
+       x1="42.373707"
+       y1="5.7974987"
+       x2="52.323219"
+       y2="22.675821" />
+    <linearGradient
+       xlink:href="#linearGradient4052"
+       id="linearGradient3893"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.97680237,0,0,0.96003508,107.10579,-22.235978)"
+       x1="42.373707"
+       y1="5.7974987"
+       x2="52.323219"
+       y2="22.675821" />
+    <linearGradient
+       id="linearGradient4052-1-0">
+      <stop
+         style="stop-color:#0090ff;stop-opacity:1;"
+         offset="0"
+         id="stop4054-5-5" />
+      <stop
+         id="stop4060-8-6"
+         offset="0.5"
+         style="stop-color:#f0f1f1;stop-opacity:1;" />
+      <stop
+         style="stop-color:#0046ff;stop-opacity:1;"
+         offset="1"
+         id="stop4056-4-6" />
+    </linearGradient>
+    <linearGradient
+       y2="22.675821"
+       x2="52.323219"
+       y1="5.7974987"
+       x1="42.373707"
+       gradientTransform="matrix(0.97680237,0,0,0.96003508,-3.3630199,-18.322982)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3912"
+       xlink:href="#linearGradient4052-1-0" />
+    <linearGradient
+       id="linearGradient4052-1-0-0">
+      <stop
+         style="stop-color:#0090ff;stop-opacity:1;"
+         offset="0"
+         id="stop4054-5-5-9" />
+      <stop
+         id="stop4060-8-6-8"
+         offset="0.5"
+         style="stop-color:#f0f1f1;stop-opacity:1;" />
+      <stop
+         style="stop-color:#0046ff;stop-opacity:1;"
+         offset="1"
+         id="stop4056-4-6-4" />
+    </linearGradient>
+    <linearGradient
+       y2="22.675821"
+       x2="52.323219"
+       y1="5.7974987"
+       x1="42.373707"
+       gradientTransform="matrix(0.97680237,0,0,0.96003508,126.73769,-70.092683)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3985"
+       xlink:href="#linearGradient4052-1-0-0" />
+    <linearGradient
+       id="linearGradient4044-8">
+      <stop
+         style="stop-color:#0090ff;stop-opacity:1;"
+         offset="0"
+         id="stop4046-2" />
+      <stop
+         style="stop-color:#061aff;stop-opacity:1;"
+         offset="1"
+         id="stop4048-1" />
+    </linearGradient>
+    <linearGradient
+       y2="33.216251"
+       x2="33.928684"
+       y1="14.016123"
+       x1="44.858215"
+       gradientTransform="matrix(0.97680237,0,0,0.96003508,-26.24677,-8.4607595)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4072"
+       xlink:href="#linearGradient4044-8" />
+    <linearGradient
+       xlink:href="#linearGradient4044-8-4"
+       id="linearGradient3885-6-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.97680237,0,0,0.96003508,58.307367,54.671469)"
+       x1="44.858215"
+       y1="14.016123"
+       x2="33.928684"
+       y2="33.216251" />
+    <linearGradient
+       id="linearGradient4044-8-4">
+      <stop
+         style="stop-color:#0090ff;stop-opacity:1;"
+         offset="0"
+         id="stop4046-2-0" />
+      <stop
+         style="stop-color:#061aff;stop-opacity:1;"
+         offset="1"
+         id="stop4048-1-9" />
+    </linearGradient>
+    <linearGradient
+       y2="33.216251"
+       x2="33.928684"
+       y1="14.016123"
+       x1="44.858215"
+       gradientTransform="matrix(0.97680237,0,0,0.96003508,145.41299,94.782221)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4163"
+       xlink:href="#linearGradient4044-8-4" />
+    <linearGradient
+       id="linearGradient4052-1-0-9">
+      <stop
+         style="stop-color:#0090ff;stop-opacity:1;"
+         offset="0"
+         id="stop4054-5-5-2" />
+      <stop
+         id="stop4060-8-6-5"
+         offset="0.5"
+         style="stop-color:#f0f1f1;stop-opacity:1;" />
+      <stop
+         style="stop-color:#0046ff;stop-opacity:1;"
+         offset="1"
+         id="stop4056-4-6-5" />
+    </linearGradient>
+    <linearGradient
+       y2="22.675821"
+       x2="52.323219"
+       y1="5.7974987"
+       x1="42.373707"
+       gradientTransform="matrix(0.97680237,0,0,0.96003508,126.73769,-70.092687)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4217"
+       xlink:href="#linearGradient4052-1-0-9" />
+    <radialGradient
+       xlink:href="#linearGradient1475"
+       id="radialGradient2153"
+       cx="36.572212"
+       cy="30.972466"
+       fx="36.572212"
+       fy="30.972466"
+       r="18.483015"
+       gradientTransform="matrix(0.94353923,0,0,0.73910673,2.0756521,7.8201849)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       xlink:href="#linearGradient1930"
+       id="linearGradient1932"
+       x1="21.766993"
+       y1="36.503899"
+       x2="16.343052"
+       y2="24.589472"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       xlink:href="#linearGradient1942"
+       id="linearGradient1944"
+       x1="38.137226"
+       y1="16.171356"
+       x2="33.022259"
+       y2="10.52606"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <metadata
+     id="metadata2906">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>PartDesign_Additive_Helix</dc:title>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>bitacovir, davidosterberg</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:title>PartDesign_Revolution</dc:title>
+        <dc:date>2020/12/30</dc:date>
+        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier />
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title></dc:title>
+          </cc:Agent>
+        </dc:contributor>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1">
+    <path
+       id="path4129-2"
+       d="M 58.926505,11.748661 30.994834,35.247684"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#a40000;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <path
+       style="fill:#d5c035;fill-opacity:1;stroke-width:0.0188065"
+       d="m 24.796663,32.902359 c -2.49904,1.557545 -3.811883,4.546599 -3.864437,7.426823 -0.0012,0.445552 -0.06934,0.965067 0.0039,1.371378 1.059971,-0.840102 2.07592,-1.734317 3.112698,-2.602685 0.02511,-1.951889 -0.09937,-3.973426 0.65898,-5.820185 0.02305,-0.112323 0.110254,-0.278728 0.08891,-0.375331 z"
+       id="path1148" />
+    <g
+       stroke-linecap="square"
+       fill="none"
+       font-weight="400"
+       font-style="normal"
+       stroke-opacity="1"
+       stroke-width="1"
+       stroke="#000000"
+       font-family="'Noto Sans'"
+       font-size="35.2778px"
+       stroke-linejoin="bevel"
+       transform="matrix(0.1408925,0,0,0.1408925,32.656603,32.531155)"
+       id="g508"
+       style="fill-rule:evenodd">
+      <rect
+         x="0"
+         y="0"
+         height="0"
+         width="0"
+         id="rect506" />
+    </g>
+    <g
+       stroke-linecap="square"
+       fill="none"
+       font-weight="400"
+       font-style="normal"
+       stroke-opacity="1"
+       stroke-width="1"
+       stroke="#000000"
+       font-family="'Noto Sans'"
+       font-size="35.2778px"
+       stroke-linejoin="bevel"
+       transform="matrix(0.1408925,0,0,0.1408925,32.656603,32.531155)"
+       id="g516"
+       style="fill-rule:evenodd">
+      <rect
+         x="0"
+         y="0"
+         height="0"
+         width="0"
+         id="rect514" />
+    </g>
+    <g
+       stroke-linecap="square"
+       fill="none"
+       font-weight="400"
+       font-style="normal"
+       stroke-opacity="1"
+       stroke-width="1"
+       stroke="#000000"
+       font-family="'Noto Sans'"
+       font-size="35.2778px"
+       stroke-linejoin="bevel"
+       transform="matrix(0.1408925,0,0,0.1408925,32.656603,32.531155)"
+       id="g524"
+       style="fill-rule:evenodd">
+      <rect
+         x="0"
+         y="0"
+         height="0"
+         width="0"
+         id="rect522" />
+    </g>
+    <g
+       stroke-linecap="square"
+       fill="none"
+       font-weight="400"
+       font-style="normal"
+       stroke-opacity="1"
+       stroke-width="1"
+       stroke="#000000"
+       font-family="'Noto Sans'"
+       font-size="35.2778px"
+       stroke-linejoin="bevel"
+       transform="matrix(0.1408925,0,0,0.1408925,32.656603,32.531155)"
+       id="g532"
+       style="fill-rule:evenodd">
+      <rect
+         x="0"
+         y="0"
+         height="0"
+         width="0"
+         id="rect530" />
+    </g>
+    <g
+       stroke-linecap="square"
+       fill="none"
+       font-weight="400"
+       font-style="normal"
+       stroke-opacity="1"
+       stroke-width="1"
+       stroke="#000000"
+       font-family="'Noto Sans'"
+       font-size="35.2778px"
+       stroke-linejoin="bevel"
+       transform="matrix(0.1408925,0,0,0.1408925,32.656603,32.531155)"
+       id="g540"
+       style="fill-rule:evenodd">
+      <rect
+         x="0"
+         y="0"
+         height="0"
+         width="0"
+         id="rect538" />
+    </g>
+    <g
+       stroke-linecap="square"
+       fill="none"
+       font-weight="400"
+       font-style="normal"
+       stroke-opacity="1"
+       stroke-width="1"
+       stroke="#000000"
+       font-family="'Noto Sans'"
+       font-size="35.2778px"
+       stroke-linejoin="bevel"
+       transform="matrix(0.1408925,0,0,0.1408925,32.656603,32.531155)"
+       id="g548"
+       style="fill-rule:evenodd">
+      <rect
+         x="0"
+         y="0"
+         height="0"
+         width="0"
+         id="rect546" />
+    </g>
+    <g
+       stroke-linecap="square"
+       fill="none"
+       font-weight="400"
+       font-style="normal"
+       stroke-opacity="1"
+       stroke-width="1"
+       stroke="#000000"
+       font-family="'Noto Sans'"
+       font-size="35.2778px"
+       stroke-linejoin="bevel"
+       transform="matrix(0.1408925,0,0,0.1408925,32.656603,32.531155)"
+       id="g556"
+       style="fill-rule:evenodd">
+      <rect
+         x="0"
+         y="0"
+         height="0"
+         width="0"
+         id="rect554" />
+    </g>
+    <g
+       stroke-linecap="square"
+       fill="none"
+       font-weight="400"
+       font-style="normal"
+       stroke-opacity="1"
+       stroke-width="1"
+       stroke="#000000"
+       font-family="'Noto Sans'"
+       font-size="35.2778px"
+       stroke-linejoin="bevel"
+       transform="matrix(0.1408925,0,0,0.1408925,32.656603,32.531155)"
+       id="g564"
+       style="fill-rule:evenodd">
+      <rect
+         x="0"
+         y="0"
+         height="0"
+         width="0"
+         id="rect562" />
+    </g>
+    <g
+       stroke-linecap="square"
+       fill="none"
+       font-weight="400"
+       font-style="normal"
+       stroke-opacity="1"
+       stroke-width="1"
+       stroke="#000000"
+       font-family="'Noto Sans'"
+       font-size="35.2778px"
+       stroke-linejoin="bevel"
+       transform="matrix(0.1408925,0,0,0.1408925,32.656603,32.531155)"
+       id="g572"
+       style="fill-rule:evenodd">
+      <rect
+         x="0"
+         y="0"
+         height="0"
+         width="0"
+         id="rect570" />
+    </g>
+    <g
+       stroke-linecap="square"
+       fill="none"
+       font-weight="400"
+       font-style="normal"
+       stroke-opacity="1"
+       stroke-width="1"
+       stroke="#000000"
+       font-family="'Noto Sans'"
+       font-size="35.2778px"
+       stroke-linejoin="bevel"
+       transform="matrix(0.1408925,0,0,0.1408925,32.656603,32.531155)"
+       id="g580"
+       style="fill-rule:evenodd">
+      <rect
+         x="0"
+         y="0"
+         height="0"
+         width="0"
+         id="rect578" />
+    </g>
+    <g
+       stroke-linecap="square"
+       fill="none"
+       font-weight="400"
+       font-style="normal"
+       stroke-opacity="1"
+       stroke-width="1"
+       stroke="#000000"
+       font-family="'Noto Sans'"
+       font-size="35.2778px"
+       stroke-linejoin="bevel"
+       transform="matrix(0.1408925,0,0,0.1408925,32.656603,32.531155)"
+       id="g588"
+       style="fill-rule:evenodd">
+      <rect
+         x="0"
+         y="0"
+         height="0"
+         width="0"
+         id="rect586" />
+    </g>
+    <g
+       stroke-linecap="square"
+       fill="none"
+       font-weight="400"
+       font-style="normal"
+       stroke-opacity="1"
+       stroke-width="1"
+       stroke="#000000"
+       font-family="'Noto Sans'"
+       font-size="35.2778px"
+       stroke-linejoin="bevel"
+       transform="matrix(0.1408925,0,0,0.1408925,32.656603,32.531155)"
+       id="g596"
+       style="fill-rule:evenodd">
+      <rect
+         x="0"
+         y="0"
+         height="0"
+         width="0"
+         id="rect594" />
+    </g>
+    <g
+       stroke-linecap="square"
+       fill="none"
+       font-weight="400"
+       font-style="normal"
+       stroke-opacity="1"
+       stroke-width="1"
+       stroke="#000000"
+       font-family="'Noto Sans'"
+       font-size="35.2778px"
+       stroke-linejoin="bevel"
+       transform="matrix(0.1408925,0,0,0.1408925,32.656603,32.531155)"
+       id="g604"
+       style="fill-rule:evenodd">
+      <rect
+         x="0"
+         y="0"
+         height="0"
+         width="0"
+         id="rect602" />
+    </g>
+    <g
+       stroke-linecap="square"
+       fill="none"
+       font-weight="400"
+       font-style="normal"
+       stroke-opacity="1"
+       stroke-width="1"
+       stroke="#000000"
+       font-family="'Noto Sans'"
+       font-size="35.2778px"
+       stroke-linejoin="bevel"
+       transform="matrix(0.1408925,0,0,0.1408925,32.656603,32.531155)"
+       id="g612"
+       style="fill-rule:evenodd">
+      <rect
+         x="0"
+         y="0"
+         height="0"
+         width="0"
+         id="rect610" />
+    </g>
+    <g
+       stroke-linecap="square"
+       fill="none"
+       font-weight="400"
+       font-style="normal"
+       stroke-opacity="1"
+       stroke-width="1"
+       stroke="#000000"
+       font-family="'Noto Sans'"
+       font-size="35.2778px"
+       stroke-linejoin="bevel"
+       transform="matrix(0.1408925,0,0,0.1408925,32.656603,32.531155)"
+       id="g620"
+       style="fill-rule:evenodd">
+      <rect
+         x="0"
+         y="0"
+         height="0"
+         width="0"
+         id="rect618" />
+    </g>
+    <g
+       stroke-linecap="square"
+       fill="none"
+       font-weight="400"
+       font-style="normal"
+       stroke-opacity="1"
+       stroke-width="1"
+       stroke="#000000"
+       font-family="'Noto Sans'"
+       font-size="35.2778px"
+       stroke-linejoin="bevel"
+       transform="matrix(0.1408925,0,0,0.1408925,32.656603,32.531155)"
+       id="g628"
+       style="fill-rule:evenodd">
+      <rect
+         x="0"
+         y="0"
+         height="0"
+         width="0"
+         id="rect626" />
+    </g>
+    <g
+       stroke-linecap="square"
+       fill="none"
+       font-weight="400"
+       font-style="normal"
+       stroke-opacity="1"
+       stroke-width="1"
+       stroke="#000000"
+       font-family="'Noto Sans'"
+       font-size="35.2778px"
+       stroke-linejoin="bevel"
+       transform="matrix(0.1408925,0,0,0.1408925,32.656603,32.531155)"
+       id="g636"
+       style="fill-rule:evenodd">
+      <rect
+         x="0"
+         y="0"
+         height="0"
+         width="0"
+         id="rect634" />
+    </g>
+    <g
+       stroke-linecap="round"
+       fill="none"
+       font-weight="400"
+       font-style="normal"
+       stroke-opacity="1"
+       stroke-width="7"
+       stroke="#000000"
+       font-family="'Noto Sans'"
+       font-size="35.2778px"
+       stroke-linejoin="bevel"
+       transform="matrix(0.1408925,0,0,0.1408925,32.656603,32.531155)"
+       id="g808"
+       style="fill-rule:evenodd" />
+    <g
+       stroke-linecap="round"
+       fill="none"
+       font-weight="400"
+       font-style="normal"
+       stroke-opacity="1"
+       stroke-width="7"
+       stroke="#000000"
+       font-family="'Noto Sans'"
+       font-size="35.2778px"
+       stroke-linejoin="bevel"
+       transform="matrix(0.1329376,0,0,0.1329376,32.888438,32.182827)"
+       id="g704"
+       style="fill-rule:evenodd;stroke:#302b00;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none">
+      <path
+         d="M -19.8654,17.3031 C -24.2765,9.10641 -28.2267,0.69267 -31.7161,-7.93816"
+         vector-effect="none"
+         fill-rule="evenodd"
+         id="path702"
+         style="stroke:#302b00;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none" />
+    </g>
+    <g
+       stroke-linecap="round"
+       fill="none"
+       font-weight="400"
+       font-style="normal"
+       stroke-opacity="1"
+       stroke-width="7"
+       stroke="#000000"
+       font-family="'Noto Sans'"
+       font-size="35.2778px"
+       stroke-linejoin="bevel"
+       transform="matrix(0.1329376,0,0,0.1329376,32.888438,32.182827)"
+       id="g748"
+       style="fill-rule:evenodd;stroke:#302b00;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none">
+      <path
+         d="m -62.3807,53.2229 c -0.4529,-3.4931 -0.7343,-7.0263 -0.8442,-10.5998 -0.5306,-16.1486 2.9686,-32.6195 11.0491,-45.74076"
+         vector-effect="none"
+         fill-rule="evenodd"
+         id="path746"
+         style="stroke:#302b00;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none" />
+    </g>
+    <path
+       id="path4129-3-9"
+       d="M 58.926505,11.748661 30.994834,35.247684"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#ef2929;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <path
+       style="fill:url(#linearGradient1932);fill-opacity:1;stroke-width:0.0188065"
+       d="m 23.916128,20.482757 c -3.386694,-0.07232 -6.867398,1.108636 -9.249765,3.5733 -2.391714,2.338019 -3.582909,5.682502 -3.779695,8.973404 -0.172345,2.512484 0.04938,5.043402 0.675197,7.483401 0.422362,2.403648 2.191039,6.274971 2.496962,6.730557 2.063344,-1.572684 4.248818,-3.538549 5.975639,-4.990697 -0.269655,-2.775107 0.155628,-5.47518 1.799825,-7.788928 1.564419,-2.314174 4.284725,-3.666463 7.04316,-3.811186 3.79062,-0.257051 7.564977,1.249827 10.445209,3.661358 0.606418,0.589305 1.330169,1.21856 1.507866,2.078609 0.0075,0.553553 -0.691492,0.660588 -1.04277,0.349385 -0.816035,-0.59302 -1.247582,-1.548415 -1.863537,-2.312185 -0.473573,-0.344579 0.09815,-0.780044 -0.467054,-0.934348 -1.358758,1.139033 -3.01478,2.661015 -4.314975,3.857441 0.617274,1.179348 0.755125,1.780664 1.585082,2.816924 2.343975,2.697079 5.141523,5.173026 8.546039,6.405848 1.53912,0.502863 3.352744,0.80899 4.840819,-7.3e-4 1.490273,-0.848923 1.942162,-2.743718 1.860772,-4.345359 C 49.633285,38.37663 47.619904,34.89448 45.253857,31.923024 40.983577,26.690547 35.130131,22.602502 28.521468,21.001167 c -1.508985,-0.370446 -3.050369,-0.563304 -4.60534,-0.51841 z"
+       id="path1136" />
+    <g
+       stroke-linecap="round"
+       fill="none"
+       font-weight="400"
+       font-style="normal"
+       stroke-opacity="1"
+       stroke-width="7"
+       stroke="#000000"
+       font-family="'Noto Sans'"
+       font-size="35.2778px"
+       stroke-linejoin="bevel"
+       transform="matrix(0.1329376,0,0,0.1329376,32.888438,32.182827)"
+       id="g664"
+       style="fill-rule:evenodd;stroke:#302b00;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none">
+      <path
+         d="m -92.8825,78.9928 c -0.453,-3.493 -0.7344,-7.0264 -0.8442,-10.5999 -0.3599,-11.6552 1.3089,-23.5037 5.3662,-34.1102 4.0295,-10.6212 10.4466,-19.9665 18.8198,-27.01767"
+         vector-effect="none"
+         fill-rule="evenodd"
+         id="path662"
+         style="stroke:#302b00;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none" />
+    </g>
+    <path
+       style="fill:#c4a000;fill-opacity:1;stroke-width:0.0188065"
+       d="m 25.026234,43.110494 c -1.082051,0.902987 -2.200211,1.800646 -3.226392,2.747716 0.312698,0.810493 2.161565,2.86111 2.623196,3.598772 1.057117,-0.972474 2.382261,-1.937926 3.397772,-2.930963 -0.427046,-0.733669 -2.363283,-2.691467 -2.780583,-3.424708 z"
+       id="path1150" />
+    <g
+       stroke-linecap="round"
+       fill="none"
+       font-weight="400"
+       font-style="normal"
+       stroke-opacity="1"
+       stroke-width="7"
+       stroke="#000000"
+       font-family="'Noto Sans'"
+       font-size="35.2778px"
+       stroke-linejoin="bevel"
+       transform="matrix(0.1329376,0,0,0.1329376,32.888438,32.182827)"
+       id="g692"
+       style="fill-rule:evenodd;stroke:#302b00;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none">
+      <path
+         d="m -141.872,120.382 c -7.715,-14.341 -14.133,-29.5441 -18.826,-44.9314 -8.736,-28.4969 -11.385,-57.5741 -6.87,-82.92542 4.433,-25.39528 16.028,-46.96288 33.491,-61.64788"
+         vector-effect="none"
+         fill-rule="evenodd"
+         id="path690"
+         style="stroke:#302b00;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none" />
+    </g>
+    <path
+       style="fill:#918624;fill-opacity:1;stroke-width:0.0188065"
+       d="m 28.771279,46.949436 c -1.055916,0.854935 -2.255651,2.359524 -3.233326,3.280888 -0.03573,2.945902 -0.815144,9.23349 2.310548,10.332799 1.099611,-0.841998 3.101034,-1.835058 4.104284,-2.766729 -3.110182,-1.215562 -1.223624,-4.071391 -1.59023,-6.590516 z"
+       id="path1152" />
+    <path
+       style="fill:#c4a000;fill-opacity:1;stroke:#c4a000;stroke-width:0.0188065"
+       d="m 18.569808,48.543395 c -0.811087,0.716853 -1.703922,1.388502 -2.439289,2.164532 1.613702,2.514439 3.66414,4.745365 5.944848,6.670877 2.033202,1.581569 4.341024,3.021411 6.937977,3.381004 1.571786,0.227131 -2.158798,0.221727 -1.385949,-1.259949 0.873673,-1.639895 -0.07506,-1.398313 -0.472906,-3.132216 -0.05989,-0.404767 -0.735583,-3.220892 -1.193878,-3.270534 -2.701075,-1.021128 1.287051,-2.379268 -1.417716,-3.390552 0.214564,0.423108 -0.09782,1.116382 -0.632015,0.906043 -1.045274,-0.514062 -1.598671,-1.637318 -2.165744,-2.599055 -0.26846,-0.498873 -0.506338,-1.013468 -0.73123,-1.533232 z"
+       id="path1138" />
+    <g
+       stroke-linecap="round"
+       fill="none"
+       font-weight="400"
+       font-style="normal"
+       stroke-opacity="1"
+       stroke-width="7"
+       stroke="#000000"
+       font-family="'Noto Sans'"
+       font-size="35.2778px"
+       stroke-linejoin="bevel"
+       transform="matrix(0.1329376,0,0,0.1329376,34.28521,33.447342)"
+       id="g652"
+       style="fill-rule:evenodd;stroke:#302b00;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none">
+      <path
+         d="M -43.0796,98.2197 -73.5812,123.989"
+         vector-effect="none"
+         fill-rule="evenodd"
+         id="path650"
+         style="stroke:#302b00;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none" />
+    </g>
+    <path
+       style="fill:url(#radialGradient2153);fill-opacity:1;stroke-width:0.0188065"
+       d="m 27.947841,17.052594 c -3.174773,-0.04437 -6.432938,0.986372 -8.804323,3.135728 0.417031,-0.01726 0.899819,-0.259608 1.349443,-0.310322 4.915209,-1.040799 10.027873,0.25524 14.433596,2.480303 3.562416,1.799347 6.774091,4.25947 9.491248,7.179173 2.76224,2.960477 5.124966,6.451636 6.1483,10.411344 0.370179,1.436708 0.410534,2.97347 0.194152,4.424244 0.867207,-0.660923 1.756021,-1.352951 2.465232,-2.193975 1.115509,-1.702406 0.877058,-3.892646 0.387285,-5.765379 -1.203201,-4.211103 -3.913489,-7.823595 -6.991361,-10.865074 -4.373823,-4.218358 -9.922086,-7.41243 -15.97871,-8.343004 -0.890516,-0.142841 -1.794959,-0.156173 -2.694862,-0.153038 z"
+       id="path1142" />
+    <g
+       fill="#ffffff"
+       font-weight="400"
+       font-style="normal"
+       stroke="none"
+       font-family="'Noto Sans'"
+       font-size="35.2778px"
+       fill-opacity="1"
+       transform="matrix(0.1329376,0,0,0.1329376,32.888438,32.182827)"
+       id="g536"
+       style="fill-rule:evenodd;stroke-width:11.3562;stroke-linecap:square;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none">
+      <path
+         d="m -44.1682,-117.383 c 14.8298,-0.905 30.6277,0.795 46.59147,4.886 15.96313,4.081 32.08453,10.551 47.54303,18.9136 0.8132,-0.7664 1.6463,-1.51 2.4995,-2.2308 5.1433,-4.3488 11.0077,-7.8418 17.3648,-10.3828 5.245,-2.087 10.7397,-3.539 16.4842,-4.354 l -22.5794,-84.114 c -14.733,-0.908 -28.8363,0.52 -41.6631,4.304 -12.83165,3.775 -24.38195,9.906 -34.1424,18.159 -15.8653,13.356 -26.915,32.373 -32.0981,54.819"
+         vector-effect="non-scaling-stroke"
+         fill-rule="evenodd"
+         id="path534"
+         style="stroke-width:11.3562;stroke-miterlimit:4;stroke-dasharray:none" />
+    </g>
+    <path
+       style="fill:url(#linearGradient1944);fill-opacity:1;stroke-width:0.0188065"
+       d="m 39.592148,6.8262386 c -2.767588,-0.046717 -5.536757,0.9297193 -7.720601,2.6187189 -2.115445,1.6420095 -3.5458,4.1064365 -4.23432,6.6336705 2.615998,-0.0257 5.22389,0.430995 7.689769,1.300441 1.417169,0.482294 2.782277,1.102111 4.120266,1.770424 1.235412,-1.008282 2.714926,-1.685818 4.256621,-2.052588 0.02368,-0.392677 -0.210061,-0.84059 -0.277487,-1.250497 -0.797683,-3.011843 -1.612584,-6.0190869 -2.420525,-9.0281862 -0.471242,0.00267 -0.942483,0.00534 -1.413723,0.00802 z"
+       id="path1140" />
+    <path
+       style="fill:none;stroke:#fce94f;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 29.181036,16.119053 C 30.649523,12.064189 32.796739,9.1240641 39.75,8.3125 l 2.164063,7.765625 c -2.024029,0.641737 -3.133769,1.846842 -3.590959,3.044584"
+       id="path1936" />
+    <g
+       fill="#ffffff"
+       font-weight="400"
+       font-style="normal"
+       stroke="none"
+       font-family="'Noto Sans'"
+       font-size="35.2778px"
+       fill-opacity="1"
+       transform="matrix(0.1329376,0,0,0.1329376,32.888438,32.182827)"
+       id="g544"
+       style="fill-rule:evenodd;stroke-width:11.3562;stroke-linecap:square;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none">
+      <path
+         d="m 94.2372,-220.435 22.5798,84.115 -30.5022,25.769 -22.5794,-84.114 30.5018,-25.77"
+         vector-effect="non-scaling-stroke"
+         fill-rule="evenodd"
+         id="path542"
+         style="stroke-width:11.3562;stroke-miterlimit:4;stroke-dasharray:none" />
+    </g>
+    <path
+       style="fill:#918624;fill-opacity:1;stroke-width:0.0188065"
+       d="M 45.129267,3.843995 C 44.0137,4.5639787 43.06674,5.5317209 42.027364,6.3600992 c -0.27568,0.3165421 0.167038,0.857175 0.179899,1.2637219 0.818693,2.9835589 1.602304,6.0551079 2.44158,8.9843509 1.07244,-0.905933 2.203001,-1.760396 3.190534,-2.757336 -0.849988,-3.340503 -1.742706,-6.6852215 -2.677314,-10.0030513 -0.0098,-0.00597 -0.02195,-0.00559 -0.0328,-0.00379 z"
+       id="path1144" />
+    <g
+       fill="#ffffff"
+       font-weight="400"
+       font-style="normal"
+       stroke="none"
+       font-family="'Noto Sans'"
+       font-size="35.2778px"
+       fill-opacity="1"
+       transform="matrix(0.1329376,0,0,0.1329376,32.888438,32.182827)"
+       id="g592"
+       style="fill-rule:evenodd;stroke-width:11.3562;stroke-linecap:square;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none">
+      <path
+         d="m -12.0701,-172.202 c 9.76045,-8.253 21.31075,-14.384 34.1424,-18.159 12.8268,-3.784 26.9301,-5.212 41.6631,-4.304 l 30.5018,-25.77 c -14.7331,-0.908 -28.8364,0.52 -41.6631,4.304 -12.8316,3.775 -24.3817,9.906 -34.1422,18.159 l -30.502,25.77"
+         vector-effect="non-scaling-stroke"
+         fill-rule="evenodd"
+         id="path590"
+         style="stroke-width:11.3562;stroke-miterlimit:4;stroke-dasharray:none" />
+    </g>
+    <path
+       style="fill:#d5c035;fill-opacity:1;stroke-width:0.0188065"
+       d="M 43.28424,3.3602186 C 40.427569,3.5296102 37.530005,4.4984683 35.40141,6.456592 36.111602,6.3580162 36.839439,6.0785591 37.576712,6.0108371 38.796144,5.8259286 40.031476,5.8142236 41.261533,5.7734162 42.202963,4.9773363 43.144426,4.181294 44.085919,3.3852892 43.818776,3.3751348 43.551757,3.3529512 43.28424,3.3602186 Z"
+       id="path1146" />
+    <g
+       fill="#ffffff"
+       font-weight="400"
+       font-style="normal"
+       stroke="none"
+       font-family="'Noto Sans'"
+       font-size="35.2778px"
+       fill-opacity="1"
+       transform="matrix(0.1329376,0,0,0.1329376,32.888438,32.182827)"
+       id="g632"
+       style="fill-rule:evenodd;stroke-width:11.3562;stroke-linecap:square;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none">
+      <path
+         d="m 49.9663,-93.5834 c 3.9476,2.1349 7.8457,4.3862 11.6943,6.7539 1.8318,-6.9108 4.5629,-13.4675 8.17,-19.3675 -6.3571,2.541 -12.2215,6.034 -17.3648,10.3828 -0.8532,0.7208 -1.6863,1.4644 -2.4995,2.2308"
+         vector-effect="non-scaling-stroke"
+         fill-rule="evenodd"
+         id="path630"
+         style="stroke-width:11.3562;stroke-miterlimit:4;stroke-dasharray:none" />
+    </g>
+    <g
+       stroke-linecap="round"
+       fill="none"
+       font-weight="400"
+       font-style="normal"
+       stroke-opacity="1"
+       stroke-width="7"
+       stroke="#000000"
+       font-family="'Noto Sans'"
+       font-size="35.2778px"
+       stroke-linejoin="bevel"
+       transform="matrix(0.1329376,0,0,0.1329376,32.888438,32.182827)"
+       id="g672"
+       style="fill-rule:evenodd;stroke-width:11.3562;stroke-miterlimit:4;stroke-dasharray:none">
+      <path
+         d="m 55.9989,32.113 c -0.5836,0.5044 -2.5101,-0.5895 -5.1737,-3.4719 -2.6574,-2.8676 -6.0386,-7.5235 -9.3654,-13.737"
+         vector-effect="none"
+         fill-rule="evenodd"
+         id="path670"
+         style="stroke-width:11.3562;stroke-miterlimit:4;stroke-dasharray:none" />
+    </g>
+    <g
+       stroke-linecap="round"
+       fill="none"
+       font-weight="400"
+       font-style="normal"
+       stroke-opacity="1"
+       stroke-width="7"
+       stroke="#000000"
+       font-family="'Noto Sans'"
+       font-size="35.2778px"
+       stroke-linejoin="bevel"
+       transform="matrix(0.1329376,0,0,0.1329376,32.888438,32.182827)"
+       id="g676"
+       style="fill-rule:evenodd;stroke-width:11.3562;stroke-miterlimit:4;stroke-dasharray:none">
+      <path
+         d="m 49.9663,-93.5834 c 0.8132,-0.7664 1.6463,-1.51 2.4995,-2.2308"
+         vector-effect="none"
+         fill-rule="evenodd"
+         id="path674"
+         style="stroke-width:11.3562;stroke-miterlimit:4;stroke-dasharray:none" />
+    </g>
+    <g
+       stroke-linecap="round"
+       fill="none"
+       font-weight="400"
+       font-style="normal"
+       stroke-opacity="1"
+       stroke-width="7"
+       stroke="#000000"
+       font-family="'Noto Sans'"
+       font-size="35.2778px"
+       stroke-linejoin="bevel"
+       transform="matrix(0.1329376,0,0,0.1329376,32.888438,32.182827)"
+       id="g680"
+       style="fill-rule:evenodd;stroke:#302b00;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none">
+      <path
+         d="m 52.4658,-95.8142 c 9.3553,-7.9398 21.1562,-12.9478 33.849,-14.7368"
+         vector-effect="none"
+         fill-rule="evenodd"
+         id="path678"
+         style="stroke:#302b00;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none" />
+    </g>
+    <g
+       stroke-linecap="round"
+       fill="none"
+       font-weight="400"
+       font-style="normal"
+       stroke-opacity="1"
+       stroke-width="7"
+       stroke="#000000"
+       font-family="'Noto Sans'"
+       font-size="35.2778px"
+       stroke-linejoin="bevel"
+       transform="matrix(0.1329376,0,0,0.1329376,32.888438,32.182827)"
+       id="g700"
+       style="fill-rule:evenodd;stroke:#302b00;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none">
+      <path
+         d="m 120.537,108.499 c -9.02,7.671 -22.9951,9.433 -39.4089,4.601 C 64.7384,108.335 45.9778,96.9835 28.0518,80.2462 14.7085,67.8195 1.85002,52.4649 -9.26713,35.247"
+         vector-effect="none"
+         fill-rule="evenodd"
+         id="path698"
+         style="stroke:#302b00;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none" />
+    </g>
+    <g
+       stroke-linecap="round"
+       fill="none"
+       font-weight="400"
+       font-style="normal"
+       stroke-opacity="1"
+       stroke-width="7"
+       stroke="#000000"
+       font-family="'Noto Sans'"
+       font-size="35.2778px"
+       stroke-linejoin="bevel"
+       transform="matrix(0.1329376,0,0,0.1329376,32.888438,32.182827)"
+       id="g716"
+       style="fill-rule:evenodd;stroke:#302b00;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none">
+      <path
+         d="M 86.3148,-110.551 63.7354,-194.665"
+         vector-effect="none"
+         fill-rule="evenodd"
+         id="path714"
+         style="stroke:#302b00;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none" />
+    </g>
+    <g
+       stroke-linecap="round"
+       fill="none"
+       font-weight="400"
+       font-style="normal"
+       stroke-opacity="1"
+       stroke-width="7"
+       stroke="#000000"
+       font-family="'Noto Sans'"
+       font-size="35.2778px"
+       stroke-linejoin="bevel"
+       transform="matrix(0.1329376,0,0,0.1329376,32.888438,32.182827)"
+       id="g720"
+       style="fill-rule:evenodd;stroke:#302b00;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none">
+      <path
+         d="m 63.7354,-194.665 30.5018,-25.77"
+         vector-effect="none"
+         fill-rule="evenodd"
+         id="path718"
+         style="stroke:#302b00;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none" />
+    </g>
+    <g
+       stroke-linecap="round"
+       fill="none"
+       font-weight="400"
+       font-style="normal"
+       stroke-opacity="1"
+       stroke-width="7"
+       stroke="#000000"
+       font-family="'Noto Sans'"
+       font-size="35.2778px"
+       stroke-linejoin="bevel"
+       transform="matrix(0.1329376,0,0,0.1329376,32.888438,32.182827)"
+       id="g724"
+       style="fill-rule:evenodd;stroke:#302b00;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none">
+      <path
+         d="m 94.2372,-220.435 22.5798,84.115"
+         vector-effect="none"
+         fill-rule="evenodd"
+         id="path722"
+         style="stroke:#302b00;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none" />
+    </g>
+    <g
+       stroke-linecap="round"
+       fill="none"
+       font-weight="400"
+       font-style="normal"
+       stroke-opacity="1"
+       stroke-width="7"
+       stroke="#000000"
+       font-family="'Noto Sans'"
+       font-size="35.2778px"
+       stroke-linejoin="bevel"
+       transform="matrix(0.1329376,0,0,0.1329376,32.888438,32.182827)"
+       id="g728"
+       style="fill-rule:evenodd;stroke:#302b00;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none">
+      <path
+         d="m 116.817,-136.32 -30.5022,25.769"
+         vector-effect="none"
+         fill-rule="evenodd"
+         id="path726"
+         style="stroke:#302b00;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none" />
+    </g>
+    <g
+       stroke-linecap="round"
+       fill="none"
+       font-weight="400"
+       font-style="normal"
+       stroke-opacity="1"
+       stroke-width="7"
+       stroke="#000000"
+       font-family="'Noto Sans'"
+       font-size="35.2778px"
+       stroke-linejoin="bevel"
+       transform="matrix(0.1329376,0,0,0.1329376,32.888438,32.182827)"
+       id="g740"
+       style="fill-rule:evenodd;stroke:#302b00;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none">
+      <path
+         d="m 18.4319,-197.972 c 9.7605,-8.253 21.3106,-14.384 34.1422,-18.159 12.8267,-3.784 26.93,-5.212 41.6631,-4.304"
+         vector-effect="none"
+         fill-rule="evenodd"
+         id="path738"
+         style="stroke:#302b00;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none" />
+    </g>
+    <g
+       stroke-linecap="round"
+       fill="none"
+       font-weight="400"
+       font-style="normal"
+       stroke-opacity="1"
+       stroke-width="7"
+       stroke="#000000"
+       font-family="'Noto Sans'"
+       font-size="35.2778px"
+       stroke-linejoin="bevel"
+       transform="matrix(0.1329376,0,0,0.1329376,32.888438,32.182827)"
+       id="g780"
+       style="fill-rule:evenodd;stroke:#302b00;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none">
+      <path
+         d="m -134.077,-69.1227 30.502,-25.7696"
+         vector-effect="none"
+         fill-rule="evenodd"
+         id="path778"
+         style="stroke:#302b00;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none" />
+    </g>
+    <g
+       stroke-linecap="round"
+       fill="none"
+       font-weight="400"
+       font-style="normal"
+       stroke-opacity="1"
+       stroke-width="7"
+       stroke="#000000"
+       font-family="'Noto Sans'"
+       font-size="35.2778px"
+       stroke-linejoin="bevel"
+       transform="matrix(0.1329376,0,0,0.1329376,32.888438,32.182827)"
+       id="g784"
+       style="fill-rule:evenodd;stroke:#302b00;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none">
+      <path
+         d="M 120.537,108.499 151.038,82.7294"
+         vector-effect="none"
+         fill-rule="evenodd"
+         id="path782"
+         style="stroke:#302b00;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none" />
+    </g>
+    <g
+       stroke-linecap="round"
+       fill="none"
+       font-weight="400"
+       font-style="normal"
+       stroke-opacity="1"
+       stroke-width="7"
+       stroke="#000000"
+       font-family="'Noto Sans'"
+       font-size="35.2778px"
+       stroke-linejoin="bevel"
+       transform="matrix(0.1329376,0,0,0.1329376,32.888438,32.182827)"
+       id="g788"
+       style="fill-rule:evenodd;stroke:#302b00;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none">
+      <path
+         d="M -12.214558,-173.378 18.4319,-197.972"
+         vector-effect="none"
+         fill-rule="evenodd"
+         id="path786"
+         style="stroke:#302b00;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none" />
+    </g>
+    <g
+       stroke-linecap="round"
+       fill="none"
+       font-weight="400"
+       font-style="normal"
+       stroke-opacity="1"
+       stroke-width="7"
+       stroke="#000000"
+       font-family="'Noto Sans'"
+       font-size="35.2778px"
+       stroke-linejoin="bevel"
+       transform="matrix(0.1329376,0,0,0.1329376,32.888438,32.182827)"
+       id="g696"
+       style="fill-rule:evenodd;stroke:#302b00;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none">
+      <path
+         d="m -136.56904,-67.451752 c 5.077,-4.2872 13.09104,-9.658448 19.06004,-12.771848 11.731,-6.1243 25.0754,-9.8715 39.4046,-11.1345 14.3253,-1.273 29.6291,-0.0622 45.1711,3.4595 15.5412,3.5125 31.31403,9.3334 46.5521,17.0294 15.2402,7.6887 29.9395,17.2473 43.3909,28.0328 13.4568,10.7797 25.6609,22.7802 36.0468,35.21878 C 103.45,4.81927 112.021,17.6872 118.41,30.1551 c 6.398,12.4696 10.612,24.5322 12.528,35.4025 1.924,10.875 1.551,20.5514 -0.975,28.3784 -1.935,6.012 -5.131,10.937 -9.426,14.563"
+         vector-effect="none"
+         fill-rule="evenodd"
+         id="path694"
+         style="stroke:#302b00;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none" />
+    </g>
+    <g
+       stroke-linecap="round"
+       fill="none"
+       font-weight="400"
+       font-style="normal"
+       stroke-opacity="1"
+       stroke-width="7"
+       stroke="#000000"
+       font-family="'Noto Sans'"
+       font-size="35.2778px"
+       stroke-linejoin="bevel"
+       transform="matrix(0.1329376,0,0,0.1329376,32.888438,32.182827)"
+       id="g736"
+       style="fill-rule:evenodd;stroke:#302b00;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none">
+      <path
+         d="m -103.575,-94.8923 c 5.0768,-4.2872 10.5993,-7.9877 16.5677,-11.1007 11.7308,-6.124 25.0755,-9.872 39.4047,-11.135 14.3252,-1.273 29.629,-0.062 45.171,3.46 15.5411,3.513 31.3139,9.333 46.552,17.0293 15.2402,7.6884 29.9393,17.2473 43.3909,28.0325 13.4567,10.7799 25.6607,22.7803 36.0467,35.2189 10.393,12.4368 18.964,25.30468 25.354,37.77262 6.398,12.46958 10.611,24.53208 12.527,35.40228 1.925,10.875 1.551,20.5513 -0.975,28.3783 -1.935,6.012 -5.131,10.9374 -9.426,14.5635"
+         vector-effect="none"
+         fill-rule="evenodd"
+         id="path734"
+         style="stroke:#302b00;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none" />
+    </g>
+    <g
+       stroke-linecap="round"
+       fill="none"
+       font-weight="400"
+       font-style="normal"
+       stroke-opacity="1"
+       stroke-width="7"
+       stroke="#000000"
+       font-family="'Noto Sans'"
+       font-size="35.2778px"
+       stroke-linejoin="bevel"
+       transform="matrix(0.1329376,0,0,0.1329376,32.888438,32.182827)"
+       id="g668"
+       style="fill-rule:evenodd;stroke:#302b00;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none">
+      <path
+         d="m -69.5407,7.26503 c 2.4343,-2.05601 5.0172,-3.91638 7.7488,-5.58111 10.7338,-6.57586 23.668,-9.8685 36.9611,-9.96691 13.2885,-0.14605 26.86499,2.87413 38.7504,7.611484 C 25.8301,4.04195 35.9904,10.4045 43.1555,16.2505 c 7.2099,5.8541 11.4026,11.1152 12.6197,13.8516 0.468,1.0679 0.5425,1.7382 0.2237,2.0109"
+         vector-effect="none"
+         fill-rule="evenodd"
+         id="path666"
+         style="stroke:#302b00;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none" />
+    </g>
+    <path
+       style="fill:none;stroke:#302b00;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 27.129489,16.33306 C 28.681813,9.425144 33.7554,6.4786485 41.208349,6.2089354"
+       id="path1902" />
+    <g
+       stroke-linecap="round"
+       fill="none"
+       font-weight="400"
+       font-style="normal"
+       stroke-opacity="1"
+       stroke-width="7"
+       stroke="#000000"
+       font-family="'Noto Sans'"
+       font-size="35.2778px"
+       stroke-linejoin="bevel"
+       transform="matrix(0.1329376,0,0,0.1329376,32.836311,32.182827)"
+       id="g688"
+       style="fill-rule:evenodd;stroke:#302b00;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none">
+      <path
+         d="m -36.016943,217.43636 c -3.234323,-0.71246 -6.579068,-1.69327 -10.012557,-2.94736 -13.8196,-5.004 -29.0161,-14.375 -43.814,-27.436 -14.8005,-13.035 -29.1755,-29.743 -41.4305,-48.727"
+         vector-effect="none"
+         fill-rule="evenodd"
+         id="path686"
+         style="stroke:#302b00;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none" />
+    </g>
+    <g
+       stroke-linecap="round"
+       fill="none"
+       font-weight="400"
+       font-style="normal"
+       stroke-opacity="1"
+       stroke-width="7"
+       stroke="#000000"
+       font-family="'Noto Sans'"
+       font-size="35.2778px"
+       stroke-linejoin="bevel"
+       transform="matrix(0.1329376,0,0,0.1329376,32.888438,32.182827)"
+       id="g660"
+       style="fill-rule:evenodd;stroke:#302b00;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none">
+      <path
+         d="m -66.0074,135.192 c -0.7085,0.624 -3.4374,-1.167 -7.0352,-5.635 -4.5147,-5.563 -10.343,-15.431 -14.6165,-28.079"
+         vector-effect="none"
+         fill-rule="evenodd"
+         id="path658"
+         style="stroke:#302b00;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none" />
+    </g>
+    <g
+       stroke-linecap="round"
+       fill="none"
+       font-weight="400"
+       font-style="normal"
+       stroke-opacity="1"
+       stroke-width="7"
+       stroke="#000000"
+       font-family="'Noto Sans'"
+       font-size="35.2778px"
+       stroke-linejoin="bevel"
+       transform="matrix(0.1329376,0,0,0.1329376,33.638438,32.635952)"
+       id="g744"
+       style="fill-rule:evenodd;stroke:#302b00;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none">
+      <path
+         d="M -45.286,100.084 C -49.2516,94.3238 -53.7098,85.8966 -57.1573,75.7078"
+         vector-effect="none"
+         fill-rule="evenodd"
+         id="path742"
+         style="stroke:#302b00;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none" />
+    </g>
+    <path
+       style="fill:none;stroke:#fce94f;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 27.073998,58.893891 C 26.374159,58.58674 25.629561,58.162485 24.860888,57.634135 20.547019,54.668985 15.474854,48.42533 13.300006,41.202978"
+       id="path1948" />
+    <path
+       style="fill:none;stroke:#fce94f;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 31.881451,29.143409 C 23.438189,27.548365 17.098791,35.070653 18.627844,42.227533"
+       id="path1952" />
+    <path
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#a40000;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="M 30.994834,35.247684 4.9882777,57.127101"
+       id="path4129" />
+    <path
+       style="fill:none;stroke:#ef2929;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 30.994834,35.247684 33.356721,33.26062"
+       id="path1922" />
+    <path
+       style="fill:#a40000;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 30.1875,32.101562 -1.675781,1.316407 4.015625,-0.816407 z"
+       id="path1924" />
+    <path
+       style="fill:none;stroke:#fce94f;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 41.96838,30.635065 C 23.12635,13.035362 8.0415638,24.530545 13.300006,41.202978"
+       id="path1934" />
+    <path
+       style="fill:none;stroke:#fce94f;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 34.5625,37.65625 c 13.919539,16.589812 19.160278,4.467411 7.40588,-7.021185"
+       id="path1946" />
+    <path
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#ef2929;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="M 30.994834,35.247684 4.9882777,57.127101"
+       id="path4129-3" />
+    <path
+       style="fill:none;stroke:#fce94f;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 23.048024,52.063877 1.537168,5.309878"
+       id="path1950" />
+    <path
+       style="fill:none;stroke:#fce94f;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 47.650709,28.810484 C 46.38919,27.295217 44.915873,25.846136 43.168127,24.482815"
+       id="path1954" />
+    <g
+       stroke-linecap="round"
+       fill="none"
+       font-weight="400"
+       font-style="normal"
+       stroke-opacity="1"
+       stroke-width="7"
+       stroke="#000000"
+       font-family="'Noto Sans'"
+       font-size="35.2778px"
+       stroke-linejoin="bevel"
+       transform="matrix(0.1329376,0,0,0.1329376,27.341563,40.667202)"
+       id="g644"
+       style="fill-rule:evenodd;stroke:#302b00;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none">
+      <path
+         d="M 4.96832,153.335 32.766564,128.74036"
+         vector-effect="none"
+         fill-rule="evenodd"
+         id="path642"
+         style="stroke:#302b00;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none" />
+    </g>
+    <g
+       style="fill-rule:evenodd;stroke:#302b00;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none"
+       id="g716-3"
+       transform="matrix(0.1329376,0,0,0.1329376,26.061397,82.93774)"
+       stroke-linejoin="bevel"
+       font-size="35.2778px"
+       font-family="'Noto Sans'"
+       stroke="#000000"
+       stroke-width="7"
+       stroke-opacity="1"
+       font-style="normal"
+       font-weight="400"
+       fill="none"
+       stroke-linecap="round">
+      <path
+         style="stroke:#302b00;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path714-9"
+         fill-rule="evenodd"
+         vector-effect="none"
+         d="m 11.847572,-165.07165 -22.5794,-84.114" />
+    </g>
+    <g
+       style="fill-rule:evenodd;stroke:#302b00;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none"
+       id="g724-0"
+       transform="matrix(0.1329376,0,0,0.1329376,16.161902,75.689896)"
+       stroke-linejoin="bevel"
+       font-size="35.2778px"
+       font-family="'Noto Sans'"
+       stroke="#000000"
+       stroke-width="7"
+       stroke-opacity="1"
+       font-style="normal"
+       font-weight="400"
+       fill="none"
+       stroke-linecap="round">
+      <path
+         style="stroke:#302b00;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path722-5"
+         fill-rule="evenodd"
+         vector-effect="none"
+         d="m 94.2372,-220.435 22.5798,84.115" />
+    </g>
+  </g>
+</svg>

--- a/src/Mod/PartDesign/Gui/Resources/icons/PartDesign_Subtractive_Helix.svg
+++ b/src/Mod/PartDesign/Gui/Resources/icons/PartDesign_Subtractive_Helix.svg
@@ -1,0 +1,1456 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.1"
+   id="svg2901"
+   height="64px"
+   width="64px">
+  <title
+     id="title1085">PartDesign_Subtractive_Helix</title>
+  <defs
+     id="defs2903">
+    <linearGradient
+       id="linearGradient1942">
+      <stop
+         id="stop1938"
+         offset="0"
+         style="stop-color:#204a87;stop-opacity:1" />
+      <stop
+         id="stop1940"
+         offset="1"
+         style="stop-color:#729fcf;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1930">
+      <stop
+         id="stop1926"
+         offset="0"
+         style="stop-color:#204a87;stop-opacity:1" />
+      <stop
+         id="stop1928"
+         offset="1"
+         style="stop-color:#729fcf;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1475">
+      <stop
+         id="stop1471"
+         offset="0"
+         style="stop-color:#729fcf;stop-opacity:1" />
+      <stop
+         id="stop1473"
+         offset="1"
+         style="stop-color:#204a87;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4237">
+      <stop
+         style="stop-color:#f82b39;stop-opacity:1;"
+         offset="0"
+         id="stop4239" />
+      <stop
+         style="stop-color:#520001;stop-opacity:1;"
+         offset="1"
+         id="stop4241" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4052">
+      <stop
+         id="stop4054"
+         offset="0"
+         style="stop-color:#0090ff;stop-opacity:1;" />
+      <stop
+         style="stop-color:#f0f1f1;stop-opacity:1;"
+         offset="0.5"
+         id="stop4060" />
+      <stop
+         id="stop4056"
+         offset="1"
+         style="stop-color:#0046ff;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4044">
+      <stop
+         id="stop4046"
+         offset="0"
+         style="stop-color:#0090ff;stop-opacity:1;" />
+      <stop
+         id="stop4048"
+         offset="1"
+         style="stop-color:#061aff;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3273">
+      <stop
+         style="stop-color:#c8e0f9;stop-opacity:1;"
+         offset="0"
+         id="stop3275" />
+      <stop
+         style="stop-color:#f7f9fa;stop-opacity:0.09649123;"
+         offset="1"
+         id="stop3277" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3377">
+      <stop
+         style="stop-color:#c8e0f9;stop-opacity:1;"
+         offset="0"
+         id="stop3379" />
+      <stop
+         style="stop-color:#002795;stop-opacity:1;"
+         offset="1"
+         id="stop3381" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.97680237,0,0,0.96003508,1.4694319,0.12765765)"
+       gradientUnits="userSpaceOnUse"
+       y2="33.216251"
+       x2="33.928684"
+       y1="14.016123"
+       x1="44.858215"
+       id="linearGradient4050"
+       xlink:href="#linearGradient4044" />
+    <linearGradient
+       gradientTransform="matrix(0.97680237,0,0,0.96003508,1.4694319,0.12765765)"
+       gradientUnits="userSpaceOnUse"
+       y2="22.675821"
+       x2="52.323219"
+       y1="5.7974987"
+       x1="42.373707"
+       id="linearGradient4058"
+       xlink:href="#linearGradient4052" />
+    <linearGradient
+       gradientTransform="matrix(0.97680237,0,0,0.96003508,1.4694319,0.12765765)"
+       gradientUnits="userSpaceOnUse"
+       y2="22.675821"
+       x2="52.323219"
+       y1="5.7974987"
+       x1="42.373707"
+       id="linearGradient4058-6"
+       xlink:href="#linearGradient4052-1" />
+    <linearGradient
+       id="linearGradient4052-1">
+      <stop
+         id="stop4054-5"
+         offset="0"
+         style="stop-color:#1f5fe0;stop-opacity:1;" />
+      <stop
+         style="stop-color:#71b2f8;stop-opacity:1;"
+         offset="0.5"
+         id="stop4060-8" />
+      <stop
+         id="stop4056-4"
+         offset="1"
+         style="stop-color:#002795;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient4052-1"
+       id="linearGradient4078"
+       gradientUnits="userSpaceOnUse"
+       x1="42.373707"
+       y1="5.7974987"
+       x2="52.323219"
+       y2="22.675821"
+       gradientTransform="translate(-30.295225,-2.9287147)" />
+    <linearGradient
+       y2="33.216251"
+       x2="33.928684"
+       y1="14.016123"
+       x1="44.858215"
+       gradientTransform="matrix(0.97680237,0,0,0.96003508,107.10579,-22.235978)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3885"
+       xlink:href="#linearGradient4044" />
+    <linearGradient
+       y2="22.675821"
+       x2="52.323219"
+       y1="5.7974987"
+       x1="42.373707"
+       gradientTransform="matrix(0.97680237,0,0,0.96003508,107.10579,-22.235978)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3890"
+       xlink:href="#linearGradient4052-1" />
+    <linearGradient
+       y2="22.675821"
+       x2="52.323219"
+       y1="5.7974987"
+       x1="42.373707"
+       gradientTransform="matrix(0.97680237,0,0,0.96003508,107.10579,-22.235978)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3893"
+       xlink:href="#linearGradient4052" />
+    <linearGradient
+       id="linearGradient4052-1-0">
+      <stop
+         id="stop4054-5-5"
+         offset="0"
+         style="stop-color:#0090ff;stop-opacity:1;" />
+      <stop
+         style="stop-color:#f0f1f1;stop-opacity:1;"
+         offset="0.5"
+         id="stop4060-8-6" />
+      <stop
+         id="stop4056-4-6"
+         offset="1"
+         style="stop-color:#0046ff;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient4052-1-0"
+       id="linearGradient3912"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.97680237,0,0,0.96003508,-3.3630199,-18.322982)"
+       x1="42.373707"
+       y1="5.7974987"
+       x2="52.323219"
+       y2="22.675821" />
+    <linearGradient
+       id="linearGradient4052-1-0-0">
+      <stop
+         id="stop4054-5-5-9"
+         offset="0"
+         style="stop-color:#0090ff;stop-opacity:1;" />
+      <stop
+         style="stop-color:#f0f1f1;stop-opacity:1;"
+         offset="0.5"
+         id="stop4060-8-6-8" />
+      <stop
+         id="stop4056-4-6-4"
+         offset="1"
+         style="stop-color:#0046ff;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient4052-1-0-0"
+       id="linearGradient3985"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.97680237,0,0,0.96003508,126.73769,-70.092683)"
+       x1="42.373707"
+       y1="5.7974987"
+       x2="52.323219"
+       y2="22.675821" />
+    <linearGradient
+       id="linearGradient4044-8">
+      <stop
+         id="stop4046-2"
+         offset="0"
+         style="stop-color:#0090ff;stop-opacity:1;" />
+      <stop
+         id="stop4048-1"
+         offset="1"
+         style="stop-color:#061aff;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient4044-8"
+       id="linearGradient4072"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.97680237,0,0,0.96003508,-26.24677,-8.4607595)"
+       x1="44.858215"
+       y1="14.016123"
+       x2="33.928684"
+       y2="33.216251" />
+    <linearGradient
+       y2="33.216251"
+       x2="33.928684"
+       y1="14.016123"
+       x1="44.858215"
+       gradientTransform="matrix(0.97680237,0,0,0.96003508,58.307367,54.671469)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3885-6-5"
+       xlink:href="#linearGradient4044-8-4" />
+    <linearGradient
+       id="linearGradient4044-8-4">
+      <stop
+         id="stop4046-2-0"
+         offset="0"
+         style="stop-color:#0090ff;stop-opacity:1;" />
+      <stop
+         id="stop4048-1-9"
+         offset="1"
+         style="stop-color:#061aff;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient4044-8-4"
+       id="linearGradient4163"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.97680237,0,0,0.96003508,145.41299,94.782221)"
+       x1="44.858215"
+       y1="14.016123"
+       x2="33.928684"
+       y2="33.216251" />
+    <linearGradient
+       id="linearGradient4052-1-0-9">
+      <stop
+         id="stop4054-5-5-2"
+         offset="0"
+         style="stop-color:#0090ff;stop-opacity:1;" />
+      <stop
+         style="stop-color:#f0f1f1;stop-opacity:1;"
+         offset="0.5"
+         id="stop4060-8-6-5" />
+      <stop
+         id="stop4056-4-6-5"
+         offset="1"
+         style="stop-color:#0046ff;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient4052-1-0-9"
+       id="linearGradient4217"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.97680237,0,0,0.96003508,126.73769,-70.092687)"
+       x1="42.373707"
+       y1="5.7974987"
+       x2="52.323219"
+       y2="22.675821" />
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.94353923,0,0,0.73910673,2.0756521,7.8201849)"
+       r="18.483015"
+       fy="30.972466"
+       fx="36.572212"
+       cy="30.972466"
+       cx="36.572212"
+       id="radialGradient2153"
+       xlink:href="#linearGradient1475" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="24.589472"
+       x2="16.343052"
+       y1="36.503899"
+       x1="21.766993"
+       id="linearGradient1932"
+       xlink:href="#linearGradient1930" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="10.52606"
+       x2="33.022259"
+       y1="16.171356"
+       x1="38.137226"
+       id="linearGradient1944"
+       xlink:href="#linearGradient1942" />
+  </defs>
+  <metadata
+     id="metadata2906">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>PartDesign_Subtractive_Helix</dc:title>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>bitacovir, davidosterberg</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:title>PartDesign_Revolution</dc:title>
+        <dc:date>2020/12/30</dc:date>
+        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier />
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title />
+          </cc:Agent>
+        </dc:contributor>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1">
+    <path
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#a40000;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="M 58.926505,11.748661 30.994834,35.247684"
+       id="path4129-2" />
+    <path
+       id="path1148"
+       d="m 24.796663,32.902359 c -2.49904,1.557545 -3.811883,4.546599 -3.864437,7.426823 -0.0012,0.445552 -0.06934,0.965067 0.0039,1.371378 1.059971,-0.840102 2.07592,-1.734317 3.112698,-2.602685 0.02511,-1.951889 -0.09937,-3.973426 0.65898,-5.820185 0.02305,-0.112323 0.110254,-0.278728 0.08891,-0.375331 z"
+       style="fill:#204a87;fill-opacity:1;stroke-width:0.0188065" />
+    <g
+       style="fill-rule:evenodd"
+       id="g508"
+       transform="matrix(0.1408925,0,0,0.1408925,32.656603,32.531155)"
+       stroke-linejoin="bevel"
+       font-size="35.2778px"
+       font-family="'Noto Sans'"
+       stroke="#000000"
+       stroke-width="1"
+       stroke-opacity="1"
+       font-style="normal"
+       font-weight="400"
+       fill="none"
+       stroke-linecap="square">
+      <rect
+         id="rect506"
+         width="0"
+         height="0"
+         y="0"
+         x="0" />
+    </g>
+    <g
+       style="fill-rule:evenodd"
+       id="g516"
+       transform="matrix(0.1408925,0,0,0.1408925,32.656603,32.531155)"
+       stroke-linejoin="bevel"
+       font-size="35.2778px"
+       font-family="'Noto Sans'"
+       stroke="#000000"
+       stroke-width="1"
+       stroke-opacity="1"
+       font-style="normal"
+       font-weight="400"
+       fill="none"
+       stroke-linecap="square">
+      <rect
+         id="rect514"
+         width="0"
+         height="0"
+         y="0"
+         x="0" />
+    </g>
+    <g
+       style="fill-rule:evenodd"
+       id="g524"
+       transform="matrix(0.1408925,0,0,0.1408925,32.656603,32.531155)"
+       stroke-linejoin="bevel"
+       font-size="35.2778px"
+       font-family="'Noto Sans'"
+       stroke="#000000"
+       stroke-width="1"
+       stroke-opacity="1"
+       font-style="normal"
+       font-weight="400"
+       fill="none"
+       stroke-linecap="square">
+      <rect
+         id="rect522"
+         width="0"
+         height="0"
+         y="0"
+         x="0" />
+    </g>
+    <g
+       style="fill-rule:evenodd"
+       id="g532"
+       transform="matrix(0.1408925,0,0,0.1408925,32.656603,32.531155)"
+       stroke-linejoin="bevel"
+       font-size="35.2778px"
+       font-family="'Noto Sans'"
+       stroke="#000000"
+       stroke-width="1"
+       stroke-opacity="1"
+       font-style="normal"
+       font-weight="400"
+       fill="none"
+       stroke-linecap="square">
+      <rect
+         id="rect530"
+         width="0"
+         height="0"
+         y="0"
+         x="0" />
+    </g>
+    <g
+       style="fill-rule:evenodd"
+       id="g540"
+       transform="matrix(0.1408925,0,0,0.1408925,32.656603,32.531155)"
+       stroke-linejoin="bevel"
+       font-size="35.2778px"
+       font-family="'Noto Sans'"
+       stroke="#000000"
+       stroke-width="1"
+       stroke-opacity="1"
+       font-style="normal"
+       font-weight="400"
+       fill="none"
+       stroke-linecap="square">
+      <rect
+         id="rect538"
+         width="0"
+         height="0"
+         y="0"
+         x="0" />
+    </g>
+    <g
+       style="fill-rule:evenodd"
+       id="g548"
+       transform="matrix(0.1408925,0,0,0.1408925,32.656603,32.531155)"
+       stroke-linejoin="bevel"
+       font-size="35.2778px"
+       font-family="'Noto Sans'"
+       stroke="#000000"
+       stroke-width="1"
+       stroke-opacity="1"
+       font-style="normal"
+       font-weight="400"
+       fill="none"
+       stroke-linecap="square">
+      <rect
+         id="rect546"
+         width="0"
+         height="0"
+         y="0"
+         x="0" />
+    </g>
+    <g
+       style="fill-rule:evenodd"
+       id="g556"
+       transform="matrix(0.1408925,0,0,0.1408925,32.656603,32.531155)"
+       stroke-linejoin="bevel"
+       font-size="35.2778px"
+       font-family="'Noto Sans'"
+       stroke="#000000"
+       stroke-width="1"
+       stroke-opacity="1"
+       font-style="normal"
+       font-weight="400"
+       fill="none"
+       stroke-linecap="square">
+      <rect
+         id="rect554"
+         width="0"
+         height="0"
+         y="0"
+         x="0" />
+    </g>
+    <g
+       style="fill-rule:evenodd"
+       id="g564"
+       transform="matrix(0.1408925,0,0,0.1408925,32.656603,32.531155)"
+       stroke-linejoin="bevel"
+       font-size="35.2778px"
+       font-family="'Noto Sans'"
+       stroke="#000000"
+       stroke-width="1"
+       stroke-opacity="1"
+       font-style="normal"
+       font-weight="400"
+       fill="none"
+       stroke-linecap="square">
+      <rect
+         id="rect562"
+         width="0"
+         height="0"
+         y="0"
+         x="0" />
+    </g>
+    <g
+       style="fill-rule:evenodd"
+       id="g572"
+       transform="matrix(0.1408925,0,0,0.1408925,32.656603,32.531155)"
+       stroke-linejoin="bevel"
+       font-size="35.2778px"
+       font-family="'Noto Sans'"
+       stroke="#000000"
+       stroke-width="1"
+       stroke-opacity="1"
+       font-style="normal"
+       font-weight="400"
+       fill="none"
+       stroke-linecap="square">
+      <rect
+         id="rect570"
+         width="0"
+         height="0"
+         y="0"
+         x="0" />
+    </g>
+    <g
+       style="fill-rule:evenodd"
+       id="g580"
+       transform="matrix(0.1408925,0,0,0.1408925,32.656603,32.531155)"
+       stroke-linejoin="bevel"
+       font-size="35.2778px"
+       font-family="'Noto Sans'"
+       stroke="#000000"
+       stroke-width="1"
+       stroke-opacity="1"
+       font-style="normal"
+       font-weight="400"
+       fill="none"
+       stroke-linecap="square">
+      <rect
+         id="rect578"
+         width="0"
+         height="0"
+         y="0"
+         x="0" />
+    </g>
+    <g
+       style="fill-rule:evenodd"
+       id="g588"
+       transform="matrix(0.1408925,0,0,0.1408925,32.656603,32.531155)"
+       stroke-linejoin="bevel"
+       font-size="35.2778px"
+       font-family="'Noto Sans'"
+       stroke="#000000"
+       stroke-width="1"
+       stroke-opacity="1"
+       font-style="normal"
+       font-weight="400"
+       fill="none"
+       stroke-linecap="square">
+      <rect
+         id="rect586"
+         width="0"
+         height="0"
+         y="0"
+         x="0" />
+    </g>
+    <g
+       style="fill-rule:evenodd"
+       id="g596"
+       transform="matrix(0.1408925,0,0,0.1408925,32.656603,32.531155)"
+       stroke-linejoin="bevel"
+       font-size="35.2778px"
+       font-family="'Noto Sans'"
+       stroke="#000000"
+       stroke-width="1"
+       stroke-opacity="1"
+       font-style="normal"
+       font-weight="400"
+       fill="none"
+       stroke-linecap="square">
+      <rect
+         id="rect594"
+         width="0"
+         height="0"
+         y="0"
+         x="0" />
+    </g>
+    <g
+       style="fill-rule:evenodd"
+       id="g604"
+       transform="matrix(0.1408925,0,0,0.1408925,32.656603,32.531155)"
+       stroke-linejoin="bevel"
+       font-size="35.2778px"
+       font-family="'Noto Sans'"
+       stroke="#000000"
+       stroke-width="1"
+       stroke-opacity="1"
+       font-style="normal"
+       font-weight="400"
+       fill="none"
+       stroke-linecap="square">
+      <rect
+         id="rect602"
+         width="0"
+         height="0"
+         y="0"
+         x="0" />
+    </g>
+    <g
+       style="fill-rule:evenodd"
+       id="g612"
+       transform="matrix(0.1408925,0,0,0.1408925,32.656603,32.531155)"
+       stroke-linejoin="bevel"
+       font-size="35.2778px"
+       font-family="'Noto Sans'"
+       stroke="#000000"
+       stroke-width="1"
+       stroke-opacity="1"
+       font-style="normal"
+       font-weight="400"
+       fill="none"
+       stroke-linecap="square">
+      <rect
+         id="rect610"
+         width="0"
+         height="0"
+         y="0"
+         x="0" />
+    </g>
+    <g
+       style="fill-rule:evenodd"
+       id="g620"
+       transform="matrix(0.1408925,0,0,0.1408925,32.656603,32.531155)"
+       stroke-linejoin="bevel"
+       font-size="35.2778px"
+       font-family="'Noto Sans'"
+       stroke="#000000"
+       stroke-width="1"
+       stroke-opacity="1"
+       font-style="normal"
+       font-weight="400"
+       fill="none"
+       stroke-linecap="square">
+      <rect
+         id="rect618"
+         width="0"
+         height="0"
+         y="0"
+         x="0" />
+    </g>
+    <g
+       style="fill-rule:evenodd"
+       id="g628"
+       transform="matrix(0.1408925,0,0,0.1408925,32.656603,32.531155)"
+       stroke-linejoin="bevel"
+       font-size="35.2778px"
+       font-family="'Noto Sans'"
+       stroke="#000000"
+       stroke-width="1"
+       stroke-opacity="1"
+       font-style="normal"
+       font-weight="400"
+       fill="none"
+       stroke-linecap="square">
+      <rect
+         id="rect626"
+         width="0"
+         height="0"
+         y="0"
+         x="0" />
+    </g>
+    <g
+       style="fill-rule:evenodd"
+       id="g636"
+       transform="matrix(0.1408925,0,0,0.1408925,32.656603,32.531155)"
+       stroke-linejoin="bevel"
+       font-size="35.2778px"
+       font-family="'Noto Sans'"
+       stroke="#000000"
+       stroke-width="1"
+       stroke-opacity="1"
+       font-style="normal"
+       font-weight="400"
+       fill="none"
+       stroke-linecap="square">
+      <rect
+         id="rect634"
+         width="0"
+         height="0"
+         y="0"
+         x="0" />
+    </g>
+    <g
+       style="fill-rule:evenodd"
+       id="g808"
+       transform="matrix(0.1408925,0,0,0.1408925,32.656603,32.531155)"
+       stroke-linejoin="bevel"
+       font-size="35.2778px"
+       font-family="'Noto Sans'"
+       stroke="#000000"
+       stroke-width="7"
+       stroke-opacity="1"
+       font-style="normal"
+       font-weight="400"
+       fill="none"
+       stroke-linecap="round" />
+    <g
+       style="fill-rule:evenodd;stroke:#0b1521;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none"
+       id="g704"
+       transform="matrix(0.1329376,0,0,0.1329376,32.888438,32.182827)"
+       stroke-linejoin="bevel"
+       font-size="35.2778px"
+       font-family="'Noto Sans'"
+       stroke="#000000"
+       stroke-width="7"
+       stroke-opacity="1"
+       font-style="normal"
+       font-weight="400"
+       fill="none"
+       stroke-linecap="round">
+      <path
+         style="stroke:#0b1521;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path702"
+         fill-rule="evenodd"
+         vector-effect="none"
+         d="M -19.8654,17.3031 C -24.2765,9.10641 -28.2267,0.69267 -31.7161,-7.93816" />
+    </g>
+    <g
+       style="fill-rule:evenodd;stroke:#0b1521;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none"
+       id="g748"
+       transform="matrix(0.1329376,0,0,0.1329376,32.888438,32.182827)"
+       stroke-linejoin="bevel"
+       font-size="35.2778px"
+       font-family="'Noto Sans'"
+       stroke="#000000"
+       stroke-width="7"
+       stroke-opacity="1"
+       font-style="normal"
+       font-weight="400"
+       fill="none"
+       stroke-linecap="round">
+      <path
+         style="stroke:#0b1521;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path746"
+         fill-rule="evenodd"
+         vector-effect="none"
+         d="m -62.3807,53.2229 c -0.4529,-3.4931 -0.7343,-7.0263 -0.8442,-10.5998 -0.5306,-16.1486 2.9686,-32.6195 11.0491,-45.74076" />
+    </g>
+    <path
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#ef2929;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="M 58.926505,11.748661 30.994834,35.247684"
+       id="path4129-3-9" />
+    <path
+       id="path1136"
+       d="m 23.916128,20.482757 c -3.386694,-0.07232 -6.867398,1.108636 -9.249765,3.5733 -2.391714,2.338019 -3.582909,5.682502 -3.779695,8.973404 -0.172345,2.512484 0.04938,5.043402 0.675197,7.483401 0.422362,2.403648 2.191039,6.274971 2.496962,6.730557 2.063344,-1.572684 4.248818,-3.538549 5.975639,-4.990697 -0.269655,-2.775107 0.155628,-5.47518 1.799825,-7.788928 1.564419,-2.314174 4.284725,-3.666463 7.04316,-3.811186 3.79062,-0.257051 7.564977,1.249827 10.445209,3.661358 0.606418,0.589305 1.330169,1.21856 1.507866,2.078609 0.0075,0.553553 -0.691492,0.660588 -1.04277,0.349385 -0.816035,-0.59302 -1.247582,-1.548415 -1.863537,-2.312185 -0.473573,-0.344579 0.09815,-0.780044 -0.467054,-0.934348 -1.358758,1.139033 -3.01478,2.661015 -4.314975,3.857441 0.617274,1.179348 0.755125,1.780664 1.585082,2.816924 2.343975,2.697079 5.141523,5.173026 8.546039,6.405848 1.53912,0.502863 3.352744,0.80899 4.840819,-7.3e-4 1.490273,-0.848923 1.942162,-2.743718 1.860772,-4.345359 C 49.633285,38.37663 47.619904,34.89448 45.253857,31.923024 40.983577,26.690547 35.130131,22.602502 28.521468,21.001167 c -1.508985,-0.370446 -3.050369,-0.563304 -4.60534,-0.51841 z"
+       style="fill:url(#linearGradient1932);fill-opacity:1;stroke-width:0.0188065" />
+    <g
+       style="fill-rule:evenodd;stroke:#0b1521;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none"
+       id="g664"
+       transform="matrix(0.1329376,0,0,0.1329376,32.888438,32.182827)"
+       stroke-linejoin="bevel"
+       font-size="35.2778px"
+       font-family="'Noto Sans'"
+       stroke="#000000"
+       stroke-width="7"
+       stroke-opacity="1"
+       font-style="normal"
+       font-weight="400"
+       fill="none"
+       stroke-linecap="round">
+      <path
+         style="stroke:#0b1521;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path662"
+         fill-rule="evenodd"
+         vector-effect="none"
+         d="m -92.8825,78.9928 c -0.453,-3.493 -0.7344,-7.0264 -0.8442,-10.5999 -0.3599,-11.6552 1.3089,-23.5037 5.3662,-34.1102 4.0295,-10.6212 10.4466,-19.9665 18.8198,-27.01767" />
+    </g>
+    <path
+       id="path1150"
+       d="m 25.026234,43.110494 c -1.082051,0.902987 -2.200211,1.800646 -3.226392,2.747716 0.312698,0.810493 2.161565,2.86111 2.623196,3.598772 1.057117,-0.972474 2.382261,-1.937926 3.397772,-2.930963 -0.427046,-0.733669 -2.363283,-2.691467 -2.780583,-3.424708 z"
+       style="fill:#204a87;fill-opacity:1;stroke-width:0.0188065" />
+    <g
+       style="fill-rule:evenodd;stroke:#0b1521;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none"
+       id="g692"
+       transform="matrix(0.1329376,0,0,0.1329376,32.888438,32.182827)"
+       stroke-linejoin="bevel"
+       font-size="35.2778px"
+       font-family="'Noto Sans'"
+       stroke="#000000"
+       stroke-width="7"
+       stroke-opacity="1"
+       font-style="normal"
+       font-weight="400"
+       fill="none"
+       stroke-linecap="round">
+      <path
+         style="stroke:#0b1521;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path690"
+         fill-rule="evenodd"
+         vector-effect="none"
+         d="m -141.872,120.382 c -7.715,-14.341 -14.133,-29.5441 -18.826,-44.9314 -8.736,-28.4969 -11.385,-57.5741 -6.87,-82.92542 4.433,-25.39528 16.028,-46.96288 33.491,-61.64788" />
+    </g>
+    <path
+       id="path1152"
+       d="m 28.771279,46.949436 c -1.055916,0.854935 -2.255651,2.359524 -3.233326,3.280888 -0.03573,2.945902 -0.815144,9.23349 2.310548,10.332799 1.099611,-0.841998 3.101034,-1.835058 4.104284,-2.766729 -3.110182,-1.215562 -1.223624,-4.071391 -1.59023,-6.590516 z"
+       style="fill:#204a87;fill-opacity:1;stroke-width:0.0188065" />
+    <path
+       id="path1138"
+       d="m 18.569808,48.543395 c -0.811087,0.716853 -1.703922,1.388502 -2.439289,2.164532 1.613702,2.514439 3.66414,4.745365 5.944848,6.670877 2.033202,1.581569 4.341024,3.021411 6.937977,3.381004 1.571786,0.227131 -2.158798,0.221727 -1.385949,-1.259949 0.873673,-1.639895 -0.07506,-1.398313 -0.472906,-3.132216 -0.05989,-0.404767 -0.735583,-3.220892 -1.193878,-3.270534 -2.701075,-1.021128 1.287051,-2.379268 -1.417716,-3.390552 0.214564,0.423108 -0.09782,1.116382 -0.632015,0.906043 -1.045274,-0.514062 -1.598671,-1.637318 -2.165744,-2.599055 -0.26846,-0.498873 -0.506338,-1.013468 -0.73123,-1.533232 z"
+       style="fill:#204a87;fill-opacity:1;stroke:#c4a000;stroke-width:0.0188065" />
+    <g
+       style="fill-rule:evenodd;stroke:#0b1521;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none"
+       id="g652"
+       transform="matrix(0.1329376,0,0,0.1329376,34.28521,33.447342)"
+       stroke-linejoin="bevel"
+       font-size="35.2778px"
+       font-family="'Noto Sans'"
+       stroke="#000000"
+       stroke-width="7"
+       stroke-opacity="1"
+       font-style="normal"
+       font-weight="400"
+       fill="none"
+       stroke-linecap="round">
+      <path
+         style="stroke:#0b1521;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path650"
+         fill-rule="evenodd"
+         vector-effect="none"
+         d="M -43.0796,98.2197 -73.5812,123.989" />
+    </g>
+    <path
+       id="path1142"
+       d="m 27.947841,17.052594 c -3.174773,-0.04437 -6.432938,0.986372 -8.804323,3.135728 0.417031,-0.01726 0.899819,-0.259608 1.349443,-0.310322 4.915209,-1.040799 10.027873,0.25524 14.433596,2.480303 3.562416,1.799347 6.774091,4.25947 9.491248,7.179173 2.76224,2.960477 5.124966,6.451636 6.1483,10.411344 0.370179,1.436708 0.410534,2.97347 0.194152,4.424244 0.867207,-0.660923 1.756021,-1.352951 2.465232,-2.193975 1.115509,-1.702406 0.877058,-3.892646 0.387285,-5.765379 -1.203201,-4.211103 -3.913489,-7.823595 -6.991361,-10.865074 -4.373823,-4.218358 -9.922086,-7.41243 -15.97871,-8.343004 -0.890516,-0.142841 -1.794959,-0.156173 -2.694862,-0.153038 z"
+       style="fill:url(#radialGradient2153);fill-opacity:1;stroke-width:0.0188065" />
+    <g
+       style="fill-rule:evenodd;stroke-width:11.3562;stroke-linecap:square;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+       id="g536"
+       transform="matrix(0.1329376,0,0,0.1329376,32.888438,32.182827)"
+       fill-opacity="1"
+       font-size="35.2778px"
+       font-family="'Noto Sans'"
+       stroke="none"
+       font-style="normal"
+       font-weight="400"
+       fill="#ffffff">
+      <path
+         style="stroke-width:11.3562;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path534"
+         fill-rule="evenodd"
+         vector-effect="non-scaling-stroke"
+         d="m -44.1682,-117.383 c 14.8298,-0.905 30.6277,0.795 46.59147,4.886 15.96313,4.081 32.08453,10.551 47.54303,18.9136 0.8132,-0.7664 1.6463,-1.51 2.4995,-2.2308 5.1433,-4.3488 11.0077,-7.8418 17.3648,-10.3828 5.245,-2.087 10.7397,-3.539 16.4842,-4.354 l -22.5794,-84.114 c -14.733,-0.908 -28.8363,0.52 -41.6631,4.304 -12.83165,3.775 -24.38195,9.906 -34.1424,18.159 -15.8653,13.356 -26.915,32.373 -32.0981,54.819" />
+    </g>
+    <path
+       id="path1140"
+       d="m 39.592148,6.8262386 c -2.767588,-0.046717 -5.536757,0.9297193 -7.720601,2.6187189 -2.115445,1.6420095 -3.5458,4.1064365 -4.23432,6.6336705 2.615998,-0.0257 5.22389,0.430995 7.689769,1.300441 1.417169,0.482294 2.782277,1.102111 4.120266,1.770424 1.235412,-1.008282 2.714926,-1.685818 4.256621,-2.052588 0.02368,-0.392677 -0.210061,-0.84059 -0.277487,-1.250497 -0.797683,-3.011843 -1.612584,-6.0190869 -2.420525,-9.0281862 -0.471242,0.00267 -0.942483,0.00534 -1.413723,0.00802 z"
+       style="fill:url(#linearGradient1944);fill-opacity:1;stroke-width:0.0188065" />
+    <path
+       id="path1936"
+       d="M 29.181036,16.119053 C 30.649523,12.064189 32.796739,9.1240641 39.75,8.3125 l 2.164063,7.765625 c -2.024029,0.641737 -3.133769,1.846842 -3.590959,3.044584"
+       style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <g
+       style="fill-rule:evenodd;stroke-width:11.3562;stroke-linecap:square;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+       id="g544"
+       transform="matrix(0.1329376,0,0,0.1329376,32.888438,32.182827)"
+       fill-opacity="1"
+       font-size="35.2778px"
+       font-family="'Noto Sans'"
+       stroke="none"
+       font-style="normal"
+       font-weight="400"
+       fill="#ffffff">
+      <path
+         style="stroke-width:11.3562;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path542"
+         fill-rule="evenodd"
+         vector-effect="non-scaling-stroke"
+         d="m 94.2372,-220.435 22.5798,84.115 -30.5022,25.769 -22.5794,-84.114 30.5018,-25.77" />
+    </g>
+    <path
+       id="path1144"
+       d="M 45.129267,3.843995 C 44.0137,4.5639787 43.06674,5.5317209 42.027364,6.3600992 c -0.27568,0.3165421 0.167038,0.857175 0.179899,1.2637219 0.818693,2.9835589 1.602304,6.0551079 2.44158,8.9843509 1.07244,-0.905933 2.203001,-1.760396 3.190534,-2.757336 -0.849988,-3.340503 -1.742706,-6.6852215 -2.677314,-10.0030513 -0.0098,-0.00597 -0.02195,-0.00559 -0.0328,-0.00379 z"
+       style="fill:#204a87;fill-opacity:1;stroke-width:0.0188065" />
+    <g
+       style="fill-rule:evenodd;stroke-width:11.3562;stroke-linecap:square;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+       id="g592"
+       transform="matrix(0.1329376,0,0,0.1329376,32.888438,32.182827)"
+       fill-opacity="1"
+       font-size="35.2778px"
+       font-family="'Noto Sans'"
+       stroke="none"
+       font-style="normal"
+       font-weight="400"
+       fill="#ffffff">
+      <path
+         style="stroke-width:11.3562;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path590"
+         fill-rule="evenodd"
+         vector-effect="non-scaling-stroke"
+         d="m -12.0701,-172.202 c 9.76045,-8.253 21.31075,-14.384 34.1424,-18.159 12.8268,-3.784 26.9301,-5.212 41.6631,-4.304 l 30.5018,-25.77 c -14.7331,-0.908 -28.8364,0.52 -41.6631,4.304 -12.8316,3.775 -24.3817,9.906 -34.1422,18.159 l -30.502,25.77" />
+    </g>
+    <path
+       id="path1146"
+       d="M 43.28424,3.3602186 C 40.427569,3.5296102 37.530005,4.4984683 35.40141,6.456592 36.111602,6.3580162 36.839439,6.0785591 37.576712,6.0108371 38.796144,5.8259286 40.031476,5.8142236 41.261533,5.7734162 42.202963,4.9773363 43.144426,4.181294 44.085919,3.3852892 43.818776,3.3751348 43.551757,3.3529512 43.28424,3.3602186 Z"
+       style="fill:#729fcf;fill-opacity:1;stroke-width:0.0188065" />
+    <g
+       style="fill-rule:evenodd;stroke-width:11.3562;stroke-linecap:square;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none"
+       id="g632"
+       transform="matrix(0.1329376,0,0,0.1329376,32.888438,32.182827)"
+       fill-opacity="1"
+       font-size="35.2778px"
+       font-family="'Noto Sans'"
+       stroke="none"
+       font-style="normal"
+       font-weight="400"
+       fill="#ffffff">
+      <path
+         style="stroke-width:11.3562;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path630"
+         fill-rule="evenodd"
+         vector-effect="non-scaling-stroke"
+         d="m 49.9663,-93.5834 c 3.9476,2.1349 7.8457,4.3862 11.6943,6.7539 1.8318,-6.9108 4.5629,-13.4675 8.17,-19.3675 -6.3571,2.541 -12.2215,6.034 -17.3648,10.3828 -0.8532,0.7208 -1.6863,1.4644 -2.4995,2.2308" />
+    </g>
+    <g
+       style="fill-rule:evenodd;stroke-width:11.3562;stroke-miterlimit:4;stroke-dasharray:none"
+       id="g672"
+       transform="matrix(0.1329376,0,0,0.1329376,32.888438,32.182827)"
+       stroke-linejoin="bevel"
+       font-size="35.2778px"
+       font-family="'Noto Sans'"
+       stroke="#000000"
+       stroke-width="7"
+       stroke-opacity="1"
+       font-style="normal"
+       font-weight="400"
+       fill="none"
+       stroke-linecap="round">
+      <path
+         style="stroke-width:11.3562;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path670"
+         fill-rule="evenodd"
+         vector-effect="none"
+         d="m 55.9989,32.113 c -0.5836,0.5044 -2.5101,-0.5895 -5.1737,-3.4719 -2.6574,-2.8676 -6.0386,-7.5235 -9.3654,-13.737" />
+    </g>
+    <g
+       style="fill-rule:evenodd;stroke-width:11.3562;stroke-miterlimit:4;stroke-dasharray:none"
+       id="g676"
+       transform="matrix(0.1329376,0,0,0.1329376,32.888438,32.182827)"
+       stroke-linejoin="bevel"
+       font-size="35.2778px"
+       font-family="'Noto Sans'"
+       stroke="#000000"
+       stroke-width="7"
+       stroke-opacity="1"
+       font-style="normal"
+       font-weight="400"
+       fill="none"
+       stroke-linecap="round">
+      <path
+         style="stroke-width:11.3562;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path674"
+         fill-rule="evenodd"
+         vector-effect="none"
+         d="m 49.9663,-93.5834 c 0.8132,-0.7664 1.6463,-1.51 2.4995,-2.2308" />
+    </g>
+    <g
+       style="fill-rule:evenodd;stroke:#0b1521;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none"
+       id="g680"
+       transform="matrix(0.1329376,0,0,0.1329376,32.888438,32.182827)"
+       stroke-linejoin="bevel"
+       font-size="35.2778px"
+       font-family="'Noto Sans'"
+       stroke="#000000"
+       stroke-width="7"
+       stroke-opacity="1"
+       font-style="normal"
+       font-weight="400"
+       fill="none"
+       stroke-linecap="round">
+      <path
+         style="stroke:#0b1521;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path678"
+         fill-rule="evenodd"
+         vector-effect="none"
+         d="m 52.4658,-95.8142 c 9.3553,-7.9398 21.1562,-12.9478 33.849,-14.7368" />
+    </g>
+    <g
+       style="fill-rule:evenodd;stroke:#0b1521;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none"
+       id="g700"
+       transform="matrix(0.1329376,0,0,0.1329376,32.888438,32.182827)"
+       stroke-linejoin="bevel"
+       font-size="35.2778px"
+       font-family="'Noto Sans'"
+       stroke="#000000"
+       stroke-width="7"
+       stroke-opacity="1"
+       font-style="normal"
+       font-weight="400"
+       fill="none"
+       stroke-linecap="round">
+      <path
+         style="stroke:#0b1521;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path698"
+         fill-rule="evenodd"
+         vector-effect="none"
+         d="m 120.537,108.499 c -9.02,7.671 -22.9951,9.433 -39.4089,4.601 C 64.7384,108.335 45.9778,96.9835 28.0518,80.2462 14.7085,67.8195 1.85002,52.4649 -9.26713,35.247" />
+    </g>
+    <g
+       style="fill-rule:evenodd;stroke:#0b1521;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none"
+       id="g716"
+       transform="matrix(0.1329376,0,0,0.1329376,32.888438,32.182827)"
+       stroke-linejoin="bevel"
+       font-size="35.2778px"
+       font-family="'Noto Sans'"
+       stroke="#000000"
+       stroke-width="7"
+       stroke-opacity="1"
+       font-style="normal"
+       font-weight="400"
+       fill="none"
+       stroke-linecap="round">
+      <path
+         style="stroke:#0b1521;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path714"
+         fill-rule="evenodd"
+         vector-effect="none"
+         d="M 86.3148,-110.551 63.7354,-194.665" />
+    </g>
+    <g
+       style="fill-rule:evenodd;stroke:#0b1521;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none"
+       id="g720"
+       transform="matrix(0.1329376,0,0,0.1329376,32.888438,32.182827)"
+       stroke-linejoin="bevel"
+       font-size="35.2778px"
+       font-family="'Noto Sans'"
+       stroke="#000000"
+       stroke-width="7"
+       stroke-opacity="1"
+       font-style="normal"
+       font-weight="400"
+       fill="none"
+       stroke-linecap="round">
+      <path
+         style="stroke:#0b1521;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path718"
+         fill-rule="evenodd"
+         vector-effect="none"
+         d="m 63.7354,-194.665 30.5018,-25.77" />
+    </g>
+    <g
+       style="fill-rule:evenodd;stroke:#0b1521;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none"
+       id="g724"
+       transform="matrix(0.1329376,0,0,0.1329376,32.888438,32.182827)"
+       stroke-linejoin="bevel"
+       font-size="35.2778px"
+       font-family="'Noto Sans'"
+       stroke="#000000"
+       stroke-width="7"
+       stroke-opacity="1"
+       font-style="normal"
+       font-weight="400"
+       fill="none"
+       stroke-linecap="round">
+      <path
+         style="stroke:#0b1521;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path722"
+         fill-rule="evenodd"
+         vector-effect="none"
+         d="m 94.2372,-220.435 22.5798,84.115" />
+    </g>
+    <g
+       style="fill-rule:evenodd;stroke:#0b1521;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none"
+       id="g728"
+       transform="matrix(0.1329376,0,0,0.1329376,32.888438,32.182827)"
+       stroke-linejoin="bevel"
+       font-size="35.2778px"
+       font-family="'Noto Sans'"
+       stroke="#000000"
+       stroke-width="7"
+       stroke-opacity="1"
+       font-style="normal"
+       font-weight="400"
+       fill="none"
+       stroke-linecap="round">
+      <path
+         style="stroke:#0b1521;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path726"
+         fill-rule="evenodd"
+         vector-effect="none"
+         d="m 116.817,-136.32 -30.5022,25.769" />
+    </g>
+    <g
+       style="fill-rule:evenodd;stroke:#0b1521;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none"
+       id="g740"
+       transform="matrix(0.1329376,0,0,0.1329376,32.888438,32.182827)"
+       stroke-linejoin="bevel"
+       font-size="35.2778px"
+       font-family="'Noto Sans'"
+       stroke="#000000"
+       stroke-width="7"
+       stroke-opacity="1"
+       font-style="normal"
+       font-weight="400"
+       fill="none"
+       stroke-linecap="round">
+      <path
+         style="stroke:#0b1521;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path738"
+         fill-rule="evenodd"
+         vector-effect="none"
+         d="m 18.4319,-197.972 c 9.7605,-8.253 21.3106,-14.384 34.1422,-18.159 12.8267,-3.784 26.93,-5.212 41.6631,-4.304" />
+    </g>
+    <g
+       style="fill-rule:evenodd;stroke:#0b1521;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none"
+       id="g780"
+       transform="matrix(0.1329376,0,0,0.1329376,32.888438,32.182827)"
+       stroke-linejoin="bevel"
+       font-size="35.2778px"
+       font-family="'Noto Sans'"
+       stroke="#000000"
+       stroke-width="7"
+       stroke-opacity="1"
+       font-style="normal"
+       font-weight="400"
+       fill="none"
+       stroke-linecap="round">
+      <path
+         style="stroke:#0b1521;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path778"
+         fill-rule="evenodd"
+         vector-effect="none"
+         d="m -134.077,-69.1227 30.502,-25.7696" />
+    </g>
+    <g
+       style="fill-rule:evenodd;stroke:#0b1521;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none"
+       id="g784"
+       transform="matrix(0.1329376,0,0,0.1329376,32.888438,32.182827)"
+       stroke-linejoin="bevel"
+       font-size="35.2778px"
+       font-family="'Noto Sans'"
+       stroke="#000000"
+       stroke-width="7"
+       stroke-opacity="1"
+       font-style="normal"
+       font-weight="400"
+       fill="none"
+       stroke-linecap="round">
+      <path
+         style="stroke:#0b1521;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path782"
+         fill-rule="evenodd"
+         vector-effect="none"
+         d="M 120.537,108.499 151.038,82.7294" />
+    </g>
+    <g
+       style="fill-rule:evenodd;stroke:#0b1521;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none"
+       id="g788"
+       transform="matrix(0.1329376,0,0,0.1329376,32.888438,32.182827)"
+       stroke-linejoin="bevel"
+       font-size="35.2778px"
+       font-family="'Noto Sans'"
+       stroke="#000000"
+       stroke-width="7"
+       stroke-opacity="1"
+       font-style="normal"
+       font-weight="400"
+       fill="none"
+       stroke-linecap="round">
+      <path
+         style="stroke:#0b1521;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path786"
+         fill-rule="evenodd"
+         vector-effect="none"
+         d="M -12.214558,-173.378 18.4319,-197.972" />
+    </g>
+    <g
+       style="fill-rule:evenodd;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none"
+       id="g696"
+       transform="matrix(0.1329376,0,0,0.1329376,32.888438,32.182827)"
+       stroke-linejoin="bevel"
+       font-size="35.2778px"
+       font-family="'Noto Sans'"
+       stroke="#000000"
+       stroke-width="7"
+       stroke-opacity="1"
+       font-style="normal"
+       font-weight="400"
+       fill="none"
+       stroke-linecap="round">
+      <path
+         style="stroke:#0b1521;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path694"
+         fill-rule="evenodd"
+         vector-effect="none"
+         d="m -136.56904,-67.451752 c 5.077,-4.2872 13.09104,-9.658448 19.06004,-12.771848 11.731,-6.1243 25.0754,-9.8715 39.4046,-11.1345 14.3253,-1.273 29.6291,-0.0622 45.1711,3.4595 15.5412,3.5125 31.31403,9.3334 46.5521,17.0294 15.2402,7.6887 29.9395,17.2473 43.3909,28.0328 13.4568,10.7797 25.6609,22.7802 36.0468,35.21878 C 103.45,4.81927 112.021,17.6872 118.41,30.1551 c 6.398,12.4696 10.612,24.5322 12.528,35.4025 1.924,10.875 1.551,20.5514 -0.975,28.3784 -1.935,6.012 -5.131,10.937 -9.426,14.563" />
+    </g>
+    <g
+       style="fill-rule:evenodd;stroke:#0b1521;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none"
+       id="g736"
+       transform="matrix(0.1329376,0,0,0.1329376,32.888438,32.182827)"
+       stroke-linejoin="bevel"
+       font-size="35.2778px"
+       font-family="'Noto Sans'"
+       stroke="#000000"
+       stroke-width="7"
+       stroke-opacity="1"
+       font-style="normal"
+       font-weight="400"
+       fill="none"
+       stroke-linecap="round">
+      <path
+         style="stroke:#0b1521;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path734"
+         fill-rule="evenodd"
+         vector-effect="none"
+         d="m -103.575,-94.8923 c 5.0768,-4.2872 10.5993,-7.9877 16.5677,-11.1007 11.7308,-6.124 25.0755,-9.872 39.4047,-11.135 14.3252,-1.273 29.629,-0.062 45.171,3.46 15.5411,3.513 31.3139,9.333 46.552,17.0293 15.2402,7.6884 29.9393,17.2473 43.3909,28.0325 13.4567,10.7799 25.6607,22.7803 36.0467,35.2189 10.393,12.4368 18.964,25.30468 25.354,37.77262 6.398,12.46958 10.611,24.53208 12.527,35.40228 1.925,10.875 1.551,20.5513 -0.975,28.3783 -1.935,6.012 -5.131,10.9374 -9.426,14.5635" />
+    </g>
+    <g
+       style="fill-rule:evenodd;stroke:#0b1521;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none"
+       id="g668"
+       transform="matrix(0.1329376,0,0,0.1329376,32.888438,32.182827)"
+       stroke-linejoin="bevel"
+       font-size="35.2778px"
+       font-family="'Noto Sans'"
+       stroke="#000000"
+       stroke-width="7"
+       stroke-opacity="1"
+       font-style="normal"
+       font-weight="400"
+       fill="none"
+       stroke-linecap="round">
+      <path
+         style="stroke:#0b1521;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path666"
+         fill-rule="evenodd"
+         vector-effect="none"
+         d="m -69.5407,7.26503 c 2.4343,-2.05601 5.0172,-3.91638 7.7488,-5.58111 10.7338,-6.57586 23.668,-9.8685 36.9611,-9.96691 13.2885,-0.14605 26.86499,2.87413 38.7504,7.611484 C 25.8301,4.04195 35.9904,10.4045 43.1555,16.2505 c 7.2099,5.8541 11.4026,11.1152 12.6197,13.8516 0.468,1.0679 0.5425,1.7382 0.2237,2.0109" />
+    </g>
+    <path
+       id="path1902"
+       d="M 27.129489,16.33306 C 28.681813,9.425144 33.7554,6.4786485 41.208349,6.2089354"
+       style="fill:none;stroke:#0b1521;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <g
+       style="fill-rule:evenodd;stroke:#0b1521;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none"
+       id="g688"
+       transform="matrix(0.1329376,0,0,0.1329376,32.836311,32.182827)"
+       stroke-linejoin="bevel"
+       font-size="35.2778px"
+       font-family="'Noto Sans'"
+       stroke="#000000"
+       stroke-width="7"
+       stroke-opacity="1"
+       font-style="normal"
+       font-weight="400"
+       fill="none"
+       stroke-linecap="round">
+      <path
+         style="stroke:#0b1521;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path686"
+         fill-rule="evenodd"
+         vector-effect="none"
+         d="m -36.016943,217.43636 c -3.234323,-0.71246 -6.579068,-1.69327 -10.012557,-2.94736 -13.8196,-5.004 -29.0161,-14.375 -43.814,-27.436 -14.8005,-13.035 -29.1755,-29.743 -41.4305,-48.727" />
+    </g>
+    <g
+       style="fill-rule:evenodd;stroke:#0b1521;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none"
+       id="g660"
+       transform="matrix(0.1329376,0,0,0.1329376,32.888438,32.182827)"
+       stroke-linejoin="bevel"
+       font-size="35.2778px"
+       font-family="'Noto Sans'"
+       stroke="#000000"
+       stroke-width="7"
+       stroke-opacity="1"
+       font-style="normal"
+       font-weight="400"
+       fill="none"
+       stroke-linecap="round">
+      <path
+         style="stroke:#0b1521;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path658"
+         fill-rule="evenodd"
+         vector-effect="none"
+         d="m -66.0074,135.192 c -0.7085,0.624 -3.4374,-1.167 -7.0352,-5.635 -4.5147,-5.563 -10.343,-15.431 -14.6165,-28.079" />
+    </g>
+    <g
+       style="fill-rule:evenodd;stroke:#0b1521;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none"
+       id="g744"
+       transform="matrix(0.1329376,0,0,0.1329376,33.638438,32.635952)"
+       stroke-linejoin="bevel"
+       font-size="35.2778px"
+       font-family="'Noto Sans'"
+       stroke="#000000"
+       stroke-width="7"
+       stroke-opacity="1"
+       font-style="normal"
+       font-weight="400"
+       fill="none"
+       stroke-linecap="round">
+      <path
+         style="stroke:#0b1521;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path742"
+         fill-rule="evenodd"
+         vector-effect="none"
+         d="M -45.286,100.084 C -49.2516,94.3238 -53.7098,85.8966 -57.1573,75.7078" />
+    </g>
+    <path
+       id="path1948"
+       d="M 27.073998,58.893891 C 26.374159,58.58674 25.629561,58.162485 24.860888,57.634135 20.547019,54.668985 15.474854,48.42533 13.300006,41.202978"
+       style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path1952"
+       d="M 31.881451,29.143409 C 23.438189,27.548365 17.098791,35.070653 18.627844,42.227533"
+       style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path4129"
+       d="M 30.994834,35.247684 4.9882777,57.127101"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#a40000;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <path
+       id="path1922"
+       d="M 30.994834,35.247684 33.356721,33.26062"
+       style="fill:none;stroke:#ef2929;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path1924"
+       d="m 30.1875,32.101562 -1.675781,1.316407 4.015625,-0.816407 z"
+       style="fill:#a40000;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       id="path1934"
+       d="M 41.96838,30.635065 C 23.12635,13.035362 8.0415638,24.530545 13.300006,41.202978"
+       style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path1946"
+       d="m 34.5625,37.65625 c 13.919539,16.589812 19.160278,4.467411 7.40588,-7.021185"
+       style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path4129-3"
+       d="M 30.994834,35.247684 4.9882777,57.127101"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#ef2929;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <path
+       id="path1950"
+       d="m 23.048024,52.063877 1.537168,5.309878"
+       style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path1954"
+       d="M 47.650709,28.810484 C 46.38919,27.295217 44.915873,25.846136 43.168127,24.482815"
+       style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <g
+       style="fill-rule:evenodd;stroke:#0b1521;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none"
+       id="g644"
+       transform="matrix(0.1329376,0,0,0.1329376,27.341563,40.667202)"
+       stroke-linejoin="bevel"
+       font-size="35.2778px"
+       font-family="'Noto Sans'"
+       stroke="#000000"
+       stroke-width="7"
+       stroke-opacity="1"
+       font-style="normal"
+       font-weight="400"
+       fill="none"
+       stroke-linecap="round">
+      <path
+         style="stroke:#0b1521;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path642"
+         fill-rule="evenodd"
+         vector-effect="none"
+         d="M 4.96832,153.335 32.766564,128.74036" />
+    </g>
+    <g
+       stroke-linecap="round"
+       fill="none"
+       font-weight="400"
+       font-style="normal"
+       stroke-opacity="1"
+       stroke-width="7"
+       stroke="#000000"
+       font-family="'Noto Sans'"
+       font-size="35.2778px"
+       stroke-linejoin="bevel"
+       transform="matrix(0.1329376,0,0,0.1329376,26.061397,82.93774)"
+       id="g716-3"
+       style="fill-rule:evenodd;stroke:#0b1521;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none">
+      <path
+         d="m 11.847572,-165.07165 -22.5794,-84.114"
+         vector-effect="none"
+         fill-rule="evenodd"
+         id="path714-9"
+         style="stroke:#0b1521;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none" />
+    </g>
+    <g
+       stroke-linecap="round"
+       fill="none"
+       font-weight="400"
+       font-style="normal"
+       stroke-opacity="1"
+       stroke-width="7"
+       stroke="#000000"
+       font-family="'Noto Sans'"
+       font-size="35.2778px"
+       stroke-linejoin="bevel"
+       transform="matrix(0.1329376,0,0,0.1329376,16.161902,75.689896)"
+       id="g724-0"
+       style="fill-rule:evenodd;stroke:#0b1521;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none">
+      <path
+         d="m 94.2372,-220.435 22.5798,84.115"
+         vector-effect="none"
+         fill-rule="evenodd"
+         id="path722-5"
+         style="stroke:#0b1521;stroke-width:15.0447;stroke-miterlimit:4;stroke-dasharray:none" />
+    </g>
+  </g>
+</svg>

--- a/src/Mod/PartDesign/Gui/TaskHelixParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskHelixParameters.cpp
@@ -1,0 +1,511 @@
+/***************************************************************************
+ *   Copyright (c) 2011 Juergen Riegel <FreeCAD@juergen-riegel.net>        *
+ *                 2020 David Österberg                                    *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#include "PreCompiled.h"
+
+#ifndef _PreComp_
+#endif
+
+#include <Base/UnitsApi.h>
+#include <Base/Console.h>
+#include <App/Application.h>
+#include <App/Document.h>
+#include <App/Origin.h>
+#include <App/OriginFeature.h>
+#include <Gui/Application.h>
+#include <Gui/Document.h>
+#include <Gui/BitmapFactory.h>
+#include <Gui/ViewProvider.h>
+#include <Gui/WaitCursor.h>
+#include <Gui/Selection.h>
+#include <Gui/Command.h>
+#include <Gui/ViewProviderOrigin.h>
+#include <Mod/PartDesign/App/DatumLine.h>
+#include <Mod/PartDesign/App/FeatureHelix.h>
+#include <Mod/PartDesign/App/FeatureGroove.h>
+#include <Mod/Sketcher/App/SketchObject.h>
+#include <Mod/PartDesign/App/Body.h>
+#include <QString>
+
+#include "ReferenceSelection.h"
+#include "Utils.h"
+
+#include "ui_TaskHelixParameters.h"
+#include "TaskHelixParameters.h"
+
+using namespace PartDesignGui;
+using namespace Gui;
+
+
+/* TRANSLATOR PartDesignGui::TaskHelixParameters */
+
+TaskHelixParameters::TaskHelixParameters(PartDesignGui::ViewProviderHelix *HelixView, QWidget *parent)
+    : TaskSketchBasedParameters(HelixView, parent, "PartDesign_Additive_Helix",tr("Helix parameters")),
+    ui (new Ui_TaskHelixParameters)
+{
+    // we need a separate container widget to add all controls to
+    proxy = new QWidget(this);
+    ui->setupUi(proxy);
+    QMetaObject::connectSlotsByName(this);
+
+    connect(ui->pitch, SIGNAL(valueChanged(double)),
+            this, SLOT(onPitchChanged(double)));
+    connect(ui->height, SIGNAL(valueChanged(double)),
+            this, SLOT(onHeightChanged(double)));
+    connect(ui->turns, SIGNAL(valueChanged(double)),
+            this, SLOT(onTurnsChanged(double)));
+    connect(ui->coneAngle, SIGNAL(valueChanged(double)),
+            this, SLOT(onAngleChanged(double)));
+    connect(ui->axis, SIGNAL(activated(int)),
+            this, SLOT(onAxisChanged(int)));
+    connect(ui->checkBoxLeftHanded, SIGNAL(toggled(bool)),
+            this, SLOT(onLeftHandedChanged(bool)));
+    connect(ui->checkBoxReversed, SIGNAL(toggled(bool)),
+            this, SLOT(onReversedChanged(bool)));
+    connect(ui->checkBoxUpdateView, SIGNAL(toggled(bool)),
+            this, SLOT(onUpdateView(bool)));
+    connect(ui->inputMode, SIGNAL(activated(int)),
+            this, SLOT(onModeChanged(int)));
+    connect(ui->checkBoxOutside, SIGNAL(toggled(bool)),
+            this, SLOT(onOutsideChanged(bool)));
+
+    this->groupLayout()->addWidget(proxy);
+
+    // Temporarily prevent unnecessary feature recomputes
+    ui->axis->blockSignals(true);
+    ui->pitch->blockSignals(true);
+    ui->height->blockSignals(true);
+    ui->turns->blockSignals(true);
+    ui->coneAngle->blockSignals(true);
+    ui->checkBoxLeftHanded->blockSignals(true);
+    ui->checkBoxReversed->blockSignals(true);
+    ui->checkBoxOutside->blockSignals(true);
+
+    //bind property mirrors
+    PartDesign::ProfileBased* pcFeat = static_cast<PartDesign::ProfileBased*>(vp->getObject());
+
+    PartDesign::Helix* rev = static_cast<PartDesign::Helix*>(vp->getObject());
+
+    if (!(rev->HasBeenEdited).getValue()) {
+        rev->proposeParameters();
+        recomputeFeature();
+    }
+
+    this->propAngle = &(rev->Angle);
+    this->propPitch = &(rev->Pitch);
+    this->propHeight = &(rev->Height);
+    this->propTurns = &(rev->Turns);
+    this->propReferenceAxis = &(rev->ReferenceAxis);
+    this->propLeftHanded = &(rev->LeftHanded);
+    this->propReversed = &(rev->Reversed);
+    this->propMode = &(rev->Mode);
+    this->propOutside = &(rev->Outside);
+
+    double pitch = propPitch->getValue();
+    double height = propHeight->getValue();
+    double turns = propTurns->getValue();
+    double angle = propAngle->getValue();
+    bool leftHanded = propLeftHanded->getValue();
+    bool reversed = propReversed->getValue();
+    int index = propMode->getValue();
+    bool outside = propOutside->getValue();
+
+    ui->pitch->setValue(pitch);
+    ui->height->setValue(height);
+    ui->turns->setValue(turns);
+    ui->coneAngle->setValue(angle);
+    ui->checkBoxLeftHanded->setChecked(leftHanded);
+    ui->checkBoxReversed->setChecked(reversed);
+    ui->inputMode->setCurrentIndex(index);
+    ui->checkBoxOutside->setChecked(outside);
+
+    blockUpdate = false;
+    updateUI();
+
+    // enable use of parametric expressions for the numerical fields
+    ui->pitch->bind(static_cast<PartDesign::Helix *>(pcFeat)->Pitch);
+    ui->height->bind(static_cast<PartDesign::Helix *>(pcFeat)->Height);
+    ui->turns->bind(static_cast<PartDesign::Helix *>(pcFeat)->Turns);
+    ui->coneAngle->bind(static_cast<PartDesign::Helix *>(pcFeat)->Angle);
+
+    ui->axis->blockSignals(false);
+    ui->pitch->blockSignals(false);
+    ui->height->blockSignals(false);
+    ui->turns->blockSignals(false);
+    ui->coneAngle->blockSignals(false);
+    ui->checkBoxLeftHanded->blockSignals(false);
+    ui->checkBoxReversed->blockSignals(false);
+    ui->checkBoxOutside->blockSignals(false);
+
+    setFocus ();
+
+    //show the parts coordinate system axis for selection
+    PartDesign::Body * body = PartDesign::Body::findBodyOf ( vp->getObject () );
+    if(body) {
+        try {
+            App::Origin *origin = body->getOrigin();
+            ViewProviderOrigin* vpOrigin;
+            vpOrigin = static_cast<ViewProviderOrigin*>(Gui::Application::Instance->getViewProvider(origin));
+            vpOrigin->setTemporaryVisibility(true, false);
+        } catch (const Base::Exception &ex) {
+            ex.ReportException();
+        }
+     }
+}
+
+void TaskHelixParameters::fillAxisCombo(bool forceRefill)
+{
+    bool oldVal_blockUpdate = blockUpdate;
+    blockUpdate = true;
+
+    if (axesInList.empty())
+        forceRefill = true;//not filled yet, full refill
+
+    if (forceRefill){
+        ui->axis->clear();
+
+        this->axesInList.clear();
+
+        //add sketch axes
+        PartDesign::ProfileBased* pcFeat = static_cast<PartDesign::ProfileBased*>(vp->getObject());
+        Part::Part2DObject* pcSketch = dynamic_cast<Part::Part2DObject*>(pcFeat->Profile.getValue());
+        if (pcSketch){
+            addAxisToCombo(pcSketch,"V_Axis",QObject::tr("Vertical sketch axis"));
+            addAxisToCombo(pcSketch,"H_Axis",QObject::tr("Horizontal sketch axis"));
+            for (int i=0; i < pcSketch->getAxisCount(); i++) {
+                QString itemText = QObject::tr("Construction line %1").arg(i+1);
+                std::stringstream sub;
+                sub << "Axis" << i;
+                addAxisToCombo(pcSketch,sub.str(),itemText);
+            }
+        }
+
+        //add part axes
+        PartDesign::Body * body = PartDesign::Body::findBodyOf ( pcFeat );
+        if (body) {
+            try {
+                App::Origin* orig = body->getOrigin();
+                addAxisToCombo(orig->getX(),"",tr("Base X axis"));
+                addAxisToCombo(orig->getY(),"",tr("Base Y axis"));
+                addAxisToCombo(orig->getZ(),"",tr("Base Z axis"));
+            } catch (const Base::Exception &ex) {
+                ex.ReportException();
+            }
+        }
+
+        //add "Select reference"
+        addAxisToCombo(0,std::string(),tr("Select reference..."));
+    }//endif forceRefill
+
+    //add current link, if not in list
+    //first, figure out the item number for current axis
+    int indexOfCurrent = -1;
+    App::DocumentObject* ax = propReferenceAxis->getValue();
+    const std::vector<std::string> &subList = propReferenceAxis->getSubValues();
+    for (size_t i = 0; i < axesInList.size(); i++) {
+        if (ax == axesInList[i]->getValue() && subList == axesInList[i]->getSubValues())
+            indexOfCurrent = i;
+    }
+    if (indexOfCurrent == -1  &&  ax) {
+        assert(subList.size() <= 1);
+        std::string sub;
+        if (!subList.empty())
+            sub = subList[0];
+        addAxisToCombo(ax, sub, getRefStr(ax, subList));
+        indexOfCurrent = axesInList.size()-1;
+    }
+
+    //highlight current.
+    if (indexOfCurrent != -1)
+        ui->axis->setCurrentIndex(indexOfCurrent);
+
+    blockUpdate = oldVal_blockUpdate;
+}
+
+void TaskHelixParameters::addAxisToCombo(App::DocumentObject* linkObj,
+                                              std::string linkSubname,
+                                              QString itemText)
+{
+    this->ui->axis->addItem(itemText);
+    this->axesInList.emplace_back(new App::PropertyLinkSub);
+    App::PropertyLinkSub &lnk = *(axesInList[axesInList.size()-1]);
+    lnk.setValue(linkObj,std::vector<std::string>(1,linkSubname));
+}
+
+void TaskHelixParameters::updateUI()
+{
+    fillAxisCombo();
+
+    auto pcHelix = static_cast<PartDesign::Helix*>(vp->getObject());
+    auto status = std::string(pcHelix->getStatusString());
+    if (status.compare("Valid")==0 || status.compare("Touched")==0) {
+        if (pcHelix->safePitch() > propPitch->getValue())
+            status = "Warning: helix might be self intersecting";
+        else
+            status = "";
+    }
+    ui->labelMessage->setText(QString::fromUtf8(status.c_str()));
+
+    bool isPitchVisible  = false;
+    bool isHeightVisible = false;
+    bool isTurnsVisible  = false;
+    bool isOutsideVisible = false;
+
+    if(pcHelix->getAddSubType() == PartDesign::FeatureAddSub::Subtractive)
+        isOutsideVisible = true;
+
+    switch (propMode->getValue()) {
+        case 0:
+            isPitchVisible = true;
+            isHeightVisible = true;
+            break;
+        case 1:
+            isPitchVisible = true;
+            isTurnsVisible = true;
+            break;
+        default:
+            isHeightVisible = true;
+            isTurnsVisible = true;
+    }
+
+    ui->pitch->setVisible(isPitchVisible);
+    ui->labelPitch->setVisible(isPitchVisible);
+
+    ui->height->setVisible(isHeightVisible);
+    ui->labelHeight->setVisible(isHeightVisible);
+
+    ui->turns->setVisible(isTurnsVisible);
+    ui->labelTurns->setVisible(isTurnsVisible);
+
+    ui->checkBoxOutside->setVisible(isOutsideVisible);
+
+}
+
+void TaskHelixParameters::onSelectionChanged(const Gui::SelectionChanges& msg)
+{
+    if (msg.Type == Gui::SelectionChanges::AddSelection) {
+
+        exitSelectionMode();
+        std::vector<std::string> axis;
+        App::DocumentObject* selObj;
+        if (getReferencedSelection(vp->getObject(), msg, selObj, axis) && selObj) {
+            propReferenceAxis->setValue(selObj, axis);
+            recomputeFeature();
+            updateUI();
+        }
+    }
+}
+
+
+void TaskHelixParameters::onPitchChanged(double len)
+{
+    propPitch->setValue(len);
+    recomputeFeature();
+    updateUI();
+}
+
+void TaskHelixParameters::onHeightChanged(double len)
+{
+    propHeight->setValue(len);
+    recomputeFeature();
+    updateUI();
+}
+
+void TaskHelixParameters::onTurnsChanged(double len)
+{
+    propTurns->setValue(len);
+    recomputeFeature();
+    updateUI();
+}
+
+void TaskHelixParameters::onAngleChanged(double len)
+{
+    propAngle->setValue(len);
+    recomputeFeature();
+    updateUI();
+}
+
+void TaskHelixParameters::onAxisChanged(int num)
+{
+    PartDesign::ProfileBased* pcHelix = static_cast<PartDesign::ProfileBased*>(vp->getObject());
+
+    if (axesInList.empty())
+        return;
+
+    App::DocumentObject *oldRefAxis = propReferenceAxis->getValue();
+    std::vector<std::string> oldSubRefAxis = propReferenceAxis->getSubValues();
+    std::string oldRefName;
+    if (!oldSubRefAxis.empty())
+        oldRefName = oldSubRefAxis.front();
+
+    App::PropertyLinkSub &lnk = *(axesInList[num]);
+    if (lnk.getValue() == 0) {
+        // enter reference selection mode
+        TaskSketchBasedParameters::onSelectReference(true, true, false, true);
+    } else {
+        if (!pcHelix->getDocument()->isIn(lnk.getValue())){
+            Base::Console().Error("Object was deleted\n");
+            return;
+        }
+        propReferenceAxis->Paste(lnk);
+        exitSelectionMode();
+    }
+
+    try {
+        App::DocumentObject *newRefAxis = propReferenceAxis->getValue();
+        const std::vector<std::string> &newSubRefAxis = propReferenceAxis->getSubValues();
+        std::string newRefName;
+        if (!newSubRefAxis.empty())
+            newRefName = newSubRefAxis.front();
+
+        if (oldRefAxis != newRefAxis ||
+            oldSubRefAxis.size() != newSubRefAxis.size() ||
+            oldRefName != newRefName) {
+            bool reversed = propReversed->getValue();
+            if (reversed != propReversed->getValue()) {
+                propReversed->setValue(reversed);
+                ui->checkBoxReversed->blockSignals(true);
+                ui->checkBoxReversed->setChecked(reversed);
+                ui->checkBoxReversed->blockSignals(false);
+            }
+        }
+
+        recomputeFeature();
+    }
+    catch (const Base::Exception& e) {
+        e.ReportException();
+    }
+}
+
+void TaskHelixParameters::onModeChanged(int index)
+{
+
+    propMode->setValue(index);
+
+    ui->pitch->setValue(propPitch->getValue());
+    ui->height->setValue(propHeight->getValue());
+    ui->turns->setValue((propHeight->getValue())/(propPitch->getValue()));
+
+    recomputeFeature();
+    updateUI();
+}
+
+void TaskHelixParameters::onLeftHandedChanged(bool on)
+{
+    propLeftHanded->setValue(on);
+    recomputeFeature();
+}
+
+void TaskHelixParameters::onReversedChanged(bool on)
+{
+    propReversed->setValue(on);
+    recomputeFeature();
+    updateUI();
+}
+
+void TaskHelixParameters::onOutsideChanged(bool on)
+{
+    propOutside->setValue(on);
+    recomputeFeature();
+    updateUI();
+}
+
+
+TaskHelixParameters::~TaskHelixParameters()
+{
+    try {
+        //hide the parts coordinate system axis for selection
+        PartDesign::Body * body = vp ? PartDesign::Body::findBodyOf(vp->getObject()) : 0;
+        if (body) {
+            App::Origin *origin = body->getOrigin();
+            ViewProviderOrigin* vpOrigin;
+            vpOrigin = static_cast<ViewProviderOrigin*>(Gui::Application::Instance->getViewProvider(origin));
+            vpOrigin->resetTemporaryVisibility();
+        }
+    } catch (const Base::Exception &ex) {
+        ex.ReportException();
+    }
+
+}
+
+void TaskHelixParameters::changeEvent(QEvent *e)
+{
+    TaskBox::changeEvent(e);
+    if (e->type() == QEvent::LanguageChange) {
+        ui->retranslateUi(proxy);
+    }
+}
+
+void TaskHelixParameters::getReferenceAxis(App::DocumentObject*& obj, std::vector<std::string>& sub) const
+{
+    if (axesInList.empty())
+        throw Base::RuntimeError("Not initialized!");
+
+    int num = ui->axis->currentIndex();
+    const App::PropertyLinkSub &lnk = *(axesInList[num]);
+    if (lnk.getValue() == 0) {
+        throw Base::RuntimeError("Still in reference selection mode; reference wasn't selected yet");
+    } else {
+        PartDesign::ProfileBased* pcRevolution = static_cast<PartDesign::ProfileBased*>(vp->getObject());
+        if (!pcRevolution->getDocument()->isIn(lnk.getValue())){
+            throw Base::RuntimeError("Object was deleted");
+        }
+
+        obj = lnk.getValue();
+        sub = lnk.getSubValues();
+    }
+}
+
+// this is used for logging the command fully when recording macros
+void TaskHelixParameters::apply()
+{
+    std::vector<std::string> sub;
+    App::DocumentObject* obj;
+    getReferenceAxis(obj, sub);
+    std::string axis = buildLinkSingleSubPythonStr(obj, sub);
+    auto tobj = vp->getObject();
+    FCMD_OBJ_CMD(tobj,"ReferenceAxis = " << axis);
+    FCMD_OBJ_CMD(tobj,"Mode = " << propMode->getValue());
+    FCMD_OBJ_CMD(tobj,"Pitch = " << propPitch->getValue());
+    FCMD_OBJ_CMD(tobj,"Height = " << propHeight->getValue());
+    FCMD_OBJ_CMD(tobj,"Turns = " << propTurns->getValue());
+    FCMD_OBJ_CMD(tobj,"Angle = " << propAngle->getValue());
+    FCMD_OBJ_CMD(tobj,"LeftHanded = " << (propLeftHanded->getValue() ? 1 : 0));
+    FCMD_OBJ_CMD(tobj,"Reversed = " << (propReversed->getValue() ? 1 : 0));
+}
+
+
+//**************************************************************************
+//**************************************************************************
+// TaskDialog
+//++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+TaskDlgHelixParameters::TaskDlgHelixParameters(ViewProviderHelix *HelixView)
+    : TaskDlgSketchBasedParameters(HelixView)
+{
+    assert(HelixView);
+    Content.push_back(new TaskHelixParameters(HelixView));
+}
+
+
+#include "moc_TaskHelixParameters.cpp"

--- a/src/Mod/PartDesign/Gui/TaskHelixParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskHelixParameters.h
@@ -1,0 +1,131 @@
+/***************************************************************************
+ *   Copyright (c) 2011 Juergen Riegel <FreeCAD@juergen-riegel.net>        *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#ifndef GUI_TASKVIEW_TaskHelixParameters_H
+#define GUI_TASKVIEW_TaskHelixParameters_H
+
+#include <Gui/TaskView/TaskView.h>
+#include <Gui/Selection.h>
+#include <Gui/TaskView/TaskDialog.h>
+
+#include "TaskSketchBasedParameters.h"
+#include "ViewProviderHelix.h"
+
+class Ui_TaskHelixParameters;
+
+namespace App {
+class Property;
+}
+
+namespace Gui {
+class ViewProvider;
+}
+
+namespace PartDesignGui {
+
+
+
+class TaskHelixParameters : public TaskSketchBasedParameters
+{
+    Q_OBJECT
+
+public:
+    TaskHelixParameters(ViewProviderHelix *HelixView,QWidget *parent = 0);
+    ~TaskHelixParameters();
+
+    virtual void apply() override;
+
+    /**
+     * @brief fillAxisCombo fills the combo and selects the item according to
+     * current value of revolution object's axis reference.
+     * @param forceRefill if true, the combo box will be completely refilled. If
+     * false, the current value of revolution object's axis will be added to the
+     * list (if necessary), and selected. If the list is empty, it will be refilled anyway.
+     */
+    void fillAxisCombo(bool forceRefill = false);
+    void addAxisToCombo(App::DocumentObject *linkObj, std::string linkSubname, QString itemText);
+
+private Q_SLOTS:
+    void onPitchChanged(double);
+    void onHeightChanged(double);
+    void onTurnsChanged(double);
+    void onAngleChanged(double);
+    void onAxisChanged(int);
+    void onLeftHandedChanged(bool);
+    void onReversedChanged(bool);
+    void onModeChanged(int);
+    void onOutsideChanged(bool);
+
+
+protected:
+    void onSelectionChanged(const Gui::SelectionChanges& msg) override;
+    void changeEvent(QEvent *e) override;
+    bool updateView() const;
+    void getReferenceAxis(App::DocumentObject *&obj, std::vector<std::string> &sub) const;
+
+
+    //mirrors of helixes's properties
+    App::PropertyLength*      propPitch;
+    App::PropertyLength*      propHeight;
+    App::PropertyFloat*       propTurns;
+    App::PropertyBool*        propLeftHanded;
+    App::PropertyBool*        propReversed;
+    App::PropertyLinkSub*     propReferenceAxis;
+    App::PropertyAngle*       propAngle;
+    App::PropertyEnumeration* propMode;
+    App::PropertyBool*        propOutside;
+
+
+private:
+    void updateUI();
+
+private:
+    QWidget* proxy;
+    Ui_TaskHelixParameters* ui;
+
+    /**
+     * @brief axesInList is the list of links corresponding to axis combo; must
+     * be kept in sync with the combo. A special value of zero-pointer link is
+     * for "Select axis" item.
+     *
+     * It is a list of pointers, because properties prohibit assignment. Use new
+     * when adding stuff, and delete when removing stuff.
+     */
+    std::vector<std::unique_ptr<App::PropertyLinkSub>> axesInList;
+};
+
+/// simulation dialog for the TaskView
+class TaskDlgHelixParameters : public TaskDlgSketchBasedParameters
+{
+    Q_OBJECT
+
+public:
+    TaskDlgHelixParameters(ViewProviderHelix *HelixView);
+
+    ViewProviderHelix* getHelixView() const
+    { return static_cast<ViewProviderHelix*>(vp); }
+};
+
+} //namespace PartDesignGui
+
+#endif // GUI_TASKVIEW_TaskHelixParameters_H

--- a/src/Mod/PartDesign/Gui/TaskHelixParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskHelixParameters.ui
@@ -1,0 +1,303 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>PartDesignGui::TaskHelixParameters</class>
+ <widget class="QWidget" name="PartDesignGui::TaskHelixParameters">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>278</width>
+    <height>193</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+
+    <item>
+    <layout class="QHBoxLayout" name="horizontalLayoutStatus">
+     <item>
+      <widget class="QLabel" name="labelStatus">
+       <property name="text">
+        <string>Status:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="labelMessage">
+       <property name="text">
+        <string>Valid</string>
+       </property>
+      </widget>
+     </item>
+     </layout>
+   </item>
+
+    <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLabel" name="label0">
+       <property name="text">
+        <string>Axis:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="axis">
+       <item>
+        <property name="text">
+         <string>Base X axis</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Base Y axis</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Base Z axis</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Horizontal sketch axis</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Vertical sketch axis</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Select reference...</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+    </layout>
+   </item>
+
+    <item>
+    <layout class="QHBoxLayout" name="horizontalLayoutMode">
+     <item>
+      <widget class="QLabel" name="label4">
+       <property name="text">
+        <string>Mode:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="inputMode">
+       <item>
+        <property name="text">
+         <string>Pitch-Height</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Pitch-Turns</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Height-Turns</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+    </layout>
+   </item>
+
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayoutPitch">
+     <item>
+      <widget class="QLabel" name="labelPitch">
+       <property name="text">
+        <string>Pitch:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="Gui::QuantitySpinBox" name="pitch">
+       <property name="keyboardTracking">
+        <bool>false</bool>
+       </property>
+       <property name="unit" stdset="0">
+        <string notr="true">mm</string>
+       </property>
+       <property name="minimum">
+        <double>0.000000000000000</double>
+       </property>
+       <property name="singleStep">
+        <double>1.000000000000000</double>
+       </property>
+       <property name="value">
+        <double>10.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayoutHeight">
+     <item>
+      <widget class="QLabel" name="labelHeight">
+       <property name="text">
+        <string>Height:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="Gui::QuantitySpinBox" name="height">
+       <property name="keyboardTracking">
+        <bool>false</bool>
+       </property>
+       <property name="unit" stdset="0">
+        <string notr="true">mm</string>
+       </property>
+       <property name="minimum">
+        <double>0.000000000000000</double>
+       </property>
+       <property name="singleStep">
+        <double>1.000000000000000</double>
+       </property>
+       <property name="value">
+        <double>30.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayoutTurns">
+     <item>
+      <widget class="QLabel" name="labelTurns">
+       <property name="text">
+        <string>Turns:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="Gui::QuantitySpinBox" name="turns">
+       <property name="keyboardTracking">
+        <bool>false</bool>
+       </property>
+       <property name="minimum">
+        <double>0.000000000000000</double>
+       </property>
+       <property name="singleStep">
+        <double>1.000000000000000</double>
+       </property>
+       <property name="value">
+        <double>3.0000000000000</double>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayoutConeAngle">
+     <item>
+      <widget class="QLabel" name="label5">
+       <property name="text">
+        <string>Cone angle:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="Gui::QuantitySpinBox" name="coneAngle">
+       <property name="keyboardTracking">
+        <bool>false</bool>
+       </property>
+       <property name="unit" stdset="0">
+        <string notr="true">deg</string>
+       </property>
+       <property name="minimum">
+        <double>-89.000000000000000</double>
+       </property>
+       <property name="maximum">
+        <double>89.000000000000000</double>
+       </property>
+       <property name="singleStep">
+        <double>5.000000000000000</double>
+       </property>
+       <property name="value">
+        <double>0.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+
+   <item>
+    <widget class="QCheckBox" name="checkBoxLeftHanded">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="text">
+      <string>Left handed</string>
+     </property>
+    </widget>
+   </item>
+
+   <item>
+    <widget class="QCheckBox" name="checkBoxReversed">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="text">
+      <string>Reversed</string>
+     </property>
+    </widget>
+   </item>
+
+   <item>
+    <widget class="QCheckBox" name="checkBoxOutside">
+     <property name="text">
+      <string>Remove outside of profile</string>
+     </property>
+     <property name="checked">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+
+   <item>
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+
+   <item>
+    <widget class="QCheckBox" name="checkBoxUpdateView">
+     <property name="text">
+      <string>Update view</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+
+
+
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>Gui::QuantitySpinBox</class>
+   <extends>QWidget</extends>
+   <header>Gui/QuantitySpinBox.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/Mod/PartDesign/Gui/ViewProviderHelix.h
+++ b/src/Mod/PartDesign/Gui/ViewProviderHelix.h
@@ -1,5 +1,5 @@
 /***************************************************************************
- *  Copyright (C) 2015 Alexander Golubev (Fat-Zer) <fatzer2@gmail.com>     *
+ *   Copyright (c) 2011 Juergen Riegel <FreeCAD@juergen-riegel.net>        *
  *                                                                         *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *
@@ -21,55 +21,42 @@
  ***************************************************************************/
 
 
-#include "PreCompiled.h"
+#ifndef PARTGUI_ViewProviderHelix_H
+#define PARTGUI_ViewProviderHelix_H
 
-#ifndef _PreComp_
-#endif
-
-#include <Gui/Application.h>
-#include <Mod/Sketcher/App/SketchObject.h>
-#include <Mod/PartDesign/App/FeatureSketchBased.h>
-
-#include "ViewProviderSketchBased.h"
+#include "ViewProviderAddSub.h"
 
 
-using namespace PartDesignGui;
+namespace PartDesignGui {
 
-PROPERTY_SOURCE(PartDesignGui::ViewProviderSketchBased, PartDesignGui::ViewProvider)
-
-
-ViewProviderSketchBased::ViewProviderSketchBased()
+class PartDesignGuiExport ViewProviderHelix : public ViewProviderAddSub
 {
-}
+    PROPERTY_HEADER(PartDesignGui::ViewProviderHelix);
+
+public:
+    /// constructor
+    ViewProviderHelix();
+    /// destructor
+    virtual ~ViewProviderHelix();
+
+    void setupContextMenu(QMenu*, QObject*, const char*);
+
+    /// grouping handling
+    std::vector<App::DocumentObject*> claimChildren(void)const;
+
+    virtual bool onDelete(const std::vector<std::string> &);
+
+protected:
+    virtual QIcon getIcon(void) const;
+
+    /// Returns a newly created TaskDlgHelixParameters
+    virtual TaskDlgFeatureParameters *getEditDialog();
+    virtual bool  setEdit(int ModNum);
+    virtual void unsetEdit(int ModNum);
+};
 
 
-ViewProviderSketchBased::~ViewProviderSketchBased()
-{
-}
+} // namespace PartDesignGui
 
 
-std::vector<App::DocumentObject*> ViewProviderSketchBased::claimChildren(void) const {
-    std::vector<App::DocumentObject*> temp;
-    App::DocumentObject* sketch = static_cast<PartDesign::ProfileBased*>(getObject())->Profile.getValue();
-    if (sketch != NULL && sketch->isDerivedFrom(Part::Part2DObject::getClassTypeId()))
-        temp.push_back(sketch);
-
-    return temp;
-}
-
-
-bool ViewProviderSketchBased::onDelete(const std::vector<std::string> &s) {
-    PartDesign::ProfileBased* feature = static_cast<PartDesign::ProfileBased*>(getObject());
-
-    // get the Sketch
-    Sketcher::SketchObject *pcSketch = 0;
-    if (feature->Profile.getValue())
-        pcSketch = static_cast<Sketcher::SketchObject*>(feature->Profile.getValue());
-
-    // if abort command deleted the object the sketch is visible again
-    if (pcSketch && Gui::Application::Instance->getViewProvider(pcSketch))
-        Gui::Application::Instance->getViewProvider(pcSketch)->show();
-
-    return ViewProvider::onDelete(s);
-}
-
+#endif // PARTGUI_ViewProviderHelix_H

--- a/src/Mod/PartDesign/Gui/ViewProviderSketchBased.h
+++ b/src/Mod/PartDesign/Gui/ViewProviderSketchBased.h
@@ -23,7 +23,7 @@
 #ifndef VIEWPROVIDERSKETCHBASED_H_QKP3UG9A
 #define VIEWPROVIDERSKETCHBASED_H_QKP3UG9A
 
-#include "ViewProvider.h"
+#include "ViewProviderAddSub.h"
 
 namespace PartDesignGui {
 
@@ -44,6 +44,7 @@ public:
     std::vector<App::DocumentObject*> claimChildren(void)const;
 
     virtual bool onDelete(const std::vector<std::string> &);
+
 };
 
 } /* PartDesignGui  */

--- a/src/Mod/PartDesign/Gui/Workbench.cpp
+++ b/src/Mod/PartDesign/Gui/Workbench.cpp
@@ -409,6 +409,8 @@ void Workbench::activated()
         "PartDesign_SubtractivePipe",
         "PartDesign_AdditiveLoft",
         "PartDesign_SubtractiveLoft",
+        "PartDesign_AdditiveHelix",
+        "PartDesign_SubtractiveHelix",
         0};
     Watcher.push_back(new Gui::TaskView::TaskWatcherCommands(
         "SELECT Sketcher::SketchObject COUNT 1",
@@ -496,14 +498,14 @@ Gui::MenuItem* Workbench::setupMenuBar() const
     Gui::MenuItem* additives = new Gui::MenuItem;
     additives->setCommand("Create an additive feature");
     *additives << "PartDesign_Pad" << "PartDesign_Revolution"
-        << "PartDesign_AdditiveLoft" << "PartDesign_AdditivePipe";
+        << "PartDesign_AdditiveLoft" << "PartDesign_AdditivePipe" << "PartDesign_AdditiveHelix";
 
     // subtractives
     Gui::MenuItem* subtractives = new Gui::MenuItem;
     subtractives->setCommand("Create a subtractive feature");
     *subtractives << "PartDesign_Pocket" << "PartDesign_Hole"
         << "PartDesign_Groove" << "PartDesign_SubtractiveLoft"
-        << "PartDesign_SubtractivePipe";
+        << "PartDesign_SubtractivePipe" << "PartDesign_SubtractiveHelix";
 
     // transformations
     Gui::MenuItem* transformations = new Gui::MenuItem;
@@ -598,6 +600,7 @@ Gui::ToolBarItem* Workbench::setupToolBars() const
           << "PartDesign_Revolution"
           << "PartDesign_AdditiveLoft"
           << "PartDesign_AdditivePipe"
+          << "PartDesign_AdditiveHelix"
           << "PartDesign_CompPrimitiveAdditive"
           << "Separator"
           << "PartDesign_Pocket"
@@ -605,6 +608,7 @@ Gui::ToolBarItem* Workbench::setupToolBars() const
           << "PartDesign_Groove"
           << "PartDesign_SubtractiveLoft"
           << "PartDesign_SubtractivePipe"
+          << "PartDesign_SubtractiveHelix"
           << "PartDesign_CompPrimitiveSubtractive"
           << "Separator"
           << "PartDesign_Mirrored"


### PR DESCRIPTION
New feature proposal for the PartDesign WB.

This feature allows for simple creation of a helical sweeps from within PartDesign.
Sample application is threads, springs, coils, augers, etc.

Forum discussion:
https://forum.freecadweb.org/viewtopic.php?f=8&t=53714

Icon discussion
https://forum.freecadweb.org/viewtopic.php?f=34&t=53820

Workflow with new tool is similar to the Revolve/Groove tool. Code is based  primarily on on the Pipe feature in PartDesign.

For additive Helix we start with a sketch (the construction line is one way to defines the axis)
![sketch](https://user-images.githubusercontent.com/1278189/103367044-64325e00-4ac4-11eb-8cef-9f9d8392955d.png)

We click the Additive Helix icon in the toolbar
![icon_add](https://user-images.githubusercontent.com/1278189/103438346-aaa5cb00-4c32-11eb-99ea-c42741b24543.png)

Dialog and result:
![add_dialog_and_result](https://user-images.githubusercontent.com/1278189/103368278-7366db00-4ac7-11eb-9919-39fc9728dbff.png)


For subractive helix we start with the stock
![thread_stock](https://user-images.githubusercontent.com/1278189/103367323-12d69e80-4ac5-11eb-9ab7-60a6e0d52c17.png)

Followed by the sketch:
![sketch_and_construction_line](https://user-images.githubusercontent.com/1278189/103367510-97292180-4ac5-11eb-983a-781799ff92a0.png)

Press the icon in the toolbar:
![icon_sub](https://user-images.githubusercontent.com/1278189/103438352-bc876e00-4c32-11eb-9737-def1cbba64cf.png)


And set up the helix
![dialog_and_result](https://user-images.githubusercontent.com/1278189/103367573-c2137580-4ac5-11eb-8b18-76fa17a8303c.png)




**Todo list**
- [x] Reverse option
- [x] Fix issue with axis from feature line
- [x] Fix issue where base object is moved
- [x] Fix issue with self intersecting not being detected and handled correctly
- [x] Fix issue with helix starting point when axis from construction line
- [x] Create Update view checkbox, as recomputes sometimes can be slow 
- [x] Fix bug present with OCC version >= 7.5.0 which causes the Helix path to be oriented incorrectly
- [x] Update icons with feedback from the UI/UX forum
- [x] Add different input modes (pitch-turns, heigh-turns) 
- [x] Add some operation validation
- [x] Add "remove outside" option, so that boolean intersection is covered as a possibility. 
- [x] Make sure that command is usable from Python
- [x] Make sure that recorded macros play back correctly




**Wont fix**
- Up to face (usecase not so great, and complicated)
- Silent failure in case of multiple solids. Issue error message in this case. (appears all other PD features have this problem except Pad. Not clear to me how Pad solves this)