### PR TITLE
LGTM: Don't check PyCXX

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -9,6 +9,7 @@ path_classifiers:
   - "src/zipios++/"
   - "src/3rdParty/"
   - "src/Mod/Import/App/SCL"
+  - "src/CXX/"
   template:
   - "src/Tools/examplePy2wiki.py"
   unmaintained:


### PR DESCRIPTION
Remove PyCXX from LGTM's analysis.

---

- [X]  Your pull request is confined strictly to a single module.
- Minor change.
- [X]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [X]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- No ticket.