### PR TITLE
[Sketcher] make more pointers to the UI std::unique_ptr

### DIFF
--- a/src/Mod/Sketcher/Gui/SketchMirrorDialog.cpp
+++ b/src/Mod/Sketcher/Gui/SketchMirrorDialog.cpp
@@ -49,7 +49,6 @@ SketchMirrorDialog::SketchMirrorDialog(void)
 
 SketchMirrorDialog::~SketchMirrorDialog()
 {
-    delete ui;
 }
 
 void SketchMirrorDialog::accept()

--- a/src/Mod/Sketcher/Gui/SketchMirrorDialog.h
+++ b/src/Mod/Sketcher/Gui/SketchMirrorDialog.h
@@ -43,7 +43,7 @@ public:
     void accept();
 
 private:
-    Ui_SketchMirrorDialog* ui;
+    std::unique_ptr<Ui_SketchMirrorDialog> ui;
 };
 
 }

--- a/src/Mod/Sketcher/Gui/SketchOrientationDialog.cpp
+++ b/src/Mod/Sketcher/Gui/SketchOrientationDialog.cpp
@@ -52,7 +52,6 @@ SketchOrientationDialog::SketchOrientationDialog(void)
 
 SketchOrientationDialog::~SketchOrientationDialog()
 {
-    delete ui;
 }
 
 void SketchOrientationDialog::accept()

--- a/src/Mod/Sketcher/Gui/SketchOrientationDialog.h
+++ b/src/Mod/Sketcher/Gui/SketchOrientationDialog.h
@@ -46,7 +46,7 @@ protected Q_SLOTS:
     void onPreview();
 
 private:
-    Ui_SketchOrientationDialog* ui;
+    std::unique_ptr<Ui_SketchOrientationDialog> ui;
 };
 
 }

--- a/src/Mod/Sketcher/Gui/SketchRectangularArrayDialog.cpp
+++ b/src/Mod/Sketcher/Gui/SketchRectangularArrayDialog.cpp
@@ -53,7 +53,6 @@ SketchRectangularArrayDialog::SketchRectangularArrayDialog(void)
 
 SketchRectangularArrayDialog::~SketchRectangularArrayDialog()
 {
-    delete ui;
 }
 
 void SketchRectangularArrayDialog::accept()

--- a/src/Mod/Sketcher/Gui/SketchRectangularArrayDialog.h
+++ b/src/Mod/Sketcher/Gui/SketchRectangularArrayDialog.h
@@ -48,7 +48,7 @@ public:
 protected:
     void updateValues(void);
 private:
-    Ui_SketchRectangularArrayDialog* ui;
+    std::unique_ptr<Ui_SketchRectangularArrayDialog> ui;
 };
 
 }

--- a/src/Mod/Sketcher/Gui/SketcherRegularPolygonDialog.cpp
+++ b/src/Mod/Sketcher/Gui/SketcherRegularPolygonDialog.cpp
@@ -49,7 +49,6 @@ SketcherRegularPolygonDialog::SketcherRegularPolygonDialog(void)
 
 SketcherRegularPolygonDialog::~SketcherRegularPolygonDialog()
 {
-    delete ui;
 }
 
 void SketcherRegularPolygonDialog::accept()

--- a/src/Mod/Sketcher/Gui/SketcherRegularPolygonDialog.h
+++ b/src/Mod/Sketcher/Gui/SketcherRegularPolygonDialog.h
@@ -44,7 +44,7 @@ public:
 protected:
     void updateValues(void);
 private:
-    Ui_SketcherRegularPolygonDialog* ui;
+    std::unique_ptr<Ui_SketcherRegularPolygonDialog> ui;
 };
 
 }

--- a/src/Mod/Sketcher/Gui/SketcherSettings.cpp
+++ b/src/Mod/Sketcher/Gui/SketcherSettings.cpp
@@ -62,7 +62,6 @@ SketcherSettings::SketcherSettings(QWidget* parent)
 SketcherSettings::~SketcherSettings()
 {
     // no need to delete child widgets, Qt does it all for us
-    delete ui;
 }
 
 void SketcherSettings::saveSettings()
@@ -141,7 +140,6 @@ SketcherSettingsDisplay::SketcherSettingsDisplay(QWidget* parent)
 SketcherSettingsDisplay::~SketcherSettingsDisplay()
 {
     // no need to delete child widgets, Qt does it all for us
-    delete ui;
 }
 
 void SketcherSettingsDisplay::saveSettings()
@@ -241,7 +239,6 @@ SketcherSettingsColors::SketcherSettingsColors(QWidget* parent)
 SketcherSettingsColors::~SketcherSettingsColors()
 {
     // no need to delete child widgets, Qt does it all for us
-    delete ui;
 }
 
 void SketcherSettingsColors::saveSettings()

--- a/src/Mod/Sketcher/Gui/SketcherSettings.h
+++ b/src/Mod/Sketcher/Gui/SketcherSettings.h
@@ -50,7 +50,7 @@ protected:
     void changeEvent(QEvent *e);
 
 private:
-    Ui_SketcherSettings* ui;
+    std::unique_ptr<Ui_SketcherSettings> ui;
     SketcherGeneralWidget* form;
 };
 
@@ -76,7 +76,7 @@ private Q_SLOTS:
     void onBtnTVApplyClicked(bool);
 
 private:
-    Ui_SketcherSettingsDisplay* ui;
+    std::unique_ptr<Ui_SketcherSettingsDisplay> ui;
 };
 
 /**
@@ -98,7 +98,7 @@ protected:
     void changeEvent(QEvent *e);
 
 private:
-    Ui_SketcherSettingsColors* ui;
+    std::unique_ptr<Ui_SketcherSettingsColors> ui;
 };
 
 } // namespace SketcherGui


### PR DESCRIPTION
addendum to PR #4362

(Same as PR #4293, just for Sketcher

as noted in https://github.com/FreeCAD/FreeCAD/pull/4271#discussion_r554673632
the pointer to the UI should be a unique pointer.

This PR does this for all Sketcher dialogs that don't already use a unique_ptr.)