### PR TITLE
LGTM: Minor fixes to FreeCADApp.py

### DIFF
--- a/src/App/FreeCADInit.py
+++ b/src/App/FreeCADInit.py
@@ -34,18 +34,17 @@ def removeFromPath(module_name):
 	"""removes the module from the sys.path. The entry point for imports
 		will therefore always be FreeCAD.
 		eg.: from FreeCAD.Module.submodule import function"""
-	import sys, os
+	import sys
 	paths = sys.path
 	for path in paths:
 		if module_name in path:
 			sys.path.remove(path)
 			return
-	else:
-		Wrn(module_name + " not found in sys.path\n")
+	Wrn(module_name + " not found in sys.path\n")
 
 def setupSearchPaths(PathExtension):
 	# DLL resolution in Python 3.8 on Windows has changed
-	import sys, os
+	import sys
 	if sys.platform == 'win32' and hasattr(os, "add_dll_directory"):
 		if "FREECAD_LIBPACK_BIN" in os.environ:
 			os.add_dll_directory(os.environ["FREECAD_LIBPACK_BIN"])
@@ -253,7 +252,7 @@ App.__unit_test__ = []
 Log ('Init: starting App::FreeCADInit.py\n')
 
 try:
-    import sys,os,traceback,io,inspect
+    import sys,os,traceback,inspect
     from datetime import datetime
 except ImportError:
     FreeCAD.Console.PrintError("\n\nSeems the python standard libs are not installed, bailing out!\n\n")
@@ -632,7 +631,6 @@ FreeCAD.Logger = FCADLogger
 
 # init every application by importing Init.py
 try:
-	import traceback
 	InitApplications()
 except Exception as e:
 	Err('Error in InitApplications ' + str(e) + '\n')


### PR DESCRIPTION
LGTM flagged several redundant imports, which this commit removes. It also flagged a superfluous `else` clause in a `for` loop: the loop contains `return`s, not `break`s, so the `else` clause is _always_ hit if the loop runs to completion. The `else` can be removed entirely, leaving just the code it executed at the termination of the loop.

---

- [X]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- Small fix
- [X]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [X]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [X]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- No ticket