### PR TITLE
[OpenSCAD] Fix colors not working correctly when polygons are extruded

### DIFF
--- a/src/Mod/OpenSCAD/importCSG.py
+++ b/src/Mod/OpenSCAD/importCSG.py
@@ -50,12 +50,45 @@ from OpenSCADUtils import *
 
 params = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/OpenSCAD")
 printverbose = params.GetBool('printVerbose',False)
-
+hassetcolor=[]
+alreadyhidden=[]
 printverbose = True
 
 # Get the token map from the lexer.  This is required.
 import tokrules
 from tokrules import tokens
+
+def shallHide(subject):
+    for obj in subject.OutListRecursive:
+        if "Matrix_Union" in str(obj.FullName):
+            return False
+        if "Extrude" in str(obj.FullName):
+            return True
+    return False
+
+def setColorRecursively(obj,color,transp):
+    if(obj.TypeId=="Part::Fuse" or obj.TypeId=="Part::MultiFuse"):
+                for currentObject in obj.OutList:
+                    if (currentObject.TypeId=="Part::Fuse" or currentObject.TypeId=="Part::MultiFuse"):
+                        setColorRecursively(currentObject,color,transp)
+                    else:
+                        print("Fixing up colors for: "+str(currentObject.FullName))
+                    if(currentObject not in hassetcolor):
+                        currentObject.ViewObject.ShapeColor=color
+                        currentObject.ViewObject.Transparency=transp
+                        setColorRecursively(currentObject,color,transp)
+                    else:
+                        setColorRecursively(currentObject,color,transp)
+
+def fixVisibility():
+    for obj in FreeCAD.ActiveDocument.Objects:
+         if(( obj.TypeId=="Part::Fuse" or obj.TypeId=="Part::MultiFuse") and shallHide(obj)):
+            if "Group" in obj.FullName:
+                alreadyhidden.append(obj)
+                obj.ViewObject.Visibility=False
+                for currentObject in obj.OutList:
+                    if(currentObject not in alreadyhidden):
+                        currentObject.ViewObject.Visibility=True
 
 if gui:
     try:
@@ -146,6 +179,9 @@ def processcsg(filename):
     if printverbose:
         print('End Parser')
         print(result)
+    fixVisibility()
+    hassetcolor.clear()
+    alreadyhidden.clear()
     FreeCAD.Console.PrintMessage('End processing CSG file\n')
     doc.recompute()
 
@@ -178,6 +214,7 @@ def p_group_action1(p):
         p[0] = [fuse(p[5],"Group")]
     else :
         p[0] = p[5]
+
 
 def p_group_action2(p) :
     'group_action2 : group LPAREN RPAREN SEMICOL'
@@ -490,8 +527,27 @@ def p_color_action(p):
     transp = 100 - int(math.floor(100*float(p[3][3]))) #Alpha
     if gui:
         for obj in p[6]:
-            obj.ViewObject.ShapeColor =color
-            obj.ViewObject.Transparency = transp
+            if shallHide(obj):
+                if "Group" in obj.FullName:
+                    obj.ViewObject.Visibility=False
+                    alreadyhidden.append(obj)
+                if(obj.TypeId=="Part::Fuse" or obj.TypeId=="Part::MultiFuse"):
+                    for currentObject in obj.OutList:
+                        if (currentObject.TypeId=="Part::Fuse" or   currentObject.TypeId=="Part::MultiFuse"):
+                            setColorRecursively(currentObject,color,transp)
+                        if(currentObject not in hassetcolor):
+                            currentObject.ViewObject.ShapeColor=color
+                            currentObject.ViewObject.Transparency=transp
+                            setColorRecursively(currentObject,color,transp)
+                        else:
+                            setColorRecursively(currentObject,color,transp)
+                else:
+                    obj.ViewObject.ShapeColor =color
+                    obj.ViewObject.Transparency = transp
+            else:
+                obj.ViewObject.ShapeColor =color
+                obj.ViewObject.Transparency = transp
+            hassetcolor.append(obj)
     p[0] = p[6]
 
 # Error rule for syntax errors
@@ -794,6 +850,10 @@ def p_multmatrix_action(p):
     transform_matrix = FreeCAD.Matrix()
     if printverbose: print("Multmatrix")
     if printverbose: print(p[3])
+    if gui:
+        parentcolor=p[6][0].ViewObject.ShapeColor
+        parenttransparency=p[6][0].ViewObject.Transparency
+
     m1l=sum(p[3],[])
     if any('x' in me for me in m1l): #hexfloats
         m1l=[float.fromhex(me) for me in m1l]
@@ -873,6 +933,9 @@ def p_multmatrix_action(p):
         p[0] = [newobj]
     else :
         p[0] = [new_part]
+    if gui:
+        new_part.ViewObject.ShapeColor=parentcolor
+        new_part.ViewObject.Transparency = parenttransparency
     if printverbose: print("Multmatrix applied")
     
 def p_matrix(p):


### PR DESCRIPTION
When importing OpenSCAD models, colors sometimes disappear, especially when using for loops and dxf imported polygons with linear extrude.
This commit fixes that, I don't know if its the best way, but basically it saves every set color, then loops over all groups, and if a group member doesn't have any set colors yet, it will change the color to the groups, then it hides the group the prevent single faces having the wrong colors.

Demo files are available in this [gist](https://gist.github.com/helaslo/074259a2c7b6d0b0f89025080dfc33a9)

Here it is how they shall render according to OpenSCAD
![openscad_render](https://user-images.githubusercontent.com/78400832/108762368-4dead080-7550-11eb-9a83-2adbdae7ca3f.png)

Here it is how they render with the latest version of FreeCAD
![without_patches](https://user-images.githubusercontent.com/78400832/108762277-34498900-7550-11eb-923b-0fca98dd1f48.png)

And here it is how they render with the patches applied
![with_patches](https://user-images.githubusercontent.com/78400832/108762272-33185c00-7550-11eb-98d2-9db4bf5e94ce.png)

