### PR TITLE
LGTM: Eliminate float-to-double overflow warning

### DIFF
--- a/src/Mod/Mesh/App/Core/Grid.cpp
+++ b/src/Mod/Mesh/App/Core/Grid.cpp
@@ -291,7 +291,8 @@ void MeshGrid::CalculateGridLength (unsigned long ulCtGrid, unsigned long ulMaxG
         else
             fAreaElem = fArea / float(_ulCtElements);
 
-        fGridLen = sqrt(fAreaElem * float(ulCtGrid));
+        float fRepresentativeArea = fAreaElem * static_cast<float>(ulCtGrid);
+        fGridLen = sqrt(fRepresentativeArea);
     }
 
     if (fGridLen > 0) {


### PR DESCRIPTION
LGTM complains if this calculation is done from inside the `sqrt()` call because it sees multiplication of two floats and assumes that `sqrt()` is intended to take a double, thus resulting in a potential overflow of the float before the cast to double by `sqrt()`. By performing the multiplication separately and assigning it to a float, it should be clear both to the analyzer and to future readers that no conversion to double is expected.

---

- [X]  Your pull request is confined strictly to a single module. 
- [ ]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [X]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [X]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- No tracker ticket