### PR TITLE
[0.19] [Part] fix regression in location dialog layout

### DIFF
--- a/src/Mod/Part/Gui/Location.ui
+++ b/src/Mod/Part/Gui/Location.ui
@@ -28,17 +28,17 @@
      <property name="title">
       <string>Position</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout">
-      <item row="0" column="0">
-       <layout class="QHBoxLayout" name="horizontalLayout_5">
-        <item>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <layout class="QGridLayout" name="gridLayout">
+        <item row="0" column="0">
          <widget class="QLabel" name="labelLength2_2">
           <property name="text">
            <string>X</string>
           </property>
          </widget>
         </item>
-        <item>
+        <item row="0" column="1">
          <widget class="Gui::QuantitySpinBox" name="XPositionQSB">
           <property name="keyboardTracking">
            <bool>false</bool>
@@ -48,18 +48,14 @@
           </property>
          </widget>
         </item>
-       </layout>
-      </item>
-      <item row="1" column="0">
-       <layout class="QHBoxLayout" name="horizontalLayout_8">
-        <item>
+        <item row="1" column="0">
          <widget class="QLabel" name="labelLength2_3">
           <property name="text">
            <string>Y</string>
           </property>
          </widget>
         </item>
-        <item>
+        <item row="1" column="1">
          <widget class="Gui::QuantitySpinBox" name="YPositionQSB">
           <property name="keyboardTracking">
            <bool>false</bool>
@@ -69,18 +65,14 @@
           </property>
          </widget>
         </item>
-       </layout>
-      </item>
-      <item row="2" column="0">
-       <layout class="QHBoxLayout" name="horizontalLayout_9">
-        <item>
+        <item row="2" column="0">
          <widget class="QLabel" name="labelLength2_4">
           <property name="text">
            <string>Z</string>
           </property>
          </widget>
         </item>
-        <item>
+        <item row="2" column="1">
          <widget class="Gui::QuantitySpinBox" name="ZPositionQSB">
           <property name="keyboardTracking">
            <bool>false</bool>
@@ -92,7 +84,7 @@
         </item>
        </layout>
       </item>
-      <item row="3" column="0">
+      <item>
        <widget class="QPushButton" name="viewPositionButton">
         <property name="text">
          <string>3D view</string>
@@ -119,15 +111,15 @@ the sketch plane's normal vector will be used</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_3">
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_6">
-        <item>
+       <layout class="QGridLayout" name="gridLayout_2">
+        <item row="0" column="0">
          <widget class="QLabel" name="labelXSkew">
           <property name="text">
            <string>x</string>
           </property>
          </widget>
         </item>
-        <item>
+        <item row="0" column="1">
          <widget class="Gui::DoubleSpinBox" name="XDirectionEdit">
           <property name="toolTip">
            <string>x-component of direction vector</string>
@@ -149,18 +141,14 @@ the sketch plane's normal vector will be used</string>
           </property>
          </widget>
         </item>
-       </layout>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_7">
-        <item>
+        <item row="1" column="0">
          <widget class="QLabel" name="labelYSkew">
           <property name="text">
            <string>y</string>
           </property>
          </widget>
         </item>
-        <item>
+        <item row="1" column="1">
          <widget class="Gui::DoubleSpinBox" name="YDirectionEdit">
           <property name="toolTip">
            <string>y-component of direction vector</string>
@@ -182,18 +170,14 @@ the sketch plane's normal vector will be used</string>
           </property>
          </widget>
         </item>
-       </layout>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_18">
-        <item>
+        <item row="2" column="0">
          <widget class="QLabel" name="labelZSkew">
           <property name="text">
            <string>z</string>
           </property>
          </widget>
         </item>
-        <item>
+        <item row="2" column="1">
          <widget class="Gui::DoubleSpinBox" name="ZDirectionEdit">
           <property name="toolTip">
            <string>z-component of direction vector</string>
@@ -218,18 +202,14 @@ the sketch plane's normal vector will be used</string>
           </property>
          </widget>
         </item>
-       </layout>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_4">
-        <item>
+        <item row="3" column="0">
          <widget class="QLabel" name="labelLength2">
           <property name="text">
            <string>Angle</string>
           </property>
          </widget>
         </item>
-        <item>
+        <item row="3" column="1">
          <widget class="Gui::QuantitySpinBox" name="AngleQSB">
           <property name="unit" stdset="0">
            <string notr="true"/>


### PR DESCRIPTION
For some reason the horizontal alignment got broken. This PR replaces the different grids with each on grid per groupbox

Until December die dialog looked like this: https://wiki.freecadweb.org/images/6/63/Part_Placement-primitive-dialog.png

With current master it looks like this for me:
![FreeCAD_SaZwuof59S](https://user-images.githubusercontent.com/1828501/108611136-d6943000-73db-11eb-9359-d1081083a66f.png)

I cannot see a change that caused this other than that I compile meanwhile using Qt 5.15.

However with the fix it looks correct again:
![FreeCAD_lhS3FGecDJ](https://user-images.githubusercontent.com/1828501/108611154-017e8400-73dc-11eb-8fed-52eae7b17e7d.png)