### PR TITLE
LGTM: Remove extra comma in Asymptote surface color definition

### DIFF
--- a/src/Mod/Mesh/App/Core/MeshIO.cpp
+++ b/src/Mod/Mesh/App/Core/MeshIO.cpp
@@ -2515,7 +2515,7 @@ bool MeshOutput::SaveAsymptote(std::ostream &out) const
             for (int i = 0; i < 3; i++) {
                 const App::Color& c = _material->diffuseColor[face._aulPoints[i]];
                 out << "rgb(" << c.r << ", " << c.g << ", " << c.b << ")";
-                if (i < 3)
+                if (i < 2)
                     out << ", ";
             }
             out << "}));\n";


### PR DESCRIPTION
When specifying per-vertex colors in an Asymptote surface, the loop currently has an off-by-one error in its comma-insertion logic. As currently written, the conditional is never false. This commit corrects the output, removing the extra comma after the third RGB triplet. Asymptote documentation can be found here: https://asymptote.sourceforge.io/asymptote.pdf.

Found via LGTM.

---

- [X] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- No tracker ticket filed.