### PR TITLE
[GUI] Add library versions to LibraryVersions.h

### DIFF
--- a/LibraryVersions.h.cmake
+++ b/LibraryVersions.h.cmake
@@ -9,5 +9,42 @@
 #  include <${OCC_INCLUDE_DIR}/Standard_Version.hxx>
 #endif
 
+
+/* No need for Boost (version info is always included in the source) */
+/* No need for Coin (version info is always included in the source) */
+/* No need for Python (version info is always included in the source) */
+/* No need for Qt (version info is always included in the source) */
+/* No need for zlib (version info is always included in the source) */
+
+// No CMake version info for SMESH, libarea, Zipios, or KDL
+
+// Eigen3
+constexpr char * FC_EIGEN3_VERSION = "${EIGEN3_VERSION}";
+
+// FreeType
+constexpr char * FC_FREETYPE_VERSION = "${FREETYPE_VERSION_STRING}";
+
+// pcl
+constexpr char * FC_PCL_VERSION = "${PCL_VERSION}";
+
+// PyCXX
+constexpr char * FC_PYCXX_VERSION = "${PYCXX_VERSION}";
+
+// PySide
+constexpr char * FC_PYSIDE_VERSION = "${PySide2_VERSION}";
+
+// PyBind
+constexpr char * FC_PYBIND11_VERSION = "${pybind11_VERSION}";
+
+// Shiboken
+constexpr char * FC_SHIBOKEN_VERSION = "${Shiboken2_VERSION}";
+
+// vtk
+constexpr char * FC_VTK_VERSION = "${VTK_VERSION}";
+
+// Xerces-C
+constexpr char * FC_XERCESC_VERSION = "${XercesC_VERSION}";
+
+
 #endif // LIBRARY_VERSIONS_H
 

--- a/src/Gui/Splashscreen.cpp
+++ b/src/Gui/Splashscreen.cpp
@@ -558,9 +558,6 @@ void AboutDialog::showLicenseInformation()
     QString baseurl = QString::fromLatin1("file:///%1/ThirdPartyLibraries.html")
             .arg(QString::fromUtf8(App::Application::getHelpDir().c_str()));
 
-    //FIXME: Put all needed information into LibraryVersions.h
-    //
-
     // Boost
     li.name = QLatin1String("Boost");
     li.href = baseurl + QLatin1String("#_TocBoost");
@@ -579,14 +576,14 @@ void AboutDialog::showLicenseInformation()
     li.name = QLatin1String("Eigen3");
     li.href = baseurl + QLatin1String("#_TocEigen3");
     li.url = QLatin1String("http://eigen.tuxfamily.org/");
-    li.version.clear();
+    li.version = QString::fromLatin1(FC_EIGEN3_VERSION);
     libInfo << li;
 
     // FreeType
     li.name = QLatin1String("FreeType");
     li.href = baseurl + QLatin1String("#_TocFreeType");
     li.url = QLatin1String("http://freetype.org");
-    li.version.clear();
+    li.version = QString::fromLatin1(FC_FREETYPE_VERSION);
     libInfo << li;
 
     // KDL
@@ -616,14 +613,14 @@ void AboutDialog::showLicenseInformation()
     li.name = QLatin1String("Point Cloud Library");
     li.href = baseurl + QLatin1String("#_TocPcl");
     li.url = QLatin1String("http://www.pointclouds.org");
-    li.version.clear();
+    li.version = QString::fromLatin1(FC_PCL_VERSION);
     libInfo << li;
 
     // PyCXX
     li.name = QLatin1String("PyCXX");
     li.href = baseurl + QLatin1String("#_TocPyCXX");
     li.url = QLatin1String("http://cxx.sourceforge.net");
-    li.version.clear();
+    li.version = QString::fromLatin1(FC_PYCXX_VERSION);
     libInfo << li;
 
     // Python
@@ -637,7 +634,7 @@ void AboutDialog::showLicenseInformation()
     li.name = QLatin1String("PySide");
     li.href = baseurl + QLatin1String("#_TocPySide");
     li.url = QLatin1String("http://www.pyside.org");
-    li.version.clear();
+    li.version = QString::fromLatin1(FC_PYSIDE_VERSION);
     libInfo << li;
 
     // Qt
@@ -658,21 +655,21 @@ void AboutDialog::showLicenseInformation()
     li.name = QLatin1String("Shiboken");
     li.href = baseurl + QLatin1String("#_TocPySide");
     li.url = QLatin1String("http://www.pyside.org");
-    li.version.clear();
+    li.version = QString::fromLatin1(FC_SHIBOKEN_VERSION);
     libInfo << li;
 
     // vtk
     li.name = QLatin1String("vtk");
     li.href = baseurl + QLatin1String("#_TocVtk");
     li.url = QLatin1String("https://www.vtk.org");
-    li.version.clear();
+    li.version = QString::fromLatin1(FC_VTK_VERSION);
     libInfo << li;
 
     // Xerces-C
     li.name = QLatin1String("Xerces-C");
     li.href = baseurl + QLatin1String("#_TocXercesC");
     li.url = QLatin1String("https://xerces.apache.org/xerces-c");
-    li.version.clear();
+    li.version = QString::fromLatin1(FC_XERCESC_VERSION);
     libInfo << li;
 
     // Zipios++


### PR DESCRIPTION
There was a "FIXME" in Splashscreen.cpp suggesting that we should include other library version information in LibraryVersions.h -- this implements that suggestion. Not all libraries are supported right now: several don't have version information available to CMake, though it's possible that is due to our older CMake facilities which could be updated.

---

- [X]  Your pull request is confined strictly to a single module.
- [X]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [X]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [X]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) 
- [X]  Your pull request is well written and has a good description, and its title starts with the module name, 
- [X]  No tracker