### PR TITLE
[PD] fix alignment in pocket dialog

### DIFF
--- a/src/Mod/PartDesign/Gui/TaskPocketParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskPocketParameters.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>241</width>
+    <width>193</width>
     <height>233</height>
    </rect>
   </property>
@@ -15,35 +15,8 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QLabel" name="textLabel1">
-       <property name="text">
-        <string>Type</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QComboBox" name="changeMode">
-       <item>
-        <property name="text">
-         <string>Dimension</string>
-        </property>
-       </item>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
-     <item>
-      <widget class="QLabel" name="labelLength">
-       <property name="text">
-        <string>Length</string>
-       </property>
-      </widget>
-     </item>
-     <item>
+    <layout class="QGridLayout" name="gridLayout">
+     <item row="1" column="1">
       <widget class="Gui::PrefQuantitySpinBox" name="lengthEdit">
        <property name="keyboardTracking">
         <bool>false</bool>
@@ -53,21 +26,40 @@
        </property>
       </widget>
      </item>
-    </layout>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_5">
-     <item>
-      <widget class="QLabel" name="labelOffset">
-       <property name="text">
-        <string>Offset</string>
-       </property>
-      </widget>
-     </item>
-     <item>
+     <item row="2" column="1">
       <widget class="Gui::PrefQuantitySpinBox" name="offsetEdit">
        <property name="keyboardTracking">
         <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="QLabel" name="textLabel1">
+       <property name="text">
+        <string>Type</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QComboBox" name="changeMode">
+       <item>
+        <property name="text">
+         <string>Dimension</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="labelLength">
+       <property name="text">
+        <string>Length</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="labelOffset">
+       <property name="text">
+        <string>Offset</string>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
just a minor UI issue: when you decrease the width of the pocket dialog (e.g. because you have a small screen), the alignment of the widgets is lost. This PR fixes this by grouping the widgets in a grid.

Current look:
![FreeCAD_Adlgj1huQU](https://user-images.githubusercontent.com/1828501/104818585-c612f780-5828-11eb-8a17-74b2163632b2.png)

With this PR:
![FreeCAD_X4BuXksfBN](https://user-images.githubusercontent.com/1828501/104818591-cd3a0580-5828-11eb-9613-bf8007be7cd6.png)
