### PR TITLE
Fix Qt deprecation warnings.

### DIFF
--- a/src/Gui/GraphvizView.cpp
+++ b/src/Gui/GraphvizView.cpp
@@ -445,7 +445,11 @@ bool GraphvizView::onHasMsg(const char* pMsg) const
 void GraphvizView::print(QPrinter* printer)
 {
     QPainter p(printer);
+#if QT_VERSION >= 0x050300
+    QRect rect = printer->pageLayout().paintRectPixels(printer->resolution());
+#else
     QRect rect = printer->pageRect();
+#endif
     view->scene()->render(&p, rect);
     //QByteArray buffer = exportGraph(QString::fromLatin1("svg"));
     //QSvgRenderer svg(buffer);

--- a/src/Gui/View3DInventor.cpp
+++ b/src/Gui/View3DInventor.cpp
@@ -536,7 +536,11 @@ void View3DInventor::print(QPrinter* printer)
         return;
     }
 
+#if QT_VERSION >= 0x050300
+    QRect rect = printer->pageLayout().paintRectPixels(printer->resolution());
+#else
     QRect rect = printer->pageRect();
+#endif
     QImage img;
     _viewer->imageFromFramebuffer(rect.width(), rect.height(), 8, QColor(255,255,255), img);
     p.drawImage(0,0,img);

--- a/src/Mod/Drawing/Gui/DrawingView.cpp
+++ b/src/Mod/Drawing/Gui/DrawingView.cpp
@@ -612,12 +612,20 @@ void DrawingView::print(QPrinter* printer)
         qApp->restoreOverrideCursor();
         return;
     }
+#if QT_VERSION >= 0x050300
+    QRect rect = printer->pageLayout().fullRectPixels(printer->resolution());
+#else
     QRect rect = printer->paperRect();
+#endif
 #ifdef Q_OS_WIN32
     // On Windows the preview looks broken when using paperRect as render area.
     // Although the picture is scaled when using pageRect, it looks just fine.
     if (paintType == QPaintEngine::Picture)
-        rect = printer->pageRect();
+#if QT_VERSION >= 0x050300
+        QRect rect = printer->pageLayout().paintRectPixels(printer->resolution());
+#else
+        QRect rect = printer->pageRect();
+#endif
 #endif
     this->m_view->scene()->render(&p, rect);
     p.end();

--- a/src/Mod/TechDraw/Gui/MDIViewPage.cpp
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.cpp
@@ -757,12 +757,20 @@ void MDIViewPage::print(QPrinter* printer)
         return;
     }
 
+#if QT_VERSION >= 0x050300
+    QRect targetRect = printer->pageLayout().fullRectPixels(printer->resolution());
+#else
     QRect targetRect = printer->paperRect();
+#endif
 #ifdef Q_OS_WIN32
     // On Windows the preview looks broken when using paperRect as render area.
     // Although the picture is scaled when using pageRect, it looks just fine.
     if (paintType == QPaintEngine::Picture)
-        targetRect = printer->pageRect();
+#if QT_VERSION >= 0x050300
+        QRect targetRect = printer->pageLayout().paintRectPixels(printer->resolution());
+#else
+        QRect targetRect = printer->pageRect();
+#endif
 #endif
 
     //bool block =


### PR DESCRIPTION
QPrinter::paperRect() and QPrinter::pageRect() are obsolete.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---

Cheers,
Mateusz