### PR TITLE
[GUI] Make UrlLabel in About styleable

### DIFF
--- a/src/Gui/AboutApplication.ui
+++ b/src/Gui/AboutApplication.ui
@@ -115,7 +115,10 @@
            <item>
             <widget class="Gui::UrlLabel" name="labelAuthor">
              <property name="text">
-              <string notr="true">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-family: MS Shell Dlg 2; font-weight:600; text-decoration: underline; color:#0000ff;&quot;&gt; Unknown Application (c) Unknown Author&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              <string notr="true">Unknown Application (c) Unknown Author</string>
+             </property>
+             <property name="textFormat">
+              <enum>Qt::PlainText</enum>
              </property>
             </widget>
            </item>

--- a/src/Gui/Widgets.cpp
+++ b/src/Gui/Widgets.cpp
@@ -825,6 +825,10 @@ UrlLabel::UrlLabel(QWidget * parent, Qt::WindowFlags f)
 {
     _url = QString::fromLatin1("http://localhost");
     setToolTip(this->_url);
+
+    if (qApp->styleSheet().isEmpty()) {
+        setStyleSheet(QString::fromLatin1("Gui--UrlLabel {color: #0000FF;text-decoration: underline;}"));
+    }
 }
 
 UrlLabel::~UrlLabel()


### PR DESCRIPTION
Right now the `UrlLabel` in the About FreeCAD box is not styleable because its rich-text contents overrides any styling applied to it. This commit converts it to a plain text label that can then be styled in a stylesheet using the `Gui--UrlLabel` selector. If no stylesheet is applied, the `UrlLabel` styles itself using the old-school blue text with an underline, but any applied stylesheet completely overrides this default.

This does not affect the "clickability" of a `UrlLabel` widget, which is handled independently of the label's content (including its textual hyperlink, which was and still is ignored).

I have not marked a specific version target for this, considering the late date, but I do think it would be nice if we can get it into 0.19.

Thanks to @luzpaz and @hyarion for their assistance in tracking this down.
