### PR TITLE
[0.19] [PD] [Crash] Fix isFeatureMovable() to check null status of property

### DIFF
--- a/src/Mod/PartDesign/Gui/Utils.cpp
+++ b/src/Mod/PartDesign/Gui/Utils.cpp
@@ -450,19 +450,19 @@ bool isFeatureMovable(App::DocumentObject* const feat)
 
         if (auto prop = static_cast<App::PropertyLinkSub*>(prim->getPropertyByName("ReferenceAxis"))) {
             App::DocumentObject* axis = prop->getValue();
-            if (!isFeatureMovable(static_cast<App::DocumentObject*>(axis)))
+            if (axis && !isFeatureMovable(static_cast<App::DocumentObject*>(axis)))
                 return false;
         }
 
         if (auto prop = static_cast<App::PropertyLinkSub*>(prim->getPropertyByName("Spine"))) {
-            App::DocumentObject* axis = prop->getValue();
-            if (!isFeatureMovable(static_cast<App::DocumentObject*>(axis)))
+            App::DocumentObject* spine = prop->getValue();
+            if (spine && !isFeatureMovable(static_cast<App::DocumentObject*>(spine)))
                 return false;
         }
 
         if (auto prop = static_cast<App::PropertyLinkSub*>(prim->getPropertyByName("AuxillerySpine"))) {
-            App::DocumentObject* axis = prop->getValue();
-            if (!isFeatureMovable(static_cast<App::DocumentObject*>(axis)))
+            App::DocumentObject* auxSpine = prop->getValue();
+            if (auxSpine && !isFeatureMovable(static_cast<App::DocumentObject*>(auxSpine)))
                 return false;
         }
 


### PR DESCRIPTION
As reported by @donovaly , if you try to move a pipe that does not have an auxiliary spine, the code segfaults. This commit adds a check to ensure that not only does the property exist (which in this case it always does), but also that it does not contain a null. That is a valid value for the property to have, but cannot be itself interrogated for moveability by the `isFeatureMovable` recursive call. This fix is also applied to the other similar conditions in that function to ensure they never yield the same segmentation fault.

Forums topic: https://forum.freecadweb.org/viewtopic.php?p=479388#p479388

---

- [X]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [X]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [X]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [X]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- No tracker ticket