### PR TITLE
[0.19] [Draft] Add better error message in get_svg for direction

### DIFF
--- a/src/Mod/Draft/draftfunctions/svg.py
+++ b/src/Mod/Draft/draftfunctions/svg.py
@@ -468,6 +468,8 @@ def get_svg(obj,
                 plane.alignToPointAndAxis_SVG(App.Vector(0, 0, 0),
                                               direction.negative().negative(),
                                               0)
+            else:
+                raise ValueError("'direction' cannot be: Vector(0, 0, 0)")
         elif isinstance(direction, WorkingPlane.plane):
             plane = direction
 

--- a/src/Mod/Draft/drafttests/test_svg.py
+++ b/src/Mod/Draft/drafttests/test_svg.py
@@ -87,6 +87,28 @@ class DraftSVG(unittest.TestCase):
         obj = Draft.export_svg(out_file)
         self.assertTrue(obj, "'{}' failed".format(operation))
 
+    def test_get_svg_from_arch_space_with_zero_vector(self):
+        """Try to get a svg string from an Arch Space with a zero-vector as direction."""
+        import Part
+        import Arch
+        import Draft
+
+        sb = Part.makeBox(1,1,1)
+        b = App.ActiveDocument.addObject('Part::Feature','Box')
+        b.Shape = sb
+
+        s = Arch.makeSpace(b)
+        App.ActiveDocument.recompute()
+
+        try:
+            Draft.get_svg(s, direction=App.Vector(0,0,0))
+        except AttributeError as err:
+            self.fail("Cryptic exception thrown: {}".format(err))
+        except ValueError as err:
+            App.Console.PrintLog("Exception thrown, OK: {}".format(err))
+        else:
+            self.fail("no exception thrown")
+
     def tearDown(self):
         """Finish the test.
 


### PR DESCRIPTION
An AttributeError is raised when `direction=Vector(0,0,0)` and obj is an Arch::Space on line: https://github.com/FreeCAD/FreeCAD/blob/bead9bb9381d039d6dda438b07e30dace7cf33ae/src/Mod/Draft/draftfunctions/svg.py#L799

This patch checks early on if the direction vector is a zero vector and raises a ValueError with a description of what has gone wrong.

A caveat with this solution is that this new behaviour might break old code which depends on that invalid directions can be used.

Forum thread is here: https://forum.freecadweb.org/viewtopic.php?f=23&t=55006

(Found with Coverity)

---

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
-  ~Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists´~

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
