### PR TITLE
Fix ODR violation, correct Ui_TaskSketcherGeneral namespace

### DIFF
--- a/src/Mod/Sketcher/Gui/TaskSketcherGeneral.h
+++ b/src/Mod/Sketcher/Gui/TaskSketcherGeneral.h
@@ -28,8 +28,6 @@
 #include <Gui/Selection.h>
 #include <boost_signals2.hpp>
 
-class Ui_TaskSketcherGeneral;
-
 namespace App {
 class Property;
 }
@@ -40,6 +38,7 @@ class ViewProvider;
 
 namespace SketcherGui {
 
+class Ui_TaskSketcherGeneral;
 class ViewProviderSketch;
 
 class SketcherGeneralWidget : public QWidget


### PR DESCRIPTION
The generated ui_TaskSketcherGeneral.h defines the class in the
SketcherGui namespace.

Fixes #4529

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [X] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [X] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
