### PR TITLE
Add SVG icons of eight Std View menu commands

### DIFF
--- a/src/Gui/CommandFeat.cpp
+++ b/src/Gui/CommandFeat.cpp
@@ -75,6 +75,7 @@ StdCmdRandomColor::StdCmdRandomColor()
     sToolTipText  = QT_TR_NOOP("Random color");
     sWhatsThis    = "Std_RandomColor";
     sStatusTip    = QT_TR_NOOP("Random color");
+    sPixmap       = "Std_RandomColor";
 }
 
 void StdCmdRandomColor::activated(int iMsg)

--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -563,6 +563,7 @@ StdCmdToggleClipPlane::StdCmdToggleClipPlane()
     sToolTipText  = QT_TR_NOOP("Toggles clipping plane for active view");
     sWhatsThis    = "Std_ToggleClipPlane";
     sStatusTip    = QT_TR_NOOP("Toggles clipping plane for active view");
+    sPixmap       = "Std_ToggleClipPlane";
     eType         = Alter3DView;
 }
 
@@ -1188,7 +1189,7 @@ StdCmdViewHome::StdCmdViewHome()
     sToolTipText  = QT_TR_NOOP("Set to default home view");
     sWhatsThis    = "Std_ViewHome";
     sStatusTip    = QT_TR_NOOP("Set to default home view");
-    //sPixmap       = "view-home";
+    sPixmap       = "Std_ViewHome";
     sAccel        = "Home";
     eType         = Alter3DView;
 }
@@ -1384,6 +1385,7 @@ StdCmdViewDimetric::StdCmdViewDimetric()
     sToolTipText= QT_TR_NOOP("Set to dimetric view");
     sWhatsThis  = "Std_ViewDimetric";
     sStatusTip  = QT_TR_NOOP("Set to dimetric view");
+    sPixmap       = "Std_ViewDimetric";
     eType         = Alter3DView;
 }
 
@@ -1406,6 +1408,7 @@ StdCmdViewTrimetric::StdCmdViewTrimetric()
     sToolTipText= QT_TR_NOOP("Set to trimetric view");
     sWhatsThis  = "Std_ViewTrimetric";
     sStatusTip  = QT_TR_NOOP("Set to trimetric view");
+    sPixmap       = "Std_ViewTrimetric";
     eType         = Alter3DView;
 }
 
@@ -2025,6 +2028,7 @@ StdCmdToggleNavigation::StdCmdToggleNavigation()
     sWhatsThis    = "Std_ToggleNavigation";
   //iAccel        = Qt::SHIFT+Qt::Key_Space;
     sAccel        = "Esc";
+    sPixmap       = "Std_ToggleNavigation";
     eType         = Alter3DView;
 }
 
@@ -2072,6 +2076,7 @@ public:
         sToolTipText  = QT_TR_NOOP("Toggle axis cross");
         sStatusTip    = QT_TR_NOOP("Toggle axis cross");
         sWhatsThis    = "Std_AxisCross";
+        sPixmap       = "Std_AxisCross";
     }
     ~StdCmdAxisCross()
     {
@@ -3099,6 +3104,7 @@ StdCmdTextureMapping::StdCmdTextureMapping()
     sToolTipText  = QT_TR_NOOP("Texture mapping");
     sWhatsThis    = "Std_TextureMapping";
     sStatusTip    = QT_TR_NOOP("Texture mapping");
+    sPixmap       = "Std_TextureMapping";
     eType         = Alter3DView;
 }
 

--- a/src/Gui/Icons/Std_AxisCross.svg
+++ b/src/Gui/Icons/Std_AxisCross.svg
@@ -1,0 +1,231 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   width="64"
+   height="64"
+   viewBox="0 0 64 64"
+   id="svg2"
+   version="1.1">
+  <title
+     id="title930">Std_AxisCross</title>
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient926">
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1"
+         offset="0"
+         id="stop922" />
+      <stop
+         style="stop-color:#a40000;stop-opacity:1"
+         offset="1"
+         id="stop924" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient918">
+      <stop
+         style="stop-color:#8ae234;stop-opacity:1"
+         offset="0"
+         id="stop914" />
+      <stop
+         style="stop-color:#4e9a06;stop-opacity:1"
+         offset="1"
+         id="stop916" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient910">
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1"
+         offset="0"
+         id="stop906" />
+      <stop
+         style="stop-color:#204a87;stop-opacity:1"
+         offset="1"
+         id="stop908" />
+    </linearGradient>
+    <marker
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4732"
+       style="overflow:visible">
+      <path
+         id="path4734"
+         style="fill:#00ff00;fill-opacity:1;fill-rule:evenodd;stroke:#00ff08;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-1.1,0,0,-1.1,-1.1,0)" />
+    </marker>
+    <marker
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow2Lstart"
+       style="overflow:visible">
+      <path
+         id="path4174"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(1.1,0,0,1.1,1.1,0)" />
+    </marker>
+    <marker
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Lstart"
+       style="overflow:visible">
+      <path
+         id="path4156"
+         d="M 0,0 5,-5 -12.5,0 5,5 0,0 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.8,0,0,0.8,10,0)" />
+    </marker>
+    <linearGradient
+       id="linearGradient4067-6">
+      <stop
+         style="stop-color:#888a85;stop-opacity:1;"
+         offset="0"
+         id="stop4069-7" />
+      <stop
+         style="stop-color:#2e3436;stop-opacity:1;"
+         offset="1"
+         id="stop4071-5" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient910"
+       id="linearGradient912"
+       x1="16.275192"
+       y1="999.11859"
+       x2="20.275194"
+       y2="1005.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-0.32823259,0.25769489)" />
+    <linearGradient
+       xlink:href="#linearGradient918"
+       id="linearGradient920"
+       x1="37.791718"
+       y1="1008.163"
+       x2="41.744087"
+       y2="1014.2588"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,0.67970822)" />
+    <linearGradient
+       xlink:href="#linearGradient926"
+       id="linearGradient928"
+       x1="32.554726"
+       y1="1037.6899"
+       x2="38.136963"
+       y2="1044.7837"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,0.67970822)" />
+  </defs>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Std_AxisCross</dc:title>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[bitacovir]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:date>2020/12/20</dc:date>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     transform="translate(0,-988.36216)">
+    <g
+       id="g4036-9-5"
+       transform="matrix(0.42333463,-1.0406928,1.2322046,0.04560555,-18.902112,1031.4247)"
+       style="fill:#73d216;fill-opacity:1;stroke:#172a04;stroke-width:1.753;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
+      <g
+         id="g4033-8-3"
+         transform="matrix(0.70857077,0.64561924,-0.7760537,0.70710678,30.848953,1.7173836)"
+         style="fill:#73d216;fill-opacity:1;stroke:#172a04;stroke-width:1.75119;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
+        <rect
+           style="fill:#73d216;fill-opacity:1;stroke:#172a04;stroke-width:1.75119;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="rect3261-1-56"
+           width="23"
+           height="6"
+           x="-25"
+           y="-38"
+           transform="scale(-1)" />
+      </g>
+    </g>
+    <path
+       style="fill:none;fill-opacity:1;stroke:#8ae234;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 17.758513,1025.996 23.516681,-15.1976"
+       id="path4083-0-29" />
+    <g
+       style="fill:#cc0000;fill-opacity:1;stroke:#280000;stroke-width:1.77168;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(-0.09950839,-1.2704661,0.99694669,-0.07808517,-7.0272263,1034.6728)"
+       id="g4033-8-5">
+      <rect
+         transform="matrix(-0.61568026,0.78799608,-0.61567913,-0.78799696,0,0)"
+         y="-22.253193"
+         x="11.761694"
+         height="4.9622731"
+         width="24.257404"
+         id="rect3261-1-6"
+         style="fill:#cc0000;fill-opacity:1;stroke:#280000;stroke-width:1.65466;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <path
+       style="fill:none;stroke:#ef2929;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 38.136962,1045.4634 17.397878,1027.7269"
+       id="path4083-0-2" />
+    <path
+       id="path872-8"
+       d="m 44,1049.0419 -8.562552,-14.5923 c -4.048591,1.9848 -5.937899,5.0071 -7.162254,8.3488 z"
+       style="fill:url(#linearGradient928);fill-opacity:1;stroke:#280000;stroke-width:2.50713;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="fill:url(#linearGradient920);fill-opacity:1;stroke:#172a04;stroke-width:2.50713;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 52.025756,1005.4549 -16.544154,3.5417 c 0.611589,4.4672 2.886818,7.2108 5.674284,9.4235 z"
+       id="path872-8-1" />
+    <g
+       id="g4036-9"
+       transform="matrix(-0.64428531,-0.92040759,0.70710678,-1.0101525,0.936348,1060.8558)"
+       style="fill:#3465a4;fill-opacity:1;stroke:#0b1521;stroke-width:1.753;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
+      <g
+         id="g4033-8"
+         transform="matrix(0.53748674,0.48973482,-0.7760537,0.70710678,30.821878,1.6927139)"
+         style="fill:#3465a4;fill-opacity:1;stroke:#0b1521;stroke-width:1.75119;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
+        <rect
+           style="fill:#3465a4;fill-opacity:1;stroke:#0b1521;stroke-width:1.75119;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="rect3261-1"
+           width="23"
+           height="6"
+           x="-25"
+           y="-38"
+           transform="scale(-1)" />
+      </g>
+    </g>
+    <path
+       style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 16.157967,1027.8686 V 999.86865"
+       id="path4083-0" />
+    <path
+       style="fill:url(#linearGradient912);fill-opacity:1;stroke:#0b1521;stroke-width:2.50713;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 17.171767,991.6197 -5.5,16.0002 c 4.142481,1.7805 7.666483,1.2466 11,0 z"
+       id="path872" />
+  </g>
+</svg>

--- a/src/Gui/Icons/Std_RandomColor.svg
+++ b/src/Gui/Icons/Std_RandomColor.svg
@@ -1,0 +1,299 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   width="64"
+   height="64"
+   id="svg1307"
+   version="1.1">
+  <title
+     id="title953">Std_RandomColor</title>
+  <defs
+     id="defs1309">
+    <linearGradient
+       id="linearGradient951">
+      <stop
+         id="stop947"
+         offset="0"
+         style="stop-color:#4e9a06;stop-opacity:1" />
+      <stop
+         id="stop949"
+         offset="1"
+         style="stop-color:#8ae234;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient945">
+      <stop
+         id="stop941"
+         offset="0"
+         style="stop-color:#ce5c00;stop-opacity:1" />
+      <stop
+         id="stop943"
+         offset="1"
+         style="stop-color:#fcaf3e;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3851">
+      <stop
+         style="stop-color:#5c3566;stop-opacity:1"
+         offset="0"
+         id="stop3853" />
+      <stop
+         style="stop-color:#ad7fa8;stop-opacity:1"
+         offset="1"
+         id="stop3855" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2684">
+      <stop
+         id="stop2686"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop2688"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2584">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop2586" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop2588" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5075">
+      <stop
+         style="stop-color:#adb0a8;stop-opacity:1;"
+         offset="0"
+         id="stop5077" />
+      <stop
+         style="stop-color:#464744;stop-opacity:1"
+         offset="1"
+         id="stop5079" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3340">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop3342" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.62886596;"
+         offset="1"
+         id="stop3344" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient5075"
+       id="linearGradient2306"
+       gradientUnits="userSpaceOnUse"
+       x1="71.288956"
+       y1="124.11652"
+       x2="70.826942"
+       y2="95"
+       gradientTransform="translate(-105.00042,-71.09425)" />
+    <linearGradient
+       xlink:href="#linearGradient2684"
+       id="linearGradient2690"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.128181,0,0,1.128181,-113.99314,-83.36009)"
+       x1="70.913956"
+       y1="101.74152"
+       x2="70.951942"
+       y2="88.923729" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="12.5"
+       x2="6.75"
+       y1="0.5"
+       x1="6.75"
+       id="linearGradient7035"
+       xlink:href="#linearGradient7029" />
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,1.0057859,0,-2.4948735)"
+       r="9.3095722"
+       fy="431.19708"
+       fx="466.73566"
+       cy="431.19708"
+       cx="466.73566"
+       id="radialGradient6052"
+       xlink:href="#linearGradient17794" />
+    <linearGradient
+       y2="424.95065"
+       x2="461.39169"
+       y1="436.79602"
+       x1="472.42236"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient2438"
+       xlink:href="#linearGradient17794" />
+    <linearGradient
+       y2="424.95065"
+       x2="461.39169"
+       y1="436.79602"
+       x1="472.42236"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient24732"
+       xlink:href="#linearGradient17794" />
+    <linearGradient
+       id="linearGradient17794">
+      <stop
+         id="stop17798"
+         offset="0"
+         style="stop-color:#f18383;stop-opacity:1;" />
+      <stop
+         style="stop-color:#ed6767;stop-opacity:1;"
+         offset="0.3807947"
+         id="stop8006" />
+      <stop
+         id="stop17796"
+         offset="1"
+         style="stop-color:#e62323;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7029">
+      <stop
+         id="stop7031"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop7033"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient945"
+       id="linearGradient3857"
+       x1="35.599998"
+       y1="60.799999"
+       x2="27.200001"
+       y2="27.199999"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.83333333,0,0,0.83333332,17.035644,-8.666666)" />
+    <linearGradient
+       gradientTransform="matrix(0.83333333,0,0,0.83333332,-6.6522187,-8.7504872)"
+       gradientUnits="userSpaceOnUse"
+       y2="27.199999"
+       x2="27.200001"
+       y1="60.799999"
+       x1="35.599998"
+       id="linearGradient3857-0"
+       xlink:href="#linearGradient951" />
+    <linearGradient
+       xlink:href="#linearGradient3851"
+       id="linearGradient3857-0-8"
+       x1="35.599998"
+       y1="60.799999"
+       x2="27.200001"
+       y2="27.199999"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.83333333,0,0,0.83333332,5.3496667,-32.545057)" />
+  </defs>
+  <metadata
+     id="metadata1312">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Std_RandomColor</dc:title>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>bitacovir</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/by-sa/2.0/" />
+        <dc:subject>
+          <rdf:Bag />
+        </dc:subject>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title />
+          </cc:Agent>
+        </dc:contributor>
+        <dc:date>2020/12/15</dc:date>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by-sa/2.0/">
+        <cc:permits
+           rdf:resource="http://web.resource.org/cc/Reproduction" />
+        <cc:permits
+           rdf:resource="http://web.resource.org/cc/Distribution" />
+        <cc:requires
+           rdf:resource="http://web.resource.org/cc/Notice" />
+        <cc:requires
+           rdf:resource="http://web.resource.org/cc/Attribution" />
+        <cc:permits
+           rdf:resource="http://web.resource.org/cc/DerivativeWorks" />
+        <cc:requires
+           rdf:resource="http://web.resource.org/cc/ShareAlike" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer4"
+     style="display:inline"
+     transform="translate(0,16)" />
+  <g
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,16)">
+    <circle
+       style="fill:#ef2929;fill-opacity:1;stroke:#321900;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6;stroke-opacity:1"
+       id="path3831"
+       cx="43.702312"
+       cy="28"
+       r="17" />
+    <circle
+       style="display:inline;fill:url(#linearGradient3857);fill-opacity:1;stroke:#fcaf3e;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6;stroke-opacity:1"
+       id="path3831-6"
+       cx="43.702312"
+       cy="28"
+       r="15" />
+    <circle
+       r="17"
+       cy="27.916178"
+       cx="20.01445"
+       id="path3831-7"
+       style="display:inline;fill:#ef2929;fill-opacity:1;stroke:#172a04;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6;stroke-opacity:1" />
+    <circle
+       r="15"
+       cy="27.916178"
+       cx="20.01445"
+       id="path3831-6-9"
+       style="display:inline;fill:url(#linearGradient3857-0);fill-opacity:1;stroke:#8ae234;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6;stroke-opacity:1" />
+    <circle
+       style="display:inline;fill:#ef2929;fill-opacity:1;stroke:#171018;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6;stroke-opacity:1"
+       id="path3831-7-5"
+       cx="32.016338"
+       cy="4.1216102"
+       r="17" />
+    <circle
+       style="display:inline;fill:url(#linearGradient3857-0-8);fill-opacity:1;stroke:#ad7fa8;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6;stroke-opacity:1"
+       id="path3831-6-9-0"
+       cx="32.016338"
+       cy="4.1216102"
+       r="15" />
+  </g>
+</svg>

--- a/src/Gui/Icons/Std_TextureMapping.svg
+++ b/src/Gui/Icons/Std_TextureMapping.svg
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.1"
+   id="svg6248"
+   height="64px"
+   width="64px">
+  <title
+     id="title856">Std_TextureMapping</title>
+  <defs
+     id="defs6250">
+    <linearGradient
+       id="linearGradient3253">
+      <stop
+         id="stop3255"
+         offset="0"
+         style="stop-color:#89d5f8;stop-opacity:1;" />
+      <stop
+         id="stop3257"
+         offset="1"
+         style="stop-color:#00899e;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6816">
+      <stop
+         id="stop6818"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop6820"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6781">
+      <stop
+         id="stop6783"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop6785"
+         offset="1"
+         style="stop-color:#3465a4;stop-opacity:0;" />
+    </linearGradient>
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1581633,0,0,0.6558985,-7.29237,16.126077)"
+       r="25.198714"
+       fy="51.929391"
+       fx="33.369828"
+       cy="51.929391"
+       cx="33.369828"
+       id="radialGradient6822"
+       xlink:href="#linearGradient6816" />
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9724373,-0.105657,5.0523169e-2,0.4650009,-0.3519546,9.5854384)"
+       r="27.986705"
+       fy="17.013988"
+       fx="18.417862"
+       cy="17.013988"
+       cx="18.417862"
+       id="radialGradient3259"
+       xlink:href="#linearGradient3253" />
+    <radialGradient
+       r="27.986705"
+       fy="17.013988"
+       fx="18.417862"
+       cy="17.013988"
+       cx="18.417862"
+       gradientTransform="matrix(0.9724373,-0.105657,0.05052317,0.4650009,-0.3519546,9.5854384)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3270"
+       xlink:href="#linearGradient3253" />
+  </defs>
+  <metadata
+     id="metadata6253">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Std_TextureMapping</dc:title>
+        <dc:date>2020/12/17</dc:date>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[bitacovir]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:subject>
+          <rdf:Bag />
+        </dc:subject>
+        <dc:description />
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title />
+          </cc:Agent>
+        </dc:contributor>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1">
+    <g
+       transform="matrix(-1,0,0,0.99363058,4,0.0382165)"
+       id="g3913-7" />
+    <rect
+       style="fill:#000000;fill-rule:evenodd;stroke:#000000;stroke-width:3.86437;stroke-linecap:round;stroke-linejoin:round"
+       id="rect848"
+       width="42"
+       height="56"
+       x="11"
+       y="4" />
+    <rect
+       style="fill:none;fill-rule:evenodd;stroke:#cc0000;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect890"
+       width="40"
+       height="53.97327"
+       x="12"
+       y="5.0267296" />
+    <rect
+       style="fill:#cc0000;fill-rule:evenodd;stroke:#cc0000;stroke-width:3.96136;stroke-linecap:round;stroke-linejoin:miter"
+       id="rect850"
+       width="17"
+       height="24"
+       x="13"
+       y="6" />
+    <rect
+       y="34"
+       x="34"
+       height="24"
+       width="17"
+       id="rect850-1"
+       style="fill:#cc0000;fill-rule:evenodd;stroke:#cc0000;stroke-width:3.96136;stroke-linecap:round;stroke-linejoin:miter" />
+  </g>
+</svg>

--- a/src/Gui/Icons/Std_ToggleClipPlane.svg
+++ b/src/Gui/Icons/Std_ToggleClipPlane.svg
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   width="64px"
+   height="64px"
+   id="svg2985"
+   version="1.1">
+  <title
+     id="title849">Std_ToggleClipPlane</title>
+  <defs
+     id="defs2987">
+    <linearGradient
+       id="linearGradient3764">
+      <stop
+         style="stop-color:#06989a;stop-opacity:1"
+         offset="0"
+         id="stop3766" />
+      <stop
+         style="stop-color:#34e0e2;stop-opacity:1"
+         offset="1"
+         id="stop3768" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3778">
+      <stop
+         style="stop-color:#06989a;stop-opacity:1"
+         offset="0"
+         id="stop3780" />
+      <stop
+         style="stop-color:#34e0e2;stop-opacity:1"
+         offset="1"
+         id="stop3782" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3778"
+       id="linearGradient3784"
+       x1="31.905455"
+       y1="47.934547"
+       x2="20.734545"
+       y2="7.9054546"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       xlink:href="#linearGradient3764"
+       id="linearGradient3770"
+       x1="34"
+       y1="60"
+       x2="32"
+       y2="6"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       xlink:href="#linearGradient3764-6"
+       id="linearGradient3770-3"
+       x1="34"
+       y1="60"
+       x2="32"
+       y2="6"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3764-6">
+      <stop
+         style="stop-color:#c4a000;stop-opacity:1"
+         offset="0"
+         id="stop3766-7" />
+      <stop
+         style="stop-color:#fce94f;stop-opacity:1"
+         offset="1"
+         id="stop3768-5" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata2990">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Std_ToggleClipPlane</dc:title>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[bitacovir]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:title>Arch_SectionPlane</dc:title>
+        <dc:date>2020-12-17</dc:date>
+        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier />
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>Based on Agryson's work</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1">
+    <path
+       style="fill:url(#linearGradient3770);fill-opacity:1;stroke:#042a2a;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
+       d="m 31,61 h 4 V 4 h -4 z"
+       id="path2994" />
+    <circle
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3784);fill-opacity:1;fill-rule:nonzero;stroke:#042a2a;stroke-width:1.86182;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="path2993"
+       transform="matrix(1.0742187,0,0,1.0742187,1.7265638,-1.4921872)"
+       cx="28.181818"
+       cy="27.454546"
+       r="23.272728" />
+    <circle
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#34e0e2;stroke-width:2.02372;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="path2993-3"
+       transform="matrix(0.98828121,0,0,0.98828121,4.1484387,0.86718805)"
+       cx="28.181818"
+       cy="27.454546"
+       r="23.272728" />
+    <path
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#042a2a;fill-opacity:1;fill-rule:nonzero;stroke:#042a2a;stroke-width:1.82686;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="path2997"
+       d="m 11.783744,34.785983 0,-35.39014963 30.648768,17.69507463 z"
+       transform="matrix(0.84832121,0,0,1.4128225,21.0036,4.8535806)" />
+    <g
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:27.778px;line-height:125%;font-family:Arial;-inkscape-font-specification:Arial;letter-spacing:0px;word-spacing:0px;fill:#042a2a;fill-opacity:1;stroke:none"
+       id="text3767">
+      <path
+         d="M 27.128129,36 24.756995,29.567069 H 15.301914 L 12.916053,36 H 10 l 8.468336,-22 h 3.195876 L 30,36 H 27.128129 M 21.251841,19.980128 c -0.157105,-0.416355 -0.309289,-0.83793 -0.456554,-1.264727 -0.137468,-0.426763 -0.260197,-0.811905 -0.368188,-1.155429 -0.108007,-0.353896 -0.201287,-0.645356 -0.279824,-0.874379 -0.06873,-0.239394 -0.108018,-0.385123 -0.11782,-0.43719 -0.01964,0.05207 -0.06382,0.197796 -0.132548,0.43719 -0.06875,0.239433 -0.162013,0.536096 -0.279823,0.889992 -0.108008,0.353934 -0.23565,0.744281 -0.382916,1.171043 -0.137467,0.426797 -0.279832,0.848373 -0.427098,1.264728 l -2.650958,7.229241 h 7.761414 l -2.665685,-7.260469"
+         id="path2990"
+         style="fill:#042a2a;stroke:none" />
+    </g>
+  </g>
+</svg>

--- a/src/Gui/Icons/Std_ToggleNavigation.svg
+++ b/src/Gui/Icons/Std_ToggleNavigation.svg
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   width="64px"
+   height="64px"
+   id="svg3000"
+   version="1.1">
+  <title
+     id="title863">Std_ToggleNavigation</title>
+  <defs
+     id="defs3002">
+    <linearGradient
+       id="linearGradient3393">
+      <stop
+         style="stop-color:#06989a;stop-opacity:1"
+         offset="0"
+         id="stop3395" />
+      <stop
+         style="stop-color:#34e0e2;stop-opacity:1"
+         offset="1"
+         id="stop3397" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3393"
+       id="linearGradient3399"
+       x1="1699.6969"
+       y1="1840.5964"
+       x2="2044.969"
+       y2="1629.2852"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.25534521,-0.95296128,0.96517316,0.25861737,-283.46374,3042.7301)" />
+    <linearGradient
+       xlink:href="#linearGradient3393-7"
+       id="linearGradient3399-1"
+       x1="1669.7314"
+       y1="1726.0585"
+       x2="2067.1702"
+       y2="1726.0585"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.98657811,0,0,0.99922078,20.129251,-2.6811697)" />
+    <linearGradient
+       id="linearGradient3393-7">
+      <stop
+         style="stop-color:#003ddd;stop-opacity:1;"
+         offset="0"
+         id="stop3395-4" />
+      <stop
+         style="stop-color:#639ef0;stop-opacity:1;"
+         offset="1"
+         id="stop3397-0" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3806"
+       id="linearGradient3012"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-6.7448605,1.6807825,-1.7046474,-6.8406287,2050.6498,1897.1039)"
+       x1="42.755482"
+       y1="44.981819"
+       x2="40.373039"
+       y2="19.265453" />
+    <linearGradient
+       id="linearGradient3806">
+      <stop
+         style="stop-color:#34e0e2;stop-opacity:1"
+         offset="0"
+         id="stop3808" />
+      <stop
+         style="stop-color:#06989a;stop-opacity:1"
+         offset="1"
+         id="stop3810" />
+    </linearGradient>
+  </defs>
+  <g
+     id="layer1">
+    <g
+       id="g3405"
+       transform="matrix(0.1369365,0,0,0.1369365,-222.21754,-203.36512)">
+      <g
+         id="g845"
+         transform="rotate(60,1857.7825,1712.6959)">
+        <path
+           style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3399);fill-opacity:1;fill-rule:evenodd;stroke:#042a2a;stroke-width:14.6053;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           d="m 1880.5373,1902.9135 c 106.1484,-2.3589 189.8111,-89.4894 186.7502,-194.4908 -3.0611,-105.0013 -91.6921,-188.303 -197.8404,-185.9442 -55.9403,1.2433 -105.6257,26.0285 -139.6708,64.565 -3.5749,0.6134 55.4935,44.1756 55.4935,44.1756 22.1039,-24.0141 53.73,-39.3793 89.2346,-40.1684 69.1228,-1.536 126.8308,52.7017 128.824,121.0778 1.9931,68.3762 -52.4788,125.1377 -121.6017,126.6738 -19.7778,0.4394 -38.6039,-3.7029 -55.475,-11.4237 l -31.3948,57.7752 c 26.0336,11.9963 55.1182,18.4389 85.6804,17.7597 z"
+           id="path2396" />
+        <path
+           style="display:inline;overflow:visible;visibility:visible;fill:none;stroke:#34e0e2;stroke-width:14.6053;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           d="m 1885.0707,1887.6865 c 78.8923,-1.5361 138.9163,-54.9141 161.631,-130.1829 32.4053,-107.38 -55.6977,-196.5384 -121.2835,-214.3605 -82.1688,-22.3283 -143.0328,13.9353 -176.6519,44.1474 l 34.9363,26.3413 c 48.9255,-39.4093 87.6337,-43.7301 132.6063,-32.3857 52.2393,13.1774 118.2783,78.5389 98.4143,164.5079 -17.2644,74.7179 -82.9486,105.1278 -134.9353,106.5777 -17.3999,2.1436 -33.9339,-2.2822 -47.106,-6.2036 l -17.5742,32.2101 c 20.5378,6.6037 46.0171,9.8144 69.963,9.3483 z"
+           id="path2396-9" />
+        <path
+           id="path3343"
+           d="m 1780.0348,1858.0991 -48.445,-79.2683 129.8702,-32.1384 -15.945,-66.5353 -129.864,31.7262 4.1865,-90.2537 -135.1728,159.1019 z"
+           style="fill:url(#linearGradient3012);fill-opacity:1;fill-rule:evenodd;stroke:#042a2a;stroke-width:14.6053;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path3343-2"
+           d="m 1746.6502,1828.9145 -35.8887,-57.8065 134.1381,-34.2002 -10.6194,-40.0654 -131.4171,30.129 2.7243,-69.6957 -96.6391,116.9739 z"
+           style="fill:none;stroke:#34e0e2;stroke-width:14.6053;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4.8;stroke-dasharray:none;stroke-opacity:1" />
+      </g>
+    </g>
+  </g>
+  <metadata
+     id="metadata5324">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Std_ToggleNavigation</dc:title>
+        <cc:license
+           rdf:resource="https://www.gnu.org/licenses/lgpl-3.0.en.html" />
+        <dc:date>2020/12/17</dc:date>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[bitacovir]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier />
+        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>based on Alexander Gryson, wmayer's work</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+        <dc:description />
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>esc</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <dc:title>arrow-ccw</dc:title>
+        <cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+</svg>

--- a/src/Gui/Icons/Std_ViewDimetric.svg
+++ b/src/Gui/Icons/Std_ViewDimetric.svg
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.1"
+   id="svg6248"
+   height="64px"
+   width="64px">
+  <title
+     id="title856">Std_ViewDimetric</title>
+  <defs
+     id="defs6250">
+    <linearGradient
+       id="linearGradient3253">
+      <stop
+         id="stop3255"
+         offset="0"
+         style="stop-color:#89d5f8;stop-opacity:1;" />
+      <stop
+         id="stop3257"
+         offset="1"
+         style="stop-color:#00899e;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6816">
+      <stop
+         id="stop6818"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop6820"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6781">
+      <stop
+         id="stop6783"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop6785"
+         offset="1"
+         style="stop-color:#3465a4;stop-opacity:0;" />
+    </linearGradient>
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1581633,0,0,0.6558985,-7.29237,16.126077)"
+       r="25.198714"
+       fy="51.929391"
+       fx="33.369828"
+       cy="51.929391"
+       cx="33.369828"
+       id="radialGradient6822"
+       xlink:href="#linearGradient6816" />
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9724373,-0.105657,5.0523169e-2,0.4650009,-0.3519546,9.5854384)"
+       r="27.986705"
+       fy="17.013988"
+       fx="18.417862"
+       cy="17.013988"
+       cx="18.417862"
+       id="radialGradient3259"
+       xlink:href="#linearGradient3253" />
+    <radialGradient
+       r="27.986705"
+       fy="17.013988"
+       fx="18.417862"
+       cy="17.013988"
+       cx="18.417862"
+       gradientTransform="matrix(0.9724373,-0.105657,0.05052317,0.4650009,-0.3519546,9.5854384)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3270"
+       xlink:href="#linearGradient3253" />
+  </defs>
+  <metadata
+     id="metadata6253">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Std_ViewDimetric</dc:title>
+        <dc:date>2020/12/10</dc:date>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[bitacovir]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:subject>
+          <rdf:Bag />
+        </dc:subject>
+        <dc:description />
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title></dc:title>
+          </cc:Agent>
+        </dc:contributor>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1">
+    <g
+       transform="matrix(-1,0,0,0.99363058,4,0.0382165)"
+       id="g3913-7" />
+    <path
+       id="path858"
+       d="M 5,17 32,5 59,17 V 47 L 32,59 5,47 Z"
+       style="fill:none;stroke:#042a2a;stroke-width:6;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="fill:none;stroke:#34e0e2;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 5,17 32,5 59,17 V 47 L 32,59 5,47 Z"
+       id="path858-8" />
+    <g
+       style="font-size:45.4849px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#34e0e2;stroke:#042a2a;stroke-width:2.274;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       id="text877"
+       aria-label="D">
+      <path
+         id="path850"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:37.3333px;font-family:Cambria;-inkscape-font-specification:Cambria;stroke-width:2.274;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+         d="M 21.928259,44.379818 V 43.48659 q 0.838541,-0.21875 1.203124,-0.419271 0.364583,-0.200521 0.565104,-0.510416 0.20052,-0.309896 0.291666,-0.893229 0.09115,-0.583332 0.09115,-1.841144 V 24.054314 q 0,-1.27604 -0.09115,-1.841144 -0.09115,-0.583333 -0.309896,-0.893228 -0.20052,-0.309896 -0.546874,-0.492187 -0.346354,-0.200521 -1.203124,-0.4375 v -0.893228 h 7.984368 q 3.44531,0 5.632808,0.765624 2.205727,0.747395 3.718747,2.223956 1.513019,1.476562 2.260414,3.682289 0.747396,2.187498 0.747396,5.231766 0,3.080727 -0.710937,5.432287 -0.692708,2.333332 -2.041665,3.919268 -1.166666,1.385415 -2.861977,2.278644 -1.403645,0.729166 -3.244789,1.039061 -1.841144,0.309896 -4.885412,0.309896 z m 5.559891,-1.695311 q 0.729166,0.07292 2.15104,0.07292 1.531249,0 2.734373,-0.255209 1.203124,-0.255208 2.187498,-0.802082 0.984374,-0.546875 1.768227,-1.51302 0.783854,-0.984374 1.276041,-2.242185 0.492187,-1.276041 0.710937,-2.825519 0.236979,-1.549478 0.236979,-3.390622 0,-3.700518 -1.07552,-6.070307 -1.057291,-2.388019 -3.00781,-3.481768 -1.93229,-1.093749 -4.630204,-1.093749 -1.239583,0 -2.351561,0.07292 z" />
+    </g>
+  </g>
+</svg>

--- a/src/Gui/Icons/Std_ViewHome.svg
+++ b/src/Gui/Icons/Std_ViewHome.svg
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.1"
+   id="svg6248"
+   height="64px"
+   width="64px">
+  <title
+     id="title856">Std_ViewHome</title>
+  <defs
+     id="defs6250">
+    <linearGradient
+       id="linearGradient3253">
+      <stop
+         id="stop3255"
+         offset="0"
+         style="stop-color:#89d5f8;stop-opacity:1;" />
+      <stop
+         id="stop3257"
+         offset="1"
+         style="stop-color:#00899e;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6816">
+      <stop
+         id="stop6818"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop6820"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6781">
+      <stop
+         id="stop6783"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop6785"
+         offset="1"
+         style="stop-color:#3465a4;stop-opacity:0;" />
+    </linearGradient>
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1581633,0,0,0.6558985,-7.29237,16.126077)"
+       r="25.198714"
+       fy="51.929391"
+       fx="33.369828"
+       cy="51.929391"
+       cx="33.369828"
+       id="radialGradient6822"
+       xlink:href="#linearGradient6816" />
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9724373,-0.105657,5.0523169e-2,0.4650009,-0.3519546,9.5854384)"
+       r="27.986705"
+       fy="17.013988"
+       fx="18.417862"
+       cy="17.013988"
+       cx="18.417862"
+       id="radialGradient3259"
+       xlink:href="#linearGradient3253" />
+    <radialGradient
+       r="27.986705"
+       fy="17.013988"
+       fx="18.417862"
+       cy="17.013988"
+       cx="18.417862"
+       gradientTransform="matrix(0.9724373,-0.105657,0.05052317,0.4650009,-0.3519546,9.5854384)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3270"
+       xlink:href="#linearGradient3253" />
+  </defs>
+  <metadata
+     id="metadata6253">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Std_ViewHome</dc:title>
+        <dc:date>2020/12/15</dc:date>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[bitacovir]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:subject>
+          <rdf:Bag />
+        </dc:subject>
+        <dc:description />
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title></dc:title>
+          </cc:Agent>
+        </dc:contributor>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1">
+    <g
+       transform="matrix(-1,0,0,0.99363058,4,0.0382165)"
+       id="g3913-7" />
+    <path
+       id="path858"
+       d="M 40,29 V 54 H 59 V 17 L 32,5 5,17 V 54 H 24 V 29 Z"
+       style="fill:none;stroke:#042a2a;stroke-width:6;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="fill:none;stroke:#34e0e2;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 40,54 H 59 V 17 L 32,5 5,17 V 54 H 24 V 29 h 16 z"
+       id="path858-8" />
+  </g>
+</svg>

--- a/src/Gui/Icons/Std_ViewTrimetric.svg
+++ b/src/Gui/Icons/Std_ViewTrimetric.svg
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.1"
+   id="svg6248"
+   height="64px"
+   width="64px">
+  <title
+     id="title856">Std_ViewTrimetric</title>
+  <defs
+     id="defs6250">
+    <linearGradient
+       id="linearGradient3253">
+      <stop
+         id="stop3255"
+         offset="0"
+         style="stop-color:#89d5f8;stop-opacity:1;" />
+      <stop
+         id="stop3257"
+         offset="1"
+         style="stop-color:#00899e;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6816">
+      <stop
+         id="stop6818"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop6820"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6781">
+      <stop
+         id="stop6783"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop6785"
+         offset="1"
+         style="stop-color:#3465a4;stop-opacity:0;" />
+    </linearGradient>
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1581633,0,0,0.6558985,-7.29237,16.126077)"
+       r="25.198714"
+       fy="51.929391"
+       fx="33.369828"
+       cy="51.929391"
+       cx="33.369828"
+       id="radialGradient6822"
+       xlink:href="#linearGradient6816" />
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9724373,-0.105657,5.0523169e-2,0.4650009,-0.3519546,9.5854384)"
+       r="27.986705"
+       fy="17.013988"
+       fx="18.417862"
+       cy="17.013988"
+       cx="18.417862"
+       id="radialGradient3259"
+       xlink:href="#linearGradient3253" />
+    <radialGradient
+       r="27.986705"
+       fy="17.013988"
+       fx="18.417862"
+       cy="17.013988"
+       cx="18.417862"
+       gradientTransform="matrix(0.9724373,-0.105657,0.05052317,0.4650009,-0.3519546,9.5854384)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3270"
+       xlink:href="#linearGradient3253" />
+  </defs>
+  <metadata
+     id="metadata6253">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Std_ViewTrimetric</dc:title>
+        <dc:date>2020/12/10</dc:date>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[bitacovir]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:subject>
+          <rdf:Bag />
+        </dc:subject>
+        <dc:description />
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title></dc:title>
+          </cc:Agent>
+        </dc:contributor>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1">
+    <g
+       transform="matrix(-1,0,0,0.99363058,4,0.0382165)"
+       id="g3913-7" />
+    <path
+       id="path858"
+       d="M 5,17 32,5 59,17 V 47 L 32,59 5,47 Z"
+       style="fill:none;stroke:#042a2a;stroke-width:6;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="fill:none;stroke:#34e0e2;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 5,17 32,5 59,17 V 47 L 32,59 5,47 Z"
+       id="path858-8" />
+    <g
+       style="font-size:37.3333px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#34e0e2;stroke:#042a2a;stroke-width:2.274;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       id="text877"
+       aria-label="T">
+      <path
+         id="path850"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:37.3333px;font-family:Cambria;-inkscape-font-specification:Cambria;stroke-width:2.274;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+         d="m 22.229531,19.882719 h 19.723942 v 6.343745 h -1.786457 q -0.401041,-1.567707 -0.802083,-2.479165 -0.382812,-0.911457 -0.820312,-1.385415 -0.437499,-0.473958 -0.947915,-0.674479 -0.492187,-0.20052 -1.494791,-0.20052 h -2.315102 v 18.66665 q 0,1.07552 0.109375,1.713541 0.127604,0.63802 0.364583,1.020832 0.255208,0.364583 0.674479,0.583333 0.41927,0.20052 1.312498,0.401041 v 0.893229 h -8.330722 v -0.893229 q 0.546875,-0.127604 0.966145,-0.273437 0.419271,-0.145833 0.674479,-0.346354 0.273437,-0.21875 0.4375,-0.546875 0.182291,-0.328124 0.273437,-0.893228 0.109375,-0.565104 0.109375,-1.658853 v -18.66665 h -2.296873 q -0.85677,0 -1.421874,0.164062 -0.546875,0.164062 -1.020833,0.692708 -0.473957,0.510416 -0.874999,1.476561 -0.382812,0.947916 -0.729166,2.406248 h -1.804686 z" />
+    </g>
+  </g>
+</svg>

--- a/src/Gui/Icons/resource.qrc
+++ b/src/Gui/Icons/resource.qrc
@@ -141,6 +141,7 @@
         <file>DrawStyleHiddenLine.svg</file>
         <file>DrawStyleNoShading.svg</file>
         <file>user.svg</file>
+        <file>Std_AxisCross.svg</file>
         <file>Std_CoordinateSystem.svg</file>
         <file>Std_CoordinateSystem_alt.svg</file>
         <file>Std_Placement.svg</file>
@@ -158,11 +159,15 @@
         <file>Std_Import.svg</file>
         <file>Std_MergeProjects.svg</file>
         <file>Std_PrintPdf.svg</file>
+        <file>Std_RandomColor.svg</file>
         <file>Std_RecentFiles.svg</file>
         <file>Std_Revert.svg</file>
         <file>Std_SaveAll.svg</file>
         <file>Std_SaveCopy.svg</file>
         <file>Std_SetAppearance.svg</file>
+        <file>Std_TextureMapping.svg</file>
+        <file>Std_ToggleClipPlane.svg</file>
+        <file>Std_ToggleNavigation.svg</file>
         <file>Std_Tool1.svg</file>
         <file>Std_Tool2.svg</file>
         <file>Std_Tool3.svg</file>
@@ -175,11 +180,14 @@
         <file>Std_Tool10.svg</file>
         <file>Std_Tool11.svg</file>
         <file>Std_Tool12.svg</file>
+        <file>Std_ViewDimetric.svg</file>
+        <file>Std_ViewHome.svg</file>
         <file>Std_ViewIvStereoInterleavedColumns.svg</file>
         <file>Std_ViewIvStereoInterleavedRows.svg</file>
         <file>Std_ViewIvStereoOff.svg</file>
         <file>Std_ViewIvStereoQuadBuff.svg</file>
         <file>Std_ViewIvStereoRedGreen.svg</file>
+        <file>Std_ViewTrimetric.svg</file>
         <file>Std_WindowCascade.svg</file>
         <file>Std_WindowNext.svg</file>
         <file>Std_WindowPrev.svg</file>


### PR DESCRIPTION
Eight  Std View Menu commands don't have icons in the FreeCAD UI.

This commit adds 8 SVG files with icons for these commands. Also, it makes the necessary changes on CommandView.cpp CommandFeat.cpp and resource.qrc files.

The new SVG icons follow the FreeCAD Artwork Guidelines and were saved as Plain SVG format.

Forum Discussion: https://forum.freecadweb.org/viewtopic.php?f=34&t=53119