### PR TITLE
Sketcher: [skip ci] fix computing of hotspot of sketcher icons on Wayland

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchHandler.cpp
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandler.cpp
@@ -29,6 +29,7 @@
 # include <Inventor/nodes/SoText2.h>
 # include <Inventor/nodes/SoFont.h>
 # include <QPainter>
+# include <QGuiApplication>
 # include <cmath>
 #endif  // #ifndef _PreComp_
 
@@ -113,12 +114,13 @@ void DrawSketchHandler::setSvgCursor(const QString & cursorName, int x, int y, c
     qreal pRatio = devicePixelRatio();
     bool isRatioOne = (pRatio == 1.0);
     qreal defaultCursorSize = isRatioOne ? 64 : 32;
-#if defined(Q_OS_WIN32) || defined(Q_OS_MAC)
     qreal hotX = x;
     qreal hotY = y;
-#else
-    qreal hotX = x * pRatio;
-    qreal hotY = y * pRatio;
+#if !defined(Q_OS_WIN32) && !defined(Q_OS_MAC)
+    if (qGuiApp->platformName() == QLatin1String("xcb")) {
+        hotX *= pRatio;
+        hotY *= pRatio;
+    }
 #endif
     qreal cursorSize = defaultCursorSize * pRatio;
 
@@ -155,12 +157,13 @@ void DrawSketchHandler::setCursor(const QPixmap &p,int x,int y, bool autoScale)
 #if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
             p1.setDevicePixelRatio(pRatio);
 #endif
-#if defined(Q_OS_WIN32) || defined(Q_OS_MAC)
             qreal hotX = x;
             qreal hotY = y;
-#else
-            qreal hotX = x * pRatio;
-            qreal hotY = y * pRatio;
+#if !defined(Q_OS_WIN32) && !defined(Q_OS_MAC)
+            if (qGuiApp->platformName() == QLatin1String("xcb")) {
+                hotX *= pRatio;
+                hotY *= pRatio;
+            }
 #endif
             cursor = QCursor(p1, hotX, hotY);
         } else {

--- a/src/Mod/Sketcher/Gui/PreCompiled.h
+++ b/src/Mod/Sketcher/Gui/PreCompiled.h
@@ -95,6 +95,7 @@
 # include <Gui/Qt4All.h>
 #endif
 
+# include <QGuiApplication>
 # include <QMessageBox>
 #include <qdebug.h>
 #include <QString>


### PR DESCRIPTION
Restrict the hotspot multiplication on unix platforms to X11 (xcb platform)

---

hopefully the PreCompiled change is correct?