### PR TITLE
LGTM: Silence incorrect LGTM warning

### DIFF
--- a/src/Mod/Mesh/App/MeshProperties.cpp
+++ b/src/Mod/Mesh/App/MeshProperties.cpp
@@ -541,7 +541,7 @@ void PropertyMeshKernel::setPointIndices(const std::vector<std::pair<unsigned lo
 PyObject *PropertyMeshKernel::getPyObject(void)
 {
     if (!meshPyObject) {
-        meshPyObject = new MeshPy(&*_meshObject);
+        meshPyObject = new MeshPy(&*_meshObject); // Lgtm[cpp/resource-not-released-in-destructor] ** Not destroyed in this class because it is reference-counted and destroyed elsewhere
         meshPyObject->setConst(); // set immutable
         meshPyObject->parentProperty = this;
     }


### PR DESCRIPTION
LGTM warns on this allocation because it can't find a deallocation in the same class. It's a reference-counted object that may be held in Python code even after the C++ class instance is destroyed, the lack of deallocation is correct (at least, according to the comment in this class's destructor!).