### PR TITLE
[0.19] PartDesign: Fix hardcoded through all distance in ProfileBased

### DIFF
--- a/src/Mod/PartDesign/App/FeatureSketchBased.cpp
+++ b/src/Mod/PartDesign/App/FeatureSketchBased.cpp
@@ -543,6 +543,20 @@ void ProfileBased::getUpToFace(TopoDS_Face& upToFace,
     }
 }
 
+double ProfileBased::getThroughAllLength() {
+    TopoDS_Shape profileshape;
+    TopoDS_Shape base;
+    profileshape = getVerifiedFace();
+    base = getBaseShape();
+    Bnd_Box box;
+    BRepBndLib::Add(base, box);
+    BRepBndLib::Add(profileshape, box);
+    box.SetGap(0.0);
+    // The diagonal of the bounding box, plus 1%  extra to eliminate risk of
+    // co-planar issues, gives a length that is guaranteed to go through all.
+    return 1.01*sqrt(box.SquareExtent());
+}
+
 void ProfileBased::generatePrism(TopoDS_Shape& prism,
                                 const TopoDS_Shape& sketchshape,
                                 const std::string& method,
@@ -556,9 +570,7 @@ void ProfileBased::generatePrism(TopoDS_Shape& prism,
         double Ltotal = L;
         double Loffset = 0.;
         if (method == "ThroughAll")
-            // "ThroughAll" is modelled as a very long, but finite prism to avoid problems with pockets
-            // Note: 1E6 created problems once...
-            Ltotal = 1E4;
+            Ltotal = getThroughAllLength();
 
 
         if (method == "TwoLengths") {

--- a/src/Mod/PartDesign/App/FeatureSketchBased.h
+++ b/src/Mod/PartDesign/App/FeatureSketchBased.h
@@ -113,6 +113,9 @@ public:
     //backwards compatibility: profile property was renamed and has different type now
     virtual void Restore(Base::XMLReader& reader);
 
+    // calculate the through all length
+    double getThroughAllLength();
+
 protected:
     void remapSupportShape(const TopoDS_Shape&);
 
@@ -132,14 +135,14 @@ protected:
       * Generate a linear prism
       * It will be a stand-alone solid created with BRepPrimAPI_MakePrism
       */
-    static void generatePrism(TopoDS_Shape& prism,
-                              const TopoDS_Shape& sketchshape,
-                              const std::string& method,
-                              const gp_Dir& direction,
-                              const double L,
-                              const double L2,
-                              const bool midplane,
-                              const bool reversed);
+    void generatePrism(TopoDS_Shape& prism,
+                       const TopoDS_Shape& sketchshape,
+                       const std::string& method,
+                       const gp_Dir& direction,
+                       const double L,
+                       const double L2,
+                       const bool midplane,
+                       const bool reversed);
     /**
       * Generate a linear prism
       * It will be a stand-alone solid created with BRepFeat_MakePrism


### PR DESCRIPTION
Before the throughall distance was 10 m, which is not enough for
many applications. The fix is to use the bounding box of the base shape
together with the sketch profile to calculate dynamically a large enough
length.

**Before:**
![before](https://user-images.githubusercontent.com/1278189/107699975-1d38aa80-6cb7-11eb-9c67-87aefcd9805b.png)

**After:**
![after](https://user-images.githubusercontent.com/1278189/107699985-20cc3180-6cb7-11eb-98e7-2a148882a3cc.png)
