### PR TITLE
Fix build warnings from deprecated Boost headers (1.74)

### DIFF
--- a/src/Mod/Path/App/Area.cpp
+++ b/src/Mod/Path/App/Area.cpp
@@ -35,7 +35,7 @@
 #   include "boost_fix/intrusive/detail/memory_util.hpp"
 #   include "boost_fix/container/detail/memory_util.hpp"
 # endif
-# include <boost/geometry.hpp>
+# include <boost_geometry.hpp>
 # include <boost/geometry/index/rtree.hpp>
 # include <boost/geometry/geometries/geometries.hpp>
 # include <boost/geometry/geometries/register/point.hpp>

--- a/src/boost_geometry.hpp
+++ b/src/boost_geometry.hpp
@@ -1,0 +1,9 @@
+#ifndef FREECAD_GEOMETRY_HPP_WORKAROUND
+#define FREECAD_GEOMETRY_HPP_WORKAROUND
+
+// Workaround for boost >= 1.74
+#define BOOST_ALLOW_DEPRECATED_HEADERS
+#include <boost/geometry.hpp>
+#undef BOOST_ALLOW_DEPRECATED_HEADERS
+
+#endif // #ifndef FREECAD_GEOMETRY_HPP_WORKAROUND


### PR DESCRIPTION
Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---

Cheers,
Mateusz