### PR TITLE
[Sketcher] Colorful status flags and other Sketcher improvements

### DIFF
--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -4670,6 +4670,8 @@ void DocumentObjectItem::testStatus(bool resetStatus, QIcon &icon1, QIcon &icon2
 
         icon.addPixmap(pxOn, QIcon::Normal, QIcon::On);
         icon.addPixmap(pxOff, QIcon::Normal, QIcon::Off);
+
+        icon = object()->mergeColorfulOverlayIcons(icon);
     }
 
 

--- a/src/Gui/ViewProvider.cpp
+++ b/src/Gui/ViewProvider.cpp
@@ -302,10 +302,10 @@ void ViewProvider::update(const App::Property* prop)
 
 QIcon ViewProvider::getIcon(void) const
 {
-    return mergeOverlayIcons (Gui::BitmapFactory().pixmap(sPixmap));
+    return mergeGreyableOverlayIcons (Gui::BitmapFactory().pixmap(sPixmap));
 }
 
-QIcon ViewProvider::mergeOverlayIcons (const QIcon & orig) const
+QIcon ViewProvider::mergeGreyableOverlayIcons (const QIcon & orig) const
 {
     auto vector = getExtensionsDerivedFromType<Gui::ViewProviderExtension>();
 
@@ -313,7 +313,21 @@ QIcon ViewProvider::mergeOverlayIcons (const QIcon & orig) const
 
     for (Gui::ViewProviderExtension* ext : vector) {
         if (!ext->ignoreOverlayIcon())
-            overlayedIcon = ext->extensionMergeOverlayIcons(overlayedIcon);
+            overlayedIcon = ext->extensionMergeGreyableOverlayIcons(overlayedIcon);
+    }
+
+    return overlayedIcon;
+}
+
+QIcon ViewProvider::mergeColorfulOverlayIcons (const QIcon & orig) const
+{
+    auto vector = getExtensionsDerivedFromType<Gui::ViewProviderExtension>();
+
+    QIcon overlayedIcon = orig;
+
+    for (Gui::ViewProviderExtension* ext : vector) {
+        if (!ext->ignoreOverlayIcon())
+            overlayedIcon = ext->extensionMergeColorfullOverlayIcons(overlayedIcon);
     }
 
     return overlayedIcon;

--- a/src/Gui/ViewProvider.h
+++ b/src/Gui/ViewProvider.h
@@ -237,11 +237,19 @@ public:
     /** @name Methods used by the Tree
       * If you want to take control over the
       * appearance of your object in the tree you
-      * can reimplemnt these methods.
+      * can reimplement these methods.
      */
     //@{
     /// deliver the icon shown in the tree view
     virtual QIcon getIcon(void) const;
+
+     /** @name Methods used by the Tree
+     * If you want to take control over the
+     * viewprovider specific overlay icons that will be drawn with color
+     * regardless of whether the icon is greyed out or not, such as status, you
+     * can reimplement this method.
+     */
+    virtual QIcon mergeColorfulOverlayIcons (const QIcon & orig) const;
 
     /** deliver the children belonging to this object
       * this method is used to deliver the objects to
@@ -530,13 +538,12 @@ protected:
     /// Reimplemented from subclass
     void onChanged(const App::Property* prop);
 
-
     /** @name Methods used by the Tree
      * If you want to take control over the
-     * viewprovider specific overlay icons, such as status, you
-     * can reimplement this method.
+     * viewprovider specific overlay icons, that will be grayed out together
+     * with the base icon, you can reimplement this method.
      */
-    virtual QIcon mergeOverlayIcons (const QIcon & orig) const;
+    virtual QIcon mergeGreyableOverlayIcons (const QIcon & orig) const;
 
     /// Turn on mode switch
     virtual void setModeSwitch();

--- a/src/Gui/ViewProviderDocumentObjectGroup.cpp
+++ b/src/Gui/ViewProviderDocumentObjectGroup.cpp
@@ -80,7 +80,7 @@ bool ViewProviderDocumentObjectGroup::isShow(void) const
 
 QIcon ViewProviderDocumentObjectGroup::getIcon(void) const
 {
-    return mergeOverlayIcons (Gui::BitmapFactory().iconFromTheme(sPixmap));
+    return mergeGreyableOverlayIcons (Gui::BitmapFactory().iconFromTheme(sPixmap));
 }
 
 /**

--- a/src/Gui/ViewProviderExtension.h
+++ b/src/Gui/ViewProviderExtension.h
@@ -101,7 +101,8 @@ public:
     bool ignoreOverlayIcon() const {
         return m_ignoreOverlayIcon;
     }
-    virtual QIcon extensionMergeOverlayIcons(const QIcon & orig) const {return orig;}
+    virtual QIcon extensionMergeGreyableOverlayIcons(const QIcon & orig) const {return orig;}
+    virtual QIcon extensionMergeColorfullOverlayIcons(const QIcon & orig) const {return orig;}
 
     virtual void extensionStartRestoring() {}
     virtual void extensionFinishRestoring() {}

--- a/src/Gui/ViewProviderPythonFeature.h
+++ b/src/Gui/ViewProviderPythonFeature.h
@@ -212,7 +212,7 @@ public:
         if (icon.isNull())
             icon = ViewProviderT::getIcon();
         else
-            icon = ViewProviderT::mergeOverlayIcons(icon);
+            icon = ViewProviderT::mergeGreyableOverlayIcons(icon);
         return icon;
     }
 

--- a/src/Mod/Part/Gui/ViewProviderAttachExtension.cpp
+++ b/src/Mod/Part/Gui/ViewProviderAttachExtension.cpp
@@ -50,7 +50,7 @@ ViewProviderAttachExtension::ViewProviderAttachExtension()
     initExtensionType(ViewProviderAttachExtension::getExtensionClassTypeId());
 }
 
-QIcon ViewProviderAttachExtension::extensionMergeOverlayIcons(const QIcon & orig) const
+QIcon ViewProviderAttachExtension::extensionMergeColorfullOverlayIcons (const QIcon & orig) const
 {
     QIcon mergedicon = orig;
 

--- a/src/Mod/Part/Gui/ViewProviderAttachExtension.h
+++ b/src/Mod/Part/Gui/ViewProviderAttachExtension.h
@@ -39,7 +39,7 @@ public:
     ViewProviderAttachExtension(void);
     virtual ~ViewProviderAttachExtension() = default;
 
-    virtual QIcon extensionMergeOverlayIcons(const QIcon & orig) const override;
+    virtual QIcon extensionMergeColorfullOverlayIcons (const QIcon & orig) const override;
 
     virtual void extensionUpdateData(const App::Property*) override;
     virtual void extensionSetupContextMenu(QMenu*, QObject*, const char*) override;

--- a/src/Mod/PartDesign/Gui/ViewProvider.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProvider.cpp
@@ -221,7 +221,7 @@ void ViewProvider::setTipIcon(bool onoff) {
     signalChangeIcon();
 }
 
-QIcon ViewProvider::mergeOverlayIcons (const QIcon & orig) const
+QIcon ViewProvider::mergeColorfulOverlayIcons (const QIcon & orig) const
 {
     QIcon mergedicon = orig;
 
@@ -248,7 +248,7 @@ QIcon ViewProvider::mergeOverlayIcons (const QIcon & orig) const
 
     }
 
-    return Gui::ViewProvider::mergeOverlayIcons(mergedicon);
+    return Gui::ViewProvider::mergeColorfulOverlayIcons (mergedicon);
 }
 
 bool ViewProvider::onDelete(const std::vector<std::string> &)

--- a/src/Mod/PartDesign/Gui/ViewProvider.h
+++ b/src/Mod/PartDesign/Gui/ViewProvider.h
@@ -70,14 +70,14 @@ public:
 
     virtual PyObject* getPyObject(void) override;
 
+    virtual QIcon mergeColorfulOverlayIcons (const QIcon & orig) const override;
+
 protected:
     virtual void setupContextMenu(QMenu* menu, QObject* receiver, const char* member) override;
     virtual bool setEdit(int ModNum) override;
     virtual void unsetEdit(int ModNum) override;
 
     virtual bool onDelete(const std::vector<std::string> &) override;
-
-    virtual QIcon mergeOverlayIcons (const QIcon & orig) const override;
 
     /**
      * Returns a newly create dialog for the part to be placed in the task view

--- a/src/Mod/PartDesign/Gui/ViewProviderLoft.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderLoft.cpp
@@ -174,6 +174,6 @@ QIcon ViewProviderLoft::getIcon(void) const {
         str += QString::fromLatin1("Subtractive_");
 
     str += QString::fromLatin1("Loft.svg");
-    return PartDesignGui::ViewProvider::mergeOverlayIcons(Gui::BitmapFactory().pixmap(str.toStdString().c_str()));
+    return PartDesignGui::ViewProvider::mergeGreyableOverlayIcons(Gui::BitmapFactory().pixmap(str.toStdString().c_str()));
 }
 

--- a/src/Mod/PartDesign/Gui/ViewProviderPipe.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderPipe.cpp
@@ -207,6 +207,6 @@ QIcon ViewProviderPipe::getIcon(void) const {
         str += QString::fromLatin1("Subtractive_");
 
     str += QString::fromLatin1("Pipe.svg");
-    return PartDesignGui::ViewProvider::mergeOverlayIcons(Gui::BitmapFactory().pixmap(str.toStdString().c_str()));
+    return PartDesignGui::ViewProvider::mergeGreyableOverlayIcons(Gui::BitmapFactory().pixmap(str.toStdString().c_str()));
 }
 

--- a/src/Mod/PartDesign/Gui/ViewProviderPrimitive.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderPrimitive.cpp
@@ -172,5 +172,5 @@ QIcon ViewProviderPrimitive::getIcon(void) const {
     }
 
     str += QString::fromLatin1(".svg");
-    return PartDesignGui::ViewProvider::mergeOverlayIcons(Gui::BitmapFactory().pixmap(str.toStdString().c_str()));
+    return PartDesignGui::ViewProvider::mergeGreyableOverlayIcons(Gui::BitmapFactory().pixmap(str.toStdString().c_str()));
 }

--- a/src/Mod/Sketcher/App/Sketch.cpp
+++ b/src/Mod/Sketcher/App/Sketch.cpp
@@ -76,7 +76,6 @@ Sketch::Sketch()
   , RecalculateInitialSolutionWhileMovingPoint(false)
   , GCSsys(), ConstraintsCounter(0)
   , isInitMove(false), isFine(true), moveStep(0)
-  , malformedConstraints(false)
   , defaultSolver(GCS::DogLeg)
   , defaultSolverRedundant(GCS::DogLeg)
   , debugMode(GCS::Minimal)
@@ -127,7 +126,8 @@ void Sketch::clear(void)
     isInitMove = false;
     ConstraintsCounter = 0;
     Conflicting.clear();
-    malformedConstraints = false;
+    Redundant.clear();
+    MalformedConstraints.clear();
 }
 
 bool Sketch::analyseBlockedGeometry( const std::vector<Part::Geometry *> &internalGeoList,
@@ -1913,8 +1913,9 @@ int Sketch::addConstraints(const std::vector<Constraint *> &ConstraintList)
         rtn = addConstraint (*it);
 
         if(rtn == -1) {
-            Base::Console().Error("Sketcher constraint number %d is malformed!\n",cid);
-            malformedConstraints = true;
+            int humanconstraintid = cid + 1;
+            Base::Console().Error("Sketcher constraint number %d is malformed!\n",humanconstraintid);
+            MalformedConstraints.push_back(humanconstraintid);
         }
     }
 
@@ -1932,8 +1933,9 @@ int Sketch::addConstraints(const std::vector<Constraint *> &ConstraintList,
             rtn = addConstraint (*it);
 
             if(rtn == -1) {
-                Base::Console().Error("Sketcher constraint number %d is malformed!\n",cid);
-                malformedConstraints = true;
+                int humanconstraintid = cid + 1;
+                Base::Console().Error("Sketcher constraint number %d is malformed!\n",humanconstraintid);
+                MalformedConstraints.push_back(humanconstraintid);
             }
         }
         else {

--- a/src/Mod/Sketcher/App/Sketch.h
+++ b/src/Mod/Sketcher/App/Sketch.h
@@ -106,7 +106,8 @@ public:
 
     inline float getSolveTime() const { return SolveTime; }
 
-    inline bool hasMalformedConstraints(void) const { return malformedConstraints; }
+    inline bool hasMalformedConstraints(void) const { return !MalformedConstraints.empty(); }
+    inline const std::vector<int> &getMalformedConstraints(void) const { return MalformedConstraints; }
 public:
     std::set < std::pair< int, Sketcher::PointPos>> getDependencyGroup(int geoId, PointPos pos) const;
 
@@ -425,6 +426,7 @@ protected:
     int ConstraintsCounter;
     std::vector<int> Conflicting;
     std::vector<int> Redundant;
+    std::vector<int> MalformedConstraints;
 
     std::vector<double *> pDependentParametersList;
 
@@ -452,8 +454,6 @@ protected:
     bool isFine;
     Base::Vector3d initToPoint;
     double moveStep;
-
-    bool malformedConstraints;
 
 public:
     GCS::Algorithm defaultSolver;

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -110,6 +110,7 @@ SketchObject::SketchObject()
     ADD_PROPERTY_TYPE(Geometry,        (0)  ,"Sketch",(App::PropertyType)(App::Prop_None),"Sketch geometry");
     ADD_PROPERTY_TYPE(Constraints,     (0)  ,"Sketch",(App::PropertyType)(App::Prop_None),"Sketch constraints");
     ADD_PROPERTY_TYPE(ExternalGeometry,(0,0),"Sketch",(App::PropertyType)(App::Prop_None),"Sketch external geometry");
+    ADD_PROPERTY_TYPE(FullyConstrained, (false),"Sketch",(App::PropertyType)(App::Prop_Output|App::Prop_ReadOnly |App::Prop_Hidden),"Sketch is fully constrained");
 
     Geometry.setOrderRelevant(true);
 
@@ -251,6 +252,7 @@ int SketchObject::solve(bool updateGeoAfterSolving/*=true*/)
     lastDoF = solvedSketch.setUpSketch(getCompleteGeometry(), Constraints.getValues(),
                                   getExternalGeometryCount());
 
+    FullyConstrained.setValue(lastDoF == 0);
     // At this point we have the solver information about conflicting/redundant/over-constrained, but the sketch is NOT solved.
     // Some examples:
     // Redundant: a vertical line, a horizontal line and an angle constraint of 90 degrees between the two lines

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -216,6 +216,9 @@ App::DocumentObjectExecReturn *SketchObject::execute(void)
     else if (err == -1) { // Solver failed
         return new App::DocumentObjectExecReturn("Solving the sketch failed",this);
     }
+    else if (solvedSketch.hasMalformedConstraints()) {
+        return new App::DocumentObjectExecReturn("Sketch has malformed constraints");
+    }
 
     // this is not necessary for sketch representation in edit mode, unless we want to trigger an update of
     // the objects that depend on this sketch (like pads)

--- a/src/Mod/Sketcher/App/SketchObject.h
+++ b/src/Mod/Sketcher/App/SketchObject.h
@@ -306,6 +306,8 @@ public:
     static void appendConflictMsg(const std::vector<int> &conflicting, std::string &msg);
     /// generates a warning message about redundant constraints and appends it to the given message
     static void appendRedundantMsg(const std::vector<int> &redundant, std::string &msg);
+    /// generates a warning message about malformed constraints and appends it to the given message
+    static void appendMalformedConstraintsMsg(const std::vector<int> &malformed, std::string &msg);
 
     double calculateAngleViaPoint(int geoId1, int geoId2, double px, double py);
     bool isPointOnCurve(int geoIdCurve, double px, double py);
@@ -346,6 +348,8 @@ public:
     inline bool getLastHasConflicts() const {return lastHasConflict;}
     /// gets HasRedundancies status of last solver execution
     inline bool getLastHasRedundancies() const {return lastHasRedundancies;}
+    /// gets HasMalformedConstraints status of last solver execution
+    inline bool getLastHasMalformedConstraints() const {return lastHasMalformedConstraints;}
     /// gets solver status of last solver execution
     inline int getLastSolverStatus() const {return lastSolverStatus;}
     /// gets solver SolveTime of last solver execution
@@ -354,6 +358,8 @@ public:
     inline const std::vector<int> &getLastConflicting(void) const { return lastConflicting; }
     /// gets the redundant constraints of last solver execution
     inline const std::vector<int> &getLastRedundant(void) const { return lastRedundant; }
+    /// gets the redundant constraints of last solver execution
+    inline const std::vector<int> &getLastMalformedConstraints(void) const { return lastMalformedConstraints; }
 
 public: /* Solver exposed interface */
     /// gets the solved sketch as a reference
@@ -476,6 +482,14 @@ protected:
     // migration functions
     void migrateSketch(void);
 
+    static void appendConstraintsMsg(const std::vector<int> &vector,
+                                     const std::string & singularmsg,
+                                     const std::string & pluralmsg,
+                                     std::string &msg);
+
+    // retrieves redundant, conflicting and malformed constraint information from the solver
+    void retrieveSolverDiagnostics();
+
 private:
     /// Flag to allow external geometry from other bodies than the one this sketch belongs to
     bool allowOtherBody;
@@ -498,11 +512,13 @@ private:
     int lastDoF;
     bool lastHasConflict;
     bool lastHasRedundancies;
+    bool lastHasMalformedConstraints;
     int lastSolverStatus;
     float lastSolveTime;
 
     std::vector<int> lastConflicting;
     std::vector<int> lastRedundant;
+    std::vector<int> lastMalformedConstraints;
 
     boost::signals2::scoped_connection constraintsRenamedConn;
     boost::signals2::scoped_connection constraintsRemovedConn;

--- a/src/Mod/Sketcher/App/SketchObject.h
+++ b/src/Mod/Sketcher/App/SketchObject.h
@@ -67,6 +67,7 @@ public:
     Part    ::PropertyGeometryList   Geometry;
     Sketcher::PropertyConstraintList Constraints;
     App     ::PropertyLinkSubList    ExternalGeometry;
+    App     ::PropertyBool           FullyConstrained;
     /** @name methods override Feature */
     //@{
     short mustExecute() const override;

--- a/src/Mod/Sketcher/App/SketchObject.h
+++ b/src/Mod/Sketcher/App/SketchObject.h
@@ -108,6 +108,8 @@ public:
      \retval int - 0 if successful
      */
     int delGeometry(int GeoId, bool deleteinternalgeo = true);
+    /// Deletes just the GeoIds indicated, it does not look for internal geometry
+    int delGeometriesExclusiveList(const std::vector<int>& GeoIds);
     /// Does the same as \a delGeometry but allows to delete several geometries in one step
     int delGeometries(const std::vector<int>& GeoIds);
     /// deletes all the elements/constraints of the sketch except for external geometry

--- a/src/Mod/Sketcher/App/SketchObjectPy.xml
+++ b/src/Mod/Sketcher/App/SketchObjectPy.xml
@@ -28,6 +28,11 @@
         <UserDocu>delete a geometric object from the sketch</UserDocu>
       </Documentation>
     </Methode>
+    <Methode Name="delGeometries">
+      <Documentation>
+        <UserDocu>delete a list of geometric objects from the sketch, including any internal alignment geometry thereof</UserDocu>
+      </Documentation>
+    </Methode>
     <Methode Name="deleteAllGeometry">
         <Documentation>
             <UserDocu>delete all the geometry objects and constraints from the sketch except external geometry</UserDocu>

--- a/src/Mod/Sketcher/App/SketchObjectPyImp.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectPyImp.cpp
@@ -216,6 +216,44 @@ PyObject* SketchObjectPy::delGeometry(PyObject *args)
     Py_Return;
 }
 
+PyObject* SketchObjectPy::delGeometries(PyObject *args)
+{
+    PyObject *pcObj;
+
+    if (!PyArg_ParseTuple(args, "O", &pcObj))
+    return 0;
+
+    if (PyObject_TypeCheck(pcObj, &(PyList_Type)) ||
+        PyObject_TypeCheck(pcObj, &(PyTuple_Type)) ) {
+
+        std::vector<int> geoIdList;
+        Py::Sequence list(pcObj);
+        for (Py::Sequence::iterator it = list.begin(); it != list.end(); ++it) {
+#if PY_MAJOR_VERSION >= 3
+            if (PyLong_Check((*it).ptr()))
+                geoIdList.push_back(PyLong_AsLong((*it).ptr()));
+#else
+            if (PyInt_Check((*it).ptr()))
+                geoIdList.push_back(PyInt_AsLong((*it).ptr()));
+#endif
+        }
+
+        if(this->getSketchObjectPtr()->delGeometries(geoIdList)) {
+            std::stringstream str;
+            str << "Not able to delete geometries";
+            PyErr_SetString(PyExc_ValueError, str.str().c_str());
+            return 0;
+        }
+
+        Py_Return;
+
+    }
+
+    std::string error = std::string("type must be list of GeoIds, not ");
+    error += pcObj->ob_type->tp_name;
+    throw Py::TypeError(error);
+}
+
 PyObject* SketchObjectPy::deleteAllGeometry(PyObject *args)
 {
     if (!PyArg_ParseTuple(args, ""))

--- a/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp
+++ b/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp
@@ -538,6 +538,59 @@ bool CmdSketcherSelectRedundantConstraints::isActive(void)
     return isSketcherAcceleratorActive(getActiveGuiDocument(), false);
 }
 
+DEF_STD_CMD_A(CmdSketcherSelectMalformedConstraints)
+
+CmdSketcherSelectMalformedConstraints::CmdSketcherSelectMalformedConstraints()
+    :Command("Sketcher_SelectMalformedConstraints")
+{
+    sAppModule      = "Sketcher";
+    sGroup          = QT_TR_NOOP("Sketcher");
+    sMenuText       = QT_TR_NOOP("Select malformed constraints");
+    sToolTipText    = QT_TR_NOOP("Select malformed constraints");
+    sWhatsThis      = "Sketcher_SelectMalformedConstraints";
+    sStatusTip      = sToolTipText;
+    sPixmap         = "Sketcher_SelectMalformedConstraints";
+    sAccel          = "CTRL+SHIFT+R";
+    eType           = ForEdit;
+}
+
+void CmdSketcherSelectMalformedConstraints::activated(int iMsg)
+{
+    Q_UNUSED(iMsg);
+    Gui::Document * doc= getActiveGuiDocument();
+    ReleaseHandler(doc);
+    SketcherGui::ViewProviderSketch* vp = static_cast<SketcherGui::ViewProviderSketch*>(doc->getInEdit());
+    Sketcher::SketchObject* Obj= vp->getSketchObject();
+
+    std::string doc_name = Obj->getDocument()->getName();
+    std::string obj_name = Obj->getNameInDocument();
+
+    // get the needed lists and objects
+    const std::vector< int > &solvermalformed = vp->getSketchObject()->getLastMalformedConstraints();
+    const std::vector< Sketcher::Constraint * > &vals = Obj->Constraints.getValues();
+
+    getSelection().clearSelection();
+
+    // push the constraints
+    int i = 0;
+    for (std::vector< Sketcher::Constraint * >::const_iterator it= vals.begin();it != vals.end(); ++it,++i) {
+        for(std::vector< int >::const_iterator itc= solvermalformed.begin();itc != solvermalformed.end(); ++itc) {
+            if ((*itc) - 1 == i) {
+                Gui::Selection().addSelection(doc_name.c_str(),
+                                              obj_name.c_str(),
+                                              Sketcher::PropertyConstraintList::getConstraintName(i).c_str());
+                break;
+            }
+        }
+    }
+}
+
+bool CmdSketcherSelectMalformedConstraints::isActive(void)
+{
+    return isSketcherAcceleratorActive(getActiveGuiDocument(), false);
+}
+
+
 DEF_STD_CMD_A(CmdSketcherSelectConflictingConstraints)
 
 CmdSketcherSelectConflictingConstraints::CmdSketcherSelectConflictingConstraints()
@@ -2053,6 +2106,7 @@ void CreateSketcherCommandsConstraintAccel(void)
     rcCmdMgr.addCommand(new CmdSketcherSelectHorizontalAxis());
     rcCmdMgr.addCommand(new CmdSketcherSelectRedundantConstraints());
     rcCmdMgr.addCommand(new CmdSketcherSelectConflictingConstraints());
+    rcCmdMgr.addCommand(new CmdSketcherSelectMalformedConstraints());
     rcCmdMgr.addCommand(new CmdSketcherSelectElementsAssociatedWithConstraints());
     rcCmdMgr.addCommand(new CmdSketcherSelectElementsWithDoFs());
     rcCmdMgr.addCommand(new CmdSketcherRestoreInternalAlignmentGeometry());

--- a/src/Mod/Sketcher/Gui/TaskSketcherMessages.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherMessages.cpp
@@ -107,13 +107,15 @@ void TaskSketcherMessages::on_labelConstrainStatus_linkActivated(const QString &
 {
     if( str == QString::fromLatin1("#conflicting"))
         Gui::Application::Instance->commandManager().runCommandByName("Sketcher_SelectConflictingConstraints");
-
+    else
     if( str == QString::fromLatin1("#redundant"))
         Gui::Application::Instance->commandManager().runCommandByName("Sketcher_SelectRedundantConstraints");
-
+    else
     if( str == QString::fromLatin1("#dofs"))
         Gui::Application::Instance->commandManager().runCommandByName("Sketcher_SelectElementsWithDoFs");
-
+    else
+    if( str == QString::fromLatin1("#malformed"))
+        Gui::Application::Instance->commandManager().runCommandByName("Sketcher_SelectMalformedConstraints");
 }
 
 void TaskSketcherMessages::on_autoUpdate_stateChanged(int state)

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -289,7 +289,7 @@ const Part::Geometry* GeoById(const std::vector<Part::Geometry*> GeoList, int Id
 
 /* TRANSLATOR SketcherGui::ViewProviderSketch */
 
-PROPERTY_SOURCE(SketcherGui::ViewProviderSketch, PartGui::ViewProvider2DObjectGrid)
+PROPERTY_SOURCE_WITH_EXTENSIONS(SketcherGui::ViewProviderSketch, PartGui::ViewProvider2DObjectGrid)
 
 
 ViewProviderSketch::ViewProviderSketch()
@@ -7005,4 +7005,34 @@ void ViewProviderSketch::showRestoreInformationLayer() {
 
     visibleInformationChanged = true ;
     draw(false,false);
+}
+
+QIcon ViewProviderSketch::mergeColorfulOverlayIcons (const QIcon & orig) const
+{
+    QIcon mergedicon = orig;
+
+    if(!getSketchObject()->FullyConstrained.getValue()) {
+        QPixmap px;
+
+        static const char * const sketcher_notfullyconstrained_xpm[]={
+            "9 9 3 1",
+            ". c None",
+            "# c #ff4500",
+            "a c #ffffff",
+            "##.....##",
+            "#a#...#a#",
+            "#aa#.#aa#",
+            ".#a#.#a#.",
+            ".#a#.#a#.",
+            ".#a#.#a#.",
+            "#aa#.#aa#",
+            "#a#...#a#",
+            "##.....##"};
+        px = QPixmap( sketcher_notfullyconstrained_xpm );
+
+        mergedicon = Gui::BitmapFactoryInst::mergePixmap(mergedicon, px, Gui::BitmapFactoryInst::BottomRight);
+
+    }
+
+    return Gui::ViewProvider::mergeColorfulOverlayIcons (mergedicon);
 }

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -7030,8 +7030,8 @@ QIcon ViewProviderSketch::mergeColorfulOverlayIcons (const QIcon & orig) const
         static const char * const sketcher_notfullyconstrained_xpm[]={
             "9 9 3 1",
             ". c None",
-            "# c #ff4500",
-            "a c #ffffff",
+            "# c #dbaf00",
+            "a c #ffcc00",
             "##.....##",
             "#a#...#a#",
             "#aa#.#aa#",

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -301,6 +301,8 @@ ViewProviderSketch::ViewProviderSketch()
     isShownVirtualSpace(false),
     listener(0)
 {
+    PartGui::ViewProviderAttachExtension::initExtension(this);
+
     ADD_PROPERTY_TYPE(Autoconstraints,(true),"Auto Constraints",(App::PropertyType)(App::Prop_None),"Create auto constraints");
     ADD_PROPERTY_TYPE(AvoidRedundant,(true),"Auto Constraints",(App::PropertyType)(App::Prop_None),"Avoid redundant autoconstraint");
     ADD_PROPERTY_TYPE(TempoVis,(Py::None()),"Visibility automation",(App::PropertyType)(App::Prop_None),"Object that handles hiding and showing other objects when entering/leaving sketch.");

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.h
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.h
@@ -25,6 +25,7 @@
 #define SKETCHERGUI_VIEWPROVIDERSKETCH_H
 
 #include <Mod/Part/Gui/ViewProvider2DObject.h>
+#include <Mod/Part/Gui/ViewProviderAttachExtension.h>
 #include <Mod/Part/App/BodyBase.h>
 #include <Inventor/SbImage.h>
 #include <Inventor/SbColor.h>
@@ -84,7 +85,8 @@ class DrawSketchHandler;
   * of new geometry while editing.
   */
 class SketcherGuiExport ViewProviderSketch : public PartGui::ViewProvider2DObjectGrid
-                                           , public Gui::SelectionObserver
+                                            , public PartGui::ViewProviderAttachExtension
+                                            , public Gui::SelectionObserver
 {
     Q_DECLARE_TR_FUNCTIONS(SketcherGui::ViewProviderSketch)
     /// generates a warning message about constraint conflicts and appends it to the given message

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.h
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.h
@@ -229,24 +229,24 @@ public:
 
     /** @name base class implementer */
     //@{
-    virtual void attach(App::DocumentObject *);
-    virtual void updateData(const App::Property *);
+    virtual void attach(App::DocumentObject *) override;
+    virtual void updateData(const App::Property *) override;
 
-    virtual void setupContextMenu(QMenu *menu, QObject *receiver, const char *member);
+    virtual void setupContextMenu(QMenu *menu, QObject *receiver, const char *member) override;
     /// is called when the Provider is in edit and a deletion request occurs
-    virtual bool onDelete(const std::vector<std::string> &);
+    virtual bool onDelete(const std::vector<std::string> &) override;
     /// Is called by the tree if the user double clicks on the object. It returns the string
     /// for the transaction that will be shown in the undo/redo dialog.
     /// If null is returned then no transaction will be opened.
-    virtual const char* getTransactionText() const { return nullptr; }
+    virtual const char* getTransactionText() const override { return nullptr; }
     /// is called by the tree if the user double clicks on the object
-    virtual bool doubleClicked(void);
+    virtual bool doubleClicked(void) override;
     /// is called when the Provider is in edit and the mouse is moved
-    virtual bool mouseMove(const SbVec2s &pos, Gui::View3DInventorViewer *viewer);
+    virtual bool mouseMove(const SbVec2s &pos, Gui::View3DInventorViewer *viewer) override;
     /// is called when the Provider is in edit and a key event ocours. Only ESC ends edit.
-    virtual bool keyPressed(bool pressed, int key);
+    virtual bool keyPressed(bool pressed, int key) override;
     /// is called when the Provider is in edit and the mouse is clicked
-    virtual bool mouseButtonPressed(int Button, bool pressed, const SbVec2s& cursorPos, const Gui::View3DInventorViewer* viewer);
+    virtual bool mouseButtonPressed(int Button, bool pressed, const SbVec2s& cursorPos, const Gui::View3DInventorViewer* viewer) override;
     //@}
 
     void deleteSelected();
@@ -274,17 +274,17 @@ public:
 protected:
     Base::Placement getEditingPlacement() const;
 
-    virtual bool setEdit(int ModNum);
-    virtual void unsetEdit(int ModNum);
-    virtual void setEditViewer(Gui::View3DInventorViewer*, int ModNum);
-    virtual void unsetEditViewer(Gui::View3DInventorViewer*);
+    virtual bool setEdit(int ModNum) override;
+    virtual void unsetEdit(int ModNum) override;
+    virtual void setEditViewer(Gui::View3DInventorViewer*, int ModNum) override;
+    virtual void unsetEditViewer(Gui::View3DInventorViewer*) override;
     void deactivateHandler();
     /// update solver information based on last solving at SketchObject
     void UpdateSolverInformation(void);
     /// helper to detect whether the picked point lies on the sketch
     bool isPointOnSketch(const SoPickedPoint *pp) const;
     /// get called by the container whenever a property has been changed
-    virtual void onChanged(const App::Property *prop);
+    virtual void onChanged(const App::Property *prop) override;
 
     /// get called if a subelement is double clicked while editing
     void editDoubleClicked(void);

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.h
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.h
@@ -93,8 +93,10 @@ class SketcherGuiExport ViewProviderSketch : public PartGui::ViewProvider2DObjec
     static QString appendConflictMsg(const std::vector<int> &conflicting);
     /// generates a warning message about redundant constraints and appends it to the given message
     static QString appendRedundantMsg(const std::vector<int> &redundant);
+    /// generates a warning message about redundant constraints and appends it to the given message
+    static QString appendMalformedMsg(const std::vector<int> &redundant);
 
-    PROPERTY_HEADER(SketcherGui::ViewProviderSketch);
+    PROPERTY_HEADER_WITH_OVERRIDE(SketcherGui::ViewProviderSketch);
 
 public:
     /// constructor
@@ -302,6 +304,11 @@ protected:
     boost::signals2::connection connectRedoDocument;
 
     void forceUpdateData();
+
+    /// Auxiliary function to generate messages about conflicting, redundant and malformed constraints
+    static QString appendConstraintMsg( const QString & singularmsg,
+                                        const QString & pluralmsg,
+                                        const std::vector<int> &vector);
 
     /// Return display string for constraint including hiding units if
     //requested.

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.h
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.h
@@ -254,6 +254,9 @@ public:
     void setIsShownVirtualSpace(bool isshownvirtualspace);
     bool getIsShownVirtualSpace(void) const;
 
+    /// Icons and Icon overlays
+    virtual QIcon mergeColorfulOverlayIcons (const QIcon & orig) const override;
+
     friend class DrawSketchHandler;
     friend struct ::EditData;
 

--- a/src/Mod/Sketcher/Gui/Workbench.cpp
+++ b/src/Mod/Sketcher/Gui/Workbench.cpp
@@ -309,7 +309,7 @@ inline void SketcherAddWorkbenchConstraints<Gui::ToolBarItem>(Gui::ToolBarItem& 
             << "Sketcher_CompConstrainRadDia"
             << "Sketcher_ConstrainAngle"
             << "Sketcher_ConstrainSnellsLaw"
-            << "Sketcher_ConstrainInternalAlignment"
+            // << "Sketcher_ConstrainInternalAlignment" // This constrain is never used by the user - Do not use precious toolbar space
             << "Separator"
             << "Sketcher_ToggleDrivingConstraint"
             << "Sketcher_ToggleActiveConstraint";

--- a/src/Mod/TechDraw/Gui/ViewProviderCosmeticExtension.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderCosmeticExtension.cpp
@@ -47,7 +47,7 @@ ViewProviderCosmeticExtension::ViewProviderCosmeticExtension()
     initExtensionType(ViewProviderCosmeticExtension::getExtensionClassTypeId());
 }
 
-QIcon ViewProviderCosmeticExtension::extensionMergeOverlayIcons(const QIcon & orig) const
+QIcon ViewProviderCosmeticExtension::extensionMergeGreyableOverlayIcons(const QIcon & orig) const
 {
     QIcon mergedicon = orig;
 

--- a/src/Mod/TechDraw/Gui/ViewProviderCosmeticExtension.h
+++ b/src/Mod/TechDraw/Gui/ViewProviderCosmeticExtension.h
@@ -39,7 +39,7 @@ public:
     ViewProviderCosmeticExtension(void);
     virtual ~ViewProviderCosmeticExtension() = default;
 
-    virtual QIcon extensionMergeOverlayIcons(const QIcon & orig) const override;
+    virtual QIcon extensionMergeGreyableOverlayIcons(const QIcon & orig) const override;
 
     virtual void extensionUpdateData(const App::Property*) override;
 


### PR DESCRIPTION
- Show attachment overlay icon for Sketch.
- Allow a developer to select whether to use overlay icons that will deactivate when visibility is lost, or overlay icons that remain colorful when visibility is lost.
- Sketch will show an overlay icon if it is not fully constrained (at bottom-right position)
- Treat malformed constraints as errors (shown in sketcher messages and causing the sketch to error on recompute)
- Improve deletion of geometry from the UI - Fix report view errors when deleting geometry having internal geometry
- Expose deletion of multiple geometries at once to Python
- Remove Internal Alignment constraint from toolbar.