### PR TITLE
[PD] hole dialog UI fixes

### DIFF
--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
@@ -152,11 +152,28 @@ TaskHoleParameters::TaskHoleParameters(ViewProviderHole *HoleView, QWidget *pare
         ui->drillPointAngled->setChecked(true);
     ui->DrillPointAngle->setValue(pcHole->DrillPointAngle.getValue());
     ui->DrillForDepth->setChecked(pcHole->DrillForDepth.getValue());
-    // DrillForDepth is only enabled (sensible) if type is 'Dimension'
-    if (std::string(pcHole->DepthType.getValueAsString()) == "Dimension")
+    // drill point settings are only enabled (sensible) if type is 'Dimension'
+    if (std::string(pcHole->DepthType.getValueAsString()) == "Dimension") {
+        ui->drillPointFlat->setEnabled(true);
+        ui->drillPointAngled->setEnabled(true);
+        ui->DrillPointAngle->setEnabled(true);
         ui->DrillForDepth->setEnabled(true);
-    else
+    }
+    else {
+        ui->drillPointFlat->setEnabled(false);
+        ui->drillPointAngled->setEnabled(false);
+        ui->DrillPointAngle->setEnabled(false);
         ui->DrillForDepth->setEnabled(false);
+    }
+    // drill point is sensible but flat, disable angle and option
+    if (!ui->drillPointFlat->isChecked()) {
+        ui->DrillPointAngle->setEnabled(true);
+        ui->DrillForDepth->setEnabled(true);
+    }
+    else {
+        ui->DrillPointAngle->setEnabled(false);
+        ui->DrillForDepth->setEnabled(false);
+    }
     ui->Tapered->setChecked(pcHole->Tapered.getValue());
     // Angle is only enabled (sensible) if tapered
     ui->TaperedAngle->setEnabled(pcHole->Tapered.getValue());
@@ -171,7 +188,7 @@ TaskHoleParameters::TaskHoleParameters(ViewProviderHole *HoleView, QWidget *pare
     connect(ui->Diameter, SIGNAL(valueChanged(double)), this, SLOT(threadDiameterChanged(double)));
     connect(ui->directionRightHand, SIGNAL(clicked(bool)), this, SLOT(threadDirectionChanged()));
     connect(ui->directionLeftHand, SIGNAL(clicked(bool)), this, SLOT(threadDirectionChanged()));
-    connect(ui->HoleCutType, SIGNAL(currentIndexChanged(int)), this, SLOT(holeCutChanged(int)));
+    connect(ui->HoleCutType, SIGNAL(currentIndexChanged(int)), this, SLOT(holeCutTypeChanged(int)));
     connect(ui->HoleCutDiameter, SIGNAL(valueChanged(double)), this, SLOT(holeCutDiameterChanged(double)));
     connect(ui->HoleCutDepth, SIGNAL(valueChanged(double)), this, SLOT(holeCutDepthChanged(double)));
     connect(ui->HoleCutCountersinkAngle, SIGNAL(valueChanged(double)), this, SLOT(holeCutCountersinkAngleChanged(double)));
@@ -254,7 +271,7 @@ void TaskHoleParameters::threadCutOffOuterChanged(double value)
     recomputeFeature();
 }
 
-void TaskHoleParameters::holeCutChanged(int index)
+void TaskHoleParameters::holeCutTypeChanged(int index)
 {
     if (index < 0)
         return;
@@ -306,7 +323,7 @@ void TaskHoleParameters::holeCutCountersinkAngleChanged(double value)
 {
     PartDesign::Hole* pcHole = static_cast<PartDesign::Hole*>(vp->getObject());
 
-    pcHole->HoleCutCountersinkAngle.setValue((double)value);
+    pcHole->HoleCutCountersinkAngle.setValue(value);
     recomputeFeature();
 }
 
@@ -316,11 +333,19 @@ void TaskHoleParameters::depthChanged(int index)
 
     pcHole->DepthType.setValue(index);
 
-    // disable DrillforDepth if not 'Dimension'
-    if (std::string(pcHole->DepthType.getValueAsString()) == "Dimension")
+    // disable drill point widgets if not 'Dimension'
+    if (std::string(pcHole->DepthType.getValueAsString()) == "Dimension") {
+        ui->drillPointFlat->setEnabled(true);
+        ui->drillPointAngled->setEnabled(true);
+        ui->DrillPointAngle->setEnabled(true);
         ui->DrillForDepth->setEnabled(true);
-    else
+    }
+    else {
+        ui->drillPointFlat->setEnabled(false);
+        ui->drillPointAngled->setEnabled(false);
+        ui->DrillPointAngle->setEnabled(false);
         ui->DrillForDepth->setEnabled(false);
+    }
     recomputeFeature();
 }
 

--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.h
@@ -93,7 +93,7 @@ private Q_SLOTS:
     void threadAngleChanged(double value);    
     void threadDiameterChanged(double value);
     void threadDirectionChanged();
-    void holeCutChanged(int index);
+    void holeCutTypeChanged(int index);
     void holeCutDiameterChanged(double value);
     void holeCutDepthChanged(double value);
     void holeCutCountersinkAngleChanged(double value);

--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>354</width>
+    <width>335</width>
     <height>463</height>
    </rect>
   </property>
@@ -40,10 +40,10 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="1" colspan="5">
+   <item row="1" column="1" colspan="4">
     <widget class="QComboBox" name="ThreadType">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
@@ -58,6 +58,12 @@
    </item>
    <item row="2" column="1">
     <widget class="QCheckBox" name="Threaded">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="toolTip">
       <string>Whether the hole gets a thread</string>
      </property>
@@ -84,6 +90,12 @@
    </item>
    <item row="3" column="1">
     <widget class="QRadioButton" name="directionRightHand">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="toolTip">
       <string/>
      </property>
@@ -97,6 +109,12 @@
    </item>
    <item row="5" column="1">
     <widget class="QRadioButton" name="directionLeftHand">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="text">
       <string>Left hand</string>
      </property>
@@ -121,37 +139,43 @@
    <item row="6" column="1">
     <widget class="QComboBox" name="ThreadSize">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
      <property name="maximumSize">
       <size>
-       <width>140</width>
+       <width>16777215</width>
        <height>16777215</height>
       </size>
      </property>
     </widget>
    </item>
-   <item row="6" column="3">
+   <item row="6" column="2">
     <widget class="QLabel" name="label_3">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="text">
       <string>Clearance</string>
      </property>
     </widget>
    </item>
-   <item row="6" column="5">
+   <item row="6" column="4">
     <widget class="QComboBox" name="ThreadFit">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
      <property name="maximumSize">
       <size>
-       <width>110</width>
+       <width>16777215</width>
        <height>16777215</height>
       </size>
      </property>
@@ -192,14 +216,14 @@ Only available for holes without thread</string>
    <item row="7" column="1">
     <widget class="QComboBox" name="ThreadClass">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
      <property name="maximumSize">
       <size>
-       <width>140</width>
+       <width>16777215</width>
        <height>16777215</height>
       </size>
      </property>
@@ -208,23 +232,7 @@ Only available for holes without thread</string>
      </property>
     </widget>
    </item>
-   <item row="7" column="2">
-    <spacer name="horizontalSpacer">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Fixed</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>13</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="7" column="3" colspan="2">
+   <item row="7" column="2" colspan="2">
     <widget class="QLabel" name="label_7">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
@@ -237,17 +245,17 @@ Only available for holes without thread</string>
      </property>
     </widget>
    </item>
-   <item row="7" column="5">
+   <item row="7" column="4">
     <widget class="Gui::PrefQuantitySpinBox" name="Diameter">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
      <property name="maximumSize">
       <size>
-       <width>110</width>
+       <width>16777215</width>
        <height>16777215</height>
       </size>
      </property>
@@ -278,14 +286,14 @@ Only available for holes without thread</string>
    <item row="8" column="1">
     <widget class="QComboBox" name="DepthType">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
      <property name="maximumSize">
       <size>
-       <width>140</width>
+       <width>16777215</width>
        <height>16777215</height>
       </size>
      </property>
@@ -301,10 +309,10 @@ Only available for holes without thread</string>
      </item>
     </widget>
    </item>
-   <item row="8" column="3" colspan="3">
+   <item row="8" column="2" colspan="3">
     <widget class="Gui::PrefQuantitySpinBox" name="Depth">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
@@ -334,10 +342,10 @@ Only available for holes without thread</string>
      </property>
     </widget>
    </item>
-   <item row="10" column="1" colspan="5">
+   <item row="10" column="1" colspan="4">
     <widget class="QComboBox" name="HoleCutType">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
@@ -355,15 +363,21 @@ Only available for holes without thread</string>
    </item>
    <item row="11" column="1">
     <widget class="QLabel" name="label_11">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="text">
       <string>Diameter</string>
      </property>
     </widget>
    </item>
-   <item row="11" column="3" colspan="3">
+   <item row="11" column="2" colspan="3">
     <widget class="Gui::PrefQuantitySpinBox" name="HoleCutDiameter">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
@@ -390,15 +404,21 @@ Only available for holes without thread</string>
    </item>
    <item row="12" column="1">
     <widget class="QLabel" name="label_12">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="text">
       <string>Depth</string>
      </property>
     </widget>
    </item>
-   <item row="12" column="3" colspan="3">
+   <item row="12" column="2" colspan="3">
     <widget class="Gui::PrefQuantitySpinBox" name="HoleCutDepth">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
@@ -422,15 +442,21 @@ Only available for holes without thread</string>
    </item>
    <item row="13" column="1">
     <widget class="QLabel" name="label_10">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="text">
       <string>Countersink angle</string>
      </property>
     </widget>
    </item>
-   <item row="13" column="3" colspan="3">
+   <item row="13" column="2" colspan="3">
     <widget class="Gui::PrefQuantitySpinBox" name="HoleCutCountersinkAngle">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
@@ -467,6 +493,12 @@ Only available for holes without thread</string>
    </item>
    <item row="15" column="0">
     <widget class="QLabel" name="label_15">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="text">
       <string>Type</string>
      </property>
@@ -478,7 +510,7 @@ Only available for holes without thread</string>
    <item row="15" column="1">
     <widget class="QRadioButton" name="drillPointFlat">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
@@ -494,7 +526,7 @@ Only available for holes without thread</string>
    <item row="18" column="1">
     <widget class="QRadioButton" name="drillPointAngled">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
@@ -507,10 +539,10 @@ Only available for holes without thread</string>
      </attribute>
     </widget>
    </item>
-   <item row="18" column="3" colspan="3">
+  <item row="18" column="2" colspan="3">
     <widget class="Gui::PrefQuantitySpinBox" name="DrillPointAngle">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
@@ -523,8 +555,14 @@ Only available for holes without thread</string>
      </property>
     </widget>
    </item>
-   <item row="19" column="3" colspan="3">
+   <item row="19" column="2" colspan="3">
     <widget class="QCheckBox" name="DrillForDepth">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="toolTip">
       <string>The size of the drill point will be taken into
 account for the depth of blind holes</string>
@@ -543,6 +581,12 @@ account for the depth of blind holes</string>
    </item>
    <item row="21" column="0">
     <widget class="QCheckBox" name="Tapered">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="text">
       <string>Tapered</string>
      </property>
@@ -550,6 +594,12 @@ account for the depth of blind holes</string>
    </item>
    <item row="21" column="1">
     <widget class="Gui::PrefQuantitySpinBox" name="TaperedAngle">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="toolTip">
       <string>Taper angle for the hole
 90 degree: straight hole
@@ -564,8 +614,14 @@ over 90: larger hole radius at the bottom</string>
      </property>
     </widget>
    </item>
-   <item row="21" column="4" colspan="2">
+   <item row="21" column="3" colspan="2">
     <widget class="QCheckBox" name="Reversed">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="toolTip">
       <string>Reverses the hole direction</string>
      </property>
@@ -574,7 +630,7 @@ over 90: larger hole radius at the bottom</string>
      </property>
     </widget>
    </item>
-  </layout>
+   </layout>
  </widget>
  <customwidgets>
   <customwidget>
@@ -620,28 +676,12 @@ over 90: larger hole radius at the bottom</string>
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>49</x>
-     <y>451</y>
+     <x>40</x>
+     <y>540</y>
     </hint>
     <hint type="destinationlabel">
-     <x>163</x>
-     <y>453</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>Threaded</sender>
-   <signal>clicked(bool)</signal>
-   <receiver>ThreadFit</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
      <x>136</x>
-     <y>63</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>344</x>
-     <y>142</y>
+     <y>540</y>
     </hint>
    </hints>
   </connection>
@@ -656,14 +696,30 @@ over 90: larger hole radius at the bottom</string>
      <y>63</y>
     </hint>
     <hint type="destinationlabel">
-     <x>163</x>
-     <y>168</y>
+     <x>136</x>
+     <y>280</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>Threaded</sender>
+   <signal>clicked(bool)</signal>
+   <receiver>ThreadFit</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>136</x>
+     <y>63</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>322</x>
+     <y>254</y>
     </hint>
    </hints>
   </connection>
  </connections>
  <buttongroups>
-  <buttongroup name="drillPointButtonGroup"/>
   <buttongroup name="directionButtonGroup"/>
+  <buttongroup name="drillPointButtonGroup"/>
  </buttongroups>
 </ui>


### PR DESCRIPTION
This PR is the first in a series of 3 PRs to fix known hole dialog bugs. (PR #4344 and PR #4347 depend on this PR)

This one fixes:

- the .ui file issues
- readonly status issues of some widgets/properties (e.g. when the hole is through all, disable drill point settings)
- the bug that updateHoleCutParams() overwrote the previously correctly determined hole diameter
- the missing check that the counterbore/sink diameter must not be <= than the hole diameter
- just a trifle: change a function name to fit into the naming scheme

Here is the changed dialog as it looks for me:
![FreeCAD_lcZwDdKIjP](https://user-images.githubusercontent.com/1828501/106398578-e390b580-6413-11eb-93fa-929ec7c5e7e5.png)
