### PR TITLE
3Dconnexion: Clarify ambivalent console output warning [skip ci]

### DIFF
--- a/src/Gui/3Dconnexion/GuiNativeEventLinux.cpp
+++ b/src/Gui/3Dconnexion/GuiNativeEventLinux.cpp
@@ -49,7 +49,7 @@ void Gui::GuiNativeEvent::initSpaceball(QMainWindow *window)
 {
 	Q_UNUSED(window)
     if (spnav_open() == -1) {
-        Base::Console().Log("Couldn't connect to spacenav daemon\n");
+        Base::Console().Log("Couldn't connect to spacenav daemon. Please ignore if you don't have a spacemouse.\n");
     } else {
         Base::Console().Log("Connected to spacenav daemon\n");
 		QSocketNotifier* SpacenavNotifier = new QSocketNotifier(spnav_fd(), QSocketNotifier::Read, this);

--- a/src/Gui/3Dconnexion/GuiNativeEventLinuxX11.cpp
+++ b/src/Gui/3Dconnexion/GuiNativeEventLinuxX11.cpp
@@ -73,7 +73,7 @@ void Gui::GuiNativeEvent::initSpaceball(QMainWindow *window)
     }
 #endif
     if (spnav_x11_open(QX11Info::display(), window->winId()) == -1) {
-        Base::Console().Log("Couldn't connect to spacenav daemon on X11\n");
+        Base::Console().Log("Couldn't connect to spacenav daemon on X11. Please ignore if you don't have a spacemouse.\n");
     } else {
         Base::Console().Log("Connected to spacenav daemon on X11\n");
         mainApp->setSpaceballPresent(true);


### PR DESCRIPTION
This commit simply demystifies the warning that most users will see when they boot in to FreeCAD "Couldn't connect to spacenav daemon." by adding 
"Please ignore if you don't have a spacemouse."
