### PR TITLE
Draft: Prevent Draft_Wire from setting a single-edge wire as closed

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_lines.py
+++ b/src/Mod/Draft/draftguitools/gui_lines.py
@@ -122,9 +122,13 @@ class Line(gui_base_original.Creator):
                 if not self.isWire and len(self.node) == 2:
                     self.finish(False, cont=True)
                 if len(self.node) > 2:
+                    # The wire is closed
                     if (self.point - self.node[0]).Length < utils.tolerance():
                         self.undolast()
-                        self.finish(True, cont=True)
+                        if len(self.node) > 2:
+                            self.finish(True, cont=True)
+                        else:
+                            self.finish(False, cont=True)
 
     def finish(self, closed=False, cont=False):
         """Terminate the operation and close the polyline if asked.


### PR DESCRIPTION
When create a Draft polyline, if the third point close the wire with the first point, the edge created in this step overlap the first edge. The command create a single-edge wire but sets it as closed.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
