### PR TITLE
Part: Part.CompoundTools.Explode.explodeCompound access a property of...

### DIFF
--- a/src/Mod/Part/CompoundTools/Explode.py
+++ b/src/Mod/Part/CompoundTools/Explode.py
@@ -20,7 +20,8 @@ def explodeCompound(compound_obj, b_group = None):
         cf.Base = compound_obj
         cf.FilterType = 'specific items'
         cf.items = str(i)
-        cf.ViewObject.DontUnhideOnDelete = True
+        if cf.ViewObject is not None:
+            cf.ViewObject.DontUnhideOnDelete = True
         features_created.append(cf)
     return (group, features_created)
 


### PR DESCRIPTION
...a sometimes null object with an error

Python code, file `src/Mod/Part/CompoundTools/Explode.py`
The `explodeCompound` function can be called in a context without assigning the `ViewObject` property, for example from a command line script.

The error that is fixed by this patch. 
```
Traceback (most recent call last):
  ...
  File "/opt/freecad/Mod/Part/CompoundTools/Explode.py", line 23, in explodeCompound
    cf.ViewObject.DontUnhideOnDelete = True
AttributeError: 'NoneType' object has no attribute 'DontUnhideOnDelete']
```

Patch submitted by marioamb.  
Fix 0004421  
https://tracker.freecadweb.org/view.php?id=4421
