### PR TITLE
[0.19][ARCH] Arch: Fix LGTM warning of missing param for translate() in ArchPanel.py

### DIFF
--- a/src/Mod/Arch/ArchPanel.py
+++ b/src/Mod/Arch/ArchPanel.py
@@ -29,7 +29,7 @@ if FreeCAD.GuiUp:
     import draftguitools.gui_trackers as DraftTrackers
 else:
     # \cond
-    def translate(ctxt,txt):
+    def translate(ctxt,txt,utf8_decode=False):
         return txt
     def QT_TRANSLATE_NOOP(ctxt,txt):
         return txt


### PR DESCRIPTION
Even though this is ignored per the docs[1], LGTM complains[2] about it. This commit adds the superfluous param. Note: there is precedent in ArchReference.py[3] and ArchWall.py[4].
 
[1] https://github.com/FreeCAD/FreeCAD/blob/master/src/Mod/Draft/draftutils/translate.py#L73-L78  
[2] https://lgtm.com/projects/g/FreeCAD/FreeCAD/snapshot/17db14c9700ae65d042d3548ef07f9518a115ba4/files/src/Mod/Arch/ArchPanel.py#L32  
[3] https://github.com/FreeCAD/FreeCAD/blob/45dd1a7f608f822aaab4dc52d2308edb977a3f5a/src/Mod/Arch/ArchReference.py#L39  
[4] https://github.com/FreeCAD/FreeCAD/blob/45dd1a7f608f822aaab4dc52d2308edb977a3f5a/src/Mod/Arch/ArchWall.py#L42