### PR TITLE
[TD] don't allow tolerances for exact values

### DIFF
--- a/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
@@ -325,6 +325,14 @@ void QGIDatumLabel::setToleranceString()
         m_tolTextOver->hide();
         m_tolTextUnder->hide();
         return;
+    } else if (dim->TheoreticalExact.getValue()) {
+        m_tolTextOver->hide();
+        m_tolTextUnder->hide();
+        // we must explicitly empy the text other wise the frame drawn for
+        // TheoreticalExact would be as wide as necessary for the text
+        m_tolTextOver->setPlainText(QString());
+        m_tolTextUnder->setPlainText(QString());
+        return;
     }
     m_tolTextOver->show();
     m_tolTextUnder->show();
@@ -586,11 +594,10 @@ void QGIViewDimension::updateView(bool update)
         float y = Rez::guiX(dim->Y.getValue());
         datumLabel->setPosFromCenter(x,-y);
         updateDim();
-     }
-     else if(vp->Fontsize.isTouched() ||
-               vp->Font.isTouched()) {
-         updateDim();
-    } else if (vp->LineWidth.isTouched()) {           //never happens!!
+    } else if(vp->Fontsize.isTouched() ||
+        vp->Font.isTouched()) {
+        updateDim();
+    } else if (vp->LineWidth.isTouched()) {
         m_lineWidth = vp->LineWidth.getValue();
         updateDim();
     } else {


### PR DESCRIPTION
as discussed here: https://forum.freecadweb.org/viewtopic.php?f=35&t=54218
when a value is theoretically exact, it must not have a tolerance

This PR
* fixes this
* also fixes the bug that OverTolerance must not be negative if the tolerances are equal