### PR TITLE
[Path] Fix AttributeError on deleting corrupt dressup

### DIFF
--- a/src/Mod/Path/PathScripts/PathDressupTagGui.py
+++ b/src/Mod/Path/PathScripts/PathDressupTagGui.py
@@ -418,7 +418,7 @@ class PathDressupTagViewProvider:
         '''this makes sure that the base operation is added back to the job and visible'''
         # pylint: disable=unused-argument
         PathLog.track()
-        if self.obj.Base.ViewObject:
+        if self.obj.Base and self.obj.Base.ViewObject:
             self.obj.Base.ViewObject.Visibility = True
         job = PathUtils.findParentJob(self.obj)
         if arg1.Object and arg1.Object.Base and job:


### PR DESCRIPTION
self.obj.Base can be None which raises an exception on deletion so the dressup can never be deleted. This small change fixes that.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
