### PR TITLE
[GUI] Modify behavior of VectorListEditor

### DIFF
--- a/src/Gui/VectorListEditor.cpp
+++ b/src/Gui/VectorListEditor.cpp
@@ -255,6 +255,7 @@ void VectorListEditor::setValues(const QList<Base::Vector3d>& v)
         ui->spinBox->setRange(1, 1);
         ui->spinBox->setEnabled(false);
         ui->toolButtonRemove->setEnabled(false);
+        ui->toolButtonAccept->setEnabled(false);
     }
     else {
         ui->spinBox->setRange(1, v.size());
@@ -310,10 +311,16 @@ void VectorListEditor::acceptCurrent()
 
 void VectorListEditor::addRow()
 {
-    model->insertRow(ui->tableWidget->currentIndex().row() + 1);
+    auto newRow = ui->tableWidget->currentIndex().row() + 1;
+    model->insertRow(newRow);
+    ui->tableWidget->setCurrentIndex(model->index(newRow, 0));
+    QSignalBlocker blocker(ui->spinBox);
     ui->spinBox->setMaximum(model->rowCount());
+    ui->spinBox->setValue(newRow + 1);
     ui->spinBox->setEnabled(true);
     ui->toolButtonRemove->setEnabled(true);
+    ui->toolButtonAccept->setEnabled(true);
+    acceptCurrent(); // The new row gets the values from the spinboxes
 }
 
 void VectorListEditor::removeRow()


### PR DESCRIPTION
VectorListEditor allows row-by-row creation of a list of three-component vector values. Values are manipulated using spinboxes. The previous behavior was that the spinboxes only affected the existing rows: when creating a row the contents of the spinboxes were ignored. This commit modifies that behavior so that a new row gets the contents of the spinboxes. In addition, in the original code the "Accept" button was enabled even when there was no row to edit, making it unclear whether a user needed to click the add row button or the accept button. Clicking the accept button did nothing if there was no existing row, and if compiled in debug mode, an assertion was raised.

---

- [X]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [X]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [X]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [X]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- No ticket