### PR TITLE
[Part] Coverity: dtors can't throw

### DIFF
--- a/src/Gui/ViewProviderLink.cpp
+++ b/src/Gui/ViewProviderLink.cpp
@@ -2739,9 +2739,14 @@ void ViewProviderLink::dragMotionCallback(void *data, SoDragger *) {
 }
 
 void ViewProviderLink::updateLinks(ViewProvider *vp) {
-    auto ext = vp->getExtensionByType<ViewProviderLinkObserver>(true);
-    if(ext && ext->linkInfo)
-        ext->linkInfo->update();
+    try {
+        auto ext = vp->getExtensionByType<ViewProviderLinkObserver>(true);
+        if (ext && ext->linkInfo)
+            ext->linkInfo->update();
+    }
+    catch (const Base::TypeError &e) {
+        e.ReportException();
+    }
 }
 
 PyObject *ViewProviderLink::getPyObject() {

--- a/src/Mod/Part/Gui/DlgProjectionOnSurface.cpp
+++ b/src/Mod/Part/Gui/DlgProjectionOnSurface.cpp
@@ -178,7 +178,12 @@ DlgProjectionOnSurface::~DlgProjectionOnSurface()
   delete ui;
   for ( auto it : m_projectionSurfaceVec)
   {
-    higlight_object(it.partFeature, it.partName, false, 0);
+    try {
+      higlight_object(it.partFeature, it.partName, false, 0);
+    }
+    catch (Standard_NoSuchObject& e) {
+      Base::Console().Warning("DlgProjectionOnSurface::~DlgProjectionOnSurface: %s", e.GetMessageString());
+    }
     PartGui::ViewProviderPartExt* vp = dynamic_cast<PartGui::ViewProviderPartExt*>(Gui::Application::Instance->getViewProvider(it.partFeature));
     if (vp)
     {

--- a/src/Mod/Part/Gui/TaskCheckGeometry.cpp
+++ b/src/Mod/Part/Gui/TaskCheckGeometry.cpp
@@ -393,7 +393,13 @@ TaskCheckGeometryResults::TaskCheckGeometryResults(QWidget *parent) : QWidget(pa
 
 TaskCheckGeometryResults::~TaskCheckGeometryResults()
 {
-    Gui::Selection().clearSelection();
+    try {
+        Gui::Selection().clearSelection();
+    }
+    catch (const Py::Exception&) {
+        Base::PyException e; // extract the Python error text
+        e.ReportException();
+    }
 }
 
 void TaskCheckGeometryResults::setupInterface()

--- a/src/Mod/Part/Gui/TaskDimension.cpp
+++ b/src/Mod/Part/Gui/TaskDimension.cpp
@@ -522,7 +522,13 @@ PartGui::TaskMeasureLinear::TaskMeasureLinear()
 
 PartGui::TaskMeasureLinear::~TaskMeasureLinear()
 {
-  Gui::Selection().clearSelection();
+  try {
+    Gui::Selection().clearSelection();
+  }
+  catch (const Py::Exception&) {
+    Base::PyException e; // extract the Python error text
+    e.ReportException();
+  }
 }
 
 void PartGui::TaskMeasureLinear::onSelectionChanged(const Gui::SelectionChanges& msg)
@@ -1513,7 +1519,13 @@ PartGui::TaskMeasureAngular::TaskMeasureAngular()
 
 PartGui::TaskMeasureAngular::~TaskMeasureAngular()
 {
-  Gui::Selection().clearSelection();
+  try {
+    Gui::Selection().clearSelection();
+  }
+  catch (const Py::Exception&) {
+    Base::PyException e; // extract the Python error text
+    e.ReportException();
+  }
 }
 
 void PartGui::TaskMeasureAngular::onSelectionChanged(const Gui::SelectionChanges& msg)


### PR DESCRIPTION
Catch and report exceptions in destructors to prevent them from propagating out. Found via Coverity.

---

- [X]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- Small fix
- [X]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [X]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- No ticket