### PR TITLE
PartDesign: Select sketching plane by double click in picker dialog

### DIFF
--- a/src/Mod/PartDesign/Gui/TaskFeaturePick.cpp
+++ b/src/Mod/PartDesign/Gui/TaskFeaturePick.cpp
@@ -26,6 +26,7 @@
 #ifndef _PreComp_
 # include <QListIterator>
 # include <QTimer>
+# include <QListWidgetItem>
 #endif
 
 #include <Gui/Application.h>
@@ -96,6 +97,8 @@ TaskFeaturePick::TaskFeaturePick(std::vector<App::DocumentObject*>& objects,
     connect(ui->radioDependent, SIGNAL(toggled(bool)), this, SLOT(onUpdate(bool)));
     connect(ui->radioXRef, SIGNAL(toggled(bool)), this, SLOT(onUpdate(bool)));
     connect(ui->listWidget, SIGNAL(itemSelectionChanged()), this, SLOT(onItemSelectionChanged()));
+    connect(ui->listWidget, SIGNAL(itemDoubleClicked(QListWidgetItem *)), this, SLOT(onDoubleClick(QListWidgetItem *)));
+
 
     enum { axisBit=0, planeBit = 1};
 
@@ -471,6 +474,18 @@ void TaskFeaturePick::onItemSelectionChanged()
     doSelection = false;
 }
 
+void TaskFeaturePick::onDoubleClick(QListWidgetItem *item)
+{
+    if (doSelection)
+        return;
+    doSelection = true;
+    QString t = item->data(Qt::UserRole).toString();
+    Gui::Selection().addSelection(documentName.c_str(), t.toLatin1());
+    doSelection = false;
+
+    QMetaObject::invokeMethod(qobject_cast<Gui::ControlSingleton*>(&Gui::Control()), "accept", Qt::QueuedConnection);
+}
+
 void TaskFeaturePick::slotDeletedObject(const Gui::ViewProviderDocumentObject& Obj)
 {
     std::vector<Gui::ViewProviderOrigin*>::iterator it;
@@ -570,6 +585,7 @@ void TaskDlgFeaturePick::showExternal(bool val)
 {
     pick->showExternal(val);
 }
+
 
 
 #include "moc_TaskFeaturePick.cpp"

--- a/src/Mod/PartDesign/Gui/TaskFeaturePick.h
+++ b/src/Mod/PartDesign/Gui/TaskFeaturePick.h
@@ -31,6 +31,7 @@
 #include <App/DocumentObject.h>
 
 #include <boost/function.hpp>
+#include <QListWidgetItem>
 
 namespace PartDesignGui {
 
@@ -55,22 +56,23 @@ public:
         afterTip
     };
 
-    TaskFeaturePick(std::vector<App::DocumentObject*> &objects, 
+    TaskFeaturePick(std::vector<App::DocumentObject*> &objects,
                     const std::vector<featureStatus> &status,
                     QWidget *parent = 0);
-    
+
     ~TaskFeaturePick();
 
     std::vector<App::DocumentObject*> getFeatures();
     std::vector<App::DocumentObject*> buildFeatures();
     void showExternal(bool val);
-    
+
     static App::DocumentObject* makeCopy(App::DocumentObject* obj, std::string sub, bool independent);
-    
+
 protected Q_SLOTS:
     void onUpdate(bool);
     void onSelectionChanged(const Gui::SelectionChanges& msg);
     void onItemSelectionChanged();
+    void onDoubleClick(QListWidgetItem *item);
 
 protected:
     /** Notifies when the object is about to be removed. */
@@ -117,15 +119,16 @@ public:
     virtual bool accept();
     /// is called by the framework if the dialog is rejected (Cancel)
     virtual bool reject();
-    /// is called by the framework if the user presses the help button 
+    /// is called by the framework if the user presses the help button
     virtual bool isAllowedAlterDocument(void) const
     { return false; }
-    
+
     void showExternal(bool val);
 
-    /// returns for Close and Help button 
+    /// returns for Close and Help button
     virtual QDialogButtonBox::StandardButtons getStandardButtons(void) const
     { return QDialogButtonBox::Ok|QDialogButtonBox::Cancel; }
+
 
 protected:
     TaskFeaturePick  *pick;


### PR DESCRIPTION
Small UI improvement. Allow the user to pick the sketch plane by double clicking instead of click to select followed by click on OK. 

Forum discussion:
https://forum.freecadweb.org/viewtopic.php?f=8&t=54876#p471829


Thanks to @0penBrain for solving the only real difficulty with this PR. 

![double_click_plane_pick](https://user-images.githubusercontent.com/1278189/106501794-d7fcc780-64c3-11eb-94e1-3cf81e8bcae5.gif)




