### PR TITLE
[PATH] toolbits: hide confusing unused cutting edge height

### DIFF
--- a/src/Mod/Path/PathScripts/PathToolBitEdit.py
+++ b/src/Mod/Path/PathScripts/PathToolBitEdit.py
@@ -132,10 +132,16 @@ class ToolBitEditor(object):
                 PathLog.debug("create row: {} [{}]  {}".format(nr, name, type(qsb)))
                 if hasattr(qsb, 'editingFinished'):
                     qsb.editingFinished.connect(self.updateTool)
+            
+            if tool.ShapeName in ['chamfer','v_bit']:
+                if  (name == "CuttingEdgeHeight") :
+                    label.hide()
+                    qsb.hide()
+            
 
             if nr >= layout.rowCount():
                 layout.addRow(label, qsb)
-            usedRows = usedRows + 1
+            usedRows += 1
 
         # hide all rows which aren't being used
         PathLog.track(usedRows, len(self.widgets))
@@ -181,7 +187,6 @@ class ToolBitEditor(object):
 
                 group.appendRow([label, value])
             self.model.appendRow(group)
-
 
         if setup:
             self.form.attrTree.setModel(self.model)

--- a/src/Mod/Path/PathScripts/PathToolBitGui.py
+++ b/src/Mod/Path/PathScripts/PathToolBitGui.py
@@ -194,7 +194,7 @@ def GetNewToolFile(parent=None):
     if parent is None:
         parent = QtGui.QApplication.activeWindow()
 
-    foo = QtGui.QFileDialog.getSaveFileName(parent, 'Tool',
+    foo = QtGui.QFileDialog.getSaveFileName(parent, 'Save New Tool As ...' ,
                                             PathPreferences.lastPathToolBit(),
                                             '*.fctb')
     if foo and foo[0]:


### PR DESCRIPTION
On angled tools such as v-bit and chamfer the cutting edge height is redundant since it determined by other dimensions and is generally not given by manufacturers. 
It is unused by OCL and not needed for paths. As such its presence is just a cause of confusion for the user. 
This PR simply hides the inputs for these two tool types. 
https://forum.freecadweb.org/viewtopic.php?f=15&t=54880&p=478425#p478425

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [x]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
Also changes the title of the initial save dialogue to indicate clearly what is happening. "Tool" gave no idea what it was doing and why there was another dlg shown.