### PR TITLE
[GUI] fix missing Std_AxisCross icon

### DIFF
--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -2170,6 +2170,7 @@ StdCmdAxisCross::StdCmdAxisCross()
         sToolTipText  = QT_TR_NOOP("Toggle axis cross");
         sStatusTip    = QT_TR_NOOP("Toggle axis cross");
         sWhatsThis    = "Std_AxisCross";
+        sPixmap       = "Std_AxisCross";
         sAccel        = "A,C";
 }
 


### PR DESCRIPTION
in commit 7587658ae3 the icon was not also added to the used Std_AxisCross menu entry