### PR TITLE
[PD] fix dressup feature display when broken

### DIFF
--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -61,6 +61,7 @@
 #include <Mod/PartDesign/App/DatumPoint.h>
 #include <Mod/PartDesign/App/DatumLine.h>
 #include <Mod/PartDesign/App/DatumPlane.h>
+#include <Mod/PartDesign/App/FeatureDressUp.h>
 #include <Mod/PartDesign/App/ShapeBinder.h>
 
 #include "TaskFeaturePick.h"
@@ -1889,6 +1890,15 @@ void finishDressupFeature(const Gui::Command* cmd, const std::string& which,
     FCMD_OBJ_CMD(Feat,"Base = " << str.str());
     cmd->doCommand(cmd->Gui,"Gui.Selection.clearSelection()");
     finishFeature(cmd, Feat, base);
+
+    App::DocumentObject* baseFeature = static_cast<PartDesign::DressUp*>(Feat)->Base.getValue();
+    if (baseFeature) {
+        PartDesignGui::ViewProvider* view = dynamic_cast<PartDesignGui::ViewProvider*>(Gui::Application::Instance->getViewProvider(baseFeature));
+        // in case there is an error, for example when a fillet is larger than the available space
+        // display the base feature to avoid that the users sees nothing
+        if (view && Feat->isError())
+            view->Visibility.setValue(true);
+    }
 }
 
 void makeChamferOrFillet(Gui::Command* cmd, const std::string& which)

--- a/src/Mod/PartDesign/Gui/TaskChamferParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskChamferParameters.cpp
@@ -102,6 +102,9 @@ TaskChamferParameters::TaskChamferParameters(ViewProviderDressUp *DressUpView, Q
         this, SLOT(setSelection(QListWidgetItem*)));
     connect(ui->listWidgetReferences, SIGNAL(itemDoubleClicked(QListWidgetItem*)),
         this, SLOT(doubleClicked(QListWidgetItem*)));
+
+    // the dialog can be called on a broken chamfer, then hide the chamfer
+    hideOnError();
 }
 
 void TaskChamferParameters::setUpUI(PartDesign::Chamfer* pcChamfer)
@@ -231,6 +234,8 @@ void TaskChamferParameters::onRefDeleted(void)
     pcChamfer->Base.setValue(base, refs);
     // recompute the feature
     pcChamfer->recomputeFeature();
+    // hide the chamfer if there was a computation error
+    hideOnError();
 
     // if there is only one item left, it cannot be deleted
     if (ui->listWidgetReferences->count() == 1) {
@@ -248,6 +253,8 @@ void TaskChamferParameters::onTypeChanged(int index)
     ui->stackedWidget->setCurrentIndex(index);
     ui->flipDirection->setEnabled(index != 0); // Enable if type is not "Equal distance"
     pcChamfer->getDocument()->recomputeFeature(pcChamfer);
+    // hide the chamfer if there was a computation error
+    hideOnError();
 }
 
 void TaskChamferParameters::onSizeChanged(double len)
@@ -256,6 +263,8 @@ void TaskChamferParameters::onSizeChanged(double len)
     setupTransaction();
     pcChamfer->Size.setValue(len);
     pcChamfer->getDocument()->recomputeFeature(pcChamfer);
+    // hide the chamfer if there was a computation error
+    hideOnError();
 }
 
 void TaskChamferParameters::onSize2Changed(double len)
@@ -264,6 +273,8 @@ void TaskChamferParameters::onSize2Changed(double len)
     setupTransaction();
     pcChamfer->Size2.setValue(len);
     pcChamfer->getDocument()->recomputeFeature(pcChamfer);
+    // hide the chamfer if there was a computation error
+    hideOnError();
 }
 
 void TaskChamferParameters::onAngleChanged(double angle)
@@ -272,6 +283,8 @@ void TaskChamferParameters::onAngleChanged(double angle)
     setupTransaction();
     pcChamfer->Angle.setValue(angle);
     pcChamfer->getDocument()->recomputeFeature(pcChamfer);
+    // hide the chamfer if there was a computation error
+    hideOnError();
 }
 
 void TaskChamferParameters::onFlipDirection(bool flip)
@@ -280,6 +293,8 @@ void TaskChamferParameters::onFlipDirection(bool flip)
     setupTransaction();
     pcChamfer->FlipDirection.setValue(flip);
     pcChamfer->getDocument()->recomputeFeature(pcChamfer);
+    // hide the chamfer if there was a computation error
+    hideOnError();
 }
 
 int TaskChamferParameters::getType(void) const
@@ -305,6 +320,19 @@ double TaskChamferParameters::getAngle(void) const
 bool TaskChamferParameters::getFlipDirection(void) const
 {
     return ui->flipDirection->isChecked();
+}
+
+void TaskChamferParameters::hideOnError() {
+    PartDesign::Chamfer* pcChamfer = static_cast<PartDesign::Chamfer*>(DressUpView->getObject());
+    // in case of an error, e.g. chamfer too large, show the base feature and hide the broken chamfer
+    App::DocumentObject* baseFeature = getBase();
+    if (baseFeature) {
+        PartDesignGui::ViewProvider* view = dynamic_cast<PartDesignGui::ViewProvider*>(Gui::Application::Instance->getViewProvider(baseFeature));
+        if (pcChamfer->isError())
+            TaskDressUpParameters::hideObject();
+        else
+            TaskDressUpParameters::showObject();
+    }
 }
 
 TaskChamferParameters::~TaskChamferParameters()
@@ -389,7 +417,6 @@ TaskDlgChamferParameters::~TaskDlgChamferParameters()
 //}
 bool TaskDlgChamferParameters::accept()
 {
-    parameter->showObject();
     parameter->apply();
 
     return TaskDlgDressUpParameters::accept();

--- a/src/Mod/PartDesign/Gui/TaskChamferParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskChamferParameters.h
@@ -66,6 +66,7 @@ protected:
 
 private:
     void setUpUI(PartDesign::Chamfer* pcChamfer);
+    void hideOnError();
 
     std::unique_ptr<Ui_TaskChamferParameters> ui;
 };

--- a/src/Mod/PartDesign/Gui/TaskDraftParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskDraftParameters.cpp
@@ -118,6 +118,9 @@ TaskDraftParameters::TaskDraftParameters(ViewProviderDressUp *DressUpView, QWidg
     ref = pcDraft->PullDirection.getValue();
     strings = pcDraft->PullDirection.getSubValues();
     ui->lineLine->setText(getRefStr(ref, strings));
+
+    // the dialog can be called on a broken draft, then hide the draft
+    hideOnError();
 }
 
 void TaskDraftParameters::onSelectionChanged(const Gui::SelectionChanges& msg)
@@ -171,6 +174,8 @@ void TaskDraftParameters::onSelectionChanged(const Gui::SelectionChanges& msg)
             pcDraft->getDocument()->recomputeFeature(pcDraft);
             // highlight existing references for possible further selections
             DressUpView->highlightReferences(true);
+            // hide the draft if there was a computation error
+            hideOnError();
         } else if (selectionMode == line) {
             PartDesign::Draft* pcDraft = static_cast<PartDesign::Draft*>(DressUpView->getObject());
             std::vector<std::string> edges;
@@ -185,6 +190,8 @@ void TaskDraftParameters::onSelectionChanged(const Gui::SelectionChanges& msg)
             pcDraft->getDocument()->recomputeFeature(pcDraft);
             // highlight existing references for possible further selections
             DressUpView->highlightReferences(true);
+            // hide the draft if there was a computation error
+            hideOnError();
         }
     }
 }
@@ -260,6 +267,8 @@ void TaskDraftParameters::onRefDeleted(void)
     pcDraft->Base.setValue(base, refs);
     // recompute the feature
     pcDraft->recomputeFeature();
+    // hide the draft if there was a computation error
+    hideOnError();
 
     // if there is only one item left, it cannot be deleted
     if (ui->listWidgetReferences->count() == 1) {
@@ -295,6 +304,8 @@ void TaskDraftParameters::onAngleChanged(double angle)
     setupTransaction();
     pcDraft->Angle.setValue(angle);
     pcDraft->getDocument()->recomputeFeature(pcDraft);
+    // hide the draft if there was a computation error
+    hideOnError();
 }
 
 double TaskDraftParameters::getAngle(void) const
@@ -308,11 +319,26 @@ void TaskDraftParameters::onReversedChanged(const bool on) {
     setupTransaction();
     pcDraft->Reversed.setValue(on);
     pcDraft->getDocument()->recomputeFeature(pcDraft);
+    // hide the draft if there was a computation error
+    hideOnError();
 }
 
 bool TaskDraftParameters::getReversed(void) const
 {
     return ui->checkReverse->isChecked();
+}
+
+void TaskDraftParameters::hideOnError() {
+    PartDesign::Draft* pcDraft = static_cast<PartDesign::Draft*>(DressUpView->getObject());
+    // in case of an error, e.g. angle too large, show the base feature and hide the broken draft
+    App::DocumentObject* baseFeature = getBase();
+    if (baseFeature) {
+        PartDesignGui::ViewProvider* view = dynamic_cast<PartDesignGui::ViewProvider*>(Gui::Application::Instance->getViewProvider(baseFeature));
+        if (pcDraft->isError())
+            TaskDressUpParameters::hideObject();
+        else
+            TaskDressUpParameters::showObject();
+    }
 }
 
 TaskDraftParameters::~TaskDraftParameters()
@@ -373,8 +399,6 @@ TaskDlgDraftParameters::~TaskDlgDraftParameters()
 
 bool TaskDlgDraftParameters::accept()
 {
-    parameter->showObject();
-
     std::vector<std::string> strings;
     App::DocumentObject* obj;
     TaskDraftParameters* draftparameter = static_cast<TaskDraftParameters*>(parameter);

--- a/src/Mod/PartDesign/Gui/TaskDraftParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskDraftParameters.h
@@ -61,6 +61,7 @@ protected:
 
 private:
     std::unique_ptr<Ui_TaskDraftParameters> ui;
+    void hideOnError();
 };
 
 /// simulation dialog for the TaskView

--- a/src/Mod/PartDesign/Gui/TaskFilletParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskFilletParameters.h
@@ -54,6 +54,7 @@ protected:
 
 private:
     std::unique_ptr<Ui_TaskFilletParameters> ui;
+    void hideOnError();
 };
 
 /// simulation dialog for the TaskView

--- a/src/Mod/PartDesign/Gui/TaskThicknessParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskThicknessParameters.cpp
@@ -118,6 +118,9 @@ TaskThicknessParameters::TaskThicknessParameters(ViewProviderDressUp *DressUpVie
 
     int join = pcThickness->Join.getValue();
     ui->joinComboBox->setCurrentIndex(join);
+
+    // the dialog can be called on a broken thickness, then hide the thickness
+    hideOnError();
 }
 
 void TaskThicknessParameters::onSelectionChanged(const Gui::SelectionChanges& msg)
@@ -208,6 +211,8 @@ void TaskThicknessParameters::onRefDeleted(void)
     pcThickness->Base.setValue(base, refs);
     // recompute the feature
     pcThickness->recomputeFeature();
+    // hide the thickness if there was a computation error
+    hideOnError();
 
     // if there is only one item left, it cannot be deleted
     if (ui->listWidgetReferences->count() == 1) {
@@ -225,6 +230,8 @@ void TaskThicknessParameters::onValueChanged(double angle)
     setupTransaction();
     pcThickness->Value.setValue(angle);
     pcThickness->getDocument()->recomputeFeature(pcThickness);
+    // hide the thickness if there was a computation error
+    hideOnError();
 }
 
 void TaskThicknessParameters::onJoinTypeChanged(int join) {
@@ -234,6 +241,8 @@ void TaskThicknessParameters::onJoinTypeChanged(int join) {
     setupTransaction();
     pcThickness->Join.setValue(join);
     pcThickness->getDocument()->recomputeFeature(pcThickness);
+    // hide the thickness if there was a computation error
+    hideOnError();
 }
 
 void TaskThicknessParameters::onModeChanged(int mode) {
@@ -243,6 +252,8 @@ void TaskThicknessParameters::onModeChanged(int mode) {
     setupTransaction();
     pcThickness->Mode.setValue(mode);
     pcThickness->getDocument()->recomputeFeature(pcThickness);
+    // hide the thickness if there was a computation error
+    hideOnError();
 }
 
 double TaskThicknessParameters::getValue(void) const
@@ -256,6 +267,8 @@ void TaskThicknessParameters::onReversedChanged(const bool on) {
     setupTransaction();
     pcThickness->Reversed.setValue(on);
     pcThickness->getDocument()->recomputeFeature(pcThickness);
+    // hide the thickness if there was a computation error
+    hideOnError();
 }
 
 bool TaskThicknessParameters::getReversed(void) const
@@ -268,6 +281,8 @@ void TaskThicknessParameters::onIntersectionChanged(const bool on) {
     PartDesign::Thickness* pcThickness = static_cast<PartDesign::Thickness*>(DressUpView->getObject());
     pcThickness->Intersection.setValue(on);
     pcThickness->getDocument()->recomputeFeature(pcThickness);
+    // hide the thickness if there was a computation error
+    hideOnError();
 }
 
 bool TaskThicknessParameters::getIntersection(void) const
@@ -285,6 +300,18 @@ int TaskThicknessParameters::getMode(void) const {
     return ui->modeComboBox->currentIndex();
 }
 
+void TaskThicknessParameters::hideOnError() {
+    PartDesign::Thickness* pcThickness = static_cast<PartDesign::Thickness*>(DressUpView->getObject());
+    // in case of an error, e.g. thickness too thin, show the base feature and hide the broken thickness
+    App::DocumentObject* baseFeature = getBase();
+    if (baseFeature) {
+        PartDesignGui::ViewProvider* view = dynamic_cast<PartDesignGui::ViewProvider*>(Gui::Application::Instance->getViewProvider(baseFeature));
+        if (pcThickness->isError())
+            TaskDressUpParameters::hideObject();
+        else
+            TaskDressUpParameters::showObject();
+    }
+}
 
 TaskThicknessParameters::~TaskThicknessParameters()
 {
@@ -349,8 +376,6 @@ TaskDlgThicknessParameters::~TaskDlgThicknessParameters()
 
 bool TaskDlgThicknessParameters::accept()
 {
-    parameter->showObject();
-
     TaskThicknessParameters* draftparameter = static_cast<TaskThicknessParameters*>(parameter);
 
     auto obj = vp->getObject();

--- a/src/Mod/PartDesign/Gui/TaskThicknessParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskThicknessParameters.h
@@ -61,6 +61,7 @@ protected:
 
 private:
     std::unique_ptr<Ui_TaskThicknessParameters> ui;
+    void hideOnError();
 };
 
 /// simulation dialog for the TaskView


### PR DESCRIPTION
As discussed in https://forum.freecadweb.org/viewtopic.php?p=479647#p479377
the user can end up without either seeing nothing or an inexisting dressup feature.

This PR fixes this. See https://forum.freecadweb.org/viewtopic.php?f=3&t=55735&p=479707#p479707 for details.