### PR TITLE
Sketcher/GCS: New Block constraint fixes

### DIFF
--- a/src/Mod/Sketcher/App/Sketch.h
+++ b/src/Mod/Sketcher/App/Sketch.h
@@ -499,6 +499,71 @@ private:
     int checkGeoId(int geoId) const;
     GCS::Curve* getGCSCurveByGeoId(int geoId);
     const GCS::Curve* getGCSCurveByGeoId(int geoId) const;
+
+    // Block constraints
+
+    /** This function performs a pre-analysis of blocked geometries, separating them into:
+     *
+     *  1) onlyblockedGeometry : Geometries affected exclusively by a block constraint.
+     *
+     *  2) blockedGeoIds       : Geometries affected notonly by a block constraint.
+     *
+     * This is important because 1) can be pre-fixed when creating geometry and constraints
+     * before GCS::diagnose() via initSolution(). This is important because if no other constraint
+     * affect the geometry, the geometry parameters won't even appear in the Jacobian, and they won't
+     * be reported as dependent parameters.
+     *
+     * On the contrary 2) cannot be pre-fixed because it would lead to redundant constraints and requires
+     * a post-analysis, see analyseBlockedConstraintDependentParameters, to fix just the parameters that
+     * fulfil the dependacy groups.
+     */
+    bool analyseBlockedGeometry( const std::vector<Part::Geometry *> &internalGeoList,
+                                 const std::vector<Constraint *> &constraintList,
+                                 std::vector<bool> &onlyblockedGeometry,
+                                 std::vector<int> &blockedGeoIds) const;
+
+    /* This function performs a post-analysis of blocked geometries (see analyseBlockedGeometry for more detail
+     * on the pre-analysis).
+     *
+     * Basically identifies which parameters shall be fixed to make geometries having blocking constraints fixed,
+     * while not leading to redundant/conflicting constraints. These parameters must belong to blocked geometry. This
+     * is, groups may comprise parameters belonging to blocked geometry and parameters belonging to unconstrained geometry.
+     * It is licit that the latter remain as dependent parameters. The former are referred to as "blockable parameters".
+     *
+     * Extending this concept, there may be unsatisfiable groups (because they do not comprise any bloackable parameter),
+     * and it is the desired outcome NOT to satisfy such groups.
+     *
+     * There is not a single combination of fixed parameters from the blockable parameters that satisfy all the dependency
+     * groups. However:
+     *
+     * 1) some combinations do not satisfy all the dependency groups that must be satisfied (e.g. fixing one
+     * group containing two blockable parameters with a given one may result in another group, fixable only by the former, not
+     * to be satisfied). This leads, in a subsequent diagnosis, to satisfiable unsatisfied groups.
+     *
+     * 2) some combinations lead to partially redundant constraints, that the solver will silently drop in a subsequent diagnosis,
+     * thereby reducing the rank of the system fixing less than it should.
+     *
+     * Implementation rationale (at this time):
+     *
+     * The implementation is on the order of the groups provided by the QR decomposition used to reveal the parameters
+     * (see System::identifyDependentParameters in GCS). Zeros are made over the pilot of the full R matrix of the QR decomposition,
+     * which is a top triangular matrix.This, together with the permutation matrix, allow to know groups of dependent parameters
+     * (cols between rank and full size). Each group refers to a new parameter not affected by the rank in combination with other free
+     * parameters intervening in the rank (because of the triangular shape of the R matrix). This results in that each the first column
+     * between the rank and the full size, may only depend on a number of parameters, while the last full size colum may dependent on
+     * any amount of previously introduced parameters.
+     *
+     * Thus the rationale is start from the last group (having **potentially** the larger amount of parameters) and selecting as blocking
+     * for that group the latest blockable parameter. Because previous groups do not have access to the last parameter, this can never
+     * interfere with previous groups. However, because the last parameter may not be a blockable one, there is a risk of selecting a parameter
+     * common with other group, albeit the probability is reduced and probably (I have not demonstrated it though and I am not sure), it leads
+     * to the right solution in one iteration.
+     *
+     */
+    bool analyseBlockedConstraintDependentParameters(std::vector<int> &blockedGeoIds, std::vector<double *> &params_to_block) const;
+
+    /// utility function refactoring fixing the provided parameters and running a new diagnose
+    void fixParametersAndDiagnose(std::vector<double *> &params_to_block);
 };
 
 } //namespace Part

--- a/src/Mod/Sketcher/App/planegcs/GCS.h
+++ b/src/Mod/Sketcher/App/planegcs/GCS.h
@@ -106,7 +106,7 @@ namespace GCS
 
         // This is a map of primary and secondary identifiers that are found dependent by the solver
         // GCS ignores from a type point
-        std::vector< std::set<double *> > pDependentParametersGroups;
+        std::vector< std::vector<double *> > pDependentParametersGroups;
 
         std::vector<Constraint *> clist;
         std::map<Constraint *,VEC_pD > c2p; // constraint to parameter adjacency list
@@ -363,7 +363,7 @@ namespace GCS
           { redundantOut = hasDiagnosis ? redundantTags : VEC_I(0); }
         void getDependentParams(VEC_pD &pdependentparameterlist) const
           { pdependentparameterlist = pDependentParameters;}
-        void getDependentParamsGroups(std::vector<std::set<double *>> &pdependentparametergroups) const
+        void getDependentParamsGroups(std::vector<std::vector<double *>> &pdependentparametergroups) const
           { pdependentparametergroups = pDependentParametersGroups;}
         bool isEmptyDiagnoseMatrix() const {return emptyDiagnoseMatrix;}
         void invalidatedDiagnosis();


### PR DESCRIPTION
========================================

Previous versions relied on a heuristic that proved insufficient for cummulative use of the Block constraint.
The effect is that Block constraints stopped blocking, which is a major bug, as it lead to inadvertedly moving
geometry that was supposed to be blocked.

Fixes:
https://forum.freecadweb.org/viewtopic.php?f=13&t=53515&start=30#p461215
(Thanks Chaospilot)

Know problems with old block constraint (v0.18):
1. If driving constraints were present, they were ignored if inserted before the block constraint (to avoid
redundancy/conflicting). They resulted in

Principles of Working of the new block constraint:
1. Handling of the new block constraint is based two processes, a pre-analysis and a post-analysis. Pre-analysis
works *before* diagnosing the system in the solver. Post-analysis works *after* diagnosing the system in the solver.

2. Pre-analysis is directed to detect geometries affected *exclusively* by a block constraint. This is important
because these geometries can be pre-fixed when creating the solver geometry and constraints before GCS::diagnose()
via initSolution() AND because if no other constraint affects the geometry, the geometry parameters won't even appear
in the Jacobian of GCS, so they won't be reported as dependent parameters (for which post-analysis would be of no use).

3. Post-analysis is directed to detect Geometries affected *not only* by a block constraint. This is important
because pre-fixing these geometries would lead to redundant constraints. The post-analysis, enables to fix just the
parameters that fulfil the dependacy groups.

4. Post-analysis basically identifies which parameters shall be fixed to make geometries having blocking constraints
fixed, while not leading to redundant/conflicting constraints. These parameters must belong to blocked geometry. This
is, groups may comprise parameters belonging to blocked geometry and parameters belonging to unconstrained geometry. It
is licit that the latter remain as dependent parameters. The former are referred to as "blockable parameters". Extending
this concept, there may be unsatisfiable groups (because they do not comprise any bloackable parameter), and it is the
desired outcome NOT to satisfy such groups. It must be emphasised that there is not a single combination of fixed parameters
from the blockable parameters that satisfy all the dependency groups. However:
     1) some combinations do not satisfy all the dependency groups that must be satisfied (e.g. fixing one group containing
        two blockable parameters with a given one may result in another group, fixable only by the former, not to be satisfied).
        This leads, in a subsequent diagnosis, to satisfiable unsatisfied groups.
     2) some combinations lead to partially redundant constraints, that the solver will silently drop in a subsequent diagnosis,
        thereby reducing the rank of the system fixing less than it should.

5. The implementation rationale is as follows:
     1) The implementation is on the order of the groups provided by the QR decomposition used to reveal the parameters
        (see System::identifyDependentParameters in GCS). Zeros are made over the pilot of the full R matrix of the QR decomposition,
        which is a top triangular matrix.This, together with the permutation matrix, allow to know groups of dependent parameters
        (cols between rank and full size). Each group refers to a new parameter not affected by the rank in combination with other free
        parameters intervening in the rank (because of the triangular shape of the R matrix). This results in that each the first column
        between the rank and the full size, may only depend on a number of parameters, while the last full size colum may dependent on
        any amount of previously introduced parameters.
     2) Thus the rationale is to start from the last group (having **potentially** the larger amount of parameters) and selecting as blocking
        for that group the latest blockable parameter. Because previous groups do not have access to the last parameter, this can never
        interfere with previous groups. However, because the last parameter may not be a blockable one, there is a risk of selecting a parameter
        common with other group, albeit the probability is reduced and probably (I have not demonstrated it though and I am not sure), it
        systematically leads to the right solution in one iteration.

GCS: Change dependency group from std::set to std::vector to prevent reordering of parameters.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
