### PR TITLE
[0.20] [GUI] Add tooltip to f(x) when there is no expression

### DIFF
--- a/src/Gui/QuantitySpinBox.cpp
+++ b/src/Gui/QuantitySpinBox.cpp
@@ -307,6 +307,7 @@ QuantitySpinBox::QuantitySpinBox(QWidget *parent)
     iconLabel->setPixmap(pixmap);
     iconLabel->setStyleSheet(QString::fromLatin1("QLabel { border: none; padding: 0px; padding-top: %2px; width: %1px; height: %1px }").arg(iconHeight).arg(frameWidth/2));
     iconLabel->hide();
+    static_cast<ExpressionLabel *>(iconLabel)->setExpressionText(QString());
     lineEdit()->setStyleSheet(QString::fromLatin1("QLineEdit { padding-right: %1px } ").arg(iconHeight+frameWidth));
     // When a style sheet is set the text margins for top/bottom must be set to avoid to squash the widget
 #ifndef Q_OS_MAC
@@ -442,7 +443,7 @@ void Gui::QuantitySpinBox::onChange()
             p.setColor(QPalette::Text, Qt::lightGray);
             lineEdit()->setPalette(p);
         }
-        iconLabel->setToolTip(Base::Tools::fromStdString(getExpression()->toString()));
+        static_cast<ExpressionLabel*>(iconLabel)->setExpressionText(Base::Tools::fromStdString(getExpression()->toString()));
     }
     else {
         setReadOnly(false);
@@ -451,7 +452,7 @@ void Gui::QuantitySpinBox::onChange()
         QPalette p(lineEdit()->palette());
         p.setColor(QPalette::Active, QPalette::Text, defaultPalette.color(QPalette::Text));
         lineEdit()->setPalette(p);
-        iconLabel->setToolTip(QString());
+        static_cast<ExpressionLabel*>(iconLabel)->setExpressionText(QString());
     }
 }
 
@@ -506,7 +507,7 @@ void QuantitySpinBox::resizeEvent(QResizeEvent * event)
                 p.setColor(QPalette::Text, Qt::lightGray);
                 lineEdit()->setPalette(p);
             }
-            iconLabel->setToolTip(Base::Tools::fromStdString(getExpression()->toString()));
+            static_cast<ExpressionLabel*>(iconLabel)->setExpressionText(Base::Tools::fromStdString(getExpression()->toString()));
         }
         else {
             setReadOnly(false);
@@ -516,7 +517,7 @@ void QuantitySpinBox::resizeEvent(QResizeEvent * event)
             QPalette p(lineEdit()->palette());
             p.setColor(QPalette::Active, QPalette::Text, defaultPalette.color(QPalette::Text));
             lineEdit()->setPalette(p);
-            iconLabel->setToolTip(QString());
+            static_cast<ExpressionLabel*>(iconLabel)->setExpressionText(QString());
         }
     }
     catch (const Base::Exception & e) {

--- a/src/Gui/QuantitySpinBox_p.h
+++ b/src/Gui/QuantitySpinBox_p.h
@@ -30,6 +30,14 @@ class ExpressionLabel : public QLabel
     Q_OBJECT
 public:
     ExpressionLabel(QWidget * parent) : QLabel(parent) { }
+
+    void setExpressionText(const QString& text) {
+        if (text.isEmpty()) 
+            this->setToolTip(genericFormulaEditorTooltip);
+        else 
+            this->setToolTip(formulaEditorTooltipPrefix + text);
+    }
+
 protected:
     void mouseReleaseEvent(QMouseEvent * event) {
         if (rect().contains(event->pos()))
@@ -38,6 +46,11 @@ protected:
 
 Q_SIGNALS:
     void clicked();
+
+private:
+
+    const QString genericFormulaEditorTooltip = tr("Enter an expression...");
+    const QString formulaEditorTooltipPrefix = tr("Expression: ");
 };
 
 #endif // QUANTITYSPINBOX_P_H

--- a/src/Gui/SpinBox.cpp
+++ b/src/Gui/SpinBox.cpp
@@ -163,6 +163,7 @@ UIntSpinBox::UIntSpinBox (QWidget* parent)
     iconLabel->setPixmap(pixmap);
     iconLabel->setStyleSheet(QString::fromLatin1("QLabel { border: none; padding: 0px; padding-top: %2px; width: %1px; height: %1px }").arg(iconHeight).arg(frameWidth/2));
     iconLabel->hide();
+    static_cast<ExpressionLabel*>(iconLabel)->setExpressionText(QString());
     lineEdit()->setStyleSheet(QString::fromLatin1("QLineEdit { padding-right: %1px } ").arg(iconHeight+frameWidth));
 
     QObject::connect(iconLabel, SIGNAL(clicked()), this, SLOT(openFormulaDialog()));
@@ -295,7 +296,7 @@ void UIntSpinBox::onChange() {
             p.setColor(QPalette::Text, Qt::lightGray);
             lineEdit()->setPalette(p);
         }
-        iconLabel->setToolTip(Base::Tools::fromStdString(getExpression()->toString()));
+        static_cast<ExpressionLabel*>(iconLabel)->setExpressionText(Base::Tools::fromStdString(getExpression()->toString()));
     }
     else {
         setReadOnly(false);
@@ -303,7 +304,7 @@ void UIntSpinBox::onChange() {
         QPalette p(lineEdit()->palette());
         p.setColor(QPalette::Active, QPalette::Text, defaultPalette.color(QPalette::Text));
         lineEdit()->setPalette(p);
-        iconLabel->setToolTip(QString());
+        static_cast<ExpressionLabel*>(iconLabel)->setExpressionText(QString());
     }
 }
 
@@ -346,7 +347,7 @@ void UIntSpinBox::resizeEvent(QResizeEvent * event)
                 p.setColor(QPalette::Text, Qt::lightGray);
                 lineEdit()->setPalette(p);
             }
-            iconLabel->setToolTip(Base::Tools::fromStdString(getExpression()->toString()));
+            static_cast<ExpressionLabel*>(iconLabel)->setExpressionText(Base::Tools::fromStdString(getExpression()->toString()));
         }
         else {
             setReadOnly(false);
@@ -356,7 +357,7 @@ void UIntSpinBox::resizeEvent(QResizeEvent * event)
             QPalette p(lineEdit()->palette());
             p.setColor(QPalette::Active, QPalette::Text, defaultPalette.color(QPalette::Text));
             lineEdit()->setPalette(p);
-            iconLabel->setToolTip(QString());
+            static_cast<ExpressionLabel*>(iconLabel)->setExpressionText(QString());
         }
     }
     catch (const Base::Exception & e) {
@@ -443,6 +444,7 @@ IntSpinBox::IntSpinBox(QWidget* parent) : QSpinBox(parent) {
     iconLabel->setPixmap(pixmap);
     iconLabel->setStyleSheet(QString::fromLatin1("QLabel { border: none; padding: 0px; padding-top: %2px; width: %1px; height: %1px }").arg(iconHeight).arg(frameWidth/2));
     iconLabel->hide();
+    static_cast<ExpressionLabel*>(iconLabel)->setExpressionText(QString());
     lineEdit()->setStyleSheet(QString::fromLatin1("QLineEdit { padding-right: %1px } ").arg(iconHeight+frameWidth));
 
     QObject::connect(iconLabel, SIGNAL(clicked()), this, SLOT(openFormulaDialog()));
@@ -504,7 +506,7 @@ void IntSpinBox::onChange() {
             p.setColor(QPalette::Text, Qt::lightGray);
             lineEdit()->setPalette(p);
         }
-        iconLabel->setToolTip(Base::Tools::fromStdString(getExpression()->toString()));
+        static_cast<ExpressionLabel*>(iconLabel)->setExpressionText(Base::Tools::fromStdString(getExpression()->toString()));
     }
     else {
         setReadOnly(false);
@@ -512,7 +514,7 @@ void IntSpinBox::onChange() {
         QPalette p(lineEdit()->palette());
         p.setColor(QPalette::Active, QPalette::Text, defaultPalette.color(QPalette::Text));
         lineEdit()->setPalette(p);
-        iconLabel->setToolTip(QString());
+        static_cast<ExpressionLabel*>(iconLabel)->setExpressionText(QString());
     }
 }
 
@@ -539,7 +541,7 @@ void IntSpinBox::resizeEvent(QResizeEvent * event)
                 p.setColor(QPalette::Text, Qt::lightGray);
                 lineEdit()->setPalette(p);
             }
-            iconLabel->setToolTip(Base::Tools::fromStdString(getExpression()->toString()));
+            static_cast<ExpressionLabel*>(iconLabel)->setExpressionText(Base::Tools::fromStdString(getExpression()->toString()));
         }
         else {
             setReadOnly(false);
@@ -549,7 +551,7 @@ void IntSpinBox::resizeEvent(QResizeEvent * event)
             QPalette p(lineEdit()->palette());
             p.setColor(QPalette::Active, QPalette::Text, defaultPalette.color(QPalette::Text));
             lineEdit()->setPalette(p);
-            iconLabel->setToolTip(QString());
+            static_cast<ExpressionLabel*>(iconLabel)->setExpressionText(QString());
         }
     }
     catch (const Base::Exception & e) {
@@ -636,6 +638,7 @@ DoubleSpinBox::DoubleSpinBox(QWidget* parent): QDoubleSpinBox(parent) {
     iconLabel->setPixmap(pixmap);
     iconLabel->setStyleSheet(QString::fromLatin1("QLabel { border: none; padding: 0px; padding-top: %2px; width: %1px; height: %1px }").arg(iconHeight).arg(frameWidth/2));
     iconLabel->hide();
+    static_cast<ExpressionLabel*>(iconLabel)->setExpressionText(QString());
     lineEdit()->setStyleSheet(QString::fromLatin1("QLineEdit { padding-right: %1px } ").arg(iconHeight+frameWidth));
 
     QObject::connect(iconLabel, SIGNAL(clicked()), this, SLOT(openFormulaDialog()));
@@ -697,7 +700,7 @@ void DoubleSpinBox::onChange() {
             p.setColor(QPalette::Text, Qt::lightGray);
             lineEdit()->setPalette(p);
         }
-        iconLabel->setToolTip(Base::Tools::fromStdString(getExpression()->toString()));
+        static_cast<ExpressionLabel*>(iconLabel)->setExpressionText(Base::Tools::fromStdString(getExpression()->toString()));
     }
     else {
         setReadOnly(false);
@@ -705,7 +708,7 @@ void DoubleSpinBox::onChange() {
         QPalette p(lineEdit()->palette());
         p.setColor(QPalette::Active, QPalette::Text, defaultPalette.color(QPalette::Text));
         lineEdit()->setPalette(p);
-        iconLabel->setToolTip(QString());
+        static_cast<ExpressionLabel*>(iconLabel)->setExpressionText(QString());
     }
 }
 
@@ -732,7 +735,7 @@ void DoubleSpinBox::resizeEvent(QResizeEvent * event)
                 p.setColor(QPalette::Text, Qt::lightGray);
                 lineEdit()->setPalette(p);
             }
-            iconLabel->setToolTip(Base::Tools::fromStdString(getExpression()->toString()));
+            static_cast<ExpressionLabel*>(iconLabel)->setExpressionText(Base::Tools::fromStdString(getExpression()->toString()));
         }
         else {
             setReadOnly(false);
@@ -742,7 +745,7 @@ void DoubleSpinBox::resizeEvent(QResizeEvent * event)
             QPalette p(lineEdit()->palette());
             p.setColor(QPalette::Active, QPalette::Text, defaultPalette.color(QPalette::Text));
             lineEdit()->setPalette(p);
-            iconLabel->setToolTip(QString());
+            static_cast<ExpressionLabel*>(iconLabel)->setExpressionText(QString());
         }
     }
     catch (const Base::Exception & e) {

--- a/src/Gui/Widgets.cpp
+++ b/src/Gui/Widgets.cpp
@@ -1370,6 +1370,7 @@ ExpLineEdit::ExpLineEdit(QWidget* parent, bool expressionOnly)
     iconLabel->setPixmap(pixmap);
     iconLabel->setStyleSheet(QString::fromLatin1("QLabel { border: none; padding: 0px; padding-top: %2px; width: %1px; height: %1px }").arg(iconHeight).arg(frameWidth/2));
     iconLabel->hide();
+    static_cast<ExpressionLabel*>(iconLabel)->setExpressionText(QString());
     setStyleSheet(QString::fromLatin1("QLineEdit { padding-right: %1px } ").arg(iconHeight+frameWidth));
 
     QObject::connect(iconLabel, SIGNAL(clicked()), this, SLOT(openFormulaDialog()));
@@ -1431,7 +1432,7 @@ void ExpLineEdit::onChange() {
         QPalette p(palette());
         p.setColor(QPalette::Text, Qt::lightGray);
         setPalette(p);
-        iconLabel->setToolTip(Base::Tools::fromStdString(getExpression()->toString()));
+        static_cast<ExpressionLabel*>(iconLabel)->setExpressionText(Base::Tools::fromStdString(getExpression()->toString()));
     }
     else {
         setReadOnly(false);
@@ -1439,7 +1440,7 @@ void ExpLineEdit::onChange() {
         QPalette p(palette());
         p.setColor(QPalette::Active, QPalette::Text, defaultPalette.color(QPalette::Text));
         setPalette(p);
-        iconLabel->setToolTip(QString());
+        static_cast<ExpressionLabel*>(iconLabel)->setExpressionText(QString());
     }
 }
 
@@ -1461,7 +1462,7 @@ void ExpLineEdit::resizeEvent(QResizeEvent * event)
             QPalette p(palette());
             p.setColor(QPalette::Text, Qt::lightGray);
             setPalette(p);
-            iconLabel->setToolTip(Base::Tools::fromStdString(getExpression()->toString()));
+            static_cast<ExpressionLabel*>(iconLabel)->setExpressionText(Base::Tools::fromStdString(getExpression()->toString()));
         }
         else {
             setReadOnly(false);
@@ -1471,7 +1472,7 @@ void ExpLineEdit::resizeEvent(QResizeEvent * event)
             QPalette p(palette());
             p.setColor(QPalette::Active, QPalette::Text, defaultPalette.color(QPalette::Text));
             setPalette(p);
-            iconLabel->setToolTip(QString());
+            static_cast<ExpressionLabel*>(iconLabel)->setExpressionText(QString());
         }
     }
     catch (const Base::Exception & e) {


### PR DESCRIPTION
As suggested by @luzpaz, this adds a tooltip to the f(x) icon of all of the widgets that use it: `QuantitySpinBox`, `UIntSpinBox`, `IntSpinBox`, `DoubleSpinBox`, and `ExpLineEdit`. These five classes are divided across three files, and all five classes duplicate the same basic code. In the existing code, no tooltip is shown if there is no expression. If there is an expression, it (alone) is used as the tooltip.

This commit modifies that behavior to have explanatory text as the tooltip when there is no expression, and when there is, to prepend a short string to the beginning.

To reduce further code duplication, this is implemented by adding a new function to `ExpressionLabel` allowing the text of the expression to be set. It checks that text and if it's empty, uses a preset default string as the tooltip. If there is expression text, it instead prepends another bit of text to the front and sets the entire expression+prefix as the tooltip.

TODO: In the future a lot of the preexisting code duplication could be removed by making the `ExpressionLabel` class do more internal management of the expression.

Thanks to @kisolre for the assistance tracking these down, and suggesting the default text used. Forum discussion topic: https://forum.freecadweb.org/viewtopic.php?f=17&t=55146

---

- [X] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- No tracker ticket