### PR TITLE
Gui: Prevent crash when trying to access sub-objects of a deleted object from a SelectionObject

### DIFF
--- a/src/Gui/SelectionObjectPyImp.cpp
+++ b/src/Gui/SelectionObjectPyImp.cpp
@@ -116,18 +116,23 @@ Py::Object SelectionObjectPy::getObject(void) const
 
 Py::Tuple SelectionObjectPy::getSubObjects(void) const
 {
-    std::vector<PyObject *> objs;
+    App::DocumentObject *obj = getSelectionObjectPtr()->getObject();
+    if (!obj)
+        throw Py::RuntimeError("Cannot get sub-objects of deleted object");
+
+    std::vector<PyObject *> subObjs;
 
     for(const auto &subname : getSelectionObjectPtr()->getSubNames()) {
         PyObject *pyObj=0;
         Base::Matrix4D mat;
-        getSelectionObjectPtr()->getObject()->getSubObject(subname.c_str(),&pyObj,&mat);
-        if(pyObj) objs.push_back(pyObj);
+        obj->getSubObject(subname.c_str(),&pyObj,&mat);
+        if(pyObj)
+            subObjs.push_back(pyObj);
     }
 
-    Py::Tuple temp(objs.size());
+    Py::Tuple temp(subObjs.size());
     Py::sequence_index_type index = 0;
-    for(std::vector<PyObject *>::const_iterator it= objs.begin();it!=objs.end();++it)
+    for(std::vector<PyObject *>::const_iterator it= subObjs.begin();it!=subObjs.end();++it)
         temp.setItem(index++, Py::asObject(*it));
 
     return temp;


### PR DESCRIPTION
Identical to #4228 but when trying to access the SubObjects attribute.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
