### PR TITLE
[Part] Fix signature of TempoVis dummy function

### DIFF
--- a/src/Mod/Part/AttachmentEditor/TaskAttachmentEditor.py
+++ b/src/Mod/Part/AttachmentEditor/TaskAttachmentEditor.py
@@ -33,7 +33,7 @@ try:
     from Show import TempoVis
     from Show.DepGraphTools import getAllDependent
 except ImportError as err:
-    def TempoVis(doc):
+    def TempoVis(doc,tag):
         return None
     def getAllDependent(feature):
         return []


### PR DESCRIPTION
If the import of TempoVis fails, TaskAttachmentEditor creates s dummy function to replace the real TempoVis function. That function's signature did not match the real TempoVis. Caught by LGTM.

---

- [X]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [X]  Small change
- [X]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [X]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [X]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [X]  No ticket