### PR TITLE
Coverity: geoit can be end() when dereferenced

### DIFF
--- a/src/Mod/Sketcher/App/Sketch.cpp
+++ b/src/Mod/Sketcher/App/Sketch.cpp
@@ -184,7 +184,7 @@ bool Sketch::analyseBlockedGeometry( const std::vector<Part::Geometry *> &intern
 
                 auto geoit = std::find(blockedGeoIds.begin(),blockedGeoIds.end(),c->Second);
 
-                if(geoit != blockedGeoIds.end() || onlyblockedGeometry[c->Second]) { // internal alignment geometry found, add to list
+                if(geoit != blockedGeoIds.end() && onlyblockedGeometry[c->Second]) { // internal alignment geometry found, add to list
                     // check if pre-fix or post-analyses
                     bool blockAffectedOnly = true;
 


### PR DESCRIPTION
Coverity has identified a potential bug that this PR seeks to address: in the Sketcher function `analyseBlockedGeometry()` there is a conditional:
```
auto geoit = std::find(blockedGeoIds.begin(),blockedGeoIds.end(),c->Second);
if(geoit != blockedGeoIds.end() || onlyblockedGeometry[c->Second]) { // internal alignment geometry found, add to list
```
and then later on inside that conditional
```
blockedGeoIds.push_back(*geoit);
```
However, since the condition is an OR, it is apparently possible that `geoit` is `end()`, in which case dereferencing it is illegal. The fix proposed in this PR is to modify the OR to an AND. However, this needs review.

This fix is a joint effort with @hyarion.