### PR TITLE
Crowdin: removing obsolete strings from PartDesign.ts [skip ci]

### DIFF
--- a/src/Mod/PartDesign/Gui/Resources/translations/PartDesign.ts
+++ b/src/Mod/PartDesign/Gui/Resources/translations/PartDesign.ts
@@ -1133,16 +1133,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../TaskChamferParameters.ui" line="22"/>
-        <source>Add ref</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../TaskChamferParameters.ui" line="32"/>
-        <source>Remove ref</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../TaskChamferParameters.ui" line="50"/>
         <source>Size:</source>
         <translation type="unfinished"></translation>


### PR DESCRIPTION
Uncertain to why but lupdate is not removing obsolete strings from `PartDesign.ts`. This PR manually removes obsoletes strings from it.

ref:
https://crowdin.com/translate/freecad/564/en-de?filter=basic&value=0#6500474
https://crowdin.com/translate/freecad/564/en-en?filter=basic&value=0#6500475