### PR TITLE
[TD] add dialog to modify some dimension settings

### DIFF
--- a/src/Mod/TechDraw/App/DrawViewDimension.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDimension.cpp
@@ -101,7 +101,7 @@ const char* DrawViewDimension::MeasureTypeEnums[]= {"True",
 // constraint to set the step size to 0.1
 static const App::PropertyQuantityConstraint::Constraints ToleranceConstraint = { -DBL_MAX, DBL_MAX, 0.1 };
 // constraint to force positive values
-static const App::PropertyQuantityConstraint::Constraints PositiveConstraint = { DBL_MIN, DBL_MAX, 0.1 };
+static const App::PropertyQuantityConstraint::Constraints PositiveConstraint = { 0.0, DBL_MAX, 0.1 };
 
 DrawViewDimension::DrawViewDimension(void)
 {
@@ -119,18 +119,18 @@ DrawViewDimension::DrawViewDimension(void)
     ADD_PROPERTY(Type, ((long)0));
     MeasureType.setEnums(MeasureTypeEnums);
     ADD_PROPERTY(MeasureType, ((long)1));                             //Projected (or True) measurement
-    ADD_PROPERTY_TYPE(TheoreticalExact,(false), "", App::Prop_Output, "Set for theoretical exact (basic) dimension");
+    ADD_PROPERTY_TYPE(TheoreticalExact,(false), "", App::Prop_Output, "If theoretical exact (basic) dimension");
     ADD_PROPERTY_TYPE(EqualTolerance, (true), "", App::Prop_Output, "If over- and undertolerance are equal");
 
-    ADD_PROPERTY_TYPE(OverTolerance, (0.0), "", App::Prop_Output, "Overtolerance value\nIf 'Equal Tolerance' is true this is also the value for 'Under Tolerance'");
+    ADD_PROPERTY_TYPE(OverTolerance, (0.0), "", App::Prop_Output, "Overtolerance value\nIf 'Equal Tolerance' is true this is also\nthe negated value for 'Under Tolerance'");
     OverTolerance.setUnit(Base::Unit::Length);
     OverTolerance.setConstraints(&ToleranceConstraint);
-    ADD_PROPERTY_TYPE(UnderTolerance, (0.0), "", App::Prop_Output, "Undertolerance value\nIf 'Equal Tolerance' it will be replaced by negative value of 'Over Tolerance'");
+    ADD_PROPERTY_TYPE(UnderTolerance, (0.0), "", App::Prop_Output, "Undertolerance value\nIf 'Equal Tolerance' is true it will be replaced\nby negative value of 'Over Tolerance'");
     UnderTolerance.setUnit(Base::Unit::Length);
     UnderTolerance.setConstraints(&ToleranceConstraint);
     ADD_PROPERTY_TYPE(Inverted, (false), "", App::Prop_Output, "The dimensional value is displayed inverted");
 
-    //hide the DrawView properties that don't apply to Dimensions
+    // hide the DrawView properties that don't apply to Dimensions
     ScaleType.setStatus(App::Property::ReadOnly, true);
     ScaleType.setStatus(App::Property::Hidden, true);
     Scale.setStatus(App::Property::ReadOnly, true);
@@ -183,7 +183,7 @@ void DrawViewDimension::onChanged(const App::Property* prop)
         }
         else if (prop == &References3D) {   //have to rebuild the Measurement object
 //            Base::Console().Message("DVD::onChanged - References3D\n");
-            clear3DMeasurements();                                                             //Measurement object
+            clear3DMeasurements();                             //Measurement object
             if (!(References3D.getValues()).empty()) {
                 setAll3DMeasurement();
             } else {
@@ -224,9 +224,9 @@ void DrawViewDimension::onChanged(const App::Property* prop)
             // if EqualTolerance set negated overtolerance for untertolerance
             // then also the OverTolerance must be positive
             if (EqualTolerance.getValue()) {
-                // if OverTolerance is negative or zero, first set it to smallest positive value
-                if (OverTolerance.getValue() <= 0) {
-                    OverTolerance.setValue(DBL_MIN);
+                // if OverTolerance is negative or zero, first set it to zero
+                if (OverTolerance.getValue() < 0) {
+                    OverTolerance.setValue(0.0);
                 }
                 OverTolerance.setConstraints(&PositiveConstraint);
                 UnderTolerance.setValue(-1.0 * OverTolerance.getValue());

--- a/src/Mod/TechDraw/Gui/CMakeLists.txt
+++ b/src/Mod/TechDraw/Gui/CMakeLists.txt
@@ -35,47 +35,48 @@ set(TechDrawGui_LIBS
 )
 
 set(TechDrawGui_MOC_HDRS
+    DlgPrefsTechDrawAdvancedImp.h
+    DlgPrefsTechDrawAnnotationImp.h
+    DlgPrefsTechDrawColorsImp.h
+    DlgPrefsTechDrawDimensionsImp.h
+    DlgPrefsTechDrawGeneralImp.h
+    DlgPrefsTechDrawHLRImp.h
+    DlgPrefsTechDrawScaleImp.h
+    DlgTemplateField.h
     MDIViewPage.h
-    QGVPage.h
+    mrichtextedit.h
+    mtextedit.h
+    QGEPath.h
+    QGIDrawingTemplate.h
+    QGIGhostHighlight.h
+    QGILeaderLine.h
+    QGIRichAnno.h
     QGITemplate.h
     QGISVGTemplate.h
-    QGIDrawingTemplate.h
     QGIView.h
     QGIViewDimension.h
     QGIViewBalloon.h
-    TaskProjGroup.h
-    DlgPrefsTechDrawGeneralImp.h
-    DlgPrefsTechDrawScaleImp.h
-    DlgPrefsTechDrawAnnotationImp.h
-    DlgPrefsTechDrawDimensionsImp.h
-    DlgPrefsTechDrawColorsImp.h
-    DlgPrefsTechDrawAdvancedImp.h
-    DlgPrefsTechDrawHLRImp.h
-    TaskLinkDim.h
-    DlgTemplateField.h
-    TaskSectionView.h
+    QGIWeldSymbol.h
+    QGMText.h
+    QGTracker.h
+    QGVPage.h
+    TaskActiveView.h
+    TaskBalloon.h
+    TaskCenterLine.h
+    TaskCosmeticLine.h
+    TaskCosVertex.h
+    TaskDetail.h
+    TaskDimension.h
     TaskGeomHatch.h
     TaskHatch.h
     TaskLeaderLine.h
-    TaskRichAnno.h
-    TaskCosVertex.h
-    TaskCenterLine.h
+    TaskLinkDim.h
     TaskLineDecor.h
+    TaskProjGroup.h
+    TaskRichAnno.h
+    TaskSectionView.h
     TaskWeldingSymbol.h
-    QGEPath.h
-    QGTracker.h
-    QGILeaderLine.h
-    QGIRichAnno.h
-    QGMText.h
-    mrichtextedit.h
-    mtextedit.h
-    TaskBalloon.h
-    QGIWeldSymbol.h
-    SymbolChooser.h
-    TaskActiveView.h
-    TaskDetail.h
-    QGIGhostHighlight.h
-    TaskCosmeticLine.h
+    SymbolChooser.h   
 )
 
 fc_wrap_cpp(TechDrawGui_MOC_SRCS ${TechDrawGui_MOC_HDRS})
@@ -88,32 +89,33 @@ else()
 endif()
 
 set(TechDrawGui_UIC_SRCS
-    DlgPrefsTechDrawGeneral.ui
-    DlgPrefsTechDrawScale.ui
-    DlgPrefsTechDrawAnnotation.ui
-    DlgPrefsTechDrawDimensions.ui
-    DlgPrefsTechDrawColors.ui
     DlgPrefsTechDrawAdvanced.ui
+    DlgPrefsTechDrawAnnotation.ui
+    DlgPrefsTechDrawColors.ui
+    DlgPrefsTechDrawDimensions.ui
+    DlgPrefsTechDrawGeneral.ui
     DlgPrefsTechDrawHLR.ui
-    TaskProjGroup.ui
-    TaskLinkDim.ui
+    DlgPrefsTechDrawScale.ui
     DlgTemplateField.ui
-    TaskSectionView.ui
+    mrichtextedit.ui
+    TaskActiveView.ui
+    TaskBalloon.ui
+    TaskCosmeticLine.ui
+    TaskCosVertex.ui
+    TaskCenterLine.ui
+    TaskDetail.ui
+    TaskDimension.ui
     TaskGeomHatch.ui
     TaskHatch.ui
     TaskLeaderLine.ui
-    TaskRichAnno.ui
-    mrichtextedit.ui
-    TaskBalloon.ui
-    TaskCosVertex.ui
-    TaskCenterLine.ui
     TaskLineDecor.ui
+    TaskLinkDim.ui
+    TaskProjGroup.ui
     TaskRestoreLines.ui
+    TaskRichAnno.ui
+    TaskSectionView.ui
     TaskWeldingSymbol.ui
     SymbolChooser.ui
-    TaskActiveView.ui
-    TaskDetail.ui
-    TaskCosmeticLine.ui
 )
 
 if(BUILD_QT5)
@@ -186,6 +188,9 @@ SET(TechDrawGui_SRCS
     TaskBalloon.ui
     TaskBalloon.cpp
     TaskBalloon.h
+    TaskDimension.ui
+    TaskDimension.cpp
+    TaskDimension.h
     TaskGeomHatch.ui
     TaskGeomHatch.cpp
     TaskGeomHatch.h
@@ -392,6 +397,7 @@ SET(TechDrawGuiTaskDlgs_SRCS
     mrichtextedit.ui
     TaskBalloon.ui
     TaskCenterLine.ui
+    TaskDimension.ui
     TaskLineDecor.ui
     TaskRestoreLines.ui
     TaskWeldingSymbol.ui

--- a/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
@@ -52,6 +52,7 @@
 #include <Base/Parameter.h>
 #include <Base/UnitsApi.h>
 #include <Gui/Command.h>
+#include <Gui/Control.h>
 
 #include <Mod/Part/App/PartFeature.h>
 
@@ -75,6 +76,7 @@
 #include "QGIViewDimension.h"
 #include "ViewProviderDimension.h"
 #include "DrawGuiUtil.h"
+#include "TaskDimension.h"
 
 #define NORMAL 0
 #define PRE 1
@@ -169,6 +171,20 @@ void QGIDatumLabel::mouseReleaseEvent(QGraphicsSceneMouseEvent * event)
     QGraphicsItem::mouseReleaseEvent(event);
 }
 
+void QGIDatumLabel::mouseDoubleClickEvent(QGraphicsSceneMouseEvent* event)
+{
+    QGIViewDimension* qgivDimension = dynamic_cast<QGIViewDimension*>(parentItem());
+    if (qgivDimension == nullptr) {
+        return;
+    }
+    auto ViewProvider = static_cast<ViewProviderDimension*>(qgivDimension->getViewProvider(qgivDimension->getViewObject()));
+    if (ViewProvider == nullptr) {
+        return;
+    }
+    Gui::Control().showDialog(new TaskDlgDimension(qgivDimension, ViewProvider));
+    QGraphicsItem::mouseDoubleClickEvent(event);
+}
+
 void QGIDatumLabel::hoverEnterEvent(QGraphicsSceneHoverEvent *event)
 {
     Q_EMIT hover(true);
@@ -227,7 +243,7 @@ void QGIDatumLabel::setPosFromCenter(const double &xCenter, const double &yCente
     prepareGeometryChange();
     QGIViewDimension* qgivd = dynamic_cast<QGIViewDimension*>(parentItem());
     if( qgivd == nullptr ) {
-        return;                  //tarfu
+        return;
     }
     const auto dim( dynamic_cast<TechDraw::DrawViewDimension *>(qgivd->getViewObject()) );
     if( dim == nullptr ) {
@@ -440,6 +456,7 @@ void QGIDatumLabel::setColor(QColor c)
 
 //**************************************************************
 QGIViewDimension::QGIViewDimension() :
+    dvDimension(nullptr),
     hasHover(false),
     m_lineWidth(0.0)
 {
@@ -629,14 +646,15 @@ void QGIViewDimension::updateDim()
             labelText = QString::fromUtf8(dim->getFormattedDimensionValue(1).c_str()); //just the number pref/spec/suf
             unitText  = QString::fromUtf8(dim->getFormattedDimensionValue(2).c_str()); //just the unit
         }
-        // if there is an equal over-/undertolerance, add the tolerance to dimension
-        if (dim->EqualTolerance.getValue() && !DrawUtil::fpCompare(dim->OverTolerance.getValue(), 0.0)) {
+        // if there is an equal over-/undertolerance and not theoretically exact, add the tolerance to dimension
+        if (dim->EqualTolerance.getValue() && !DrawUtil::fpCompare(dim->OverTolerance.getValue(), 0.0)
+            && !dim->TheoreticalExact.getValue()) {
             std::pair<std::string, std::string> ToleranceText, ToleranceUnit;
             QString tolerance = QString::fromStdString(dim->getFormattedToleranceValue(1).c_str());
             // tolerance might start with a plus sign that we don't want, so cut it off
             if (tolerance.at(0) == QChar::fromLatin1('+'))
                 tolerance.remove(0, 1);
-            // add the tolerance to the dimension using the ± sign
+            // add the tolerance to the dimension using the Â± sign
             labelText = labelText + QString::fromUtf8(" \xC2\xB1 ") + tolerance;
         }
     }

--- a/src/Mod/TechDraw/Gui/QGIViewDimension.h
+++ b/src/Mod/TechDraw/Gui/QGIViewDimension.h
@@ -95,6 +95,7 @@ public:
 
     double getTolAdjust(void);
 /*    bool hasHover;*/
+    QGIViewDimension* parent;
 
     bool isFramed(void) { return m_isFramed; }
     void setFramed(bool framed) { m_isFramed = framed; }
@@ -115,6 +116,7 @@ protected:
     virtual void mousePressEvent(QGraphicsSceneMouseEvent *event) override;
     virtual void hoverEnterEvent(QGraphicsSceneHoverEvent *event) override;
     virtual void hoverLeaveEvent(QGraphicsSceneHoverEvent *event) override;
+    virtual void mouseDoubleClickEvent(QGraphicsSceneMouseEvent* event) override;
 //    virtual void mouseReleaseEvent( QGraphicsSceneMouseEvent * event) override;
 
     QGCustomText* m_dimText;
@@ -153,6 +155,7 @@ public:
                         const QStyleOptionGraphicsItem * option,
                         QWidget * widget = 0 ) override;
 
+    TechDraw::DrawViewDimension *dvDimension;
     virtual void drawBorder() override;
     virtual void updateView(bool update = false) override;
     virtual QColor prefNormalColor(void);

--- a/src/Mod/TechDraw/Gui/QGVPage.cpp
+++ b/src/Mod/TechDraw/Gui/QGVPage.cpp
@@ -478,6 +478,7 @@ QGIView * QGVPage::addViewDimension(TechDraw::DrawViewDimension *dim)
     ourScene->addItem(dimGroup);
 
     dimGroup->setViewPartFeature(dim);
+    dimGroup->dvDimension = dim;
 
     // Find if it belongs to a parent
     QGIView *parent = 0;

--- a/src/Mod/TechDraw/Gui/TaskDimension.cpp
+++ b/src/Mod/TechDraw/Gui/TaskDimension.cpp
@@ -1,0 +1,314 @@
+/***************************************************************************
+ *   Copyright (c) 2021 Uwe Stöhr <uwestoehr@lyx.org>                      *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "PreCompiled.h"
+
+#ifndef _PreComp_
+#include <cmath>
+#endif // #ifndef _PreComp_
+
+#include <Base/Console.h>
+
+#include <Gui/Application.h>
+#include <Gui/BitmapFactory.h>
+#include <Gui/Command.h>
+#include <Gui/Document.h>
+#include <Gui/Selection.h>
+#include <Gui/ViewProvider.h>
+
+#include <App/Application.h>
+#include <App/Document.h>
+#include <App/DocumentObject.h>
+
+#include <Mod/TechDraw/App/DrawViewDimension.h>
+#include <Mod/TechDraw/App/DrawPage.h>
+
+#include "QGIViewDimension.h"
+#include "ViewProviderDimension.h"
+#include "ui_TaskDimension.h"
+#include "TaskDimension.h"
+
+using namespace Gui;
+using namespace TechDraw;
+using namespace TechDrawGui;
+
+TaskDimension::TaskDimension(QGIViewDimension *parent, ViewProviderDimension *dimensionVP) :
+    ui(new Ui_TaskDimension)
+{
+    int i = 0;
+    m_parent = parent;
+    m_dimensionVP = dimensionVP;
+
+    ui->setupUi(this);
+
+    // Tolerancing
+    ui->cbTheoreticallyExact->setChecked(parent->dvDimension->TheoreticalExact.getValue());
+    connect(ui->cbTheoreticallyExact, SIGNAL(stateChanged(int)), this, SLOT(onTheoreticallyExactChanged()));
+    // if TheoreticalExact disable tolerances
+    if (parent->dvDimension->TheoreticalExact.getValue()) {
+        ui->cbEqualTolerance->setDisabled(true);
+        ui->qsbOvertolerance->setDisabled(true);
+        ui->qsbUndertolerance->setDisabled(true);
+    }
+    ui->cbEqualTolerance->setChecked(parent->dvDimension->EqualTolerance.getValue());
+    connect(ui->cbEqualTolerance, SIGNAL(stateChanged(int)), this, SLOT(onEqualToleranceChanged()));
+    // if EqualTolerance overtolernace must not be negative
+    if (parent->dvDimension->EqualTolerance.getValue())
+        ui->qsbOvertolerance->setMinimum(0.0);
+    if ((parent->dvDimension->Type.isValue("Angle")) ||
+        (parent->dvDimension->Type.isValue("Angle3Pt"))) {
+        ui->qsbOvertolerance->setUnit(Base::Unit::Angle);
+        ui->qsbUndertolerance->setUnit(Base::Unit::Angle);
+    }
+    else {
+        ui->qsbOvertolerance->setUnit(Base::Unit::Length);
+        ui->qsbUndertolerance->setUnit(Base::Unit::Length);
+    }
+    ui->qsbOvertolerance->setValue(parent->dvDimension->OverTolerance.getValue());
+    ui->qsbUndertolerance->setValue(parent->dvDimension->UnderTolerance.getValue());
+    connect(ui->qsbOvertolerance, SIGNAL(valueChanged(double)), this, SLOT(onOvertoleranceChanged()));
+    connect(ui->qsbUndertolerance, SIGNAL(valueChanged(double)), this, SLOT(onUndertoleranceChanged()));
+    // undertolerance is disabled when EqualTolerance is true
+    if (ui->cbEqualTolerance->isChecked())
+        ui->qsbUndertolerance->setDisabled(true);
+
+    // Formatting
+    std::string StringValue = parent->dvDimension->FormatSpec.getValue();
+    QString qs = QString::fromUtf8(StringValue.data(), StringValue.size());
+    ui->leFormatSpecifier->setText(qs);
+    connect(ui->leFormatSpecifier, SIGNAL(textChanged(QString)), this, SLOT(onFormatSpecifierChanged()));
+    ui->cbArbitrary->setChecked(parent->dvDimension->Arbitrary.getValue());
+    connect(ui->cbArbitrary, SIGNAL(stateChanged(int)), this, SLOT(onArbitraryChanged()));
+    StringValue = parent->dvDimension->FormatSpecTolerance.getValue();
+    qs = QString::fromUtf8(StringValue.data(), StringValue.size());
+    ui->leToleranceFormatSpecifier->setText(qs);
+    connect(ui->leToleranceFormatSpecifier, SIGNAL(textChanged(QString)), this, SLOT(onToleranceFormatSpecifierChanged()));
+    ui->cbArbitraryTolerances->setChecked(parent->dvDimension->ArbitraryTolerances.getValue());
+    connect(ui->cbArbitraryTolerances, SIGNAL(stateChanged(int)), this, SLOT(onArbitraryTolerancesChanged()));
+
+    // Display Style
+    if (dimensionVP != nullptr) {
+        ui->cbArrowheads->setChecked(dimensionVP->FlipArrowheads.getValue());
+        connect(ui->cbArrowheads, SIGNAL(stateChanged(int)), this, SLOT(onFlipArrowheadsChanged()));
+        ui->dimensionColor->setColor(dimensionVP->Color.getValue().asValue<QColor>());
+        connect(ui->dimensionColor, SIGNAL(changed()), this, SLOT(onColorChanged()));
+        ui->qsbFontSize->setValue(dimensionVP->Fontsize.getValue());
+        ui->qsbFontSize->setUnit(Base::Unit::Length);
+        ui->qsbFontSize->setMinimum(0);
+        connect(ui->qsbFontSize, SIGNAL(valueChanged(double)), this, SLOT(onFontsizeChanged()));
+        ui->comboDrawingStyle->setCurrentIndex(dimensionVP->StandardAndStyle.getValue());
+        connect(ui->comboDrawingStyle, SIGNAL(currentIndexChanged(int)), this, SLOT(onDrawingStyleChanged()));
+    }  
+}
+
+TaskDimension::~TaskDimension()
+{
+}
+
+bool TaskDimension::accept()
+{
+    m_parent->dvDimension->TheoreticalExact.setValue(ui->cbTheoreticallyExact->isChecked());
+    m_parent->dvDimension->EqualTolerance.setValue(ui->cbEqualTolerance->isChecked());
+    m_parent->dvDimension->OverTolerance.setValue(ui->qsbOvertolerance->value().getValue());
+    m_parent->dvDimension->UnderTolerance.setValue(ui->qsbUndertolerance->value().getValue());
+
+    m_parent->dvDimension->FormatSpec.setValue(ui->leFormatSpecifier->text().toUtf8().constData());
+    m_parent->dvDimension->Arbitrary.setValue(ui->cbArbitrary->isChecked());
+    m_parent->dvDimension->FormatSpecTolerance.setValue(ui->leToleranceFormatSpecifier->text().toUtf8().constData());
+    m_parent->dvDimension->ArbitraryTolerances.setValue(ui->cbArbitraryTolerances->isChecked());
+
+    m_dimensionVP->FlipArrowheads.setValue(ui->cbArrowheads->isChecked());
+    App::Color ac;
+    ac.setValue<QColor>(ui->dimensionColor->color());
+    m_dimensionVP->Color.setValue(ac);
+    m_dimensionVP->Fontsize.setValue(ui->qsbFontSize->value().getValue());
+    m_dimensionVP->StandardAndStyle.setValue(ui->comboDrawingStyle->currentIndex());
+
+    m_parent->updateView(true);
+
+    return true;
+}
+
+bool TaskDimension::reject()
+{
+    return false;
+}
+
+void TaskDimension::recomputeFeature()
+{
+    App::DocumentObject* objVP = m_dimensionVP->getObject();
+    assert(objVP);
+    objVP->getDocument()->recomputeFeature(objVP);
+}
+
+void TaskDimension::onTheoreticallyExactChanged()
+{
+    m_parent->dvDimension->TheoreticalExact.setValue(ui->cbTheoreticallyExact->isChecked());
+    // if TheoreticalExact disable tolerances and set them to zero
+    if (ui->cbTheoreticallyExact->isChecked()) {
+        ui->qsbOvertolerance->setValue(0.0);
+        ui->qsbUndertolerance->setValue(0.0);
+        ui->cbEqualTolerance->setDisabled(true);
+        ui->qsbOvertolerance->setDisabled(true);
+        ui->qsbUndertolerance->setDisabled(true);
+    }
+    else {
+        ui->cbEqualTolerance->setDisabled(false);
+        ui->qsbOvertolerance->setDisabled(false);
+        if (!ui->cbEqualTolerance->isChecked())
+            ui->qsbUndertolerance->setDisabled(false);
+    }
+    recomputeFeature();
+}
+
+void TaskDimension::onEqualToleranceChanged()
+{
+    m_parent->dvDimension->EqualTolerance.setValue(ui->cbEqualTolerance->isChecked());
+    // if EqualTolerance set negated overtolerance for untertolerance
+    // then also the OverTolerance must be positive
+    if (ui->cbEqualTolerance->isChecked()) {
+        // if OverTolerance is negative or zero, first set it to zero
+        if (ui->qsbOvertolerance->value().getValue() < 0)
+            ui->qsbOvertolerance->setValue(0.0);
+        ui->qsbOvertolerance->setMinimum(0.0);
+        ui->qsbUndertolerance->setValue(-1.0 * ui->qsbOvertolerance->value().getValue());
+        ui->qsbUndertolerance->setUnit(ui->qsbOvertolerance->value().getUnit());
+        ui->qsbUndertolerance->setDisabled(true);
+    }
+    else {
+        ui->qsbOvertolerance->setMinimum(-DBL_MAX);
+        if (!ui->cbTheoreticallyExact->isChecked())
+            ui->qsbUndertolerance->setDisabled(false);
+    }
+    ui->qsbUndertolerance->setDisabled(ui->cbEqualTolerance->isChecked());
+    recomputeFeature();
+}
+
+void TaskDimension::onOvertoleranceChanged()
+{
+    m_parent->dvDimension->OverTolerance.setValue(ui->qsbOvertolerance->value().getValue());
+    // if EqualTolerance set negated overtolerance for untertolerance
+    if (ui->cbEqualTolerance->isChecked()) {
+        ui->qsbUndertolerance->setValue(-1.0 * ui->qsbOvertolerance->value().getValue());
+        ui->qsbUndertolerance->setUnit(ui->qsbOvertolerance->value().getUnit());
+    }
+    recomputeFeature();
+}
+
+void TaskDimension::onUndertoleranceChanged()
+{
+    m_parent->dvDimension->UnderTolerance.setValue(ui->qsbUndertolerance->value().getValue());
+    recomputeFeature();
+}
+
+void TaskDimension::onFormatSpecifierChanged()
+{
+    m_parent->dvDimension->FormatSpec.setValue(ui->leFormatSpecifier->text().toUtf8().constData());
+    recomputeFeature();
+}
+
+void TaskDimension::onArbitraryChanged()
+{
+    m_parent->dvDimension->Arbitrary.setValue(ui->cbArbitrary->isChecked());
+    recomputeFeature();
+}
+
+void TaskDimension::onToleranceFormatSpecifierChanged()
+{
+    m_parent->dvDimension->FormatSpecTolerance.setValue(ui->leToleranceFormatSpecifier->text().toUtf8().constData());
+    recomputeFeature();
+}
+
+void TaskDimension::onArbitraryTolerancesChanged()
+{
+    m_parent->dvDimension->ArbitraryTolerances.setValue(ui->cbArbitraryTolerances->isChecked());
+    recomputeFeature();
+}
+
+void TaskDimension::onFlipArrowheadsChanged()
+{
+    m_dimensionVP->FlipArrowheads.setValue(ui->cbArrowheads->isChecked());
+    recomputeFeature();
+}
+
+void TaskDimension::onColorChanged()
+{
+    App::Color ac;
+    ac.setValue<QColor>(ui->dimensionColor->color());
+    m_dimensionVP->Color.setValue(ac);
+    recomputeFeature();
+}
+
+void TaskDimension::onFontsizeChanged()
+{
+    m_dimensionVP->Fontsize.setValue(ui->qsbFontSize->value().getValue());
+    recomputeFeature();
+}
+
+void TaskDimension::onDrawingStyleChanged()
+{
+    m_dimensionVP->StandardAndStyle.setValue(ui->comboDrawingStyle->currentIndex());
+    recomputeFeature();
+}
+
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+TaskDlgDimension::TaskDlgDimension(QGIViewDimension *parent, ViewProviderDimension *dimensionVP) :
+    TaskDialog()
+{
+    widget  = new TaskDimension(parent, dimensionVP);
+    taskbox = new Gui::TaskView::TaskBox(Gui::BitmapFactory().pixmap("TechDraw_Dimension"), widget->windowTitle(), true, 0);
+    taskbox->groupLayout()->addWidget(widget);
+    Content.push_back(taskbox);
+}
+
+TaskDlgDimension::~TaskDlgDimension()
+{
+}
+
+void TaskDlgDimension::update()
+{
+}
+
+//==== calls from the TaskView ===============================================================
+void TaskDlgDimension::open()
+{
+}
+
+void TaskDlgDimension::clicked(int i)
+{
+    Q_UNUSED(i);
+}
+
+bool TaskDlgDimension::accept()
+{
+    widget->accept();
+    return true;
+}
+
+bool TaskDlgDimension::reject()
+{
+    widget->reject();
+    return true;
+}
+
+#include "moc_TaskDimension.cpp"

--- a/src/Mod/TechDraw/Gui/TaskDimension.h
+++ b/src/Mod/TechDraw/Gui/TaskDimension.h
@@ -1,0 +1,105 @@
+/***************************************************************************
+ *   Copyright (c) 2021 Uwe Stöhr <uwestoehr@lyx.org>                      *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef GUI_TASKVIEW_TASKDIMENSION_H
+#define GUI_TASKVIEW_TASKDIMENSION_H
+
+#include <Gui/TaskView/TaskView.h>
+#include <Gui/TaskView/TaskDialog.h>
+
+#include <Mod/TechDraw/Gui/ui_TaskDimension.h>
+
+#include "QGIViewDimension.h"
+#include "ViewProviderDimension.h"
+
+class Ui_TaskDimension;
+
+namespace TechDrawGui
+{
+
+class TaskDimension : public QWidget
+{
+    Q_OBJECT
+
+public:
+    TaskDimension(QGIViewDimension *parent, ViewProviderDimension *dimensionVP);
+    ~TaskDimension();
+
+public:
+    virtual bool accept();
+    virtual bool reject();
+    void recomputeFeature();
+
+private Q_SLOTS:
+    void onTheoreticallyExactChanged();
+    void onEqualToleranceChanged();
+    void onOvertoleranceChanged();
+    void onUndertoleranceChanged();
+    void onFormatSpecifierChanged();
+    void onArbitraryChanged();
+    void onToleranceFormatSpecifierChanged();
+    void onArbitraryTolerancesChanged();
+    void onFlipArrowheadsChanged();
+    void onColorChanged();
+    void onFontsizeChanged();
+    void onDrawingStyleChanged();
+
+private:
+    std::unique_ptr<Ui_TaskDimension> ui;
+    QGIViewDimension *m_parent;
+    ViewProviderDimension *m_dimensionVP;
+};
+
+class TaskDlgDimension : public Gui::TaskView::TaskDialog
+{
+    Q_OBJECT
+
+public:
+    TaskDlgDimension(QGIViewDimension *parent, ViewProviderDimension *dimensionVP);
+    ~TaskDlgDimension();
+
+public:
+    /// is called the TaskView when the dialog is opened
+    virtual void open();
+    /// is called by the framework if an button is clicked which has no accept or reject role
+    virtual void clicked(int);
+    /// is called by the framework if the dialog is accepted (Ok)
+    virtual bool accept();
+    /// is called by the framework if the dialog is rejected (Cancel)
+    virtual bool reject();
+    /// is called by the framework if the user presses the help button
+    virtual void helpRequested() { return;}
+    virtual bool isAllowedAlterDocument(void) const
+    { return false; }
+
+    void update();
+
+protected:
+
+private:
+    TaskDimension* widget;
+    Gui::TaskView::TaskBox* taskbox;
+};
+
+} //namespace TechDrawGui
+
+#endif // #ifndef GUI_TASKVIEW_TASKDIMENSION_H

--- a/src/Mod/TechDraw/Gui/TaskDimension.ui
+++ b/src/Mod/TechDraw/Gui/TaskDimension.ui
@@ -1,0 +1,312 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>TechDrawGui::TaskDimension</class>
+ <widget class="QWidget" name="TechDrawGui::TaskDimension">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>330</width>
+    <height>417</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dimension</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_4">
+   <item>
+    <widget class="QGroupBox" name="gbTolerancing">
+     <property name="title">
+      <string>Tolerancing</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <layout class="QGridLayout" name="gridLayout_2">
+        <item row="0" column="0">
+         <widget class="QCheckBox" name="cbTheoreticallyExact">
+          <property name="toolTip">
+           <string>If theoretical exact (basic) dimension</string>
+          </property>
+          <property name="text">
+           <string>Theoretically Exact</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QCheckBox" name="cbEqualTolerance">
+          <property name="toolTip">
+           <string>Reverses usual direction of dimension line terminators</string>
+          </property>
+          <property name="text">
+           <string>Equal Tolerance</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="label_2">
+          <property name="text">
+           <string>Overtolerance:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="Gui::QuantitySpinBox" name="qsbOvertolerance">
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>20</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Overtolerance value
+If 'Equal Tolerance' is checked this is also
+the negated value for 'Under Tolerance'.</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+          <property name="singleStep">
+           <double>0.100000000000000</double>
+          </property>
+          <property name="value">
+           <double>0.000000000000000</double>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="0">
+         <widget class="QLabel" name="label_8">
+          <property name="text">
+           <string>Undertolerance:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="1">
+         <widget class="Gui::QuantitySpinBox" name="qsbUndertolerance">
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>20</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Undertolerance value
+If 'Equal Tolerance' is checked it will be replaced
+by negative value of 'Over Tolerance'.</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+          <property name="singleStep">
+           <double>0.100000000000000</double>
+          </property>
+          <property name="value">
+           <double>0.000000000000000</double>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="gbFormatting">
+     <property name="title">
+      <string>Formatting</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <layout class="QGridLayout" name="gridLayout">
+        <item row="0" column="0">
+         <widget class="QLabel" name="label_11">
+          <property name="text">
+           <string>Format Specifier:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QLineEdit" name="leFormatSpecifier">
+          <property name="toolTip">
+           <string>Text to be displayed</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QCheckBox" name="cbArbitrary">
+          <property name="toolTip">
+           <string>If checked the content of 'Format Spec' will
+be used instead if the dimension value</string>
+          </property>
+          <property name="text">
+           <string>Arbitrary Text</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>Tolerance Format Specifier:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="QLineEdit" name="leToleranceFormatSpecifier">
+          <property name="toolTip">
+           <string>Text to be displayed</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="0">
+         <widget class="QCheckBox" name="cbArbitraryTolerances">
+          <property name="toolTip">
+           <string>If checked the content of 'Format Spec' will
+be used instead if the dimension value</string>
+          </property>
+          <property name="text">
+           <string>Arbitrary Tolerance Text</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="gbDisplayStyle">
+     <property name="title">
+      <string>Display Style</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_3">
+      <item>
+       <layout class="QGridLayout" name="gridLayout_3">
+        <item row="0" column="0">
+         <widget class="QCheckBox" name="cbArrowheads">
+          <property name="toolTip">
+           <string>Reverses usual direction of dimension line terminators</string>
+          </property>
+          <property name="text">
+           <string>Flip Arrowheads</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="label_5">
+          <property name="text">
+           <string>Color:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="Gui::ColorButton" name="dimensionColor">
+          <property name="toolTip">
+           <string>Color of the dimension</string>
+          </property>
+          <property name="color">
+           <color>
+            <red>0</red>
+            <green>0</green>
+            <blue>0</blue>
+           </color>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="label_7">
+          <property name="text">
+           <string>Font Size:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="Gui::QuantitySpinBox" name="qsbFontSize">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>20</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Fontsize for 'Text'</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+          <property name="minimum">
+           <double>0.000000000000000</double>
+          </property>
+          <property name="value">
+           <double>4.000000000000000</double>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>FontSize</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>/Mod/TechDraw/Dimensions</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="0">
+         <widget class="QLabel" name="label_4">
+          <property name="text">
+           <string>Drawing Style:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="1">
+         <widget class="QComboBox" name="comboDrawingStyle">
+          <property name="toolTip">
+           <string>Standard and style according to which dimension is drawn</string>
+          </property>
+          <item>
+           <property name="text">
+            <string>ISO Oriented</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>ISO Referencing</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>ASME Inlined</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>ASME Referencing</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>Gui::QuantitySpinBox</class>
+   <extends>QWidget</extends>
+   <header>Gui/QuantitySpinBox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>Gui::ColorButton</class>
+   <extends>QPushButton</extends>
+   <header>Gui/Widgets.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources>
+  <include location="Resources/TechDraw.qrc"/>
+ </resources>
+ <connections/>
+</ui>

--- a/src/Mod/TechDraw/Gui/ViewProviderDimension.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderDimension.cpp
@@ -38,12 +38,13 @@
 #include <App/Document.h>
 #include <App/DocumentObject.h>
 #include <App/Material.h>
+#include <Gui/Control.h>
 
 #include <Mod/TechDraw/App/LineGroup.h>
 #include <Mod/TechDraw/App/LandmarkDimension.h>
-//#include <Mod/TechDraw/App/Preferences.h>
 
 #include "PreferencesGui.h"
+#include "TaskDimension.h"
 #include "QGIViewDimension.h"
 #include "ViewProviderDimension.h"
 
@@ -74,16 +75,16 @@ ViewProviderDimension::ViewProviderDimension()
                                                                      "Dimension text size in units");
     ADD_PROPERTY_TYPE(LineWidth, (prefWeight()), group, (App::PropertyType)(App::Prop_None), 
                                                         "Dimension line width");
-    ADD_PROPERTY_TYPE(Color,(prefColor()),group,App::Prop_None,"The color of the Dimension");
+    ADD_PROPERTY_TYPE(Color, (prefColor()), group, App::Prop_None, "Color of the dimension");
     ADD_PROPERTY_TYPE(StandardAndStyle, (prefStandardAndStyle()), group, App::Prop_None, 
-                                        "Specifies the standard according to which this dimension is drawn");
+                                        "Standard and style according to which dimension is drawn");
     StandardAndStyle.setEnums(StandardAndStyleEnums);
 
-    ADD_PROPERTY_TYPE(RenderingExtent, (REND_EXTENT_NORMAL),  group, App::Prop_None,
+    ADD_PROPERTY_TYPE(RenderingExtent, (REND_EXTENT_NORMAL), group, App::Prop_None,
                                          "Select the rendering mode by space requirements");
     RenderingExtent.setEnums(RenderingExtentEnums);
     ADD_PROPERTY_TYPE(FlipArrowheads, (false), group, App::Prop_None,
-                                          "Reverses the usual direction of dimension line terminators");
+                                          "Reverses usual direction of dimension line terminators");
 }
 
 ViewProviderDimension::~ViewProviderDimension()
@@ -112,6 +113,42 @@ std::vector<std::string> ViewProviderDimension::getDisplayModes(void) const
     std::vector<std::string> StrList = ViewProviderDrawingView::getDisplayModes();
 
     return StrList;
+}
+
+bool ViewProviderDimension::setEdit(int ModNum)
+{
+    if (ModNum == ViewProvider::Default) {
+        if (Gui::Control().activeDialog()) { // if TaskPanel already open
+            return false;
+        }
+        // clear the selection (convenience)
+        Gui::Selection().clearSelection();
+        auto qgivDimension(dynamic_cast<QGIViewDimension*>(getQView()));
+        if (qgivDimension) {
+            Gui::Control().showDialog(new TaskDlgDimension(qgivDimension, this));
+        }
+        return true;
+    }
+    else {
+        return ViewProviderDrawingView::setEdit(ModNum);
+    }
+    return true;
+}
+
+void ViewProviderDimension::unsetEdit(int ModNum)
+{
+    if (ModNum == ViewProvider::Default) {
+        Gui::Control().closeDialog();
+    }
+    else {
+        ViewProviderDrawingView::unsetEdit(ModNum);
+    }
+}
+
+bool ViewProviderDimension::doubleClicked(void)
+{
+    setEdit(ViewProvider::Default);
+    return true;
 }
 
 void ViewProviderDimension::updateData(const App::Property* p)

--- a/src/Mod/TechDraw/Gui/ViewProviderDimension.h
+++ b/src/Mod/TechDraw/Gui/ViewProviderDimension.h
@@ -72,6 +72,9 @@ public:
     virtual std::vector<std::string> getDisplayModes(void) const;
     virtual void updateData(const App::Property*);
     virtual void onChanged(const App::Property* p);
+    virtual bool setEdit(int ModNum);
+    virtual void unsetEdit(int ModNum);
+    virtual bool doubleClicked(void);
 
     virtual TechDraw::DrawViewDimension* getViewObject() const;
 


### PR DESCRIPTION
The dimension object is the only one in TechDraw not having a dialog. This PR add this.
It can either be called by double-clicking on a dimension in the model tree or by double-clicking directly onto a dimension in the drawing. (The latter is a real boost in productivity since one usually has dozens of dimensions and every time first single-click on one in the drawing, then going to the model tree, the double-click needs is with the time tiring/annoying.)

There is how the dialog looks:
![FreeCAD_BoJXxnoXJz](https://user-images.githubusercontent.com/1828501/104141200-dbfe6380-53b5-11eb-9933-037d4bbf2745.png)

Maybe some more settings should appear there, however, for now it is important to have at least a dialog.

I also changed with the PR some wording.

The PR contains already the fixes I made in PR #4263 to avoid merge conflicts.