### PR TITLE
[0.19] [Path] Add `UseOutline` feature to Adaptive op [1 of 3 per dev conversation]

### DIFF
--- a/src/Mod/Path/PathScripts/PathAdaptive.py
+++ b/src/Mod/Path/PathScripts/PathAdaptive.py
@@ -603,6 +603,11 @@ class PathAdaptive(PathOp.ObjectOp):
         obj.addProperty("App::PropertyAngle", "HelixConeAngle", "Adaptive",  "Helix cone angle (degrees)")
         obj.addProperty("App::PropertyLength", "HelixDiameterLimit", "Adaptive", "Limit helix entry diameter, if limit larger than tool diameter or 0, tool diameter is used")
 
+        if not hasattr(obj, "UseOutline"):
+            obj.addProperty("App::PropertyBool",
+                            "UseOutline",
+                            "Adaptive",
+                            "Uses the outline of the base geometry.")
 
     def opSetDefaultValues(self, obj, job):
         obj.Side="Inside"
@@ -623,6 +628,7 @@ class PathAdaptive(PathOp.ObjectOp):
         obj.StockToLeave = 0
         obj.KeepToolDownRatio = 3.0
         obj.UseHelixArcs = False
+        obj.UseOutline = False
 
     def opExecute(self, obj):
         '''opExecute(obj) ... called whenever the receiver needs to be recalculated.

--- a/src/Mod/Path/PathScripts/PathAdaptive.py
+++ b/src/Mod/Path/PathScripts/PathAdaptive.py
@@ -34,6 +34,11 @@ import math
 import area
 from pivy import coin
 
+# lazily loaded modules
+from lazy_loader.lazy_loader import LazyLoader
+Part = LazyLoader('Part', globals(), 'Part')
+TechDraw = LazyLoader('TechDraw', globals(), 'TechDraw')
+
 __doc__ = "Class and implementation of the Adaptive path operation."
 
 def convertTo2d(pathArray):

--- a/src/Mod/Path/PathScripts/PathAdaptiveGui.py
+++ b/src/Mod/Path/PathScripts/PathAdaptiveGui.py
@@ -140,6 +140,11 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         form.FinishingProfile.setChecked(True)
         formLayout.addRow(QtGui.QLabel("Finishing Profile"), form.FinishingProfile)
 
+        # Use outline checkbox
+        form.useOutline = QtGui.QCheckBox()
+        form.useOutline.setChecked(False)
+        formLayout.addRow(QtGui.QLabel("Use outline"), form.useOutline)
+
         layout.addLayout(formLayout)
 
         # stop button
@@ -170,6 +175,7 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         # signals.append(self.form.ProcessHoles.stateChanged)
         signals.append(self.form.ForceInsideOut.stateChanged)
         signals.append(self.form.FinishingProfile.stateChanged)
+        signals.append(self.form.useOutline.stateChanged)
         signals.append(self.form.StopButton.toggled)
         return signals
 
@@ -191,6 +197,7 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         # self.form.ProcessHoles.setChecked(obj.ProcessHoles)
         self.form.ForceInsideOut.setChecked(obj.ForceInsideOut)
         self.form.FinishingProfile.setChecked(obj.FinishingProfile)
+        self.form.useOutline.setChecked(obj.UseOutline)
         self.setupToolController(obj, self.form.ToolController)
         self.setupCoolant(obj, self.form.coolantController)
         self.form.StopButton.setChecked(obj.Stopped)
@@ -221,6 +228,7 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
 
         obj.ForceInsideOut = self.form.ForceInsideOut.isChecked()
         obj.FinishingProfile = self.form.FinishingProfile.isChecked()
+        obj.UseOutline = self.form.useOutline.isChecked()
         obj.Stopped = self.form.StopButton.isChecked()
         if(obj.Stopped):
             self.form.StopButton.setChecked(False)  # reset the button


### PR DESCRIPTION
This PR isolates the addition of the `UseOutline` feature to the Adaptive operation at found in PR #4324 .  The feature is cloned from PocketShape.

I recommend consideration of PR #4345 as a possible chaser.  It adds a simple Adaptive test framework to the Path workbench test suite and is already coded for testing this `UseOutline` feature.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
