### PR TITLE
[0.19] Spreadsheet: Don't autocomplete when writing strings in cells

### DIFF
--- a/src/Gui/ExpressionCompleter.cpp
+++ b/src/Gui/ExpressionCompleter.cpp
@@ -473,8 +473,8 @@ void ExpressionCompleter::slotUpdate(const QString & prefix, int pos)
 
     // No tokens
     if (tokens.size() == 0) {
-        if (popup())
-            popup()->setVisible(false);
+        if (auto p = popup())
+            p->setVisible(false);
         return;
     }
 
@@ -520,8 +520,8 @@ void ExpressionCompleter::slotUpdate(const QString & prefix, int pos)
 
     // Not an unclosed string and the last character is a space
     if(!stringing && prefix.size() && prefix[prefixEnd-1] == QChar(32)) {
-        if (popup())
-            popup()->setVisible(false);
+        if (auto p = popup())
+            p->setVisible(false);
         return;
     }
 
@@ -560,14 +560,14 @@ void ExpressionCompleter::slotUpdate(const QString & prefix, int pos)
     if (!completionPrefix.empty() && widget()->hasFocus())
         complete();
     else {
-        if (popup())
-            popup()->setVisible(false);
+        if (auto p = popup())
+            p->setVisible(false);
     }
 }
 
 ExpressionLineEdit::ExpressionLineEdit(QWidget *parent, bool noProperty, bool requireLeadingEqualSign)
     : QLineEdit(parent)
-    , completer(0)
+    , completer(nullptr)
     , block(true)
     , noProperty(noProperty)
     , exactMatch(false)
@@ -681,7 +681,7 @@ void ExpressionLineEdit::contextMenuEvent(QContextMenuEvent *event)
 
 ExpressionTextEdit::ExpressionTextEdit(QWidget *parent)
     : QPlainTextEdit(parent)
-    , completer(0)
+    , completer(nullptr)
     , block(true)
     , exactMatch(false)
 {
@@ -703,7 +703,7 @@ void ExpressionTextEdit::setDocumentObject(const App::DocumentObject * currentDo
         return;
     }
 
-    if (currentDocObj != 0) {
+    if (currentDocObj != nullptr) {
         completer = new ExpressionCompleter(currentDocObj, this);
 #if QT_VERSION>=QT_VERSION_CHECK(5,2,0)
         if (!exactMatch)

--- a/src/Gui/ExpressionCompleter.h
+++ b/src/Gui/ExpressionCompleter.h
@@ -65,6 +65,7 @@ public:
     void setDocumentObject(const App::DocumentObject*);
 
     void setNoProperty(bool enabled=true);
+    void setRequireLeadingEqualSign(bool enabled);
 
 public Q_SLOTS:
     void slotUpdate(const QString &prefix, int pos);
@@ -76,6 +77,7 @@ private:
 
     int prefixStart = 0;
     int prefixEnd = 0;
+    bool requireLeadingEqualSign = false;
 
     App::DocumentObjectT currentObj;
     bool noProperty;
@@ -85,7 +87,7 @@ private:
 class GuiExport ExpressionLineEdit : public QLineEdit {
     Q_OBJECT
 public:
-    ExpressionLineEdit(QWidget *parent = 0, bool noProperty=false);
+    ExpressionLineEdit(QWidget *parent = 0, bool noProperty = false, bool requireLeadingEqualSign = false);
     void setDocumentObject(const App::DocumentObject *currentDocObj);
     bool completerActive() const;
     void hideCompleter();
@@ -104,6 +106,7 @@ private:
     bool block;
     bool noProperty;
     bool exactMatch;
+    bool requireLeadingEqualSign;
 };
 
 class GuiExport ExpressionTextEdit : public QPlainTextEdit {

--- a/src/Gui/ExpressionCompleter.h
+++ b/src/Gui/ExpressionCompleter.h
@@ -51,7 +51,7 @@ class GuiExport ExpressionCompleter : public QCompleter
     Q_OBJECT
 public:
     ExpressionCompleter(const App::DocumentObject * currentDocObj,
-            QObject *parent = 0, bool noProperty = false);
+            QObject *parent = nullptr, bool noProperty = false);
 
     void getPrefixRange(int &start, int &end) const {
         start = prefixStart;
@@ -87,7 +87,7 @@ private:
 class GuiExport ExpressionLineEdit : public QLineEdit {
     Q_OBJECT
 public:
-    ExpressionLineEdit(QWidget *parent = 0, bool noProperty = false, bool requireLeadingEqualSign = false);
+    ExpressionLineEdit(QWidget *parent = nullptr, bool noProperty = false, bool requireLeadingEqualSign = false);
     void setDocumentObject(const App::DocumentObject *currentDocObj);
     bool completerActive() const;
     void hideCompleter();
@@ -112,7 +112,7 @@ private:
 class GuiExport ExpressionTextEdit : public QPlainTextEdit {
     Q_OBJECT
 public:
-    ExpressionTextEdit(QWidget *parent = 0);
+    ExpressionTextEdit(QWidget *parent = nullptr);
     void setDocumentObject(const App::DocumentObject *currentDocObj);
     bool completerActive() const;
     void hideCompleter();

--- a/src/Mod/Spreadsheet/Gui/LineEdit.cpp
+++ b/src/Mod/Spreadsheet/Gui/LineEdit.cpp
@@ -31,7 +31,7 @@
 using namespace SpreadsheetGui;
 
 LineEdit::LineEdit(QWidget *parent)
-    : Gui::ExpressionLineEdit(parent)
+    : Gui::ExpressionLineEdit(parent, false, true)
     , current()
     , deltaCol(0)
     , deltaRow(0)


### PR DESCRIPTION
I consider this to be a bug fix since the current behaviour will just confuse people.
I think it will be easier to review this change when it's just one PR even though it touches both Spreadsheet and Gui.
I can split it if needed.


After pull request #4215 it doesn't make much sense helping the user to write expressions without leading '=', as that content will be parsed as a string and not as an expression as it was before.

This change adjusts the behaviour in SpreadsheetGui's LineEdit to avoid popping up the ExpressionCompleter when no leading equal sign is used.

Some cleaning has also been preformed on the code as a separate commit.

---

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [ ]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [x]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
-  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
