### PR TITLE
PartDesign: fix regression in Helix introduced in #4374

### DIFF
--- a/src/Mod/PartDesign/App/FeatureHelix.cpp
+++ b/src/Mod/PartDesign/App/FeatureHelix.cpp
@@ -397,6 +397,14 @@ TopoDS_Shape Helix::generateHelixPath(void)
     double radius = std::fabs(axisOffset);
     bool turned = axisOffset < 0;
 
+    if (radius <  Precision::Confusion()) {
+        // in this case ensure that axis is not in the sketch plane
+        if (v*normal < Precision::Confusion())
+            throw Base::ValueError("Error: Result is self intersecting");
+        radius = 1.0; //fallback to radius 1
+        startOffset = 0.0;
+    }
+
     //build the helix path
     TopoShape helix = TopoShape().makeLongHelix(pitch, height, radius, angle, leftHanded);
     TopoDS_Shape path = helix.getShape();


### PR DESCRIPTION
Fix a regression that snuck in in #4374. A special case got lost for when the helix axis is along the normal of the sketch. 
In this PR this special case is added back. 