### PR TITLE
Part: fix ViewProviderExt::updateVisual() on incomplete mesh

### DIFF
--- a/src/Mod/Part/Gui/ViewProviderExt.cpp
+++ b/src/Mod/Part/Gui/ViewProviderExt.cpp
@@ -1133,7 +1133,10 @@ void ViewProviderPartExt::updateVisual()
             const TopoDS_Face &actFace = TopoDS::Face(faceMap(i));
             // get the mesh of the shape
             Handle (Poly_Triangulation) mesh = BRep_Tool::Triangulation(actFace,aLoc);
-            if (mesh.IsNull()) continue;
+            if (mesh.IsNull()) {
+                parts[ii] = 0;
+                continue;
+            }
 
             // getting the transformation of the shape/face
             gp_Trsf myTransf;


### PR DESCRIPTION
For some invalid shapes, there may be faces with null mesh. In this case, Part::ViewProviderExt may produce an invalid SoBrepFaceSet::partIndex.