### PR TITLE
[ArchComponent] Fix Link Of Window Hosts if empty got error as Wall Child

### DIFF
--- a/src/Mod/Arch/ArchComponent.py
+++ b/src/Mod/Arch/ArchComponent.py
@@ -757,8 +757,8 @@ class Component(ArchIFC.IfcProduct):
         subs = obj.Subtractions
         for link in obj.InListRecursive:
             if hasattr(link,"Hosts"):
-                for host in link.Hosts:
-                    if host == obj:
+                if link.Hosts:
+                    if obj in link.Hosts:
                         subs.append(link)
             elif hasattr(link,"Host") and Draft.getType(link) != "Rebar":
                 if link.Host == obj:
@@ -1120,14 +1120,15 @@ class Component(ArchIFC.IfcProduct):
         """
 
         hosts = []
+
         for link in obj.InListRecursive:
             if hasattr(link,"Host"):
                 if link.Host:
                     if link.Host == obj:
                         hosts.append(link)
             elif hasattr(link,"Hosts"):
-                for host in link.Hosts:
-                    if host == obj:
+                if link.Hosts:
+                    if obj in link.Hosts:
                         hosts.append(link)
         return hosts
 


### PR DESCRIPTION
Enable Link of Window to be created with Hosts empty, otherwise ArchWall will return error in original code.

Subsequent to forum discussion [ Link of Window Not Creating Hole](https://forum.freecadweb.org/viewtopic.php?f=23&t=50364)

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
