### PR TITLE
[Spreadsheet] Add cleanup() function at destruct

### DIFF
--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -1649,6 +1649,10 @@ Document::~Document()
     Console().Log("-Delete Features of %s \n",getName());
 #endif
 
+    for (auto it = d->objectMap.begin(); it != d->objectMap.end(); ++it) {
+        it->second->cleanup();
+    }
+
     d->objectArray.clear();
     for (auto it = d->objectMap.begin(); it != d->objectMap.end(); ++it) {
         it->second->setStatus(ObjectStatus::Destroy, true);

--- a/src/App/DocumentObject.cpp
+++ b/src/App/DocumentObject.cpp
@@ -95,6 +95,10 @@ DocumentObject::~DocumentObject(void)
     }
 }
 
+void App::DocumentObject::cleanup()
+{
+}
+
 App::DocumentObjectExecReturn *DocumentObject::recompute(void)
 {
     //check if the links are valid before making the recompute

--- a/src/App/DocumentObject.h
+++ b/src/App/DocumentObject.h
@@ -129,7 +129,12 @@ public:
 
     /// Constructor
     DocumentObject(void);
+
+    /// Destructor - call cleanup() prior to destroying
     virtual ~DocumentObject();
+
+    /// Allow subclasses to remove links and references to objects being destroyed, prior to their destruction
+    virtual void cleanup();
 
     /// returns the name which is set in the document for this object (not the name property!)
     const char *getNameInDocument(void) const;

--- a/src/Mod/Spreadsheet/App/Sheet.cpp
+++ b/src/Mod/Spreadsheet/App/Sheet.cpp
@@ -100,7 +100,8 @@ Sheet::Sheet()
 
 Sheet::~Sheet()
 {
-    clearAll();
+    if (!cleanupComplete)
+        FC_WARN("Sheet's destructor called without a prior call to cleanup()");
 }
 
 /**
@@ -750,6 +751,12 @@ void Sheet::touchCells(Range range) {
     do {
         cells.setDirty(*range);
     }while(range.next());
+}
+
+void Spreadsheet::Sheet::cleanup()
+{
+    clearAll();
+    cleanupComplete = true; // As long as the destructor is called immediately afterwards
 }
 
 /**

--- a/src/Mod/Spreadsheet/App/Sheet.h
+++ b/src/Mod/Spreadsheet/App/Sheet.h
@@ -175,6 +175,8 @@ public:
 
     void touchCells(App::Range range);
 
+    void cleanup() override;
+
     // Signals
 
     boost::signals2::signal<void (App::CellAddress)> cellUpdated;
@@ -252,6 +254,8 @@ protected:
 
     int currentRow = -1;
     int currentCol = -1;
+
+    bool cleanupComplete = false;
 
     friend class SheetObserver;
 


### PR DESCRIPTION
When a spreadsheet is destroyed, it tries to clear all of its references to other objects. If those objects have already been destroyed, however, that process will fail as the sheet tries to access those deleted items' data members. This commit adds a virtual function to `DocumentObject` that is called before destruction, allowing Spreadsheet to remove its references while those objects still exist, and deleting them in a second pass.

Discussion: https://forum.freecadweb.org/viewtopic.php?f=8&t=55245
Fix from @wwmayer : https://forum.freecadweb.org/viewtopic.php?f=8&t=55245#p480645

---

- [X]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [X]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [X]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [X]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [X]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- No ticket