### PR TITLE
ArchRoof.py: Fix for self referencing relative profile issue

### DIFF
--- a/src/Mod/Arch/ArchRoof.py
+++ b/src/Mod/Arch/ArchRoof.py
@@ -438,8 +438,9 @@ class _Roof(ArchComponent.Component):
         rel = profilCurr["idrel"]
         if i != rel and 0 <= rel < numEdges:
             profilRel = self.profilsDico[rel]
-            # do not use data from the relative profile if it in turn references a relative profile:
-            if 0 <= profilRel["idrel"] < numEdges:
+            # do not use data from the relative profile if it in turn references a relative profile
+            # other than itself:
+            if 0 <= profilRel["idrel"] < numEdges and rel != profilRel["idrel"]:
                 hgt = self.calcHeight(i)
                 profilCurr["height"] = hgt
             elif ang == 0.0 and run == 0.0:


### PR DESCRIPTION
A relative profile can now be used if it references itself. This fixes a compatibility issue with the V0.18 version of ArchRoof, where the first profile initially always references itself.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
