### PR TITLE
Draft: Fix multiple crashes when using modification functions - fixes #0004243, #0003971

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_array_simple.py
+++ b/src/Mod/Draft/draftguitools/gui_array_simple.py
@@ -79,16 +79,14 @@ class Array(gui_base_original.Modifier):
             if self.ui:
                 self.ui.selectUi()
                 _msg(translate("draft", "Select an object to array"))
-                self.call = \
-                    self.view.addEventCallback("SoEvent",
-                                               gui_tool_utils.selectObject)
+                self.call = self.view.addEventCallback(
+                    "SoEvent",
+                     gui_tool_utils.selectObject)
         else:
             self.proceed()
 
     def proceed(self):
         """Proceed with the command if one object was selected."""
-        if self.call:
-            self.view.removeEventCallback("SoEvent", self.call)
         if Gui.Selection.getSelection():
             obj = Gui.Selection.getSelection()[0]
             Gui.addModule("Draft")

--- a/src/Mod/Draft/draftguitools/gui_clone.py
+++ b/src/Mod/Draft/draftguitools/gui_clone.py
@@ -80,17 +80,14 @@ class Clone(gui_base_original.Modifier):
             if self.ui:
                 self.ui.selectUi()
                 _msg(translate("draft", "Select an object to clone"))
-                self.call = \
-                    self.view.addEventCallback("SoEvent",
-                                               gui_tool_utils.selectObject)
+                self.call = self.view.addEventCallback(
+                    "SoEvent",
+                    gui_tool_utils.selectObject)
         else:
             self.proceed()
 
     def proceed(self):
         """Proceed with the command if one object was selected."""
-        if self.call:
-            self.view.removeEventCallback("SoEvent", self.call)
-
         if Gui.Selection.getSelection():
             sels = len(Gui.Selection.getSelection())
             Gui.addModule("Draft")

--- a/src/Mod/Draft/draftguitools/gui_downgrade.py
+++ b/src/Mod/Draft/draftguitools/gui_downgrade.py
@@ -71,17 +71,14 @@ class Downgrade(gui_base_original.Modifier):
             if not Gui.Selection.getSelection():
                 self.ui.selectUi()
                 _msg(translate("draft", "Select an object to upgrade"))
-                self.call = \
-                    self.view.addEventCallback("SoEvent",
-                                               gui_tool_utils.selectObject)
+                self.call = self.view.addEventCallback(
+                    "SoEvent",
+                    gui_tool_utils.selectObject)
             else:
                 self.proceed()
 
     def proceed(self):
         """Proceed with execution of the command after selection."""
-        if self.call:
-            self.view.removeEventCallback("SoEvent", self.call)
-
         if Gui.Selection.getSelection():
             Gui.addModule("Draft")
             _cmd = 'Draft.downgrade'

--- a/src/Mod/Draft/draftguitools/gui_draft2sketch.py
+++ b/src/Mod/Draft/draftguitools/gui_draft2sketch.py
@@ -71,17 +71,14 @@ class Draft2Sketch(gui_base_original.Modifier):
             if self.ui:
                 self.ui.selectUi()
                 _msg(translate("draft", "Select an object to convert."))
-                self.call = \
-                    self.view.addEventCallback("SoEvent",
-                                               gui_tool_utils.selectObject)
+                self.call = self.view.addEventCallback(
+                    "SoEvent",
+                    gui_tool_utils.selectObject)
         else:
             self.proceed()
 
     def proceed(self):
         """Proceed with the command if one object was selected."""
-        if self.call:
-            self.view.removeEventCallback("SoEvent", self.call)
-
         sel = Gui.Selection.getSelection()
         allSketches = True
         allDraft = True

--- a/src/Mod/Draft/draftguitools/gui_facebinders.py
+++ b/src/Mod/Draft/draftguitools/gui_facebinders.py
@@ -70,16 +70,14 @@ class Facebinder(gui_base_original.Creator):
             if self.ui:
                 self.ui.selectUi()
                 _msg(translate("draft", "Select faces from existing objects"))
-                self.call = \
-                    self.view.addEventCallback("SoEvent",
-                                               gui_tool_utils.selectObject)
+                self.call = self.view.addEventCallback(
+                    "SoEvent",
+                    gui_tool_utils.selectObject)
         else:
             self.proceed()
 
     def proceed(self):
         """Proceed when a valid selection has been made."""
-        if self.call:
-            self.view.removeEventCallback("SoEvent", self.call)
         if Gui.Selection.getSelection():
             App.ActiveDocument.openTransaction("Create Facebinder")
             Gui.addModule("Draft")

--- a/src/Mod/Draft/draftguitools/gui_join.py
+++ b/src/Mod/Draft/draftguitools/gui_join.py
@@ -78,8 +78,9 @@ class Join(gui_base_original.Modifier):
         if not Gui.Selection.getSelection():
             self.ui.selectUi()
             _msg(translate("draft", "Select an object to join"))
-            self.call = self.view.addEventCallback("SoEvent",
-                                                   gui_tool_utils.selectObject)
+            self.call = self.view.addEventCallback(
+                "SoEvent",
+                gui_tool_utils.selectObject)
         else:
             self.proceed()
 
@@ -90,8 +91,6 @@ class Join(gui_base_original.Modifier):
         visually share a point. This is due to the underlying `joinWires`
         method not handling the points correctly.
         """
-        if self.call:
-            self.view.removeEventCallback("SoEvent", self.call)
         if Gui.Selection.getSelection():
             self.print_selection()
             Gui.addModule("Draft")

--- a/src/Mod/Draft/draftguitools/gui_offset.py
+++ b/src/Mod/Draft/draftguitools/gui_offset.py
@@ -78,9 +78,9 @@ class Offset(gui_base_original.Modifier):
             if not Gui.Selection.getSelection():
                 self.ui.selectUi()
                 _msg(translate("draft", "Select an object to offset"))
-                self.call = \
-                    self.view.addEventCallback("SoEvent",
-                                               gui_tool_utils.selectObject)
+                self.call = self.view.addEventCallback(
+                    "SoEvent",
+                    gui_tool_utils.selectObject)
             elif len(Gui.Selection.getSelection()) > 1:
                 _wrn(translate("draft", "Offset only works "
                                         "on one object at a time."))

--- a/src/Mod/Draft/draftguitools/gui_patharray.py
+++ b/src/Mod/Draft/draftguitools/gui_patharray.py
@@ -103,9 +103,6 @@ class PathArray(gui_base_original.Modifier):
 
     def proceed(self):
         """Proceed with the command if one object was selected."""
-        if self.call:
-            self.view.removeEventCallback("SoEvent", self.call)
-
         sel = Gui.Selection.getSelectionEx()
         if len(sel) != 2:
             _err(_tr("Please select exactly two objects, "

--- a/src/Mod/Draft/draftguitools/gui_pathtwistedarray.py
+++ b/src/Mod/Draft/draftguitools/gui_pathtwistedarray.py
@@ -80,9 +80,6 @@ class PathTwistedArray(gui_base_original.Modifier):
 
     def proceed(self):
         """Proceed with the command if one object was selected."""
-        if self.call:
-            self.view.removeEventCallback("SoEvent", self.call)
-
         sel = Gui.Selection.getSelectionEx()
         if len(sel) != 2:
             _err(_tr("Please select exactly two objects, "

--- a/src/Mod/Draft/draftguitools/gui_pointarray.py
+++ b/src/Mod/Draft/draftguitools/gui_pointarray.py
@@ -113,9 +113,6 @@ class PointArray(gui_base_original.Modifier):
 
     def proceed(self):
         """Proceed with the command if one object was selected."""
-        if self.call:
-            self.view.removeEventCallback("SoEvent", self.call)
-
         sel = Gui.Selection.getSelectionEx()
         if len(sel) != 2:
             _err(_tr("Please select exactly two objects, "

--- a/src/Mod/Draft/draftguitools/gui_shape2dview.py
+++ b/src/Mod/Draft/draftguitools/gui_shape2dview.py
@@ -75,17 +75,14 @@ class Shape2DView(gui_base_original.Modifier):
             if self.ui:
                 self.ui.selectUi()
                 _msg(translate("draft", "Select an object to project"))
-                self.call = \
-                    self.view.addEventCallback("SoEvent",
-                                               gui_tool_utils.selectObject)
+                self.call = self.view.addEventCallback(
+                    "SoEvent",
+                    gui_tool_utils.selectObject)
         else:
             self.proceed()
 
     def proceed(self):
         """Proceed with the command if one object was selected."""
-        if self.call:
-            self.view.removeEventCallback("SoEvent", self.call)
-
         faces = []
         objs = []
         vec = Gui.ActiveDocument.ActiveView.getViewDirection().negative()

--- a/src/Mod/Draft/draftguitools/gui_split.py
+++ b/src/Mod/Draft/draftguitools/gui_split.py
@@ -112,8 +112,6 @@ class Split(gui_base_original.Modifier):
         self.commit(translate("draft", "Split line"),
                     _cmd_list)
 
-        if self.call:
-            self.view.removeEventCallback("SoEvent", self.call)
         self.finish()
 
 

--- a/src/Mod/Draft/draftguitools/gui_upgrade.py
+++ b/src/Mod/Draft/draftguitools/gui_upgrade.py
@@ -73,17 +73,14 @@ class Upgrade(gui_base_original.Modifier):
             if not Gui.Selection.getSelection():
                 self.ui.selectUi()
                 _msg(translate("draft", "Select an object to upgrade"))
-                self.call = \
-                    self.view.addEventCallback("SoEvent",
-                                               gui_tool_utils.selectObject)
+                self.call = self.view.addEventCallback(
+                    "SoEvent",
+                    gui_tool_utils.selectObject)
             else:
                 self.proceed()
 
     def proceed(self):
         """Proceed with execution of the command after selection."""
-        if self.call:
-            self.view.removeEventCallback("SoEvent", self.call)
-
         if Gui.Selection.getSelection():
             Gui.addModule("Draft")
             _cmd = 'Draft.upgrade'


### PR DESCRIPTION
See https://tracker.freecadweb.org/view.php?id=4243 and https://tracker.freecadweb.org/view.php?id=3971
The reported crash is reproducible in most Draft modification functions (even interleaving them) by following the steps indicated in a higher number of repetitions. In my particular case I had to perform 4 or more loops. Sometimes a freeze occurs prior to crash.
The problem is due to a double attempt to remove the Coin callback.
Removing the call to the removeEventCallback method in the draftguifunctions and leaving only the call made in the inherited self.finish method is enough to resolve the bug.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
