### PR TITLE
[0.19] Spreadsheet: Fix SpreadsheetView warning from Coverity

### DIFF
--- a/src/Mod/Spreadsheet/Gui/SpreadsheetView.cpp
+++ b/src/Mod/Spreadsheet/Gui/SpreadsheetView.cpp
@@ -234,9 +234,7 @@ void SheetView::updateContentLine()
 
     if (i.isValid()) {
         std::string str;
-        Cell * cell = sheet->getCell(CellAddress(i.row(), i.column()));
-
-        if (cell)
+        if (const auto * cell = sheet->getCell(CellAddress(i.row(), i.column())))
             (void)cell->getStringContent(str);
         ui->cellContent->setText(QString::fromUtf8(str.c_str()));
         ui->cellContent->setIndex(i);
@@ -253,9 +251,7 @@ void SheetView::updateAliasLine()
 
     if (i.isValid()) {
         std::string str;
-        Cell * cell = sheet->getCell(CellAddress(i.row(), i.column()));
-
-        if (cell)
+        if (const auto * cell = sheet->getCell(CellAddress(i.row(), i.column())))
             (void)cell->getAlias(str);
         ui->cellAlias->setText(QString::fromUtf8(str.c_str()));
         ui->cellAlias->setIndex(i);
@@ -350,8 +346,7 @@ void SheetView::editingFinished()
         ui->cellAlias->setDocumentObject(sheet);
         ui->cells->model()->setData(i, QVariant(ui->cellContent->text()), Qt::EditRole);
 
-        Cell * cell = sheet->getCell(CellAddress(i.row(), i.column()));
-        if (cell){
+        if (const auto * cell = sheet->getCell(CellAddress(i.row(), i.column()))){
             if (!aliasOkay){
                 //do not show error message if failure to set new alias is because it is already the same string
                 std::string current_alias;

--- a/src/Mod/Spreadsheet/Gui/SpreadsheetView.cpp
+++ b/src/Mod/Spreadsheet/Gui/SpreadsheetView.cpp
@@ -237,7 +237,7 @@ void SheetView::updateContentLine()
         Cell * cell = sheet->getCell(CellAddress(i.row(), i.column()));
 
         if (cell)
-            cell->getStringContent(str);
+            (void)cell->getStringContent(str);
         ui->cellContent->setText(QString::fromUtf8(str.c_str()));
         ui->cellContent->setIndex(i);
         ui->cellContent->setEnabled(true);
@@ -256,7 +256,7 @@ void SheetView::updateAliasLine()
         Cell * cell = sheet->getCell(CellAddress(i.row(), i.column()));
 
         if (cell)
-            cell->getAlias(str);
+            (void)cell->getAlias(str);
         ui->cellAlias->setText(QString::fromUtf8(str.c_str()));
         ui->cellAlias->setIndex(i);
         ui->cellAlias->setEnabled(true);
@@ -355,7 +355,7 @@ void SheetView::editingFinished()
             if (!aliasOkay){
                 //do not show error message if failure to set new alias is because it is already the same string
                 std::string current_alias;
-                cell->getAlias(current_alias);
+                (void)cell->getAlias(current_alias);
                 if (str != QString::fromUtf8(current_alias.c_str())){
                     Base::Console().Error("Unable to set alias: %s\n", Base::Tools::toStdString(str).c_str());
                 }


### PR DESCRIPTION
This has a draft status since it hasn't been tested yet. Will remove draft status and this line once it's ready for review.

There are no reason to check the return values for these functions
as the string passed as an argument will be set to an empty string
if it false. An empty string is a valid option in these instances.

Coverity warnings fixed:

CID 316520 (1 of 1): Unchecked return value (CHECKED_RETURN)
3. check_return: Calling getAlias without checking return value (as is done elsewhere 8 out of 10 times).

CID 316557 (1 of 1): Unchecked return value (CHECKED_RETURN)
8. check_return: Calling getAlias without checking return value (as is done elsewhere 8 out of 10 times).

---

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [x]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
-  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
