### PR TITLE
LGTM: Remove superfluous conditional

### DIFF
--- a/src/Mod/Part/App/TopoShapeSolidPyImp.cpp
+++ b/src/Mod/Part/App/TopoShapeSolidPyImp.cpp
@@ -123,7 +123,7 @@ int TopoShapeSolidPy::PyInit(PyObject* args, PyObject* /*kwd*/)
             BRepBuilderAPI_MakeSolid mkSolid(compsolid);
             TopoDS_Solid solid = mkSolid.Solid();
             getTopoShapePtr()->setShape(solid);
-        } else if (count > 1) {
+        } else /*if (count > 1)*/ {
             Standard_Failure::Raise("Only one compsolid can be accepted. Provided shape has more than one compsolid.");
         }
 


### PR DESCRIPTION
This conditional always evaluates to true if the previous two branches are false, so the condition is redundant. Commented out rather than removed for documentation purposes.

---

- [X] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
