### PR TITLE
[WIP] PartDesign: New Text utility

### DIFF
--- a/src/Mod/PartDesign/App/AppPartDesign.cpp
+++ b/src/Mod/PartDesign/App/AppPartDesign.cpp
@@ -59,6 +59,7 @@
 #include "FeatureLoft.h"
 #include "ShapeBinder.h"
 #include "FeatureBase.h"
+#include "FeatureText.h"
 
 namespace PartDesign {
 extern PyObject* initModule();
@@ -116,6 +117,7 @@ PyMOD_INIT_FUNC(_PartDesign)
     PartDesign::Loft                        ::init();
     PartDesign::AdditiveLoft                ::init();
     PartDesign::SubtractiveLoft             ::init();
+    PartDesign::Text                        ::init();
     PartDesign::ShapeBinder                 ::init();
     PartDesign::SubShapeBinder              ::init();
     PartDesign::Plane                       ::init();

--- a/src/Mod/PartDesign/App/CMakeLists.txt
+++ b/src/Mod/PartDesign/App/CMakeLists.txt
@@ -109,6 +109,8 @@ SET(FeaturesSketchBased_SRCS
     FeaturePipe.cpp
     FeatureLoft.h
     FeatureLoft.cpp
+    FeatureText.h
+    FeatureText.cpp
 )
 
 SOURCE_GROUP("SketchBasedFeatures" FILES ${FeaturesSketchBased_SRCS})

--- a/src/Mod/PartDesign/App/FeatureText.cpp
+++ b/src/Mod/PartDesign/App/FeatureText.cpp
@@ -1,0 +1,352 @@
+/***************************************************************************
+ *   Copyright (c) 2010 Juergen Riegel <FreeCAD@juergen-riegel.net>        *
+ *                 2020 David Österberg                                    *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#include "PreCompiled.h"
+#ifndef _PreComp_
+# include <BRep_Builder.hxx>
+# include <BRepBndLib.hxx>
+# include <BRepPrimAPI_MakeRevol.hxx>
+# include <BRepBuilderAPI_MakeFace.hxx>
+# include <BRepExtrema_DistShapeShape.hxx>
+# include <BRepBuilderAPI_MakeEdge.hxx>
+# include <BRepExtrema_DistShapeShape.hxx>
+# include <BRepAlgoAPI_Cut.hxx>
+# include <TopoDS.hxx>
+# include <TopoDS_Face.hxx>
+# include <TopoDS_Wire.hxx>
+# include <TopExp_Explorer.hxx>
+# include <BRepAlgoAPI_Fuse.hxx>
+# include <BRepAlgoAPI_Common.hxx>
+# include <Precision.hxx>
+# include <gp_Lin.hxx>
+# include <BRepBuilderAPI_MakeWire.hxx>
+# include <BRepAdaptor_Surface.hxx>
+# include <Law_Function.hxx>
+# include <BRepOffsetAPI_MakePipeShell.hxx>
+# include <BRepBuilderAPI_MakeSolid.hxx>
+# include <BRepBuilderAPI_Sewing.hxx>
+# include <BRepClass3d_SolidClassifier.hxx>
+# include <ShapeAnalysis.hxx>
+# include <gp_Ax1.hxx>
+# include <gp_Ax3.hxx>
+
+#endif
+
+# include <string>
+# include <Standard_Version.hxx>
+# include <Base/Axis.h>
+# include <Base/Console.h>
+# include <Base/Exception.h>
+# include <Base/Placement.h>
+# include <Base/Tools.h>
+#include "boost/filesystem.hpp"
+
+# include <Mod/Part/App/TopoShape.h>
+# include <Mod/Part/App/TopoShapePy.h>
+# include <Mod/Part/App/FaceMakerCheese.h>
+
+# include "FeatureText.h"
+
+
+using namespace PartDesign;
+
+
+PROPERTY_SOURCE(PartDesign::Text, PartDesign::ProfileBased)
+
+Text::Text()
+{
+
+    ADD_PROPERTY_TYPE(ReferenceAxis,(0),"Helix", App::Prop_None, "Reference axis of revolution");
+    ADD_PROPERTY_TYPE(Base,(Base::Vector3d(0.0,0.0,0.0)),"Text", App::Prop_ReadOnly, "Base");
+    ADD_PROPERTY_TYPE(Axis,(Base::Vector3d(0.0,1.0,0.0)),"Text", App::Prop_ReadOnly, "Axis");
+    ADD_PROPERTY_TYPE(TextString,("FreeCAD rocks!"),"Text", App::Prop_None, "Text");
+    ADD_PROPERTY_TYPE(Font,("/usr/share/fonts/truetype/ttf-bitstream-vera/VeraMono.ttf"),"Text", App::Prop_None, "Font");
+    ADD_PROPERTY_TYPE(Size,(20.0),"Text", App::Prop_None, "Size");
+    ADD_PROPERTY_TYPE(Height,(30.0),"Text", App::Prop_None, "Height");
+    ADD_PROPERTY_TYPE(Offset, (0.0), "Text", App::Prop_None, "Offset from face in which text will end");
+    static const App::PropertyQuantityConstraint::Constraints signedLengthConstraint = {-DBL_MAX, DBL_MAX, 1.0};
+    Offset.setConstraints(&signedLengthConstraint);
+}
+
+
+
+short Text::mustExecute() const
+{
+    if (Placement.isTouched() ||
+        ReferenceAxis.isTouched() ||
+        Axis.isTouched() ||
+        Base.isTouched() ||
+        Height.isTouched())
+        return 1;
+    return ProfileBased::mustExecute();
+}
+
+App::DocumentObjectExecReturn *Text::execute(void)
+{
+
+    std::string text = std::string(TextString.getValue());
+    std::string fontpath = std::string(Font.getValue());
+    double size = Size.getValue();
+
+    Base::Console().Warning("Text: %s\n", text.c_str());
+    Base::Console().Warning("Font: %s\n", fontpath.c_str());
+    Base::Console().Warning("Size: %f\n", size);
+
+    // update Axis from ReferenceAxis
+    try {
+        updateAxis();
+    } catch (const Base::Exception& e) {
+        return new App::DocumentObjectExecReturn(e.what());
+    }
+
+    // get revolve axis
+    Base::Vector3d b = Base.getValue();
+    gp_Pnt pnt(b.x,b.y,b.z);
+    Base::Vector3d v = Axis.getValue();
+    gp_Dir dir(v.x,v.y,v.z);
+
+
+    // Validate parameters
+    double L = Height.getValue();
+    double L2 = 0.0;
+    bool imprint = false;
+    if (L > Precision::Confusion())
+        L2 = 0.0;
+    else if (L < - Precision::Confusion()) {
+        L2 = L;
+        L = 0.0;
+    } else {
+        imprint = true;
+        L = 0.0;
+        L2 = 0.0;
+    }
+
+
+    Part::Feature* obj = 0;
+    TopoDS_Shape sketchshape, textshape;
+
+
+    try {
+        obj = getVerifiedObject();
+        sketchshape = getVerifiedFace();
+        // (const std::string& text, const std::string& fontpath, double height, double track)
+        textshape = textToShape(text, fontpath, size, 0.0);
+
+    } catch (const Base::Exception& e) {
+        return new App::DocumentObjectExecReturn(e.what());
+    }
+
+    // if the Base property has a valid shape, fuse the prism into it
+    TopoDS_Shape base;
+    try {
+        base = getBaseShape();
+    } catch (const Base::Exception&) {
+        base = TopoDS_Shape();
+    }
+
+    // get the Sketch plane
+    Base::Placement SketchPos = obj->Placement.getValue();
+    // get the normal vector of the sketch
+    Base::Vector3d SketchVector = getProfileNormal();
+
+    Base::Vector3d paddingDirection = SketchVector;
+
+    try {
+        this->positionByPrevious();
+        TopLoc_Location invObjLoc = this->getLocation().Inverted();
+
+        base.Move(invObjLoc);
+
+
+        //Py::Object charList = makeWireString(const Py::Tuple& args);
+
+        // create vector in padding direction with length 1
+        gp_Dir dir(paddingDirection.x, paddingDirection.y, paddingDirection.z);
+
+        // The length of a gp_Dir is 1 so the resulting pad would have
+        // the length L in the direction of dir. But we want to have its height in the
+        // direction of the normal vector.
+        // Therefore we must multiply L by the factor that is necessary
+        // to make dir as long that its projection to the SketchVector
+        // equals the SketchVector.
+        // This is the scalar product of both vectors.
+        // Since the pad length cannot be negative, the factor must not be negative.
+
+        double factor = fabs(dir * gp_Dir(SketchVector.x, SketchVector.y, SketchVector.z));
+
+        // factor would be zero if vectors are orthogonal
+        if (factor < Precision::Confusion())
+            return new App::DocumentObjectExecReturn("Pad: Creation failed because direction is orthogonal to sketch's normal vector");
+
+        // perform the length correction
+        L = L / factor;
+        L2 = L2 / factor;
+
+        dir.Transform(invObjLoc.Transformation());
+
+        if (textshape.IsNull())
+            return new App::DocumentObjectExecReturn("Pad: Creating a face from sketch failed");
+        textshape.Move(invObjLoc);
+
+        TopoDS_Shape prism;
+        std::string method("Length");
+
+        generatePrism(prism, textshape, method, dir, L, L2,
+                          Midplane.getValue(), Reversed.getValue());
+
+        if (prism.IsNull())
+            return new App::DocumentObjectExecReturn("Pad: Resulting shape is empty");
+
+        // set the additive shape property for later usage in e.g. pattern
+        prism = refineShapeIfActive(prism);
+        this->AddSubShape.setValue(prism);
+
+        if (!base.IsNull()) {
+//             auto obj = getDocument()->addObject("Part::Feature", "prism");
+//             static_cast<Part::Feature*>(obj)->Shape.setValue(getSolid(prism));
+            // Let's call algorithm computing a fuse operation:
+            BRepAlgoAPI_Fuse mkFuse(base, prism);
+            // Let's check if the fusion has been successful
+            if (!mkFuse.IsDone())
+                return new App::DocumentObjectExecReturn("Pad: Fusion with base feature failed");
+            TopoDS_Shape result = mkFuse.Shape();
+
+            // we have to get the solids (fuse sometimes creates compounds)
+            TopoDS_Shape solRes = this->getSolid(result);
+            // lets check if the result is a solid
+            if (solRes.IsNull())
+                return new App::DocumentObjectExecReturn("Pad: Resulting shape is not a solid");
+
+            int solidCount = countSolids(result);
+            if (solidCount > 1) {
+                return new App::DocumentObjectExecReturn("Pad: Result has multiple solids. This is not supported at this time.");
+            }
+
+            solRes = refineShapeIfActive(solRes);
+            this->Shape.setValue(getSolid(solRes));
+        } else {
+            int solidCount = countSolids(prism);
+            if (solidCount > 1) {
+                return new App::DocumentObjectExecReturn("Pad: Result has multiple solids. This is not supported at this time.");
+            }
+
+           this->Shape.setValue(getSolid(prism));
+        }
+
+        return App::DocumentObject::StdReturn;
+    }
+    catch (Standard_Failure& e) {
+
+        if (std::string(e.GetMessageString()) == "TopoDS::Face")
+            return new App::DocumentObjectExecReturn("Could not create face from sketch.\n"
+                "Intersecting sketch entities or multiple faces in a sketch are not allowed.");
+        else
+            return new App::DocumentObjectExecReturn(e.GetMessageString());
+    }
+    catch (Base::Exception& e) {
+        return new App::DocumentObjectExecReturn(e.what());
+    }
+}
+
+
+
+void Text::updateAxis(void)
+{
+    App::DocumentObject *pcReferenceAxis = ReferenceAxis.getValue();
+    const std::vector<std::string> &subReferenceAxis = ReferenceAxis.getSubValues();
+    Base::Vector3d base;
+    Base::Vector3d dir;
+    getAxis(pcReferenceAxis, subReferenceAxis, base, dir);
+
+    Base.setValue(base.x,base.y,base.z);
+    Axis.setValue(dir.x,dir.y,dir.z);
+}
+
+
+TopoDS_Shape Text::textToShape(const std::string& text, const std::string& fontpath, double height, double track = 0.0)
+{
+    Base::Console().Warning("textToShape was called\n");
+
+    Py::Module mod(PyImport_ImportModule("Part"), true);
+    if (mod.isNull())
+        throw Py::Exception();
+
+    Base::Console().Warning("PyImport_ImportModule was succsessfull\n");
+
+    Py::Callable method(mod.getAttr(std::string("makeWireString")));
+
+    Py::Tuple args(4);
+
+    args.setItem(0, Py::String(text));
+    args.setItem(1, Py::String(fontpath));
+    args.setItem(2, Py::Float(height));
+    args.setItem(3, Py::Float(track));
+
+    Py::List charList(method.apply(args));
+
+    TopoDS_Compound comp;
+    BRep_Builder builder;
+    builder.MakeCompound(comp);
+
+
+    for (Py::List::iterator it = charList.begin(); it != charList.end(); ++it) {
+        Py::List glyph(*it);
+        for (Py::List::iterator jt = glyph.begin(); jt != glyph.end(); ++jt) {
+            if (PyObject_TypeCheck((*jt).ptr(), &Part::TopoShapePy::Type)) {
+                TopoShape* ptr = static_cast<Part::TopoShapePy*>((*jt).ptr())->getTopoShapePtr();
+                if (!ptr->getShape().IsNull()) {
+                    builder.Add(comp, ptr->getShape());
+                }
+            }
+        }
+    }
+
+
+    // make faces from the wires (simplified from getVerifiedFace)
+    const char* err = nullptr;
+    TopoShape shape;
+    try {
+        shape = TopoShape(comp);
+        if(shape.isNull())
+            err = "Linked shape object is empty";
+        else {
+            auto faces = shape.getSubTopoShapes(TopAbs_FACE);
+            if(faces.empty()) {
+                if(!shape.hasSubShape(TopAbs_WIRE))
+                    shape = shape.makEWires();
+                if(shape.hasSubShape(TopAbs_WIRE))
+                    shape = shape.makEFace(0,"Part::FaceMakerCheese");
+                else
+                    err = "Cannot make face from profile";
+            } else if (faces.size() == 1)
+                shape = faces.front();
+            else
+                shape = TopoShape().makECompound(faces);
+        }
+    } catch (Standard_Failure &e) {
+        throw Base::RuntimeError (err);;
+    }
+    Base::Console().Warning("textToShape if about to return\n");
+    return shape.getShape();
+
+}

--- a/src/Mod/PartDesign/App/FeatureText.cpp
+++ b/src/Mod/PartDesign/App/FeatureText.cpp
@@ -49,7 +49,6 @@
 # include <ShapeAnalysis.hxx>
 # include <gp_Ax1.hxx>
 # include <gp_Ax3.hxx>
-
 #endif
 
 # include <string>
@@ -59,8 +58,10 @@
 # include <Base/Exception.h>
 # include <Base/Placement.h>
 # include <Base/Tools.h>
-#include "boost/filesystem.hpp"
+# include <App/Application.h>
 
+
+// needed for textToShape
 # include <Mod/Part/App/TopoShape.h>
 # include <Mod/Part/App/TopoShapePy.h>
 # include <Mod/Part/App/FaceMakerCheese.h>
@@ -76,11 +77,14 @@ PROPERTY_SOURCE(PartDesign::Text, PartDesign::ProfileBased)
 Text::Text()
 {
 
+    std::string fontDir = App::Application::getResourceDir() + "Mod/TechDraw/Resources/fonts/";
+    std::string fontFile = fontDir + "osifont-lgpl3fe.ttf";
+
     ADD_PROPERTY_TYPE(ReferenceAxis,(0),"Helix", App::Prop_None, "Reference axis of revolution");
     ADD_PROPERTY_TYPE(Base,(Base::Vector3d(0.0,0.0,0.0)),"Text", App::Prop_ReadOnly, "Base");
     ADD_PROPERTY_TYPE(Axis,(Base::Vector3d(0.0,1.0,0.0)),"Text", App::Prop_ReadOnly, "Axis");
     ADD_PROPERTY_TYPE(TextString,("FreeCAD rocks!"),"Text", App::Prop_None, "Text");
-    ADD_PROPERTY_TYPE(Font,("/usr/share/fonts/truetype/ttf-bitstream-vera/VeraMono.ttf"),"Text", App::Prop_None, "Font");
+    ADD_PROPERTY_TYPE(Font,(fontFile.c_str()),"Text", App::Prop_None, "Font");
     ADD_PROPERTY_TYPE(Size,(20.0),"Text", App::Prop_None, "Size");
     ADD_PROPERTY_TYPE(Height,(30.0),"Text", App::Prop_None, "Height");
     ADD_PROPERTY_TYPE(Offset, (0.0), "Text", App::Prop_None, "Offset from face in which text will end");
@@ -286,7 +290,6 @@ void Text::updateAxis(void)
 TopoDS_Shape Text::textToShape(const std::string& text, const std::string& fontpath, double height, double track = 0.0)
 {
     Base::Console().Warning("textToShape was called\n");
-
     Py::Module mod(PyImport_ImportModule("Part"), true);
     if (mod.isNull())
         throw Py::Exception();
@@ -321,7 +324,6 @@ TopoDS_Shape Text::textToShape(const std::string& text, const std::string& fontp
         }
     }
 
-
     // make faces from the wires (simplified from getVerifiedFace)
     const char* err = nullptr;
     TopoShape shape;
@@ -346,7 +348,7 @@ TopoDS_Shape Text::textToShape(const std::string& text, const std::string& fontp
     } catch (Standard_Failure &e) {
         throw Base::RuntimeError (err);;
     }
-    Base::Console().Warning("textToShape if about to return\n");
+    Base::Console().Warning("textToShape is about to return\n");
     return shape.getShape();
 
 }

--- a/src/Mod/PartDesign/App/FeatureText.cpp
+++ b/src/Mod/PartDesign/App/FeatureText.cpp
@@ -147,13 +147,11 @@ App::DocumentObjectExecReturn *Text::execute(void)
 
 
     Part::Feature* obj = 0;
-    TopoDS_Shape sketchshape, textshape;
+    TopoDS_Shape textshape;
 
 
     try {
         obj = getVerifiedObject();
-        sketchshape = getVerifiedFace();
-        // (const std::string& text, const std::string& fontpath, double height, double track)
         textshape = textToShape(text, fontpath, size, 0.0);
 
     } catch (const Base::Exception& e) {
@@ -289,12 +287,10 @@ void Text::updateAxis(void)
 
 TopoDS_Shape Text::textToShape(const std::string& text, const std::string& fontpath, double height, double track = 0.0)
 {
-    Base::Console().Warning("textToShape was called\n");
+    Base::PyGILStateLocker lock;
     Py::Module mod(PyImport_ImportModule("Part"), true);
     if (mod.isNull())
         throw Py::Exception();
-
-    Base::Console().Warning("PyImport_ImportModule was succsessfull\n");
 
     Py::Callable method(mod.getAttr(std::string("makeWireString")));
 
@@ -348,7 +344,6 @@ TopoDS_Shape Text::textToShape(const std::string& text, const std::string& fontp
     } catch (Standard_Failure &e) {
         throw Base::RuntimeError (err);;
     }
-    Base::Console().Warning("textToShape is about to return\n");
     return shape.getShape();
 
 }

--- a/src/Mod/PartDesign/App/FeatureText.h
+++ b/src/Mod/PartDesign/App/FeatureText.h
@@ -27,13 +27,6 @@
 #include <App/PropertyUnits.h>
 #include "FeatureSketchBased.h"
 
-namespace Part
-{
-// I declare this here for now, as there is no AppPartPy.h
-// better solution is probably to create an AppPartPy.h. Why does it not exist?
-Py::Object makeWireString(const Py::Tuple& args);
-}
-
 namespace PartDesign
 {
 

--- a/src/Mod/PartDesign/App/FeatureText.h
+++ b/src/Mod/PartDesign/App/FeatureText.h
@@ -1,0 +1,89 @@
+/***************************************************************************
+ *   Copyright (c) 2010 Juergen Riegel <FreeCAD@juergen-riegel.net>        *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#ifndef PARTDESIGN_Text_H
+#define PARTDESIGN_Text_H
+
+#include <App/PropertyUnits.h>
+#include "FeatureSketchBased.h"
+
+namespace Part
+{
+// I declare this here for now, as there is no AppPartPy.h
+// better solution is probably to create an AppPartPy.h. Why does it not exist?
+Py::Object makeWireString(const Py::Tuple& args);
+}
+
+namespace PartDesign
+{
+
+class PartDesignExport Text : public ProfileBased
+{
+    PROPERTY_HEADER(PartDesign::Text);
+
+public:
+    Text();
+
+    App::PropertyVector      Base;
+    App::PropertyVector      Axis;
+    App::PropertyString      TextString;
+    App::PropertyFont        Font;
+    App::PropertyLength      Size;
+    App::PropertyLength      Height;
+    App::PropertyLength      Offset;
+
+
+    /** if this property is set to a valid link, both Axis and Base properties
+     *  are calculated according to the linked line
+    */
+    App::PropertyLinkSub ReferenceAxis;
+
+    /** @name methods override feature */
+    //@{
+    App::DocumentObjectExecReturn *execute(void);
+    short mustExecute() const;
+    /// returns the type name of the view provider
+    const char* getViewProviderName(void) const {
+        return "PartDesignGui::ViewProviderText";
+    }
+    //@}
+
+    void getFontPaths(std::map <std::string, std::string> &fontPath);
+
+protected:
+    /// updates Axis from ReferenceAxis
+    void updateAxis(void);
+
+    /// convert the text to an OCCT shape.
+    TopoDS_Shape textToShape(const std::string& text, const std::string& fontpath, double height, double track);
+
+private:
+
+
+};
+
+
+} //namespace PartDesign
+
+
+#endif // PART_Text_H

--- a/src/Mod/PartDesign/Gui/AppPartDesignGui.cpp
+++ b/src/Mod/PartDesign/Gui/AppPartDesignGui.cpp
@@ -61,6 +61,7 @@
 #include "ViewProviderThickness.h"
 #include "ViewProviderPipe.h"
 #include "ViewProviderLoft.h"
+#include "ViewProviderText.h"
 #include "ViewProviderShapeBinder.h"
 #include "ViewProviderBase.h"
 
@@ -156,6 +157,7 @@ PyMOD_INIT_FUNC(PartDesignGui)
     PartDesignGui::ViewProviderPrimitive     ::init();
     PartDesignGui::ViewProviderPipe          ::init();
     PartDesignGui::ViewProviderLoft          ::init();
+    PartDesignGui::ViewProviderText          ::init();
     PartDesignGui::ViewProviderBase          ::init();
 
      // add resources and reloads the translators

--- a/src/Mod/PartDesign/Gui/CMakeLists.txt
+++ b/src/Mod/PartDesign/Gui/CMakeLists.txt
@@ -55,6 +55,7 @@ set(PartDesignGui_MOC_HDRS
     TaskPrimitiveParameters.h
     TaskPipeParameters.h
     TaskLoftParameters.h
+    TaskTextParameters.h
 )
 fc_wrap_cpp(PartDesignGui_MOC_SRCS ${PartDesignGui_MOC_HDRS})
 SOURCE_GROUP("Moc" FILES ${PartDesignGui_MOC_SRCS})
@@ -89,6 +90,7 @@ set(PartDesignGui_UIC_SRCS
     TaskPipeScaling.ui
     TaskLoftParameters.ui
     DlgReference.ui
+    TaskTextParameters.ui
 )
 
 if(BUILD_QT5)
@@ -158,7 +160,9 @@ SET(PartDesignGuiViewProvider_SRCS
     ViewProviderPipe.cpp
     ViewProviderLoft.h
     ViewProviderLoft.cpp
-    ViewProviderBase.h 
+    ViewProviderText.h
+    ViewProviderText.cpp
+    ViewProviderBase.h
     ViewProviderBase.cpp
 )
 SOURCE_GROUP("ViewProvider" FILES ${PartDesignGuiViewProvider_SRCS})
@@ -237,6 +241,9 @@ SET(PartDesignGuiTaskDlgs_SRCS
     TaskLoftParameters.ui
     TaskLoftParameters.h
     TaskLoftParameters.cpp
+    TaskTextParameters.ui
+    TaskTextParameters.h
+    TaskTextParameters.cpp
 )
 SOURCE_GROUP("TaskDialogs" FILES ${PartDesignGuiTaskDlgs_SRCS})
 

--- a/src/Mod/PartDesign/Gui/Resources/PartDesign.qrc
+++ b/src/Mod/PartDesign/Gui/Resources/PartDesign.qrc
@@ -55,6 +55,7 @@
         <file>icons/PartDesignWorkbench.svg</file>
         <file>icons/Tree_PartDesign_Pad.svg</file>
         <file>icons/Tree_PartDesign_Revolution.svg</file>
+        <file>icons/PartDesign_Text.svg</file>
         <file>translations/PartDesign_af.qm</file>
         <file>translations/PartDesign_ar.qm</file>
         <file>translations/PartDesign_ca.qm</file>

--- a/src/Mod/PartDesign/Gui/Resources/icons/PartDesign_Text.svg
+++ b/src/Mod/PartDesign/Gui/Resources/icons/PartDesign_Text.svg
@@ -1,0 +1,424 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64px"
+   height="64px"
+   id="svg2901"
+   version="1.1"
+   sodipodi:docname="PartDesign_Text.svg"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1947"
+     inkscape:window-height="1376"
+     id="namedview1225"
+     showgrid="false"
+     inkscape:zoom="4.248165"
+     inkscape:cx="-3.0498104"
+     inkscape:cy="15.013995"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2901" />
+  <title
+     id="title1085">PartDesign_Additive_Helix</title>
+  <defs
+     id="defs2903">
+    <linearGradient
+       id="linearGradient1942">
+      <stop
+         style="stop-color:#d5c035;stop-opacity:1;"
+         offset="0"
+         id="stop1938" />
+      <stop
+         style="stop-color:#fce94f;stop-opacity:1"
+         offset="1"
+         id="stop1940" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1930">
+      <stop
+         style="stop-color:#c4a000;stop-opacity:1"
+         offset="0"
+         id="stop1926" />
+      <stop
+         style="stop-color:#fce94f;stop-opacity:1"
+         offset="1"
+         id="stop1928" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1475">
+      <stop
+         style="stop-color:#fce94f;stop-opacity:1"
+         offset="0"
+         id="stop1471" />
+      <stop
+         style="stop-color:#836b00;stop-opacity:1"
+         offset="1"
+         id="stop1473" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4237">
+      <stop
+         id="stop4239"
+         offset="0"
+         style="stop-color:#f82b39;stop-opacity:1;" />
+      <stop
+         id="stop4241"
+         offset="1"
+         style="stop-color:#520001;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4052">
+      <stop
+         style="stop-color:#0090ff;stop-opacity:1;"
+         offset="0"
+         id="stop4054" />
+      <stop
+         id="stop4060"
+         offset="0.5"
+         style="stop-color:#f0f1f1;stop-opacity:1;" />
+      <stop
+         style="stop-color:#0046ff;stop-opacity:1;"
+         offset="1"
+         id="stop4056" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4044">
+      <stop
+         style="stop-color:#0090ff;stop-opacity:1;"
+         offset="0"
+         id="stop4046" />
+      <stop
+         style="stop-color:#061aff;stop-opacity:1;"
+         offset="1"
+         id="stop4048" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3273">
+      <stop
+         id="stop3275"
+         offset="0"
+         style="stop-color:#c8e0f9;stop-opacity:1;" />
+      <stop
+         id="stop3277"
+         offset="1"
+         style="stop-color:#f7f9fa;stop-opacity:0.09649123;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3377">
+      <stop
+         id="stop3379"
+         offset="0"
+         style="stop-color:#c8e0f9;stop-opacity:1;" />
+      <stop
+         id="stop3381"
+         offset="1"
+         style="stop-color:#002795;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient4044"
+       id="linearGradient4050"
+       x1="44.858215"
+       y1="14.016123"
+       x2="33.928684"
+       y2="33.216251"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.97680237,0,0,0.96003508,1.4694319,0.12765765)" />
+    <linearGradient
+       xlink:href="#linearGradient4052"
+       id="linearGradient4058"
+       x1="42.373707"
+       y1="5.7974987"
+       x2="52.323219"
+       y2="22.675821"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.97680237,0,0,0.96003508,1.4694319,0.12765765)" />
+    <linearGradient
+       xlink:href="#linearGradient4052-1"
+       id="linearGradient4058-6"
+       x1="42.373707"
+       y1="5.7974987"
+       x2="52.323219"
+       y2="22.675821"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.97680237,0,0,0.96003508,1.4694319,0.12765765)" />
+    <linearGradient
+       id="linearGradient4052-1">
+      <stop
+         style="stop-color:#1f5fe0;stop-opacity:1;"
+         offset="0"
+         id="stop4054-5" />
+      <stop
+         id="stop4060-8"
+         offset="0.5"
+         style="stop-color:#71b2f8;stop-opacity:1;" />
+      <stop
+         style="stop-color:#002795;stop-opacity:1;"
+         offset="1"
+         id="stop4056-4" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-30.295225,-2.9287147)"
+       y2="22.675821"
+       x2="52.323219"
+       y1="5.7974987"
+       x1="42.373707"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4078"
+       xlink:href="#linearGradient4052-1" />
+    <linearGradient
+       xlink:href="#linearGradient4044"
+       id="linearGradient3885"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.97680237,0,0,0.96003508,107.10579,-22.235978)"
+       x1="44.858215"
+       y1="14.016123"
+       x2="33.928684"
+       y2="33.216251" />
+    <linearGradient
+       xlink:href="#linearGradient4052-1"
+       id="linearGradient3890"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.97680237,0,0,0.96003508,107.10579,-22.235978)"
+       x1="42.373707"
+       y1="5.7974987"
+       x2="52.323219"
+       y2="22.675821" />
+    <linearGradient
+       xlink:href="#linearGradient4052"
+       id="linearGradient3893"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.97680237,0,0,0.96003508,107.10579,-22.235978)"
+       x1="42.373707"
+       y1="5.7974987"
+       x2="52.323219"
+       y2="22.675821" />
+    <linearGradient
+       id="linearGradient4052-1-0">
+      <stop
+         style="stop-color:#0090ff;stop-opacity:1;"
+         offset="0"
+         id="stop4054-5-5" />
+      <stop
+         id="stop4060-8-6"
+         offset="0.5"
+         style="stop-color:#f0f1f1;stop-opacity:1;" />
+      <stop
+         style="stop-color:#0046ff;stop-opacity:1;"
+         offset="1"
+         id="stop4056-4-6" />
+    </linearGradient>
+    <linearGradient
+       y2="22.675821"
+       x2="52.323219"
+       y1="5.7974987"
+       x1="42.373707"
+       gradientTransform="matrix(0.97680237,0,0,0.96003508,-3.3630199,-18.322982)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3912"
+       xlink:href="#linearGradient4052-1-0" />
+    <linearGradient
+       id="linearGradient4052-1-0-0">
+      <stop
+         style="stop-color:#0090ff;stop-opacity:1;"
+         offset="0"
+         id="stop4054-5-5-9" />
+      <stop
+         id="stop4060-8-6-8"
+         offset="0.5"
+         style="stop-color:#f0f1f1;stop-opacity:1;" />
+      <stop
+         style="stop-color:#0046ff;stop-opacity:1;"
+         offset="1"
+         id="stop4056-4-6-4" />
+    </linearGradient>
+    <linearGradient
+       y2="22.675821"
+       x2="52.323219"
+       y1="5.7974987"
+       x1="42.373707"
+       gradientTransform="matrix(0.97680237,0,0,0.96003508,126.73769,-70.092683)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3985"
+       xlink:href="#linearGradient4052-1-0-0" />
+    <linearGradient
+       id="linearGradient4044-8">
+      <stop
+         style="stop-color:#0090ff;stop-opacity:1;"
+         offset="0"
+         id="stop4046-2" />
+      <stop
+         style="stop-color:#061aff;stop-opacity:1;"
+         offset="1"
+         id="stop4048-1" />
+    </linearGradient>
+    <linearGradient
+       y2="33.216251"
+       x2="33.928684"
+       y1="14.016123"
+       x1="44.858215"
+       gradientTransform="matrix(0.97680237,0,0,0.96003508,-26.24677,-8.4607595)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4072"
+       xlink:href="#linearGradient4044-8" />
+    <linearGradient
+       xlink:href="#linearGradient4044-8-4"
+       id="linearGradient3885-6-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.97680237,0,0,0.96003508,58.307367,54.671469)"
+       x1="44.858215"
+       y1="14.016123"
+       x2="33.928684"
+       y2="33.216251" />
+    <linearGradient
+       id="linearGradient4044-8-4">
+      <stop
+         style="stop-color:#0090ff;stop-opacity:1;"
+         offset="0"
+         id="stop4046-2-0" />
+      <stop
+         style="stop-color:#061aff;stop-opacity:1;"
+         offset="1"
+         id="stop4048-1-9" />
+    </linearGradient>
+    <linearGradient
+       y2="33.216251"
+       x2="33.928684"
+       y1="14.016123"
+       x1="44.858215"
+       gradientTransform="matrix(0.97680237,0,0,0.96003508,145.41299,94.782221)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4163"
+       xlink:href="#linearGradient4044-8-4" />
+    <linearGradient
+       id="linearGradient4052-1-0-9">
+      <stop
+         style="stop-color:#0090ff;stop-opacity:1;"
+         offset="0"
+         id="stop4054-5-5-2" />
+      <stop
+         id="stop4060-8-6-5"
+         offset="0.5"
+         style="stop-color:#f0f1f1;stop-opacity:1;" />
+      <stop
+         style="stop-color:#0046ff;stop-opacity:1;"
+         offset="1"
+         id="stop4056-4-6-5" />
+    </linearGradient>
+    <linearGradient
+       y2="22.675821"
+       x2="52.323219"
+       y1="5.7974987"
+       x1="42.373707"
+       gradientTransform="matrix(0.97680237,0,0,0.96003508,126.73769,-70.092687)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4217"
+       xlink:href="#linearGradient4052-1-0-9" />
+    <radialGradient
+       xlink:href="#linearGradient1475"
+       id="radialGradient2153"
+       cx="36.572212"
+       cy="30.972466"
+       fx="36.572212"
+       fy="30.972466"
+       r="18.483015"
+       gradientTransform="matrix(0.94353923,0,0,0.73910673,2.0756521,7.8201849)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       xlink:href="#linearGradient1930"
+       id="linearGradient1932"
+       x1="21.766993"
+       y1="36.503899"
+       x2="16.343052"
+       y2="24.589472"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       xlink:href="#linearGradient1942"
+       id="linearGradient1944"
+       x1="38.137226"
+       y1="16.171356"
+       x2="33.022259"
+       y2="10.52606"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1475"
+       id="linearGradient1239"
+       x1="7.3424487"
+       y1="31.847927"
+       x2="58.481621"
+       y2="31.847927"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <metadata
+     id="metadata2906">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>PartDesign_Additive_Helix</dc:title>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>bitacovir, davidosterberg</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:title>PartDesign_Revolution</dc:title>
+        <dc:date>2020/12/30</dc:date>
+        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier />
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title />
+          </cc:Agent>
+        </dc:contributor>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <rect
+     style="fill:url(#linearGradient1239);fill-opacity:1.0;stroke-width:1.6;stroke-linecap:square"
+     id="rect1231"
+     width="51.139172"
+     height="55.272446"
+     x="7.3424487"
+     y="4.2117052"
+     ry="11.218294" />
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:69.9398px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;"
+     x="12.341751"
+     y="52.804955"
+     id="text1229"><tspan
+       sodipodi:role="line"
+       id="tspan1227"
+       x="12.341751"
+       y="52.804955"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Tlwg Typewriter';-inkscape-font-specification:'Tlwg Typewriter Bold';stroke-width:1;fill:#000000;fill-opacity:1;">T</tspan></text>
+</svg>

--- a/src/Mod/PartDesign/Gui/TaskTextParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskTextParameters.cpp
@@ -1,0 +1,441 @@
+/***************************************************************************
+ *   Copyright (c) 2011 Juergen Riegel <FreeCAD@juergen-riegel.net>        *
+ *                 2020 David Österberg                                    *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#include "PreCompiled.h"
+
+#ifndef _PreComp_
+#include <QStandardPaths>
+#include <QDir>
+#include <QDirIterator>
+#include <QFontDatabase>
+#include <map>
+#endif
+
+#include <Base/UnitsApi.h>
+#include <Base/Console.h>
+#include <App/Application.h>
+#include <App/Document.h>
+#include <App/Origin.h>
+#include <App/OriginFeature.h>
+#include <Gui/Application.h>
+#include <Gui/Document.h>
+#include <Gui/BitmapFactory.h>
+#include <Gui/ViewProvider.h>
+#include <Gui/WaitCursor.h>
+#include <Gui/Selection.h>
+#include <Gui/Command.h>
+#include <Gui/ViewProviderOrigin.h>
+#include <Mod/PartDesign/App/DatumLine.h>
+#include <Mod/PartDesign/App/FeatureText.h>
+#include <Mod/PartDesign/App/FeatureGroove.h>
+#include <Mod/Sketcher/App/SketchObject.h>
+#include <Mod/PartDesign/App/Body.h>
+#include <QString>
+#include <QLineEdit>
+#include <QFont>
+#include <QStandardPaths>
+
+#include "ReferenceSelection.h"
+#include "Utils.h"
+
+#include "ui_TaskTextParameters.h"
+#include "TaskTextParameters.h"
+
+using namespace PartDesignGui;
+using namespace Gui;
+
+
+/* TRANSLATOR PartDesignGui::TaskTextParameters */
+
+TaskTextParameters::TaskTextParameters(PartDesignGui::ViewProviderText *TextView, QWidget *parent)
+    : TaskSketchBasedParameters(TextView, parent, "PartDesign_Text",tr("Text parameters")),
+    ui (new Ui_TaskTextParameters)
+{
+    // we need a separate container widget to add all controls to
+    proxy = new QWidget(this);
+    ui->setupUi(proxy);
+    QMetaObject::connectSlotsByName(this);
+
+    connect(ui->axis, SIGNAL(activated(int)),
+            this, SLOT(onAxisChanged(int)));
+    connect(ui->text, SIGNAL(textChanged(const QString &)),
+            this, SLOT(onTextChanged(QString)));
+    connect(ui->font, SIGNAL(currentFontChanged(const QFont &)),
+            this, SLOT(onFontChanged(QFont)));
+    connect(ui->size, SIGNAL(valueChanged(double)),
+            this, SLOT(onSizeChanged(double)));
+    connect(ui->height, SIGNAL(valueChanged(double)),
+            this, SLOT(onHeightChanged(double)));
+
+
+
+    this->groupLayout()->addWidget(proxy);
+
+    getFontPaths();
+
+    ui->font->setWritingSystem(QFontDatabase::Latin);
+    ui->font->setFontFilters(QFontComboBox::ScalableFonts);
+
+
+    // Temporarily prevent unnecessary feature recomputes
+    ui->axis->blockSignals(true);
+    ui->text->blockSignals(true);
+    ui->font->blockSignals(true);
+    ui->size->blockSignals(true);
+    ui->height->blockSignals(true);
+
+    //bind property mirrors
+    PartDesign::ProfileBased* pcFeat = static_cast<PartDesign::ProfileBased*>(vp->getObject());
+
+    PartDesign::Text* rev = static_cast<PartDesign::Text*>(vp->getObject());
+
+    this->propReferenceAxis = &(rev->ReferenceAxis);
+    this->propText = &(rev->TextString);
+    this->propFont = &(rev->Font);
+    this->propSize = &(rev->Size);
+    this->propHeight = &(rev->Height);
+
+    QString text(QString::fromUtf8(propText->getValue()));
+    QString fontFam(QString::fromUtf8(propFont->getValue()));
+    int pointSize = -1;
+    int weight = -1;
+    bool italic = false;
+    QFont font(fontFam, pointSize, weight, italic);
+    double size = propSize->getValue();
+    double height = propHeight->getValue();
+
+    ui->text->setText(text);
+    //ui->font->setCurrentFont(font);
+    ui->size->setValue(size);
+    ui->height->setValue(height);
+
+    blockUpdate = false;
+    updateUI();
+
+    // make it possible to use expressions for the height and size
+    ui->height->bind(static_cast<PartDesign::Text *>(pcFeat)->Height);
+    ui->size->bind(static_cast<PartDesign::Text *>(pcFeat)->Size);
+
+    ui->axis->blockSignals(false);
+    ui->text->blockSignals(false);
+    ui->font->blockSignals(false);
+    ui->size->blockSignals(false);
+    ui->height->blockSignals(false);
+
+    setFocus ();
+
+    //show the parts coordinate system axis for selection
+    PartDesign::Body * body = PartDesign::Body::findBodyOf ( vp->getObject () );
+    if(body) {
+        try {
+            App::Origin *origin = body->getOrigin();
+            ViewProviderOrigin* vpOrigin;
+            vpOrigin = static_cast<ViewProviderOrigin*>(Gui::Application::Instance->getViewProvider(origin));
+            vpOrigin->setTemporaryVisibility(true, false);
+        } catch (const Base::Exception &ex) {
+            ex.ReportException();
+        }
+     }
+}
+
+void TaskTextParameters::fillAxisCombo(bool forceRefill)
+{
+    bool oldVal_blockUpdate = blockUpdate;
+    blockUpdate = true;
+
+    if (axesInList.empty())
+        forceRefill = true;//not filled yet, full refill
+
+    if (forceRefill){
+        ui->axis->clear();
+
+        this->axesInList.clear();
+
+        //add sketch axes
+        PartDesign::ProfileBased* pcFeat = static_cast<PartDesign::ProfileBased*>(vp->getObject());
+        Part::Part2DObject* pcSketch = dynamic_cast<Part::Part2DObject*>(pcFeat->Profile.getValue());
+        if (pcSketch){
+            addAxisToCombo(pcSketch,"V_Axis",QObject::tr("Vertical sketch axis"));
+            addAxisToCombo(pcSketch,"H_Axis",QObject::tr("Horizontal sketch axis"));
+            for (int i=0; i < pcSketch->getAxisCount(); i++) {
+                QString itemText = QObject::tr("Construction line %1").arg(i+1);
+                std::stringstream sub;
+                sub << "Axis" << i;
+                addAxisToCombo(pcSketch,sub.str(),itemText);
+            }
+        }
+
+        //add part axes
+        PartDesign::Body * body = PartDesign::Body::findBodyOf ( pcFeat );
+        if (body) {
+            try {
+                App::Origin* orig = body->getOrigin();
+                addAxisToCombo(orig->getX(),"",tr("Base X axis"));
+                addAxisToCombo(orig->getY(),"",tr("Base Y axis"));
+                addAxisToCombo(orig->getZ(),"",tr("Base Z axis"));
+            } catch (const Base::Exception &ex) {
+                ex.ReportException();
+            }
+        }
+
+        //add "Select reference"
+        addAxisToCombo(0,std::string(),tr("Select reference..."));
+    }//endif forceRefill
+
+    //add current link, if not in list
+    //first, figure out the item number for current axis
+    int indexOfCurrent = -1;
+    App::DocumentObject* ax = propReferenceAxis->getValue();
+    const std::vector<std::string> &subList = propReferenceAxis->getSubValues();
+    for (size_t i = 0; i < axesInList.size(); i++) {
+        if (ax == axesInList[i]->getValue() && subList == axesInList[i]->getSubValues())
+            indexOfCurrent = i;
+    }
+    if (indexOfCurrent == -1  &&  ax) {
+        assert(subList.size() <= 1);
+        std::string sub;
+        if (!subList.empty())
+            sub = subList[0];
+        addAxisToCombo(ax, sub, getRefStr(ax, subList));
+        indexOfCurrent = axesInList.size()-1;
+    }
+
+    //highlight current.
+    if (indexOfCurrent != -1)
+        ui->axis->setCurrentIndex(indexOfCurrent);
+
+    blockUpdate = oldVal_blockUpdate;
+}
+
+void TaskTextParameters::addAxisToCombo(App::DocumentObject* linkObj,
+                                              std::string linkSubname,
+                                              QString itemText)
+{
+    this->ui->axis->addItem(itemText);
+    this->axesInList.emplace_back(new App::PropertyLinkSub);
+    App::PropertyLinkSub &lnk = *(axesInList[axesInList.size()-1]);
+    lnk.setValue(linkObj,std::vector<std::string>(1,linkSubname));
+}
+
+void TaskTextParameters::updateUI()
+{
+    fillAxisCombo();
+
+    PartDesign::ProfileBased* pcText = static_cast<PartDesign::ProfileBased*>(vp->getObject());
+    ui->labelMessage->setText(QString::fromUtf8(pcText->getStatusString()));
+
+}
+
+void TaskTextParameters::onSelectionChanged(const Gui::SelectionChanges& msg)
+{
+    if (msg.Type == Gui::SelectionChanges::AddSelection) {
+
+        exitSelectionMode();
+        std::vector<std::string> axis;
+        App::DocumentObject* selObj;
+        if (getReferencedSelection(vp->getObject(), msg, selObj, axis) && selObj) {
+            propReferenceAxis->setValue(selObj, axis);
+
+            if (blockUpdate)
+                return;
+
+            recomputeFeature();
+            updateUI();
+        }
+    }
+}
+
+
+void TaskTextParameters::onTextChanged(QString s)
+{
+    propText->setValue(s.toStdString());
+    recomputeFeature();
+    updateUI();
+}
+
+
+void TaskTextParameters::onFontChanged(QFont font)
+{
+
+    Base::Console().Warning("%s\n", font.family().toStdString().c_str());
+
+    auto itr = fontPath.find(font.family());
+    if (itr == fontPath.end())
+        throw Base::ValueError("Could not find selected font");
+
+    propFont->setValue((itr->second).toStdString());
+    recomputeFeature();
+    updateUI();
+}
+
+void TaskTextParameters::onSizeChanged(double size)
+{
+    propSize->setValue(size);
+    recomputeFeature();
+    updateUI();
+}
+
+void TaskTextParameters::onHeightChanged(double h)
+{
+    propHeight->setValue(h);
+    recomputeFeature();
+    updateUI();
+}
+
+void TaskTextParameters::onAxisChanged(int num)
+{
+    PartDesign::ProfileBased* pcText = static_cast<PartDesign::ProfileBased*>(vp->getObject());
+
+    if (axesInList.empty())
+        return;
+
+    App::PropertyLinkSub &lnk = *(axesInList[num]);
+    if (lnk.getValue() == 0) {
+        // enter reference selection mode
+        TaskSketchBasedParameters::onSelectReference(true, true, false, true);
+    } else {
+        if (!pcText->getDocument()->isIn(lnk.getValue())){
+            Base::Console().Error("Object was deleted\n");
+            return;
+        }
+        propReferenceAxis->Paste(lnk);
+        exitSelectionMode();
+    }
+
+    try {
+        recomputeFeature();
+        updateUI();
+    }
+    catch (const Base::Exception& e) {
+        e.ReportException();
+    }
+}
+
+
+TaskTextParameters::~TaskTextParameters()
+{
+    try {
+        //hide the parts coordinate system axis for selection
+        PartDesign::Body * body = vp ? PartDesign::Body::findBodyOf(vp->getObject()) : 0;
+        if (body) {
+            App::Origin *origin = body->getOrigin();
+            ViewProviderOrigin* vpOrigin;
+            vpOrigin = static_cast<ViewProviderOrigin*>(Gui::Application::Instance->getViewProvider(origin));
+            vpOrigin->resetTemporaryVisibility();
+        }
+    } catch (const Base::Exception &ex) {
+        ex.ReportException();
+    }
+
+}
+
+void TaskTextParameters::changeEvent(QEvent *e)
+{
+    TaskBox::changeEvent(e);
+    if (e->type() == QEvent::LanguageChange) {
+        ui->retranslateUi(proxy);
+    }
+}
+
+void TaskTextParameters::getReferenceAxis(App::DocumentObject*& obj, std::vector<std::string>& sub) const
+{
+    if (axesInList.empty())
+        throw Base::RuntimeError("Not initialized!");
+
+    int num = ui->axis->currentIndex();
+    const App::PropertyLinkSub &lnk = *(axesInList[num]);
+    if (lnk.getValue() == 0) {
+        throw Base::RuntimeError("Still in reference selection mode; reference wasn't selected yet");
+    } else {
+        PartDesign::ProfileBased* pcRevolution = static_cast<PartDesign::ProfileBased*>(vp->getObject());
+        if (!pcRevolution->getDocument()->isIn(lnk.getValue())){
+            throw Base::RuntimeError("Object was deleted");
+        }
+
+        obj = lnk.getValue();
+        sub = lnk.getSubValues();
+    }
+}
+
+// this is used for logging the command fully when recording macros
+void TaskTextParameters::apply()
+{
+    std::vector<std::string> sub;
+    App::DocumentObject* obj;
+    getReferenceAxis(obj, sub);
+    std::string axis = buildLinkSingleSubPythonStr(obj, sub);
+    auto tobj = vp->getObject();
+    FCMD_OBJ_CMD(tobj,"ReferenceAxis = " << axis);
+    FCMD_OBJ_CMD(tobj,"TextString = \"" << propText->getValue() << "\"");
+    FCMD_OBJ_CMD(tobj,"Font = \"" << propFont->getValue() << "\"");
+    FCMD_OBJ_CMD(tobj,"Size = " << propSize->getValue());
+    FCMD_OBJ_CMD(tobj,"Height = " << propHeight->getValue());
+}
+
+
+// Based on https://stackoverflow.com/a/64729615
+// Ported to c++
+// Modified to ignore Non-TrueType fonts
+void TaskTextParameters::getFontPaths(void)
+{
+    QStringList font_paths = QStandardPaths::standardLocations(QStandardPaths::FontsLocation);
+    QFontDatabase* db = new QFontDatabase();
+    QStringListIterator fpathIterator(font_paths);
+    while (fpathIterator.hasNext()) {
+        QString fpath = fpathIterator.next();
+        QDirIterator filenameIt(fpath, QDirIterator::Subdirectories);
+        while (filenameIt.hasNext()) {
+            QString filename = filenameIt.next();
+            //if (!filename.endsWith(QString::fromUtf8(".ttf"))  && !filename.endsWith(QString::fromUtf8(".ttc")))
+            if (!filename.endsWith(QString::fromUtf8(".ttf")))
+                continue;
+            QString path = QDir(fpath).filePath(filename);
+            int idx = db->addApplicationFont(path);  // add font path
+            if (idx >= 0) { // success
+                QStringList names = db->applicationFontFamilies(idx);  // load back font family name
+                QStringListIterator namesIterator(names);
+                while (namesIterator.hasNext()) {
+                    QString name = namesIterator.next();
+                    if(fontPath.count(name) == 0) {
+                        fontPath.insert({name, path});
+                    }
+                }
+            }
+        }
+    }
+}
+
+//**************************************************************************
+//**************************************************************************
+// TaskDialog
+//++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+TaskDlgTextParameters::TaskDlgTextParameters(ViewProviderText *TextView)
+    : TaskDlgSketchBasedParameters(TextView)
+{
+    assert(TextView);
+    Content.push_back(new TaskTextParameters(TextView));
+}
+
+
+#include "moc_TaskTextParameters.cpp"

--- a/src/Mod/PartDesign/Gui/TaskTextParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskTextParameters.cpp
@@ -400,7 +400,7 @@ void TaskTextParameters::apply()
 void TaskTextParameters::getFontPaths(void)
 {
     QStringList font_paths = QStandardPaths::standardLocations(QStandardPaths::FontsLocation);
-    QFontDatabase* db = new QFontDatabase();
+    QFontDatabase db;
     QStringListIterator fpathIterator(font_paths);
     while (fpathIterator.hasNext()) {
         QString fpath = fpathIterator.next();
@@ -411,9 +411,9 @@ void TaskTextParameters::getFontPaths(void)
             if (!filename.endsWith(QString::fromUtf8(".ttf")))
                 continue;
             QString path = QDir(fpath).filePath(filename);
-            int idx = db->addApplicationFont(path);  // add font path
+            int idx = db.addApplicationFont(path);  // add font path
             if (idx >= 0) { // success
-                QStringList names = db->applicationFontFamilies(idx);  // load back font family name
+                QStringList names = db.applicationFontFamilies(idx);  // load back font family name
                 QStringListIterator namesIterator(names);
                 while (namesIterator.hasNext()) {
                     QString name = namesIterator.next();

--- a/src/Mod/PartDesign/Gui/TaskTextParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskTextParameters.h
@@ -1,0 +1,127 @@
+/***************************************************************************
+ *   Copyright (c) 2011 Juergen Riegel <FreeCAD@juergen-riegel.net>        *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#ifndef GUI_TASKVIEW_TaskTextParameters_H
+#define GUI_TASKVIEW_TaskTextParameters_H
+
+#include <Gui/TaskView/TaskView.h>
+#include <Gui/Selection.h>
+#include <Gui/TaskView/TaskDialog.h>
+
+#include "TaskSketchBasedParameters.h"
+#include "ViewProviderText.h"
+
+class Ui_TaskTextParameters;
+
+namespace App {
+class Property;
+}
+
+namespace Gui {
+class ViewProvider;
+}
+
+namespace PartDesignGui {
+
+
+
+class TaskTextParameters : public TaskSketchBasedParameters
+{
+    Q_OBJECT
+
+public:
+    TaskTextParameters(ViewProviderText *TextView,QWidget *parent = 0);
+    ~TaskTextParameters();
+
+    virtual void apply() override;
+
+    /**
+     * @brief fillAxisCombo fills the combo and selects the item according to
+     * current value of revolution object's axis reference.
+     * @param forceRefill if true, the combo box will be completely refilled. If
+     * false, the current value of revolution object's axis will be added to the
+     * list (if necessary), and selected. If the list is empty, it will be refilled anyway.
+     */
+    void fillAxisCombo(bool forceRefill = false);
+    void addAxisToCombo(App::DocumentObject *linkObj, std::string linkSubname, QString itemText);
+
+private Q_SLOTS:
+    void onAxisChanged(int);
+    void onTextChanged(QString);
+    void onFontChanged(QFont);
+    void onSizeChanged(double);
+    void onHeightChanged(double);
+
+private:
+    void updateUI();
+
+    QWidget* proxy;
+
+    Ui_TaskTextParameters* ui;
+
+    /**
+     * @brief axesInList is the list of links corresponding to axis combo; must
+     * be kept in sync with the combo. A special value of zero-pointer link is
+     * for "Select axis" item.
+     *
+     * It is a list of pointers, because properties prohibit assignment. .
+     */
+    std::vector<std::unique_ptr<App::PropertyLinkSub>> axesInList;
+
+    // this is a map between font family name and filepath to the font file.
+    std::map<QString, QString> fontPath;
+
+    // this method populates fontPath.
+    void getFontPaths(void);
+
+protected:
+    void onSelectionChanged(const Gui::SelectionChanges& msg) override;
+    void changeEvent(QEvent *e) override;
+    bool updateView() const;
+    void getReferenceAxis(App::DocumentObject *&obj, std::vector<std::string> &sub) const;
+
+
+    //mirrors of helixes's properties
+    App::PropertyString*      propText;
+    App::PropertyLength*      propHeight;
+    App::PropertyFont*        propFont;
+    App::PropertyLength*      propSize;
+    App::PropertyLinkSub*     propReferenceAxis;
+
+};
+
+/// simulation dialog for the TaskView
+class TaskDlgTextParameters : public TaskDlgSketchBasedParameters
+{
+    Q_OBJECT
+
+public:
+    TaskDlgTextParameters(ViewProviderText *TextView);
+
+    ViewProviderText* getTextView() const
+    { return static_cast<ViewProviderText*>(vp); }
+};
+
+} //namespace PartDesignGui
+
+#endif // GUI_TASKVIEW_TaskTextParameters_H

--- a/src/Mod/PartDesign/Gui/TaskTextParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskTextParameters.ui
@@ -1,0 +1,187 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>PartDesignGui::TaskTextParameters</class>
+ <widget class="QWidget" name="PartDesignGui::TaskTextParameters">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>278</width>
+    <height>193</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+
+    <item>
+    <layout class="QHBoxLayout" name="horizontalLayoutStatus">
+     <item>
+      <widget class="QLabel" name="labelStatus">
+       <property name="text">
+        <string>Status:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="labelMessage">
+       <property name="text">
+        <string>Valid</string>
+       </property>
+      </widget>
+     </item>
+     </layout>
+   </item>
+
+    <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLabel" name="label0">
+       <property name="text">
+        <string>Axis:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="axis">
+       <item>
+        <property name="text">
+         <string>Horizontal sketch axis</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Vertical sketch axis</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+    </layout>
+   </item>
+
+    <item>
+    <layout class="QHBoxLayout" name="horizontalLayoutTurns">
+     <item>
+      <widget class="QLabel" name="labelText">
+       <property name="text">
+        <string>Text:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="text"/>
+     </item>
+    </layout>
+   </item>
+
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayoutFont">
+     <item>
+      <widget class="QLabel" name="labelFont">
+       <property name="text">
+        <string>Font:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QFontComboBox" name="font"/>
+     </item>
+    </layout>
+   </item>
+
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayoutSize">
+     <item>
+      <widget class="QLabel" name="labelSize">
+       <property name="text">
+        <string>Font size:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="Gui::QuantitySpinBox" name="size">
+       <property name="keyboardTracking">
+        <bool>false</bool>
+       </property>
+       <property name="unit" stdset="0">
+        <string notr="true">mm</string>
+       </property>
+       <property name="minimum">
+        <double>0.000000000000000</double>
+       </property>
+       <property name="singleStep">
+        <double>1.000000000000000</double>
+       </property>
+       <property name="value">
+        <double>10.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+
+    <item>
+    <layout class="QHBoxLayout" name="horizontalLayoutHeight">
+     <item>
+      <widget class="QLabel" name="labelHeight">
+       <property name="text">
+        <string>Text offset (+/-):</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="Gui::QuantitySpinBox" name="height">
+       <property name="keyboardTracking">
+        <bool>false</bool>
+       </property>
+       <property name="unit" stdset="0">
+        <string notr="true">mm</string>
+       </property>
+       <property name="minimum">
+        <double>0.000000000000000</double>
+       </property>
+       <property name="singleStep">
+        <double>1.000000000000000</double>
+       </property>
+       <property name="value">
+        <double>30.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+
+   <item>
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+
+   <item>
+    <widget class="QCheckBox" name="checkBoxUpdateView">
+     <property name="text">
+      <string>Update view</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+
+
+
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>Gui::QuantitySpinBox</class>
+   <extends>QWidget</extends>
+   <header>Gui/QuantitySpinBox.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/Mod/PartDesign/Gui/ViewProviderText.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderText.cpp
@@ -1,0 +1,67 @@
+/***************************************************************************
+ *   Copyright (c) 2011 Juergen Riegel <FreeCAD@juergen-riegel.net>        *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#include "PreCompiled.h"
+
+#ifndef _PreComp_
+# include <QAction>
+# include <QMenu>
+#endif
+
+#include <Mod/PartDesign/App/FeatureText.h>
+#include <Gui/BitmapFactory.h>
+
+#include "TaskTextParameters.h"
+#include "ViewProviderText.h"
+
+using namespace PartDesignGui;
+
+PROPERTY_SOURCE(PartDesignGui::ViewProviderText,PartDesignGui::ViewProvider)
+
+
+ViewProviderText::ViewProviderText()
+{
+}
+
+ViewProviderText::~ViewProviderText()
+{
+}
+
+void ViewProviderText::setupContextMenu(QMenu* menu, QObject* receiver, const char* member)
+{
+    QAction* act;
+    act = menu->addAction(QObject::tr("Edit text"), receiver, member);
+    act->setData(QVariant((int)ViewProvider::Default));
+    PartDesignGui::ViewProviderSketchBased::setupContextMenu(menu, receiver, member);
+}
+
+TaskDlgFeatureParameters *ViewProviderText::getEditDialog()
+{
+    return new TaskDlgTextParameters( this );
+}
+
+QIcon ViewProviderText::getIcon(void) const {
+    QString str = QString::fromLatin1("PartDesign_Text.svg");
+    return PartDesignGui::ViewProvider::mergeOverlayIcons(Gui::BitmapFactory().pixmap(str.toStdString().c_str()));
+}
+

--- a/src/Mod/PartDesign/Gui/ViewProviderText.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderText.cpp
@@ -62,6 +62,6 @@ TaskDlgFeatureParameters *ViewProviderText::getEditDialog()
 
 QIcon ViewProviderText::getIcon(void) const {
     QString str = QString::fromLatin1("PartDesign_Text.svg");
-    return PartDesignGui::ViewProvider::mergeOverlayIcons(Gui::BitmapFactory().pixmap(str.toStdString().c_str()));
+    return PartDesignGui::ViewProvider::mergeGreyableOverlayIcons(Gui::BitmapFactory().pixmap(str.toStdString().c_str()));
 }
 

--- a/src/Mod/PartDesign/Gui/ViewProviderText.h
+++ b/src/Mod/PartDesign/Gui/ViewProviderText.h
@@ -1,0 +1,55 @@
+/***************************************************************************
+ *   Copyright (c) 2011 Juergen Riegel <FreeCAD@juergen-riegel.net>        *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#ifndef PARTGUI_ViewProviderText_H
+#define PARTGUI_ViewProviderText_H
+
+#include "ViewProviderSketchBased.h"
+
+
+namespace PartDesignGui {
+
+class PartDesignGuiExport ViewProviderText : public ViewProviderSketchBased
+{
+    PROPERTY_HEADER(PartDesignGui::ViewProviderText);
+
+public:
+    /// constructor
+    ViewProviderText();
+    /// destructor
+    virtual ~ViewProviderText();
+
+    void setupContextMenu(QMenu*, QObject*, const char*);
+
+protected:
+    virtual QIcon getIcon(void) const;
+
+    /// Returns a newly created TaskDlgTextParameters
+    virtual TaskDlgFeatureParameters *getEditDialog();
+};
+
+
+} // namespace PartDesignGui
+
+
+#endif // PARTGUI_ViewProviderText_H

--- a/src/Mod/PartDesign/Gui/Workbench.cpp
+++ b/src/Mod/PartDesign/Gui/Workbench.cpp
@@ -409,6 +409,7 @@ void Workbench::activated()
         "PartDesign_SubtractivePipe",
         "PartDesign_AdditiveLoft",
         "PartDesign_SubtractiveLoft",
+        "PartDesign_Text",
         0};
     Watcher.push_back(new Gui::TaskView::TaskWatcherCommands(
         "SELECT Sketcher::SketchObject COUNT 1",
@@ -516,7 +517,7 @@ Gui::MenuItem* Workbench::setupMenuBar() const
     Gui::MenuItem* dressups = new Gui::MenuItem;
     dressups->setCommand("Apply a dress-up feature");
     *dressups << "PartDesign_Fillet" << "PartDesign_Chamfer"
-        << "PartDesign_Draft" << "PartDesign_Thickness";
+        << "PartDesign_Draft" << "PartDesign_Thickness" << "PartDesign_Text";
 
     *part << "PartDesign_Body"
           << "Separator"
@@ -617,6 +618,7 @@ Gui::ToolBarItem* Workbench::setupToolBars() const
           << "PartDesign_Chamfer"
           << "PartDesign_Draft"
           << "PartDesign_Thickness"
+          << "PartDesign_Text"
           << "Separator"
           << "PartDesign_Boolean";
 


### PR DESCRIPTION
Allow for easy and parametric additive and subractive text features in PartDesign.

Work is very much in progress. No need for detail review at this stage. 

Forum discussion:
https://forum.freecadweb.org/viewtopic.php?f=19&t=53833

![image](https://user-images.githubusercontent.com/1278189/103812187-6cf3d880-505e-11eb-8801-13df67d77e94.png)
![demo1](https://user-images.githubusercontent.com/1278189/103897403-cbb76180-50f3-11eb-93b1-a48c62026e76.gif)


What works
- Font selection with QFontComboBox
- Generation of text shapes

Todo:

- [x] Fix segfault when recomputing
- [x] Implement the text location by sketch logic
- [ ] Ship a small selection of fonts with FreeCAD, so that models using those fonts will be platform independent, and distinguish these in the UI.
- [ ] implement subractive, additive, and imprint modes by observing the sign of the input 
- [ ] Filter out non TrueType fonts from QFontComboBox (subclass?)
- [ ] Scale text to exact desired height by means of Bounding box command.
