### PR TITLE
[Start] Shadow fix and add unit tests

### DIFF
--- a/src/Mod/Start/CMakeLists.txt
+++ b/src/Mod/Start/CMakeLists.txt
@@ -2,6 +2,7 @@ add_subdirectory(App)
 
 set(Start_Scripts
     Init.py
+    TestStartGui.py
 )
 
 if(BUILD_GUI)
@@ -11,8 +12,20 @@ if(BUILD_GUI)
     add_subdirectory(StartPage)
 endif(BUILD_GUI)
 
+set(Start_Tests
+    TestStart/__init__.py
+    TestStart/TestStartPage.py)
+
+set(Start_Test_Files
+    ${Start_Tests}
+    ${Start_Scripts})
+
 add_custom_target(StartScripts ALL
     SOURCES ${Start_Scripts}
+)
+
+add_custom_target(StartTests ALL
+    SOURCES ${Start_Test_Files}
 )
 
 fc_target_copy_resource(StartScripts
@@ -20,9 +33,19 @@ fc_target_copy_resource(StartScripts
     ${CMAKE_BINARY_DIR}/Mod/Start
     ${Start_Scripts})
 
+fc_copy_sources(StartTests "${CMAKE_BINARY_DIR}/Mod/Start" ${Start_Test_Files})
+
+
 INSTALL(
     FILES
         ${Start_Scripts}
     DESTINATION
         Mod/Start
+)
+
+INSTALL(
+    FILES
+        ${Start_Tests}
+    DESTINATION
+        Mod/Start/testStart
 )

--- a/src/Mod/Start/InitGui.py
+++ b/src/Mod/Start/InitGui.py
@@ -47,3 +47,5 @@ class StartWorkbench ( Workbench ):
         return "StartGui::Workbench"
 
 Gui.addWorkbench(StartWorkbench())
+
+FreeCAD.__unit_test__ += [ "TestStartGui" ]

--- a/src/Mod/Start/StartPage/StartPage.py
+++ b/src/Mod/Start/StartPage/StartPage.py
@@ -547,6 +547,7 @@ def handle():
     HTML = HTML.replace("TEXTCOLOR",TEXTCOLOR)
     HTML = HTML.replace("BGTCOLOR",BGTCOLOR)
     HTML = HTML.replace("BACKGROUND",BACKGROUND)
+    HTML = HTML.replace("SHADOW",SHADOW)
     HTML = HTML.replace("FONTFAMILY",FONTFAMILY)
     HTML = HTML.replace("FONTSIZE",str(FONTSIZE)+"px")
 

--- a/src/Mod/Start/TestStart/TestStartPage.py
+++ b/src/Mod/Start/TestStart/TestStartPage.py
@@ -34,3 +34,39 @@ class TestStartPage(unittest.TestCase):
 
     def setUp(self):
         pass
+
+    def test_all_css_placeholders_removed(self):
+        """Check to see if all of the CSS placeholders have been replaced."""
+        placeholders = ["BACKGROUND","BGTCOLOR","FONTFAMILY","FONTSIZE","LINKCOLOR",
+                        "TEXTCOLOR","BOXCOLOR","BASECOLOR","SHADOW"]
+        
+        page = StartPage.handle()
+        for placeholder in placeholders:
+            self.assertNotIn (placeholder, page, "{} was not removed from the CSS".format(placeholder))
+
+    def test_all_js_placeholders_removed(self):
+        """Check to see if all of the JavaScript placeholders have been replaced."""
+        placeholders = ["IMAGE_SRC_INSTALLED"]
+        page = StartPage.handle()
+        for placeholder in placeholders:
+            self.assertNotIn (placeholder, page, "{} was not removed from the JS".format(placeholder))
+
+    def test_all_html_placeholders_removed(self):
+        """Check to see if all of the HTML placeholders have been replaced."""
+        placeholders = ["T_TITLE","VERSIONSTRING","T_DOCUMENTS","T_HELP","T_ACTIVITY",
+                        "SECTION_RECENTFILES","T_TIP","T_ADJUSTRECENT","SECTION_EXAMPLES",
+                        "SECTION_CUSTOM","T_CUSTOM","T_NOTES","T_GENERALDOCUMENTATION",
+                        "IMAGE_SRC_USERHUB", "T_USERHUB", "T_DESCR_USERHUB",
+                        "IMAGE_SRC_POWERHUB","T_POWERHUB","T_DESCR_POWERHUB",
+                        "IMAGE_SRC_DEVHUB",  "T_DEVHUB",  "T_DESCR_DEVHUB",
+                        "IMAGE_SRC_MANUAL",  "T_MANUAL",  "T_DESCR_MANUAL",
+                        "T_WBHELP","T_DESCR_WBHELP","UL_WORKBENCHES",
+                        "T_COMMUNITYHELP","T_DESCR_COMMUNITYHELP1","T_DESCR_COMMUNITYHELP2",
+                        "T_DESCR_COMMUNITYHELP3","T_ADDONS","T_DESCR_ADDONS",
+                        "T_OFFLINEPLACEHOLDER","T_OFFLINEHELP","T_EXTERNALLINKS",
+                        "T_RECENTCOMMITS","T_DESCR_RECENTCOMMITS","T_EXTERNALLINKS",
+                        "T_SEEONGITHUB","T_FORUM","T_DESCR_FORUM"]
+        page = StartPage.handle()
+        for placeholder in placeholders:
+            self.assertNotIn (placeholder, page, "{} was not removed from the HTML".format(placeholder))
+    

--- a/src/Mod/Start/TestStart/TestStartPage.py
+++ b/src/Mod/Start/TestStart/TestStartPage.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+# ***************************************************************************
+# *   Copyright (c) 2021 Chris Hennes <chennes@pioneerlibrarysystem.org>    *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   This program is distributed in the hope that it will be useful,       *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with this program; if not, write to the Free Software   *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+
+import unittest
+import FreeCAD
+import Start
+from StartPage import StartPage
+from html.parser import HTMLParser
+
+class TestStartPage(unittest.TestCase):
+    """Basic validation of the generated Start page."""
+
+    MODULE = 'TestStartPage' # file name without extension
+
+
+    def setUp(self):
+        pass

--- a/src/Mod/Start/TestStartGui.py
+++ b/src/Mod/Start/TestStartGui.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+# ***************************************************************************
+# *   Copyright (c) 2021 Chris Hennes <chennes@pioneerlibrarysystem.org>    *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   This program is distributed in the hope that it will be useful,       *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with this program; if not, write to the Free Software   *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+
+import TestApp
+
+from TestStart.TestStartPage import TestStartPage
+
+# dummy usage to get flake8 and lgtm quiet
+False if TestApp.__name__ else True
+False if TestStartPage.__name__ else True


### PR DESCRIPTION
The real purpose of this PR is to fix a single missing replacement line from the Start page's generated HTML: the CSS for the shadow behind the file cards was not getting replaced, leaving the word "SHADOW" in the final CSS instead. a0aaae7ea corrects that, adding a single line to src/Mod/Start/StartPage/StartPage.py.

However, currently Start does not have any unit tests, so fcdd44115 adds the test framework to Start (without adding any tests), and d18a76e9b adds a complete test for all expected replacements. It's broken up into three tests, one for each component of the final web page: the CSS, the JS, and the HTML. The CSS test will fail unless a0aaae7ea is applied. 

Thanks to @hyarion in the FreeCAD forums for the suggested commit structure.
