### PR TITLE
[Arch] ArchStructure.py wrongly used Part.Line (endless line) to clos…

### DIFF
--- a/src/Mod/Arch/ArchStructure.py
+++ b/src/Mod/Arch/ArchStructure.py
@@ -774,7 +774,7 @@ class _Structure(ArchComponent.Component):
                                     p0 = w.OrderedVertexes[0].Point
                                     p1 = w.OrderedVertexes[-1].Point
                                     if p0 != p1:
-                                        e = Part.Line(p0,p1).toShape()
+                                        e = Part.LineSegment(p0,p1).toShape()
                                         w.add(e)
                                 w.fix(0.1,0,1) # fixes self-intersecting wires
                                 f = Part.Face(w)


### PR DESCRIPTION
[Arch] ArchStructure.py wrongly used Part.Line (endless line) to close a wire.