### PR TITLE
[v0.20][BUILD] - Optimize includes to reduce compile time

### DIFF
--- a/src/App/AutoTransaction.h
+++ b/src/App/AutoTransaction.h
@@ -23,6 +23,8 @@
 #ifndef APP_AUTOTRANSACTION_H
 #define APP_AUTOTRANSACTION_H
 
+#include <stdlib.h>
+
 namespace App {
 
 class Application;

--- a/src/App/Branding.h
+++ b/src/App/Branding.h
@@ -27,10 +27,10 @@
 #include <string>
 #include <QMap>
 #include <QVector>
-#include <QString>
 #include <QDomDocument>
 
 class QIODevice;
+class QString;
 
 namespace App {
 

--- a/src/App/ComplexGeoData.cpp
+++ b/src/App/ComplexGeoData.cpp
@@ -30,7 +30,7 @@
 #include <boost/algorithm/string/predicate.hpp>
 
 #include <Base/Exception.h>
-#include <Base/Console.h>
+#include <Base/Placement.h>
 #include "ComplexGeoData.h"
 
 using namespace Data;

--- a/src/App/ComplexGeoData.h
+++ b/src/App/ComplexGeoData.h
@@ -24,16 +24,22 @@
 #ifndef _AppComplexGeoData_h_
 #define _AppComplexGeoData_h_
 
-#include <Base/Placement.h>
+#include <vector>
+
 #include <Base/Persistence.h>
-#include <Base/Handle.h>
 #include <Base/Matrix.h>
 #include <Base/BoundBox.h>
-#include <Base/Rotation.h>
+#include <Base/Handle.h>
 
 #ifdef __GNUC__
 # include <stdint.h>
 #endif
+
+namespace Base
+{
+class Placement;
+class Rotation;
+}
 
 
 namespace Data

--- a/src/App/Document.h
+++ b/src/App/Document.h
@@ -24,8 +24,6 @@
 #define APP_DOCUMENT_H
 
 #include <CXX/Objects.hxx>
-#include <Base/Observer.h>
-#include <Base/Persistence.h>
 #include <Base/Type.h>
 
 #include "PropertyContainer.h"
@@ -34,8 +32,6 @@
 
 #include <map>
 #include <vector>
-#include <stack>
-#include <functional>
 
 #include <boost_signals2.hpp>
 
@@ -47,8 +43,6 @@ namespace App
 {
     class TransactionalObject;
     class DocumentObject;
-    class DocumentObjectExecReturn;
-    class Document;
     class DocumentPy; // the python document class
     class Application;
     class Transaction;

--- a/src/App/DocumentObject.cpp
+++ b/src/App/DocumentObject.cpp
@@ -25,6 +25,7 @@
 #include "PreCompiled.h"
 
 #ifndef _PreComp_
+#include <stack>
 #endif
 
 #include <Base/Writer.h>

--- a/src/App/DocumentObject.cpp
+++ b/src/App/DocumentObject.cpp
@@ -42,6 +42,7 @@
 #include "PropertyExpressionEngine.h"
 #include "DocumentObjectExtension.h"
 #include "GeoFeatureGroupExtension.h"
+#include <App/ComplexGeoData.h>
 #include <App/DocumentObjectPy.h>
 #include <boost/bind/bind.hpp>
 

--- a/src/App/DocumentObject.h
+++ b/src/App/DocumentObject.h
@@ -31,12 +31,16 @@
 #include <App/PropertyExpressionEngine.h>
 
 #include <Base/TimeInfo.h>
-#include <Base/Matrix.h>
 #include <CXX/Objects.hxx>
 
 #include <unordered_map>
 #include <bitset>
 #include <boost_signals2.hpp>
+
+namespace Base
+{
+class Matrix4D;
+}
 
 namespace App
 {

--- a/src/App/DocumentObjectGroup.h
+++ b/src/App/DocumentObjectGroup.h
@@ -26,9 +26,7 @@
 
 #include "FeaturePython.h"
 #include "DocumentObject.h"
-#include "PropertyLinks.h"
 #include "GroupExtension.h"
-#include <vector>
 
 
 namespace App

--- a/src/App/DocumentPyImp.cpp
+++ b/src/App/DocumentPyImp.cpp
@@ -29,6 +29,7 @@
 
 #include "Document.h"
 #include <Base/FileInfo.h>
+#include <Base/Interpreter.h>
 #include "DocumentObject.h"
 #include "DocumentObjectPy.h"
 #include "MergeDocuments.h"

--- a/src/App/Expression.h
+++ b/src/App/Expression.h
@@ -30,16 +30,17 @@
 #include <App/PropertyLinks.h>
 #include <App/ObjectIdentifier.h>
 #include <Base/BaseClass.h>
-#include <Base/Quantity.h>
 #include <set>
-#include <deque>
 #include <App/Range.h>
 
 #if defined(__clang__)
 # pragma clang diagnostic push
 # pragma clang diagnostic ignored "-Woverloaded-virtual"
 #endif
-
+namespace Base
+{
+class Quantity;
+}
 namespace App  {
 
 class DocumentObject;

--- a/src/App/ExpressionParser.h
+++ b/src/App/ExpressionParser.h
@@ -25,8 +25,12 @@
 #ifndef EXPRESSION_PARSER_H
 #define EXPRESSION_PARSER_H
 
-#include <Base/Interpreter.h>
 #include "Expression.h"
+#include <deque>
+#include <CXX/Objects.hxx>
+#include <Base/BaseClass.h>
+#include <Base/Quantity.h>
+#include "ObjectIdentifier.h"
 
 namespace App {
 

--- a/src/App/ExpressionVisitors.h
+++ b/src/App/ExpressionVisitors.h
@@ -24,10 +24,9 @@
 #define RENAMEOBJECTIDENTIFIEREXPRESSIONVISITOR_H
 
 #include <Base/BaseClass.h>
-#include "Expression.h"
 
 namespace App {
-
+class Expression;
 /**
  * @brief The RenameObjectIdentifierExpressionVisitor class is a functor used to visit each node of an expression, and
  * possibly rename VariableExpression nodes.

--- a/src/App/Extension.h
+++ b/src/App/Extension.h
@@ -26,9 +26,7 @@
 
 #include "PropertyContainer.h"
 #include "PropertyPythonObject.h"
-#include "ExtensionContainer.h"
 #include "Base/Interpreter.h"
-#include <CXX/Objects.hxx>
 
 namespace App {
 

--- a/src/App/ExtensionContainer.cpp
+++ b/src/App/ExtensionContainer.cpp
@@ -32,6 +32,8 @@
 #include "DocumentObject.h"
 #include "Base/Exception.h"
 #include <Base/Console.h>
+#include <Base/Reader.h>
+#include <Base/Writer.h>
 
 using namespace App;
 

--- a/src/App/ExtensionContainer.h
+++ b/src/App/ExtensionContainer.h
@@ -24,16 +24,18 @@
 #ifndef APP_EXTENSIONCONTAINER_H
 #define APP_EXTENSIONCONTAINER_H
 
-#include "Extension.h"
 #include "PropertyContainer.h"
-#include "PropertyPythonObject.h"
-#include "DynamicProperty.h"
-#include <CXX/Objects.hxx>
-#include <Base/Writer.h>
-#include <Base/Reader.h>
+#include "Property.h"
+
+namespace Base
+{
+    class Writer;
+    class Reader;
+}
 
 namespace App {
 
+class Extension;
 /**
  * @brief Container which can hold extensions
  *

--- a/src/App/ExtensionContainerPyImp.cpp
+++ b/src/App/ExtensionContainerPyImp.cpp
@@ -27,6 +27,7 @@
 # include <sstream>
 #endif
 
+#include "Extension.h"
 #include "Application.h"
 #include "DocumentObject.h"
 

--- a/src/App/FeatureCustom.h
+++ b/src/App/FeatureCustom.h
@@ -26,9 +26,6 @@
 #define APP_FEATURECUSTOM_H
 
 
-#include <Base/Writer.h>
-#include <App/DocumentObject.h>
-
 namespace App
 {
 

--- a/src/App/FeaturePython.cpp
+++ b/src/App/FeaturePython.cpp
@@ -33,6 +33,7 @@
 #include <Base/MatrixPy.h>
 #include <Base/Tools.h>
 #include <App/DocumentObjectPy.h>
+#include <App/GeoFeature.h>
 #include "FeaturePython.h"
 #include "FeaturePythonPyImp.h"
 

--- a/src/App/FeaturePython.h
+++ b/src/App/FeaturePython.h
@@ -27,16 +27,21 @@
 
 
 #include <Base/Exception.h>
-#include <Base/Writer.h>
-#include <App/GeoFeature.h>
-#include <App/DynamicProperty.h>
+#include <App/DocumentObject.h>
+#include <App/PropertyContainer.h>
 #include <App/PropertyPythonObject.h>
 #include <App/PropertyGeo.h>
+
+namespace Base
+{
+ class Matrix4D;
+}
 
 namespace App
 {
 
 class Property;
+class GeoFeature;
 
 // Helper class to hide implementation details
 class AppExport FeaturePythonImp

--- a/src/App/GeoFeature.cpp
+++ b/src/App/GeoFeature.cpp
@@ -28,6 +28,7 @@
 
 #include "GeoFeature.h"
 #include "GeoFeatureGroupExtension.h"
+#include <App/ComplexGeoData.h>
 #include <App/GeoFeaturePy.h>
 
 using namespace App;

--- a/src/App/GroupExtension.h
+++ b/src/App/GroupExtension.h
@@ -24,15 +24,17 @@
 #ifndef APP_GROUPEXTENSION_H
 #define APP_GROUPEXTENSION_H
 
+#include <vector>
+#include <unordered_map>
+
 #include <boost_signals2.hpp>
-#include "FeaturePython.h"
-#include "DocumentObject.h"
 #include "PropertyLinks.h"
 #include "DocumentObjectExtension.h"
-#include <vector>
+
 
 namespace App
 {
+class DocumentObject;
 class DocumentObjectGroup;
 class GroupExtensionPy;
 

--- a/src/App/Link.h
+++ b/src/App/Link.h
@@ -36,8 +36,6 @@
 #include "FeaturePython.h"
 #include "PropertyLinks.h"
 #include "DocumentObjectExtension.h"
-#include "FeaturePython.h"
-#include "GroupExtension.h"
 
 //FIXME: ISO C++11 requires at least one argument for the "..." in a variadic macro
 #if defined(__clang__)
@@ -53,6 +51,7 @@
 
 namespace App
 {
+class GroupExtension;
 
 class AppExport LinkBaseExtension : public App::DocumentObjectExtension
 {

--- a/src/App/ObjectIdentifier.cpp
+++ b/src/App/ObjectIdentifier.cpp
@@ -45,6 +45,8 @@
 #include <Base/QuantityPy.h>
 #include <App/Link.h>
 #include <Base/Console.h>
+#include <Base/Reader.h>
+#include <Base/Writer.h>
 
 FC_LOG_LEVEL_INIT("Expression",true,true)
 

--- a/src/App/Part.h
+++ b/src/App/Part.h
@@ -26,6 +26,7 @@
 
 #include "OriginGroupExtension.h"
 #include "PropertyLinks.h"
+#include "App/GeoFeature.h"
 
 
 

--- a/src/App/Placement.h
+++ b/src/App/Placement.h
@@ -24,21 +24,9 @@
 #ifndef _AppPlacement_h_
 #define _AppPlacement_h_
 
-#include <Base/Placement.h>
-
 #include "FeaturePython.h"
 #include "GeoFeature.h"
-#include "PropertyGeo.h"
-
-
-namespace Base
-{
-//  class Vector3D;
-  //class Matrix4D;
-}
-
-//using Base::Vector3D;
-//using Base::Matrix4D;
+#include "PropertyContainer.h"
 
 namespace App
 {

--- a/src/App/PropertyGeo.h
+++ b/src/App/PropertyGeo.h
@@ -34,7 +34,6 @@
 
 #include "Property.h"
 #include "PropertyLinks.h"
-#include "ComplexGeoData.h"
 
 namespace Base {
 class Writer;

--- a/src/App/PropertyStandard.cpp
+++ b/src/App/PropertyStandard.cpp
@@ -34,7 +34,7 @@
 #include <boost/algorithm/string/predicate.hpp>
 
 #include <Base/Console.h>
-#include <Base/Exception.h>
+#include <Base/Interpreter.h>
 #include <Base/Reader.h>
 #include <Base/Writer.h>
 #include <Base/Stream.h>

--- a/src/Base/BoundBox.h
+++ b/src/Base/BoundBox.h
@@ -25,14 +25,14 @@
 #define BASE_BOUNDBOX_H
 
 #include "Vector3D.h"
-#include "Matrix.h"
-#include "ViewProj.h"
 #include "Tools2D.h"
 #include <limits>
+#include <iostream>
 
 namespace Base {
 
 class ViewProjMethod;
+class Matrix4D;
 
 /** The 3D bounding box class. */
 template <class _Precision>

--- a/src/Base/CoordinateSystem.cpp
+++ b/src/Base/CoordinateSystem.cpp
@@ -27,6 +27,7 @@
 #endif
 
 #include "CoordinateSystem.h"
+#include "Matrix.h"
 #include "Exception.h"
 
 using namespace Base;

--- a/src/Base/GeometryPyCXX.h
+++ b/src/Base/GeometryPyCXX.h
@@ -27,7 +27,6 @@
 #include <CXX/Objects.hxx>
 #include <CXX/Extensions.hxx>
 #include <Base/Vector3D.h>
-#include <Base/Matrix.h>
 #include <Base/MatrixPy.h>
 #include <Base/Rotation.h>
 #include <Base/RotationPy.h>
@@ -37,6 +36,8 @@
 #include <Base/Tools2D.h>
 
 namespace Base {
+class Matrix4D;
+
 template <typename T>
 inline Vector3<T> getVectorFromTuple(PyObject* o)
 {

--- a/src/Base/Handle.h
+++ b/src/Base/Handle.h
@@ -28,8 +28,6 @@
 // Std. configurations
 
 #include <string>
-#include <map>
-#include <typeinfo>
 
 class QAtomicInt;
 

--- a/src/Base/Placement.cpp
+++ b/src/Base/Placement.cpp
@@ -25,6 +25,7 @@
 #endif
 
 #include "Placement.h"
+#include "Matrix.h"
 #include "Rotation.h"
 #include "DualQuaternion.h"
 

--- a/src/Base/Placement.h
+++ b/src/Base/Placement.h
@@ -25,7 +25,6 @@
 
 #include "Vector3D.h"
 #include "Rotation.h"
-#include "Matrix.h"
 
 
 namespace Base {

--- a/src/Base/Tools.h
+++ b/src/Base/Tools.h
@@ -32,7 +32,8 @@
 #include <string>
 #include <boost_signals2.hpp>
 #include <QString>
-#include <QObject>
+
+class QObject;
 
 #if (QT_VERSION < 0x050300)
 class QSignalBlocker

--- a/src/Base/Tools.h
+++ b/src/Base/Tools.h
@@ -36,6 +36,7 @@
 class QObject;
 
 #if (QT_VERSION < 0x050300)
+#include <QObject>
 class QSignalBlocker
 {
 public:

--- a/src/Base/Unit.h
+++ b/src/Base/Unit.h
@@ -30,7 +30,8 @@
 #  include <stdint.h>
 #endif
 #include <string>
-#include <QString>
+
+class QString;
 
 namespace Base {
 

--- a/src/Base/UnitsApi.cpp
+++ b/src/Base/UnitsApi.cpp
@@ -36,6 +36,7 @@
 #include "UnitsSchemaMmMin.h"
 #include "UnitsSchemaFemMilliMeterNewton.h"
 #include "StdStlTools.h"
+#include "Quantity.h"
 
 #ifndef M_PI
 #define M_PI       3.14159265358979323846

--- a/src/Base/UnitsApi.h
+++ b/src/Base/UnitsApi.h
@@ -27,12 +27,14 @@
 #include <CXX/WrapPython.h>
 #include <memory>
 #include <string>
-#include <QString>
 #include "UnitsSchema.h"
-#include "Quantity.h"
+#include "Unit.h"
+#include <QString>
 
 
-namespace Base {
+namespace Base
+{
+class Quantity;
 typedef std::unique_ptr<UnitsSchema> UnitsSchemaPtr;
 
 /**

--- a/src/Base/UnitsSchema.cpp
+++ b/src/Base/UnitsSchema.cpp
@@ -29,7 +29,7 @@
 #include <QString>
 #include <QLocale>
 
-#include "Exception.h"
+#include "Quantity.h"
 #include "UnitsApi.h"
 #include "UnitsSchema.h"
 

--- a/src/Base/UnitsSchema.h
+++ b/src/Base/UnitsSchema.h
@@ -26,11 +26,11 @@
 
 
 #include <string>
-#include <QString>
-#include <Base/Quantity.h>
 
+class QString;
 
 namespace Base {
+class Quantity;
 
 /** Units systems */
 enum class UnitSystem {

--- a/src/Base/UnitsSchemaCentimeters.cpp
+++ b/src/Base/UnitsSchemaCentimeters.cpp
@@ -27,6 +27,7 @@
 #endif
 
 #include <QString>
+#include "Quantity.h"
 #include "Exception.h"
 #include "UnitsApi.h"
 #include "UnitsSchemaCentimeters.h"

--- a/src/Base/UnitsSchemaFemMilliMeterNewton.cpp
+++ b/src/Base/UnitsSchemaFemMilliMeterNewton.cpp
@@ -28,7 +28,7 @@
 #endif
 
 #include <QString>
-#include "Exception.h"
+#include "Quantity.h"
 #include "UnitsApi.h"
 #include "UnitsSchemaFemMilliMeterNewton.h"
 #include <cmath>

--- a/src/Base/UnitsSchemaImperial1.cpp
+++ b/src/Base/UnitsSchemaImperial1.cpp
@@ -30,8 +30,7 @@
 #endif
 
 #include <QString>
-#include "Console.h"
-#include "Exception.h"
+#include "Quantity.h"
 #include "UnitsApi.h"
 #include "UnitsSchemaImperial1.h"
 #include <cmath>

--- a/src/Base/UnitsSchemaInternal.cpp
+++ b/src/Base/UnitsSchemaInternal.cpp
@@ -27,6 +27,7 @@
 #endif
 
 #include <QString>
+#include "Quantity.h"
 #include "Exception.h"
 #include "UnitsApi.h"
 #include "UnitsSchemaInternal.h"

--- a/src/Base/UnitsSchemaMKS.cpp
+++ b/src/Base/UnitsSchemaMKS.cpp
@@ -27,7 +27,7 @@
 #endif
 
 #include <QString>
-#include "Exception.h"
+#include "Quantity.h"
 #include "UnitsApi.h"
 #include "UnitsSchemaMKS.h"
 #include <cmath>

--- a/src/Base/UnitsSchemaMmMin.cpp
+++ b/src/Base/UnitsSchemaMmMin.cpp
@@ -27,6 +27,7 @@
 #endif
 
 #include <QString>
+#include "Quantity.h"
 #include "Exception.h"
 #include "UnitsApi.h"
 #include "UnitsSchemaMmMin.h"

--- a/src/Gui/Action.cpp
+++ b/src/Gui/Action.cpp
@@ -42,6 +42,7 @@
 #endif
 
 #include <Base/Tools.h>
+#include <App/Document.h>
 #include "Action.h"
 #include "Application.h"
 #include "BitmapFactory.h"

--- a/src/Gui/Action.cpp
+++ b/src/Gui/Action.cpp
@@ -60,6 +60,7 @@
 #include "WorkbenchManager.h"
 
 #include <Base/Exception.h>
+#include <Base/Interpreter.h>
 #include <App/Application.h>
 
 using namespace Gui;

--- a/src/Gui/ActiveObjectList.cpp
+++ b/src/Gui/ActiveObjectList.cpp
@@ -29,6 +29,7 @@
 #endif
 
 #include <Base/Console.h>
+#include <App/Document.h>
 #include "ActiveObjectList.h"
 #include <Gui/Application.h>
 #include <Gui/Document.h>

--- a/src/Gui/AxisOriginPyImp.cpp
+++ b/src/Gui/AxisOriginPyImp.cpp
@@ -29,6 +29,7 @@
 
 #include "AxisOriginPy.h"
 #include "AxisOriginPy.cpp"
+#include <Base/Interpreter.h>
 
 using namespace Gui;
 

--- a/src/Gui/ComboView.h
+++ b/src/Gui/ComboView.h
@@ -26,7 +26,6 @@
 #define GUI_DOCKWND_COMBOVIEW_H
 
 #include "DockWindow.h"
-#include "Selection.h"
 
 class QTabWidget;
 class QTreeView;

--- a/src/Gui/CommandDoc.cpp
+++ b/src/Gui/CommandDoc.cpp
@@ -71,6 +71,7 @@
 #include "ViewProvider.h"
 #include <Gui/View3DInventor.h>
 #include <Gui/View3DInventorViewer.h>
+#include <Gui/SelectionObject.h>
 #include "MergeDocuments.h"
 #include "NavigationStyle.h"
 #include "GraphvizView.h"

--- a/src/Gui/CommandFeat.cpp
+++ b/src/Gui/CommandFeat.cpp
@@ -28,6 +28,7 @@
 #include "Application.h"
 #include "CommandT.h"
 #include "Document.h"
+#include "SelectionObject.h"
 #include "Selection.h"
 #include "ViewProvider.h"
 #include "ViewProviderDocumentObject.h"

--- a/src/Gui/CommandLink.cpp
+++ b/src/Gui/CommandLink.cpp
@@ -39,10 +39,9 @@
 #include "BitmapFactory.h"
 #include "ViewProviderDocumentObject.h"
 
-#include <Base/Console.h>
 #include <Base/Exception.h>
-#include <Base/Parameter.h>
 #include <App/Application.h>
+#include <App/ComplexGeoData.h>
 #include <App/Document.h>
 #include <App/DocumentObject.h>
 #include <App/DocumentObserver.h>

--- a/src/Gui/CommandT.h
+++ b/src/Gui/CommandT.h
@@ -24,6 +24,7 @@
 #ifndef GUI_COMMAND_T_H
 #define GUI_COMMAND_T_H
 
+#include <Base/Console.h>
 #include <Base/Exception.h>
 #include <App/Document.h>
 #include <App/DocumentObject.h>

--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -57,6 +57,7 @@
 #include "DlgDisplayPropertiesImp.h"
 #include "DlgSettingsImageImp.h"
 #include "Selection.h"
+#include "SelectionObject.h"
 #include "SoFCOffscreenRenderer.h"
 #include "SoFCBoundingBox.h"
 #include "SoFCUnifiedSelection.h"

--- a/src/Gui/DAGView/DAGFilter.cpp
+++ b/src/Gui/DAGView/DAGFilter.cpp
@@ -25,6 +25,7 @@
 #endif
 
 #include <Base/Type.h>
+#include <App/DocumentObject.h>
 #include <Gui/ViewProviderDocumentObject.h>
 
 

--- a/src/Gui/DAGView/DAGModel.cpp
+++ b/src/Gui/DAGView/DAGModel.cpp
@@ -52,6 +52,7 @@
 
 #include <Base/TimeInfo.h>
 #include <Base/Console.h>
+#include <App/Document.h>
 #include <Gui/Application.h>
 #include <Gui/Document.h>
 #include <Gui/ViewProviderDocumentObject.h>

--- a/src/Gui/DlgPropertyLink.cpp
+++ b/src/Gui/DlgPropertyLink.cpp
@@ -33,11 +33,13 @@
 #include <QStyledItemDelegate>
 
 #include <Base/Tools.h>
+#include <Base/Interpreter.h>
 #include <App/Application.h>
 #include <App/Document.h>
 #include <App/DocumentObject.h>
 #include <App/GeoFeature.h>
 #include <App/DocumentObserver.h>
+#include <App/PropertyPythonObject.h>
 
 #include "Document.h"
 #include "View3DInventor.h"

--- a/src/Gui/DockWindow.h
+++ b/src/Gui/DockWindow.h
@@ -24,8 +24,6 @@
 #ifndef GUI_DOCKWINDOW_H
 #define GUI_DOCKWINDOW_H
 
-
-#include <Base/Parameter.h>
 #include <Gui/View.h>
 #include <QWidget>
 

--- a/src/Gui/DockWindowManager.h
+++ b/src/Gui/DockWindowManager.h
@@ -24,6 +24,7 @@
 #ifndef GUI_DOCKWINDOWMANAGER_H
 #define GUI_DOCKWINDOWMANAGER_H
 
+#include <QObject>
 #include <QStringList>
 
 class QDockWidget;

--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -48,6 +48,7 @@
 #include <Base/Writer.h>
 #include <Base/Tools.h>
 
+#include <App/ComplexGeoData.h>
 #include <App/Document.h>
 #include <App/DocumentObject.h>
 #include <App/DocumentObjectGroup.h>

--- a/src/Gui/Document.h
+++ b/src/Gui/Document.h
@@ -24,7 +24,6 @@
 #ifndef GUI_DOCUMENT_H
 #define GUI_DOCUMENT_H
 
-#include "MDIView.h"
 
 #include <list>
 #include <map>
@@ -44,10 +43,12 @@ class Matrix4D;
 namespace App {
 class DocumentObjectGroup;
 class Document;
+class Transaction;
 }
 
 namespace Gui {
 
+class MDIView;
 class ViewProvider;
 class ViewProviderDocumentObject;
 class Application;

--- a/src/Gui/Document.h
+++ b/src/Gui/Document.h
@@ -31,7 +31,6 @@
 #include <string>
 
 #include <Base/Persistence.h>
-#include <App/Document.h>
 
 #include "Tree.h"
 
@@ -44,6 +43,7 @@ class Matrix4D;
 
 namespace App {
 class DocumentObjectGroup;
+class Document;
 }
 
 namespace Gui {

--- a/src/Gui/DocumentPyImp.cpp
+++ b/src/Gui/DocumentPyImp.cpp
@@ -41,6 +41,7 @@
 #include "DocumentPy.cpp"
 #include <App/DocumentObjectPy.h>
 #include "Tree.h"
+#include "MDIView.h"
 #include "ViewProviderDocumentObject.h"
 #include "ViewProviderDocumentObjectPy.h"
 #include "ViewProviderPy.h"

--- a/src/Gui/FileDialog.cpp
+++ b/src/Gui/FileDialog.cpp
@@ -25,6 +25,7 @@
 #ifndef _PreComp_
 # include <QApplication>
 # include <QButtonGroup>
+# include <QFileSystemModel>
 # include <QCompleter>
 # include <QComboBox>
 # include <QDesktopServices>

--- a/src/Gui/FileDialog.h
+++ b/src/Gui/FileDialog.h
@@ -26,10 +26,10 @@
 
 #include <QFileDialog>
 #include <QFileIconProvider>
-#include <QFileSystemModel>
-#include <QCompleter>
 #include <QPointer>
 
+class QCompleter;
+class QFileSystemModel;
 class QButtonGroup;
 class QGridLayout;
 class QGroupBox;

--- a/src/Gui/GestureNavigationStyle.cpp
+++ b/src/Gui/GestureNavigationStyle.cpp
@@ -73,6 +73,7 @@
 
 #include <App/Application.h>
 #include <Base/Console.h>
+#include <Base/Interpreter.h>
 #include "View3DInventorViewer.h"
 #include "Application.h"
 #include "SoTouchEvents.h"

--- a/src/Gui/MDIView.cpp
+++ b/src/Gui/MDIView.cpp
@@ -42,6 +42,7 @@
 #include "Application.h"
 #include "MainWindow.h"
 #include "ViewProviderDocumentObject.h"
+#include <Base/Interpreter.h>
 
 using namespace Gui;
 namespace bp = boost::placeholders;

--- a/src/Gui/MDIView.cpp
+++ b/src/Gui/MDIView.cpp
@@ -43,6 +43,7 @@
 #include "MainWindow.h"
 #include "ViewProviderDocumentObject.h"
 #include <Base/Interpreter.h>
+#include <App/Document.h>
 
 using namespace Gui;
 namespace bp = boost::placeholders;

--- a/src/Gui/MDIViewPy.cpp
+++ b/src/Gui/MDIViewPy.cpp
@@ -24,6 +24,7 @@
 #include "PreCompiled.h"
 
 #include "MDIViewPy.h"
+#include "MDIView.h"
 #include "Application.h"
 #include "Document.h"
 

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -67,6 +67,7 @@
 #include <Base/Reader.h>
 #include <Base/Writer.h>
 #include <App/Application.h>
+#include <App/Document.h>
 #include <App/DocumentObject.h>
 #include <App/DocumentObjectGroup.h>
 

--- a/src/Gui/Placement.cpp
+++ b/src/Gui/Placement.cpp
@@ -37,9 +37,10 @@
 #include <Gui/Application.h>
 #include <Gui/Command.h>
 #include <Gui/Document.h>
-#include <Gui/Selection.h>
+#include <Gui/SelectionObject.h>
 #include <Gui/ViewProvider.h>
 #include <Gui/Window.h>
+#include <App/ComplexGeoData.h>
 #include <App/Document.h>
 #include <App/GeoFeature.h>
 #include <App/PropertyGeo.h>

--- a/src/Gui/Placement.h
+++ b/src/Gui/Placement.h
@@ -24,7 +24,6 @@
 #define GUI_PLACEMENT_H
 
 #include <Gui/InputVector.h>
-#include <Gui/SelectionObject.h>
 #include <Gui/TaskView/TaskDialog.h>
 #include <Gui/TaskView/TaskView.h>
 #include <Base/Placement.h>
@@ -35,6 +34,7 @@ class QSignalMapper;
 
 namespace Gui {
 class Document;
+class SelectionObject;
 
 namespace Dialog {
 

--- a/src/Gui/PropertyView.cpp
+++ b/src/Gui/PropertyView.cpp
@@ -43,6 +43,7 @@
 
 #include "PropertyView.h"
 #include "Application.h"
+#include "SelectionObject.h"
 #include "MainWindow.h"
 #include "Document.h"
 #include "BitmapFactory.h"

--- a/src/Gui/QuantitySpinBox.cpp
+++ b/src/Gui/QuantitySpinBox.cpp
@@ -46,6 +46,7 @@
 #include "Tools.h"
 #include "Command.h"
 #include <Base/Tools.h>
+#include <Base/UnitsApi.h>
 #include <Base/Exception.h>
 #include <App/Application.h>
 #include <App/Document.h>

--- a/src/Gui/Selection.cpp
+++ b/src/Gui/Selection.cpp
@@ -30,7 +30,6 @@
 # include <boost_bind_bind.hpp>
 # include <QApplication>
 # include <QString>
-# include <QStatusBar>
 #endif
 
 #include <boost/algorithm/string/predicate.hpp>
@@ -42,6 +41,7 @@
 #include "SelectionFilter.h"
 #include "View3DInventor.h"
 #include <Base/Exception.h>
+#include <Base/Quantity.h>
 #include <Base/Console.h>
 #include <Base/Tools.h>
 #include <Base/Interpreter.h>

--- a/src/Gui/Selection.h
+++ b/src/Gui/Selection.h
@@ -30,27 +30,23 @@
 #include <string>
 #include <vector>
 #include <list>
-#include <map>
 #include <deque>
 #include <boost_signals2.hpp>
 #include <CXX/Objects.hxx>
 
 #include <Base/Observer.h>
 #include <Base/Type.h>
-#include <App/Document.h>
 #include <App/DocumentObject.h>
 #include <App/DocumentObserver.h>
-#include <Gui/SelectionObject.h>
 
 namespace App
 {
-  class DocumentObject;
   class Document;
 }
 
 namespace Gui
 {
-
+    class SelectionObject;
     class SelectionFilter;
 
 /** Transport the changes of the Selection

--- a/src/Gui/SelectionFilter.cpp
+++ b/src/Gui/SelectionFilter.cpp
@@ -36,8 +36,8 @@
 #include <CXX/Objects.hxx>
 
 #include "Selection.h"
+#include "SelectionObject.h"
 #include "SelectionFilter.h"
-//#include "SelectionFilterPy.h"
 #include "Application.h"
 
 using namespace Gui;

--- a/src/Gui/SelectionView.cpp
+++ b/src/Gui/SelectionView.cpp
@@ -35,8 +35,8 @@
 #endif
 
 /// Here the FreeCAD includes sorted by Base,App,Gui......
-#include <Base/Console.h>
 #include <App/Document.h>
+#include <App/ComplexGeoData.h>
 #include <App/GeoFeature.h>
 #include "SelectionView.h"
 #include "Command.h"

--- a/src/Gui/TaskCSysDragger.cpp
+++ b/src/Gui/TaskCSysDragger.cpp
@@ -30,6 +30,7 @@
 #include <QGridLayout>
 #include <QFontMetrics>
 
+#include <App/Document.h>
 #include <Gui/TaskView/TaskView.h>
 #include "QuantitySpinBox.h"
 #include <Gui/Application.h>

--- a/src/Gui/TaskElementColors.cpp
+++ b/src/Gui/TaskElementColors.cpp
@@ -37,6 +37,7 @@
 
 #include <Base/Console.h>
 #include <App/ComplexGeoData.h>
+#include <Gui/SelectionObject.h>
 
 #include "Application.h"
 #include "Control.h"

--- a/src/Gui/TaskView/TaskDialog.h
+++ b/src/Gui/TaskView/TaskDialog.h
@@ -30,8 +30,6 @@
 
 #include <QDialogButtonBox>
 
-#include <Gui/Selection.h>
-
 namespace App {
 
 }

--- a/src/Gui/TaskView/TaskSelectLinkProperty.cpp
+++ b/src/Gui/TaskView/TaskSelectLinkProperty.cpp
@@ -30,6 +30,7 @@
 #include "ui_TaskSelectLinkProperty.h"
 #include "TaskSelectLinkProperty.h"
 #include <Base/Console.h>
+#include <App/Document.h>
 #include <App/DocumentObject.h>
 #include <Gui/Application.h>
 #include <Gui/Document.h>
@@ -37,6 +38,7 @@
 #include <Gui/ViewProvider.h>
 #include <Gui/WaitCursor.h>
 #include <Gui/SelectionFilter.h>
+#include <Gui/SelectionObject.h>
 
 using namespace Gui::TaskView;
 

--- a/src/Gui/TaskView/TaskWatcher.h
+++ b/src/Gui/TaskView/TaskWatcher.h
@@ -24,12 +24,9 @@
 #ifndef GUI_TASKVIEW_TASKWATCHER_H
 #define GUI_TASKVIEW_TASKWATCHER_H
 
-#include <map>
-#include <string>
 #include <vector>
 #include <QObject>
 
-#include <Gui/Selection.h>
 #include <Gui/SelectionFilter.h>
 
 namespace App {

--- a/src/Gui/TextEdit.h
+++ b/src/Gui/TextEdit.h
@@ -28,7 +28,6 @@
 
 #include <QListWidget>
 #include <QPlainTextEdit>
-#include "View.h"
 #include "Window.h"
 
 namespace Gui {

--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -44,6 +44,8 @@
 #include <Base/Console.h>
 #include <Base/Sequencer.h>
 #include <Base/Tools.h>
+#include <Base/Reader.h>
+#include <Base/Writer.h>
 
 #include <App/Document.h>
 #include <App/DocumentObject.h>

--- a/src/Gui/Tree.h
+++ b/src/Gui/Tree.h
@@ -31,13 +31,17 @@
 
 #include <Base/Parameter.h>
 #include <Base/Persistence.h>
-#include <App/Document.h>
-#include <App/Application.h>
 
 #include <Gui/DockWindow.h>
 #include <Gui/Selection.h>
 
 class QLineEdit;
+
+namespace App
+{
+ class Document;
+ class DocumentObject;
+}
 
 namespace Gui {
 

--- a/src/Gui/Tree.h
+++ b/src/Gui/Tree.h
@@ -25,6 +25,7 @@
 #define GUI_TREE_H
 
 #include <unordered_map>
+#include <memory>
 #include <QTreeWidget>
 #include <QElapsedTimer>
 #include <QStyledItemDelegate>

--- a/src/Gui/TreeView.h
+++ b/src/Gui/TreeView.h
@@ -26,12 +26,6 @@
 
 #include <QTreeView>
 
-#include <App/Document.h>
-#include <App/Application.h>
-
-#include <Gui/DockWindow.h>
-#include <Gui/Selection.h>
-
 namespace Gui {
 
 class GuiExport TreeView : public QTreeView

--- a/src/Gui/View3DInventor.cpp
+++ b/src/Gui/View3DInventor.cpp
@@ -66,6 +66,7 @@
 #include <Base/Console.h>
 #include <Base/FileInfo.h>
 
+#include <App/Document.h>
 #include <App/DocumentObject.h>
 
 #include "View3DInventor.h"

--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -74,7 +74,6 @@
 # include <Inventor/projectors/SbSphereSheetProjector.h>
 # include <Inventor/SoOffscreenRenderer.h>
 # include <Inventor/SoPickedPoint.h>
-# include <Inventor/VRMLnodes/SoVRMLGroup.h>
 # include <Inventor/nodes/SoPickStyle.h>
 # include <Inventor/nodes/SoTransparencyType.h>
 # include <QApplication>
@@ -100,11 +99,13 @@
 
 #include <sstream>
 #include <Base/Console.h>
+#include <Base/Quantity.h>
 #include <Base/Stream.h>
 #include <Base/FileInfo.h>
 #include <Base/Sequencer.h>
 #include <Base/Tools.h>
 #include <Base/UnitsApi.h>
+#include <App/Document.h>
 #include <App/GeoFeatureGroupExtension.h>
 
 #include "View3DInventorViewer.h"

--- a/src/Gui/ViewProviderAnnotation.cpp
+++ b/src/Gui/ViewProviderAnnotation.cpp
@@ -47,6 +47,7 @@
 # include <Inventor/draggers/SoTranslate2Dragger.h>
 
 #include "ViewProviderAnnotation.h"
+#include <App/Document.h>
 #include <App/Annotation.h>
 #include <App/PropertyGeo.h>
 #include <App/Application.h>

--- a/src/Gui/ViewProviderDocumentObject.cpp
+++ b/src/Gui/ViewProviderDocumentObject.cpp
@@ -44,6 +44,7 @@
 #include <Base/Tools.h>
 #include <Base/BoundBox.h>
 #include <App/Material.h>
+#include <App/Document.h>
 #include <App/DocumentObjectGroup.h>
 #include <App/DocumentObserver.h>
 #include <App/Origin.h>

--- a/src/Gui/ViewProviderDocumentObject.h
+++ b/src/Gui/ViewProviderDocumentObject.h
@@ -27,7 +27,7 @@
 #include <Inventor/SoType.h>
 
 #include "ViewProvider.h"
-#include <App/DocumentObject.h>
+#include <App/PropertyStandard.h>
 
 class SoMaterial;
 class SoDrawStyle;

--- a/src/Gui/ViewProviderExtension.cpp
+++ b/src/Gui/ViewProviderExtension.cpp
@@ -29,6 +29,7 @@
 #endif
 
 #include "ViewProviderExtension.h"
+#include "ViewProviderDocumentObject.h"
 #include "ViewProviderExtensionPy.h"
 
 using namespace Gui;

--- a/src/Gui/ViewProviderExtension.h
+++ b/src/Gui/ViewProviderExtension.h
@@ -26,10 +26,9 @@
 
 #include "App/Extension.h"
 #include "ViewProvider.h"
-#include "ViewProviderDocumentObject.h"
 
 namespace Gui {
-
+class ViewProviderDocumentObject;
 /**
  * @brief Extension with special viewprovider calls
  *

--- a/src/Gui/ViewProviderGeoFeatureGroupExtension.cpp
+++ b/src/Gui/ViewProviderGeoFeatureGroupExtension.cpp
@@ -29,6 +29,7 @@
 #endif
 
 #include "ViewProviderGeoFeatureGroupExtension.h"
+#include "ViewProviderDocumentObject.h"
 #include "Command.h"
 #include "Application.h"
 #include "Document.h"

--- a/src/Gui/ViewProviderGroupExtension.cpp
+++ b/src/Gui/ViewProviderGroupExtension.cpp
@@ -26,9 +26,8 @@
 #ifndef _PreComp_
 #endif
 
-//#include "ViewProviderGroupExtensionPy.h"
 #include "ViewProviderGroupExtension.h"
-
+#include "ViewProviderDocumentObject.h"
 #include "Command.h"
 #include "Application.h"
 #include "Document.h"

--- a/src/Gui/ViewProviderLink.cpp
+++ b/src/Gui/ViewProviderLink.cpp
@@ -53,8 +53,10 @@
 #include <Base/MatrixPy.h>
 #include <Base/BoundBoxPy.h>
 #include <Base/Tools.h>
+#include <App/GroupExtension.h>
 #include <App/ComplexGeoData.h>
 #include <App/GeoFeature.h>
+#include <App/Link.h>
 #include "Application.h"
 #include "BitmapFactory.h"
 #include "Document.h"

--- a/src/Gui/ViewProviderLink.cpp
+++ b/src/Gui/ViewProviderLink.cpp
@@ -53,6 +53,7 @@
 #include <Base/MatrixPy.h>
 #include <Base/BoundBoxPy.h>
 #include <Base/Tools.h>
+#include <App/Document.h>
 #include <App/GroupExtension.h>
 #include <App/ComplexGeoData.h>
 #include <App/GeoFeature.h>

--- a/src/Gui/ViewProviderLink.h
+++ b/src/Gui/ViewProviderLink.h
@@ -25,7 +25,6 @@
 #define GUI_VIEWPROVIDER_LINK_H
 
 #include <boost/preprocessor/seq/for_each.hpp>
-#include <App/PropertyGeo.h>
 #include "SoFCUnifiedSelection.h"
 #include "ViewProviderPythonFeature.h"
 #include "ViewProviderDocumentObject.h"

--- a/src/Gui/ViewProviderLink.h
+++ b/src/Gui/ViewProviderLink.h
@@ -26,7 +26,6 @@
 
 #include <boost/preprocessor/seq/for_each.hpp>
 #include <App/PropertyGeo.h>
-#include <App/Link.h>
 #include "SoFCUnifiedSelection.h"
 #include "ViewProviderPythonFeature.h"
 #include "ViewProviderDocumentObject.h"
@@ -36,9 +35,14 @@ class SoBase;
 class SoDragger;
 class SoMaterialBinding;
 
+namespace App {
+class LinkBaseExtension;
+}
+
 namespace Gui {
 
 class LinkInfo;
+
 typedef boost::intrusive_ptr<LinkInfo> LinkInfoPtr;
 
 class GuiExport ViewProviderLinkObserver: public ViewProviderExtension {

--- a/src/Gui/ViewProviderMeasureDistance.cpp
+++ b/src/Gui/ViewProviderMeasureDistance.cpp
@@ -47,8 +47,8 @@
 #include "View3DInventorViewer.h"
 #include "ViewParams.h"
 
+#include <App/Document.h>
 #include <App/PropertyGeo.h>
-#include <App/PropertyStandard.h>
 #include <App/MeasureDistance.h>
 #include <Base/Console.h>
 #include <Base/Quantity.h>

--- a/src/Gui/ViewProviderPart.h
+++ b/src/Gui/ViewProviderPart.h
@@ -25,7 +25,7 @@
 #define GUI_VIEWPROVIDER_ViewProviderPart_H
 
 
-#include "ViewProviderOriginGroup.h"
+#include "ViewProviderOriginGroupExtension.h"
 #include "ViewProviderDragger.h"
 #include "ViewProviderPythonFeature.h"
 

--- a/src/Gui/ViewProviderPythonFeature.h
+++ b/src/Gui/ViewProviderPythonFeature.h
@@ -24,12 +24,10 @@
 #ifndef GUI_VIEWPROVIDERPYTHONFEATURE_H
 #define GUI_VIEWPROVIDERPYTHONFEATURE_H
 
-#include <App/Application.h>
 #include <App/AutoTransaction.h>
 #include <Gui/ViewProviderGeometryObject.h>
 #include <Gui/Document.h>
 #include <App/PropertyPythonObject.h>
-#include <App/DynamicProperty.h>
 #include <App/FeaturePython.h>
 
 class SoSensor;

--- a/src/Gui/ViewProviderTextDocument.cpp
+++ b/src/Gui/ViewProviderTextDocument.cpp
@@ -30,6 +30,7 @@
 #endif
 
 #include <Base/Type.h>
+#include <App/Application.h>
 #include <Gui/ViewProviderDocumentObject.h>
 #include <Gui/TextDocumentEditorView.h>
 #include <Gui/MainWindow.h>

--- a/src/Gui/Window.h
+++ b/src/Gui/Window.h
@@ -26,7 +26,6 @@
 
 
 #include <Base/Parameter.h>
-#include "View.h"
 
 namespace Gui {
 

--- a/src/Gui/Workbench.h
+++ b/src/Gui/Workbench.h
@@ -28,13 +28,15 @@
 #include <string>
 #include <Base/BaseClass.h>
 #include <Base/Parameter.h>
-#include <Gui/TaskView/TaskWatcher.h>
 
 namespace Base {
 class PyObjectBase;
 }
 
 namespace Gui {
+namespace TaskView {
+class TaskWatcher;
+}
 
 class MenuItem;
 class ToolBarItem;

--- a/src/Gui/propertyeditor/PropertyItem.cpp
+++ b/src/Gui/propertyeditor/PropertyItem.cpp
@@ -39,6 +39,7 @@
 
 #include <boost/algorithm/string/predicate.hpp>
 
+#include <Base/UnitsApi.h>
 #include <Base/Tools.h>
 #include <Base/Console.h>
 #include <Base/Interpreter.h>

--- a/src/Gui/propertyeditor/PropertyItem.h
+++ b/src/Gui/propertyeditor/PropertyItem.h
@@ -34,7 +34,6 @@
 #include <Base/Matrix.h>
 #include <Base/Placement.h>
 #include <Base/Quantity.h>
-#include <Base/UnitsApi.h>
 #include <App/DocumentObserver.h>
 #include <App/PropertyStandard.h>
 #include <Gui/Widgets.h>

--- a/src/Mod/Drawing/Gui/DrawingView.cpp
+++ b/src/Mod/Drawing/Gui/DrawingView.cpp
@@ -58,6 +58,7 @@
 #include <Base/gzstream.h>
 #include <Base/PyObjectBase.h>
 #include <App/Document.h>
+#include <App/Application.h>
 #include <Gui/Document.h>
 #include <Gui/ViewProvider.h>
 #include <Gui/FileDialog.h>

--- a/src/Mod/Drawing/Gui/TaskOrthoViews.h
+++ b/src/Mod/Drawing/Gui/TaskOrthoViews.h
@@ -31,6 +31,7 @@
 #include <vector>
 #include <boost_signals2.hpp>
 
+#include <App/Document.h>
 #include <Mod/Drawing/App/FeatureViewPart.h>
 
 

--- a/src/Mod/Fem/App/FemSetObject.h
+++ b/src/Mod/Fem/App/FemSetObject.h
@@ -26,7 +26,6 @@
 
 #include <App/DocumentObject.h>
 #include <App/PropertyLinks.h>
-#include "FemSetObject.h"
 
 namespace Fem
 {

--- a/src/Mod/Fem/Gui/Command.cpp
+++ b/src/Mod/Fem/Gui/Command.cpp
@@ -45,7 +45,7 @@
 #include <Gui/Command.h>
 #include <Gui/MainWindow.h>
 #include <Gui/FileDialog.h>
-#include <Gui/Selection.h>
+#include <Gui/SelectionObject.h>
 #include <Gui/SelectionFilter.h>
 #include <Gui/Document.h>
 #include <Gui/WaitCursor.h>

--- a/src/Mod/Fem/Gui/TaskFemConstraintContact.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintContact.cpp
@@ -48,7 +48,7 @@
 #include <App/Application.h>
 #include <Base/Tools.h>
 #include <Gui/Command.h>
-#include <Gui/Selection.h>
+#include <Gui/SelectionObject.h>
 #include <Gui/SelectionFilter.h>
 #include <Mod/Part/App/PartFeature.h>
 

--- a/src/Mod/Fem/Gui/TaskFemConstraintDisplacement.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintDisplacement.cpp
@@ -51,7 +51,7 @@
 #include <App/Application.h>
 #include <Base/Tools.h>
 #include <Gui/Command.h>
-#include <Gui/Selection.h>
+#include <Gui/SelectionObject.h>
 #include <Gui/SelectionFilter.h>
 #include <Mod/Part/App/PartFeature.h>
 

--- a/src/Mod/Fem/Gui/TaskFemConstraintFixed.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintFixed.cpp
@@ -24,11 +24,7 @@
 #include "PreCompiled.h"
 
 #ifndef _PreComp_
-# include <BRepAdaptor_Curve.hxx>
-# include <BRepAdaptor_Surface.hxx>
 # include <Geom_Line.hxx>
-# include <Geom_Plane.hxx>
-# include <Precision.hxx>
 
 # include <QAction>
 # include <QKeyEvent>
@@ -43,13 +39,15 @@
 # include <sstream>
 #endif
 
+
 #include "Mod/Fem/App/FemConstraintFixed.h"
 #include "TaskFemConstraintFixed.h"
 #include "ui_TaskFemConstraintFixed.h"
+#include <App/Document.h>
 #include <App/Application.h>
 #include <Base/Tools.h>
 #include <Gui/Command.h>
-#include <Gui/Selection.h>
+#include <Gui/SelectionObject.h>
 #include <Gui/SelectionFilter.h>
 #include <Mod/Part/App/PartFeature.h>
 

--- a/src/Mod/Fem/Gui/TaskFemConstraintFluidBoundary.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintFluidBoundary.cpp
@@ -59,7 +59,7 @@
 #include <Gui/BitmapFactory.h>
 #include <Gui/ViewProvider.h>
 #include <Gui/WaitCursor.h>
-#include <Gui/Selection.h>
+#include <Gui/SelectionObject.h>
 #include <Gui/Command.h>
 #include <Mod/Fem/App/FemConstraintFluidBoundary.h>
 #include <Mod/Fem/App/FemMeshObject.h>

--- a/src/Mod/Fem/Gui/TaskFemConstraintForce.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintForce.cpp
@@ -56,7 +56,7 @@
 #include <Gui/BitmapFactory.h>
 #include <Gui/ViewProvider.h>
 #include <Gui/WaitCursor.h>
-#include <Gui/Selection.h>
+#include <Gui/SelectionObject.h>
 #include <Gui/Command.h>
 #include <Mod/Fem/App/FemConstraintForce.h>
 #include <Mod/Fem/App/FemTools.h>

--- a/src/Mod/Fem/Gui/TaskFemConstraintHeatflux.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintHeatflux.cpp
@@ -51,6 +51,7 @@
 #include <App/Application.h>
 #include <Base/Tools.h>
 #include <Gui/Command.h>
+#include <Gui/SelectionObject.h>
 #include <Mod/Part/App/PartFeature.h>
 
 using namespace FemGui;

--- a/src/Mod/Fem/Gui/TaskFemConstraintPlaneRotation.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintPlaneRotation.cpp
@@ -57,7 +57,7 @@
 #include <Gui/BitmapFactory.h>
 #include <Gui/ViewProvider.h>
 #include <Gui/WaitCursor.h>
-#include <Gui/Selection.h>
+#include <Gui/SelectionObject.h>
 #include <Gui/Command.h>
 #include <Mod/Fem/App/FemConstraintPlaneRotation.h>
 #include <Mod/Fem/App/FemTools.h>

--- a/src/Mod/Fem/Gui/TaskFemConstraintPressure.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintPressure.cpp
@@ -48,7 +48,7 @@
 #include <App/Application.h>
 #include <Base/Tools.h>
 #include <Gui/Command.h>
-#include <Gui/Selection.h>
+#include <Gui/SelectionObject.h>
 #include <Gui/SelectionFilter.h>
 #include <Mod/Part/App/PartFeature.h>
 

--- a/src/Mod/Fem/Gui/TaskFemConstraintTemperature.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintTemperature.cpp
@@ -47,10 +47,11 @@
 #include "Mod/Fem/App/FemConstraintTemperature.h"
 #include "TaskFemConstraintTemperature.h"
 #include "ui_TaskFemConstraintTemperature.h"
+#include <App/Document.h>
 #include <App/Application.h>
 #include <Base/Tools.h>
 #include <Gui/Command.h>
-#include <Gui/Selection.h>
+#include <Gui/SelectionObject.h>
 #include <Gui/SelectionFilter.h>
 #include <Mod/Part/App/PartFeature.h>
 

--- a/src/Mod/Fem/Gui/TaskFemConstraintTransform.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintTransform.cpp
@@ -52,7 +52,7 @@
 #include <Base/Console.h>
 #include <Base/Tools.h>
 #include <Gui/Command.h>
-#include <Gui/Selection.h>
+#include <Gui/SelectionObject.h>
 #include <Gui/SelectionFilter.h>
 #include <Mod/Part/App/PartFeature.h>
 #include <Mod/Fem/App/FemTools.h>

--- a/src/Mod/Fem/Gui/TaskPostBoxes.cpp
+++ b/src/Mod/Fem/Gui/TaskPostBoxes.cpp
@@ -30,7 +30,6 @@
 # include <Inventor/nodes/SoBaseColor.h>
 # include <Inventor/nodes/SoFontStyle.h>
 # include <Inventor/nodes/SoPickStyle.h>
-# include <Inventor/nodes/SoText2.h>
 # include <Inventor/nodes/SoTranslation.h>
 # include <Inventor/nodes/SoCoordinate3.h>
 # include <Inventor/nodes/SoIndexedLineSet.h>
@@ -55,7 +54,6 @@
 #include "ViewProviderFemPostFunction.h"
 #include "ViewProviderFemPostFilter.h"
 
-#include <Mod/Fem/App/FemPostObject.h>
 #include <Mod/Fem/App/FemPostFilter.h>
 #include <Mod/Fem/App/FemPostPipeline.h>
 #include <Gui/BitmapFactory.h>
@@ -65,15 +63,14 @@
 #include <Gui/MainWindow.h>
 #include <Gui/Action.h>
 #include <Gui/View3DInventor.h>
-#include <Gui/View3DInventorViewer.h>
 
 #include <Gui/View3DInventorViewer.h>
 #include <Gui/Inventor/MarkerBitmaps.h>
 #include <Base/Console.h>
 
+#include <App/Document.h>
 #include <App/PropertyGeo.h>
 #include <App/PropertyStandard.h>
-#include <Base/Quantity.h>
 
 using namespace FemGui;
 using namespace Gui;

--- a/src/Mod/Fem/Gui/ViewProviderFemPostFunction.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemPostFunction.cpp
@@ -64,6 +64,7 @@
 #include <Gui/TaskView/TaskDialog.h>
 #include <Gui/Control.h>
 #include <App/PropertyUnits.h>
+#include <App/Document.h>
 
 #include "ui_PlaneWidget.h"
 #include "ui_SphereWidget.h"

--- a/src/Mod/Image/Gui/ImageView.cpp
+++ b/src/Mod/Image/Gui/ImageView.cpp
@@ -29,6 +29,7 @@
 
 #include "ImageView.h"
 #include "../App/ImageBase.h"
+#include <App/Application.h>
 #include "XpmImages.h"
 
 using namespace ImageGui;

--- a/src/Mod/Mesh/App/Core/Algorithm.cpp
+++ b/src/Mod/Mesh/App/Core/Algorithm.cpp
@@ -34,6 +34,7 @@
 #include "Grid.h"
 #include "Triangulation.h"
 
+#include <Base/ViewProj.h>
 #include <Base/Console.h>
 #include <Base/Sequencer.h>
 

--- a/src/Mod/Mesh/App/Core/MeshKernel.h
+++ b/src/Mod/Mesh/App/Core/MeshKernel.h
@@ -32,9 +32,9 @@
 
 #include <Base/BoundBox.h>
 #include <Base/Vector3D.h>
-#include <Base/Matrix.h>
 
 namespace Base{
+  class Matrix4D;
   class Polygon2d;
   class ViewProjMethod;
 }

--- a/src/Mod/Mesh/App/Facet.h
+++ b/src/Mod/Mesh/App/Facet.h
@@ -24,8 +24,6 @@
 #ifndef MESH_FACET_H
 #define MESH_FACET_H
 
-#include <Base/Matrix.h>
-#include <Base/Vector3D.h>
 #include <Base/Handle.h>
 
 #include "Core/Elements.h"

--- a/src/Mod/Mesh/App/MeshPyImp.cpp
+++ b/src/Mod/Mesh/App/MeshPyImp.cpp
@@ -29,6 +29,7 @@
 #include <Base/Converter.h>
 #include <Base/GeometryPyCXX.h>
 #include <Base/MatrixPy.h>
+#include <Base/ViewProj.h>
 #include <Base/Tools.h>
 
 #include "Mesh.h"

--- a/src/Mod/Mesh/Gui/DlgRegularSolidImp.cpp
+++ b/src/Mod/Mesh/Gui/DlgRegularSolidImp.cpp
@@ -33,6 +33,7 @@
 #include <Base/PyObjectBase.h>
 #include <Base/Interpreter.h>
 #include <Base/UnitsApi.h>
+#include <App/Document.h>
 #include <Gui/Application.h>
 #include <Gui/Command.h>
 #include <Gui/Document.h>

--- a/src/Mod/Mesh/Gui/RemeshGmsh.cpp
+++ b/src/Mod/Mesh/Gui/RemeshGmsh.cpp
@@ -35,6 +35,7 @@
 #include <Base/Console.h>
 #include <Base/FileInfo.h>
 #include <Base/Tools.h>
+#include <App/Document.h>
 #include <App/Application.h>
 #include <Gui/Application.h>
 #include <Gui/Document.h>

--- a/src/Mod/MeshPart/App/AppMeshPartPy.cpp
+++ b/src/Mod/MeshPart/App/AppMeshPartPy.cpp
@@ -25,6 +25,7 @@
 #ifndef _PreComp_
 # include <BRepBuilderAPI_MakePolygon.hxx>
 # include <TopoDS.hxx>
+# include <TopoDS_Wire.hxx>
 #endif
 
 #include <CXX/Extensions.hxx>

--- a/src/Mod/MeshPart/Gui/CrossSections.cpp
+++ b/src/Mod/MeshPart/Gui/CrossSections.cpp
@@ -53,6 +53,7 @@
 #include <Mod/Mesh/App/MeshFeature.h>
 #include <Mod/Mesh/App/Core/Algorithm.h>
 #include <Mod/Mesh/App/Core/Grid.h>
+#include <App/Document.h>
 #include <Gui/BitmapFactory.h>
 #include <Gui/ViewProvider.h>
 #include <Gui/Application.h>

--- a/src/Mod/Part/App/AttachExtension.cpp
+++ b/src/Mod/Part/App/AttachExtension.cpp
@@ -25,10 +25,10 @@
 #endif
 
 #include "AttachExtension.h"
+#include "Attacher.h"
 
 #include <Base/Console.h>
 #include <App/Application.h>
-
 #include <App/FeaturePythonPyImp.h>
 #include "AttachExtensionPy.h"
 

--- a/src/Mod/Part/App/AttachExtension.h
+++ b/src/Mod/Part/App/AttachExtension.h
@@ -27,20 +27,20 @@
 #ifndef PARTATTACHABLEOBJECT_H
 #define PARTATTACHABLEOBJECT_H
 
+#include <string>
+
 #include <App/PropertyStandard.h>
 #include <App/PropertyLinks.h>
-#include <App/GeoFeature.h>
+#include <App/PropertyGeo.h>
 #include <App/DocumentObjectExtension.h>
-#include <Base/Vector3D.h>
-#include <Base/Placement.h>
 #include <Base/Exception.h>
 
-#include "PartFeature.h"
-#include "Attacher.h"
-
-#include <QString>
-
 #include <gp_Vec.hxx>
+
+namespace Attacher
+{
+class AttachEngine;
+}
 
 namespace Part
 {

--- a/src/Mod/Part/App/Attacher.h
+++ b/src/Mod/Part/App/Attacher.h
@@ -28,10 +28,12 @@
 #ifndef PARTATTACHER_H
 #define PARTATTACHER_H
 
+#include <vector>
+
 #include <App/PropertyStandard.h>
 #include <App/PropertyLinks.h>
+#include <App/PropertyGeo.h>
 #include <App/GeoFeature.h>
-#include <Base/Vector3D.h>
 #include <Base/Placement.h>
 #include <Base/Exception.h>
 

--- a/src/Mod/Part/App/DatumFeature.h
+++ b/src/Mod/Part/App/DatumFeature.h
@@ -25,7 +25,6 @@
 #ifndef PART_DATUMFEATURE_H
 #define PART_DATUMFEATURE_H
 
-#include <QString>
 #include <App/PropertyLinks.h>
 
 #include "PartFeature.h"

--- a/src/Mod/Part/App/FeatureMirroring.h
+++ b/src/Mod/Part/App/FeatureMirroring.h
@@ -26,7 +26,6 @@
 
 #include <App/PropertyStandard.h>
 #include "PartFeature.h"
-#include <Base/Matrix.h>
 
 namespace Part
 {

--- a/src/Mod/Part/App/Geometry.cpp
+++ b/src/Mod/Part/App/Geometry.cpp
@@ -136,6 +136,9 @@
 #include <Mod/Part/App/ToroidPy.h>
 
 #include <Base/Exception.h>
+#include <Base/Rotation.h>
+#include <Base/Matrix.h>
+#include <Base/Placement.h>
 #include <Base/Writer.h>
 #include <Base/Reader.h>
 #include <Base/Tools.h>

--- a/src/Mod/Part/App/Geometry.h
+++ b/src/Mod/Part/App/Geometry.h
@@ -60,15 +60,18 @@
 #include <vector>
 #include <Base/Persistence.h>
 #include <Base/Vector3D.h>
-#include <Base/Matrix.h>
-#include <Base/Placement.h>
 
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 
-#include "GeometryExtension.h"
+namespace Base
+{
+class Placement;
+class Matrix4D;
+}
 
 namespace Part {
+class GeometryExtension;
 
 class PartExport Geometry: public Base::Persistence
 {

--- a/src/Mod/Part/App/GeometryExtension.h
+++ b/src/Mod/Part/App/GeometryExtension.h
@@ -25,10 +25,15 @@
 #define PART_GEOMETRYEXTENSION_H
 
 #include <Base/StdStlTools.h>
-#include <Base/Persistence.h>
+#include <Base/BaseClass.h>
 #include <memory>
 #include <string>
 
+namespace Base
+{
+class Writer;
+class XMLReader;
+}
 
 namespace Part {
 

--- a/src/Mod/Part/App/GeometryMigrationExtension.h
+++ b/src/Mod/Part/App/GeometryMigrationExtension.h
@@ -24,6 +24,7 @@
 #define PART_GEOMETRYMIGRATIONEXTENSION_H
 
 #include <Mod/Part/App/Geometry.h>
+#include <Mod/Part/App/GeometryExtension.h>
 #include <bitset>
 
 namespace Part

--- a/src/Mod/Part/App/Part2DObject.cpp
+++ b/src/Mod/Part/App/Part2DObject.cpp
@@ -53,6 +53,7 @@
 #include "Part2DObject.h"
 #include "Geometry.h"
 #include "DatumFeature.h"
+#include "Attacher.h"
 
 #include <App/FeaturePythonPyImp.h>
 #include <Mod/Part/App/Part2DObjectPy.h>

--- a/src/Mod/Part/App/PartFeature.h
+++ b/src/Mod/Part/App/PartFeature.h
@@ -31,7 +31,6 @@
 #include <App/PropertyGeo.h>
 // includes for findAllFacesCutBy()
 #include <TopoDS_Face.hxx>
-#include <BRep_Builder.hxx>
 #include <TopoDS_Compound.hxx>
 class gp_Dir;
 

--- a/src/Mod/Part/App/PropertyGeometryList.h
+++ b/src/Mod/Part/App/PropertyGeometryList.h
@@ -26,11 +26,10 @@
 
 // Std. configurations
 
-
+#include <memory>
 #include <vector>
 #include <string>
 #include <App/Property.h>
-#include "Geometry.h"
 
 namespace Base {
 class Writer;

--- a/src/Mod/Part/App/PropertyTopoShape.h
+++ b/src/Mod/Part/App/PropertyTopoShape.h
@@ -26,7 +26,6 @@
 
 #include "TopoShape.h"
 #include <TopAbs_ShapeEnum.hxx>
-#include <App/DocumentObject.h>
 #include <App/PropertyGeo.h>
 #include <map>
 #include <vector>

--- a/src/Mod/Part/App/TopoShape.cpp
+++ b/src/Mod/Part/App/TopoShape.cpp
@@ -46,7 +46,6 @@
 # include <BRepAlgoAPI_Fuse.hxx>
 # include <BRepAlgoAPI_Section.hxx>
 # include <BRepBndLib.hxx>
-# include <BRepBuilderAPI_FindPlane.hxx>
 # include <BRepLib_FindSurface.hxx>
 # include <BRepBuilderAPI_GTransform.hxx>
 # include <BRepBuilderAPI_MakeEdge.hxx>
@@ -101,7 +100,6 @@
 # include <GProp_GProps.hxx>
 # include <Law_BSpFunc.hxx>
 # include <Law_BSpline.hxx>
-# include <Law_BSpFunc.hxx>
 # include <Law_Constant.hxx>
 # include <Law_Linear.hxx>
 # include <Law_S.hxx>
@@ -114,7 +112,6 @@
 # include <IGESData_IGESModel.hxx>
 # include <STEPControl_Writer.hxx>
 # include <STEPControl_Reader.hxx>
-# include <TopTools_MapOfShape.hxx>
 # include <TopoDS.hxx>
 # include <TopoDS_Compound.hxx>
 # include <TopoDS_Iterator.hxx>
@@ -193,6 +190,7 @@
 #include <Base/Builder3D.h>
 #include <Base/FileInfo.h>
 #include <Base/Exception.h>
+#include <Base/Placement.h>
 #include <Base/Tools.h>
 #include <Base/Console.h>
 #include <App/Material.h>

--- a/src/Mod/Part/App/TopoShape.h
+++ b/src/Mod/Part/App/TopoShape.h
@@ -25,8 +25,7 @@
 #define PART_TOPOSHAPE_H
 
 #include <iosfwd>
-#include <TopoDS_Compound.hxx>
-#include <TopoDS_Wire.hxx>
+#include <TopoDS_Shape.hxx>
 #include <TopTools_ListOfShape.hxx>
 #include <App/ComplexGeoData.h>
 #include <Base/Exception.h>
@@ -35,6 +34,9 @@ class gp_Ax1;
 class gp_Ax2;
 class gp_Pln;
 class gp_Vec;
+
+class TopoDS_Wire;
+class TopoDS_Compound;
 
 namespace App {
 class Color;

--- a/src/Mod/Part/Gui/Command.cpp
+++ b/src/Mod/Part/Gui/Command.cpp
@@ -52,7 +52,7 @@
 #include <Gui/Document.h>
 #include <Gui/FileDialog.h>
 #include <Gui/MainWindow.h>
-#include <Gui/Selection.h>
+#include <Gui/SelectionObject.h>
 #include <Gui/View3DInventor.h>
 #include <Gui/View3DInventorViewer.h>
 #include <Gui/WaitCursor.h>

--- a/src/Mod/Part/Gui/CommandSimple.cpp
+++ b/src/Mod/Part/Gui/CommandSimple.cpp
@@ -37,7 +37,7 @@
 #include <Gui/Command.h>
 #include <Gui/Document.h>
 #include <Gui/MainWindow.h>
-#include <Gui/Selection.h>
+#include <Gui/SelectionObject.h>
 #include <Gui/WaitCursor.h>
 
 #include "../App/PartFeature.h"

--- a/src/Mod/Part/Gui/CrossSections.cpp
+++ b/src/Mod/Part/Gui/CrossSections.cpp
@@ -48,6 +48,7 @@
 
 #include "ui_CrossSections.h"
 #include "CrossSections.h"
+#include <App/Document.h>
 #include <Mod/Part/App/PartFeature.h>
 #include <Mod/Part/App/CrossSection.h>
 #include <Gui/BitmapFactory.h>

--- a/src/Mod/Part/Gui/DlgFilletEdges.cpp
+++ b/src/Mod/Part/Gui/DlgFilletEdges.cpp
@@ -68,7 +68,7 @@
 #include <Gui/Command.h>
 #include <Gui/QuantitySpinBox.h>
 #include <Gui/WaitCursor.h>
-#include <Gui/Selection.h>
+#include <Gui/SelectionObject.h>
 #include <Gui/SelectionFilter.h>
 #include <Gui/SoFCUnifiedSelection.h>
 #include <Gui/ViewProvider.h>

--- a/src/Mod/Part/Gui/DlgProjectionOnSurface.cpp
+++ b/src/Mod/Part/Gui/DlgProjectionOnSurface.cpp
@@ -51,10 +51,11 @@
 #include "DlgProjectionOnSurface.h"
 #include "ui_DlgProjectionOnSurface.h"
 
+#include <App/Document.h>
 #include <Gui/BitmapFactory.h>
-
 #include "Gui/MainWindow.h"
 #include "Gui/MDIView.h"
+#include <Gui/SelectionObject.h>
 #include "Gui/View3DInventor.h"
 #include "Gui/View3DInventorViewer.h"
 #include "Inventor/SbVec3d.h"

--- a/src/Mod/Part/Gui/TaskDimension.cpp
+++ b/src/Mod/Part/Gui/TaskDimension.cpp
@@ -56,7 +56,6 @@
 # include <Inventor/nodes/SoSeparator.h>
 # include <Inventor/nodes/SoCone.h>
 # include <Inventor/nodes/SoCoordinate3.h>
-# include <Inventor/nodes/SoNurbsCurve.h>
 # include <Inventor/engines/SoComposeVec3f.h>
 # include <Inventor/engines/SoCalculator.h>
 # include <Inventor/nodes/SoResetTransform.h>
@@ -67,7 +66,8 @@
 #endif
 
 #include <Base/Console.h>
-#include <Base/UnitsApi.h>
+#include <Base/Quantity.h>
+#include <App/Document.h>
 #include "../App/PartFeature.h"
 #include <Gui/Application.h>
 #include <Gui/Selection.h>

--- a/src/Mod/Part/Gui/TaskDimension.h
+++ b/src/Mod/Part/Gui/TaskDimension.h
@@ -38,7 +38,6 @@
 
 #include <Gui/TaskView/TaskDialog.h>
 #include <Gui/TaskView/TaskView.h>
-#include <Base/Matrix.h>
 
 class TopoDS_Shape;
 class TopoDS_Face;
@@ -50,7 +49,10 @@ class BRepExtrema_DistShapeShape;
 class QPushButton;
 class QPixmap;
 class QLabel;
-
+namespace Base
+{
+class Matrix4D;
+}
 namespace Gui{class View3dInventorViewer;}
 
 namespace PartGui

--- a/src/Mod/Part/Gui/TaskShapeBuilder.cpp
+++ b/src/Mod/Part/Gui/TaskShapeBuilder.cpp
@@ -41,7 +41,7 @@
 #include <Gui/BitmapFactory.h>
 #include <Gui/Command.h>
 #include <Gui/Document.h>
-#include <Gui/Selection.h>
+#include <Gui/SelectionObject.h>
 #include <Gui/SelectionFilter.h>
 
 #include <Base/Console.h>

--- a/src/Mod/Part/Gui/TaskSweep.cpp
+++ b/src/Mod/Part/Gui/TaskSweep.cpp
@@ -44,7 +44,7 @@
 #include <Gui/BitmapFactory.h>
 #include <Gui/Command.h>
 #include <Gui/Document.h>
-#include <Gui/Selection.h>
+#include <Gui/SelectionObject.h>
 #include <Gui/SelectionFilter.h>
 #include <Gui/ViewProvider.h>
 #include <Gui/WaitCursor.h>

--- a/src/Mod/Part/Gui/TaskSweep.cpp
+++ b/src/Mod/Part/Gui/TaskSweep.cpp
@@ -33,6 +33,7 @@
 # include <ShapeAnalysis_FreeBounds.hxx>
 # include <TopExp_Explorer.hxx>
 # include <TopoDS.hxx>
+# include <TopoDS_Wire.hxx>
 # include <TopoDS_Iterator.hxx>
 # include <TopTools_HSequenceOfShape.hxx>
 #endif

--- a/src/Mod/Part/Gui/TaskThickness.cpp
+++ b/src/Mod/Part/Gui/TaskThickness.cpp
@@ -35,7 +35,7 @@
 #include <Gui/BitmapFactory.h>
 #include <Gui/CommandT.h>
 #include <Gui/Document.h>
-#include <Gui/Selection.h>
+#include <Gui/SelectionObject.h>
 #include <Gui/SelectionFilter.h>
 #include <Gui/ViewProvider.h>
 

--- a/src/Mod/PartDesign/App/Body.h
+++ b/src/Mod/PartDesign/App/Body.h
@@ -24,13 +24,13 @@
 #ifndef PARTDESIGN_Body_H
 #define PARTDESIGN_Body_H
 
-#include <App/PropertyStandard.h>
 #include <Mod/Part/App/BodyBase.h>
 
 #include <boost_signals2.hpp>
 
 namespace App {
     class Origin;
+    class Property;
 }
 
 namespace PartDesign

--- a/src/Mod/PartDesign/App/DatumCS.cpp
+++ b/src/Mod/PartDesign/App/DatumCS.cpp
@@ -30,6 +30,7 @@
 
 #include <Mod/Part/App/PartPyCXX.h>
 #include <Mod/Part/App/OCCError.h>
+#include <Mod/Part/App/Attacher.h>
 #include "DatumCS.h"
 
 using namespace PartDesign;

--- a/src/Mod/PartDesign/App/DatumLine.cpp
+++ b/src/Mod/PartDesign/App/DatumLine.cpp
@@ -31,6 +31,7 @@
 #endif
 
 #include "DatumLine.h"
+#include <Mod/Part/App/Attacher.h>
 
 using namespace PartDesign;
 using namespace Attacher;

--- a/src/Mod/PartDesign/App/DatumPlane.cpp
+++ b/src/Mod/PartDesign/App/DatumPlane.cpp
@@ -31,6 +31,7 @@
 #endif
 
 #include "DatumPlane.h"
+#include <Mod/Part/App/Attacher.h>
 
 using namespace PartDesign;
 using namespace Attacher;

--- a/src/Mod/PartDesign/App/DatumPoint.cpp
+++ b/src/Mod/PartDesign/App/DatumPoint.cpp
@@ -67,6 +67,7 @@
 #include <Base/Console.h>
 #include <Base/Exception.h>
 #include "Mod/Part/App/PrimitiveFeature.h"
+#include <Mod/Part/App/Attacher.h>
 
 #ifndef M_PI
 #define M_PI       3.14159265358979323846

--- a/src/Mod/PartDesign/App/FeatureAddSub.h
+++ b/src/Mod/PartDesign/App/FeatureAddSub.h
@@ -25,7 +25,6 @@
 #define PARTDESIGN_FeatureAdditive_H
 
 #include <App/PropertyStandard.h>
-#include <Mod/Part/App/PropertyTopoShape.h>
 
 #include "Feature.h"
 

--- a/src/Mod/PartDesign/App/FeatureDressUp.cpp
+++ b/src/Mod/PartDesign/App/FeatureDressUp.cpp
@@ -27,6 +27,7 @@
 #include <TopTools_IndexedDataMapOfShapeListOfShape.hxx>
 #include <TopExp.hxx>
 #include <TopoDS.hxx>
+#include <BRep_Builder.hxx>
 #include <BRep_Tool.hxx>
 #include <TopoDS_Edge.hxx>
 #endif

--- a/src/Mod/PartDesign/App/FeatureSketchBased.cpp
+++ b/src/Mod/PartDesign/App/FeatureSketchBased.cpp
@@ -78,6 +78,7 @@
 #include <App/OriginFeature.h>
 #include <App/Document.h>
 #include <Mod/Part/App/FaceMakerCheese.h>
+#include <Mod/Part/App/Attacher.h>
 #include "FeatureSketchBased.h"
 #include "DatumPlane.h"
 #include "DatumLine.h"

--- a/src/Mod/PartDesign/App/ShapeBinder.h
+++ b/src/Mod/PartDesign/App/ShapeBinder.h
@@ -21,13 +21,12 @@
  ***************************************************************************/
 
 
-#ifndef PARTDESIGN_DATUMSHAPE_H
-#define PARTDESIGN_DATUMSHAPE_H
+#ifndef PARTDESIGN_SHAPEBINDER_H
+#define PARTDESIGN_SHAPEBINDER_H
 
-#include <QString>
 #include <boost_signals2.hpp>
 #include <App/PropertyLinks.h>
-#include <Mod/Part/App/DatumFeature.h>
+#include <Mod/Part/App/PartFeature.h>
 
 namespace PartDesign
 {
@@ -131,4 +130,4 @@ protected:
 } //namespace PartDesign
 
 
-#endif // PARTDESIGN_DATUMSHAPE_H
+#endif // PARTDESIGN_SHAPEBINDER_H

--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -37,14 +37,14 @@
 # include <algorithm>
 #endif
 
-#include <App/DocumentObjectGroup.h>
+#include <App/Document.h>
 #include <App/Origin.h>
 #include <App/OriginFeature.h>
 #include <App/Part.h>
 #include <Gui/Application.h>
 #include <Gui/Command.h>
 #include <Gui/Control.h>
-#include <Gui/Selection.h>
+#include <Gui/SelectionObject.h>
 #include <Gui/MainWindow.h>
 #include <Gui/Document.h>
 #include <Gui/View3DInventor.h>
@@ -61,6 +61,7 @@
 #include <Mod/PartDesign/App/DatumLine.h>
 #include <Mod/PartDesign/App/DatumPlane.h>
 #include <Mod/PartDesign/App/ShapeBinder.h>
+#include <Mod/Part/App/Attacher.h>
 
 #include "TaskFeaturePick.h"
 #include "ReferenceSelection.h"

--- a/src/Mod/PartDesign/Gui/CommandBody.cpp
+++ b/src/Mod/PartDesign/Gui/CommandBody.cpp
@@ -31,6 +31,7 @@
 #endif
 
 #include <Base/Console.h>
+#include <App/Document.h>
 #include <App/Origin.h>
 #include <App/Part.h>
 #include <Gui/Command.h>
@@ -46,6 +47,7 @@
 #include <Mod/PartDesign/App/Feature.h>
 #include <Mod/PartDesign/App/FeatureBase.h>
 #include <Mod/PartDesign/App/FeatureSketchBased.h>
+#include <Mod/Part/App/Attacher.h>
 
 #include "Utils.h"
 #include "TaskFeaturePick.h"

--- a/src/Mod/PartDesign/Gui/ReferenceSelection.cpp
+++ b/src/Mod/PartDesign/Gui/ReferenceSelection.cpp
@@ -33,6 +33,7 @@
 
 #include <App/OriginFeature.h>
 #include <App/GeoFeatureGroupExtension.h>
+#include <App/Document.h>
 #include <App/Origin.h>
 #include <App/Part.h>
 #include <Gui/Application.h>

--- a/src/Mod/PartDesign/Gui/TaskFeaturePick.cpp
+++ b/src/Mod/PartDesign/Gui/TaskFeaturePick.cpp
@@ -55,6 +55,7 @@
 #include <Mod/PartDesign/App/DatumPlane.h>
 #include <Mod/PartDesign/App/FeaturePrimitive.h>
 #include <Mod/Part/App/DatumFeature.h>
+#include <Mod/Part/App/Attacher.h>
 
 using namespace PartDesignGui;
 using namespace Attacher;

--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
@@ -31,6 +31,7 @@
 #include "TaskHoleParameters.h"
 #include <Base/Console.h>
 #include <Base/Tools.h>
+#include <App/Document.h>
 #include <Gui/Application.h>
 #include <Gui/BitmapFactory.h>
 #include <Gui/Command.h>

--- a/src/Mod/PartDesign/Gui/TaskPrimitiveParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPrimitiveParameters.cpp
@@ -35,6 +35,7 @@
 #include "ui_TaskPrimitiveParameters.h"
 #include "ViewProviderDatumCS.h"
 
+#include <App/Document.h>
 #include <App/Origin.h>
 #include <Base/Console.h>
 #include <Base/Interpreter.h>

--- a/src/Mod/PartDesign/Gui/TaskScaledParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskScaledParameters.cpp
@@ -40,7 +40,7 @@
 #include <Gui/ViewProvider.h>
 #include <Gui/WaitCursor.h>
 #include <Base/Console.h>
-#include <Gui/Selection.h>
+#include <Gui/SelectionObject.h>
 #include <Gui/Command.h>
 #include <Mod/PartDesign/App/FeatureScaled.h>
 #include <Mod/Sketcher/App/SketchObject.h>

--- a/src/Mod/PartDesign/Gui/TaskShapeBinder.cpp
+++ b/src/Mod/PartDesign/Gui/TaskShapeBinder.cpp
@@ -28,6 +28,8 @@
 # include <QMessageBox>
 #endif
 
+#include <App/Document.h>
+
 #include <Gui/Application.h>
 #include <Gui/BitmapFactory.h>
 #include <Gui/Command.h>

--- a/src/Mod/PartDesign/Gui/Utils.cpp
+++ b/src/Mod/PartDesign/Gui/Utils.cpp
@@ -29,6 +29,7 @@
 #endif
 
 #include <Base/Console.h>
+#include <App/Document.h>
 #include <App/Part.h>
 #include <App/Origin.h>
 #include <App/OriginFeature.h>
@@ -41,6 +42,7 @@
 
 #include <Mod/Sketcher/App/SketchObject.h>
 
+#include <Mod/Part/App/Attacher.h>
 #include <Mod/PartDesign/App/Feature.h>
 #include <Mod/PartDesign/App/Body.h>
 #include <Mod/PartDesign/App/FeaturePrimitive.h>

--- a/src/Mod/PartDesign/Gui/ViewProvider.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProvider.cpp
@@ -31,6 +31,8 @@
 #include <Inventor/nodes/SoSwitch.h>
 #endif
 
+#include <App/Document.h>
+
 #include <Gui/Command.h>
 #include <Gui/MDIView.h>
 #include <Gui/Control.h>

--- a/src/Mod/PartDesign/Gui/ViewProviderBody.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderBody.cpp
@@ -32,6 +32,7 @@
 #endif
 
 #include <Base/Console.h>
+#include <App/Document.h>
 #include <App/Part.h>
 #include <App/Origin.h>
 #include <Gui/ActionFunction.h>

--- a/src/Mod/PartDesign/Gui/ViewProviderDatum.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderDatum.cpp
@@ -56,6 +56,7 @@
 
 #include <App/DocumentObjectGroup.h>
 #include <App/GeoFeatureGroupExtension.h>
+#include <App/Document.h>
 #include <Gui/Control.h>
 #include <Gui/Command.h>
 #include <Gui/Application.h>

--- a/src/Mod/PartDesign/Gui/ViewProviderMultiTransform.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderMultiTransform.cpp
@@ -30,6 +30,7 @@
 #include "TaskMultiTransformParameters.h"
 #include <Mod/PartDesign/App/FeatureMultiTransform.h>
 #include <Gui/Command.h>
+#include <App/Document.h>
 
 using namespace PartDesignGui;
 

--- a/src/Mod/PartDesign/Gui/ViewProviderShapeBinder.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderShapeBinder.cpp
@@ -32,6 +32,8 @@
 # include <TopTools_IndexedMapOfShape.hxx>
 #endif
 
+#include <App/Document.h>
+
 #include <Base/Console.h>
 #include <Gui/Application.h>
 #include <Gui/Control.h>

--- a/src/Mod/PartDesign/Gui/ViewProviderTransformed.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderTransformed.cpp
@@ -49,6 +49,7 @@
 
 #include "ViewProviderTransformed.h"
 #include "TaskTransformedParameters.h"
+#include <App/Document.h>
 #include <Base/Console.h>
 #include <Gui/Control.h>
 #include <Gui/Command.h>

--- a/src/Mod/PartDesign/Gui/Workbench.cpp
+++ b/src/Mod/PartDesign/Gui/Workbench.cpp
@@ -28,6 +28,7 @@
 # include <QMessageBox>
 #endif
 
+#include <App/Document.h>
 #include <Gui/Application.h>
 #include <Gui/Command.h>
 #include <Gui/Control.h>

--- a/src/Mod/PartDesign/Gui/Workbench.cpp
+++ b/src/Mod/PartDesign/Gui/Workbench.cpp
@@ -30,6 +30,7 @@
 
 #include <App/Document.h>
 #include <Gui/Application.h>
+#include <Gui/TaskView/TaskWatcher.h>
 #include <Gui/Command.h>
 #include <Gui/Control.h>
 #include <Gui/MDIView.h>

--- a/src/Mod/Path/Gui/Command.cpp
+++ b/src/Mod/Path/Gui/Command.cpp
@@ -31,7 +31,7 @@
 #include <Gui/Application.h>
 #include <Gui/MainWindow.h>
 #include <Gui/Command.h>
-#include <Gui/Selection.h>
+#include <Gui/SelectionObject.h>
 #include <Gui/SelectionFilter.h>
 #include <Gui/Document.h>
 #include <Gui/Control.h>

--- a/src/Mod/Points/App/Points.h
+++ b/src/Mod/Points/App/Points.h
@@ -32,6 +32,7 @@
 #include <Base/Reader.h>
 #include <Base/Writer.h>
 
+#include <App/ComplexGeoData.h>
 #include <App/PropertyStandard.h>
 #include <App/PropertyGeo.h>
 

--- a/src/Mod/Points/App/Properties.h
+++ b/src/Mod/Points/App/Properties.h
@@ -27,15 +27,15 @@
 #include <vector>
 
 #include <Base/Vector3D.h>
-#include <Base/Matrix.h>
 #include <Base/Reader.h>
 #include <Base/Writer.h>
 
 #include <App/PropertyStandard.h>
 #include <App/PropertyGeo.h>
 
-#include "Points.h"
-
+namespace Base {
+class Matrix4D;
+}
 namespace Points
 {
 

--- a/src/Mod/Raytracing/Gui/Command.cpp
+++ b/src/Mod/Raytracing/Gui/Command.cpp
@@ -54,7 +54,7 @@
 #include <Gui/FileDialog.h>
 #include <Gui/View.h>
 #include <Gui/ViewProvider.h>
-#include <Gui/Selection.h>
+#include <Gui/SelectionObject.h>
 #include <Gui/FileDialog.h>
 #include <Gui/MainWindow.h>
 

--- a/src/Mod/ReverseEngineering/Gui/FitBSplineSurface.cpp
+++ b/src/Mod/ReverseEngineering/Gui/FitBSplineSurface.cpp
@@ -44,6 +44,7 @@
 #include <Base/Converter.h>
 #include <Base/CoordinateSystem.h>
 #include <App/Application.h>
+#include <App/ComplexGeoData.h>
 #include <App/Document.h>
 #include <App/Placement.h>
 #include <Mod/Mesh/App/Core/Approximation.h>

--- a/src/Mod/Robot/Gui/Command.cpp
+++ b/src/Mod/Robot/Gui/Command.cpp
@@ -31,7 +31,7 @@
 #include <Gui/MainWindow.h>
 #include <Gui/Command.h>
 #include <Gui/FileDialog.h>
-#include <Gui/Selection.h>
+#include <Gui/SelectionObject.h>
 #include <Gui/SelectionFilter.h>
 #include <Gui/Document.h>
 #include <Gui/Control.h>

--- a/src/Mod/Robot/Gui/CommandTrajectory.cpp
+++ b/src/Mod/Robot/Gui/CommandTrajectory.cpp
@@ -32,7 +32,7 @@
 #include <Gui/Command.h>
 #include <Gui/MainWindow.h>
 #include <Gui/FileDialog.h>
-#include <Gui/Selection.h>
+#include <Gui/SelectionObject.h>
 #include <Gui/Document.h>
 #include <Gui/Placement.h>
 #include <Gui/Control.h>

--- a/src/Mod/Robot/Gui/TaskWatcher.cpp
+++ b/src/Mod/Robot/Gui/TaskWatcher.cpp
@@ -30,7 +30,7 @@
 
 
 #include "TaskWatcher.h"
-
+#include <Gui/SelectionObject.h>
 
 using namespace RobotGui;
 

--- a/src/Mod/Sandbox/Gui/GLGraphicsView.cpp
+++ b/src/Mod/Sandbox/Gui/GLGraphicsView.cpp
@@ -57,6 +57,7 @@
 #include <QUrl>
 
 #include "GLGraphicsView.h"
+#include <App/Application.h>
 #include <Gui/Document.h>
 #include <Gui/ViewProvider.h>
 

--- a/src/Mod/Sandbox/Gui/Workbench.cpp
+++ b/src/Mod/Sandbox/Gui/Workbench.cpp
@@ -37,6 +37,7 @@
 #include <QtOpenGL.h>
 
 #include "Workbench.h"
+#include <App/Application.h>
 #include <Gui/MenuManager.h>
 #include <Gui/ToolBarManager.h>
 #include <Gui/MainWindow.h>

--- a/src/Mod/Sketcher/App/ExternalGeometryFacade.h
+++ b/src/Mod/Sketcher/App/ExternalGeometryFacade.h
@@ -26,7 +26,8 @@
 
 #include <Base/BaseClass.h>
 
-#include <Base/Console.h> // Only for Debug - To be removed
+#include <Base/Placement.h>
+#include <Base/Matrix.h>
 #include <boost/uuid/uuid_io.hpp>
 
 #include <Mod/Part/App/Geometry.h>

--- a/src/Mod/Sketcher/App/GeometryFacade.h
+++ b/src/Mod/Sketcher/App/GeometryFacade.h
@@ -26,7 +26,8 @@
 
 #include <Base/BaseClass.h>
 
-#include <Base/Console.h> // Only for Debug - To be removed
+#include <Base/Placement.h>
+#include <Base/Matrix.h>
 #include <boost/uuid/uuid_io.hpp>
 
 #include <Mod/Part/App/Geometry.h>

--- a/src/Mod/Sketcher/App/SketchGeometryExtension.h
+++ b/src/Mod/Sketcher/App/SketchGeometryExtension.h
@@ -24,6 +24,7 @@
 #define SKETCHER_SKETCHGEOMETRYEXTENSION_H
 
 #include <Mod/Part/App/Geometry.h>
+#include <Mod/Part/App/GeometryExtension.h>
 #include <atomic>
 #include <bitset>
 #include <array>

--- a/src/Mod/Sketcher/Gui/Command.cpp
+++ b/src/Mod/Sketcher/Gui/Command.cpp
@@ -40,6 +40,7 @@
 #include <Gui/Control.h>
 #include <Gui/MainWindow.h>
 #include <Gui/DlgEditFileIncludePropertyExternal.h>
+#include <Gui/SelectionObject.h>
 #include <Gui/SelectionFilter.h>
 
 #include <Mod/Sketcher/App/SketchObjectSF.h>

--- a/src/Mod/Sketcher/Gui/CommandAlterGeometry.cpp
+++ b/src/Mod/Sketcher/Gui/CommandAlterGeometry.cpp
@@ -29,7 +29,7 @@
 #include <Gui/Action.h>
 #include <Gui/Application.h>
 #include <Gui/Document.h>
-#include <Gui/Selection.h>
+#include <Gui/SelectionObject.h>
 #include <Gui/CommandT.h>
 #include <Gui/MainWindow.h>
 #include <Gui/BitmapFactory.h>

--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -34,7 +34,7 @@
 #include <App/Application.h>
 #include <Gui/Application.h>
 #include <Gui/Document.h>
-#include <Gui/Selection.h>
+#include <Gui/SelectionObject.h>
 #include <Gui/SelectionFilter.h>
 #include <Gui/CommandT.h>
 #include <Gui/MainWindow.h>

--- a/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp
+++ b/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp
@@ -35,7 +35,7 @@
 #include <App/Application.h>
 #include <Gui/Application.h>
 #include <Gui/Document.h>
-#include <Gui/Selection.h>
+#include <Gui/SelectionObject.h>
 #include <Gui/CommandT.h>
 #include <Gui/MainWindow.h>
 #include <Gui/DlgEditFileIncludePropertyExternal.h>

--- a/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp
+++ b/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp
@@ -35,7 +35,7 @@
 #include <App/Application.h>
 #include <Gui/Application.h>
 #include <Gui/Document.h>
-#include <Gui/Selection.h>
+#include <Gui/SelectionObject.h>
 #include <Gui/CommandT.h>
 #include <Gui/MainWindow.h>
 #include <Gui/DlgEditFileIncludePropertyExternal.h>

--- a/src/Mod/Sketcher/Gui/CommandSketcherVirtualSpace.cpp
+++ b/src/Mod/Sketcher/Gui/CommandSketcherVirtualSpace.cpp
@@ -35,7 +35,7 @@
 #include <App/Application.h>
 #include <Gui/Application.h>
 #include <Gui/Document.h>
-#include <Gui/Selection.h>
+#include <Gui/SelectionObject.h>
 #include <Gui/CommandT.h>
 #include <Gui/MainWindow.h>
 #include <Gui/DlgEditFileIncludePropertyExternal.h>

--- a/src/Mod/Sketcher/Gui/TaskDlgEditSketch.cpp
+++ b/src/Mod/Sketcher/Gui/TaskDlgEditSketch.cpp
@@ -30,6 +30,7 @@
 #include "TaskDlgEditSketch.h"
 #include "ViewProviderSketch.h"
 #include <Gui/Command.h>
+#include <App/Application.h>
 
 using namespace SketcherGui;
 

--- a/src/Mod/Sketcher/Gui/TaskSketcherConstrains.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstrains.cpp
@@ -49,7 +49,7 @@
 #include <App/Document.h>
 #include <Gui/Application.h>
 #include <Gui/Document.h>
-#include <Gui/Selection.h>
+#include <Gui/SelectionObject.h>
 #include <Gui/BitmapFactory.h>
 #include <Gui/ViewProvider.h>
 #include <Gui/CommandT.h>

--- a/src/Mod/Sketcher/Gui/TaskSketcherElements.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherElements.cpp
@@ -48,7 +48,7 @@
 #include <App/DocumentObject.h>
 #include <Gui/Application.h>
 #include <Gui/Document.h>
-#include <Gui/Selection.h>
+#include <Gui/SelectionObject.h>
 #include <Gui/BitmapFactory.h>
 #include <Gui/ViewProvider.h>
 #include <Gui/BitmapFactory.h>

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -90,7 +90,7 @@
 #include <Gui/Document.h>
 #include <Gui/CommandT.h>
 #include <Gui/Control.h>
-#include <Gui/Selection.h>
+#include <Gui/SelectionObject.h>
 #include <Gui/Tools.h>
 #include <Gui/Utilities.h>
 #include <Gui/MainWindow.h>

--- a/src/Mod/Sketcher/Gui/ViewProviderSketchGeometryExtension.h
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketchGeometryExtension.h
@@ -23,7 +23,7 @@
 #ifndef SKETCHER_VIEWPROVIDERSKETCHGEOMETRYEXTENSION_H
 #define SKETCHER_VIEWPROVIDERSKETCHGEOMETRYEXTENSION_H
 
-#include <Mod/Part/App/Geometry.h>
+#include <Mod/Part/App/GeometryExtension.h>
 
 namespace SketcherGui {
 

--- a/src/Mod/Spreadsheet/Gui/AppSpreadsheetGui.cpp
+++ b/src/Mod/Spreadsheet/Gui/AppSpreadsheetGui.cpp
@@ -36,6 +36,7 @@
 #include <Base/Console.h>
 #include <Base/Exception.h>
 #include <Base/FileInfo.h>
+#include <App/Document.h>
 #include <App/Application.h>
 #include <Gui/MainWindow.h>
 #include <Gui/Document.h>

--- a/src/Mod/Spreadsheet/Gui/SheetModel.cpp
+++ b/src/Mod/Spreadsheet/Gui/SheetModel.cpp
@@ -37,6 +37,7 @@
 #include "../App/Sheet.h"
 #include <Gui/Command.h>
 #include <Base/Tools.h>
+#include <Base/Interpreter.h>
 #include <Base/UnitsApi.h>
 #include <boost_bind_bind.hpp>
 

--- a/src/Mod/Spreadsheet/Gui/SheetTableView.cpp
+++ b/src/Mod/Spreadsheet/Gui/SheetTableView.cpp
@@ -30,6 +30,8 @@
 # include <QMimeData>
 #endif
 
+#include <Base/Writer.h>
+#include <Base/Reader.h>
 #include <App/Application.h>
 #include <App/AutoTransaction.h>
 #include <App/Document.h>

--- a/src/Mod/Spreadsheet/Gui/Workbench.h
+++ b/src/Mod/Spreadsheet/Gui/Workbench.h
@@ -25,6 +25,7 @@
 #ifndef SPREADSHEET_WORKBENCH_H
 #define SPREADSHEET_WORKBENCH_H
 
+#include <memory>
 #include <Gui/Workbench.h>
 
 class QtColorPicker;

--- a/src/Mod/Surface/Gui/Command.cpp
+++ b/src/Mod/Surface/Gui/Command.cpp
@@ -52,7 +52,7 @@
 #include <Gui/Document.h>
 #include <Gui/FileDialog.h>
 #include <Gui/MainWindow.h>
-#include <Gui/Selection.h>
+#include <Gui/SelectionObject.h>
 #include <Gui/SelectionFilter.h>
 #include <Gui/View3DInventor.h>
 #include <Gui/View3DInventorViewer.h>

--- a/src/Mod/Surface/Gui/TaskFilling.cpp
+++ b/src/Mod/Surface/Gui/TaskFilling.cpp
@@ -31,6 +31,7 @@
 #include <TopTools_IndexedDataMapOfShapeListOfShape.hxx>
 #include <TopTools_ListIteratorOfListOfShape.hxx>
 
+#include <App/Document.h>
 #include <Gui/ViewProvider.h>
 #include <Gui/Application.h>
 #include <Gui/Document.h>

--- a/src/Mod/Surface/Gui/TaskFillingEdge.cpp
+++ b/src/Mod/Surface/Gui/TaskFillingEdge.cpp
@@ -23,23 +23,21 @@
 
 #include "PreCompiled.h"
 #include <QAction>
-#include <QMenu>
 #include <QMessageBox>
 #include <QTimer>
-#include <GeomAbs_Shape.hxx>
 #include <TopExp.hxx>
+#include <GeomAbs_Shape.hxx>
 #include <TopTools_IndexedMapOfShape.hxx>
 #include <TopTools_IndexedDataMapOfShapeListOfShape.hxx>
 #include <TopTools_ListIteratorOfListOfShape.hxx>
 
+#include <Base/Console.h>
+#include <App/Document.h>
 #include <Gui/ViewProvider.h>
 #include <Gui/Application.h>
 #include <Gui/Document.h>
 #include <Gui/Command.h>
 #include <Gui/SelectionObject.h>
-#include <Base/Console.h>
-#include <Gui/Control.h>
-#include <Gui/BitmapFactory.h>
 #include <Mod/Part/Gui/ViewProvider.h>
 
 #include "TaskFillingEdge.h"

--- a/src/Mod/Surface/Gui/TaskFillingVertex.cpp
+++ b/src/Mod/Surface/Gui/TaskFillingVertex.cpp
@@ -22,23 +22,18 @@
 
 #include "PreCompiled.h"
 #include <QAction>
-#include <QMenu>
-#include <QMessageBox>
 #include <QTimer>
-#include <GeomAbs_Shape.hxx>
 #include <TopExp.hxx>
 #include <TopTools_IndexedMapOfShape.hxx>
 #include <TopTools_IndexedDataMapOfShapeListOfShape.hxx>
 #include <TopTools_ListIteratorOfListOfShape.hxx>
 
+#include <App/Document.h>
 #include <Gui/ViewProvider.h>
 #include <Gui/Application.h>
 #include <Gui/Document.h>
 #include <Gui/Command.h>
 #include <Gui/SelectionObject.h>
-#include <Base/Console.h>
-#include <Gui/Control.h>
-#include <Gui/BitmapFactory.h>
 #include <Mod/Part/Gui/ViewProvider.h>
 
 #include "TaskFillingVertex.h"

--- a/src/Mod/Surface/Gui/TaskGeomFillSurface.cpp
+++ b/src/Mod/Surface/Gui/TaskGeomFillSurface.cpp
@@ -29,6 +29,8 @@
 #include <TopExp.hxx>
 #include <TopTools_IndexedMapOfShape.hxx>
 
+
+#include <App/Document.h>
 #include <Gui/ViewProvider.h>
 #include <Gui/Application.h>
 #include <Gui/Document.h>

--- a/src/Mod/Surface/Gui/TaskSections.cpp
+++ b/src/Mod/Surface/Gui/TaskSections.cpp
@@ -25,18 +25,15 @@
 #include <QMenu>
 #include <QMessageBox>
 #include <QTimer>
-#include <GeomAbs_Shape.hxx>
 #include <TopExp.hxx>
 #include <TopTools_IndexedMapOfShape.hxx>
-#include <TopTools_IndexedDataMapOfShapeListOfShape.hxx>
-#include <TopTools_ListIteratorOfListOfShape.hxx>
 
+#include <App/Document.h>
 #include <Gui/ViewProvider.h>
 #include <Gui/Application.h>
 #include <Gui/Document.h>
 #include <Gui/Command.h>
 #include <Gui/SelectionObject.h>
-#include <Base/Console.h>
 #include <Gui/Control.h>
 #include <Gui/BitmapFactory.h>
 #include <Mod/Part/Gui/ViewProvider.h>

--- a/src/Mod/TechDraw/App/DrawDimHelper.cpp
+++ b/src/Mod/TechDraw/App/DrawDimHelper.cpp
@@ -36,6 +36,7 @@
 #include <BndLib_Add2dCurve.hxx>
 #include <Bnd_Box.hxx>
 #include <BRepBndLib.hxx>
+#include <BRep_Tool.hxx>
 #include <Extrema_ExtCC2d.hxx>
 #include <Geom2dAdaptor_Curve.hxx>
 #include <Geom2d_Curve.hxx>

--- a/src/Mod/TechDraw/App/DrawUtil.cpp
+++ b/src/Mod/TechDraw/App/DrawUtil.cpp
@@ -76,6 +76,7 @@
 #include "Preferences.h"
 #include "GeometryObject.h"
 #include "DrawUtil.h"
+#include "LineGroup.h"
 
 using namespace TechDraw;
 

--- a/src/Mod/TechDraw/App/DrawUtil.h
+++ b/src/Mod/TechDraw/App/DrawUtil.h
@@ -47,10 +47,6 @@
 #include <Base/Vector3D.h>
 #include <Base/Matrix.h>
 
-#include <Mod/Part/App/PartFeature.h>
-
-#include "LineGroup.h"
-
 
 #ifndef M_2PI
     #define M_2PI ((M_PI)*2.0)

--- a/src/Mod/TechDraw/App/ShapeExtractor.cpp
+++ b/src/Mod/TechDraw/App/ShapeExtractor.cpp
@@ -25,7 +25,7 @@
 #ifndef _PreComp_
 # include <sstream>
 #endif
-
+#include <BRep_Builder.hxx>
 #include <BRepAlgoAPI_Fuse.hxx>
 #include <BRepTools.hxx>
 #include <BRepBuilderAPI_Copy.hxx>

--- a/src/Mod/TechDraw/Gui/Command.cpp
+++ b/src/Mod/TechDraw/Gui/Command.cpp
@@ -63,7 +63,7 @@
 #include <Gui/Document.h>
 #include <Gui/FileDialog.h>
 #include <Gui/MainWindow.h>
-#include <Gui/Selection.h>
+#include <Gui/SelectionObject.h>
 #include <Gui/ViewProvider.h>
 #include <Gui/WaitCursor.h>
 

--- a/src/Mod/TechDraw/Gui/CommandAnnotate.cpp
+++ b/src/Mod/TechDraw/Gui/CommandAnnotate.cpp
@@ -38,7 +38,7 @@
 #include <Gui/Command.h>
 #include <Gui/Control.h>
 #include <Gui/Document.h>
-#include <Gui/Selection.h>
+#include <Gui/SelectionObject.h>
 #include <Gui/MainWindow.h>
 #include <Gui/FileDialog.h>
 #include <Gui/ViewProvider.h>

--- a/src/Mod/TechDraw/Gui/CommandCreateDims.cpp
+++ b/src/Mod/TechDraw/Gui/CommandCreateDims.cpp
@@ -22,49 +22,40 @@
 
 #include "PreCompiled.h"
 #ifndef _PreComp_
+# include <QApplication>
 # include <QMessageBox>
 # include <iostream>
 # include <string>
 # include <sstream>
 # include <cstdlib>
-# include <exception>
 #endif  //#ifndef _PreComp_
 
 #include <QGraphicsView>
 
-# include <App/DocumentObject.h>
-# include <Base/Exception.h>
+#include <App/Document.h>
+#include <App/DocumentObject.h>
 #include <Base/Console.h>
 #include <Base/Type.h>
-# include <Gui/Action.h>
-# include <Gui/Application.h>
-# include <Gui/BitmapFactory.h>
-# include <Gui/Command.h>
-# include <Gui/Control.h>
-# include <Gui/Document.h>
-# include <Gui/Selection.h>
-# include <Gui/MainWindow.h>
-# include <Gui/FileDialog.h>
-# include <Gui/ViewProvider.h>
+#include <Gui/Action.h>
+#include <Gui/Application.h>
+#include <Gui/BitmapFactory.h>
+#include <Gui/Command.h>
+#include <Gui/Control.h>
+#include <Gui/SelectionObject.h>
+#include <Gui/Document.h>
+#include <Gui/MainWindow.h>
 
-# include <Mod/Part/App/PartFeature.h>
-
-# include <Mod/TechDraw/App/DrawViewPart.h>
-# include <Mod/TechDraw/App/DrawProjGroupItem.h>
-# include <Mod/TechDraw/App/DrawProjGroup.h>
-# include <Mod/TechDraw/App/DrawViewDimension.h>
-# include <Mod/TechDraw/App/DrawDimHelper.h>
-# include <Mod/TechDraw/App/LandmarkDimension.h>
-# include <Mod/TechDraw/App/DrawPage.h>
-# include <Mod/TechDraw/App/DrawUtil.h>
-# include <Mod/TechDraw/App/Geometry.h>
-
-#include <Mod/TechDraw/Gui/QGVPage.h>
-
+#include <Mod/Part/App/PartFeature.h>
+#include <Mod/TechDraw/App/DrawPage.h>
+#include <Mod/TechDraw/App/DrawViewPart.h>
+#include <Mod/TechDraw/App/DrawProjGroupItem.h>
+#include <Mod/TechDraw/App/DrawProjGroup.h>
+#include <Mod/TechDraw/App/DrawViewDimension.h>
+#include <Mod/TechDraw/App/DrawDimHelper.h>
+#include <Mod/TechDraw/App/LandmarkDimension.h>
+#include <Mod/TechDraw/App/DrawUtil.h>
 
 #include "DrawGuiUtil.h"
-#include "MDIViewPage.h"
-#include "ViewProviderPage.h"
 #include "TaskLinkDim.h"
 
 using namespace TechDrawGui;

--- a/src/Mod/TechDraw/Gui/CommandDecorate.cpp
+++ b/src/Mod/TechDraw/Gui/CommandDecorate.cpp
@@ -33,6 +33,7 @@
 #include <QGraphicsView>
 
 # include <Base/Tools.h>
+# include <App/Document.h>
 # include <App/DocumentObject.h>
 # include <Gui/Action.h>
 # include <Gui/Application.h>
@@ -40,7 +41,7 @@
 # include <Gui/Command.h>
 # include <Gui/Control.h>
 # include <Gui/Document.h>
-# include <Gui/Selection.h>
+# include <Gui/SelectionObject.h>
 # include <Gui/MainWindow.h>
 # include <Gui/FileDialog.h>
 # include <Gui/ViewProvider.h>

--- a/src/Mod/TechDraw/Gui/MDIViewPage.cpp
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.cpp
@@ -66,7 +66,7 @@
 #include <Gui/Command.h>
 #include <Gui/Window.h>
 #include <Gui/MainWindow.h>
-#include <Gui/Selection.h>
+#include <Gui/SelectionObject.h>
 
 #include <Mod/TechDraw/App/DrawHatch.h>
 #include <Mod/TechDraw/App/DrawPage.h>

--- a/src/Mod/TechDraw/Gui/TaskActiveView.cpp
+++ b/src/Mod/TechDraw/Gui/TaskActiveView.cpp
@@ -35,6 +35,8 @@
 #include <Base/Tools.h>
 #include <Base/UnitsApi.h>
 
+#include <App/Document.h>
+
 #include <Gui/Application.h>
 #include <Gui/BitmapFactory.h>
 #include <Gui/Command.h>

--- a/src/Mod/TechDraw/Gui/TaskCenterLine.cpp
+++ b/src/Mod/TechDraw/Gui/TaskCenterLine.cpp
@@ -56,6 +56,7 @@
 
 #include <Mod/TechDraw/Gui/ui_TaskCenterLine.h>
 
+#include <Mod/TechDraw/App/LineGroup.h>
 #include "DrawGuiStd.h"
 #include "PreferencesGui.h"
 #include "QGVPage.h"

--- a/src/Mod/TechDraw/Gui/TaskDetail.cpp
+++ b/src/Mod/TechDraw/Gui/TaskDetail.cpp
@@ -32,6 +32,8 @@
 #include <Base/Quantity.h>
 #include <Base/UnitsApi.h>
 
+#include <App/Document.h>
+
 #include <Gui/Application.h>
 #include <Gui/BitmapFactory.h>
 #include <Gui/Command.h>

--- a/src/Mod/TechDraw/Gui/TaskLeaderLine.cpp
+++ b/src/Mod/TechDraw/Gui/TaskLeaderLine.cpp
@@ -32,6 +32,7 @@
 #include <Base/Console.h>
 #include <Base/Tools.h>
 
+#include <App/Document.h>
 #include <Gui/Application.h>
 #include <Gui/BitmapFactory.h>
 #include <Gui/Command.h>
@@ -42,6 +43,7 @@
 #include <Gui/ViewProvider.h>
 #include <Gui/WaitCursor.h>
 
+#include <Mod/TechDraw/App/LineGroup.h>
 #include <Mod/TechDraw/App/DrawPage.h>
 #include <Mod/TechDraw/App/DrawUtil.h>
 #include <Mod/TechDraw/App/DrawView.h>

--- a/src/Mod/TechDraw/Gui/TaskRichAnno.cpp
+++ b/src/Mod/TechDraw/Gui/TaskRichAnno.cpp
@@ -33,6 +33,8 @@
 #include <Base/Console.h>
 #include <Base/Tools.h>
 
+#include <App/Document.h>
+
 #include <Gui/Application.h>
 #include <Gui/BitmapFactory.h>
 #include <Gui/Command.h>
@@ -43,6 +45,7 @@
 #include <Gui/ViewProvider.h>
 #include <Gui/WaitCursor.h>
 
+#include <Mod/TechDraw/App/LineGroup.h>
 #include <Mod/TechDraw/App/DrawPage.h>
 #include <Mod/TechDraw/App/DrawUtil.h>
 #include <Mod/TechDraw/App/DrawView.h>

--- a/src/Mod/TechDraw/Gui/TaskWeldingSymbol.cpp
+++ b/src/Mod/TechDraw/Gui/TaskWeldingSymbol.cpp
@@ -37,6 +37,8 @@
 #include <Base/Tools.h>
 #include <Base/UnitsApi.h>
 
+#include <App/Document.h>
+
 #include <Gui/Application.h>
 #include <Gui/BitmapFactory.h>
 #include <Gui/Command.h>

--- a/src/Mod/Web/Gui/BrowserView.cpp
+++ b/src/Mod/Web/Gui/BrowserView.cpp
@@ -79,6 +79,7 @@
 #include <QRegExp>
 #include "BrowserView.h"
 #include "CookieJar.h"
+#include <App/Document.h>
 #include <Gui/Application.h>
 #include <Gui/MainWindow.h>
 #include <Gui/ProgressBar.h>


### PR DESCRIPTION
**Only preprocessor changes in this changeset**
The original goal of this changeset is to eliminate the cycling include between Extension and ExtensionContainer, but I took the time to eliminate the include avalanche mainly in 
Link
ExtensionContainer
App/Document
Gui/Document
ViewProviderLink
ViewProviderPythonFeature
Tree

The result is measureable improvement in build time, at the expense of a few compulsory includes in a few files
The only risk is that App/Application, Base/Interpreter, Base/Reader+Writer  are not cascaded everywhere, so I tried to find all problematic files, but I dont have access to a windows machine to be 100% . I am relying on travis for this


Remove unused includes from
App/Document.h
App/Extesion.h
App/TreeView.h
App/Link.h
App/ViewProviderLink.h
App/FeaturePython.h
App/ExtensionContainer.h
Gui/Document.h
Gui/ViewProviderLink.h
Gui/ViewProviderDocumentObject.h
Base/Handle.h

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
