### PR TITLE
LGTM: Remove catch block for plain C strings

### DIFF
--- a/src/Base/PyObjectBase.h
+++ b/src/Base/PyObjectBase.h
@@ -482,10 +482,6 @@ BaseExport extern PyObject* BaseExceptionFreeCADAbort;
     {                                                               \
         R;                                                          \
     }                                                               \
-    catch(const char *e)                                            \
-    {                                                               \
-        _Py_Error(R,Base::BaseExceptionFreeCADError,e);             \
-    }                                                               \
 
 #ifndef DONT_CATCH_CXX_EXCEPTIONS
 /// see docu of PY_TRY


### PR DESCRIPTION
LGTM complains about this construct leaking memory. Commit 13927b2465 eliminated the parts of FreeCAD that throw those strings. This commit eliminates the catch block.