### PR TITLE
[Draft] OpenSCAD/DXF error: fix DXF import with no layers

### DIFF
--- a/src/Mod/Draft/importDXF.py
+++ b/src/Mod/Draft/importDXF.py
@@ -2220,7 +2220,7 @@ def processdxf(document, filename, getShapes=False, reComputeFlag=True):
                     drawstyle = "Dashdot"
                 locateLayer(name, color, drawstyle)
     else:
-        locateLayer("0", [0.0, 0.0, 0.0], "Solid")
+        locateLayer("0", (0.0, 0.0, 0.0), "Solid")
 
      # Draw lines
     lines = drawing.entities.get_type("line")

--- a/src/Mod/OpenSCAD/OpenSCAD2Dgeom.py
+++ b/src/Mod/OpenSCAD/OpenSCAD2Dgeom.py
@@ -500,7 +500,9 @@ def importDXFface(filename,layer=None,doc=None):
         #shapeobj.Document.removeObject(shapeobj.Name)
     #groupobj[0].Document.removeObject(groupobj[0].Name)
     for layer in layers: #remove everything that has been imported
-        layer.removeObjectsFromDocument()
+        removeOp = getattr(layer, "removeObjectsFromDocument", None)
+        if callable(removeOp):
+            layer.removeObjectsFromDocument()
         #for obj in layer.Group:
         #    obj.Document.removeObject(obj.Name)
         layer.Document.removeObject(layer.Name)


### PR DESCRIPTION
As discussed in https://forum.freecadweb.org/viewtopic.php?f=3&t=54842, if OpenSCAD creates a DXF with no layers in it, the code that is supposed to handle that in FreeCAD has a minor type error in it that prevents the import from working. For example, loading the OpenSCAD workbench and entering the following code will fail without this change:
```
minkowski(){
    square( [10,10] );
    circle( d=2 );
}
```
The first failure is due to the color of the default layer being created as an array instead of a tuple -- this PR changes the type to a tuple. The second failure is due to the layer object not having the required removal function. This PR checks for the existence and callability of that function before calling it.


---

- [X] Branch rebased on latest master `git pull --rebase upstream master`
- [X] Draft Unit tests confirmed to pass
- [X] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- No tracker ticket has been filed
