### PR TITLE
Draft: Replace Part.getSortedClusters by Part.sortEdges in draftify function

### DIFF
--- a/src/Mod/Draft/draftfunctions/upgrade.py
+++ b/src/Mod/Draft/draftfunctions/upgrade.py
@@ -504,18 +504,10 @@ def upgrade(objects, delete=False, force=None):
                     if result:
                         _msg(_tr("Found closed wires: creating faces"))
             # wires or edges: we try to join them
-            elif len(wires) > 1 or len(loneedges) > 1:
+            elif len(objects) > 1 and len(edges) > 1:
                 result = makeWires(objects)
                 if result:
                     _msg(_tr("Found several wires or edges: wiring them"))
-            # TODO: improve draftify function
-            # only one object: if not parametric, we "draftify" it
-            # elif (len(objects) == 1
-            #       and not objects[0].isDerivedFrom("Part::Part2DObjectPython")):
-            #     result = ext_draftify.draftify(objects[0])
-            #     if result:
-            #         _msg(_tr("Found 1 non-parametric objects: "
-            #                  "draftifying it"))
             # special case, we have only one open wire. We close it,
             # unless it has only 1 edge!
             elif len(objects) == 1 and len(openwires) == 1:
@@ -524,14 +516,23 @@ def upgrade(objects, delete=False, force=None):
                 if result:
                     _msg(_tr("Found 1 open wire: closing it"))
             # we have only one object that contains one edge
-            # TODO: this case should be considered in draftify
-            elif len(objects) == 1 and len(edges) == 1:
-                # turn to Draft Line
+            # TODO: improve draftify function
+            # only one object: if not parametric, we "draftify" it
+            # elif (len(objects) == 1
+            #       and not objects[0].isDerivedFrom("Part::Part2DObjectPython")):
+            #     result = ext_draftify.draftify(objects[0])
+            #     if result:
+            #         _msg(_tr("Found 1 non-parametric objects: "
+            #                  "draftifying it"))
+            elif (len(objects) == 1 and len(edges) == 1
+                  and not objects[0].isDerivedFrom("Part::Part2DObjectPython")):
                 e = objects[0].Shape.Edges[0]
-                if isinstance(e.Curve, (Part.LineSegment, Part.Line)):
-                    result = turnToLine(objects[0])
+                edge_type = DraftGeomUtils.geomType(e)
+                # currently only support Line and Circle
+                if edge_type in ("Line", "Circle"):
+                    result = ext_draftify.draftify(objects[0])
                     if result:
-                        _msg(_tr("Found 1 linear object: converting to line"))
+                        _msg(_tr("Found 1 object: draftifying it"))
             # only points, no edges
             elif not edges and len(objects) > 1:
                 result = makeCompound(objects)


### PR DESCRIPTION
See https://forum.freecadweb.org/viewtopic.php?f=3&t=53389
The reported behavior is due to a bug in Part.getSortedClusters, so the function is replaced by Part.sortEdges.
The draftify function can now deal with circular arc objects and some minor changes are added to the update function.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
