### PR TITLE
[0.19] PartDesign: Fix preview bug in Helix

### DIFF
--- a/src/Mod/PartDesign/Gui/TaskHelixParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskHelixParameters.cpp
@@ -305,7 +305,6 @@ void TaskHelixParameters::updateUI()
 void TaskHelixParameters::onSelectionChanged(const Gui::SelectionChanges& msg)
 {
     if (msg.Type == Gui::SelectionChanges::AddSelection) {
-
         exitSelectionMode();
         std::vector<std::string> axis;
         App::DocumentObject* selObj;
@@ -363,12 +362,15 @@ void TaskHelixParameters::onAxisChanged(int num)
     if (lnk.getValue() == 0) {
         // enter reference selection mode
         TaskSketchBasedParameters::onSelectReference(true, true, false, true);
+        return;
     } else {
         if (!pcHelix->getDocument()->isIn(lnk.getValue())){
             Base::Console().Error("Object was deleted\n");
             return;
         }
         propReferenceAxis->Paste(lnk);
+
+        // in case user is in selection mode, but changed his mind before selecting anything.
         exitSelectionMode();
     }
 
@@ -474,6 +476,32 @@ void TaskHelixParameters::getReferenceAxis(App::DocumentObject*& obj, std::vecto
 
         obj = lnk.getValue();
         sub = lnk.getSubValues();
+    }
+}
+
+void TaskHelixParameters::startReferenceSelection(App::DocumentObject* profile, App::DocumentObject* base)
+{
+    PartDesign::ProfileBased* pcHelix = dynamic_cast<PartDesign::Helix*>(vp->getObject());
+    if (pcHelix->getAddSubType() == PartDesign::FeatureAddSub::Subtractive) {
+        Gui::Document* doc = vp->getDocument();
+        if (doc) {
+            doc->setHide(profile->getNameInDocument());
+        }
+    } else {
+        TaskSketchBasedParameters::startReferenceSelection(profile, base);
+    }
+}
+
+void TaskHelixParameters::finishReferenceSelection(App::DocumentObject* profile, App::DocumentObject* base)
+{
+    PartDesign::ProfileBased* pcHelix = dynamic_cast<PartDesign::Helix*>(vp->getObject());
+    if (pcHelix->getAddSubType() == PartDesign::FeatureAddSub::Subtractive) {
+        Gui::Document* doc = vp->getDocument();
+        if (doc) {
+            doc->setShow(profile->getNameInDocument());
+        }
+    } else {
+        TaskSketchBasedParameters::finishReferenceSelection(profile, base);
     }
 }
 

--- a/src/Mod/PartDesign/Gui/TaskHelixParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskHelixParameters.h
@@ -82,7 +82,8 @@ protected:
     void changeEvent(QEvent *e) override;
     bool updateView() const;
     void getReferenceAxis(App::DocumentObject *&obj, std::vector<std::string> &sub) const;
-
+    void startReferenceSelection(App::DocumentObject* profile, App::DocumentObject* base) override;
+    void finishReferenceSelection(App::DocumentObject* profile, App::DocumentObject* base) override;
 
     //mirrors of helixes's properties
     App::PropertyLength*      propPitch;

--- a/src/Mod/PartDesign/Gui/TaskSketchBasedParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskSketchBasedParameters.cpp
@@ -92,6 +92,27 @@ const QString TaskSketchBasedParameters::onAddSelection(const Gui::SelectionChan
     return refStr;
 }
 
+
+void TaskSketchBasedParameters::startReferenceSelection(App::DocumentObject* profile, App::DocumentObject* base)
+{
+    Gui::Document* doc = vp->getDocument();
+    if (doc) {
+        doc->setHide(profile->getNameInDocument());
+        if (base)
+            doc->setShow(base->getNameInDocument());
+    }
+}
+
+void TaskSketchBasedParameters::finishReferenceSelection(App::DocumentObject* profile, App::DocumentObject* base)
+{
+    Gui::Document* doc = vp->getDocument();
+    if (doc) {
+        doc->setShow(profile->getNameInDocument());
+        if (base)
+            doc->setHide(base->getNameInDocument());
+    }
+}
+
 void TaskSketchBasedParameters::onSelectReference(const bool pressed, const bool edge, const bool face, const bool planar) {
     // Note: Even if there is no solid, App::Plane and Part::Datum can still be selected
 
@@ -101,26 +122,17 @@ void TaskSketchBasedParameters::onSelectReference(const bool pressed, const bool
         App::DocumentObject* prevSolid = pcSketchBased->getBaseObject( /* silent =*/ true );
 
         if (pressed) {
-            Gui::Document* doc = vp->getDocument();
-            if (doc) {
-                doc->setHide(pcSketchBased->getNameInDocument());
-                if (prevSolid)
-                    doc->setShow(prevSolid->getNameInDocument());
-            }
+            startReferenceSelection(pcSketchBased, prevSolid);
             Gui::Selection().clearSelection();
             Gui::Selection().addSelectionGate
                 (new ReferenceSelection(prevSolid, edge, face, planar));
         } else {
             Gui::Selection().rmvSelectionGate();
-            Gui::Document* doc = vp->getDocument();
-            if (doc) {
-                doc->setShow(pcSketchBased->getNameInDocument());
-                if (prevSolid)
-                    doc->setHide(prevSolid->getNameInDocument());
-            }
+            finishReferenceSelection(pcSketchBased, prevSolid);
         }
     }
 }
+
 
 void TaskSketchBasedParameters::exitSelectionMode()
 {

--- a/src/Mod/PartDesign/Gui/TaskSketchBasedParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskSketchBasedParameters.h
@@ -51,6 +51,8 @@ public:
 protected:
     void onSelectionChanged(const Gui::SelectionChanges& msg)=0;
     const QString onAddSelection(const Gui::SelectionChanges& msg);
+    virtual void startReferenceSelection(App::DocumentObject* profile, App::DocumentObject* base);
+    virtual void finishReferenceSelection(App::DocumentObject* profile, App::DocumentObject* base);
     void onSelectReference(const bool pressed, const bool edge, const bool face, const bool planar);
     void exitSelectionMode();
     QVariant setUpToFace(const QString& text);


### PR DESCRIPTION
There was a bug where the base object became invisible in the preview after the select reference axis option was used. This fixes this.

Current behavior was highlighted as "slightly annoying" in a YouTube tutorial here: https://youtu.be/G6aPsFPGPDQ?t=502