### PR TITLE
[Spreadsheet] Remove alias from dynamic properties on removeRows/Columns

### DIFF
--- a/src/Mod/Spreadsheet/App/PropertySheet.cpp
+++ b/src/Mod/Spreadsheet/App/PropertySheet.cpp
@@ -741,6 +741,18 @@ bool PropertySheet::rowSortFunc(const CellAddress & a, const CellAddress & b) {
         return false;
 }
 
+std::vector<CellAddress> PropertySheet::getRows(int row, int count) const
+{
+    std::vector<CellAddress> keys;
+
+    for (const auto &i : data) {
+        auto key = i.first;
+        if (key.row() >= row && key.row() < row + count)
+            keys.push_back(key);
+    }
+    return keys;
+}
+
 void PropertySheet::removeRows(int row, int count)
 {
     std::vector<CellAddress> keys;
@@ -847,6 +859,18 @@ bool PropertySheet::colSortFunc(const CellAddress & a, const CellAddress & b) {
         return true;
     else
         return false;
+}
+
+std::vector<CellAddress> PropertySheet::getColumns(int column, int count) const
+{
+    std::vector<CellAddress> keys;
+
+    for (const auto &i : data) {
+        auto key = i.first;
+        if (key.col() >= column && key.col() < column + count)
+            keys.push_back(key);
+    }
+    return keys;
 }
 
 void PropertySheet::removeColumns(int col, int count)

--- a/src/Mod/Spreadsheet/App/PropertySheet.h
+++ b/src/Mod/Spreadsheet/App/PropertySheet.h
@@ -130,9 +130,13 @@ public:
 
     void insertRows(int row, int count);
 
+    std::vector<App::CellAddress> getRows(int row, int count) const;
+
     void removeRows(int row, int count);
 
     void insertColumns(int col, int count);
+
+    std::vector<App::CellAddress> getColumns(int column, int count) const;
 
     void removeColumns(int col, int count);
 

--- a/src/Mod/Spreadsheet/App/Sheet.cpp
+++ b/src/Mod/Spreadsheet/App/Sheet.cpp
@@ -1135,6 +1135,14 @@ void Sheet::insertColumns(int col, int count)
 
 void Sheet::removeColumns(int col, int count)
 {
+    // Remove aliases, if defined
+    for (auto address : cells.getColumns(col, count)) {
+        auto cell = getCell(address);
+        std::string aliasStr;
+        if (cell && cell->getAlias(aliasStr))
+            removeDynamicProperty(aliasStr.c_str());
+    }
+
     cells.removeColumns(col, count);
     updateColumnsOrRows(true,col,-count);
 }
@@ -1163,6 +1171,14 @@ void Sheet::insertRows(int row, int count)
 
 void Sheet::removeRows(int row, int count)
 {
+    // Remove aliases, if defined
+    for (auto address : cells.getRows(row, count)) {
+        auto cell = getCell(address);
+        std::string aliasStr;
+        if (cell && cell->getAlias(aliasStr))
+            removeDynamicProperty(aliasStr.c_str());
+    }
+
     cells.removeRows(row, count);
     updateColumnsOrRows(false,row,-count);
 }

--- a/src/Mod/Spreadsheet/TestSpreadsheet.py
+++ b/src/Mod/Spreadsheet/TestSpreadsheet.py
@@ -1073,6 +1073,14 @@ class SpreadsheetCases(unittest.TestCase):
         self.doc.recompute()
         self.assertEqual(sheet.A3, 3)
 
+    def testRemoveRowsAliasReuseName(self):
+        """ Regression test for issue 4492; deleted aliases remains in database"""
+        sheet = self.doc.addObject('Spreadsheet::Sheet','Spreadsheet')
+        sheet.setAlias('B2', 'test')
+        self.doc.recompute()
+        sheet.removeRows('2', 1)
+        sheet.setAlias('B3','test')
+
     def testRemoveColumnsAlias(self):
         """ Regression test for issue 4429; remove columns from sheet with aliases"""
         sheet = self.doc.addObject('Spreadsheet::Sheet','Spreadsheet')
@@ -1085,6 +1093,14 @@ class SpreadsheetCases(unittest.TestCase):
         sheet.removeColumns('A', 1)
         self.doc.recompute()
         self.assertEqual(sheet.C1, 3)
+
+    def testRemoveColumnsAliasReuseName(self):
+        """ Regression test for issue 4492; deleted aliases remains in database"""
+        sheet = self.doc.addObject('Spreadsheet::Sheet','Spreadsheet')
+        sheet.setAlias('B2', 'test')
+        self.doc.recompute()
+        sheet.removeColumns('B', 1)
+        sheet.setAlias('C3','test')
 
     def tearDown(self):
         #closing doc


### PR DESCRIPTION
This fixes [0004492: Spreadsheet deleted value remains in database](https://tracker.freecadweb.org/view.php?id=4492)

Previously, when removing a row in a spreadsheet which had an assigned alias, the
alias will not be removed from the list of dynamic properties.

This made it impossible to create a new alias which used the same name
even though the original was removed with the row or column.

See testcases in TestSpreadsheet.py for more information on the issue.

Here is the forum post discussing this issue: https://forum.freecadweb.org/viewtopic.php?f=8&t=52116

---

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [x] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
