### PR TITLE
[PD] make pointers to the UI std::unique_ptr

### DIFF
--- a/src/Mod/PartDesign/Gui/TaskBooleanParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskBooleanParameters.cpp
@@ -53,13 +53,14 @@ using namespace Gui;
 /* TRANSLATOR PartDesignGui::TaskBooleanParameters */
 
 TaskBooleanParameters::TaskBooleanParameters(ViewProviderBoolean *BooleanView,QWidget *parent)
-    : TaskBox(Gui::BitmapFactory().pixmap("PartDesign_Boolean"),tr("Boolean parameters"),true, parent),BooleanView(BooleanView)
+    : TaskBox(Gui::BitmapFactory().pixmap("PartDesign_Boolean"), tr("Boolean parameters"), true, parent),
+    BooleanView(BooleanView),
+    ui(new Ui_TaskBooleanParameters)
 {
     selectionMode = none;
 
     // we need a separate container widget to add all controls to
     proxy = new QWidget(this);
-    ui = new Ui_TaskBooleanParameters();
     ui->setupUi(proxy);
     QMetaObject::connectSlotsByName(this);
 
@@ -289,7 +290,6 @@ void TaskBooleanParameters::onBodyDeleted(void)
 
 TaskBooleanParameters::~TaskBooleanParameters()
 {
-    delete ui;
 }
 
 void TaskBooleanParameters::changeEvent(QEvent *e)

--- a/src/Mod/PartDesign/Gui/TaskBooleanParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskBooleanParameters.h
@@ -70,7 +70,7 @@ protected:
 
 private:
     QWidget* proxy;
-    Ui_TaskBooleanParameters* ui;
+    std::unique_ptr<Ui_TaskBooleanParameters> ui;
     ViewProviderBoolean *BooleanView;
 
     enum selectionModes { none, bodyAdd, bodyRemove };

--- a/src/Mod/PartDesign/Gui/TaskChamferParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskChamferParameters.cpp
@@ -56,11 +56,10 @@ using namespace Gui;
 /* TRANSLATOR PartDesignGui::TaskChamferParameters */
 
 TaskChamferParameters::TaskChamferParameters(ViewProviderDressUp *DressUpView, QWidget *parent)
-    : TaskDressUpParameters(DressUpView, true, true, parent)
+    : TaskDressUpParameters(DressUpView, true, true, parent), ui(new Ui_TaskChamferParameters)
 {
     // we need a separate container widget to add all controls to
     proxy = new QWidget(this);
-    ui = new Ui_TaskChamferParameters();
     ui->setupUi(proxy);
     this->groupLayout()->addWidget(proxy);
 
@@ -311,8 +310,6 @@ TaskChamferParameters::~TaskChamferParameters()
 {
     Gui::Selection().clearSelection();
     Gui::Selection().rmvSelectionGate();
-
-    delete ui;
 }
 
 bool TaskChamferParameters::event(QEvent *e)

--- a/src/Mod/PartDesign/Gui/TaskChamferParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskChamferParameters.h
@@ -67,7 +67,7 @@ protected:
 private:
     void setUpUI(PartDesign::Chamfer* pcChamfer);
 
-    Ui_TaskChamferParameters* ui;
+    std::unique_ptr<Ui_TaskChamferParameters> ui;
 };
 
 /// simulation dialog for the TaskView

--- a/src/Mod/PartDesign/Gui/TaskDraftParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskDraftParameters.cpp
@@ -55,11 +55,10 @@ using namespace Gui;
 /* TRANSLATOR PartDesignGui::TaskDraftParameters */
 
 TaskDraftParameters::TaskDraftParameters(ViewProviderDressUp *DressUpView, QWidget *parent)
-    : TaskDressUpParameters(DressUpView, false, true, parent)
+    : TaskDressUpParameters(DressUpView, false, true, parent), ui(new Ui_TaskDraftParameters)
 {
     // we need a separate container widget to add all controls to
     proxy = new QWidget(this);
-    ui = new Ui_TaskDraftParameters();
     ui->setupUi(proxy);
 
     this->groupLayout()->addWidget(proxy);
@@ -319,8 +318,6 @@ TaskDraftParameters::~TaskDraftParameters()
 {
     Gui::Selection().clearSelection();
     Gui::Selection().rmvSelectionGate();
-
-    delete ui;
 }
 
 bool TaskDraftParameters::event(QEvent *e)

--- a/src/Mod/PartDesign/Gui/TaskDraftParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskDraftParameters.h
@@ -60,7 +60,7 @@ protected:
     virtual void onSelectionChanged(const Gui::SelectionChanges& msg);
 
 private:
-    Ui_TaskDraftParameters* ui;
+    std::unique_ptr<Ui_TaskDraftParameters> ui;
 };
 
 /// simulation dialog for the TaskView

--- a/src/Mod/PartDesign/Gui/TaskFeaturePick.h
+++ b/src/Mod/PartDesign/Gui/TaskFeaturePick.h
@@ -84,7 +84,7 @@ protected:
     virtual void slotDeleteDocument(const Gui::Document& Doc);
 
 private:
-    Ui_TaskFeaturePick* ui;
+    std::unique_ptr<Ui_TaskFeaturePick> ui;
     QWidget* proxy;
     std::vector<Gui::ViewProviderOrigin*> origins;
     bool doSelection;

--- a/src/Mod/PartDesign/Gui/TaskFilletParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskFilletParameters.cpp
@@ -53,11 +53,10 @@ using namespace Gui;
 /* TRANSLATOR PartDesignGui::TaskFilletParameters */
 
 TaskFilletParameters::TaskFilletParameters(ViewProviderDressUp *DressUpView, QWidget *parent)
-    : TaskDressUpParameters(DressUpView, true, true, parent)
+    : TaskDressUpParameters(DressUpView, true, true, parent), ui(new Ui_TaskFilletParameters)
 {
     // we need a separate container widget to add all controls to
     proxy = new QWidget(this);
-    ui = new Ui_TaskFilletParameters();
     ui->setupUi(proxy);
 
     this->groupLayout()->addWidget(proxy);
@@ -214,8 +213,6 @@ TaskFilletParameters::~TaskFilletParameters()
 {
     Gui::Selection().clearSelection(); 
     Gui::Selection().rmvSelectionGate();
-
-    delete ui;
 }
 
 bool TaskFilletParameters::event(QEvent *e)

--- a/src/Mod/PartDesign/Gui/TaskFilletParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskFilletParameters.h
@@ -53,7 +53,7 @@ protected:
     virtual void onSelectionChanged(const Gui::SelectionChanges& msg);
 
 private:
-    Ui_TaskFilletParameters* ui;
+    std::unique_ptr<Ui_TaskFilletParameters> ui;
 };
 
 /// simulation dialog for the TaskView

--- a/src/Mod/PartDesign/Gui/TaskHelixParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskHelixParameters.cpp
@@ -61,7 +61,7 @@ using namespace Gui;
 /* TRANSLATOR PartDesignGui::TaskHelixParameters */
 
 TaskHelixParameters::TaskHelixParameters(PartDesignGui::ViewProviderHelix *HelixView, QWidget *parent)
-    : TaskSketchBasedParameters(HelixView, parent, "PartDesign_Additive_Helix",tr("Helix parameters")),
+    : TaskSketchBasedParameters(HelixView, parent, "PartDesign_Additive_Helix", tr("Helix parameters")),
     ui (new Ui_TaskHelixParameters)
 {
     // we need a separate container widget to add all controls to

--- a/src/Mod/PartDesign/Gui/TaskHelixParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskHelixParameters.h
@@ -101,7 +101,7 @@ private:
 
 private:
     QWidget* proxy;
-    Ui_TaskHelixParameters* ui;
+    std::unique_ptr<Ui_TaskHelixParameters> ui;
 
     /**
      * @brief axesInList is the list of links corresponding to axis combo; must

--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
@@ -57,13 +57,13 @@ namespace bp = boost::placeholders;
 #endif
 
 TaskHoleParameters::TaskHoleParameters(ViewProviderHole *HoleView, QWidget *parent)
-    : TaskSketchBasedParameters(HoleView, parent, "PartDesign_Hole",tr("Hole parameters"))
-    , observer(new Observer(this, static_cast<PartDesign::Hole*>(vp->getObject())))
-    , isApplying(false)
+    : TaskSketchBasedParameters(HoleView, parent, "PartDesign_Hole", tr("Hole parameters")),
+    observer(new Observer(this, static_cast<PartDesign::Hole*>(vp->getObject()))),
+    isApplying(false),
+    ui(new Ui_TaskHoleParameters)
 {
     // we need a separate container widget to add all controls to
     proxy = new QWidget(this);
-    ui = new Ui_TaskHoleParameters();
     ui->setupUi(proxy);
     QMetaObject::connectSlotsByName(this);
 
@@ -203,7 +203,6 @@ TaskHoleParameters::TaskHoleParameters(ViewProviderHole *HoleView, QWidget *pare
 
 TaskHoleParameters::~TaskHoleParameters()
 {
-    delete ui;
 }
 
 void TaskHoleParameters::threadedChanged()

--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.h
@@ -131,7 +131,7 @@ private:
 
     std::unique_ptr<Observer> observer;
     QWidget* proxy;
-    Ui_TaskHoleParameters* ui;
+    std::unique_ptr<Ui_TaskHoleParameters> ui;
     bool isApplying;
 };
 

--- a/src/Mod/PartDesign/Gui/TaskLinearPatternParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskLinearPatternParameters.cpp
@@ -63,11 +63,10 @@ using namespace Gui;
 /* TRANSLATOR PartDesignGui::TaskLinearPatternParameters */
 
 TaskLinearPatternParameters::TaskLinearPatternParameters(ViewProviderTransformed *TransformedView,QWidget *parent)
-        : TaskTransformedParameters(TransformedView, parent)
+        : TaskTransformedParameters(TransformedView, parent), ui(new Ui_TaskLinearPatternParameters)
 {
     // we need a separate container widget to add all controls to
     proxy = new QWidget(this);
-    ui = new Ui_TaskLinearPatternParameters();
     ui->setupUi(proxy);
     QMetaObject::connectSlotsByName(this);
 
@@ -83,10 +82,9 @@ TaskLinearPatternParameters::TaskLinearPatternParameters(ViewProviderTransformed
 }
 
 TaskLinearPatternParameters::TaskLinearPatternParameters(TaskMultiTransformParameters *parentTask, QLayout *layout)
-        : TaskTransformedParameters(parentTask)
+        : TaskTransformedParameters(parentTask), ui(new Ui_TaskLinearPatternParameters)
 {
     proxy = new QWidget(parentTask);
-    ui = new Ui_TaskLinearPatternParameters();
     ui->setupUi(proxy);
     connect(ui->buttonOK, SIGNAL(pressed()),
             parentTask, SLOT(onSubTaskButtonOK()));
@@ -415,7 +413,6 @@ TaskLinearPatternParameters::~TaskLinearPatternParameters()
         Base::Console().Error ("%s\n", ex.what () );
     }
 
-    delete ui;
     if (proxy)
         delete proxy;
 }

--- a/src/Mod/PartDesign/Gui/TaskLinearPatternParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskLinearPatternParameters.h
@@ -85,7 +85,7 @@ private:
     void kickUpdateViewTimer() const;
 
 private:
-    Ui_TaskLinearPatternParameters* ui;
+    std::unique_ptr<Ui_TaskLinearPatternParameters> ui;
     QTimer* updateViewTimer;
 
     ComboLinks dirLinks;

--- a/src/Mod/PartDesign/Gui/TaskLoftParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskLoftParameters.cpp
@@ -56,11 +56,11 @@ using namespace Gui;
 /* TRANSLATOR PartDesignGui::TaskLoftParameters */
 
 TaskLoftParameters::TaskLoftParameters(ViewProviderLoft *LoftView,bool /*newObj*/, QWidget *parent)
-    : TaskSketchBasedParameters(LoftView, parent, "PartDesign_Additive_Loft",tr("Loft parameters"))
+    : TaskSketchBasedParameters(LoftView, parent, "PartDesign_Additive_Loft", tr("Loft parameters")),
+    ui(new Ui_TaskLoftParameters)
 {
     // we need a separate container widget to add all controls to
     proxy = new QWidget(this);
-    ui = new Ui_TaskLoftParameters();
     ui->setupUi(proxy);
     QMetaObject::connectSlotsByName(this);
 
@@ -134,7 +134,6 @@ TaskLoftParameters::TaskLoftParameters(ViewProviderLoft *LoftView,bool /*newObj*
 
 TaskLoftParameters::~TaskLoftParameters()
 {
-    delete ui;
 }
 
 void TaskLoftParameters::updateUI(int index)

--- a/src/Mod/PartDesign/Gui/TaskLoftParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskLoftParameters.h
@@ -75,7 +75,7 @@ private:
 
 private:
     QWidget* proxy;
-    Ui_TaskLoftParameters* ui;
+    std::unique_ptr<Ui_TaskLoftParameters> ui;
 
     enum selectionModes { none, refAdd, refRemove, refProfile };
     selectionModes selectionMode = none;

--- a/src/Mod/PartDesign/Gui/TaskMirroredParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskMirroredParameters.cpp
@@ -60,11 +60,10 @@ using namespace Gui;
 /* TRANSLATOR PartDesignGui::TaskMirroredParameters */
 
 TaskMirroredParameters::TaskMirroredParameters(ViewProviderTransformed *TransformedView, QWidget *parent)
-        : TaskTransformedParameters(TransformedView, parent)
+        : TaskTransformedParameters(TransformedView, parent), ui(new Ui_TaskMirroredParameters)
 {
     // we need a separate container widget to add all controls to
     proxy = new QWidget(this);
-    ui = new Ui_TaskMirroredParameters();
     ui->setupUi(proxy);
     QMetaObject::connectSlotsByName(this);
 
@@ -80,10 +79,9 @@ TaskMirroredParameters::TaskMirroredParameters(ViewProviderTransformed *Transfor
 }
 
 TaskMirroredParameters::TaskMirroredParameters(TaskMultiTransformParameters *parentTask, QLayout *layout)
-        : TaskTransformedParameters(parentTask)
+        : TaskTransformedParameters(parentTask), ui(new Ui_TaskMirroredParameters)
 {
     proxy = new QWidget(parentTask);
-    ui = new Ui_TaskMirroredParameters();
     ui->setupUi(proxy);
     connect(ui->buttonOK, SIGNAL(pressed()),
             parentTask, SLOT(onSubTaskButtonOK()));
@@ -318,7 +316,6 @@ TaskMirroredParameters::~TaskMirroredParameters()
         Base::Console().Error ("%s\n", ex.what () );
     }
 
-    delete ui;
     if (proxy)
         delete proxy;
 }

--- a/src/Mod/PartDesign/Gui/TaskMirroredParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskMirroredParameters.h
@@ -79,7 +79,7 @@ private:
     ComboLinks planeLinks;
 
 private:
-    Ui_TaskMirroredParameters* ui;
+    std::unique_ptr<Ui_TaskMirroredParameters> ui;
 };
 
 

--- a/src/Mod/PartDesign/Gui/TaskMultiTransformParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskMultiTransformParameters.cpp
@@ -61,11 +61,11 @@ using namespace Gui;
 /* TRANSLATOR PartDesignGui::TaskMultiTransformParameters */
 
 TaskMultiTransformParameters::TaskMultiTransformParameters(ViewProviderTransformed *TransformedView,QWidget *parent)
-    : TaskTransformedParameters(TransformedView, parent), subTask(nullptr), subFeature(nullptr)
+    : TaskTransformedParameters(TransformedView, parent), subTask(nullptr), subFeature(nullptr),
+    ui(new Ui_TaskMultiTransformParameters)
 {
     // we need a separate container widget to add all controls to
     proxy = new QWidget(this);
-    ui = new Ui_TaskMultiTransformParameters();
     ui->setupUi(proxy);
     QMetaObject::connectSlotsByName(this);
     this->groupLayout()->addWidget(proxy);
@@ -484,7 +484,6 @@ void TaskMultiTransformParameters::apply()
 TaskMultiTransformParameters::~TaskMultiTransformParameters()
 {
     closeSubTask();
-    delete ui;
     if (proxy)
         delete proxy;
 }

--- a/src/Mod/PartDesign/Gui/TaskMultiTransformParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskMultiTransformParameters.h
@@ -100,7 +100,7 @@ private:
     void finishAdd(std::string &newFeatName);
 
 private:
-    Ui_TaskMultiTransformParameters* ui;
+    std::unique_ptr<Ui_TaskMultiTransformParameters> ui;
     /// The subTask and subFeature currently active in the UI
     TaskTransformedParameters* subTask;
     PartDesign::Transformed* subFeature;

--- a/src/Mod/PartDesign/Gui/TaskPadParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPadParameters.cpp
@@ -54,11 +54,11 @@ using namespace Gui;
 /* TRANSLATOR PartDesignGui::TaskPadParameters */
 
 TaskPadParameters::TaskPadParameters(ViewProviderPad *PadView, QWidget *parent, bool newObj)
-    : TaskSketchBasedParameters(PadView, parent, "PartDesign_Pad",tr("Pad parameters"))
+    : TaskSketchBasedParameters(PadView, parent, "PartDesign_Pad", tr("Pad parameters")),
+    ui(new Ui_TaskPadParameters)
 {
     // we need a separate container widget to add all controls to
     proxy = new QWidget(this);
-    ui = new Ui_TaskPadParameters();
     ui->setupUi(proxy);
 #if QT_VERSION >= 0x040700
     ui->lineFaceName->setPlaceholderText(tr("No face selected"));
@@ -487,7 +487,6 @@ QString TaskPadParameters::getFaceName(void) const
 
 TaskPadParameters::~TaskPadParameters()
 {
-    delete ui;
 }
 
 void TaskPadParameters::changeEvent(QEvent *e)

--- a/src/Mod/PartDesign/Gui/TaskPadParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskPadParameters.h
@@ -90,7 +90,7 @@ private:
 
 private:
     QWidget* proxy;
-    Ui_TaskPadParameters* ui;
+    std::unique_ptr<Ui_TaskPadParameters> ui;
 };
 
 /// simulation dialog for the TaskView

--- a/src/Mod/PartDesign/Gui/TaskPipeParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPipeParameters.cpp
@@ -72,11 +72,11 @@ using namespace Gui;
 //++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 TaskPipeParameters::TaskPipeParameters(ViewProviderPipe *PipeView, bool /*newObj*/, QWidget *parent)
-    : TaskSketchBasedParameters(PipeView, parent, "PartDesign_Additive_Pipe",tr("Pipe parameters"))
+    : TaskSketchBasedParameters(PipeView, parent, "PartDesign_Additive_Pipe", tr("Pipe parameters")),
+    ui(new Ui_TaskPipeParameters)
 {
     // we need a separate container widget to add all controls to
     proxy = new QWidget(this);
-    ui = new Ui_TaskPipeParameters();
     ui->setupUi(proxy);
     QMetaObject::connectSlotsByName(this);
 
@@ -163,8 +163,6 @@ TaskPipeParameters::~TaskPipeParameters()
         // getDocument() may raise an exception
         e.ReportException();
     }
-
-    delete ui;
 }
 
 void TaskPipeParameters::updateUI()
@@ -441,11 +439,11 @@ void TaskPipeParameters::exitSelectionMode() {
 //++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 TaskPipeOrientation::TaskPipeOrientation(ViewProviderPipe* PipeView, bool /*newObj*/, QWidget* parent)
-    : TaskSketchBasedParameters(PipeView, parent, "PartDesign_Additive_Pipe", tr("Section orientation")) {
-
+    : TaskSketchBasedParameters(PipeView, parent, "PartDesign_Additive_Pipe", tr("Section orientation")),
+    ui(new Ui_TaskPipeOrientation)
+{
     // we need a separate container widget to add all controls to
     proxy = new QWidget(this);
-    ui = new Ui_TaskPipeOrientation();
     ui->setupUi(proxy);
     QMetaObject::connectSlotsByName(this);
 
@@ -768,11 +766,11 @@ void TaskPipeOrientation::updateUI(int idx) {
 // Task Scaling
 //++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 TaskPipeScaling::TaskPipeScaling(ViewProviderPipe* PipeView, bool /*newObj*/, QWidget* parent)
-    : TaskSketchBasedParameters(PipeView, parent, "PartDesign_Additive_Pipe", tr("Section transformation"))
+    : TaskSketchBasedParameters(PipeView, parent, "PartDesign_Additive_Pipe", tr("Section transformation")),
+    ui(new Ui_TaskPipeScaling)
 {
     // we need a separate container widget to add all controls to
     proxy = new QWidget(this);
-    ui = new Ui_TaskPipeScaling();
     ui->setupUi(proxy);
     QMetaObject::connectSlotsByName(this);
 

--- a/src/Mod/PartDesign/Gui/TaskPipeParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskPipeParameters.h
@@ -84,7 +84,7 @@ private:
     
 private:
     QWidget* proxy;
-    Ui_TaskPipeParameters* ui;
+    std::unique_ptr<Ui_TaskPipeParameters> ui;
 };
 
 class TaskPipeOrientation : public TaskSketchBasedParameters
@@ -123,7 +123,7 @@ private:
 
 private:
     QWidget* proxy;
-    Ui_TaskPipeOrientation* ui;
+    std::unique_ptr<Ui_TaskPipeOrientation> ui;
 };
 
 
@@ -157,7 +157,7 @@ private:
 
 private:
     QWidget* proxy;
-    Ui_TaskPipeScaling* ui;
+    std::unique_ptr<Ui_TaskPipeScaling> ui;
 };
 
 

--- a/src/Mod/PartDesign/Gui/TaskPocketParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPocketParameters.cpp
@@ -53,12 +53,12 @@ using namespace Gui;
 /* TRANSLATOR PartDesignGui::TaskPocketParameters */
 
 TaskPocketParameters::TaskPocketParameters(ViewProviderPocket *PocketView,QWidget *parent, bool newObj)
-    : TaskSketchBasedParameters(PocketView, parent, "PartDesign_Pocket",tr("Pocket parameters"))
-    , oldLength(0)
+    : TaskSketchBasedParameters(PocketView, parent, "PartDesign_Pocket", tr("Pocket parameters")),
+    oldLength(0),
+    ui(new Ui_TaskPocketParameters)
 {
     // we need a separate container widget to add all controls to
     proxy = new QWidget(this);
-    ui = new Ui_TaskPocketParameters();
     ui->setupUi(proxy);
 #if QT_VERSION >= 0x040700
     ui->lineFaceName->setPlaceholderText(tr("No face selected"));
@@ -422,7 +422,6 @@ QString TaskPocketParameters::getFaceName(void) const
 
 TaskPocketParameters::~TaskPocketParameters()
 {
-    delete ui;
 }
 
 void TaskPocketParameters::changeEvent(QEvent *e)

--- a/src/Mod/PartDesign/Gui/TaskPocketParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskPocketParameters.h
@@ -82,7 +82,7 @@ private:
 
 private:
     QWidget* proxy;
-    Ui_TaskPocketParameters* ui;
+    std::unique_ptr<Ui_TaskPocketParameters> ui;
     double oldLength;
 };
 

--- a/src/Mod/PartDesign/Gui/TaskPolarPatternParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPolarPatternParameters.cpp
@@ -61,11 +61,10 @@ using namespace Gui;
 /* TRANSLATOR PartDesignGui::TaskPolarPatternParameters */
 
 TaskPolarPatternParameters::TaskPolarPatternParameters(ViewProviderTransformed *TransformedView,QWidget *parent)
-        : TaskTransformedParameters(TransformedView, parent)
+        : TaskTransformedParameters(TransformedView, parent), ui(new Ui_TaskPolarPatternParameters)
 {
     // we need a separate container widget to add all controls to
     proxy = new QWidget(this);
-    ui = new Ui_TaskPolarPatternParameters();
     ui->setupUi(proxy);
     QMetaObject::connectSlotsByName(this);
 
@@ -81,10 +80,9 @@ TaskPolarPatternParameters::TaskPolarPatternParameters(ViewProviderTransformed *
 }
 
 TaskPolarPatternParameters::TaskPolarPatternParameters(TaskMultiTransformParameters *parentTask, QLayout *layout)
-        : TaskTransformedParameters(parentTask)
+        : TaskTransformedParameters(parentTask), ui(new Ui_TaskPolarPatternParameters)
 {
     proxy = new QWidget(parentTask);
-    ui = new Ui_TaskPolarPatternParameters();
     ui->setupUi(proxy);
     connect(ui->buttonOK, SIGNAL(pressed()),
             parentTask, SLOT(onSubTaskButtonOK()));
@@ -406,7 +404,6 @@ TaskPolarPatternParameters::~TaskPolarPatternParameters()
         Base::Console().Error ("%s\n", ex.what () );
     }
 
-    delete ui;
     if (proxy)
         delete proxy;
 }

--- a/src/Mod/PartDesign/Gui/TaskPolarPatternParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskPolarPatternParameters.h
@@ -87,7 +87,7 @@ private:
     void kickUpdateViewTimer() const;
 
 private:
-    Ui_TaskPolarPatternParameters* ui;
+    std::unique_ptr<Ui_TaskPolarPatternParameters> ui;
     QTimer* updateViewTimer;
 
     ComboLinks axesLinks;

--- a/src/Mod/PartDesign/Gui/TaskRevolutionParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskRevolutionParameters.cpp
@@ -58,11 +58,11 @@ using namespace Gui;
 /* TRANSLATOR PartDesignGui::TaskRevolutionParameters */
 
 TaskRevolutionParameters::TaskRevolutionParameters(PartDesignGui::ViewProvider* RevolutionView, QWidget *parent)
-    : TaskSketchBasedParameters(RevolutionView, parent, "PartDesign_Revolution",tr("Revolution parameters"))
+    : TaskSketchBasedParameters(RevolutionView, parent, "PartDesign_Revolution", tr("Revolution parameters")),
+    ui(new Ui_TaskRevolutionParameters)
 {
     // we need a separate container widget to add all controls to
     proxy = new QWidget(this);
-    ui = new Ui_TaskRevolutionParameters();
     ui->setupUi(proxy);
     QMetaObject::connectSlotsByName(this);
 
@@ -378,8 +378,6 @@ TaskRevolutionParameters::~TaskRevolutionParameters()
     } catch (const Base::Exception &ex) {
         ex.ReportException();
     }
-
-    delete ui;
 
     for (size_t i = 0; i < axesInList.size(); i++) {
         delete axesInList[i];

--- a/src/Mod/PartDesign/Gui/TaskRevolutionParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskRevolutionParameters.h
@@ -92,7 +92,7 @@ private:
 
 private:
     QWidget* proxy;
-    Ui_TaskRevolutionParameters* ui;    
+    std::unique_ptr<Ui_TaskRevolutionParameters> ui;
 
     /**
      * @brief axesInList is the list of links corresponding to axis combo; must

--- a/src/Mod/PartDesign/Gui/TaskScaledParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskScaledParameters.cpp
@@ -51,11 +51,10 @@ using namespace Gui;
 /* TRANSLATOR PartDesignGui::TaskScaledParameters */
 
 TaskScaledParameters::TaskScaledParameters(ViewProviderTransformed *TransformedView,QWidget *parent)
-        : TaskTransformedParameters(TransformedView, parent)
+        : TaskTransformedParameters(TransformedView, parent), ui(new Ui_TaskScaledParameters)
 {
     // we need a separate container widget to add all controls to
     proxy = new QWidget(this);
-    ui = new Ui_TaskScaledParameters();
     ui->setupUi(proxy);
     QMetaObject::connectSlotsByName(this);
 
@@ -69,10 +68,9 @@ TaskScaledParameters::TaskScaledParameters(ViewProviderTransformed *TransformedV
 }
 
 TaskScaledParameters::TaskScaledParameters(TaskMultiTransformParameters *parentTask, QLayout *layout)
-        : TaskTransformedParameters(parentTask)
+        : TaskTransformedParameters(parentTask), ui(new Ui_TaskScaledParameters)
 {
     proxy = new QWidget(parentTask);
-    ui = new Ui_TaskScaledParameters();
     ui->setupUi(proxy);
     connect(ui->buttonOK, SIGNAL(pressed()),
             parentTask, SLOT(onSubTaskButtonOK()));
@@ -242,7 +240,6 @@ unsigned TaskScaledParameters::getOccurrences(void) const
 
 TaskScaledParameters::~TaskScaledParameters()
 {
-    delete ui;
     if (proxy)
         delete proxy;
 }

--- a/src/Mod/PartDesign/Gui/TaskScaledParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskScaledParameters.h
@@ -76,7 +76,7 @@ private:
     void updateUI();
 
 private:
-    Ui_TaskScaledParameters* ui;
+    std::unique_ptr<Ui_TaskScaledParameters> ui;
 };
 
 

--- a/src/Mod/PartDesign/Gui/TaskShapeBinder.cpp
+++ b/src/Mod/PartDesign/Gui/TaskShapeBinder.cpp
@@ -58,12 +58,12 @@ using namespace Gui;
 
 TaskShapeBinder::TaskShapeBinder(ViewProviderShapeBinder *view, bool /*newObj*/, QWidget *parent)
     : Gui::TaskView::TaskBox(Gui::BitmapFactory().pixmap("PartDesign_ShapeBinder"),
-                             tr("Datum shape parameters"), true, parent)
-    , SelectionObserver(view)
+                             tr("Datum shape parameters"), true, parent),
+    SelectionObserver(view),
+    ui(new Ui_TaskShapeBinder)
 {
     // we need a separate container widget to add all controls to
     proxy = new QWidget(this);
-    ui = new Ui_TaskShapeBinder();
     ui->setupUi(proxy);
     QMetaObject::connectSlotsByName(this);
 
@@ -159,7 +159,6 @@ TaskShapeBinder::~TaskShapeBinder()
     }
     static_cast<ViewProviderPipe*>(vp)->highlightReferences(false, false);
     */
-    delete ui;
 }
 
 void TaskShapeBinder::changeEvent(QEvent *)

--- a/src/Mod/PartDesign/Gui/TaskShapeBinder.h
+++ b/src/Mod/PartDesign/Gui/TaskShapeBinder.h
@@ -76,7 +76,7 @@ private:
     
 private:
     QWidget* proxy;
-    Ui_TaskShapeBinder* ui;
+    std::unique_ptr<Ui_TaskShapeBinder> ui;
     ViewProviderShapeBinder* vp;
 };
 

--- a/src/Mod/PartDesign/Gui/TaskThicknessParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskThicknessParameters.cpp
@@ -53,11 +53,10 @@ using namespace Gui;
 /* TRANSLATOR PartDesignGui::TaskThicknessParameters */
 
 TaskThicknessParameters::TaskThicknessParameters(ViewProviderDressUp *DressUpView, QWidget *parent)
-    : TaskDressUpParameters(DressUpView, false, true, parent)
+    : TaskDressUpParameters(DressUpView, false, true, parent), ui(new Ui_TaskThicknessParameters)
 {
     // we need a separate container widget to add all controls to
     proxy = new QWidget(this);
-    ui = new Ui_TaskThicknessParameters();
     ui->setupUi(proxy);
     this->groupLayout()->addWidget(proxy);
 
@@ -290,8 +289,6 @@ TaskThicknessParameters::~TaskThicknessParameters()
 {
     Gui::Selection().clearSelection();
     Gui::Selection().rmvSelectionGate();
-
-    delete ui;
 }
 
 bool TaskThicknessParameters::event(QEvent *e)

--- a/src/Mod/PartDesign/Gui/TaskThicknessParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskThicknessParameters.h
@@ -60,7 +60,7 @@ protected:
     virtual void onSelectionChanged(const Gui::SelectionChanges& msg);
 
 private:
-    Ui_TaskThicknessParameters* ui;
+    std::unique_ptr<Ui_TaskThicknessParameters> ui;
 };
 
 /// simulation dialog for the TaskView

--- a/src/Mod/PartDesign/Gui/TaskTransformedMessages.cpp
+++ b/src/Mod/PartDesign/Gui/TaskTransformedMessages.cpp
@@ -40,12 +40,12 @@ using namespace Gui::TaskView;
 namespace bp = boost::placeholders;
 
 TaskTransformedMessages::TaskTransformedMessages(ViewProviderTransformed *transformedView_)
-    : TaskBox(Gui::BitmapFactory().pixmap("document-new"),tr("Transformed feature messages"),true, 0),
-      transformedView(transformedView_)
+    : TaskBox(Gui::BitmapFactory().pixmap("document-new"), tr("Transformed feature messages"), true, 0),
+    transformedView(transformedView_),
+    ui(new Ui_TaskTransformedMessages)
 {
     // we need a separate container widget to add all controls to
     proxy = new QWidget(this);
-    ui = new Ui_TaskTransformedMessages();
     ui->setupUi(proxy);
     // set a minimum height to avoid a sudden resize and to
     // lose focus of the currently used spin boxes
@@ -61,7 +61,6 @@ TaskTransformedMessages::TaskTransformedMessages(ViewProviderTransformed *transf
 TaskTransformedMessages::~TaskTransformedMessages()
 {
     connectionDiagnosis.disconnect();
-    delete ui;
 }
 
 void TaskTransformedMessages::slotDiagnosis(QString msg)

--- a/src/Mod/PartDesign/Gui/TaskTransformedMessages.h
+++ b/src/Mod/PartDesign/Gui/TaskTransformedMessages.h
@@ -56,7 +56,7 @@ protected:
 
 private:
     QWidget* proxy;
-    Ui_TaskTransformedMessages* ui;
+    std::unique_ptr<Ui_TaskTransformedMessages> ui;
 };
 
 } //namespace PartDesignGui


### PR DESCRIPTION
Same as PR #4293, just for PartDesign

as noted in https://github.com/FreeCAD/FreeCAD/pull/4271#discussion_r554673632
the pointer to the UI should be a unique pointer.

This PR does this for all PartDesign dialogs that don't already use a unique_ptr.