### PR TITLE
[TD] show balloon dialog on double-clicking

### DIFF
--- a/src/Mod/TechDraw/Gui/QGIViewBalloon.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewBalloon.cpp
@@ -150,7 +150,15 @@ void QGIBalloonLabel::mouseReleaseEvent(QGraphicsSceneMouseEvent * event)
 
 void QGIBalloonLabel::mouseDoubleClickEvent(QGraphicsSceneMouseEvent * event)
 {
-//    Gui::Control().showDialog(new TaskDlgBalloon(parent));   //only from tree
+    QGIViewBalloon* qgivBalloon = dynamic_cast<QGIViewBalloon*>(parentItem());
+    if (qgivBalloon == nullptr) {
+        return;
+    }
+    auto ViewProvider = static_cast<ViewProviderBalloon*>(qgivBalloon->getViewProvider(qgivBalloon->getViewObject()));
+    if (ViewProvider == nullptr) {
+        return;
+    }
+    Gui::Control().showDialog(new TaskDlgBalloon(qgivBalloon, ViewProvider));
     QGraphicsItem::mouseDoubleClickEvent(event);
 }
 

--- a/src/Mod/TechDraw/Gui/TaskBalloon.cpp
+++ b/src/Mod/TechDraw/Gui/TaskBalloon.cpp
@@ -28,7 +28,6 @@
 #endif // #ifndef _PreComp_
 
 #include <Base/Console.h>
-#include <Base/Vector3D.h>
 
 #include <Gui/Application.h>
 #include <Gui/BitmapFactory.h>
@@ -41,11 +40,8 @@
 #include <App/Document.h>
 #include <App/DocumentObject.h>
 
-#include <Mod/Part/App/PartFeature.h>
-
 #include <Mod/TechDraw/App/DrawViewBalloon.h>
 #include <Mod/TechDraw/App/DrawPage.h>
-#include <Mod/TechDraw/App/DrawUtil.h>
 #include <Mod/TechDraw/App/ArrowPropEnum.h>
 
 #include <Mod/TechDraw/Gui/ui_TaskBalloon.h>

--- a/src/Mod/TechDraw/Gui/TaskBalloon.h
+++ b/src/Mod/TechDraw/Gui/TaskBalloon.h
@@ -29,8 +29,6 @@
 
 #include <Mod/TechDraw/Gui/ui_TaskBalloon.h>
 
-#include <Mod/TechDraw/App/DrawViewPart.h>
-
 #include "QGIViewBalloon.h"
 #include "ViewProviderBalloon.h"
 


### PR DESCRIPTION
When adding GD&T statements as described in
https://wiki.freecadweb.org/TechDraw_Geometric_dimensioning_and_tolerancing#Geometrical_Tolerancing
you will quickly get a lot of balloons and it is then very tiring to be forced to first select a balloon with a single-click in the drawing, then go to the model tree and there double-click to get the dialog.

With this PR you can directly double-click in the drawing to open the dialog directly.

This PR also removes unused includes from the dialog code.