### PR TITLE
[FCBT] Clean up various LGTM-flagged items

### DIFF
--- a/src/Tools/fcbt/CreateModule.py
+++ b/src/Tools/fcbt/CreateModule.py
@@ -27,8 +27,7 @@
 #*   Werner Mayer 2003                                                     *
 #***************************************************************************
 
-import os,sys,string
-import FCFileTools
+import os,sys
 import MakeAppTools
 import re
 
@@ -110,7 +109,7 @@ def validateApp(AppName):
 	clName="class "+AppName+": self=0"
 	try:
 		exec(clName)
-	except:
+	except Exception:
 		# Invalid class name
 		sys.stdout.write("Invalid name: '"+AppName+"'\n")
 		sys.exit()

--- a/src/Tools/fcbt/CreatePyModule.py
+++ b/src/Tools/fcbt/CreatePyModule.py
@@ -27,8 +27,7 @@
 #*   Werner Mayer 2003                                                     *
 #***************************************************************************
 
-import os,sys,string
-import FCFileTools
+import os,sys
 import MakeAppTools
 import re
 
@@ -110,7 +109,7 @@ def validateApp(AppName):
 	clName="class "+AppName+": self=0"
 	try:
 		exec(clName)
-	except:
+	except Exception:
 		# Invalid class name
 		sys.stdout.write("Invalid name: '"+AppName+"'\n")
 		sys.exit()

--- a/src/Tools/fcbt/DistBin.py
+++ b/src/Tools/fcbt/DistBin.py
@@ -4,7 +4,7 @@
 import os,sys
 #sys.path.append( "E:\\Develop\\Projekte\\FreeCADWin\\src\\Tools" )
 
-import DistTools, FileTools
+from . import DistTools, FileTools
 
 # line separator
 ls = os.linesep
@@ -23,7 +23,7 @@ DistDir  = "../../DistTemp/"
 
 DistTools.EnsureDir(DistDir)
 if (DistTools.EnsureDir(DistDir+DistBin) == 1):
-    raise "Dist path already there!!"
+    raise RuntimeError("Dist path already there!!")
 
 #====================================================================
 # copy src

--- a/src/Tools/fcbt/DistSetup.py
+++ b/src/Tools/fcbt/DistSetup.py
@@ -1,17 +1,12 @@
 
 
 # shell and operating system
-import os,sys
+import os
+
+#import sys
 #sys.path.append( "E:\\Develop\\Projekte\\FreeCADWin\\src\\Tools" )
 
-import DistTools,FileTools
-
-# line separator 
-ls = os.linesep
-# path separator
-ps = os.pathsep
-# dir separator
-ds = os.sep
+from . import DistTools,FileTools
 
 DistName = DistTools.BuildDistName()
 

--- a/src/Tools/fcbt/DistSrc.py
+++ b/src/Tools/fcbt/DistSrc.py
@@ -4,7 +4,7 @@
 import os,sys
 #sys.path.append( "E:\\Develop\\Projekte\\FreeCADWin\\src\\Tools" )
 
-import DistTools, FileTools
+from . import DistTools, FileTools
 
 # line separator 
 ls = os.linesep
@@ -23,7 +23,7 @@ DistDir  = "../../DistTemp/"
 
 DistTools.EnsureDir(DistDir)
 if (DistTools.EnsureDir(DistDir+DistSrc) == 1):
-    raise "Dist path already there!!"
+    raise RuntimeError("Dist path already there!!")
 
 #====================================================================
 # copy src 

--- a/src/Tools/fcbt/DistTools.py
+++ b/src/Tools/fcbt/DistTools.py
@@ -1,7 +1,7 @@
 
 
 # shell and operating system
-import os, sys, re, FileTools
+import os
 verbose = 0
 dcount = fcount = 0
 maxfileload = 100000
@@ -9,13 +9,6 @@ blksize = 1024 * 8
 
 
 def BuildDistName():
-    # line separator 
-    ls = os.linesep
-    # path separator
-    ps = os.pathsep
-    # dir separator
-    ds = os.sep
-
     # Building dist name
     # reading the last Version information
     [FCVersionMajor,FCVersionMinor,FCVersionBuild,FCVersionDisDa] = open("../Version.h",'r').readlines()
@@ -23,13 +16,6 @@ def BuildDistName():
 
     return DistName
 def BuildSetupName():
-    # line separator 
-    ls = os.linesep
-    # path separator
-    ps = os.pathsep
-    # dir separator
-    ds = os.sep
-
     # Building dist name
     # reading the last Version information
     [FCVersionMajor,FCVersionMinor,FCVersionBuild,FCVersionDisDa] = open("../Version.h",'r').readlines()
@@ -38,39 +24,18 @@ def BuildSetupName():
     return DistName
 
 def GetVersion():
-    # line separator 
-    ls = os.linesep
-    # path separator
-    ps = os.pathsep
-    # dir separator
-    ds = os.sep
-
     # Building dist name
     # reading the last Version information
     [FCVersionMajor,FCVersionMinor,FCVersionBuild,FCVersionDisDa] = open("../Version.h",'r').readlines()
     return  FCVersionMajor[23:-1] + '.' +FCVersionMinor[23:-1] 
 
 def GetBuildNbr():
-    # line separator 
-    ls = os.linesep
-    # path separator
-    ps = os.pathsep
-    # dir separator
-    ds = os.sep
-
     # Building dist name
     # reading the last Version information
     [FCVersionMajor,FCVersionMinor,FCVersionBuild,FCVersionDisDa] = open("../Version.h",'r').readlines()
     return  FCVersionBuild[23:-1] 
 
 def GetBuildDate():
-    # line separator 
-    ls = os.linesep
-    # path separator
-    ps = os.pathsep
-    # dir separator
-    ds = os.sep
-
     # Building dist name
     # reading the last Version information
     [FCVersionMajor,FCVersionMinor,FCVersionBuild,FCVersionDisDa] = open("../Version.h",'r').readlines()
@@ -127,12 +92,12 @@ BinFilter = ["^Plugin\\.*$",
           "^.*\\.lib$",
           "^.*\\.exp$",
           "^.*\\.bsc$",
-          "^.*\\CADD.exe$",
-          "^.*\\CADAppD.dll$",
-          "^.*\\CmdD.exe$",
-          "^.*\\BaseD.dll$",
-          "^.*\\CADDCmdPy.dll$",
-          "^.*\\GuiD.dll$",
+          "^.*CADD.exe$",
+          "^.*CADAppD.dll$",
+          "^.*CmdD.exe$",
+          "^.*BaseD.dll$",
+          "^.*CADDCmdPy.dll$",
+          "^.*GuiD.dll$",
           "^.*\\.bsc$",
           "^.*\\.FCScript\\..*$",
           "^.*\\.FCParam$",
@@ -147,11 +112,11 @@ LibFilter = ["^Plugin\\.*$",
           "^.*\\.exe$",
           "^.*\\.exp$",
           "^.*\\.bsc$",
-          "^.*\\CADD.lib$",
-          "^.*\\CADAppD.lib$",
-          "^.*\\CmdD.lib$",
-          "^.*\\BaseD.lib$",
-          "^.*\\GuiD.lib$",
+          "^.*CADD.lib$",
+          "^.*CADAppD.lib$",
+          "^.*CmdD.lib$",
+          "^.*BaseD.lib$",
+          "^.*GuiD.lib$",
           "^.*\\.FCScript\\..*$",
           "^.*\\.FCParam$"]
 
@@ -169,7 +134,7 @@ ModFilter = ["^.*\\.o$",
           "^CVS$",
           "^Attic$",
           "^.*\\.opt$",
-          "^.*\\_d\.pyd$",
+          "^.*_d\.pyd$",
           "^.*\\.opt$",
           "^.*\\.ilg$",
           "^.*\\.ps$",
@@ -190,7 +155,7 @@ ModFilter = ["^.*\\.o$",
           "^.*\\.exp$",
           "^.*\\.lib$",
           "^.*\\.ui$",
-          "^.*\\Makefile$",
+          "^.*Makefile$",
           "^.*\\.plg$",]
 
 DocFilter = ["^.*\\.o$",

--- a/src/Tools/fcbt/FileTools.py
+++ b/src/Tools/fcbt/FileTools.py
@@ -1,5 +1,3 @@
-
-
 # shell and operating system
 import os, sys, re
 verbose = 0
@@ -43,7 +41,7 @@ def cpall(dirFrom, dirTo):
                 if verbose > 1: print('copying', pathFrom, 'to', pathTo)
                 cpfile(pathFrom, pathTo)
                 fcount = fcount+1
-            except:
+            except Exception:
                 print('Error copying', pathFrom, 'to', pathTo, '--skipped')
                 print(sys.exc_type, sys.exc_value)
         else:
@@ -52,7 +50,7 @@ def cpall(dirFrom, dirTo):
                 os.mkdir(pathTo)                          # make new subdir
                 cpall(pathFrom, pathTo)                   # recur into subdirs
                 dcount = dcount+1
-            except:
+            except Exception:
                 print('Error creating', pathTo, '--skipped')
                 print(sys.exc_type, sys.exc_value)
 
@@ -82,7 +80,7 @@ def cpallWithFilter(dirFrom, dirTo,MatchList):
                     if verbose > 1: print('copying', pathFrom, 'to', pathTo)
                     cpfile(pathFrom, pathTo)
                     fcount = fcount+1
-                except:
+                except Exception:
                     print('Error copying', pathFrom, 'to', pathTo, '--skipped')
                     print(sys.exc_type, sys.exc_value)
             else:
@@ -91,7 +89,7 @@ def cpallWithFilter(dirFrom, dirTo,MatchList):
                     os.mkdir(pathTo)                            # make new subdir
                     cpallWithFilter(pathFrom, pathTo,MatchList) # recur into subdirs
                     dcount = dcount+1
-                except:
+                except Exception:
                     print('Error creating', pathTo, '--skipped')
                     print(sys.exc_type, sys.exc_value)
 


### PR DESCRIPTION
Static analysis showed some unused variables and imports, and running the code in Python 3.9 revealed a few invalid escapes (previous versions of Python silently "fixed" these, so the code change here will not affect the results).

Many of the unused variables followed the same sequence (things like getting the path separator in every function): it's not clear to me if it would have been more appropriate to comment them out instead, if they had some use that was not clear from the code.

---

- [X]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [X]  Small changes only
- [X]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [X]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/)
- [X]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- No tracker ticket