### PR TITLE
Fix Qt deprecation warnings.

### DIFF
--- a/src/Gui/View3DInventor.cpp
+++ b/src/Gui/View3DInventor.cpp
@@ -513,12 +513,11 @@ void View3DInventor::printPreview()
 {
     QPrinter printer(QPrinter::ScreenResolution);
     printer.setFullPage(true);
-#if (QT_VERSION > QT_VERSION_CHECK(5, 9, 0))
-    printer.setPageSize(QPrinter::A4);
-#endif
 #if QT_VERSION >= 0x050300
+    printer.setPageSize(QPageSize(QPageSize::A4));
     printer.setPageOrientation(QPageLayout::Landscape);
 #else
+    printer.setPageSize(QPrinter::A4);
     printer.setOrientation(QPrinter::Landscape);
 #endif
 

--- a/src/Mod/Drawing/Gui/DrawingView.cpp
+++ b/src/Mod/Drawing/Gui/DrawingView.cpp
@@ -260,10 +260,11 @@ DrawingView::DrawingView(Gui::Document* doc, QWidget* parent)
     //setWindowTitle(tr("SVG Viewer"));
 #if QT_VERSION >= 0x050300
     m_orientation = QPageLayout::Landscape;
+    m_pageSize = QPageSize::A4;
 #else
     m_orientation = QPrinter::Landscape;
-#endif
     m_pageSize = QPrinter::A4;
+#endif
 
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath
             ("User parameter:BaseApp/Preferences/View");
@@ -319,6 +320,29 @@ void DrawingView::findPrinterSettings(const QString& fileName)
 #endif
     }
 
+#if QT_VERSION >= 0x050300
+    QMap<QPageSize::PageSizeId, QString> pageSizes;
+    pageSizes[QPageSize::A0] = QString::fromLatin1("A0");
+    pageSizes[QPageSize::A1] = QString::fromLatin1("A1");
+    pageSizes[QPageSize::A2] = QString::fromLatin1("A2");
+    pageSizes[QPageSize::A3] = QString::fromLatin1("A3");
+    pageSizes[QPageSize::A4] = QString::fromLatin1("A4");
+    pageSizes[QPageSize::A5] = QString::fromLatin1("A5");
+    pageSizes[QPageSize::A6] = QString::fromLatin1("A6");
+    pageSizes[QPageSize::A7] = QString::fromLatin1("A7");
+    pageSizes[QPageSize::A8] = QString::fromLatin1("A8");
+    pageSizes[QPageSize::A9] = QString::fromLatin1("A9");
+    pageSizes[QPageSize::B0] = QString::fromLatin1("B0");
+    pageSizes[QPageSize::B1] = QString::fromLatin1("B1");
+    pageSizes[QPageSize::B2] = QString::fromLatin1("B2");
+    pageSizes[QPageSize::B3] = QString::fromLatin1("B3");
+    pageSizes[QPageSize::B4] = QString::fromLatin1("B4");
+    pageSizes[QPageSize::B5] = QString::fromLatin1("B5");
+    pageSizes[QPageSize::B6] = QString::fromLatin1("B6");
+    pageSizes[QPageSize::B7] = QString::fromLatin1("B7");
+    pageSizes[QPageSize::B8] = QString::fromLatin1("B8");
+    pageSizes[QPageSize::B9] = QString::fromLatin1("B9");
+#else
     QMap<QPrinter::PageSize, QString> pageSizes;
     pageSizes[QPrinter::A0] = QString::fromLatin1("A0");
     pageSizes[QPrinter::A1] = QString::fromLatin1("A1");
@@ -340,7 +364,12 @@ void DrawingView::findPrinterSettings(const QString& fileName)
     pageSizes[QPrinter::B7] = QString::fromLatin1("B7");
     pageSizes[QPrinter::B8] = QString::fromLatin1("B8");
     pageSizes[QPrinter::B9] = QString::fromLatin1("B9");
+#endif
+#if QT_VERSION >= 0x050300
+    for (QMap<QPageSize::PageSizeId, QString>::iterator it = pageSizes.begin(); it != pageSizes.end(); ++it) {
+#else
     for (QMap<QPrinter::PageSize, QString>::iterator it = pageSizes.begin(); it != pageSizes.end(); ++it) {
+#endif
         if (fileName.startsWith(it.value(), Qt::CaseInsensitive)) {
             m_pageSize = it.key();
             break;
@@ -499,6 +528,20 @@ void DrawingView::printPdf()
     formLayout->addWidget(groupBox, 0, 0, 1, 1);
 
     groupBox->setTitle(tr("Page sizes"));
+#if QT_VERSION >= 0x050300
+    item = new QListWidgetItem(tr("A0"), listWidget);
+    item->setData(Qt::UserRole, QVariant(QPageSize::A0));
+    item = new QListWidgetItem(tr("A1"), listWidget);
+    item->setData(Qt::UserRole, QVariant(QPageSize::A1));
+    item = new QListWidgetItem(tr("A2"), listWidget);
+    item->setData(Qt::UserRole, QVariant(QPageSize::A2));
+    item = new QListWidgetItem(tr("A3"), listWidget);
+    item->setData(Qt::UserRole, QVariant(QPageSize::A3));
+    item = new QListWidgetItem(tr("A4"), listWidget);
+    item->setData(Qt::UserRole, QVariant(QPageSize::A4));
+    item = new QListWidgetItem(tr("A5"), listWidget);
+    item->setData(Qt::UserRole, QVariant(QPageSize::A5));
+#else
     item = new QListWidgetItem(tr("A0"), listWidget);
     item->setData(Qt::UserRole, QVariant(QPrinter::A0));
     item = new QListWidgetItem(tr("A1"), listWidget);
@@ -511,6 +554,7 @@ void DrawingView::printPdf()
     item->setData(Qt::UserRole, QVariant(QPrinter::A4));
     item = new QListWidgetItem(tr("A5"), listWidget);
     item->setData(Qt::UserRole, QVariant(QPrinter::A5));
+#endif
     int index = 4; // by default A4
     for (int i=0; i<listWidget->count(); i++) {
         if (listWidget->item(i)->data(Qt::UserRole).toInt() == m_pageSize) {
@@ -536,7 +580,11 @@ void DrawingView::printPdf()
         QList<QListWidgetItem*> items = listWidget->selectedItems();
         if (items.size() == 1) {
             int AX = items.front()->data(Qt::UserRole).toInt();
+#if QT_VERSION >= 0x050300
+            printer.setPageSize(QPageSize(QPageSize::PageSizeId(AX)));
+#else
             printer.setPaperSize(QPrinter::PageSize(AX));
+#endif
         }
 
         print(&printer);
@@ -547,10 +595,12 @@ void DrawingView::print()
 {
     QPrinter printer(QPrinter::HighResolution);
     printer.setFullPage(true);
-    printer.setPageSize(m_pageSize);
+
 #if QT_VERSION >= 0x050300
+    printer.setPageSize(QPageSize(m_pageSize));
     printer.setPageOrientation(m_orientation);
 #else
+    printer.setPageSize(m_pageSize);
     printer.setOrientation(m_orientation);
 #endif
 
@@ -564,10 +614,12 @@ void DrawingView::printPreview()
 {
     QPrinter printer(QPrinter::HighResolution);
     printer.setFullPage(true);
-    printer.setPageSize(m_pageSize);
+
 #if QT_VERSION >= 0x050300
+    printer.setPageSize(QPageSize(m_pageSize));
     printer.setPageOrientation(m_orientation);
 #else
+    printer.setPageSize(m_pageSize);
     printer.setOrientation(m_orientation);
 #endif
 
@@ -594,8 +646,13 @@ void DrawingView::print(QPrinter* printer)
     if (printer->outputFormat() == QPrinter::NativeFormat) {
         int w = printer->widthMM();
         int h = printer->heightMM();
+#if QT_VERSION >= 0x050300
+        QPageSize::PageSizeId realPaperSize = getPageSize(w, h);
+        QPageSize::PageSizeId curPaperSize = printer->pageLayout().pageSize().id();
+#else
         QPrinter::PaperSize realPaperSize = getPageSize(w, h);
         QPrinter::PaperSize curPaperSize = printer->paperSize();
+#endif
 
         // for the preview a 'Picture' paint engine is used which we don't
         // care if it uses wrong printer settings
@@ -658,7 +715,11 @@ void DrawingView::print(QPrinter* printer)
     p.end();
 }
 
+#if QT_VERSION >= 0x050300
+QPageSize::PageSizeId DrawingView::getPageSize(int w, int h) const
+#else
 QPrinter::PageSize DrawingView::getPageSize(int w, int h) const
+#endif
 {
     static const float paperSizes[][2] = {
         {210, 297}, // A4
@@ -693,17 +754,29 @@ QPrinter::PageSize DrawingView::getPageSize(int w, int h) const
         {279.4f, 431.8f} // Tabloid
     };
 
+#if QT_VERSION >= 0x050300
+    QPageSize::PageSizeId ps = QPageSize::Custom;
+#else
     QPrinter::PageSize ps = QPrinter::Custom;
+#endif
     for (int i=0; i<30; i++) {
         if (std::abs(paperSizes[i][0]-w) <= 1 &&
             std::abs(paperSizes[i][1]-h) <= 1) {
+#if QT_VERSION >= 0x050300
+            ps = static_cast<QPageSize::PageSizeId>(i);
+#else
             ps = static_cast<QPrinter::PageSize>(i);
+#endif
             break;
         }
         else
         if (std::abs(paperSizes[i][0]-h) <= 1 &&
             std::abs(paperSizes[i][1]-w) <= 1) {
+#if QT_VERSION >= 0x050300
+            ps = static_cast<QPageSize::PageSizeId>(i);
+#else
             ps = static_cast<QPrinter::PageSize>(i);
+#endif
             break;
         }
     }

--- a/src/Mod/Drawing/Gui/DrawingView.h
+++ b/src/Mod/Drawing/Gui/DrawingView.h
@@ -107,7 +107,11 @@ protected:
     void contextMenuEvent(QContextMenuEvent *event);
     void closeEvent(QCloseEvent*);
     void findPrinterSettings(const QString&);
+#if QT_VERSION >= 0x050300
+    QPageSize::PageSizeId getPageSize(int w, int h) const;
+#else
     QPrinter::PageSize getPageSize(int w, int h) const;
+#endif
 
 private:
     QAction *m_nativeAction;
@@ -123,10 +127,11 @@ private:
     QString m_currentPath;
 #if QT_VERSION >= 0x050300
     QPageLayout::Orientation m_orientation;
+    QPageSize::PageSizeId m_pageSize;
 #else
     QPrinter::Orientation m_orientation;
-#endif
     QPrinter::PageSize m_pageSize;
+#endif
 };
 
 } // namespace DrawingViewGui

--- a/src/Mod/TechDraw/Gui/MDIViewPage.h
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.h
@@ -128,7 +128,12 @@ protected:
 
     void contextMenuEvent(QContextMenuEvent *event);
     void closeEvent(QCloseEvent*);
+#if QT_VERSION >= 0x050300
+    QPageSize::PageSizeId getPaperSize(int w, int h) const;
+#else
     QPrinter::PaperSize getPaperSize(int w, int h) const;
+#endif
+
     void setDimensionGroups(void);
     void setBalloonGroups(void);
     void setLeaderGroups(void);
@@ -161,10 +166,11 @@ private:
     QString m_currentPath;
 #if QT_VERSION >= 0x050300
     QPageLayout::Orientation m_orientation;
+    QPageSize::PageSizeId m_paperSize;
 #else
     QPrinter::Orientation m_orientation;
-#endif
     QPrinter::PaperSize m_paperSize;
+#endif
     ViewProviderPage *m_vpPage;
 
     QList<QGraphicsItem*> m_qgSceneSelected;        //items in selection order


### PR DESCRIPTION
QPrinter::paperSize() and QPrinter::setPaperSize() are obsolete.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---

Cheers,
Mateusz