### PR TITLE
LGTM: Move seq->next out of loop control

### DIFF
--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -3484,7 +3484,7 @@ int Document::recompute(const std::vector<App::DocumentObject*> &objs, bool forc
             if(canAbort)
                 seq.reset(new Base::SequencerLauncher("Recompute...", topoSortedObjects.size()));
             FC_LOG("Recompute pass " << passes);
-            for (;idx<topoSortedObjects.size();(seq?seq->next(true):true),++idx) {
+            for (; idx < topoSortedObjects.size(); ++idx) {
                 auto obj = topoSortedObjects[idx];
                 if(!obj->getNameInDocument() || filter.find(obj)!=filter.end())
                     continue;
@@ -3515,6 +3515,8 @@ int Document::recompute(const std::vector<App::DocumentObject*> &objs, bool forc
                     for (auto inObjIt : obj->getInList())
                         inObjIt->enforceRecompute();
                 }
+                if (seq)
+                    seq->next(true);
             }
             // check if all objects are recomputed but still thouched
             for (size_t i=0;i<topoSortedObjects.size();++i) {


### PR DESCRIPTION
LGTM points out that the construct use in the loop here "does nothing" -- that is, it is a conditional whose result is never used. It is apparently being used simply to ensure that the next() function is called on each loop iteration, but because sequence may be null, it is shoehorned into a trinary :? operator. To clarify the intent and ensure that later readers (including LGTM) do not misunderstand it, this code is broken out into a more standard conditional construct at the end of each loop iteration.

---

- [X] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- No tracker ticket