### PR TITLE
[MeshPart] Fix copy-paste error

### DIFF
--- a/src/Mod/MeshPart/App/Mesher.cpp
+++ b/src/Mod/MeshPart/App/Mesher.cpp
@@ -368,7 +368,7 @@ Mesh::MeshObject* Mesher::createMesh() const
         if (maxLen > 0)
             hyp2d->SetMaxSize(maxLen);
         if (minLen > 0)
-            hyp2d->SetMinSize(maxLen);
+            hyp2d->SetMinSize(minLen);
 
         hyp2d->SetQuadAllowed(allowquad);
         hyp2d->SetOptimize(optimize);


### PR DESCRIPTION
It doesn't make sense to check `minLen` and then call `SetMinSize` with `maxLen`,
hence, this must be a copy-paste error.

Introduced in https://github.com/FreeCAD/FreeCAD/commit/f681b86abdddd55e2dcb80bc4612251570cc9b8b
With code submitted in issue #0004426

Found with Coverity.

---

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [x] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
