### PR TITLE
Path: Removes unused imports from PathToolBit.py

### DIFF
--- a/src/Mod/Path/PathScripts/PathToolBit.py
+++ b/src/Mod/Path/PathScripts/PathToolBit.py
@@ -21,16 +21,12 @@
 # ***************************************************************************
 
 import FreeCAD
-import PathScripts.PathGeom as PathGeom
 import PathScripts.PathLog as PathLog
 import PathScripts.PathPreferences as PathPreferences
 import PathScripts.PathPropertyBag as PathPropertyBag
-import PathScripts.PathSetupSheetOpPrototype as PathSetupSheetOpPrototype
 import PathScripts.PathUtil as PathUtil
 import PySide
-import Sketcher
 import json
-import math
 import os
 import zipfile
 


### PR DESCRIPTION
lgtm.com showed unused imports in PathToolBit.py.  This patch removes them.  The tests in TestPathApp still pass.
