### PR TITLE
[Path]: Added support for Part.OffsetCurve to flipEdge.

### DIFF
--- a/src/Mod/Path/PathScripts/PathGeom.py
+++ b/src/Mod/Path/PathScripts/PathGeom.py
@@ -542,13 +542,18 @@ def flipEdge(edge):
         flipped.buildFromPolesMultsKnots(poles, mults , knots, perio, degree, weights, ratio)
 
         return Part.Edge(flipped)
+    elif type(edge.Curve) == Part.OffsetCurve:
+        return edge.reversed()
 
     global OddsAndEnds # pylint: disable=global-statement
     OddsAndEnds.append(edge)
-    PathLog.warning(translate('PathGeom', "%s not support for flipping") % type(edge.Curve))
+    PathLog.warning(translate('PathGeom', "%s not supported for flipping") % type(edge.Curve))
+
+Wire = []
 
 def flipWire(wire):
     '''Flip the entire wire and all its edges so it is being processed the other way around.'''
+    Wire.append(wire)
     edges = [flipEdge(e) for e in wire.Edges]
     edges.reverse()
     PathLog.debug(edges)

--- a/src/Mod/Path/PathTests/TestPathGeom.py
+++ b/src/Mod/Path/PathTests/TestPathGeom.py
@@ -522,4 +522,16 @@ class TestPathGeom(PathTestBase):
         edge = Part.Edge(Part.BSplineCurve([Vector(-8,4,0), Vector(1,-5,0), Vector(5,11,0), Vector(12,-5,0)], weights=[2,3,5,7]))
         self.assertEdgeShapesMatch(edge, PathGeom.flipEdge(edge))
 
+    def test76(self):
+        '''Flip an offset wire'''
+
+        e0 = Part.Edge(Part.BSplineCurve([Vector(-8,4,0), Vector(1,-5,0), Vector(5,11,0), Vector(12,-5,0)], weights=[2,3,5,7]))
+        e1 = Part.Edge(Part.LineSegment(Vector(12,-5,0), Vector(0,-7,0)))
+        e2 = Part.Edge(Part.LineSegment(Vector(0,-7,0), Vector(-8,4,0)))
+        w0 = Part.Wire([e0, e1, e2])
+        w1 = w0.makeOffset2D(1)
+        w2 = PathGeom.flipWire(w1)
+        # do some sanity checks
+        self.assertTrue(w2.isValid())
+        self.assertTrue(w2.isClosed())
 


### PR DESCRIPTION
gitter user found error when using deburr - seems a new type of curve is not supported for flipping, which was required in this case.