### PR TITLE
Fix various typos [skip ci]

### DIFF
--- a/src/Base/core-base.dox
+++ b/src/Base/core-base.dox
@@ -23,5 +23,5 @@
 
 /** \defgroup GeomPrimers Geometry primers
  *  \ingroup BASE
-    \brief Basic structures used by geomoetric objects
+    \brief Basic structures used by geometric objects
 */

--- a/src/Mod/Path/Tools/README.md
+++ b/src/Mod/Path/Tools/README.md
@@ -75,7 +75,7 @@ solid is updated to the correct representation.
    * this creates a PropertyBag object inside the Body (assuming it was selected)
    * add properties to which define the tool bit's shape and put those into the group 'Shape'
    * add any other properties to the bag which might be useful for the tool bit
-1. Construct the body of the tool bit and assign experssions referencing properties from the PropertyBag (in the
+1. Construct the body of the tool bit and assign expressions referencing properties from the PropertyBag (in the
    `Shape` Group) for all constraints.
    * Position the tip of the tool bit on the origin (0,0)
 1. Save the document as a new file in the Shape directory

--- a/src/Mod/Sketcher/App/planegcs/Constraints.cpp
+++ b/src/Mod/Sketcher/App/planegcs/Constraints.cpp
@@ -2085,7 +2085,7 @@ void ConstraintEqualLineLength::errorgrad(double *err, double *grad, double *par
         //
         // So here we maintain the very small derivative of 1e-10 when the gradient is under such value, such
         // that the diagnose function with pivot threshold of 1e-13 treats the value as non-zero and correctly
-        // detects and can tell appart when a parameter is fully constrained or just locked into a maximum/minimum
+        // detects and can tell apart when a parameter is fully constrained or just locked into a maximum/minimum
         if(fabs(*grad)  < 1e-10) {
             double surrogate = 1e-10;
             if( param == l1.p1.x )


### PR DESCRIPTION
Found via codespell v2.1.dev0  
```
codespell -q 3 -L aci,ake,aline,alle,alledges,alocation,als,ang,anid,apoints,ba,beginn,behaviour,bloaded,byteorder,calculater,cancelled,cancelling,cas,cascade,centimetre,childs,colour,colours,commen,connexion,currenty,dof,doubleclick,dum,eiter,elemente,ende,feld,finde,findf,freez,hist,iff,indicies,initialisation,initialise,initialised,initialises,initialisiert,ist,kilometre,lod,mantatory,methode,metres,millimetre,modell,nd,noe,normale,normaly,nto,numer,oder,orgin,orginx,orginy,ot,pard,pres,programm,que,recurrance,rougly,seperator,serie,sinc,strack,substraction,te,thist,thru,tread,uint,unter,vertexes,wallthickness,whitespaces -S ./.git,*.po,*.ts,./ChangeLog.txt,./src/3rdParty,./src/Mod/Assembly/App/opendcm,./src/CXX,./src/zipios++,./src/Base/swig*,./src/Mod/Robot/App/kdl_cp,./src/Mod/Import/App/SCL,./src/WindowsInstaller,./src/Doc/FreeCAD.uml,./build/doc/SourceDocu
```