### PR TITLE
Gui: Prevent crash when trying to access a deleted object from a SelectionObject

### DIFF
--- a/src/Gui/SelectionObjectPy.xml
+++ b/src/Gui/SelectionObjectPy.xml
@@ -56,7 +56,7 @@
 	  </Attribute>
 	  <Attribute Name="Document" ReadOnly="true">
 		  <Documentation>
-			  <UserDocu>Selected document</UserDocu>
+			  <UserDocu>Document of the selected object</UserDocu>
 		  </Documentation>
 		  <Parameter Name="Document" Type="Object" />
 	  </Attribute>

--- a/src/Gui/SelectionObjectPyImp.cpp
+++ b/src/Gui/SelectionObjectPyImp.cpp
@@ -100,12 +100,18 @@ Py::String SelectionObjectPy::getDocumentName(void) const
 
 Py::Object SelectionObjectPy::getDocument(void) const
 {
-    return Py::Object(getSelectionObjectPtr()->getObject()->getDocument()->getPyObject(), true);
+    App::DocumentObject *obj = getSelectionObjectPtr()->getObject();
+    if (!obj)
+        throw Py::RuntimeError("Cannot get document of deleted object");
+    return Py::Object(obj->getDocument()->getPyObject(), true);
 }
 
 Py::Object SelectionObjectPy::getObject(void) const
 {
-    return Py::Object(getSelectionObjectPtr()->getObject()->getPyObject(), true);
+    App::DocumentObject *obj = getSelectionObjectPtr()->getObject();
+    if (!obj)
+        throw Py::RuntimeError("Object already deleted");
+    return Py::Object(obj->getPyObject(), true);
 }
 
 Py::Tuple SelectionObjectPy::getSubObjects(void) const


### PR DESCRIPTION
A crash occurs when trying to access the Document and Object attributes of a SelectionObject.
Steps to reproduce the crash:
Create any object on the tree and select it.
create a SelectionObject from the command line:
sel_obj, = Gui.Selection.getSelectionEx()
Delete the object from the tree.
Try to access the sel_obj.Document or sel_obj.Object attributes.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
