### PR TITLE
Modify LGTM config to exclude legacy/unmaintained

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -5,9 +5,19 @@ path_classifiers:
   - "src/Mod/Import/App/config_control_design.py"
   - "src/Mod/Import/App/ifc2x3.py"
   - "src/Mod/Import/App/ifc4.py"
-queries: 
-  - exclude:  "src/zipios++/**"
-  - exclude:  "src/Mod/Robot/App/kdl_cp/**"
+  library:
+  - "src/zipios++/"
+  - "src/3rdParty/"
+  - "src/Mod/Import/App/SCL"
+  template:
+  - "src/Tools/examplePy2wiki.py"
+  unmaintained:
+  - "src/Mod/Robot/"
+  - "src/Mod/Ship/"
+  legacy:
+  - "src/Mod/Assembly/"
+  - "src/Mod/Drawing/"
+
 extraction:
   javascript:
     index:


### PR DESCRIPTION
This PR corrects the exclusion of zipios, and adds several additional tags that are excluded from analysis.
* **library** is a build-in LGTM tag which now explicitly includes 3rdParty and zipios
* **template** is a built-in LGTM tag which lists code intended purely as templates. I added the first one I found, but there are others we can add over time.
* **unmaintained** is a list of the Workbenches included in our source tree that do not have a maintainer right now, so are excluded from analysis.
* **legacy** is a list of the Workbenches in our tree that are no longer updated, so are now excluded from the analysis.

I've included the exclusions that I was pretty sure about: this PR and/or commit can easily be modified to include other things that should be excluded from the analysis. The language for talking about this is a bit convoluted: everything _included_ in these lists is _excluded_ from the LGTM analysis.