### PR TITLE
[PD] fix several hole bugs

### DIFF
--- a/src/Mod/PartDesign/App/FeatureHole.cpp
+++ b/src/Mod/PartDesign/App/FeatureHole.cpp
@@ -71,7 +71,8 @@ namespace PartDesign {
 
 const char* Hole::DepthTypeEnums[]                   = { "Dimension", "ThroughAll", /*, "UpToFirst", */ NULL };
 const char* Hole::ThreadTypeEnums[]                  = { "None", "ISOMetricProfile", "ISOMetricFineProfile", "UNC", "UNF", "UNEF", NULL};
-const char* Hole::ThreadFitEnums[]                   = { "Standard", "Close", "Wide", NULL};
+const char* Hole::ThreadFitMetricEnums[]             = { "Standard", "Close", "Wide", NULL};
+const char* Hole::ThreadFitUTSEnums[]                = { "Normal", "Close", "Loose", NULL };
 const char* Hole::DrillPointEnums[]                  = { "Flat", "Angled", NULL};
 
 /* "None" profile */
@@ -447,6 +448,39 @@ const double Hole::metricHoleDiameters[36][4] =
         { 68.0,     70.0,  	77.0,   78.0}
 };
 
+const Hole::UTSClearanceDefinition Hole::UTSHoleDiameters[22] =
+{
+    /* UTS clearance hole diameters according to ASME B18.2.8 */
+    // for information: the norm defines a drill bit number (that is in turn standardized in another ASME norm).
+    // as result the norm defines a minimal clearance which is the diameter of that drill bit.
+    // we use here this minimal clearance as the theoretical exact hole diameter as this is also done in the ISO norm.
+    // {screw class, close, normal, loose}
+        { "#0",     1.7,  1.9,  2.4 },
+        { "#1",     2.1,  2.3,  2.6 },
+        { "#2",     2.4,  2.6,  2.9 },
+        { "#3",     2.7,  2.9,  3.3 },
+        { "#4",     3.0,  3.3,  3.7 },
+        { "#5",     3.6,  4.0,  4.4 },
+        { "#6",     3.9,  4.3,  4.7 },
+        { "#8",     4.6,  5.0,  5.4 },
+        { "#10",    5.2,  5.6,  6.0 },
+        // "#12" not defined
+        { "1/4",    6.8,  7.1,  7.5 },
+        { "5/16",   8.3,  8.7,  9.1 },
+        { "3/8",    9.9, 10.3, 10.7 },
+        { "7/16",  11.5, 11.9, 12.3 },
+        { "1/2",   13.5, 14.3, 15.5 },
+        // "9/16" not defined
+        { "5/8",   16.7, 17.5, 18.6 },
+        { "3/4",   19.8, 20.6, 23.0 },
+        { "7/8",   23.0, 23.8, 26.2 },
+        { "1",     26.2, 27.8, 29.4 },
+        { "1 1/8", 29.4, 31.0, 33.3 },
+        { "1 1/4", 32.5, 34.1, 36.5 },
+        { "1 3/8", 36.5, 38.1, 40.9 },
+        { "1 1/2", 39.7, 41.3, 44.0 }
+};
+
 /* ISO coarse metric enums */
 std::vector<std::string> Hole::HoleCutType_ISOmetric_Enums  = { "None", "Counterbore", "Countersink", "Cheesehead (deprecated)", "Countersink socket screw (deprecated)", "Cap screw (deprecated)" };
 const char* Hole::ThreadSize_ISOmetric_Enums[]   = { "M1",   "M1.1", "M1.2", "M1.4", "M1.6",
@@ -565,7 +599,7 @@ Hole::Hole()
     ThreadClass.setEnums(ThreadClass_None_Enums);
 
     ADD_PROPERTY_TYPE(ThreadFit, (0L), "Hole", App::Prop_None, "Thread fit");
-    ThreadFit.setEnums(ThreadFitEnums);
+    ThreadFit.setEnums(ThreadFitMetricEnums);
 
     ADD_PROPERTY_TYPE(Diameter, (6.0), "Hole", App::Prop_None, "Diameter");
 
@@ -575,6 +609,8 @@ Hole::Hole()
 
     ADD_PROPERTY_TYPE(HoleCutType, (0L), "Hole", App::Prop_None, "Head cut type");
     HoleCutType.setEnums(HoleCutType_None_Enums);
+
+    ADD_PROPERTY_TYPE(HoleCutCustomValues, (false), "Hole", App::Prop_None, "Custom cut values");
 
     ADD_PROPERTY_TYPE(HoleCutDiameter, (0.0), "Hole", App::Prop_None, "Head cut diameter");
 
@@ -636,6 +672,7 @@ void Hole::updateHoleCutParams()
             }
             if (HoleCutDepth.getValue() == 0.0)
                 HoleCutDepth.setValue(dimen.depth);
+            HoleCutCountersinkAngle.setReadOnly(true);
         }
         else if (holeCutType == "Countersink") {
             // read ISO 10642 values
@@ -648,6 +685,7 @@ void Hole::updateHoleCutParams()
             if (HoleCutCountersinkAngle.getValue() == 0.0) {
                 HoleCutCountersinkAngle.setValue(counter.angle);
             }
+            HoleCutCountersinkAngle.setReadOnly(false);
         }
 
         // cut definition
@@ -664,8 +702,11 @@ void Hole::updateHoleCutParams()
                     HoleCutDiameter.setValue(Diameter.getValue() + 0.1);
                     HoleCutDepth.setValue(0.1);
                 } else {
-                    HoleCutDiameter.setValue(dimen.diameter);
-                    HoleCutDepth.setValue(dimen.depth);
+                    // set normed values
+                    if (!HoleCutCustomValues.getValue()) {
+                        HoleCutDiameter.setValue(dimen.diameter);
+                        HoleCutDepth.setValue(dimen.depth);
+                    }
                 }
             } else if (counter.cut_type == CutDimensionSet::Countersink) {
                 const CounterSinkDimension &dimen = counter.get_sink(threadSize);
@@ -677,8 +718,14 @@ void Hole::updateHoleCutParams()
                         HoleCutCountersinkAngle.setValue(counter.angle);
                     }
                 } else {
-                    HoleCutDiameter.setValue(dimen.diameter);
-                    HoleCutCountersinkAngle.setValue(counter.angle);
+                    // set normed values
+                    if (!HoleCutCustomValues.getValue()) {
+                        HoleCutDiameter.setValue(dimen.diameter);
+                        HoleCutCountersinkAngle.setValue(counter.angle);
+                        HoleCutCountersinkAngle.setReadOnly(true);
+                    }
+                    else
+                        HoleCutCountersinkAngle.setReadOnly(false);
                 }
             }
         }
@@ -792,52 +839,128 @@ void Hole::updateDiameterParam()
     }
     else { // we have a clearance hole
         bool found = false;
-        int MatrixRowSize = sizeof(metricHoleDiameters) / sizeof(metricHoleDiameters[0]);
-        switch ( ThreadFit.getValue() ) {
-        case 0: /* standard fit */
-            // read diameter out of matrix
-            for (int i = 0; i < MatrixRowSize; i++) {
-                if (metricHoleDiameters[i][0] == diameter) {
-                    diameter = metricHoleDiameters[i][2];
-                    found = true;
-                    break;
+        std::string threadType = ThreadType.getValueAsString();
+        // UTS and metric have a different clearance hole set
+        if (threadType == "ISOMetricProfile" || threadType == "ISOMetricFineProfile") {
+            int MatrixRowSizeMetric = sizeof(metricHoleDiameters) / sizeof(metricHoleDiameters[0]);
+            switch (ThreadFit.getValue()) {
+            case 0: /* standard fit */
+                // read diameter out of matrix
+                for (int i = 0; i < MatrixRowSizeMetric; i++) {
+                    if (metricHoleDiameters[i][0] == diameter) {
+                        diameter = metricHoleDiameters[i][2];
+                        found = true;
+                        break;
+                    }
                 }
-            }
-            // if nothing was found (e.g. if not metric), we must calculate
-            if (!found) {
-                diameter = (5 * ((int)((diameter * 110) / 5))) / 100.0;
-            }
-            break;
-        case 1: /* close fit */
-            // read diameter out of matrix
-            for (int i = 0; i < MatrixRowSize; i++) {
-                if (metricHoleDiameters[i][0] == diameter) {
-                    diameter = metricHoleDiameters[i][1];
-                    found = true;
-                    break;
+                // if nothing was found (e.g. if not metric), we must calculate
+                if (!found) {
+                    diameter = diameter * 1.1;
                 }
-            }
-            // if nothing was found, we must calculate
-            if (!found) {
-                diameter = (5 * ((int)((diameter * 105) / 5))) / 100.0;
-            }
-            break;
-        case 2: /* wide fit */
-            // read diameter out of matrix
-            for (int i = 0; i < MatrixRowSize; i++) {
-                if (metricHoleDiameters[i][0] == diameter) {
-                    diameter = metricHoleDiameters[i][3];
-                    found = true;
-                    break;
+                break;
+            case 1: /* close fit */
+                // read diameter out of matrix
+                for (int i = 0; i < MatrixRowSizeMetric; i++) {
+                    if (metricHoleDiameters[i][0] == diameter) {
+                        diameter = metricHoleDiameters[i][1];
+                        found = true;
+                        break;
+                    }
                 }
+                // if nothing was found, we must calculate
+                if (!found) {
+                    diameter = diameter * 1.05;
+                }
+                break;
+            case 2: /* wide fit */
+                // read diameter out of matrix
+                for (int i = 0; i < MatrixRowSizeMetric; i++) {
+                    if (metricHoleDiameters[i][0] == diameter) {
+                        diameter = metricHoleDiameters[i][3];
+                        found = true;
+                        break;
+                    }
+                }
+                // if nothing was found, we must calculate
+                if (!found) {
+                    diameter = diameter * 1.15;
+                }
+                break;
+            default:
+                throw Base::IndexError("Thread fit out of range");
             }
-            // if nothing was found, we must calculate
-            if (!found) {
-                diameter = (5 * ((int)((diameter * 115) / 5))) / 100.0;
+        }
+        else if (threadType == "UNC" || threadType == "UNF" || threadType == "UNEF") {
+            const char* ThreadSizeChar = ThreadSize.getValueAsString();
+            int MatrixRowSizeUTS = sizeof(UTSHoleDiameters) / sizeof(UTSHoleDiameters[0]);
+            switch (ThreadFit.getValue()) {
+            case 0: /* normal fit */
+                // read diameter out of matrix
+                for (int i = 0; i < MatrixRowSizeUTS; i++) {
+                    if (UTSHoleDiameters[i].designation == ThreadSizeChar) {
+                        diameter = UTSHoleDiameters[i].normal;
+                        found = true;
+                        break;
+                    }
+                }
+                // if nothing was found (e.g. if not metric), we must calculate
+                if (!found) {
+                    diameter = diameter * 1.1;
+                }
+                break;
+            case 1: /* close fit */
+                // read diameter out of matrix
+                for (int i = 0; i < MatrixRowSizeUTS; i++) {
+                    if (UTSHoleDiameters[i].designation == ThreadSizeChar) {
+                        diameter = UTSHoleDiameters[i].close;
+                        found = true;
+                        break;
+                    }
+                }
+                // if nothing was found, we must calculate
+                if (!found) {
+                    diameter = diameter * 1.05;
+                }
+                break;
+            case 2: /* loose fit */
+                // read diameter out of matrix
+                for (int i = 0; i < MatrixRowSizeUTS; i++) {
+                    if (UTSHoleDiameters[i].designation == ThreadSizeChar) {
+                        diameter = UTSHoleDiameters[i].loose;
+                        found = true;
+                        break;
+                    }
+                }
+                // if nothing was found, we must calculate
+                if (!found) {
+                    diameter = diameter * 1.15;
+                }
+                break;
+            default:
+                throw Base::IndexError("Thread fit out of range");
             }
-            break;
-        default:
-            assert( 0 );
+        }
+        else {
+            switch (ThreadFit.getValue()) {
+            case 0: /* normal fit */
+                // we must calculate
+                if (!found) {
+                    diameter = diameter * 1.1;
+                }
+                break;
+            case 1: /* close fit */
+                if (!found) {
+                    diameter = diameter * 1.05;
+                }
+                break;
+            case 2: /* loose fit */
+                if (!found) {
+                    diameter = diameter * 1.15;
+                }
+                break;
+            default:
+                throw Base::IndexError("Thread fit out of range");
+            }
         }
     }
     Diameter.setValue(diameter);
@@ -867,6 +990,7 @@ void Hole::onChanged(const App::Property *prop)
             ThreadSize.setEnums(ThreadSize_ISOmetric_Enums);
             ThreadClass.setEnums(ThreadClass_ISOmetric_Enums);
             HoleCutType.setEnums(HoleCutType_ISOmetric_Enums);
+            ThreadFit.setEnums(ThreadFitMetricEnums);
             Threaded.setReadOnly(false);
             ThreadSize.setReadOnly(false);
             // thread class and direction are only sensible if threaded
@@ -879,6 +1003,7 @@ void Hole::onChanged(const App::Property *prop)
             ThreadSize.setEnums(ThreadSize_ISOmetricfine_Enums);
             ThreadClass.setEnums(ThreadClass_ISOmetricfine_Enums);
             HoleCutType.setEnums(HoleCutType_ISOmetricfine_Enums);
+            ThreadFit.setEnums(ThreadFitMetricEnums);
             Threaded.setReadOnly(false);
             ThreadSize.setReadOnly(false);
             // thread class and direction are only sensible if threaded
@@ -891,6 +1016,7 @@ void Hole::onChanged(const App::Property *prop)
             ThreadSize.setEnums(ThreadSize_UNC_Enums);
             ThreadClass.setEnums(ThreadClass_UNC_Enums);
             HoleCutType.setEnums(HoleCutType_UNC_Enums);
+            ThreadFit.setEnums(ThreadFitUTSEnums);
             Threaded.setReadOnly(false);
             ThreadSize.setReadOnly(false);
             // thread class and direction are only sensible if threaded
@@ -903,6 +1029,7 @@ void Hole::onChanged(const App::Property *prop)
             ThreadSize.setEnums(ThreadSize_UNF_Enums);
             ThreadClass.setEnums(ThreadClass_UNF_Enums);
             HoleCutType.setEnums(HoleCutType_UNF_Enums);
+            ThreadFit.setEnums(ThreadFitUTSEnums);
             Threaded.setReadOnly(false);
             ThreadSize.setReadOnly(false);
             // thread class and direction are only sensible if threaded
@@ -915,6 +1042,7 @@ void Hole::onChanged(const App::Property *prop)
             ThreadSize.setEnums(ThreadSize_UNEF_Enums);
             ThreadClass.setEnums(ThreadClass_UNEF_Enums);
             HoleCutType.setEnums(HoleCutType_UNEF_Enums);
+            ThreadFit.setEnums(ThreadFitUTSEnums);
             Threaded.setReadOnly(false);
             ThreadSize.setReadOnly(false);
             // thread class and direction are only sensible if threaded
@@ -925,24 +1053,37 @@ void Hole::onChanged(const App::Property *prop)
         }
 
         if (holeCutType == "None") {
+            HoleCutCustomValues.setReadOnly(true);
             HoleCutDiameter.setReadOnly(true);
             HoleCutDepth.setReadOnly(true);
             HoleCutCountersinkAngle.setReadOnly(true);
         }
         else if (holeCutType == "Counterbore") {
+            HoleCutCustomValues.setReadOnly(true);
             HoleCutDiameter.setReadOnly(false);
             HoleCutDepth.setReadOnly(false);
             HoleCutCountersinkAngle.setReadOnly(true);
         }
         else if (holeCutType == "Countersink") {
+            HoleCutCustomValues.setReadOnly(true);
             HoleCutDiameter.setReadOnly(false);
             HoleCutDepth.setReadOnly(false);
             HoleCutCountersinkAngle.setReadOnly(false);
         }
         else { // screw definition
-            HoleCutDiameter.setReadOnly(false);
-            HoleCutDepth.setReadOnly(false);
-            HoleCutCountersinkAngle.setReadOnly(false);
+            HoleCutCustomValues.setReadOnly(false);
+            if (HoleCutCustomValues.getValue()) {
+                HoleCutDiameter.setReadOnly(false);
+                HoleCutDepth.setReadOnly(false);
+                // we must not set HoleCutCountersinkAngle here because the info if this can
+                // be enabled is first available in updateHoleCutParams and thus handled there
+                updateHoleCutParams();
+            }
+            else {
+                HoleCutDiameter.setReadOnly(true);
+                HoleCutDepth.setReadOnly(true);
+                HoleCutCountersinkAngle.setReadOnly(true);
+            }
         }
 
         // Signal changes to these
@@ -1019,28 +1160,57 @@ void Hole::onChanged(const App::Property *prop)
         if (HoleCutType.isValid())
             holeCutType = HoleCutType.getValueAsString();
         if (holeCutType == "None") {
+            HoleCutCustomValues.setReadOnly(true);
             HoleCutDiameter.setReadOnly(true);
             HoleCutDepth.setReadOnly(true);
             HoleCutCountersinkAngle.setReadOnly(true);
         }
         else if (holeCutType == "Counterbore") {
+            HoleCutCustomValues.setReadOnly(true);
             HoleCutDiameter.setReadOnly(false);
             HoleCutDepth.setReadOnly(false);
             HoleCutCountersinkAngle.setReadOnly(true);
         }
         else if (holeCutType == "Countersink") {
+            HoleCutCustomValues.setReadOnly(true);
             HoleCutDiameter.setReadOnly(false);
             HoleCutDepth.setReadOnly(false);
             HoleCutCountersinkAngle.setReadOnly(false);
         }
         else { // screw definition
-            HoleCutDiameter.setReadOnly(false);
-            HoleCutDepth.setReadOnly(false);
-            HoleCutCountersinkAngle.setReadOnly(false);
+            HoleCutCustomValues.setReadOnly(false);
+            if (HoleCutCustomValues.getValue()) {
+                HoleCutDiameter.setReadOnly(false);
+                HoleCutDepth.setReadOnly(false);
+                // don't set HoleCutCountersinkAngle because the knowledge is first
+                // available in updateHoleCutParams() and thus set there
+            }
+            else {
+                HoleCutDiameter.setReadOnly(true);
+                HoleCutDepth.setReadOnly(true);
+                HoleCutCountersinkAngle.setReadOnly(true);
+            }
         }
+
         ProfileBased::onChanged(&HoleCutDiameter);
         ProfileBased::onChanged(&HoleCutDepth);
         ProfileBased::onChanged(&HoleCutCountersinkAngle);
+        updateHoleCutParams();
+    }
+    else if (prop == &HoleCutCustomValues) {
+        if (HoleCutCustomValues.getValue()) {
+            HoleCutDiameter.setReadOnly(false);
+            HoleCutDepth.setReadOnly(false);
+            // don't set HoleCutCountersinkAngle because the knowledge is first
+            // available in updateHoleCutParams() and thus set there
+        }
+        else {
+            HoleCutDiameter.setReadOnly(true);
+            HoleCutDepth.setReadOnly(true);
+            HoleCutCountersinkAngle.setReadOnly(true);    
+        }
+        // when going back to standardized values, we must recalculate
+        // also to find out if HoleCutCountersinkAngle can be ReadOnly
         updateHoleCutParams();
     }
     else if (prop == &DepthType) {

--- a/src/Mod/PartDesign/App/FeatureHole.h
+++ b/src/Mod/PartDesign/App/FeatureHole.h
@@ -57,6 +57,7 @@ public:
     App::PropertyLength         Diameter;
     App::PropertyEnumeration    ThreadDirection;
     App::PropertyEnumeration    HoleCutType;
+    App::PropertyBool           HoleCutCustomValues;
     App::PropertyLength         HoleCutDiameter;
     App::PropertyLength         HoleCutDepth;
     App::PropertyAngle          HoleCutCountersinkAngle;
@@ -90,6 +91,14 @@ public:
 
     static const double metricHoleDiameters[36][4];
 
+    typedef struct {
+        const char* designation;
+        double close;
+        double normal;
+        double loose;
+    } UTSClearanceDefinition;
+    static const UTSClearanceDefinition UTSHoleDiameters[22];
+
     virtual void Restore(Base::XMLReader & reader);
 
     virtual void updateProps();
@@ -99,7 +108,8 @@ protected:
 private:
     static const char* DepthTypeEnums[];
     static const char* ThreadTypeEnums[];
-    static const char* ThreadFitEnums[];
+    static const char* ThreadFitMetricEnums[];
+    static const char* ThreadFitUTSEnums[];
     static const char* DrillPointEnums[];
     static const char* ThreadDirectionEnums[];
 

--- a/src/Mod/PartDesign/App/FeatureHole.h
+++ b/src/Mod/PartDesign/App/FeatureHole.h
@@ -92,7 +92,7 @@ public:
     static const double metricHoleDiameters[36][4];
 
     typedef struct {
-        const char* designation;
+        std::string designation;
         double close;
         double normal;
         double loose;

--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
@@ -115,6 +115,7 @@ TaskHoleParameters::TaskHoleParameters(ViewProviderHole *HoleView, QWidget *pare
         ++cursor;
     }
     ui->HoleCutType->setCurrentIndex(pcHole->HoleCutType.getValue());
+    ui->HoleCutCustomValues->setChecked(pcHole->HoleCutCustomValues.getValue());
     ui->HoleCutDiameter->setValue(pcHole->HoleCutDiameter.getValue());
     ui->HoleCutDepth->setValue(pcHole->HoleCutDepth.getValue());
     ui->HoleCutCountersinkAngle->setValue(pcHole->HoleCutCountersinkAngle.getValue());
@@ -124,24 +125,36 @@ TaskHoleParameters::TaskHoleParameters(ViewProviderHole *HoleView, QWidget *pare
         holeCutType = pcHole->HoleCutType.getValueAsString();
 
     if (holeCutType == "None") {
+        ui->HoleCutCustomValues->setEnabled(false);
         ui->HoleCutDiameter->setEnabled(false);
         ui->HoleCutDepth->setEnabled(false);
         ui->HoleCutCountersinkAngle->setEnabled(false);
     }
     else if (holeCutType == "Counterbore") {
+        ui->HoleCutCustomValues->setEnabled(false);
         ui->HoleCutDiameter->setEnabled(true);
         ui->HoleCutDepth->setEnabled(true);
         ui->HoleCutCountersinkAngle->setEnabled(false);
     }
     else if (holeCutType == "Countersink") {
+        ui->HoleCutCustomValues->setEnabled(false);
         ui->HoleCutDiameter->setEnabled(true);
         ui->HoleCutDepth->setEnabled(true);
         ui->HoleCutCountersinkAngle->setEnabled(true);
     }
     else { // screw definition
-        ui->HoleCutDiameter->setEnabled(true);
-        ui->HoleCutDepth->setEnabled(true);
-        ui->HoleCutCountersinkAngle->setEnabled(true);
+        ui->HoleCutCustomValues->setEnabled(true);
+        if (ui->HoleCutCustomValues->isChecked()) {
+            ui->HoleCutDiameter->setEnabled(true);
+            ui->HoleCutDepth->setEnabled(true);
+            if (!pcHole->HoleCutCountersinkAngle.isReadOnly())
+                ui->HoleCutCountersinkAngle->setEnabled(true);
+        }
+        else {
+            ui->HoleCutDiameter->setEnabled(false);
+            ui->HoleCutDepth->setEnabled(false);
+            ui->HoleCutCountersinkAngle->setEnabled(false);
+        }  
     }
 
     ui->DepthType->setCurrentIndex(pcHole->DepthType.getValue());
@@ -171,7 +184,8 @@ TaskHoleParameters::TaskHoleParameters(ViewProviderHole *HoleView, QWidget *pare
     connect(ui->Diameter, SIGNAL(valueChanged(double)), this, SLOT(threadDiameterChanged(double)));
     connect(ui->directionRightHand, SIGNAL(clicked(bool)), this, SLOT(threadDirectionChanged()));
     connect(ui->directionLeftHand, SIGNAL(clicked(bool)), this, SLOT(threadDirectionChanged()));
-    connect(ui->HoleCutType, SIGNAL(currentIndexChanged(int)), this, SLOT(holeCutChanged(int)));
+    connect(ui->HoleCutType, SIGNAL(currentIndexChanged(int)), this, SLOT(holeCutTypeChanged(int)));
+    connect(ui->HoleCutCustomValues, SIGNAL(clicked(bool)), this, SLOT(holeCutCustomValuesChanged(bool)));
     connect(ui->HoleCutDiameter, SIGNAL(valueChanged(double)), this, SLOT(holeCutDiameterChanged(double)));
     connect(ui->HoleCutDepth, SIGNAL(valueChanged(double)), this, SLOT(holeCutDepthChanged(double)));
     connect(ui->HoleCutCountersinkAngle, SIGNAL(valueChanged(double)), this, SLOT(holeCutCountersinkAngleChanged(double)));
@@ -254,7 +268,7 @@ void TaskHoleParameters::threadCutOffOuterChanged(double value)
     recomputeFeature();
 }
 
-void TaskHoleParameters::holeCutChanged(int index)
+void TaskHoleParameters::holeCutTypeChanged(int index)
 {
     if (index < 0)
         return;
@@ -267,6 +281,52 @@ void TaskHoleParameters::holeCutChanged(int index)
 
     pcHole->HoleCutType.setValue(index);
     recomputeFeature();
+
+    // HoleCutCustomValues is only enabled for screw definitions
+    // we must do this after recomputeFeature() because this gives us the info if 
+    // the type is a countersink and thus if HoleCutCountersinkAngle can be ensabled
+    std::string HoleCutTypeString = pcHole->HoleCutType.getValueAsString();
+    if (HoleCutTypeString == "None" || HoleCutTypeString == "Counterbore"
+        || HoleCutTypeString == "Countersink") {
+        ui->HoleCutCustomValues->setEnabled(false);
+    }
+    else { // screw definition
+        ui->HoleCutCustomValues->setEnabled(true);
+        if (ui->HoleCutCustomValues->isChecked()) {
+            ui->HoleCutDiameter->setEnabled(true);
+            ui->HoleCutDepth->setEnabled(true);
+            if (!pcHole->HoleCutCountersinkAngle.isReadOnly())
+                ui->HoleCutCountersinkAngle->setEnabled(true);
+        }
+        else {
+            ui->HoleCutDiameter->setEnabled(false);
+            ui->HoleCutDepth->setEnabled(false);
+            ui->HoleCutCountersinkAngle->setEnabled(false);
+        }
+    }
+    
+}
+
+void TaskHoleParameters::holeCutCustomValuesChanged(bool value)
+{
+    PartDesign::Hole* pcHole = static_cast<PartDesign::Hole*>(vp->getObject());
+
+    pcHole->HoleCutCustomValues.setValue(ui->HoleCutCustomValues->isChecked());
+
+    if (value) {
+        ui->HoleCutDiameter->setEnabled(true);
+        ui->HoleCutDepth->setEnabled(true);
+        if (!pcHole->HoleCutCountersinkAngle.isReadOnly())
+            ui->HoleCutCountersinkAngle->setEnabled(true);
+    }
+    else {
+        ui->HoleCutDiameter->setEnabled(false);
+        ui->HoleCutDepth->setEnabled(false);
+        ui->HoleCutCountersinkAngle->setEnabled(false);
+    }
+
+    recomputeFeature();
+    
 }
 
 void TaskHoleParameters::holeCutDiameterChanged(double value)
@@ -306,7 +366,7 @@ void TaskHoleParameters::holeCutCountersinkAngleChanged(double value)
 {
     PartDesign::Hole* pcHole = static_cast<PartDesign::Hole*>(vp->getObject());
 
-    pcHole->HoleCutCountersinkAngle.setValue((double)value);
+    pcHole->HoleCutCountersinkAngle.setValue(value);
     recomputeFeature();
 }
 
@@ -415,31 +475,37 @@ void TaskHoleParameters::threadTypeChanged(int index)
     // now set the new type, this will reset the comboboxes to item 0
     pcHole->ThreadType.setValue(index);
 
-    // Size
-    // the size for ISO type has either the form "M3x0.35" or just "M3"
-    // so we need to check if the size contains a 'x'. If yes, check if the string
-    // up to the 'x' is exists in the new list
+    // size and clearance
     if (TypeClass == QByteArray("ISO")) {
+        // the size for ISO type has either the form "M3x0.35" or just "M3"
+        // so we need to check if the size contains a 'x'. If yes, check if the string
+        // up to the 'x' is exists in the new list 
         if (ThreadSizeString.indexOf(QString::fromLatin1("x")) > -1) {
             // we have an ISO fine size
             // cut of the part behind the 'x'
             ThreadSizeString = ThreadSizeString.left(ThreadSizeString.indexOf(QString::fromLatin1("x")));
         }
-
         // search if the string exists in the combobox
         int threadSizeIndex = ui->ThreadSize->findText(ThreadSizeString, Qt::MatchContains);
         if (threadSizeIndex > -1) {
             // we can set it
             ui->ThreadSize->setCurrentIndex(threadSizeIndex);
         }
-    }
-
-    // for the UTS types the entries are the same
-    if (TypeClass == QByteArray("UTS")) {
+        // the names of the clearance types are different in ISO and UTS
+        ui->ThreadFit->setItemText(0, QCoreApplication::translate("TaskHoleParameters", "Standard", nullptr));
+        ui->ThreadFit->setItemText(1, QCoreApplication::translate("TaskHoleParameters", "Close", nullptr));
+        ui->ThreadFit->setItemText(2, QCoreApplication::translate("TaskHoleParameters", "Wide", nullptr));
+    } 
+    else if (TypeClass == QByteArray("UTS")) {
+        // for the UTS types the size entries are the same
         int threadSizeIndex = ui->ThreadSize->findText(ThreadSizeString, Qt::MatchContains);
         if (threadSizeIndex > -1) {
             ui->ThreadSize->setCurrentIndex(threadSizeIndex);
         }
+        // the names of the clearance types are different in ISO and UTS
+        ui->ThreadFit->setItemText(0, QCoreApplication::translate("TaskHoleParameters", "Normal", nullptr));
+        ui->ThreadFit->setItemText(1, QCoreApplication::translate("TaskHoleParameters", "Close", nullptr));
+        ui->ThreadFit->setItemText(2, QCoreApplication::translate("TaskHoleParameters", "Loose", nullptr));
     }
 
     // Class and cut type

--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.h
@@ -93,7 +93,8 @@ private Q_SLOTS:
     void threadAngleChanged(double value);    
     void threadDiameterChanged(double value);
     void threadDirectionChanged();
-    void holeCutChanged(int index);
+    void holeCutTypeChanged(int index);
+    void holeCutCustomValuesChanged(bool value);
     void holeCutDiameterChanged(double value);
     void holeCutDepthChanged(double value);
     void holeCutCountersinkAngleChanged(double value);

--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>354</width>
-    <height>463</height>
+    <width>342</width>
+    <height>486</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -40,7 +40,7 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="1" colspan="5">
+   <item row="1" column="1" colspan="4">
     <widget class="QComboBox" name="ThreadType">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -128,30 +128,30 @@
      </property>
      <property name="maximumSize">
       <size>
-       <width>140</width>
+       <width>16777215</width>
        <height>16777215</height>
       </size>
      </property>
     </widget>
    </item>
-   <item row="6" column="3">
+   <item row="6" column="2">
     <widget class="QLabel" name="label_3">
      <property name="text">
       <string>Clearance</string>
      </property>
     </widget>
    </item>
-   <item row="6" column="5">
+   <item row="6" column="4">
     <widget class="QComboBox" name="ThreadFit">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
      <property name="maximumSize">
       <size>
-       <width>110</width>
+       <width>16777215</width>
        <height>16777215</height>
       </size>
      </property>
@@ -199,7 +199,7 @@ Only available for holes without thread</string>
      </property>
      <property name="maximumSize">
       <size>
-       <width>140</width>
+       <width>16777215</width>
        <height>16777215</height>
       </size>
      </property>
@@ -208,23 +208,7 @@ Only available for holes without thread</string>
      </property>
     </widget>
    </item>
-   <item row="7" column="2">
-    <spacer name="horizontalSpacer">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Fixed</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>13</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="7" column="3" colspan="2">
+   <item row="7" column="2" colspan="2">
     <widget class="QLabel" name="label_7">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
@@ -237,7 +221,7 @@ Only available for holes without thread</string>
      </property>
     </widget>
    </item>
-   <item row="7" column="5">
+   <item row="7" column="4">
     <widget class="Gui::PrefQuantitySpinBox" name="Diameter">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -247,7 +231,7 @@ Only available for holes without thread</string>
      </property>
      <property name="maximumSize">
       <size>
-       <width>110</width>
+       <width>16777215</width>
        <height>16777215</height>
       </size>
      </property>
@@ -285,7 +269,7 @@ Only available for holes without thread</string>
      </property>
      <property name="maximumSize">
       <size>
-       <width>140</width>
+       <width>16777215</width>
        <height>16777215</height>
       </size>
      </property>
@@ -301,7 +285,7 @@ Only available for holes without thread</string>
      </item>
     </widget>
    </item>
-   <item row="8" column="3" colspan="3">
+   <item row="8" column="2" colspan="3">
     <widget class="Gui::PrefQuantitySpinBox" name="Depth">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -334,7 +318,7 @@ Only available for holes without thread</string>
      </property>
     </widget>
    </item>
-   <item row="10" column="1" colspan="5">
+   <item row="10" column="1" colspan="4">
     <widget class="QComboBox" name="HoleCutType">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -354,13 +338,23 @@ Only available for holes without thread</string>
     </widget>
    </item>
    <item row="11" column="1">
+    <widget class="QCheckBox" name="HoleCutCustomValues">
+     <property name="toolTip">
+      <string>Check to override the values predefined by the 'Type'</string>
+     </property>
+     <property name="text">
+      <string>Custom values</string>
+     </property>
+    </widget>
+   </item>
+   <item row="12" column="1">
     <widget class="QLabel" name="label_11">
      <property name="text">
       <string>Diameter</string>
      </property>
     </widget>
    </item>
-   <item row="11" column="3" colspan="3">
+   <item row="12" column="2" colspan="3">
     <widget class="Gui::PrefQuantitySpinBox" name="HoleCutDiameter">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -388,14 +382,14 @@ Only available for holes without thread</string>
      </property>
     </widget>
    </item>
-   <item row="12" column="1">
+   <item row="13" column="1">
     <widget class="QLabel" name="label_12">
      <property name="text">
       <string>Depth</string>
      </property>
     </widget>
    </item>
-   <item row="12" column="3" colspan="3">
+   <item row="13" column="2" colspan="3">
     <widget class="Gui::PrefQuantitySpinBox" name="HoleCutDepth">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -420,14 +414,14 @@ Only available for holes without thread</string>
      </property>
     </widget>
    </item>
-   <item row="13" column="1">
+   <item row="14" column="1">
     <widget class="QLabel" name="label_10">
      <property name="text">
       <string>Countersink angle</string>
      </property>
     </widget>
    </item>
-   <item row="13" column="3" colspan="3">
+   <item row="14" column="2" colspan="3">
     <widget class="Gui::PrefQuantitySpinBox" name="HoleCutCountersinkAngle">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -449,7 +443,7 @@ Only available for holes without thread</string>
      </property>
     </widget>
    </item>
-   <item row="14" column="0">
+   <item row="15" column="0">
     <widget class="QLabel" name="label_9">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
@@ -465,7 +459,7 @@ Only available for holes without thread</string>
      </property>
     </widget>
    </item>
-   <item row="15" column="0">
+   <item row="16" column="0">
     <widget class="QLabel" name="label_15">
      <property name="text">
       <string>Type</string>
@@ -475,7 +469,7 @@ Only available for holes without thread</string>
      </property>
     </widget>
    </item>
-   <item row="15" column="1">
+   <item row="16" column="1">
     <widget class="QRadioButton" name="drillPointFlat">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -491,7 +485,7 @@ Only available for holes without thread</string>
      </attribute>
     </widget>
    </item>
-   <item row="18" column="1">
+   <item row="19" column="1">
     <widget class="QRadioButton" name="drillPointAngled">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -507,7 +501,7 @@ Only available for holes without thread</string>
      </attribute>
     </widget>
    </item>
-   <item row="18" column="3" colspan="3">
+   <item row="19" column="2" colspan="3">
     <widget class="Gui::PrefQuantitySpinBox" name="DrillPointAngle">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -523,8 +517,14 @@ Only available for holes without thread</string>
      </property>
     </widget>
    </item>
-   <item row="19" column="3" colspan="3">
+   <item row="20" column="2" colspan="3">
     <widget class="QCheckBox" name="DrillForDepth">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="toolTip">
       <string>The size of the drill point will be taken into
 account for the depth of blind holes</string>
@@ -534,21 +534,21 @@ account for the depth of blind holes</string>
      </property>
     </widget>
    </item>
-   <item row="20" column="0">
+  <item row="21" column="0">
     <widget class="QLabel" name="label_16">
      <property name="text">
       <string>&lt;b&gt;Misc&lt;/b&gt;</string>
      </property>
     </widget>
    </item>
-   <item row="21" column="0">
+   <item row="22" column="0">
     <widget class="QCheckBox" name="Tapered">
      <property name="text">
       <string>Tapered</string>
      </property>
     </widget>
    </item>
-   <item row="21" column="1">
+   <item row="22" column="1">
     <widget class="Gui::PrefQuantitySpinBox" name="TaperedAngle">
      <property name="toolTip">
       <string>Taper angle for the hole
@@ -564,7 +564,7 @@ over 90: larger hole radius at the bottom</string>
      </property>
     </widget>
    </item>
-   <item row="21" column="4" colspan="2">
+   <item row="22" column="3" colspan="2">
     <widget class="QCheckBox" name="Reversed">
      <property name="toolTip">
       <string>Reverses the hole direction</string>
@@ -574,7 +574,7 @@ over 90: larger hole radius at the bottom</string>
      </property>
     </widget>
    </item>
-  </layout>
+   </layout>
  </widget>
  <customwidgets>
   <customwidget>
@@ -600,13 +600,13 @@ over 90: larger hole radius at the bottom</string>
   <tabstop>DepthType</tabstop>
   <tabstop>Depth</tabstop>
   <tabstop>HoleCutType</tabstop>
+  <tabstop>HoleCutCustomValues</tabstop>
   <tabstop>HoleCutDiameter</tabstop>
   <tabstop>HoleCutDepth</tabstop>
   <tabstop>HoleCutCountersinkAngle</tabstop>
   <tabstop>drillPointFlat</tabstop>
   <tabstop>drillPointAngled</tabstop>
   <tabstop>DrillPointAngle</tabstop>
-  <tabstop>DrillForDepth</tabstop>
   <tabstop>Tapered</tabstop>
   <tabstop>TaperedAngle</tabstop>
   <tabstop>Reversed</tabstop>
@@ -620,28 +620,12 @@ over 90: larger hole radius at the bottom</string>
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>49</x>
-     <y>451</y>
+     <x>40</x>
+     <y>540</y>
     </hint>
     <hint type="destinationlabel">
-     <x>163</x>
-     <y>453</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>Threaded</sender>
-   <signal>clicked(bool)</signal>
-   <receiver>ThreadFit</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
      <x>136</x>
-     <y>63</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>344</x>
-     <y>142</y>
+     <y>540</y>
     </hint>
    </hints>
   </connection>
@@ -656,14 +640,30 @@ over 90: larger hole radius at the bottom</string>
      <y>63</y>
     </hint>
     <hint type="destinationlabel">
-     <x>163</x>
-     <y>168</y>
+     <x>136</x>
+     <y>280</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>Threaded</sender>
+   <signal>clicked(bool)</signal>
+   <receiver>ThreadFit</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>136</x>
+     <y>63</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>322</x>
+     <y>254</y>
     </hint>
    </hints>
   </connection>
  </connections>
  <buttongroups>
-  <buttongroup name="drillPointButtonGroup"/>
   <buttongroup name="directionButtonGroup"/>
+  <buttongroup name="drillPointButtonGroup"/>
  </buttongroups>
 </ui>


### PR DESCRIPTION
- fix bug B reported here: https://forum.freecadweb.org/viewtopic.php?f=3&t=54408&sid=91194a40335be7962781e0aa7958a760
The problem was that we have normed screw head cuts. These values can be overridden but we must store the info about the overriding. Why? - because when you have e.g. made a custom change to a normed countersink and then change to another countersink norm, you would either not get the values defined in the norm or you get these values but loose e.g. your depth settings

- fix bug D reported here:
https://forum.freecadweb.org/viewtopic.php?f=3&t=54408&sid=91194a40335be7962781e0aa7958a760
The ReadOnly state of HoleCutCountersinkAngle was not correctly set for all cases

- fix bug C reported here: https://forum.freecadweb.org/viewtopic.php?f=3&t=54408&sid=91194a40335be7962781e0aa7958a760
There were 2 issues: the diameter widget had a fixed maximum and there was a superfluous spacer leading to unnecessary whitespace

- fix wrong clearance hole diameters when we have a UTS hole
We only had metric clearance holes defined and we calculated the UTS ones. However, there is a norm defining UTS clearances and since these do not follow a formula all UTS clearance holes are not correct.
This PR implements the norm ASME B18.2.8 to get rid of the calculation, this will only be used as fallback.

- fix tab order of the hole dialog

- fix this compiler warning: "C26451 Arithmetic overflow"
  (the code for the clearance hole diameters was anyway horrible and unnecessary)

- just a trifle: change a function name to fit into the naming scheme

Note for the merger: if possible, either please first only merge PR #4134 or this one, but not both the same day. They depend on each other, and I will have to adapt the second PR once the first is in.