### PR TITLE
[Spreadsheet] Only evaluate cell values when prefixed with '='

### DIFF
--- a/src/Mod/Spreadsheet/TestSpreadsheet.py
+++ b/src/Mod/Spreadsheet/TestSpreadsheet.py
@@ -668,6 +668,23 @@ class SpreadsheetCases(unittest.TestCase):
         self.assertEqual(sheet.A17, 0.5)
         self.assertEqual(sheet.A18, 0.5)
 
+    def testQuantitiesAndFractionsAsNumbers(self):
+        """ Test quantities and simple fractions as numbers """
+        sheet = self.doc.addObject('Spreadsheet::Sheet','Spreadsheet')
+        sheet.set('A1', '1mm')
+        sheet.set('A2', '1/2')
+        sheet.set('A3', '4mm/2')
+        sheet.set('A4', '2/mm')
+        sheet.set('A5', '4/2mm')
+        sheet.set('A6', '6mm/3s')
+        self.doc.recompute()
+        self.assertEqual(sheet.A1, Units.Quantity('1 mm'))
+        self.assertEqual(sheet.A2, 0.5)
+        self.assertEqual(sheet.A3, Units.Quantity('2 mm'))
+        self.assertEqual(sheet.A4, Units.Quantity('2 1/mm'))
+        self.assertEqual(sheet.A5, Units.Quantity('2 1/mm'))
+        self.assertEqual(sheet.A6, Units.Quantity('2 mm/s'))
+
     def testRemoveRows(self):
         """ Removing rows -- check renaming of internal cells """
         sheet = self.doc.addObject('Spreadsheet::Sheet','Spreadsheet')
@@ -1033,6 +1050,16 @@ class SpreadsheetCases(unittest.TestCase):
         sheet.set('C1', '=max(A1:B1;3mm)')
         self.doc.recompute()
         self.assertEqual(sheet.get('C1'), Units.Quantity('3 mm'))
+
+    def testIssue4156(self):
+        """ Regression test for issue 4156; necessarily use of leading '=' to enter an expression, creates inconsistent behavior depending on the spreadsheet state"""
+        sheet = self.doc.addObject('Spreadsheet::Sheet','Spreadsheet')
+        sheet.set('A3', 'A1')
+        sheet.set('A1', '1000')
+        self.doc.recompute()
+        sheet.set('A3', '')
+        sheet.set('A3', 'A1')
+        self.assertEqual(sheet.getContents('A3'), 'A1')
 
     def testInsertRowsAlias(self):
         """ Regression test for issue 4429; insert rows to sheet with aliases"""


### PR DESCRIPTION
This commit only changes the user interaction with spreadsheet and does
not affect backwards compatibility (as valid cell expressions are
prefixed with '=' when serialized).

This fixes [#4156](https://tracker.freecadweb.org/view.php?id=4156),
which is discussed in the forum thread:
https://forum.freecadweb.org/viewtopic.php?f=3&t=39665

There has been additional logic added to handle numbers and simple
fractions without using '='.
The behaviour is what is expected by the spreadsheet test cases
and in line with how other spreadsheet software works.
The '-prefix can still be used to force number input to be handled as
as string instead.

Example of numbers and fractions handled are:
 * 3
 * 2mm
 * 1/8
 * 1mm/2
 * 1/2mm
 * 2/m
 * 1mm/2s

More complex expressions are not handled without '=' and will be stored
as strings instead, for example:
 * 2 / 3 / 2
 * 1 + 1/3

---

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [x] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
