### PR TITLE
[TD] make pointers to the UI a std::unique_ptr

### DIFF
--- a/src/Mod/TechDraw/Gui/TaskActiveView.cpp
+++ b/src/Mod/TechDraw/Gui/TaskActiveView.cpp
@@ -89,7 +89,6 @@ TaskActiveView::TaskActiveView(TechDraw::DrawPage* pageFeat) :
 
 TaskActiveView::~TaskActiveView()
 {
-    delete ui;
 }
 
 void TaskActiveView::updateTask()

--- a/src/Mod/TechDraw/Gui/TaskActiveView.h
+++ b/src/Mod/TechDraw/Gui/TaskActiveView.h
@@ -80,7 +80,7 @@ protected:
     TechDraw::DrawViewSymbol* createActiveView(void);
 
 private:
-    Ui_TaskActiveView* ui;
+    std::unique_ptr<Ui_TaskActiveView> ui;
 
     TechDraw::DrawPage*       m_pageFeat;
     TechDraw::DrawViewSymbol* m_symbolFeat;

--- a/src/Mod/TechDraw/Gui/TaskBalloon.cpp
+++ b/src/Mod/TechDraw/Gui/TaskBalloon.cpp
@@ -111,7 +111,6 @@ TaskBalloon::TaskBalloon(QGIViewBalloon *parent, ViewProviderBalloon *balloonVP)
 
 TaskBalloon::~TaskBalloon()
 {
-    delete ui;
 }
 
 bool TaskBalloon::accept()

--- a/src/Mod/TechDraw/Gui/TaskBalloon.h
+++ b/src/Mod/TechDraw/Gui/TaskBalloon.h
@@ -63,7 +63,7 @@ private Q_SLOTS:
     void onKinkLengthChanged();
 
 private:
-    Ui_TaskBalloon *ui;
+    std::unique_ptr<Ui_TaskBalloon> ui;
     QGIViewBalloon *m_parent;
     ViewProviderBalloon* m_balloonVP;
 };

--- a/src/Mod/TechDraw/Gui/TaskCenterLine.cpp
+++ b/src/Mod/TechDraw/Gui/TaskCenterLine.cpp
@@ -156,7 +156,6 @@ TaskCenterLine::TaskCenterLine(TechDraw::DrawViewPart* partFeat,
 
 TaskCenterLine::~TaskCenterLine()
 {
-    delete ui;
 }
 
 void TaskCenterLine::updateTask()

--- a/src/Mod/TechDraw/Gui/TaskCenterLine.h
+++ b/src/Mod/TechDraw/Gui/TaskCenterLine.h
@@ -130,7 +130,7 @@ private Q_SLOTS:
     void onFlipChanged();
 
 private:
-    Ui_TaskCenterLine * ui;
+    std::unique_ptr<Ui_TaskCenterLine> ui;
 
     TechDraw::DrawViewPart* m_partFeat;
     TechDraw::DrawPage* m_basePage;

--- a/src/Mod/TechDraw/Gui/TaskCosVertex.cpp
+++ b/src/Mod/TechDraw/Gui/TaskCosVertex.cpp
@@ -115,7 +115,6 @@ TaskCosVertex::TaskCosVertex(TechDraw::DrawViewPart* baseFeat,
 
 TaskCosVertex::~TaskCosVertex()
 {
-    delete ui;
 }
 
 void TaskCosVertex::updateTask()

--- a/src/Mod/TechDraw/Gui/TaskCosVertex.h
+++ b/src/Mod/TechDraw/Gui/TaskCosVertex.h
@@ -100,7 +100,7 @@ protected:
    QGIView* findParentQGIV();
 
 private:
-    Ui_TaskCosVertex * ui;
+    std::unique_ptr<Ui_TaskCosVertex> ui;
     bool blockUpdate;
 
     QGTracker* m_tracker;

--- a/src/Mod/TechDraw/Gui/TaskCosmeticLine.cpp
+++ b/src/Mod/TechDraw/Gui/TaskCosmeticLine.cpp
@@ -126,7 +126,6 @@ TaskCosmeticLine::TaskCosmeticLine(TechDraw::DrawViewPart* partFeat,
 
 TaskCosmeticLine::~TaskCosmeticLine()
 {
-    delete ui;
     if (m_saveCE != nullptr) {
         delete m_saveCE;
     }

--- a/src/Mod/TechDraw/Gui/TaskCosmeticLine.h
+++ b/src/Mod/TechDraw/Gui/TaskCosmeticLine.h
@@ -91,7 +91,7 @@ protected:
     void updateCosmeticLine(void);
 
 private:
-    Ui_TaskCosmeticLine * ui;
+    std::unique_ptr<Ui_TaskCosmeticLine> ui;
 
     TechDraw::DrawViewPart* m_partFeat;
 

--- a/src/Mod/TechDraw/Gui/TaskDetail.cpp
+++ b/src/Mod/TechDraw/Gui/TaskDetail.cpp
@@ -238,7 +238,6 @@ TaskDetail::TaskDetail(TechDraw::DrawViewDetail* detailFeat):
 TaskDetail::~TaskDetail()
 {
     m_ghost->deleteLater();  //this might not exist if scene is destroyed before TaskDetail is deleted?
-    delete ui;
 }
 
 void TaskDetail::updateTask()

--- a/src/Mod/TechDraw/Gui/TaskDetail.h
+++ b/src/Mod/TechDraw/Gui/TaskDetail.h
@@ -110,7 +110,7 @@ protected:
     TechDraw::DrawViewDetail* getDetailFeat();
 
 private:
-    Ui_TaskDetail * ui;
+    std::unique_ptr<Ui_TaskDetail> ui;
     bool blockUpdate;
 
     QGIGhostHighlight* m_ghost;

--- a/src/Mod/TechDraw/Gui/TaskGeomHatch.cpp
+++ b/src/Mod/TechDraw/Gui/TaskGeomHatch.cpp
@@ -68,7 +68,6 @@ TaskGeomHatch::TaskGeomHatch(TechDraw::DrawGeomHatch* inHatch,TechDrawGui::ViewP
 
 TaskGeomHatch::~TaskGeomHatch()
 {
-    delete ui;
 }
 
 

--- a/src/Mod/TechDraw/Gui/TaskGeomHatch.h
+++ b/src/Mod/TechDraw/Gui/TaskGeomHatch.h
@@ -76,7 +76,7 @@ private Q_SLOTS:
     void onColorChanged();
 
 private:
-    Ui_TaskGeomHatch * ui;
+    std::unique_ptr<Ui_TaskGeomHatch> ui;
     TechDraw::DrawGeomHatch* m_hatch;
     TechDrawGui::ViewProviderGeomHatch* m_Vp;
     App::DocumentObject* m_source;

--- a/src/Mod/TechDraw/Gui/TaskHatch.cpp
+++ b/src/Mod/TechDraw/Gui/TaskHatch.cpp
@@ -68,7 +68,6 @@ TaskHatch::TaskHatch(TechDraw::DrawHatch* inHatch, TechDrawGui::ViewProviderHatc
 
 TaskHatch::~TaskHatch()
 {
-    delete ui;
 }
 
 void TaskHatch::initUi()

--- a/src/Mod/TechDraw/Gui/TaskHatch.h
+++ b/src/Mod/TechDraw/Gui/TaskHatch.h
@@ -73,7 +73,7 @@ private Q_SLOTS:
     void onColorChanged();
 
 private:
-    Ui_TaskHatch * ui;
+    std::unique_ptr<Ui_TaskHatch> ui;
     TechDraw::DrawHatch* m_hatch;
     TechDrawGui::ViewProviderHatch* m_Vp;
     App::DocumentObject* m_source;

--- a/src/Mod/TechDraw/Gui/TaskLeaderLine.cpp
+++ b/src/Mod/TechDraw/Gui/TaskLeaderLine.cpp
@@ -233,7 +233,6 @@ TaskLeaderLine::TaskLeaderLine(TechDraw::DrawView* baseFeat,
 
 TaskLeaderLine::~TaskLeaderLine()
 {
-    delete ui;
 }
 
 void TaskLeaderLine::saveState()

--- a/src/Mod/TechDraw/Gui/TaskLeaderLine.h
+++ b/src/Mod/TechDraw/Gui/TaskLeaderLine.h
@@ -130,7 +130,7 @@ private Q_SLOTS:
     void onLineStyleChanged();
 
 private:
-    Ui_TaskLeaderLine * ui;
+    std::unique_ptr<Ui_TaskLeaderLine> ui;
     bool blockUpdate;
 
     QGTracker* m_tracker;

--- a/src/Mod/TechDraw/Gui/TaskLineDecor.cpp
+++ b/src/Mod/TechDraw/Gui/TaskLineDecor.cpp
@@ -280,7 +280,6 @@ TaskRestoreLines::TaskRestoreLines(TechDraw::DrawViewPart* partFeat,
 
 TaskRestoreLines::~TaskRestoreLines()
 {
-    delete ui;
 }
 
 void TaskRestoreLines::initUi()

--- a/src/Mod/TechDraw/Gui/TaskLineDecor.h
+++ b/src/Mod/TechDraw/Gui/TaskLineDecor.h
@@ -112,7 +112,7 @@ protected:
     void restoreInvisibleCenters(void);
 
 private:
-    Ui_TaskRestoreLines* ui;
+    std::unique_ptr<Ui_TaskRestoreLines> ui;
     TechDraw::DrawViewPart* m_partFeat;
     TaskLineDecor* m_parent;
 };

--- a/src/Mod/TechDraw/Gui/TaskLinkDim.cpp
+++ b/src/Mod/TechDraw/Gui/TaskLinkDim.cpp
@@ -86,7 +86,6 @@ TaskLinkDim::TaskLinkDim(std::vector<App::DocumentObject*> parts, std::vector<st
 
 TaskLinkDim::~TaskLinkDim()
 {
-    delete ui;
 }
 
 void TaskLinkDim::loadAvailDims()

--- a/src/Mod/TechDraw/Gui/TaskLinkDim.h
+++ b/src/Mod/TechDraw/Gui/TaskLinkDim.h
@@ -63,7 +63,7 @@ protected:
     bool dimReferencesSelection(const TechDraw::DrawViewDimension* dim) const;
 
 private:
-    Ui_TaskLinkDim * ui;
+    std::unique_ptr<Ui_TaskLinkDim> ui;
     const std::vector<App::DocumentObject*> m_parts;
     const std::vector<std::string> m_subs;
     TechDraw::DrawPage* m_page;

--- a/src/Mod/TechDraw/Gui/TaskProjGroup.cpp
+++ b/src/Mod/TechDraw/Gui/TaskProjGroup.cpp
@@ -138,7 +138,6 @@ TaskProjGroup::TaskProjGroup(TechDraw::DrawProjGroup* featView, bool mode) :
 
 TaskProjGroup::~TaskProjGroup()
 {
-    delete ui;
 }
 
 void TaskProjGroup::saveGroupState()

--- a/src/Mod/TechDraw/Gui/TaskProjGroup.h
+++ b/src/Mod/TechDraw/Gui/TaskProjGroup.h
@@ -109,7 +109,7 @@ protected:
     MDIViewPage* m_mdi;
 
 private:
-    Ui_TaskProjGroup * ui;
+    std::unique_ptr<Ui_TaskProjGroup> ui;
     TechDraw::DrawProjGroup* multiView;
     bool m_createMode;
 

--- a/src/Mod/TechDraw/Gui/TaskRichAnno.cpp
+++ b/src/Mod/TechDraw/Gui/TaskRichAnno.cpp
@@ -202,7 +202,6 @@ TaskRichAnno::TaskRichAnno(TechDraw::DrawView* baseFeat,
 
 TaskRichAnno::~TaskRichAnno()
 {
-    delete ui;
 }
 
 void TaskRichAnno::updateTask()

--- a/src/Mod/TechDraw/Gui/TaskRichAnno.h
+++ b/src/Mod/TechDraw/Gui/TaskRichAnno.h
@@ -103,7 +103,7 @@ protected:
     App::Color prefLineColor(void);
 
 private:
-    Ui_TaskRichAnno * ui;
+    std::unique_ptr<Ui_TaskRichAnno> ui;
     bool blockUpdate;
 
     MDIViewPage* m_mdi;

--- a/src/Mod/TechDraw/Gui/TaskSectionView.cpp
+++ b/src/Mod/TechDraw/Gui/TaskSectionView.cpp
@@ -152,7 +152,6 @@ TaskSectionView::TaskSectionView(TechDraw::DrawViewSection* section) :
 
 TaskSectionView::~TaskSectionView()
 {
-    delete ui;
 }
 
 void TaskSectionView::setUiPrimary()

--- a/src/Mod/TechDraw/Gui/TaskSectionView.h
+++ b/src/Mod/TechDraw/Gui/TaskSectionView.h
@@ -84,7 +84,7 @@ protected:
     bool isSectionValid(void);
 
 private:
-    Ui_TaskSectionView * ui;
+    std::unique_ptr<Ui_TaskSectionView> ui;
     TechDraw::DrawViewPart* m_base;
     TechDraw::DrawViewSection* m_section;
     std::string m_symbol;

--- a/src/Mod/TechDraw/Gui/TaskWeldingSymbol.cpp
+++ b/src/Mod/TechDraw/Gui/TaskWeldingSymbol.cpp
@@ -184,7 +184,6 @@ TaskWeldingSymbol::TaskWeldingSymbol(TechDraw::DrawWeldSymbol* weld) :
 
 TaskWeldingSymbol::~TaskWeldingSymbol()
 {
-    delete ui;
 }
 
 void TaskWeldingSymbol::updateTask()

--- a/src/Mod/TechDraw/Gui/TaskWeldingSymbol.h
+++ b/src/Mod/TechDraw/Gui/TaskWeldingSymbol.h
@@ -146,7 +146,7 @@ protected:
     QString m_currDir;
 
 private:
-    Ui_TaskWeldingSymbol* ui;
+    std::unique_ptr<Ui_TaskWeldingSymbol> ui;
 
     TechDraw::DrawLeaderLine* m_leadFeat;
     TechDraw::DrawWeldSymbol* m_weldFeat;


### PR DESCRIPTION
as noted in https://github.com/FreeCAD/FreeCAD/pull/4271#discussion_r554673632
the pointer to the UI should be a unique pointer.

This PR does this for all TD dialogs that don't already use a unique_ptr.