### PR TITLE
[Path]: Set operation Visibility to False, and turn it back on while editing.

### DIFF
--- a/src/Mod/Path/PathScripts/PathOpGui.py
+++ b/src/Mod/Path/PathScripts/PathOpGui.py
@@ -1094,6 +1094,8 @@ class TaskPanel(object):
         self.selectionFactory = selectionFactory
         self.obj = obj
         self.isdirty = deleteOnReject
+        self.visibility = obj.ViewObject.Visibility
+        obj.ViewObject.Visibility = True
 
     def isDirty(self):
         '''isDirty() ... returns true if the model is not in sync with the UI anymore.'''
@@ -1137,6 +1139,7 @@ class TaskPanel(object):
         PathSelection.clear()
         FreeCADGui.Selection.removeObserver(self)
         self.obj.ViewObject.Proxy.clearTaskPanel()
+        self.obj.ViewObject.Visibility = self.visibility
 
     def cleanup(self, resetEdit):
         '''cleanup() ... implements common cleanup tasks.'''
@@ -1277,6 +1280,7 @@ def Create(res):
     obj = res.objFactory(res.name)
     if obj.Proxy:
         obj.ViewObject.Proxy = ViewProvider(obj.ViewObject, res)
+        obj.ViewObject.Visibility = False
 
         FreeCAD.ActiveDocument.commitTransaction()
         obj.ViewObject.Document.setEdit(obj.ViewObject, 0)


### PR DESCRIPTION
This is a small change to hide an op by default, make it visible while it is being edited and restore the previous visibility afterwards. Typically the generated Path of the op is still visible through the visibility of the Job object.

The reason for this change is the many confusion and annoyance the double display of an op's path causes for users, especially newer users.