### PR TITLE
[PartDesign] Transform patterns can be created from multiple base features

### DIFF
--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -821,7 +821,7 @@ void CmdPartDesignNewSketch::activated(int iMsg)
                 Gui::Control().closeDialog();
 
             Gui::Selection().clearSelection();
-            Gui::Control().showDialog(new PartDesignGui::TaskDlgFeaturePick(planes, status, accepter, worker, quitter));
+            Gui::Control().showDialog(new PartDesignGui::TaskDlgFeaturePick(planes, status, accepter, worker, true, quitter));
         }
     }
 }
@@ -1151,7 +1151,7 @@ void prepareProfileBased(PartDesign::Body *pcActiveBody, Gui::Command* cmd, cons
             Gui::Control().closeDialog();
 
         Gui::Selection().clearSelection();
-        pickDlg = new PartDesignGui::TaskDlgFeaturePick(sketches, status, accepter, sketch_worker);
+        pickDlg = new PartDesignGui::TaskDlgFeaturePick(sketches, status, accepter, sketch_worker, true);
         // Logically dead code because 'bNoSketchWasSelected' must be true
         //if (!bNoSketchWasSelected && extReference)
         //    pickDlg->showExternal(true);
@@ -1979,7 +1979,7 @@ void prepareTransformed(PartDesign::Body *pcActiveBody, Gui::Command* cmd, const
                 Gui::Control().closeDialog();
 
             Gui::Selection().clearSelection();
-            Gui::Control().showDialog(new PartDesignGui::TaskDlgFeaturePick(features, status, accepter, worker));
+            Gui::Control().showDialog(new PartDesignGui::TaskDlgFeaturePick(features, status, accepter, worker, false));
             return;
         } else if (features.empty()) {
             QMessageBox::warning(Gui::getMainWindow(), QObject::tr("No valid features in this document"),

--- a/src/Mod/PartDesign/Gui/CommandBody.cpp
+++ b/src/Mod/PartDesign/Gui/CommandBody.cpp
@@ -286,7 +286,7 @@ void CmdPartDesignBody::activated(int iMsg)
                     Gui::TaskView::TaskDialog *dlg = Gui::Control().activeDialog();
                     if (!dlg) {
                         Gui::Selection().clearSelection();
-                        Gui::Control().showDialog(new PartDesignGui::TaskDlgFeaturePick(planes, status, accepter, worker, quitter));
+                        Gui::Control().showDialog(new PartDesignGui::TaskDlgFeaturePick(planes, status, accepter, worker, true, quitter));
                     }
                 }
             }

--- a/src/Mod/PartDesign/Gui/TaskFeaturePick.cpp
+++ b/src/Mod/PartDesign/Gui/TaskFeaturePick.cpp
@@ -79,11 +79,13 @@ const QString TaskFeaturePick::getFeatureStatusString(const featureStatus st)
 
 TaskFeaturePick::TaskFeaturePick(std::vector<App::DocumentObject*>& objects,
                                  const std::vector<featureStatus>& status,
+                                 bool singleFeatureSelect,
                                  QWidget* parent)
   : TaskBox(Gui::BitmapFactory().pixmap("edit-select-box"),
             tr("Select feature"), true, parent)
   , ui(new Ui_TaskFeaturePick)
   , doSelection(false)
+  , singleFeatureSelect(singleFeatureSelect)
 {
 
     proxy = new QWidget(this);
@@ -96,6 +98,10 @@ TaskFeaturePick::TaskFeaturePick(std::vector<App::DocumentObject*>& objects,
     connect(ui->radioDependent, SIGNAL(toggled(bool)), this, SLOT(onUpdate(bool)));
     connect(ui->radioXRef, SIGNAL(toggled(bool)), this, SLOT(onUpdate(bool)));
     connect(ui->listWidget, SIGNAL(itemSelectionChanged()), this, SLOT(onItemSelectionChanged()));
+
+    if (!singleFeatureSelect) {
+        ui->listWidget->setSelectionMode(QAbstractItemView::ExtendedSelection);
+    }
 
     enum { axisBit=0, planeBit = 1};
 
@@ -273,7 +279,6 @@ std::vector<App::DocumentObject*> TaskFeaturePick::buildFeatures()
                     result.push_back(obj);
                 }
 
-                break;
             }
 
             index++;
@@ -510,10 +515,11 @@ TaskDlgFeaturePick::TaskDlgFeaturePick( std::vector<App::DocumentObject*> &objec
                                         const std::vector<TaskFeaturePick::featureStatus> &status,
                                         boost::function<bool (std::vector<App::DocumentObject*>)> afunc,
                                         boost::function<void (std::vector<App::DocumentObject*>)> wfunc,
+                                        bool singleFeatureSelect,
                                         boost::function<void (void)> abortfunc /* = NULL */ )
     : TaskDialog(), accepted(false)
 {
-    pick  = new TaskFeaturePick(objects, status);
+    pick  = new TaskFeaturePick(objects, status, singleFeatureSelect);
     Content.push_back(pick);
 
     acceptFunction = afunc;

--- a/src/Mod/PartDesign/Gui/TaskFeaturePick.h
+++ b/src/Mod/PartDesign/Gui/TaskFeaturePick.h
@@ -57,6 +57,7 @@ public:
 
     TaskFeaturePick(std::vector<App::DocumentObject*> &objects, 
                     const std::vector<featureStatus> &status,
+                    bool singleFeatureSelect,
                     QWidget *parent = 0);
     
     ~TaskFeaturePick();
@@ -85,6 +86,7 @@ private:
     QWidget* proxy;
     std::vector<Gui::ViewProviderOrigin*> origins;
     bool doSelection;
+    bool singleFeatureSelect;
     std::string documentName;
 
     std::vector<QString> features;
@@ -105,7 +107,8 @@ public:
                         const std::vector<TaskFeaturePick::featureStatus> &status,
                         boost::function<bool (std::vector<App::DocumentObject*>)> acceptfunc,
                         boost::function<void (std::vector<App::DocumentObject*>)> workfunc,
-                        boost::function<void (void)> abortfunc = 0 );
+                        bool singleFeatureSelect,
+                        boost::function<void (void)> abortfunc = 0);
     ~TaskDlgFeaturePick();
 
 public:


### PR DESCRIPTION
The infrastructure/piping seems to have been in place for a long while.
Not tested for all variations of pattern transforms.
The major enabler was removing the `break`.
Some extra piping added to let the code at call-site decide if to select multiple features or not.

[Forum thread](https://forum.freecadweb.org/viewtopic.php?f=19&t=53821)

-------

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [✅] Branch rebased on latest master `git pull --rebase upstream master`
- [✅] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [☑] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [N/A] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
