### PR TITLE
[Gui] Add support for touchscreen multi-select in tree

### DIFF
--- a/src/Gui/DlgPropertyLink.cpp
+++ b/src/Gui/DlgPropertyLink.cpp
@@ -897,7 +897,7 @@ QTreeWidgetItem *DlgPropertyLink::createItem(
     if(allowSubObject) {
         item->setChildIndicatorPolicy(obj->getLinkedObject(true)->getOutList().size()?
                 QTreeWidgetItem::ShowIndicator:QTreeWidgetItem::DontShowIndicator);
-        item->setFlags(item->flags() | Qt::ItemIsEditable);
+        item->setFlags(item->flags() | Qt::ItemIsEditable | Qt::ItemIsUserCheckable);
     }
 
     const char *typeName = obj->getTypeId().getName();

--- a/src/Gui/DlgSettingsNavigation.cpp
+++ b/src/Gui/DlgSettingsNavigation.cpp
@@ -107,6 +107,9 @@ void DlgSettingsNavigation::saveSettings()
         hCustom->SetFloat("Q2", q2);
         hCustom->SetFloat("Q3", q3);
     }
+
+    ui->checkBoxSelectionCheckBoxes->onSave();
+    TreeWidget::instance()->synchronizeSelectionCheckBoxes();
 }
 
 void DlgSettingsNavigation::loadSettings()
@@ -158,6 +161,8 @@ void DlgSettingsNavigation::loadSettings()
         q2 = hCustom->GetFloat("Q2", q2);
         q3 = hCustom->GetFloat("Q3", q3);
     }
+
+    ui->checkBoxSelectionCheckBoxes->onRestore();
 
     connect(ui->comboNewDocView, SIGNAL(currentIndexChanged(int)),
             this, SLOT(onNewDocViewChanged(int)));

--- a/src/Gui/DlgSettingsNavigation.ui
+++ b/src/Gui/DlgSettingsNavigation.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>500</width>
-    <height>363</height>
+    <width>518</width>
+    <height>468</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -500,7 +500,7 @@ Mouse tilting is not disabled by this setting.</string>
      </layout>
     </widget>
    </item>
-   <item row="2" column="0">
+   <item row="3" column="0">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -512,6 +512,31 @@ Mouse tilting is not disabled by this setting.</string>
       </size>
      </property>
     </spacer>
+   </item>
+   <item row="2" column="0">
+    <widget class="QGroupBox" name="groupBoxSelection">
+     <property name="title">
+      <string>Selection</string>
+     </property>
+     <property name="checkable">
+      <bool>false</bool>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_6">
+      <item row="0" column="0">
+       <widget class="Gui::PrefCheckBox" name="checkBoxSelectionCheckBoxes">
+        <property name="text">
+         <string>Add checkboxes for selection in document tree</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <string>CheckBoxSelectionCheckBoxes</string>
+        </property>
+        <property name="prefPath" stdset="0">
+         <string>View</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/src/Gui/Tree.h
+++ b/src/Gui/Tree.h
@@ -129,6 +129,8 @@ public:
     void startItemSearch(QLineEdit*);
     void itemSearch(const QString &text, bool select);
 
+    void synchronizeSelectionCheckBoxes();
+
 protected:
     /// Observer message from the Selection
     void onSelectionChanged(const SelectionChanges& msg) override;
@@ -176,6 +178,7 @@ protected Q_SLOTS:
 
 private Q_SLOTS:
     void onItemSelectionChanged(void);
+    void onItemChanged(QTreeWidgetItem*, int);
     void onItemEntered(QTreeWidgetItem * item);
     void onItemCollapsed(QTreeWidgetItem * item);
     void onItemExpanded(QTreeWidgetItem * item);
@@ -436,6 +439,8 @@ public:
     TreeWidget *getTree() const;
 
 private:
+    void setCheckState(bool checked);
+
     QBrush bgBrush;
     DocumentItem *myOwner;
     DocumentObjectDataPtr myData;


### PR DESCRIPTION
Checkboxes are optionally added using the parameter
"UseSelectionCheckboxes" set to true in the Edit Parameters in:
"User parameter:BaseApp/Preferences/TreeView"

Forum thread for feature the request:
https://forum.freecadweb.org/viewtopic.php?f=34&t=53065

Video showing the how to enable it and how it looks can be found here:
https://youtu.be/8cN0IGJsBIk

---
Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [x] ~Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists~

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
