### PR TITLE
PathToolBitLibraryGui: Fix LinuxCNC tool table format

### DIFF
--- a/src/Mod/Path/PathScripts/PathToolBitLibraryGui.py
+++ b/src/Mod/Path/PathScripts/PathToolBitLibraryGui.py
@@ -736,7 +736,7 @@ class ToolBitLibrary(object):
                 if bit:
                     PathLog.track(bit)
 
-                    pocket = bit.Pocket if hasattr(bit, "Pocket") else ""
+                    pocket = bit.Pocket if hasattr(bit, "Pocket") else "0"
                     xoffset = bit.Xoffset if hasattr(bit, "Xoffset") else "0"
                     yoffset = bit.Yoffset if hasattr(bit, "Yoffset") else "0"
                     zoffset = bit.Zoffset if hasattr(bit, "Zoffset") else "0"


### PR DESCRIPTION
The currently exported tool table for LinuxCNC results in the following warning:

  "Requested tool 1 not found in the tool table"

The debug output provides:

  "File: default_tool_table.tbl Unrecognized line skipped: \
      T1 P X0 Y0 Z0 A0 B0 C0 U0 V0 W0 D4.00 I0 J0 Q0;      \
      4mm_2F_Compression_Carbide_Endmill"

This is due to a missing/blank P (pocket) entry.

Signed-off-by: Lee Jones <lee.jones@linaro.org>