### PR TITLE
[0.19][Surface] Fix segfault in surface task view

### DIFF
--- a/src/Gui/TaskView/TaskView.cpp
+++ b/src/Gui/TaskView/TaskView.cpp
@@ -775,6 +775,10 @@ void TaskView::removeTaskWatcher(void)
 
 void TaskView::accept()
 {
+    if (!ActiveDialog) { // Protect against segfaults due to out-of-order deletions
+        Base::Console().Warning("ActiveDialog was null in call to TaskView::accept()");
+        return;
+    }
     // Make sure that if 'accept' calls 'closeDialog' the deletion is postponed until
     // the dialog leaves the 'accept' method
     ActiveDialog->setProperty("taskview_accept_or_reject", true);
@@ -786,6 +790,10 @@ void TaskView::accept()
 
 void TaskView::reject()
 {
+    if (!ActiveDialog) { // Protect against segfaults due to out-of-order deletions
+        Base::Console().Warning("ActiveDialog was null in call to TaskView::reject()");
+        return;
+    }
     // Make sure that if 'reject' calls 'closeDialog' the deletion is postponed until
     // the dialog leaves the 'reject' method
     ActiveDialog->setProperty("taskview_accept_or_reject", true);

--- a/src/Mod/Surface/Gui/TaskFilling.cpp
+++ b/src/Mod/Surface/Gui/TaskFilling.cpp
@@ -362,6 +362,7 @@ void FillingPanel::hideEvent(QHideEvent* event)
     // If the dialog was hidden by ESC being pressed in the 3D view, we need to remove the highlights
     // and selection gate, which is all that reject() does.
     reject();
+    QWidget::hideEvent(event);
 }
 
 

--- a/src/Mod/Surface/Gui/TaskFilling.cpp
+++ b/src/Mod/Surface/Gui/TaskFilling.cpp
@@ -89,17 +89,6 @@ bool ViewProviderFilling::setEdit(int ModNum)
     }
 }
 
-void ViewProviderFilling::unsetEdit(int ModNum)
-{
-    if (ModNum == ViewProvider::Default) {
-        // when pressing ESC make sure to close the dialog
-        QTimer::singleShot(0, &Gui::Control(), SLOT(closeDialog()));
-    }
-    else {
-        PartGui::ViewProviderSpline::unsetEdit(ModNum);
-    }
-}
-
 QIcon ViewProviderFilling::getIcon(void) const
 {
     return Gui::BitmapFactory().pixmap("Surface_Filling");
@@ -367,6 +356,14 @@ void FillingPanel::changeEvent(QEvent *e)
         QWidget::changeEvent(e);
     }
 }
+
+void FillingPanel::hideEvent(QHideEvent* event)
+{
+    // If the dialog was hidden by ESC being pressed in the 3D view, we need to remove the highlights
+    // and selection gate, which is all that reject() does.
+    reject();
+}
+
 
 void FillingPanel::open()
 {

--- a/src/Mod/Surface/Gui/TaskFilling.h
+++ b/src/Mod/Surface/Gui/TaskFilling.h
@@ -49,7 +49,6 @@ public:
     enum ShapeType {Vertex, Edge, Face};
     virtual void setupContextMenu(QMenu*, QObject*, const char*);
     virtual bool setEdit(int ModNum);
-    virtual void unsetEdit(int ModNum);
     QIcon getIcon(void) const;
     void highlightReferences(ShapeType type, const References& refs, bool on);
 };
@@ -83,6 +82,7 @@ public:
 
 protected:
     void changeEvent(QEvent *e);
+    virtual void hideEvent(QHideEvent* event);
     virtual void onSelectionChanged(const Gui::SelectionChanges& msg);
     /** Notifies on undo */
     virtual void slotUndoDocument(const Gui::Document& Doc);


### PR DESCRIPTION
Forums discussion: https://forum.freecadweb.org/viewtopic.php?f=8&t=55036

If the surface task view is not closed prior to double-clicking on a sketch, the code segfaults due to the active dialog being removed while Sketcher is asking the user if they want to do that. This corrects the bad access by removing the task panel's self-deletion when unsetEdit was called, and replacing it with code that clears the active highlights and selection gate when the task view is hidden. This ensures that Escape-key behavior is still correct.

---

- [X] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- No tracker ticket