### PR TITLE
LGTM: exclude zipios++ and kdl (orocos) libraries from analysis

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -5,6 +5,9 @@ path_classifiers:
   - "src/Mod/Import/App/config_control_design.py"
   - "src/Mod/Import/App/ifc2x3.py"
   - "src/Mod/Import/App/ifc4.py"
+queries: 
+  - exclude:  "src/zipios++/**""
+  - exclude:  "src/Mod/Robot/App/kdl_cp/**"
 extraction:
   javascript:
     index:


### PR DESCRIPTION
Ref: https://lgtm.com/help/lgtm/lgtm.yml-configuration-file