### PR TITLE
[UI] 0.19 Replace 3 FEM WB icons

### DIFF
--- a/src/Mod/Fem/Gui/Resources/icons/FEM_ConstraintElectrostaticPotential.svg
+++ b/src/Mod/Fem/Gui/Resources/icons/FEM_ConstraintElectrostaticPotential.svg
@@ -1,21 +1,341 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" id="svg8" version="1.1" viewBox="0 0 64 64" height="64" width="64">
-  <defs id="defs2" />
-  <metadata id="metadata5">
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.1"
+   id="svg3052"
+   height="64px"
+   width="64px">
+  <title
+     id="title930">FEM_ConstraintElectrostaticPotential</title>
+  <defs
+     id="defs3054">
+    <linearGradient
+       id="linearGradient1464">
+      <stop
+         id="stop1460"
+         offset="0"
+         style="stop-color:#ef2929;stop-opacity:1" />
+      <stop
+         id="stop1462"
+         offset="1"
+         style="stop-color:#a40000;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1403">
+      <stop
+         id="stop1399"
+         offset="0"
+         style="stop-color:#ef2929;stop-opacity:1" />
+      <stop
+         id="stop1401"
+         offset="1"
+         style="stop-color:#a40000;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1267">
+      <stop
+         id="stop1263"
+         offset="0"
+         style="stop-color:#ef2929;stop-opacity:1" />
+      <stop
+         id="stop1265"
+         offset="1"
+         style="stop-color:#a40000;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient876">
+      <stop
+         id="stop872"
+         offset="0"
+         style="stop-color:#4e9a06;stop-opacity:1" />
+      <stop
+         id="stop874"
+         offset="1"
+         style="stop-color:#8ae234;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4032">
+      <stop
+         id="stop4034"
+         offset="0"
+         style="stop-color:#71b2f8;stop-opacity:1;" />
+      <stop
+         id="stop4036"
+         offset="1"
+         style="stop-color:#002795;stop-opacity:1;" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(1.6244669,-0.05136783,0.04345521,0.9993132,-102.99033,7.7040438)"
+       r="19.467436"
+       fy="81.869568"
+       fx="148.88333"
+       cy="81.869568"
+       cx="148.88333"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3705"
+       xlink:href="#linearGradient3377" />
+    <linearGradient
+       id="linearGradient3377">
+      <stop
+         style="stop-color:#4bff54;stop-opacity:1;"
+         offset="0"
+         id="stop3379" />
+      <stop
+         style="stop-color:#00b800;stop-opacity:1;"
+         offset="1"
+         id="stop3381" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(0.87904684,0.2250379,-0.41709097,2.0016728,56.73751,-127.99883)"
+       r="19.467436"
+       fy="97.369568"
+       fx="135.38333"
+       cy="97.369568"
+       cx="135.38333"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3703"
+       xlink:href="#linearGradient3206" />
+    <linearGradient
+       id="linearGradient3199">
+      <stop
+         style="stop-color:#faff2b;stop-opacity:1;"
+         offset="0"
+         id="stop3201" />
+      <stop
+         style="stop-color:#ffaa00;stop-opacity:1;"
+         offset="1"
+         id="stop3203" />
+    </linearGradient>
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       r="19.467436"
+       fy="28.869568"
+       fx="45.883327"
+       cy="28.869568"
+       cx="45.883327"
+       id="radialGradient3692"
+       xlink:href="#linearGradient3377" />
+    <linearGradient
+       id="linearGradient3206">
+      <stop
+         style="stop-color:#faff2b;stop-opacity:1;"
+         offset="0"
+         id="stop3208" />
+      <stop
+         style="stop-color:#ffaa00;stop-opacity:1;"
+         offset="1"
+         id="stop3210" />
+    </linearGradient>
+    <radialGradient
+       r="19.467436"
+       fy="81.869568"
+       fx="148.88333"
+       cy="81.869568"
+       cx="148.88333"
+       gradientTransform="matrix(1.260164,-0.05136783,0.03370995,0.9993132,-43.139781,7.2044077)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4030"
+       xlink:href="#linearGradient4032" />
+    <linearGradient
+       id="linearGradient3836-0-6-92-4-6">
+      <stop
+         id="stop3838-2-7-06-8-7"
+         offset="0"
+         style="stop-color:#a40000;stop-opacity:1" />
+      <stop
+         id="stop3840-5-5-8-7-5"
+         offset="1"
+         style="stop-color:#ef2929;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3836-0-6-92-4-6-5">
+      <stop
+         id="stop3838-2-7-06-8-7-3"
+         offset="0"
+         style="stop-color:#a40000;stop-opacity:1" />
+      <stop
+         id="stop3840-5-5-8-7-5-5"
+         offset="1"
+         style="stop-color:#ef2929;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="6.7979431"
+       x2="74.693367"
+       y1="43.547943"
+       x1="95.806496"
+       id="linearGradient878"
+       xlink:href="#linearGradient876" />
+    <linearGradient
+       y2="57.854782"
+       x2="33.467113"
+       y1="46.315926"
+       x1="27.71979"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3291-8"
+       xlink:href="#linearGradient3873" />
+    <linearGradient
+       id="linearGradient3873">
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1;"
+         offset="0"
+         id="stop3875" />
+      <stop
+         style="stop-color:#204a87;stop-opacity:1"
+         offset="1"
+         id="stop3877" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.4482473,0,0,1.4426984,3.8621569,-43.045828)"
+       y2="57.854782"
+       x2="33.467113"
+       y1="46.315926"
+       x1="27.71979"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1084"
+       xlink:href="#linearGradient3873" />
+    <linearGradient
+       gradientTransform="matrix(0.86997005,0,0,0.86663677,-38.085519,-77.218368)"
+       xlink:href="#linearGradient1267"
+       id="linearGradient1084-6"
+       gradientUnits="userSpaceOnUse"
+       x1="27.71979"
+       y1="46.315926"
+       x2="33.467113"
+       y2="57.854782" />
+    <linearGradient
+       gradientTransform="matrix(1.2926501,0,0,1.2876974,-21.92397,-34.99464)"
+       xlink:href="#linearGradient1403"
+       id="linearGradient1084-2"
+       gradientUnits="userSpaceOnUse"
+       x1="27.71979"
+       y1="46.315926"
+       x2="33.467113"
+       y2="57.854782" />
+    <linearGradient
+       xlink:href="#linearGradient1464"
+       id="linearGradient1084-9"
+       gradientUnits="userSpaceOnUse"
+       x1="27.71979"
+       y1="46.315926"
+       x2="33.467113"
+       y2="57.854782"
+       gradientTransform="matrix(1.4482473,0,0,1.4426984,-26.818279,-43.080958)" />
+  </defs>
+  <metadata
+     id="metadata3057">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>FEM_ConstraintElectrostaticPotential</dc:title>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[bitacovir]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:title>PartDesign_MoveTip</dc:title>
+        <dc:date>12-02-2021</dc:date>
+        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier />
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title />
+          </cc:Agent>
+        </dc:contributor>
+        <dc:subject>
+          <rdf:Bag />
+        </dc:subject>
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g transform="matrix(15.229651,0,0,15.229651,-3.9499368,-4458.0565)" id="layer1" style="stroke-width:0.06566139">
-    <g aria-label="Pes" id="text6140" style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.61281px;line-height:1.25;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.00428902">
-      <path d="M 0.59289825,293.63026 H 1.4081256 q 0.363599,0 0.5575185,0.16202 0.1951952,0.16075 0.1951952,0.45928 0,0.29981 -0.1951952,0.46184 -0.1939195,0.16075 -0.5575185,0.16075 H 1.0840759 V 295.535 H 0.59289825 Z m 0.49117765,0.35594 v 0.532 h 0.2717424 q 0.1428881,0 0.220711,-0.0689 0.077823,-0.0702 0.077823,-0.19775 0,-0.12758 -0.077823,-0.19647 -0.077823,-0.0689 -0.220711,-0.0689 z" style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans Bold';stroke-width:0.00428902" id="path835" />
-      <path d="m 3.3377543,295.59069 v 0.0846 H 2.6436614 q 0.01078,0.10448 0.075463,0.15673 0.064682,0.0522 0.1807793,0.0522 0.093707,0 0.1915596,-0.0274 0.098682,-0.0282 0.2023402,-0.0846 v 0.22888 q -0.1053164,0.0398 -0.2106328,0.0597 -0.1053163,0.0207 -0.2106327,0.0207 -0.2520959,0 -0.3922413,-0.1277 -0.1393161,-0.12854 -0.1393161,-0.3599 0,-0.22722 0.1368283,-0.35741 0.1376576,-0.1302 0.3781438,-0.1302 0.2189254,0 0.3499489,0.13185 0.1318528,0.13186 0.1318528,0.35244 z m -0.3051687,-0.0987 q 0,-0.0846 -0.049756,-0.136 -0.048927,-0.0522 -0.1285357,-0.0522 -0.086243,0 -0.1401454,0.0489 -0.053902,0.0481 -0.06717,0.13932 z" style="font-size:1.69833px;baseline-shift:sub;stroke-width:0.00428902" id="path837" />
-      <path d="m 4.2880894,295.15782 v 0.22556 q -0.095365,-0.0398 -0.1840964,-0.0597 -0.088731,-0.0199 -0.167511,-0.0199 -0.084585,0 -0.126048,0.0216 -0.040634,0.0207 -0.040634,0.0647 0,0.0357 0.030683,0.0547 0.031512,0.0191 0.1119505,0.0282 l 0.052244,0.007 q 0.2280473,0.029 0.3068272,0.0954 0.07878,0.0663 0.07878,0.20815 0,0.14844 -0.1094627,0.22307 -0.1094627,0.0746 -0.3267295,0.0746 -0.092048,0 -0.1907304,-0.0149 -0.097853,-0.0141 -0.2015109,-0.0431 v -0.22556 q 0.088731,0.0431 0.1816086,0.0647 0.093707,0.0216 0.1899011,0.0216 0.087073,0 0.1310235,-0.024 0.043951,-0.0241 0.043951,-0.0713 0,-0.0398 -0.030683,-0.0589 -0.029853,-0.0199 -0.1202431,-0.0307 l -0.052243,-0.007 q -0.1981938,-0.0249 -0.277803,-0.0921 -0.079609,-0.0672 -0.079609,-0.204 0,-0.14761 0.10117,-0.21892 0.1011701,-0.0713 0.3101443,-0.0713 0.082097,0 0.1724866,0.0124 0.09039,0.0124 0.1965353,0.039 z" style="font-size:1.69833px;baseline-shift:sub;stroke-width:0.00428902" id="path839" />
-    </g>
-    <text id="text6144" y="291.55859" x="2.7012193" style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.0173729" xml:space="preserve"><tspan style="stroke-width:0.0173729" y="301.09158" x="2.7012193" id="tspan6142" /></text>
+  <g
+     id="layer1">
+    <path
+       style="fill:none;stroke:#280000;stroke-width:6;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 11.959992,29.955113 c 0.63218,19.246015 7.322788,28.869818 19.975766,29.023977"
+       id="path1147-0-0-6" />
+    <path
+       id="path1147-7-21-8-4"
+       d="m 11.959992,29.955114 c 0.63218,19.246014 7.322788,28.869817 19.975766,29.023976"
+       style="fill:none;stroke:#ef2929;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path1147-0-2"
+       d="M 11.957052,34.012155 C 12.589232,14.76614 19.27984,5.142337 31.932818,4.988178"
+       style="fill:none;stroke:#280000;stroke-width:6;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="fill:none;stroke:#ef2929;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 11.957052,34.012154 C 12.589232,14.76614 19.27984,5.142337 31.932818,4.988178"
+       id="path1147-7-21-1" />
+    <path
+       id="path1147-0-0"
+       d="M 51.905644,29.955113 C 51.273464,49.201128 44.582856,58.824931 31.929878,58.97909"
+       style="fill:none;stroke:#0b1521;stroke-width:6;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 51.905644,29.955114 C 51.273464,49.201128 44.582856,58.824931 31.929878,58.97909"
+       id="path1147-7-21-8" />
+    <path
+       style="fill:none;stroke:#0b1521;stroke-width:6;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 51.908584,34.012155 C 51.276404,14.76614 44.585796,5.142337 31.932818,4.988178"
+       id="path1147-0" />
+    <path
+       id="path1147-7-21"
+       d="M 51.908584,34.012154 C 51.276404,14.76614 44.585796,5.142337 31.932818,4.988178"
+       style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <circle
+       r="11.652966"
+       id="path3024-39-1-4-4"
+       style="fill:none;stroke:#0b1521;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4.5;stroke-dasharray:none;stroke-dashoffset:20.4;stroke-opacity:1"
+       cx="47.336685"
+       cy="32.09763" />
+    <circle
+       r="11.652966"
+       id="path3024-3-54-9-4-6"
+       style="fill:url(#linearGradient1084);fill-opacity:1;stroke:#729fcf;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4.5;stroke-dasharray:none;stroke-dashoffset:20.4;stroke-opacity:1"
+       cx="47.336685"
+       cy="32.09763" />
+    <path
+       id="path1362"
+       d="M 55.662124,32.083027 H 38.853773"
+       style="fill:none;stroke:#ffffff;stroke-width:4.48148;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <circle
+       cy="32.0625"
+       cx="16.65625"
+       style="fill:none;stroke:#280000;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4.5;stroke-dasharray:none;stroke-dashoffset:20.4;stroke-opacity:1"
+       id="path3024-39-1-4-4-97"
+       r="11.652966" />
+    <circle
+       cy="32.0625"
+       cx="16.65625"
+       style="fill:url(#linearGradient1084-9);fill-opacity:1;stroke:#ef2929;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4.5;stroke-dasharray:none;stroke-dashoffset:20.4;stroke-opacity:1"
+       id="path3024-3-54-9-4-6-08"
+       r="11.652966" />
+    <path
+       style="fill:none;stroke:#ffffff;stroke-width:4.48148;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 24.981688,32.047897 H 8.1733378"
+       id="path1362-1" />
+    <path
+       id="path1362-1-4"
+       d="m 16.6875,23.689575 v 16.80835"
+       style="fill:none;stroke:#ffffff;stroke-width:4.48148;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
 </svg>

--- a/src/Mod/Fem/Gui/Resources/icons/FEM_ConstraintFlowVelocity.svg
+++ b/src/Mod/Fem/Gui/Resources/icons/FEM_ConstraintFlowVelocity.svg
@@ -5,72 +5,269 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   id="svg8"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.1"
-   viewBox="0 0 64 64"
-   height="64"
-   width="64"
-   sodipodi:docname="fem-constraint-flow-velocity.svg"
-   inkscape:version="0.92.2 (unknown)">
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1163"
-     id="namedview10"
-     showgrid="false"
-     inkscape:zoom="7.375"
-     inkscape:cx="18.37157"
-     inkscape:cy="14.137902"
-     inkscape:window-x="1920"
-     inkscape:window-y="0"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg8" />
+   id="svg3052"
+   height="64px"
+   width="64px">
+  <title
+     id="title930">FEM_ConstraintFlowVelocity</title>
   <defs
-     id="defs2" />
+     id="defs3054">
+    <linearGradient
+       id="linearGradient1098">
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1"
+         offset="0"
+         id="stop1094" />
+      <stop
+         style="stop-color:#204a87;stop-opacity:1"
+         offset="1"
+         id="stop1096" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4032">
+      <stop
+         id="stop4034"
+         offset="0"
+         style="stop-color:#71b2f8;stop-opacity:1;" />
+      <stop
+         id="stop4036"
+         offset="1"
+         style="stop-color:#002795;stop-opacity:1;" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(1.6244669,-0.05136783,0.04345521,0.9993132,-102.99033,7.7040438)"
+       r="19.467436"
+       fy="81.869568"
+       fx="148.88333"
+       cy="81.869568"
+       cx="148.88333"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3705"
+       xlink:href="#linearGradient3377" />
+    <linearGradient
+       id="linearGradient3377">
+      <stop
+         style="stop-color:#4bff54;stop-opacity:1;"
+         offset="0"
+         id="stop3379" />
+      <stop
+         style="stop-color:#00b800;stop-opacity:1;"
+         offset="1"
+         id="stop3381" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(0.87904684,0.2250379,-0.41709097,2.0016728,56.73751,-127.99883)"
+       r="19.467436"
+       fy="97.369568"
+       fx="135.38333"
+       cy="97.369568"
+       cx="135.38333"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3703"
+       xlink:href="#linearGradient3206" />
+    <linearGradient
+       id="linearGradient3199">
+      <stop
+         style="stop-color:#faff2b;stop-opacity:1;"
+         offset="0"
+         id="stop3201" />
+      <stop
+         style="stop-color:#ffaa00;stop-opacity:1;"
+         offset="1"
+         id="stop3203" />
+    </linearGradient>
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       r="19.467436"
+       fy="28.869568"
+       fx="45.883327"
+       cy="28.869568"
+       cx="45.883327"
+       id="radialGradient3692"
+       xlink:href="#linearGradient3377" />
+    <linearGradient
+       id="linearGradient3206">
+      <stop
+         style="stop-color:#faff2b;stop-opacity:1;"
+         offset="0"
+         id="stop3208" />
+      <stop
+         style="stop-color:#ffaa00;stop-opacity:1;"
+         offset="1"
+         id="stop3210" />
+    </linearGradient>
+    <radialGradient
+       r="19.467436"
+       fy="81.869568"
+       fx="148.88333"
+       cy="81.869568"
+       cx="148.88333"
+       gradientTransform="matrix(1.260164,-0.05136783,0.03370995,0.9993132,-43.139781,7.2044077)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4030"
+       xlink:href="#linearGradient4032" />
+    <linearGradient
+       id="linearGradient3836-0-6-92-4-6">
+      <stop
+         id="stop3838-2-7-06-8-7"
+         offset="0"
+         style="stop-color:#a40000;stop-opacity:1" />
+      <stop
+         id="stop3840-5-5-8-7-5"
+         offset="1"
+         style="stop-color:#ef2929;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3836-0-6-92-4-6-5">
+      <stop
+         id="stop3838-2-7-06-8-7-3"
+         offset="0"
+         style="stop-color:#a40000;stop-opacity:1" />
+      <stop
+         id="stop3840-5-5-8-7-5-5"
+         offset="1"
+         style="stop-color:#ef2929;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient1098"
+       id="linearGradient1100"
+       x1="148.3927"
+       y1="8.0433396"
+       x2="196.49864"
+       y2="8.0433396"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-139.99194,4.6349894)" />
+    <linearGradient
+       xlink:href="#linearGradient1098"
+       id="linearGradient1160"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-139.99194,4.6349894)"
+       x1="148.3927"
+       y1="8.0433396"
+       x2="196.49864"
+       y2="8.0433396" />
+    <linearGradient
+       xlink:href="#linearGradient1098"
+       id="linearGradient1197"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-139.99194,4.6349894)"
+       x1="148.3927"
+       y1="8.0433396"
+       x2="196.49864"
+       y2="8.0433396" />
+    <linearGradient
+       xlink:href="#linearGradient1098"
+       id="linearGradient1234"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-139.99194,4.6349894)"
+       x1="148.3927"
+       y1="8.0433396"
+       x2="196.49864"
+       y2="8.0433396" />
+  </defs>
   <metadata
-     id="metadata5">
+     id="metadata3057">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title>FEM_ConstraintFlowVelocity</dc:title>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[bitacovir]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:title>PartDesign_MoveTip</dc:title>
+        <dc:date>12-02-2021</dc:date>
+        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier />
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title />
+          </cc:Agent>
+        </dc:contributor>
+        <dc:subject>
+          <rdf:Bag />
+        </dc:subject>
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     transform="matrix(15.229651,0,0,15.229651,-3.9499368,-4458.0565)"
-     id="layer1"
-     style="stroke-width:0.06566139">
-    <text
-       id="text6140"
-       y="296.17419"
-       x="0.7462678"
-       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:3.54142189px;line-height:1.25;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.00581337"
-       xml:space="preserve"><tspan
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans Bold';stroke-width:0.00581337"
-         y="296.17419"
-         x="0.7462678"
-         id="tspan6138">V</tspan></text>
-    <text
-       id="text6144"
-       y="291.55859"
-       x="2.7012193"
-       style="font-style:normal;font-weight:normal;font-size:10.58333302px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.01737291"
-       xml:space="preserve"><tspan
-         style="stroke-width:0.01737291"
-         y="301.09158"
-         x="2.7012193"
-         id="tspan6142" /></text>
+     id="layer1">
+    <g
+       id="g1158"
+       transform="matrix(1.0702522,0,0,0.98942891,-2.595467,0.13403978)">
+      <path
+         id="path868-3-0"
+         d="m 10.40076,13.118102 c 3.13332,-6.530797 10.73525,-6.726483 23.35499,0 12.44251,6.610552 17.99088,4.162438 20.75095,0"
+         style="fill:none;stroke:#0b1521;stroke-width:12;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         style="fill:none;stroke:#729fcf;stroke-width:7.87089;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 10.400761,13.118102 c 3.133326,-6.5307975 10.735249,-6.7264835 23.354989,0 12.44251,6.610551 17.99088,4.162437 20.75095,0"
+         id="path868-3" />
+      <path
+         id="path868-8-2"
+         d="m 10.400761,13.118102 c 3.133327,-6.5307975 10.735249,-6.7264825 23.354989,0 12.44251,6.610551 17.99088,4.162437 20.75095,0"
+         style="fill:none;stroke:#ffffff;stroke-width:4;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         style="fill:none;stroke:url(#linearGradient1160);stroke-width:4;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 10.40076,13.118102 c 3.13332,-6.5307975 10.73525,-6.7264825 23.35499,0 12.44251,6.610551 17.99088,4.162437 20.75095,0"
+         id="path868-8-2-4" />
+    </g>
+    <g
+       transform="matrix(1.0702522,0,0,0.98942891,-2.7370941,19.787328)"
+       id="g1158-0">
+      <path
+         style="fill:none;stroke:#0b1521;stroke-width:12;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 10.40076,13.118102 c 3.13332,-6.530797 10.73525,-6.726483 23.35499,0 12.44251,6.610552 17.99088,4.162438 20.75095,0"
+         id="path868-3-0-6" />
+      <path
+         id="path868-3-5"
+         d="m 10.400761,13.118102 c 3.133326,-6.5307975 10.735249,-6.7264835 23.354989,0 12.44251,6.610551 17.99088,4.162437 20.75095,0"
+         style="fill:none;stroke:#729fcf;stroke-width:7.87089;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         style="fill:none;stroke:#ffffff;stroke-width:4;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 10.400761,13.118102 c 3.133327,-6.5307975 10.735249,-6.7264825 23.354989,0 12.44251,6.610551 17.99088,4.162437 20.75095,0"
+         id="path868-8-2-41" />
+      <path
+         id="path868-8-2-4-1"
+         d="m 10.40076,13.118102 c 3.13332,-6.5307975 10.73525,-6.7264825 23.35499,0 12.44251,6.610551 17.99088,4.162437 20.75095,0"
+         style="fill:none;stroke:url(#linearGradient1197);stroke-width:4;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="g1158-0-3"
+       transform="matrix(1.0702522,0,0,0.98942891,-2.7812882,38.940411)">
+      <path
+         id="path868-3-0-6-5"
+         d="m 10.40076,13.118102 c 3.13332,-6.530797 10.73525,-6.726483 23.35499,0 12.44251,6.610552 17.99088,4.162438 20.75095,0"
+         style="fill:none;stroke:#0b1521;stroke-width:12;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         style="fill:none;stroke:#729fcf;stroke-width:7.87089;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 10.400761,13.118102 c 3.133326,-6.5307975 10.735249,-6.7264835 23.354989,0 12.44251,6.610551 17.99088,4.162437 20.75095,0"
+         id="path868-3-5-4" />
+      <path
+         id="path868-8-2-41-0"
+         d="m 10.400761,13.118102 c 3.133327,-6.5307975 10.735249,-6.7264825 23.354989,0 12.44251,6.610551 17.99088,4.162437 20.75095,0"
+         style="fill:none;stroke:#ffffff;stroke-width:4;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         style="fill:none;stroke:url(#linearGradient1234);stroke-width:4;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 10.40076,13.118102 c 3.13332,-6.5307975 10.73525,-6.7264825 23.35499,0 12.44251,6.610551 17.99088,4.162437 20.75095,0"
+         id="path868-8-2-4-1-1" />
+    </g>
   </g>
 </svg>

--- a/src/Mod/Fem/Gui/Resources/icons/FEM_ConstraintInitialFlowVelocity.svg
+++ b/src/Mod/Fem/Gui/Resources/icons/FEM_ConstraintInitialFlowVelocity.svg
@@ -5,58 +5,287 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
-   width="64"
-   height="64"
-   viewBox="0 0 64 64"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.1"
-   id="svg8">
+   id="svg3052"
+   height="64px"
+   width="64px">
+  <title
+     id="title930">FEM_ConstraintInitialFlowVelocity</title>
   <defs
-     id="defs2" />
+     id="defs3054">
+    <linearGradient
+       id="linearGradient1098">
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1"
+         offset="0"
+         id="stop1094" />
+      <stop
+         style="stop-color:#204a87;stop-opacity:1"
+         offset="1"
+         id="stop1096" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4032">
+      <stop
+         id="stop4034"
+         offset="0"
+         style="stop-color:#71b2f8;stop-opacity:1;" />
+      <stop
+         id="stop4036"
+         offset="1"
+         style="stop-color:#002795;stop-opacity:1;" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(1.6244669,-0.05136783,0.04345521,0.9993132,-102.99033,7.7040438)"
+       r="19.467436"
+       fy="81.869568"
+       fx="148.88333"
+       cy="81.869568"
+       cx="148.88333"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3705"
+       xlink:href="#linearGradient3377" />
+    <linearGradient
+       id="linearGradient3377">
+      <stop
+         style="stop-color:#4bff54;stop-opacity:1;"
+         offset="0"
+         id="stop3379" />
+      <stop
+         style="stop-color:#00b800;stop-opacity:1;"
+         offset="1"
+         id="stop3381" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(0.87904684,0.2250379,-0.41709097,2.0016728,56.73751,-127.99883)"
+       r="19.467436"
+       fy="97.369568"
+       fx="135.38333"
+       cy="97.369568"
+       cx="135.38333"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3703"
+       xlink:href="#linearGradient3206" />
+    <linearGradient
+       id="linearGradient3199">
+      <stop
+         style="stop-color:#faff2b;stop-opacity:1;"
+         offset="0"
+         id="stop3201" />
+      <stop
+         style="stop-color:#ffaa00;stop-opacity:1;"
+         offset="1"
+         id="stop3203" />
+    </linearGradient>
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       r="19.467436"
+       fy="28.869568"
+       fx="45.883327"
+       cy="28.869568"
+       cx="45.883327"
+       id="radialGradient3692"
+       xlink:href="#linearGradient3377" />
+    <linearGradient
+       id="linearGradient3206">
+      <stop
+         style="stop-color:#faff2b;stop-opacity:1;"
+         offset="0"
+         id="stop3208" />
+      <stop
+         style="stop-color:#ffaa00;stop-opacity:1;"
+         offset="1"
+         id="stop3210" />
+    </linearGradient>
+    <radialGradient
+       r="19.467436"
+       fy="81.869568"
+       fx="148.88333"
+       cy="81.869568"
+       cx="148.88333"
+       gradientTransform="matrix(1.260164,-0.05136783,0.03370995,0.9993132,-43.139781,7.2044077)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4030"
+       xlink:href="#linearGradient4032" />
+    <linearGradient
+       id="linearGradient3836-0-6-92-4-6">
+      <stop
+         id="stop3838-2-7-06-8-7"
+         offset="0"
+         style="stop-color:#a40000;stop-opacity:1" />
+      <stop
+         id="stop3840-5-5-8-7-5"
+         offset="1"
+         style="stop-color:#ef2929;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3836-0-6-92-4-6-5">
+      <stop
+         id="stop3838-2-7-06-8-7-3"
+         offset="0"
+         style="stop-color:#a40000;stop-opacity:1" />
+      <stop
+         id="stop3840-5-5-8-7-5-5"
+         offset="1"
+         style="stop-color:#ef2929;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient1098"
+       id="linearGradient1100"
+       x1="148.3927"
+       y1="8.0433396"
+       x2="196.49864"
+       y2="8.0433396"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-139.99194,4.6349894)" />
+    <linearGradient
+       xlink:href="#linearGradient1098"
+       id="linearGradient1160"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.73296217,0,0,0.67761034,-103.70058,3.8690963)"
+       x1="148.3927"
+       y1="8.0433396"
+       x2="196.49864"
+       y2="8.0433396" />
+    <linearGradient
+       xlink:href="#linearGradient1098"
+       id="linearGradient1197"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.73296217,0,0,0.67761034,-103.79758,18.91964)"
+       x1="148.3927"
+       y1="8.0433396"
+       x2="196.49864"
+       y2="8.0433396" />
+    <linearGradient
+       xlink:href="#linearGradient1098"
+       id="linearGradient1234"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.73296217,0,0,0.67761034,-103.82784,33.804395)"
+       x1="148.3927"
+       y1="8.0433396"
+       x2="196.49864"
+       y2="8.0433396" />
+  </defs>
   <metadata
-     id="metadata5">
+     id="metadata3057">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title>FEM_ConstraintInitialFlowVelocity</dc:title>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[bitacovir]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:title>PartDesign_MoveTip</dc:title>
+        <dc:date>12-02-2021</dc:date>
+        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier />
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title />
+          </cc:Agent>
+        </dc:contributor>
+        <dc:subject>
+          <rdf:Bag />
+        </dc:subject>
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     style="stroke-width:0.06915656"
-     id="layer1"
-     transform="matrix(14.459945,0,0,14.459945,-3.1824365,-4231.6137)">
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:3.54142189px;line-height:1.25;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.00612281"
-       x="0.7462678"
-       y="296.17419"
-       id="text6140"><tspan
-         id="tspan6138"
-         x="0.7462678"
-         y="296.17419"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans Bold';stroke-width:0.00612281">V</tspan></text>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-weight:normal;font-size:10.58333302px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.01829767"
-       x="2.7012193"
-       y="291.55859"
-       id="text6144"><tspan
-         id="tspan6142"
-         x="2.7012193"
-         y="301.09158"
-         style="stroke-width:0.01829767" /></text>
+     id="layer1">
+    <path
+       style="fill:none;stroke:#0b1521;stroke-width:8.45694;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 6.5315767,9.617341 c 2.2966051,-4.4253355 7.8685323,-4.5579344 17.1183243,0 9.119889,4.479378 13.186634,2.820511 15.209661,0"
+       id="path868-3-0" />
+    <path
+       id="path868-3"
+       d="m 6.5315774,9.617341 c 2.2966092,-4.4253358 7.8685316,-4.5579347 17.1183236,0 9.119889,4.479378 13.186634,2.820511 15.209661,0"
+       style="fill:none;stroke:#729fcf;stroke-width:5.54696;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="fill:none;stroke:#ffffff;stroke-width:2.81897;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 6.5315774,9.617341 c 2.2966099,-4.4253358 7.8685316,-4.557934 17.1183236,0 9.119889,4.479378 13.186634,2.820511 15.209661,0"
+       id="path868-8-2" />
+    <path
+       id="path868-8-2-4"
+       d="m 6.5315767,9.617341 c 2.2966051,-4.4253358 7.8685323,-4.557934 17.1183243,0 9.119889,4.479378 13.186634,2.820511 15.209661,0"
+       style="fill:none;stroke:url(#linearGradient1160);stroke-width:2.81897;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path868-3-0-6"
+       d="m 6.4345834,24.667884 c 2.2966052,-4.425335 7.8685316,-4.557934 17.1183246,0 9.119888,4.479379 13.186634,2.820512 15.20966,0"
+       style="fill:none;stroke:#0b1521;stroke-width:8.45694;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="fill:none;stroke:#729fcf;stroke-width:5.54696;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 6.4345841,24.667884 c 2.2966093,-4.425335 7.8685309,-4.557934 17.1183239,0 9.119888,4.479378 13.186634,2.820511 15.20966,0"
+       id="path868-3-5" />
+    <path
+       id="path868-8-2-41"
+       d="m 6.4345841,24.667884 c 2.2966099,-4.425335 7.8685309,-4.557934 17.1183239,0 9.119888,4.479378 13.186634,2.820511 15.20966,0"
+       style="fill:none;stroke:#ffffff;stroke-width:2.81897;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="fill:none;stroke:url(#linearGradient1197);stroke-width:2.81897;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 6.4345834,24.667884 c 2.2966052,-4.425335 7.8685316,-4.557934 17.1183246,0 9.119888,4.479378 13.186634,2.820511 15.20966,0"
+       id="path868-8-2-4-1" />
+    <path
+       style="fill:none;stroke:#0b1521;stroke-width:8.45694;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 6.4043171,39.552639 c 2.2966052,-4.425335 7.8685319,-4.557934 17.1183239,0 9.119889,4.479379 13.186634,2.820512 15.209661,0"
+       id="path868-3-0-6-5" />
+    <path
+       id="path868-3-5-4"
+       d="m 6.4043178,39.552639 c 2.2966093,-4.425335 7.8685312,-4.557934 17.1183232,0 9.119889,4.479378 13.186634,2.820511 15.209661,0"
+       style="fill:none;stroke:#729fcf;stroke-width:5.54696;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="fill:none;stroke:#ffffff;stroke-width:2.81897;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 6.4043178,39.552639 c 2.29661,-4.425335 7.8685312,-4.557934 17.1183232,0 9.119889,4.479378 13.186634,2.820511 15.209661,0"
+       id="path868-8-2-41-0" />
+    <path
+       id="path868-8-2-4-1-1"
+       d="m 6.4043171,39.552639 c 2.2966052,-4.425335 7.8685319,-4.557934 17.1183239,0 9.119889,4.479378 13.186634,2.820511 15.209661,0"
+       style="fill:none;stroke:url(#linearGradient1234);stroke-width:2.81897;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="fill:none;stroke:#0b1521;stroke-width:6.7853;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 45.631517,58.646328 H 58.594551"
+       id="path1262" />
+    <path
+       style="fill:none;stroke:#0b1521;stroke-width:6.7853;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 52.497183,58.696306 c 0.04997,-0.199914 0,-16.043075 0,-16.043075"
+       id="path1264" />
+    <path
+       style="fill:none;stroke:#0b1521;stroke-width:6.7853;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 48.049103,43.202994 h 4.498058"
+       id="path1266" />
+    <path
+       id="path1262-3"
+       d="M 45.631517,58.646328 H 58.594551"
+       style="fill:none;stroke:#729fcf;stroke-width:3.39265;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path1264-4"
+       d="m 52.497183,58.696306 c 0.04997,-0.199914 0,-16.043075 0,-16.043075"
+       style="fill:none;stroke:#729fcf;stroke-width:3.39265;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path1266-2"
+       d="m 48.049103,43.202994 h 4.498058"
+       style="fill:none;stroke:#729fcf;stroke-width:3.39265;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <circle
+       style="fill:#729fcf;fill-rule:evenodd;stroke:#0b1521;stroke-width:1.69632;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;paint-order:markers fill stroke"
+       id="path1289"
+       cx="51.480988"
+       cy="31.725163"
+       r="3.8874092" />
   </g>
-  <text
-     id="text3703"
-     y="57.802486"
-     x="38.059044"
-     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:51.01147079px;line-height:0px;font-family:'CMU Serif';-inkscape-font-specification:'CMU Serif';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     xml:space="preserve"><tspan
-       style="fill:#ff0000;stroke-width:0.26458332px"
-       y="57.802486"
-       x="38.059044"
-       id="tspan3701">I</tspan></text>
 </svg>


### PR DESCRIPTION
Three FEM WB icons do not follow the FC art guide lines and they do not look good with dark themes.
FEM ConstraintElectrostaticPotential
FEM ConstraintFlowVelocity
FEM ConstraintInitialFlowVelocity

This commit replaces SVG files with new icon designs. The new SVG icons follow the FreeCAD Artwork Guidelines and were saved as Plain SVG format.

Forum Discussion: https://forum.freecadweb.org/viewtopic.php?f=34&t=55426
