### PR TITLE
[TD] Fix equilateral angular tolerance missing degree unit char, fix arbitary under/overtolerances

### DIFF
--- a/src/Mod/TechDraw/App/DrawViewDimension.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDimension.cpp
@@ -923,17 +923,21 @@ std::string DrawViewDimension::getFormattedDimensionValue(int partial)
 {
     QString qFormatSpec = QString::fromUtf8(FormatSpec.getStrValue().data());
 
-    if (Arbitrary.getValue()) {
+    if (Arbitrary.getValue() && !EqualTolerance.getValue()) {
         return FormatSpec.getStrValue();
     }
 
     // if there is an equal over-/undertolerance and not theoretically exact, add the tolerance to dimension
-    if (EqualTolerance.getValue() && !DrawUtil::fpCompare(OverTolerance.getValue(), 0.0)
-            && !TheoreticalExact.getValue()) {
+    if (EqualTolerance.getValue() && !TheoreticalExact.getValue() &&
+            (!DrawUtil::fpCompare(OverTolerance.getValue(), 0.0) || ArbitraryTolerances.getValue())) {
         QString labelText = QString::fromUtf8(formatValue(getDimValue(), qFormatSpec, 1).c_str()); //just the number pref/spec/suf
         QString unitText = QString::fromUtf8(formatValue(getDimValue(), qFormatSpec, 2).c_str()); //just the unit
         QString tolerance = QString::fromStdString(getFormattedToleranceValue(1).c_str());
         QString result;
+        if (Arbitrary.getValue()) {
+            labelText = QString::fromStdString(FormatSpec.getStrValue());
+            unitText = QString();
+        }
         // tolerance might start with a plus sign that we don't want, so cut it off
         if (tolerance.at(0) == QChar::fromLatin1('+'))
             tolerance.remove(0, 1);

--- a/src/Mod/TechDraw/App/DrawViewDimension.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDimension.cpp
@@ -216,10 +216,13 @@ void DrawViewDimension::onChanged(const App::Property* prop)
                 UnderTolerance.setReadOnly(true);
                 FormatSpecOverTolerance.setReadOnly(true);
                 FormatSpecUnderTolerance.setReadOnly(true);
+                ArbitraryTolerances.setValue(false);
+                ArbitraryTolerances.setReadOnly(true);
             }
             else {
                 OverTolerance.setReadOnly(false);
                 FormatSpecOverTolerance.setReadOnly(false);
+                ArbitraryTolerances.setReadOnly(false);
                 if (!EqualTolerance.getValue()) {
                     UnderTolerance.setReadOnly(false);
                     FormatSpecUnderTolerance.setReadOnly(false);
@@ -923,7 +926,8 @@ std::string DrawViewDimension::getFormattedDimensionValue(int partial)
 {
     QString qFormatSpec = QString::fromUtf8(FormatSpec.getStrValue().data());
 
-    if (Arbitrary.getValue() && !EqualTolerance.getValue()) {
+    if ( (Arbitrary.getValue() && !EqualTolerance.getValue())
+        || (Arbitrary.getValue() && TheoreticalExact.getValue()) ) {
         return FormatSpec.getStrValue();
     }
 

--- a/src/Mod/TechDraw/App/DrawViewDimension.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDimension.cpp
@@ -111,7 +111,8 @@ DrawViewDimension::DrawViewDimension(void)
     References3D.setScope(App::LinkScope::Global);
 
     ADD_PROPERTY_TYPE(FormatSpec, (getDefaultFormatSpec()), "Format", App::Prop_Output,"Dimension Format");
-    ADD_PROPERTY_TYPE(FormatSpecTolerance, (getDefaultFormatSpec(true)), "Format", App::Prop_Output, "Dimension tolerance format");
+    ADD_PROPERTY_TYPE(FormatSpecUnderTolerance, (getDefaultFormatSpec(true)), "Format", App::Prop_Output, "Dimension tolerance format");
+    ADD_PROPERTY_TYPE(FormatSpecOverTolerance, (getDefaultFormatSpec(true)), "Format", App::Prop_Output, "Dimension tolerance format");
     ADD_PROPERTY_TYPE(Arbitrary,(false), "Format", App::Prop_Output, "Value overridden by user");
     ADD_PROPERTY_TYPE(ArbitraryTolerances, (false), "Format", App::Prop_Output, "Tolerance values overridden by user");
 
@@ -846,11 +847,12 @@ std::string DrawViewDimension::formatValue(qreal value, QString qFormatSpec, int
     }
 
     return result;
+
 }
 
 std::string DrawViewDimension::getFormattedToleranceValue(int partial)
 {
-    QString FormatSpec = QString::fromUtf8(FormatSpecTolerance.getStrValue().data());
+    QString FormatSpec = QString::fromUtf8(FormatSpecOverTolerance.getStrValue().data());
     QString ToleranceString;
 
     if (ArbitraryTolerances.getValue())
@@ -863,25 +865,26 @@ std::string DrawViewDimension::getFormattedToleranceValue(int partial)
 
 std::pair<std::string, std::string> DrawViewDimension::getFormattedToleranceValues(int partial)
 {
-    QString FormatSpec = QString::fromUtf8(FormatSpecTolerance.getStrValue().data());
+    QString underFormatSpec = QString::fromUtf8(FormatSpecUnderTolerance.getStrValue().data());
+    QString overFormatSpec = QString::fromUtf8(FormatSpecOverTolerance.getStrValue().data());
     std::pair<std::string, std::string> tolerances;
     QString underTolerance, overTolerance;
 
     if (ArbitraryTolerances.getValue()) {
-        underTolerance = FormatSpec;
-        overTolerance = FormatSpec;
+        underTolerance = underFormatSpec;
+        overTolerance = overFormatSpec;
     } else {
         if (DrawUtil::fpCompare(UnderTolerance.getValue(), 0.0)) {
             underTolerance = QString::fromUtf8(formatValue(UnderTolerance.getValue(), QString::fromUtf8("%.0f"), partial).c_str());
         }
         else {
-            underTolerance = QString::fromUtf8(formatValue(UnderTolerance.getValue(), FormatSpec, partial).c_str());
+            underTolerance = QString::fromUtf8(formatValue(UnderTolerance.getValue(), underFormatSpec, partial).c_str());
         }
         if (DrawUtil::fpCompare(OverTolerance.getValue(), 0.0)) {
             overTolerance = QString::fromUtf8(formatValue(OverTolerance.getValue(), QString::fromUtf8("%.0f"), partial).c_str());
         }
         else {
-            overTolerance = QString::fromUtf8(formatValue(OverTolerance.getValue(), FormatSpec, partial).c_str());
+            overTolerance = QString::fromUtf8(formatValue(OverTolerance.getValue(), overFormatSpec, partial).c_str());
         }
     }
 

--- a/src/Mod/TechDraw/App/DrawViewDimension.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDimension.cpp
@@ -902,6 +902,29 @@ std::string DrawViewDimension::getFormattedDimensionValue(int partial)
         return FormatSpec.getStrValue();
     }
 
+    // if there is an equal over-/undertolerance and not theoretically exact, add the tolerance to dimension
+    if (EqualTolerance.getValue() && !DrawUtil::fpCompare(OverTolerance.getValue(), 0.0)
+            && !TheoreticalExact.getValue()) {
+        QString labelText = QString::fromUtf8(formatValue(getDimValue(), qFormatSpec, 1).c_str()); //just the number pref/spec/suf
+        QString unitText = QString::fromUtf8(formatValue(getDimValue(), qFormatSpec, 2).c_str()); //just the unit
+        QString tolerance = QString::fromStdString(getFormattedToleranceValue(1).c_str());
+        QString result;
+        // tolerance might start with a plus sign that we don't want, so cut it off
+        if (tolerance.at(0) == QChar::fromLatin1('+'))
+            tolerance.remove(0, 1);
+        if ((Type.isValue("Angle")) || (Type.isValue("Angle3Pt"))) {
+            result = labelText + unitText + QString::fromUtf8(" \xC2\xB1 ") + tolerance;
+        } else {
+            // add the tolerance to the dimension using the ± sign
+            result = labelText + QString::fromUtf8(" \xC2\xB1 ") + tolerance;
+        }
+        if (partial == 2) {
+            result = unitText;
+        }
+
+        return result.toStdString();
+    }
+
     return formatValue(getDimValue(), qFormatSpec, partial);
 }
 

--- a/src/Mod/TechDraw/App/DrawViewDimension.h
+++ b/src/Mod/TechDraw/App/DrawViewDimension.h
@@ -102,8 +102,8 @@ public:
     App::PropertyBool               TheoreticalExact;
     App::PropertyBool               Inverted;
     App::PropertyString             FormatSpec;
-    App::PropertyString             FormatSpecUnderTolerance;
     App::PropertyString             FormatSpecOverTolerance;
+    App::PropertyString             FormatSpecUnderTolerance;
     App::PropertyBool               Arbitrary;
     App::PropertyBool               ArbitraryTolerances;
     App::PropertyBool               EqualTolerance;

--- a/src/Mod/TechDraw/App/DrawViewDimension.h
+++ b/src/Mod/TechDraw/App/DrawViewDimension.h
@@ -102,7 +102,8 @@ public:
     App::PropertyBool               TheoreticalExact;
     App::PropertyBool               Inverted;
     App::PropertyString             FormatSpec;
-    App::PropertyString             FormatSpecTolerance;
+    App::PropertyString             FormatSpecUnderTolerance;
+    App::PropertyString             FormatSpecOverTolerance;
     App::PropertyBool               Arbitrary;
     App::PropertyBool               ArbitraryTolerances;
     App::PropertyBool               EqualTolerance;

--- a/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
@@ -628,7 +628,8 @@ void QGIViewDimension::updateDim()
  
     QString labelText;
     QString unitText;
-    if (dim->Arbitrary.getValue() && !dim->EqualTolerance.getValue()) {
+    if ( (dim->Arbitrary.getValue() && !dim->EqualTolerance.getValue())
+        || (dim->Arbitrary.getValue() && dim->TheoreticalExact.getValue()) ) {
         labelText = QString::fromUtf8(dim->getFormattedDimensionValue(1).c_str()); //just the number pref/spec/suf
     } else {
         if (dim->isMultiValueSchema()) {

--- a/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
@@ -646,17 +646,6 @@ void QGIViewDimension::updateDim()
             labelText = QString::fromUtf8(dim->getFormattedDimensionValue(1).c_str()); //just the number pref/spec/suf
             unitText  = QString::fromUtf8(dim->getFormattedDimensionValue(2).c_str()); //just the unit
         }
-        // if there is an equal over-/undertolerance and not theoretically exact, add the tolerance to dimension
-        if (dim->EqualTolerance.getValue() && !DrawUtil::fpCompare(dim->OverTolerance.getValue(), 0.0)
-            && !dim->TheoreticalExact.getValue()) {
-            std::pair<std::string, std::string> ToleranceText, ToleranceUnit;
-            QString tolerance = QString::fromStdString(dim->getFormattedToleranceValue(1).c_str());
-            // tolerance might start with a plus sign that we don't want, so cut it off
-            if (tolerance.at(0) == QChar::fromLatin1('+'))
-                tolerance.remove(0, 1);
-            // add the tolerance to the dimension using the ± sign
-            labelText = labelText + QString::fromUtf8(" \xC2\xB1 ") + tolerance;
-        }
     }
     QFont font = datumLabel->getFont();
     font.setFamily(QString::fromUtf8(vp->Font.getValue()));

--- a/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
@@ -337,14 +337,10 @@ void QGIDatumLabel::setToleranceString()
     if( dim == nullptr ) {
         return;
         // don't show if both are zero or if EqualTolerance is true
-    } else if (!dim->hasOverUnderTolerance() || dim->EqualTolerance.getValue()) {
+    } else if (!dim->hasOverUnderTolerance() || dim->EqualTolerance.getValue() || dim->TheoreticalExact.getValue()) {
         m_tolTextOver->hide();
         m_tolTextUnder->hide();
-        return;
-    } else if (dim->TheoreticalExact.getValue()) {
-        m_tolTextOver->hide();
-        m_tolTextUnder->hide();
-        // we must explicitly empy the text other wise the frame drawn for
+        // we must explicitly empty the text otherwise the frame drawn for
         // TheoreticalExact would be as wide as necessary for the text
         m_tolTextOver->setPlainText(QString());
         m_tolTextUnder->setPlainText(QString());
@@ -352,11 +348,6 @@ void QGIDatumLabel::setToleranceString()
     }
     m_tolTextOver->show();
     m_tolTextUnder->show();
-
-    QString tolSuffix;
-    if ((dim->Type.isValue("Angle")) || (dim->Type.isValue("Angle3Pt"))) {
-        tolSuffix = QString::fromUtf8(dim->getFormattedDimensionValue(2).c_str()); //just the unit
-    }
 
     std::pair<std::string, std::string> labelTexts, unitTexts;
 
@@ -637,14 +628,22 @@ void QGIViewDimension::updateDim()
  
     QString labelText;
     QString unitText;
-    if (dim->Arbitrary.getValue()) {
+    if (dim->Arbitrary.getValue() && !dim->EqualTolerance.getValue()) {
         labelText = QString::fromUtf8(dim->getFormattedDimensionValue(1).c_str()); //just the number pref/spec/suf
     } else {
         if (dim->isMultiValueSchema()) {
             labelText = QString::fromUtf8(dim->getFormattedDimensionValue(0).c_str()); //don't format multis
         } else {
             labelText = QString::fromUtf8(dim->getFormattedDimensionValue(1).c_str()); //just the number pref/spec/suf
-            unitText  = QString::fromUtf8(dim->getFormattedDimensionValue(2).c_str()); //just the unit
+            if (dim->EqualTolerance.getValue()) {
+                if (dim->ArbitraryTolerances.getValue()) {
+                    unitText = QString();
+                } else {
+                    unitText = QString::fromUtf8(dim->getFormattedToleranceValue(2).c_str()); //just the unit
+                }
+            } else {
+                unitText = QString::fromUtf8(dim->getFormattedDimensionValue(2).c_str()); //just the unit
+            }
         }
     }
     QFont font = datumLabel->getFont();

--- a/src/Mod/TechDraw/Gui/TaskDimension.cpp
+++ b/src/Mod/TechDraw/Gui/TaskDimension.cpp
@@ -98,7 +98,7 @@ TaskDimension::TaskDimension(QGIViewDimension *parent, ViewProviderDimension *di
     connect(ui->leFormatSpecifier, SIGNAL(textChanged(QString)), this, SLOT(onFormatSpecifierChanged()));
     ui->cbArbitrary->setChecked(parent->dvDimension->Arbitrary.getValue());
     connect(ui->cbArbitrary, SIGNAL(stateChanged(int)), this, SLOT(onArbitraryChanged()));
-    StringValue = parent->dvDimension->FormatSpecTolerance.getValue();
+    StringValue = parent->dvDimension->FormatSpecOverTolerance.getValue();
     qs = QString::fromUtf8(StringValue.data(), StringValue.size());
     ui->leToleranceFormatSpecifier->setText(qs);
     connect(ui->leToleranceFormatSpecifier, SIGNAL(textChanged(QString)), this, SLOT(onToleranceFormatSpecifierChanged()));
@@ -133,7 +133,7 @@ bool TaskDimension::accept()
 
     m_parent->dvDimension->FormatSpec.setValue(ui->leFormatSpecifier->text().toUtf8().constData());
     m_parent->dvDimension->Arbitrary.setValue(ui->cbArbitrary->isChecked());
-    m_parent->dvDimension->FormatSpecTolerance.setValue(ui->leToleranceFormatSpecifier->text().toUtf8().constData());
+    m_parent->dvDimension->FormatSpecOverTolerance.setValue(ui->leToleranceFormatSpecifier->text().toUtf8().constData());
     m_parent->dvDimension->ArbitraryTolerances.setValue(ui->cbArbitraryTolerances->isChecked());
 
     m_dimensionVP->FlipArrowheads.setValue(ui->cbArrowheads->isChecked());
@@ -234,7 +234,7 @@ void TaskDimension::onArbitraryChanged()
 
 void TaskDimension::onToleranceFormatSpecifierChanged()
 {
-    m_parent->dvDimension->FormatSpecTolerance.setValue(ui->leToleranceFormatSpecifier->text().toUtf8().constData());
+    m_parent->dvDimension->FormatSpecOverTolerance.setValue(ui->leToleranceFormatSpecifier->text().toUtf8().constData());
     recomputeFeature();
 }
 

--- a/src/Mod/TechDraw/Gui/TaskDimension.cpp
+++ b/src/Mod/TechDraw/Gui/TaskDimension.cpp
@@ -180,11 +180,14 @@ void TaskDimension::onTheoreticallyExactChanged()
         ui->qsbUndertolerance->setDisabled(true);
         ui->leFormatSpecifierOverTolerance->setDisabled(true);
         ui->leFormatSpecifierUnderTolerance->setDisabled(true);
+        ui->cbArbitraryTolerances->setDisabled(true);
+        ui->cbArbitraryTolerances->setChecked(false);
     }
     else {
         ui->cbEqualTolerance->setDisabled(false);
         ui->qsbOvertolerance->setDisabled(false);
         ui->leFormatSpecifierOverTolerance->setDisabled(false);
+        ui->cbArbitraryTolerances->setDisabled(false);
         if (!ui->cbEqualTolerance->isChecked()) {
             ui->qsbUndertolerance->setDisabled(false);
             ui->leFormatSpecifierUnderTolerance->setDisabled(false);

--- a/src/Mod/TechDraw/Gui/TaskDimension.cpp
+++ b/src/Mod/TechDraw/Gui/TaskDimension.cpp
@@ -54,7 +54,6 @@ using namespace TechDrawGui;
 TaskDimension::TaskDimension(QGIViewDimension *parent, ViewProviderDimension *dimensionVP) :
     ui(new Ui_TaskDimension)
 {
-    int i = 0;
     m_parent = parent;
     m_dimensionVP = dimensionVP;
 
@@ -68,6 +67,8 @@ TaskDimension::TaskDimension(QGIViewDimension *parent, ViewProviderDimension *di
         ui->cbEqualTolerance->setDisabled(true);
         ui->qsbOvertolerance->setDisabled(true);
         ui->qsbUndertolerance->setDisabled(true);
+        ui->leFormatSpecifierOverTolerance->setDisabled(true);
+        ui->leFormatSpecifierUnderTolerance->setDisabled(true);
     }
     ui->cbEqualTolerance->setChecked(parent->dvDimension->EqualTolerance.getValue());
     connect(ui->cbEqualTolerance, SIGNAL(stateChanged(int)), this, SLOT(onEqualToleranceChanged()));
@@ -88,8 +89,10 @@ TaskDimension::TaskDimension(QGIViewDimension *parent, ViewProviderDimension *di
     connect(ui->qsbOvertolerance, SIGNAL(valueChanged(double)), this, SLOT(onOvertoleranceChanged()));
     connect(ui->qsbUndertolerance, SIGNAL(valueChanged(double)), this, SLOT(onUndertoleranceChanged()));
     // undertolerance is disabled when EqualTolerance is true
-    if (ui->cbEqualTolerance->isChecked())
+    if (ui->cbEqualTolerance->isChecked()) {
         ui->qsbUndertolerance->setDisabled(true);
+        ui->leFormatSpecifierUnderTolerance->setDisabled(true);
+    }
 
     // Formatting
     std::string StringValue = parent->dvDimension->FormatSpec.getValue();
@@ -100,8 +103,12 @@ TaskDimension::TaskDimension(QGIViewDimension *parent, ViewProviderDimension *di
     connect(ui->cbArbitrary, SIGNAL(stateChanged(int)), this, SLOT(onArbitraryChanged()));
     StringValue = parent->dvDimension->FormatSpecOverTolerance.getValue();
     qs = QString::fromUtf8(StringValue.data(), StringValue.size());
-    ui->leToleranceFormatSpecifier->setText(qs);
-    connect(ui->leToleranceFormatSpecifier, SIGNAL(textChanged(QString)), this, SLOT(onToleranceFormatSpecifierChanged()));
+    ui->leFormatSpecifierOverTolerance->setText(qs);
+    StringValue = parent->dvDimension->FormatSpecUnderTolerance.getValue();
+    qs = QString::fromUtf8(StringValue.data(), StringValue.size());
+    ui->leFormatSpecifierUnderTolerance->setText(qs);
+    connect(ui->leFormatSpecifierOverTolerance, SIGNAL(textChanged(QString)), this, SLOT(onFormatSpecifierOverToleranceChanged()));
+    connect(ui->leFormatSpecifierUnderTolerance, SIGNAL(textChanged(QString)), this, SLOT(onFormatSpecifierUnderToleranceChanged()));
     ui->cbArbitraryTolerances->setChecked(parent->dvDimension->ArbitraryTolerances.getValue());
     connect(ui->cbArbitraryTolerances, SIGNAL(stateChanged(int)), this, SLOT(onArbitraryTolerancesChanged()));
 
@@ -133,7 +140,8 @@ bool TaskDimension::accept()
 
     m_parent->dvDimension->FormatSpec.setValue(ui->leFormatSpecifier->text().toUtf8().constData());
     m_parent->dvDimension->Arbitrary.setValue(ui->cbArbitrary->isChecked());
-    m_parent->dvDimension->FormatSpecOverTolerance.setValue(ui->leToleranceFormatSpecifier->text().toUtf8().constData());
+    m_parent->dvDimension->FormatSpecOverTolerance.setValue(ui->leFormatSpecifierOverTolerance->text().toUtf8().constData());
+    m_parent->dvDimension->FormatSpecUnderTolerance.setValue(ui->leFormatSpecifierUnderTolerance->text().toUtf8().constData());
     m_parent->dvDimension->ArbitraryTolerances.setValue(ui->cbArbitraryTolerances->isChecked());
 
     m_dimensionVP->FlipArrowheads.setValue(ui->cbArrowheads->isChecked());
@@ -170,12 +178,17 @@ void TaskDimension::onTheoreticallyExactChanged()
         ui->cbEqualTolerance->setDisabled(true);
         ui->qsbOvertolerance->setDisabled(true);
         ui->qsbUndertolerance->setDisabled(true);
+        ui->leFormatSpecifierOverTolerance->setDisabled(true);
+        ui->leFormatSpecifierUnderTolerance->setDisabled(true);
     }
     else {
         ui->cbEqualTolerance->setDisabled(false);
         ui->qsbOvertolerance->setDisabled(false);
-        if (!ui->cbEqualTolerance->isChecked())
+        ui->leFormatSpecifierOverTolerance->setDisabled(false);
+        if (!ui->cbEqualTolerance->isChecked()) {
             ui->qsbUndertolerance->setDisabled(false);
+            ui->leFormatSpecifierUnderTolerance->setDisabled(false);
+        }
     }
     recomputeFeature();
 }
@@ -193,13 +206,15 @@ void TaskDimension::onEqualToleranceChanged()
         ui->qsbUndertolerance->setValue(-1.0 * ui->qsbOvertolerance->value().getValue());
         ui->qsbUndertolerance->setUnit(ui->qsbOvertolerance->value().getUnit());
         ui->qsbUndertolerance->setDisabled(true);
+        ui->leFormatSpecifierUnderTolerance->setDisabled(true);
     }
     else {
         ui->qsbOvertolerance->setMinimum(-DBL_MAX);
-        if (!ui->cbTheoreticallyExact->isChecked())
+        if (!ui->cbTheoreticallyExact->isChecked()) {
             ui->qsbUndertolerance->setDisabled(false);
+            ui->leFormatSpecifierUnderTolerance->setDisabled(false);
+        }
     }
-    ui->qsbUndertolerance->setDisabled(ui->cbEqualTolerance->isChecked());
     recomputeFeature();
 }
 
@@ -232,9 +247,23 @@ void TaskDimension::onArbitraryChanged()
     recomputeFeature();
 }
 
-void TaskDimension::onToleranceFormatSpecifierChanged()
+void TaskDimension::onFormatSpecifierOverToleranceChanged()
 {
-    m_parent->dvDimension->FormatSpecOverTolerance.setValue(ui->leToleranceFormatSpecifier->text().toUtf8().constData());
+    m_parent->dvDimension->FormatSpecOverTolerance.setValue(ui->leFormatSpecifierOverTolerance->text().toUtf8().constData());
+    if (!ui->cbArbitraryTolerances->isChecked()) {
+        ui->leFormatSpecifierUnderTolerance->setText(ui->leFormatSpecifierOverTolerance->text());
+        m_parent->dvDimension->FormatSpecUnderTolerance.setValue(ui->leFormatSpecifierUnderTolerance->text().toUtf8().constData());
+    }
+    recomputeFeature();
+}
+
+void TaskDimension::onFormatSpecifierUnderToleranceChanged()
+{
+    m_parent->dvDimension->FormatSpecUnderTolerance.setValue(ui->leFormatSpecifierUnderTolerance->text().toUtf8().constData());
+    if (!ui->cbArbitraryTolerances->isChecked()) {
+        ui->leFormatSpecifierOverTolerance->setText(ui->leFormatSpecifierUnderTolerance->text());
+        m_parent->dvDimension->FormatSpecOverTolerance.setValue(ui->leFormatSpecifierOverTolerance->text().toUtf8().constData());
+    }
     recomputeFeature();
 }
 

--- a/src/Mod/TechDraw/Gui/TaskDimension.h
+++ b/src/Mod/TechDraw/Gui/TaskDimension.h
@@ -56,7 +56,8 @@ private Q_SLOTS:
     void onUndertoleranceChanged();
     void onFormatSpecifierChanged();
     void onArbitraryChanged();
-    void onToleranceFormatSpecifierChanged();
+    void onFormatSpecifierOverToleranceChanged();
+    void onFormatSpecifierUnderToleranceChanged();
     void onArbitraryTolerancesChanged();
     void onFlipArrowheadsChanged();
     void onColorChanged();

--- a/src/Mod/TechDraw/Gui/TaskDimension.ui
+++ b/src/Mod/TechDraw/Gui/TaskDimension.ui
@@ -145,18 +145,32 @@ be used instead if the dimension value</string>
         <item row="2" column="0">
          <widget class="QLabel" name="label">
           <property name="text">
-           <string>Tolerance Format Specifier:</string>
+           <string>OverTolerance Format Specifier:</string>
           </property>
          </widget>
         </item>
         <item row="2" column="1">
-         <widget class="QLineEdit" name="leToleranceFormatSpecifier">
+         <widget class="QLineEdit" name="leFormatSpecifierOverTolerance">
           <property name="toolTip">
-           <string>Text to be displayed</string>
+           <string>Specifies the overtolerance format in printf() style, or arbitrary text</string>
           </property>
          </widget>
         </item>
         <item row="3" column="0">
+         <widget class="QLabel" name="label_12">
+          <property name="text">
+           <string>UnderTolerance Format Specifier:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="1">
+         <widget class="QLineEdit" name="leFormatSpecifierUnderTolerance">
+          <property name="toolTip">
+            <string>Specifies the undertolerance format in printf() style, or arbitrary text</string>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="0">
          <widget class="QCheckBox" name="cbArbitraryTolerances">
           <property name="toolTip">
            <string>If checked the content of 'Format Spec' will


### PR DESCRIPTION
This PR fixes two bugs:  The new equilateral tolerances are missing a degree sign for angles. Also, arbitrary under/overtolerances have somehow lost the possibility to be set separately.  E.g. "std project tolerance" for under, and "as tight as possible" for upper.  The bugs were reported [here](https://forum.freecadweb.org/viewtopic.php?f=35&t=54740)



Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
