### PR TITLE
[WIP] [Spreadsheet] allow valid expressions as alias

### DIFF
--- a/src/Mod/Spreadsheet/App/Cell.cpp
+++ b/src/Mod/Spreadsheet/App/Cell.cpp
@@ -186,7 +186,7 @@ void Cell::setExpression(App::ExpressionPtr &&expr)
     owner->removeDependencies(address);
 
     if(expr && expr->comment.size()) {
-        if(!boost::starts_with(expr->comment,"<Cell "))
+        if (!boost::starts_with(expr->comment, "<Cell "))
             FC_WARN("Unknown style of cell "
                 << owner->sheet()->getFullName() << '.' << address.toString());
         else {
@@ -194,8 +194,8 @@ void Cell::setExpression(App::ExpressionPtr &&expr)
                 std::istringstream in(expr->comment);
                 ReaderPrivate reader("<memory>", in);
                 reader.read();
-                restore(reader,true);
-            }catch(Base::Exception &e) {
+                restore(reader, true);
+            } catch (Base::Exception &e) {
                 e.ReportException();
                 FC_ERR("Failed to restore style of cell "
                     << owner->sheet()->getFullName() << '.' 
@@ -221,8 +221,8 @@ void Cell::setExpression(App::ExpressionPtr &&expr)
 
 const App::Expression *Cell::getExpression(bool withFormat) const
 {
-    if(withFormat && expression) {
-        if((used & (ALIGNMENT_SET
+    if (withFormat && expression) {
+        if ((used & (ALIGNMENT_SET
                                 | STYLE_SET
                                 | FOREGROUND_COLOR_SET
                                 | BACKGROUND_COLOR_SET
@@ -231,7 +231,7 @@ const App::Expression *Cell::getExpression(bool withFormat) const
                                 | SPANS_SET)))
         {
             std::ostringstream ss;
-            save(ss,"",true);
+            save(ss, "", true);
             expression->comment = ss.str();
         }
     }
@@ -283,14 +283,14 @@ void Cell::setContent(const char * value)
 
     clearException();
     if (value != 0) {
-        if(owner->sheet()->isRestoring()) {
-            expression.reset(new App::StringExpression(owner->sheet(),value));
+        if (owner->sheet()->isRestoring()) {
+            expression.reset(new App::StringExpression(owner->sheet(), value));
             setUsed(EXPRESSION_SET, true);
             return;
         }
-        if (*value == '=') {
+        if (*value == '=') { // if content starts with '='
             try {
-                expr = App::ExpressionParser::parse(owner->sheet(), value + 1);
+                expr = App::ExpressionParser::parse(owner->sheet(), value + 1); // check content except of the '='
             }
             catch (Base::Exception & e) {
                 expr = new App::StringExpression(owner->sheet(), value);

--- a/src/Mod/Spreadsheet/App/Sheet.cpp
+++ b/src/Mod/Spreadsheet/App/Sheet.cpp
@@ -689,10 +689,10 @@ void Sheet::updateProperty(CellAddress key)
         /* Eval returns either NumberExpression or StringExpression, or
          * PyObjectExpression objects */
         auto number = freecad_dynamic_cast<NumberExpression>(output.get());
-        if(number) {
+        if (number) {
             long l;
             auto constant = freecad_dynamic_cast<ConstantExpression>(output.get());
-            if(constant && !constant->isNumber()) {
+            if (constant && !constant->isNumber()) {
                 Base::PyGILStateLocker lock;
                 setObjectProperty(key, constant->getPyValue());
             } else if (!number->getUnit().isEmpty())
@@ -701,14 +701,14 @@ void Sheet::updateProperty(CellAddress key)
                 setIntegerProperty(key,l);
             else
                 setFloatProperty(key, number->getValue());
-        }else{
+        } else {
             auto str_expr = freecad_dynamic_cast<StringExpression>(output.get());
-            if(str_expr) 
+            if (str_expr) 
                 setStringProperty(key, str_expr->getText().c_str());
             else {
                 Base::PyGILStateLocker lock;
                 auto py_expr = freecad_dynamic_cast<PyObjectExpression>(output.get());
-                if(py_expr) 
+                if (py_expr) 
                     setObjectProperty(key, py_expr->getPyValue());
                 else
                     setObjectProperty(key, Py::Object());
@@ -852,24 +852,24 @@ DocumentObjectExecReturn *Sheet::execute(void)
         boost::topological_sort(graph, std::front_inserter(make_order));
         // Recompute cells
         FC_LOG("recomputing " << getFullName());
-        for(auto &pos : make_order) {
+        for (auto &pos : make_order) {
             const auto &addr = VertexIndexList[pos];
             FC_LOG(addr.toString());
             recomputeCell(addr);
         }
     } catch (std::exception &) {
-        for(auto &v : VertexList) {
+        for (auto &v : VertexList) {
             Cell * cell = cells.getValue(v.first);
             // Mark as erroneous
             if(cell)  {
                 cellErrors.insert(v.first);
-                cell->setException("Pending computation due to cyclic dependency",true);
+                cell->setException("Pending computation due to cyclic dependency", true);
                 cellUpdated(v.first);
             }
         }
 
         // Try to be more user friendly by finding individual loops
-        while(dirtyCells.size()) {
+        while (dirtyCells.size()) {
 
             std::deque<CellAddress> workQueue;
             DependencyList graph;
@@ -921,10 +921,10 @@ DocumentObjectExecReturn *Sheet::execute(void)
                     ss << v.first.toString();
                 }
                 std::string msg = ss.str();
-                for(auto &v : VertexList) {
+                for (auto &v : VertexList) {
                     Cell * cell = cells.getValue(v.first);
                     if (cell) {
-                        cell->setException(msg.c_str(),true);
+                        cell->setException(msg.c_str(), true);
                         cellUpdated(v.first);
                     }
                 }


### PR DESCRIPTION
currently it is not possible to set e.g. an alias named "Höhe" despite this is a valid expression and you can for example use non-ASCII characters already use in sketch constraint names.

To overcome this issue, this PR checks the alias if it is a valid expression and not if the alias contains only ASCII characters.
See this thread why this PR is marked as work in progress: https://forum.freecadweb.org/viewtopic.php?f=10&t=54754

(- it also adds 2 comments and some whitespace automagically added by MSVC)