### PR TITLE
[PD] correct hole cut definitions

### DIFF
--- a/src/Mod/PartDesign/Resources/Hole/iso10642.json
+++ b/src/Mod/PartDesign/Resources/Hole/iso10642.json
@@ -4,17 +4,14 @@
     "thread_type": "metric",
     "angle": 90,
     "data": [
-    { "thread": "M1.6", "diameter":  3.6 },
-    { "thread": "M2",   "diameter":  4.5 },
-    { "thread": "M2.5", "diameter":  5.6 },
 	{ "thread": "M3",   "diameter":  6.7 },
 	{ "thread": "M4",   "diameter":  9.0 },
 	{ "thread": "M5",   "diameter": 12.2 },
-	{ "thread": "M6",   "diameter": 13.5 },
-	{ "thread": "M8",   "diameter": 18.0 },
+	{ "thread": "M6",   "diameter": 13.4 },
+	{ "thread": "M8",   "diameter": 17.9 },
 	{ "thread": "M10",  "diameter": 22.4 },
-	{ "thread": "M12",  "diameter": 26.8 },
-	{ "thread": "M14",  "diameter": 30.9 },
+	{ "thread": "M12",  "diameter": 26.9 },
+	{ "thread": "M14",  "diameter": 30.8 },
 	{ "thread": "M16",  "diameter": 33.6 },
 	{ "thread": "M20",  "diameter": 40.3 }
     ]

--- a/src/Mod/PartDesign/Resources/Hole/iso7046.json
+++ b/src/Mod/PartDesign/Resources/Hole/iso7046.json
@@ -4,13 +4,15 @@
     "thread_type": "metric",
     "angle": 90,
     "data": [
-    { "thread": "M2",   "diameter":  4.3 },
-    { "thread": "M2.5", "diameter":  5.3 },
+    { "thread": "M1.6", "diameter":  3.6 }
+    { "thread": "M2",   "diameter":  4.4 },
+    { "thread": "M2.5", "diameter":  5.5 },
 	{ "thread": "M3",   "diameter":  6.3 },
-	{ "thread": "M4",   "diameter":  9.5 },
-	{ "thread": "M5",   "diameter": 10.5 },
-	{ "thread": "M6",   "diameter": 12.7 },
-	{ "thread": "M8",   "diameter": 17.7 },
-	{ "thread": "M10",  "diameter": 20.5 }
+	{ "thread": "M3.5", "diameter":  8.2 },
+	{ "thread": "M4",   "diameter":  9.4 },
+	{ "thread": "M5",   "diameter": 10.4 },
+	{ "thread": "M6",   "diameter": 12.6 },
+	{ "thread": "M8",   "diameter": 17.3 },
+	{ "thread": "M10",  "diameter": 20.0 }
     ]
 }


### PR DESCRIPTION
I was able to get the norms and could update the definitions accordingly.
For example in the ISO 10462, sizes smaller than M3 are not defined and your definition files should only contain what is really defined.