### PR TITLE
[Arch] LGTM issues in Dice3DS

### DIFF
--- a/src/Mod/Arch/Dice3DS/dom3ds.py
+++ b/src/Mod/Arch/Dice3DS/dom3ds.py
@@ -16,7 +16,7 @@ data of the second object like this:
 
 """
 
-import os, sys, struct
+import sys, struct
 
 import numpy
 
@@ -550,7 +550,7 @@ class UnknownChunk(UndefinedChunk):
     __slots__ = ['tag']
     label = "UNKNOWN"
     def __init__(self,tag):
-        self.tag = tag
+        super().__init__(tag=tag)
 
 
 class ErrorChunk(UndefinedChunk):
@@ -558,9 +558,7 @@ class ErrorChunk(UndefinedChunk):
     label = "ERROR"
     tag = 0xEEEE
     def __init__(self,intended_tag=None,intended_label=None,error_msg=None):
-        self.intended_tag = intended_tag
-        self.intended_label = intended_label
-        self.error_msg = error_msg
+        super().__init__(intended_tag=intended_tag,intended_label=intended_label,error_msg=error_msg)
     def dump(self,flo,indent,flags):
         super(ErrorChunk,self).dump(flo,indent,flags)
         if self.intended_tag is not None:
@@ -695,7 +693,6 @@ class TrackChunk(ChunkBase):
             n = self.nkeys
         else:
             n = min(flags['arraylines'],self.nkeys)
-        indent2 = indent+"    "
         for i in xrange(n):
             kf = self.keys[i]
             flo.write("%skeys[0] = %s.Key\n" % (indent,self.label))


### PR DESCRIPTION
LGTM identified a few minor issues in the Dice3DS code -- none of them appear to be real errors, so the changes here should not affect the behavior of the code. (Note that it appears that this library is no longer maintained outside of FreeCAD, so I'm treating it like it's part of our codebase, rather than as a 3rd party library -- we could also choose to exclude it from analysis, if that's preferred).

---

- [X]  Your pull request is confined strictly to a single module.
- [X]  Small changes
- [X]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [X]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [X]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [X]  No tracker ticket