### PR TITLE
[Draft] Fix localize_vectors double definition

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_edit.py
+++ b/src/Mod/Draft/draftguitools/gui_edit.py
@@ -714,11 +714,11 @@ class Edit(gui_base_original.Modifier):
 
         for index, point in enumerate(obj.Points):
             if index == edgeIndex:
-                newPoints.append(self.localize_vectors(obj, newPoint))
+                newPoints.append(self.localize_vector(obj, newPoint))
             newPoints.append(point)
         if obj.Closed and edgeIndex == len(obj.Points):
             # last segment when object is closed
-            newPoints.append(self.localize_vectors(obj, newPoint))
+            newPoints.append(self.localize_vector(obj, newPoint))
         obj.Points = newPoints
 
     def addPointToCurve(self, point, obj, info=None):
@@ -766,11 +766,11 @@ class Edit(gui_base_original.Modifier):
                 uPoints.append(curve.parameter(p))
             for i in range(len(uPoints) - 1):
                 if ( uNewPoint > uPoints[i] ) and ( uNewPoint < uPoints[i+1] ):
-                    pts.insert(i + 1, self.localize_vectors(obj, point))
+                    pts.insert(i + 1, self.localize_vector(obj, point))
                     break
             # DNC: fix: add points to last segment if curve is closed
             if obj.Closed and (uNewPoint > uPoints[-1]):
-                pts.append(self.localize_vectors(obj, point))
+                pts.append(self.localize_vector(obj, point))
         obj.Points = pts
 
     # ------------------------------------------------------------------------
@@ -865,7 +865,7 @@ class Edit(gui_base_original.Modifier):
 
     def update(self, obj, nodeIndex, v):
         """Apply the App.Vector to the modified point and update obj."""
-        v = self.localize_vectors(obj, v)
+        v = self.localize_vector(obj, v)
         App.ActiveDocument.openTransaction("Edit")
         self.update_object(obj, nodeIndex, v)
         App.ActiveDocument.commitTransaction()
@@ -996,11 +996,11 @@ class Edit(gui_base_original.Modifier):
         """Return the given point list in the given object coordinate system."""
         plist = []
         for p in pointList:
-            point = self.localize_vectors(obj, p)
+            point = self.localize_vector(obj, p)
             plist.append(point)
         return plist
 
-    def localize_vectors(self, obj, point):
+    def localize_vector(self, obj, point):
         """Return the given point in the given object coordinate system."""
         if hasattr(obj, "getGlobalPlacement"):
             return obj.getGlobalPlacement().inverse().multVec(point)

--- a/src/Mod/Draft/draftguitools/gui_edit_draft_objects.py
+++ b/src/Mod/Draft/draftguitools/gui_edit_draft_objects.py
@@ -315,10 +315,10 @@ class DraftCircleGuiTools(GuiTools):
                 # edit by 3 points
                 if node_idx == 0:
                     # center point
-                    p1 = edit_command.localize_vectors(obj, obj.Shape.Vertexes[0].Point)
-                    p2 = edit_command.localize_vectors(obj, obj.Shape.Vertexes[1].Point)
-                    p0 = DraftVecUtils.project(edit_command.localize_vectors(obj, v),
-                                                edit_command.localize_vectors(obj, (self.getArcMid(obj, global_placement=True))))
+                    p1 = edit_command.localize_vector(obj, obj.Shape.Vertexes[0].Point)
+                    p2 = edit_command.localize_vector(obj, obj.Shape.Vertexes[1].Point)
+                    p0 = DraftVecUtils.project(edit_command.localize_vector(obj, v),
+                                                edit_command.localize_vector(obj, (self.getArcMid(obj, global_placement=True))))
                     edit_command.ghost.autoinvert=False
                     edit_command.ghost.setRadius(p1.sub(p0).Length)
                     edit_command.ghost.setStartPoint(obj.Shape.Vertexes[1].Point)
@@ -347,7 +347,7 @@ class DraftCircleGuiTools(GuiTools):
                 elif node_idx == 2:
                     edit_command.ghost.setEndPoint(v)
                 elif node_idx == 3:
-                    edit_command.ghost.setRadius(edit_command.localize_vectors(obj, v).Length)
+                    edit_command.ghost.setRadius(edit_command.localize_vector(obj, v).Length)
 
 
     def getArcStart(self, obj, global_placement=False):#Returns object midpoint


### PR DESCRIPTION
LGTM identified an instance where a function was defined twice: in this case, one version was intended to take a list of items and the second version just a single item. Because they share the same name and number of arguments, the second definition overrode the first. This causes no problems in the current code because the version that takes a list is never used. However, for consistency with the analogous `globalize_vectors` and `globalize_vector` functions, the `localize*` versions are changed to match that pattern. All calls are converted to the singular use.

---

- [X]  Your pull request is confined strictly to a single module.
- [X]  Small change
- [X]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [X]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [X]  No tracker ticket