### PR TITLE
[Sketcher] Fix crash in SketcherObject::setDatum

### DIFF
--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -362,7 +362,7 @@ int SketchObject::setDatum(int ConstrId, double Datum)
     int err = solve();
 
     if (err)
-        newVals[ConstrId]->setValue(oldDatum);
+        this->Constraints.getValues()[ConstrId]->setValue(oldDatum); // newVals is a shell now
 
     return err;
 }


### PR DESCRIPTION
The variable newVals can't be used after std::move, fetch it from the constraint instead it if an error occurs.

Since this bug [just got merged into master](https://github.com/FreeCAD/FreeCAD/pull/4257/files#diff-b9dbc09c2c4b8417d6df9b1640fe0b24441cf026658dd5220d8917aa1ebcf356R365), I hope that we can get this resolved rather quickly.

@abdullahtahiriyo

---

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [x] ~Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists~

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
