### PR TITLE
[0.19] [TD] Fix error in editable status of DOCUMENT_TYPE

### DIFF
--- a/src/Mod/TechDraw/Templates/A0_Landscape_ISO7200_Pep.svg
+++ b/src/Mod/TechDraw/Templates/A0_Landscape_ISO7200_Pep.svg
@@ -186,7 +186,7 @@
     <text freecad:editable="TITLELINE-1" x="1037" y="809"><tspan>FreeCAD</tspan></text>
     <text freecad:editable="TITLELINE-2" x="1037" y="813"><tspan></tspan></text>
     <text freecad:editable="TITLELINE-3" x="1037" y="817"><tspan></tspan></text>
-    <text freecad:editable="DOCUMENT_TYPE" x="1059" y="822">Mechanical assembly drawing<tspan></tspan></text>
+    <text freecad:editable="DOCUMENT_TYPE" x="1059" y="822"><tspan>Mechanical assembly drawing</tspan></text>
     <text freecad:editable="SHEET" x="1162" y="796"><tspan>99 of 99</tspan></text>
     <text freecad:editable="SCALE" x="1132" y="796"><tspan>M x:x</tspan></text>
     <text freecad:editable="TOLERANCE" x="1132" y="800"><tspan>+/- ?</tspan></text>

--- a/src/Mod/TechDraw/Templates/A1_Landscape_ISO7200_Pep.svg
+++ b/src/Mod/TechDraw/Templates/A1_Landscape_ISO7200_Pep.svg
@@ -146,7 +146,7 @@
     <text freecad:editable="TITLELINE-1" x="689" y="562"><tspan>FreeCAD</tspan></text>
     <text freecad:editable="TITLELINE-2" x="689" y="566"><tspan></tspan></text>
     <text freecad:editable="TITLELINE-3" x="689" y="570"><tspan></tspan></text>
-    <text freecad:editable="DOCUMENT_TYPE" x="711" y="575">Mechanical assembly drawing<tspan></tspan></text>
+    <text freecad:editable="DOCUMENT_TYPE" x="711" y="575"><tspan>Mechanical assembly drawing</tspan></text>
     <text freecad:editable="SHEET" x="814" y="549"><tspan>99 of 99</tspan></text>
     <text freecad:editable="SCALE" x="784" y="549"><tspan>M x:x</tspan></text>
     <text freecad:editable="TOLERANCE" x="784" y="553"><tspan>+/- ?</tspan></text>

--- a/src/Mod/TechDraw/Templates/A2_Landscape_ISO7200_Pep.svg
+++ b/src/Mod/TechDraw/Templates/A2_Landscape_ISO7200_Pep.svg
@@ -118,7 +118,7 @@
     <text freecad:editable="TITLELINE-1" x="442" y="388"><tspan>FreeCAD</tspan></text>
     <text freecad:editable="TITLELINE-2" x="442" y="392"><tspan></tspan></text>
     <text freecad:editable="TITLELINE-3" x="442" y="396"><tspan></tspan></text>
-    <text freecad:editable="DOCUMENT_TYPE" x="464" y="401">Mechanical assembly drawing<tspan></tspan></text>
+    <text freecad:editable="DOCUMENT_TYPE" x="464" y="401"><tspan>Mechanical assembly drawing</tspan></text>
     <text freecad:editable="SHEET" x="567" y="375"><tspan>99 of 99</tspan></text>
     <text freecad:editable="SCALE" x="537" y="375"><tspan>M x:x</tspan></text>
     <text freecad:editable="TOLERANCE" x="537" y="379"><tspan>+/- ?</tspan></text>

--- a/src/Mod/TechDraw/Templates/A4_Landscape_ISO7200_Pep.svg
+++ b/src/Mod/TechDraw/Templates/A4_Landscape_ISO7200_Pep.svg
@@ -196,8 +196,8 @@
        id="text81"
        y="198"
        x="174"
-       freecad:editable="DOCUMENT_TYPE">Mechanical assembly drawing<tspan
-   id="tspan79" />
+       freecad:editable="DOCUMENT_TYPE"><tspan
+   id="tspan79">Mechanical assembly drawing</tspan>
 </text>
     <text
        id="text85"

--- a/src/Mod/TechDraw/Templates/A4_Portrait_ISO7200Pep.svg
+++ b/src/Mod/TechDraw/Templates/A4_Portrait_ISO7200Pep.svg
@@ -41,7 +41,7 @@
     <text freecad:editable="TITLELINE-1" x="65" y="272"><tspan>FreeCAD</tspan></text>
     <text freecad:editable="TITLELINE-2" x="65" y="276"><tspan></tspan></text>
     <text freecad:editable="TITLELINE-3" x="65" y="280"><tspan></tspan></text>
-    <text freecad:editable="DOCUMENT_TYPE" x="87" y="285">Mechanical assembly drawing<tspan></tspan></text>
+    <text freecad:editable="DOCUMENT_TYPE" x="87" y="285"><tspan>Mechanical assembly drawing</tspan></text>
     <text freecad:editable="SHEET" x="190" y="259"><tspan>99 of 99</tspan></text>
     <text freecad:editable="SCALE" x="160" y="259"><tspan>M x:x</tspan></text>
     <text freecad:editable="TOLERANCE" x="160" y="263"><tspan>+/- ?</tspan></text>


### PR DESCRIPTION
Modify all of the TechDraw ISO7200_Pep templates so that the DOCUMENT_TYPE area is fully editable, allowing the user to overwrite the default contents entirely instead of just adding to it. Bug reported by mattbaker.digital in https://forum.freecadweb.org/viewtopic.php?f=3&t=55652

---

- [X]  Your pull request is confined strictly to a single module.
- [X]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [X]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [X]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- No tracker ticket