### PR TITLE
[DRAFT] Refactor sync_snap_toolbar_button

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_snaps.py
+++ b/src/Mod/Draft/draftguitools/gui_snaps.py
@@ -73,6 +73,7 @@ def sync_snap_toolbar_button(button, status):
                     action.setToolTip(a.toolTip().replace("OFF","ON"))
                 else:
                     action.setToolTip(a.toolTip().replace("ON","OFF"))
+                return
 
 
 def sync_snap_statusbar_button(button, status):
@@ -96,6 +97,7 @@ def sync_snap_statusbar_button(button, status):
         for a in actions:
             if a.objectName() == button:
                 a.setChecked(status)
+                return
 
 
 # SNAP GUI TOOLS ------------------------------------------------------------

--- a/src/Mod/Draft/draftguitools/gui_snaps.py
+++ b/src/Mod/Draft/draftguitools/gui_snaps.py
@@ -56,21 +56,23 @@ def sync_snap_toolbar_button(button, status):
     snap_toolbar = Gui.Snapper.get_snap_toolbar()
     if not snap_toolbar:
         return
-    for a in snap_toolbar.actions():
-        if a.objectName() == button:
-            if button == "Draft_Snap_Lock_Button":
-                # for lock button
-                snap_toolbar.actions()[0].setChecked(status)
-                for a in snap_toolbar.actions()[1:]:
-                    if a.objectName()[:10] == "Draft_Snap":
-                        a.setEnabled(status)
-            else:
-                # for every other button
-                a.setChecked(status)
-                if a.isChecked():
-                    a.setToolTip(a.toolTip().replace("OFF","ON"))
+
+    # Setting the snap lock button enables or disables all of the other snap actions:
+    if button == "Draft_Snap_Lock_Button":
+        snap_toolbar.actions()[0].setChecked(status) # Snap lock must be the first button
+        for action in snap_toolbar.actions()[1:]:
+            if action.objectName()[:10] == "Draft_Snap":
+                action.setEnabled(status)
+
+    # All other buttons only affect themselves
+    else:
+        for action in snap_toolbar.actions():
+            if action.objectName() == button:
+                action.setChecked(status)
+                if action.isChecked():
+                    action.setToolTip(a.toolTip().replace("OFF","ON"))
                 else:
-                    a.setToolTip(a.toolTip().replace("ON","OFF"))
+                    action.setToolTip(a.toolTip().replace("ON","OFF"))
 
 
 def sync_snap_statusbar_button(button, status):


### PR DESCRIPTION
LGTM objected to the re-use of the loop variable `a` in the original algorithm. Upon closer inspection, the algorithm in this function could be modified to match the algorithm in `sync_snap_statusbar_button` (which does the same thing to the statusbar that this does to the toolbar). This change eliminates the double-use, and does not affect the functionality of the routine.

A second (purely optional) commit makes a small optimization to the two routines, returning once the requested button has been found and handled.

- [X]  Your pull request is confined strictly to a single module. 
- [X]  Small fix only
- [X]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [X]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [X]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [X]  No tracker ticket