### PR TITLE
[0.19] PartDesign: Fix outdated icon filenames

### DIFF
--- a/src/Mod/PartDesign/Gui/ViewProviderHelix.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderHelix.cpp
@@ -68,9 +68,9 @@ QIcon ViewProviderHelix::getIcon(void) const {
     QString str = QString::fromLatin1("PartDesign_");
     auto* prim = static_cast<PartDesign::Helix*>(getObject());
     if(prim->getAddSubType() == PartDesign::FeatureAddSub::Additive)
-        str += QString::fromLatin1("Additive_");
+        str += QString::fromLatin1("Additive");
     else
-        str += QString::fromLatin1("Subtractive_");
+        str += QString::fromLatin1("Subtractive");
 
     str += QString::fromLatin1("Helix.svg");
     return PartDesignGui::ViewProvider::mergeGreyableOverlayIcons(Gui::BitmapFactory().pixmap(str.toStdString().c_str()));

--- a/src/Mod/PartDesign/Gui/ViewProviderLoft.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderLoft.cpp
@@ -169,9 +169,9 @@ QIcon ViewProviderLoft::getIcon(void) const {
     QString str = QString::fromLatin1("PartDesign_");
     auto* prim = static_cast<PartDesign::Loft*>(getObject());
     if(prim->getAddSubType() == PartDesign::FeatureAddSub::Additive)
-        str += QString::fromLatin1("Additive_");
+        str += QString::fromLatin1("Additive");
     else
-        str += QString::fromLatin1("Subtractive_");
+        str += QString::fromLatin1("Subtractive");
 
     str += QString::fromLatin1("Loft.svg");
     return PartDesignGui::ViewProvider::mergeGreyableOverlayIcons(Gui::BitmapFactory().pixmap(str.toStdString().c_str()));

--- a/src/Mod/PartDesign/Gui/ViewProviderPipe.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderPipe.cpp
@@ -202,9 +202,9 @@ QIcon ViewProviderPipe::getIcon(void) const {
     QString str = QString::fromLatin1("PartDesign_");
     auto* prim = static_cast<PartDesign::Pipe*>(getObject());
     if(prim->getAddSubType() == PartDesign::FeatureAddSub::Additive)
-        str += QString::fromLatin1("Additive_");
+        str += QString::fromLatin1("Additive");
     else
-        str += QString::fromLatin1("Subtractive_");
+        str += QString::fromLatin1("Subtractive");
 
     str += QString::fromLatin1("Pipe.svg");
     return PartDesignGui::ViewProvider::mergeGreyableOverlayIcons(Gui::BitmapFactory().pixmap(str.toStdString().c_str()));

--- a/src/Mod/PartDesign/Gui/ViewProviderPrimitive.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderPrimitive.cpp
@@ -140,9 +140,9 @@ QIcon ViewProviderPrimitive::getIcon(void) const {
     QString str = QString::fromLatin1("PartDesign_");
     auto* prim = static_cast<PartDesign::FeaturePrimitive*>(getObject());
     if(prim->getAddSubType() == PartDesign::FeatureAddSub::Additive)
-        str += QString::fromLatin1("Additive_");
+        str += QString::fromLatin1("Additive");
     else
-        str += QString::fromLatin1("Subtractive_");
+        str += QString::fromLatin1("Subtractive");
 
     switch(prim->getPrimitiveType()) {
     case PartDesign::FeaturePrimitive::Box:


### PR DESCRIPTION
This fixes some cases that were missed in commit 2834075d6abcd36b9e