### PR TITLE
[PD] hole fix custom cut handling 

### DIFF
--- a/src/Mod/PartDesign/App/FeatureHole.cpp
+++ b/src/Mod/PartDesign/App/FeatureHole.cpp
@@ -612,6 +612,8 @@ Hole::Hole()
     ADD_PROPERTY_TYPE(HoleCutType, (0L), "Hole", App::Prop_None, "Head cut type");
     HoleCutType.setEnums(HoleCutType_None_Enums);
 
+    ADD_PROPERTY_TYPE(HoleCutCustomValues, (false), "Hole", App::Prop_None, "Custom cut values");
+
     ADD_PROPERTY_TYPE(HoleCutDiameter, (0.0), "Hole", App::Prop_None, "Head cut diameter");
 
     ADD_PROPERTY_TYPE(HoleCutDepth, (0.0), "Hole", App::Prop_None, "Head cut deth");
@@ -684,6 +686,8 @@ void Hole::updateHoleCutParams()
             }
             if (HoleCutDepth.getValue() == 0.0)
                 HoleCutDepth.setValue(dimen.depth);
+            HoleCutDiameter.setReadOnly(false);
+            HoleCutDepth.setReadOnly(false);
             HoleCutCountersinkAngle.setReadOnly(true);
         }
         else if (holeCutType == "Countersink") {
@@ -702,6 +706,8 @@ void Hole::updateHoleCutParams()
             if (HoleCutCountersinkAngle.getValue() == 0.0) {
                 HoleCutCountersinkAngle.setValue(counter.angle);
             }
+            HoleCutDiameter.setReadOnly(false);
+            HoleCutDepth.setReadOnly(false);
             HoleCutCountersinkAngle.setReadOnly(false);
         }
 
@@ -718,9 +724,31 @@ void Hole::updateHoleCutParams()
                     // valid values for visual feedback
                     HoleCutDiameter.setValue(Diameter.getValue() + 0.1);
                     HoleCutDepth.setValue(0.1);
+                    // we force custom values since there are no normed ones
+                    HoleCutCustomValues.setReadOnly(true);
+                    // important to set only if not already true, to avoid loop call of updateHoleCutParams()
+                    if (!HoleCutCustomValues.getValue()) {
+                        HoleCutCustomValues.setValue(true);
+                        HoleCutDiameter.setReadOnly(false);
+                        HoleCutDepth.setReadOnly(false);
+                    }
                 } else {
-                    HoleCutDiameter.setValue(dimen.diameter);
-                    HoleCutDepth.setValue(dimen.depth);
+                    // set normed values if not overwritten or if previously there
+                    // were no normed values available and thus HoleCutCustomValues is checked and read-only
+                    if (!HoleCutCustomValues.getValue()
+                        || (HoleCutCustomValues.getValue() && HoleCutCustomValues.isReadOnly())) {
+                        HoleCutDiameter.setValue(dimen.diameter);
+                        HoleCutDepth.setValue(dimen.depth);
+                        HoleCutDiameter.setReadOnly(true);
+                        HoleCutDepth.setReadOnly(true);
+                        if (HoleCutCustomValues.getValue() && HoleCutCustomValues.isReadOnly())
+                            HoleCutCustomValues.setValue(false);
+                    }
+                    else {
+                        HoleCutDiameter.setReadOnly(false);
+                        HoleCutDepth.setReadOnly(false);
+                    }
+                    HoleCutCustomValues.setReadOnly(false);
                 }
             } else if (counter.cut_type == CutDimensionSet::Countersink) {
                 const CounterSinkDimension &dimen = counter.get_sink(threadSize);
@@ -728,12 +756,37 @@ void Hole::updateHoleCutParams()
                     // valid values for visual feedback
                     HoleCutDiameter.setValue(Diameter.getValue() + 0.1);
                     // there might be an angle of zero (if no norm exists for the size)
-                     if (HoleCutCountersinkAngle.getValue() == 0.0) {
+                    if (HoleCutCountersinkAngle.getValue() == 0.0) {
                         HoleCutCountersinkAngle.setValue(counter.angle);
                     }
+                    // we force custom values since there are no normed ones
+                    HoleCutCustomValues.setReadOnly(true);
+                    // important to set only if not already true, to avoid loop call of updateHoleCutParams()
+                    if (!HoleCutCustomValues.getValue()) {
+                        HoleCutCustomValues.setValue(true);
+                        HoleCutDiameter.setReadOnly(false);
+                        HoleCutDepth.setReadOnly(false);
+                        HoleCutCountersinkAngle.setReadOnly(false);
+                    }
                 } else {
-                    HoleCutDiameter.setValue(dimen.diameter);
-                    HoleCutCountersinkAngle.setValue(counter.angle);
+                    // set normed values if not overwritten or if previously there
+                    // were no normed values available and thus HoleCutCustomValues is checked and read-only
+                    if (!HoleCutCustomValues.getValue()
+                        || (HoleCutCustomValues.getValue() && HoleCutCustomValues.isReadOnly())) {
+                        HoleCutDiameter.setValue(dimen.diameter);
+                        HoleCutDiameter.setReadOnly(true);
+                        HoleCutDepth.setReadOnly(true);
+                        HoleCutCountersinkAngle.setValue(counter.angle);
+                        HoleCutCountersinkAngle.setReadOnly(true);
+                        if (HoleCutCustomValues.getValue() && HoleCutCustomValues.isReadOnly())
+                            HoleCutCustomValues.setValue(false);
+                    }
+                    else {
+                        HoleCutDiameter.setReadOnly(false);
+                        HoleCutDepth.setReadOnly(false);
+                        HoleCutCountersinkAngle.setReadOnly(false);
+                    }
+                    HoleCutCustomValues.setReadOnly(false);
                 }
             }
         }
@@ -745,6 +798,8 @@ void Hole::updateHoleCutParams()
         else if (holeCutType == "Cheesehead (deprecated)") {
             HoleCutDiameter.setValue(diameterVal * 1.6);
             HoleCutDepth.setValue(diameterVal * 0.6);
+            HoleCutDiameter.setReadOnly(false);
+            HoleCutDepth.setReadOnly(false);
         }
         else if (holeCutType == "Countersink socket screw (deprecated)") {
             HoleCutDiameter.setValue(diameterVal * 2.0);
@@ -752,10 +807,15 @@ void Hole::updateHoleCutParams()
             if (HoleCutCountersinkAngle.getValue() == 0.0) {
                 HoleCutCountersinkAngle.setValue(90.0);
             }
+            HoleCutDiameter.setReadOnly(false);
+            HoleCutDepth.setReadOnly(false);
+            HoleCutCountersinkAngle.setReadOnly(false);
         }
         else if (holeCutType == "Cap screw (deprecated)") {
             HoleCutDiameter.setValue(diameterVal * 1.5);
             HoleCutDepth.setValue(diameterVal * 1.25);
+            HoleCutDiameter.setReadOnly(false);
+            HoleCutDepth.setReadOnly(false);
         }
     }
     else { // we have an UTS profile or none
@@ -771,6 +831,8 @@ void Hole::updateHoleCutParams()
             }
             if (HoleCutDepth.getValue() == 0.0)
                 HoleCutDepth.setValue(diameterVal * 0.9);
+            HoleCutDiameter.setReadOnly(false);
+            HoleCutDepth.setReadOnly(false);
         }
         else if (holeCutType == "Countersink") {
             if (HoleCutDiameter.getValue() == 0.0 || HoleCutDiameter.getValue() <= diameterVal) {
@@ -787,6 +849,9 @@ void Hole::updateHoleCutParams()
                 else
                     HoleCutCountersinkAngle.setValue(90.0);
             }
+            HoleCutDiameter.setReadOnly(false);
+            HoleCutDepth.setReadOnly(false);
+            HoleCutCountersinkAngle.setReadOnly(false);
         }
     }
 }
@@ -1062,24 +1127,37 @@ void Hole::onChanged(const App::Property *prop)
         }
 
         if (holeCutType == "None") {
+            HoleCutCustomValues.setReadOnly(true);
             HoleCutDiameter.setReadOnly(true);
             HoleCutDepth.setReadOnly(true);
             HoleCutCountersinkAngle.setReadOnly(true);
         }
         else if (holeCutType == "Counterbore") {
+            HoleCutCustomValues.setReadOnly(true);
             HoleCutDiameter.setReadOnly(false);
             HoleCutDepth.setReadOnly(false);
             HoleCutCountersinkAngle.setReadOnly(true);
         }
         else if (holeCutType == "Countersink") {
+            HoleCutCustomValues.setReadOnly(true);
             HoleCutDiameter.setReadOnly(false);
             HoleCutDepth.setReadOnly(false);
             HoleCutCountersinkAngle.setReadOnly(false);
         }
         else { // screw definition
-            HoleCutDiameter.setReadOnly(false);
-            HoleCutDepth.setReadOnly(false);
-            HoleCutCountersinkAngle.setReadOnly(false);
+            HoleCutCustomValues.setReadOnly(false);
+            if (HoleCutCustomValues.getValue()) {
+                HoleCutDiameter.setReadOnly(false);
+                HoleCutDepth.setReadOnly(false);
+                // we must not set HoleCutCountersinkAngle here because the info if this can
+                // be enabled is first available in updateHoleCutParams and thus handled there
+                updateHoleCutParams();
+            }
+            else {
+                HoleCutDiameter.setReadOnly(true);
+                HoleCutDepth.setReadOnly(true);
+                HoleCutCountersinkAngle.setReadOnly(true);
+            }
         }
 
         // Signal changes to these
@@ -1161,32 +1239,17 @@ void Hole::onChanged(const App::Property *prop)
         updateHoleCutParams();
     }
     else if (prop == &HoleCutType) {
-        std::string holeCutType;
-        if (HoleCutType.isValid())
-            holeCutType = HoleCutType.getValueAsString();
-        if (holeCutType == "None") {
-            HoleCutDiameter.setReadOnly(true);
-            HoleCutDepth.setReadOnly(true);
-            HoleCutCountersinkAngle.setReadOnly(true);
-        }
-        else if (holeCutType == "Counterbore") {
-            HoleCutDiameter.setReadOnly(false);
-            HoleCutDepth.setReadOnly(false);
-            HoleCutCountersinkAngle.setReadOnly(true);
-        }
-        else if (holeCutType == "Countersink") {
-            HoleCutDiameter.setReadOnly(false);
-            HoleCutDepth.setReadOnly(false);
-            HoleCutCountersinkAngle.setReadOnly(false);
-        }
-        else { // screw definition
-            HoleCutDiameter.setReadOnly(false);
-            HoleCutDepth.setReadOnly(false);
-            HoleCutCountersinkAngle.setReadOnly(false);
-        }
         ProfileBased::onChanged(&HoleCutDiameter);
         ProfileBased::onChanged(&HoleCutDepth);
         ProfileBased::onChanged(&HoleCutCountersinkAngle);
+
+        // the read-only states are set in updateHoleCutParams()
+        updateHoleCutParams();
+    }
+    else if (prop == &HoleCutCustomValues) {
+        // when going back to standardized values, we must recalculate
+        // also to find out if HoleCutCountersinkAngle can be ReadOnly
+        // both an also the read-only states is done in updateHoleCutParams()
         updateHoleCutParams();
     }
     else if (prop == &DepthType) {

--- a/src/Mod/PartDesign/App/FeatureHole.cpp
+++ b/src/Mod/PartDesign/App/FeatureHole.cpp
@@ -424,7 +424,9 @@ const double Hole::metricHoleDiameters[36][4] =
         { 6.0,      6.4,    6.6,    7.0},
         { 7.0,      7.4,    7.6,    8.0},
         { 8.0,      8.4,    9.0,    10.0},
+        // 9.0 undefined
         { 10.0,     10.5,   11.0,   12.0},
+        // 11.0 undefined
         { 12.0,     13.0,   13.5,   14.5},
         { 14.0,     15.0,   15.5,   16.5},
         { 16.0,     17.0,  	17.5,   18.5},
@@ -612,6 +614,10 @@ void Hole::updateHoleCutParams()
         return;
     }
 
+    // get diameter and size
+    double diameterVal = Diameter.getValue();
+
+    // handle thread types
     std::string threadType = ThreadType.getValueAsString();
     if (threadType == "ISOMetricProfile" || threadType == "ISOMetricFineProfile") {
         if (ThreadSize.getValue() < 0) {
@@ -619,35 +625,50 @@ void Hole::updateHoleCutParams()
             return;
         }
 
-        // get diameter and size
-        double diameter = threadDescription[ThreadType.getValue()][ThreadSize.getValue()].diameter;
         std::string threadSize{ ThreadSize.getValueAsString() };
 
         // we don't update for these settings but we need to set a value for new holes
+        // furthermore we must assure the hole cut diameter is not <= the hole diameter
         // if we have a cut but the values are zero, we assume it is a new hole
         // we take in this case the values from the norm ISO 4762 or ISO 10642
         if (holeCutType == "Counterbore") {
             // read ISO 4762 values
             const CutDimensionSet& counter = find_cutDimensionSet(threadType, "ISO 4762");
             const CounterBoreDimension& dimen = counter.get_bore(threadSize);
-            if (HoleCutDiameter.getValue() == 0.0) {
-                HoleCutDiameter.setValue(dimen.diameter);
-                HoleCutDepth.setValue(dimen.depth);
+            if (HoleCutDiameter.getValue() == 0.0 || HoleCutDiameter.getValue() <= diameterVal) {
+                // there is no norm defining counterbores for all sizes, thus we need to use the
+                // same fallback as for the case HoleCutTypeMap.count(key)
+                if (dimen.diameter != 0.0) {
+                    HoleCutDiameter.setValue(dimen.diameter);
+                    HoleCutDepth.setValue(dimen.depth);
+                }
+                else {
+                    // valid values for visual feedback
+                    HoleCutDiameter.setValue(Diameter.getValue() + 0.1);
+                    HoleCutDepth.setValue(0.1);
+                }
             }
             if (HoleCutDepth.getValue() == 0.0)
                 HoleCutDepth.setValue(dimen.depth);
+            HoleCutCountersinkAngle.setReadOnly(true);
         }
         else if (holeCutType == "Countersink") {
             // read ISO 10642 values
             const CutDimensionSet& counter = find_cutDimensionSet(threadType, "ISO 10642");
-            if (HoleCutDiameter.getValue() == 0.0) {
+            if (HoleCutDiameter.getValue() == 0.0 || HoleCutDiameter.getValue() <= diameterVal) {
                 const CounterSinkDimension& dimen = counter.get_sink(threadSize);
-                HoleCutDiameter.setValue(dimen.diameter);
+                if (dimen.diameter != 0.0) {
+                    HoleCutDiameter.setValue(dimen.diameter);
+                } 
+                else {
+                    HoleCutDiameter.setValue(Diameter.getValue() + 0.1);
+                }
                 HoleCutCountersinkAngle.setValue(counter.angle);
             }
             if (HoleCutCountersinkAngle.getValue() == 0.0) {
                 HoleCutCountersinkAngle.setValue(counter.angle);
             }
+            HoleCutCountersinkAngle.setReadOnly(false);
         }
 
         // cut definition
@@ -688,39 +709,38 @@ void Hole::updateHoleCutParams()
         // handle legacy types but don’t change user settings for
         // user defined None, Counterbore and Countersink
         else if (holeCutType == "Cheesehead (deprecated)") {
-            HoleCutDiameter.setValue(diameter * 1.6);
-            HoleCutDepth.setValue(diameter * 0.6);
+            HoleCutDiameter.setValue(diameterVal * 1.6);
+            HoleCutDepth.setValue(diameterVal * 0.6);
         }
         else if (holeCutType == "Countersink socket screw (deprecated)") {
-            HoleCutDiameter.setValue(diameter * 2.0);
-            HoleCutDepth.setValue(diameter * 0.0);
+            HoleCutDiameter.setValue(diameterVal * 2.0);
+            HoleCutDepth.setValue(diameterVal * 0.0);
             if (HoleCutCountersinkAngle.getValue() == 0.0) {
                 HoleCutCountersinkAngle.setValue(90.0);
             }
         }
         else if (holeCutType == "Cap screw (deprecated)") {
-            HoleCutDiameter.setValue(diameter * 1.5);
-            HoleCutDepth.setValue(diameter * 1.25);
+            HoleCutDiameter.setValue(diameterVal * 1.5);
+            HoleCutDepth.setValue(diameterVal * 1.25);
         }
     }
     else { // we have an UTS profile or none
-        // get diameter
-        double diameter = threadDescription[ThreadType.getValue()][ThreadSize.getValue()].diameter;
 
         // we don't update for these settings but we need to set a value for new holes
+        // furthermore we must assure the hole cut diameter is not <= the hole diameter
         // if we have a cut but the values are zero, we assume it is a new hole
         // we use rules of thumbs as proposal
         if (holeCutType == "Counterbore") {
-            if (HoleCutDiameter.getValue() == 0.0) {
-                HoleCutDiameter.setValue(diameter * 1.6);
-                HoleCutDepth.setValue(diameter * 0.9);
+            if (HoleCutDiameter.getValue() == 0.0 || HoleCutDiameter.getValue() <= diameterVal) {
+                HoleCutDiameter.setValue(diameterVal * 1.6);
+                HoleCutDepth.setValue(diameterVal * 0.9);
             }
             if (HoleCutDepth.getValue() == 0.0)
-                HoleCutDepth.setValue(diameter * 0.9);
+                HoleCutDepth.setValue(diameterVal * 0.9);
         }
         else if (holeCutType == "Countersink") {
-            if (HoleCutDiameter.getValue() == 0.0) {
-                HoleCutDiameter.setValue(diameter * 1.7);
+            if (HoleCutDiameter.getValue() == 0.0 || HoleCutDiameter.getValue() <= diameterVal) {
+                HoleCutDiameter.setValue(diameterVal * 1.7);
                 // 82 degrees for UTS, 90 otherwise
                 if (threadType != "None")       
                     HoleCutCountersinkAngle.setValue(82.0);
@@ -996,10 +1016,14 @@ void Hole::onChanged(const App::Property *prop)
         ThreadCutOffOuter.setReadOnly(v);
     }
     else if (prop == &DrillPoint) {
-        if (DrillPoint.getValue() == 1)
+        if (DrillPoint.getValue() == 1) {
             DrillPointAngle.setReadOnly(false);
-        else
+            DrillForDepth.setReadOnly(false);
+        }
+        else {
             DrillPointAngle.setReadOnly(true);
+            DrillForDepth.setReadOnly(true);
+        }
     }
     else if (prop == &Tapered) {
         if (Tapered.getValue())
@@ -1009,10 +1033,15 @@ void Hole::onChanged(const App::Property *prop)
     }
     else if (prop == &ThreadSize) {
         updateDiameterParam();
-        updateHoleCutParams();
+        // updateHoleCutParams() will automatcially be called because updateDiameterParam() changes &Diameter
     }
     else if (prop == &ThreadFit) {
         updateDiameterParam();
+    }
+    else if (prop == &Diameter) {
+        // a changed diameter means we also need to check the hole cut
+        // because the hole cut diameter must not be <= than the diameter
+        updateHoleCutParams();
     }
     else if (prop == &HoleCutType) {
         std::string holeCutType;
@@ -1045,6 +1074,8 @@ void Hole::onChanged(const App::Property *prop)
     }
     else if (prop == &DepthType) {
         Depth.setReadOnly((std::string(DepthType.getValueAsString()) != "Dimension"));
+        DrillPoint.setReadOnly((std::string(DepthType.getValueAsString()) != "Dimension"));
+        DrillPointAngle.setReadOnly((std::string(DepthType.getValueAsString()) != "Dimension"));
         DrillForDepth.setReadOnly((std::string(DepthType.getValueAsString()) != "Dimension"));
     }
     ProfileBased::onChanged(prop);

--- a/src/Mod/PartDesign/App/FeatureHole.cpp
+++ b/src/Mod/PartDesign/App/FeatureHole.cpp
@@ -639,10 +639,10 @@ Hole::Hole()
 
 void Hole::updateHoleCutParams()
 {
-    std::string holeCutType = HoleCutType.getValueAsString();
+    std::string holeCutTypeStr = HoleCutType.getValueAsString();
 
     // there is no cut, thus return
-    if (holeCutType == "None")
+    if (holeCutTypeStr == "None")
         return;
 
     if (ThreadType.getValue() < 0) {
@@ -654,23 +654,23 @@ void Hole::updateHoleCutParams()
     double diameterVal = Diameter.getValue();
 
     // handle thread types
-    std::string threadType = ThreadType.getValueAsString();
-    if (threadType == "ISOMetricProfile" || threadType == "ISOMetricFineProfile") {
+    std::string threadTypeStr = ThreadType.getValueAsString();
+    if (threadTypeStr == "ISOMetricProfile" || threadTypeStr == "ISOMetricFineProfile") {
         if (ThreadSize.getValue() < 0) {
             throw Base::IndexError("Thread size out of range");
             return;
         }
 
-        std::string threadSize{ ThreadSize.getValueAsString() };
+        std::string threadSizeStr = ThreadSize.getValueAsString();
 
         // we don't update for these settings but we need to set a value for new holes
         // furthermore we must assure the hole cut diameter is not <= the hole diameter
         // if we have a cut but the values are zero, we assume it is a new hole
         // we take in this case the values from the norm ISO 4762 or ISO 10642
-        if (holeCutType == "Counterbore") {
+        if (holeCutTypeStr == "Counterbore") {
             // read ISO 4762 values
-            const CutDimensionSet& counter = find_cutDimensionSet(threadType, "ISO 4762");
-            const CounterBoreDimension& dimen = counter.get_bore(threadSize);
+            const CutDimensionSet& counter = find_cutDimensionSet(threadTypeStr, "ISO 4762");
+            const CounterBoreDimension& dimen = counter.get_bore(threadSizeStr);
             if (HoleCutDiameter.getValue() == 0.0 || HoleCutDiameter.getValue() <= diameterVal) {
                 // there is no norm defining counterbores for all sizes, thus we need to use the
                 // same fallback as for the case HoleCutTypeMap.count(key)
@@ -690,11 +690,11 @@ void Hole::updateHoleCutParams()
             HoleCutDepth.setReadOnly(false);
             HoleCutCountersinkAngle.setReadOnly(true);
         }
-        else if (holeCutType == "Countersink") {
+        else if (holeCutTypeStr == "Countersink") {
             // read ISO 10642 values
-            const CutDimensionSet& counter = find_cutDimensionSet(threadType, "ISO 10642");
+            const CutDimensionSet& counter = find_cutDimensionSet(threadTypeStr, "ISO 10642");
             if (HoleCutDiameter.getValue() == 0.0 || HoleCutDiameter.getValue() <= diameterVal) {
-                const CounterSinkDimension& dimen = counter.get_sink(threadSize);
+                const CounterSinkDimension& dimen = counter.get_sink(threadSizeStr);
                 if (dimen.diameter != 0.0) {
                     HoleCutDiameter.setValue(dimen.diameter);
                 } 
@@ -712,14 +712,14 @@ void Hole::updateHoleCutParams()
         }
 
         // cut definition
-        CutDimensionKey key { threadType, holeCutType };
+        CutDimensionKey key { threadTypeStr, holeCutTypeStr };
         if (HoleCutTypeMap.count(key)) {
             const CutDimensionSet &counter = find_cutDimensionSet(key);
             if (counter.cut_type == CutDimensionSet::Counterbore) {
                 // disable HoleCutCountersinkAngle and reset it to ISO's default
                 HoleCutCountersinkAngle.setValue(90.0);
                 HoleCutCountersinkAngle.setReadOnly(true);
-                const CounterBoreDimension &dimen = counter.get_bore(threadSize);
+                const CounterBoreDimension &dimen = counter.get_bore(threadSizeStr);
                 if (dimen.thread == "None") {
                     // valid values for visual feedback
                     HoleCutDiameter.setValue(Diameter.getValue() + 0.1);
@@ -751,7 +751,7 @@ void Hole::updateHoleCutParams()
                     HoleCutCustomValues.setReadOnly(false);
                 }
             } else if (counter.cut_type == CutDimensionSet::Countersink) {
-                const CounterSinkDimension &dimen = counter.get_sink(threadSize);
+                const CounterSinkDimension &dimen = counter.get_sink(threadSizeStr);
                 if (dimen.thread == "None") {
                     // valid values for visual feedback
                     HoleCutDiameter.setValue(Diameter.getValue() + 0.1);
@@ -795,13 +795,13 @@ void Hole::updateHoleCutParams()
         // user defined None, Counterbore and Countersink
         // handle legacy types but don’t change user settings for
         // user defined None, Counterbore and Countersink
-        else if (holeCutType == "Cheesehead (deprecated)") {
+        else if (holeCutTypeStr == "Cheesehead (deprecated)") {
             HoleCutDiameter.setValue(diameterVal * 1.6);
             HoleCutDepth.setValue(diameterVal * 0.6);
             HoleCutDiameter.setReadOnly(false);
             HoleCutDepth.setReadOnly(false);
         }
-        else if (holeCutType == "Countersink socket screw (deprecated)") {
+        else if (holeCutTypeStr == "Countersink socket screw (deprecated)") {
             HoleCutDiameter.setValue(diameterVal * 2.0);
             HoleCutDepth.setValue(diameterVal * 0.0);
             if (HoleCutCountersinkAngle.getValue() == 0.0) {
@@ -811,7 +811,7 @@ void Hole::updateHoleCutParams()
             HoleCutDepth.setReadOnly(false);
             HoleCutCountersinkAngle.setReadOnly(false);
         }
-        else if (holeCutType == "Cap screw (deprecated)") {
+        else if (holeCutTypeStr == "Cap screw (deprecated)") {
             HoleCutDiameter.setValue(diameterVal * 1.5);
             HoleCutDepth.setValue(diameterVal * 1.25);
             HoleCutDiameter.setReadOnly(false);
@@ -824,7 +824,7 @@ void Hole::updateHoleCutParams()
         // furthermore we must assure the hole cut diameter is not <= the hole diameter
         // if we have a cut but the values are zero, we assume it is a new hole
         // we use rules of thumbs as proposal
-        if (holeCutType == "Counterbore") {
+        if (holeCutTypeStr == "Counterbore") {
             if (HoleCutDiameter.getValue() == 0.0 || HoleCutDiameter.getValue() <= diameterVal) {
                 HoleCutDiameter.setValue(diameterVal * 1.6);
                 HoleCutDepth.setValue(diameterVal * 0.9);
@@ -834,17 +834,17 @@ void Hole::updateHoleCutParams()
             HoleCutDiameter.setReadOnly(false);
             HoleCutDepth.setReadOnly(false);
         }
-        else if (holeCutType == "Countersink") {
+        else if (holeCutTypeStr == "Countersink") {
             if (HoleCutDiameter.getValue() == 0.0 || HoleCutDiameter.getValue() <= diameterVal) {
                 HoleCutDiameter.setValue(diameterVal * 1.7);
                 // 82 degrees for UTS, 90 otherwise
-                if (threadType != "None")       
+                if (threadTypeStr != "None")       
                     HoleCutCountersinkAngle.setValue(82.0);
                 else
                     HoleCutCountersinkAngle.setValue(90.0);
             }
             if (HoleCutCountersinkAngle.getValue() == 0.0) {
-                if (threadType != "None")
+                if (threadTypeStr != "None")
                     HoleCutCountersinkAngle.setValue(82.0);
                 else
                     HoleCutCountersinkAngle.setValue(90.0);
@@ -1043,11 +1043,11 @@ void Hole::updateDiameterParam()
 void Hole::onChanged(const App::Property *prop)
 {
     if (prop == &ThreadType) {
-        std::string type, holeCutType;
+        std::string type, holeCutTypeStr;
         if (ThreadType.isValid())
             type = ThreadType.getValueAsString();
         if (HoleCutType.isValid())
-            holeCutType = HoleCutType.getValueAsString();
+            holeCutTypeStr = HoleCutType.getValueAsString();
 
         if (type == "None" ) {
             ThreadSize.setEnums(ThreadSize_None_Enums);
@@ -1126,19 +1126,19 @@ void Hole::onChanged(const App::Property *prop)
             Diameter.setReadOnly(true);
         }
 
-        if (holeCutType == "None") {
+        if (holeCutTypeStr == "None") {
             HoleCutCustomValues.setReadOnly(true);
             HoleCutDiameter.setReadOnly(true);
             HoleCutDepth.setReadOnly(true);
             HoleCutCountersinkAngle.setReadOnly(true);
         }
-        else if (holeCutType == "Counterbore") {
+        else if (holeCutTypeStr == "Counterbore") {
             HoleCutCustomValues.setReadOnly(true);
             HoleCutDiameter.setReadOnly(false);
             HoleCutDepth.setReadOnly(false);
             HoleCutCountersinkAngle.setReadOnly(true);
         }
-        else if (holeCutType == "Countersink") {
+        else if (holeCutTypeStr == "Countersink") {
             HoleCutCustomValues.setReadOnly(true);
             HoleCutDiameter.setReadOnly(false);
             HoleCutDepth.setReadOnly(false);
@@ -1228,7 +1228,7 @@ void Hole::onChanged(const App::Property *prop)
     }
     else if (prop == &ThreadSize) {
         updateDiameterParam();
-        // updateHoleCutParams() will automatcially be called because updateDiameterParam() changes &Diameter
+        // updateHoleCutParams() will later automatically be called because updateDiameterParam() changes &Diameter
     }
     else if (prop == &ThreadFit) {
         updateDiameterParam();

--- a/src/Mod/PartDesign/App/FeatureHole.h
+++ b/src/Mod/PartDesign/App/FeatureHole.h
@@ -57,6 +57,7 @@ public:
     App::PropertyLength         Diameter;
     App::PropertyEnumeration    ThreadDirection;
     App::PropertyEnumeration    HoleCutType;
+    App::PropertyBool           HoleCutCustomValues;
     App::PropertyLength         HoleCutDiameter;
     App::PropertyLength         HoleCutDepth;
     App::PropertyAngle          HoleCutCountersinkAngle;

--- a/src/Mod/PartDesign/App/FeatureHole.h
+++ b/src/Mod/PartDesign/App/FeatureHole.h
@@ -90,6 +90,14 @@ public:
 
     static const double metricHoleDiameters[36][4];
 
+    typedef struct {
+        std::string designation;
+        double close;
+        double normal;
+        double loose;
+    } UTSClearanceDefinition;
+    static const UTSClearanceDefinition UTSHoleDiameters[22];
+
     virtual void Restore(Base::XMLReader & reader);
 
     virtual void updateProps();
@@ -99,7 +107,8 @@ protected:
 private:
     static const char* DepthTypeEnums[];
     static const char* ThreadTypeEnums[];
-    static const char* ThreadFitEnums[];
+    static const char* ClearanceMetricEnums[];
+    static const char* ClearanceUTSEnums[];
     static const char* DrillPointEnums[];
     static const char* ThreadDirectionEnums[];
 

--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
@@ -440,31 +440,37 @@ void TaskHoleParameters::threadTypeChanged(int index)
     // now set the new type, this will reset the comboboxes to item 0
     pcHole->ThreadType.setValue(index);
 
-    // Size
-    // the size for ISO type has either the form "M3x0.35" or just "M3"
-    // so we need to check if the size contains a 'x'. If yes, check if the string
-    // up to the 'x' is exists in the new list
+    // size and clearance
     if (TypeClass == QByteArray("ISO")) {
+        // the size for ISO type has either the form "M3x0.35" or just "M3"
+        // so we need to check if the size contains a 'x'. If yes, check if the string
+        // up to the 'x' is exists in the new list 
         if (ThreadSizeString.indexOf(QString::fromLatin1("x")) > -1) {
             // we have an ISO fine size
             // cut of the part behind the 'x'
             ThreadSizeString = ThreadSizeString.left(ThreadSizeString.indexOf(QString::fromLatin1("x")));
         }
-
         // search if the string exists in the combobox
         int threadSizeIndex = ui->ThreadSize->findText(ThreadSizeString, Qt::MatchContains);
         if (threadSizeIndex > -1) {
             // we can set it
             ui->ThreadSize->setCurrentIndex(threadSizeIndex);
         }
-    }
-
-    // for the UTS types the entries are the same
-    if (TypeClass == QByteArray("UTS")) {
+        // the names of the clearance types are different in ISO and UTS
+        ui->ThreadFit->setItemText(0, QCoreApplication::translate("TaskHoleParameters", "Standard", nullptr));
+        ui->ThreadFit->setItemText(1, QCoreApplication::translate("TaskHoleParameters", "Close", nullptr));
+        ui->ThreadFit->setItemText(2, QCoreApplication::translate("TaskHoleParameters", "Wide", nullptr));
+    } 
+    else if (TypeClass == QByteArray("UTS")) {
+        // for all UTS types the size entries are the same
         int threadSizeIndex = ui->ThreadSize->findText(ThreadSizeString, Qt::MatchContains);
         if (threadSizeIndex > -1) {
             ui->ThreadSize->setCurrentIndex(threadSizeIndex);
         }
+        // the names of the clearance types are different in ISO and UTS
+        ui->ThreadFit->setItemText(0, QCoreApplication::translate("TaskHoleParameters", "Normal", nullptr));
+        ui->ThreadFit->setItemText(1, QCoreApplication::translate("TaskHoleParameters", "Close", nullptr));
+        ui->ThreadFit->setItemText(2, QCoreApplication::translate("TaskHoleParameters", "Loose", nullptr));
     }
 
     // Class and cut type
@@ -475,6 +481,8 @@ void TaskHoleParameters::threadTypeChanged(int index)
     int holeCutIndex = ui->HoleCutType->findText(CutTypeString, Qt::MatchContains);
     if (holeCutIndex > -1)
         ui->HoleCutType->setCurrentIndex(holeCutIndex);
+
+    recomputeFeature();
 }
 
 void TaskHoleParameters::threadSizeChanged(int index)

--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
@@ -152,11 +152,28 @@ TaskHoleParameters::TaskHoleParameters(ViewProviderHole *HoleView, QWidget *pare
         ui->drillPointAngled->setChecked(true);
     ui->DrillPointAngle->setValue(pcHole->DrillPointAngle.getValue());
     ui->DrillForDepth->setChecked(pcHole->DrillForDepth.getValue());
-    // DrillForDepth is only enabled (sensible) if type is 'Dimension'
-    if (std::string(pcHole->DepthType.getValueAsString()) == "Dimension")
+    // drill point settings are only enabled (sensible) if type is 'Dimension'
+    if (std::string(pcHole->DepthType.getValueAsString()) == "Dimension") {
+        ui->drillPointFlat->setEnabled(true);
+        ui->drillPointAngled->setEnabled(true);
+        ui->DrillPointAngle->setEnabled(true);
         ui->DrillForDepth->setEnabled(true);
-    else
+    }
+    else {
+        ui->drillPointFlat->setEnabled(false);
+        ui->drillPointAngled->setEnabled(false);
+        ui->DrillPointAngle->setEnabled(false);
         ui->DrillForDepth->setEnabled(false);
+    }
+    // drill point is sensible but flat, disable angle and option
+    if (!ui->drillPointFlat->isChecked()) {
+        ui->DrillPointAngle->setEnabled(true);
+        ui->DrillForDepth->setEnabled(true);
+    }
+    else {
+        ui->DrillPointAngle->setEnabled(false);
+        ui->DrillForDepth->setEnabled(false);
+    }
     ui->Tapered->setChecked(pcHole->Tapered.getValue());
     // Angle is only enabled (sensible) if tapered
     ui->TaperedAngle->setEnabled(pcHole->Tapered.getValue());
@@ -171,7 +188,7 @@ TaskHoleParameters::TaskHoleParameters(ViewProviderHole *HoleView, QWidget *pare
     connect(ui->Diameter, SIGNAL(valueChanged(double)), this, SLOT(threadDiameterChanged(double)));
     connect(ui->directionRightHand, SIGNAL(clicked(bool)), this, SLOT(threadDirectionChanged()));
     connect(ui->directionLeftHand, SIGNAL(clicked(bool)), this, SLOT(threadDirectionChanged()));
-    connect(ui->HoleCutType, SIGNAL(currentIndexChanged(int)), this, SLOT(holeCutChanged(int)));
+    connect(ui->HoleCutType, SIGNAL(currentIndexChanged(int)), this, SLOT(holeCutTypeChanged(int)));
     connect(ui->HoleCutDiameter, SIGNAL(valueChanged(double)), this, SLOT(holeCutDiameterChanged(double)));
     connect(ui->HoleCutDepth, SIGNAL(valueChanged(double)), this, SLOT(holeCutDepthChanged(double)));
     connect(ui->HoleCutCountersinkAngle, SIGNAL(valueChanged(double)), this, SLOT(holeCutCountersinkAngleChanged(double)));
@@ -254,7 +271,7 @@ void TaskHoleParameters::threadCutOffOuterChanged(double value)
     recomputeFeature();
 }
 
-void TaskHoleParameters::holeCutChanged(int index)
+void TaskHoleParameters::holeCutTypeChanged(int index)
 {
     if (index < 0)
         return;
@@ -306,7 +323,7 @@ void TaskHoleParameters::holeCutCountersinkAngleChanged(double value)
 {
     PartDesign::Hole* pcHole = static_cast<PartDesign::Hole*>(vp->getObject());
 
-    pcHole->HoleCutCountersinkAngle.setValue((double)value);
+    pcHole->HoleCutCountersinkAngle.setValue(value);
     recomputeFeature();
 }
 
@@ -316,11 +333,19 @@ void TaskHoleParameters::depthChanged(int index)
 
     pcHole->DepthType.setValue(index);
 
-    // disable DrillforDepth if not 'Dimension'
-    if (std::string(pcHole->DepthType.getValueAsString()) == "Dimension")
+    // disable drill point widgets if not 'Dimension'
+    if (std::string(pcHole->DepthType.getValueAsString()) == "Dimension") {
+        ui->drillPointFlat->setEnabled(true);
+        ui->drillPointAngled->setEnabled(true);
+        ui->DrillPointAngle->setEnabled(true);
         ui->DrillForDepth->setEnabled(true);
-    else
+    }
+    else {
+        ui->drillPointFlat->setEnabled(false);
+        ui->drillPointAngled->setEnabled(false);
+        ui->DrillPointAngle->setEnabled(false);
         ui->DrillForDepth->setEnabled(false);
+    }
     recomputeFeature();
 }
 

--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
@@ -537,6 +537,10 @@ void TaskHoleParameters::threadSizeChanged(int index)
 
     pcHole->ThreadSize.setValue(index);
     recomputeFeature();
+
+    // apply the recompute result to the widgets
+    ui->HoleCutCustomValues->setDisabled(pcHole->HoleCutCustomValues.isReadOnly());
+    ui->HoleCutCustomValues->setChecked(pcHole->HoleCutCustomValues.getValue());
 }
 
 void TaskHoleParameters::threadClassChanged(int index)

--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.h
@@ -69,6 +69,7 @@ public:
     Base::Quantity getDiameter() const;
     long   getThreadDirection() const;
     long   getHoleCutType() const;
+    bool   getHoleCutCustomValues() const;
     Base::Quantity getHoleCutDiameter() const;
     Base::Quantity getHoleCutDepth() const;
     Base::Quantity getHoleCutCountersinkAngle() const;
@@ -94,6 +95,7 @@ private Q_SLOTS:
     void threadDiameterChanged(double value);
     void threadDirectionChanged();
     void holeCutTypeChanged(int index);
+    void holeCutCustomValuesChanged();
     void holeCutDiameterChanged(double value);
     void holeCutDepthChanged(double value);
     void holeCutCountersinkAngleChanged(double value);

--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.h
@@ -93,7 +93,7 @@ private Q_SLOTS:
     void threadAngleChanged(double value);    
     void threadDiameterChanged(double value);
     void threadDirectionChanged();
-    void holeCutChanged(int index);
+    void holeCutTypeChanged(int index);
     void holeCutDiameterChanged(double value);
     void holeCutDepthChanged(double value);
     void holeCutCountersinkAngleChanged(double value);

--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>335</width>
-    <height>463</height>
+    <width>342</width>
+    <height>486</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -362,6 +362,22 @@ Only available for holes without thread</string>
     </widget>
    </item>
    <item row="11" column="1">
+    <widget class="QCheckBox" name="HoleCutCustomValues">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="toolTip">
+      <string>Check to override the values predefined by the 'Type'</string>
+     </property>
+     <property name="text">
+      <string>Custom values</string>
+     </property>
+    </widget>
+   </item>
+   <item row="12" column="1">
     <widget class="QLabel" name="label_11">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
@@ -374,7 +390,7 @@ Only available for holes without thread</string>
      </property>
     </widget>
    </item>
-   <item row="11" column="2" colspan="3">
+   <item row="12" column="2" colspan="3">
     <widget class="Gui::PrefQuantitySpinBox" name="HoleCutDiameter">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -402,7 +418,7 @@ Only available for holes without thread</string>
      </property>
     </widget>
    </item>
-   <item row="12" column="1">
+   <item row="13" column="1">
     <widget class="QLabel" name="label_12">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
@@ -415,7 +431,7 @@ Only available for holes without thread</string>
      </property>
     </widget>
    </item>
-   <item row="12" column="2" colspan="3">
+   <item row="13" column="2" colspan="3">
     <widget class="Gui::PrefQuantitySpinBox" name="HoleCutDepth">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -440,7 +456,7 @@ Only available for holes without thread</string>
      </property>
     </widget>
    </item>
-   <item row="13" column="1">
+   <item row="14" column="1">
     <widget class="QLabel" name="label_10">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
@@ -453,7 +469,7 @@ Only available for holes without thread</string>
      </property>
     </widget>
    </item>
-   <item row="13" column="2" colspan="3">
+   <item row="14" column="2" colspan="3">
     <widget class="Gui::PrefQuantitySpinBox" name="HoleCutCountersinkAngle">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -475,7 +491,7 @@ Only available for holes without thread</string>
      </property>
     </widget>
    </item>
-   <item row="14" column="0">
+   <item row="15" column="0">
     <widget class="QLabel" name="label_9">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
@@ -491,7 +507,7 @@ Only available for holes without thread</string>
      </property>
     </widget>
    </item>
-   <item row="15" column="0">
+   <item row="16" column="0">
     <widget class="QLabel" name="label_15">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
@@ -507,7 +523,7 @@ Only available for holes without thread</string>
      </property>
     </widget>
    </item>
-   <item row="15" column="1">
+   <item row="16" column="1">
     <widget class="QRadioButton" name="drillPointFlat">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -523,7 +539,7 @@ Only available for holes without thread</string>
      </attribute>
     </widget>
    </item>
-   <item row="18" column="1">
+   <item row="19" column="1">
     <widget class="QRadioButton" name="drillPointAngled">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -539,7 +555,7 @@ Only available for holes without thread</string>
      </attribute>
     </widget>
    </item>
-  <item row="18" column="2" colspan="3">
+   <item row="19" column="2" colspan="3">
     <widget class="Gui::PrefQuantitySpinBox" name="DrillPointAngle">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -555,7 +571,7 @@ Only available for holes without thread</string>
      </property>
     </widget>
    </item>
-   <item row="19" column="2" colspan="3">
+   <item row="20" column="2" colspan="3">
     <widget class="QCheckBox" name="DrillForDepth">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -572,14 +588,14 @@ account for the depth of blind holes</string>
      </property>
     </widget>
    </item>
-   <item row="20" column="0">
+   <item row="21" column="0">
     <widget class="QLabel" name="label_16">
      <property name="text">
       <string>&lt;b&gt;Misc&lt;/b&gt;</string>
      </property>
     </widget>
    </item>
-   <item row="21" column="0">
+   <item row="22" column="0">
     <widget class="QCheckBox" name="Tapered">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -592,7 +608,7 @@ account for the depth of blind holes</string>
      </property>
     </widget>
    </item>
-   <item row="21" column="1">
+   <item row="22" column="1">
     <widget class="Gui::PrefQuantitySpinBox" name="TaperedAngle">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -614,7 +630,7 @@ over 90: larger hole radius at the bottom</string>
      </property>
     </widget>
    </item>
-   <item row="21" column="3" colspan="2">
+   <item row="22" column="3" colspan="2">
     <widget class="QCheckBox" name="Reversed">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -630,7 +646,7 @@ over 90: larger hole radius at the bottom</string>
      </property>
     </widget>
    </item>
-   </layout>
+  </layout>
  </widget>
  <customwidgets>
   <customwidget>
@@ -656,6 +672,7 @@ over 90: larger hole radius at the bottom</string>
   <tabstop>DepthType</tabstop>
   <tabstop>Depth</tabstop>
   <tabstop>HoleCutType</tabstop>
+  <tabstop>HoleCutCustomValues</tabstop>
   <tabstop>HoleCutDiameter</tabstop>
   <tabstop>HoleCutDepth</tabstop>
   <tabstop>HoleCutCountersinkAngle</tabstop>

--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>354</width>
+    <width>335</width>
     <height>463</height>
    </rect>
   </property>
@@ -40,10 +40,10 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="1" colspan="5">
+   <item row="1" column="1" colspan="4">
     <widget class="QComboBox" name="ThreadType">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
@@ -58,6 +58,12 @@
    </item>
    <item row="2" column="1">
     <widget class="QCheckBox" name="Threaded">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="toolTip">
       <string>Whether the hole gets a thread</string>
      </property>
@@ -84,6 +90,12 @@
    </item>
    <item row="3" column="1">
     <widget class="QRadioButton" name="directionRightHand">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="toolTip">
       <string/>
      </property>
@@ -97,6 +109,12 @@
    </item>
    <item row="5" column="1">
     <widget class="QRadioButton" name="directionLeftHand">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="text">
       <string>Left hand</string>
      </property>
@@ -121,37 +139,43 @@
    <item row="6" column="1">
     <widget class="QComboBox" name="ThreadSize">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
      <property name="maximumSize">
       <size>
-       <width>140</width>
+       <width>16777215</width>
        <height>16777215</height>
       </size>
      </property>
     </widget>
    </item>
-   <item row="6" column="3">
+   <item row="6" column="2">
     <widget class="QLabel" name="label_3">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="text">
       <string>Clearance</string>
      </property>
     </widget>
    </item>
-   <item row="6" column="5">
+   <item row="6" column="4">
     <widget class="QComboBox" name="ThreadFit">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
      <property name="maximumSize">
       <size>
-       <width>110</width>
+       <width>16777215</width>
        <height>16777215</height>
       </size>
      </property>
@@ -192,14 +216,14 @@ Only available for holes without thread</string>
    <item row="7" column="1">
     <widget class="QComboBox" name="ThreadClass">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
      <property name="maximumSize">
       <size>
-       <width>140</width>
+       <width>16777215</width>
        <height>16777215</height>
       </size>
      </property>
@@ -208,23 +232,7 @@ Only available for holes without thread</string>
      </property>
     </widget>
    </item>
-   <item row="7" column="2">
-    <spacer name="horizontalSpacer">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Fixed</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>13</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="7" column="3" colspan="2">
+   <item row="7" column="2" colspan="2">
     <widget class="QLabel" name="label_7">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
@@ -237,17 +245,17 @@ Only available for holes without thread</string>
      </property>
     </widget>
    </item>
-   <item row="7" column="5">
+   <item row="7" column="4">
     <widget class="Gui::PrefQuantitySpinBox" name="Diameter">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
      <property name="maximumSize">
       <size>
-       <width>110</width>
+       <width>16777215</width>
        <height>16777215</height>
       </size>
      </property>
@@ -278,14 +286,14 @@ Only available for holes without thread</string>
    <item row="8" column="1">
     <widget class="QComboBox" name="DepthType">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
      <property name="maximumSize">
       <size>
-       <width>140</width>
+       <width>16777215</width>
        <height>16777215</height>
       </size>
      </property>
@@ -301,10 +309,10 @@ Only available for holes without thread</string>
      </item>
     </widget>
    </item>
-   <item row="8" column="3" colspan="3">
+   <item row="8" column="2" colspan="3">
     <widget class="Gui::PrefQuantitySpinBox" name="Depth">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
@@ -334,10 +342,10 @@ Only available for holes without thread</string>
      </property>
     </widget>
    </item>
-   <item row="10" column="1" colspan="5">
+   <item row="10" column="1" colspan="4">
     <widget class="QComboBox" name="HoleCutType">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
@@ -355,15 +363,21 @@ Only available for holes without thread</string>
    </item>
    <item row="11" column="1">
     <widget class="QLabel" name="label_11">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="text">
       <string>Diameter</string>
      </property>
     </widget>
    </item>
-   <item row="11" column="3" colspan="3">
+   <item row="11" column="2" colspan="3">
     <widget class="Gui::PrefQuantitySpinBox" name="HoleCutDiameter">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
@@ -390,15 +404,21 @@ Only available for holes without thread</string>
    </item>
    <item row="12" column="1">
     <widget class="QLabel" name="label_12">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="text">
       <string>Depth</string>
      </property>
     </widget>
    </item>
-   <item row="12" column="3" colspan="3">
+   <item row="12" column="2" colspan="3">
     <widget class="Gui::PrefQuantitySpinBox" name="HoleCutDepth">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
@@ -422,15 +442,21 @@ Only available for holes without thread</string>
    </item>
    <item row="13" column="1">
     <widget class="QLabel" name="label_10">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="text">
       <string>Countersink angle</string>
      </property>
     </widget>
    </item>
-   <item row="13" column="3" colspan="3">
+   <item row="13" column="2" colspan="3">
     <widget class="Gui::PrefQuantitySpinBox" name="HoleCutCountersinkAngle">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
@@ -467,6 +493,12 @@ Only available for holes without thread</string>
    </item>
    <item row="15" column="0">
     <widget class="QLabel" name="label_15">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="text">
       <string>Type</string>
      </property>
@@ -478,7 +510,7 @@ Only available for holes without thread</string>
    <item row="15" column="1">
     <widget class="QRadioButton" name="drillPointFlat">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
@@ -494,7 +526,7 @@ Only available for holes without thread</string>
    <item row="18" column="1">
     <widget class="QRadioButton" name="drillPointAngled">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
@@ -507,10 +539,10 @@ Only available for holes without thread</string>
      </attribute>
     </widget>
    </item>
-   <item row="18" column="3" colspan="3">
+  <item row="18" column="2" colspan="3">
     <widget class="Gui::PrefQuantitySpinBox" name="DrillPointAngle">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
@@ -523,8 +555,14 @@ Only available for holes without thread</string>
      </property>
     </widget>
    </item>
-   <item row="19" column="3" colspan="3">
+   <item row="19" column="2" colspan="3">
     <widget class="QCheckBox" name="DrillForDepth">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="toolTip">
       <string>The size of the drill point will be taken into
 account for the depth of blind holes</string>
@@ -543,6 +581,12 @@ account for the depth of blind holes</string>
    </item>
    <item row="21" column="0">
     <widget class="QCheckBox" name="Tapered">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="text">
       <string>Tapered</string>
      </property>
@@ -550,6 +594,12 @@ account for the depth of blind holes</string>
    </item>
    <item row="21" column="1">
     <widget class="Gui::PrefQuantitySpinBox" name="TaperedAngle">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="toolTip">
       <string>Taper angle for the hole
 90 degree: straight hole
@@ -564,8 +614,14 @@ over 90: larger hole radius at the bottom</string>
      </property>
     </widget>
    </item>
-   <item row="21" column="4" colspan="2">
+   <item row="21" column="3" colspan="2">
     <widget class="QCheckBox" name="Reversed">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="toolTip">
       <string>Reverses the hole direction</string>
      </property>
@@ -574,7 +630,7 @@ over 90: larger hole radius at the bottom</string>
      </property>
     </widget>
    </item>
-  </layout>
+   </layout>
  </widget>
  <customwidgets>
   <customwidget>
@@ -620,28 +676,12 @@ over 90: larger hole radius at the bottom</string>
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>49</x>
-     <y>451</y>
+     <x>40</x>
+     <y>540</y>
     </hint>
     <hint type="destinationlabel">
-     <x>163</x>
-     <y>453</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>Threaded</sender>
-   <signal>clicked(bool)</signal>
-   <receiver>ThreadFit</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
      <x>136</x>
-     <y>63</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>344</x>
-     <y>142</y>
+     <y>540</y>
     </hint>
    </hints>
   </connection>
@@ -656,14 +696,30 @@ over 90: larger hole radius at the bottom</string>
      <y>63</y>
     </hint>
     <hint type="destinationlabel">
-     <x>163</x>
-     <y>168</y>
+     <x>136</x>
+     <y>280</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>Threaded</sender>
+   <signal>clicked(bool)</signal>
+   <receiver>ThreadFit</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>136</x>
+     <y>63</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>322</x>
+     <y>254</y>
     </hint>
    </hints>
   </connection>
  </connections>
  <buttongroups>
-  <buttongroup name="drillPointButtonGroup"/>
   <buttongroup name="directionButtonGroup"/>
+  <buttongroup name="drillPointButtonGroup"/>
  </buttongroups>
 </ui>


### PR DESCRIPTION
This PR is based on PR #4344. It:

handles custom counterbore/sink values correctly
See bug B reported here: https://forum.freecadweb.org/viewtopic.php?f=3&t=54408&sid=91194a40335be7962781e0aa7958a760
We have normed screw head cuts. These values can be overridden but we must store the info about the overriding. Why? - because when you have e.g. made a custom change to a normed countersink and then change to another countersink norm, you would either not get the values defined in the norm or you get these values but loose e.g. your depth settings

Only review the commit cad4d82, the other commits are just the changes from PR #4343 and PR #4344 .

This PR is meant to be merged after PR #4344 was merged.