### PR TITLE
[Draft] Eliminate unused loop iteration variables

### DIFF
--- a/src/Mod/Draft/draftviewproviders/view_array.py
+++ b/src/Mod/Draft/draftviewproviders/view_array.py
@@ -60,8 +60,7 @@ class ViewProviderDraftArray(ViewProviderDraft):
                 else:
                     c = vobj.Object.Base.ViewObject.ShapeColor
                     c = (c[0],c[1],c[2],vobj.Object.Base.ViewObject.Transparency/100.0)
-                    for f in vobj.Object.Base.Shape.Faces:
-                        colors.append(c)
+                    colors += [c] * len(vobj.Object.Base.Shape.Faces)
         if colors:
             n = 1
             if hasattr(vobj.Object,"ArrayType"):

--- a/src/Mod/Draft/draftviewproviders/view_clone.py
+++ b/src/Mod/Draft/draftviewproviders/view_clone.py
@@ -61,9 +61,7 @@ class ViewProviderClone:
                 else:
                     c = o.ViewObject.ShapeColor
                     c = (c[0],c[1],c[2],o.ViewObject.Transparency/100.0)
-                    for f in o.Shape.Faces: # TODO: verify this line
-                        colors.append(c)
-
+                    colors += [c] * len(o.Shape.Faces) # TODO: verify this line
             elif o.hasExtension("App::GeoFeatureGroupExtension"):
                 for so in vobj.Object.Group:
                     if so.isDerivedFrom("Part::Feature"):
@@ -72,8 +70,7 @@ class ViewProviderClone:
                         else:
                             c = so.ViewObject.ShapeColor
                             c = (c[0],c[1],c[2],so.ViewObject.Transparency/100.0)
-                            for f in so.Shape.Faces:
-                                colors.append(c)
+                            colors += [c] * len(so.Shape.Faces)
         if colors:
             vobj.DiffuseColor = colors
 


### PR DESCRIPTION
When creating arrays of colors, the color information is often created to be the same length as some array of objects. In three instances this was achieved with a loop over that list of objects, even though the objects themselves are never used. This commit eliminates those loops and creates the required number of color instances directly.

Identified by LGTM.

---

- [X]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [X]  Small changes
- [X]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [X]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [X] No tracker ticket