### PR TITLE
FEM: Improve Gmsh log, when Gmsh is not installed

### DIFF
--- a/src/Mod/Fem/femmesh/gmshtools.py
+++ b/src/Mod/Fem/femmesh/gmshtools.py
@@ -40,6 +40,10 @@ from femtools import femutils
 from femtools import geomtools
 
 
+class GmshError(Exception):
+    pass
+
+
 class GmshTools():
     def __init__(self, gmsh_mesh_obj, analysis=None):
 
@@ -154,12 +158,15 @@ class GmshTools():
         self.write_geo()
 
     def create_mesh(self):
-        self.update_mesh_data()
-        self.get_tmp_file_paths()
-        self.get_gmsh_command()
-        self.write_gmsh_input_files()
-        error = self.run_gmsh_with_geo()
-        self.read_and_set_new_mesh()
+        try:
+            self.update_mesh_data()
+            self.get_tmp_file_paths()
+            self.get_gmsh_command()
+            self.write_gmsh_input_files()
+            error = self.run_gmsh_with_geo()
+            self.read_and_set_new_mesh()
+        except GmshError as e:
+            error = str(e)
         return error
 
     def start_logs(self):
@@ -292,7 +299,7 @@ class GmshTools():
                         "in FEM preferences tab Gmsh.\n"
                     )
                     Console.PrintError(error_message)
-                    raise Exception(error_message)
+                    raise GmshError(error_message)
                 self.gmsh_bin = gmsh_path
             else:
                 error_message = (
@@ -300,7 +307,7 @@ class GmshTools():
                     "Set GMHS binary path in FEM preferences.\n"
                 )
                 Console.PrintError(error_message)
-                raise Exception(error_message)
+                raise GmshError(error_message)
         else:
             if not self.gmsh_bin:
                 self.gmsh_bin = FreeCAD.ParamGet(

--- a/src/Mod/Fem/femtaskpanels/task_mesh_gmsh.py
+++ b/src/Mod/Fem/femtaskpanels/task_mesh_gmsh.py
@@ -207,6 +207,7 @@ class _TaskPanel:
                 "Unexpected error when creating mesh: {}\n"
                 .format(sys.exc_info()[0])
             )
+            error = sys.exc_info()[0].strip();
         if error:
             FreeCAD.Console.PrintMessage("Gmsh had warnings ...\n")
             FreeCAD.Console.PrintMessage("{}\n".format(error))


### PR DESCRIPTION
**Before this PR:**
Even when Gmsh is not installed, everything looks fine:
![everything_looks_fine](https://user-images.githubusercontent.com/1278189/107143800-51b70a00-6937-11eb-8356-fc45b7c25af6.png)
![but_it_is_not](https://user-images.githubusercontent.com/1278189/107143806-55e32780-6937-11eb-916e-56e776aea46d.png)

**After PR:**
![after](https://user-images.githubusercontent.com/1278189/107143820-6b585180-6937-11eb-88f9-6ce0cb96dea7.png)

Also ensure that any unexpected exception is also shown in the Gmsh dialog log