### PR TITLE
[0.19] PartDesign: Subtractive Loft. Raise error when base is null.

### DIFF
--- a/src/Mod/PartDesign/App/FeatureLoft.cpp
+++ b/src/Mod/PartDesign/App/FeatureLoft.cpp
@@ -179,6 +179,9 @@ App::DocumentObjectExecReturn *Loft::execute(void)
         AddSubShape.setValue(result);
 
         if(base.IsNull()) {
+            if (getAddSubType() == FeatureAddSub::Subtractive)
+                return new App::DocumentObjectExecReturn("Loft: There is nothing to subtract from\n");
+
             Shape.setValue(getSolid(result));
             return App::DocumentObject::StdReturn;
         }


### PR DESCRIPTION
Previously Subtractive loft would create a shape if there is no base
object. This is because the code is shared with Additive Loft, where
that is the right thing to do. Now we check for this, and return error
if there is nothing to subtract from.

In 0.19, this behavior has already been corrected in the Helix, and the Pipe features. Therefore it is logical if it is fixed for Loft also in 0.19 so there is consistency. 

Forum:
https://forum.freecadweb.org/viewtopic.php?f=3&t=55634