### PR TITLE
Part: Fix source typo in API Base::Placement getplacement() 

### DIFF
--- a/src/Mod/Part/App/TopoShape.cpp
+++ b/src/Mod/Part/App/TopoShape.cpp
@@ -718,7 +718,7 @@ void TopoShape::setPlacement(const Base::Placement& rclTrf)
     _Shape.Location(loc);
 }
 
-Base::Placement TopoShape::getPlacemet(void) const
+Base::Placement TopoShape::getPlacement(void) const
 {
     TopLoc_Location loc = _Shape.Location();
     gp_Trsf trsf = loc.Transformation();

--- a/src/Mod/Part/App/TopoShape.h
+++ b/src/Mod/Part/App/TopoShape.h
@@ -114,7 +114,7 @@ public:
     /// get the transformation of the CasCade Shape
     Base::Matrix4D getTransform(void) const;
     /// get the transformation of the CasCade Shape
-    Base::Placement getPlacemet(void) const;
+    Base::Placement getPlacement(void) const;
     /// Bound box from the CasCade shape
     Base::BoundBox3d getBoundBox(void)const;
     virtual bool getCenterOfGravity(Base::Vector3d& center) const;


### PR DESCRIPTION
Found originally by @pavltom in https://github.com/FreeCAD/FreeCAD/pull/4342/files#diff-35c6defb9ecd4c77532452e5aec35493d3728057e4e7b205655cd2d4b4e00181 