### PR TITLE
[Sketcher] make pointers to the UI std::unique_ptr

### DIFF
--- a/src/Mod/Sketcher/Gui/TaskSketcherConstrains.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstrains.cpp
@@ -634,13 +634,13 @@ void ConstraintView::swapNamedOfSelectedItems()
 
 // ----------------------------------------------------------------------------
 
-TaskSketcherConstrains::TaskSketcherConstrains(ViewProviderSketch *sketchView)
-    : TaskBox(Gui::BitmapFactory().pixmap("document-new"),tr("Constraints"),true, 0)
-    , sketchView(sketchView), inEditMode(false)
+TaskSketcherConstrains::TaskSketcherConstrains(ViewProviderSketch *sketchView) :
+    TaskBox(Gui::BitmapFactory().pixmap("document-new"), tr("Constraints"), true, 0),
+    sketchView(sketchView), inEditMode(false),
+    ui(new Ui_TaskSketcherConstrains)
 {
     // we need a separate container widget to add all controls to
     proxy = new QWidget(this);
-    ui = new Ui_TaskSketcherConstrains();
     ui->setupUi(proxy);
     ui->listWidgetConstraints->setSelectionMode(QAbstractItemView::ExtendedSelection);
     ui->listWidgetConstraints->setEditTriggers(QListWidget::EditKeyPressed);
@@ -700,7 +700,6 @@ TaskSketcherConstrains::~TaskSketcherConstrains()
     this->ui->filterInternalAlignment->onSave();
     this->ui->extendedInformation->onSave();
     connectionConstraintsChanged.disconnect();
-    delete ui;
 }
 
 void TaskSketcherConstrains::onSelectionChanged(const Gui::SelectionChanges& msg)

--- a/src/Mod/Sketcher/Gui/TaskSketcherConstrains.h
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstrains.h
@@ -101,7 +101,7 @@ protected:
 private:
     QWidget* proxy;
     bool inEditMode;
-    Ui_TaskSketcherConstrains* ui;
+    std::unique_ptr<Ui_TaskSketcherConstrains> ui;
 };
 
 } //namespace SketcherGui

--- a/src/Mod/Sketcher/Gui/TaskSketcherElements.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherElements.cpp
@@ -342,7 +342,6 @@ TaskSketcherElements::~TaskSketcherElements()
     }
 
     connectionElementsChanged.disconnect();
-    delete ui;
 }
 
 void TaskSketcherElements::onSelectionChanged(const Gui::SelectionChanges& msg)

--- a/src/Mod/Sketcher/Gui/TaskSketcherElements.h
+++ b/src/Mod/Sketcher/Gui/TaskSketcherElements.h
@@ -139,7 +139,7 @@ protected:
 
 private:
     QWidget* proxy;
-    Ui_TaskSketcherElements* ui;
+    std::unique_ptr<Ui_TaskSketcherElements> ui;
     int focusItemIndex;
     int previouslySelectedItemIndex;
 

--- a/src/Mod/Sketcher/Gui/TaskSketcherGeneral.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherGeneral.cpp
@@ -69,7 +69,6 @@ SketcherGeneralWidget::SketcherGeneralWidget(QWidget *parent)
 
 SketcherGeneralWidget::~SketcherGeneralWidget()
 {
-    delete ui;
 }
 
 bool SketcherGeneralWidget::eventFilter(QObject *object, QEvent *event)

--- a/src/Mod/Sketcher/Gui/TaskSketcherGeneral.h
+++ b/src/Mod/Sketcher/Gui/TaskSketcherGeneral.h
@@ -75,7 +75,7 @@ protected:
     void changeEvent(QEvent *e);
 
 private:
-    Ui_TaskSketcherGeneral* ui;
+    std::unique_ptr<Ui_TaskSketcherGeneral> ui;
 };
 
 class TaskSketcherGeneral : public Gui::TaskView::TaskBox,

--- a/src/Mod/Sketcher/Gui/TaskSketcherMessages.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherMessages.cpp
@@ -47,13 +47,13 @@ using namespace SketcherGui;
 using namespace Gui::TaskView;
 namespace bp = boost::placeholders;
 
-TaskSketcherMessages::TaskSketcherMessages(ViewProviderSketch *sketchView)
-    : TaskBox(Gui::BitmapFactory().pixmap("document-new"),tr("Solver messages"),true, 0)
-    , sketchView(sketchView)
+TaskSketcherMessages::TaskSketcherMessages(ViewProviderSketch *sketchView) :
+    TaskBox(Gui::BitmapFactory().pixmap("document-new"), tr("Solver messages"), true, 0),
+    sketchView(sketchView),
+    ui(new Ui_TaskSketcherMessages)
 {
     // we need a separate container widget to add all controls to
     proxy = new QWidget(this);
-    ui = new Ui_TaskSketcherMessages();
     ui->setupUi(proxy);
     QMetaObject::connectSlotsByName(this);
 
@@ -90,7 +90,6 @@ TaskSketcherMessages::~TaskSketcherMessages()
 {
     connectionSetUp.disconnect();
     connectionSolved.disconnect();
-    delete ui;
 }
 
 void TaskSketcherMessages::slotSetUp(QString msg)

--- a/src/Mod/Sketcher/Gui/TaskSketcherMessages.h
+++ b/src/Mod/Sketcher/Gui/TaskSketcherMessages.h
@@ -63,7 +63,7 @@ protected:
 
 private:
     QWidget* proxy;
-    Ui_TaskSketcherMessages* ui;
+    std::unique_ptr<Ui_TaskSketcherMessages> ui;
 };
 
 } //namespace SketcherGui

--- a/src/Mod/Sketcher/Gui/TaskSketcherSolverAdvanced.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherSolverAdvanced.cpp
@@ -60,13 +60,13 @@
 using namespace SketcherGui;
 using namespace Gui::TaskView;
 
-TaskSketcherSolverAdvanced::TaskSketcherSolverAdvanced(ViewProviderSketch *sketchView)
-    : TaskBox(Gui::BitmapFactory().pixmap("document-new"),tr("Advanced solver control"),true, 0)
-    , sketchView(sketchView)
+TaskSketcherSolverAdvanced::TaskSketcherSolverAdvanced(ViewProviderSketch *sketchView) :
+    TaskBox(Gui::BitmapFactory().pixmap("document-new"), tr("Advanced solver control"), true, 0),
+    sketchView(sketchView),
+    ui(new Ui_TaskSketcherSolverAdvanced)
 {
     // we need a separate container widget to add all controls to
     proxy = new QWidget(this);
-    ui = new Ui_TaskSketcherSolverAdvanced();
     ui->setupUi(proxy);
     QMetaObject::connectSlotsByName(this);
 
@@ -90,7 +90,6 @@ TaskSketcherSolverAdvanced::TaskSketcherSolverAdvanced(ViewProviderSketch *sketc
 
 TaskSketcherSolverAdvanced::~TaskSketcherSolverAdvanced()
 {
-    delete ui;
 }
 
 void TaskSketcherSolverAdvanced::updateDefaultMethodParameters(void)

--- a/src/Mod/Sketcher/Gui/TaskSketcherSolverAdvanced.h
+++ b/src/Mod/Sketcher/Gui/TaskSketcherSolverAdvanced.h
@@ -76,7 +76,7 @@ protected:
 
 private:
     QWidget* proxy;
-    Ui_TaskSketcherSolverAdvanced* ui;
+    std::unique_ptr<Ui_TaskSketcherSolverAdvanced> ui;
 };
 
 } //namespace SketcherGui


### PR DESCRIPTION
Same as PR #4293, just for Sketcher

as noted in https://github.com/FreeCAD/FreeCAD/pull/4271#discussion_r554673632
the pointer to the UI should be a unique pointer.

This PR does this for all Sketcher dialogs that don't already use a unique_ptr.