### PR TITLE
[DRAFT] Remove unused loop variable

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_trimex.py
+++ b/src/Mod/Draft/draftguitools/gui_trimex.py
@@ -120,8 +120,7 @@ class Trimex(gui_base_original.Modifier):
             self.extrudeMode = True
             self.ghost = [trackers.ghostTracker([self.obj])]
             self.normal = self.obj.Shape.Faces[0].normalAt(0.5, 0.5)
-            for v in self.obj.Shape.Vertexes:
-                self.ghost.append(trackers.lineTracker())
+            self.ghost += [trackers.lineTracker()] * len(self.obj.Shape.Vertexes)
         elif len(self.obj.Shape.Faces) > 1:
             # face extrude mode, a new object is created
             ss = Gui.Selection.getSelectionEx()[0]
@@ -132,8 +131,7 @@ class Trimex(gui_base_original.Modifier):
                     self.extrudeMode = True
                     self.ghost = [trackers.ghostTracker([self.obj])]
                     self.normal = self.obj.Shape.Faces[0].normalAt(0.5, 0.5)
-                    for v in self.obj.Shape.Vertexes:
-                        self.ghost.append(trackers.lineTracker())
+                    self.ghost += [trackers.lineTracker()] * len(self.obj.Shape.Vertexes)
         else:
             # normal wire trimex mode
             self.color = self.obj.ViewObject.LineColor


### PR DESCRIPTION
LGTM is concerned about the unused loop variable in this algorithm. While there was nothing wrong here, to eliminate the alarm the loop was removed entirely, since Python allows the use of the multiplication operator here to achieve the same effect.

---

- [X]  Your pull request is confined strictly to a single module. 
- [X]  Minor change
- [X]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [X]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [X]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [X]  No ticket