### PR TITLE
[TD] make more pointers to the UI std::unique_ptr

### DIFF
--- a/src/Mod/TechDraw/Gui/SymbolChooser.h
+++ b/src/Mod/TechDraw/Gui/SymbolChooser.h
@@ -54,7 +54,7 @@ protected:
     void loadSymbolNames(QString pathToSymbols);
 
 private:
-    Ui_SymbolChooser* ui;
+    std::unique_ptr<Ui_SymbolChooser> ui;
     QString m_symbolDir;
     QString m_symbolPath;
     QString m_source;

--- a/src/Mod/TechDraw/Gui/TaskLineDecor.cpp
+++ b/src/Mod/TechDraw/Gui/TaskLineDecor.cpp
@@ -79,7 +79,6 @@ TaskLineDecor::TaskLineDecor(TechDraw::DrawViewPart* partFeat,
 
 TaskLineDecor::~TaskLineDecor()
 {
-    delete ui;
 }
 
 void TaskLineDecor::initUi()

--- a/src/Mod/TechDraw/Gui/TaskLineDecor.h
+++ b/src/Mod/TechDraw/Gui/TaskLineDecor.h
@@ -70,7 +70,7 @@ protected:
     void getDefaults(void);
 
 private:
-    Ui_TaskLineDecor* ui;
+    std::unique_ptr<Ui_TaskLineDecor> ui;
     TechDraw::DrawViewPart* m_partFeat;
     std::vector<std::string> m_edges;
     int m_style;


### PR DESCRIPTION
addendum to PR #4293

(as noted in https://github.com/FreeCAD/FreeCAD/pull/4271#discussion_r554673632
the pointer to the UI should be a unique pointer.

This PR does this for remaining TD dialogs that don't already use a unique_ptr.)