### PR TITLE
[0.20] PartDesign: Hole performance improvements

### DIFF
--- a/src/Mod/PartDesign/App/FeatureHole.cpp
+++ b/src/Mod/PartDesign/App/FeatureHole.cpp
@@ -1959,9 +1959,9 @@ App::DocumentObjectExecReturn *Hole::execute(void)
         BRep_Builder builder;
         TopoDS_Compound holes;
         builder.MakeCompound(holes);
-
         TopTools_IndexedMapOfShape edgeMap;
         TopExp::MapShapes(profileshape, TopAbs_EDGE, edgeMap);
+        Base::Placement SketchPos = profile->Placement.getValue();
         for ( int i=1 ; i<=edgeMap.Extent() ; i++ ) {
             Standard_Real c_start;
             Standard_Real c_end;
@@ -1973,49 +1973,36 @@ App::DocumentObjectExecReturn *Hole::execute(void)
                 continue;
 
             Handle(Geom_Circle) circle = Handle(Geom_Circle)::DownCast(c);
-
             gp_Pnt loc = circle->Axis().Location();
 
-            gp_Trsf sketchTransformation;
+
             gp_Trsf localSketchTransformation;
-            Base::Placement SketchPos = profile->Placement.getValue();
-            Base::Matrix4D mat = SketchPos.toMatrix();
-            sketchTransformation.SetValues(
-                        mat[0][0], mat[0][1], mat[0][2], mat[0][3],
-                        mat[1][0], mat[1][1], mat[1][2], mat[1][3],
-                        mat[2][0], mat[2][1], mat[2][2], mat[2][3]
-#if OCC_VERSION_HEX < 0x060800
-                        , 0.00001, 0.00001
-#endif
-                    ); //precision was removed in OCCT CR0025194
             localSketchTransformation.SetTranslation( gp_Pnt( 0, 0, 0 ),
                                                       gp_Pnt(loc.X(), loc.Y(), loc.Z()) );
 
             TopoDS_Shape copy = protoHole;
-            BRepBuilderAPI_Transform transformer(copy, localSketchTransformation );
-
-            copy = transformer.Shape();
-            BRepAlgoAPI_Cut mkCut( base, copy );
-            if (!mkCut.IsDone())
-                return new App::DocumentObjectExecReturn("Hole: Cut out of base feature failed");
-
-            TopoDS_Shape result = mkCut.Shape();
-
-            // We have to get the solids (fuse sometimes creates compounds)
-            base = getSolid(result);
-            if (base.IsNull())
-                return new App::DocumentObjectExecReturn("Hole: Resulting shape is not a solid");
-            base = refineShapeIfActive(base);
-            builder.Add(holes, transformer.Shape() );
+            copy.Move(localSketchTransformation);
+            builder.Add(holes, copy);
         }
 
-        // Do not apply a placement to the AddSubShape property (#0003547)
-        //holes.Move( this->getLocation().Inverted() );
+        this->AddSubShape.setValue(holes);
 
-        // set the subtractive shape property for later usage in e.g. pattern
-        this->AddSubShape.setValue( holes );
+        // For some reason it is faster to do the cut through a BooleanOperation.
+        std::unique_ptr<BRepAlgoAPI_BooleanOperation> mkBool(new BRepAlgoAPI_Cut(base, holes));
+        if (!mkBool->IsDone()) {
+            std::stringstream error;
+            error << "Boolean operation failed";
+            return new App::DocumentObjectExecReturn(error.str());
+        }
+        TopoDS_Shape result = mkBool->Shape();
 
-        remapSupportShape(base);
+
+        // We have to get the solids (fuse sometimes creates compounds)
+        base = getSolid(result);
+        if (base.IsNull())
+            return new App::DocumentObjectExecReturn("Hole: Resulting shape is not a solid");
+        base = refineShapeIfActive(base);
+
 
 
         int solidCount = countSolids(base);


### PR DESCRIPTION
With PR #4274, the hole feature can be very slow if thread modeling is enabled for a large hole pattern. 
This PR contains some performance optimization. With debug build the performance improvement is about 30%. 


  | Build type | Debug |   |  
-- | -- | -- | -- | --
  | Test case | Hole pattern 6 x M10x25 |   |  
  |   |   |   |  
Commit | Variant | time (average of 10) |   | Improvement
db9525e7d7 | Original Hole | 3,1325 | s | 0,00 %
6f63b105da | Compound then cut | 2,22 | s | 29,13 %
354ab5528 | remove unused code | 2,19 | s | 30,09 %



A note about changes in behavior.

Previously it was posssible for the holes to overlap each other. Now this is no-longer supported as this would be more computationally demanding. If it is seen as needed to support overlapping holes, support for overlapping holes can be implemented if necessary.
