### PR TITLE
WIP: Sketcher refactor

### DIFF
--- a/src/Mod/Sketcher/App/CMakeLists.txt
+++ b/src/Mod/Sketcher/App/CMakeLists.txt
@@ -52,6 +52,9 @@ SOURCE_GROUP("Properties" FILES ${Properties_SRCS})
 
 
 SET(Features_SRCS
+    filterChain/Filter.h
+    filterChain/FilterChain.h
+    filterChain/FilterOperation.h
     SketchObjectSF.cpp
     SketchObjectSF.h
     SketchGeometryExtension.cpp

--- a/src/Mod/Sketcher/App/CMakeLists.txt
+++ b/src/Mod/Sketcher/App/CMakeLists.txt
@@ -60,6 +60,10 @@ SET(Features_SRCS
     ExternalGeometryExtension.h
     SolverGeometryExtension.cpp
     SolverGeometryExtension.h
+    GeometryType.h
+    GeometryType.cpp
+    SketchStorage.h
+    SketchStorage.cpp
     SketchObject.cpp
     SketchObject.h
     SketchAnalysis.h

--- a/src/Mod/Sketcher/App/Constraint.cpp
+++ b/src/Mod/Sketcher/App/Constraint.cpp
@@ -47,7 +47,7 @@ const int Constraint::GeoUndef = -2000;
 
 Constraint::Constraint()
 : Value(0.0),
-  Type(None),
+  Type(ConstraintType::None),
   AlignmentType(Undef),
   Name(""),
   First(GeoUndef),
@@ -113,20 +113,20 @@ Quantity Constraint::getPresentationValue() const
 {
     Quantity quantity;
     switch (Type) {
-    case Distance:
-    case Radius:
-    case Diameter:
-    case DistanceX:
-    case DistanceY:
+    case ConstraintType::Distance:
+    case ConstraintType::Radius:
+    case ConstraintType::Diameter:
+    case ConstraintType::DistanceX:
+    case ConstraintType::DistanceY:
         quantity.setValue(Value);
         quantity.setUnit(Unit::Length);
         break;
-    case Angle:
+    case ConstraintType::Angle:
         quantity.setValue(toDegrees<double>(Value));
         quantity.setUnit(Unit::Angle);
         break;
-    case SnellsLaw:
-    case Weight:
+    case ConstraintType::SnellsLaw:
+    case ConstraintType::Weight:
         quantity.setValue(Value);
         break;
     default:
@@ -153,7 +153,7 @@ void Constraint::Save (Writer &writer) const
     writer.Stream() << writer.ind()     << "<Constrain "
     << "Name=\""                        <<  encodeName              << "\" "
     << "Type=\""                        <<  (int)Type               << "\" ";
-    if(this->Type==InternalAlignment)
+    if(this->Type==ConstraintType::InternalAlignment)
         writer.Stream()
         << "InternalAlignmentType=\""   <<  (int)AlignmentType      << "\" "
         << "InternalAlignmentIndex=\""  <<  InternalAlignmentIndex  << "\" ";
@@ -185,7 +185,7 @@ void Constraint::Restore(XMLReader &reader)
     Second    = reader.getAttributeAsInteger("Second");
     SecondPos = (PointPos)  reader.getAttributeAsInteger("SecondPos");
 
-    if(this->Type==InternalAlignment) {
+    if(this->Type==ConstraintType::InternalAlignment) {
         AlignmentType = (InternalAlignmentType) reader.getAttributeAsInteger("InternalAlignmentType");
 
         if (reader.hasAttribute("InternalAlignmentIndex"))

--- a/src/Mod/Sketcher/App/Constraint.h
+++ b/src/Mod/Sketcher/App/Constraint.h
@@ -37,7 +37,7 @@ namespace Sketcher
  This is mandatory in order to keep the handling of constraint types upward compatible which means that
  this program version ignores later introduced constraint types when reading them from a project file.
  */
-enum ConstraintType {
+enum class ConstraintType {
     None = 0,
     Coincident = 1,
     Horizontal = 2,
@@ -117,8 +117,17 @@ public:
     }
 
     inline bool isDimensional() const {
-        return Type == Distance || Type == DistanceX || Type == DistanceY ||
-               Type == Radius || Type == Diameter || Type == Angle || Type == SnellsLaw || Type == Weight;
+        return Type == ConstraintType::Distance || Type == ConstraintType::DistanceX || Type == ConstraintType::DistanceY ||
+               Type == ConstraintType::Radius || Type == ConstraintType::Diameter || Type == ConstraintType::Angle || Type == ConstraintType::SnellsLaw || Type == ConstraintType::Weight;
+    }
+    inline bool isDatum() {
+       return 
+       Type == ConstraintType::Distance || // Datum constraint
+       Type == ConstraintType::DistanceX ||
+       Type == ConstraintType::DistanceY ||
+       Type == ConstraintType::Radius ||
+       Type == ConstraintType::Diameter ||
+       Type == ConstraintType::Angle;
     }
 
     friend class PropertyConstraintList;

--- a/src/Mod/Sketcher/App/Constraint.h
+++ b/src/Mod/Sketcher/App/Constraint.h
@@ -30,6 +30,8 @@
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 
+#include "PointPosition.h"
+
 namespace Sketcher
 {
 /*!
@@ -74,9 +76,6 @@ enum InternalAlignmentType {
     BSplineControlPoint     = 9,
     BSplineKnotPoint        = 10,
 };
-
-/// define if you want to use the end or start point
-enum PointPos { none, start, end, mid };
 
 class SketcherExport Constraint : public Base::Persistence
 {

--- a/src/Mod/Sketcher/App/ConstraintPyImp.cpp
+++ b/src/Mod/Sketcher/App/ConstraintPyImp.cpp
@@ -67,17 +67,17 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
     // ConstraintType, GeoIndex
     if (PyArg_ParseTuple(args, "si", &ConstraintType, &FirstIndex)) {
         if (strcmp("Horizontal",ConstraintType) == 0) {
-            this->getConstraintPtr()->Type = Horizontal;
+            this->getConstraintPtr()->Type = ConstraintType::Horizontal;
             this->getConstraintPtr()->First = FirstIndex;
             return 0;
         }
         else if (strcmp("Vertical",ConstraintType) == 0) {
-            this->getConstraintPtr()->Type = Vertical;
+            this->getConstraintPtr()->Type = ConstraintType::Vertical;
             this->getConstraintPtr()->First = FirstIndex;
             return 0;
         }
         else if (strcmp("Block",ConstraintType) == 0) {
-            this->getConstraintPtr()->Type = Block;
+            this->getConstraintPtr()->Type = ConstraintType::Block;
             this->getConstraintPtr()->First = FirstIndex;
             return 0;
         }
@@ -95,23 +95,23 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
 #endif
             bool valid = false;
             if (strcmp("Tangent",ConstraintType) == 0) {
-                this->getConstraintPtr()->Type = Tangent;
+                this->getConstraintPtr()->Type = ConstraintType::Tangent;
                 valid = true;
             }
             else if (strcmp("Parallel",ConstraintType) == 0) {
-                this->getConstraintPtr()->Type = Parallel;
+                this->getConstraintPtr()->Type = ConstraintType::Parallel;
                 valid = true;
             }
             else if (strcmp("Perpendicular",ConstraintType) == 0) {
-                this->getConstraintPtr()->Type = Perpendicular;
+                this->getConstraintPtr()->Type = ConstraintType::Perpendicular;
                 valid = true;
             }
             else if (strcmp("Equal",ConstraintType) == 0) {
-                this->getConstraintPtr()->Type = Equal;
+                this->getConstraintPtr()->Type = ConstraintType::Equal;
                 valid = true;
             }
             else if (strstr(ConstraintType,"InternalAlignment") != NULL) {
-                this->getConstraintPtr()->Type = InternalAlignment;
+                this->getConstraintPtr()->Type = ConstraintType::InternalAlignment;
 
                 valid = true;
                 if(strstr(ConstraintType,"EllipseMajorDiameter") != NULL)
@@ -135,7 +135,7 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
             Value = PyFloat_AsDouble(index_or_value);
             bool valid = false;
             if (strcmp("Distance",ConstraintType) == 0 ) {
-                this->getConstraintPtr()->Type = Distance;
+                this->getConstraintPtr()->Type = ConstraintType::Distance;
                 valid = true;
             }
             else if (strcmp("Angle",ConstraintType) == 0 ) {
@@ -144,33 +144,33 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
                     if (q.getUnit() == Base::Unit::Angle)
                         Value = q.getValueAs(Base::Quantity::Radian);
                 }
-                this->getConstraintPtr()->Type = Angle;
+                this->getConstraintPtr()->Type = ConstraintType::Angle;
                 valid = true;
             }
             else if (strcmp("DistanceX",ConstraintType) == 0) {
-                this->getConstraintPtr()->Type = DistanceX;
+                this->getConstraintPtr()->Type = ConstraintType::DistanceX;
                 valid = true;
             }
             else if (strcmp("DistanceY",ConstraintType) == 0) {
-                this->getConstraintPtr()->Type = DistanceY;
+                this->getConstraintPtr()->Type = ConstraintType::DistanceY;
                 valid = true;
             }
             else if (strcmp("Radius",ConstraintType) == 0) {
-                this->getConstraintPtr()->Type = Radius;
+                this->getConstraintPtr()->Type = ConstraintType::Radius;
                 // set a value that is out of range of result of atan2
                 // this value is handled in ViewProviderSketch
                 this->getConstraintPtr()->LabelPosition = 10;
                 valid = true;
             }
             else if (strcmp("Diameter",ConstraintType) == 0) {
-                this->getConstraintPtr()->Type = Diameter;
+                this->getConstraintPtr()->Type = ConstraintType::Diameter;
                 // set a value that is out of range of result of atan2
                 // this value is handled in ViewProviderSketch
                 this->getConstraintPtr()->LabelPosition = 10;
                 valid = true;
             }
             else if (strcmp("Weight",ConstraintType) == 0) {
-                this->getConstraintPtr()->Type = Weight;
+                this->getConstraintPtr()->Type = ConstraintType::Weight;
                 // set a value that is out of range of result of atan2
                 // this value is handled in ViewProviderSketch
                 this->getConstraintPtr()->LabelPosition = 10;
@@ -198,19 +198,19 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
 #endif
             bool valid = false;
             if (strcmp("Perpendicular", ConstraintType) == 0) {
-                this->getConstraintPtr()->Type = Perpendicular;
+                this->getConstraintPtr()->Type = ConstraintType::Perpendicular;
                 valid = true;
             }
             else if (strcmp("Tangent", ConstraintType) == 0) {
-                this->getConstraintPtr()->Type = Tangent;
+                this->getConstraintPtr()->Type = ConstraintType::Tangent;
                 valid = true;
             }
             else if (strcmp("PointOnObject", ConstraintType) == 0) {
-                this->getConstraintPtr()->Type = PointOnObject;
+                this->getConstraintPtr()->Type = ConstraintType::PointOnObject;
                 valid = true;
             }
             else if (strstr(ConstraintType,"InternalAlignment") != NULL) {
-                this->getConstraintPtr()->Type = InternalAlignment;
+                this->getConstraintPtr()->Type = ConstraintType::InternalAlignment;
 
                 valid = true;
 
@@ -249,7 +249,7 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
                     if (q.getUnit() == Base::Unit::Angle)
                         Value = q.getValueAs(Base::Quantity::Radian);
                 }
-                this->getConstraintPtr()->Type   = Angle;
+                this->getConstraintPtr()->Type   = ConstraintType::Angle;
                 this->getConstraintPtr()->First  = FirstIndex;
                 this->getConstraintPtr()->Second = SecondIndex;
                 this->getConstraintPtr()->setValue(Value);
@@ -258,7 +258,7 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
             else if (strcmp("DistanceX",ConstraintType) == 0) {
                 FirstPos = SecondIndex;
                 SecondIndex = -1;
-                this->getConstraintPtr()->Type = DistanceX;
+                this->getConstraintPtr()->Type = ConstraintType::DistanceX;
                 this->getConstraintPtr()->First    = FirstIndex;
                 this->getConstraintPtr()->FirstPos = (Sketcher::PointPos) FirstPos;
                 this->getConstraintPtr()->setValue(Value);
@@ -267,7 +267,7 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
             else if (strcmp("DistanceY",ConstraintType) == 0) {
                 FirstPos = SecondIndex;
                 SecondIndex = -1;
-                this->getConstraintPtr()->Type = DistanceY;
+                this->getConstraintPtr()->Type = ConstraintType::DistanceY;
                 this->getConstraintPtr()->First    = FirstIndex;
                 this->getConstraintPtr()->FirstPos = (Sketcher::PointPos) FirstPos;
                 this->getConstraintPtr()->setValue(Value);
@@ -288,27 +288,27 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
 #endif
             bool valid = false;
             if (strcmp("Coincident", ConstraintType) == 0) {
-                this->getConstraintPtr()->Type = Coincident;
+                this->getConstraintPtr()->Type = ConstraintType::Coincident;
                 valid = true;
             }
             else if (strcmp("Horizontal", ConstraintType) == 0) {
-                this->getConstraintPtr()->Type = Horizontal;
+                this->getConstraintPtr()->Type = ConstraintType::Horizontal;
                 valid = true;
             }
             else if (strcmp("Vertical", ConstraintType) == 0) {
-                this->getConstraintPtr()->Type = Vertical;
+                this->getConstraintPtr()->Type = ConstraintType::Vertical;
                 valid = true;
             }
             else if (strcmp("Perpendicular", ConstraintType) == 0) {
-                this->getConstraintPtr()->Type = Perpendicular;
+                this->getConstraintPtr()->Type = ConstraintType::Perpendicular;
                 valid = true;
             }
             else if (strcmp("Tangent", ConstraintType) == 0) {
-                this->getConstraintPtr()->Type = Tangent;
+                this->getConstraintPtr()->Type = ConstraintType::Tangent;
                 valid = true;
             }
             else if (strcmp("TangentViaPoint", ConstraintType) == 0) {
-                this->getConstraintPtr()->Type = Tangent;
+                this->getConstraintPtr()->Type = ConstraintType::Tangent;
                 //valid = true;//non-standard assignment
                 this->getConstraintPtr()->First     = intArg1;
                 this->getConstraintPtr()->FirstPos  = Sketcher::none;
@@ -319,7 +319,7 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
                 return 0;
             }
             else if (strcmp("PerpendicularViaPoint", ConstraintType) == 0) {
-                this->getConstraintPtr()->Type = Perpendicular;
+                this->getConstraintPtr()->Type = ConstraintType::Perpendicular;
                 //valid = true;//non-standard assignment
                 this->getConstraintPtr()->First     = intArg1;
                 this->getConstraintPtr()->FirstPos  = Sketcher::none;
@@ -330,7 +330,7 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
                 return 0;
             }
             else if (strstr(ConstraintType,"InternalAlignment") != NULL) { // InteralAlignment with InternalElementIndex argument
-                this->getConstraintPtr()->Type = InternalAlignment;
+                this->getConstraintPtr()->Type = ConstraintType::InternalAlignment;
 
                 valid = true;
 
@@ -363,7 +363,7 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
         if (PyNumber_Check(oNumArg4)) { // can be float or int
             Value = PyFloat_AsDouble(oNumArg4);
             if (strcmp("Distance",ConstraintType) == 0 ) {
-                this->getConstraintPtr()->Type = Distance;
+                this->getConstraintPtr()->Type = ConstraintType::Distance;
                 this->getConstraintPtr()->First    = intArg1;
                 this->getConstraintPtr()->FirstPos = (Sketcher::PointPos) intArg2;
                 this->getConstraintPtr()->Second   = intArg3;
@@ -384,7 +384,7 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
             intArg5 = PyInt_AsLong(oNumArg5);
 #endif
             if (strcmp("Symmetric",ConstraintType) == 0 ) {
-                this->getConstraintPtr()->Type = Symmetric;
+                this->getConstraintPtr()->Type = ConstraintType::Symmetric;
                 this->getConstraintPtr()->First     = intArg1;
                 this->getConstraintPtr()->FirstPos  = (Sketcher::PointPos) intArg2;
                 this->getConstraintPtr()->Second    = intArg3;
@@ -398,15 +398,15 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
             Value = PyFloat_AsDouble(oNumArg5);
             bool valid=false;
             if (strcmp("Distance",ConstraintType) == 0 ) {
-                this->getConstraintPtr()->Type = Distance;
+                this->getConstraintPtr()->Type = ConstraintType::Distance;
                 valid = true;
             }
             else if (strcmp("DistanceX",ConstraintType) == 0) {
-                this->getConstraintPtr()->Type = DistanceX;
+                this->getConstraintPtr()->Type = ConstraintType::DistanceX;
                 valid = true;
             }
             else if (strcmp("DistanceY",ConstraintType) == 0) {
-                this->getConstraintPtr()->Type = DistanceY;
+                this->getConstraintPtr()->Type = ConstraintType::DistanceY;
                 valid = true;
             }
             else if (strcmp("Angle",ConstraintType) == 0 ) {
@@ -415,7 +415,7 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
                     if (q.getUnit() == Base::Unit::Angle)
                         Value = q.getValueAs(Base::Quantity::Radian);
                 }
-                this->getConstraintPtr()->Type = Angle;
+                this->getConstraintPtr()->Type = ConstraintType::Angle;
                 valid = true;
             }
             else if (strcmp("AngleViaPoint",ConstraintType) == 0 ) {
@@ -424,7 +424,7 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
                     if (q.getUnit() == Base::Unit::Angle)
                         Value = q.getValueAs(Base::Quantity::Radian);
                 }
-                this->getConstraintPtr()->Type = Angle;
+                this->getConstraintPtr()->Type = ConstraintType::Angle;
                 //valid = true;//non-standard assignment
                 this->getConstraintPtr()->First     = intArg1;
                 this->getConstraintPtr()->FirstPos  = Sketcher::none;
@@ -457,7 +457,7 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
 #endif
             // ConstraintType, GeoIndex1, PosIndex1, GeoIndex2, PosIndex2, GeoIndex3, PosIndex3
             if (strcmp("Symmetric",ConstraintType) == 0 ) {
-                this->getConstraintPtr()->Type = Symmetric;
+                this->getConstraintPtr()->Type = ConstraintType::Symmetric;
                 this->getConstraintPtr()->First     = FirstIndex;
                 this->getConstraintPtr()->FirstPos  = (Sketcher::PointPos) FirstPos;
                 this->getConstraintPtr()->Second    = SecondIndex;
@@ -470,7 +470,7 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
         if (PyNumber_Check(index_or_value)) { // can be float or int
             Value = PyFloat_AsDouble(index_or_value);
             if (strcmp("SnellsLaw",ConstraintType) == 0 ) {
-                this->getConstraintPtr()->Type = SnellsLaw;
+                this->getConstraintPtr()->Type = ConstraintType::SnellsLaw;
                 this->getConstraintPtr()->First     = FirstIndex;
                 this->getConstraintPtr()->FirstPos  = (Sketcher::PointPos) FirstPos;
                 this->getConstraintPtr()->Second    = SecondIndex;
@@ -501,39 +501,39 @@ std::string ConstraintPy::representation(void) const
     std::stringstream result;
     result << "<Constraint " ;
     switch(this->getConstraintPtr()->Type) {
-        case None               : result << "'None'>";break;
-        case DistanceX          : result << "'DistanceX'>";break;
-        case DistanceY          : result << "'DistanceY'>";break;
-        case Coincident         : result << "'Coincident'>";break;
-        case Horizontal         : result << "'Horizontal' (" << getConstraintPtr()->First << ")>";break;
-        case Vertical           : result << "'Vertical' (" << getConstraintPtr()->First << ")>";break;
-        case Block            	: result << "'Block' (" << getConstraintPtr()->First << ")>";break;
-        case Radius             : result << "'Radius'>";break;
-        case Diameter           : result << "'Diameter'>";break;
-        case Weight             : result << "'Weight'>";break;
-        case Parallel           : result << "'Parallel'>";break;
-        case Tangent            :
+        case ConstraintType::None               : result << "'None'>";break;
+        case ConstraintType::DistanceX          : result << "'DistanceX'>";break;
+        case ConstraintType::DistanceY          : result << "'DistanceY'>";break;
+        case ConstraintType::Coincident         : result << "'Coincident'>";break;
+        case ConstraintType::Horizontal         : result << "'Horizontal' (" << getConstraintPtr()->First << ")>";break;
+        case ConstraintType::Vertical           : result << "'Vertical' (" << getConstraintPtr()->First << ")>";break;
+        case ConstraintType::Block            	: result << "'Block' (" << getConstraintPtr()->First << ")>";break;
+        case ConstraintType::Radius             : result << "'Radius'>";break;
+        case ConstraintType::Diameter           : result << "'Diameter'>";break;
+        case ConstraintType::Weight             : result << "'Weight'>";break;
+        case ConstraintType::Parallel           : result << "'Parallel'>";break;
+        case ConstraintType::Tangent            :
             if (this->getConstraintPtr()->Third == Constraint::GeoUndef)
                 result << "'Tangent'>";
             else
                 result << "'TangentViaPoint'>";
         break;
-        case Perpendicular            :
+        case ConstraintType::Perpendicular            :
             if (this->getConstraintPtr()->Third == Constraint::GeoUndef)
                 result << "'Perpendicular'>";
             else
                 result << "'PerpendicularViaPoint'>";
         break;
-        case Distance           : result << "'Distance'>";break;
-        case Angle              :
+        case ConstraintType::Distance           : result << "'Distance'>";break;
+        case ConstraintType::Angle              :
             if (this->getConstraintPtr()->Third == Constraint::GeoUndef)
                 result << "'Angle'>";
             else
                 result << "'AngleViaPoint'>";
         break;
-        case Symmetric          : result << "'Symmetric'>"; break;
-        case SnellsLaw          : result << "'SnellsLaw'>"; break;
-        case InternalAlignment  :
+        case ConstraintType::Symmetric          : result << "'Symmetric'>"; break;
+        case ConstraintType::SnellsLaw          : result << "'SnellsLaw'>"; break;
+        case ConstraintType::InternalAlignment  :
             switch(this->getConstraintPtr()->AlignmentType) {
                 case Undef                  : result << "'InternalAlignment:Undef'>";break;
                 case EllipseMajorDiameter   : result << "'InternalAlignment:EllipseMajorDiameter'>";break;
@@ -543,8 +543,8 @@ std::string ConstraintPy::representation(void) const
                 default                     : result << "'InternalAlignment:?'>";break;
             }
         break;
-        case Equal              : result << "'Equal' (" << getConstraintPtr()->First << "," << getConstraintPtr()->Second << ")>";break;
-        case PointOnObject      : result << "'PointOnObject' (" << getConstraintPtr()->First << "," << getConstraintPtr()->Second << ")>";break;
+        case ConstraintType::Equal              : result << "'Equal' (" << getConstraintPtr()->First << "," << getConstraintPtr()->Second << ")>";break;
+        case ConstraintType::PointOnObject      : result << "'PointOnObject' (" << getConstraintPtr()->First << "," << getConstraintPtr()->Second << ")>";break;
         default                 : result << "'?'>";break;
     }
     return result.str();
@@ -553,26 +553,26 @@ std::string ConstraintPy::representation(void) const
 Py::String ConstraintPy::getType(void) const
 {
     switch(this->getConstraintPtr()->Type) {
-        case None               : return Py::String("None");break;
-        case DistanceX          : return Py::String("DistanceX");break;
-        case DistanceY          : return Py::String("DistanceY");break;
-        case Coincident         : return Py::String("Coincident");break;
-        case Horizontal         : return Py::String("Horizontal");break;
-        case Vertical           : return Py::String("Vertical");break;
-        case Block              : return Py::String("Block");break;
-        case Radius             : return Py::String("Radius");break;
-        case Diameter           : return Py::String("Diameter");break;
-        case Weight             : return Py::String("Weight");break;
-        case Parallel           : return Py::String("Parallel");break;
-        case Tangent            : return Py::String("Tangent");break;
-        case Perpendicular      : return Py::String("Perpendicular");break;
-        case Distance           : return Py::String("Distance");break;
-        case Angle              : return Py::String("Angle");break;
-        case Symmetric          : return Py::String("Symmetric"); break;
-        case SnellsLaw          : return Py::String("SnellsLaw"); break;
-        case InternalAlignment  : return Py::String("InternalAlignment"); break;
-        case Equal              : return Py::String("Equal"); break;
-        case PointOnObject      : return Py::String("PointOnObject"); break;
+        case ConstraintType::None               : return Py::String("None");break;
+        case ConstraintType::DistanceX          : return Py::String("DistanceX");break;
+        case ConstraintType::DistanceY          : return Py::String("DistanceY");break;
+        case ConstraintType::Coincident         : return Py::String("Coincident");break;
+        case ConstraintType::Horizontal         : return Py::String("Horizontal");break;
+        case ConstraintType::Vertical           : return Py::String("Vertical");break;
+        case ConstraintType::Block              : return Py::String("Block");break;
+        case ConstraintType::Radius             : return Py::String("Radius");break;
+        case ConstraintType::Diameter           : return Py::String("Diameter");break;
+        case ConstraintType::Weight             : return Py::String("Weight");break;
+        case ConstraintType::Parallel           : return Py::String("Parallel");break;
+        case ConstraintType::Tangent            : return Py::String("Tangent");break;
+        case ConstraintType::Perpendicular      : return Py::String("Perpendicular");break;
+        case ConstraintType::Distance           : return Py::String("Distance");break;
+        case ConstraintType::Angle              : return Py::String("Angle");break;
+        case ConstraintType::Symmetric          : return Py::String("Symmetric"); break;
+        case ConstraintType::SnellsLaw          : return Py::String("SnellsLaw"); break;
+        case ConstraintType::InternalAlignment  : return Py::String("InternalAlignment"); break;
+        case ConstraintType::Equal              : return Py::String("Equal"); break;
+        case ConstraintType::PointOnObject      : return Py::String("PointOnObject"); break;
         default                 : return Py::String("Undefined");break;
     }
 }

--- a/src/Mod/Sketcher/App/GeometryType.cpp
+++ b/src/Mod/Sketcher/App/GeometryType.cpp
@@ -1,4 +1,8 @@
+#include "PreCompiled.h"
 #include "GeometryType.h"
+
+#include <Mod/Part/App/Geometry.h>
+
 using namespace Sketcher;
 const char * GeometryType::str() const {
 
@@ -25,4 +29,12 @@ const char * GeometryType::str() const {
 	    default:
 	        return "unknown";
     }
+}
+
+GeometryType GeometryType::from(const Base::Type & geometryClassType) {
+
+	if(geometryClassType == Part::GeomPoint::getClassTypeId()){
+		return GeometryType::Point;
+	}
+	return GeometryType::None;
 }

--- a/src/Mod/Sketcher/App/GeometryType.cpp
+++ b/src/Mod/Sketcher/App/GeometryType.cpp
@@ -1,0 +1,28 @@
+#include "GeometryType.h"
+using namespace Sketcher;
+const char * GeometryType::str() const {
+
+	switch (value) {
+	    case Point:
+	        return "point";
+	    case Line:
+	        return "line";
+	    case Arc:
+	        return "arc";
+	    case Circle:
+	        return "circle";
+	    case Ellipse:
+	        return "ellipse";
+	    case ArcOfEllipse:
+	        return "arcofellipse";
+	    case ArcOfHyperbola:
+	        return "arcofhyperbola";
+	    case ArcOfParabola:
+	        return "arcofparabola";
+	    case BSpline:
+	        return "bspline";
+	    case None:
+	    default:
+	        return "unknown";
+    }
+}

--- a/src/Mod/Sketcher/App/GeometryType.h
+++ b/src/Mod/Sketcher/App/GeometryType.h
@@ -1,35 +1,39 @@
 #ifndef SKETCHER_GEOTYPE_H
 #define SKETCHER_GEOTYPE_H
 
+#include <Base/BaseClass.h>
+
+
 namespace Sketcher
 {
-	class GeometryType {
-	public:
-		enum Value {
-			None    = 0,
-		    Point   = 1, // 1 Point(start), 2 Parameters(x,y)
-		    Line    = 2, // 2 Points(start,end), 4 Parameters(x1,y1,x2,y2)
-		    Arc     = 3, // 3 Points(start,end,mid), (4)+5 Parameters((x1,y1,x2,y2),x,y,r,a1,a2)
-		    Circle  = 4, // 1 Point(mid), 3 Parameters(x,y,r)
-		    Ellipse = 5,  // 1 Point(mid), 5 Parameters(x,y,r1,r2,phi)  phi=angle xaxis of ellipse with respect of sketch xaxis
-		    ArcOfEllipse = 6,
-		    ArcOfHyperbola = 7,
-		    ArcOfParabola = 8,
-		    BSpline = 9
-		};
-		GeometryType() = default;
-  		constexpr GeometryType(Value t) : value(t) { }
-		constexpr explicit GeometryType(int t) : value((Value)t) { }
+    class GeometryType {
+    public:
+        enum Value {
+        None    = 0,
+        Point   = 1, // 1 Point(start), 2 Parameters(x,y)
+        Line    = 2, // 2 Points(start,end), 4 Parameters(x1,y1,x2,y2)
+        Arc     = 3, // 3 Points(start,end,mid), (4)+5 Parameters((x1,y1,x2,y2),x,y,r,a1,a2)
+        Circle  = 4, // 1 Point(mid), 3 Parameters(x,y,r)
+        Ellipse = 5,  // 1 Point(mid), 5 Parameters(x,y,r1,r2,phi)  phi=angle xaxis of ellipse with respect of sketch xaxis
+        ArcOfEllipse = 6,
+        ArcOfHyperbola = 7,
+        ArcOfParabola = 8,
+        BSpline = 9
+        };
+        GeometryType() = default;
+        constexpr GeometryType(Value t) : value(t) { }
+        constexpr explicit GeometryType(int t) : value((Value)t) { }
 
-	    explicit operator bool() = delete;
-	    operator int() const {return value;}
+        explicit operator bool() = delete;
+        operator int() const {return value;}
 
-		const char * str() const;
-		static GeometryType from(char *str);
+        const char * str() const;
+        static GeometryType from(const char * const str);
+        static GeometryType from(const Base::Type & geometryClassType);
 
-	private:
-		Value value;
-	};
+    private:
+        Value value;
+    };
 }
 
 #endif // SKETCHER_GEOTYPE_H

--- a/src/Mod/Sketcher/App/GeometryType.h
+++ b/src/Mod/Sketcher/App/GeometryType.h
@@ -1,0 +1,35 @@
+#ifndef SKETCHER_GEOTYPE_H
+#define SKETCHER_GEOTYPE_H
+
+namespace Sketcher
+{
+	class GeometryType {
+	public:
+		enum Value {
+			None    = 0,
+		    Point   = 1, // 1 Point(start), 2 Parameters(x,y)
+		    Line    = 2, // 2 Points(start,end), 4 Parameters(x1,y1,x2,y2)
+		    Arc     = 3, // 3 Points(start,end,mid), (4)+5 Parameters((x1,y1,x2,y2),x,y,r,a1,a2)
+		    Circle  = 4, // 1 Point(mid), 3 Parameters(x,y,r)
+		    Ellipse = 5,  // 1 Point(mid), 5 Parameters(x,y,r1,r2,phi)  phi=angle xaxis of ellipse with respect of sketch xaxis
+		    ArcOfEllipse = 6,
+		    ArcOfHyperbola = 7,
+		    ArcOfParabola = 8,
+		    BSpline = 9
+		};
+		GeometryType() = default;
+  		constexpr GeometryType(Value t) : value(t) { }
+		constexpr explicit GeometryType(int t) : value((Value)t) { }
+
+	    explicit operator bool() = delete;
+	    operator int() const {return value;}
+
+		const char * str() const;
+		static GeometryType from(char *str);
+
+	private:
+		Value value;
+	};
+}
+
+#endif // SKETCHER_GEOTYPE_H

--- a/src/Mod/Sketcher/App/PointPosition.h
+++ b/src/Mod/Sketcher/App/PointPosition.h
@@ -1,0 +1,11 @@
+#ifndef SKETCHER_POINT_POSITION_H
+#define SKETCHER_POINT_POSITION_H
+
+
+namespace Sketcher
+{
+    /// define if you want to use the end or start point. These end up in the save file, so changing the values breaks stuff
+    enum PointPos  { none=0, edge=0, start=1, end=2, mid=3, size=4 };
+}
+
+#endif //SKETCHER_POINT_POSITION_H

--- a/src/Mod/Sketcher/App/PropertyConstraintList.cpp
+++ b/src/Mod/Sketcher/App/PropertyConstraintList.cpp
@@ -330,7 +330,7 @@ void PropertyConstraintList::Restore(Base::XMLReader &reader)
         Constraint *newC = new Constraint();
         newC->Restore(reader);
         // To keep upward compatibility ignore unknown constraint types
-        if (newC->Type < Sketcher::NumConstraintTypes) {
+        if (newC->Type < ConstraintType::NumConstraintTypes) {
             values.push_back(newC);
         }
         else {
@@ -514,7 +514,7 @@ void PropertyConstraintList::setPathValue(const ObjectIdentifier &path, const bo
     if (c1.isArray()) {
         size_t index = c1.getIndex(_lValueList.size());
         switch (_lValueList[index]->Type) {
-        case Angle:
+        case ConstraintType::Angle:
             dvalue = Base::toRadians<double>(dvalue);
             break;
         default:
@@ -531,7 +531,7 @@ void PropertyConstraintList::setPathValue(const ObjectIdentifier &path, const bo
 
             if ((*it)->Name == c1.getName()) {
                 switch (_lValueList[index]->Type) {
-                case Angle:
+                case ConstraintType::Angle:
                     dvalue = Base::toRadians<double>(dvalue);
                     break;
                 default:

--- a/src/Mod/Sketcher/App/Sketch.h
+++ b/src/Mod/Sketcher/App/Sketch.h
@@ -28,6 +28,7 @@
 #include <Mod/Part/App/Geometry.h>
 #include <Mod/Part/App/TopoShape.h>
 #include "Constraint.h"
+#include "SketchStorage.h"
 
 #include "planegcs/GCS.h"
 
@@ -148,8 +149,6 @@ public:
     //@{
     /// add a point
     int addPoint(const Part::GeomPoint &point, bool fixed=false);
-    /// add an infinite line
-    int addLine(const Part::GeomLineSegment &line, bool fixed=false);
     /// add a line segment
     int addLineSegment(const Part::GeomLineSegment &lineSegment, bool fixed=false);
     /// add a arc (circle segment)
@@ -375,52 +374,16 @@ public:
     double calculateConstraintError(int icstr) { return GCSsys.calculateConstraintErrorByTag(icstr);}
 
     /// Returns the size of the Geometry
-    int getGeometrySize(void) const {return Geoms.size();}
+    int getGeometrySize(void) const {return storage.Geoms.size();}
 
-    enum GeoType {
-        None    = 0,
-        Point   = 1, // 1 Point(start), 2 Parameters(x,y)
-        Line    = 2, // 2 Points(start,end), 4 Parameters(x1,y1,x2,y2)
-        Arc     = 3, // 3 Points(start,end,mid), (4)+5 Parameters((x1,y1,x2,y2),x,y,r,a1,a2)
-        Circle  = 4, // 1 Point(mid), 3 Parameters(x,y,r)
-        Ellipse = 5,  // 1 Point(mid), 5 Parameters(x,y,r1,r2,phi)  phi=angle xaxis of ellipse with respect of sketch xaxis
-        ArcOfEllipse = 6,
-        ArcOfHyperbola = 7,
-        ArcOfParabola = 8,
-        BSpline = 9
-    };
+
 
 protected:
     float SolveTime;
     bool RecalculateInitialSolutionWhileMovingPoint;
 
 protected:
-    /// container element to store and work with the geometric elements of this sketch
-    struct GeoDef {
-        GeoDef() : geo(0),type(None),external(false),index(-1),
-                   startPointId(-1),midPointId(-1),endPointId(-1) {}
-        Part::Geometry  * geo;             // pointer to the geometry
-        GeoType           type;            // type of the geometry
-        bool              external;        // flag for external geometries
-        int               index;           // index in the corresponding storage vector (Lines, Arcs, Circles, ...)
-        int               startPointId;    // index in Points of the start point of this geometry
-        int               midPointId;      // index in Points of the start point of this geometry
-        int               endPointId;      // index in Points of the end point of this geometry
-    };
-    /// container element to store and work with the constraints of this sketch
-    struct ConstrDef {
-        ConstrDef() : constr(0)
-                    , driving(true)
-                    , value(0)
-                    , secondvalue(0) {}
-        Constraint *    constr;             // pointer to the constraint
-        bool            driving;
-        double *        value;
-        double *        secondvalue;        // this is needed for SnellsLaw
-    };
 
-    std::vector<GeoDef> Geoms;
-    std::vector<ConstrDef> Constrs;
     GCS::System GCSsys;
     int ConstraintsCounter;
     std::vector<int> Conflicting;
@@ -438,15 +401,7 @@ protected:
     std::vector<double*> DrivenParameters;    // with memory allocation
     std::vector<double*> FixParameters; // with memory allocation
     std::vector<double> MoveParameters, InitParameters;
-    std::vector<GCS::Point>  Points;
-    std::vector<GCS::Line>   Lines;
-    std::vector<GCS::Arc>    Arcs;
-    std::vector<GCS::Circle> Circles;
-    std::vector<GCS::Ellipse> Ellipses;
-    std::vector<GCS::ArcOfEllipse> ArcsOfEllipse;
-    std::vector<GCS::ArcOfHyperbola> ArcsOfHyperbola;
-    std::vector<GCS::ArcOfParabola> ArcsOfParabola;
-    std::vector<GCS::BSpline> BSplines;
+    SketchStorage storage;
 
     bool isInitMove;
     bool isFine;

--- a/src/Mod/Sketcher/App/SketchAnalysis.cpp
+++ b/src/Mod/Sketcher/App/SketchAnalysis.cpp
@@ -238,7 +238,7 @@ int SketchAnalysis::detectMissingPointOnPointConstraints(double precision, bool 
             for (vn = vt+1; vn != vertexIds.end(); ++vn) {
                 if (pred(*vt,*vn)) {
                     ConstraintIds id;
-                    id.Type = Coincident; // default point on point restriction
+                    id.Type = ConstraintType::Coincident; // default point on point restriction
                     id.v = vt->v;
                     id.First = vt->GeoId;
                     id.FirstPos = vt->PosId;
@@ -260,9 +260,9 @@ int SketchAnalysis::detectMissingPointOnPointConstraints(double precision, bool 
     // If there is none but two vertexes can be considered equal a coincident constraint is missing.
     std::vector<Sketcher::Constraint*> constraint = sketch->Constraints.getValues();
     for (std::vector<Sketcher::Constraint*>::iterator it = constraint.begin(); it != constraint.end(); ++it) {
-        if ((*it)->Type == Sketcher::Coincident ||
-            (*it)->Type == Sketcher::Tangent ||
-            (*it)->Type == Sketcher::Perpendicular) {
+        if ((*it)->Type == ConstraintType::Coincident ||
+            (*it)->Type == ConstraintType::Tangent ||
+            (*it)->Type == ConstraintType::Perpendicular) {
             ConstraintIds id;
             id.First = (*it)->First;
             id.FirstPos = (*it)->FirstPos;
@@ -325,10 +325,10 @@ void SketchAnalysis::analyseMissingPointOnPointCoincident(double angleprecision)
                 Base::Vector3d tgv2 = curve2->firstDerivativeAtParameter(u2).Normalize();
 
                 if(fabs(tgv1*tgv2)>fabs(cos(angleprecision))) {
-                    vc.Type = Sketcher::Tangent;
+                    vc.Type = ConstraintType::Tangent;
                 }
                 else if(fabs(tgv1*tgv2)<fabs(cos(M_PI/2 - angleprecision))) {
-                    vc.Type = Sketcher::Perpendicular;
+                    vc.Type = ConstraintType::Perpendicular;
                 }
 
             }
@@ -411,11 +411,11 @@ int SketchAnalysis::detectMissingVerticalHorizontalConstraints(double anglepreci
             id.SecondPos = Sketcher::none;
 
             if( checkVertical(dir, angleprecision) ) {
-                id.Type = Sketcher::Vertical;
+                id.Type = ConstraintType::Vertical;
                 verthorizConstraints.push_back(id);
             }
             else if (checkHorizontal(dir, angleprecision)  ) {
-                id.Type = Sketcher::Horizontal;
+                id.Type = ConstraintType::Horizontal;
                 verthorizConstraints.push_back(id);
             }
         }
@@ -525,7 +525,7 @@ int SketchAnalysis::detectMissingEqualityConstraints(double precision)
             for (vn = vt+1; vn != lineedgeIds.end(); ++vn) {
                 if (pred(*vt,*vn)) {
                     ConstraintIds id;
-                    id.Type = Equal;
+                    id.Type = ConstraintType::Equal;
                     id.v.x = vt->l;
                     id.First = vt->GeoId;
                     id.FirstPos = Sketcher::none;
@@ -555,7 +555,7 @@ int SketchAnalysis::detectMissingEqualityConstraints(double precision)
             for (vn = vt+1; vn != radiusedgeIds.end(); ++vn) {
                 if (pred(*vt,*vn)) {
                     ConstraintIds id;
-                    id.Type = Equal;
+                    id.Type = ConstraintType::Equal;
                     id.v.x = vt->l;
                     id.First = vt->GeoId;
                     id.FirstPos = Sketcher::none;
@@ -578,7 +578,7 @@ int SketchAnalysis::detectMissingEqualityConstraints(double precision)
     // If there is none but two vertexes can be considered equal a coincident constraint is missing.
     std::vector<Sketcher::Constraint*> constraint = sketch->Constraints.getValues();
     for (std::vector<Sketcher::Constraint*>::iterator it = constraint.begin(); it != constraint.end(); ++it) {
-        if ((*it)->Type == Sketcher::Equal) {
+        if ((*it)->Type == ConstraintType::Equal) {
             ConstraintIds id;
             id.First = (*it)->First;
             id.FirstPos = (*it)->FirstPos;

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -7162,14 +7162,11 @@ void SketchObject::getGeometryWithDependentParameters(std::vector<std::pair<int,
                     //
                     // For this reason, this function returns edge as dependent parameter if and only if constraining the
                     // parameters of the points would not suffice to constraint the element.
-                    if (solvext->getEdge() == SolverGeometryExtension::Dependent)
-                        geometrymap.emplace_back(geoid,Sketcher::none);
-                    if (solvext->getStart() == SolverGeometryExtension::Dependent)
-                        geometrymap.emplace_back(geoid,Sketcher::start);
-                    if (solvext->getEnd() == SolverGeometryExtension::Dependent)
-                        geometrymap.emplace_back(geoid,Sketcher::start);
-                    if (solvext->getMid() == SolverGeometryExtension::Dependent)
-                        geometrymap.emplace_back(geoid,Sketcher::start);
+                    for(PointPos i: {PointPos::edge, PointPos::start, PointPos::end, PointPos::mid})
+                    {
+                        if (solvext->get(i) == SolverGeometryExtension::Dependent)
+                            geometrymap.emplace_back(geoid,i);
+                    }
                 }
             }
         }
@@ -7397,7 +7394,7 @@ bool SketchObject::isPointOnCurve(int geoIdCurve, double px, double py)
     Base::Vector3d pp;
     pp.x = px; pp.y = py;
     Part::GeomPoint p(pp);
-    int ipnt = sk.addPoint(p);
+    int ipnt = sk.addGeometry(&p);
     int icstr = sk.addPointOnObjectConstraint(ipnt, Sketcher::start, icrv);
     double err = sk.calculateConstraintError(icstr);
     return err*err < 10.0*sk.getSolverPrecision();

--- a/src/Mod/Sketcher/App/SketchObjectPyImp.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectPyImp.cpp
@@ -726,19 +726,19 @@ PyObject* SketchObjectPy::getDatum(PyObject *args)
     while (false);
 
     ConstraintType type = constr->Type;
-    if (type != Distance &&
-        type != DistanceX &&
-        type != DistanceY &&
-        type != Radius &&
-        type != Diameter &&
-        type != Angle) {
+    if (type != ConstraintType::Distance &&
+        type != ConstraintType::DistanceX &&
+        type != ConstraintType::DistanceY &&
+        type != ConstraintType::Radius &&
+        type != ConstraintType::Diameter &&
+        type != ConstraintType::Angle) {
         PyErr_SetString(PyExc_TypeError, "Constraint is not a datum");
         return 0;
     }
 
     Base::Quantity datum;
     datum.setValue(constr->getValue());
-    if (type == Angle) {
+    if (type == ConstraintType::Angle) {
         datum.setValue(Base::toDegrees<double>(datum.getValue()));
         datum.setUnit(Base::Unit::Angle);
     }
@@ -1579,7 +1579,7 @@ Py::List SketchObjectPy::getMissingPointOnPointConstraints(void) const
         t.setItem(1, Py::Long(((c.FirstPos == Sketcher::none)?0:(c.FirstPos == Sketcher::start)?1:(c.FirstPos == Sketcher::end)?2:3)));
         t.setItem(2, Py::Long(c.Second));
         t.setItem(3, Py::Long(((c.SecondPos == Sketcher::none)?0:(c.SecondPos == Sketcher::start)?1:(c.SecondPos == Sketcher::end)?2:3)));
-        t.setItem(4, Py::Long(c.Type));
+        t.setItem(4, Py::Long((long)c.Type));
         list.append(t);
     }
     return list;
@@ -1620,7 +1620,7 @@ Py::List SketchObjectPy::getMissingVerticalHorizontalConstraints(void) const
         t.setItem(1, Py::Long(((c.FirstPos == Sketcher::none)?0:(c.FirstPos == Sketcher::start)?1:(c.FirstPos == Sketcher::end)?2:3)));
         t.setItem(2, Py::Long(c.Second));
         t.setItem(3, Py::Long(((c.SecondPos == Sketcher::none)?0:(c.SecondPos == Sketcher::start)?1:(c.SecondPos == Sketcher::end)?2:3)));
-        t.setItem(4, Py::Long(c.Type));
+        t.setItem(4, Py::Long((long)c.Type));
         list.append(t);
     }
     return list;
@@ -1682,7 +1682,7 @@ void SketchObjectPy::setMissingLineEqualityConstraints(Py::List arg)
         c.FirstPos = checkpos(t,1);
         c.Second = (long)Py::Long(t.getItem(2));
         c.SecondPos = checkpos(t,3);
-        c.Type = Sketcher::Equal;
+        c.Type = ConstraintType::Equal;
 
         constraints.push_back(c);
     }
@@ -1722,7 +1722,7 @@ void SketchObjectPy::setMissingRadiusConstraints(Py::List arg)
         c.FirstPos = checkpos(t,1);
         c.Second = (long)Py::Long(t.getItem(2));
         c.SecondPos = checkpos(t,3);
-        c.Type = Sketcher::Equal;
+        c.Type = ConstraintType::Equal;
 
         constraints.push_back(c);
     }

--- a/src/Mod/Sketcher/App/SketchObjectPyImp.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectPyImp.cpp
@@ -725,28 +725,12 @@ PyObject* SketchObjectPy::getDatum(PyObject *args)
     }
     while (false);
 
-    ConstraintType type = constr->Type;
-    if (type != ConstraintType::Distance &&
-        type != ConstraintType::DistanceX &&
-        type != ConstraintType::DistanceY &&
-        type != ConstraintType::Radius &&
-        type != ConstraintType::Diameter &&
-        type != ConstraintType::Angle) {
+    if (!constr->isDatum()) {
         PyErr_SetString(PyExc_TypeError, "Constraint is not a datum");
         return 0;
     }
 
-    Base::Quantity datum;
-    datum.setValue(constr->getValue());
-    if (type == ConstraintType::Angle) {
-        datum.setValue(Base::toDegrees<double>(datum.getValue()));
-        datum.setUnit(Base::Unit::Angle);
-    }
-    else {
-        datum.setUnit(Base::Unit::Length);
-    }
-
-    return new Base::QuantityPy(new Base::Quantity(datum));
+    return new Base::QuantityPy(new Base::Quantity(constr->getPresentationValue()));
 }
 
 PyObject* SketchObjectPy::setDriving(PyObject *args)

--- a/src/Mod/Sketcher/App/SketchStorage.cpp
+++ b/src/Mod/Sketcher/App/SketchStorage.cpp
@@ -1,0 +1,7 @@
+#include "PreCompiled.h"
+#include "SketchStorage.h"
+
+using namespace Sketcher;
+
+SketchStorage::SketchStorage() {}
+SketchStorage::~SketchStorage() {}

--- a/src/Mod/Sketcher/App/SketchStorage.cpp
+++ b/src/Mod/Sketcher/App/SketchStorage.cpp
@@ -5,3 +5,24 @@ using namespace Sketcher;
 
 SketchStorage::SketchStorage() {}
 SketchStorage::~SketchStorage() {}
+
+
+// void SketchStorage::addPoint(Part::GeomPoint &point)
+// {
+//     size_t geometry = addGeometry(point);
+//     Geoms[geometry].pointIds[PointPos::start] =
+//     Geoms[geometry].pointIds[PointPos::mid] =
+//     Geoms[geometry].pointIds[PointPos::end] =
+//     Points.size();
+
+//     Points.push_back(point);
+// }
+
+// size_t SketchStorage::addGeometry(const Part::Geometry & geometry)
+// {
+//     SketchStorage::GeoDef def;
+//     def.geo  = geometry;
+//     def.type = GeometryType::from(geometry.getTypeId());
+//     Geoms.push_back(def);
+//     return  Geoms.size()-1;
+// }

--- a/src/Mod/Sketcher/App/SketchStorage.h
+++ b/src/Mod/Sketcher/App/SketchStorage.h
@@ -9,70 +9,79 @@
 namespace Sketcher
 {
 class SketcherExport SketchStorage 
-{ 
-	public:
-		SketchStorage();
-		~SketchStorage();
+{
+    public:
+    SketchStorage();
+        ~SketchStorage();
 
-	    void clear(void) {
+        void clear(void) {
 
-	    	Points.clear();
-		    Lines.clear();
-		    Arcs.clear();
-		    Circles.clear();
-		    Ellipses.clear();
-		    ArcsOfEllipse.clear();
-		    ArcsOfHyperbola.clear();
-		    ArcsOfParabola.clear();
-		    BSplines.clear();
+            Points.clear();
+            Lines.clear();
+            Arcs.clear();
+            Circles.clear();
+            Ellipses.clear();
+            ArcsOfEllipse.clear();
+            ArcsOfHyperbola.clear();
+            ArcsOfParabola.clear();
+            BSplines.clear();
 
-		      for (auto &it : Geoms)
-		      {
-				if (it.geo)
-					delete it.geo;
-		      }
-        		
-    		Geoms.clear();
-		    Constrs.clear();
+              for (auto &it : Geoms)
+              {
+                if (it.geo)
+                    delete it.geo;
+              }
+                
+            Geoms.clear();
+            Constrs.clear();
 
-	    }
-		
-		std::vector<GCS::Point>  Points;
-	    std::vector<GCS::Line>   Lines;
-	    std::vector<GCS::Arc>    Arcs;
-	    std::vector<GCS::Circle> Circles;
-	    std::vector<GCS::Ellipse> Ellipses;
-	    std::vector<GCS::ArcOfEllipse> ArcsOfEllipse;
-	    std::vector<GCS::ArcOfHyperbola> ArcsOfHyperbola;
-	    std::vector<GCS::ArcOfParabola> ArcsOfParabola;
-	    std::vector<GCS::BSpline> BSplines;
+        }
+        
+        std::vector<GCS::Point>  Points;
+        std::vector<GCS::Line>   Lines;
+        std::vector<GCS::Arc>    Arcs;
+        std::vector<GCS::Circle> Circles;
+        std::vector<GCS::Ellipse> Ellipses;
+        std::vector<GCS::ArcOfEllipse> ArcsOfEllipse;
+        std::vector<GCS::ArcOfHyperbola> ArcsOfHyperbola;
+        std::vector<GCS::ArcOfParabola> ArcsOfParabola;
+        std::vector<GCS::BSpline> BSplines;
     /// container element to store and work with the geometric elements of this sketch
 
-	    struct GeoDef {
-	        GeoDef() : geo(0),type(GeometryType::None),external(false),index(-1),
-	                   startPointId(-1),midPointId(-1),endPointId(-1) {}
-	        Part::Geometry  * geo;             // pointer to the geometry
-	        GeometryType       type;            // type of the geometry
-	        bool              external;        // flag for external geometries
-	        int               index;           // index in the corresponding storage vector (Lines, Arcs, Circles, ...)
-	        int               startPointId;    // index in Points of the start point of this geometry
-	        int               midPointId;      // index in Points of the start point of this geometry
-	        int               endPointId;      // index in Points of the end point of this geometry
-	    };
+        struct GeoDef {
+            GeoDef() : geo(0),type(GeometryType::None),external(false),index(-1)
+                      {
+                        for (int i=0; i < PointPos::size; i++)
+                        {
+                            pointIds[i]=-1;
+                        }
+                      }
+            Part::Geometry  * geo;             // pointer to the geometry
+            GeometryType       type;            // type of the geometry
+            bool              external;        // flag for external geometries
+            int               index;           // index in the corresponding storage vector (Lines, Arcs, Circles, ...)
+            int  pointIds[PointPos::size];  //Index in Points for startt, midle, and end of this geometry where applicable
+            // int               startPointId;    // index in Points of the start point of this geometry
+            // int               midPointId;      // index in Points of the start point of this geometry
+            // int               endPointId;      // index in Points of the end point of this geometry
+        };
     /// container element to store and work with the constraints of this sketch
-	    struct ConstrDef {
-	        ConstrDef() : constr(0)
-	                    , driving(true)
-	                    , value(0)
-	                    , secondvalue(0) {}
-	        Constraint *    constr;             // pointer to the constraint
-	        bool            driving;
-	        double *        value;
-	        double *        secondvalue;        // this is needed for SnellsLaw
-	    };
+        struct ConstrDef {
+            ConstrDef() : constr(0)
+                        , driving(true)
+                        , value(0)
+                        , secondvalue(0) {}
+            Constraint *    constr;             // pointer to the constraint
+            bool            driving;
+            double *        value;
+            double *        secondvalue;        // this is needed for SnellsLaw
+        };
 
     std::vector<GeoDef> Geoms;
     std::vector<ConstrDef> Constrs;
+
+    private:
+
 
 };
 

--- a/src/Mod/Sketcher/App/SketchStorage.h
+++ b/src/Mod/Sketcher/App/SketchStorage.h
@@ -1,0 +1,83 @@
+#ifndef SKETCHER_SKETCH_STORAGE_H
+#define SKETCHER_SKETCH_STORAGE_H
+
+#include <Mod/Part/App/Geometry.h>
+#include "planegcs/GCS.h"
+#include "GeometryType.h"
+#include "Constraint.h"
+
+namespace Sketcher
+{
+class SketcherExport SketchStorage 
+{ 
+	public:
+		SketchStorage();
+		~SketchStorage();
+
+	    void clear(void) {
+
+	    	Points.clear();
+		    Lines.clear();
+		    Arcs.clear();
+		    Circles.clear();
+		    Ellipses.clear();
+		    ArcsOfEllipse.clear();
+		    ArcsOfHyperbola.clear();
+		    ArcsOfParabola.clear();
+		    BSplines.clear();
+
+		      for (auto &it : Geoms)
+		      {
+				if (it.geo)
+					delete it.geo;
+		      }
+        		
+    		Geoms.clear();
+		    Constrs.clear();
+
+	    }
+		
+		std::vector<GCS::Point>  Points;
+	    std::vector<GCS::Line>   Lines;
+	    std::vector<GCS::Arc>    Arcs;
+	    std::vector<GCS::Circle> Circles;
+	    std::vector<GCS::Ellipse> Ellipses;
+	    std::vector<GCS::ArcOfEllipse> ArcsOfEllipse;
+	    std::vector<GCS::ArcOfHyperbola> ArcsOfHyperbola;
+	    std::vector<GCS::ArcOfParabola> ArcsOfParabola;
+	    std::vector<GCS::BSpline> BSplines;
+    /// container element to store and work with the geometric elements of this sketch
+
+	    struct GeoDef {
+	        GeoDef() : geo(0),type(GeometryType::None),external(false),index(-1),
+	                   startPointId(-1),midPointId(-1),endPointId(-1) {}
+	        Part::Geometry  * geo;             // pointer to the geometry
+	        GeometryType       type;            // type of the geometry
+	        bool              external;        // flag for external geometries
+	        int               index;           // index in the corresponding storage vector (Lines, Arcs, Circles, ...)
+	        int               startPointId;    // index in Points of the start point of this geometry
+	        int               midPointId;      // index in Points of the start point of this geometry
+	        int               endPointId;      // index in Points of the end point of this geometry
+	    };
+    /// container element to store and work with the constraints of this sketch
+	    struct ConstrDef {
+	        ConstrDef() : constr(0)
+	                    , driving(true)
+	                    , value(0)
+	                    , secondvalue(0) {}
+	        Constraint *    constr;             // pointer to the constraint
+	        bool            driving;
+	        double *        value;
+	        double *        secondvalue;        // this is needed for SnellsLaw
+	    };
+
+    std::vector<GeoDef> Geoms;
+    std::vector<ConstrDef> Constrs;
+
+};
+
+
+}
+
+
+#endif // SKETCHER_SKETCH_STORAGE_H

--- a/src/Mod/Sketcher/App/SolverGeometryExtension.cpp
+++ b/src/Mod/Sketcher/App/SolverGeometryExtension.cpp
@@ -32,24 +32,18 @@ using namespace Sketcher;
 //---------- Geometry Extension
 TYPESYSTEM_SOURCE(Sketcher::SolverGeometryExtension,Part::GeometryExtension)
 
-SolverGeometryExtension::SolverGeometryExtension():
-    Edge(SolverGeometryExtension::Dependent),
-    Start(SolverGeometryExtension::Dependent),
-    Mid(SolverGeometryExtension::Dependent),
-    End(SolverGeometryExtension::Dependent)
+SolverGeometryExtension::SolverGeometryExtension()
 {
-
+    for(auto &status: statuses) 
+        status = SolverGeometryExtension::Dependent;
 }
 
 std::unique_ptr<Part::GeometryExtension> SolverGeometryExtension::copy(void) const
 {
     auto cpy = std::make_unique<SolverGeometryExtension>();
 
-    cpy->Edge = this->Edge;
-    cpy->Start = this->Start;
-    cpy->End  = this->End;
-    cpy->Mid = this->Mid;
-
+    for(PointPos i=(PointPos)0;i<PointPos::size;i=(PointPos)(i+1))
+        cpy->statuses[i]=this->statuses[i];
     cpy->setName(this->getName()); // Base Class
 
 #if defined (__GNUC__) && (__GNUC__ <=4)

--- a/src/Mod/Sketcher/App/SolverGeometryExtension.h
+++ b/src/Mod/Sketcher/App/SolverGeometryExtension.h
@@ -24,6 +24,7 @@
 #define SKETCHER_SOLVERGEOMETRYEXTENSION_H
 
 #include <Mod/Part/App/GeometryExtension.h>
+#include "PointPosition.h"
 
 namespace Sketcher
 {
@@ -52,38 +53,43 @@ public:
 
     virtual PyObject *getPyObject(void) override;
 
-    SolverStatus getGeometry() const  {return ( Edge == Independent &&
-                                                Start == Independent &&
-                                                End == Independent &&
-                                                Mid == Independent) ? FullyConstraint : NotFullyConstraint;}
+    SolverStatus getGeometry() const
+    {
+        for( auto status : statuses)
+        {
+            if (status != Independent)
+                return NotFullyConstraint;
+        }
+        return FullyConstraint;
+    }
+    ParameterStatus get(PointPos i) const { return statuses[i];}
+    void set(PointPos i, ParameterStatus status) { statuses[i]=status;}
+    // ParameterStatus getEdge() const  {return Edge;}
+    // void setEdge(ParameterStatus status) {Edge = status;}
 
-    ParameterStatus getEdge() const  {return Edge;}
-    void setEdge(ParameterStatus status) {Edge = status;}
+    // ParameterStatus getStart() const  {return Start;}
+    // void setStart(ParameterStatus status) {Start = status;}
 
-    ParameterStatus getStart() const  {return Start;}
-    void setStart(ParameterStatus status) {Start = status;}
+    // ParameterStatus getMid() const  {return Mid;}
+    // void setMid(ParameterStatus status) {Mid = status;}
 
-    ParameterStatus getMid() const  {return Mid;}
-    void setMid(ParameterStatus status) {Mid = status;}
+    // ParameterStatus getEnd() const  {return End;}
+    // void setEnd(ParameterStatus status) {End = status;}
 
-    ParameterStatus getEnd() const  {return End;}
-    void setEnd(ParameterStatus status) {End = status;}
+    void init(ParameterStatus s) {
 
-    void init(ParameterStatus status) {
-        Edge = status;
-        Start = status;
-        Mid = status;
-        End = status;
+        for( auto &status : statuses)
+            status=s;
     }
 
 private:
     SolverGeometryExtension(const SolverGeometryExtension&) = default;
 
 private:
-    ParameterStatus    Edge;
-    ParameterStatus    Start;
-    ParameterStatus    Mid;
-    ParameterStatus    End;
+    ParameterStatus    statuses[PointPos::size];
+    // ParameterStatus    Start;
+    // ParameterStatus    Mid;
+    // ParameterStatus    End;
 };
 
 } //namespace Sketcher

--- a/src/Mod/Sketcher/App/filterChain/Filter.h
+++ b/src/Mod/Sketcher/App/filterChain/Filter.h
@@ -1,0 +1,73 @@
+#ifndef SKETCHER_FILTER_H
+#define SKETCHER_FILTER_H
+
+#include "FilterOperation.h"
+
+namespace Sketcher
+{
+    namespace FilterChain
+    {
+        template<typename INPUT, typename OUTPUT> class Filter;
+        template<typename OUTPUT>
+        class FilterOutput
+        {
+            public:
+                const Outcome outcome;
+                const OUTPUT output;
+                FilterOutput(Outcome outcome): outcome(outcome), output(0) {}
+                FilterOutput(Outcome outcome, const OUTPUT output): outcome(outcome), output(output) {}
+                FilterOutput(const FilterOutput & outcome) = default;
+                static const FilterOutput defaultContinue() 
+                {
+                    return FilterOutput(Outcome::Continue);
+                }
+        };
+        template<>
+        class FilterOutput<void>
+         {
+            public:
+                const Outcome outcome;
+                FilterOutput(Outcome outcome):outcome(outcome){}
+                FilterOutput(const FilterOutput & outcome) = default;
+                static const FilterOutput defaultContinue() 
+                {
+                    return FilterOutput(Outcome::Continue);
+                }
+        };
+
+
+        template<typename DATA, typename OUTPUT>
+        class FilterInput
+        {
+            public:
+                const DATA& data;
+                Filter<DATA,OUTPUT> * const originator;
+
+                FilterInput(const DATA & data, Filter<DATA,OUTPUT> * originator):
+                data(data), originator(originator){}
+
+                FilterInput<DATA,OUTPUT> withOriginator(Filter<DATA,OUTPUT> * const newOriginator) const
+                {
+                    return FilterInput(data, newOriginator);
+                }
+
+                FilterInput<DATA,OUTPUT> withData(const DATA& data) const
+                {
+                    return FilterInput(data, originator);
+                }
+        };
+
+        template<typename DATA, typename OUTPUT>
+        class Filter
+        {
+        public:
+            using InputType = FilterInput<DATA,OUTPUT> ;
+            using OutputType = FilterOutput<OUTPUT>;
+            Filter() = default;
+            Filter(Filter const&f) = default;
+            virtual OutputType execute(const InputType & )=0;
+        };
+    }
+}
+
+#endif //SKETCHER_FILTER_H

--- a/src/Mod/Sketcher/App/filterChain/FilterChain.h
+++ b/src/Mod/Sketcher/App/filterChain/FilterChain.h
@@ -1,0 +1,34 @@
+#ifndef SKETCHER_FILTER_CHAIN_H
+#define SKETCHER_FILTER_CHAIN_H
+#include <vector>
+#include <memory>
+#include "Filter.h"
+
+namespace Sketcher
+{
+    namespace FilterChain
+    {
+        template<typename DATA, typename OUTPUT>
+        class FilterChain : public Filter<DATA,OUTPUT>
+        {
+        public:
+            using FilterType = Filter<DATA,OUTPUT> ;
+
+            std::vector<std::unique_ptr<FilterType > > filters;
+            virtual FilterOutput<OUTPUT> execute(const typename FilterType::InputType& input)
+            {
+                auto request = input.withOriginator(this);
+                for(const auto &filter: filters){
+                    auto response = filter->execute(request);
+                    if(response.outcome == Outcome::Stop)
+                        return response;
+                }
+                return FilterType::OutputType::defaultContinue();
+            }
+
+
+        };
+    }
+}
+
+#endif //SKETCHER_FILTER_CHAIN_H

--- a/src/Mod/Sketcher/App/filterChain/FilterOperation.h
+++ b/src/Mod/Sketcher/App/filterChain/FilterOperation.h
@@ -1,0 +1,24 @@
+#ifndef SKETCHER_FILTER_OPERATION_H
+#define SKETCHER_FILTER_OPERATION_H
+
+namespace Sketcher
+{
+    namespace FilterChain
+    {
+        enum class Operation
+        {
+            Add,
+            Remove,
+            Inspect,
+        };
+
+        enum class Outcome
+        {
+            Continue,
+            Stop,
+            Restart
+        };
+    }
+}
+
+#endif //SKETCHER_GEOMETRY_FILTER_OPERATION_H

--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -1116,18 +1116,18 @@ void CmdSketcherConstrainHorizontal::activated(int iMsg)
             // check if the edge already has a Horizontal/Vertical/Block constraint
             for (std::vector< Sketcher::Constraint * >::const_iterator it= vals.begin();
                  it != vals.end(); ++it) {
-                if ((*it)->Type == Sketcher::Horizontal && (*it)->First == GeoId && (*it)->FirstPos == Sketcher::none){
+                if ((*it)->Type == Sketcher::ConstraintType::Horizontal && (*it)->First == GeoId && (*it)->FirstPos == Sketcher::none){
                     QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Double constraint"),
                         QObject::tr("The selected edge already has a horizontal constraint!"));
                     return;
                 }
-                if ((*it)->Type == Sketcher::Vertical && (*it)->First == GeoId && (*it)->FirstPos == Sketcher::none) {
+                if ((*it)->Type == Sketcher::ConstraintType::Vertical && (*it)->First == GeoId && (*it)->FirstPos == Sketcher::none) {
                     QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Impossible constraint"),
                                          QObject::tr("The selected edge already has a vertical constraint!"));
                     return;
                 }
                 // check if the edge already has a Block constraint
-                if ((*it)->Type == Sketcher::Block && (*it)->First == GeoId && (*it)->FirstPos == Sketcher::none) {
+                if ((*it)->Type == Sketcher::ConstraintType::Block && (*it)->First == GeoId && (*it)->FirstPos == Sketcher::none) {
                     QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Impossible constraint"),
                                          QObject::tr("The selected edge already has a Block constraint!"));
                     return;
@@ -1354,18 +1354,18 @@ void CmdSketcherConstrainVertical::activated(int iMsg)
             // check if the edge already has a Horizontal/Vertical/Block constraint
             for (std::vector< Sketcher::Constraint * >::const_iterator it= vals.begin();
                  it != vals.end(); ++it) {
-                if ((*it)->Type == Sketcher::Vertical && (*it)->First == GeoId && (*it)->FirstPos == Sketcher::none){
+                if ((*it)->Type == Sketcher::ConstraintType::Vertical && (*it)->First == GeoId && (*it)->FirstPos == Sketcher::none){
                     QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Double constraint"),
                                          QObject::tr("The selected edge already has a vertical constraint!"));
                     return;
                 }
-                if ((*it)->Type == Sketcher::Horizontal && (*it)->First == GeoId && (*it)->FirstPos == Sketcher::none) {
+                if ((*it)->Type == Sketcher::ConstraintType::Horizontal && (*it)->First == GeoId && (*it)->FirstPos == Sketcher::none) {
                     QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Impossible constraint"),
                                          QObject::tr("The selected edge already has a horizontal constraint!"));
                     return;
                 }
                 // check if the edge already has a Block constraint
-                if ((*it)->Type == Sketcher::Block && (*it)->First == GeoId && (*it)->FirstPos == Sketcher::none) {
+                if ((*it)->Type == Sketcher::ConstraintType::Block && (*it)->First == GeoId && (*it)->FirstPos == Sketcher::none) {
                     QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Impossible constraint"),
                                          QObject::tr("The selected edge already has a Block constraint!"));
                     return;
@@ -1447,18 +1447,18 @@ void CmdSketcherConstrainVertical::applyConstraint(std::vector<SelIdPair> &selSe
             // check if the edge already has a Horizontal or Vertical constraint
             for (std::vector< Sketcher::Constraint * >::const_iterator it= vals.begin();
                  it != vals.end(); ++it) {
-                if ((*it)->Type == Sketcher::Horizontal && (*it)->First == CrvId && (*it)->FirstPos == Sketcher::none){
+                if ((*it)->Type == Sketcher::ConstraintType::Horizontal && (*it)->First == CrvId && (*it)->FirstPos == Sketcher::none){
                     QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Impossible constraint"),
                                          QObject::tr("The selected edge already has a horizontal constraint!"));
                     return;
                 }
-                if ((*it)->Type == Sketcher::Vertical && (*it)->First == CrvId && (*it)->FirstPos == Sketcher::none) {
+                if ((*it)->Type == Sketcher::ConstraintType::Vertical && (*it)->First == CrvId && (*it)->FirstPos == Sketcher::none) {
                     QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Double constraint"),
                                          QObject::tr("The selected edge already has a vertical constraint!"));
                     return;
                 }
                 // check if the edge already has a Block constraint
-                if ((*it)->Type == Sketcher::Block && (*it)->First == CrvId && (*it)->FirstPos == Sketcher::none) {
+                if ((*it)->Type == Sketcher::ConstraintType::Block && (*it)->First == CrvId && (*it)->FirstPos == Sketcher::none) {
                     QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Impossible constraint"),
                                          QObject::tr("The selected edge already has a Block constraint!"));
                     return;
@@ -1822,7 +1822,7 @@ void CmdSketcherConstrainBlock::activated(int iMsg)
         }
 
         // check if the edge already has a Block constraint
-        if ( checkConstraint(vals, Sketcher::Block, GeoIdt, Sketcher::none)) {
+        if ( checkConstraint(vals, Sketcher::ConstraintType::Block, GeoIdt, Sketcher::none)) {
             QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Double constraint"),
                                  QObject::tr("The selected edge already has a Block constraint!"));
             return;
@@ -1870,7 +1870,7 @@ void CmdSketcherConstrainBlock::applyConstraint(std::vector<SelIdPair> &selSeq, 
             // check if the edge already has a Block constraint
             const std::vector< Sketcher::Constraint * > &vals = static_cast<Sketcher::SketchObject *>(sketchgui->getObject())->Constraints.getValues();
 
-            if ( checkConstraint(vals, Sketcher::Block, selSeq.front().GeoId, Sketcher::none)) {
+            if ( checkConstraint(vals, Sketcher::ConstraintType::Block, selSeq.front().GeoId, Sketcher::none)) {
                 QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Double constraint"),
                                      QObject::tr("The selected edge already has a Block constraint!"));
                 return;
@@ -2141,7 +2141,7 @@ void CmdSketcherConstrainCoincident::activated(int iMsg)
 
         int j=0;
         for (std::vector<Constraint *>::const_iterator it = cvals.begin(); it != cvals.end(); ++it,++j) {
-            if( (*it)->Type == Sketcher::Tangent &&
+            if( (*it)->Type == Sketcher::ConstraintType::Tangent &&
                 (*it)->FirstPos == Sketcher::none && (*it)->SecondPos == Sketcher::none &&
                 (*it)->Third == Constraint::GeoUndef &&
                 (((*it)->First == GeoId1 && (*it)->Second == GeoId2) ||
@@ -4305,7 +4305,7 @@ void CmdSketcherConstrainTangent::activated(int iMsg)
             const std::vector< Constraint * > &cvals = Obj->Constraints.getValues();
 
             for (std::vector<Constraint *>::const_iterator it = cvals.begin(); it != cvals.end(); ++it) {
-                if( (*it)->Type == Sketcher::Coincident &&
+                if( (*it)->Type == Sketcher::ConstraintType::Coincident &&
                     (((*it)->First == GeoId1 && (*it)->Second == GeoId2) ||
                     ((*it)->Second == GeoId1 && (*it)->First == GeoId2)) ) {
 
@@ -7182,7 +7182,7 @@ void CmdSketcherConstrainInternalAlignment::activated(int iMsg)
 
         for (std::vector< Sketcher::Constraint * >::const_iterator it= vals.begin();
                 it != vals.end(); ++it) {
-            if((*it)->Type == Sketcher::InternalAlignment && (*it)->Second == GeoId)
+            if((*it)->Type == Sketcher::ConstraintType::InternalAlignment && (*it)->Second == GeoId)
             {
                 switch((*it)->AlignmentType){
                     case Sketcher::EllipseMajorDiameter:
@@ -7360,7 +7360,7 @@ void CmdSketcherConstrainInternalAlignment::activated(int iMsg)
 
         for (std::vector< Sketcher::Constraint * >::const_iterator it= vals.begin();
                 it != vals.end(); ++it) {
-            if((*it)->Type == Sketcher::InternalAlignment && (*it)->First == GeoId)
+            if((*it)->Type == Sketcher::ConstraintType::InternalAlignment && (*it)->First == GeoId)
             {
                 switch((*it)->AlignmentType){
                     case Sketcher::EllipseMajorDiameter:

--- a/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
+++ b/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
@@ -179,7 +179,7 @@ void removeRedundantHorizontalVertical(Sketcher::SketchObject* psketch,
             axis = false;
 
             for(std::vector<AutoConstraint>::const_iterator it = sug.begin(); it!=sug.end(); ++it) {
-                if( (*it).Type == Sketcher::Coincident && ext == false) {
+                if( (*it).Type == Sketcher::ConstraintType::Coincident && ext == false) {
                     const std::map<int, Sketcher::PointPos> coincidents = psketch->getAllCoincidentPoints((*it).GeoId, (*it).PosId);
 
                     if(!coincidents.empty()) {
@@ -200,7 +200,7 @@ void removeRedundantHorizontalVertical(Sketcher::SketchObject* psketch,
                         orig = ((*it).GeoId == -1 && (*it).PosId == Sketcher::start);
                     }
                 }
-                else if( (*it).Type == Sketcher::PointOnObject && axis == false) {
+                else if( (*it).Type == Sketcher::ConstraintType::PointOnObject && axis == false) {
                     axis = (((*it).GeoId == -1 && (*it).PosId == Sketcher::none) || ((*it).GeoId == -2 && (*it).PosId == Sketcher::none));
                 }
 
@@ -219,7 +219,7 @@ void removeRedundantHorizontalVertical(Sketcher::SketchObject* psketch,
 
         if(rmvhorvert) {
             for(std::vector<AutoConstraint>::reverse_iterator it = sug2.rbegin(); it!=sug2.rend(); ++it) {
-                if( (*it).Type == Sketcher::Horizontal || (*it).Type == Sketcher::Vertical) {
+                if( (*it).Type == Sketcher::ConstraintType::Horizontal || (*it).Type == Sketcher::ConstraintType::Vertical) {
                     sug2.erase(std::next(it).base());
                     it = sug2.rbegin(); // erase invalidates the iterator
                 }
@@ -887,7 +887,7 @@ public:
             // we set up a transition from the neighbouring segment.
             // (peviousCurve, previousPosId, dirVec, TransitionMode)
             for (unsigned int i=0; i < sugConstr1.size(); i++)
-                if (sugConstr1[i].Type == Sketcher::Coincident) {
+                if (sugConstr1[i].Type == Sketcher::ConstraintType::Coincident) {
                     const Part::Geometry *geom = sketchgui->getSketchObject()->getGeometry(sugConstr1[i].GeoId);
                     if ((geom->getTypeId() == Part::GeomLineSegment::getClassTypeId() ||
                          geom->getTypeId() == Part::GeomArcOfCircle::getClassTypeId()) &&
@@ -1071,7 +1071,7 @@ public:
                     // exclude any coincidence constraints
                     std::vector<AutoConstraint> sugConstr;
                     for (unsigned int i=0; i < sugConstr2.size(); i++) {
-                        if (sugConstr2[i].Type != Sketcher::Coincident)
+                        if (sugConstr2[i].Type != Sketcher::ConstraintType::Coincident)
                             sugConstr.push_back(sugConstr2[i]);
                     }
                     createAutoConstraints(sugConstr, getHighestCurveIndex(), Sketcher::end);
@@ -4109,7 +4109,7 @@ public:
 
             // check if coincident with first pole
             for(std::vector<AutoConstraint>::const_iterator it = sugConstr[CurrentConstraint].begin(); it != sugConstr[CurrentConstraint].end(); it++) {
-                if( (*it).Type == Sketcher::Coincident && (*it).GeoId == FirstPoleGeoId && (*it).PosId == Sketcher::mid ) {
+                if( (*it).Type == Sketcher::ConstraintType::Coincident && (*it).GeoId == FirstPoleGeoId && (*it).PosId == Sketcher::mid ) {
 
                     IsClosed = true;
                     }
@@ -4571,7 +4571,7 @@ public:
             if (seekAutoConstraint(sugConstr1, onSketchPos, Base::Vector2d(0.f,0.f),
                                    AutoConstraint::CURVE)) {
                 // Disable tangent snap on 1st point
-                if (sugConstr1.back().Type == Sketcher::Tangent)
+                if (sugConstr1.back().Type == Sketcher::ConstraintType::Tangent)
                     sugConstr1.pop_back();
                 else
                     renderSuggestConstraintsCursor(sugConstr1);
@@ -4609,7 +4609,7 @@ public:
                     if (seekAutoConstraint(sugConstr2, onSketchPos, Base::Vector2d(0.f,0.f),
                                         AutoConstraint::CURVE)) {
                         // Disable tangent snap on 2nd point
-                        if (sugConstr2.back().Type == Sketcher::Tangent)
+                        if (sugConstr2.back().Type == Sketcher::ConstraintType::Tangent)
                             sugConstr2.pop_back();
                         else
                             renderSuggestConstraintsCursor(sugConstr2);

--- a/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp
+++ b/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp
@@ -658,7 +658,7 @@ void CmdSketcherIncreaseKnotMultiplicity::activated(int iMsg)
         const std::vector<Sketcher::Constraint *> &vals = Obj->Constraints.getValues();
 
         for (std::vector<Sketcher::Constraint *>::const_iterator it= vals.begin(); it != vals.end(); ++it) {
-            if ((*it)->Type == Sketcher::InternalAlignment
+            if ((*it)->Type == Sketcher::ConstraintType::InternalAlignment
                 && (*it)->First == GeoId
                 && (*it)->AlignmentType == Sketcher::BSplineKnotPoint)
             {
@@ -813,7 +813,7 @@ void CmdSketcherDecreaseKnotMultiplicity::activated(int iMsg)
         const std::vector< Sketcher::Constraint * > &vals = Obj->Constraints.getValues();
 
         for (std::vector< Sketcher::Constraint * >::const_iterator it= vals.begin(); it != vals.end(); ++it) {
-            if ((*it)->Type == Sketcher::InternalAlignment
+            if ((*it)->Type == Sketcher::ConstraintType::InternalAlignment
                 && (*it)->First == GeoId
                 && (*it)->AlignmentType == Sketcher::BSplineKnotPoint)
             {

--- a/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp
+++ b/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp
@@ -637,6 +637,8 @@ void CmdSketcherSelectElementsAssociatedWithConstraints::activated(int iMsg)
 
                     switch(vals[ConstrId]->FirstPos)
                     {
+                        default:
+                            break;
                         case Sketcher::none:
                             ss << "Edge" << vals[ConstrId]->First + 1;
                             break;
@@ -647,6 +649,7 @@ void CmdSketcherSelectElementsAssociatedWithConstraints::activated(int iMsg)
                             if(vertex>-1)
                                 ss << "Vertex" <<  vertex + 1;
                             break;
+
                     }
 
                     Gui::Selection().addSelection(doc_name.c_str(), obj_name.c_str(), ss.str().c_str());
@@ -658,6 +661,8 @@ void CmdSketcherSelectElementsAssociatedWithConstraints::activated(int iMsg)
 
                     switch(vals[ConstrId]->SecondPos)
                     {
+                        default:
+                            break;
                         case Sketcher::none:
                             ss << "Edge" << vals[ConstrId]->Second + 1;
                             break;
@@ -770,14 +775,11 @@ void CmdSketcherSelectElementsWithDoFs::activated(int iMsg)
                 if (solvext->getGeometry() == Sketcher::SolverGeometryExtension::NotFullyConstraint) {
                     // Coded for consistency with getGeometryWithDependentParameters, read the comments
                     // on that function
-                    if (solvext->getEdge() == SolverGeometryExtension::Dependent)
+                    if (solvext->get(PointPos::edge) == SolverGeometryExtension::Dependent)
                         testselectedge(geoid);
-                    if (solvext->getStart() == SolverGeometryExtension::Dependent)
-                        testselectvertex(geoid, Sketcher::start);
-                    if (solvext->getEnd() == SolverGeometryExtension::Dependent)
-                        testselectvertex(geoid, Sketcher::end);
-                    if (solvext->getMid() == SolverGeometryExtension::Dependent)
-                        testselectvertex(geoid, Sketcher::mid);
+                    for( PointPos p : {PointPos::start, PointPos::end, PointPos::mid})
+                        if (solvext->get(p) == SolverGeometryExtension::Dependent)
+                            testselectvertex(geoid, p);
                 }
             }
         }

--- a/src/Mod/Sketcher/Gui/EditDatumDialog.cpp
+++ b/src/Mod/Sketcher/Gui/EditDatumDialog.cpp
@@ -91,31 +91,31 @@ void EditDatumDialog::exec(bool atCursor)
         }
         double datum = Constr->getValue();
 
-        if (Constr->Type == Sketcher::Angle) {
+        if (Constr->Type == Sketcher::ConstraintType::Angle) {
             datum = Base::toDegrees<double>(datum);
             dlg.setWindowTitle(tr("Insert angle"));
             init_val.setUnit(Base::Unit::Angle);
             ui_ins_datum->label->setText(tr("Angle:"));
             ui_ins_datum->labelEdit->setParamGrpPath(QByteArray("User parameter:BaseApp/History/SketcherAngle"));
         }
-        else if (Constr->Type == Sketcher::Radius) {
+        else if (Constr->Type == Sketcher::ConstraintType::Radius) {
             dlg.setWindowTitle(tr("Insert radius"));
             init_val.setUnit(Base::Unit::Length);
             ui_ins_datum->label->setText(tr("Radius:"));
             ui_ins_datum->labelEdit->setParamGrpPath(QByteArray("User parameter:BaseApp/History/SketcherLength"));
         }
-        else if (Constr->Type == Sketcher::Diameter) {
+        else if (Constr->Type == Sketcher::ConstraintType::Diameter) {
             dlg.setWindowTitle(tr("Insert diameter"));
             init_val.setUnit(Base::Unit::Length);
             ui_ins_datum->label->setText(tr("Diameter:"));
             ui_ins_datum->labelEdit->setParamGrpPath(QByteArray("User parameter:BaseApp/History/SketcherLength"));
         }
-        else if (Constr->Type == Sketcher::Weight) {
+        else if (Constr->Type == Sketcher::ConstraintType::Weight) {
             dlg.setWindowTitle(tr("Insert weight"));
             ui_ins_datum->label->setText(tr("Weight:"));
             ui_ins_datum->labelEdit->setParamGrpPath(QByteArray("User parameter:BaseApp/History/SketcherWeight"));
         }
-        else if (Constr->Type == Sketcher::SnellsLaw) {
+        else if (Constr->Type == Sketcher::ConstraintType::SnellsLaw) {
             dlg.setWindowTitle(tr("Refractive index ratio", "Constraint_SnellsLaw"));
             ui_ins_datum->label->setText(tr("Ratio n2/n1:", "Constraint_SnellsLaw"));
             ui_ins_datum->labelEdit->setParamGrpPath(QByteArray("User parameter:BaseApp/History/SketcherRefrIndexRatio"));
@@ -164,8 +164,8 @@ void EditDatumDialog::accepted()
 {
     Base::Quantity newQuant = ui_ins_datum->labelEdit->value();
     if( newQuant.isQuantity() ||
-        (Constr->Type == Sketcher::SnellsLaw && newQuant.isDimensionless()) ||
-        (Constr->Type == Sketcher::Weight && newQuant.isDimensionless())) {
+        (Constr->Type == Sketcher::ConstraintType::SnellsLaw && newQuant.isDimensionless()) ||
+        (Constr->Type == Sketcher::ConstraintType::Weight && newQuant.isDimensionless())) {
 
         // save the value for the history
         ui_ins_datum->labelEdit->pushToHistory();

--- a/src/Mod/Sketcher/Gui/PropertyConstraintListItem.cpp
+++ b/src/Mod/Sketcher/Gui/PropertyConstraintListItem.cpp
@@ -76,12 +76,7 @@ void PropertyConstraintListItem::initialize()
     std::vector<PropertyUnitItem *> unnamed;
 
     for (std::vector< Sketcher::Constraint* >::const_iterator it = vals.begin();it != vals.end(); ++it, ++id) {
-        if ((*it)->Type == Sketcher::Distance || // Datum constraint
-            (*it)->Type == Sketcher::DistanceX ||
-            (*it)->Type == Sketcher::DistanceY ||
-            (*it)->Type == Sketcher::Radius ||
-            (*it)->Type == Sketcher::Diameter ||
-            (*it)->Type == Sketcher::Angle ) {
+        if ((*it)->isDatum()) {
 
             PropertyUnitItem* item = static_cast<PropertyUnitItem*>(PropertyUnitItem::create());
 
@@ -169,12 +164,7 @@ void PropertyConstraintListItem::assignProperty(const App::Property* prop)
     this->onlyUnnamed = true;
 
     for (std::vector< Sketcher::Constraint* >::const_iterator it = vals.begin();it != vals.end(); ++it, ++id) {
-        if ((*it)->Type == Sketcher::Distance || // Datum constraint
-            (*it)->Type == Sketcher::DistanceX ||
-            (*it)->Type == Sketcher::DistanceY ||
-            (*it)->Type == Sketcher::Radius ||
-            (*it)->Type == Sketcher::Diameter ||
-            (*it)->Type == Sketcher::Angle ) {
+        if ((*it)->isDatum() ) {
 
             PropertyUnitItem* child = nullptr;
             if ((*it)->Name.empty()) {
@@ -246,15 +236,10 @@ QVariant PropertyConstraintListItem::value(const App::Property* prop) const
 
     const std::vector< Sketcher::Constraint * > &vals = static_cast<const Sketcher::PropertyConstraintList*>(prop)->getValues();
     for (std::vector< Sketcher::Constraint* >::const_iterator it = vals.begin();it != vals.end(); ++it, ++id) {
-        if ((*it)->Type == Sketcher::Distance || // Datum constraint
-            (*it)->Type == Sketcher::DistanceX ||
-            (*it)->Type == Sketcher::DistanceY ||
-            (*it)->Type == Sketcher::Radius ||
-            (*it)->Type == Sketcher::Diameter ||
-            (*it)->Type == Sketcher::Angle ) {
+        if ((*it)->isDatum()) {
 
             Base::Quantity quant;
-            if ((*it)->Type == Sketcher::Angle ) {
+            if ((*it)->Type == Sketcher::ConstraintType::Angle ) {
                 double datum = Base::toDegrees<double>((*it)->getValue());
                 quant.setUnit(Base::Unit::Angle);
                 quant.setValue(datum);
@@ -325,18 +310,13 @@ bool PropertyConstraintListItem::event (QEvent* ev)
 
             const std::vector< Sketcher::Constraint * > &vals = item->getValues();
             for (std::vector< Sketcher::Constraint* >::const_iterator it = vals.begin();it != vals.end(); ++it, ++id) {
-                if ((*it)->Type == Sketcher::Distance || // Datum constraint
-                    (*it)->Type == Sketcher::DistanceX ||
-                    (*it)->Type == Sketcher::DistanceY ||
-                    (*it)->Type == Sketcher::Radius ||
-                    (*it)->Type == Sketcher::Diameter ||
-                    (*it)->Type == Sketcher::Angle ) {
+                if ((*it)->isDatum() ) {
 
                     // Get the internal name
                     QString internalName = QString::fromLatin1("Constraint%1").arg(id+1);
                     if (internalName == propName) {
                         double datum = quant.getValue();
-                        if ((*it)->Type == Sketcher::Angle)
+                        if ((*it)->Type == Sketcher::ConstraintType::Angle)
                             datum = Base::toRadians<double>(datum);
                         std::unique_ptr<Sketcher::Constraint> copy((*it)->clone());
                         copy->setValue(datum);

--- a/src/Mod/Sketcher/Gui/TaskSketcherConstrains.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstrains.cpp
@@ -123,27 +123,27 @@ public:
             QString name = Base::Tools::fromStdString(Sketcher::PropertyConstraintList::getConstraintName(constraint->Name, ConstraintNbr));
 
             switch (constraint->Type) {
-            case Sketcher::Horizontal:
-            case Sketcher::Vertical:
-            case Sketcher::Coincident:
-            case Sketcher::PointOnObject:
-            case Sketcher::Parallel:
-            case Sketcher::Perpendicular:
-            case Sketcher::Tangent:
-            case Sketcher::Equal:
-            case Sketcher::Symmetric:
-            case Sketcher::Block:
+            case Sketcher::ConstraintType::Horizontal:
+            case Sketcher::ConstraintType::Vertical:
+            case Sketcher::ConstraintType::Coincident:
+            case Sketcher::ConstraintType::PointOnObject:
+            case Sketcher::ConstraintType::Parallel:
+            case Sketcher::ConstraintType::Perpendicular:
+            case Sketcher::ConstraintType::Tangent:
+            case Sketcher::ConstraintType::Equal:
+            case Sketcher::ConstraintType::Symmetric:
+            case Sketcher::ConstraintType::Block:
                 break;
-            case Sketcher::Distance:
-            case Sketcher::DistanceX:
-            case Sketcher::DistanceY:
-            case Sketcher::Radius:
-            case Sketcher::Weight:
-            case Sketcher::Diameter:
-            case Sketcher::Angle:
+            case Sketcher::ConstraintType::Distance:
+            case Sketcher::ConstraintType::DistanceX:
+            case Sketcher::ConstraintType::DistanceY:
+            case Sketcher::ConstraintType::Radius:
+            case Sketcher::ConstraintType::Weight:
+            case Sketcher::ConstraintType::Diameter:
+            case Sketcher::ConstraintType::Angle:
                 name = QString::fromLatin1("%1 (%2)").arg(name).arg(constraint->getPresentationValue().getUserString());
                 break;
-            case Sketcher::SnellsLaw: {
+            case Sketcher::ConstraintType::SnellsLaw: {
                 double v = constraint->getPresentationValue().getValue();
                 double n1 = 1.0;
                 double n2 = 1.0;
@@ -155,7 +155,7 @@ public:
                 name = QString::fromLatin1("%1 (%2/%3)").arg(name).arg(n2).arg(n1);
                 break;
             }
-            case Sketcher::InternalAlignment:
+            case Sketcher::ConstraintType::InternalAlignment:
                 break;
             default:
                 break;
@@ -231,42 +231,42 @@ public:
             };
 
             switch(constraint->Type){
-            case Sketcher::Horizontal:
+            case Sketcher::ConstraintType::Horizontal:
                 return selicon(constraint,horiz,horiz);
-            case Sketcher::Vertical:
+            case Sketcher::ConstraintType::Vertical:
                 return selicon(constraint,vert,vert);
-            case Sketcher::Coincident:
+            case Sketcher::ConstraintType::Coincident:
                 return selicon(constraint,coinc,coinc);
-            case Sketcher::Block:
+            case Sketcher::ConstraintType::Block:
                 return selicon(constraint,block,block);
-            case Sketcher::PointOnObject:
+            case Sketcher::ConstraintType::PointOnObject:
                 return selicon(constraint,pntoo,pntoo);
-            case Sketcher::Parallel:
+            case Sketcher::ConstraintType::Parallel:
                 return selicon(constraint,para,para);
-            case Sketcher::Perpendicular:
+            case Sketcher::ConstraintType::Perpendicular:
                 return selicon(constraint,perp,perp);
-            case Sketcher::Tangent:
+            case Sketcher::ConstraintType::Tangent:
                 return selicon(constraint,tang,tang);
-            case Sketcher::Equal:
+            case Sketcher::ConstraintType::Equal:
                 return selicon(constraint,equal,equal);
-            case Sketcher::Symmetric:
+            case Sketcher::ConstraintType::Symmetric:
                 return selicon(constraint,symm,symm);
-            case Sketcher::Distance:
+            case Sketcher::ConstraintType::Distance:
                 return selicon(constraint,dist,dist_driven);
-            case Sketcher::DistanceX:
+            case Sketcher::ConstraintType::DistanceX:
                 return selicon(constraint,hdist,hdist_driven);
-            case Sketcher::DistanceY:
+            case Sketcher::ConstraintType::DistanceY:
                 return selicon(constraint,vdist,vdist_driven);
-            case Sketcher::Radius:
-            case Sketcher::Weight:
+            case Sketcher::ConstraintType::Radius:
+            case Sketcher::ConstraintType::Weight:
                 return selicon(constraint,radi,radi_driven);
-            case Sketcher::Diameter:
+            case Sketcher::ConstraintType::Diameter:
                 return selicon(constraint,dia,dia_driven);
-            case Sketcher::Angle:
+            case Sketcher::ConstraintType::Angle:
                 return selicon(constraint,angl,angl_driven);
-            case Sketcher::SnellsLaw:
+            case Sketcher::ConstraintType::SnellsLaw:
                 return selicon(constraint,snell,snell_driven);
-            case Sketcher::InternalAlignment:
+            case Sketcher::ConstraintType::InternalAlignment:
                 switch(constraint->AlignmentType){
                 case Sketcher::EllipseMajorDiameter:
                     return selicon(constraint,iaellipsemajoraxis,iaellipsemajoraxis);
@@ -308,31 +308,31 @@ public:
         const Sketcher::Constraint * constraint = sketch->Constraints[ConstraintNbr];
 
         switch (constraint->Type) {
-        case Sketcher::None:
-        case Sketcher::NumConstraintTypes:
+        case Sketcher::ConstraintType::None:
+        case Sketcher::ConstraintType::NumConstraintTypes:
             assert( false );
             return false;
-        case Sketcher::Horizontal:
-        case Sketcher::Vertical:
-        case Sketcher::Coincident:
-        case Sketcher::Block:
-        case Sketcher::PointOnObject:
-        case Sketcher::Parallel:
-        case Sketcher::Perpendicular:
-        case Sketcher::Tangent:
-        case Sketcher::Equal:
-        case Sketcher::Symmetric:
+        case Sketcher::ConstraintType::Horizontal:
+        case Sketcher::ConstraintType::Vertical:
+        case Sketcher::ConstraintType::Coincident:
+        case Sketcher::ConstraintType::Block:
+        case Sketcher::ConstraintType::PointOnObject:
+        case Sketcher::ConstraintType::Parallel:
+        case Sketcher::ConstraintType::Perpendicular:
+        case Sketcher::ConstraintType::Tangent:
+        case Sketcher::ConstraintType::Equal:
+        case Sketcher::ConstraintType::Symmetric:
             return true;
-        case Sketcher::Distance:
-        case Sketcher::DistanceX:
-        case Sketcher::DistanceY:
-        case Sketcher::Radius:
-        case Sketcher::Diameter:
-        case Sketcher::Weight:
-        case Sketcher::Angle:
-        case Sketcher::SnellsLaw:
+        case Sketcher::ConstraintType::Distance:
+        case Sketcher::ConstraintType::DistanceX:
+        case Sketcher::ConstraintType::DistanceY:
+        case Sketcher::ConstraintType::Radius:
+        case Sketcher::ConstraintType::Diameter:
+        case Sketcher::ConstraintType::Weight:
+        case Sketcher::ConstraintType::Angle:
+        case Sketcher::ConstraintType::SnellsLaw:
             return ( constraint->First >= 0 || constraint->Second >= 0 || constraint->Third >= 0 );
-        case Sketcher::InternalAlignment:
+        case Sketcher::ConstraintType::InternalAlignment:
             return true;
         }
         return false;
@@ -932,29 +932,29 @@ void TaskSketcherConstrains::slotConstraintsChanged(void)
         bool hideInternalAlignment = this->ui->filterInternalAlignment->isChecked();
 
         switch(constraint->Type) {
-        case Sketcher::Horizontal:
-        case Sketcher::Vertical:
-        case Sketcher::Coincident:
-        case Sketcher::PointOnObject:
-        case Sketcher::Parallel:
-        case Sketcher::Perpendicular:
-        case Sketcher::Tangent:
-        case Sketcher::Equal:
-        case Sketcher::Symmetric:
-        case Sketcher::Block:
+        case Sketcher::ConstraintType::Horizontal:
+        case Sketcher::ConstraintType::Vertical:
+        case Sketcher::ConstraintType::Coincident:
+        case Sketcher::ConstraintType::PointOnObject:
+        case Sketcher::ConstraintType::Parallel:
+        case Sketcher::ConstraintType::Perpendicular:
+        case Sketcher::ConstraintType::Tangent:
+        case Sketcher::ConstraintType::Equal:
+        case Sketcher::ConstraintType::Symmetric:
+        case Sketcher::ConstraintType::Block:
             visible = showNormal || showNamed;
             break;
-        case Sketcher::Distance:
-        case Sketcher::DistanceX:
-        case Sketcher::DistanceY:
-        case Sketcher::Radius:
-        case Sketcher::Weight:
-        case Sketcher::Diameter:
-        case Sketcher::Angle:
-        case Sketcher::SnellsLaw:
+        case Sketcher::ConstraintType::Distance:
+        case Sketcher::ConstraintType::DistanceX:
+        case Sketcher::ConstraintType::DistanceY:
+        case Sketcher::ConstraintType::Radius:
+        case Sketcher::ConstraintType::Weight:
+        case Sketcher::ConstraintType::Diameter:
+        case Sketcher::ConstraintType::Angle:
+        case Sketcher::ConstraintType::SnellsLaw:
             visible = (showDatums || showNamed || showNonDriving);
             break;
-        case Sketcher::InternalAlignment:
+        case Sketcher::ConstraintType::InternalAlignment:
             visible = ((showNormal || showNamed) && !hideInternalAlignment);
         default:
             break;

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -1190,7 +1190,7 @@ bool ViewProviderSketch::mouseMove(const SbVec2s &cursorPos, Gui::View3DInventor
                         std::vector<int> polegeoids;
 
                         for( auto c : getSketchObject()->Constraints.getValues()) {
-                            if( c->Type == Sketcher::InternalAlignment &&
+                            if( c->Type == Sketcher::ConstraintType::InternalAlignment &&
                                 c->AlignmentType == BSplineControlPoint &&
                                 c->First == edit->DragCurve ) {
 
@@ -1205,7 +1205,7 @@ bool ViewProviderSketch::mouseMove(const SbVec2s &cursorPos, Gui::View3DInventor
                         }
 
                         for( auto c : getSketchObject()->Constraints.getValues()) {
-                            if( c->Type == Sketcher::InternalAlignment &&
+                            if( c->Type == Sketcher::ConstraintType::InternalAlignment &&
                                 c->AlignmentType == BSplineControlPoint &&
                                 c->Second == bsplinegeoid ) {
 
@@ -1389,8 +1389,8 @@ void ViewProviderSketch::moveConstraint(int constNum, const Base::Vector2d &toPo
            || Constr->First != Constraint::GeoUndef);
 #endif
 
-    if (Constr->Type == Distance || Constr->Type == DistanceX || Constr->Type == DistanceY ||
-        Constr->Type == Radius || Constr->Type == Diameter || Constr-> Type == Weight) {
+    if (Constr->Type == ConstraintType::Distance || Constr->Type == ConstraintType::DistanceX || Constr->Type == ConstraintType::DistanceY ||
+        Constr->Type == ConstraintType::Radius || Constr->Type == ConstraintType::Diameter || Constr-> Type == ConstraintType::Weight) {
 
         Base::Vector3d p1(0.,0.,0.), p2(0.,0.,0.);
         if (Constr->SecondPos != Sketcher::none) { // point to point distance
@@ -1433,7 +1433,7 @@ void ViewProviderSketch::moveConstraint(int constNum, const Base::Vector2d &toPo
                     angle = atan2(tmpDir.y, tmpDir.x);
                 }
 
-                if(Constr->Type == Sketcher::Diameter)
+                if(Constr->Type == Sketcher::ConstraintType::Diameter)
                     p1 = center - radius * Base::Vector3d(cos(angle),sin(angle),0.);
 
                 p2 = center + radius * Base::Vector3d(cos(angle),sin(angle),0.);
@@ -1448,10 +1448,10 @@ void ViewProviderSketch::moveConstraint(int constNum, const Base::Vector2d &toPo
 
                 Base::Vector3d dir = radius * tmpDir.Normalize();
 
-                if(Constr->Type == Sketcher::Diameter)
+                if(Constr->Type == Sketcher::ConstraintType::Diameter)
                     p1 = center - dir;
 
-                if(Constr->Type == Sketcher::Weight) {
+                if(Constr->Type == Sketcher::ConstraintType::Weight) {
 
                     double scalefactor = 1.0;
 
@@ -1477,27 +1477,27 @@ void ViewProviderSketch::moveConstraint(int constNum, const Base::Vector2d &toPo
         Base::Vector3d vec = Base::Vector3d(toPos.x, toPos.y, 0) - p2;
 
         Base::Vector3d dir;
-        if (Constr->Type == Distance || Constr->Type == Radius || Constr->Type == Diameter || Constr->Type == Weight)
+        if (Constr->Type == ConstraintType::Distance || Constr->Type == ConstraintType::Radius || Constr->Type == ConstraintType::Diameter || Constr->Type == ConstraintType::Weight)
             dir = (p2-p1).Normalize();
-        else if (Constr->Type == DistanceX)
+        else if (Constr->Type == ConstraintType::DistanceX)
             dir = Base::Vector3d( (p2.x - p1.x >= FLT_EPSILON) ? 1 : -1, 0, 0);
-        else if (Constr->Type == DistanceY)
+        else if (Constr->Type == ConstraintType::DistanceY)
             dir = Base::Vector3d(0, (p2.y - p1.y >= FLT_EPSILON) ? 1 : -1, 0);
 
-        if (Constr->Type == Radius || Constr->Type == Diameter || Constr->Type == Weight) {
+        if (Constr->Type == ConstraintType::Radius || Constr->Type == ConstraintType::Diameter || Constr->Type == ConstraintType::Weight) {
             Constr->LabelDistance = vec.x * dir.x + vec.y * dir.y;
             Constr->LabelPosition = atan2(dir.y, dir.x);
         } else {
             Base::Vector3d normal(-dir.y,dir.x,0);
             Constr->LabelDistance = vec.x * normal.x + vec.y * normal.y;
-            if (Constr->Type == Distance ||
-                Constr->Type == DistanceX || Constr->Type == DistanceY) {
+            if (Constr->Type == ConstraintType::Distance ||
+                Constr->Type == ConstraintType::DistanceX || Constr->Type == ConstraintType::DistanceY) {
                 vec = Base::Vector3d(toPos.x, toPos.y, 0) - (p2 + p1) / 2;
                 Constr->LabelPosition = vec.x * dir.x + vec.y * dir.y;
             }
         }
     }
-    else if (Constr->Type == Angle) {
+    else if (Constr->Type == ConstraintType::Angle) {
 
         Base::Vector3d p0(0.,0.,0.);
         double factor = 0.5;
@@ -3006,20 +3006,20 @@ void ViewProviderSketch::updateColor(void)
         // Check Constraint Type
         Sketcher::Constraint* constraint = getSketchObject()->Constraints.getValues()[i];
         ConstraintType type = constraint->Type;
-        bool hasDatumLabel  = (type == Sketcher::Angle ||
-                               type == Sketcher::Radius ||
-                               type == Sketcher::Diameter ||
-                               type == Sketcher::Weight ||
-                               type == Sketcher::Symmetric ||
-                               type == Sketcher::Distance ||
-                               type == Sketcher::DistanceX ||
-                               type == Sketcher::DistanceY);
+        bool hasDatumLabel  = (type == Sketcher::ConstraintType::Angle ||
+                               type == Sketcher::ConstraintType::Radius ||
+                               type == Sketcher::ConstraintType::Diameter ||
+                               type == Sketcher::ConstraintType::Weight ||
+                               type == Sketcher::ConstraintType::Symmetric ||
+                               type == Sketcher::ConstraintType::Distance ||
+                               type == Sketcher::ConstraintType::DistanceX ||
+                               type == Sketcher::ConstraintType::DistanceY);
 
         // Non DatumLabel Nodes will have a material excluding coincident
         bool hasMaterial = false;
 
         SoMaterial *m = 0;
-        if (!hasDatumLabel && type != Sketcher::Coincident && type != Sketcher::InternalAlignment) {
+        if (!hasDatumLabel && type != Sketcher::ConstraintType::Coincident && type != Sketcher::ConstraintType::InternalAlignment) {
             hasMaterial = true;
             m = static_cast<SoMaterial *>(s->getChild(CONSTRAINT_SEPARATOR_INDEX_MATERIAL_OR_DATUMLABEL));
         }
@@ -3030,7 +3030,7 @@ void ViewProviderSketch::updateColor(void)
                 l->textColor = SelectColor;
             } else if (hasMaterial) {
                 m->diffuseColor = SelectColor;
-            } else if (type == Sketcher::Coincident) {
+            } else if (type == Sketcher::ConstraintType::Coincident) {
                 auto selectpoint = [this, pcolor, PtNum](int geoid, Sketcher::PointPos pos){
                     if(geoid >= 0) {
                         int index = getSolvedSketch().getPointId(geoid, pos) + 1;
@@ -3041,7 +3041,7 @@ void ViewProviderSketch::updateColor(void)
 
                 selectpoint(constraint->First, constraint->FirstPos);
                 selectpoint(constraint->Second, constraint->SecondPos);
-            } else if (type == Sketcher::InternalAlignment) {
+            } else if (type == Sketcher::ConstraintType::InternalAlignment) {
                 switch(constraint->AlignmentType) {
                     case EllipseMajorDiameter:
                     case EllipseMinorDiameter:
@@ -3195,25 +3195,25 @@ QString ViewProviderSketch::iconTypeFromConstraint(Constraint *constraint)
 {
     /*! TODO: Consider pushing this functionality up into Constraint */
     switch(constraint->Type) {
-    case Horizontal:
+    case ConstraintType::Horizontal:
         return QString::fromLatin1("small/Constraint_Horizontal_sm");
-    case Vertical:
+    case ConstraintType::Vertical:
         return QString::fromLatin1("small/Constraint_Vertical_sm");
-    case PointOnObject:
+    case ConstraintType::PointOnObject:
         return QString::fromLatin1("small/Constraint_PointOnObject_sm");
-    case Tangent:
+    case ConstraintType::Tangent:
         return QString::fromLatin1("small/Constraint_Tangent_sm");
-    case Parallel:
+    case ConstraintType::Parallel:
         return QString::fromLatin1("small/Constraint_Parallel_sm");
-    case Perpendicular:
+    case ConstraintType::Perpendicular:
         return QString::fromLatin1("small/Constraint_Perpendicular_sm");
-    case Equal:
+    case ConstraintType::Equal:
         return QString::fromLatin1("small/Constraint_EqualLength_sm");
-    case Symmetric:
+    case ConstraintType::Symmetric:
         return QString::fromLatin1("small/Constraint_Symmetric_sm");
-    case SnellsLaw:
+    case ConstraintType::SnellsLaw:
         return QString::fromLatin1("small/Constraint_SnellsLaw_sm");
-    case Block:
+    case ConstraintType::Block:
         return QString::fromLatin1("small/Constraint_Block_sm");
     default:
         return QString();
@@ -3305,7 +3305,7 @@ void ViewProviderSketch::drawConstraintIcons()
 
         switch((*it)->Type) {
 
-        case Tangent:
+        case ConstraintType::Tangent:
             {   // second icon is available only for colinear line segments
                 const Part::Geometry *geo1 = getSketchObject()->getGeometry((*it)->First);
                 const Part::Geometry *geo2 = getSketchObject()->getGeometry((*it)->Second);
@@ -3315,8 +3315,8 @@ void ViewProviderSketch::drawConstraintIcons()
                 }
             }
             break;
-        case Horizontal:
-        case Vertical:
+        case ConstraintType::Horizontal:
+        case ConstraintType::Vertical:
             {   // second icon is available only for point alignment
                 if ((*it)->Second != Constraint::GeoUndef &&
                     (*it)->FirstPos != Sketcher::none &&
@@ -3325,15 +3325,15 @@ void ViewProviderSketch::drawConstraintIcons()
                 }
             }
             break;
-        case Parallel:
+        case ConstraintType::Parallel:
             multipleIcons = true;
             break;
-        case Perpendicular:
+        case ConstraintType::Perpendicular:
             // second icon is available only when there is no common point
             if ((*it)->FirstPos == Sketcher::none && (*it)->Third == Constraint::GeoUndef)
                 multipleIcons = true;
             break;
-        case Equal:
+        case ConstraintType::Equal:
             multipleIcons = true;
             break;
         default:
@@ -3368,7 +3368,7 @@ void ViewProviderSketch::drawConstraintIcons()
         thisIcon.destination = coinIconPtr;
         thisIcon.infoPtr = infoPtr;
 
-        if ((*it)->Type==Symmetric) {
+        if ((*it)->Type==ConstraintType::Symmetric) {
             Base::Vector3d startingpoint = getSketchObject()->getPoint((*it)->First,(*it)->FirstPos);
             Base::Vector3d endpoint = getSketchObject()->getPoint((*it)->Second,(*it)->SecondPos);
 
@@ -3839,7 +3839,7 @@ void ViewProviderSketch::draw(bool temp /*=false*/, bool rebuildinformationlayer
             // This code produces the scaled up version of the geometry for the scenograph
             if(gf->getInternalType() == InternalType::BSplineControlPoint) {
                 for( auto c : getSketchObject()->Constraints.getValues()) {
-                    if( c->Type == InternalAlignment && c->AlignmentType == BSplineControlPoint && c->First == GeoId) {
+                    if( c->Type == ConstraintType::InternalAlignment && c->AlignmentType == BSplineControlPoint && c->First == GeoId) {
                         auto bspline = dynamic_cast<const Part::GeomBSplineCurve *>((*geomlist)[c->Second]);
 
                         if(bspline){
@@ -4745,12 +4745,12 @@ Restart:
 
             // distinguish different constraint types to build up
             switch (Constr->Type) {
-                case Block:
-                case Horizontal: // write the new position of the Horizontal constraint Same as vertical position.
-                case Vertical: // write the new position of the Vertical constraint
+                case ConstraintType::Block:
+                case ConstraintType::Horizontal: // write the new position of the Horizontal constraint Same as vertical position.
+                case ConstraintType::Vertical: // write the new position of the Vertical constraint
                     {
                         assert(Constr->First >= -extGeoCount && Constr->First < intGeoCount);
-                        bool alignment = Constr->Type!=Block && Constr->Second != Constraint::GeoUndef;
+                        bool alignment = Constr->Type!=ConstraintType::Block && Constr->Second != Constraint::GeoUndef;
 
                         // get the geometry
                         const Part::Geometry *geo = GeoById(*geomlist, Constr->First);
@@ -4908,7 +4908,7 @@ Restart:
                         }
                     }
                     break;
-                case Perpendicular:
+                case ConstraintType::Perpendicular:
                     {
                         assert(Constr->First >= -extGeoCount && Constr->First < intGeoCount);
                         assert(Constr->Second >= -extGeoCount && Constr->Second < intGeoCount);
@@ -5007,8 +5007,8 @@ Restart:
 
                     }
                     break;
-                case Parallel:
-                case Equal:
+                case ConstraintType::Parallel:
+                case ConstraintType::Equal:
                     {
                         assert(Constr->First >= -extGeoCount && Constr->First < intGeoCount);
                         assert(Constr->Second >= -extGeoCount && Constr->Second < intGeoCount);
@@ -5020,7 +5020,7 @@ Restart:
                         Base::Vector3d midpos2, dir2, norm2;
                         if (geo1->getTypeId() != Part::GeomLineSegment::getClassTypeId() ||
                             geo2->getTypeId() != Part::GeomLineSegment::getClassTypeId()) {
-                            if (Constr->Type == Equal) {
+                            if (Constr->Type == ConstraintType::Equal) {
                                 double r1a=0,r1b=0,r2a=0,r2b=0;
                                 double angle1,angle1plus=0.,  angle2, angle2plus=0.;//angle1 = rotation of object as a whole; angle1plus = arc angle (t parameter for ellipses).
                                 if (geo1->getTypeId() == Part::GeomCircle::getClassTypeId()) {
@@ -5198,9 +5198,9 @@ Restart:
 
                     }
                     break;
-                case Distance:
-                case DistanceX:
-                case DistanceY:
+                case ConstraintType::Distance:
+                case ConstraintType::DistanceX:
+                case ConstraintType::DistanceY:
                     {
                         assert(Constr->First >= -extGeoCount && Constr->First < intGeoCount);
 
@@ -5251,11 +5251,11 @@ Restart:
                         // Get presentation string (w/o units if option is set)
                         asciiText->string = SbString( getPresentationString(Constr).toUtf8().constData() );
 
-                        if (Constr->Type == Distance)
+                        if (Constr->Type == ConstraintType::Distance)
                             asciiText->datumtype = SoDatumLabel::DISTANCE;
-                        else if (Constr->Type == DistanceX)
+                        else if (Constr->Type == ConstraintType::DistanceX)
                             asciiText->datumtype = SoDatumLabel::DISTANCEX;
-                        else if (Constr->Type == DistanceY)
+                        else if (Constr->Type == ConstraintType::DistanceY)
                              asciiText->datumtype = SoDatumLabel::DISTANCEY;
 
                         // Assign the Datum Points
@@ -5272,18 +5272,18 @@ Restart:
                         asciiText->param2 = Constr->LabelPosition;
                     }
                     break;
-                case PointOnObject:
-                case Tangent:
-                case SnellsLaw:
+                case ConstraintType::PointOnObject:
+                case ConstraintType::Tangent:
+                case ConstraintType::SnellsLaw:
                     {
                         assert(Constr->First >= -extGeoCount && Constr->First < intGeoCount);
                         assert(Constr->Second >= -extGeoCount && Constr->Second < intGeoCount);
 
                         Base::Vector3d pos, relPos;
-                        if (  Constr->Type == PointOnObject ||
-                              Constr->Type == SnellsLaw ||
-                              (Constr->Type == Tangent && Constr->Third != Constraint::GeoUndef) || //Tangency via point
-                              (Constr->Type == Tangent && Constr->FirstPos != Sketcher::none) //endpoint-to-curve or endpoint-to-endpoint tangency
+                        if (  Constr->Type == ConstraintType::PointOnObject ||
+                              Constr->Type == ConstraintType::SnellsLaw ||
+                              (Constr->Type == ConstraintType::Tangent && Constr->Third != Constraint::GeoUndef) || //Tangency via point
+                              (Constr->Type == ConstraintType::Tangent && Constr->FirstPos != Sketcher::none) //endpoint-to-curve or endpoint-to-endpoint tangency
                                 ) {
 
                             //find the point of tangency/point that is on object
@@ -5312,7 +5312,7 @@ Restart:
                             static_cast<SoZoomTranslation *>(sep->getChild(CONSTRAINT_SEPARATOR_INDEX_FIRST_TRANSLATION))->abPos = SbVec3f(pos.x, pos.y, zConstr); //Absolute Reference
                             static_cast<SoZoomTranslation *>(sep->getChild(CONSTRAINT_SEPARATOR_INDEX_FIRST_TRANSLATION))->translation = SbVec3f(relPos.x, relPos.y, 0);
                         }
-                        else if (Constr->Type == Tangent) {
+                        else if (Constr->Type == ConstraintType::Tangent) {
                             // get the geometry
                             const Part::Geometry *geo1 = GeoById(*geomlist, Constr->First);
                             const Part::Geometry *geo2 = GeoById(*geomlist, Constr->Second);
@@ -5425,7 +5425,7 @@ Restart:
                         }
                     }
                     break;
-                case Symmetric:
+                case ConstraintType::Symmetric:
                     {
                         assert(Constr->First >= -extGeoCount && Constr->First < intGeoCount);
                         assert(Constr->Second >= -extGeoCount && Constr->Second < intGeoCount);
@@ -5453,7 +5453,7 @@ Restart:
                         static_cast<SoTranslation *>(sep->getChild(CONSTRAINT_SEPARATOR_INDEX_FIRST_TRANSLATION))->translation = (p1 + p2)/2;
                     }
                     break;
-                case Angle:
+                case ConstraintType::Angle:
                     {
                         assert(Constr->First >= -extGeoCount && Constr->First < intGeoCount);
                         assert((Constr->Second >= -extGeoCount && Constr->Second < intGeoCount) ||
@@ -5568,7 +5568,7 @@ Restart:
 
                     }
                     break;
-                case Diameter:
+                case ConstraintType::Diameter:
                     {
                         assert(Constr->First >= -extGeoCount && Constr->First < intGeoCount);
 
@@ -5626,8 +5626,8 @@ Restart:
                         asciiText->pnts.finishEditing();
                     }
                     break;
-                    case Weight:
-                    case Radius:
+                    case ConstraintType::Weight:
+                    case ConstraintType::Radius:
                     {
                         assert(Constr->First >= -extGeoCount && Constr->First < intGeoCount);
 
@@ -5654,7 +5654,7 @@ Restart:
 
                                 double radius;
 
-                                if(Constr->Type == Weight) {
+                                if(Constr->Type == ConstraintType::Weight) {
                                     double scalefactor = 1.0;
 
                                     if(circle->hasExtension(SketcherGui::ViewProviderSketchGeometryExtension::getClassTypeId()))
@@ -5689,7 +5689,7 @@ Restart:
                         SoDatumLabel *asciiText = static_cast<SoDatumLabel *>(sep->getChild(CONSTRAINT_SEPARATOR_INDEX_MATERIAL_OR_DATUMLABEL));
 
                         // Get display string with units hidden if so requested
-                        if(Constr->Type == Weight)
+                        if(Constr->Type == ConstraintType::Weight)
                             asciiText->string = SbString( QString::number(Constr->getValue()).toStdString().c_str());
                         else
                             asciiText->string = SbString( getPresentationString(Constr).toUtf8().constData() );
@@ -5707,10 +5707,10 @@ Restart:
                         asciiText->pnts.finishEditing();
                     }
                     break;
-                case Coincident: // nothing to do for coincident
-                case None:
-                case InternalAlignment:
-                case NumConstraintTypes:
+                case ConstraintType::Coincident: // nothing to do for coincident
+                case ConstraintType::None:
+                case ConstraintType::InternalAlignment:
+                case ConstraintType::NumConstraintTypes:
                     break;
             }
 
@@ -5777,13 +5777,13 @@ void ViewProviderSketch::rebuildConstraintsVisual(void)
 
         // distinguish different constraint types to build up
         switch ((*it)->Type) {
-            case Distance:
-            case DistanceX:
-            case DistanceY:
-            case Radius:
-            case Diameter:
-            case Weight:
-            case Angle:
+            case ConstraintType::Distance:
+            case ConstraintType::DistanceX:
+            case ConstraintType::DistanceY:
+            case ConstraintType::Radius:
+            case ConstraintType::Diameter:
+            case ConstraintType::Weight:
+            case ConstraintType::Angle:
             {
                 SoDatumLabel *text = new SoDatumLabel();
                 text->norm.setValue(norm);
@@ -5808,9 +5808,9 @@ void ViewProviderSketch::rebuildConstraintsVisual(void)
                 continue; // jump to next constraint
             }
             break;
-            case Horizontal:
-            case Vertical:
-            case Block:
+            case ConstraintType::Horizontal:
+            case ConstraintType::Vertical:
+            case ConstraintType::Block:
             {
                 // #define CONSTRAINT_SEPARATOR_INDEX_MATERIAL_OR_DATUMLABEL 0
                 sep->addChild(mat);
@@ -5831,12 +5831,12 @@ void ViewProviderSketch::rebuildConstraintsVisual(void)
                 edit->vConstrType.push_back((*it)->Type);
             }
             break;
-            case Coincident: // no visual for coincident so far
-                edit->vConstrType.push_back(Coincident);
+            case ConstraintType::Coincident: // no visual for coincident so far
+                edit->vConstrType.push_back(ConstraintType::Coincident);
                 break;
-            case Parallel:
-            case Perpendicular:
-            case Equal:
+            case ConstraintType::Parallel:
+            case ConstraintType::Perpendicular:
+            case ConstraintType::Equal:
             {
                 // #define CONSTRAINT_SEPARATOR_INDEX_MATERIAL_OR_DATUMLABEL 0
                 sep->addChild(mat);
@@ -5857,9 +5857,9 @@ void ViewProviderSketch::rebuildConstraintsVisual(void)
                 edit->vConstrType.push_back((*it)->Type);
             }
             break;
-            case PointOnObject:
-            case Tangent:
-            case SnellsLaw:
+            case ConstraintType::PointOnObject:
+            case ConstraintType::Tangent:
+            case ConstraintType::SnellsLaw:
             {
                 // #define CONSTRAINT_SEPARATOR_INDEX_MATERIAL_OR_DATUMLABEL 0
                 sep->addChild(mat);
@@ -5870,7 +5870,7 @@ void ViewProviderSketch::rebuildConstraintsVisual(void)
                 // #define CONSTRAINT_SEPARATOR_INDEX_FIRST_CONSTRAINTID 3
                 sep->addChild(new SoInfo());
 
-                if ((*it)->Type == Tangent) {
+                if ((*it)->Type == ConstraintType::Tangent) {
                     const Part::Geometry *geo1 = getSketchObject()->getGeometry((*it)->First);
                     const Part::Geometry *geo2 = getSketchObject()->getGeometry((*it)->Second);
                     if (!geo1 || !geo2) {
@@ -5890,7 +5890,7 @@ void ViewProviderSketch::rebuildConstraintsVisual(void)
                 edit->vConstrType.push_back((*it)->Type);
             }
             break;
-            case Symmetric:
+            case ConstraintType::Symmetric:
             {
                 SoDatumLabel *arrows = new SoDatumLabel();
                 arrows->norm.setValue(norm);
@@ -5909,7 +5909,7 @@ void ViewProviderSketch::rebuildConstraintsVisual(void)
                 edit->vConstrType.push_back((*it)->Type);
             }
             break;
-            case InternalAlignment:
+            case ConstraintType::InternalAlignment:
             {
                 edit->vConstrType.push_back((*it)->Type);
             }
@@ -6928,7 +6928,7 @@ bool ViewProviderSketch::onDelete(const std::vector<std::string> &subList)
 
             if (GeoId != Constraint::GeoUndef) {
                 for (std::vector< Sketcher::Constraint * >::const_iterator it= vals.begin(); it != vals.end(); ++it) {
-                    if (((*it)->Type == Sketcher::Coincident) && (((*it)->First == GeoId && (*it)->FirstPos == PosId) ||
+                    if (((*it)->Type == Sketcher::ConstraintType::Coincident) && (((*it)->First == GeoId && (*it)->FirstPos == PosId) ||
                         ((*it)->Second == GeoId && (*it)->SecondPos == PosId)) ) {
                         try {
                             Gui::cmdAppObjectArgs(getObject(), "delConstraintOnPoint(%i,%i)", GeoId, (int)PosId);

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -1176,7 +1176,7 @@ bool ViewProviderSketch::mouseMove(const SbVec2s &cursorPos, Gui::View3DInventor
                                         geo->getExtension(Sketcher::SolverGeometryExtension::getClassTypeId()).lock());
 
                         // Edge parameters are Independent, so weight won't move
-                        if(solvext->getEdge()==Sketcher::SolverGeometryExtension::Independent) {
+                        if(solvext->get(PointPos::edge)==Sketcher::SolverGeometryExtension::Independent) {
                             Mode = STATUS_NONE;
                             return false;
                         }


### PR DESCRIPTION
Rationale:

The sketcher is contained in very few very large files with extreme repetition and copy-pasting.
I propose a gradual and complete rewrite of Mod/Sketcher "hard to read" files, and reduce code size by at least 30%
The goal of the rewrite is to be able to reason about new future additions in a comprehensive way.

Technical Goals:
1) decouple driving code from geometry specific code : points should be handled elsewhere than BSplines etc.
2) Reuse functionality: the umpteenth time I came across `switch( type of geometry)` I nearly lost it. 
3) Make the code dimension-agnostic. The GCS code is 2d, but that can change later.
4) Make code multi-threading ready. Use immutable objects, reduce coupling and transform the handling code into a stream-like pipeline.

Technical Analysis:

Objective 1:

I propose a Filter/Interceptor chain handling of geometry-specific code where needed. I have sketched (pun intended) a solution for **Sketcher.cpp/h.**
Instead of handling each geometry type in a method in a trillion line file, I have specified a `FilterChain` that represents a chain of transformations and operations that need to be applied, described in a `FilterInput` object. The chain allows each filter the option to terminate the chain execution, or to transform the Input into a different one, or to spawn different executions of the chain to handle derived operations: 
inserting a line (should but not yet done) spawns insertion of 2 points. 
Inserting a BSpline knot point transforms the insertion into a `fixed=true` insertion and recuses.
In essence : https://en.wikipedia.org/wiki/Interceptor_pattern

The interceptor pattern accommodates all five of the https://en.wikipedia.org/wiki/SOLID principles with respect to different geometry types.
I have NOT seperated the filters and the chain from the Sketcher file, just to avoid messing everyone's mind that is not used to dependency inverted code. These Filter Objects will be moved into a different file each.
FilterChains would only be generated at specified gather point files (Single responsibility principle) and could be extended with various additions.
Objective 2:
Generate testing code for each and every refactored line.

Objective 3:
Explore options for 3d constraint solving, implement  bspline   to <other geometry> intersections, etc.