### PR TITLE
Draft: Fixes #0004113: When Clone is used in Draft/Scale, the cloned part placement is always set to origin whatever is the reference point

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_scale.py
+++ b/src/Mod/Draft/draftguitools/gui_scale.py
@@ -224,13 +224,26 @@ class Scale(gui_base_original.Modifier):
         else:
             _cmd_name = translate("draft", "Scale")
 
+        # the correction translation of the clone placement is
+        # (node[0] - clone.Placement.Base) - (node[0] - clone.Placement.Base)\
+        #   .scale(delta.x,delta.y,delta.z)
+        # equivalent to:
+        # (node[0] - clone.Placement.Base)\
+        #   .scale(1-delta.x,1-delta.y,1-delta.z)
+        str_node0 = DraftVecUtils.toString(self.node[0])
+        str_delta = DraftVecUtils.toString(self.delta)
+        str_delta_corr = DraftVecUtils.toString(App.Vector(1,1,1) - self.delta)
+
         _cmd = 'Draft.clone'
         _cmd += '('
         _cmd += objects + ', '
         _cmd += 'forcedraft=True'
         _cmd += ')'
         _cmd_list = ['clone = ' + _cmd,
-                     'clone.Scale = ' + DraftVecUtils.toString(self.delta),
+                     'clone.Scale = ' + str_delta,
+                     'clone_corr = (' + str_node0 + ' - clone.Placement.Base)'\
+                        + '.scale(*'+ str_delta_corr + ')',
+                     'clone.Placement.move(clone_corr)',
                      'FreeCAD.ActiveDocument.recompute()']
         self.commit(_cmd_name, _cmd_list)
 


### PR DESCRIPTION
See https://forum.freecadweb.org/viewtopic.php?p=331467#p330738

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [x] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
