### PR TITLE
[0.19] PartDesign: Check closedness in AddSub refine function

### DIFF
--- a/src/Mod/PartDesign/App/FeatureAddSub.cpp
+++ b/src/Mod/PartDesign/App/FeatureAddSub.cpp
@@ -71,6 +71,9 @@ TopoDS_Shape FeatureAddSub::refineShapeIfActive(const TopoDS_Shape& oldShape) co
         try {
             Part::BRepBuilderAPI_RefineModel mkRefine(oldShape);
             TopoDS_Shape resShape = mkRefine.Shape();
+            if (!TopoShape(resShape).isClosed()) {
+                return oldShape;
+            }
             return resShape;
         }
         catch (Standard_Failure&) {


### PR DESCRIPTION
In attached model, the refine=true will cause a surface to fail, and the resulting model is no longer a solid, and since there is no check the user will have a broken model without any error notification.

[refine.zip](https://github.com/FreeCAD/FreeCAD/files/6001495/refine.zip)

In this PR we introduce a check in refine, and fall back to the old shape if required. 
Question: Should we issue a warning as well?

Forum thread:
https://forum.freecadweb.org/viewtopic.php?f=8&t=53714&start=80#p479421

This also partially fixes this issue:
https://forum.freecadweb.org/viewtopic.php?f=3&t=55583

