### PR TITLE
Add SVG icon for Std Windows command

### DIFF
--- a/src/Gui/CommandWindow.cpp
+++ b/src/Gui/CommandWindow.cpp
@@ -257,7 +257,7 @@ StdCmdWindows::StdCmdWindows()
     sToolTipText  = QT_TR_NOOP("Windows list");
     sWhatsThis    = "Std_Windows";
     sStatusTip    = QT_TR_NOOP("Windows list");
-    //sPixmap     = "";
+    sPixmap       = "Std_Windows";
     eType         = 0;
 }
 

--- a/src/Gui/Icons/Std_Windows.svg
+++ b/src/Gui/Icons/Std_Windows.svg
@@ -1,0 +1,292 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   width="64px"
+   height="64px"
+   id="svg2985"
+   version="1.1">
+  <title
+     id="title889">Std_Windows</title>
+  <defs
+     id="defs2987">
+    <linearGradient
+       id="linearGradient3319">
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1"
+         offset="0"
+         id="stop3315" />
+      <stop
+         style="stop-color:#204a87;stop-opacity:1"
+         offset="1"
+         id="stop3317" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4387">
+      <stop
+         style="stop-color:#71b2f8;stop-opacity:1;"
+         offset="0"
+         id="stop4389" />
+      <stop
+         style="stop-color:#002795;stop-opacity:1;"
+         offset="1"
+         id="stop4391" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6321">
+      <stop
+         style="stop-color:#71b2f8;stop-opacity:1;"
+         offset="0"
+         id="stop6323" />
+      <stop
+         style="stop-color:#002795;stop-opacity:1;"
+         offset="1"
+         id="stop6325" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient3377"
+       id="radialGradient3692"
+       cx="45.883327"
+       cy="28.869568"
+       fx="45.883327"
+       fy="28.869568"
+       r="19.467436"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-0.23443224,0.23443198)" />
+    <linearGradient
+       id="linearGradient3377">
+      <stop
+         id="stop3379"
+         offset="0"
+         style="stop-color:#faff2b;stop-opacity:1;" />
+      <stop
+         id="stop3381"
+         offset="1"
+         style="stop-color:#ffaa00;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3377-3">
+      <stop
+         id="stop3379-8"
+         offset="0"
+         style="stop-color:#faff2b;stop-opacity:1;" />
+      <stop
+         id="stop3381-3"
+         offset="1"
+         style="stop-color:#ffaa00;stop-opacity:1;" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient3377-3"
+       id="radialGradient6412"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.67067175,0,0,0.64145918,-63.380792,0.83845403)"
+       cx="45.883327"
+       cy="28.869568"
+       fx="45.883327"
+       fy="28.869568"
+       r="19.467436" />
+    <linearGradient
+       y2="56.000233"
+       x2="20.93985"
+       y1="50.468616"
+       x1="14.824193"
+       gradientTransform="rotate(33.834399,20.280412,56.143946)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3049"
+       xlink:href="#linearGradient3036" />
+    <linearGradient
+       id="linearGradient3036">
+      <stop
+         id="stop3038"
+         offset="0"
+         style="stop-color:#ef2929;stop-opacity:1" />
+      <stop
+         id="stop3040"
+         offset="1"
+         style="stop-color:#a40000;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3895-6">
+      <stop
+         id="stop3897-7"
+         offset="0"
+         style="stop-color:#729fcf;stop-opacity:1;" />
+      <stop
+         id="stop3899-5"
+         offset="1"
+         style="stop-color:#204a87;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3319"
+       id="linearGradient3307"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="rotate(33.834399,-6.8783909,90.878388)"
+       x1="14.824193"
+       y1="50.468616"
+       x2="20.93985"
+       y2="56.000233" />
+    <linearGradient
+       gradientTransform="matrix(1.6433254,0,0,0.97077226,-45.241374,0.95414569)"
+       xlink:href="#linearGradient3842"
+       id="linearGradient3848"
+       x1="49"
+       y1="16"
+       x2="48"
+       y2="4"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3842">
+      <stop
+         style="stop-color:#204a87;stop-opacity:1"
+         offset="0"
+         id="stop3844" />
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1"
+         offset="1"
+         id="stop3846" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3830"
+       id="linearGradient3836"
+       x1="49"
+       y1="54"
+       x2="43"
+       y2="14"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.8458495,0,0,0.65353286,-54.81737,8.8166943)" />
+    <linearGradient
+       id="linearGradient3830">
+      <stop
+         style="stop-color:#d3d7cf;stop-opacity:1;"
+         offset="0"
+         id="stop3832" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="1"
+         id="stop3834" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="4"
+       x2="48"
+       y1="16"
+       x1="49"
+       id="linearGradient3848-5"
+       xlink:href="#linearGradient3842"
+       gradientTransform="matrix(1.6433254,0,0,0.97077226,-45.25917,44.291622)" />
+  </defs>
+  <metadata
+     id="metadata2990">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Std_Windows</dc:title>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[bitacovir]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:title>Part_Shape_from_Mesh</dc:title>
+        <dc:date>2021/01/04</dc:date>
+        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier />
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title />
+          </cc:Agent>
+        </dc:contributor>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>window</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <dc:description>Window with list of elements</dc:description>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <rect
+     y="5.8080096"
+     x="12.275028"
+     height="52.421707"
+     width="39.439812"
+     id="rect3020"
+     style="fill:none;stroke:#204a87;stroke-width:7.5783;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6;stroke-opacity:1" />
+  <rect
+     y="5.8080096"
+     x="12.275028"
+     height="52.421707"
+     width="39.439812"
+     id="rect3020-6"
+     style="fill:none;stroke:#729fcf;stroke-width:2.5261;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6;stroke-opacity:1" />
+  <rect
+     y="5.8080068"
+     x="12.275028"
+     height="7.7661781"
+     width="39.439812"
+     id="rect3826"
+     style="fill:url(#linearGradient3848);fill-opacity:1;stroke:#729fcf;stroke-width:2.5261;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6;stroke-opacity:1" />
+  <rect
+     y="17.31262"
+     x="17.170778"
+     height="27.448381"
+     width="29.533592"
+     id="rect3828"
+     style="fill:url(#linearGradient3836);fill-opacity:1;stroke:#ffffff;stroke-width:2.30937;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6;stroke-opacity:1" />
+  <path
+     id="path3838"
+     d="M 13.532966,15.515748 H 50.426045"
+     style="fill:none;stroke:#204a87;stroke-width:2.55182;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  <path
+     id="path3840"
+     d="M 13.671701,9.691097 H 26.818305"
+     style="fill:none;stroke:#ffffff;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     id="path1619-0"
+     d="M 20.590449,27.862348 H 43.628164"
+     style="fill:none;stroke:#555753;stroke-width:2.33762;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     style="fill:none;stroke:#555753;stroke-width:2.33762;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 20.565033,33.623598 h 23.12479"
+     id="path1619-0-3" />
+  <rect
+     style="fill:url(#linearGradient3848-5);fill-opacity:1;stroke:#729fcf;stroke-width:2.5261;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6;stroke-opacity:1"
+     id="rect3826-5"
+     width="39.439812"
+     height="7.7661781"
+     x="12.257233"
+     y="49.145481" />
+  <path
+     style="fill:none;stroke:#204a87;stroke-width:2.55182;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="M 13.520488,46.620649 H 50.413567"
+     id="path3838-2" />
+  <path
+     style="fill:none;stroke:#ffffff;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 37.190176,53.059357 H 50.33678"
+     id="path3840-4" />
+  <path
+     style="fill:none;stroke:#ffffff;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 21.521082,52.972283 H 34.667686"
+     id="path3840-5" />
+  <path
+     style="fill:none;stroke:#555753;stroke-width:2.33762;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 20.62131,22.102998 H 43.659025"
+     id="path1619-0-9" />
+</svg>

--- a/src/Gui/Icons/resource.qrc
+++ b/src/Gui/Icons/resource.qrc
@@ -196,6 +196,7 @@
         <file>Std_ViewIvStereoQuadBuff.svg</file>
         <file>Std_ViewIvStereoRedGreen.svg</file>
         <file>Std_ViewTrimetric.svg</file>
+        <file>Std_Windows.svg</file>
         <file>Std_WindowCascade.svg</file>
         <file>Std_WindowNext.svg</file>
         <file>Std_WindowPrev.svg</file>


### PR DESCRIPTION
Std Windows command does not have icon for the FreeCAD UI (Menu windows).

This commit adds a SVG file with icon for this command. Also, it makes the necessary changes on CommandWindow.cpp and resource.qrc files.

The new SVG icon follow the FreeCAD Artwork Guidelines and was saved as Plain SVG format.

Forum Discussion: https://forum.freecadweb.org/viewtopic.php?f=34&t=54028