### PR TITLE
[UI] Add SVG icon for Mesh SplitComponents

### DIFF
--- a/src/Mod/Mesh/Gui/Command.cpp
+++ b/src/Mod/Mesh/Gui/Command.cpp
@@ -1832,7 +1832,7 @@ CmdMeshSplitComponents::CmdMeshSplitComponents()
     sToolTipText  = QT_TR_NOOP("Split selected mesh into its components");
     sWhatsThis    = "Mesh_SplitComponents";
     sStatusTip    = sToolTipText;
-  //sPixmap       = "Mesh_SplitComponents";
+    sPixmap       = "Mesh_SplitComponents";
 }
 
 void CmdMeshSplitComponents::activated(int)

--- a/src/Mod/Mesh/Gui/Resources/Mesh.qrc
+++ b/src/Mod/Mesh/Gui/Resources/Mesh.qrc
@@ -30,6 +30,7 @@
         <file>icons/Mesh_Segmentation_Best_Fit.svg</file>
         <file>icons/Mesh_Segmentation.svg</file>
         <file>icons/Mesh_Smoothing.svg</file>
+        <file>icons/Mesh_SplitComponents.svg</file>
         <file>icons/Mesh_Tree.svg</file>
         <file>icons/Mesh_Tree_Curvature_Plot.svg</file>
         <file>icons/Mesh_Trim_by_Plane.svg</file>

--- a/src/Mod/Mesh/Gui/Resources/icons/Mesh_SplitComponents.svg
+++ b/src/Mod/Mesh/Gui/Resources/icons/Mesh_SplitComponents.svg
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   version="1.1"
+   id="svg2985"
+   height="64px"
+   width="64px">
+  <title
+     id="title850">Mesh_SplitComponents</title>
+  <defs
+     id="defs2987" />
+  <metadata
+     id="metadata2990">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Mesh_SplitComponents</dc:title>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[wmayer]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:title>Arch_SplitMesh</dc:title>
+        <dc:date>2011-10-10</dc:date>
+        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier></dc:identifier>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>[agryson] Alexander Gryson</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1">
+    <path
+       id="path3009-9"
+       d="M 49,45 37,39 v 16 l 12,6 z"
+       style="fill:#73d216;fill-opacity:1;stroke:#172a04;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path3009-6-7"
+       d="M 61,39 49,45 V 61 L 61,55 Z"
+       style="fill:#4e9a06;fill-opacity:1;stroke:#172a04;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path3029-1"
+       d="m 37,39 12,-6 12,6 -12,6 z"
+       style="fill:#8ae234;fill-opacity:1;stroke:#172a04;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path3009"
+       d="M 19,23 3,15 v 36 l 16,10 z"
+       style="fill:#73d216;fill-opacity:1;stroke:#172a04;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path3009-6"
+       d="M 49,11 19,23 V 61 L 31,53 V 31 l 18,-8 z"
+       style="fill:#4e9a06;fill-opacity:1;stroke:#172a04;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path3029"
+       d="M 3,15 33,3 49,11 19,23 Z"
+       style="fill:#8ae234;fill-opacity:1;stroke:#172a04;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path2991"
+       d="M 5.0346836,18.231134 V 49.832408 L 17,57.33532 17.034684,24.231134 Z"
+       style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       id="path2993"
+       d="M 19,23 3,51"
+       style="fill:none;stroke:#172a04;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       id="path2995"
+       d="M 3,15 49,11"
+       style="fill:none;stroke:#172a04;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       id="path2997"
+       d="m 46.965316,13.965316 v 7.757215 L 29,29.693673 l 0.03468,22.208102 -8,5.306327 L 21,24.312153 Z"
+       style="fill:none;stroke:#73d216;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       id="path2993-3"
+       d="M 31,31 19,23"
+       style="fill:none;stroke:#172a04;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       id="path2993-6"
+       d="M 49,12 31,31"
+       style="fill:none;stroke:#172a04;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       id="path2993-7"
+       d="M 31,31 19,61"
+       style="fill:none;stroke:#172a04;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       id="path3031"
+       d="M 39,42.215199 V 53.760276 L 46.975475,57.730225 47,46.288774 Z"
+       style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       id="path3031-5"
+       d="m 58.985149,42.241106 v 11.545077 l -7.975475,3.969949 -0.02453,-11.441451 z"
+       style="fill:none;stroke:#73d216;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       id="path2993-7-3"
+       d="M 61,39 36.9019,39.04905"
+       style="fill:none;stroke:#172a04;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       id="path2993-7-5"
+       d="M 61,39 49,61"
+       style="fill:none;stroke:#172a04;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       id="path2993-7-6"
+       d="M 49,45 37,55"
+       style="fill:none;stroke:#172a04;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  </g>
+</svg>


### PR DESCRIPTION
Mesh SplitComponents command does not have icon for the FreeCAD UI (Menu Meshes).

This commit adds a SVG file with icon for this command. Also, it makes the necessary changes on Command.cpp and Mesh.qrc files.

The new SVG icon follows the FreeCAD Artwork Guidelines and was saved as Plain SVG format.

Forum Discussion: https://forum.freecadweb.org/viewtopic.php?f=34&t=47494&start=50#p464476