### PR TITLE
[PD] Add missing CutDimensionSet constructor variable initialization (Coverity)

### DIFF
--- a/src/Mod/PartDesign/App/FeatureHole.cpp
+++ b/src/Mod/PartDesign/App/FeatureHole.cpp
@@ -1832,14 +1832,14 @@ const Hole::CutDimensionSet& Hole::find_cutDimensionSet(const CutDimensionKey &k
 }
 
 Hole::CutDimensionSet::CutDimensionSet(const std::string &nme,
-      std::vector<CounterBoreDimension> &&d, CutType cut, ThreadType thread) :
-    bore_data{ std::move(d) }, cut_type{ cut }, thread_type{thread}, name{nme}
+      std::vector<CounterBoreDimension> &&d, CutType cut, ThreadType thread, double a) :
+    bore_data{ std::move(d) }, cut_type{ cut }, thread_type{thread}, name{nme}, angle{a}
 {
 }
 
 Hole::CutDimensionSet::CutDimensionSet(const std::string &nme,
-      std::vector<CounterSinkDimension> &&d, CutType cut, ThreadType thread) :
-    sink_data{ std::move(d) }, cut_type{ cut }, thread_type{thread}, name{nme}
+      std::vector<CounterSinkDimension> &&d, CutType cut, ThreadType thread, double a) :
+    sink_data{ std::move(d) }, cut_type{ cut }, thread_type{thread}, name{nme}, angle{a}
 {
 }
 

--- a/src/Mod/PartDesign/App/FeatureHole.h
+++ b/src/Mod/PartDesign/App/FeatureHole.h
@@ -165,11 +165,11 @@ private:
         enum CutType { Counterbore, Countersink };
         enum ThreadType { Metric, MetricFine };
 
-        CutDimensionSet() {}
+        CutDimensionSet():cut_type(Counterbore),thread_type(Metric),angle(0.0) {}
         CutDimensionSet(const std::string &nme,
-              std::vector<CounterBoreDimension> &&d, CutType cut, ThreadType thread);
+              std::vector<CounterBoreDimension> &&d, CutType cut, ThreadType thread, double angle = 0.0);
         CutDimensionSet(const std::string &nme,
-              std::vector<CounterSinkDimension> &&d, CutType cut, ThreadType thread);
+              std::vector<CounterSinkDimension> &&d, CutType cut, ThreadType thread, double angle = 0.0);
 
         const CounterBoreDimension &get_bore(const std::string &t) const;
         const CounterSinkDimension &get_sink(const std::string &t) const;


### PR DESCRIPTION
The `angle` variable was not being initialized in any of the constructors for the `CutDimensionSet`, and nothing was being initialized by the default constructor. This commit adds `angle` as an optional final argument to the parameterized constructors, defaulting to 0.0, and adds default values to the default constructor using the first of each enum and 0.0 for the angle. The default constructor is required elsewhere in the code so cannot be trivially removed. Issue identified by Coverity.

---

- [X]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [ ]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [X]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [X]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`