### PR TITLE
Draft: change in default Draft.makeCopy

### DIFF
--- a/src/Mod/Draft/draftmake/make_copy.py
+++ b/src/Mod/Draft/draftmake/make_copy.py
@@ -59,12 +59,18 @@ def make_copy(obj, force=None, reparent=False, simple_copy=False):
     newobj = None
 
     if simple_copy and hasattr(obj, 'Shape'):
+        # this was the old implementation that is actyally not used by default
         _name = utils.get_real_name(obj.Name)
         newobj = App.ActiveDocument.addObject("Part::Feature", _name)
         newobj.Shape = obj.Shape
         gui_utils.format_object(newobj, obj)
     elif not simple_copy:
-        newobj = App.ActiveDocument.copyObject(obj)
+        # this is the new implementation using doc.copyObject API
+        if obj.hasExtension("App::OriginGroupExtension"):
+            # always copy with dependencies when copying App::Part and PartDesign::Body
+            newobj = App.ActiveDocument.copyObject(obj, True)
+        else:
+            newobj = App.ActiveDocument.copyObject(obj)
 
     if not newobj:
         return None


### PR DESCRIPTION
always copy with dependencies when copying App::Part and PartDesign::Body

https://forum.freecadweb.org/viewtopic.php?f=23&t=53940&p=463601#p463601
https://forum.freecadweb.org/viewtopic.php?f=3&t=49753&start=10
.

