### PR TITLE
Path: Pocket clearing extension [New Feature]

### DIFF
--- a/src/Mod/Path/PathScripts/PathPocketShape.py
+++ b/src/Mod/Path/PathScripts/PathPocketShape.py
@@ -276,6 +276,11 @@ class ObjectPocket(PathPocketBase.ObjectPocket):
         if not hasattr(obj, 'ExtensionCorners'):
             obj.addProperty('App::PropertyBool', 'ExtensionCorners', 'Extension', QtCore.QT_TRANSLATE_NOOP('PathPocketShape', 'When enabled connected extension edges are combined to wires.'))
             obj.ExtensionCorners = True
+        if not hasattr(obj, "AllAccessExtension"):
+            obj.addProperty("App::PropertyLength",
+                            "AllAccessExtension",
+                            "Extension",
+                            QtCore.QT_TRANSLATE_NOOP('PathPocketShape','Extends the face by this value where physically possible, enabling all physical access available to clear the face. A zero value disables and the suggested max value is tool diameter.'))
 
         obj.setEditorMode('ExtensionFeature', 2)
         self.initRotationOp(obj)
@@ -453,6 +458,18 @@ class ObjectPocket(PathPocketBase.ObjectPocket):
                                 PathLog.debug('LimitDepthToFace adj_final_dep: {}'.format(adj_final_dep))
                     # Eif
 
+                    # Apply All Access Extension feature when enabled
+                    aa_value = obj.AllAccessExtension.Value
+                    if aa_value > 0.0:
+                        aa_face = PathUtils._get_all_access_face(obj, 
+                                                                 subBase.Shape,
+                                                                 face,
+                                                                 aa_value,
+                                                                 discretize_factor=0.5)
+                        if aa_face:
+                            face = aa_face
+                    # Eif All Access Extension
+
                     face.translate(FreeCAD.Vector(0.0, 0.0, adj_final_dep - faceZMin - clrnc))
                     zExtVal = start_dep - adj_final_dep + (2 * clrnc)
                     extShp = face.removeSplitter().extrude(FreeCAD.Vector(0, 0, zExtVal))
@@ -496,6 +513,7 @@ class ObjectPocket(PathPocketBase.ObjectPocket):
         obj.AttemptInverseAngle = True
         obj.LimitDepthToFace = True
         obj.setExpression('ExtensionLengthDefault', 'OpToolDiameter / 2')
+        obj.AllAccessExtension.Value = 0.0  # Zero value disables feature
 
     def createExtension(self, obj, extObj, extFeature, extSub):
         return Extension(extObj, extFeature, extSub, obj.ExtensionLengthDefault, Extension.DirectionNormal)
@@ -987,6 +1005,7 @@ def SetupProperties():
     setup.append("InverseAngle")
     setup.append("AttemptInverseAngle")
     setup.append("LimitDepthToFace")
+    setup.append('AllAccessExtension')
     return setup
 
 


### PR DESCRIPTION
This is a new feature. It is clean, elegant, and simple with zero regressions.  It allows clearing of odd-shaped pockets where current ops fail.  This extension feature includes some collision avoidance with the model, only allowing travel within voids in the model.  It is only 2D and collision does not include overhangs - additional coding required for overhang awareness.

Thanks to forum user MRx for pushing the boundaries of the current `Pocket` op and seeking a solution.

This new feature is applied to both the PocketShape and Adaptive operations.  The code is independent and is not entangled within either of the improved operations.  There is only a single function and it is placed in the PathUtils module.

This PR also clones the current `UseOutline` feature from PocketShape to the Adaptive op, making Adaptive a bit more robust for clearing material.

**EDIT: Laying in bed, it occurred to me there is one regression starring me blatantly in the face!  Holes!  I'll try to get to it soon.**  
**EDIT: Holes issue fixed and feature applied to Adaptive op also.**  


Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
![Snip macro screenshot-f56165](https://user-images.githubusercontent.com/47639332/104545577-05a2cf00-55f0-11eb-810d-66ba1eebaad0.png)

![Snip macro screenshot-75dea3](https://user-images.githubusercontent.com/47639332/104545642-28cd7e80-55f0-11eb-83a3-2f2099442c50.png)
