### PR TITLE
[0.19] PartDesign: Improve Helix parameter proposals

### DIFF
--- a/src/Mod/PartDesign/App/FeatureHelix.cpp
+++ b/src/Mod/PartDesign/App/FeatureHelix.cpp
@@ -504,7 +504,12 @@ double Helix::safePitch()
 void Helix::proposeParameters(bool force)
 {
     if (force || !HasBeenEdited.getValue()) {
-        double pitch = 1.1*safePitch();
+        TopoDS_Shape sketchshape = getVerifiedFace();
+        Bnd_Box bb;
+        BRepBndLib::Add(sketchshape, bb);
+        bb.SetGap(0.0);
+        double pitch = 1.1 * sqrt(bb.SquareExtent());
+
         Pitch.setValue(pitch);
         Height.setValue(pitch*3.0);
         HasBeenEdited.setValue(1);


### PR DESCRIPTION
The current initial proposed parameters (pitch and height) can cause self intersection if the selects a different helix axis. In this PR the diagonal of the bounding box is used, guaranteeing that the pitch and height parameters never lead to self intersecting. 

Current behavior was identified in a YouTube tutorial here: https://youtu.be/G6aPsFPGPDQ?t=68
