### PR TITLE
[Gui] Make inventor markers symmetric

### DIFF
--- a/src/Gui/Inventor/MarkerBitmaps.cpp
+++ b/src/Gui/Inventor/MarkerBitmaps.cpp
@@ -345,12 +345,12 @@ const char circleLine11_marker[CIRCLE_LINE11_WIDTH * CIRCLE_LINE11_HEIGHT + 1] =
 "           "
 "   xxxxxx  "
 "  xxxxxxxx "
-"  xx    xx "
+" xxx    xxx"
 " xx      xx"
 " xx      xx"
 " xx      xx"
 " xx      xx"
-"  xx    xx "
+" xxx    xxx"
 "  xxxxxxxx "
 "   xxxxxx  "};
 
@@ -381,8 +381,8 @@ const char circleLine15_marker[CIRCLE_LINE15_WIDTH * CIRCLE_LINE15_HEIGHT + 1] =
 "               "
 "     xxxxxx    "
 "   xxxxxxxxxx  "
+"  xxx      xxx "
 "  xx        xx "
-"  xx        xx "
 " xx          xx"
 " xx          xx"
 " xx          xx"
@@ -390,7 +390,7 @@ const char circleLine15_marker[CIRCLE_LINE15_WIDTH * CIRCLE_LINE15_HEIGHT + 1] =
 " xx          xx"
 " xx          xx"
 "  xx        xx "
-"   xx      xxxx"
+"  xxx      xxx "
 "   xxxxxxxxxx  "
 "     xxxxxx    "};
 
@@ -401,12 +401,12 @@ const char circleFilled11_marker[CIRCLE_FILLED11_WIDTH * CIRCLE_FILLED11_HEIGHT 
 "           "
 "   xxxxxx  "
 "  xxxxxxxx "
-"  xxxxxxxx "
 " xxxxxxxxxx"
 " xxxxxxxxxx"
 " xxxxxxxxxx"
 " xxxxxxxxxx"
-"  xxxxxxxx "
+" xxxxxxxxxx"
+" xxxxxxxxxx"
 "  xxxxxxxx "
 "   xxxxxx  "};
 
@@ -446,7 +446,7 @@ const char circleFilled15_marker[CIRCLE_FILLED15_WIDTH * CIRCLE_FILLED15_HEIGHT 
 " xxxxxxxxxxxxxx"
 " xxxxxxxxxxxxxx"
 "  xxxxxxxxxxxx "
-"   xxxxxxxxxxxx"
+"  xxxxxxxxxxxx "
 "   xxxxxxxxxx  "
 "     xxxxxx    "};
 


### PR DESCRIPTION
These changes makes the round markers symmetric horizontally, vertically and on the diagonal.

The changes to the round markers, that are used in sketcher, are shown in the screenshot below.
![image](https://user-images.githubusercontent.com/349748/106066311-e4b4a080-60fc-11eb-925a-fba4ccbc41c1.png)

The circle versions has similar changes applied.

This forum post highlighted, unintentionally the issue: https://forum.freecadweb.org/viewtopic.php?p=470763#p470763

---

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- ~Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists~

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
