### PR TITLE
Path: fix crash on edit

### DIFF
--- a/src/Mod/Path/PathScripts/PathIconViewProvider.py
+++ b/src/Mod/Path/PathScripts/PathIconViewProvider.py
@@ -78,7 +78,7 @@ class ViewProvider(object):
         # pylint: disable=unused-argument
         if 0 == mode:
             self._onEditCallback(True)
-        return True
+        return False
 
     def unsetEdit(self, arg1, arg2):
         # pylint: disable=unused-argument


### PR DESCRIPTION
Many `Path` object forward its editing operation to the job object. It is possible that some editing option change may lead to removing of the editing object (e.g. changing stock type) causing crash. It is possible to just open the task panel without setting any editing object by returning `False` in `ViewProvider.setEdit()`.

Reported at realthunder/FreeCAD_Assembly3#393