### PR TITLE
Spreadsheet: Allow alias that has been removed by undo to be reused

### DIFF
--- a/src/Mod/Spreadsheet/App/Cell.cpp
+++ b/src/Mod/Spreadsheet/App/Cell.cpp
@@ -503,15 +503,19 @@ void Cell::setAlias(const std::string &n)
 
         owner->revAliasProp.erase(alias);
 
-        alias = n;
-
         // Update owner
-        if (alias != "") {
+        if (n != "") {
             owner->aliasProp[address] = n;
             owner->revAliasProp[n] = address;
         }
         else
             owner->aliasProp.erase(address);
+        if (alias != "") {
+            auto * docObj = static_cast<App::DocumentObject*>(owner->getContainer());
+            docObj->removeDynamicProperty(alias.c_str());
+        }
+
+        alias = n;
 
         setUsed(ALIAS_SET, !alias.empty());
         setDirty();

--- a/src/Mod/Spreadsheet/TestSpreadsheet.py
+++ b/src/Mod/Spreadsheet/TestSpreadsheet.py
@@ -1102,6 +1102,19 @@ class SpreadsheetCases(unittest.TestCase):
         sheet.removeColumns('B', 1)
         sheet.setAlias('C3','test')
 
+    def testUndoAliasCreationReuseName(self):
+        """ Test deleted aliases by undo remains in database"""
+        sheet = self.doc.addObject('Spreadsheet::Sheet','Spreadsheet')
+
+        self.doc.openTransaction("create alias")
+        sheet.setAlias('B2', 'test')
+        self.doc.commitTransaction()
+        self.doc.recompute()
+
+        self.doc.undo()
+        self.doc.recompute()
+        sheet.setAlias('C3','test')
+
     def tearDown(self):
         #closing doc
         FreeCAD.closeDocument(self.doc.Name)


### PR DESCRIPTION
This solves the issue where an alias cannot be reused if it has been removed by undo.
More information about the issue can be found at: https://forum.freecadweb.org/viewtopic.php?f=3&t=54009

~Unit test has been _**omitted**_ since I either get false negatives or false positives.
Test case with false positives can be found here: https://github.com/hyarion/FreeCAD/commit/30e2cf52670cf5476e834ac3f59ac5ed63d2aa16
Discussion about the failing unit tests can be found here: https://forum.freecadweb.org/viewtopic.php?p=470387#p470387 .~

I've made this a draft again as werner mentioned that this might have been fixed in another PR.

---

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [x] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/freecad/freecad/4305)
<!-- Reviewable:end -->
