### PR TITLE
[Part/Sketcher] Geometry extensions refactor copy save restore notification 

### DIFF
--- a/src/Mod/Part/App/Geometry.cpp
+++ b/src/Mod/Part/App/Geometry.cpp
@@ -334,22 +334,25 @@ std::weak_ptr<const GeometryExtension> Geometry::getExtension(std::string name) 
 }
 
 
-void Geometry::setExtension(std::unique_ptr<GeometryExtension> && geo)
+void Geometry::setExtension(std::unique_ptr<GeometryExtension> && geoext )
 {
     bool hasext=false;
 
     for( auto & ext : extensions) {
         // if same type and name, this modifies the existing extension.
-        if( ext->getTypeId() == geo->getTypeId() &&
-            ext->getName() == geo->getName()){
-            ext = std::move(geo);
+        if( ext->getTypeId() == geoext->getTypeId() &&
+            ext->getName() == geoext->getName()){
+            ext = std::move( geoext );
+            ext->notifyAttachment(this);
             hasext = true;
             break;
         }
     }
 
-    if(!hasext) // new type-name unique id, so add.
-        extensions.push_back(std::move(geo));
+    if(!hasext) { // new type-name unique id, so add.
+        extensions.push_back(std::move( geoext ));
+        extensions.back()->notifyAttachment(this);
+    }
 }
 
 void Geometry::deleteExtension(Base::Type type)
@@ -400,8 +403,10 @@ void Geometry::assignTag(const Part::Geometry * geo)
 
 void Geometry::copyNonTag(const Part::Geometry * src)
 {
-    for(auto & ext: src->extensions)
+    for(auto & ext: src->extensions) {
         this->extensions.push_back(ext->copy());
+        extensions.back()->notifyAttachment(this);
+    }
 }
 
 Geometry *Geometry::clone(void) const

--- a/src/Mod/Part/App/GeometryDefaultExtension.cpp
+++ b/src/Mod/Part/App/GeometryDefaultExtension.cpp
@@ -44,27 +44,28 @@ GeometryDefaultExtension<T>::GeometryDefaultExtension(const T& val, std::string 
     setName(name);
 }
 
-// Persistence implementer
+
 template <typename T>
-void GeometryDefaultExtension<T>::Save(Base::Writer &writer) const
+void GeometryDefaultExtension<T>::copyAttributes(Part::GeometryExtension * cpy) const
 {
-
-    writer.Stream() << writer.ind() << "<GeoExtension type=\"" << this->getTypeId().getName();
-
-    const std::string name = getName();
-
-    if(name.size() > 0)
-        writer.Stream() << "\" name=\"" << name;
-
-    writer.Stream() << "\" value=\"" << value << "\"/>" << std::endl;
+    Part::GeometryPersistenceExtension::copyAttributes(cpy);
+    static_cast<GeometryDefaultExtension<T> *>(cpy)->value = this->value;
 }
 
 template <typename T>
-void GeometryDefaultExtension<T>::Restore(Base::XMLReader &reader)
+void GeometryDefaultExtension<T>::restoreAttributes(Base::XMLReader &reader)
 {
-    restoreNameAttribute(reader);
+    Part::GeometryPersistenceExtension::restoreAttributes(reader);
 
     value = reader.getAttribute("value");
+}
+
+template <typename T>
+void GeometryDefaultExtension<T>::saveAttributes(Base::Writer &writer) const
+{
+    Part::GeometryPersistenceExtension::saveAttributes(writer);
+
+    writer.Stream() << "\" value=\"" << value;
 }
 
 template <typename T>
@@ -72,8 +73,7 @@ std::unique_ptr<Part::GeometryExtension> GeometryDefaultExtension<T>::copy(void)
 {
     std::unique_ptr<GeometryDefaultExtension<T>> cpy = std::make_unique<GeometryDefaultExtension<T>>();
 
-    cpy->value = this->value;
-    cpy->setName(this->getName());
+    copyAttributes(cpy.get());
 
     #if (defined(__GNUC__) && __GNUC__ < 7 ) || defined(_MSC_VER)
         return std::move(cpy); // GCC 4.8 and MSC do not support automatic move constructor call if the compiler fails to elide
@@ -117,9 +117,9 @@ PyObject * GeometryDefaultExtension<long>::getPyObject(void)
 }
 
 template <>
-void GeometryDefaultExtension<long>::Restore(Base::XMLReader &reader)
+void GeometryDefaultExtension<long>::restoreAttributes(Base::XMLReader &reader)
 {
-    restoreNameAttribute(reader);
+    Part::GeometryPersistenceExtension::restoreAttributes(reader);
 
     value = reader.getAttributeAsInteger("value");
 }
@@ -143,9 +143,9 @@ PyObject * GeometryDefaultExtension<bool>::getPyObject(void)
 }
 
 template <>
-void GeometryDefaultExtension<bool>::Restore(Base::XMLReader &reader)
+void GeometryDefaultExtension<bool>::restoreAttributes(Base::XMLReader &reader)
 {
-    restoreNameAttribute(reader);
+    Part::GeometryPersistenceExtension::restoreAttributes(reader);
 
     value = (bool)reader.getAttributeAsInteger("value");
 }
@@ -160,9 +160,9 @@ PyObject * GeometryDefaultExtension<double>::getPyObject(void)
 }
 
 template <>
-void GeometryDefaultExtension<double>::Restore(Base::XMLReader &reader)
+void GeometryDefaultExtension<double>::restoreAttributes(Base::XMLReader &reader)
 {
-    restoreNameAttribute(reader);
+    Part::GeometryPersistenceExtension::restoreAttributes(reader);
 
     value = reader.getAttributeAsFloat("value");
 }

--- a/src/Mod/Part/App/GeometryDefaultExtension.h
+++ b/src/Mod/Part/App/GeometryDefaultExtension.h
@@ -41,13 +41,14 @@ namespace Part {
         inline void setValue(const T& val) {value = val;};
         inline const T &getValue() const {return value;};
 
-        // Persistence implementer ---------------------
-        virtual void Save(Base::Writer &/*writer*/) const override;
-        virtual void Restore(Base::XMLReader &/*reader*/) override;
-
         virtual std::unique_ptr<Part::GeometryExtension> copy(void) const override;
 
         virtual PyObject *getPyObject(void) override;
+
+    protected:
+        virtual void copyAttributes(Part::GeometryExtension * cpy) const override;
+        virtual void restoreAttributes(Base::XMLReader &reader) override;
+        virtual void saveAttributes(Base::Writer &writer) const override;
 
     private:
         GeometryDefaultExtension(const GeometryDefaultExtension<T>&) = default;

--- a/src/Mod/Part/App/GeometryExtension.cpp
+++ b/src/Mod/Part/App/GeometryExtension.cpp
@@ -45,12 +45,39 @@ PyObject* GeometryExtension::copyPyObject() const
     return static_cast<GeometryExtensionPy *>(obj.ptr())->copy(tuple.ptr());
 }
 
+void GeometryExtension::copyAttributes(Part::GeometryExtension * cpy) const
+{
+    cpy->setName(this->getName()); // Base Class
+}
+
 TYPESYSTEM_SOURCE_ABSTRACT(Part::GeometryPersistenceExtension,Part::GeometryExtension)
 
-void GeometryPersistenceExtension::restoreNameAttribute(Base::XMLReader &reader)
+void GeometryPersistenceExtension::restoreAttributes(Base::XMLReader &reader)
 {
     if(reader.hasAttribute("name")) {
         std::string name = reader.getAttribute("name");
         setName(name);
     }
+}
+void GeometryPersistenceExtension::saveAttributes(Base::Writer &writer) const
+{
+    const std::string name = getName();
+
+    if(name.size() > 0)
+        writer.Stream() << "\" name=\"" << name;
+
+}
+
+void GeometryPersistenceExtension::Save(Base::Writer &writer) const
+{
+    writer.Stream() << writer.ind() << "<GeoExtension type=\"" << this->getTypeId().getName();
+
+    saveAttributes(writer);
+
+    writer.Stream() << "\"/>" << std::endl;
+}
+
+void GeometryPersistenceExtension::Restore(Base::XMLReader &reader)
+{
+    restoreAttributes(reader);
 }

--- a/src/Mod/Part/App/GeometryExtension.h
+++ b/src/Mod/Part/App/GeometryExtension.h
@@ -32,6 +32,8 @@
 
 namespace Part {
 
+class Geometry;
+
 class PartExport GeometryExtension: public Base::BaseClass
 {
     TYPESYSTEM_HEADER();
@@ -46,10 +48,16 @@ public:
     inline void setName(const std::string& str) {name = str;}
     inline const std::string &getName () const {return name;}
 
+    // Default method to notify an extension that it has been attached
+    // to a given geometry
+    virtual void notifyAttachment(Part::Geometry *) {}
+
 protected:
     GeometryExtension();
     GeometryExtension(const GeometryExtension &obj) = default;
     GeometryExtension& operator= (const GeometryExtension &obj) = default;
+
+    virtual void copyAttributes(Part::GeometryExtension * cpy) const;
 
 private:
     std::string name;
@@ -64,11 +72,13 @@ public:
     virtual ~GeometryPersistenceExtension() = default;
 
     // Own Persistence implementer - Not Base::Persistence - managed by Part::Geometry
-    virtual void Save(Base::Writer &/*writer*/) const = 0;
-    virtual void Restore(Base::XMLReader &/*reader*/) = 0;
+    void Save(Base::Writer &/*writer*/) const;
+    void Restore(Base::XMLReader &/*reader*/);
 
 protected:
-    void restoreNameAttribute(Base::XMLReader &/*reader*/);
+    virtual void restoreAttributes(Base::XMLReader &/*reader*/);
+    virtual void saveAttributes(Base::Writer &writer) const;
+
 };
 
 }

--- a/src/Mod/Part/App/GeometryMigrationExtension.cpp
+++ b/src/Mod/Part/App/GeometryMigrationExtension.cpp
@@ -37,14 +37,18 @@ GeometryMigrationExtension::GeometryMigrationExtension():ConstructionState(false
 
 }
 
+void GeometryMigrationExtension::copyAttributes(Part::GeometryExtension * cpy) const
+{
+    Part::GeometryExtension::copyAttributes(cpy);
+    static_cast<GeometryMigrationExtension *>(cpy)->ConstructionState = this->ConstructionState;
+    static_cast<GeometryMigrationExtension *>(cpy)->GeometryMigrationFlags  = this->GeometryMigrationFlags;
+}
+
 std::unique_ptr<Part::GeometryExtension> GeometryMigrationExtension::copy(void) const
 {
     auto cpy = std::make_unique<GeometryMigrationExtension>();
 
-    cpy->ConstructionState = this->ConstructionState;
-    cpy->GeometryMigrationFlags  = this->GeometryMigrationFlags;
-
-    cpy->setName(this->getName()); // Base Class
+    copyAttributes(cpy.get());
 
 #if defined (__GNUC__) && (__GNUC__ <=4)
     return std::move(cpy);

--- a/src/Mod/Part/App/GeometryMigrationExtension.h
+++ b/src/Mod/Part/App/GeometryMigrationExtension.h
@@ -65,6 +65,8 @@ public:
     virtual bool testMigrationType(int flag) const { return GeometryMigrationFlags.test((size_t)(flag)); };
     virtual void setMigrationType(int flag, bool v=true) { GeometryMigrationFlags.set((size_t)(flag), v); };
 
+protected:
+    virtual void copyAttributes(Part::GeometryExtension * cpy) const override;
 
 private:
     GeometryMigrationExtension(const GeometryMigrationExtension&) = default;

--- a/src/Mod/Sketcher/App/ExternalGeometryExtension.cpp
+++ b/src/Mod/Sketcher/App/ExternalGeometryExtension.cpp
@@ -37,36 +37,35 @@ constexpr std::array<const char *, ExternalGeometryExtension::NumFlags> External
 
 TYPESYSTEM_SOURCE(Sketcher::ExternalGeometryExtension,Part::GeometryPersistenceExtension)
 
-// Persistence implementer
-void ExternalGeometryExtension::Save(Base::Writer &writer) const
+void ExternalGeometryExtension::copyAttributes(Part::GeometryExtension * cpy) const
 {
-    writer.Stream() << writer.ind() << "<GeoExtension type=\"" << this->getTypeId().getName();
+    Part::GeometryPersistenceExtension::copyAttributes(cpy);
 
-    const std::string name = getName();
-
-    if(name.size() > 0)
-        writer.Stream() << "\" name=\"" << name;
-
-    writer.Stream() << "\" Ref=\"" << Ref << "\" Flags=\"" << Flags.to_string() << "\"/>" << std::endl;
+    static_cast<ExternalGeometryExtension *>(cpy)->Ref = this->Ref;
+    static_cast<ExternalGeometryExtension *>(cpy)->Flags = this->Flags;
 }
 
-void ExternalGeometryExtension::Restore(Base::XMLReader &reader)
+void ExternalGeometryExtension::restoreAttributes(Base::XMLReader &reader)
 {
-    restoreNameAttribute(reader);
+    Part::GeometryPersistenceExtension::restoreAttributes(reader);
 
     Ref = reader.getAttribute("Ref");
     Flags = FlagType(reader.getAttribute("Flags"));
+}
 
+void ExternalGeometryExtension::saveAttributes(Base::Writer &writer) const
+{
+    Part::GeometryPersistenceExtension::saveAttributes(writer);
+
+    writer.Stream() << "\" Ref=\"" << Ref
+                    << "\" Flags=\"" << Flags.to_string();
 }
 
 std::unique_ptr<Part::GeometryExtension> ExternalGeometryExtension::copy(void) const
 {
     auto cpy = std::make_unique<ExternalGeometryExtension>();
 
-    cpy->Ref = this->Ref;
-    cpy->Flags = this->Flags;
-
-    cpy->setName(this->getName()); // Base Class
+    copyAttributes(cpy.get());
 
 #if defined (__GNUC__) && (__GNUC__ <=4)
     return std::move(cpy);

--- a/src/Mod/Sketcher/App/ExternalGeometryExtension.h
+++ b/src/Mod/Sketcher/App/ExternalGeometryExtension.h
@@ -67,10 +67,6 @@ public:
     ExternalGeometryExtension() = default;
     virtual ~ExternalGeometryExtension() override = default;
 
-    // Persistence implementer ---------------------
-    virtual void Save(Base::Writer &/*writer*/) const override;
-    virtual void Restore(Base::XMLReader &/*reader*/) override;
-
     virtual std::unique_ptr<Part::GeometryExtension> copy(void) const override;
 
     virtual PyObject *getPyObject(void) override;
@@ -87,6 +83,11 @@ public:
     virtual void setRef(const std::string & ref) override {Ref = ref;}
 
     static bool getFlagsFromName(std::string str, ExternalGeometryExtension::Flag &flag);
+
+protected:
+    virtual void copyAttributes(Part::GeometryExtension * cpy) const override;
+    virtual void restoreAttributes(Base::XMLReader &reader) override;
+    virtual void saveAttributes(Base::Writer &writer) const override;
 
 private:
     ExternalGeometryExtension(const ExternalGeometryExtension&) = default;

--- a/src/Mod/Sketcher/App/Sketch.cpp
+++ b/src/Mod/Sketcher/App/Sketch.cpp
@@ -4121,8 +4121,11 @@ TopoShape Sketch::toShape(void) const
         auto gf = GeometryFacade::getFacade(it->geo);
         if (!it->external && !gf->getConstruction()) {
 
-            if (it->type != Point)
-                edge_list.push_back(TopoDS::Edge(it->geo->toShape()));
+            if (it->type != Point) {
+                auto shape =it->geo->toShape();
+                if(!shape.IsNull())
+                    edge_list.push_back(TopoDS::Edge(shape));
+            }
             else
                 vertex_list.push_back(TopoDS::Vertex(it->geo->toShape()));
         }

--- a/src/Mod/Sketcher/App/SketchGeometryExtension.h
+++ b/src/Mod/Sketcher/App/SketchGeometryExtension.h
@@ -82,10 +82,6 @@ public:
     SketchGeometryExtension(long cid);
     virtual ~SketchGeometryExtension() override = default;
 
-    // Persistence implementer ---------------------
-    virtual void Save(Base::Writer &/*writer*/) const override;
-    virtual void Restore(Base::XMLReader &/*reader*/) override;
-
     virtual std::unique_ptr<Part::GeometryExtension> copy(void) const override;
 
     virtual PyObject *getPyObject(void) override;
@@ -106,6 +102,11 @@ public:
     static bool getInternalTypeFromName(std::string str, InternalType::InternalType &type);
 
     static bool getGeometryModeFromName(std::string str, GeometryMode::GeometryMode &type);
+
+protected:
+    virtual void copyAttributes(Part::GeometryExtension * cpy) const override;
+    virtual void restoreAttributes(Base::XMLReader &reader) override;
+    virtual void saveAttributes(Base::Writer &writer) const override;
 
 private:
     SketchGeometryExtension(const SketchGeometryExtension&) = default;

--- a/src/Mod/Sketcher/App/SolverGeometryExtension.cpp
+++ b/src/Mod/Sketcher/App/SolverGeometryExtension.cpp
@@ -41,16 +41,20 @@ SolverGeometryExtension::SolverGeometryExtension():
 
 }
 
+void SolverGeometryExtension::copyAttributes(Part::GeometryExtension * cpy) const
+{
+    Part::GeometryExtension::copyAttributes(cpy);
+    static_cast<SolverGeometryExtension *>(cpy)->Edge = this->Edge;
+    static_cast<SolverGeometryExtension *>(cpy)->Start = this->Start;
+    static_cast<SolverGeometryExtension *>(cpy)->End  = this->End;
+    static_cast<SolverGeometryExtension *>(cpy)->Mid = this->Mid;
+}
+
 std::unique_ptr<Part::GeometryExtension> SolverGeometryExtension::copy(void) const
 {
     auto cpy = std::make_unique<SolverGeometryExtension>();
 
-    cpy->Edge = this->Edge;
-    cpy->Start = this->Start;
-    cpy->End  = this->End;
-    cpy->Mid = this->Mid;
-
-    cpy->setName(this->getName()); // Base Class
+    copyAttributes(cpy.get());
 
 #if defined (__GNUC__) && (__GNUC__ <=4)
     return std::move(cpy);

--- a/src/Mod/Sketcher/App/SolverGeometryExtension.h
+++ b/src/Mod/Sketcher/App/SolverGeometryExtension.h
@@ -76,6 +76,9 @@ public:
         End = status;
     }
 
+protected:
+    virtual void copyAttributes(Part::GeometryExtension * cpy) const override;
+
 private:
     SolverGeometryExtension(const SolverGeometryExtension&) = default;
 

--- a/src/Mod/Sketcher/Gui/ViewProviderSketchGeometryExtension.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketchGeometryExtension.cpp
@@ -39,13 +39,17 @@ ViewProviderSketchGeometryExtension::ViewProviderSketchGeometryExtension():Repre
 
 }
 
+void ViewProviderSketchGeometryExtension::copyAttributes(Part::GeometryExtension * cpy) const
+{
+    Part::GeometryExtension::copyAttributes(cpy);
+    static_cast<ViewProviderSketchGeometryExtension *>(cpy)->RepresentationFactor = this->RepresentationFactor;
+}
+
 std::unique_ptr<Part::GeometryExtension> ViewProviderSketchGeometryExtension::copy(void) const
 {
     auto cpy = std::make_unique<ViewProviderSketchGeometryExtension>();
 
-    cpy->RepresentationFactor = this->RepresentationFactor;
-
-    cpy->setName(this->getName()); // Base Class
+    copyAttributes(cpy.get());
 
 #if defined (__GNUC__) && (__GNUC__ <=4)
     return std::move(cpy);

--- a/src/Mod/Sketcher/Gui/ViewProviderSketchGeometryExtension.h
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketchGeometryExtension.h
@@ -50,6 +50,9 @@ public:
     virtual double getRepresentationFactor() const {return RepresentationFactor;}
     virtual void setRepresentationFactor(double representationFactor) {RepresentationFactor = representationFactor;}
 
+protected:
+    virtual void copyAttributes(Part::GeometryExtension * cpy) const override;
+
 private:
     ViewProviderSketchGeometryExtension(const ViewProviderSketchGeometryExtension&) = default;
 


### PR DESCRIPTION

The API of Geometry Extensions regarding copy, save and restore did not make effective use of code reuse and was error-prone.

For all extensions:
- Regarding copy, a new virtual method copyAttributes() ensures that all the geometry extension hierarchy is called to copy its members.

For GeometryPersistentExtensions:
- similarly saveAttributes() and restoreAttributes virtual functions ensure that members in the hierarchy are called for save and restore.

Addition for all extensions:
- A notify Attachment trigger, notifying an extension that has been attached to a new geometry object, providing as argument a pointer to the geometry object. This ensures that an extension has a valid pointer to the geometry, enabling it to extend properties and functionalities of the Part::Geometry object.