### PR TITLE
[0.20] PartDesign: Allow customization of Helix preview modes

### DIFF
--- a/src/Mod/PartDesign/Gui/TaskHelixParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskHelixParameters.cpp
@@ -481,21 +481,27 @@ void TaskHelixParameters::getReferenceAxis(App::DocumentObject*& obj, std::vecto
 
 void TaskHelixParameters::startReferenceSelection(App::DocumentObject* profile, App::DocumentObject* base)
 {
+    ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/PartDesign");
     PartDesign::ProfileBased* pcHelix = dynamic_cast<PartDesign::Helix*>(vp->getObject());
-    if (pcHelix->getAddSubType() == PartDesign::FeatureAddSub::Subtractive) {
+    if ((hGrp->GetBool("SubractiveHelixPreview", true) && pcHelix->getAddSubType() == PartDesign::FeatureAddSub::Subtractive) ||
+        (hGrp->GetBool("AdditiveHelixPreview", false) && pcHelix->getAddSubType() == PartDesign::FeatureAddSub::Additive))
+    {
         Gui::Document* doc = vp->getDocument();
         if (doc) {
             doc->setHide(profile->getNameInDocument());
         }
-    } else {
+    }
+    else {
         TaskSketchBasedParameters::startReferenceSelection(profile, base);
     }
 }
 
 void TaskHelixParameters::finishReferenceSelection(App::DocumentObject* profile, App::DocumentObject* base)
 {
+    ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/PartDesign");
     PartDesign::ProfileBased* pcHelix = dynamic_cast<PartDesign::Helix*>(vp->getObject());
-    if (pcHelix->getAddSubType() == PartDesign::FeatureAddSub::Subtractive) {
+    if ((hGrp->GetBool("SubractiveHelixPreview", true) && pcHelix->getAddSubType() == PartDesign::FeatureAddSub::Subtractive) ||
+        (hGrp->GetBool("AdditiveHelixPreview", false) && pcHelix->getAddSubType() == PartDesign::FeatureAddSub::Additive)) {
         Gui::Document* doc = vp->getDocument();
         if (doc) {
             doc->setShow(profile->getNameInDocument());

--- a/src/Mod/PartDesign/Gui/ViewProviderHelix.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderHelix.cpp
@@ -81,7 +81,14 @@ bool ViewProviderHelix::setEdit(int ModNum)
 
     if (ModNum == ViewProvider::Default ) {
         auto* prim = static_cast<PartDesign::Helix*>(getObject());
-        setPreviewDisplayMode(prim->getAddSubType() == PartDesign::FeatureAddSub::Subtractive);
+        ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/PartDesign");
+        if((hGrp->GetBool("AdditiveHelixPreview", false) && prim->getAddSubType() == PartDesign::FeatureAddSub::Additive) ||
+           (hGrp->GetBool("SubractiveHelixPreview", true) && prim->getAddSubType() == PartDesign::FeatureAddSub::Subtractive))
+        {
+            setPreviewDisplayMode(true);
+        } else {
+            setPreviewDisplayMode(false);
+        }
     }
     return ViewProviderAddSub::setEdit(ModNum);
 }


### PR DESCRIPTION
Introduce two new preferences:

AdditiveHelixPreview (true / false) with default false. Turning this on will create a yellow preview of the helix. Independent of the base object. This is useful as it will give hints to why the helix op fails (e.g the helix does not intersect the base object).
![image](https://user-images.githubusercontent.com/1278189/108327866-30261000-71cc-11eb-9bb6-a9b3125559bb.png)



SubtractiveHelixPreview (true / false) with default true. Turning this off will make the behavior similar to the groove tool

