### PR TITLE
AddonManager: removes unused imports

### DIFF
--- a/src/Mod/AddonManager/AddonManager.py
+++ b/src/Mod/AddonManager/AddonManager.py
@@ -26,14 +26,11 @@
 from __future__ import print_function
 
 import os
-import re
 import shutil
 import stat
-import sys
 import tempfile
 
 from PySide import QtGui, QtCore
-import AddonManager_rc
 import FreeCADGui
 
 from addonmanager_utilities import translate  # this needs to be as is for pylupdate

--- a/src/Mod/AddonManager/InitGui.py
+++ b/src/Mod/AddonManager/InitGui.py
@@ -4,7 +4,6 @@
 # License LGPL
 
 import AddonManager
-import AddonManager_rc
 
 FreeCADGui.addLanguagePath(":/translations")
 FreeCADGui.addCommand('Std_AddonMgr', AddonManager.CommandAddonManager())

--- a/src/Mod/AddonManager/addonmanager_workers.py
+++ b/src/Mod/AddonManager/addonmanager_workers.py
@@ -24,9 +24,7 @@
 import os
 import re
 import shutil
-import stat
 import sys
-import tempfile
 
 from PySide import QtCore, QtGui
 


### PR DESCRIPTION
Removes all the unused imports in the AddonManager module as flagged by LGTM.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [ ]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [ ]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [x]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
