### PR TITLE
[GUI] Fix minor issues with Workbenches preference panel

### DIFF
--- a/src/Gui/DlgPreferencesImp.cpp
+++ b/src/Gui/DlgPreferencesImp.cpp
@@ -70,7 +70,7 @@ DlgPreferencesImp::DlgPreferencesImp(QWidget* parent, Qt::WindowFlags fl)
 {
     ui->setupUi(this);
     ui->listBox->setFixedWidth(108);
-    ui->listBox->setGridSize(QSize(90, 75));
+    ui->listBox->setGridSize(QSize(108, 75));
 
     connect(ui->buttonBox,  SIGNAL (helpRequested()),
             getMainWindow(), SLOT (whatsThis()));
@@ -140,7 +140,7 @@ QTabWidget* DlgPreferencesImp::createTabForGroup(const std::string &groupName)
             qWarning() << "No group icon found for " << fileName.c_str();
         }
         else if (icon.size() != QSize(48, 48)) {
-            icon = Gui::BitmapFactory().resize(48, 48, icon, Qt::TransparentMode);
+            icon = icon.scaled(48, 48, Qt::KeepAspectRatio, Qt::SmoothTransformation);
             qWarning() << "Group icon for " << fileName.c_str() << " is not of size 48x48, so it was scaled";
         }
     }

--- a/src/Gui/DlgSettingsLazyLoadedImp.cpp
+++ b/src/Gui/DlgSettingsLazyLoadedImp.cpp
@@ -100,6 +100,7 @@ void DlgSettingsLazyLoadedImp::buildUnloadedWorkbenchList()
             ui->workbenchList->addItem(wbRow); // Transfers ownership to the QListWidget
         }
     }
+    ui->workbenchList->sortItems();
 }
 
 /**


### PR DESCRIPTION
This fixes three issues with the new Workbench Loader preferences panel reported by users:
* Some icons were not being properly scaled to the new 48x48 size
* Some text was being incorrectly cut off, despite fitting in the column
* The sort order of the workbenches was incorrect when external workbenches were added

---

- [X] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- No tracker tickets filed