### PR TITLE
Fix Qt deprecation warnings. 

### DIFF
--- a/src/Gui/GraphvizView.cpp
+++ b/src/Gui/GraphvizView.cpp
@@ -461,7 +461,11 @@ void GraphvizView::print()
 {
     QPrinter printer(QPrinter::HighResolution);
     printer.setFullPage(true);
+#if QT_VERSION >= 0x050300
+    printer.setPageOrientation(QPageLayout::Landscape);
+#else
     printer.setOrientation(QPrinter::Landscape);
+#endif
     QPrintDialog dlg(&printer, this);
     if (dlg.exec() == QDialog::Accepted) {
         print(&printer);
@@ -491,7 +495,11 @@ void GraphvizView::printPreview()
 {
     QPrinter printer(QPrinter::HighResolution);
     printer.setFullPage(true);
+#if QT_VERSION >= 0x050300
+    printer.setPageOrientation(QPageLayout::Landscape);
+#else
     printer.setOrientation(QPrinter::Landscape);
+#endif
 
     QPrintPreviewDialog dlg(&printer, this);
     connect(&dlg, SIGNAL(paintRequested (QPrinter *)),

--- a/src/Gui/View3DInventor.cpp
+++ b/src/Gui/View3DInventor.cpp
@@ -516,7 +516,11 @@ void View3DInventor::printPreview()
 #if (QT_VERSION > QT_VERSION_CHECK(5, 9, 0))
     printer.setPageSize(QPrinter::A4);
 #endif
+#if QT_VERSION >= 0x050300
+    printer.setPageOrientation(QPageLayout::Landscape);
+#else
     printer.setOrientation(QPrinter::Landscape);
+#endif
 
     QPrintPreviewDialog dlg(&printer, this);
     connect(&dlg, SIGNAL(paintRequested (QPrinter *)),

--- a/src/Mod/Drawing/Gui/DrawingView.cpp
+++ b/src/Mod/Drawing/Gui/DrawingView.cpp
@@ -258,8 +258,11 @@ DrawingView::DrawingView(Gui::Document* doc, QWidget* parent)
 
     setCentralWidget(m_view);
     //setWindowTitle(tr("SVG Viewer"));
-
+#if QT_VERSION >= 0x050300
+    m_orientation = QPageLayout::Landscape;
+#else
     m_orientation = QPrinter::Landscape;
+#endif
     m_pageSize = QPrinter::A4;
 
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath
@@ -302,10 +305,18 @@ void DrawingView::load (const QString & fileName)
 void DrawingView::findPrinterSettings(const QString& fileName)
 {
     if (fileName.indexOf(QLatin1String("Portrait"), Qt::CaseInsensitive) >= 0) {
+#if QT_VERSION >= 0x050300
+        m_orientation = QPageLayout::Portrait;
+#else
         m_orientation = QPrinter::Portrait;
+#endif
     }
     else {
+#if QT_VERSION >= 0x050300
+        m_orientation = QPageLayout::Landscape;
+#else
         m_orientation = QPrinter::Landscape;
+#endif
     }
 
     QMap<QPrinter::PageSize, QString> pageSizes;
@@ -517,7 +528,11 @@ void DrawingView::printPdf()
         printer.setFullPage(true);
         printer.setOutputFormat(QPrinter::PdfFormat);
         printer.setOutputFileName(filename);
+#if QT_VERSION >= 0x050300
+        printer.setPageOrientation(m_orientation);
+#else
         printer.setOrientation(m_orientation);
+#endif
         QList<QListWidgetItem*> items = listWidget->selectedItems();
         if (items.size() == 1) {
             int AX = items.front()->data(Qt::UserRole).toInt();
@@ -533,7 +548,11 @@ void DrawingView::print()
     QPrinter printer(QPrinter::HighResolution);
     printer.setFullPage(true);
     printer.setPageSize(m_pageSize);
+#if QT_VERSION >= 0x050300
+    printer.setPageOrientation(m_orientation);
+#else
     printer.setOrientation(m_orientation);
+#endif
 
     QPrintDialog dlg(&printer, this);
     if (dlg.exec() == QDialog::Accepted) {
@@ -546,7 +565,11 @@ void DrawingView::printPreview()
     QPrinter printer(QPrinter::HighResolution);
     printer.setFullPage(true);
     printer.setPageSize(m_pageSize);
+#if QT_VERSION >= 0x050300
+    printer.setPageOrientation(m_orientation);
+#else
     printer.setOrientation(m_orientation);
+#endif
 
     QPrintPreviewDialog dlg(&printer, this);
     connect(&dlg, SIGNAL(paintRequested (QPrinter *)),
@@ -578,7 +601,11 @@ void DrawingView::print(QPrinter* printer)
         // care if it uses wrong printer settings
         bool doPrint = paintType != QPaintEngine::Picture;
 
+#if QT_VERSION >= 0x050300
+        if (doPrint && printer->pageLayout().orientation() != this->m_orientation) {
+#else
         if (doPrint && printer->orientation() != this->m_orientation) {
+#endif
             int ret = QMessageBox::warning(this, tr("Different orientation"),
                 tr("The printer uses a different orientation than the drawing.\n"
                    "Do you want to continue?"),

--- a/src/Mod/Drawing/Gui/DrawingView.h
+++ b/src/Mod/Drawing/Gui/DrawingView.h
@@ -121,7 +121,11 @@ private:
     std::string m_objectName;
 
     QString m_currentPath;
+#if QT_VERSION >= 0x050300
+    QPageLayout::Orientation m_orientation;
+#else
     QPrinter::Orientation m_orientation;
+#endif
     QPrinter::PageSize m_pageSize;
 };
 

--- a/src/Mod/TechDraw/Gui/MDIViewPage.cpp
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.cpp
@@ -117,7 +117,11 @@ TYPESYSTEM_SOURCE_ABSTRACT(TechDrawGui::MDIViewPage, Gui::MDIView)
 
 MDIViewPage::MDIViewPage(ViewProviderPage *pageVp, Gui::Document* doc, QWidget* parent)
   : Gui::MDIView(doc, parent),
+#if QT_VERSION >= 0x050300
+    m_orientation(QPageLayout::Landscape),
+#else
     m_orientation(QPrinter::Landscape),
+#endif
     m_paperSize(QPrinter::A4),
     m_vpPage(pageVp)
 {
@@ -311,9 +315,17 @@ void MDIViewPage::attachTemplate(TechDraw::DrawTemplate *obj)
     double height =  obj->Height.getValue();
     m_paperSize = getPaperSize(int(round(width)),int(round(height)));
     if (width > height) {
+#if QT_VERSION >= 0x050300
+        m_orientation = QPageLayout::Landscape;
+#else
         m_orientation = QPrinter::Landscape;
+#endif
     } else {
+#if QT_VERSION >= 0x050300
+        m_orientation = QPageLayout::Portrait;
+#else
         m_orientation = QPrinter::Portrait;
+#endif
     }
 }
 
@@ -664,9 +676,17 @@ void MDIViewPage::printPdf(std::string file)
     printer.setFullPage(true);
     printer.setOutputFileName(filename);
     if (m_paperSize == QPrinter::Ledger)  {
+#if QT_VERSION >= 0x050300
+        printer.setPageOrientation((QPageLayout::Orientation) (1 - m_orientation));  //reverse 0/1
+#else
         printer.setOrientation((QPrinter::Orientation) (1 - m_orientation));  //reverse 0/1
+#endif
     } else {
+#if QT_VERSION >= 0x050300
+        printer.setPageOrientation(m_orientation);
+#else
         printer.setOrientation(m_orientation);
+#endif
     }
     printer.setPaperSize(m_paperSize);
     print(&printer);
@@ -677,7 +697,11 @@ void MDIViewPage::print()
     QPrinter printer(QPrinter::HighResolution);
     printer.setFullPage(true);
     printer.setPaperSize(m_paperSize);
+#if QT_VERSION >= 0x050300
+    printer.setPageOrientation(m_orientation);
+#else
     printer.setOrientation(m_orientation);
+#endif
     QPrintDialog dlg(&printer, this);
     if (dlg.exec() == QDialog::Accepted) {
         print(&printer);
@@ -689,7 +713,11 @@ void MDIViewPage::printPreview()
     QPrinter printer(QPrinter::HighResolution);
     printer.setFullPage(true);
     printer.setPaperSize(m_paperSize);
+#if QT_VERSION >= 0x050300
+    printer.setPageOrientation(m_orientation);
+#else
     printer.setOrientation(m_orientation);
+#endif
 
     QPrintPreviewDialog dlg(&printer, this);
     connect(&dlg, SIGNAL(paintRequested (QPrinter *)),
@@ -722,7 +750,11 @@ void MDIViewPage::print(QPrinter* printer)
         // care if it uses wrong printer settings
         bool doPrint = paintType != QPaintEngine::Picture;
 
+#if QT_VERSION >= 0x050300
+        if (doPrint && printer->pageLayout().orientation() != m_orientation) {
+#else
         if (doPrint && printer->orientation() != m_orientation) {
+#endif
             int ret = QMessageBox::warning(this, tr("Different orientation"),
                 tr("The printer uses a different orientation  than the drawing.\n"
                    "Do you want to continue?"),

--- a/src/Mod/TechDraw/Gui/MDIViewPage.h
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.h
@@ -159,7 +159,11 @@ private:
     QTimer *m_timer;
 
     QString m_currentPath;
+#if QT_VERSION >= 0x050300
+    QPageLayout::Orientation m_orientation;
+#else
     QPrinter::Orientation m_orientation;
+#endif
     QPrinter::PaperSize m_paperSize;
     ViewProviderPage *m_vpPage;
 


### PR DESCRIPTION
QPrinter::orientation() and QPrinter::setOrientation() are obsolete.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---

Cheers,
Mateusz