### PR TITLE
[TD] MDIViewPage: Add support for Qt5 automatic paper size handling …

### DIFF
--- a/src/Mod/TechDraw/Gui/MDIViewPage.cpp
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.cpp
@@ -312,23 +312,23 @@ void MDIViewPage::closeEvent(QCloseEvent* ev)
 void MDIViewPage::attachTemplate(TechDraw::DrawTemplate *obj)
 {
     m_view->setPageTemplate(obj);
-    double width  =  obj->Width.getValue();
-    double height =  obj->Height.getValue();
-
-    if (width > height) {
+    pagewidth  =  obj->Width.getValue();
+    pageheight =  obj->Height.getValue();
 #if QT_VERSION >= 0x050300
-        m_paperSize = QPageSize::id(QSizeF(height, width), QPageSize::Millimeter);
+    m_paperSize = QPageSize::id(QSizeF(pagewidth, pageheight), QPageSize::Millimeter, QPageSize::FuzzyOrientationMatch);
+#else
+    m_paperSize = getPaperSize(int(round(pagewidth)), int(round(pageheight)));
+#endif
+    if (pagewidth > pageheight) {
+#if QT_VERSION >= 0x050300
         m_orientation = QPageLayout::Landscape;
 #else
-        m_paperSize = getPaperSize(int(round(width)), int(round(height)));
         m_orientation = QPrinter::Landscape;
 #endif
     } else {
 #if QT_VERSION >= 0x050300
-        m_paperSize = QPageSize::id(QSizeF(width, height), QPageSize::Millimeter);
         m_orientation = QPageLayout::Portrait;
 #else
-        m_paperSize = getPaperSize(int(round(width)), int(round(height)));
         m_orientation = QPrinter::Portrait;
 #endif
     }
@@ -686,7 +686,11 @@ void MDIViewPage::printPdf(std::string file)
 #endif
     }
 #if QT_VERSION >= 0x050300
-    printer.setPageSize(QPageSize(m_paperSize));
+    if (m_paperSize == QPageSize::Custom) {
+        printer.setPageSize(QPageSize(QSizeF(pagewidth, pageheight), QPageSize::Millimeter));
+    } else {
+        printer.setPageSize(QPageSize(m_paperSize));
+    }
 #else
     printer.setPaperSize(m_paperSize);
 #endif
@@ -698,7 +702,11 @@ void MDIViewPage::print()
     QPrinter printer(QPrinter::HighResolution);
     printer.setFullPage(true);
 #if QT_VERSION >= 0x050300
-    printer.setPageSize(QPageSize(m_paperSize));
+    if (m_paperSize == QPageSize::Custom) {
+        printer.setPageSize(QPageSize(QSizeF(pagewidth, pageheight), QPageSize::Millimeter));
+    } else {
+        printer.setPageSize(QPageSize(m_paperSize));
+    }
     printer.setPageOrientation(m_orientation);
 #else
     printer.setPaperSize(m_paperSize);
@@ -715,7 +723,11 @@ void MDIViewPage::printPreview()
     QPrinter printer(QPrinter::HighResolution);
     printer.setFullPage(true);
 #if QT_VERSION >= 0x050300
-    printer.setPageSize(QPageSize(m_paperSize));
+    if (m_paperSize == QPageSize::Custom) {
+        printer.setPageSize(QPageSize(QSizeF(pagewidth, pageheight), QPageSize::Millimeter));
+    } else {
+        printer.setPageSize(QPageSize(m_paperSize));
+    }
     printer.setPageOrientation(m_orientation);
 #else
     printer.setPaperSize(m_paperSize);

--- a/src/Mod/TechDraw/Gui/MDIViewPage.cpp
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.cpp
@@ -314,17 +314,21 @@ void MDIViewPage::attachTemplate(TechDraw::DrawTemplate *obj)
     m_view->setPageTemplate(obj);
     double width  =  obj->Width.getValue();
     double height =  obj->Height.getValue();
-    m_paperSize = getPaperSize(int(round(width)),int(round(height)));
+
     if (width > height) {
 #if QT_VERSION >= 0x050300
+        m_paperSize = QPageSize::id(QSizeF(height, width), QPageSize::Millimeter);
         m_orientation = QPageLayout::Landscape;
 #else
+        m_paperSize = getPaperSize(int(round(width)), int(round(height)));
         m_orientation = QPrinter::Landscape;
 #endif
     } else {
 #if QT_VERSION >= 0x050300
+        m_paperSize = QPageSize::id(QSizeF(width, height), QPageSize::Millimeter);
         m_orientation = QPageLayout::Portrait;
 #else
+        m_paperSize = getPaperSize(int(round(width)), int(round(height)));
         m_orientation = QPrinter::Portrait;
 #endif
     }
@@ -496,17 +500,6 @@ void MDIViewPage::fixOrphans(bool force)
             }
         }
     }
-
-    // Update all the QGIVxxxx
-    // WF: why do we do this?  views should be keeping themselves up to date.
-//    const std::vector<QGIView *> &upviews = m_view->getViews();
-//    for(std::vector<QGIView *>::const_iterator it = upviews.begin(); it != upviews.end(); ++it) {
-//        Base::Console().Message("TRACE - MDIVP::fixOrphans - updating a QGIVxxxx\n");
-//        if((*it)->getViewObject()->isTouched() ||
-//           forceUpdate) {
-//            (*it)->updateView(forceUpdate);
-//        }
-//    }
 }
 
 //NOTE: this doesn't add missing views.  see fixOrphans()
@@ -530,6 +523,7 @@ void MDIViewPage::redraw1View(TechDraw::DrawView* dv)
         }
     }
 }
+
 void MDIViewPage::findMissingViews(const std::vector<App::DocumentObject*> &list, std::vector<App::DocumentObject*> &missing)
 {
     for(std::vector<App::DocumentObject*>::const_iterator it = list.begin(); it != list.end(); ++it) {
@@ -750,13 +744,9 @@ void MDIViewPage::print(QPrinter* printer)
     // a certain scaling effect can be observed and the content becomes smaller.
     QPaintEngine::Type paintType = printer->paintEngine()->type();
     if (printer->outputFormat() == QPrinter::NativeFormat) {
-        int w = printer->widthMM();
-        int h = printer->heightMM();
 #if QT_VERSION >= 0x050300
-        QPageSize::PageSizeId psPrtCalcd = getPaperSize(w, h);
         QPageSize::PageSizeId psPrtSetting = printer->pageLayout().pageSize().id();
 #else
-        QPrinter::PaperSize psPrtCalcd = getPaperSize(w, h);
         QPrinter::PaperSize psPrtSetting = printer->paperSize();
 #endif
 
@@ -776,15 +766,7 @@ void MDIViewPage::print(QPrinter* printer)
             if (ret != QMessageBox::Yes)
                 return;
         }
-        else if (doPrint && psPrtCalcd != m_paperSize) {
-            int ret = QMessageBox::warning(this, tr("Different paper size"),
-                tr("The printer uses a different paper size than the drawing.\n"
-                   "Do you want to continue?"),
-                   QMessageBox::Yes | QMessageBox::No);
-            if (ret != QMessageBox::Yes)
-                return;
-        }
-        else if (doPrint && psPrtSetting != m_paperSize) {
+        if (doPrint && psPrtSetting != m_paperSize) {
             int ret = QMessageBox::warning(this, tr("Different paper size"),
                 tr("The printer uses a different paper size than the drawing.\n"
                    "Do you want to continue?"),
@@ -850,11 +832,8 @@ void MDIViewPage::print(QPrinter* printer)
     static_cast<void> (blockConnection(false));
 }
 
-#if QT_VERSION >= 0x050300
-QPageSize::PageSizeId MDIViewPage::getPaperSize(int w, int h) const
-#else
+#if QT_VERSION < 0x050300
 QPrinter::PaperSize MDIViewPage::getPaperSize(int w, int h) const
-#endif
 {
     static const float paperSizes[][2] = {
         {210, 297}, // A4
@@ -889,49 +868,29 @@ QPrinter::PaperSize MDIViewPage::getPaperSize(int w, int h) const
         {279.4f, 431.8f} // Tabloid (29)   causes trouble with orientation on PDF export
     };
 
-#if QT_VERSION >= 0x050300
-    QPageSize::PageSizeId ps = QPageSize::Custom;
-#else
     QPrinter::PaperSize ps = QPrinter::Custom;
-#endif
     for (int i=0; i<30; i++) {
         if (std::abs(paperSizes[i][0]-w) <= 1 &&
             std::abs(paperSizes[i][1]-h) <= 1) {
-#if QT_VERSION >= 0x050300
-            ps = static_cast<QPageSize::PageSizeId>(i);
-#else
             ps = static_cast<QPrinter::PaperSize>(i);
-#endif
             break;
         }
         else                                          //handle landscape & portrait w/h
         if (std::abs(paperSizes[i][0]-h) <= 1 &&
             std::abs(paperSizes[i][1]-w) <= 1) {
-#if QT_VERSION >= 0x050300
-            ps = static_cast<QPageSize::PageSizeId>(i);
-#else
             ps = static_cast<QPrinter::PaperSize>(i);
-#endif
             break;
         }
     }
-#if QT_VERSION >= 0x050300
-    if (ps == QPageSize::Ledger)  {                    //check if really Tabloid
-        if (w < 431) {
-            ps = QPageSize::Tabloid;
-        }
-    }
-#else
     if (ps == QPrinter::Ledger)  {                    //check if really Tabloid
         if (w < 431) {
             ps = QPrinter::Tabloid;
         }
     }
-#endif
-
 
     return ps;
 }
+#endif
 
 PyObject* MDIViewPage::getPyObject()
 {

--- a/src/Mod/TechDraw/Gui/MDIViewPage.h
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.h
@@ -128,9 +128,7 @@ protected:
 
     void contextMenuEvent(QContextMenuEvent *event);
     void closeEvent(QCloseEvent*);
-#if QT_VERSION >= 0x050300
-    QPageSize::PageSizeId getPaperSize(int w, int h) const;
-#else
+#if QT_VERSION < 0x050300
     QPrinter::PaperSize getPaperSize(int w, int h) const;
 #endif
 

--- a/src/Mod/TechDraw/Gui/MDIViewPage.h
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.h
@@ -169,6 +169,7 @@ private:
     QPrinter::Orientation m_orientation;
     QPrinter::PaperSize m_paperSize;
 #endif
+    qreal pagewidth, pageheight;
     ViewProviderPage *m_vpPage;
 
     QList<QGraphicsItem*> m_qgSceneSelected;        //items in selection order


### PR DESCRIPTION
…with many new paper sizes possible.  See forum request and discussion in [here](https://forum.freecadweb.org/viewtopic.php?f=35&t=54512), apparently "Arch C" and other paper sizes are missing.  This commit should add all the new paper sizes in Qt 5.3 and newer, whereas for Qt 4 the paper size handling is unchanged and only the old paper sizes remain possible.


Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
