### PR TITLE
[PD] disallow invalid polar/linear pattern settings

### DIFF
--- a/src/Mod/PartDesign/App/FeatureLinearPattern.cpp
+++ b/src/Mod/PartDesign/App/FeatureLinearPattern.cpp
@@ -49,12 +49,15 @@ namespace PartDesign {
 
 PROPERTY_SOURCE(PartDesign::LinearPattern, PartDesign::Transformed)
 
+const App::PropertyIntegerConstraint::Constraints intOccurrences = { 1, INT_MAX, 1 };
+
 LinearPattern::LinearPattern()
 {
     ADD_PROPERTY_TYPE(Direction,(0),"LinearPattern",(App::PropertyType)(App::Prop_None),"Direction");
     ADD_PROPERTY(Reversed,(0));
     ADD_PROPERTY(Length,(100.0));
     ADD_PROPERTY(Occurrences,(3));
+    Occurrences.setConstraints(&intOccurrences);
 }
 
 short LinearPattern::mustExecute() const
@@ -185,6 +188,18 @@ const std::list<gp_Trsf> LinearPattern::getTransformations(const std::vector<App
     }
 
     return transformations;
+}
+
+void LinearPattern::handleChangedPropertyType(Base::XMLReader& reader, const char* TypeName, App::Property* prop)
+// transforms properties that had been changed
+{
+    // property Occurrences had the App::PropertyInteger and was changed to App::PropertyIntegerConstraint
+    if (prop == &Occurrences && strcmp(TypeName, "App::PropertyInteger") == 0) {
+        App::PropertyInteger OccurrencesProperty;
+        // restore the PropertyInteger to be able to set its value
+        OccurrencesProperty.Restore(reader);
+        Occurrences.setValue(OccurrencesProperty.getValue());
+    }
 }
 
 }

--- a/src/Mod/PartDesign/App/FeatureLinearPattern.h
+++ b/src/Mod/PartDesign/App/FeatureLinearPattern.h
@@ -41,7 +41,7 @@ public:
     App::PropertyLinkSub Direction;
     App::PropertyBool    Reversed;
     App::PropertyLength  Length;
-    App::PropertyInteger Occurrences;
+    App::PropertyIntegerConstraint Occurrences;
 
    /** @name methods override feature */
     //@{
@@ -63,6 +63,9 @@ public:
       * If Reversed is true, the direction of transformation will be opposite
       */
     const std::list<gp_Trsf> getTransformations(const std::vector<App::DocumentObject*> );
+
+protected:
+    virtual void handleChangedPropertyType(Base::XMLReader& reader, const char* TypeName, App::Property* prop);
 };
 
 } //namespace PartDesign

--- a/src/Mod/PartDesign/App/FeaturePolarPattern.cpp
+++ b/src/Mod/PartDesign/App/FeaturePolarPattern.cpp
@@ -48,12 +48,17 @@ namespace PartDesign {
 
 PROPERTY_SOURCE(PartDesign::PolarPattern, PartDesign::Transformed)
 
+const App::PropertyIntegerConstraint::Constraints intOccurrences = { 1, INT_MAX, 1 };
+const App::PropertyAngle::Constraints floatAngle = { Base::toDegrees<double>(Precision::Angular()), 360.0, 1.0 };
+
 PolarPattern::PolarPattern()
 {
-    ADD_PROPERTY_TYPE(Axis,(0),"PolarPattern",(App::PropertyType)(App::Prop_None),"Direction");
-    ADD_PROPERTY(Reversed,(0));
-    ADD_PROPERTY(Angle,(360.0));
-    ADD_PROPERTY(Occurrences,(3));
+    ADD_PROPERTY_TYPE(Axis, (0), "PolarPattern", (App::PropertyType)(App::Prop_None), "Direction");
+    ADD_PROPERTY(Reversed, (0));
+    ADD_PROPERTY(Angle, (360.0));
+    Angle.setConstraints(&floatAngle);
+    ADD_PROPERTY(Occurrences, (3));
+    Occurrences.setConstraints(&intOccurrences);
 }
 
 short PolarPattern::mustExecute() const
@@ -171,6 +176,18 @@ const std::list<gp_Trsf> PolarPattern::getTransformations(const std::vector<App:
     }
 
     return transformations;
+}
+
+void PolarPattern::handleChangedPropertyType(Base::XMLReader& reader, const char* TypeName, App::Property* prop)
+// transforms properties that had been changed
+{
+    // property Occurrences had the App::PropertyInteger and was changed to App::PropertyIntegerConstraint
+    if (prop == &Occurrences && strcmp(TypeName, "App::PropertyInteger") == 0) {
+        App::PropertyInteger OccurrencesProperty;
+        // restore the PropertyInteger to be able to set its value
+        OccurrencesProperty.Restore(reader);
+        Occurrences.setValue(OccurrencesProperty.getValue());
+    }
 }
 
 }

--- a/src/Mod/PartDesign/App/FeaturePolarPattern.h
+++ b/src/Mod/PartDesign/App/FeaturePolarPattern.h
@@ -42,7 +42,7 @@ public:
     App::PropertyLinkSub Axis;
     App::PropertyBool    Reversed;
     App::PropertyAngle   Angle;
-    App::PropertyInteger Occurrences;
+    App::PropertyIntegerConstraint Occurrences;
 
    /** @name methods override feature */
     //@{
@@ -65,6 +65,9 @@ public:
       * If Reversed is true, the direction of rotation will be opposite.
       */
     const std::list<gp_Trsf> getTransformations(const std::vector<App::DocumentObject*>);
+
+protected:
+    virtual void handleChangedPropertyType(Base::XMLReader& reader, const char* TypeName, App::Property* prop);
 };
 
 } //namespace PartDesign


### PR DESCRIPTION
as discussed in https://github.com/FreeCAD/FreeCAD/commit/356db441a6c4bf546828e149d7269b2d61c9f039 we should disallow invalid property settings

at the moment we allow errors like these: 
![Zf9cUPnInH](https://user-images.githubusercontent.com/1828501/109587191-eb24a680-7b06-11eb-90b4-711660e5be87.gif)


This PR sets constraints to avoid this.