### PR TITLE
Path: Profile Op - Fix `Expand Profile` feature; include some code cleanup

### DIFF
--- a/src/Mod/Path/PathScripts/PathProfile.py
+++ b/src/Mod/Path/PathScripts/PathProfile.py
@@ -269,12 +269,8 @@ class ObjectProfile(PathAreaOp.ObjectOp):
         params['Coplanar'] = 0
         params['PocketMode'] = 1
         params['SectionCount'] = -1
-        # params['Angle'] = obj.ZigZagAngle
-        # params['FromCenter'] = (obj.StartAt == "Center")
         params['PocketStepover'] = self.tool.Diameter.Value * (float(obj.ExpandProfileStepOver) / 100.0)
         extraOffset = obj.OffsetExtra.Value
-        if False:  # self.pocketInvertExtraOffset():  # Method simply returns False
-            extraOffset = 0.0 - extraOffset
         params['PocketExtraOffset'] = extraOffset
         params['ToolRadius'] = self.radius
 

--- a/src/Mod/Path/PathScripts/PathProfile.py
+++ b/src/Mod/Path/PathScripts/PathProfile.py
@@ -271,7 +271,7 @@ class ObjectProfile(PathAreaOp.ObjectOp):
         params['SectionCount'] = -1
         # params['Angle'] = obj.ZigZagAngle
         # params['FromCenter'] = (obj.StartAt == "Center")
-        params['PocketStepover'] = self.tool.Diameter * (float(obj.ExpandProfileStepOver) / 100.0)
+        params['PocketStepover'] = self.tool.Diameter.Value * (float(obj.ExpandProfileStepOver) / 100.0)
         extraOffset = obj.OffsetExtra.Value
         if False:  # self.pocketInvertExtraOffset():  # Method simply returns False
             extraOffset = 0.0 - extraOffset
@@ -638,7 +638,7 @@ class ObjectProfile(PathAreaOp.ObjectOp):
         def calculateOffsetValue(obj, isHole):
             offset = obj.ExpandProfile.Value + obj.OffsetExtra.Value  # 0.0
             if obj.UseComp:
-                offset = obj.OffsetExtra.Value + self.tool.Diameter
+                offset = obj.OffsetExtra.Value + self.tool.Diameter.Value
                 offset += obj.ExpandProfile.Value
             if isHole:
                 if obj.Side == 'Outside':
@@ -711,7 +711,7 @@ class ObjectProfile(PathAreaOp.ObjectOp):
         basewires = list()
         delPairs = list()
         ezMin = None
-        self.cutOut = self.tool.Diameter * (float(obj.ExpandProfileStepOver) / 100.0)
+        self.cutOut = self.tool.Diameter.Value * (float(obj.ExpandProfileStepOver) / 100.0)
 
         for p in range(0, len(obj.Base)):
             (base, subsList) = obj.Base[p]

--- a/src/Mod/Path/PathScripts/PathProfile.py
+++ b/src/Mod/Path/PathScripts/PathProfile.py
@@ -37,6 +37,8 @@ from PySide import QtCore
 from lazy_loader.lazy_loader import LazyLoader
 ArchPanel = LazyLoader('ArchPanel', globals(), 'ArchPanel')
 Part = LazyLoader('Part', globals(), 'Part')
+DraftGeomUtils = LazyLoader('DraftGeomUtils', globals(), 'DraftGeomUtils')
+PathSurfaceSupport = LazyLoader('PathScripts.PathSurfaceSupport', globals(), 'PathScripts.PathSurfaceSupport')
 
 
 __title__ = "Path Profile Operation"
@@ -339,8 +341,6 @@ class ObjectProfile(PathAreaOp.ObjectOp):
         self.JOB = PathUtils.findParentJob(obj)
 
         if obj.ExpandProfile.Value != 0.0:
-            import PathScripts.PathSurfaceSupport as PathSurfaceSupport
-            self.PathSurfaceSupport = PathSurfaceSupport
             self.expandProfile = True
 
         if obj.UseComp:
@@ -638,9 +638,8 @@ class ObjectProfile(PathAreaOp.ObjectOp):
                     offset = 0 - offset
             return offset
 
-        faceEnv = self.PathSurfaceSupport.getShapeEnvelope(faceShape)
-        # newFace = self.PathSurfaceSupport.getSliceFromEnvelope(faceEnv)
-        newFace = self.PathSurfaceSupport.getShapeSlice(faceEnv)
+        faceEnv = PathSurfaceSupport.getShapeEnvelope(faceShape)
+        newFace = PathSurfaceSupport.getShapeSlice(faceEnv)
         # Compute necessary offset
         offsetVal = calculateOffsetValue(obj, isHole)
         expandedFace = PathUtils.getOffsetArea(newFace, offsetVal, newFace)
@@ -683,7 +682,7 @@ class ObjectProfile(PathAreaOp.ObjectOp):
             if hasattr(base, 'Shape'):
                 env = PathUtils.getEnvelope(partshape=base.Shape, subshape=None, depthparams=self.depthparams)
                 if self.expandProfile:
-                    eSlice = self.PathSurfaceSupport.getCrossSection(env)  # getSliceFromEnvelope(env)
+                    eSlice = PathSurfaceSupport.getCrossSection(env)  # getSliceFromEnvelope(env)
                     eSlice.translate(FreeCAD.Vector(0.0, 0.0, base.Shape.BoundBox.ZMin - env.BoundBox.ZMin))
                     self._addDebugObject('ModelSlice', eSlice)
                     shapeEnv = self._getExpandedProfileEnvelope(obj, eSlice, False, obj.StartDepth.Value, obj.FinalDepth.Value)
@@ -696,7 +695,6 @@ class ObjectProfile(PathAreaOp.ObjectOp):
 
     # Edges pre-processing
     def _processEdges(self, obj):
-        import DraftGeomUtils
         shapes = list()
         basewires = list()
         delPairs = list()

--- a/src/Mod/Path/PathScripts/PathProfile.py
+++ b/src/Mod/Path/PathScripts/PathProfile.py
@@ -643,7 +643,7 @@ class ObjectProfile(PathAreaOp.ObjectOp):
         newFace = self.PathSurfaceSupport.getShapeSlice(faceEnv)
         # Compute necessary offset
         offsetVal = calculateOffsetValue(obj, isHole)
-        expandedFace = self.PathSurfaceSupport.extractFaceOffset(newFace, offsetVal, newFace)
+        expandedFace = PathUtils.getOffsetArea(newFace, offsetVal, newFace)
         if expandedFace:
             if shapeZ != 0.0:
                 expandedFace.translate(FreeCAD.Vector(0.0, 0.0, shapeZ))


### PR DESCRIPTION
This PR addresses two primary errors related to `Expand Profile` feature: a faulty `tool.Diameter` reference and incorrect reference  created by PR #3585.  The PR also includes some code cleanup: LGTM, application of LazyLoader, and removal of obsolete comments and code.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
