### PR TITLE
[GUI] Add option to auto-show selection view

### DIFF
--- a/src/Gui/SelectionView.cpp
+++ b/src/Gui/SelectionView.cpp
@@ -55,8 +55,9 @@ using namespace Gui::DockWnd;
 
 SelectionView::SelectionView(Gui::Document* pcDocument, QWidget *parent)
   : DockWindow(pcDocument,parent)
-  , SelectionObserver(false,0)
+  , SelectionObserver(true,0)
   , x(0.0f), y(0.0f), z(0.0f)
+  , openedAutomatically(false)
 {
     setWindowTitle(tr("Selection View"));
 
@@ -128,6 +129,22 @@ void SelectionView::leaveEvent(QEvent *)
 /// @cond DOXERR
 void SelectionView::onSelectionChanged(const SelectionChanges &Reason)
 {
+    ParameterGrp::handle hGrp = App::GetApplication().GetUserParameter().GetGroup("BaseApp")
+        ->GetGroup("Preferences")->GetGroup("Selection");
+    bool autoShow = hGrp->GetBool("AutoShowSelectionView", false);
+    hGrp->SetBool("AutoShowSelectionView", autoShow); // Remove this line once the preferences window item is implemented
+
+    if (autoShow) {
+        if (!parentWidget()->isVisible() && Selection().hasSelection()) {
+            parentWidget()->show();
+            openedAutomatically = true;
+        }
+        else if (openedAutomatically && !Selection().hasSelection()) {
+            parentWidget()->hide();
+            openedAutomatically = false;
+        }
+    }
+
     QString selObject;
     QTextStream str(&selObject);
     if (Reason.Type == SelectionChanges::AddSelection) {
@@ -608,14 +625,10 @@ bool SelectionView::onMsg(const char* /*pMsg*/,const char** /*ppReturn*/)
 }
 
 void SelectionView::hideEvent(QHideEvent *ev) {
-    FC_TRACE(this << " detaching selection observer");
-    this->detachSelection();
     DockWindow::hideEvent(ev);
 }
 
 void SelectionView::showEvent(QShowEvent *ev) {
-    FC_TRACE(this << " attaching selection observer");
-    this->attachSelection();
     enablePickList->setChecked(Selection().needPickedList());
     Gui::DockWindow::showEvent(ev);
 }

--- a/src/Gui/SelectionView.h
+++ b/src/Gui/SelectionView.h
@@ -110,6 +110,7 @@ private:
 private:
     float x,y,z;
     std::vector<App::DocumentObject*> searchList;
+    bool openedAutomatically;
 };
 
 } // namespace DockWnd


### PR DESCRIPTION
This is one stage in the implementation of [Feature #4268](https://tracker.freecadweb.org/view.php?id=4268) -- Multi-Geometry Modal Selection and Deselection. [Forums discussion](https://forum.freecadweb.org/viewtopic.php?f=8&t=43438). It implements the automatic showing and hiding of the SelectionView, controllable by a (currently hidden) user parameter that defaults to `false`.

The SelectionView dock window was already an observer of the current selection when it was showing. This changes it to continuously monitor the selection even when invisible. If the user sets the parameter BaseApp/Preferences/Selection/AutoShowSelectionView to `true`, when there is an item selected, the view will show itself if it was hidden, and will re-hide itself when the selection is cleared. The option has no effect if the user had chosen to manually show the selection view prior to beginning a selection.

The long-term plan is to implement all of 4268 and group the many user settings it will add into a new preferences group in the Preferences dialog. For now this is a hidden preference, though it will add itself to the Parameters list for access via the "Edit parameters..." dialog the first time you make a selection.