### PR TITLE
App/Gui: New restoreError Document status and Gui pop-up

### DIFF
--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -2745,6 +2745,7 @@ void Document::restore (const char *filename,
     }
     catch (const Base::Exception& e) {
         Base::Console().Error("Invalid Document.xml: %s\n", e.what());
+        setStatus(Document::RestoreError, true);
     }
 
     d->partialLoadObjects.clear();

--- a/src/App/Document.h
+++ b/src/App/Document.h
@@ -74,6 +74,7 @@ public:
         PartialDoc = 7,
         AllowPartialRecompute = 8, // allow recomputing editing object if SkipRecompute is set
         TempDoc = 9, // Mark as temporary document without prompt for save
+        RestoreError = 10
     };
 
     /** @name Properties */

--- a/src/Gui/CommandDoc.cpp
+++ b/src/Gui/CommandDoc.cpp
@@ -160,6 +160,14 @@ void StdCmdOpen::activated(int iMsg)
     else {
         for (SelectModule::Dict::iterator it = dict.begin(); it != dict.end(); ++it) {
             getGuiApplication()->open(it.key().toUtf8(), it.value().toLatin1());
+
+            App::Document *doc = App::GetApplication().getActiveDocument();
+
+            if(doc && doc->testStatus(App::Document::PartialRestore))
+                QMessageBox::critical(getMainWindow(), QObject::tr("Error"), QObject::tr("There were errors while loading the file. Some data might have been modified or not recovered at all. Look in the report view for more specific information about the objects involved."));
+
+            if(doc && doc->testStatus(App::Document::RestoreError))
+                QMessageBox::critical(getMainWindow(), QObject::tr("Error"), QObject::tr("There were serious errors while loading the file. Some data might have been modified or not recovered at all. Saving the project will most likely result in loss of data."));
         }
     }
 }

--- a/src/Mod/Web/Gui/BrowserView.cpp
+++ b/src/Mod/Web/Gui/BrowserView.cpp
@@ -554,6 +554,9 @@ void BrowserView::onLinkClicked (const QUrl & url)
                 App::Document *doc = BaseView::getAppDocument();
                 if(doc && doc->testStatus(App::Document::PartialRestore))
                     QMessageBox::critical(this, tr("Error"), tr("There were errors while loading the file. Some data might have been modified or not recovered at all. Look in the report view for more specific information about the objects involved."));
+
+                if(doc && doc->testStatus(App::Document::RestoreError))
+                    QMessageBox::critical(this, tr("Error"), tr("There were serious errors while loading the file. Some data might have been modified or not recovered at all. Saving the project will most likely result in loss of data."));
             }
         }
         else {


### PR DESCRIPTION
Summary:

If the restore of Document.xml results in invalid Document.xml (because unhandled exceptions occurred), the
document status Document::restoreError is set. The GUI or Mod/Web if a link was clicked, show a pop-up indicating
this situation.

This commit also shows an appropriate pop-up for the partialRestore when opening from the menu, that before only
appeared when opening by clicking a link.

