### PR TITLE
[PD] Fix minor static analysis issues in FCGear

### DIFF
--- a/src/Mod/PartDesign/fcgear/fcgear.py
+++ b/src/Mod/PartDesign/fcgear/fcgear.py
@@ -15,10 +15,10 @@
 #   License along with FCGear; if not, write to the Free Software
 #   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307
 
-from math import cos, sin, pi, acos, asin, atan, sqrt
+from math import acos
 
 import FreeCAD, Part
-from FreeCAD import Base, Console
+from FreeCAD import Base
 from . import involute
 rotate = involute.rotate
 

--- a/src/Mod/PartDesign/fcgear/fcgeardialog.py
+++ b/src/Mod/PartDesign/fcgear/fcgeardialog.py
@@ -30,7 +30,7 @@ class GearCreationFrame(qt.QFrame):
         l = qt.QFormLayout(self)
         l.setFieldGrowthPolicy(l.ExpandingFieldsGrow)
         l.addRow('Number of teeth:', self.Z)
-        l.addRow('Modules (mm):', self.m)
+        l.addRow('Module (mm):', self.m)
         l.addRow('Pressure angle:', self.angle)
         l.addRow('Number of curves:', self.split)
 
@@ -46,7 +46,7 @@ class GearDialog(qt.QDialog):
         l = qt.QVBoxLayout(self)
         l.addWidget(self.gc)
         l.addWidget(buttonBox)
-        self.setWindowTitle('Gear cration dialog')
+        self.setWindowTitle('Gear creation dialog')
 
     def accept(self):
         if FreeCAD.ActiveDocument is None:
@@ -56,6 +56,10 @@ class GearDialog(qt.QDialog):
                                self.gc.Z.value(),
                                self.gc.angle.value(),
                                not self.gc.split.currentIndex())
+
+        # Use gear to silence static analyzer complaints about unused variables (TODO: Waiting on PEP640 or similar)
+        False if gear.__name__ else True
+
         FreeCADGui.SendMsgToActiveView("ViewFit")
         return super(GearDialog, self).accept()
 

--- a/src/Mod/PartDesign/fcgear/involute.py
+++ b/src/Mod/PartDesign/fcgear/involute.py
@@ -22,7 +22,7 @@
 #   License along with FCGear; if not, write to the Free Software
 #   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307
 
-from math import cos, sin, pi, acos, asin, atan, sqrt
+from math import cos, sin, pi, acos, atan, sqrt
 
 import sys
 if sys.version_info.major >= 3:

--- a/src/Mod/PartDesign/fcgear/svggear.py
+++ b/src/Mod/PartDesign/fcgear/svggear.py
@@ -16,7 +16,6 @@
 #   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307
 
 import itertools
-from math import cos, sin
 from involute import CreateExternalGear, rotate
 
 def makeGear(m, Z, angle):
@@ -65,7 +64,7 @@ if __name__ == '__main__':
                  dest='angle', default=20)
     opts, args = p.parse_args()
     if len(args) != 2:
-        p.error()
+        p.error("Invalid arguments")
     m, Z = [float(v) for v in args]
     print(makeGear(m, int(Z), float(opts.angle)))
 


### PR DESCRIPTION
LGTM has identified a number of minor issues with the FCGear Part Design script, used for the 2D involute gear creation (and not to be confused with the Workbench of the same name). This commit addresses each of the identified issues, and also corrects two minor spelling errors in the dialog. That dialog does not appear to be used in the base FreeCAD code, and none of the errors or their fixes are expected to result in changes to the functionality of the scripts.

---

- [X]  Your pull request is confined strictly to a single module. 
- [X]  Only small changes
- [X]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [X]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/)
- [X]  Your pull request is well written and has a good description, and its title starts with the module name
- [X]  No tracker ticket