### PR TITLE
Draft: Fixes #0004562: Active working plane changes when I close Draft Edit panel

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_base_original.py
+++ b/src/Mod/Draft/draftguitools/gui_base_original.py
@@ -183,7 +183,6 @@ class DraftTool:
             self.ui.sourceCmd = None
         if self.planetrack:
             self.planetrack.finalize()
-        App.DraftWorkingPlane.restore()
         if hasattr(Gui, "Snapper"):
             Gui.Snapper.off()
         if self.call:

--- a/src/Mod/Draft/draftguitools/gui_edit.py
+++ b/src/Mod/Draft/draftguitools/gui_edit.py
@@ -361,7 +361,6 @@ class Edit(gui_base_original.Modifier):
             self.deformat_objects_after_editing(self.edited_objects)
         
         super(Edit, self).finish()
-        App.DraftWorkingPlane.restore()
         if Gui.Snapper.grid:
             Gui.Snapper.grid.set()
         self.running = False


### PR DESCRIPTION
To reproduce the reported error, two BuildingParts must be activated consecutively, so that the DraftWorkingPlane.save method is executed and overwrite the DraftWorkingPlane.stored attribute with the information from the previous working plane.
This behavior is not limited to the edit command. The same happens with the rest of the modification commands in Draft but when they are executed twice.
Removing the call to DraftWorkingPlane.restore in draftguitools's finish method solve the problem.
https://tracker.freecadweb.org/view.php?id=4562


Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [ ]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [x]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
