### PR TITLE
Enable LGTM analysis of core C++ source code

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -10,3 +10,52 @@ extraction:
     index:
       filters:
         exclude: "**/translations/*.ts"
+  cpp:
+    prepare:
+      packages:
+      - "cmake"
+      - "cmake-gui"
+      - "libboost-date-time-dev"
+      - "libboost-dev"
+      - "libboost-filesystem-dev"
+      - "libboost-graph-dev"
+      - "libboost-iostreams-dev"
+      - "libboost-program-options-dev"
+      - "libboost-python-dev"
+      - "libboost-regex-dev"
+      - "libboost-serialization-dev"
+      - "libboost-thread-dev"
+      - "libcoin-dev"
+      - "libeigen3-dev"
+      - "libgts-bin"
+      - "libgts-dev"
+      - "libkdtree++-dev"
+      - "libmedc-dev"
+      - "libocct-data-exchange-dev"
+      - "libocct-ocaf-dev"
+      - "libocct-visualization-dev"
+      - "libopencv-dev"
+      - "libproj-dev"
+      - "libpyside2-dev"
+      - "libshiboken2-dev"
+      - "libspnav-dev"
+      - "libvtk7-dev"
+      - "libx11-dev"
+      - "libxerces-c-dev"
+      - "libzipios++-dev"
+      - "occt-draw"
+      - "pyside2-tools"
+      - "python3-dev"
+      - "python3-matplotlib"
+      - "python3-pivy"
+      - "python3-ply"
+      - "python3-pyside2.qtcore"
+      - "python3-pyside2uic"
+      - "qtbase5-dev"
+      - "qttools5-dev"
+      - "swig"
+    configure:
+      command: "cmake ./ -DPYTHON_EXECUTABLE=/usr/bin/python3 -DBUILD_GUI=OFF -DBUILD_ARCH=OFF\
+        \ -DBUILD_DRAWING=OFF -DBUILD_IMAGE=OFF -DBUILD_INSPECTION=OFF -DBUILD_OPENSCAD=OFF\
+        \ -DBUILD_RAYTRACING=OFF -DBUILD_REVERSEENGINEERING=OFF -DBUILD_SURFACE=OFF -DBUILD_START=OFF\
+        \ -DBUILD_ROBOT=OFF -DBUILD_PATH=OFF -DBUILD_FEM=OFF"


### PR DESCRIPTION
FreeCAD as a whole is too large for LGTM to analyze the entire codebase: the operation times out after three hours. By focusing only on the core code, this patch allows the automated testing framework there to analyze our C++ code, in addition to the Python and JavaScript analysis it was already doing. 

---

- [X] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists
