### PR TITLE
[Sketcher] check for BSpline knot instead of construction point

### DIFF
--- a/src/Mod/Sketcher/Gui/CommandConstraints.h
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.h
@@ -31,7 +31,7 @@ namespace SketcherGui {
 
 bool checkBothExternal(int GeoId1, int GeoId2);
 
-bool checkBothExternalOrConstructionPoints(const Sketcher::SketchObject* Obj,int GeoId1, int GeoId2);
+bool checkBothExternalOrBSplinePoints(const Sketcher::SketchObject* Obj,int GeoId1, int GeoId2);
 
 bool isPointOrSegmentFixed(const Sketcher::SketchObject* Obj, int GeoId);
 
@@ -47,7 +47,7 @@ bool inline isEdge(int GeoId, Sketcher::PointPos PosId);
 
 bool isSimpleVertex(const Sketcher::SketchObject* Obj, int GeoId, Sketcher::PointPos PosId);
 
-bool isConstructionPoint(const Sketcher::SketchObject* Obj, int GeoId);
+bool isBsplineKnot(const Sketcher::SketchObject* Obj, int GeoId);
 
 bool IsPointAlreadyOnCurve(int GeoIdCurve, int GeoIdPoint, Sketcher::PointPos PosIdPoint, Sketcher::SketchObject* Obj);
 


### PR DESCRIPTION
==============================================================

Previously construction points was used to code bspline knots.
Now construction points are normal sketcher points, which can be
made defining.

This commit renames and adapts the checks for fixed geometry.

fixes:
https://forum.freecadweb.org/posting.php?mode=quote&f=3&p=461472#pr461472

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
