### PR TITLE
[PD] fix multi-transform view

### DIFF
--- a/src/Mod/PartDesign/Gui/TaskMultiTransformParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskMultiTransformParameters.cpp
@@ -229,7 +229,8 @@ void TaskMultiTransformParameters::closeSubTask()
 
 void TaskMultiTransformParameters::onTransformDelete()
 {
-    if (editHint) return; // Can't delete the hint...
+    if (editHint)
+        return; // Can't delete the hint...
     int row = ui->listTransformFeatures->currentIndex().row();
     PartDesign::MultiTransform* pcMultiTransform = static_cast<PartDesign::MultiTransform*>(TransformedView->getObject());
     std::vector<App::DocumentObject*> transformFeatures = pcMultiTransform->Transformations.getValues();
@@ -254,7 +255,8 @@ void TaskMultiTransformParameters::onTransformDelete()
 
 void TaskMultiTransformParameters::onTransformEdit()
 {
-    if (editHint) return; // Can't edit the hint...
+    if (editHint)
+        return; // Can't edit the hint...
     closeSubTask(); // For example if user is editing one subTask and then double-clicks on another without OK'ing first
     ui->listTransformFeatures->currentItem()->setSelected(true);
     int row = ui->listTransformFeatures->currentIndex().row();
@@ -288,17 +290,23 @@ void TaskMultiTransformParameters::onTransformAddMirrored()
     closeSubTask();
     std::string newFeatName = TransformedView->getObject()->getDocument()->getUniqueObjectName("Mirrored");
     auto pcActiveBody = PartDesignGui::getBody(false);
-    if(!pcActiveBody) return;
+    if (!pcActiveBody)
+        return;
 
     Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Mirrored"));
-    FCMD_OBJ_CMD(pcActiveBody,"newObject('PartDesign::Mirrored','"<<newFeatName<<"')");
+    FCMD_OBJ_CMD(pcActiveBody, "newObject('PartDesign::Mirrored','"<<newFeatName<<"')");
     auto Feat = pcActiveBody->getDocument()->getObject(newFeatName.c_str());
+    if (!Feat)
+        return;
     //Gui::Command::updateActive();
     App::DocumentObject* sketch = getSketchObject();
     if (sketch)
-        FCMD_OBJ_CMD(Feat,"MirrorPlane = ("<<Gui::Command::getObjectCmd(sketch)<<",['V_Axis'])");
+        FCMD_OBJ_CMD(Feat, "MirrorPlane = ("<<Gui::Command::getObjectCmd(sketch)<<",['V_Axis'])");
 
     finishAdd(newFeatName);
+    // show the new view when no error
+    if (!Feat->isError())
+        TransformedView->getObject()->Visibility.setValue(true);
 }
 
 void TaskMultiTransformParameters::onTransformAddLinearPattern()
@@ -308,29 +316,35 @@ void TaskMultiTransformParameters::onTransformAddLinearPattern()
     closeSubTask();
     std::string newFeatName = TransformedView->getObject()->getDocument()->getUniqueObjectName("LinearPattern");
     auto pcActiveBody = PartDesignGui::getBody(false);
-    if(!pcActiveBody) return;
+    if (!pcActiveBody)
+        return;
 
     Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Make LinearPattern"));
-    FCMD_OBJ_CMD(pcActiveBody,"newObject('PartDesign::LinearPattern','"<<newFeatName<<"')");
+    FCMD_OBJ_CMD(pcActiveBody, "newObject('PartDesign::LinearPattern','"<<newFeatName<<"')");
     auto Feat = pcActiveBody->getDocument()->getObject(newFeatName.c_str());
+    if (!Feat)
+        return;
     //Gui::Command::updateActive();
     App::DocumentObject* sketch = getSketchObject();
     if (sketch) {
-        FCMD_OBJ_CMD(Feat,"Direction = ("<<Gui::Command::getObjectCmd(sketch)<<",['H_Axis'])");
+        FCMD_OBJ_CMD(Feat, "Direction = ("<<Gui::Command::getObjectCmd(sketch)<<",['H_Axis'])");
     }
     else {
         // set Direction value before filling up the combo box to avoid creating an empty item
         // inside updateUI()
         PartDesign::Body* body = static_cast<PartDesign::Body*>(Part::BodyBase::findBodyOf(getObject()));
         if (body) {
-            FCMD_OBJ_CMD(Feat,"Direction = ("<<Gui::Command::getObjectCmd(body->getOrigin()->getX())<<",[''])");
+            FCMD_OBJ_CMD(Feat, "Direction = ("<<Gui::Command::getObjectCmd(body->getOrigin()->getX())<<",[''])");
         }
     }
 
-    FCMD_OBJ_CMD(Feat,"Length = 100");
-    FCMD_OBJ_CMD(Feat,"Occurrences = 2");
+    FCMD_OBJ_CMD(Feat, "Length = 100");
+    FCMD_OBJ_CMD(Feat, "Occurrences = 2");
 
     finishAdd(newFeatName);
+    // show the new view when no error
+    if (!Feat->isError())
+        TransformedView->getObject()->Visibility.setValue(true);
 }
 
 void TaskMultiTransformParameters::onTransformAddPolarPattern()
@@ -338,19 +352,25 @@ void TaskMultiTransformParameters::onTransformAddPolarPattern()
     closeSubTask();
     std::string newFeatName = TransformedView->getObject()->getDocument()->getUniqueObjectName("PolarPattern");
     auto pcActiveBody = PartDesignGui::getBody(false);
-    if(!pcActiveBody) return;
+    if (!pcActiveBody)
+        return;
 
     Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "PolarPattern"));
-    FCMD_OBJ_CMD(pcActiveBody,"newObject('PartDesign::PolarPattern','"<<newFeatName<<"')");
+    FCMD_OBJ_CMD(pcActiveBody, "newObject('PartDesign::PolarPattern','"<<newFeatName<<"')");
     auto Feat = pcActiveBody->getDocument()->getObject(newFeatName.c_str());
+    if (!Feat)
+        return;
     //Gui::Command::updateActive();
     App::DocumentObject* sketch = getSketchObject();
     if (sketch)
         FCMD_OBJ_CMD(Feat, "Axis = ("<<Gui::Command::getObjectCmd(sketch)<<",['N_Axis'])");
-    FCMD_OBJ_CMD(Feat,"Angle = 360");
-    FCMD_OBJ_CMD(Feat,"Occurrences = 2");
+    FCMD_OBJ_CMD(Feat, "Angle = 360");
+    FCMD_OBJ_CMD(Feat, "Occurrences = 2");
 
     finishAdd(newFeatName);
+    // show the new view when no error
+    if (!Feat->isError())
+        TransformedView->getObject()->Visibility.setValue(true);
 }
 
 void TaskMultiTransformParameters::onTransformAddScaled()
@@ -358,16 +378,22 @@ void TaskMultiTransformParameters::onTransformAddScaled()
     closeSubTask();
     std::string newFeatName = TransformedView->getObject()->getDocument()->getUniqueObjectName("Scaled");
     auto pcActiveBody = PartDesignGui::getBody(false);
-    if(!pcActiveBody) return;
+    if (!pcActiveBody)
+        return;
 
     Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Scaled"));
-    FCMD_OBJ_CMD(pcActiveBody,"newObject('PartDesign::Scaled','"<<newFeatName<<"')");
+    FCMD_OBJ_CMD(pcActiveBody, "newObject('PartDesign::Scaled','"<<newFeatName<<"')");
     auto Feat = pcActiveBody->getDocument()->getObject(newFeatName.c_str());
+    if (!Feat)
+        return;
     //Gui::Command::updateActive();
-    FCMD_OBJ_CMD(Feat,"Factor = 2");
-    FCMD_OBJ_CMD(Feat,"Occurrences = 2");
+    FCMD_OBJ_CMD(Feat, "Factor = 2");
+    FCMD_OBJ_CMD(Feat, "Occurrences = 2");
 
     finishAdd(newFeatName);
+    // show the new view when no error
+    if (!Feat->isError())
+        TransformedView->getObject()->Visibility.setValue(true);
 }
 
 void TaskMultiTransformParameters::finishAdd(std::string &newFeatName)

--- a/src/Mod/PartDesign/Gui/TaskPolarPatternParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPolarPatternParameters.cpp
@@ -156,6 +156,7 @@ void TaskPolarPatternParameters::setupUI()
 
     ui->polarAngle->bind(pcPolarPattern->Angle);
     ui->spinOccurrences->setMaximum(INT_MAX);
+    ui->spinOccurrences->setMinimum(2);
     ui->spinOccurrences->bind(pcPolarPattern->Occurrences);
 
     ui->comboAxis->setEnabled(true);


### PR DESCRIPTION
- fixes regression bug 4581
  See the first issue reported here:
  https://forum.freecadweb.org/viewtopic.php?f=3&t=56093#p482553

- also fix issue that one could set 1 occurrence for polar patterns despite 2 are required at least

- also fix potential dereferencing null pointer (reported by MSVC)

When this goes in, it should also go in for FC 0.19.1