### PR TITLE
Remove ExtensionProxy and rely on default Python proxy for extensions

### DIFF
--- a/src/App/Extension.h
+++ b/src/App/Extension.h
@@ -336,13 +336,9 @@ public:
     ExtensionPythonT() {
         ExtensionT::m_isPythonExtension = true;
         ExtensionT::initExtensionType(ExtensionPythonT::getExtensionClassTypeId());
-
-        EXTENSION_ADD_PROPERTY(ExtensionProxy,(Py::Object()));
     }
     virtual ~ExtensionPythonT() {
     }
-
-    PropertyPythonObject ExtensionProxy;
 };
 
 typedef ExtensionPythonT<App::Extension> ExtensionPython;
@@ -352,7 +348,7 @@ typedef ExtensionPythonT<App::Extension> ExtensionPython;
     Base::PyGILStateLocker lock;\
     Py::Object result;\
     try {\
-        Property* proxy = this->extensionGetPropertyByName("ExtensionProxy");\
+        Property* proxy = this->getExtendedContainer()->getPropertyByName("Proxy");\
         if (proxy && proxy->getTypeId() == PropertyPythonObject::getClassTypeId()) {\
             Py::Object feature = static_cast<PropertyPythonObject*>(proxy)->getValue();\
             if (feature.hasAttr(std::string("function"))) {\

--- a/src/App/ExtensionContainerPy.xml
+++ b/src/App/ExtensionContainerPy.xml
@@ -17,8 +17,7 @@
     </Documentation>
     <Methode Name="addExtension">
       <Documentation>
-        <UserDocu>Adds an extension to the object. Requires the string identifier as well as the python object 
-                  used to check for overridden functions (most likely self)</UserDocu>
+        <UserDocu>Adds an extension to the object. Requires the string identifier for the python extension as argument</UserDocu>
       </Documentation>
     </Methode>
     <Methode Name="hasExtension" Const="true">

--- a/src/App/ExtensionContainerPyImp.cpp
+++ b/src/App/ExtensionContainerPyImp.cpp
@@ -198,8 +198,7 @@ PyObject* ExtensionContainerPy::hasExtension(PyObject *args) {
 PyObject* ExtensionContainerPy::addExtension(PyObject *args) {
 
     char *typeId;
-    PyObject* proxy;
-    if (!PyArg_ParseTuple(args, "sO", &typeId, &proxy))
+    if (!PyArg_ParseTuple(args, "s", &typeId))
         return NULL;
 
     //get the extension type asked for
@@ -223,16 +222,7 @@ PyObject* ExtensionContainerPy::addExtension(PyObject *args) {
     GetApplication().signalBeforeAddingDynamicExtension(*getExtensionContainerPtr(), typeId);
     ext->initExtension(getExtensionContainerPtr());
 
-    //set the proxy to allow python overrides
-    App::Property* pp = ext->extensionGetPropertyByName("ExtensionProxy");
-    if (!pp) {
-        std::stringstream str;
-        str << "Accessing the proxy property failed!" << std::ends;
-        throw Py::Exception(Base::BaseExceptionFreeCADError,str.str());
-    }
-    static_cast<PropertyPythonObject*>(pp)->setPyObject(proxy);
-
-    // The PyTypeObject is shared by all instances of this type and therefore
+      // The PyTypeObject is shared by all instances of this type and therefore
     // we have to add new methods only once.
     PyObject* obj = ext->getExtensionPyObject();
     PyMethodDef* meth = reinterpret_cast<PyMethodDef*>(obj->ob_type->tp_methods);

--- a/src/Gui/ViewProviderExtension.h
+++ b/src/Gui/ViewProviderExtension.h
@@ -130,13 +130,9 @@ public:
     ViewProviderExtensionPythonT() {
         ExtensionT::m_isPythonExtension = true;
         ExtensionT::initExtensionType(ViewProviderExtensionPythonT::getExtensionClassTypeId());
-
-        EXTENSION_ADD_PROPERTY(ExtensionProxy,(Py::Object()));
     }
     virtual ~ViewProviderExtensionPythonT() {
     }
-
-    App::PropertyPythonObject ExtensionProxy;
 };
 
 typedef ViewProviderExtensionPythonT<Gui::ViewProviderExtension> ViewProviderExtensionPython;

--- a/src/Mod/Arch/ArchBuildingPart.py
+++ b/src/Mod/Arch/ArchBuildingPart.py
@@ -323,8 +323,8 @@ class BuildingPart(ArchIFC.IfcProduct):
     def __init__(self,obj):
 
         obj.Proxy = self
-        obj.addExtension('App::GroupExtensionPython', self)
-        #obj.addExtension('App::OriginGroupExtensionPython', self)
+        obj.addExtension('App::GroupExtensionPython')
+        #obj.addExtension('App::OriginGroupExtensionPython')
         self.setProperties(obj)
 
     def setProperties(self,obj):
@@ -488,8 +488,8 @@ class ViewProviderBuildingPart:
 
     def __init__(self,vobj):
 
-        vobj.addExtension("Gui::ViewProviderGroupExtensionPython", self)
-        #vobj.addExtension("Gui::ViewProviderGeoFeatureGroupExtensionPython", self)
+        vobj.addExtension("Gui::ViewProviderGroupExtensionPython")
+        #vobj.addExtension("Gui::ViewProviderGeoFeatureGroupExtensionPython")
         vobj.Proxy = self
         self.setProperties(vobj)
         vobj.ShapeColor = ArchCommands.getDefaultColor("Helpers")

--- a/src/Mod/Arch/ArchProject.py
+++ b/src/Mod/Arch/ArchProject.py
@@ -158,7 +158,7 @@ class _Project(ArchIFC.IfcContext):
         ArchIFC.IfcContext.setProperties(self, obj)
         pl = obj.PropertiesList
         if not hasattr(obj,"Group"):
-            obj.addExtension("App::GroupExtensionPython", self)
+            obj.addExtension("App::GroupExtensionPython")
         self.Type = "Project"
 
     def onDocumentRestored(self, obj):
@@ -185,7 +185,7 @@ class _ViewProviderProject(ArchIFCView.IfcContextView):
 
     def __init__(self,vobj):
         vobj.Proxy = self
-        vobj.addExtension("Gui::ViewProviderGroupExtensionPython", self)
+        vobj.addExtension("Gui::ViewProviderGroupExtensionPython")
 
     def getIcon(self):
         """Return the path to the appropriate icon.

--- a/src/Mod/Arch/ArchSite.py
+++ b/src/Mod/Arch/ArchSite.py
@@ -631,7 +631,7 @@ class _Site(ArchIFC.IfcProduct):
         if not "OriginOffset" in pl:
             obj.addProperty("App::PropertyVector","OriginOffset","Site",QT_TRANSLATE_NOOP("App::Property","An optional offset between the model (0,0,0) origin and the point indicated by the geocoordinates"))
         if not hasattr(obj,"Group"):
-            obj.addExtension("App::GroupExtensionPython", self)
+            obj.addExtension("App::GroupExtensionPython")
         if not "IfcType" in pl:
             obj.addProperty("App::PropertyEnumeration","IfcType","IFC",QT_TRANSLATE_NOOP("App::Property","The type of this object"))
             obj.IfcType = ArchIFC.IfcTypes
@@ -819,7 +819,7 @@ class _ViewProviderSite:
 
     def __init__(self,vobj):
         vobj.Proxy = self
-        vobj.addExtension("Gui::ViewProviderGroupExtensionPython", self)
+        vobj.addExtension("Gui::ViewProviderGroupExtensionPython")
         self.setProperties(vobj)
 
     def setProperties(self,vobj):

--- a/src/Mod/Draft/draftmake/make_clone.py
+++ b/src/Mod/Draft/draftmake/make_clone.py
@@ -108,7 +108,7 @@ def make_clone(obj, delta=None, forcedraft=False):
     # fall back to Draft clone mode
     if not cl:
         cl = App.ActiveDocument.addObject("Part::FeaturePython","Clone")
-        cl.addExtension("Part::AttachExtensionPython", None)
+        cl.addExtension("Part::AttachExtensionPython")
         cl.Label = prefix + obj[0].Label
     Clone(cl)
     if App.GuiUp:

--- a/src/Mod/Draft/draftobjects/draftlink.py
+++ b/src/Mod/Draft/draftobjects/draftlink.py
@@ -79,7 +79,7 @@ class DraftLink(DraftObject):
     def attach(self, obj):
         """Set up the properties when the object is attached."""
         if self.use_link:
-            obj.addExtension('App::LinkExtensionPython', None)
+            obj.addExtension('App::LinkExtensionPython')
             self.linkSetup(obj)
 
     def canLinkProperties(self, _obj):

--- a/src/Mod/Fem/femsolver/solverbase.py
+++ b/src/Mod/Fem/femsolver/solverbase.py
@@ -48,7 +48,7 @@ class Proxy(object):
 
     def __init__(self, obj):
         obj.Proxy = self
-        obj.addExtension("App::GroupExtensionPython", self)
+        obj.addExtension("App::GroupExtensionPython")
 
     def createMachine(self, obj, directory, testmode):
         raise NotImplementedError()
@@ -78,7 +78,7 @@ class ViewProxy(object):
 
     def __init__(self, vobj):
         vobj.Proxy = self
-        vobj.addExtension("Gui::ViewProviderGroupExtensionPython", self)
+        vobj.addExtension("Gui::ViewProviderGroupExtensionPython")
 
     def setEdit(self, vobj, mode=0):
         try:

--- a/src/Mod/Part/BasicShapes/Shapes.py
+++ b/src/Mod/Part/BasicShapes/Shapes.py
@@ -43,7 +43,7 @@ class TubeFeature:
         obj.addProperty("App::PropertyLength","OuterRadius","Tube","Outer radius").OuterRadius = 5.0
         obj.addProperty("App::PropertyLength","InnerRadius","Tube","Inner radius").InnerRadius = 2.0
         obj.addProperty("App::PropertyLength","Height","Tube", "Height of the tube").Height = 10.0
-        obj.addExtension("Part::AttachExtensionPython", self)
+        obj.addExtension("Part::AttachExtensionPython")
 
     def execute(self, fp):
         if fp.InnerRadius >= fp.OuterRadius:

--- a/src/Mod/Part/BasicShapes/ViewProviderShapes.py
+++ b/src/Mod/Part/BasicShapes/ViewProviderShapes.py
@@ -36,7 +36,7 @@ class ViewProviderTube:
     def __init__(self, obj):
         ''' Set this object to the proxy object of the actual view provider '''
         obj.Proxy = self
-        obj.addExtension("PartGui::ViewProviderAttachExtensionPython", self)
+        obj.addExtension("PartGui::ViewProviderAttachExtensionPython")
         obj.setIgnoreOverlayIcon(True, "PartGui::ViewProviderAttachExtensionPython")
 
     def attach(self, obj):

--- a/src/Mod/Test/Document.py
+++ b/src/Mod/Test/Document.py
@@ -245,7 +245,7 @@ class DocumentBasicCases(unittest.TestCase):
     #we should have all methods we need to handle extensions
     try:
       self.failUnless(not grp.hasExtension("App::GroupExtensionPython"))
-      grp.addExtension("App::GroupExtensionPython", self)
+      grp.addExtension("App::GroupExtensionPython")
       self.failUnless(grp.hasExtension("App::GroupExtension"))
       self.failUnless(grp.hasExtension("App::GroupExtensionPython"))
       grp.addObject(obj)
@@ -260,8 +260,9 @@ class DocumentBasicCases(unittest.TestCase):
             return False;
 
     callback = SpecialGroup()
-    grp2 = self.Doc.addObject("App::DocumentObject", "Extension_3")
-    grp2.addExtension("App::GroupExtensionPython", callback)
+    grp2 = self.Doc.addObject("App::FeaturePython", "Extension_3")
+    grp2.addExtension("App::GroupExtensionPython")
+    grp2.Proxy = callback
 
     try:
       self.failUnless(grp2.hasExtension("App::GroupExtension"))
@@ -281,7 +282,7 @@ class DocumentBasicCases(unittest.TestCase):
 
         class MyExtension():
             def __init__(self, obj):
-                obj.addExtension("App::GroupExtensionPython", self)
+                obj.addExtension("App::GroupExtensionPython")
 
         obj = self.Doc.addObject("App::DocumentObject", "myObj")
         MyExtension(obj)
@@ -293,7 +294,7 @@ class DocumentBasicCases(unittest.TestCase):
   def testExtensionGroup(self):
     obj = self.Doc.addObject("App::DocumentObject", "Obj")
     grp = self.Doc.addObject("App::FeaturePython", "Extension_2")
-    grp.addExtension("App::GroupExtensionPython", None)
+    grp.addExtension("App::GroupExtensionPython")
     grp.Group = [obj]
     self.assertTrue(obj in grp.Group)
 
@@ -301,11 +302,11 @@ class DocumentBasicCases(unittest.TestCase):
 
     class Layer():
       def __init__(self, obj):
-        obj.addExtension("App::GroupExtensionPython", self)
+        obj.addExtension("App::GroupExtensionPython")
 
     class LayerViewProvider():
       def __init__(self, obj):
-        obj.addExtension("Gui::ViewProviderGroupExtensionPython", self)
+        obj.addExtension("Gui::ViewProviderGroupExtensionPython")
         obj.Proxy = self
 
     obj = self.Doc.addObject("App::FeaturePython","Layer")
@@ -385,7 +386,7 @@ class DocumentBasicCases(unittest.TestCase):
 # class must be defined in global scope to allow it to be reloaded on document open
 class SaveRestoreSpecialGroup():
     def __init__(self, obj):
-        obj.addExtension("App::GroupExtensionPython", self)
+        obj.addExtension("App::GroupExtensionPython")
         obj.Proxy = self
 
     def allowObject(self, obj):
@@ -394,7 +395,7 @@ class SaveRestoreSpecialGroup():
 # class must be defined in global scope to allow it to be reloaded on document open
 class SaveRestoreSpecialGroupViewProvider():
     def __init__(self, obj):
-        obj.addExtension("Gui::ViewProviderGroupExtensionPython", self)
+        obj.addExtension("Gui::ViewProviderGroupExtensionPython")
         obj.Proxy = self
 
     def testFunction(self):
@@ -468,7 +469,7 @@ class DocumentSaveRestoreCases(unittest.TestCase):
     grp1 = Doc.addObject("App::DocumentObject", "Extension_1")
     grp2 = Doc.addObject("App::FeaturePython", "Extension_2")
 
-    grp1.addExtension("App::GroupExtensionPython", None)
+    grp1.addExtension("App::GroupExtensionPython")
     SaveRestoreSpecialGroup(grp2)
     if FreeCAD.GuiUp:
         SaveRestoreSpecialGroupViewProvider(grp2.ViewObject)
@@ -480,16 +481,12 @@ class DocumentSaveRestoreCases(unittest.TestCase):
 
     self.failUnless(Doc.Extension_1.hasExtension("App::GroupExtension"))
     self.failUnless(Doc.Extension_2.hasExtension("App::GroupExtension"))
-    self.failUnless(Doc.Extension_1.ExtensionProxy is None)
-    self.failUnless(Doc.Extension_2.ExtensionProxy is not None)
     self.failUnless(Doc.Extension_2.Group[0] is Doc.Obj)
     self.failUnless(hasattr(Doc.Extension_2.Proxy, 'allowObject'))
-    self.failUnless(hasattr(Doc.Extension_2.ExtensionProxy, 'allowObject'))
 
     if FreeCAD.GuiUp:
       self.failUnless(Doc.Extension_2.ViewObject.hasExtension("Gui::ViewProviderGroupExtensionPython"))
       self.failUnless(hasattr(Doc.Extension_2.ViewObject.Proxy, 'testFunction'))
-      self.failUnless(hasattr(Doc.Extension_2.ViewObject.ExtensionProxy, 'testFunction'))
 
     FreeCAD.closeDocument("SaveRestoreExtensions")
 
@@ -1803,7 +1800,7 @@ class DocumentObserverCases(unittest.TestCase):
     self.failUnless(self.Obs.parameter2.pop() == 'Prop')
     self.failUnless(not self.Obs.signal and not self.Obs.parameter and not self.Obs.parameter2)
 
-    pyobj.addExtension("App::GroupExtensionPython", None)
+    pyobj.addExtension("App::GroupExtensionPython")
     self.failUnless(self.Obs.signal.pop() == 'ObjDynExt')
     self.failUnless(self.Obs.parameter.pop() is pyobj)
     self.failUnless(self.Obs.parameter2.pop() == 'App::GroupExtensionPython')
@@ -1945,7 +1942,7 @@ class DocumentObserverCases(unittest.TestCase):
     self.failUnless(self.GuiObs.parameter.pop(0) is obj.ViewObject)
     self.failUnless(not self.GuiObs.signal and not self.GuiObs.parameter and not self.GuiObs.parameter2)
 
-    obj.ViewObject.addExtension("Gui::ViewProviderGroupExtensionPython", None)
+    obj.ViewObject.addExtension("Gui::ViewProviderGroupExtensionPython")
     self.failUnless(self.Obs.signal.pop() == 'ObjDynExt')
     self.failUnless(self.Obs.parameter.pop() is obj.ViewObject)
     self.failUnless(self.Obs.parameter2.pop() == 'Gui::ViewProviderGroupExtensionPython')


### PR DESCRIPTION
This fixes #0004534

The solution is to be decided by discussion: [Forum](https://forum.freecadweb.org/viewtopic.php?f=10&t=54370)

The approach used in this pull request is the one with the most elegant outcome, but also with the largest changes regarding API breakage. It fully removes the ExtensionProxy property and uses the default Proxy property for overriding extension methods. This means that extensions can be added to all FreeCAD objects, however, method overriding only for Pythons Features, as only those have the Proxy property

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [x] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

