### PR TITLE
Path: Centroid post - Fix isinstance() `item.Proxy` error

### DIFF
--- a/src/Mod/Path/PathScripts/post/centroid_post.py
+++ b/src/Mod/Path/PathScripts/post/centroid_post.py
@@ -169,7 +169,11 @@ def export(objectslist, filename, argstring):
     # Write the preamble
     if OUTPUT_COMMENTS:
         for item in objectslist:
-            if isinstance(item.Proxy, PathScripts.PathToolController.ToolController):
+            if hasattr(item, "Proxy"):
+                itm_trgt = item.Proxy
+            else:
+                itm_trgt = item
+            if isinstance(itm_trgt, PathScripts.PathToolController.ToolController):
                 gcode += ";T{}={}\n".format(item.ToolNumber, item.Name)
         gcode += linenumber() + ";begin preamble\n"
     for line in PREAMBLE.splitlines(True):


### PR DESCRIPTION
Some items in `objectList` do not contain a `Proxy` child and cause a fatal error in post processing with this post module.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
