### PR TITLE
[Path] Stability fixes for experimental Slot operation

### DIFF
--- a/src/Mod/Path/PathScripts/PathSlot.py
+++ b/src/Mod/Path/PathScripts/PathSlot.py
@@ -159,7 +159,7 @@ class ObjectSlot(PathOp.ObjectOp):
             'CustomPoint1': FreeCAD.Vector(0.0, 0.0, 0.0),
             'ExtendPathStart': 0.0,
             'Reference1': 'Center of Mass',
-            'CustomPoint2': FreeCAD.Vector(10.0, 10.0, 0.0),
+            'CustomPoint2': FreeCAD.Vector(0.0, 0.0, 0.0),
             'ExtendPathEnd': 0.0,
             'Reference2': 'Center of Mass',
             'LayerMode': 'Multi-pass',

--- a/src/Mod/Path/PathScripts/PathSlot.py
+++ b/src/Mod/Path/PathScripts/PathSlot.py
@@ -440,33 +440,34 @@ class ObjectSlot(PathOp.ObjectOp):
                 return False
             elif p1.z == p2.z:
                 pnts = (p1, p2)
+                featureCount = 2
             else:
                 msg = translate('PathSlot',
                         'Custom points not at same Z height.')
                 FreeCAD.Console.PrintError(msg + '\n')
                 return False
-
-        baseGeom = obj.Base[0]
-        base, subsList = baseGeom
-        self.base = base
-
-        featureCount = len(subsList)
-        if  featureCount == 1:
-            PathLog.debug('Reference 1: {}'.format(obj.Reference1))
-            sub1 = subsList[0]
-            shape_1 = getattr(base.Shape, sub1)
-            self.shape1 = shape_1
-            pnts = self._processSingle(obj, shape_1, sub1)
         else:
-            PathLog.debug('Reference 1: {}'.format(obj.Reference1))
-            PathLog.debug('Reference 2: {}'.format(obj.Reference2))
-            sub1 = subsList[0]
-            sub2 = subsList[1]
-            shape_1 = getattr(base.Shape, sub1)
-            shape_2 = getattr(base.Shape, sub2)
-            self.shape1 = shape_1
-            self.shape2 = shape_2
-            pnts = self._processDouble(obj, shape_1, sub1, shape_2, sub2)
+            baseGeom = obj.Base[0]
+            base, subsList = baseGeom
+            self.base = base
+
+            featureCount = len(subsList)
+            if  featureCount == 1:
+                PathLog.debug('Reference 1: {}'.format(obj.Reference1))
+                sub1 = subsList[0]
+                shape_1 = getattr(base.Shape, sub1)
+                self.shape1 = shape_1
+                pnts = self._processSingle(obj, shape_1, sub1)
+            else:
+                PathLog.debug('Reference 1: {}'.format(obj.Reference1))
+                PathLog.debug('Reference 2: {}'.format(obj.Reference2))
+                sub1 = subsList[0]
+                sub2 = subsList[1]
+                shape_1 = getattr(base.Shape, sub1)
+                shape_2 = getattr(base.Shape, sub2)
+                self.shape1 = shape_1
+                self.shape2 = shape_2
+                pnts = self._processDouble(obj, shape_1, sub1, shape_2, sub2)
 
         if not pnts:
             return False

--- a/src/Mod/Path/PathScripts/PathSlot.py
+++ b/src/Mod/Path/PathScripts/PathSlot.py
@@ -433,7 +433,12 @@ class ObjectSlot(PathOp.ObjectOp):
             # Use custom inputs here
             p1 = obj.CustomPoint1
             p2 = obj.CustomPoint2
-            if p1.z == p2.z:
+            if p1 == p2:
+                msg = translate('PathSlot',
+                        'Custom points are identical.')
+                FreeCAD.Console.PrintError(msg + '\n')
+                return False
+            elif p1.z == p2.z:
                 pnts = (p1, p2)
             else:
                 msg = translate('PathSlot',

--- a/src/Mod/Path/PathScripts/PathSlot.py
+++ b/src/Mod/Path/PathScripts/PathSlot.py
@@ -931,7 +931,7 @@ class ObjectSlot(PathOp.ObjectOp):
             # Check that all Z values are equal (isRoughly same)
             if (abs(z1 - z2) > tolrnc or
                 abs(z1 - z3) > tolrnc ):
-#                abs(z2 - z3) > tolrnc):  3rd test redundant.
+                # abs(z2 - z3) > tolrnc):  3rd test redundant.
                 return False
             return True
 
@@ -1315,13 +1315,13 @@ class ObjectSlot(PathOp.ObjectOp):
 
     def _isParallel(self, dYdX1, dYdX2):
         """Determine if two orientation vectors are parallel."""
+        # if dYdX1.add(dYdX2).Length == 0:
+        #    return True
+        # if ((dYdX1.x + dYdX2.x) / 2.0 == dYdX1.x and
+        #    (dYdX1.y + dYdX2.y) / 2.0 == dYdX1.y):
+        #    return True
+        # return False
         return (dYdX1.cross(dYdX2) == FreeCAD.Vector(0,0,0) )
- #       if dYdX1.add(dYdX2).Length == 0:
- #           return True
- #       if ((dYdX1.x + dYdX2.x) / 2.0 == dYdX1.x and
- #               (dYdX1.y + dYdX2.y) / 2.0 == dYdX1.y):
- #           return True
- #       return False
 
     def _makePerpendicular(self, p1, p2, length):
         """_makePerpendicular(p1, p2, length)...

--- a/src/Mod/Path/PathScripts/PathSlot.py
+++ b/src/Mod/Path/PathScripts/PathSlot.py
@@ -868,16 +868,16 @@ class ObjectSlot(PathOp.ObjectOp):
     def _processSingleComplexFace(self, obj, shape):
         """Determine slot path endpoints from a single complex face."""
         PathLog.debug('_processSingleComplexFace()')
-        PNTS = list()
+        pnts = list()
 
-        def zVal(V):
-            return V.z
+        def zVal(p):
+            return p.z
 
         for E in shape.Wires[0].Edges:
             p = self._findLowestEdgePoint(E)
-            PNTS.append(p)
-        PNTS.sort(key=zVal)
-        return (PNTS[0], PNTS[1])
+            pnts.append(p)
+        pnts.sort(key=zVal)
+        return (pnts[0], pnts[1])
 
     def _processSingleVertFace(self, obj, shape):
         """Determine slot path endpoints from a single vertically oriented face


### PR DESCRIPTION
This PR includes the following fixes:
- Path: Set `CustomPoint2` and `CustomPoint1` defaults equal
- Path: Add check for `CustomPoint` input
- Path: Fix error when no `obj.Base` features selected
- Path: Fix variable naming to use lowercase
- Path: Fix comment syntax
- Path: Improve horizontal-planar and curved face handling

Forum discussion at  [0.19 Slot Op fixes](https://forum.freecadweb.org/viewtopic.php?f=15&t=56004).

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!


- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [x]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
