### PR TITLE
[Arch] Fix for ArchPipe: getProfile returned Shape instead of Wire

### DIFF
--- a/src/Mod/Arch/ArchPipe.py
+++ b/src/Mod/Arch/ArchPipe.py
@@ -311,7 +311,7 @@ class _ArchPipe(ArchComponent.Component):
             if not obj.Profile.Shape.Wires[0].isClosed():
                 FreeCAD.Console.PrintError(translate("Arch","The profile is not closed")+"\n")
                 return
-            p = obj.Profile.Shape
+            p = obj.Profile.Shape.Wires[0]
         else:
             if obj.Diameter.Value == 0:
                 return


### PR DESCRIPTION
Fix for ArchPipe: getProfile returned Shape instead of Wire

Forum topic:
https://forum.freecadweb.org/viewtopic.php?f=23&t=55401
