### PR TITLE
[0.19] [Mesh] LGTM: Correct minimum distance calculation in SplitFacet

### DIFF
--- a/src/Mod/Mesh/App/Core/TopoAlgorithm.cpp
+++ b/src/Mod/Mesh/App/Core/TopoAlgorithm.cpp
@@ -1148,7 +1148,7 @@ void MeshTopoAlgorithm::SplitFacet(unsigned long ulFacetPos, const Base::Vector3
       Base::Vector3f cDir = cEnd - cBase;
 
       float fDist = rP2.DistanceToLine(cBase, cDir);
-      if ( fMinDist < fDist )
+      if ( fDist < fMinDist )
       {
         fMinDist = fDist;
         iEdgeNo = i;
@@ -1174,7 +1174,7 @@ void MeshTopoAlgorithm::SplitFacet(unsigned long ulFacetPos, const Base::Vector3
       Base::Vector3f cDir = cEnd - cBase;
 
       float fDist = rP1.DistanceToLine(cBase, cDir);
-      if ( fMinDist < fDist )
+      if ( fDist < fMinDist )
       {
         fMinDist = fDist;
         iEdgeNo = i;
@@ -1201,13 +1201,13 @@ void MeshTopoAlgorithm::SplitFacet(unsigned long ulFacetPos, const Base::Vector3
       Base::Vector3f cDir = cEnd - cBase;
 
       float fDist = rP1.DistanceToLine(cBase, cDir);
-      if ( fMinDist1 < fDist )
+      if ( fDist < fMinDist1 )
       {
         fMinDist1 = fDist;
         iEdgeNo1 = i;
       }
       fDist = rP2.DistanceToLine(cBase, cDir);
-      if ( fMinDist2 < fDist )
+      if ( fDist < fMinDist2 )
       {
         fMinDist2 = fDist;
         iEdgeNo2 = i;


### PR DESCRIPTION
The function `SplitFacet()` appears to be unused (it has a "FIXME: Implement" note at the top), but LGTM has identified a reasonably clear error in it, which this commit resolves in the interest of making someone's life easier in the future (and shutting LGTM up). In calculations of a minimum distance, the variable `minDist` is initialized to `FLOAT_MAX`, and then later is compared to see if it is _less than_ some other value, which cannot ever be true. The sense of the comparison has been reversed.

Found via LGTM.

---

- [X] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- No tracker ticket filed.