### PR TITLE
[v0.20] Sketcher: Change constraint-conversion MsgBox to DlgCheckableMessageBox

### DIFF
--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -41,6 +41,7 @@
 #include <Gui/DlgEditFileIncludePropertyExternal.h>
 #include <Gui/Action.h>
 #include <Gui/BitmapFactory.h>
+#include <Gui/DlgCheckableMessageBox.h>
 
 #include <Mod/Part/App/Geometry.h>
 #include <Mod/Sketcher/App/SketchObject.h>
@@ -2165,8 +2166,12 @@ void CmdSketcherConstrainCoincident::activated(int iMsg)
                 ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher/General");
 
                 if(hGrp->GetBool("NotifyConstraintSubstitutions", true)) {
-                    QMessageBox::information(Gui::getMainWindow(), QObject::tr("Constraint Substitution"),
-                                            QObject::tr("Endpoint to endpoint tangency was applied instead."));
+                    Gui::Dialog::DlgCheckableMessageBox::showMessage(
+                        QObject::tr("Sketcher Constraint Substitution"),
+                        QObject::tr("Endpoint to endpoint tangency was applied instead."),
+                        false,
+                        QObject::tr("Don't tell me again")
+                    );
                 }
 
                 getSelection().clearSelection();
@@ -4327,8 +4332,12 @@ void CmdSketcherConstrainTangent::activated(int iMsg)
                     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher/General");
 
                     if(hGrp->GetBool("NotifyConstraintSubstitutions", true)) {
-                        QMessageBox::information(Gui::getMainWindow(), QObject::tr("Constraint Substitution"),
-                                         QObject::tr("Endpoint to endpoint tangency was applied. The coincident constraint was deleted."));
+                        Gui::Dialog::DlgCheckableMessageBox::showMessage(
+                            QObject::tr("Sketcher Constraint Substitution"),
+                            QObject::tr("Endpoint to endpoint tangency was applied instead."),
+                            false,
+                            QObject::tr("Don't tell me again")
+                        );
                     }
                     getSelection().clearSelection();
                     return;

--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -2166,12 +2166,15 @@ void CmdSketcherConstrainCoincident::activated(int iMsg)
                 ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher/General");
 
                 if(hGrp->GetBool("NotifyConstraintSubstitutions", true)) {
+                    auto hChecked = App::GetApplication().GetParameterGroupByPath( QByteArray("User parameter:BaseApp/CheckMessages"));
+                    hChecked->SetBool("Sketcher_Constraint_Substitution", false);
                     Gui::Dialog::DlgCheckableMessageBox::showMessage(
                         QObject::tr("Sketcher Constraint Substitution"),
                         QObject::tr("Endpoint to endpoint tangency was applied instead."),
                         false,
                         QObject::tr("Don't tell me again")
                     );
+                    hGrp->SetBool("NotifyConstraintSubstitutions", !hChecked->GetBool("Sketcher_Constraint_Substitution", true));
                 }
 
                 getSelection().clearSelection();
@@ -4332,12 +4335,15 @@ void CmdSketcherConstrainTangent::activated(int iMsg)
                     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher/General");
 
                     if(hGrp->GetBool("NotifyConstraintSubstitutions", true)) {
+                        auto hChecked = App::GetApplication().GetParameterGroupByPath( QByteArray("User parameter:BaseApp/CheckMessages"));
+                        hChecked->SetBool("Sketcher_Constraint_Substitution", false);
                         Gui::Dialog::DlgCheckableMessageBox::showMessage(
                             QObject::tr("Sketcher Constraint Substitution"),
                             QObject::tr("Endpoint to endpoint tangency was applied instead."),
                             false,
                             QObject::tr("Don't tell me again")
                         );
+                        hGrp->SetBool("NotifyConstraintSubstitutions", !hChecked->GetBool("Sketcher_Constraint_Substitution", true));
                     }
                     getSelection().clearSelection();
                     return;

--- a/src/Mod/Sketcher/Gui/SketcherSettings.cpp
+++ b/src/Mod/Sketcher/Gui/SketcherSettings.cpp
@@ -70,7 +70,6 @@ void SketcherSettings::saveSettings()
     ui->checkBoxAdvancedSolverTaskBox->onSave();
     ui->checkBoxRecalculateInitialSolutionWhileDragging->onSave();
     ui->checkBoxEnableEscape->onSave();
-    ui->checkBoxNotifyConstraintSubstitutions->onSave();
     ui->checkBoxAutoRemoveRedundants->onSave();
     form->saveSettings();
 }
@@ -81,7 +80,6 @@ void SketcherSettings::loadSettings()
     ui->checkBoxAdvancedSolverTaskBox->onRestore();
     ui->checkBoxRecalculateInitialSolutionWhileDragging->onRestore();
     ui->checkBoxEnableEscape->onRestore();
-    ui->checkBoxNotifyConstraintSubstitutions->onRestore();
     ui->checkBoxAutoRemoveRedundants->onRestore();
     form->loadSettings();
 }

--- a/src/Mod/Sketcher/Gui/SketcherSettings.ui
+++ b/src/Mod/Sketcher/Gui/SketcherSettings.ui
@@ -147,25 +147,6 @@ Requires to re-enter edit mode to take effect.</string>
         </property>
        </widget>
       </item>
-      <item>
-       <widget class="Gui::PrefCheckBox" name="checkBoxNotifyConstraintSubstitutions">
-        <property name="toolTip">
-         <string>Notifies about automatic constraint substitutions</string>
-        </property>
-        <property name="text">
-         <string>Notify automatic constraint substitutions</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>NotifyConstraintSubstitutions</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Sketcher/General</cstring>
-        </property>
-       </widget>
-      </item>
      </layout>
     </widget>
    </item>


### PR DESCRIPTION
Forum discussion
https://forum.freecadweb.org/viewtopic.php?f=34&t=55437

![opt-out-notify](https://user-images.githubusercontent.com/1278189/107568221-f743d500-6be6-11eb-9072-e5a2b760bc29.gif)


The 3 commits outlines several possibilities for how to deal with the existing preference.

**Only commit 1**
In this case the Sketcher settings checkbox becomes kind of broken if the user uses the checkbox in the MessageBox. 

**Commit 1 +  2**
In this case the Sketcher Settings checkbox is still the master. The preference can be changed either from the Settings dialog, or from the messagebox.

**Commit 1 + 3**
In this case the MessageBox preference replaces the old preference. The preference is removed from the Sketcher Settings dialog

**Commit 1 + 2 + 3**
The old preference is still master. But it is controlled from the MessageBox only.  If you want to get your warning back, you have to use the Preferences editor. 