### PR TITLE
[Path]: bugfix/invalid base geometry robustness

### DIFF
--- a/src/Mod/Path/PathScripts/PathOp.py
+++ b/src/Mod/Path/PathScripts/PathOp.py
@@ -514,7 +514,7 @@ class ObjectOp(object):
         if not self._setBaseAndStock(obj):
             return
 
-        # make sure Base is stil valid or clear it
+        # make sure Base is still valid or clear it
         self.sanitizeBase(obj)
 
         if FeatureCoolant & self.opFeatures(obj):

--- a/src/Mod/Path/PathScripts/PathOp.py
+++ b/src/Mod/Path/PathScripts/PathOp.py
@@ -300,6 +300,13 @@ class ObjectOp(object):
     def onChanged(self, obj, prop):
         '''onChanged(obj, prop) ... base implementation of the FC notification framework.
         Do not overwrite, overwrite opOnChanged() instead.'''
+
+        # there's a bit of cycle going on here, if sanitizeBase causes the transaction to
+        # be cancelled we end right here again with the unsainitized Base - if that is the
+        # case, stop the cycle and return immediately
+        if prop == 'Base' and self.sanitizeBase(obj):
+            return
+
         if 'Restore' not in obj.State and prop in ['Base', 'StartDepth', 'FinalDepth']:
             self.updateDepths(obj, True)
 
@@ -463,6 +470,19 @@ class ObjectOp(object):
 
         self.opUpdateDepths(obj)
 
+    def sanitizeBase(self, obj):
+        '''sanitizeBase(obj) ... check if Base is valid and clear on errors.'''
+        if hasattr(obj, 'Base'):
+            try:
+                for (o, sublist) in obj.Base:
+                    for sub in sublist:
+                        e = o.Shape.getElement(sub)
+            except Part.OCCError as e:
+                PathLog.error("{} - stale base geometry detected - clearing.".format(obj.Label))
+                obj.Base = []
+                return True
+        return False
+
     @waiting_effects
     def execute(self, obj):
         '''execute(obj) ... base implementation - do not overwrite!
@@ -493,6 +513,9 @@ class ObjectOp(object):
 
         if not self._setBaseAndStock(obj):
             return
+
+        # make sure Base is stil valid or clear it
+        self.sanitizeBase(obj)
 
         if FeatureCoolant & self.opFeatures(obj):
             if not hasattr(obj, 'CoolantMode'):

--- a/src/Mod/Path/PathScripts/PathOpGui.py
+++ b/src/Mod/Path/PathScripts/PathOpGui.py
@@ -1177,6 +1177,7 @@ class TaskPanel(object):
     def panelSetFields(self):
         '''panelSetFields() ... invoked to trigger a complete transfer of the model's properties to the UI.'''
         PathLog.track()
+        self.obj.Proxy.sanitizeBase(self.obj)
         for page in self.featurePages:
             page.pageSetFields()
 


### PR DESCRIPTION
currently if the base geometry of an op becomes invalid the op cannot be edited to fix the base geometry because it throws an exception during task panel initialisation which prevents the event handlers to be registered - rendering the task panel mostly unresponsive (OK and Cancel still works though).

This change checks the base geometry and resets it if it is found invalid, allowing the task panel to be created successfully and let the user fix the base geometry.