### PR TITLE
Gui: fix potential external edit reset crash

### DIFF
--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -477,8 +477,10 @@ void Document::_resetEdit(void)
         // the editing object gets deleted inside the above call to
         // 'finishEditing()', which will trigger our slotDeletedObject(), which
         // nullifies _editViewProvider.
-        if (d->_editViewProvider && d->_editViewProvider->isDerivedFrom(ViewProviderDocumentObject::getClassTypeId()))
-            signalResetEdit(*(static_cast<ViewProviderDocumentObject*>(d->_editViewProvider)));
+        if (d->_editViewProvider && d->_editViewProvider->isDerivedFrom(ViewProviderDocumentObject::getClassTypeId())) {
+            auto vpd = static_cast<ViewProviderDocumentObject*>(d->_editViewProvider);
+            vpd->getDocument()->signalResetEdit(*vpd);
+        }
         d->_editViewProvider = 0;
 
         // The logic below is not necessary anymore, because this method is


### PR DESCRIPTION
The crash is reported at https://forum.freecadweb.org/viewtopic.php?f=19&t=52221&start=50#p460591

The crash is triggered by assertion failure in DAG view, because it cannot find the editing object. The root cause is because it is an external linked object, so the editing document (which is the owner of the top parent object) is different from the owner document of the editing object. This PR makes sure to use the owner document of the editing object to fire the signal.