### PR TITLE
PartDesign: [Helix] Fix helix starting point bug

### DIFF
--- a/src/Mod/PartDesign/App/FeatureHelix.h
+++ b/src/Mod/PartDesign/App/FeatureHelix.h
@@ -77,6 +77,9 @@ protected:
     // project shape on plane. Used for detecting self intersection.
     TopoDS_Shape projectShape(const TopoDS_Shape& input, const gp_Ax2& plane);
 
+    // center of profile bounding box
+    Base::Vector3d getProfileCenterPoint();
+
 private:
     static const char* ModeEnums[];
 };


### PR DESCRIPTION
Fix bug reported here:
https://forum.freecadweb.org/viewtopic.php?f=8&t=53714&p=474585#p474514

Previously the internal helix spine had a radius calculated as the minimum distance of the profile to the helix axis. When significant cone angle was selected this method sometimes causes the helix to start win the wrong place. 

Now the internal helix spine has radius calculated as the middle of the profile bounding box. 