### PR TITLE
[Surface] Fix task panel Delete shortcut use to use Widget context

### DIFF
--- a/src/Mod/Surface/Gui/TaskFilling.cpp
+++ b/src/Mod/Surface/Gui/TaskFilling.cpp
@@ -272,6 +272,7 @@ FillingPanel::FillingPanel(ViewProviderFilling* vp, Surface::Filling* obj)
     // Create context menu
     QAction* action = new QAction(tr("Remove"), this);
     action->setShortcut(QString::fromLatin1("Del"));
+    action->setShortcutContext(Qt::WidgetShortcut);
     ui->listBoundary->addAction(action);
     connect(action, SIGNAL(triggered()), this, SLOT(onDeleteEdge()));
     ui->listBoundary->setContextMenuPolicy(Qt::ActionsContextMenu);

--- a/src/Mod/Surface/Gui/TaskFillingEdge.cpp
+++ b/src/Mod/Surface/Gui/TaskFillingEdge.cpp
@@ -128,6 +128,7 @@ FillingEdgePanel::FillingEdgePanel(ViewProviderFilling* vp, Surface::Filling* ob
     // Create context menu
     QAction* action = new QAction(tr("Remove"), this);
     action->setShortcut(QString::fromLatin1("Del"));
+    action->setShortcutContext(Qt::WidgetShortcut);
     ui->listUnbound->addAction(action);
     connect(action, SIGNAL(triggered()), this, SLOT(onDeleteUnboundEdge()));
     ui->listUnbound->setContextMenuPolicy(Qt::ActionsContextMenu);

--- a/src/Mod/Surface/Gui/TaskFillingVertex.cpp
+++ b/src/Mod/Surface/Gui/TaskFillingVertex.cpp
@@ -127,6 +127,7 @@ FillingVertexPanel::FillingVertexPanel(ViewProviderFilling* vp, Surface::Filling
     // Create context menu
     QAction* action = new QAction(tr("Remove"), this);
     action->setShortcut(QString::fromLatin1("Del"));
+    action->setShortcutContext(Qt::WidgetShortcut);
     ui->listFreeVertex->addAction(action);
     connect(action, SIGNAL(triggered()), this, SLOT(onDeleteVertex()));
     ui->listFreeVertex->setContextMenuPolicy(Qt::ActionsContextMenu);


### PR DESCRIPTION
The Delete key shortcut of the three different panels in the Surface Workbench TaskFilling sidebar conflicted between the panels if multiple were showing. This is resolved by making the QAction's context the widget, rather than the window.

Discussion here: https://forum.freecadweb.org/viewtopic.php?f=8&t=55037

Thanks to @0penBrain for figuring out the problem and proposing this fix.

---

- [X] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- No associated tracker ticket