### PR TITLE
PartDesign: Fix small bugs in the Pipe feature

### DIFF
--- a/src/Mod/PartDesign/App/FeaturePipe.cpp
+++ b/src/Mod/PartDesign/App/FeaturePipe.cpp
@@ -303,6 +303,9 @@ App::DocumentObjectExecReturn *Pipe::execute(void)
         AddSubShape.setValue(result);
 
         if(base.IsNull()) {
+            if (getAddSubType() == FeatureAddSub::Subtractive)
+                return new App::DocumentObjectExecReturn("Pipe: There is nothing to subtract from\n");
+
             result = refineShapeIfActive(result);
             Shape.setValue(getSolid(result));
             return App::DocumentObject::StdReturn;

--- a/src/Mod/PartDesign/App/FeaturePipe.h
+++ b/src/Mod/PartDesign/App/FeaturePipe.h
@@ -88,4 +88,4 @@ public:
 } //namespace PartDesign
 
 
-#endif // PART_Pipe_H
+#endif // PARTDESIGN_Pipe_H

--- a/src/Mod/PartDesign/App/FeaturePipe.h
+++ b/src/Mod/PartDesign/App/FeaturePipe.h
@@ -33,12 +33,12 @@ namespace PartDesign
 
 class PartDesignExport Pipe : public ProfileBased
 {
-    PROPERTY_HEADER(PartDesign::Pad);
+    PROPERTY_HEADER(PartDesign::Pipe);
 
 public:
     Pipe();
 
-    
+
     App::PropertyLinkSub     Spine;
     App::PropertyBool        SpineTangent;
     App::PropertyLinkSub     AuxillerySpine;
@@ -57,7 +57,7 @@ public:
         return "PartDesignGui::ViewProviderPipe";
     }
     //@}
-    
+
 protected:
     ///get the given edges and all their tangent ones
     void getContiniusEdges(Part::TopoShape TopShape, std::vector< std::string >& SubNames);
@@ -72,14 +72,14 @@ private:
 };
 
 class PartDesignExport AdditivePipe : public Pipe {
-    
+
     PROPERTY_HEADER(PartDesign::AdditivePipe);
 public:
     AdditivePipe();
 };
 
 class PartDesignExport SubtractivePipe : public Pipe {
-    
+
     PROPERTY_HEADER(PartDesign::SubtractivePipe);
 public:
     SubtractivePipe();
@@ -88,4 +88,4 @@ public:
 } //namespace PartDesign
 
 
-#endif // PART_Pad_H
+#endif // PART_Pipe_H


### PR DESCRIPTION
- Previously a subtractive pipe on a body with no solids would create a solid. Now Pipe will generate an error.
- Fix incorrect property header. Previously Pipe was identifying itself as Pad (copy paste error)
