### PR TITLE
[v0.18] App/Gui: New restoreError Document status and Gui pop-up

### DIFF
--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -1861,6 +1861,7 @@ void Document::restore (void)
     }
     catch (const Base::Exception& e) {
         Base::Console().Error("Invalid Document.xml: %s\n", e.what());
+        setStatus(Document::RestoreError, true);
     }
 
     // Special handling for Gui document, the view representations must already

--- a/src/App/Document.h
+++ b/src/App/Document.h
@@ -70,6 +70,7 @@ public:
         Restoring = 3,
         Recomputing = 4,
         PartialRestore = 5
+        RestoreError = 10
     };
 
     /** @name Properties */

--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -518,6 +518,14 @@ void Application::open(const char* FileName, const char* Module)
                     Command::doCommand(Command::Gui, "Gui.SendMsgToActiveView(\"ViewFit\")");
             }
 
+            App::Document *doc = App::GetApplication().getActiveDocument();
+
+            if(doc && doc->testStatus(App::Document::PartialRestore))
+                QMessageBox::critical(getMainWindow(), QObject::tr("Error"), QObject::tr("There were errors while loading the file. Some data might have been modified or not recovered at all. Look in the report view for more specific information about the objects involved."));
+
+            if(doc && doc->testStatus(App::Document::RestoreError))
+                QMessageBox::critical(getMainWindow(), QObject::tr("Error"), QObject::tr("There were serious errors while loading the file. Some data might have been modified or not recovered at all. Saving the project will most likely result in loss of data."));
+
             // the original file name is required
             QString filename = QString::fromUtf8(File.filePath().c_str());
             getMainWindow()->appendRecentFile(filename);

--- a/src/Mod/Web/Gui/BrowserView.cpp
+++ b/src/Mod/Web/Gui/BrowserView.cpp
@@ -341,6 +341,9 @@ void BrowserView::onLinkClicked (const QUrl & url)
                 App::Document *doc = BaseView::getAppDocument();
                 if(doc && doc->testStatus(App::Document::PartialRestore))
                     QMessageBox::critical(this, tr("Error"), tr("There were errors while loading the file. Some data might have been modified or not recovered at all. Look in the report view for more specific information about the objects involved."));
+
+                if(doc && doc->testStatus(App::Document::RestoreError))
+                    QMessageBox::critical(this, tr("Error"), tr("There were serious errors while loading the file. Some data might have been modified or not recovered at all. Saving the project will most likely result in loss of data."));
             }
         }
         else {


### PR DESCRIPTION
========================================================

If the restore of Document.xml results in invalid Document.xml (because unhandled exceptions occurred), the
document status Document::restoreError is set. The GUI or Mod/Web if a link was clicked, show a pop-up indicating
this situation.

This commit also shows an appropriate pop-up for the partialRestore when opening from the menu, that before only
appeared when opening by clicking a link.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
