### PR TITLE
[Draft] Fix snap to center of faces of solids

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_snapper.py
+++ b/src/Mod/Draft/draftguitools/gui_snapper.py
@@ -410,14 +410,8 @@ class Snapper:
                 if (not self.maxEdges) or (len(shape.Edges) <= self.maxEdges):
                     if "Edge" in comp:
                         # we are snapping to an edge
-                        edge = None
                         if shape.ShapeType == "Edge":
                             edge = shape
-                        else:
-                            en = int(comp[4:])-1
-                            if len(shape.Edges) > en:
-                                edge = shape.Edges[en]
-                        if edge:
                             snaps.extend(self.snapToEndpoints(edge))
                             snaps.extend(self.snapToMidpoint(edge))
                             snaps.extend(self.snapToPerpendicular(edge, lastpoint))
@@ -433,9 +427,9 @@ class Snapper:
                                 # extra ellipse options
                                 snaps.extend(self.snapToCenter(edge))
                     elif "Face" in comp:
-                        en = int(comp[4:])-1
-                        if len(shape.Faces) > en:
-                            face = shape.Faces[en]
+                        # we are snapping to a face
+                        if shape.ShapeType == "Face":
+                            face = shape
                             snaps.extend(self.snapToFace(face))
                     elif "Vertex" in comp:
                         # directly snapped to a vertex


### PR DESCRIPTION
The code would only find a center snap on the face with index=0 of solids.

In V0.19 Part.getShape was introduced (line 399). But not all consequences were not fully implemented.

In the '# we are snapping to an edge' section (line 411) the code could be cleaned up. There is no need to check if the index of the edge is correct for the parent object since we are no longer dealing with a parent object. That portion was effectively dead code.

The '# we are snapping to a face' section (line 429 in the revised code) has been modified accordingly, which fixes the bug.

Forum discussion:
https://forum.freecadweb.org/viewtopic.php?f=23&t=54747