### PR TITLE
[Part] make pointers to the UI std::unique_ptr

### DIFF
--- a/src/Mod/Part/Gui/CrossSections.cpp
+++ b/src/Mod/Part/Gui/CrossSections.cpp
@@ -124,9 +124,8 @@ private:
 }
 
 CrossSections::CrossSections(const Base::BoundBox3d& bb, QWidget* parent, Qt::WindowFlags fl)
-  : QDialog(parent, fl), bbox(bb)
+  : QDialog(parent, fl), bbox(bb), ui(new Ui_CrossSections)
 {
-    ui = new Ui_CrossSections();
     ui->setupUi(this);
     ui->position->setRange(-DBL_MAX, DBL_MAX);
     ui->position->setUnit(Base::Unit::Length);
@@ -151,7 +150,6 @@ CrossSections::CrossSections(const Base::BoundBox3d& bb, QWidget* parent, Qt::Wi
 CrossSections::~CrossSections()
 {
     // no need to delete child widgets, Qt does it all for us
-    delete ui;
     if (view) {
         view->getViewer()->removeViewProvider(vp);
     }

--- a/src/Mod/Part/Gui/CrossSections.h
+++ b/src/Mod/Part/Gui/CrossSections.h
@@ -71,7 +71,7 @@ private:
     Plane plane() const;
 
 private:
-    Ui_CrossSections* ui;
+    std::unique_ptr<Ui_CrossSections> ui;
     Base::BoundBox3d bbox;
     ViewProviderCrossSections* vp;
     QPointer<Gui::View3DInventor> view;

--- a/src/Mod/Part/Gui/DlgBooleanOperation.cpp
+++ b/src/Mod/Part/Gui/DlgBooleanOperation.cpp
@@ -102,7 +102,6 @@ DlgBooleanOperation::DlgBooleanOperation(QWidget* parent)
 DlgBooleanOperation::~DlgBooleanOperation()
 {
     // no need to delete child widgets, Qt does it all for us
-    delete ui;
     this->connectNewObject.disconnect();
     this->connectModObject.disconnect();
 }

--- a/src/Mod/Part/Gui/DlgBooleanOperation.h
+++ b/src/Mod/Part/Gui/DlgBooleanOperation.h
@@ -63,7 +63,7 @@ private Q_SLOTS:
     void currentItemChanged(QTreeWidgetItem*, QTreeWidgetItem*);
 
 private:
-    Ui_DlgBooleanOperation* ui;
+    std::unique_ptr<Ui_DlgBooleanOperation> ui;
     Connection connectNewObject;
     Connection connectModObject;
     std::list<const App::DocumentObject*> observe;

--- a/src/Mod/Part/Gui/DlgExtrusion.cpp
+++ b/src/Mod/Part/Gui/DlgExtrusion.cpp
@@ -139,7 +139,6 @@ DlgExtrusion::~DlgExtrusion()
     }
 
     // no need to delete child widgets, Qt does it all for us
-    delete ui;
 }
 
 void DlgExtrusion::changeEvent(QEvent *e)

--- a/src/Mod/Part/Gui/DlgExtrusion.h
+++ b/src/Mod/Part/Gui/DlgExtrusion.h
@@ -91,7 +91,7 @@ private:
     void autoSolid();
 
 private:
-    Ui_DlgExtrusion* ui;
+    std::unique_ptr<Ui_DlgExtrusion> ui;
     std::string document, label;
     class EdgeSelection;
     EdgeSelection* filter;

--- a/src/Mod/Part/Gui/DlgRevolution.cpp
+++ b/src/Mod/Part/Gui/DlgRevolution.cpp
@@ -101,10 +101,8 @@ public:
 };
 
 DlgRevolution::DlgRevolution(QWidget* parent, Qt::WindowFlags fl)
-  : QDialog(parent, fl), filter(0)
+  : QDialog(parent, fl), filter(0), ui(new Ui_DlgRevolution)
 {
-    ui = new Ui_DlgRevolution();
-
     ui->setupUi(this);
 
     ui->xPos->setRange(-DBL_MAX,DBL_MAX);
@@ -141,7 +139,6 @@ DlgRevolution::~DlgRevolution()
 {
     // no need to delete child widgets, Qt does it all for us
     Gui::Selection().rmvSelectionGate();
-    delete ui;
 }
 
 Base::Vector3d DlgRevolution::getDirection() const

--- a/src/Mod/Part/Gui/DlgRevolution.h
+++ b/src/Mod/Part/Gui/DlgRevolution.h
@@ -76,7 +76,7 @@ private:
     void autoSolid();
 
 private:
-    Ui_DlgRevolution* ui;
+    std::unique_ptr<Ui_DlgRevolution> ui;
     class EdgeSelection;
     EdgeSelection* filter;
 };

--- a/src/Mod/Part/Gui/DlgSettingsGeneral.cpp
+++ b/src/Mod/Part/Gui/DlgSettingsGeneral.cpp
@@ -40,9 +40,8 @@
 using namespace PartGui;
 
 DlgSettingsGeneral::DlgSettingsGeneral(QWidget* parent)
-  : PreferencePage(parent)
+  : PreferencePage(parent), ui(new Ui_DlgSettingsGeneral)
 {
-    ui = new Ui_DlgSettingsGeneral();
     ui->setupUi(this);
 }
 
@@ -52,7 +51,6 @@ DlgSettingsGeneral::DlgSettingsGeneral(QWidget* parent)
 DlgSettingsGeneral::~DlgSettingsGeneral()
 {
     // no need to delete child widgets, Qt does it all for us
-    delete ui;
 }
 
 void DlgSettingsGeneral::saveSettings()
@@ -87,9 +85,8 @@ void DlgSettingsGeneral::changeEvent(QEvent *e)
 // ----------------------------------------------------------------------------
 
 DlgImportExportIges::DlgImportExportIges(QWidget* parent)
-  : PreferencePage(parent)
+  : PreferencePage(parent), ui(new Ui_DlgImportExportIges)
 {
-    ui = new Ui_DlgImportExportIges();
     ui->setupUi(this);
     ui->lineEditProduct->setReadOnly(true);
 
@@ -113,7 +110,6 @@ DlgImportExportIges::DlgImportExportIges(QWidget* parent)
 DlgImportExportIges::~DlgImportExportIges()
 {
     // no need to delete child widgets, Qt does it all for us
-    delete ui;
 }
 
 void DlgImportExportIges::saveSettings()
@@ -193,9 +189,8 @@ void DlgImportExportIges::changeEvent(QEvent *e)
 // ----------------------------------------------------------------------------
 
 DlgImportExportStep::DlgImportExportStep(QWidget* parent)
-  : PreferencePage(parent)
+  : PreferencePage(parent), ui(new Ui_DlgImportExportStep)
 {
-    ui = new Ui_DlgImportExportStep();
     ui->setupUi(this);
 
     ui->comboBoxSchema->setItemData(0, QByteArray("AP203"));
@@ -229,7 +224,6 @@ DlgImportExportStep::DlgImportExportStep(QWidget* parent)
 DlgImportExportStep::~DlgImportExportStep()
 {
     // no need to delete child widgets, Qt does it all for us
-    delete ui;
 }
 
 void DlgImportExportStep::saveSettings()

--- a/src/Mod/Part/Gui/DlgSettingsGeneral.h
+++ b/src/Mod/Part/Gui/DlgSettingsGeneral.h
@@ -45,7 +45,7 @@ protected:
     void changeEvent(QEvent *e);
 
 private:
-    Ui_DlgSettingsGeneral* ui;
+    std::unique_ptr<Ui_DlgSettingsGeneral> ui;
 };
 
 class Ui_DlgImportExportIges;
@@ -63,7 +63,7 @@ protected:
     void changeEvent(QEvent *e);
 
 private:
-    Ui_DlgImportExportIges* ui;
+    std::unique_ptr<Ui_DlgImportExportIges> ui;
     QButtonGroup* bg;
 };
 
@@ -82,7 +82,7 @@ protected:
     void changeEvent(QEvent *e);
 
 private:
-    Ui_DlgImportExportStep* ui;
+    std::unique_ptr<Ui_DlgImportExportStep> ui;
 };
 
 } // namespace Gui

--- a/src/Mod/Part/Gui/Mirroring.cpp
+++ b/src/Mod/Part/Gui/Mirroring.cpp
@@ -77,7 +77,6 @@ Mirroring::Mirroring(QWidget* parent)
 Mirroring::~Mirroring()
 {
     // no need to delete child widgets, Qt does it all for us
-    delete ui;
 }
 
 void Mirroring::changeEvent(QEvent *e)

--- a/src/Mod/Part/Gui/Mirroring.h
+++ b/src/Mod/Part/Gui/Mirroring.h
@@ -52,7 +52,7 @@ private:
 
 private:
     QString document;
-    Ui_Mirroring* ui;
+    std::unique_ptr<Ui_Mirroring> ui;
 };
 
 class TaskMirroring : public Gui::TaskView::TaskDialog

--- a/src/Mod/Part/Gui/TaskAttacher.cpp
+++ b/src/Mod/Part/Gui/TaskAttacher.cpp
@@ -114,7 +114,8 @@ TaskAttacher::TaskAttacher(Gui::ViewProviderDocumentObject *ViewProvider, QWidge
     : TaskBox(Gui::BitmapFactory().pixmap(picture.toLatin1()), text, true, parent),
       SelectionObserver(ViewProvider),
       ViewProvider(ViewProvider),
-      visibilityFunc(visFunc)
+      visibilityFunc(visFunc),
+      ui(new Ui_TaskAttacher)
 {
     //check if we are attachable
     if (!ViewProvider->getObject()->hasExtension(Part::AttachExtension::getExtensionClassTypeId()))
@@ -122,7 +123,6 @@ TaskAttacher::TaskAttacher(Gui::ViewProviderDocumentObject *ViewProvider, QWidge
 
     // we need a separate container widget to add all controls to
     proxy = new QWidget(this);
-    ui = new Ui_TaskAttacher();
     ui->setupUi(proxy);
     QMetaObject::connectSlotsByName(this);
 
@@ -235,7 +235,6 @@ TaskAttacher::~TaskAttacher()
 
     connectDelObject.disconnect();
     connectDelDocument.disconnect();
-    delete ui;
 }
 
 void TaskAttacher::objectDeleted(const Gui::ViewProviderDocumentObject& view)

--- a/src/Mod/Part/Gui/TaskAttacher.h
+++ b/src/Mod/Part/Gui/TaskAttacher.h
@@ -130,7 +130,7 @@ protected:
 
 private:
     QWidget* proxy;
-    Ui_TaskAttacher* ui;
+    std::unique_ptr<Ui_TaskAttacher> ui;
     VisibilityFunction visibilityFunc;
 
     // TODO fix documentation here (2015-11-10, Fat-Zer)


### PR DESCRIPTION
Same as PR #4293, just for Part

as noted in https://github.com/FreeCAD/FreeCAD/pull/4271#discussion_r554673632
the pointer to the UI should be a unique pointer.

This PR does this for all Part dialogs that don't already use a unique_ptr.