### PR TITLE
LGTM: Remove unsafe time functions

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -2292,7 +2292,16 @@ void Application::logStatus()
 {
     time_t now;
     time(&now);
-    Console().Log("Time = %s", ctime(&now));
+    struct tm timeStruct; 
+#ifdef FC_OS_WIN32
+    localtime_s(&timeStruct, &now);
+#else
+    localtime_s(&now, &timeStruct);
+#endif
+    char timeString[100];
+    if (std::strftime(timeString, sizeof(timeString), "%c", &timeStruct)) {
+        Console().Log("Time = %s\n", timeString);
+    }
 
     for (std::map<std::string,std::string>::iterator It = mConfig.begin();It!= mConfig.end();++It) {
         Console().Log("%s = %s\n",It->first.c_str(),It->second.c_str());

--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -66,6 +66,7 @@ recompute path. Also, it enables more complicated dependencies beyond trees.
 # include <climits>
 # include <bitset>
 # include <random>
+# include <ctime> 
 #endif
 
 #include <boost/algorithm/string.hpp>
@@ -2481,10 +2482,15 @@ private:
                     std::stringstream str;
                     Base::TimeInfo ti = fi.lastModified();
                     time_t s =ti.getSeconds();
-                    struct tm * timeinfo = localtime(& s);
+                    struct tm timeinfo;
+#ifdef FC_OS_WIN32
+                    localtime_s(&timeinfo, &s);
+#else
+                    localtime_s(&s, &timeinfo);
+#endif
                     char buffer[100];
 
-                    strftime(buffer,sizeof(buffer),saveBackupDateFormat.c_str(),timeinfo);
+                    strftime(buffer,sizeof(buffer),saveBackupDateFormat.c_str(),&timeinfo);
                     str << bn << buffer ;
 
                     fn = str.str();

--- a/src/Base/Console.cpp
+++ b/src/Base/Console.cpp
@@ -339,22 +339,6 @@ void ConsoleSingleton::Log( const char *pMsg, ... )
     }
 }
 
-/** Delivers the time/date
- *  This method gives you a string with the actual time/date. You can
- *  use that for Log() calls to make timestamps.
- *  @return Const string with the date/time
- */
-const char* ConsoleSingleton::Time(void)
-{
-    struct tm *newtime;
-    time_t aclock;
-    time( &aclock );                 // Get time in seconds
-    newtime = localtime( &aclock );  // Convert time to struct tm form
-    char* st = asctime( newtime );
-    st[24] = 0;
-    return st;
-}
-
 
 
 //**************************************************************************

--- a/src/Base/Console.h
+++ b/src/Base/Console.h
@@ -533,8 +533,6 @@ namespace Base {
             void NotifyError  (const char *sMsg);
             void NotifyLog    (const char *sMsg);
 
-            /// Delivers a time/date string
-            const char* Time(void);
             /// Attaches an Observer to FCConsole
             void AttachObserver(ILogger *pcObserver);
             /// Detaches an Observer from FCConsole


### PR DESCRIPTION
This PR is in two commits: the first, 7f1dc84, replaces the global-shared-memory versions of the time functions with those that work with local memory. The second, 32a34f5, eliminates entirely an unused function that would otherwise have needed both a similar fix for the time functions, and a function signature change (from char* to string) to eliminate a local version of the same flaw.

---

- [X]  Your pull request is confined strictly to a single module.
- [ ]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [X]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [X]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0` (except the four that were failing before!)
- [X]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [X]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- No tracker ticket.