### PR TITLE
[TD] Fix XSource handling of sub-objects of links to another document…

### DIFF
--- a/src/Mod/TechDraw/Gui/Command.cpp
+++ b/src/Mod/TechDraw/Gui/Command.cpp
@@ -318,6 +318,7 @@ void CmdTechDrawView::activated(int iMsg)
                                                    resolve,
                                                    single);
     for (auto& sel: selection) {
+        bool is_linked = false;
         auto obj = sel.getObject();
         if (obj->isDerivedFrom(TechDraw::DrawPage::getClassTypeId()) ) {
             continue;
@@ -325,6 +326,27 @@ void CmdTechDrawView::activated(int iMsg)
         if ( obj->isDerivedFrom(App::LinkElement::getClassTypeId()) ||
              obj->isDerivedFrom(App::LinkGroup::getClassTypeId())   ||
              obj->isDerivedFrom(App::Link::getClassTypeId()) ) {
+            is_linked = true;
+        }
+        // If parent of the obj is a link to another document, we possibly need to treat non-link obj as linked, too
+        // 1st, is obj in another document?
+        if (obj->getDocument() != this->getDocument()) {
+            std::set<App::DocumentObject *> parents = obj->getInListEx(true);
+            for (auto &parent: parents) {
+                // Only consider parents in the current document, i.e. possible links in this View's document
+                if (parent->getDocument() != this->getDocument()) {
+                    continue;
+                }
+                // 2nd, do we really have a link to obj?
+                if (parent->isDerivedFrom(App::LinkElement::getClassTypeId()) ||
+                        parent->isDerivedFrom(App::LinkGroup::getClassTypeId()) ||
+                        parent->isDerivedFrom(App::Link::getClassTypeId())) {
+                    // We have a link chain from this document to obj, and obj is in another document -> it's an XLink target
+                    is_linked = true;
+                }
+            }
+        }
+        if (is_linked) {
             xShapes.push_back(obj);
             continue;
         }
@@ -574,6 +596,7 @@ void CmdTechDrawProjectionGroup::activated(int iMsg)
                                                    resolve,
                                                    single);
     for (auto& sel: selection) {
+        bool is_linked = false;
         auto obj = sel.getObject();
         if (obj->isDerivedFrom(TechDraw::DrawPage::getClassTypeId()) ) {
             continue;
@@ -581,6 +604,27 @@ void CmdTechDrawProjectionGroup::activated(int iMsg)
         if ( obj->isDerivedFrom(App::LinkElement::getClassTypeId()) ||
              obj->isDerivedFrom(App::LinkGroup::getClassTypeId())   ||
              obj->isDerivedFrom(App::Link::getClassTypeId()) ) {
+            is_linked = true;
+        }
+        // If parent of the obj is a link to another document, we possibly need to treat non-link obj as linked, too
+        // 1st, is obj in another document?
+        if (obj->getDocument() != this->getDocument()) {
+            std::set<App::DocumentObject *> parents = obj->getInListEx(true);
+            for (auto &parent: parents) {
+                // Only consider parents in the current document, i.e. possible links in this View's document
+                if (parent->getDocument() != this->getDocument()) {
+                    continue;
+                }
+                // 2nd, do we really have a link to obj?
+                if (parent->isDerivedFrom(App::LinkElement::getClassTypeId()) ||
+                        parent->isDerivedFrom(App::LinkGroup::getClassTypeId()) ||
+                        parent->isDerivedFrom(App::Link::getClassTypeId())) {
+                    // We have a link chain from this document to obj, and obj is in another document -> it's an XLink target
+                    is_linked = true;
+                }
+            }
+        }
+        if (is_linked) {
             xShapes.push_back(obj);
             continue;
         }


### PR DESCRIPTION
…(s) in TD Views.  I reported the bug in [the forums](https://forum.freecadweb.org/viewtopic.php?f=35&t=55186).  The problem is that the current code in master does not check if a TechDraw View source objects are (a) in another document, and (b) their parents (or their parents, or ...) are links from current document to another document.  The code only checks if the source objects themselves are links, and if not, an incorrect assumption is made that objects must be-document local.  This causes the View sources to fail, when such documents are loaded.  This PR fixes the bug by detecting aforementioned indirect linking.
 

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
