### PR TITLE
[Arch] Refactor to eliminate unused variable

### DIFF
--- a/src/Mod/Arch/exportIFC.py
+++ b/src/Mod/Arch/exportIFC.py
@@ -2261,7 +2261,7 @@ def getRepresentation(ifcfile,context,obj,forcebrep=False,subtraction=False,tess
                 diffusecolor = obj.ViewObject.DiffuseColor
         if shapecolor and (shapetype != "clone"): # cloned objects are already colored
             key = None
-            rgbt = [shapecolor+(transparency,) for shape in shapes]
+            rgbt = [shapecolor+(transparency,)] * len(shapes)
             if diffusecolor \
                     and (len(diffusecolor) == len(obj.Shape.Faces)) \
                     and (len(obj.Shape.Solids) == len(colorshapes)):


### PR DESCRIPTION
LGTM complains about the unused variable in a loop that is really only using the variable to iterate a set number of times. This replaces that loop with a multiplication by the length of the array, eliminating the unused iteration variable and clarifying the intent of the code.

---

- [X]  Your pull request is confined strictly to a single module.
- [X]  Small change
- [X]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [X]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [X]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [X]  No tracker ticket