### PR TITLE
Normalize UI files step 2 and 3

### DIFF
--- a/src/Gui/AboutApplication.ui
+++ b/src/Gui/AboutApplication.ui
@@ -17,36 +17,6 @@
    <bool>true</bool>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="1" column="0">
-    <layout class="QHBoxLayout" name="boxOK">
-     <property name="spacing">
-      <number>6</number>
-     </property>
-     <property name="margin">
-      <number>0</number>
-     </property>
-     <item>
-      <spacer>
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>160</width>
-         <height>31</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QPushButton" name="okButton">
-       <property name="text">
-        <string>OK</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
    <item row="0" column="0">
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
@@ -633,7 +603,37 @@ p, li { white-space: pre-wrap; }
      </widget>
     </widget>
    </item>
-  </layout>
+  <item row="1" column="0">
+    <layout class="QHBoxLayout" name="boxOK">
+     <property name="spacing">
+      <number>6</number>
+     </property>
+     <property name="margin">
+      <number>0</number>
+     </property>
+     <item>
+      <spacer>
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>160</width>
+         <height>31</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="okButton">
+       <property name="text">
+        <string>OK</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   </layout>
  </widget>
  <customwidgets>
   <customwidget>

--- a/src/Gui/DlgAuthorization.ui
+++ b/src/Gui/DlgAuthorization.ui
@@ -17,7 +17,30 @@
    <bool>true</bool>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="1" column="0">
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_4">
+     <property name="text">
+      <string>Site:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QLabel" name="siteDescription">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>%1 at %2</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+  <item row="1" column="0">
     <widget class="QLabel" name="textLabel1">
      <property name="text">
       <string>Username:</string>
@@ -64,30 +87,7 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="label_4">
-     <property name="text">
-      <string>Site:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1">
-    <widget class="QLabel" name="siteDescription">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>%1 at %2</string>
-     </property>
-     <property name="wordWrap">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-  </layout>
+   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
  <tabstops>

--- a/src/Gui/DlgCommands.ui
+++ b/src/Gui/DlgCommands.ui
@@ -23,7 +23,28 @@
    <property name="spacing">
     <number>6</number>
    </property>
-   <item row="0" column="1">
+   <item row="0" column="0">
+    <widget class="QTreeWidget" name="categoryTreeWidget">
+     <property name="sizePolicy">
+      <sizepolicy>
+       <hsizetype>4</hsizetype>
+       <vsizetype>7</vsizetype>
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>150</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="rootIsDecorated">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+  <item row="0" column="1">
     <widget class="QTreeWidget" name="commandTreeWidget">
      <property name="rootIsDecorated">
       <bool>false</bool>
@@ -52,28 +73,7 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="0">
-    <widget class="QTreeWidget" name="categoryTreeWidget">
-     <property name="sizePolicy">
-      <sizepolicy>
-       <hsizetype>4</hsizetype>
-       <vsizetype>7</vsizetype>
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>150</width>
-       <height>16777215</height>
-      </size>
-     </property>
-     <property name="rootIsDecorated">
-      <bool>false</bool>
-     </property>
-    </widget>
-   </item>
-  </layout>
+   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
  <tabstops>

--- a/src/Gui/DlgEditor.ui
+++ b/src/Gui/DlgEditor.ui
@@ -29,143 +29,6 @@
    <property name="spacing">
     <number>6</number>
    </property>
-   <item row="1" column="0" colspan="2">
-    <widget class="QGroupBox" name="GroupBox5">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="title">
-      <string>Display items</string>
-     </property>
-     <layout class="QGridLayout">
-      <property name="leftMargin">
-       <number>9</number>
-      </property>
-      <property name="topMargin">
-       <number>9</number>
-      </property>
-      <property name="rightMargin">
-       <number>9</number>
-      </property>
-      <property name="bottomMargin">
-       <number>9</number>
-      </property>
-      <property name="spacing">
-       <number>6</number>
-      </property>
-      <item row="3" column="1">
-       <widget class="QLabel" name="label">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string>Preview:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="1" rowspan="3" colspan="2">
-       <widget class="QTextEdit" name="textEdit1">
-       </widget>
-      </item>
-      <item row="0" column="2">
-       <widget class="QComboBox" name="fontFamily">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="toolTip">
-         <string>Font family to be used for selected code type</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QLabel" name="TextLabel4">
-        <property name="text">
-         <string>Size:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>Color:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0" rowspan="7">
-       <widget class="QTreeWidget" name="displayItems">
-        <property name="toolTip">
-         <string>Color and font settings will be applied to selected type</string>
-        </property>
-        <property name="rootIsDecorated">
-         <bool>false</bool>
-        </property>
-        <column>
-         <property name="text">
-          <string notr="true">1</string>
-         </property>
-        </column>
-       </widget>
-      </item>
-      <item row="1" column="2">
-       <widget class="Gui::PrefSpinBox" name="fontSize">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="toolTip">
-         <string>Font size to be used for selected code type</string>
-        </property>
-        <property name="minimum">
-         <number>1</number>
-        </property>
-        <property name="value">
-         <number>10</number>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>FontSize</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Editor</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QLabel" name="TextLabel3">
-        <property name="text">
-         <string>Family:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="2">
-       <widget class="Gui::ColorButton" name="colorButton">
-        <property name="minimumSize">
-         <size>
-          <width>140</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="focusPolicy">
-         <enum>Qt::TabFocus</enum>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
    <item row="0" column="0">
     <widget class="QGroupBox" name="GroupBox2">
      <property name="title">
@@ -349,7 +212,144 @@
      </layout>
     </widget>
    </item>
-  </layout>
+  <item row="1" column="0" colspan="2">
+    <widget class="QGroupBox" name="GroupBox5">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="title">
+      <string>Display items</string>
+     </property>
+     <layout class="QGridLayout">
+      <property name="leftMargin">
+       <number>9</number>
+      </property>
+      <property name="topMargin">
+       <number>9</number>
+      </property>
+      <property name="rightMargin">
+       <number>9</number>
+      </property>
+      <property name="bottomMargin">
+       <number>9</number>
+      </property>
+      <property name="spacing">
+       <number>6</number>
+      </property>
+      <item row="3" column="1">
+       <widget class="QLabel" name="label">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Preview:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1" rowspan="3" colspan="2">
+       <widget class="QTextEdit" name="textEdit1">
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <widget class="QComboBox" name="fontFamily">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="toolTip">
+         <string>Font family to be used for selected code type</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLabel" name="TextLabel4">
+        <property name="text">
+         <string>Size:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>Color:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0" rowspan="7">
+       <widget class="QTreeWidget" name="displayItems">
+        <property name="toolTip">
+         <string>Color and font settings will be applied to selected type</string>
+        </property>
+        <property name="rootIsDecorated">
+         <bool>false</bool>
+        </property>
+        <column>
+         <property name="text">
+          <string notr="true">1</string>
+         </property>
+        </column>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="Gui::PrefSpinBox" name="fontSize">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="toolTip">
+         <string>Font size to be used for selected code type</string>
+        </property>
+        <property name="minimum">
+         <number>1</number>
+        </property>
+        <property name="value">
+         <number>10</number>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>FontSize</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Editor</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLabel" name="TextLabel3">
+        <property name="text">
+         <string>Family:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="2">
+       <widget class="Gui::ColorButton" name="colorButton">
+        <property name="minimumSize">
+         <size>
+          <width>140</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="focusPolicy">
+         <enum>Qt::TabFocus</enum>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>

--- a/src/Gui/DlgExpressionInput.ui
+++ b/src/Gui/DlgExpressionInput.ui
@@ -35,7 +35,7 @@
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item>
-      <widget class="QWidget" name="widget" native="true">
+      <widget class="QWidget" name="widget">
        <layout class="QVBoxLayout" name="verticalLayout_2">
         <property name="spacing">
          <number>0</number>

--- a/src/Gui/DlgKeyboard.ui
+++ b/src/Gui/DlgKeyboard.ui
@@ -20,46 +20,6 @@
    <property name="spacing">
     <number>6</number>
    </property>
-   <item row="1" column="0" colspan="4">
-    <layout class="QVBoxLayout">
-     <property name="spacing">
-      <number>6</number>
-     </property>
-     <property name="margin">
-      <number>0</number>
-     </property>
-     <item>
-      <widget class="QLabel" name="textLabelDescriptionHeader">
-       <property name="text">
-        <string>Description:</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="textLabelDescription">
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="0" column="2">
-    <spacer>
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Preferred</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>40</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
    <item row="0" column="0">
     <layout class="QVBoxLayout">
      <property name="spacing">
@@ -176,6 +136,22 @@
      </item>
     </layout>
    </item>
+   <item row="0" column="2">
+    <spacer>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Preferred</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
    <item row="0" column="3">
     <layout class="QVBoxLayout">
      <property name="spacing">
@@ -239,7 +215,31 @@
      </item>
     </layout>
    </item>
-  </layout>
+  <item row="1" column="0" colspan="4">
+    <layout class="QVBoxLayout">
+     <property name="spacing">
+      <number>6</number>
+     </property>
+     <property name="margin">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QLabel" name="textLabelDescriptionHeader">
+       <property name="text">
+        <string>Description:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="textLabelDescription">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>

--- a/src/Gui/DlgOnlineHelp.ui
+++ b/src/Gui/DlgOnlineHelp.ui
@@ -20,22 +20,6 @@
    <property name="spacing">
     <number>6</number>
    </property>
-   <item row="1" column="0">
-    <spacer>
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Expanding</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>373</width>
-       <height>291</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
    <item row="0" column="0">
     <widget class="QGroupBox" name="GroupBoxOther">
      <property name="title">
@@ -68,7 +52,23 @@
      </layout>
     </widget>
    </item>
-  </layout>
+  <item row="1" column="0">
+    <spacer>
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Expanding</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>373</width>
+       <height>291</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>

--- a/src/Gui/DlgParameter.ui
+++ b/src/Gui/DlgParameter.ui
@@ -29,6 +29,16 @@
    <property name="spacing">
     <number>6</number>
    </property>
+   <item row="0" column="0">
+    <widget class="QComboBox" name="parameterSet"/>
+   </item>
+  <item row="1" column="0">
+    <widget class="QSplitter" name="splitter3">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
    <item row="2" column="0">
     <layout class="QHBoxLayout">
      <property name="margin">
@@ -127,17 +137,7 @@
      </item>
     </layout>
    </item>
-   <item row="1" column="0">
-    <widget class="QSplitter" name="splitter3">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0">
-    <widget class="QComboBox" name="parameterSet"/>
-   </item>
-  </layout>
+   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
  <resources/>

--- a/src/Gui/DlgPropertyLink.ui
+++ b/src/Gui/DlgPropertyLink.ui
@@ -14,52 +14,6 @@
    <string>Link</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="6" column="0">
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QLabel" name="label">
-       <property name="text">
-        <string>Search</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="Gui::ExpressionLineEdit" name="searchBox">
-       <property name="toolTip">
-        <string>A search pattern to filter the results above</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="5" column="0">
-    <widget class="QTreeWidget" name="typeTree">
-     <property name="selectionMode">
-      <enum>QAbstractItemView::ExtendedSelection</enum>
-     </property>
-     <property name="rootIsDecorated">
-      <bool>false</bool>
-     </property>
-     <property name="sortingEnabled">
-      <bool>true</bool>
-     </property>
-     <attribute name="headerVisible">
-      <bool>false</bool>
-     </attribute>
-     <column>
-      <property name="text">
-       <string notr="true">1</string>
-      </property>
-     </column>
-    </widget>
-   </item>
-   <item row="10" column="0">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
-   </item>
    <item row="0" column="0">
     <widget class="QTreeWidget" name="treeWidget">
      <property name="editTriggers">
@@ -105,7 +59,53 @@
      </item>
     </layout>
    </item>
-  </layout>
+  <item row="5" column="0">
+    <widget class="QTreeWidget" name="typeTree">
+     <property name="selectionMode">
+      <enum>QAbstractItemView::ExtendedSelection</enum>
+     </property>
+     <property name="rootIsDecorated">
+      <bool>false</bool>
+     </property>
+     <property name="sortingEnabled">
+      <bool>true</bool>
+     </property>
+     <attribute name="headerVisible">
+      <bool>false</bool>
+     </attribute>
+     <column>
+      <property name="text">
+       <string notr="true">1</string>
+      </property>
+     </column>
+    </widget>
+   </item>
+   <item row="6" column="0">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Search</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="Gui::ExpressionLineEdit" name="searchBox">
+       <property name="toolTip">
+        <string>A search pattern to filter the results above</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="10" column="0">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   </layout>
  </widget>
  <customwidgets>
   <customwidget>

--- a/src/Gui/DlgRunExternal.ui
+++ b/src/Gui/DlgRunExternal.ui
@@ -62,7 +62,7 @@
     </layout>
    </item>
    <item row="1" column="0">
-    <widget class="QWidget" name="extensionWidget" native="true">
+    <widget class="QWidget" name="extensionWidget">
      <layout class="QVBoxLayout" name="verticalLayout">
       <property name="spacing">
        <number>6</number>

--- a/src/Gui/DlgSettings3DView.ui
+++ b/src/Gui/DlgSettings3DView.ui
@@ -536,7 +536,23 @@ bounding box size of the 3D object that is currently displayed.</string>
       <property name="spacing">
        <number>6</number>
       </property>
-      <item row="0" column="1">
+      <item row="0" column="0">
+       <widget class="Gui::PrefRadioButton" name="radioPerspective">
+        <property name="toolTip">
+         <string>Objects will appear in a perspective projection</string>
+        </property>
+        <property name="text">
+         <string>Perspective renderin&amp;g</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>Perspective</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>View</cstring>
+        </property>
+       </widget>
+      </item>
+     <item row="0" column="1">
        <widget class="Gui::PrefRadioButton" name="radioOrthographic">
         <property name="toolTip">
          <string>Objects will be projected in orthographic projection</string>
@@ -555,23 +571,7 @@ bounding box size of the 3D object that is currently displayed.</string>
         </property>
        </widget>
       </item>
-      <item row="0" column="0">
-       <widget class="Gui::PrefRadioButton" name="radioPerspective">
-        <property name="toolTip">
-         <string>Objects will appear in a perspective projection</string>
-        </property>
-        <property name="text">
-         <string>Perspective renderin&amp;g</string>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>Perspective</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>View</cstring>
-        </property>
-       </widget>
-      </item>
-     </layout>
+      </layout>
     </widget>
    </item>
    <item>

--- a/src/Gui/DlgSettingsLazyLoaded.ui
+++ b/src/Gui/DlgSettingsLazyLoaded.ui
@@ -14,6 +14,50 @@
    <string>Unloaded Workbenches</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_3">
+   <item row="0" column="0">
+    <widget class="QLabel" name="noteLabel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>50</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;To preserve resources, FreeCAD does not load workbenches until they are used. Loading them may provide access to additional preferences related to their functionality.&lt;/p&gt;&lt;p&gt;The following workbenches are available in your installation, but are not yet loaded:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QListWidget" name="workbenchList">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>150</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Available unloaded workbenches&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="selectionMode">
+      <enum>QAbstractItemView::ExtendedSelection</enum>
+     </property>
+    </widget>
+   </item>
    <item row="2" column="0">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
@@ -40,50 +84,6 @@
       </widget>
      </item>
     </layout>
-   </item>
-   <item row="1" column="0">
-    <widget class="QListWidget" name="workbenchList">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>150</height>
-      </size>
-     </property>
-     <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Available unloaded workbenches&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="selectionMode">
-      <enum>QAbstractItemView::ExtendedSelection</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="noteLabel">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>50</height>
-      </size>
-     </property>
-     <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;To preserve resources, FreeCAD does not load workbenches until they are used. Loading them may provide access to additional preferences related to their functionality.&lt;/p&gt;&lt;p&gt;The following workbenches are available in your installation, but are not yet loaded:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="wordWrap">
-      <bool>true</bool>
-     </property>
-    </widget>
    </item>
    <item row="3" column="0">
     <spacer>

--- a/src/Gui/DlgSettingsUnits.ui
+++ b/src/Gui/DlgSettingsUnits.ui
@@ -20,18 +20,23 @@
       <string>Units settings</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
-      <item row="4" column="0">
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>79</height>
-         </size>
-        </property>
-       </spacer>
+      <item row="0" column="0">
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>Unit system:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QComboBox" name="comboBox_ViewSystem">
+          <property name="toolTip">
+           <string>Unit system that should be used for all parts the application</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
       <item row="1" column="0">
        <layout class="QHBoxLayout" name="horizontalLayout_2">
@@ -56,47 +61,6 @@
          </widget>
         </item>
        </layout>
-      </item>
-      <item row="0" column="0">
-       <layout class="QHBoxLayout" name="horizontalLayout">
-        <item>
-         <widget class="QLabel" name="label">
-          <property name="text">
-           <string>Unit system:</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QComboBox" name="comboBox_ViewSystem">
-          <property name="toolTip">
-           <string>Unit system that should be used for all parts the application</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item row="3" column="0">
-       <widget class="QTableWidget" name="tableWidget">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="editTriggers">
-         <set>QAbstractItemView::NoEditTriggers</set>
-        </property>
-        <column>
-         <property name="text">
-          <string>Magnitude</string>
-         </property>
-        </column>
-        <column>
-         <property name="text">
-          <string>Unit</string>
-         </property>
-        </column>
-       </widget>
       </item>
       <item row="2" column="0">
        <layout class="QHBoxLayout" name="horizontalLayout_3">
@@ -151,7 +115,43 @@
         </item>
        </layout>
       </item>
-     </layout>
+     <item row="3" column="0">
+       <widget class="QTableWidget" name="tableWidget">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="editTriggers">
+         <set>QAbstractItemView::NoEditTriggers</set>
+        </property>
+        <column>
+         <property name="text">
+          <string>Magnitude</string>
+         </property>
+        </column>
+        <column>
+         <property name="text">
+          <string>Unit</string>
+         </property>
+        </column>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <spacer name="verticalSpacer">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>79</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      </layout>
     </widget>
    </item>
   </layout>

--- a/src/Gui/DlgToolbars.ui
+++ b/src/Gui/DlgToolbars.ui
@@ -23,154 +23,6 @@
    <property name="spacing">
     <number>6</number>
    </property>
-   <item row="6" column="0" colspan="4">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>&lt;html&gt;&lt;head&gt;&lt;meta name="qrichtext" content="1" /&gt;&lt;/head&gt;&lt;body style=" white-space: pre-wrap; font-family:MS Shell Dlg 2; font-size:7.8pt; font-weight:400; font-style:normal; text-decoration:none;"&gt;&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:8pt;"&gt;&lt;span style=" font-weight:600;"&gt;Note:&lt;/span&gt; The changes become active the next time you load the appropriate workbench&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="QPushButton" name="moveActionRightButton">
-     <property name="enabled">
-      <bool>true</bool>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>30</width>
-       <height>30</height>
-      </size>
-     </property>
-     <property name="toolTip">
-      <string>Move right</string>
-     </property>
-     <property name="whatsThis">
-      <string>&lt;b&gt;Move the selected item one level down.&lt;/b&gt;&lt;p&gt;This will also change the level of the parent item.&lt;/p&gt;</string>
-     </property>
-     <property name="text">
-      <string/>
-     </property>
-     <property name="icon">
-      <iconset resource="Icons/resource.qrc">:/icons/button_right.svg</iconset>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="1">
-    <spacer>
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Expanding</enum>
-     </property>
-     <property name="sizeHint">
-      <size>
-       <width>33</width>
-       <height>57</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="0" column="1">
-    <spacer>
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Expanding</enum>
-     </property>
-     <property name="sizeHint">
-      <size>
-       <width>33</width>
-       <height>58</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="2" column="1">
-    <widget class="QPushButton" name="moveActionLeftButton">
-     <property name="enabled">
-      <bool>true</bool>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>30</width>
-       <height>30</height>
-      </size>
-     </property>
-     <property name="toolTip">
-      <string>Move left</string>
-     </property>
-     <property name="whatsThis">
-      <string>&lt;b&gt;Move the selected item one level up.&lt;/b&gt;&lt;p&gt;This will also change the level of the parent item.&lt;/p&gt;</string>
-     </property>
-     <property name="text">
-      <string/>
-     </property>
-     <property name="icon">
-      <iconset resource="Icons/resource.qrc">:/icons/button_left.svg</iconset>
-     </property>
-     <property name="autoDefault">
-      <bool>true</bool>
-     </property>
-     <property name="default">
-      <bool>false</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="1">
-    <widget class="QPushButton" name="moveActionDownButton">
-     <property name="enabled">
-      <bool>true</bool>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>30</width>
-       <height>30</height>
-      </size>
-     </property>
-     <property name="toolTip">
-      <string>Move down</string>
-     </property>
-     <property name="whatsThis">
-      <string>&lt;b&gt;Move the selected item down.&lt;/b&gt;&lt;p&gt;The item will be moved within the hierarchy level.&lt;/p&gt;</string>
-     </property>
-     <property name="text">
-      <string/>
-     </property>
-     <property name="icon">
-      <iconset resource="Icons/resource.qrc">:/icons/button_down.svg</iconset>
-     </property>
-     <property name="autoDefault">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="1">
-    <widget class="QPushButton" name="moveActionUpButton">
-     <property name="enabled">
-      <bool>true</bool>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>30</width>
-       <height>30</height>
-      </size>
-     </property>
-     <property name="toolTip">
-      <string>Move up</string>
-     </property>
-     <property name="whatsThis">
-      <string>&lt;b&gt;Move the selected item up.&lt;/b&gt;&lt;p&gt;The item will be moved within the hierarchy level.&lt;/p&gt;</string>
-     </property>
-     <property name="text">
-      <string/>
-     </property>
-     <property name="icon">
-      <iconset resource="Icons/resource.qrc">:/icons/button_up.svg</iconset>
-     </property>
-    </widget>
-   </item>
    <item rowspan="6" row="0" column="0">
     <layout class="QVBoxLayout">
      <property name="margin">
@@ -190,6 +42,22 @@
       </widget>
      </item>
     </layout>
+   </item>
+   <item row="0" column="1">
+    <spacer>
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Expanding</enum>
+     </property>
+     <property name="sizeHint">
+      <size>
+       <width>33</width>
+       <height>58</height>
+      </size>
+     </property>
+    </spacer>
    </item>
    <item rowspan="6" row="0" column="2">
     <layout class="QVBoxLayout">
@@ -271,7 +139,139 @@
      </item>
     </layout>
    </item>
-  </layout>
+  <item row="1" column="1">
+    <widget class="QPushButton" name="moveActionRightButton">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>30</width>
+       <height>30</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string>Move right</string>
+     </property>
+     <property name="whatsThis">
+      <string>&lt;b&gt;Move the selected item one level down.&lt;/b&gt;&lt;p&gt;This will also change the level of the parent item.&lt;/p&gt;</string>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="icon">
+      <iconset resource="Icons/resource.qrc">:/icons/button_right.svg</iconset>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QPushButton" name="moveActionLeftButton">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>30</width>
+       <height>30</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string>Move left</string>
+     </property>
+     <property name="whatsThis">
+      <string>&lt;b&gt;Move the selected item one level up.&lt;/b&gt;&lt;p&gt;This will also change the level of the parent item.&lt;/p&gt;</string>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="icon">
+      <iconset resource="Icons/resource.qrc">:/icons/button_left.svg</iconset>
+     </property>
+     <property name="autoDefault">
+      <bool>true</bool>
+     </property>
+     <property name="default">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="QPushButton" name="moveActionUpButton">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>30</width>
+       <height>30</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string>Move up</string>
+     </property>
+     <property name="whatsThis">
+      <string>&lt;b&gt;Move the selected item up.&lt;/b&gt;&lt;p&gt;The item will be moved within the hierarchy level.&lt;/p&gt;</string>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="icon">
+      <iconset resource="Icons/resource.qrc">:/icons/button_up.svg</iconset>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="QPushButton" name="moveActionDownButton">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>30</width>
+       <height>30</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string>Move down</string>
+     </property>
+     <property name="whatsThis">
+      <string>&lt;b&gt;Move the selected item down.&lt;/b&gt;&lt;p&gt;The item will be moved within the hierarchy level.&lt;/p&gt;</string>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="icon">
+      <iconset resource="Icons/resource.qrc">:/icons/button_down.svg</iconset>
+     </property>
+     <property name="autoDefault">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="1">
+    <spacer>
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Expanding</enum>
+     </property>
+     <property name="sizeHint">
+      <size>
+       <width>33</width>
+       <height>57</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="6" column="0" colspan="4">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>&lt;html&gt;&lt;head&gt;&lt;meta name="qrichtext" content="1" /&gt;&lt;/head&gt;&lt;body style=" white-space: pre-wrap; font-family:MS Shell Dlg 2; font-size:7.8pt; font-weight:400; font-style:normal; text-decoration:none;"&gt;&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:8pt;"&gt;&lt;span style=" font-weight:600;"&gt;Note:&lt;/span&gt; The changes become active the next time you load the appropriate workbench&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+    </widget>
+   </item>
+   </layout>
  </widget>
  <pixmapfunction/>
  <resources>

--- a/src/Gui/DlgWorkbenches.ui
+++ b/src/Gui/DlgWorkbenches.ui
@@ -20,42 +20,6 @@
    <property name="spacing">
     <number>6</number>
    </property>
-   <item row="2" column="2" rowspan="8">
-    <layout class="QVBoxLayout">
-     <property name="spacing">
-      <number>6</number>
-     </property>
-     <property name="margin">
-      <number>0</number>
-     </property>
-     <item>
-      <widget class="QLabel" name="lb_enabled">
-       <property name="text">
-        <string>Enabled workbenches</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QListWidgetCustom" name="lw_enabled_workbenches"/>
-     </item>
-    </layout>
-   </item>
-   <item row="6" column="3" rowspan="4">
-    <spacer name="sp_right">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Expanding</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>33</width>
-       <height>57</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
    <item row="2" column="0" rowspan="8">
     <layout class="QVBoxLayout">
      <property name="spacing">
@@ -76,24 +40,28 @@
      </item>
     </layout>
    </item>
-   <item row="6" column="1" rowspan="4">
-    <spacer name="sp_left">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
+   <item row="2" column="2" rowspan="8">
+    <layout class="QVBoxLayout">
+     <property name="spacing">
+      <number>6</number>
      </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Expanding</enum>
+     <property name="margin">
+      <number>0</number>
      </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>33</width>
-       <height>57</height>
-      </size>
-     </property>
-    </spacer>
+     <item>
+      <widget class="QLabel" name="lb_enabled">
+       <property name="text">
+        <string>Enabled workbenches</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QListWidgetCustom" name="lw_enabled_workbenches"/>
+     </item>
+    </layout>
    </item>
-   <item row="5" column="3">
-    <widget class="QPushButton" name="shift_workbench_down_btn">
+   <item row="3" column="1">
+    <widget class="QPushButton" name="add_to_enabled_workbenches_btn">
      <property name="enabled">
       <bool>true</bool>
      </property>
@@ -104,17 +72,101 @@
       </size>
      </property>
      <property name="toolTip">
-      <string>Move down</string>
+      <string>Move right</string>
      </property>
      <property name="whatsThis">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=" font-weight:600;"&gt;Move the selected item down.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;The item will be moved down&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=" font-weight:600;"&gt;Move the selected workbench to enabled workbenches.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="text">
       <string/>
      </property>
      <property name="icon">
       <iconset resource="Icons/resource.qrc">
-       <normaloff>:/icons/button_down.svg</normaloff>:/icons/button_down.svg</iconset>
+       <normaloff>:/icons/button_right.svg</normaloff>:/icons/button_right.svg</iconset>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="3">
+    <widget class="QPushButton" name="shift_workbench_up_btn">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>30</width>
+       <height>30</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string>Move up</string>
+     </property>
+     <property name="whatsThis">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=" font-weight:600;"&gt;Move the selected item up.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;The item will be moved up.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="icon">
+      <iconset resource="Icons/resource.qrc">
+       <normaloff>:/icons/button_up.svg</normaloff>:/icons/button_up.svg</iconset>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="QPushButton" name="add_all_to_enabled_workbenches_btn">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>30</width>
+       <height>30</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string>Add all to enabled workbenches</string>
+     </property>
+     <property name="whatsThis">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=" font-weight:600;"&gt;Remove the selected workbench from enabled workbenches&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="icon">
+      <iconset resource="Icons/resource.qrc">
+       <normaloff>:/icons/button_add_all.svg</normaloff>:/icons/button_add_all.svg</iconset>
+     </property>
+     <property name="autoDefault">
+      <bool>true</bool>
+     </property>
+     <property name="default">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+  <item row="4" column="3">
+    <widget class="QPushButton" name="sort_enabled_workbenches_btn">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>30</width>
+       <height>30</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string>Sort enabled workbenches</string>
+     </property>
+     <property name="whatsThis">
+      <string>&lt;p&gt;Sort enabled workbenches&lt;/p&gt;</string>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="icon">
+      <iconset resource="Icons/resource.qrc">
+       <normaloff>:/icons/button_sort.svg</normaloff>:/icons/button_sort.svg</iconset>
      </property>
      <property name="autoDefault">
       <bool>true</bool>
@@ -153,8 +205,8 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="1">
-    <widget class="QPushButton" name="add_to_enabled_workbenches_btn">
+   <item row="5" column="3">
+    <widget class="QPushButton" name="shift_workbench_down_btn">
      <property name="enabled">
       <bool>true</bool>
      </property>
@@ -165,74 +217,54 @@
       </size>
      </property>
      <property name="toolTip">
-      <string>Move right</string>
+      <string>Move down</string>
      </property>
      <property name="whatsThis">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=" font-weight:600;"&gt;Move the selected workbench to enabled workbenches.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=" font-weight:600;"&gt;Move the selected item down.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;The item will be moved down&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="text">
       <string/>
      </property>
      <property name="icon">
       <iconset resource="Icons/resource.qrc">
-       <normaloff>:/icons/button_right.svg</normaloff>:/icons/button_right.svg</iconset>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="3">
-    <widget class="QPushButton" name="sort_enabled_workbenches_btn">
-     <property name="enabled">
-      <bool>true</bool>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>30</width>
-       <height>30</height>
-      </size>
-     </property>
-     <property name="toolTip">
-      <string>Sort enabled workbenches</string>
-     </property>
-     <property name="whatsThis">
-      <string>&lt;p&gt;Sort enabled workbenches&lt;/p&gt;</string>
-     </property>
-     <property name="text">
-      <string/>
-     </property>
-     <property name="icon">
-      <iconset resource="Icons/resource.qrc">
-       <normaloff>:/icons/button_sort.svg</normaloff>:/icons/button_sort.svg</iconset>
+       <normaloff>:/icons/button_down.svg</normaloff>:/icons/button_down.svg</iconset>
      </property>
      <property name="autoDefault">
       <bool>true</bool>
      </property>
     </widget>
    </item>
-   <item row="3" column="3">
-    <widget class="QPushButton" name="shift_workbench_up_btn">
-     <property name="enabled">
-      <bool>true</bool>
+   <item row="6" column="1" rowspan="4">
+    <spacer name="sp_left">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
      </property>
-     <property name="minimumSize">
+     <property name="sizeType">
+      <enum>QSizePolicy::Expanding</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
       <size>
-       <width>30</width>
-       <height>30</height>
+       <width>33</width>
+       <height>57</height>
       </size>
      </property>
-     <property name="toolTip">
-      <string>Move up</string>
+    </spacer>
+   </item>
+   <item row="6" column="3" rowspan="4">
+    <spacer name="sp_right">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
      </property>
-     <property name="whatsThis">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=" font-weight:600;"&gt;Move the selected item up.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;The item will be moved up.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     <property name="sizeType">
+      <enum>QSizePolicy::Expanding</enum>
      </property>
-     <property name="text">
-      <string/>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>33</width>
+       <height>57</height>
+      </size>
      </property>
-     <property name="icon">
-      <iconset resource="Icons/resource.qrc">
-       <normaloff>:/icons/button_up.svg</normaloff>:/icons/button_up.svg</iconset>
-     </property>
-    </widget>
+    </spacer>
    </item>
    <item row="10" column="0" colspan="4">
     <widget class="QLabel" name="label">
@@ -241,39 +273,7 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="1">
-    <widget class="QPushButton" name="add_all_to_enabled_workbenches_btn">
-     <property name="enabled">
-      <bool>true</bool>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>30</width>
-       <height>30</height>
-      </size>
-     </property>
-     <property name="toolTip">
-      <string>Add all to enabled workbenches</string>
-     </property>
-     <property name="whatsThis">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=" font-weight:600;"&gt;Remove the selected workbench from enabled workbenches&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="text">
-      <string/>
-     </property>
-     <property name="icon">
-      <iconset resource="Icons/resource.qrc">
-       <normaloff>:/icons/button_add_all.svg</normaloff>:/icons/button_add_all.svg</iconset>
-     </property>
-     <property name="autoDefault">
-      <bool>true</bool>
-     </property>
-     <property name="default">
-      <bool>false</bool>
-     </property>
-    </widget>
-   </item>
-  </layout>
+   </layout>
  </widget>
  <customwidgets>
   <customwidget>

--- a/src/Gui/TaskElementColors.ui
+++ b/src/Gui/TaskElementColors.ui
@@ -32,13 +32,6 @@
      </item>
     </layout>
    </item>
-   <item row="4" column="0">
-    <widget class="QCheckBox" name="recompute">
-     <property name="text">
-      <string>Recompute after commit</string>
-     </property>
-    </widget>
-   </item>
    <item row="3" column="0">
     <layout class="QGridLayout" name="gridLayout_6">
      <item row="0" column="2">
@@ -77,6 +70,13 @@
       </widget>
      </item>
     </layout>
+   </item>
+   <item row="4" column="0">
+    <widget class="QCheckBox" name="recompute">
+     <property name="text">
+      <string>Recompute after commit</string>
+     </property>
+    </widget>
    </item>
    <item row="5" column="0">
     <widget class="QCheckBox" name="onTop">

--- a/src/Mod/Arch/Resources/ui/ArchNest.ui
+++ b/src/Mod/Arch/Resources/ui/ArchNest.ui
@@ -76,24 +76,10 @@
       <string>Nesting parameters</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_3">
-        <property name="text">
-         <string>Rotations</string>
-        </property>
-       </widget>
-      </item>
       <item row="0" column="0">
        <widget class="QLabel" name="label">
         <property name="text">
          <string>Tolerance</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>Arcs subdivisions</string>
         </property>
        </widget>
       </item>
@@ -110,6 +96,13 @@
         </property>
        </widget>
       </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>Arcs subdivisions</string>
+        </property>
+       </widget>
+      </item>
       <item row="1" column="1">
        <widget class="QSpinBox" name="Subdivisions">
         <property name="toolTip">
@@ -123,6 +116,13 @@
         </property>
         <property name="value">
          <number>4</number>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_3">
+        <property name="text">
+         <string>Rotations</string>
         </property>
        </widget>
       </item>

--- a/src/Mod/Arch/Resources/ui/ArchSchedule.ui
+++ b/src/Mod/Arch/Resources/ui/ArchSchedule.ui
@@ -129,21 +129,6 @@ Leave blank to use all objects from the document</string>
    </item>
    <item>
     <layout class="QGridLayout" name="gridLayout">
-     <item row="0" column="1">
-      <widget class="QPushButton" name="buttonDel">
-       <property name="toolTip">
-        <string>Deletes the selected line</string>
-       </property>
-       <property name="text">
-        <string>Del row</string>
-       </property>
-       <property name="icon">
-        <iconset theme="remove">
-         <normaloff/>
-        </iconset>
-       </property>
-      </widget>
-     </item>
      <item row="0" column="0">
       <widget class="QPushButton" name="buttonAdd">
        <property name="toolTip">
@@ -154,6 +139,21 @@ Leave blank to use all objects from the document</string>
        </property>
        <property name="icon">
         <iconset theme="add">
+         <normaloff/>
+        </iconset>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QPushButton" name="buttonDel">
+       <property name="toolTip">
+        <string>Deletes the selected line</string>
+       </property>
+       <property name="text">
+        <string>Del row</string>
+       </property>
+       <property name="icon">
+        <iconset theme="remove">
          <normaloff/>
         </iconset>
        </property>

--- a/src/Mod/Arch/Resources/ui/DialogIfcProperties.ui
+++ b/src/Mod/Arch/Resources/ui/DialogIfcProperties.ui
@@ -47,13 +47,13 @@
    </item>
    <item>
     <layout class="QGridLayout" name="gridLayout">
-     <item row="1" column="0">
-      <widget class="QComboBox" name="comboProperty"/>
-     </item>
      <item row="0" column="0">
       <widget class="QComboBox" name="comboPset"/>
      </item>
-    </layout>
+    <item row="1" column="0">
+      <widget class="QComboBox" name="comboProperty"/>
+     </item>
+     </layout>
    </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">

--- a/src/Mod/Assembly/Gui/TaskAssemblyConstraints.ui
+++ b/src/Mod/Assembly/Gui/TaskAssemblyConstraints.ui
@@ -101,88 +101,6 @@
    <item>
     <widget class="QWidget" name="widget">
      <layout class="QGridLayout" name="gridLayout">
-      <item row="1" column="0" rowspan="2" colspan="2">
-       <widget class="QToolButton" name="angle">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the angle between the geometries normals&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-        <property name="text">
-         <string>Angle</string>
-        </property>
-        <property name="icon">
-         <iconset resource="Resources/Assembly.qrc">
-          <normaloff>:/icons/constraints/Assembly_ConstraintAngle.svg</normaloff>:/icons/constraints/Assembly_ConstraintAngle.svg</iconset>
-        </property>
-        <property name="iconSize">
-         <size>
-          <width>20</width>
-          <height>20</height>
-         </size>
-        </property>
-        <property name="checkable">
-         <bool>true</bool>
-        </property>
-        <property name="autoRepeat">
-         <bool>false</bool>
-        </property>
-        <property name="autoExclusive">
-         <bool>true</bool>
-        </property>
-        <property name="toolButtonStyle">
-         <enum>Qt::ToolButtonTextBesideIcon</enum>
-        </property>
-        <property name="autoRaise">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="5">
-       <widget class="QToolButton" name="coincident">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Special constraint which is in general used to let the geometries be on each other. Therefore it's often the same as align, with the difference that it is also defined for points, as a point can lie on a plane. Note that this constraint has a special behaviour for cylinders. For example, a cylindrical surface can't be on a plane, only touch it. Therefore this is not valid. Furthermore point and line coincident with cylinders don't work on the cylinder surface, but on its center line. The reason for that it is, that this centerline would not be accessible with other constraints, but the surface coincident can be also achieved with the align constraint and value 0.  At last specialty the cylinder cylinder constraint shall be mentioned: It works also on the cylinder centerlines and therefore makes them concentric. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-        <property name="text">
-         <string>Coincident</string>
-        </property>
-        <property name="icon">
-         <iconset resource="Resources/Assembly.qrc">
-          <normaloff>:/icons/constraints/Assembly_ConstraintCoincidence.svg</normaloff>:/icons/constraints/Assembly_ConstraintCoincidence.svg</iconset>
-        </property>
-        <property name="iconSize">
-         <size>
-          <width>20</width>
-          <height>20</height>
-         </size>
-        </property>
-        <property name="checkable">
-         <bool>true</bool>
-        </property>
-        <property name="autoRepeat">
-         <bool>false</bool>
-        </property>
-        <property name="autoExclusive">
-         <bool>true</bool>
-        </property>
-        <property name="toolButtonStyle">
-         <enum>Qt::ToolButtonTextBesideIcon</enum>
-        </property>
-        <property name="autoRaise">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
       <item row="0" column="0">
        <widget class="QToolButton" name="fix">
         <property name="sizePolicy">
@@ -306,6 +224,47 @@
         </property>
        </widget>
       </item>
+      <item row="1" column="0" rowspan="2" colspan="2">
+       <widget class="QToolButton" name="angle">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the angle between the geometries normals&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>Angle</string>
+        </property>
+        <property name="icon">
+         <iconset resource="Resources/Assembly.qrc">
+          <normaloff>:/icons/constraints/Assembly_ConstraintAngle.svg</normaloff>:/icons/constraints/Assembly_ConstraintAngle.svg</iconset>
+        </property>
+        <property name="iconSize">
+         <size>
+          <width>20</width>
+          <height>20</height>
+         </size>
+        </property>
+        <property name="checkable">
+         <bool>true</bool>
+        </property>
+        <property name="autoRepeat">
+         <bool>false</bool>
+        </property>
+        <property name="autoExclusive">
+         <bool>true</bool>
+        </property>
+        <property name="toolButtonStyle">
+         <enum>Qt::ToolButtonTextBesideIcon</enum>
+        </property>
+        <property name="autoRaise">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
       <item row="1" column="3">
        <widget class="QToolButton" name="align">
         <property name="sizePolicy">
@@ -347,7 +306,48 @@
         </property>
        </widget>
       </item>
-     </layout>
+     <item row="1" column="5">
+       <widget class="QToolButton" name="coincident">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Special constraint which is in general used to let the geometries be on each other. Therefore it's often the same as align, with the difference that it is also defined for points, as a point can lie on a plane. Note that this constraint has a special behaviour for cylinders. For example, a cylindrical surface can't be on a plane, only touch it. Therefore this is not valid. Furthermore point and line coincident with cylinders don't work on the cylinder surface, but on its center line. The reason for that it is, that this centerline would not be accessible with other constraints, but the surface coincident can be also achieved with the align constraint and value 0.  At last specialty the cylinder cylinder constraint shall be mentioned: It works also on the cylinder centerlines and therefore makes them concentric. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>Coincident</string>
+        </property>
+        <property name="icon">
+         <iconset resource="Resources/Assembly.qrc">
+          <normaloff>:/icons/constraints/Assembly_ConstraintCoincidence.svg</normaloff>:/icons/constraints/Assembly_ConstraintCoincidence.svg</iconset>
+        </property>
+        <property name="iconSize">
+         <size>
+          <width>20</width>
+          <height>20</height>
+         </size>
+        </property>
+        <property name="checkable">
+         <bool>true</bool>
+        </property>
+        <property name="autoRepeat">
+         <bool>false</bool>
+        </property>
+        <property name="autoExclusive">
+         <bool>true</bool>
+        </property>
+        <property name="toolButtonStyle">
+         <enum>Qt::ToolButtonTextBesideIcon</enum>
+        </property>
+        <property name="autoRaise">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      </layout>
     </widget>
    </item>
    <item>

--- a/src/Mod/Assembly/Gui/TaskAssemblyConstraints.ui
+++ b/src/Mod/Assembly/Gui/TaskAssemblyConstraints.ui
@@ -99,7 +99,7 @@
     </spacer>
    </item>
    <item>
-    <widget class="QWidget" name="widget" native="true">
+    <widget class="QWidget" name="widget">
      <layout class="QGridLayout" name="gridLayout">
       <item row="1" column="0" rowspan="2" colspan="2">
        <widget class="QToolButton" name="angle">
@@ -393,7 +393,7 @@
     </spacer>
    </item>
    <item>
-    <widget class="QWidget" name="value_widget" native="true">
+    <widget class="QWidget" name="value_widget">
      <layout class="QHBoxLayout" name="horizontalLayout_5">
       <item>
        <widget class="QLabel" name="value_label">
@@ -552,7 +552,7 @@
     </spacer>
    </item>
    <item>
-    <widget class="QWidget" name="orientation_widget" native="true">
+    <widget class="QWidget" name="orientation_widget">
      <layout class="QGridLayout" name="gridLayout_2">
       <item row="0" column="0">
        <widget class="QToolButton" name="parallel">

--- a/src/Mod/Draft/Resources/ui/TaskPanel_SetStyle.ui
+++ b/src/Mod/Draft/Resources/ui/TaskPanel_SetStyle.ui
@@ -23,24 +23,17 @@
       <property name="sizeConstraint">
        <enum>QLayout::SetDefaultConstraint</enum>
       </property>
-      <item row="4" column="1">
-       <widget class="Gui::ColorButton" name="ShapeColor">
-        <property name="toolTip">
-         <string>The color of faces</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_10">
-        <property name="text">
-         <string>Draw style</string>
-        </property>
-       </widget>
-      </item>
       <item row="0" column="0">
        <widget class="QLabel" name="label">
         <property name="text">
          <string>Line color</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="Gui::ColorButton" name="LineColor">
+        <property name="toolTip">
+         <string>The color of lines</string>
         </property>
        </widget>
       </item>
@@ -51,10 +44,17 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="1">
-       <widget class="Gui::ColorButton" name="LineColor">
-        <property name="toolTip">
-         <string>The color of lines</string>
+      <item row="1" column="1">
+       <widget class="QSpinBox" name="LineWidth">
+        <property name="suffix">
+         <string> px</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_10">
+        <property name="text">
+         <string>Draw style</string>
         </property>
        </widget>
       </item>
@@ -83,13 +83,6 @@
           <string>DashDot</string>
          </property>
         </item>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QSpinBox" name="LineWidth">
-        <property name="suffix">
-         <string> px</string>
-        </property>
        </widget>
       </item>
       <item row="3" column="0">
@@ -133,6 +126,13 @@
         </property>
        </widget>
       </item>
+      <item row="4" column="1">
+       <widget class="Gui::ColorButton" name="ShapeColor">
+        <property name="toolTip">
+         <string>The color of faces</string>
+        </property>
+       </widget>
+      </item>
       <item row="5" column="0">
        <widget class="QLabel" name="label_12">
         <property name="text">
@@ -162,6 +162,64 @@
       <string>Annotations</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_3" columnstretch="1,0" columnminimumwidth="0,120">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_4">
+        <property name="text">
+         <string>Text font</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QFontComboBox" name="TextFont">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="toolTip">
+         <string>The font to use for texts and dimensions</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_5">
+        <property name="text">
+         <string>Text size</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="Gui::InputField" name="TextSize">
+        <property name="toolTip">
+         <string>The size of texts and dimension texts</string>
+        </property>
+        <property name="unit" stdset="0">
+         <string notr="true"/>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_7">
+        <property name="text">
+         <string>Text color</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="Gui::ColorButton" name="TextColor">
+        <property name="toolTip">
+         <string>The color of texts and dimension texts</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="label_6">
+        <property name="text">
+         <string>Arrow style</string>
+        </property>
+       </widget>
+      </item>
       <item row="3" column="1">
        <widget class="QComboBox" name="ArrowStyle">
         <property name="toolTip">
@@ -194,74 +252,10 @@
         </item>
        </widget>
       </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_4">
+      <item row="4" column="0">
+       <widget class="QLabel" name="label_8">
         <property name="text">
-         <string>Text font</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_7">
-        <property name="text">
-         <string>Text color</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QFontComboBox" name="TextFont">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="toolTip">
-         <string>The font to use for texts and dimensions</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_5">
-        <property name="text">
-         <string>Text size</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="Gui::ColorButton" name="TextColor">
-        <property name="toolTip">
-         <string>The color of texts and dimension texts</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="Gui::InputField" name="TextSize">
-        <property name="toolTip">
-         <string>The size of texts and dimension texts</string>
-        </property>
-        <property name="unit" stdset="0">
-         <string notr="true"/>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="label_6">
-        <property name="text">
-         <string>Arrow style</string>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="1">
-       <widget class="QCheckBox" name="ShowUnit">
-        <property name="toolTip">
-         <string>If the unit suffix is shown on dimension texts or not</string>
-        </property>
-        <property name="layoutDirection">
-         <enum>Qt::RightToLeft</enum>
-        </property>
-        <property name="text">
-         <string/>
+         <string>Arrow size</string>
         </property>
        </widget>
       </item>
@@ -282,10 +276,16 @@
         </property>
        </widget>
       </item>
-      <item row="4" column="0">
-       <widget class="QLabel" name="label_8">
+      <item row="5" column="1">
+       <widget class="QCheckBox" name="ShowUnit">
+        <property name="toolTip">
+         <string>If the unit suffix is shown on dimension texts or not</string>
+        </property>
+        <property name="layoutDirection">
+         <enum>Qt::RightToLeft</enum>
+        </property>
         <property name="text">
-         <string>Arrow size</string>
+         <string/>
         </property>
        </widget>
       </item>

--- a/src/Mod/Draft/Resources/ui/TaskSelectPlane.ui
+++ b/src/Mod/Draft/Resources/ui/TaskSelectPlane.ui
@@ -81,6 +81,13 @@ view each time a command is started</string>
    </item>
    <item>
     <layout class="QGridLayout" name="gridLayout_2">
+     <item row="0" column="0">
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>Offset</string>
+       </property>
+      </widget>
+     </item>
      <item row="0" column="1">
       <widget class="Gui::InputField" name="fieldOffset">
        <property name="toolTip">
@@ -90,13 +97,6 @@ of the buttons above</string>
        </property>
        <property name="unit" stdset="0">
         <string notr="true"/>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="0">
-      <widget class="QLabel" name="label_2">
-       <property name="text">
-        <string>Offset</string>
        </property>
       </widget>
      </item>
@@ -192,27 +192,6 @@ will be moved to the center of the view</string>
        </property>
       </widget>
      </item>
-     <item row="4" column="1">
-      <widget class="QSpinBox" name="fieldSnapRadius">
-       <property name="toolTip">
-        <string>The distance at which a point can be snapped to
-when approaching the mouse. You can also change this
-value by using the [ and ] keys while drawing</string>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="0">
-      <widget class="QLabel" name="label_6">
-       <property name="toolTip">
-        <string>The distance at which a point can be snapped to
-when approaching the mouse. You can also change this
-value by using the [ and ] keys while drawing</string>
-       </property>
-       <property name="text">
-        <string>Snapping radius</string>
-       </property>
-      </widget>
-     </item>
      <item row="3" column="0">
       <widget class="QLabel" name="label_8">
        <property name="text">
@@ -233,7 +212,28 @@ value by using the [ and ] keys while drawing</string>
        </property>
       </widget>
      </item>
-    </layout>
+    <item row="4" column="0">
+      <widget class="QLabel" name="label_6">
+       <property name="toolTip">
+        <string>The distance at which a point can be snapped to
+when approaching the mouse. You can also change this
+value by using the [ and ] keys while drawing</string>
+       </property>
+       <property name="text">
+        <string>Snapping radius</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <widget class="QSpinBox" name="fieldSnapRadius">
+       <property name="toolTip">
+        <string>The distance at which a point can be snapped to
+when approaching the mouse. You can also change this
+value by using the [ and ] keys while drawing</string>
+       </property>
+      </widget>
+     </item>
+     </layout>
    </item>
    <item>
     <widget class="QPushButton" name="buttonCenter">

--- a/src/Mod/Draft/Resources/ui/dialog_AnnotationStyleEditor.ui
+++ b/src/Mod/Draft/Resources/ui/dialog_AnnotationStyleEditor.ui
@@ -164,26 +164,6 @@
           <string>Text</string>
          </property>
          <layout class="QGridLayout" name="gridLayout">
-          <item row="2" column="0">
-           <widget class="QLabel" name="label_2">
-            <property name="toolTip">
-             <string>Font size in the system units</string>
-            </property>
-            <property name="text">
-             <string>Font size</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="0">
-           <widget class="QLabel" name="label_3">
-            <property name="toolTip">
-             <string>Line spacing in system units</string>
-            </property>
-            <property name="text">
-             <string>Line spacing</string>
-            </property>
-           </widget>
-          </item>
           <item row="0" column="0">
            <widget class="QLabel" name="label">
             <property name="toolTip">
@@ -213,6 +193,16 @@
             </property>
            </widget>
           </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_2">
+            <property name="toolTip">
+             <string>Font size in the system units</string>
+            </property>
+            <property name="text">
+             <string>Font size</string>
+            </property>
+           </widget>
+          </item>
           <item row="2" column="1">
            <widget class="Gui::InputField" name="FontSize">
             <property name="toolTip">
@@ -220,6 +210,16 @@
             </property>
             <property name="quantity" stdset="0">
              <double>12.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="label_3">
+            <property name="toolTip">
+             <string>Line spacing in system units</string>
+            </property>
+            <property name="text">
+             <string>Line spacing</string>
             </property>
            </widget>
           </item>
@@ -249,36 +249,6 @@
             </property>
            </widget>
           </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="label_5">
-            <property name="toolTip">
-             <string>The number of decimals to show for dimension values</string>
-            </property>
-            <property name="text">
-             <string>Decimals</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="label_6">
-            <property name="toolTip">
-             <string>Specify a valid length unit like mm, m, in, ft, to force displaying the dimension value in this unit</string>
-            </property>
-            <property name="text">
-             <string>Unit override</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="label_7">
-            <property name="toolTip">
-             <string>If it is checked it will show the unit next to the dimension value</string>
-            </property>
-            <property name="text">
-             <string>Show unit</string>
-            </property>
-           </widget>
-          </item>
           <item row="0" column="1">
            <widget class="QDoubleSpinBox" name="ScaleMultiplier">
             <property name="toolTip">
@@ -292,20 +262,13 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="1">
-           <widget class="QLineEdit" name="UnitOverride">
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_7">
             <property name="toolTip">
-             <string>Specify a valid length unit like mm, m, in, ft, to force displaying the dimension value in this unit</string>
+             <string>If it is checked it will show the unit next to the dimension value</string>
             </property>
-           </widget>
-          </item>
-          <item row="3" column="1">
-           <widget class="QSpinBox" name="Decimals">
-            <property name="toolTip">
-             <string>The number of decimals to show for dimension values</string>
-            </property>
-            <property name="value">
-             <number>2</number>
+            <property name="text">
+             <string>Show unit</string>
             </property>
            </widget>
           </item>
@@ -322,7 +285,44 @@
             </property>
            </widget>
           </item>
-         </layout>
+         <item row="2" column="0">
+           <widget class="QLabel" name="label_6">
+            <property name="toolTip">
+             <string>Specify a valid length unit like mm, m, in, ft, to force displaying the dimension value in this unit</string>
+            </property>
+            <property name="text">
+             <string>Unit override</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QLineEdit" name="UnitOverride">
+            <property name="toolTip">
+             <string>Specify a valid length unit like mm, m, in, ft, to force displaying the dimension value in this unit</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="label_5">
+            <property name="toolTip">
+             <string>The number of decimals to show for dimension values</string>
+            </property>
+            <property name="text">
+             <string>Decimals</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QSpinBox" name="Decimals">
+            <property name="toolTip">
+             <string>The number of decimals to show for dimension values</string>
+            </property>
+            <property name="value">
+             <number>2</number>
+            </property>
+           </widget>
+          </item>
+          </layout>
         </widget>
        </item>
        <item>
@@ -331,36 +331,6 @@
           <string>Line and arrows</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_3">
-          <item row="2" column="0">
-           <widget class="QLabel" name="label_14">
-            <property name="toolTip">
-             <string>The width of the dimension lines</string>
-            </property>
-            <property name="text">
-             <string>Line width</string>
-            </property>
-           </widget>
-          </item>
-          <item row="8" column="0">
-           <widget class="QLabel" name="label_12">
-            <property name="toolTip">
-             <string>The distance that the extension lines are additionally extended beyond the dimension line</string>
-            </property>
-            <property name="text">
-             <string>Extension overshoot</string>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="0">
-           <widget class="QLabel" name="label_8">
-            <property name="toolTip">
-             <string>The size of the dimension arrows or markers in system units</string>
-            </property>
-            <property name="text">
-             <string>Arrow size</string>
-            </property>
-           </widget>
-          </item>
           <item row="0" column="0">
            <widget class="QLabel" name="label_13">
             <property name="toolTip">
@@ -368,46 +338,6 @@
             </property>
             <property name="text">
              <string>Show lines</string>
-            </property>
-           </widget>
-          </item>
-          <item row="6" column="0">
-           <widget class="QLabel" name="label_10">
-            <property name="toolTip">
-             <string>The distance that the dimension line is additionally extended</string>
-            </property>
-            <property name="text">
-             <string>Dimension overshoot</string>
-            </property>
-           </widget>
-          </item>
-          <item row="7" column="0">
-           <widget class="QLabel" name="label_11">
-            <property name="toolTip">
-             <string>The length of the extension lines</string>
-            </property>
-            <property name="text">
-             <string>Extension lines</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="0">
-           <widget class="QLabel" name="label_9">
-            <property name="toolTip">
-             <string>The type of arrows or markers to use at the end of dimension lines</string>
-            </property>
-            <property name="text">
-             <string>Arrow type</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="label_15">
-            <property name="toolTip">
-             <string>The color of dimension lines, arrows and texts</string>
-            </property>
-            <property name="text">
-             <string>Line / text color</string>
             </property>
            </widget>
           </item>
@@ -427,6 +357,16 @@
             </property>
            </widget>
           </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_14">
+            <property name="toolTip">
+             <string>The width of the dimension lines</string>
+            </property>
+            <property name="text">
+             <string>Line width</string>
+            </property>
+           </widget>
+          </item>
           <item row="2" column="1">
            <widget class="QSpinBox" name="LineWidth">
             <property name="toolTip">
@@ -437,6 +377,16 @@
             </property>
             <property name="value">
              <number>1</number>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="label_15">
+            <property name="toolTip">
+             <string>The color of dimension lines, arrows and texts</string>
+            </property>
+            <property name="text">
+             <string>Line / text color</string>
             </property>
            </widget>
           </item>
@@ -451,6 +401,16 @@
               <green>0</green>
               <blue>0</blue>
              </color>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="label_9">
+            <property name="toolTip">
+             <string>The type of arrows or markers to use at the end of dimension lines</string>
+            </property>
+            <property name="text">
+             <string>Arrow type</string>
             </property>
            </widget>
           </item>
@@ -498,6 +458,16 @@
             </item>
            </widget>
           </item>
+          <item row="5" column="0">
+           <widget class="QLabel" name="label_8">
+            <property name="toolTip">
+             <string>The size of the dimension arrows or markers in system units</string>
+            </property>
+            <property name="text">
+             <string>Arrow size</string>
+            </property>
+           </widget>
+          </item>
           <item row="5" column="1">
            <widget class="Gui::InputField" name="ArrowSize">
             <property name="toolTip">
@@ -505,6 +475,16 @@
             </property>
             <property name="quantity" stdset="0">
              <double>5.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="0">
+           <widget class="QLabel" name="label_10">
+            <property name="toolTip">
+             <string>The distance that the dimension line is additionally extended</string>
+            </property>
+            <property name="text">
+             <string>Dimension overshoot</string>
             </property>
            </widget>
           </item>
@@ -518,6 +498,16 @@
             </property>
            </widget>
           </item>
+          <item row="7" column="0">
+           <widget class="QLabel" name="label_11">
+            <property name="toolTip">
+             <string>The length of the extension lines</string>
+            </property>
+            <property name="text">
+             <string>Extension lines</string>
+            </property>
+           </widget>
+          </item>
           <item row="7" column="1">
            <widget class="Gui::InputField" name="ExtensionLines">
             <property name="toolTip">
@@ -525,6 +515,16 @@
             </property>
             <property name="quantity" stdset="0">
              <double>10.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="8" column="0">
+           <widget class="QLabel" name="label_12">
+            <property name="toolTip">
+             <string>The distance that the extension lines are additionally extended beyond the dimension line</string>
+            </property>
+            <property name="text">
+             <string>Extension overshoot</string>
             </property>
            </widget>
           </item>

--- a/src/Mod/Draft/Resources/ui/preferences-draft.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-draft.ui
@@ -241,6 +241,23 @@ This allows to point the direction and type the distance.</string>
           </property>
          </widget>
         </item>
+        <item row="0" column="1">
+         <widget class="Gui::PrefCheckBox" name="gui::prefcheckbox_3">
+          <property name="toolTip">
+           <string>Normally, after copying objects, the copies get selected.
+If this option is checked, the base objects will be selected instead.</string>
+          </property>
+          <property name="text">
+           <string>Select base objects after copying</string>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>selectBaseObjects</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/Draft</cstring>
+          </property>
+         </widget>
+        </item>
         <item row="1" column="0">
          <widget class="Gui::PrefCheckBox" name="checkBox_2">
           <property name="toolTip">
@@ -271,23 +288,6 @@ Otherwise, they will appear as wireframe</string>
           </property>
           <property name="prefEntry" stdset="0">
            <cstring>fillmode</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="Gui::PrefCheckBox" name="gui::prefcheckbox_3">
-          <property name="toolTip">
-           <string>Normally, after copying objects, the copies get selected.
-If this option is checked, the base objects will be selected instead.</string>
-          </property>
-          <property name="text">
-           <string>Select base objects after copying</string>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>selectBaseObjects</cstring>
           </property>
           <property name="prefPath" stdset="0">
            <cstring>Mod/Draft</cstring>

--- a/src/Mod/Draft/Resources/ui/preferences-draftinterface.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-draftinterface.ui
@@ -31,87 +31,6 @@
         <property name="topMargin">
          <number>0</number>
         </property>
-        <item row="4" column="1">
-         <widget class="Gui::PrefLineEdit" name="lineEdit_8">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>25</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>`</string>
-          </property>
-          <property name="maxLength">
-           <number>1</number>
-          </property>
-          <property name="placeholderText">
-           <string/>
-          </property>
-          <property name="clearButtonEnabled" stdset="0">
-           <bool>false</bool>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>inCommandShortcutCycleSnap</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="1">
-         <widget class="Gui::PrefLineEdit" name="lineEdit_9">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>25</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>S</string>
-          </property>
-          <property name="maxLength">
-           <number>1</number>
-          </property>
-          <property name="placeholderText">
-           <string/>
-          </property>
-          <property name="clearButtonEnabled" stdset="0">
-           <bool>false</bool>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>inCommandShortcutSnap</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="4">
-         <widget class="QLabel" name="label_4">
-          <property name="text">
-           <string>Close</string>
-          </property>
-         </widget>
-        </item>
         <item row="0" column="0">
          <widget class="QLabel" name="label_2">
           <property name="text">
@@ -156,40 +75,10 @@
           </property>
          </widget>
         </item>
-        <item row="0" column="5">
-         <widget class="Gui::PrefLineEdit" name="lineEdit_4">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>25</width>
-            <height>16777215</height>
-           </size>
-          </property>
+        <item row="0" column="2">
+         <widget class="QLabel" name="label_3">
           <property name="text">
-           <string>O</string>
-          </property>
-          <property name="maxLength">
-           <number>1</number>
-          </property>
-          <property name="placeholderText">
-           <string/>
-          </property>
-          <property name="clearButtonEnabled" stdset="0">
-           <bool>false</bool>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>inCommandShortcutClose</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
+           <string>Continue</string>
           </property>
          </widget>
         </item>
@@ -230,10 +119,47 @@
           </property>
          </widget>
         </item>
-        <item row="0" column="2">
-         <widget class="QLabel" name="label_3">
+        <item row="0" column="4">
+         <widget class="QLabel" name="label_4">
           <property name="text">
-           <string>Continue</string>
+           <string>Close</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="5">
+         <widget class="Gui::PrefLineEdit" name="lineEdit_4">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>25</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>O</string>
+          </property>
+          <property name="maxLength">
+           <number>1</number>
+          </property>
+          <property name="placeholderText">
+           <string/>
+          </property>
+          <property name="clearButtonEnabled" stdset="0">
+           <bool>false</bool>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>inCommandShortcutClose</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/Draft</cstring>
           </property>
          </widget>
         </item>
@@ -244,22 +170,8 @@
           </property>
          </widget>
         </item>
-        <item row="5" column="2">
-         <widget class="QLabel" name="label_15">
-          <property name="text">
-           <string>Increase Radius</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="0">
-         <widget class="QLabel" name="label_24">
-          <property name="text">
-           <string>Cycle Snap</string>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="3">
-         <widget class="Gui::PrefLineEdit" name="lineEdit_19">
+        <item row="1" column="1">
+         <widget class="Gui::PrefLineEdit" name="lineEdit_5">
           <property name="enabled">
            <bool>true</bool>
           </property>
@@ -276,7 +188,7 @@
            </size>
           </property>
           <property name="text">
-           <string>[</string>
+           <string>P</string>
           </property>
           <property name="maxLength">
            <number>1</number>
@@ -288,75 +200,17 @@
            <bool>false</bool>
           </property>
           <property name="prefEntry" stdset="0">
-           <cstring>inCommandShortcutIncreaseRadius</cstring>
+           <cstring>inCommandShortcutCopy</cstring>
           </property>
           <property name="prefPath" stdset="0">
            <cstring>Mod/Draft</cstring>
           </property>
          </widget>
         </item>
-        <item row="5" column="5">
-         <widget class="Gui::PrefLineEdit" name="lineEdit_17">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>25</width>
-            <height>16777215</height>
-           </size>
-          </property>
+        <item row="1" column="2">
+         <widget class="QLabel" name="label_6">
           <property name="text">
-           <string>]</string>
-          </property>
-          <property name="maxLength">
-           <number>1</number>
-          </property>
-          <property name="placeholderText">
-           <string/>
-          </property>
-          <property name="clearButtonEnabled" stdset="0">
-           <bool>false</bool>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>inCommandShortcutDecreaseRadius</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="0">
-         <widget class="QLabel" name="label_14">
-          <property name="text">
-           <string>Snap</string>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="4">
-         <widget class="QLabel" name="label_16">
-          <property name="text">
-           <string>Decrease Radius</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="label_20">
-          <property name="text">
-           <string>Length</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="2">
-         <widget class="QLabel" name="label_21">
-          <property name="text">
-           <string>Wipe</string>
+           <string>Subelement Mode</string>
           </property>
          </widget>
         </item>
@@ -397,10 +251,10 @@
           </property>
          </widget>
         </item>
-        <item row="2" column="4">
-         <widget class="QLabel" name="label_18">
+        <item row="1" column="4">
+         <widget class="QLabel" name="label_11">
           <property name="text">
-           <string>Add Hold</string>
+           <string>Fill</string>
           </property>
          </widget>
         </item>
@@ -448,8 +302,8 @@
           </property>
          </widget>
         </item>
-        <item row="1" column="1">
-         <widget class="Gui::PrefLineEdit" name="lineEdit_5">
+        <item row="2" column="1">
+         <widget class="Gui::PrefLineEdit" name="lineEdit_6">
           <property name="enabled">
            <bool>true</bool>
           </property>
@@ -466,7 +320,7 @@
            </size>
           </property>
           <property name="text">
-           <string>P</string>
+           <string>A</string>
           </property>
           <property name="maxLength">
            <number>1</number>
@@ -478,24 +332,17 @@
            <bool>false</bool>
           </property>
           <property name="prefEntry" stdset="0">
-           <cstring>inCommandShortcutCopy</cstring>
+           <cstring>inCommandShortcutExit</cstring>
           </property>
           <property name="prefPath" stdset="0">
            <cstring>Mod/Draft</cstring>
           </property>
          </widget>
         </item>
-        <item row="1" column="4">
-         <widget class="QLabel" name="label_11">
+        <item row="2" column="2">
+         <widget class="QLabel" name="label_17">
           <property name="text">
-           <string>Fill</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="2">
-         <widget class="QLabel" name="label_6">
-          <property name="text">
-           <string>Subelement Mode</string>
+           <string>Select Edge</string>
           </property>
          </widget>
         </item>
@@ -536,6 +383,57 @@
           </property>
          </widget>
         </item>
+        <item row="2" column="4">
+         <widget class="QLabel" name="label_18">
+          <property name="text">
+           <string>Add Hold</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="5">
+         <widget class="Gui::PrefLineEdit" name="lineEdit_15">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>25</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Q</string>
+          </property>
+          <property name="maxLength">
+           <number>1</number>
+          </property>
+          <property name="placeholderText">
+           <string/>
+          </property>
+          <property name="clearButtonEnabled" stdset="0">
+           <bool>false</bool>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>inCommandShortcutAddHold</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/Draft</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="0">
+         <widget class="QLabel" name="label_20">
+          <property name="text">
+           <string>Length</string>
+          </property>
+         </widget>
+        </item>
         <item row="3" column="1">
          <widget class="Gui::PrefLineEdit" name="lineEdit_7">
           <property name="enabled">
@@ -573,10 +471,10 @@
           </property>
          </widget>
         </item>
-        <item row="2" column="2">
-         <widget class="QLabel" name="label_17">
+        <item row="3" column="2">
+         <widget class="QLabel" name="label_21">
           <property name="text">
-           <string>Select Edge</string>
+           <string>Wipe</string>
           </property>
          </widget>
         </item>
@@ -611,80 +509,6 @@
           </property>
           <property name="prefEntry" stdset="0">
            <cstring>inCommandShortcutWipe</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="Gui::PrefLineEdit" name="lineEdit_6">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>25</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>A</string>
-          </property>
-          <property name="maxLength">
-           <number>1</number>
-          </property>
-          <property name="placeholderText">
-           <string/>
-          </property>
-          <property name="clearButtonEnabled" stdset="0">
-           <bool>false</bool>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>inCommandShortcutExit</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="5">
-         <widget class="Gui::PrefLineEdit" name="lineEdit_15">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>25</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Q</string>
-          </property>
-          <property name="maxLength">
-           <number>1</number>
-          </property>
-          <property name="placeholderText">
-           <string/>
-          </property>
-          <property name="clearButtonEnabled" stdset="0">
-           <bool>false</bool>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>inCommandShortcutAddHold</cstring>
           </property>
           <property name="prefPath" stdset="0">
            <cstring>Mod/Draft</cstring>
@@ -729,6 +553,182 @@
           </property>
           <property name="prefEntry" stdset="0">
            <cstring>inCommandShortcutSetWP</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/Draft</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="0">
+         <widget class="QLabel" name="label_24">
+          <property name="text">
+           <string>Cycle Snap</string>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="1">
+         <widget class="Gui::PrefLineEdit" name="lineEdit_8">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>25</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>`</string>
+          </property>
+          <property name="maxLength">
+           <number>1</number>
+          </property>
+          <property name="placeholderText">
+           <string/>
+          </property>
+          <property name="clearButtonEnabled" stdset="0">
+           <bool>false</bool>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>inCommandShortcutCycleSnap</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/Draft</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="0">
+         <widget class="QLabel" name="label_14">
+          <property name="text">
+           <string>Snap</string>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="1">
+         <widget class="Gui::PrefLineEdit" name="lineEdit_9">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>25</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>S</string>
+          </property>
+          <property name="maxLength">
+           <number>1</number>
+          </property>
+          <property name="placeholderText">
+           <string/>
+          </property>
+          <property name="clearButtonEnabled" stdset="0">
+           <bool>false</bool>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>inCommandShortcutSnap</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/Draft</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="2">
+         <widget class="QLabel" name="label_15">
+          <property name="text">
+           <string>Increase Radius</string>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="3">
+         <widget class="Gui::PrefLineEdit" name="lineEdit_19">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>25</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>[</string>
+          </property>
+          <property name="maxLength">
+           <number>1</number>
+          </property>
+          <property name="placeholderText">
+           <string/>
+          </property>
+          <property name="clearButtonEnabled" stdset="0">
+           <bool>false</bool>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>inCommandShortcutIncreaseRadius</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/Draft</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="4">
+         <widget class="QLabel" name="label_16">
+          <property name="text">
+           <string>Decrease Radius</string>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="5">
+         <widget class="Gui::PrefLineEdit" name="lineEdit_17">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>25</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>]</string>
+          </property>
+          <property name="maxLength">
+           <number>1</number>
+          </property>
+          <property name="placeholderText">
+           <string/>
+          </property>
+          <property name="clearButtonEnabled" stdset="0">
+           <bool>false</bool>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>inCommandShortcutDecreaseRadius</cstring>
           </property>
           <property name="prefPath" stdset="0">
            <cstring>Mod/Draft</cstring>

--- a/src/Mod/Drawing/Gui/TaskOrthoViews.ui
+++ b/src/Mod/Drawing/Gui/TaskOrthoViews.ui
@@ -26,6 +26,126 @@
    <string>Orthographic Projection</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_5">
+   <item row="0" column="0">
+    <layout class="QHBoxLayout" name="horizontalLayout_3">
+     <item>
+      <widget class="QLabel" name="label_7">
+       <property name="text">
+        <string>Projection</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="projection">
+       <property name="editable">
+        <bool>false</bool>
+       </property>
+       <item>
+        <property name="text">
+         <string>Third Angle</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>First Angle</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="1" column="0">
+    <layout class="QGridLayout" name="gridLayout_2">
+     <item row="0" column="0">
+      <widget class="QLabel" name="textLabel1">
+       <property name="text">
+        <string>View from:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QComboBox" name="view_from">
+       <property name="sizeAdjustPolicy">
+        <enum>QComboBox::AdjustToContentsOnFirstShow</enum>
+       </property>
+       <property name="frame">
+        <bool>true</bool>
+       </property>
+       <item>
+        <property name="text">
+         <string>X +ve</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Y +ve</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Z +ve</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>X -ve</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Y -ve</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Z -ve</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>Axis aligned right:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QComboBox" name="axis_right">
+       <item>
+        <property name="text">
+         <string notr="true">Y +ve</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string notr="true">Z +ve</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string notr="true">Y -ve</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string notr="true">Z -ve</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  <item row="2" column="0">
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
    <item row="3" column="0">
     <layout class="QGridLayout" name="gridLayout">
      <item row="3" column="1">
@@ -748,127 +868,7 @@
      </widget>
     </widget>
    </item>
-   <item row="0" column="0">
-    <layout class="QHBoxLayout" name="horizontalLayout_3">
-     <item>
-      <widget class="QLabel" name="label_7">
-       <property name="text">
-        <string>Projection</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QComboBox" name="projection">
-       <property name="editable">
-        <bool>false</bool>
-       </property>
-       <item>
-        <property name="text">
-         <string>Third Angle</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>First Angle</string>
-        </property>
-       </item>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="2" column="0">
-    <widget class="Line" name="line">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <layout class="QGridLayout" name="gridLayout_2">
-     <item row="0" column="0">
-      <widget class="QLabel" name="textLabel1">
-       <property name="text">
-        <string>View from:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="QComboBox" name="view_from">
-       <property name="sizeAdjustPolicy">
-        <enum>QComboBox::AdjustToContentsOnFirstShow</enum>
-       </property>
-       <property name="frame">
-        <bool>true</bool>
-       </property>
-       <item>
-        <property name="text">
-         <string>X +ve</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Y +ve</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Z +ve</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>X -ve</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Y -ve</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Z -ve</string>
-        </property>
-       </item>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="label_2">
-       <property name="text">
-        <string>Axis aligned right:</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QComboBox" name="axis_right">
-       <item>
-        <property name="text">
-         <string notr="true">Y +ve</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string notr="true">Z +ve</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string notr="true">Y -ve</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string notr="true">Z -ve</string>
-        </property>
-       </item>
-      </widget>
-     </item>
-    </layout>
-   </item>
-  </layout>
+   </layout>
  </widget>
  <resources/>
  <connections/>

--- a/src/Mod/Fem/Gui/DlgSettingsFemElmer.ui
+++ b/src/Mod/Fem/Gui/DlgSettingsFemElmer.ui
@@ -42,6 +42,45 @@
         </property>
         <item>
          <layout class="QGridLayout" name="gl_01">
+          <item row="0" column="0">
+           <widget class="QLabel" name="l_grid_binary_std">
+            <property name="text">
+             <string>ElmerGrid:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="Gui::PrefCheckBox" name="cb_grid_binary_std">
+            <property name="text">
+             <string>Search in known binary directories</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+            <property name="prefEntry" stdset="0">
+             <cstring>UseStandardGridLocation</cstring>
+            </property>
+            <property name="prefPath" stdset="0">
+             <cstring>Mod/Fem/Elmer</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="l_grid_binary_path">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>100</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="text">
+             <string>ElmerGrid binary path</string>
+            </property>
+           </widget>
+          </item>
           <item row="1" column="1">
            <widget class="Gui::PrefFileChooser" name="fc_grid_binary_path">
             <property name="enabled">
@@ -82,61 +121,6 @@
             </property>
            </widget>
           </item>
-          <item row="4" column="0">
-           <widget class="QLabel" name="l_elmer_binary_path">
-            <property name="enabled">
-             <bool>false</bool>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>100</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="text">
-             <string>ElmerSolver binary path</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="l_grid_binary_path">
-            <property name="enabled">
-             <bool>false</bool>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>100</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="text">
-             <string>ElmerGrid binary path</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0">
-           <widget class="QLabel" name="l_grid_binary_std">
-            <property name="text">
-             <string>ElmerGrid:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="Gui::PrefCheckBox" name="cb_grid_binary_std">
-            <property name="text">
-             <string>Search in known binary directories</string>
-            </property>
-            <property name="checked">
-             <bool>true</bool>
-            </property>
-            <property name="prefEntry" stdset="0">
-             <cstring>UseStandardGridLocation</cstring>
-            </property>
-            <property name="prefPath" stdset="0">
-             <cstring>Mod/Fem/Elmer</cstring>
-            </property>
-           </widget>
-          </item>
           <item row="3" column="0">
            <widget class="QLabel" name="l_elmer_binary_std">
             <property name="text">
@@ -157,6 +141,22 @@
             </property>
             <property name="prefPath" stdset="0">
              <cstring>Mod/Fem/Elmer</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="l_elmer_binary_path">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>100</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="text">
+             <string>ElmerSolver binary path</string>
             </property>
            </widget>
           </item>

--- a/src/Mod/Fem/Gui/DlgSettingsFemExportAbaqus.ui
+++ b/src/Mod/Fem/Gui/DlgSettingsFemExportAbaqus.ui
@@ -14,19 +14,6 @@
    <string>INP</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_4">
-   <item row="1" column="0">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>82</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
    <item row="0" column="0">
     <widget class="QGroupBox" name="groupBox">
      <property name="title">
@@ -116,7 +103,20 @@ not belonging to faces and faces not belonging to volumes.</string>
      </layout>
     </widget>
    </item>
-  </layout>
+  <item row="1" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>82</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   </layout>
  </widget>
  <customwidgets>
   <customwidget>

--- a/src/Mod/Fem/Gui/DlgSettingsFemGmsh.ui
+++ b/src/Mod/Fem/Gui/DlgSettingsFemGmsh.ui
@@ -39,6 +39,13 @@
         </property>
         <item>
          <layout class="QGridLayout" name="gl_01">
+          <item row="0" column="0">
+           <widget class="QLabel" name="l_gmsh_binary_std">
+            <property name="text">
+             <string>gmsh</string>
+            </property>
+           </widget>
+          </item>
           <item row="0" column="2">
            <widget class="Gui::PrefCheckBox" name="cb_gmsh_binary_std">
             <property name="text">
@@ -52,13 +59,6 @@
             </property>
             <property name="prefPath" stdset="0">
              <cstring>Mod/Fem/Gmsh</cstring>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0">
-           <widget class="QLabel" name="l_gmsh_binary_std">
-            <property name="text">
-             <string>gmsh</string>
             </property>
            </widget>
           </item>

--- a/src/Mod/Fem/Gui/DlgSettingsFemInOutVtk.ui
+++ b/src/Mod/Fem/Gui/DlgSettingsFemInOutVtk.ui
@@ -17,19 +17,6 @@
    <string/>
   </property>
   <layout class="QGridLayout" name="gridLayout_4">
-   <item row="1" column="0">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>82</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
    <item row="0" column="0">
     <widget class="QGroupBox" name="groupBox">
      <property name="title">
@@ -101,7 +88,20 @@ exported from FreeCAD.</string>
      </layout>
     </widget>
    </item>
-  </layout>
+  <item row="1" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>82</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   </layout>
  </widget>
  <customwidgets>
   <customwidget>

--- a/src/Mod/Fem/Gui/DlgSettingsFemMaterial.ui
+++ b/src/Mod/Fem/Gui/DlgSettingsFemMaterial.ui
@@ -75,7 +75,23 @@
         </item>
         <item>
          <layout class="QGridLayout" name="gridLayout">
-          <item row="1" column="1">
+          <item row="1" column="0">
+           <widget class="QLabel" name="l_custom_mat_dir">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>100</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="text">
+             <string>User directory</string>
+            </property>
+           </widget>
+          </item>
+         <item row="1" column="1">
            <widget class="Gui::PrefFileChooser" name="fc_custom_mat_dir">
             <property name="enabled">
              <bool>true</bool>
@@ -103,23 +119,7 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="l_custom_mat_dir">
-            <property name="enabled">
-             <bool>true</bool>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>100</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="text">
-             <string>User directory</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
+          </layout>
         </item>
        </layout>
       </item>

--- a/src/Mod/Fem/Gui/DlgSettingsFemZ88.ui
+++ b/src/Mod/Fem/Gui/DlgSettingsFemZ88.ui
@@ -39,6 +39,13 @@
         </property>
         <item>
          <layout class="QGridLayout" name="gl_z88">
+          <item row="0" column="0">
+           <widget class="QLabel" name="l_z88_binary_std">
+            <property name="text">
+             <string>z88r</string>
+            </property>
+           </widget>
+          </item>
           <item row="0" column="2">
            <widget class="Gui::PrefCheckBox" name="cb_z88_binary_std">
             <property name="text">
@@ -52,13 +59,6 @@
             </property>
             <property name="prefPath" stdset="0">
              <cstring>Mod/Fem/Z88</cstring>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0">
-           <widget class="QLabel" name="l_z88_binary_std">
-            <property name="text">
-             <string>z88r</string>
             </property>
            </widget>
           </item>

--- a/src/Mod/Fem/Gui/Resources/ui/Material.ui
+++ b/src/Mod/Fem/Gui/Resources/ui/Material.ui
@@ -28,6 +28,13 @@
      <layout class="QVBoxLayout" name="verticalLayout_5">
       <item>
        <layout class="QGridLayout" name="gridLayout_2">
+        <item row="1" column="0">
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>Category</string>
+          </property>
+         </widget>
+        </item>
         <item row="1" column="1">
          <widget class="QLabel" name="label_category">
           <property name="text">
@@ -35,10 +42,10 @@
           </property>
          </widget>
         </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="label">
+        <item row="2" column="0">
+         <widget class="QLabel" name="label_2">
           <property name="text">
-           <string>Category</string>
+           <string>Material card</string>
           </property>
          </widget>
         </item>
@@ -49,13 +56,6 @@
             <string>choose...</string>
            </property>
           </item>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="label_2">
-          <property name="text">
-           <string>Material card</string>
-          </property>
          </widget>
         </item>
         <item row="3" column="0">

--- a/src/Mod/Fem/Gui/Resources/ui/MaterialReinforcement.ui
+++ b/src/Mod/Fem/Gui/Resources/ui/MaterialReinforcement.ui
@@ -31,6 +31,13 @@
      <layout class="QVBoxLayout" name="verticalLayout_5">
       <item>
        <layout class="QGridLayout" name="gridLayout_2">
+        <item row="1" column="0">
+         <widget class="QLabel" name="label_2">
+          <property name="text">
+           <string>Material</string>
+          </property>
+         </widget>
+        </item>
         <item row="1" column="1">
          <widget class="QComboBox" name="cb_materials_m">
           <item>
@@ -40,10 +47,17 @@
           </item>
          </widget>
         </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="label_2">
+        <item row="2" column="0">
+         <widget class="QLabel" name="label_4">
           <property name="text">
-           <string>Material</string>
+           <string>Properties</string>
+          </property>
+         </widget>
+        </item>
+       <item row="2" column="1">
+         <widget class="QPushButton" name="pb_edit_m">
+          <property name="text">
+           <string>Edit</string>
           </property>
          </widget>
         </item>
@@ -61,21 +75,7 @@
           </property>
          </widget>
         </item>
-        <item row="2" column="1">
-         <widget class="QPushButton" name="pb_edit_m">
-          <property name="text">
-           <string>Edit</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="label_4">
-          <property name="text">
-           <string>Properties</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
+        </layout>
       </item>
       <item>
        <widget class="QLabel" name="l_description_m">
@@ -104,6 +104,13 @@
      <layout class="QVBoxLayout" name="verticalLayout_6">
       <item>
        <layout class="QGridLayout" name="gridLayout_3">
+        <item row="1" column="0">
+         <widget class="QLabel" name="label_6">
+          <property name="text">
+           <string>Material</string>
+          </property>
+         </widget>
+        </item>
         <item row="1" column="1">
          <widget class="QComboBox" name="cb_materials_r">
           <item>
@@ -113,10 +120,17 @@
           </item>
          </widget>
         </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="label_6">
+        <item row="2" column="0">
+         <widget class="QLabel" name="label_8">
           <property name="text">
-           <string>Material</string>
+           <string>Properties</string>
+          </property>
+         </widget>
+        </item>
+       <item row="2" column="1">
+         <widget class="QPushButton" name="pb_edit_r">
+          <property name="text">
+           <string>Edit</string>
           </property>
          </widget>
         </item>
@@ -134,21 +148,7 @@
           </property>
          </widget>
         </item>
-        <item row="2" column="1">
-         <widget class="QPushButton" name="pb_edit_r">
-          <property name="text">
-           <string>Edit</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="label_8">
-          <property name="text">
-           <string>Properties</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
+        </layout>
       </item>
       <item>
        <widget class="QLabel" name="l_description_r">

--- a/src/Mod/Fem/Gui/Resources/ui/MeshGmsh.ui
+++ b/src/Mod/Fem/Gui/Resources/ui/MeshGmsh.ui
@@ -153,7 +153,14 @@
         </property>
         <item row="0" column="1">
          <layout class="QGridLayout" name="gl_actions">
-          <item row="1" column="0">
+          <item row="0" column="0">
+           <widget class="QTextEdit" name="te_output">
+            <property name="lineWrapMode">
+             <enum>QTextEdit::NoWrap</enum>
+            </property>
+           </widget>
+          </item>
+         <item row="1" column="0">
            <widget class="QLabel" name="l_time">
             <property name="font">
              <font>
@@ -165,14 +172,7 @@
             </property>
            </widget>
           </item>
-          <item row="0" column="0">
-           <widget class="QTextEdit" name="te_output">
-            <property name="lineWrapMode">
-             <enum>QTextEdit::NoWrap</enum>
-            </property>
-           </widget>
-          </item>
-         </layout>
+          </layout>
         </item>
        </layout>
       </item>

--- a/src/Mod/Fem/Gui/Resources/ui/ResultHints.ui
+++ b/src/Mod/Fem/Gui/Resources/ui/ResultHints.ui
@@ -61,96 +61,10 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="1">
-           <widget class="QLabel" name="user_def_head_12">
-            <property name="text">
-             <string>mass flow rate: MF</string>
-            </property>
-            <property name="textInteractionFlags">
-             <set>Qt::TextSelectableByMouse</set>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QLabel" name="user_def_head_15">
-            <property name="baseSize">
-             <size>
-              <width>0</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="text">
-             <string>network pressure: NP</string>
-            </property>
-            <property name="textInteractionFlags">
-             <set>Qt::TextSelectableByMouse</set>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="user_def_head_13">
-            <property name="text">
-             <string>von Mises stress: vM</string>
-            </property>
-            <property name="textInteractionFlags">
-             <set>Qt::TextSelectableByMouse</set>
-            </property>
-           </widget>
-          </item>
           <item row="0" column="1">
            <widget class="QLabel" name="user_def_head_14">
             <property name="text">
              <string>temperature: T</string>
-            </property>
-            <property name="textInteractionFlags">
-             <set>Qt::TextSelectableByMouse</set>
-            </property>
-           </widget>
-          </item>
-          <item row="6" column="0">
-           <widget class="QLabel" name="user_def_head_9">
-            <property name="text">
-             <string>min. principal stress vector: s1x, s1y, s1z</string>
-            </property>
-            <property name="textInteractionFlags">
-             <set>Qt::TextSelectableByMouse</set>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="0">
-           <widget class="QLabel" name="user_def_head_6">
-            <property name="text">
-             <string>principal stresses: P1, P2, P3</string>
-            </property>
-            <property name="textInteractionFlags">
-             <set>Qt::TextSelectableByMouse</set>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="1">
-           <widget class="QLabel" name="user_def_head_5">
-            <property name="text">
-             <string>reinforcement ratio: rx, ry, rz</string>
-            </property>
-            <property name="textInteractionFlags">
-             <set>Qt::TextSelectableByMouse</set>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="0">
-           <widget class="QLabel" name="user_def_head_7">
-            <property name="text">
-             <string>equivalent plastic strain: Peeq</string>
-            </property>
-            <property name="textInteractionFlags">
-             <set>Qt::TextSelectableByMouse</set>
-            </property>
-           </widget>
-          </item>
-          <item row="7" column="0">
-           <widget class="QLabel" name="user_def_head_10">
-            <property name="text">
-             <string>med. principal stress vector: s2x, s2y, s2z</string>
             </property>
             <property name="textInteractionFlags">
              <set>Qt::TextSelectableByMouse</set>
@@ -194,6 +108,22 @@
             </property>
            </widget>
           </item>
+          <item row="1" column="1">
+           <widget class="QLabel" name="user_def_head_15">
+            <property name="baseSize">
+             <size>
+              <width>0</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="text">
+             <string>network pressure: NP</string>
+            </property>
+            <property name="textInteractionFlags">
+             <set>Qt::TextSelectableByMouse</set>
+            </property>
+           </widget>
+          </item>
           <item row="2" column="0">
            <widget class="QLabel" name="user_def_head_4">
             <property name="text">
@@ -204,10 +134,80 @@
             </property>
            </widget>
           </item>
+          <item row="2" column="1">
+           <widget class="QLabel" name="user_def_head_12">
+            <property name="text">
+             <string>mass flow rate: MF</string>
+            </property>
+            <property name="textInteractionFlags">
+             <set>Qt::TextSelectableByMouse</set>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="user_def_head_13">
+            <property name="text">
+             <string>von Mises stress: vM</string>
+            </property>
+            <property name="textInteractionFlags">
+             <set>Qt::TextSelectableByMouse</set>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QLabel" name="user_def_head_5">
+            <property name="text">
+             <string>reinforcement ratio: rx, ry, rz</string>
+            </property>
+            <property name="textInteractionFlags">
+             <set>Qt::TextSelectableByMouse</set>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="user_def_head_6">
+            <property name="text">
+             <string>principal stresses: P1, P2, P3</string>
+            </property>
+            <property name="textInteractionFlags">
+             <set>Qt::TextSelectableByMouse</set>
+            </property>
+           </widget>
+          </item>
           <item row="4" column="1">
            <widget class="QLabel" name="user_def_head_8">
             <property name="text">
              <string>Mohr Coulomb: mc</string>
+            </property>
+            <property name="textInteractionFlags">
+             <set>Qt::TextSelectableByMouse</set>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="0">
+           <widget class="QLabel" name="user_def_head_7">
+            <property name="text">
+             <string>equivalent plastic strain: Peeq</string>
+            </property>
+            <property name="textInteractionFlags">
+             <set>Qt::TextSelectableByMouse</set>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="0">
+           <widget class="QLabel" name="user_def_head_9">
+            <property name="text">
+             <string>min. principal stress vector: s1x, s1y, s1z</string>
+            </property>
+            <property name="textInteractionFlags">
+             <set>Qt::TextSelectableByMouse</set>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="0">
+           <widget class="QLabel" name="user_def_head_10">
+            <property name="text">
+             <string>med. principal stress vector: s2x, s2y, s2z</string>
             </property>
             <property name="textInteractionFlags">
              <set>Qt::TextSelectableByMouse</set>

--- a/src/Mod/Fem/Gui/Resources/ui/ResultShow.ui
+++ b/src/Mod/Fem/Gui/Resources/ui/ResultShow.ui
@@ -24,13 +24,6 @@
        <layout class="QVBoxLayout" name="verticalLayout">
         <item>
          <layout class="QGridLayout" name="gridLayout">
-          <item row="1" column="0">
-           <widget class="QRadioButton" name="rb_abs_displacement">
-            <property name="text">
-             <string>Displacement Magnitude</string>
-            </property>
-           </widget>
-          </item>
           <item row="0" column="0">
            <widget class="QRadioButton" name="rb_none">
             <property name="text">
@@ -41,38 +34,10 @@
             </property>
            </widget>
           </item>
-          <item row="3" column="0">
-           <widget class="QRadioButton" name="rb_y_displacement">
+          <item row="1" column="0">
+           <widget class="QRadioButton" name="rb_abs_displacement">
             <property name="text">
-             <string>Displacement Y</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QRadioButton" name="rb_x_displacement">
-            <property name="text">
-             <string>Displacement X</string>
-            </property>
-           </widget>
-          </item>
-          <item row="7" column="0">
-           <widget class="QRadioButton" name="rb_peeq">
-            <property name="text">
-             <string>Peeq</string>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="0">
-           <widget class="QRadioButton" name="rb_z_displacement">
-            <property name="text">
-             <string>Displacement Z</string>
-            </property>
-           </widget>
-          </item>
-          <item row="8" column="0">
-           <widget class="QRadioButton" name="rb_temperature">
-            <property name="text">
-             <string>Temperature</string>
+             <string>Displacement Magnitude</string>
             </property>
            </widget>
           </item>
@@ -83,10 +48,24 @@
             </property>
            </widget>
           </item>
+          <item row="2" column="0">
+           <widget class="QRadioButton" name="rb_x_displacement">
+            <property name="text">
+             <string>Displacement X</string>
+            </property>
+           </widget>
+          </item>
           <item row="2" column="1">
            <widget class="QRadioButton" name="rb_maxprin">
             <property name="text">
              <string>Max Principal Stress</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QRadioButton" name="rb_y_displacement">
+            <property name="text">
+             <string>Displacement Y</string>
             </property>
            </widget>
           </item>
@@ -97,6 +76,13 @@
             </property>
            </widget>
           </item>
+          <item row="5" column="0">
+           <widget class="QRadioButton" name="rb_z_displacement">
+            <property name="text">
+             <string>Displacement Z</string>
+            </property>
+           </widget>
+          </item>
           <item row="5" column="1">
            <widget class="QRadioButton" name="rb_max_shear_stress">
             <property name="text">
@@ -104,10 +90,24 @@
             </property>
            </widget>
           </item>
+          <item row="7" column="0">
+           <widget class="QRadioButton" name="rb_peeq">
+            <property name="text">
+             <string>Peeq</string>
+            </property>
+           </widget>
+          </item>
           <item row="7" column="1">
            <widget class="QRadioButton" name="rb_massflowrate">
             <property name="text">
              <string>Mass Flow Rate</string>
+            </property>
+           </widget>
+          </item>
+          <item row="8" column="0">
+           <widget class="QRadioButton" name="rb_temperature">
+            <property name="text">
+             <string>Temperature</string>
             </property>
            </widget>
           </item>

--- a/src/Mod/Mesh/Gui/DlgRegularSolid.ui
+++ b/src/Mod/Mesh/Gui/DlgRegularSolid.ui
@@ -23,61 +23,6 @@
    <property name="spacing">
     <number>6</number>
    </property>
-   <item row="1" column="0">
-    <layout class="QHBoxLayout">
-     <property name="spacing">
-      <number>6</number>
-     </property>
-     <property name="margin">
-      <number>0</number>
-     </property>
-     <item>
-      <spacer>
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeType">
-        <enum>QSizePolicy::Expanding</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>20</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QPushButton" name="createSolidButton">
-       <property name="text">
-        <string>&amp;Create</string>
-       </property>
-       <property name="shortcut">
-        <string>Alt+C</string>
-       </property>
-       <property name="autoDefault">
-        <bool>true</bool>
-       </property>
-       <property name="default">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="buttonClose">
-       <property name="text">
-        <string>Cl&amp;ose</string>
-       </property>
-       <property name="shortcut">
-        <string>Alt+O</string>
-       </property>
-       <property name="autoDefault">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
    <item row="0" column="0">
     <widget class="QGroupBox" name="groupBox1">
      <property name="title">
@@ -834,7 +779,62 @@
      </layout>
     </widget>
    </item>
-  </layout>
+  <item row="1" column="0">
+    <layout class="QHBoxLayout">
+     <property name="spacing">
+      <number>6</number>
+     </property>
+     <property name="margin">
+      <number>0</number>
+     </property>
+     <item>
+      <spacer>
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Expanding</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="createSolidButton">
+       <property name="text">
+        <string>&amp;Create</string>
+       </property>
+       <property name="shortcut">
+        <string>Alt+C</string>
+       </property>
+       <property name="autoDefault">
+        <bool>true</bool>
+       </property>
+       <property name="default">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="buttonClose">
+       <property name="text">
+        <string>Cl&amp;ose</string>
+       </property>
+       <property name="shortcut">
+        <string>Alt+O</string>
+       </property>
+       <property name="autoDefault">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>

--- a/src/Mod/Mesh/Gui/SegmentationBestFit.ui
+++ b/src/Mod/Mesh/Gui/SegmentationBestFit.ui
@@ -14,59 +14,6 @@
    <string>Mesh segmentation</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_4">
-   <item row="2" column="0" colspan="2">
-    <widget class="QGroupBox" name="groupBoxSph">
-     <property name="title">
-      <string>Sphere</string>
-     </property>
-     <property name="checkable">
-      <bool>true</bool>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_3">
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_7">
-        <property name="text">
-         <string>Tolerance</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QDoubleSpinBox" name="tolSph">
-        <property name="singleStep">
-         <double>0.010000000000000</double>
-        </property>
-        <property name="value">
-         <double>0.010000000000000</double>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_8">
-        <property name="text">
-         <string>Minimum number of faces</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QSpinBox" name="numSph">
-        <property name="maximum">
-         <number>100000</number>
-        </property>
-        <property name="value">
-         <number>100</number>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QPushButton" name="sphereParameters">
-        <property name="text">
-         <string>Parameters...</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
    <item row="0" column="0" colspan="2">
     <widget class="QGroupBox" name="groupBoxPln">
      <property name="title">
@@ -173,7 +120,60 @@
      </layout>
     </widget>
    </item>
-  </layout>
+  <item row="2" column="0" colspan="2">
+    <widget class="QGroupBox" name="groupBoxSph">
+     <property name="title">
+      <string>Sphere</string>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_3">
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_7">
+        <property name="text">
+         <string>Tolerance</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QDoubleSpinBox" name="tolSph">
+        <property name="singleStep">
+         <double>0.010000000000000</double>
+        </property>
+        <property name="value">
+         <double>0.010000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_8">
+        <property name="text">
+         <string>Minimum number of faces</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QSpinBox" name="numSph">
+        <property name="maximum">
+         <number>100000</number>
+        </property>
+        <property name="value">
+         <number>100</number>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QPushButton" name="sphereParameters">
+        <property name="text">
+         <string>Parameters...</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   </layout>
  </widget>
  <resources/>
  <connections/>

--- a/src/Mod/OpenSCAD/Resources/ui/openscadprefs-base.ui
+++ b/src/Mod/OpenSCAD/Resources/ui/openscadprefs-base.ui
@@ -355,7 +355,24 @@
           </property>
          </spacer>
         </item>
-        <item row="1" column="2">
+        <item row="0" column="2">
+         <widget class="QLabel" name="label_4">
+          <property name="toolTip">
+           <string>Deflection</string>
+          </property>
+          <property name="text">
+           <string>deflection</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="label_5">
+          <property name="text">
+           <string>Triangulation settings</string>
+          </property>
+         </widget>
+        </item>
+       <item row="1" column="2">
          <widget class="Gui::PrefDoubleSpinBox" name="doubleSpinBox_2a">
           <property name="toolTip">
            <string>Deflection</string>
@@ -377,24 +394,7 @@
           </property>
          </widget>
         </item>
-        <item row="0" column="2">
-         <widget class="QLabel" name="label_4">
-          <property name="toolTip">
-           <string>Deflection</string>
-          </property>
-          <property name="text">
-           <string>deflection</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="label_5">
-          <property name="text">
-           <string>Triangulation settings</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
+        </layout>
       </item>
      </layout>
     </widget>

--- a/src/Mod/Part/AttachmentEditor/TaskAttachmentEditor.ui
+++ b/src/Mod/Part/AttachmentEditor/TaskAttachmentEditor.ui
@@ -140,6 +140,25 @@
         </property>
        </widget>
       </item>
+      <item row="1" column="1">
+       <widget class="Gui::QuantitySpinBox" name="attachmentOffsetX">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>5</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>Note: The placement is expressed in local space of object being attached.</string>
+        </property>
+       </widget>
+      </item>
       <item row="2" column="0">
        <widget class="QLabel" name="labelOffset2">
         <property name="sizePolicy">
@@ -217,51 +236,6 @@
         </property>
        </widget>
       </item>
-      <item row="5" column="0">
-       <widget class="QLabel" name="labelPitch">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string>Around y-axis:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="0">
-       <widget class="QLabel" name="labelRoll">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string>Around z-axis:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="Gui::QuantitySpinBox" name="attachmentOffsetX">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>5</height>
-         </size>
-        </property>
-        <property name="toolTip">
-         <string>Note: The placement is expressed in local space of object being attached.</string>
-        </property>
-       </widget>
-      </item>
       <item row="4" column="1">
        <widget class="Gui::QuantitySpinBox" name="attachmentOffsetRoll">
         <property name="sizePolicy">
@@ -294,6 +268,19 @@ Note: The placement is expressed in local space of object being attached.</strin
         </property>
        </widget>
       </item>
+      <item row="5" column="0">
+       <widget class="QLabel" name="labelPitch">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Around y-axis:</string>
+        </property>
+       </widget>
+      </item>
       <item row="5" column="1">
        <widget class="Gui::QuantitySpinBox" name="attachmentOffsetPitch">
         <property name="sizePolicy">
@@ -323,6 +310,19 @@ Note: The placement is expressed in local space of object being attached.</strin
         </property>
         <property name="value" stdset="0">
          <double>0.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="0">
+       <widget class="QLabel" name="labelRoll">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Around z-axis:</string>
         </property>
        </widget>
       </item>

--- a/src/Mod/Part/Gui/DlgExtrusion.ui
+++ b/src/Mod/Part/Gui/DlgExtrusion.ui
@@ -26,26 +26,6 @@
       <string>Direction</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
-      <item row="4" column="2">
-       <widget class="QCheckBox" name="chkReversed">
-        <property name="toolTip">
-         <string>If checked, direction of extrusion is reversed.</string>
-        </property>
-        <property name="text">
-         <string>Reversed</string>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="0">
-       <widget class="QRadioButton" name="rbDirModeCustom">
-        <property name="toolTip">
-         <string>Specify direction manually using X,Y,Z values.</string>
-        </property>
-        <property name="text">
-         <string>Custom direction:</string>
-        </property>
-       </widget>
-      </item>
       <item row="3" column="0">
        <widget class="QRadioButton" name="rbDirModeNormal">
         <property name="toolTip">
@@ -59,6 +39,29 @@
         </property>
        </widget>
       </item>
+      <item row="4" column="0">
+       <widget class="QRadioButton" name="rbDirModeEdge">
+        <property name="toolTip">
+         <string>Set direction to match a direction of straight edge. Hint: to account for length of the edge too, set both lengths to zero.</string>
+        </property>
+        <property name="text">
+         <string>Along edge:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="2">
+       <widget class="QCheckBox" name="chkReversed">
+        <property name="toolTip">
+         <string>If checked, direction of extrusion is reversed.</string>
+        </property>
+        <property name="text">
+         <string>Reversed</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0">
+       <widget class="QLineEdit" name="txtLink"/>
+      </item>
       <item row="5" column="2">
        <widget class="QPushButton" name="btnSelectEdge">
         <property name="toolTip">
@@ -69,16 +72,13 @@
         </property>
        </widget>
       </item>
-      <item row="5" column="0">
-       <widget class="QLineEdit" name="txtLink"/>
-      </item>
-      <item row="4" column="0">
-       <widget class="QRadioButton" name="rbDirModeEdge">
+      <item row="6" column="0">
+       <widget class="QRadioButton" name="rbDirModeCustom">
         <property name="toolTip">
-         <string>Set direction to match a direction of straight edge. Hint: to account for length of the edge too, set both lengths to zero.</string>
+         <string>Specify direction manually using X,Y,Z values.</string>
         </property>
         <property name="text">
-         <string>Along edge:</string>
+         <string>Custom direction:</string>
         </property>
        </widget>
       </item>

--- a/src/Mod/Part/Gui/DlgImportExportStep.ui
+++ b/src/Mod/Part/Gui/DlgImportExportStep.ui
@@ -155,61 +155,6 @@ it inside the Placement property.</string>
      </layout>
     </widget>
    </item>
-   <item row="4" column="0">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>82</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="3" column="0">
-    <widget class="QGroupBox" name="groupBoxHeader">
-     <property name="toolTip">
-      <string>If not empty, field contents will be used in the STEP file header.</string>
-     </property>
-     <property name="title">
-      <string>Header</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_2">
-      <item row="1" column="1">
-       <widget class="QLineEdit" name="lineEditAuthor"/>
-      </item>
-      <item row="2" column="1">
-       <widget class="QLineEdit" name="lineEditProduct"/>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_3">
-        <property name="text">
-         <string>Author</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_4">
-        <property name="text">
-         <string>Product</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>Company</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QLineEdit" name="lineEditCompany"/>
-      </item>
-     </layout>
-    </widget>
-   </item>
    <item row="2" column="0">
     <widget class="QGroupBox" name="GroupBox2">
      <property name="title">
@@ -387,7 +332,62 @@ during file reading (slower but higher details).</string>
      </layout>
     </widget>
    </item>
-  </layout>
+  <item row="3" column="0">
+    <widget class="QGroupBox" name="groupBoxHeader">
+     <property name="toolTip">
+      <string>If not empty, field contents will be used in the STEP file header.</string>
+     </property>
+     <property name="title">
+      <string>Header</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_2">
+      <item row="1" column="1">
+       <widget class="QLineEdit" name="lineEditAuthor"/>
+      </item>
+      <item row="2" column="1">
+       <widget class="QLineEdit" name="lineEditProduct"/>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_3">
+        <property name="text">
+         <string>Author</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_4">
+        <property name="text">
+         <string>Product</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>Company</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLineEdit" name="lineEditCompany"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>82</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   </layout>
  </widget>
  <customwidgets>
   <customwidget>

--- a/src/Mod/Part/Gui/DlgRevolution.ui
+++ b/src/Mod/Part/Gui/DlgRevolution.ui
@@ -26,16 +26,6 @@
    <property name="spacing">
     <number>6</number>
    </property>
-   <item row="5" column="3">
-    <widget class="QCheckBox" name="checkSolid">
-     <property name="toolTip">
-      <string>If checked, revolving wires will produce solids. If not, revolving a wire yields a shell.</string>
-     </property>
-     <property name="text">
-      <string>Create Solid</string>
-     </property>
-    </widget>
-   </item>
    <item row="0" column="3">
     <widget class="QTreeWidget" name="treeWidget">
      <property name="selectionMode">
@@ -53,51 +43,6 @@
       </property>
      </column>
     </widget>
-   </item>
-   <item row="3" column="3">
-    <layout class="QFormLayout" name="formLayout_3">
-     <property name="horizontalSpacing">
-      <number>6</number>
-     </property>
-     <property name="verticalSpacing">
-      <number>6</number>
-     </property>
-     <property name="margin">
-      <number>0</number>
-     </property>
-     <item row="0" column="0">
-      <widget class="QLabel" name="label_5">
-       <property name="text">
-        <string>Angle:</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="Gui::QuantitySpinBox" name="angle">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="unit" stdset="0">
-        <string notr="true">deg</string>
-       </property>
-       <property name="minimum">
-        <double>-360.000000000000000</double>
-       </property>
-       <property name="maximum">
-        <double>360.000000000000000</double>
-       </property>
-       <property name="value">
-        <double>360.000000000000000</double>
-       </property>
-      </widget>
-     </item>
-    </layout>
    </item>
    <item row="1" column="3" rowspan="2">
     <widget class="QGroupBox" name="groupBox">
@@ -319,6 +264,51 @@
      </layout>
     </widget>
    </item>
+   <item row="3" column="3">
+    <layout class="QFormLayout" name="formLayout_3">
+     <property name="horizontalSpacing">
+      <number>6</number>
+     </property>
+     <property name="verticalSpacing">
+      <number>6</number>
+     </property>
+     <property name="margin">
+      <number>0</number>
+     </property>
+     <item row="0" column="0">
+      <widget class="QLabel" name="label_5">
+       <property name="text">
+        <string>Angle:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="Gui::QuantitySpinBox" name="angle">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="unit" stdset="0">
+        <string notr="true">deg</string>
+       </property>
+       <property name="minimum">
+        <double>-360.000000000000000</double>
+       </property>
+       <property name="maximum">
+        <double>360.000000000000000</double>
+       </property>
+       <property name="value">
+        <double>360.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
    <item row="4" column="3">
     <widget class="QCheckBox" name="checkSymmetric">
      <property name="toolTip">
@@ -329,7 +319,17 @@
      </property>
     </widget>
    </item>
-  </layout>
+  <item row="5" column="3">
+    <widget class="QCheckBox" name="checkSolid">
+     <property name="toolTip">
+      <string>If checked, revolving wires will produce solids. If not, revolving a wire yields a shell.</string>
+     </property>
+     <property name="text">
+      <string>Create Solid</string>
+     </property>
+    </widget>
+   </item>
+   </layout>
  </widget>
  <customwidgets>
   <customwidget>

--- a/src/Mod/Part/Gui/DlgSettings3DViewPart.ui
+++ b/src/Mod/Part/Gui/DlgSettings3DViewPart.ui
@@ -20,19 +20,6 @@
    <property name="spacing">
     <number>6</number>
    </property>
-   <item row="1" column="0">
-    <spacer>
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>61</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
    <item row="0" column="0">
     <widget class="QGroupBox" name="GroupBox12">
      <property name="title">
@@ -134,7 +121,20 @@
      </layout>
     </widget>
    </item>
-  </layout>
+  <item row="1" column="0">
+    <spacer>
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>61</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>

--- a/src/Mod/Part/Gui/TaskAttacher.ui
+++ b/src/Mod/Part/Gui/TaskAttacher.ui
@@ -140,6 +140,29 @@
         </property>
        </widget>
       </item>
+      <item row="1" column="1">
+       <widget class="Gui::PrefQuantitySpinBox" name="attachmentOffsetX">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>5</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>Note: The placement is expressed in local coordinate system
+of object being attached.</string>
+        </property>
+        <property name="keyboardTracking">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
       <item row="2" column="0">
        <widget class="QLabel" name="labelOffset2">
         <property name="sizePolicy">
@@ -225,55 +248,6 @@ of object being attached.</string>
         </property>
        </widget>
       </item>
-      <item row="5" column="0">
-       <widget class="QLabel" name="labelPitch">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string>Around y-axis:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="0">
-       <widget class="QLabel" name="labelRoll">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string>Around z-axis:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="Gui::PrefQuantitySpinBox" name="attachmentOffsetX">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>5</height>
-         </size>
-        </property>
-        <property name="toolTip">
-         <string>Note: The placement is expressed in local coordinate system
-of object being attached.</string>
-        </property>
-        <property name="keyboardTracking">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
       <item row="4" column="1">
        <widget class="Gui::QuantitySpinBox" name="attachmentOffsetRoll">
         <property name="sizePolicy">
@@ -301,6 +275,19 @@ of object being attached.</string>
         </property>
        </widget>
       </item>
+      <item row="5" column="0">
+       <widget class="QLabel" name="labelPitch">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Around y-axis:</string>
+        </property>
+       </widget>
+      </item>
       <item row="5" column="1">
        <widget class="Gui::QuantitySpinBox" name="attachmentOffsetPitch">
         <property name="sizePolicy">
@@ -325,6 +312,19 @@ of object being attached.</string>
         </property>
         <property name="maximum">
          <double>360.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="0">
+       <widget class="QLabel" name="labelRoll">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Around z-axis:</string>
         </property>
        </widget>
       </item>

--- a/src/Mod/Part/Gui/TaskFaceColors.ui
+++ b/src/Mod/Part/Gui/TaskFaceColors.ui
@@ -40,7 +40,14 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="0" colspan="2">
+      <item row="0" column="1" colspan="2">
+       <widget class="QLabel" name="labelElement">
+        <property name="text">
+         <string notr="true">[]</string>
+        </property>
+       </widget>
+      </item>
+     <item row="1" column="0" colspan="2">
        <widget class="Gui::ColorButton" name="colorButton">
         <property name="minimumSize">
          <size>
@@ -69,14 +76,7 @@
         </property>
        </spacer>
       </item>
-      <item row="0" column="1" colspan="2">
-       <widget class="QLabel" name="labelElement">
-        <property name="text">
-         <string notr="true">[]</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
+      </layout>
     </widget>
    </item>
    <item>

--- a/src/Mod/Part/Gui/TaskLoft.ui
+++ b/src/Mod/Part/Gui/TaskLoft.ui
@@ -31,7 +31,14 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="3">
+   <item row="1" column="2">
+    <widget class="QCheckBox" name="checkClosed">
+     <property name="text">
+      <string>Closed</string>
+     </property>
+    </widget>
+   </item>
+  <item row="1" column="3">
     <spacer name="horizontalSpacer">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -44,14 +51,7 @@
      </property>
     </spacer>
    </item>
-   <item row="1" column="2">
-    <widget class="QCheckBox" name="checkClosed">
-     <property name="text">
-      <string>Closed</string>
-     </property>
-    </widget>
-   </item>
-  </layout>
+   </layout>
  </widget>
  <customwidgets>
   <customwidget>

--- a/src/Mod/PartDesign/Gui/TaskPrimitiveParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskPrimitiveParameters.ui
@@ -130,22 +130,6 @@
        <property name="spacing">
         <number>6</number>
        </property>
-       <item row="1" column="0">
-        <spacer>
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::Expanding</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>0</width>
-           <height>0</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
        <item row="0" column="0">
         <layout class="QGridLayout" name="_4">
          <property name="leftMargin">
@@ -225,7 +209,23 @@
          </item>
         </layout>
        </item>
-      </layout>
+      <item row="1" column="0">
+        <spacer>
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Expanding</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>0</width>
+           <height>0</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       </layout>
      </widget>
      <widget class="QWidget" name="Page2_cylinder">
       <layout class="QGridLayout" name="_5">
@@ -244,71 +244,6 @@
        <property name="spacing">
         <number>6</number>
        </property>
-       <item row="2" column="0">
-        <layout class="QHBoxLayout" name="_6">
-         <property name="spacing">
-          <number>6</number>
-         </property>
-         <property name="leftMargin">
-          <number>0</number>
-         </property>
-         <property name="topMargin">
-          <number>0</number>
-         </property>
-         <property name="rightMargin">
-          <number>0</number>
-         </property>
-         <property name="bottomMargin">
-          <number>0</number>
-         </property>
-         <item>
-          <widget class="QLabel" name="label">
-           <property name="text">
-            <string>Angle:</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="Gui::QuantitySpinBox" name="cylinderAngle">
-           <property name="keyboardTracking">
-            <bool>false</bool>
-           </property>
-           <property name="unit" stdset="0">
-            <string notr="true">deg</string>
-           </property>
-           <property name="value">
-            <double>360.000000000000000</double>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item row="1" column="0">
-        <widget class="Line" name="line_2">
-         <property name="frameShape">
-          <enum>QFrame::HLine</enum>
-         </property>
-         <property name="frameShadow">
-          <enum>QFrame::Sunken</enum>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="0">
-        <spacer>
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::Expanding</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>0</width>
-           <height>0</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
        <item row="0" column="0">
         <layout class="QGridLayout" name="_7">
          <property name="leftMargin">
@@ -368,7 +303,72 @@
          </item>
         </layout>
        </item>
-      </layout>
+      <item row="1" column="0">
+        <widget class="Line" name="line_2">
+         <property name="frameShape">
+          <enum>QFrame::HLine</enum>
+         </property>
+         <property name="frameShadow">
+          <enum>QFrame::Sunken</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <layout class="QHBoxLayout" name="_6">
+         <property name="spacing">
+          <number>6</number>
+         </property>
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="label">
+           <property name="text">
+            <string>Angle:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="Gui::QuantitySpinBox" name="cylinderAngle">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
+           <property name="unit" stdset="0">
+            <string notr="true">deg</string>
+           </property>
+           <property name="value">
+            <double>360.000000000000000</double>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item row="3" column="0">
+        <spacer>
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Expanding</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>0</width>
+           <height>0</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       </layout>
      </widget>
      <widget class="QWidget" name="Page3_cone">
       <layout class="QGridLayout" name="_8">
@@ -387,71 +387,6 @@
        <property name="spacing">
         <number>6</number>
        </property>
-       <item row="2" column="0">
-        <layout class="QHBoxLayout" name="_9">
-         <property name="spacing">
-          <number>6</number>
-         </property>
-         <property name="leftMargin">
-          <number>0</number>
-         </property>
-         <property name="topMargin">
-          <number>0</number>
-         </property>
-         <property name="rightMargin">
-          <number>0</number>
-         </property>
-         <property name="bottomMargin">
-          <number>0</number>
-         </property>
-         <item>
-          <widget class="QLabel" name="label_4">
-           <property name="text">
-            <string>Angle:</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="Gui::QuantitySpinBox" name="coneAngle">
-           <property name="keyboardTracking">
-            <bool>false</bool>
-           </property>
-           <property name="unit" stdset="0">
-            <string notr="true">deg</string>
-           </property>
-           <property name="value">
-            <double>360.000000000000000</double>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item row="1" column="0">
-        <widget class="Line" name="line_3">
-         <property name="frameShape">
-          <enum>QFrame::HLine</enum>
-         </property>
-         <property name="frameShadow">
-          <enum>QFrame::Sunken</enum>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="0">
-        <spacer>
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::Expanding</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>0</width>
-           <height>0</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
        <item row="0" column="0">
         <layout class="QGridLayout" name="_10">
          <property name="leftMargin">
@@ -531,7 +466,72 @@
          </item>
         </layout>
        </item>
-      </layout>
+      <item row="1" column="0">
+        <widget class="Line" name="line_3">
+         <property name="frameShape">
+          <enum>QFrame::HLine</enum>
+         </property>
+         <property name="frameShadow">
+          <enum>QFrame::Sunken</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <layout class="QHBoxLayout" name="_9">
+         <property name="spacing">
+          <number>6</number>
+         </property>
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="label_4">
+           <property name="text">
+            <string>Angle:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="Gui::QuantitySpinBox" name="coneAngle">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
+           <property name="unit" stdset="0">
+            <string notr="true">deg</string>
+           </property>
+           <property name="value">
+            <double>360.000000000000000</double>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item row="3" column="0">
+        <spacer>
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Expanding</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>0</width>
+           <height>0</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       </layout>
      </widget>
      <widget class="QWidget" name="Page4_sphere">
       <layout class="QGridLayout" name="_11">
@@ -550,7 +550,46 @@
        <property name="spacing">
         <number>6</number>
        </property>
-       <item row="1" column="0">
+       <item row="0" column="0">
+        <layout class="QHBoxLayout" name="_13">
+         <property name="spacing">
+          <number>6</number>
+         </property>
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="textLabel14">
+           <property name="text">
+            <string>Radius:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="Gui::QuantitySpinBox" name="sphereRadius">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
+           <property name="unit" stdset="0">
+            <string notr="true">mm</string>
+           </property>
+           <property name="value">
+            <double>5.000000000000000</double>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+      <item row="1" column="0">
         <widget class="Line" name="line">
          <property name="frameShape">
           <enum>QFrame::HLine</enum>
@@ -664,46 +703,7 @@
          </property>
         </spacer>
        </item>
-       <item row="0" column="0">
-        <layout class="QHBoxLayout" name="_13">
-         <property name="spacing">
-          <number>6</number>
-         </property>
-         <property name="leftMargin">
-          <number>0</number>
-         </property>
-         <property name="topMargin">
-          <number>0</number>
-         </property>
-         <property name="rightMargin">
-          <number>0</number>
-         </property>
-         <property name="bottomMargin">
-          <number>0</number>
-         </property>
-         <item>
-          <widget class="QLabel" name="textLabel14">
-           <property name="text">
-            <string>Radius:</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="Gui::QuantitySpinBox" name="sphereRadius">
-           <property name="keyboardTracking">
-            <bool>false</bool>
-           </property>
-           <property name="unit" stdset="0">
-            <string notr="true">mm</string>
-           </property>
-           <property name="value">
-            <double>5.000000000000000</double>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-      </layout>
+       </layout>
      </widget>
      <widget class="QWidget" name="Page5_ellipsoid">
       <layout class="QGridLayout" name="_14">
@@ -722,29 +722,6 @@
        <property name="spacing">
         <number>6</number>
        </property>
-       <item row="3" column="0">
-        <spacer>
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>0</width>
-           <height>0</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="1" column="0">
-        <widget class="Line" name="line_5">
-         <property name="frameShape">
-          <enum>QFrame::HLine</enum>
-         </property>
-         <property name="frameShadow">
-          <enum>QFrame::Sunken</enum>
-         </property>
-        </widget>
-       </item>
        <item row="0" column="0">
         <layout class="QGridLayout" name="_15">
          <property name="leftMargin">
@@ -823,6 +800,16 @@
           </widget>
          </item>
         </layout>
+       </item>
+       <item row="1" column="0">
+        <widget class="Line" name="line_5">
+         <property name="frameShape">
+          <enum>QFrame::HLine</enum>
+         </property>
+         <property name="frameShadow">
+          <enum>QFrame::Sunken</enum>
+         </property>
+        </widget>
        </item>
        <item row="2" column="0">
         <layout class="QGridLayout" name="_16">
@@ -912,7 +899,20 @@
          </item>
         </layout>
        </item>
-      </layout>
+      <item row="3" column="0">
+        <spacer>
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>0</width>
+           <height>0</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       </layout>
      </widget>
      <widget class="QWidget" name="Page6_torus">
       <layout class="QGridLayout" name="_17">
@@ -931,7 +931,66 @@
        <property name="spacing">
         <number>6</number>
        </property>
-       <item row="1" column="0">
+       <item row="0" column="0">
+        <layout class="QGridLayout" name="_19">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <property name="spacing">
+          <number>6</number>
+         </property>
+         <item row="0" column="2">
+          <widget class="Gui::QuantitySpinBox" name="torusRadius1">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
+           <property name="unit" stdset="0">
+            <string notr="true">mm</string>
+           </property>
+           <property name="value">
+            <double>10.000000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="textLabel20">
+           <property name="text">
+            <string>Radius 2:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="0">
+          <widget class="QLabel" name="textLabel19">
+           <property name="text">
+            <string>Radius 1:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="2">
+          <widget class="Gui::QuantitySpinBox" name="torusRadius2">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
+           <property name="unit" stdset="0">
+            <string notr="true">mm</string>
+           </property>
+           <property name="value">
+            <double>2.000000000000000</double>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+      <item row="1" column="0">
         <widget class="Line" name="line_4">
          <property name="frameShape">
           <enum>QFrame::HLine</enum>
@@ -1045,66 +1104,7 @@
          </property>
         </spacer>
        </item>
-       <item row="0" column="0">
-        <layout class="QGridLayout" name="_19">
-         <property name="leftMargin">
-          <number>0</number>
-         </property>
-         <property name="topMargin">
-          <number>0</number>
-         </property>
-         <property name="rightMargin">
-          <number>0</number>
-         </property>
-         <property name="bottomMargin">
-          <number>0</number>
-         </property>
-         <property name="spacing">
-          <number>6</number>
-         </property>
-         <item row="0" column="2">
-          <widget class="Gui::QuantitySpinBox" name="torusRadius1">
-           <property name="keyboardTracking">
-            <bool>false</bool>
-           </property>
-           <property name="unit" stdset="0">
-            <string notr="true">mm</string>
-           </property>
-           <property name="value">
-            <double>10.000000000000000</double>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <widget class="QLabel" name="textLabel20">
-           <property name="text">
-            <string>Radius 2:</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="0">
-          <widget class="QLabel" name="textLabel19">
-           <property name="text">
-            <string>Radius 1:</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="2">
-          <widget class="Gui::QuantitySpinBox" name="torusRadius2">
-           <property name="keyboardTracking">
-            <bool>false</bool>
-           </property>
-           <property name="unit" stdset="0">
-            <string notr="true">mm</string>
-           </property>
-           <property name="value">
-            <double>2.000000000000000</double>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-      </layout>
+       </layout>
      </widget>
      <widget class="QWidget" name="page_prism">
       <layout class="QGridLayout" name="_20">
@@ -1469,19 +1469,6 @@
        <property name="spacing">
         <number>6</number>
        </property>
-       <item row="1" column="0">
-        <spacer>
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>0</width>
-           <height>0</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
        <item row="0" column="0">
         <layout class="QGridLayout" name="_23">
          <property name="leftMargin">
@@ -1599,7 +1586,20 @@
          </item>
         </layout>
        </item>
-      </layout>
+      <item row="1" column="0">
+        <spacer>
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>0</width>
+           <height>0</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       </layout>
      </widget>
      <widget class="QWidget" name="page9_spiral">
       <layout class="QGridLayout" name="_24">
@@ -1618,19 +1618,6 @@
        <property name="spacing">
         <number>6</number>
        </property>
-       <item row="1" column="0">
-        <spacer>
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>0</width>
-           <height>0</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
        <item row="0" column="0">
         <layout class="QGridLayout" name="_25">
          <property name="leftMargin">
@@ -1710,7 +1697,20 @@
          </item>
         </layout>
        </item>
-      </layout>
+      <item row="1" column="0">
+        <spacer>
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>0</width>
+           <height>0</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       </layout>
      </widget>
      <widget class="QWidget" name="page10_circle">
       <layout class="QGridLayout" name="gridLayout_3">

--- a/src/Mod/PartDesign/Gui/TaskThicknessParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskThicknessParameters.ui
@@ -95,13 +95,6 @@ click again to end selection</string>
        </property>
       </widget>
      </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="label_3">
-       <property name="text">
-        <string>Join Type</string>
-       </property>
-      </widget>
-     </item>
      <item row="1" column="1">
       <widget class="QComboBox" name="modeComboBox">
        <item>
@@ -119,6 +112,13 @@ click again to end selection</string>
          <string>Recto Verso</string>
         </property>
        </item>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="label_3">
+       <property name="text">
+        <string>Join Type</string>
+       </property>
       </widget>
      </item>
      <item row="2" column="1">

--- a/src/Mod/Path/Gui/DlgSettingsPathColor.ui
+++ b/src/Mod/Path/Gui/DlgSettingsPathColor.ui
@@ -23,8 +23,8 @@
       <string>Default Path colors</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_10">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_6">
         <property name="minimumSize">
          <size>
           <width>182</width>
@@ -32,27 +32,7 @@
          </size>
         </property>
         <property name="text">
-         <string>Default path marker color</string>
-        </property>
-       </widget>
-      </item>
-      <item row="7" column="1">
-       <widget class="Gui::PrefColorButton" name="DefaultBBoxNormalColor">
-        <property name="toolTip">
-         <string>The default line color for new shapes</string>
-        </property>
-        <property name="color" stdset="0">
-         <color>
-          <red>255</red>
-          <green>255</green>
-          <blue>255</blue>
-         </color>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>DefaultBBoxNormalColor</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Path</cstring>
+         <string>Default normal path color</string>
         </property>
        </widget>
       </item>
@@ -73,6 +53,54 @@
         </property>
         <property name="prefPath" stdset="0">
          <cstring>Mod/Path</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_9">
+        <property name="minimumSize">
+         <size>
+          <width>182</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Default pathline width</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="Gui::PrefSpinBox" name="DefaultPathLineWidth">
+        <property name="toolTip">
+         <string>The default line thickness for new shapes</string>
+        </property>
+        <property name="suffix">
+         <string>px</string>
+        </property>
+        <property name="maximum">
+         <number>9</number>
+        </property>
+        <property name="value">
+         <number>1</number>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>DefaultPathLineWidth</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Path</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_10">
+        <property name="minimumSize">
+         <size>
+          <width>182</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Default path marker color</string>
         </property>
        </widget>
       </item>
@@ -106,54 +134,6 @@
         </property>
         <property name="text">
          <string>Rapid path color</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="Gui::PrefSpinBox" name="DefaultPathLineWidth">
-        <property name="toolTip">
-         <string>The default line thickness for new shapes</string>
-        </property>
-        <property name="suffix">
-         <string>px</string>
-        </property>
-        <property name="maximum">
-         <number>9</number>
-        </property>
-        <property name="value">
-         <number>1</number>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>DefaultPathLineWidth</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Path</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_9">
-        <property name="minimumSize">
-         <size>
-          <width>182</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>Default pathline width</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_6">
-        <property name="minimumSize">
-         <size>
-          <width>182</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>Default normal path color</string>
         </property>
        </widget>
       </item>
@@ -270,6 +250,26 @@
         </property>
         <property name="text">
          <string>Bounding Box Normal Color</string>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="1">
+       <widget class="Gui::PrefColorButton" name="DefaultBBoxNormalColor">
+        <property name="toolTip">
+         <string>The default line color for new shapes</string>
+        </property>
+        <property name="color" stdset="0">
+         <color>
+          <red>255</red>
+          <green>255</green>
+          <blue>255</blue>
+         </color>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>DefaultBBoxNormalColor</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Path</cstring>
         </property>
        </widget>
       </item>

--- a/src/Mod/Path/Gui/Resources/panels/AxisMapEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/AxisMapEdit.ui
@@ -14,19 +14,6 @@
    <string>AxisMap Dressup</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="3" column="2">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>275</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
    <item row="0" column="0">
     <widget class="QLabel" name="lblRadius">
      <property name="text">
@@ -91,7 +78,20 @@
      </item>
     </widget>
    </item>
-  </layout>
+  <item row="3" column="2">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>275</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   </layout>
  </widget>
  <customwidgets>
   <customwidget>

--- a/src/Mod/Path/Gui/Resources/panels/DlgJobCreate.ui
+++ b/src/Mod/Path/Gui/Resources/panels/DlgJobCreate.ui
@@ -15,7 +15,7 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>
-    <widget class="QWidget" name="widget_4" native="true">
+    <widget class="QWidget" name="widget_4">
      <layout class="QGridLayout" name="gridLayout_2">
       <item row="0" column="0">
        <widget class="QGroupBox" name="templateGroup">

--- a/src/Mod/Path/Gui/Resources/panels/DlgJobTemplateExport.ui
+++ b/src/Mod/Path/Gui/Resources/panels/DlgJobTemplateExport.ui
@@ -76,16 +76,6 @@
       <bool>true</bool>
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
-      <item row="1" column="1">
-       <widget class="QCheckBox" name="settingOperationDepths">
-        <property name="text">
-         <string>Operation Depths</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
       <item row="1" column="0">
        <widget class="QCheckBox" name="settingOperationHeights">
         <property name="toolTip">
@@ -93,6 +83,16 @@
         </property>
         <property name="text">
          <string>Operation Heights</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QCheckBox" name="settingOperationDepths">
+        <property name="text">
+         <string>Operation Depths</string>
         </property>
         <property name="checked">
          <bool>true</bool>
@@ -112,13 +112,6 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="0" colspan="2">
-       <widget class="QListWidget" name="settingsOpsList">
-        <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable all Operations for which the configuration values should be exported.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Note that only operations are listed which currently have configuration values setup.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-       </widget>
-      </item>
       <item row="2" column="1">
        <widget class="QCheckBox" name="settingCoolant">
         <property name="toolTip">
@@ -132,7 +125,14 @@
         </property>
        </widget>
       </item>
-     </layout>
+     <item row="3" column="0" colspan="2">
+       <widget class="QListWidget" name="settingsOpsList">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable all Operations for which the configuration values should be exported.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Note that only operations are listed which currently have configuration values setup.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+       </widget>
+      </item>
+      </layout>
     </widget>
    </item>
    <item>
@@ -160,19 +160,6 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="0">
-       <widget class="QCheckBox" name="stockPlacement">
-        <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If enabled the current placement of the stock solid is stored in the template.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-        <property name="text">
-         <string>Placement</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
       <item row="0" column="1">
        <widget class="QLineEdit" name="stockExtentHint">
         <property name="enabled">
@@ -183,6 +170,19 @@
         </property>
         <property name="toolTip">
          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Hint about the current stock extent setting.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QCheckBox" name="stockPlacement">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If enabled the current placement of the stock solid is stored in the template.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>Placement</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
         </property>
        </widget>
       </item>

--- a/src/Mod/Path/Gui/Resources/panels/DlgToolEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/DlgToolEdit.ui
@@ -15,7 +15,7 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QWidget" name="toolEditor" native="true">
+    <widget class="QWidget" name="toolEditor">
      <layout class="QVBoxLayout" name="verticalLayout_2"/>
     </widget>
    </item>

--- a/src/Mod/Path/Gui/Resources/panels/DragKnifeEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/DragKnifeEdit.ui
@@ -14,19 +14,6 @@
    <string>Dragknife Dressup</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="3" column="2">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>275</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
    <item row="0" column="0">
     <widget class="QLabel" name="lblFilterAngle">
      <property name="text">
@@ -34,10 +21,20 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="lblPivotHeight">
+   <item row="0" column="2" colspan="2">
+    <widget class="Gui::QuantitySpinBox" name="filterAngle">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Angles less than filter angle will not receive corner actions&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="unit" stdset="0">
+      <string notr="true">deg</string>
+     </property>
+    </widget>
+   </item>
+  <item row="1" column="0">
+    <widget class="QLabel" name="lblOffSetDistance">
      <property name="text">
-      <string>Pivot Height</string>
+      <string>Offset Distance</string>
      </property>
     </widget>
    </item>
@@ -60,10 +57,10 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="lblOffSetDistance">
+   <item row="2" column="0">
+    <widget class="QLabel" name="lblPivotHeight">
      <property name="text">
-      <string>Offset Distance</string>
+      <string>Pivot Height</string>
      </property>
     </widget>
    </item>
@@ -86,17 +83,20 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="2" colspan="2">
-    <widget class="Gui::QuantitySpinBox" name="filterAngle">
-     <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Angles less than filter angle will not receive corner actions&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+   <item row="3" column="2">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
      </property>
-     <property name="unit" stdset="0">
-      <string notr="true">deg</string>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>275</height>
+      </size>
      </property>
-    </widget>
+    </spacer>
    </item>
-  </layout>
+   </layout>
  </widget>
  <customwidgets>
   <customwidget>

--- a/src/Mod/Path/Gui/Resources/panels/DressupPathBoundary.ui
+++ b/src/Mod/Path/Gui/Resources/panels/DressupPathBoundary.ui
@@ -94,17 +94,17 @@
       <item>
        <widget class="QFrame" name="stockFromBase">
         <layout class="QGridLayout" name="gridLayout_9">
-         <item row="1" column="3">
-          <widget class="Gui::InputField" name="stockExtYpos">
-           <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Extension of BoundBox's MaxY.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-           </property>
-          </widget>
-         </item>
          <item row="0" column="1">
           <widget class="QLabel" name="stockExtXLabel">
            <property name="text">
             <string>Ext. X</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="2">
+          <widget class="Gui::InputField" name="stockExtXneg">
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Extension of BoundBox's MinX.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
           </widget>
          </item>
@@ -128,10 +128,17 @@
            </property>
           </widget>
          </item>
-         <item row="0" column="2">
-          <widget class="Gui::InputField" name="stockExtXneg">
+         <item row="1" column="2">
+          <widget class="Gui::InputField" name="stockExtYneg">
            <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Extension of BoundBox's MinX.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Extension of BoundBox's MinY.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+          </widget>
+         </item>
+        <item row="1" column="3">
+          <widget class="Gui::InputField" name="stockExtYpos">
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Extension of BoundBox's MaxY.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
           </widget>
          </item>
@@ -156,37 +163,23 @@
            </property>
           </widget>
          </item>
-         <item row="1" column="2">
-          <widget class="Gui::InputField" name="stockExtYneg">
-           <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Extension of BoundBox's MinY.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
+         </layout>
        </widget>
       </item>
       <item>
        <widget class="QFrame" name="stockCreateCylinder">
         <layout class="QGridLayout" name="gridLayout_10">
-         <item row="0" column="2">
-          <widget class="Gui::InputField" name="stockCylinderRadius">
-           <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Radius of the Cylinder.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="2">
-          <widget class="Gui::InputField" name="stockCylinderHeight">
-           <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Height of the Cylinder.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-           </property>
-          </widget>
-         </item>
          <item row="0" column="1">
           <widget class="QLabel" name="stockCylinderRadiusLabel">
            <property name="text">
             <string>Radius</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="2">
+          <widget class="Gui::InputField" name="stockCylinderRadius">
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Radius of the Cylinder.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
           </widget>
          </item>
@@ -197,7 +190,14 @@
            </property>
           </widget>
          </item>
-        </layout>
+        <item row="1" column="2">
+          <widget class="Gui::InputField" name="stockCylinderHeight">
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Height of the Cylinder.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+          </widget>
+         </item>
+         </layout>
        </widget>
       </item>
       <item>
@@ -210,13 +210,6 @@
            </property>
           </widget>
          </item>
-         <item row="1" column="1">
-          <widget class="QLabel" name="stockBoxWidthLabel">
-           <property name="text">
-            <string>Width</string>
-           </property>
-          </widget>
-         </item>
          <item row="0" column="2">
           <widget class="Gui::InputField" name="stockBoxLength">
            <property name="toolTip">
@@ -224,10 +217,10 @@
            </property>
           </widget>
          </item>
-         <item row="2" column="2">
-          <widget class="Gui::InputField" name="stockBoxHeight">
-           <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Height of the Box.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         <item row="1" column="1">
+          <widget class="QLabel" name="stockBoxWidthLabel">
+           <property name="text">
+            <string>Width</string>
            </property>
           </widget>
          </item>
@@ -245,7 +238,14 @@
            </property>
           </widget>
          </item>
-        </layout>
+        <item row="2" column="2">
+          <widget class="Gui::InputField" name="stockBoxHeight">
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Height of the Box.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+          </widget>
+         </item>
+         </layout>
        </widget>
       </item>
      </layout>

--- a/src/Mod/Path/Gui/Resources/panels/DressupPathBoundary.ui
+++ b/src/Mod/Path/Gui/Resources/panels/DressupPathBoundary.ui
@@ -24,7 +24,7 @@
        <number>0</number>
       </property>
       <item>
-       <widget class="QWidget" name="widget_2" native="true">
+       <widget class="QWidget" name="widget_2">
         <layout class="QHBoxLayout" name="horizontalLayout_5">
          <item>
           <widget class="QComboBox" name="stock">

--- a/src/Mod/Path/Gui/Resources/panels/HoldingTagsEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/HoldingTagsEdit.ui
@@ -15,7 +15,7 @@
   </property>
   <layout class="QGridLayout" name="gridLayout_2">
    <item row="2" column="0">
-    <widget class="QWidget" name="removeEditAddGroup" native="true">
+    <widget class="QWidget" name="removeEditAddGroup">
      <layout class="QGridLayout" name="gridLayout">
       <property name="leftMargin">
        <number>0</number>
@@ -61,7 +61,7 @@
     </widget>
    </item>
    <item row="0" column="0">
-    <widget class="QWidget" name="parameterGroup" native="true">
+    <widget class="QWidget" name="parameterGroup">
      <layout class="QFormLayout">
       <property name="fieldGrowthPolicy">
        <enum>QFormLayout::AllNonFixedFieldsGrow</enum>

--- a/src/Mod/Path/Gui/Resources/panels/HoldingTagsEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/HoldingTagsEdit.ui
@@ -14,52 +14,6 @@
    <string>Holding Tags</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_2">
-   <item row="2" column="0">
-    <widget class="QWidget" name="removeEditAddGroup">
-     <layout class="QGridLayout" name="gridLayout">
-      <property name="leftMargin">
-       <number>0</number>
-      </property>
-      <property name="rightMargin">
-       <number>0</number>
-      </property>
-      <item row="1" column="2">
-       <widget class="QPushButton" name="pbAdd">
-        <property name="text">
-         <string>Add...</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QPushButton" name="pbDelete">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="text">
-         <string>Delete</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QPushButton" name="pbEdit">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="text">
-         <string>Edit...</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QListWidget" name="lwTags">
-     <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;List of current tags. Edit coordinates by double click or Edit button.&lt;/p&gt;&lt;p&gt;Tags are automatically disabled if they overlap with the previous tag, or don't lie on the base wire.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-    </widget>
-   </item>
    <item row="0" column="0">
     <widget class="QWidget" name="parameterGroup">
      <layout class="QFormLayout">
@@ -137,22 +91,46 @@
      </layout>
     </widget>
    </item>
-   <item row="4" column="0">
-    <widget class="QGroupBox" name="gbCopy">
-     <property name="enabled">
-      <bool>false</bool>
+   <item row="1" column="0">
+    <widget class="QListWidget" name="lwTags">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;List of current tags. Edit coordinates by double click or Edit button.&lt;/p&gt;&lt;p&gt;Tags are automatically disabled if they overlap with the previous tag, or don't lie on the base wire.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
-     <property name="title">
-      <string>Copy From</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_4">
-      <item row="0" column="0">
-       <widget class="QComboBox" name="cbSource"/>
-      </item>
-      <item row="0" column="1">
-       <widget class="QPushButton" name="pbCopy">
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QWidget" name="removeEditAddGroup">
+     <layout class="QGridLayout" name="gridLayout">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <item row="1" column="2">
+       <widget class="QPushButton" name="pbAdd">
         <property name="text">
-         <string>Replace All</string>
+         <string>Add...</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QPushButton" name="pbDelete">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>Delete</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QPushButton" name="pbEdit">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>Edit...</string>
         </property>
        </widget>
       </item>
@@ -185,7 +163,29 @@
      </layout>
     </widget>
    </item>
-  </layout>
+  <item row="4" column="0">
+    <widget class="QGroupBox" name="gbCopy">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="title">
+      <string>Copy From</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_4">
+      <item row="0" column="0">
+       <widget class="QComboBox" name="cbSource"/>
+      </item>
+      <item row="0" column="1">
+       <widget class="QPushButton" name="pbCopy">
+        <property name="text">
+         <string>Replace All</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   </layout>
  </widget>
  <customwidgets>
   <customwidget>

--- a/src/Mod/Path/Gui/Resources/panels/PageBaseGeometryEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PageBaseGeometryEdit.ui
@@ -24,6 +24,45 @@
     <normaloff>:/icons/Path_BaseGeometry.svg</normaloff>:/icons/Path_BaseGeometry.svg</iconset>
   </property>
   <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0" colspan="2">
+    <widget class="QComboBox" name="geometryImportList">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;List of operations with Base Geometry in current Job.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+    </widget>
+   </item>
+  <item row="0" column="2">
+    <widget class="QPushButton" name="geometryImportButton">
+     <property name="text">
+      <string>Import</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0" colspan="3">
+    <widget class="QListWidget" name="baseList">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select one or more features in the 3d view and press 'Add' to add them as the base items for this operation.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Selected features can be deleted entirely.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="selectionMode">
+      <enum>QAbstractItemView::ExtendedSelection</enum>
+     </property>
+    </widget>
+   </item>
    <item row="3" column="0">
     <widget class="QPushButton" name="addBase">
      <property name="toolTip">
@@ -43,19 +82,6 @@
       <string>Remove</string>
      </property>
     </widget>
-   </item>
-   <item row="7" column="0">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
    </item>
    <item row="3" column="2">
     <widget class="QPushButton" name="clearBase">
@@ -80,46 +106,20 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="0" colspan="3">
-    <widget class="QListWidget" name="baseList">
-     <property name="enabled">
-      <bool>true</bool>
+   <item row="7" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
      </property>
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
      </property>
-     <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select one or more features in the 3d view and press 'Add' to add them as the base items for this operation.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Selected features can be deleted entirely.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="selectionMode">
-      <enum>QAbstractItemView::ExtendedSelection</enum>
-     </property>
-    </widget>
+    </spacer>
    </item>
-   <item row="0" column="2">
-    <widget class="QPushButton" name="geometryImportButton">
-     <property name="text">
-      <string>Import</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0" colspan="2">
-    <widget class="QComboBox" name="geometryImportList">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;List of operations with Base Geometry in current Job.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-    </widget>
-   </item>
-  </layout>
+   </layout>
  </widget>
  <resources>
   <include location="../Path.qrc"/>

--- a/src/Mod/Path/Gui/Resources/panels/PageBaseHoleGeometryEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PageBaseHoleGeometryEdit.ui
@@ -36,6 +36,26 @@
        </column>
       </widget>
      </item>
+     <item row="1" column="0">
+      <widget class="QPushButton" name="addBase">
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Add selected items from 3d view to the list of base geometries.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="text">
+        <string>Add</string>
+       </property>
+      </widget>
+     </item>
+    <item row="1" column="1">
+      <widget class="QPushButton" name="deleteBase">
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Remove selected list items from the list of base geometries. The operation is no longer applied to them.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="text">
+        <string>Remove</string>
+       </property>
+      </widget>
+     </item>
      <item row="1" column="2">
       <widget class="QPushButton" name="resetBase">
        <property name="toolTip">
@@ -59,27 +79,7 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="1">
-      <widget class="QPushButton" name="deleteBase">
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Remove selected list items from the list of base geometries. The operation is no longer applied to them.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="text">
-        <string>Remove</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="QPushButton" name="addBase">
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Add selected items from 3d view to the list of base geometries.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="text">
-        <string>Add</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
+     </layout>
    </item>
   </layout>
  </widget>

--- a/src/Mod/Path/Gui/Resources/panels/PageBaseLocationEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PageBaseLocationEdit.ui
@@ -34,6 +34,16 @@
    <item>
     <widget class="QWidget" name="addRemoveEdit">
      <layout class="QGridLayout" name="gridLayout">
+      <item row="0" column="1">
+       <widget class="QPushButton" name="addLocation">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Opens a dialog to add arbitrary locations.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>Add</string>
+        </property>
+       </widget>
+      </item>
       <item row="0" column="2">
        <widget class="QPushButton" name="removeLocation">
         <property name="toolTip">
@@ -51,16 +61,6 @@
         </property>
         <property name="text">
          <string>Edit</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QPushButton" name="addLocation">
-        <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Opens a dialog to add arbitrary locations.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-        <property name="text">
-         <string>Add</string>
         </property>
        </widget>
       </item>

--- a/src/Mod/Path/Gui/Resources/panels/PageBaseLocationEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PageBaseLocationEdit.ui
@@ -32,7 +32,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QWidget" name="addRemoveEdit" native="true">
+    <widget class="QWidget" name="addRemoveEdit">
      <layout class="QGridLayout" name="gridLayout">
       <item row="0" column="2">
        <widget class="QPushButton" name="removeLocation">

--- a/src/Mod/Path/Gui/Resources/panels/PageDepthsEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PageDepthsEdit.ui
@@ -53,65 +53,6 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="2">
-    <widget class="Gui::QuantitySpinBox" name="finalDepth">
-     <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The depth of the operation which corresponds to the lowest value in Z-axis the operation needs to process.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="minimum" stdset="0">
-      <double>-999999999.000000000000000</double>
-     </property>
-     <property name="maximum" stdset="0">
-      <double>999999999.000000000000000</double>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="3">
-    <widget class="QToolButton" name="finalDepthSet">
-     <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Transfer the Z value of the selected feature as the Final Depth for the operation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="text">
-      <string>...</string>
-     </property>
-     <property name="icon">
-      <iconset>
-       <normaloff>:/icons/button_left.svg</normaloff>:/icons/button_left.svg</iconset>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="1">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="3" column="0" colspan="2">
-    <widget class="QLabel" name="finishDepthLabel">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>34</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
-       <height>34</height>
-      </size>
-     </property>
-     <property name="text">
-      <string>Finish Step Down</string>
-     </property>
-    </widget>
-   </item>
    <item row="0" column="3">
     <widget class="QToolButton" name="startDepthSet">
      <property name="toolTip">
@@ -145,6 +86,33 @@
      </property>
     </widget>
    </item>
+   <item row="1" column="2">
+    <widget class="Gui::QuantitySpinBox" name="finalDepth">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The depth of the operation which corresponds to the lowest value in Z-axis the operation needs to process.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="minimum" stdset="0">
+      <double>-999999999.000000000000000</double>
+     </property>
+     <property name="maximum" stdset="0">
+      <double>999999999.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="3">
+    <widget class="QToolButton" name="finalDepthSet">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Transfer the Z value of the selected feature as the Final Depth for the operation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="text">
+      <string>...</string>
+     </property>
+     <property name="icon">
+      <iconset>
+       <normaloff>:/icons/button_left.svg</normaloff>:/icons/button_left.svg</iconset>
+     </property>
+    </widget>
+   </item>
    <item row="2" column="0">
     <widget class="QLabel" name="stepDownLabel">
      <property name="minimumSize">
@@ -164,19 +132,6 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="2">
-    <widget class="Gui::QuantitySpinBox" name="finishDepth">
-     <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Depth of the final cut of the operation. Can be used to produce a cleaner finish.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="minimum" stdset="0">
-      <double>-999999999.000000000000000</double>
-     </property>
-     <property name="maximum" stdset="0">
-      <double>999999999.000000000000000</double>
-     </property>
-    </widget>
-   </item>
    <item row="2" column="2">
     <widget class="Gui::QuantitySpinBox" name="stepDown">
      <property name="toolTip">
@@ -190,7 +145,52 @@
      </property>
     </widget>
    </item>
-  </layout>
+  <item row="3" column="0" colspan="2">
+    <widget class="QLabel" name="finishDepthLabel">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>34</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>34</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>Finish Step Down</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="2">
+    <widget class="Gui::QuantitySpinBox" name="finishDepth">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Depth of the final cut of the operation. Can be used to produce a cleaner finish.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="minimum" stdset="0">
+      <double>-999999999.000000000000000</double>
+     </property>
+     <property name="maximum" stdset="0">
+      <double>999999999.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="1">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   </layout>
  </widget>
  <customwidgets>
   <customwidget>

--- a/src/Mod/Path/Gui/Resources/panels/PageDiametersEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PageDiametersEdit.ui
@@ -14,6 +14,13 @@
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <widget class="QLabel" name="startDepthLabel">
+     <property name="text">
+      <string>Min Diameter</string>
+     </property>
+    </widget>
+   </item>
    <item row="0" column="1">
     <widget class="Gui::QuantitySpinBox" name="minDiameter">
      <property name="toolTip">
@@ -27,6 +34,27 @@
      </property>
      <property name="maximum">
       <double>999999999.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="2">
+    <widget class="QToolButton" name="startDepthSet">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Transfer the Z value of the selected feature as the Start Depth for the operation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="text">
+      <string>...</string>
+     </property>
+     <property name="icon">
+      <iconset resource="../../../../../Gui/Icons/resource.qrc">
+       <normaloff>:/icons/button_left.svg</normaloff>:/icons/button_left.svg</iconset>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="finalDepthLabel">
+     <property name="text">
+      <string>Max Diameter</string>
      </property>
     </widget>
    </item>
@@ -60,47 +88,6 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="2">
-    <widget class="QToolButton" name="startDepthSet">
-     <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Transfer the Z value of the selected feature as the Start Depth for the operation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="text">
-      <string>...</string>
-     </property>
-     <property name="icon">
-      <iconset resource="../../../../../Gui/Icons/resource.qrc">
-       <normaloff>:/icons/button_left.svg</normaloff>:/icons/button_left.svg</iconset>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="startDepthLabel">
-     <property name="text">
-      <string>Min Diameter</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0" colspan="3">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="finalDepthLabel">
-     <property name="text">
-      <string>Max Diameter</string>
-     </property>
-    </widget>
-   </item>
    <item row="2" column="1">
     <spacer name="horizontalSpacer">
      <property name="orientation">
@@ -114,7 +101,20 @@
      </property>
     </spacer>
    </item>
-  </layout>
+  <item row="3" column="0" colspan="3">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   </layout>
  </widget>
  <customwidgets>
   <customwidget>

--- a/src/Mod/Path/Gui/Resources/panels/PageHeightsEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PageHeightsEdit.ui
@@ -25,26 +25,6 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label_9">
-     <property name="text">
-      <string>Clearance Height</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0" colspan="2">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
    <item row="0" column="1">
     <widget class="Gui::QuantitySpinBox" name="safeHeight">
      <property name="toolTip">
@@ -58,6 +38,13 @@
      </property>
      <property name="maximum">
       <double>999999999.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_9">
+     <property name="text">
+      <string>Clearance Height</string>
      </property>
     </widget>
    </item>
@@ -77,7 +64,20 @@
      </property>
     </widget>
    </item>
-  </layout>
+  <item row="2" column="0" colspan="2">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   </layout>
  </widget>
  <customwidgets>
   <customwidget>

--- a/src/Mod/Path/Gui/Resources/panels/PageOpCustomEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PageOpCustomEdit.ui
@@ -29,17 +29,17 @@
       <property name="bottomMargin">
        <number>0</number>
       </property>
-      <item row="0" column="1">
-       <widget class="QComboBox" name="toolController">
-        <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The tool and its settings to be used for this operation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-       </widget>
-      </item>
       <item row="0" column="0">
        <widget class="QLabel" name="label">
         <property name="text">
          <string>ToolController</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QComboBox" name="toolController">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The tool and its settings to be used for this operation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
        </widget>
       </item>

--- a/src/Mod/Path/Gui/Resources/panels/PageOpDeburrEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PageOpDeburrEdit.ui
@@ -160,7 +160,7 @@
    <item row="2" column="0">
     <layout class="QHBoxLayout" name="horizontalLayout_4">
      <item>
-      <widget class="QWidget" name="widget" native="true">
+      <widget class="QWidget" name="widget">
        <property name="minimumSize">
         <size>
          <width>125</width>
@@ -353,7 +353,7 @@
       </widget>
      </item>
      <item>
-      <widget class="QWidget" name="widget_2" native="true">
+      <widget class="QWidget" name="widget_2">
        <layout class="QGridLayout" name="gridLayout_3">
         <item row="0" column="0">
          <layout class="QVBoxLayout" name="verticalLayout_2">

--- a/src/Mod/Path/Gui/Resources/panels/PageOpDrillingEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PageOpDrillingEdit.ui
@@ -61,7 +61,7 @@
     </widget>
    </item>
    <item row="1" column="0">
-    <widget class="QWidget" name="widget" native="true">
+    <widget class="QWidget" name="widget">
      <layout class="QGridLayout" name="gridLayout">
       <item row="6" column="4">
        <widget class="QLabel" name="dwellTimelabel">

--- a/src/Mod/Path/Gui/Resources/panels/PageOpEngraveEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PageOpEngraveEdit.ui
@@ -55,7 +55,7 @@
     </widget>
    </item>
    <item row="1" column="0">
-    <widget class="QWidget" name="widget" native="true">
+    <widget class="QWidget" name="widget">
      <layout class="QGridLayout" name="gridLayout_2">
       <item row="0" column="0">
        <widget class="QLabel" name="label_2">

--- a/src/Mod/Path/Gui/Resources/panels/PageOpHelixEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PageOpHelixEdit.ui
@@ -55,7 +55,7 @@
     </widget>
    </item>
    <item row="1" column="0">
-    <widget class="QWidget" name="widget" native="true">
+    <widget class="QWidget" name="widget">
      <layout class="QFormLayout" name="formLayout">
       <item row="0" column="0">
        <widget class="QLabel" name="label_2">

--- a/src/Mod/Path/Gui/Resources/panels/PageOpPocketExtEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PageOpPocketExtEdit.ui
@@ -23,6 +23,29 @@
       <item>
        <widget class="QWidget" name="widget_2">
         <layout class="QGridLayout" name="gridLayout">
+         <item row="0" column="0">
+          <widget class="QCheckBox" name="showExtensions">
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If selected all potential extensions are visualised. Enabled extensions in purple and not enabled extensions in yellow.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="text">
+            <string>Show All</string>
+           </property>
+          </widget>
+         </item>
+        <item row="0" column="1">
+          <widget class="QCheckBox" name="extendCorners">
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Extend the corner between two edges of a pocket. If selected adjacent edges are combined.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="text">
+            <string>Extend Corners</string>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
          <item row="1" column="0">
           <widget class="QLabel" name="label">
            <property name="text">
@@ -43,30 +66,7 @@
            </property>
           </widget>
          </item>
-         <item row="0" column="1">
-          <widget class="QCheckBox" name="extendCorners">
-           <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Extend the corner between two edges of a pocket. If selected adjacent edges are combined.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-           </property>
-           <property name="text">
-            <string>Extend Corners</string>
-           </property>
-           <property name="checked">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="0">
-          <widget class="QCheckBox" name="showExtensions">
-           <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If selected all potential extensions are visualised. Enabled extensions in purple and not enabled extensions in yellow.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-           </property>
-           <property name="text">
-            <string>Show All</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
+         </layout>
        </widget>
       </item>
       <item>

--- a/src/Mod/Path/Gui/Resources/panels/PageOpPocketExtEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PageOpPocketExtEdit.ui
@@ -15,13 +15,13 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QWidget" name="extensionEdit" native="true">
+    <widget class="QWidget" name="extensionEdit">
      <layout class="QVBoxLayout" name="verticalLayout_2">
       <property name="margin">
        <number>0</number>
       </property>
       <item>
-       <widget class="QWidget" name="widget_2" native="true">
+       <widget class="QWidget" name="widget_2">
         <layout class="QGridLayout" name="gridLayout">
          <item row="1" column="0">
           <widget class="QLabel" name="label">
@@ -92,7 +92,7 @@
        </widget>
       </item>
       <item>
-       <widget class="QWidget" name="widget" native="true">
+       <widget class="QWidget" name="widget">
         <layout class="QHBoxLayout" name="horizontalLayout">
          <item>
           <widget class="QPushButton" name="buttonEnable">

--- a/src/Mod/Path/Gui/Resources/panels/PageOpPocketFullEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PageOpPocketFullEdit.ui
@@ -55,7 +55,7 @@
     </widget>
    </item>
    <item row="1" column="0">
-    <widget class="QWidget" name="facingWidget" native="true">
+    <widget class="QWidget" name="facingWidget">
      <layout class="QGridLayout" name="gridLayout_2">
       <item row="0" column="1">
        <widget class="QComboBox" name="boundaryShape">
@@ -95,7 +95,7 @@
     </widget>
    </item>
    <item row="2" column="0">
-    <widget class="QWidget" name="widget" native="true">
+    <widget class="QWidget" name="widget">
      <layout class="QFormLayout" name="formLayout">
       <property name="fieldGrowthPolicy">
        <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
@@ -265,7 +265,7 @@
     </widget>
    </item>
    <item row="3" column="0">
-    <widget class="QWidget" name="pocketWidget" native="true">
+    <widget class="QWidget" name="pocketWidget">
      <layout class="QGridLayout" name="gridLayout">
       <item row="2" column="1">
        <widget class="QCheckBox" name="minTravel">

--- a/src/Mod/Path/Gui/Resources/panels/PageOpProbeEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PageOpProbeEdit.ui
@@ -52,6 +52,13 @@
       <string>Probe Grid Points</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_3">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>X:</string>
+        </property>
+       </widget>
+      </item>
       <item row="0" column="1">
        <widget class="QSpinBox" name="PointCountX">
         <property name="minimum">
@@ -62,7 +69,14 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="4">
+      <item row="0" column="3">
+       <widget class="QLabel" name="label_3">
+        <property name="text">
+         <string>Y:</string>
+        </property>
+       </widget>
+      </item>
+     <item row="0" column="4">
        <widget class="QSpinBox" name="PointCountY">
         <property name="minimum">
          <number>3</number>
@@ -72,21 +86,7 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>X:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="3">
-       <widget class="QLabel" name="label_3">
-        <property name="text">
-         <string>Y:</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
+      </layout>
     </widget>
    </item>
    <item>
@@ -95,20 +95,6 @@
       <string>Probe</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_6">
-        <property name="text">
-         <string>Y Offset</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="Gui::InputField" name="Yoffset">
-        <property name="unit" stdset="0">
-         <string notr="true"/>
-        </property>
-       </widget>
-      </item>
       <item row="1" column="0">
        <widget class="QLabel" name="label_5">
         <property name="text">
@@ -123,7 +109,21 @@
         </property>
        </widget>
       </item>
-     </layout>
+     <item row="2" column="0">
+       <widget class="QLabel" name="label_6">
+        <property name="text">
+         <string>Y Offset</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="Gui::InputField" name="Yoffset">
+        <property name="unit" stdset="0">
+         <string notr="true"/>
+        </property>
+       </widget>
+      </item>
+      </layout>
     </widget>
    </item>
    <item>

--- a/src/Mod/Path/Gui/Resources/panels/PageOpProfileFullEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PageOpProfileFullEdit.ui
@@ -55,7 +55,7 @@
     </widget>
    </item>
    <item row="1" column="0">
-    <widget class="QWidget" name="widget" native="true">
+    <widget class="QWidget" name="widget">
      <layout class="QGridLayout" name="gridLayout">
       <item row="0" column="0">
        <widget class="QLabel" name="cutSideLabel">
@@ -160,7 +160,7 @@
     </widget>
    </item>
    <item row="2" column="0">
-    <widget class="QWidget" name="widget_2" native="true">
+    <widget class="QWidget" name="widget_2">
      <layout class="QGridLayout" name="gridLayout_2">
       <item row="0" column="0">
        <widget class="QCheckBox" name="useStartPoint">

--- a/src/Mod/Path/Gui/Resources/panels/PageOpSlotEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PageOpSlotEdit.ui
@@ -65,6 +65,16 @@
       <property name="bottomMargin">
        <number>3</number>
       </property>
+      <item row="0" column="0">
+       <widget class="QLabel" name="geo1Reference_label">
+        <property name="text">
+         <string>Start Feature Reference</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
       <item row="0" column="1">
        <widget class="QComboBox" name="geo1Reference">
         <property name="enabled">
@@ -117,16 +127,6 @@
           <string>Vertex</string>
          </property>
         </item>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="geo1Reference_label">
-        <property name="text">
-         <string>Start Feature Reference</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
        </widget>
       </item>
       <item row="1" column="0">
@@ -263,6 +263,38 @@
       <property name="bottomMargin">
        <number>3</number>
       </property>
+      <item row="0" column="0">
+       <widget class="QLabel" name="geo1Extension_label">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Extend Path Start</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+     <item row="0" column="1">
+       <widget class="Gui::InputField" name="geo1Extension">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Positive extends the beginning of the path, negative shortens.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="unit" stdset="0">
+         <string notr="true"/>
+        </property>
+       </widget>
+      </item>
       <item row="3" column="0">
        <widget class="QLabel" name="geo2Extensionlabel">
         <property name="text">
@@ -289,39 +321,7 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="1">
-       <widget class="Gui::InputField" name="geo1Extension">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Positive extends the beginning of the path, negative shortens.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-        <property name="unit" stdset="0">
-         <string notr="true"/>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="geo1Extension_label">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string>Extend Path Start</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-     </layout>
+      </layout>
     </widget>
    </item>
    <item>
@@ -346,30 +346,6 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
-       <widget class="QComboBox" name="pathOrientation">
-        <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Choose the path orientation with regard to the feature(s) selected.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-        <item>
-         <property name="text">
-          <string>Start to End</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Perpendicular</string>
-         </property>
-        </item>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="pathOrientation_label">
-        <property name="text">
-         <string>Path Orientation</string>
-        </property>
-       </widget>
-      </item>
       <item row="0" column="1">
        <widget class="QComboBox" name="layerMode">
         <property name="font">
@@ -388,6 +364,30 @@
         <item>
          <property name="text">
           <string>Multi-pass</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="pathOrientation_label">
+        <property name="text">
+         <string>Path Orientation</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QComboBox" name="pathOrientation">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Choose the path orientation with regard to the feature(s) selected.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <item>
+         <property name="text">
+          <string>Start to End</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Perpendicular</string>
          </property>
         </item>
        </widget>

--- a/src/Mod/Path/Gui/Resources/panels/PageOpSurfaceEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PageOpSurfaceEdit.ui
@@ -55,7 +55,7 @@
     </widget>
    </item>
    <item row="1" column="0">
-    <widget class="QWidget" name="widget" native="true">
+    <widget class="QWidget" name="widget">
      <layout class="QGridLayout" name="gridLayout">
       <item row="3" column="0">
        <widget class="QLabel" name="cutPattern_label">

--- a/src/Mod/Path/Gui/Resources/panels/PageOpThreadMillingEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PageOpThreadMillingEdit.ui
@@ -14,6 +14,18 @@
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <widget class="QGroupBox" name="groupBox_2">
+     <property name="title">
+      <string>Tool Controller</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <widget class="QComboBox" name="toolController"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
    <item row="1" column="0">
     <widget class="QGroupBox" name="groupBox">
      <property name="title">
@@ -152,31 +164,6 @@
      </layout>
     </widget>
    </item>
-   <item row="0" column="0">
-    <widget class="QGroupBox" name="groupBox_2">
-     <property name="title">
-      <string>Tool Controller</string>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <item>
-       <widget class="QComboBox" name="toolController"/>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="3" column="0">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
    <item row="2" column="0">
     <widget class="QGroupBox" name="groupBox_3">
      <property name="title">
@@ -231,7 +218,20 @@
      </layout>
     </widget>
    </item>
-  </layout>
+  <item row="3" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   </layout>
  </widget>
  <customwidgets>
   <customwidget>

--- a/src/Mod/Path/Gui/Resources/panels/PageOpVcarveEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PageOpVcarveEdit.ui
@@ -55,7 +55,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QWidget" name="widget" native="true">
+    <widget class="QWidget" name="widget">
      <layout class="QFormLayout" name="formLayout">
       <item row="0" column="0">
        <widget class="QLabel" name="label_2">

--- a/src/Mod/Path/Gui/Resources/panels/PageOpVcarveEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PageOpVcarveEdit.ui
@@ -23,17 +23,17 @@
       <enum>QFrame::Raised</enum>
      </property>
      <layout class="QGridLayout" name="gridLayout">
-      <item row="0" column="1">
-       <widget class="QComboBox" name="toolController">
-        <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The tool and its settings to be used for this operation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-       </widget>
-      </item>
       <item row="0" column="0">
        <widget class="QLabel" name="label">
         <property name="text">
          <string>ToolController</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QComboBox" name="toolController">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The tool and its settings to be used for this operation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
        </widget>
       </item>

--- a/src/Mod/Path/Gui/Resources/panels/PageOpWaterlineEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PageOpWaterlineEdit.ui
@@ -51,7 +51,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QWidget" name="widget" native="true">
+    <widget class="QWidget" name="widget">
      <layout class="QGridLayout" name="gridLayout">
       <item row="1" column="3">
        <widget class="QComboBox" name="boundBoxSelect">
@@ -244,7 +244,7 @@
        </widget>
       </item>
       <item row="9" column="3">
-       <widget class="Gui::InputField" name="sampleInterval" native="true">
+       <widget class="Gui::InputField" name="sampleInterval">
         <property name="toolTip">
          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the sampling resolution. Smaller values quickly increase processing time.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>

--- a/src/Mod/Path/Gui/Resources/panels/PageOpWaterlineEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PageOpWaterlineEdit.ui
@@ -53,6 +53,43 @@
    <item>
     <widget class="QWidget" name="widget">
      <layout class="QGridLayout" name="gridLayout">
+      <item row="0" column="0">
+       <widget class="QLabel" name="algorithmSelect_label">
+        <property name="text">
+         <string>Algorithm</string>
+        </property>
+       </widget>
+      </item>
+     <item row="0" column="3">
+       <widget class="QComboBox" name="algorithmSelect">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select the algorithm to use: OCL Dropcutter*, or Experimental (Not OCL based).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <item>
+         <property name="text">
+          <string>OCL Dropcutter</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Experimental</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="boundBoxSelect_label">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>BoundBox</string>
+        </property>
+       </widget>
+      </item>
       <item row="1" column="3">
        <widget class="QComboBox" name="boundBoxSelect">
         <property name="font">
@@ -75,16 +112,10 @@
         </item>
        </widget>
       </item>
-      <item row="4" column="3">
-       <widget class="QLineEdit" name="boundaryAdjustment">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Positive values push the cutter toward, or beyond, the boundary. Negative values retract the cutter away from the boundary.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      <item row="2" column="0">
+       <widget class="QLabel" name="layerMode_label">
+        <property name="text">
+         <string>Layer Mode</string>
         </property>
        </widget>
       </item>
@@ -110,43 +141,10 @@
         </item>
        </widget>
       </item>
-      <item row="0" column="3">
-       <widget class="QComboBox" name="algorithmSelect">
-        <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select the algorithm to use: OCL Dropcutter*, or Experimental (Not OCL based).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-        <item>
-         <property name="text">
-          <string>OCL Dropcutter</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Experimental</string>
-         </property>
-        </item>
-       </widget>
-      </item>
-      <item row="11" column="3">
-       <widget class="QCheckBox" name="optimizeEnabled">
-        <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable optimization of linear paths (co-linear points). Removes unnecessary co-linear points from G-Code output.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
+      <item row="3" column="0">
+       <widget class="QLabel" name="cutPattern_label">
         <property name="text">
-         <string>Optimize Linear Paths</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0">
-       <widget class="QLabel" name="boundaryAdjustment_label">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string>Boundary Adjustment</string>
+         <string>Cut Pattern</string>
         </property>
        </widget>
       </item>
@@ -197,6 +195,39 @@
         </item>
        </widget>
       </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="boundaryAdjustment_label">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Boundary Adjustment</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="3">
+       <widget class="QLineEdit" name="boundaryAdjustment">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Positive values push the cutter toward, or beyond, the boundary. Negative values retract the cutter away from the boundary.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="0">
+       <widget class="QLabel" name="stepOver_label">
+        <property name="text">
+         <string>Step over</string>
+        </property>
+       </widget>
+      </item>
       <item row="8" column="3">
        <widget class="QSpinBox" name="stepOver">
         <property name="sizePolicy">
@@ -216,30 +247,10 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="layerMode_label">
+      <item row="9" column="0">
+       <widget class="QLabel" name="sampleInterval_label">
         <property name="text">
-         <string>Layer Mode</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="boundBoxSelect_label">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string>BoundBox</string>
-        </property>
-       </widget>
-      </item>
-      <item row="8" column="0">
-       <widget class="QLabel" name="stepOver_label">
-        <property name="text">
-         <string>Step over</string>
+         <string>Sample interval</string>
         </property>
        </widget>
       </item>
@@ -253,28 +264,17 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="cutPattern_label">
+      <item row="11" column="3">
+       <widget class="QCheckBox" name="optimizeEnabled">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable optimization of linear paths (co-linear points). Removes unnecessary co-linear points from G-Code output.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
         <property name="text">
-         <string>Cut Pattern</string>
+         <string>Optimize Linear Paths</string>
         </property>
        </widget>
       </item>
-      <item row="9" column="0">
-       <widget class="QLabel" name="sampleInterval_label">
-        <property name="text">
-         <string>Sample interval</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="algorithmSelect_label">
-        <property name="text">
-         <string>Algorithm</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
+      </layout>
     </widget>
    </item>
    <item>

--- a/src/Mod/Path/Gui/Resources/panels/PathEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PathEdit.ui
@@ -144,26 +144,6 @@
       </property>
      </widget>
     </item>
-    <item row="2" column="1" colspan="2">
-     <widget class="QLineEdit" name="postProcessorArguments">
-      <property name="toolTip">
-       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Optional arguments passed to the Post Processor. The arguments are specific for each Post Processor, please see it's documentation for details.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-      </property>
-     </widget>
-    </item>
-    <item row="5" column="0">
-     <spacer name="verticalSpacer">
-      <property name="orientation">
-       <enum>Qt::Vertical</enum>
-      </property>
-      <property name="sizeHint" stdset="0">
-       <size>
-        <width>20</width>
-        <height>747</height>
-       </size>
-      </property>
-     </spacer>
-    </item>
     <item row="0" column="2">
      <widget class="QToolButton" name="postProcessorSetOutputFile">
       <property name="text">
@@ -185,6 +165,13 @@
      <widget class="QLabel" name="label_11">
       <property name="text">
        <string>Arguments</string>
+      </property>
+     </widget>
+    </item>
+    <item row="2" column="1" colspan="2">
+     <widget class="QLineEdit" name="postProcessorArguments">
+      <property name="toolTip">
+       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Optional arguments passed to the Post Processor. The arguments are specific for each Post Processor, please see it's documentation for details.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
       </property>
      </widget>
     </item>
@@ -414,7 +401,20 @@
       </layout>
      </widget>
     </item>
-   </layout>
+   <item row="5" column="0">
+     <spacer name="verticalSpacer">
+      <property name="orientation">
+       <enum>Qt::Vertical</enum>
+      </property>
+      <property name="sizeHint" stdset="0">
+       <size>
+        <width>20</width>
+        <height>747</height>
+       </size>
+      </property>
+     </spacer>
+    </item>
+    </layout>
   </widget>
   <widget class="QWidget" name="tabSetup">
    <attribute name="title">
@@ -519,15 +519,15 @@
            <item>
             <widget class="QFrame" name="stockFromBase">
              <layout class="QGridLayout" name="gridLayout_9">
-              <item row="1" column="3">
-               <widget class="Gui::InputField" name="stockExtYpos"/>
-              </item>
               <item row="0" column="1">
                <widget class="QLabel" name="stockExtXLabel">
                 <property name="text">
                  <string>Ext. X</string>
                 </property>
                </widget>
+              </item>
+              <item row="0" column="2">
+               <widget class="Gui::InputField" name="stockExtXneg"/>
               </item>
               <item row="0" column="3">
                <widget class="Gui::InputField" name="stockExtXpos">
@@ -546,8 +546,11 @@
                 </property>
                </widget>
               </item>
-              <item row="0" column="2">
-               <widget class="Gui::InputField" name="stockExtXneg"/>
+              <item row="1" column="2">
+               <widget class="Gui::InputField" name="stockExtYneg"/>
+              </item>
+             <item row="1" column="3">
+               <widget class="Gui::InputField" name="stockExtYpos"/>
               </item>
               <item row="2" column="1">
                <widget class="QLabel" name="stockExtZLabel">
@@ -562,27 +565,21 @@
               <item row="2" column="3">
                <widget class="Gui::InputField" name="stockExtZpos"/>
               </item>
-              <item row="1" column="2">
-               <widget class="Gui::InputField" name="stockExtYneg"/>
-              </item>
-             </layout>
+              </layout>
             </widget>
            </item>
            <item>
             <widget class="QFrame" name="stockCreateCylinder">
              <layout class="QGridLayout" name="gridLayout_10">
-              <item row="0" column="2">
-               <widget class="Gui::InputField" name="stockCylinderRadius"/>
-              </item>
-              <item row="1" column="2">
-               <widget class="Gui::InputField" name="stockCylinderHeight"/>
-              </item>
               <item row="0" column="1">
                <widget class="QLabel" name="stockCylinderRadiusLabel">
                 <property name="text">
                  <string>Radius</string>
                 </property>
                </widget>
+              </item>
+              <item row="0" column="2">
+               <widget class="Gui::InputField" name="stockCylinderRadius"/>
               </item>
               <item row="1" column="1">
                <widget class="QLabel" name="stockCylinderHeightLabel">
@@ -591,7 +588,10 @@
                 </property>
                </widget>
               </item>
-             </layout>
+             <item row="1" column="2">
+               <widget class="Gui::InputField" name="stockCylinderHeight"/>
+              </item>
+              </layout>
             </widget>
            </item>
            <item>
@@ -604,18 +604,15 @@
                 </property>
                </widget>
               </item>
+              <item row="0" column="2">
+               <widget class="Gui::InputField" name="stockBoxLength"/>
+              </item>
               <item row="1" column="1">
                <widget class="QLabel" name="stockBoxWidthLabel">
                 <property name="text">
                  <string>Width</string>
                 </property>
                </widget>
-              </item>
-              <item row="0" column="2">
-               <widget class="Gui::InputField" name="stockBoxLength"/>
-              </item>
-              <item row="2" column="2">
-               <widget class="Gui::InputField" name="stockBoxHeight"/>
               </item>
               <item row="1" column="2">
                <widget class="Gui::InputField" name="stockBoxWidth"/>
@@ -627,7 +624,10 @@
                 </property>
                </widget>
               </item>
-             </layout>
+             <item row="2" column="2">
+               <widget class="Gui::InputField" name="stockBoxHeight"/>
+              </item>
+              </layout>
             </widget>
            </item>
           </layout>
@@ -639,6 +639,20 @@
            <string>Alignment</string>
           </property>
           <layout class="QGridLayout" name="gridLayout_2">
+           <item row="0" column="0">
+            <widget class="QPushButton" name="moveToOrigin">
+             <property name="text">
+              <string>Move to Origin</string>
+             </property>
+            </widget>
+           </item>
+          <item row="0" column="1">
+            <widget class="QPushButton" name="setOrigin">
+             <property name="text">
+              <string>Set Origin</string>
+             </property>
+            </widget>
+           </item>
            <item row="2" column="0">
             <widget class="QPushButton" name="centerInStock">
              <property name="text">
@@ -653,21 +667,7 @@
              </property>
             </widget>
            </item>
-           <item row="0" column="1">
-            <widget class="QPushButton" name="setOrigin">
-             <property name="text">
-              <string>Set Origin</string>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="0">
-            <widget class="QPushButton" name="moveToOrigin">
-             <property name="text">
-              <string>Move to Origin</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
+           </layout>
          </widget>
         </item>
         <item>
@@ -697,6 +697,13 @@
              </property>
             </widget>
            </item>
+           <item row="1" column="0">
+            <widget class="QPushButton" name="modelSetX0">
+             <property name="text">
+              <string>X=0</string>
+             </property>
+            </widget>
+           </item>
            <item row="1" column="1">
             <widget class="QPushButton" name="modelSetY0">
              <property name="text">
@@ -708,13 +715,6 @@
             <widget class="QPushButton" name="modelSetZ0">
              <property name="text">
               <string>Z=0</string>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="0">
-            <widget class="QPushButton" name="modelSetX0">
-             <property name="text">
-              <string>X=0</string>
              </property>
             </widget>
            </item>
@@ -734,6 +734,23 @@
            <string>Move - XY</string>
           </property>
           <layout class="QGridLayout" name="gridLayout_3">
+           <item row="0" column="0">
+            <widget class="QPushButton" name="modelMoveLeftUp">
+             <property name="text">
+              <string/>
+             </property>
+             <property name="icon">
+              <iconset resource="../Path.qrc">
+               <normaloff>:/icons/arrow-left-up.svg</normaloff>:/icons/arrow-left-up.svg</iconset>
+             </property>
+             <property name="iconSize">
+              <size>
+               <width>32</width>
+               <height>32</height>
+              </size>
+             </property>
+            </widget>
+           </item>
            <item row="0" column="1">
             <widget class="QPushButton" name="modelMoveUp">
              <property name="text">
@@ -768,31 +785,14 @@
              </property>
             </widget>
            </item>
-           <item row="0" column="0">
-            <widget class="QPushButton" name="modelMoveLeftUp">
+           <item row="1" column="0">
+            <widget class="QPushButton" name="modelMoveLeft">
              <property name="text">
               <string/>
              </property>
              <property name="icon">
               <iconset resource="../Path.qrc">
-               <normaloff>:/icons/arrow-left-up.svg</normaloff>:/icons/arrow-left-up.svg</iconset>
-             </property>
-             <property name="iconSize">
-              <size>
-               <width>32</width>
-               <height>32</height>
-              </size>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="2">
-            <widget class="QPushButton" name="modelMoveRight">
-             <property name="text">
-              <string/>
-             </property>
-             <property name="icon">
-              <iconset resource="../Path.qrc">
-               <normaloff>:/icons/arrow-right.svg</normaloff>:/icons/arrow-right.svg</iconset>
+               <normaloff>:/icons/arrow-left.svg</normaloff>:/icons/arrow-left.svg</iconset>
              </property>
              <property name="iconSize">
               <size>
@@ -815,14 +815,14 @@
              </property>
             </widget>
            </item>
-           <item row="1" column="0">
-            <widget class="QPushButton" name="modelMoveLeft">
+           <item row="1" column="2">
+            <widget class="QPushButton" name="modelMoveRight">
              <property name="text">
               <string/>
              </property>
              <property name="icon">
               <iconset resource="../Path.qrc">
-               <normaloff>:/icons/arrow-left.svg</normaloff>:/icons/arrow-left.svg</iconset>
+               <normaloff>:/icons/arrow-right.svg</normaloff>:/icons/arrow-right.svg</iconset>
              </property>
              <property name="iconSize">
               <size>
@@ -892,6 +892,29 @@
            <string>Rotate - XY</string>
           </property>
           <layout class="QGridLayout" name="gridLayout_6">
+           <item row="0" column="0">
+            <widget class="QPushButton" name="modelRotateLeft">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Minimum" vsizetype="MinimumExpanding">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string/>
+             </property>
+             <property name="icon">
+              <iconset resource="../Path.qrc">
+               <normaloff>:/icons/arrow-ccw.svg</normaloff>:/icons/arrow-ccw.svg</iconset>
+             </property>
+             <property name="iconSize">
+              <size>
+               <width>32</width>
+               <height>32</height>
+              </size>
+             </property>
+            </widget>
+           </item>
            <item row="0" column="1">
             <widget class="QWidget" name="widget_5">
              <layout class="QVBoxLayout" name="verticalLayout_18">
@@ -931,29 +954,6 @@
                </widget>
               </item>
              </layout>
-            </widget>
-           </item>
-           <item row="0" column="0">
-            <widget class="QPushButton" name="modelRotateLeft">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Minimum" vsizetype="MinimumExpanding">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="text">
-              <string/>
-             </property>
-             <property name="icon">
-              <iconset resource="../Path.qrc">
-               <normaloff>:/icons/arrow-ccw.svg</normaloff>:/icons/arrow-ccw.svg</iconset>
-             </property>
-             <property name="iconSize">
-              <size>
-               <width>32</width>
-               <height>32</height>
-              </size>
-             </property>
             </widget>
            </item>
            <item row="0" column="2">

--- a/src/Mod/Path/Gui/Resources/panels/PathEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PathEdit.ui
@@ -65,7 +65,7 @@
             </widget>
            </item>
            <item>
-            <widget class="QWidget" name="widget_3" native="true">
+            <widget class="QWidget" name="widget_3">
              <layout class="QHBoxLayout" name="horizontalLayout_6">
               <item>
                <spacer name="horizontalSpacer_2">
@@ -449,7 +449,7 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QWidget" name="widget_2" native="true">
+            <widget class="QWidget" name="widget_2">
              <layout class="QHBoxLayout" name="horizontalLayout_5">
               <item>
                <widget class="QComboBox" name="stock">
@@ -893,7 +893,7 @@
           </property>
           <layout class="QGridLayout" name="gridLayout_6">
            <item row="0" column="1">
-            <widget class="QWidget" name="widget_5" native="true">
+            <widget class="QWidget" name="widget_5">
              <layout class="QVBoxLayout" name="verticalLayout_18">
               <property name="leftMargin">
                <number>0</number>
@@ -1243,7 +1243,7 @@
             </widget>
            </item>
            <item>
-            <widget class="QWidget" name="widget_4" native="true">
+            <widget class="QWidget" name="widget_4">
              <layout class="QHBoxLayout" name="horizontalLayout_2">
               <item>
                <widget class="QPushButton" name="toolControllerEdit">
@@ -1370,7 +1370,7 @@
    </attribute>
    <layout class="QVBoxLayout" name="verticalLayout_4">
     <item>
-     <widget class="QWidget" name="activeToolGroup" native="true">
+     <widget class="QWidget" name="activeToolGroup">
       <layout class="QFormLayout" name="formLayout_3">
        <property name="fieldGrowthPolicy">
         <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
@@ -1389,7 +1389,7 @@
      </widget>
     </item>
     <item>
-     <widget class="QWidget" name="widget" native="true">
+     <widget class="QWidget" name="widget">
       <layout class="QHBoxLayout" name="horizontalLayout_4">
        <item>
         <widget class="QListWidget" name="operationsList">
@@ -1399,7 +1399,7 @@
         </widget>
        </item>
        <item>
-        <widget class="QWidget" name="operationMove" native="true">
+        <widget class="QWidget" name="operationMove">
          <layout class="QVBoxLayout" name="verticalLayout_2">
           <property name="leftMargin">
            <number>0</number>
@@ -1468,7 +1468,7 @@
      </widget>
     </item>
     <item>
-     <widget class="QWidget" name="operationModify" native="true">
+     <widget class="QWidget" name="operationModify">
       <layout class="QHBoxLayout" name="horizontalLayout_3">
        <item>
         <widget class="QPushButton" name="operationEdit">

--- a/src/Mod/Path/Gui/Resources/panels/PointEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PointEdit.ui
@@ -15,7 +15,7 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QWidget" name="wPoint" native="true">
+    <widget class="QWidget" name="wPoint">
      <layout class="QFormLayout" name="formLayout">
       <item row="0" column="0">
        <widget class="QLabel" name="globalXLabel">

--- a/src/Mod/Path/Gui/Resources/panels/PropertyBag.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PropertyBag.ui
@@ -34,7 +34,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QWidget" name="widget" native="true">
+    <widget class="QWidget" name="widget">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
        <horstretch>0</horstretch>

--- a/src/Mod/Path/Gui/Resources/panels/SetupGlobal.ui
+++ b/src/Mod/Path/Gui/Resources/panels/SetupGlobal.ui
@@ -81,10 +81,23 @@
           <string>Heights</string>
          </property>
          <layout class="QGridLayout" name="gridLayout">
-          <item row="3" column="0">
-           <widget class="QLabel" name="label_6">
+          <item row="0" column="1" colspan="2">
+           <widget class="QLabel" name="label_5">
             <property name="text">
-             <string>Safe</string>
+             <string>Expression</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="3">
+           <widget class="QLabel" name="label_7">
+            <property name="text">
+             <string>Offset</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignCenter</set>
             </property>
            </widget>
           </item>
@@ -92,13 +105,6 @@
            <widget class="QLabel" name="label_4">
             <property name="text">
              <string>Clearance</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="1" colspan="2">
-           <widget class="QLineEdit" name="setupSafeHeightExpr">
-            <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Expression set as SafeHeight for new operations.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Default: &amp;quot;OpStockZMax+SetupSheet.SafeHeightOffset&amp;quot;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
            </widget>
           </item>
@@ -116,23 +122,17 @@
             </property>
            </widget>
           </item>
-          <item row="0" column="3">
-           <widget class="QLabel" name="label_7">
+          <item row="3" column="0">
+           <widget class="QLabel" name="label_6">
             <property name="text">
-             <string>Offset</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignCenter</set>
+             <string>Safe</string>
             </property>
            </widget>
           </item>
-          <item row="0" column="1" colspan="2">
-           <widget class="QLabel" name="label_5">
-            <property name="text">
-             <string>Expression</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignCenter</set>
+          <item row="3" column="1" colspan="2">
+           <widget class="QLineEdit" name="setupSafeHeightExpr">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Expression set as SafeHeight for new operations.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Default: &amp;quot;OpStockZMax+SetupSheet.SafeHeightOffset&amp;quot;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
            </widget>
           </item>

--- a/src/Mod/Path/Gui/Resources/panels/ToolBitLibraryEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/ToolBitLibraryEdit.ui
@@ -83,7 +83,7 @@
     </layout>
    </item>
    <item>
-    <widget class="QWidget" name="toolTableGroup" native="true">
+    <widget class="QWidget" name="toolTableGroup">
      <layout class="QHBoxLayout" name="horizontalLayout_3">
       <item>
        <layout class="QVBoxLayout" name="verticalLayout">

--- a/src/Mod/Path/Gui/Resources/panels/ToolBitSelector.ui
+++ b/src/Mod/Path/Gui/Resources/panels/ToolBitSelector.ui
@@ -22,7 +22,7 @@
   <widget class="QWidget" name="dockWidgetContents">
    <layout class="QVBoxLayout" name="verticalLayout">
     <item>
-     <widget class="QWidget" name="widget_2" native="true">
+     <widget class="QWidget" name="widget_2">
       <layout class="QHBoxLayout" name="horizontalLayout">
        <item>
         <widget class="QLabel" name="lblLibrary">

--- a/src/Mod/Path/Gui/Resources/panels/ToolEditor.ui
+++ b/src/Mod/Path/Gui/Resources/panels/ToolEditor.ui
@@ -185,7 +185,7 @@
      </property>
      <layout class="QHBoxLayout" name="horizontalLayout">
       <item>
-       <widget class="QWidget" name="paramImageParam" native="true">
+       <widget class="QWidget" name="paramImageParam">
         <layout class="QFormLayout" name="formLayout_3">
          <property name="fieldGrowthPolicy">
           <enum>QFormLayout::ExpandingFieldsGrow</enum>

--- a/src/Mod/Path/Gui/Resources/preferences/PathDressupHoldingTags.ui
+++ b/src/Mod/Path/Gui/Resources/preferences/PathDressupHoldingTags.ui
@@ -20,6 +20,13 @@
       <string>Tag Parameters</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Default Width</string>
+        </property>
+       </widget>
+      </item>
       <item row="0" column="1">
        <widget class="Gui::InputField" name="ifWidth">
         <property name="toolTip">
@@ -27,10 +34,24 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="label">
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_2">
         <property name="text">
-         <string>Default Width</string>
+         <string>Default Height</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="Gui::InputField" name="ifHeight">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Default height of holding tags.&lt;/p&gt;&lt;p&gt;If the specified height is 0 the dressup will use half the height of the part. Should the height be bigger than the height of the part the dressup will reduce the height to the height of the part.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_3">
+        <property name="text">
+         <string>Default Angle</string>
         </property>
        </widget>
       </item>
@@ -53,34 +74,6 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
-       <widget class="Gui::InputField" name="ifHeight">
-        <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Default height of holding tags.&lt;/p&gt;&lt;p&gt;If the specified height is 0 the dressup will use half the height of the part. Should the height be bigger than the height of the part the dressup will reduce the height to the height of the part.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_3">
-        <property name="text">
-         <string>Default Angle</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>Default Height</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
-       <widget class="Gui::InputField" name="ifRadius">
-        <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Radius of the fillet on the tag's top edge.&lt;/p&gt;&lt;p&gt;If the radius is bigger than that which the the tag shape itself supports, the resulting shape will be that of a dome.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-       </widget>
-      </item>
       <item row="3" column="0">
        <widget class="QLabel" name="label_5">
         <property name="text">
@@ -88,7 +81,14 @@
         </property>
        </widget>
       </item>
-     </layout>
+     <item row="3" column="1">
+       <widget class="Gui::InputField" name="ifRadius">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Radius of the fillet on the tag's top edge.&lt;/p&gt;&lt;p&gt;If the radius is bigger than that which the the tag shape itself supports, the resulting shape will be that of a dome.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+       </widget>
+      </item>
+      </layout>
     </widget>
    </item>
    <item>

--- a/src/Mod/Path/Gui/Resources/preferences/PathJob.ui
+++ b/src/Mod/Path/Gui/Resources/preferences/PathJob.ui
@@ -90,7 +90,7 @@
          </property>
          <layout class="QGridLayout" name="gridLayout">
           <item row="0" column="0">
-           <widget class="QWidget" name="widget_5" native="true">
+           <widget class="QWidget" name="widget_5">
             <layout class="QGridLayout" name="gridLayout_4">
              <item row="0" column="1">
               <widget class="Gui::InputField" name="geometryTolerance">
@@ -166,7 +166,7 @@
            <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
           </property>
           <item row="1" column="0">
-           <widget class="QWidget" name="widget_2" native="true">
+           <widget class="QWidget" name="widget_2">
             <layout class="QHBoxLayout" name="horizontalLayout_3">
              <item>
               <widget class="QLabel" name="label_4">
@@ -179,7 +179,7 @@
            </widget>
           </item>
           <item row="1" column="1">
-           <widget class="QWidget" name="widget" native="true">
+           <widget class="QWidget" name="widget">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
               <horstretch>0</horstretch>
@@ -205,7 +205,7 @@
            </widget>
           </item>
           <item row="2" column="0">
-           <widget class="QWidget" name="widget_3" native="true">
+           <widget class="QWidget" name="widget_3">
             <layout class="QHBoxLayout" name="horizontalLayout_4">
              <item>
               <widget class="QLabel" name="label_5">
@@ -218,7 +218,7 @@
            </widget>
           </item>
           <item row="2" column="1">
-           <widget class="QWidget" name="widget_4" native="true">
+           <widget class="QWidget" name="widget_4">
             <layout class="QHBoxLayout" name="horizontalLayout_5">
              <item>
               <widget class="QComboBox" name="cboOutputPolicy">

--- a/src/Mod/Path/Gui/Resources/preferences/PathJob.ui
+++ b/src/Mod/Path/Gui/Resources/preferences/PathJob.ui
@@ -38,17 +38,17 @@
           <string>Defaults</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_2">
-          <item row="0" column="1">
-           <widget class="QLineEdit" name="leDefaultFilePath">
-            <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Path to look for templates, post processors, tool tables and other external files.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;If left empty the macro directory is used.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-           </widget>
-          </item>
           <item row="0" column="0">
            <widget class="QLabel" name="label_7">
             <property name="text">
              <string>Path</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QLineEdit" name="leDefaultFilePath">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Path to look for templates, post processors, tool tables and other external files.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;If left empty the macro directory is used.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
            </widget>
           </item>
@@ -409,15 +409,15 @@
           <item>
            <widget class="QFrame" name="stockFromBase">
             <layout class="QGridLayout" name="gridLayout_9">
-             <item row="1" column="3">
-              <widget class="Gui::InputField" name="stockExtYpos"/>
-             </item>
              <item row="0" column="1">
               <widget class="QLabel" name="stockExtXLabel">
                <property name="text">
                 <string>Ext. X</string>
                </property>
               </widget>
+             </item>
+             <item row="0" column="2">
+              <widget class="Gui::InputField" name="stockExtXneg"/>
              </item>
              <item row="0" column="3">
               <widget class="Gui::InputField" name="stockExtXpos">
@@ -436,8 +436,11 @@
                </property>
               </widget>
              </item>
-             <item row="0" column="2">
-              <widget class="Gui::InputField" name="stockExtXneg"/>
+             <item row="1" column="2">
+              <widget class="Gui::InputField" name="stockExtYneg"/>
+             </item>
+            <item row="1" column="3">
+              <widget class="Gui::InputField" name="stockExtYpos"/>
              </item>
              <item row="2" column="1">
               <widget class="QLabel" name="stockExtZLabel">
@@ -452,27 +455,21 @@
              <item row="2" column="3">
               <widget class="Gui::InputField" name="stockExtZpos"/>
              </item>
-             <item row="1" column="2">
-              <widget class="Gui::InputField" name="stockExtYneg"/>
-             </item>
-            </layout>
+             </layout>
            </widget>
           </item>
           <item>
            <widget class="QFrame" name="stockCreateCylinder">
             <layout class="QGridLayout" name="gridLayout_10">
-             <item row="0" column="2">
-              <widget class="Gui::InputField" name="stockCylinderRadius"/>
-             </item>
-             <item row="1" column="2">
-              <widget class="Gui::InputField" name="stockCylinderHeight"/>
-             </item>
              <item row="0" column="1">
               <widget class="QLabel" name="stockCylinderRadiusLabel">
                <property name="text">
                 <string>Radius</string>
                </property>
               </widget>
+             </item>
+             <item row="0" column="2">
+              <widget class="Gui::InputField" name="stockCylinderRadius"/>
              </item>
              <item row="1" column="1">
               <widget class="QLabel" name="stockCylinderHeightLabel">
@@ -481,7 +478,10 @@
                </property>
               </widget>
              </item>
-            </layout>
+            <item row="1" column="2">
+              <widget class="Gui::InputField" name="stockCylinderHeight"/>
+             </item>
+             </layout>
            </widget>
           </item>
           <item>
@@ -494,18 +494,15 @@
                </property>
               </widget>
              </item>
+             <item row="0" column="2">
+              <widget class="Gui::InputField" name="stockBoxLength"/>
+             </item>
              <item row="1" column="1">
               <widget class="QLabel" name="stockBoxWidthLabel">
                <property name="text">
                 <string>Width</string>
                </property>
               </widget>
-             </item>
-             <item row="0" column="2">
-              <widget class="Gui::InputField" name="stockBoxLength"/>
-             </item>
-             <item row="2" column="2">
-              <widget class="Gui::InputField" name="stockBoxHeight"/>
              </item>
              <item row="1" column="2">
               <widget class="Gui::InputField" name="stockBoxWidth"/>
@@ -517,7 +514,10 @@
                </property>
               </widget>
              </item>
-            </layout>
+            <item row="2" column="2">
+              <widget class="Gui::InputField" name="stockBoxHeight"/>
+             </item>
+             </layout>
            </widget>
           </item>
           <item>
@@ -545,26 +545,6 @@
              <bool>false</bool>
             </property>
             <layout class="QGridLayout" name="gridLayout_3">
-             <item row="0" column="2">
-              <widget class="Gui::InputField" name="stockAngle"/>
-             </item>
-             <item row="4" column="0">
-              <widget class="QLabel" name="label_10">
-               <property name="text">
-                <string>Position</string>
-               </property>
-              </widget>
-             </item>
-             <item row="3" column="0">
-              <widget class="QLabel" name="label_11">
-               <property name="text">
-                <string>Axis</string>
-               </property>
-              </widget>
-             </item>
-             <item row="4" column="2">
-              <widget class="Gui::InputField" name="stockPositionX"/>
-             </item>
              <item row="0" column="0">
               <widget class="QLabel" name="label_9">
                <property name="text">
@@ -572,11 +552,15 @@
                </property>
               </widget>
              </item>
-             <item row="4" column="3">
-              <widget class="Gui::InputField" name="stockPositionY"/>
+             <item row="0" column="2">
+              <widget class="Gui::InputField" name="stockAngle"/>
              </item>
-             <item row="4" column="4">
-              <widget class="Gui::InputField" name="stockPositionZ"/>
+             <item row="3" column="0">
+              <widget class="QLabel" name="label_11">
+               <property name="text">
+                <string>Axis</string>
+               </property>
+              </widget>
              </item>
              <item row="3" column="2">
               <widget class="QDoubleSpinBox" name="stockAxisX">
@@ -599,7 +583,23 @@
                </property>
               </widget>
              </item>
-            </layout>
+            <item row="4" column="0">
+              <widget class="QLabel" name="label_10">
+               <property name="text">
+                <string>Position</string>
+               </property>
+              </widget>
+             </item>
+             <item row="4" column="2">
+              <widget class="Gui::InputField" name="stockPositionX"/>
+             </item>
+             <item row="4" column="3">
+              <widget class="Gui::InputField" name="stockPositionY"/>
+             </item>
+             <item row="4" column="4">
+              <widget class="Gui::InputField" name="stockPositionZ"/>
+             </item>
+             </layout>
            </widget>
           </item>
          </layout>

--- a/src/Mod/Points/Gui/DlgPointsRead.ui
+++ b/src/Mod/Points/Gui/DlgPointsRead.ui
@@ -52,36 +52,6 @@
       <property name="spacing">
        <number>6</number>
       </property>
-      <item row="1" column="0">
-       <layout class="QGridLayout">
-        <property name="margin">
-         <number>0</number>
-        </property>
-        <property name="spacing">
-         <number>6</number>
-        </property>
-        <item row="0" column="1">
-         <widget class="QLineEdit" name="lineEditClusterStart"/>
-        </item>
-        <item row="1" column="1">
-         <widget class="QLineEdit" name="lineEditComments"/>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="textLabel4">
-          <property name="text">
-           <string>Ignore lines starting with:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="0">
-         <widget class="QLabel" name="textLabel3">
-          <property name="text">
-           <string>Cluster by lines starting with:</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
       <item row="0" column="0">
        <widget class="QGroupBox" name="groupBox">
         <property name="title">
@@ -117,7 +87,37 @@
         </layout>
        </widget>
       </item>
-     </layout>
+     <item row="1" column="0">
+       <layout class="QGridLayout">
+        <property name="margin">
+         <number>0</number>
+        </property>
+        <property name="spacing">
+         <number>6</number>
+        </property>
+        <item row="0" column="1">
+         <widget class="QLineEdit" name="lineEditClusterStart"/>
+        </item>
+        <item row="1" column="1">
+         <widget class="QLineEdit" name="lineEditComments"/>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="textLabel4">
+          <property name="text">
+           <string>Ignore lines starting with:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="0">
+         <widget class="QLabel" name="textLabel3">
+          <property name="text">
+           <string>Cluster by lines starting with:</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      </layout>
     </widget>
    </item>
    <item>

--- a/src/Mod/Raytracing/Gui/DlgSettingsRay.ui
+++ b/src/Mod/Raytracing/Gui/DlgSettingsRay.ui
@@ -20,89 +20,6 @@
    <property name="spacing">
     <number>6</number>
    </property>
-   <item row="2" column="0">
-    <widget class="QGroupBox" name="groupBox5">
-     <property name="title">
-      <string>Mesh export settings</string>
-     </property>
-     <layout class="QVBoxLayout">
-      <property name="spacing">
-       <number>6</number>
-      </property>
-      <property name="margin">
-       <number>10</number>
-      </property>
-      <item>
-       <layout class="QHBoxLayout">
-        <property name="spacing">
-         <number>6</number>
-        </property>
-        <property name="margin">
-         <number>0</number>
-        </property>
-        <item>
-         <widget class="QLabel" name="textLabel2">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string>Max mesh deviation:</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="Gui::PrefDoubleSpinBox" name="prefFloatSpinBox1">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="value">
-           <double>0.100000000000000</double>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>MeshDeviation</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Raytracing</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <widget class="Gui::PrefCheckBox" name="prefCheckBox8">
-        <property name="text">
-         <string>Do not calculate vertex normals</string>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>NotWriteVertexNormals</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Raytracing</cstring>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="Gui::PrefCheckBox" name="prefCheckBox9">
-        <property name="text">
-         <string>Write u,v coordinates</string>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>WriteUVCoordinates</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Raytracing</cstring>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
    <item row="0" column="0">
     <widget class="QGroupBox" name="groupBox">
      <property name="title">
@@ -325,6 +242,89 @@
          </widget>
         </item>
        </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QGroupBox" name="groupBox5">
+     <property name="title">
+      <string>Mesh export settings</string>
+     </property>
+     <layout class="QVBoxLayout">
+      <property name="spacing">
+       <number>6</number>
+      </property>
+      <property name="margin">
+       <number>10</number>
+      </property>
+      <item>
+       <layout class="QHBoxLayout">
+        <property name="spacing">
+         <number>6</number>
+        </property>
+        <property name="margin">
+         <number>0</number>
+        </property>
+        <item>
+         <widget class="QLabel" name="textLabel2">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Max mesh deviation:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="Gui::PrefDoubleSpinBox" name="prefFloatSpinBox1">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="value">
+           <double>0.100000000000000</double>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>MeshDeviation</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/Raytracing</cstring>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <widget class="Gui::PrefCheckBox" name="prefCheckBox8">
+        <property name="text">
+         <string>Do not calculate vertex normals</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>NotWriteVertexNormals</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Raytracing</cstring>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="Gui::PrefCheckBox" name="prefCheckBox9">
+        <property name="text">
+         <string>Write u,v coordinates</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>WriteUVCoordinates</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Raytracing</cstring>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>

--- a/src/Mod/ReverseEngineering/Gui/Segmentation.ui
+++ b/src/Mod/ReverseEngineering/Gui/Segmentation.ui
@@ -14,20 +14,6 @@
    <string>Mesh segmentation</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_2">
-   <item row="0" column="1">
-    <widget class="QSpinBox" name="smoothSteps">
-     <property name="value">
-      <number>3</number>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0" colspan="2">
-    <widget class="QCheckBox" name="createCompound">
-     <property name="text">
-      <string>Create compound</string>
-     </property>
-    </widget>
-   </item>
    <item row="0" column="0">
     <widget class="QCheckBox" name="checkBoxSmooth">
      <property name="text">
@@ -35,6 +21,13 @@
      </property>
      <property name="checked">
       <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QSpinBox" name="smoothSteps">
+     <property name="value">
+      <number>3</number>
      </property>
     </widget>
    </item>
@@ -108,7 +101,14 @@
      </property>
     </widget>
    </item>
-  </layout>
+  <item row="3" column="0" colspan="2">
+    <widget class="QCheckBox" name="createCompound">
+     <property name="text">
+      <string>Create compound</string>
+     </property>
+    </widget>
+   </item>
+   </layout>
  </widget>
  <resources/>
  <connections/>

--- a/src/Mod/Ship/shipAreasCurve/TaskPanel.ui
+++ b/src/Mod/Ship/shipAreasCurve/TaskPanel.ui
@@ -14,13 +14,6 @@
    <string>Transversal areas curve</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="1" column="0">
-    <widget class="QTextEdit" name="OutputData">
-     <property name="textInteractionFlags">
-      <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-     </property>
-    </widget>
-   </item>
    <item row="0" column="0">
     <layout class="QGridLayout" name="gridLayout_2">
      <item row="0" column="0">
@@ -77,7 +70,14 @@
      </item>
     </layout>
    </item>
-  </layout>
+  <item row="1" column="0">
+    <widget class="QTextEdit" name="OutputData">
+     <property name="textInteractionFlags">
+      <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+     </property>
+    </widget>
+   </item>
+   </layout>
  </widget>
  <customwidgets>
   <customwidget>

--- a/src/Mod/Ship/shipCreateWeight/TaskPanel.ui
+++ b/src/Mod/Ship/shipCreateWeight/TaskPanel.ui
@@ -26,7 +26,34 @@
    <string>Create new weight</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="2" column="0">
+   <item row="1" column="0">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLabel" name="ShipLabel">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Ship</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="Ship">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>1</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  <item row="2" column="0">
     <layout class="QHBoxLayout" name="horizontalLayout_3">
      <property name="spacing">
       <number>6</number>
@@ -56,34 +83,7 @@
      </item>
     </layout>
    </item>
-   <item row="1" column="0">
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QLabel" name="ShipLabel">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>Ship</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QComboBox" name="Ship">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-         <horstretch>1</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-  </layout>
+   </layout>
  </widget>
  <customwidgets>
   <customwidget>

--- a/src/Mod/Ship/shipOutlineDraw/TaskPanel.ui
+++ b/src/Mod/Ship/shipOutlineDraw/TaskPanel.ui
@@ -14,7 +14,62 @@
    <string>Outline draw</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="2">
+   <item row="0" column="1">
+    <layout class="QVBoxLayout" name="verticalLayout" stretch="0">
+     <property name="spacing">
+      <number>0</number>
+     </property>
+     <property name="sizeConstraint">
+      <enum>QLayout::SetDefaultConstraint</enum>
+     </property>
+     <item>
+      <widget class="QTableWidget" name="Sections">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>128</width>
+         <height>256</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="alternatingRowColors">
+        <bool>true</bool>
+       </property>
+       <property name="sortingEnabled">
+        <bool>true</bool>
+       </property>
+       <property name="rowCount">
+        <number>1</number>
+       </property>
+       <property name="columnCount">
+        <number>1</number>
+       </property>
+       <attribute name="horizontalHeaderVisible">
+        <bool>false</bool>
+       </attribute>
+       <attribute name="horizontalHeaderStretchLastSection">
+        <bool>true</bool>
+       </attribute>
+       <attribute name="verticalHeaderVisible">
+        <bool>true</bool>
+       </attribute>
+       <row/>
+       <column/>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  <item row="0" column="2">
     <layout class="QVBoxLayout" name="verticalLayout_3">
      <property name="spacing">
       <number>0</number>
@@ -182,62 +237,7 @@
      </item>
     </layout>
    </item>
-   <item row="0" column="1">
-    <layout class="QVBoxLayout" name="verticalLayout" stretch="0">
-     <property name="spacing">
-      <number>0</number>
-     </property>
-     <property name="sizeConstraint">
-      <enum>QLayout::SetDefaultConstraint</enum>
-     </property>
-     <item>
-      <widget class="QTableWidget" name="Sections">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>128</width>
-         <height>256</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>16777215</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="alternatingRowColors">
-        <bool>true</bool>
-       </property>
-       <property name="sortingEnabled">
-        <bool>true</bool>
-       </property>
-       <property name="rowCount">
-        <number>1</number>
-       </property>
-       <property name="columnCount">
-        <number>1</number>
-       </property>
-       <attribute name="horizontalHeaderVisible">
-        <bool>false</bool>
-       </attribute>
-       <attribute name="horizontalHeaderStretchLastSection">
-        <bool>true</bool>
-       </attribute>
-       <attribute name="verticalHeaderVisible">
-        <bool>true</bool>
-       </attribute>
-       <row/>
-       <column/>
-      </widget>
-     </item>
-    </layout>
-   </item>
-  </layout>
+   </layout>
  </widget>
  <resources/>
  <connections/>

--- a/src/Mod/Sketcher/Gui/SketchMirrorDialog.ui
+++ b/src/Mod/Sketcher/Gui/SketchMirrorDialog.ui
@@ -47,16 +47,6 @@
      </layout>
     </widget>
    </item>
-   <item row="2" column="0" colspan="2">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
-   </item>
    <item row="1" column="0">
     <spacer name="verticalSpacer">
      <property name="orientation">
@@ -70,7 +60,17 @@
      </property>
     </spacer>
    </item>
-  </layout>
+  <item row="2" column="0" colspan="2">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   </layout>
  </widget>
  <resources/>
  <connections>

--- a/src/Mod/Sketcher/Gui/SketcherSettingsDisplay.ui
+++ b/src/Mod/Sketcher/Gui/SketcherSettingsDisplay.ui
@@ -14,19 +14,6 @@
    <string>Display</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_3">
-   <item row="2" column="0">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
    <item row="0" column="0">
     <widget class="QGroupBox" name="groupBox">
      <property name="title">
@@ -382,7 +369,20 @@ Supports all unit systems except 'US customary' and 'Building US/Euro'.</string>
      </layout>
     </widget>
    </item>
-  </layout>
+  <item row="2" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   </layout>
  </widget>
  <customwidgets>
   <customwidget>

--- a/src/Mod/Spreadsheet/Gui/PropertiesDialog.ui
+++ b/src/Mod/Spreadsheet/Gui/PropertiesDialog.ui
@@ -14,16 +14,6 @@
    <string>Cell properties</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="1" column="0">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
-   </item>
    <item row="0" column="0">
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
@@ -300,7 +290,17 @@
      </widget>
     </widget>
    </item>
-  </layout>
+  <item row="1" column="0">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   </layout>
  </widget>
  <customwidgets>
   <customwidget>

--- a/src/Mod/Start/Gui/DlgStartPreferences.ui
+++ b/src/Mod/Start/Gui/DlgStartPreferences.ui
@@ -42,10 +42,29 @@
       <string>Contents</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
-      <item row="3" column="0">
-       <widget class="QLabel" name="label_14">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_17">
         <property name="text">
-         <string>Show forum</string>
+         <string>Show notepad</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="Gui::PrefCheckBox" name="checkBox">
+        <property name="toolTip">
+         <string>Shows a notepad next to the file thumbnails, where you can keep notes across sessions</string>
+        </property>
+        <property name="layoutDirection">
+         <enum>Qt::RightToLeft</enum>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>ShowNotes</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Start</cstring>
         </property>
        </widget>
       </item>
@@ -53,13 +72,6 @@
        <widget class="QLabel" name="label_9">
         <property name="text">
          <string>Show examples folder contents</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_10">
-        <property name="text">
-         <string>Show additional folder</string>
         </property>
        </widget>
       </item>
@@ -85,22 +97,10 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="1">
-       <widget class="Gui::PrefCheckBox" name="checkBox_4">
-        <property name="toolTip">
-         <string>If this is checked, the latest posts from the FreeCAD forum will be displayed on the Activity tab</string>
-        </property>
-        <property name="layoutDirection">
-         <enum>Qt::RightToLeft</enum>
-        </property>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_10">
         <property name="text">
-         <string/>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>ShowForum</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Start</cstring>
+         <string>Show additional folder</string>
         </property>
        </widget>
       </item>
@@ -121,17 +121,17 @@ By using ";;" to separate paths, you can add several folders here</string>
         </property>
        </widget>
       </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_17">
+      <item row="3" column="0">
+       <widget class="QLabel" name="label_14">
         <property name="text">
-         <string>Show notepad</string>
+         <string>Show forum</string>
         </property>
        </widget>
       </item>
-      <item row="0" column="1">
-       <widget class="Gui::PrefCheckBox" name="checkBox">
+      <item row="3" column="1">
+       <widget class="Gui::PrefCheckBox" name="checkBox_4">
         <property name="toolTip">
-         <string>Shows a notepad next to the file thumbnails, where you can keep notes across sessions</string>
+         <string>If this is checked, the latest posts from the FreeCAD forum will be displayed on the Activity tab</string>
         </property>
         <property name="layoutDirection">
          <enum>Qt::RightToLeft</enum>
@@ -140,7 +140,7 @@ By using ";;" to separate paths, you can add several folders here</string>
          <string/>
         </property>
         <property name="prefEntry" stdset="0">
-         <cstring>ShowNotes</cstring>
+         <cstring>ShowForum</cstring>
         </property>
         <property name="prefPath" stdset="0">
          <cstring>Mod/Start</cstring>
@@ -182,131 +182,10 @@ By using ";;" to separate paths, you can add several folders here</string>
       <string>Fonts and colors</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
-      <item row="6" column="1" alignment="Qt::AlignRight">
-       <widget class="Gui::PrefColorButton" name="colorButton_3">
-        <property name="maximumSize">
-         <size>
-          <width>60</width>
-          <height>60</height>
-         </size>
-        </property>
-        <property name="toolTip">
-         <string>The background of the main start page area</string>
-        </property>
-        <property name="color">
-         <color>
-          <red>255</red>
-          <green>255</green>
-          <blue>255</blue>
-         </color>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>PageColor</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Start</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_15">
         <property name="text">
-         <string>Background color</string>
-        </property>
-       </widget>
-      </item>
-      <item row="11" column="1">
-       <layout class="QHBoxLayout" name="horizontalLayout">
-        <item>
-         <widget class="Gui::PrefRadioButton" name="radioButton_2">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-          <property name="text">
-           <string>in FreeCAD</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>InBrowser</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Start</cstring>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="Gui::PrefRadioButton" name="radioButton_1">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-          <property name="text">
-           <string>In external browser</string>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>InWeb</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Start</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_12">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="text">
-         <string>Background color down gradient</string>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="1" alignment="Qt::AlignRight">
-       <widget class="Gui::PrefColorButton" name="colorButton_2">
-        <property name="maximumSize">
-         <size>
-          <width>60</width>
-          <height>60</height>
-         </size>
-        </property>
-        <property name="toolTip">
-         <string>The color of the version text</string>
-        </property>
-        <property name="color">
-         <color>
-          <red>255</red>
-          <green>251</green>
-          <blue>247</blue>
-         </color>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>BackgroundTextColor</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Start</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="9" column="0">
-       <widget class="QLabel" name="label_8">
-        <property name="text">
-         <string>Link color</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="1">
-       <widget class="Gui::PrefFileChooser" name="fileChooser_2">
-        <property name="toolTip">
-         <string>An optional image to display as background</string>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>BackgroundImage</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Start</cstring>
+         <string>Use FreeCAD style sheet</string>
         </property>
        </widget>
       </item>
@@ -329,109 +208,10 @@ By using ";;" to separate paths, you can add several folders here</string>
         </property>
        </widget>
       </item>
-      <item row="6" column="0">
-       <widget class="QLabel" name="label_4">
+      <item row="1" column="0">
+       <widget class="QLabel" name="label">
         <property name="text">
-         <string>Page background color</string>
-        </property>
-       </widget>
-      </item>
-      <item row="7" column="1" alignment="Qt::AlignRight">
-       <widget class="Gui::PrefColorButton" name="colorButton_4">
-        <property name="maximumSize">
-         <size>
-          <width>60</width>
-          <height>60</height>
-         </size>
-        </property>
-        <property name="toolTip">
-         <string>The color of the text on the main pages</string>
-        </property>
-        <property name="color">
-         <color>
-          <red>0</red>
-          <green>0</green>
-          <blue>0</blue>
-         </color>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>PageTextColor</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Start</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0">
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>Background image</string>
-        </property>
-       </widget>
-      </item>
-      <item row="7" column="0">
-       <widget class="QLabel" name="label_5">
-        <property name="text">
-         <string>Page text color</string>
-        </property>
-       </widget>
-      </item>
-      <item row="9" column="1" alignment="Qt::AlignRight">
-       <widget class="Gui::PrefColorButton" name="colorButton_6">
-        <property name="maximumSize">
-         <size>
-          <width>60</width>
-          <height>60</height>
-         </size>
-        </property>
-        <property name="toolTip">
-         <string>The color of the links</string>
-        </property>
-        <property name="color">
-         <color>
-          <red>0</red>
-          <green>0</green>
-          <blue>255</blue>
-         </color>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>LinkColor</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Start</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="8" column="1" alignment="Qt::AlignRight">
-       <widget class="Gui::PrefColorButton" name="colorButton_5">
-        <property name="maximumSize">
-         <size>
-          <width>60</width>
-          <height>60</height>
-         </size>
-        </property>
-        <property name="toolTip">
-         <string>The background color of the boxes inside the pages</string>
-        </property>
-        <property name="color">
-         <color>
-          <red>221</red>
-          <green>221</green>
-          <blue>221</blue>
-         </color>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>BoxColor</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Start</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="8" column="0">
-       <widget class="QLabel" name="label_6">
-        <property name="text">
-         <string>Box background color</string>
+         <string>Background color</string>
         </property>
        </widget>
       </item>
@@ -458,6 +238,16 @@ By using ";;" to separate paths, you can add several folders here</string>
         </property>
         <property name="prefPath" stdset="0">
          <cstring>Mod/Start</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_12">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>Background color down gradient</string>
         </property>
        </widget>
       </item>
@@ -490,13 +280,23 @@ By using ";;" to separate paths, you can add several folders here</string>
         </property>
        </widget>
       </item>
-      <item row="11" column="0">
-       <widget class="QLabel" name="label_7">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
+      <item row="4" column="0">
+       <widget class="QLabel" name="label_2">
         <property name="text">
-         <string>Open links</string>
+         <string>Background image</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="Gui::PrefFileChooser" name="fileChooser_2">
+        <property name="toolTip">
+         <string>An optional image to display as background</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>BackgroundImage</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Start</cstring>
         </property>
        </widget>
       </item>
@@ -507,10 +307,161 @@ By using ";;" to separate paths, you can add several folders here</string>
         </property>
        </widget>
       </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_15">
+      <item row="5" column="1" alignment="Qt::AlignRight">
+       <widget class="Gui::PrefColorButton" name="colorButton_2">
+        <property name="maximumSize">
+         <size>
+          <width>60</width>
+          <height>60</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>The color of the version text</string>
+        </property>
+        <property name="color">
+         <color>
+          <red>255</red>
+          <green>251</green>
+          <blue>247</blue>
+         </color>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>BackgroundTextColor</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Start</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="0">
+       <widget class="QLabel" name="label_4">
         <property name="text">
-         <string>Use FreeCAD style sheet</string>
+         <string>Page background color</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="1" alignment="Qt::AlignRight">
+       <widget class="Gui::PrefColorButton" name="colorButton_3">
+        <property name="maximumSize">
+         <size>
+          <width>60</width>
+          <height>60</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>The background of the main start page area</string>
+        </property>
+        <property name="color">
+         <color>
+          <red>255</red>
+          <green>255</green>
+          <blue>255</blue>
+         </color>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>PageColor</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Start</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="0">
+       <widget class="QLabel" name="label_5">
+        <property name="text">
+         <string>Page text color</string>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="1" alignment="Qt::AlignRight">
+       <widget class="Gui::PrefColorButton" name="colorButton_4">
+        <property name="maximumSize">
+         <size>
+          <width>60</width>
+          <height>60</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>The color of the text on the main pages</string>
+        </property>
+        <property name="color">
+         <color>
+          <red>0</red>
+          <green>0</green>
+          <blue>0</blue>
+         </color>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>PageTextColor</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Start</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="0">
+       <widget class="QLabel" name="label_6">
+        <property name="text">
+         <string>Box background color</string>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="1" alignment="Qt::AlignRight">
+       <widget class="Gui::PrefColorButton" name="colorButton_5">
+        <property name="maximumSize">
+         <size>
+          <width>60</width>
+          <height>60</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>The background color of the boxes inside the pages</string>
+        </property>
+        <property name="color">
+         <color>
+          <red>221</red>
+          <green>221</green>
+          <blue>221</blue>
+         </color>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>BoxColor</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Start</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="9" column="0">
+       <widget class="QLabel" name="label_8">
+        <property name="text">
+         <string>Link color</string>
+        </property>
+       </widget>
+      </item>
+      <item row="9" column="1" alignment="Qt::AlignRight">
+       <widget class="Gui::PrefColorButton" name="colorButton_6">
+        <property name="maximumSize">
+         <size>
+          <width>60</width>
+          <height>60</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>The color of the links</string>
+        </property>
+        <property name="color">
+         <color>
+          <red>0</red>
+          <green>0</green>
+          <blue>255</blue>
+         </color>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>LinkColor</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Start</cstring>
         </property>
        </widget>
       </item>
@@ -563,6 +514,55 @@ By using ";;" to separate paths, you can add several folders here</string>
         </item>
        </layout>
       </item>
+      <item row="11" column="0">
+       <widget class="QLabel" name="label_7">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>Open links</string>
+        </property>
+       </widget>
+      </item>
+      <item row="11" column="1">
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="Gui::PrefRadioButton" name="radioButton_2">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="text">
+           <string>in FreeCAD</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>InBrowser</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/Start</cstring>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="Gui::PrefRadioButton" name="radioButton_1">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="text">
+           <string>In external browser</string>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>InWeb</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/Start</cstring>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
       <item row="12" column="0">
        <widget class="QLabel" name="label_18">
         <property name="text">
@@ -598,10 +598,24 @@ By using ";;" to separate paths, you can add several folders here</string>
       <string>Options</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_3">
+      <item row="0" column="0">
+       <widget class="QLabel" name="autoModuleLabel">
+        <property name="text">
+         <string>Switch workbench after loading</string>
+        </property>
+       </widget>
+      </item>
       <item row="0" column="1">
        <widget class="QComboBox" name="AutoloadModuleCombo">
         <property name="toolTip">
          <string>Choose which workbench to switch to after the program launches</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_11">
+        <property name="text">
+         <string>Close start page after loading</string>
         </property>
        </widget>
       </item>
@@ -621,20 +635,6 @@ By using ";;" to separate paths, you can add several folders here</string>
         </property>
         <property name="prefPath" stdset="0">
          <cstring>Mod/Start</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="autoModuleLabel">
-        <property name="text">
-         <string>Switch workbench after loading</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_11">
-        <property name="text">
-         <string>Close start page after loading</string>
         </property>
        </widget>
       </item>

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawAdvanced.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawAdvanced.ui
@@ -40,8 +40,42 @@
      <layout class="QVBoxLayout" name="verticalLayout">
       <item>
        <layout class="QGridLayout" name="gridLayout" columnstretch="1,0,1">
-        <item row="3" column="0">
-         <widget class="Gui::PrefCheckBox" name="cbShowLoose">
+        <item row="0" column="0">
+         <widget class="Gui::PrefCheckBox" name="cbDetectFaces">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="toolTip">
+           <string>If checked, TechDraw will attempt to build faces using the
+line segments returned by the hidden line removal algorithm.
+Faces must be detected in order to use hatching, but there
+can be a performance penalty in complex models.</string>
+          </property>
+          <property name="text">
+           <string>Detect Faces</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>HandleFaces</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>/Mod/TechDraw/General</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="2">
+         <widget class="Gui::PrefCheckBox" name="cbShowSectionEdges">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
           <property name="minimumSize">
            <size>
             <width>0</width>
@@ -49,19 +83,69 @@
            </size>
           </property>
           <property name="toolTip">
-           <string>Include 2D Objects in projection</string>
+           <string>Highlights border of section cut in section views</string>
           </property>
           <property name="text">
-           <string>Show Loose 2D Geom</string>
+           <string>Show Section Edges</string>
           </property>
           <property name="checked">
-           <bool>false</bool>
+           <bool>true</bool>
           </property>
           <property name="prefEntry" stdset="0">
-           <cstring>ShowLoose2d</cstring>
+           <cstring>ShowSectionEdges</cstring>
           </property>
           <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/General</cstring>
+           <cstring>/Mod/TechDraw/General</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="Gui::PrefCheckBox" name="cbDebugSection">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="toolTip">
+           <string>Dump intermediate results during Section view processing</string>
+          </property>
+          <property name="text">
+           <string>Debug Section</string>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>debugSection</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/debug</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="2">
+         <widget class="Gui::PrefCheckBox" name="cbDebugDetail">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>20</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Dump intermediate results during Detail view processing</string>
+          </property>
+          <property name="text">
+           <string>Debug Detail</string>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>debugDetail</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/debugDetail</cstring>
           </property>
          </widget>
         </item>
@@ -87,6 +171,77 @@
           </property>
          </widget>
         </item>
+        <item row="2" column="1">
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item row="2" column="2">
+         <widget class="Gui::PrefCheckBox" name="cbFuseBeforeSection">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>20</height>
+           </size>
+          </property>
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="toolTip">
+           <string>Perform a fuse operation on input shape(s) before Section view processing</string>
+          </property>
+          <property name="text">
+           <string>Fuse Before Section</string>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>SectionFuseFirst</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/General</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="0">
+         <widget class="Gui::PrefCheckBox" name="cbShowLoose">
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>20</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Include 2D Objects in projection</string>
+          </property>
+          <property name="text">
+           <string>Show Loose 2D Geom</string>
+          </property>
+          <property name="checked">
+           <bool>false</bool>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>ShowLoose2d</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/General</cstring>
+          </property>
+         </widget>
+        </item>
         <item row="4" column="0">
          <widget class="QLabel" name="label_5">
           <property name="minimumSize">
@@ -103,6 +258,113 @@
           </property>
           <property name="text">
            <string>Edge Fuzz</string>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="2">
+         <widget class="Gui::PrefDoubleSpinBox" name="pdsbEdgeFuzz">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>174</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="baseSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Size of selection area around edges
+Each unit is approx. 0.1 mm wide</string>
+          </property>
+          <property name="statusTip">
+           <string/>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+          <property name="value">
+           <double>10.000000000000000</double>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>EdgeFuzz</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/General</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="0">
+         <widget class="QLabel" name="label_4">
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Mark Fuzz</string>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="2">
+         <widget class="Gui::PrefDoubleSpinBox" name="pdsbMarkFuzz">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>174</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="baseSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Selection area around center marks
+Each unit is approx. 0.1 mm wide</string>
+          </property>
+          <property name="statusTip">
+           <string/>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+          <property name="value">
+           <double>5.000000000000000</double>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>MarkFuzz</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/General</cstring>
+          </property>
+         </widget>
+        </item>
+       <item row="6" column="0">
+         <widget class="QLabel" name="label_3">
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="text">
+           <string>Dimension Format</string>
           </property>
          </widget>
         </item>
@@ -125,6 +387,18 @@
           </property>
           <property name="prefPath" stdset="0">
            <cstring>/Mod/TechDraw/Dimensions</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="7" column="0">
+         <widget class="QLabel" name="label_7">
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="text">
+           <string>Line End Cap Shape</string>
           </property>
          </widget>
         </item>
@@ -174,132 +448,10 @@ Only change unless you know what you are doing!</string>
           </item>
          </widget>
         </item>
-        <item row="2" column="2">
-         <widget class="Gui::PrefCheckBox" name="cbFuseBeforeSection">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>20</height>
-           </size>
-          </property>
-          <property name="font">
-           <font>
-            <italic>true</italic>
-           </font>
-          </property>
-          <property name="toolTip">
-           <string>Perform a fuse operation on input shape(s) before Section view processing</string>
-          </property>
+        <item row="8" column="0">
+         <widget class="QLabel" name="label">
           <property name="text">
-           <string>Fuse Before Section</string>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>SectionFuseFirst</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/General</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="0">
-         <widget class="QLabel" name="label_3">
-          <property name="font">
-           <font>
-            <italic>true</italic>
-           </font>
-          </property>
-          <property name="text">
-           <string>Dimension Format</string>
-          </property>
-         </widget>
-        </item>
-        <item row="7" column="0">
-         <widget class="QLabel" name="label_7">
-          <property name="font">
-           <font>
-            <italic>true</italic>
-           </font>
-          </property>
-          <property name="text">
-           <string>Line End Cap Shape</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <spacer name="horizontalSpacer">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item row="1" column="2">
-         <widget class="Gui::PrefCheckBox" name="cbDebugDetail">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>20</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>Dump intermediate results during Detail view processing</string>
-          </property>
-          <property name="text">
-           <string>Debug Detail</string>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>debugDetail</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/debugDetail</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="2">
-         <widget class="Gui::PrefCheckBox" name="cbShowSectionEdges">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>20</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>Highlights border of section cut in section views</string>
-          </property>
-          <property name="text">
-           <string>Show Section Edges</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>ShowSectionEdges</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>/Mod/TechDraw/General</cstring>
+           <string>Max SVG Hatch Tiles</string>
           </property>
          </widget>
         </item>
@@ -336,13 +488,6 @@ Then you need to increase the tile limit.</string>
           </property>
           <property name="prefPath" stdset="0">
            <cstring>Mod/TechDraw/Decorations</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="8" column="0">
-         <widget class="QLabel" name="label">
-          <property name="text">
-           <string>Max SVG Hatch Tiles</string>
           </property>
          </widget>
         </item>
@@ -388,152 +533,7 @@ when hatching a face with a PAT pattern</string>
           </property>
          </widget>
         </item>
-        <item row="1" column="0">
-         <widget class="Gui::PrefCheckBox" name="cbDebugSection">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="toolTip">
-           <string>Dump intermediate results during Section view processing</string>
-          </property>
-          <property name="text">
-           <string>Debug Section</string>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>debugSection</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/debug</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="0">
-         <widget class="Gui::PrefCheckBox" name="cbDetectFaces">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="toolTip">
-           <string>If checked, TechDraw will attempt to build faces using the
-line segments returned by the hidden line removal algorithm.
-Faces must be detected in order to use hatching, but there
-can be a performance penalty in complex models.</string>
-          </property>
-          <property name="text">
-           <string>Detect Faces</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>HandleFaces</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>/Mod/TechDraw/General</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="0">
-         <widget class="QLabel" name="label_4">
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Mark Fuzz</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="2">
-         <widget class="Gui::PrefDoubleSpinBox" name="pdsbEdgeFuzz">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>174</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="baseSize">
-           <size>
-            <width>0</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>Size of selection area around edges
-Each unit is approx. 0.1 mm wide</string>
-          </property>
-          <property name="statusTip">
-           <string/>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-          <property name="value">
-           <double>10.000000000000000</double>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>EdgeFuzz</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/General</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="2">
-         <widget class="Gui::PrefDoubleSpinBox" name="pdsbMarkFuzz">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>174</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="baseSize">
-           <size>
-            <width>0</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>Selection area around center marks
-Each unit is approx. 0.1 mm wide</string>
-          </property>
-          <property name="statusTip">
-           <string/>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-          <property name="value">
-           <double>5.000000000000000</double>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>MarkFuzz</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/General</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
+        </layout>
       </item>
      </layout>
     </widget>

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawColors.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawColors.ui
@@ -426,6 +426,67 @@
           </property>
          </widget>
         </item>
+        <item row="6" column="0">
+         <widget class="QLabel" name="label_18">
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="text">
+           <string>Detail Highlight</string>
+          </property>
+         </widget>
+        </item>
+        <item row="6" column="1">
+         <widget class="Gui::PrefColorButton" name="pcbHighlight">
+          <property name="color">
+           <color>
+            <red>0</red>
+            <green>0</green>
+            <blue>0</blue>
+           </color>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>HighlightColor</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>/Mod/TechDraw/Decorations</cstring>
+          </property>
+         </widget>
+        </item>
+       <item row="6" column="3">
+         <widget class="QLabel" name="label_17">
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="text">
+           <string>Leaderline</string>
+          </property>
+         </widget>
+        </item>
+        <item row="6" column="4">
+         <widget class="Gui::PrefColorButton" name="pcbMarkup">
+          <property name="toolTip">
+           <string>Default color for leader lines</string>
+          </property>
+          <property name="color">
+           <color>
+            <red>0</red>
+            <green>0</green>
+            <blue>0</blue>
+           </color>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>Color</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/Markups</cstring>
+          </property>
+         </widget>
+        </item>
         <item row="7" column="0">
          <widget class="Gui::PrefCheckBox" name="pcb_PaintFaces">
           <property name="minimumSize">
@@ -473,68 +534,7 @@
           </property>
          </widget>
         </item>
-        <item row="6" column="0">
-         <widget class="QLabel" name="label_18">
-          <property name="font">
-           <font>
-            <italic>true</italic>
-           </font>
-          </property>
-          <property name="text">
-           <string>Detail Highlight</string>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="3">
-         <widget class="QLabel" name="label_17">
-          <property name="font">
-           <font>
-            <italic>true</italic>
-           </font>
-          </property>
-          <property name="text">
-           <string>Leaderline</string>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="4">
-         <widget class="Gui::PrefColorButton" name="pcbMarkup">
-          <property name="toolTip">
-           <string>Default color for leader lines</string>
-          </property>
-          <property name="color">
-           <color>
-            <red>0</red>
-            <green>0</green>
-            <blue>0</blue>
-           </color>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>Color</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/Markups</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="1">
-         <widget class="Gui::PrefColorButton" name="pcbHighlight">
-          <property name="color">
-           <color>
-            <red>0</red>
-            <green>0</green>
-            <blue>0</blue>
-           </color>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>HighlightColor</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>/Mod/TechDraw/Decorations</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
+        </layout>
       </item>
      </layout>
     </widget>

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawDimensions.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawDimensions.ui
@@ -46,6 +46,24 @@
      <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
        <layout class="QGridLayout" name="gridLayout">
+        <item row="0" column="0">
+         <widget class="QLabel" name="label_16">
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="text">
+           <string>Standard and Style</string>
+          </property>
+         </widget>
+        </item>
         <item row="0" column="2">
          <widget class="Gui::PrefComboBox" name="pcbStandardAndStyle">
           <property name="sizePolicy">
@@ -91,106 +109,30 @@
           </item>
          </widget>
         </item>
-        <item row="6" column="0">
-         <widget class="QLabel" name="label_9">
-          <property name="font">
-           <font>
-            <italic>true</italic>
-           </font>
-          </property>
-          <property name="text">
-           <string>Arrow Style</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="0">
-         <widget class="QLabel" name="label_16">
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="font">
-           <font>
-            <italic>true</italic>
-           </font>
-          </property>
-          <property name="text">
-           <string>Standard and Style</string>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="2">
-         <widget class="Gui::PrefComboBox" name="pcbArrow">
+        <item row="1" column="0">
+         <widget class="Gui::PrefCheckBox" name="cbGlobalDecimals">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>22</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>Arrowhead style</string>
-          </property>
-          <property name="currentIndex">
-           <number>-1</number>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>ArrowStyle</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/Dimensions</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="7" column="0">
-         <widget class="QLabel" name="label_12">
           <property name="font">
            <font>
             <italic>true</italic>
            </font>
           </property>
-          <property name="text">
-           <string>Arrow Size</string>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="2">
-         <widget class="Gui::PrefLineEdit" name="leDiameter">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>22</height>
-           </size>
-          </property>
-          <property name="font">
-           <font>
-            <pointsize>12</pointsize>
-           </font>
-          </property>
           <property name="toolTip">
-           <string>Character used to indicate diameter dimensions</string>
+           <string>Use system setting for number of decimals</string>
           </property>
           <property name="text">
-           <string>⌀</string>
+           <string>Use Global Decimals</string>
           </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          <property name="checked">
+           <bool>true</bool>
           </property>
           <property name="prefEntry" stdset="0">
-           <cstring>DiameterSymbol</cstring>
+           <cstring>UseGlobalDecimals</cstring>
           </property>
           <property name="prefPath" stdset="0">
            <cstring>/Mod/TechDraw/Dimensions</cstring>
@@ -225,40 +167,10 @@
           </property>
          </widget>
         </item>
-        <item row="5" column="0">
-         <widget class="QLabel" name="label_8">
+        <item row="2" column="0">
+         <widget class="QLabel" name="label_11">
           <property name="text">
-           <string>Diameter Symbol</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="Gui::PrefCheckBox" name="cbGlobalDecimals">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="font">
-           <font>
-            <italic>true</italic>
-           </font>
-          </property>
-          <property name="toolTip">
-           <string>Use system setting for number of decimals</string>
-          </property>
-          <property name="text">
-           <string>Use Global Decimals</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>UseGlobalDecimals</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>/Mod/TechDraw/Dimensions</cstring>
+           <string>Alternate Decimals</string>
           </property>
          </widget>
         </item>
@@ -293,6 +205,18 @@
           </property>
           <property name="prefPath" stdset="0">
            <cstring>/Mod/TechDraw/Dimensions</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="0">
+         <widget class="QLabel" name="label_2">
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="text">
+           <string>Font Size</string>
           </property>
          </widget>
         </item>
@@ -337,56 +261,6 @@
           </property>
           <property name="prefPath" stdset="0">
            <cstring>/Mod/TechDraw/Dimensions</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="7" column="2">
-         <widget class="Gui::PrefUnitSpinBox" name="plsb_ArrowSize">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>22</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>Arrowhead size</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-          <property name="value">
-           <double>5.000000000000000</double>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>ArrowSize</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/Dimensions</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="label_11">
-          <property name="text">
-           <string>Alternate Decimals</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="label_2">
-          <property name="font">
-           <font>
-            <italic>true</italic>
-           </font>
-          </property>
-          <property name="text">
-           <string>Font Size</string>
           </property>
          </widget>
         </item>
@@ -458,7 +332,133 @@ Multiplier of 'Font Size'</string>
           </property>
          </widget>
         </item>
-       </layout>
+       <item row="5" column="0">
+         <widget class="QLabel" name="label_8">
+          <property name="text">
+           <string>Diameter Symbol</string>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="2">
+         <widget class="Gui::PrefLineEdit" name="leDiameter">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>22</height>
+           </size>
+          </property>
+          <property name="font">
+           <font>
+            <pointsize>12</pointsize>
+           </font>
+          </property>
+          <property name="toolTip">
+           <string>Character used to indicate diameter dimensions</string>
+          </property>
+          <property name="text">
+           <string>⌀</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>DiameterSymbol</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>/Mod/TechDraw/Dimensions</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="6" column="0">
+         <widget class="QLabel" name="label_9">
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="text">
+           <string>Arrow Style</string>
+          </property>
+         </widget>
+        </item>
+        <item row="6" column="2">
+         <widget class="Gui::PrefComboBox" name="pcbArrow">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>22</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Arrowhead style</string>
+          </property>
+          <property name="currentIndex">
+           <number>-1</number>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>ArrowStyle</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/Dimensions</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="7" column="0">
+         <widget class="QLabel" name="label_12">
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="text">
+           <string>Arrow Size</string>
+          </property>
+         </widget>
+        </item>
+        <item row="7" column="2">
+         <widget class="Gui::PrefUnitSpinBox" name="plsb_ArrowSize">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>22</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Arrowhead size</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+          <property name="value">
+           <double>5.000000000000000</double>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>ArrowSize</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/Dimensions</cstring>
+          </property>
+         </widget>
+        </item>
+        </layout>
       </item>
      </layout>
     </widget>

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawGeneral.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawGeneral.ui
@@ -199,22 +199,6 @@ for ProjectionGroups</string>
      <layout class="QVBoxLayout" name="verticalLayout_4">
       <item>
        <layout class="QGridLayout" name="gridLayout_2" rowstretch="0,0" columnstretch="1,0,1">
-        <item row="0" column="1">
-         <spacer name="horizontalSpacer_2">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeType">
-           <enum>QSizePolicy::Preferred</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
         <item row="0" column="0">
          <widget class="QLabel" name="lbl_LabelFont">
           <property name="minimumSize">
@@ -238,12 +222,21 @@ for ProjectionGroups</string>
           </property>
          </widget>
         </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="label_6">
-          <property name="text">
-           <string>Label Size</string>
+        <item row="0" column="1">
+         <spacer name="horizontalSpacer_2">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
           </property>
-         </widget>
+          <property name="sizeType">
+           <enum>QSizePolicy::Preferred</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
         </item>
         <item row="0" column="2">
          <widget class="Gui::PrefFontBox" name="pfb_LabelFont">
@@ -284,6 +277,13 @@ for ProjectionGroups</string>
           </property>
           <property name="prefPath" stdset="0">
            <cstring>/Mod/TechDraw/Labels</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="label_6">
+          <property name="text">
+           <string>Label Size</string>
           </property>
          </widget>
         </item>
@@ -362,6 +362,13 @@ for ProjectionGroups</string>
      <layout class="QVBoxLayout" name="verticalLayout">
       <item>
        <layout class="QGridLayout" name="gridLayout_6" columnstretch="1,0,1">
+        <item row="0" column="0">
+         <widget class="QLabel" name="label_7">
+          <property name="text">
+           <string>Projection Group Angle</string>
+          </property>
+         </widget>
+        </item>
         <item row="0" column="1">
          <spacer name="horizontalSpacer_3">
           <property name="orientation">
@@ -374,13 +381,6 @@ for ProjectionGroups</string>
            </size>
           </property>
          </spacer>
-        </item>
-        <item row="0" column="0">
-         <widget class="QLabel" name="label_7">
-          <property name="text">
-           <string>Projection Group Angle</string>
-          </property>
-         </widget>
         </item>
         <item row="0" column="2">
          <widget class="Gui::PrefComboBox" name="cbProjAngle">

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawHLR.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawHLR.ui
@@ -49,101 +49,6 @@
      <layout class="QVBoxLayout" name="verticalLayout">
       <item>
        <layout class="QGridLayout" name="gridLayout_6">
-        <item row="1" column="0">
-         <widget class="QLabel" name="label_17">
-          <property name="text">
-           <string>Visible</string>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="2">
-         <widget class="Gui::PrefSpinBox" name="psbIsoCount">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>140</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>Number of ISO lines per face edge</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight</set>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>IsoCount</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/HLR</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="0">
-         <widget class="Gui::PrefCheckBox" name="pcbSeamViz">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="font">
-           <font>
-            <italic>true</italic>
-           </font>
-          </property>
-          <property name="toolTip">
-           <string>Show seam lines</string>
-          </property>
-          <property name="text">
-           <string>Show Seam Lines</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>SeamViz</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/HLR</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="Gui::PrefCheckBox" name="pcbSmoothViz">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="font">
-           <font>
-            <italic>true</italic>
-           </font>
-          </property>
-          <property name="toolTip">
-           <string>Show smooth lines</string>
-          </property>
-          <property name="text">
-           <string>Show Smooth Lines</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>SmoothViz</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/HLR</cstring>
-          </property>
-         </widget>
-        </item>
         <item row="0" column="0">
          <widget class="Gui::PrefCheckBox" name="pcbPolygon">
           <property name="sizePolicy">
@@ -172,59 +77,45 @@ Fast, but result is a collection of short straight lines.</string>
           </property>
          </widget>
         </item>
-        <item row="3" column="2">
-         <widget class="Gui::PrefCheckBox" name="pcbSmoothHid">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="font">
-           <font>
-            <italic>true</italic>
-           </font>
-          </property>
-          <property name="toolTip">
-           <string>Show hidden smooth edges</string>
-          </property>
+        <item row="1" column="0">
+         <widget class="QLabel" name="label_17">
           <property name="text">
-           <string>Show Smooth Lines</string>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>SmoothHid</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/HLR</cstring>
+           <string>Visible</string>
           </property>
          </widget>
         </item>
-        <item row="2" column="2">
-         <widget class="Gui::PrefCheckBox" name="pcbHardHid">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
+        <item row="1" column="1">
+         <spacer name="horizontalSpacer_2">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
           </property>
-          <property name="font">
-           <font>
-            <italic>true</italic>
-           </font>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
           </property>
-          <property name="toolTip">
-           <string>Show hidden hard and outline edges</string>
-          </property>
+         </spacer>
+        </item>
+       <item row="1" column="2">
+         <widget class="QLabel" name="label_18">
           <property name="text">
-           <string>Show Hard Lines</string>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>HardHid</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/HLR</cstring>
+           <string>Hidden</string>
           </property>
          </widget>
+        </item>
+        <item row="1" column="3">
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
         </item>
         <item row="2" column="0">
          <widget class="Gui::PrefCheckBox" name="pcbHardViz">
@@ -265,6 +156,120 @@ Fast, but result is a collection of short straight lines.</string>
           </property>
          </widget>
         </item>
+        <item row="2" column="2">
+         <widget class="Gui::PrefCheckBox" name="pcbHardHid">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="toolTip">
+           <string>Show hidden hard and outline edges</string>
+          </property>
+          <property name="text">
+           <string>Show Hard Lines</string>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>HardHid</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/HLR</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="0">
+         <widget class="Gui::PrefCheckBox" name="pcbSmoothViz">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="toolTip">
+           <string>Show smooth lines</string>
+          </property>
+          <property name="text">
+           <string>Show Smooth Lines</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>SmoothViz</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/HLR</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="2">
+         <widget class="Gui::PrefCheckBox" name="pcbSmoothHid">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="toolTip">
+           <string>Show hidden smooth edges</string>
+          </property>
+          <property name="text">
+           <string>Show Smooth Lines</string>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>SmoothHid</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/HLR</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="0">
+         <widget class="Gui::PrefCheckBox" name="pcbSeamViz">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="toolTip">
+           <string>Show seam lines</string>
+          </property>
+          <property name="text">
+           <string>Show Seam Lines</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>SeamViz</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/HLR</cstring>
+          </property>
+         </widget>
+        </item>
         <item row="4" column="2">
          <widget class="Gui::PrefCheckBox" name="pcbSeamHid">
           <property name="sizePolicy">
@@ -286,6 +291,33 @@ Fast, but result is a collection of short straight lines.</string>
           </property>
           <property name="prefEntry" stdset="0">
            <cstring>SeamHid</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/HLR</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="0">
+         <widget class="Gui::PrefCheckBox" name="pcbIsoViz">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="toolTip">
+           <string>Make lines of equal parameterization</string>
+          </property>
+          <property name="text">
+           <string>Show UV ISO Lines</string>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>IsoViz</cstring>
           </property>
           <property name="prefPath" stdset="0">
            <cstring>Mod/TechDraw/HLR</cstring>
@@ -319,13 +351,6 @@ Fast, but result is a collection of short straight lines.</string>
           </property>
          </widget>
         </item>
-        <item row="1" column="2">
-         <widget class="QLabel" name="label_18">
-          <property name="text">
-           <string>Hidden</string>
-          </property>
-         </widget>
-        </item>
         <item row="6" column="0">
          <widget class="QLabel" name="label_19">
           <property name="minimumSize">
@@ -344,60 +369,35 @@ Fast, but result is a collection of short straight lines.</string>
           </property>
          </widget>
         </item>
-        <item row="5" column="0">
-         <widget class="Gui::PrefCheckBox" name="pcbIsoViz">
+        <item row="6" column="2">
+         <widget class="Gui::PrefSpinBox" name="psbIsoCount">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
-          <property name="font">
-           <font>
-            <italic>true</italic>
-           </font>
+          <property name="maximumSize">
+           <size>
+            <width>140</width>
+            <height>16777215</height>
+           </size>
           </property>
           <property name="toolTip">
-           <string>Make lines of equal parameterization</string>
+           <string>Number of ISO lines per face edge</string>
           </property>
-          <property name="text">
-           <string>Show UV ISO Lines</string>
+          <property name="alignment">
+           <set>Qt::AlignRight</set>
           </property>
           <property name="prefEntry" stdset="0">
-           <cstring>IsoViz</cstring>
+           <cstring>IsoCount</cstring>
           </property>
           <property name="prefPath" stdset="0">
            <cstring>Mod/TechDraw/HLR</cstring>
           </property>
          </widget>
         </item>
-        <item row="1" column="3">
-         <spacer name="horizontalSpacer">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item row="1" column="1">
-         <spacer name="horizontalSpacer_2">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-       </layout>
+        </layout>
       </item>
      </layout>
     </widget>

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawScale.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawScale.ui
@@ -247,8 +247,8 @@
           </property>
          </widget>
         </item>
-        <item row="2" column="2">
-         <widget class="Gui::PrefUnitSpinBox" name="pdsbTemplateMark">
+        <item row="0" column="2">
+         <widget class="Gui::PrefDoubleSpinBox" name="pdsbVertexScale">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
             <horstretch>0</horstretch>
@@ -262,16 +262,19 @@
            </size>
           </property>
           <property name="toolTip">
-           <string>Size of template field click handles</string>
+           <string>Scale of vertex dots. Multiplier of line width.</string>
+          </property>
+          <property name="accessibleName">
+           <string/>
           </property>
           <property name="alignment">
            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
           </property>
           <property name="value">
-           <double>3.000000000000000</double>
+           <double>5.000000000000000</double>
           </property>
           <property name="prefEntry" stdset="0">
-           <cstring>TemplateDotSize</cstring>
+           <cstring>VertexScale</cstring>
           </property>
           <property name="prefPath" stdset="0">
            <cstring>Mod/TechDraw/General</cstring>
@@ -290,7 +293,20 @@
           </property>
          </widget>
         </item>
-        <item row="1" column="2">
+        <item row="1" column="1">
+         <spacer name="horizontalSpacer_3">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       <item row="1" column="2">
          <widget class="Gui::PrefDoubleSpinBox" name="pdsbCenterScale">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -334,6 +350,44 @@
           </property>
          </widget>
         </item>
+        <item row="2" column="2">
+         <widget class="Gui::PrefUnitSpinBox" name="pdsbTemplateMark">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>174</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Size of template field click handles</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+          <property name="value">
+           <double>3.000000000000000</double>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>TemplateDotSize</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/General</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="0">
+         <widget class="QLabel" name="label_5">
+          <property name="text">
+           <string>Welding Symbol Scale</string>
+          </property>
+         </widget>
+        </item>
         <item row="3" column="2">
          <widget class="Gui::PrefDoubleSpinBox" name="pdsbSymbolScale">
           <property name="toolTip">
@@ -356,61 +410,7 @@
           </property>
          </widget>
         </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="label_5">
-          <property name="text">
-           <string>Welding Symbol Scale</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="2">
-         <widget class="Gui::PrefDoubleSpinBox" name="pdsbVertexScale">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>174</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>Scale of vertex dots. Multiplier of line width.</string>
-          </property>
-          <property name="accessibleName">
-           <string/>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-          <property name="value">
-           <double>5.000000000000000</double>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>VertexScale</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/General</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <spacer name="horizontalSpacer_3">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-       </layout>
+        </layout>
       </item>
      </layout>
     </widget>

--- a/src/Mod/TechDraw/Gui/TaskCosVertex.ui
+++ b/src/Mod/TechDraw/Gui/TaskCosVertex.ui
@@ -32,7 +32,14 @@
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>
     <layout class="QGridLayout" name="gridLayout">
-     <item row="0" column="1">
+     <item row="0" column="0">
+      <widget class="QLabel" name="label_4">
+       <property name="text">
+        <string>Base View</string>
+       </property>
+      </widget>
+     </item>
+    <item row="0" column="1">
       <widget class="QLineEdit" name="leBaseView">
        <property name="enabled">
         <bool>false</bool>
@@ -48,14 +55,7 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="0">
-      <widget class="QLabel" name="label_4">
-       <property name="text">
-        <string>Base View</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
+     </layout>
    </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">

--- a/src/Mod/TechDraw/Gui/TaskCosmeticLine.ui
+++ b/src/Mod/TechDraw/Gui/TaskCosmeticLine.ui
@@ -89,6 +89,13 @@
        </property>
       </widget>
      </item>
+     <item row="0" column="1">
+      <widget class="Gui::QuantitySpinBox" name="qsbx1">
+       <property name="unit" stdset="0">
+        <string notr="true"/>
+       </property>
+      </widget>
+     </item>
      <item row="1" column="0">
       <widget class="QLabel" name="label_2">
        <property name="text">
@@ -96,8 +103,8 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="1">
-      <widget class="Gui::QuantitySpinBox" name="qsbx1">
+     <item row="1" column="1">
+      <widget class="Gui::QuantitySpinBox" name="qsby1">
        <property name="unit" stdset="0">
         <string notr="true"/>
        </property>
@@ -107,13 +114,6 @@
       <widget class="QLabel" name="label_3">
        <property name="text">
         <string>Z:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="Gui::QuantitySpinBox" name="qsby1">
-       <property name="unit" stdset="0">
-        <string notr="true"/>
        </property>
       </widget>
      </item>
@@ -155,17 +155,17 @@
    </item>
    <item>
     <layout class="QGridLayout" name="gridLayout_5" columnstretch="1,4">
-     <item row="0" column="1">
-      <widget class="Gui::QuantitySpinBox" name="qsbx2">
-       <property name="unit" stdset="0">
-        <string notr="true"/>
-       </property>
-      </widget>
-     </item>
      <item row="0" column="0">
       <widget class="QLabel" name="label_5">
        <property name="text">
         <string>X:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="Gui::QuantitySpinBox" name="qsbx2">
+       <property name="unit" stdset="0">
+        <string notr="true"/>
        </property>
       </widget>
      </item>

--- a/src/Mod/TechDraw/Gui/TaskDetail.ui
+++ b/src/Mod/TechDraw/Gui/TaskDetail.ui
@@ -32,6 +32,13 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <layout class="QGridLayout" name="gridLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="label_4">
+       <property name="text">
+        <string>Base View</string>
+       </property>
+      </widget>
+     </item>
      <item row="0" column="1">
       <widget class="QLineEdit" name="leBaseView">
        <property name="enabled">
@@ -45,13 +52,6 @@
        </property>
        <property name="acceptDrops">
         <bool>false</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="0">
-      <widget class="QLabel" name="label_4">
-       <property name="text">
-        <string>Base View</string>
        </property>
       </widget>
      </item>
@@ -120,10 +120,10 @@
    </item>
    <item>
     <layout class="QGridLayout" name="gridLayout_2" columnstretch="2,0,0">
-     <item row="5" column="0">
-      <widget class="QLabel" name="label_7">
+     <item row="0" column="0">
+      <widget class="QLabel" name="label_2">
        <property name="text">
-        <string>Reference</string>
+        <string>X</string>
        </property>
       </widget>
      </item>
@@ -159,6 +159,94 @@
        </property>
       </widget>
      </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_3">
+       <property name="text">
+        <string>Y</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="2">
+      <widget class="Gui::QuantitySpinBox" name="qsbY">
+       <property name="toolTip">
+        <string>y position of detail highlight within view</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+       <property name="keyboardTracking">
+        <bool>false</bool>
+       </property>
+       <property name="unit" stdset="0">
+        <string notr="true"/>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="label_6">
+       <property name="text">
+        <string>Radius</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="2">
+      <widget class="Gui::QuantitySpinBox" name="qsbRadius">
+       <property name="toolTip">
+        <string>size of detail view</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+       <property name="keyboardTracking">
+        <bool>false</bool>
+       </property>
+       <property name="unit" stdset="0">
+        <string notr="true"/>
+       </property>
+       <property name="value">
+        <double>10.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="label_9">
+       <property name="text">
+        <string>Scale Type</string>
+       </property>
+      </widget>
+     </item>
+    <item row="3" column="2">
+      <widget class="QComboBox" name="cbScaleType">
+       <property name="toolTip">
+        <string>Page: scale factor of page is used
+Automatic: if the detail view is larger than the page,
+                   it will be scaled down to fit into the page
+Custom: custom scale factor is used</string>
+       </property>
+       <item>
+        <property name="text">
+         <string>Page</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Automatic</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Custom</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item row="4" column="0">
+      <widget class="QLabel" name="label_8">
+       <property name="text">
+        <string>Scale Factor</string>
+       </property>
+      </widget>
+     </item>
      <item row="4" column="2">
       <widget class="Gui::QuantitySpinBox" name="qsbScale">
        <property name="enabled">
@@ -184,50 +272,10 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="0">
-      <widget class="QLabel" name="label_2">
+     <item row="5" column="0">
+      <widget class="QLabel" name="label_7">
        <property name="text">
-        <string>X</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="2">
-      <widget class="Gui::QuantitySpinBox" name="qsbRadius">
-       <property name="toolTip">
-        <string>size of detail view</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-       <property name="keyboardTracking">
-        <bool>false</bool>
-       </property>
-       <property name="unit" stdset="0">
-        <string notr="true"/>
-       </property>
-       <property name="value">
-        <double>10.000000000000000</double>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="0">
-      <widget class="QLabel" name="label_8">
-       <property name="text">
-        <string>Scale Factor</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="label_3">
-       <property name="text">
-        <string>Y</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="label_6">
-       <property name="text">
-        <string>Radius</string>
+        <string>Reference</string>
        </property>
       </widget>
      </item>
@@ -241,55 +289,7 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="2">
-      <widget class="Gui::QuantitySpinBox" name="qsbY">
-       <property name="toolTip">
-        <string>y position of detail highlight within view</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-       <property name="keyboardTracking">
-        <bool>false</bool>
-       </property>
-       <property name="unit" stdset="0">
-        <string notr="true"/>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="2">
-      <widget class="QComboBox" name="cbScaleType">
-       <property name="toolTip">
-        <string>Page: scale factor of page is used
-Automatic: if the detail view is larger than the page,
-                   it will be scaled down to fit into the page
-Custom: custom scale factor is used</string>
-       </property>
-       <item>
-        <property name="text">
-         <string>Page</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Automatic</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Custom</string>
-        </property>
-       </item>
-      </widget>
-     </item>
-     <item row="3" column="0">
-      <widget class="QLabel" name="label_9">
-       <property name="text">
-        <string>Scale Type</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
+     </layout>
    </item>
   </layout>
  </widget>

--- a/src/Mod/TechDraw/Gui/TaskGeomHatch.ui
+++ b/src/Mod/TechDraw/Gui/TaskGeomHatch.ui
@@ -40,7 +40,14 @@
      <layout class="QVBoxLayout" name="verticalLayout">
       <item>
        <layout class="QGridLayout" name="gridLayout_3" columnstretch="0,1">
-        <item row="0" column="1">
+        <item row="0" column="0">
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>Pattern File</string>
+          </property>
+         </widget>
+        </item>
+       <item row="0" column="1">
          <widget class="Gui::FileChooser" name="fcFile">
           <property name="sizePolicy">
            <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
@@ -53,14 +60,7 @@
           </property>
          </widget>
         </item>
-        <item row="0" column="0">
-         <widget class="QLabel" name="label">
-          <property name="text">
-           <string>Pattern File</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
+        </layout>
       </item>
       <item>
        <layout class="QGridLayout" name="gridLayout_2" columnstretch="1,0,1">
@@ -68,20 +68,6 @@
          <widget class="QLabel" name="label_4">
           <property name="text">
            <string>Pattern Name</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="label_5">
-          <property name="text">
-           <string>Line Weight</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="label_2">
-          <property name="text">
-           <string>Pattern Scale</string>
           </property>
          </widget>
         </item>
@@ -98,13 +84,6 @@
           </property>
          </spacer>
         </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="label_3">
-          <property name="text">
-           <string>Line Color</string>
-          </property>
-         </widget>
-        </item>
         <item row="0" column="2">
          <widget class="QComboBox" name="cbName">
           <property name="minimumSize">
@@ -118,16 +97,10 @@
           </property>
          </widget>
         </item>
-        <item row="3" column="2">
-         <widget class="Gui::ColorButton" name="ccColor">
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>22</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>Color of pattern lines</string>
+        <item row="1" column="0">
+         <widget class="QLabel" name="label_2">
+          <property name="text">
+           <string>Pattern Scale</string>
           </property>
          </widget>
         </item>
@@ -159,6 +132,13 @@
           </property>
          </widget>
         </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="label_5">
+          <property name="text">
+           <string>Line Weight</string>
+          </property>
+         </widget>
+        </item>
         <item row="2" column="2">
          <widget class="Gui::QuantitySpinBox" name="sbWeight">
           <property name="minimumSize">
@@ -187,7 +167,27 @@
           </property>
          </widget>
         </item>
-       </layout>
+       <item row="3" column="0">
+         <widget class="QLabel" name="label_3">
+          <property name="text">
+           <string>Line Color</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="2">
+         <widget class="Gui::ColorButton" name="ccColor">
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>22</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Color of pattern lines</string>
+          </property>
+         </widget>
+        </item>
+        </layout>
       </item>
      </layout>
     </widget>

--- a/src/Mod/TechDraw/Gui/TaskHatch.ui
+++ b/src/Mod/TechDraw/Gui/TaskHatch.ui
@@ -40,7 +40,14 @@
      <layout class="QVBoxLayout" name="verticalLayout">
       <item>
        <layout class="QGridLayout" name="gridLayout_3" columnstretch="0,1">
-        <item row="0" column="1">
+        <item row="0" column="0">
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>Pattern File</string>
+          </property>
+         </widget>
+        </item>
+       <item row="0" column="1">
          <widget class="Gui::FileChooser" name="fcFile">
           <property name="sizePolicy">
            <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
@@ -53,36 +60,29 @@
           </property>
          </widget>
         </item>
-        <item row="0" column="0">
-         <widget class="QLabel" name="label">
-          <property name="text">
-           <string>Pattern File</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
+        </layout>
       </item>
       <item>
        <layout class="QGridLayout" name="gridLayout_2" columnstretch="1,0,0">
-        <item row="2" column="2">
-         <widget class="Gui::ColorButton" name="ccColor">
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>22</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>Color of pattern lines</string>
+        <item row="1" column="0">
+         <widget class="QLabel" name="label_2">
+          <property name="text">
+           <string>Pattern Scale</string>
           </property>
          </widget>
         </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="label_3">
-          <property name="text">
-           <string>Line Color</string>
+       <item row="1" column="1">
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
           </property>
-         </widget>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
         </item>
         <item row="1" column="2">
          <widget class="Gui::QuantitySpinBox" name="sbScale">
@@ -112,27 +112,27 @@
           </property>
          </widget>
         </item>
-        <item row="1" column="1">
-         <spacer name="horizontalSpacer">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="label_2">
+        <item row="2" column="0">
+         <widget class="QLabel" name="label_3">
           <property name="text">
-           <string>Pattern Scale</string>
+           <string>Line Color</string>
           </property>
          </widget>
         </item>
-       </layout>
+        <item row="2" column="2">
+         <widget class="Gui::ColorButton" name="ccColor">
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>22</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Color of pattern lines</string>
+          </property>
+         </widget>
+        </item>
+        </layout>
       </item>
      </layout>
     </widget>

--- a/src/Mod/TechDraw/Gui/TaskLinkDim.ui
+++ b/src/Mod/TechDraw/Gui/TaskLinkDim.ui
@@ -61,8 +61,35 @@
          <layout class="QHBoxLayout" name="horizontalLayout">
           <item>
            <layout class="QGridLayout" name="gridLayout">
-            <item row="3" column="1">
-             <widget class="QLineEdit" name="leGeometry2">
+            <item row="0" column="0">
+             <widget class="QLabel" name="lblFeature">
+              <property name="text">
+               <string>Feature1:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QLineEdit" name="leFeature1">
+              <property name="focusPolicy">
+               <enum>Qt::NoFocus</enum>
+              </property>
+              <property name="styleSheet">
+               <string notr="true">color: rgb(120, 120, 120);</string>
+              </property>
+              <property name="readOnly">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0">
+             <widget class="QLabel" name="label">
+              <property name="text">
+               <string>Geometry1:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="QLineEdit" name="leGeometry1">
               <property name="focusPolicy">
                <enum>Qt::NoFocus</enum>
               </property>
@@ -94,46 +121,6 @@
               </property>
              </widget>
             </item>
-            <item row="0" column="1">
-             <widget class="QLineEdit" name="leFeature1">
-              <property name="focusPolicy">
-               <enum>Qt::NoFocus</enum>
-              </property>
-              <property name="styleSheet">
-               <string notr="true">color: rgb(120, 120, 120);</string>
-              </property>
-              <property name="readOnly">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="0">
-             <widget class="QLabel" name="lblFeature">
-              <property name="text">
-               <string>Feature1:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="1">
-             <widget class="QLineEdit" name="leGeometry1">
-              <property name="focusPolicy">
-               <enum>Qt::NoFocus</enum>
-              </property>
-              <property name="styleSheet">
-               <string notr="true">color: rgb(120, 120, 120);</string>
-              </property>
-              <property name="readOnly">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="0">
-             <widget class="QLabel" name="label">
-              <property name="text">
-               <string>Geometry1:</string>
-              </property>
-             </widget>
-            </item>
             <item row="3" column="0">
              <widget class="QLabel" name="label_2">
               <property name="text">
@@ -141,7 +128,20 @@
               </property>
              </widget>
             </item>
-           </layout>
+           <item row="3" column="1">
+             <widget class="QLineEdit" name="leGeometry2">
+              <property name="focusPolicy">
+               <enum>Qt::NoFocus</enum>
+              </property>
+              <property name="styleSheet">
+               <string notr="true">color: rgb(120, 120, 120);</string>
+              </property>
+              <property name="readOnly">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            </layout>
           </item>
          </layout>
         </item>

--- a/src/Mod/TechDraw/Gui/TaskProjGroup.ui
+++ b/src/Mod/TechDraw/Gui/TaskProjGroup.ui
@@ -193,54 +193,6 @@
    </item>
    <item>
     <layout class="QGridLayout" name="gridLayout" columnstretch="0,0,0">
-     <item row="1" column="1">
-      <widget class="QLineEdit" name="lePrimary">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="font">
-        <font>
-         <pointsize>11</pointsize>
-         <weight>50</weight>
-         <italic>false</italic>
-         <bold>false</bold>
-        </font>
-       </property>
-       <property name="focusPolicy">
-        <enum>Qt::NoFocus</enum>
-       </property>
-       <property name="toolTip">
-        <string>Current primary view direction</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-       <property name="readOnly">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="2">
-      <widget class="QPushButton" name="butRightRotate">
-       <property name="toolTip">
-        <string>Rotate right</string>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-       <property name="icon">
-        <iconset>
-         <normalon>:/icons/arrow-right.svg</normalon>
-        </iconset>
-       </property>
-       <property name="iconSize">
-        <size>
-         <width>24</width>
-         <height>24</height>
-        </size>
-       </property>
-      </widget>
-     </item>
      <item row="0" column="1">
       <widget class="QPushButton" name="butTopRotate">
        <property name="sizePolicy">
@@ -289,7 +241,68 @@
        </property>
       </widget>
      </item>
-     <item row="2" column="1">
+     <item row="1" column="1">
+      <widget class="QLineEdit" name="lePrimary">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="font">
+        <font>
+         <pointsize>11</pointsize>
+         <weight>50</weight>
+         <italic>false</italic>
+         <bold>false</bold>
+        </font>
+       </property>
+       <property name="focusPolicy">
+        <enum>Qt::NoFocus</enum>
+       </property>
+       <property name="toolTip">
+        <string>Current primary view direction</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+       <property name="readOnly">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="2">
+      <widget class="QPushButton" name="butRightRotate">
+       <property name="toolTip">
+        <string>Rotate right</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset>
+         <normalon>:/icons/arrow-right.svg</normalon>
+        </iconset>
+       </property>
+       <property name="iconSize">
+        <size>
+         <width>24</width>
+         <height>24</height>
+        </size>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <spacer name="horizontalSpacer_8">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    <item row="2" column="1">
       <widget class="QPushButton" name="butDownRotate">
        <property name="toolTip">
         <string>Rotate down</string>
@@ -323,20 +336,7 @@
        </property>
       </spacer>
      </item>
-     <item row="2" column="0">
-      <spacer name="horizontalSpacer_8">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
+     </layout>
    </item>
    <item>
     <widget class="Line" name="line_2">
@@ -361,13 +361,50 @@
    </item>
    <item>
     <layout class="QGridLayout" name="gridLayout_2">
-     <item row="5" column="2">
-      <widget class="QCheckBox" name="chkView8">
-       <property name="enabled">
-        <bool>true</bool>
-       </property>
+     <item row="2" column="1">
+      <widget class="QCheckBox" name="chkView0">
        <property name="toolTip">
-        <string>Bottom</string>
+        <string>LeftFrontTop</string>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">QCheckBox::indicator {
+width: 24px;
+height: 24px;
+}
+</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="iconSize">
+        <size>
+         <width>24</width>
+         <height>24</height>
+        </size>
+       </property>
+      </widget>
+     </item>
+    <item row="2" column="2">
+      <widget class="QCheckBox" name="chkView1">
+       <property name="toolTip">
+        <string>Top</string>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">QCheckBox::indicator {
+width: 24px;
+height: 24px;
+}
+</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="3">
+      <widget class="QCheckBox" name="chkView2">
+       <property name="toolTip">
+        <string>RightFrontTop</string>
        </property>
        <property name="styleSheet">
         <string notr="true">QCheckBox::indicator {
@@ -393,6 +430,23 @@ height: 24px;
         </size>
        </property>
       </spacer>
+     </item>
+     <item row="3" column="1">
+      <widget class="QCheckBox" name="chkView3">
+       <property name="toolTip">
+        <string>Left</string>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">QCheckBox::indicator {
+width: 24px;
+height: 24px;
+}
+</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
      </item>
      <item row="3" column="2">
       <widget class="QCheckBox" name="chkView4">
@@ -434,23 +488,10 @@ height: 24px;
        </property>
       </widget>
      </item>
-     <item row="3" column="5">
-      <spacer name="horizontalSpacer_2">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item row="3" column="1">
-      <widget class="QCheckBox" name="chkView3">
+     <item row="3" column="4">
+      <widget class="QCheckBox" name="chkView6">
        <property name="toolTip">
-        <string>Left</string>
+        <string>Rear</string>
        </property>
        <property name="styleSheet">
         <string notr="true">QCheckBox::indicator {
@@ -463,6 +504,19 @@ height: 24px;
         <string/>
        </property>
       </widget>
+     </item>
+     <item row="3" column="5">
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
      </item>
      <item row="5" column="1">
       <widget class="QCheckBox" name="chkView7">
@@ -481,10 +535,13 @@ height: 24px;
        </property>
       </widget>
      </item>
-     <item row="2" column="2">
-      <widget class="QCheckBox" name="chkView1">
+     <item row="5" column="2">
+      <widget class="QCheckBox" name="chkView8">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
        <property name="toolTip">
-        <string>Top</string>
+        <string>Bottom</string>
        </property>
        <property name="styleSheet">
         <string notr="true">QCheckBox::indicator {
@@ -515,64 +572,7 @@ height: 24px;
        </property>
       </widget>
      </item>
-     <item row="2" column="3">
-      <widget class="QCheckBox" name="chkView2">
-       <property name="toolTip">
-        <string>RightFrontTop</string>
-       </property>
-       <property name="styleSheet">
-        <string notr="true">QCheckBox::indicator {
-width: 24px;
-height: 24px;
-}
-</string>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="4">
-      <widget class="QCheckBox" name="chkView6">
-       <property name="toolTip">
-        <string>Rear</string>
-       </property>
-       <property name="styleSheet">
-        <string notr="true">QCheckBox::indicator {
-width: 24px;
-height: 24px;
-}
-</string>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="1">
-      <widget class="QCheckBox" name="chkView0">
-       <property name="toolTip">
-        <string>LeftFrontTop</string>
-       </property>
-       <property name="styleSheet">
-        <string notr="true">QCheckBox::indicator {
-width: 24px;
-height: 24px;
-}
-</string>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-       <property name="iconSize">
-        <size>
-         <width>24</width>
-         <height>24</height>
-        </size>
-       </property>
-      </widget>
-     </item>
-    </layout>
+     </layout>
    </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
@@ -660,6 +660,25 @@ using the given X/Y Spacing</string>
    </item>
    <item>
     <layout class="QGridLayout" name="gridLayout_3">
+     <item row="0" column="0">
+      <widget class="QLabel" name="label_10">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>X Spacing</string>
+       </property>
+      </widget>
+     </item>
      <item row="0" column="1">
       <spacer name="horizontalSpacer_10">
        <property name="orientation">
@@ -698,25 +717,6 @@ using the given X/Y Spacing</string>
        </property>
        <property name="minimum">
         <double>0.000000000000000</double>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="0">
-      <widget class="QLabel" name="label_10">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>X Spacing</string>
        </property>
       </widget>
      </item>

--- a/src/Mod/TechDraw/Gui/TaskRestoreLines.ui
+++ b/src/Mod/TechDraw/Gui/TaskRestoreLines.ui
@@ -23,27 +23,6 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="0">
-      <widget class="QPushButton" name="pb_Geometry">
-       <property name="text">
-        <string>Geometry</string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="0">
-      <widget class="QPushButton" name="pb_Center">
-       <property name="text">
-        <string>CenterLine</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="0">
-      <widget class="QPushButton" name="pb_Cosmetic">
-       <property name="text">
-        <string>Cosmetic</string>
-       </property>
-      </widget>
-     </item>
      <item row="0" column="1">
       <widget class="QLabel" name="l_All">
        <property name="text">
@@ -51,6 +30,13 @@
        </property>
        <property name="alignment">
         <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QPushButton" name="pb_Geometry">
+       <property name="text">
+        <string>Geometry</string>
        </property>
       </widget>
      </item>
@@ -64,6 +50,13 @@
        </property>
       </widget>
      </item>
+     <item row="2" column="0">
+      <widget class="QPushButton" name="pb_Cosmetic">
+       <property name="text">
+        <string>Cosmetic</string>
+       </property>
+      </widget>
+     </item>
      <item row="2" column="1">
       <widget class="QLabel" name="l_Cosmetic">
        <property name="text">
@@ -71,6 +64,13 @@
        </property>
        <property name="alignment">
         <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QPushButton" name="pb_Center">
+       <property name="text">
+        <string>CenterLine</string>
        </property>
       </widget>
      </item>

--- a/src/Mod/TechDraw/Gui/TaskWeldingSymbol.ui
+++ b/src/Mod/TechDraw/Gui/TaskWeldingSymbol.ui
@@ -36,17 +36,17 @@
       <layout class="QHBoxLayout" name="hlArrowSideLayout">
        <item>
         <layout class="QGridLayout" name="gridLayout">
-         <item row="2" column="0">
-          <widget class="QLineEdit" name="leArrowTextL">
+         <item row="0" column="1">
+          <widget class="QLineEdit" name="leArrowTextC">
            <property name="toolTip">
-            <string>Text before arrow side symbol</string>
+            <string>Text above arrow side symbol</string>
            </property>
           </widget>
          </item>
-         <item row="2" column="2">
-          <widget class="QLineEdit" name="leArrowTextR">
+        <item row="2" column="0">
+          <widget class="QLineEdit" name="leArrowTextL">
            <property name="toolTip">
-            <string>Text after arrow side symbol</string>
+            <string>Text before arrow side symbol</string>
            </property>
           </widget>
          </item>
@@ -84,14 +84,14 @@
            </property>
           </widget>
          </item>
-         <item row="0" column="1">
-          <widget class="QLineEdit" name="leArrowTextC">
+         <item row="2" column="2">
+          <widget class="QLineEdit" name="leArrowTextR">
            <property name="toolTip">
-            <string>Text above arrow side symbol</string>
+            <string>Text after arrow side symbol</string>
            </property>
           </widget>
          </item>
-        </layout>
+         </layout>
        </item>
       </layout>
      </item>
@@ -112,6 +112,13 @@
       <layout class="QHBoxLayout" name="hlOtherSideLayout">
        <item>
         <layout class="QGridLayout" name="gridLayout_2">
+         <item row="0" column="0">
+          <widget class="QLineEdit" name="leOtherTextL">
+           <property name="toolTip">
+            <string>Text before other side symbol</string>
+           </property>
+          </widget>
+         </item>
          <item row="0" column="1">
           <widget class="QPushButton" name="pbOtherSymbol">
            <property name="toolTip">
@@ -122,58 +129,10 @@
            </property>
           </widget>
          </item>
-         <item row="1" column="1">
-          <widget class="QLineEdit" name="leOtherTextC">
-           <property name="toolTip">
-            <string>Text below other side symbol</string>
-           </property>
-          </widget>
-         </item>
          <item row="0" column="2">
           <widget class="QLineEdit" name="leOtherTextR">
            <property name="toolTip">
             <string>Text after other side symbol</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="2" alignment="Qt::AlignRight">
-          <widget class="QPushButton" name="pbFlipSides">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="minimumSize">
-            <size>
-             <width>60</width>
-             <height>30</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>60</width>
-             <height>30</height>
-            </size>
-           </property>
-           <property name="baseSize">
-            <size>
-             <width>60</width>
-             <height>30</height>
-            </size>
-           </property>
-           <property name="toolTip">
-            <string>Flips the sides</string>
-           </property>
-           <property name="text">
-            <string>Flip Sides</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="0">
-          <widget class="QLineEdit" name="leOtherTextL">
-           <property name="toolTip">
-            <string>Text before other side symbol</string>
            </property>
           </widget>
          </item>
@@ -211,7 +170,48 @@
            </property>
           </widget>
          </item>
-        </layout>
+        <item row="1" column="1">
+          <widget class="QLineEdit" name="leOtherTextC">
+           <property name="toolTip">
+            <string>Text below other side symbol</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="2" alignment="Qt::AlignRight">
+          <widget class="QPushButton" name="pbFlipSides">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>60</width>
+             <height>30</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>60</width>
+             <height>30</height>
+            </size>
+           </property>
+           <property name="baseSize">
+            <size>
+             <width>60</width>
+             <height>30</height>
+            </size>
+           </property>
+           <property name="toolTip">
+            <string>Flips the sides</string>
+           </property>
+           <property name="text">
+            <string>Flip Sides</string>
+           </property>
+          </widget>
+         </item>
+         </layout>
        </item>
       </layout>
      </item>
@@ -262,21 +262,14 @@ at the kink in the leader line</string>
    </item>
    <item>
     <layout class="QGridLayout" name="gridLayout_4">
-     <item row="1" column="1">
-      <widget class="Gui::FileChooser" name="fcSymbolDir">
-       <property name="toolTip">
-        <string>Directory to welding symbols.
-This directory will be used for the symbol selection.</string>
-       </property>
-       <property name="mode">
-        <enum>Gui::FileChooser::Directory</enum>
-       </property>
-       <property name="filter">
-        <string>*.svg</string>
+     <item row="0" column="0">
+      <widget class="QLabel" name="label_5">
+       <property name="text">
+        <string>Tail Text</string>
        </property>
       </widget>
      </item>
-     <item row="0" column="1">
+    <item row="0" column="1">
       <widget class="QLineEdit" name="leTailText">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -296,14 +289,21 @@ This directory will be used for the symbol selection.</string>
        </property>
       </widget>
      </item>
-     <item row="0" column="0">
-      <widget class="QLabel" name="label_5">
-       <property name="text">
-        <string>Tail Text</string>
+     <item row="1" column="1">
+      <widget class="Gui::FileChooser" name="fcSymbolDir">
+       <property name="toolTip">
+        <string>Directory to welding symbols.
+This directory will be used for the symbol selection.</string>
+       </property>
+       <property name="mode">
+        <enum>Gui::FileChooser::Directory</enum>
+       </property>
+       <property name="filter">
+        <string>*.svg</string>
        </property>
       </widget>
      </item>
-    </layout>
+     </layout>
    </item>
   </layout>
  </widget>

--- a/src/Mod/TechDraw/Gui/mrichtextedit.ui
+++ b/src/Mod/TechDraw/Gui/mrichtextedit.ui
@@ -21,7 +21,7 @@
     <number>1</number>
    </property>
    <item>
-    <widget class="QWidget" name="f_toolbar" native="true">
+    <widget class="QWidget" name="f_toolbar">
      <layout class="QHBoxLayout" name="horizontalLayout">
       <property name="spacing">
        <number>2</number>

--- a/src/Mod/Test/Gui/UnitTest.ui
+++ b/src/Mod/Test/Gui/UnitTest.ui
@@ -26,34 +26,47 @@
    <property name="spacing">
     <number>6</number>
    </property>
-   <item row="2" column="0">
-    <widget class="QGroupBox" name="groupBox2">
+   <item row="0" column="0">
+    <widget class="QGroupBox" name="buttonGroup1">
      <property name="title">
-      <string>Failures and errors</string>
+      <string>Test</string>
      </property>
-     <layout class="QGridLayout">
+     <layout class="QHBoxLayout">
       <property name="margin">
-       <number>9</number>
+       <number>5</number>
       </property>
       <property name="spacing">
        <number>6</number>
       </property>
-      <item row="0" column="0">
-       <widget class="QTreeWidget" name="treeViewFailure">
-        <property name="rootIsDecorated">
+      <item>
+       <widget class="QLabel" name="textLabelTest">
+        <property name="text">
+         <string>Select test name:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QComboBox" name="comboTests">
+        <property name="sizePolicy">
+         <sizepolicy>
+          <hsizetype>3</hsizetype>
+          <vsizetype>0</vsizetype>
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="editable">
+         <bool>true</bool>
+        </property>
+        <property name="duplicatesEnabled">
          <bool>false</bool>
         </property>
-        <column>
-         <property name="text">
-          <string>Description</string>
-         </property>
-        </column>
        </widget>
       </item>
      </layout>
     </widget>
    </item>
-   <item rowspan="3" row="0" column="1">
+  <item rowspan="3" row="0" column="1">
     <layout class="QVBoxLayout">
      <property name="margin">
       <number>0</number>
@@ -150,19 +163,6 @@
      </item>
     </layout>
    </item>
-   <item row="3" column="0" colspan="2">
-    <widget class="QLabel" name="textLabelStatus">
-     <property name="frameShape">
-      <enum>QFrame::Panel</enum>
-     </property>
-     <property name="frameShadow">
-      <enum>QFrame::Sunken</enum>
-     </property>
-     <property name="text">
-      <string>Idle</string>
-     </property>
-    </widget>
-   </item>
    <item row="1" column="0">
     <widget class="QGroupBox" name="groupBox1">
      <property name="title">
@@ -253,47 +253,47 @@
      </layout>
     </widget>
    </item>
-   <item row="0" column="0">
-    <widget class="QGroupBox" name="buttonGroup1">
+   <item row="2" column="0">
+    <widget class="QGroupBox" name="groupBox2">
      <property name="title">
-      <string>Test</string>
+      <string>Failures and errors</string>
      </property>
-     <layout class="QHBoxLayout">
+     <layout class="QGridLayout">
       <property name="margin">
-       <number>5</number>
+       <number>9</number>
       </property>
       <property name="spacing">
        <number>6</number>
       </property>
-      <item>
-       <widget class="QLabel" name="textLabelTest">
-        <property name="text">
-         <string>Select test name:</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QComboBox" name="comboTests">
-        <property name="sizePolicy">
-         <sizepolicy>
-          <hsizetype>3</hsizetype>
-          <vsizetype>0</vsizetype>
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="editable">
-         <bool>true</bool>
-        </property>
-        <property name="duplicatesEnabled">
+      <item row="0" column="0">
+       <widget class="QTreeWidget" name="treeViewFailure">
+        <property name="rootIsDecorated">
          <bool>false</bool>
         </property>
+        <column>
+         <property name="text">
+          <string>Description</string>
+         </property>
+        </column>
        </widget>
       </item>
      </layout>
     </widget>
    </item>
-  </layout>
+   <item row="3" column="0" colspan="2">
+    <widget class="QLabel" name="textLabelStatus">
+     <property name="frameShape">
+      <enum>QFrame::Panel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Sunken</enum>
+     </property>
+     <property name="text">
+      <string>Idle</string>
+     </property>
+    </widget>
+   </item>
+   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
  <tabstops>

--- a/src/Tools/RegExp/regexpdialog.ui
+++ b/src/Tools/RegExp/regexpdialog.ui
@@ -23,10 +23,17 @@
    <property name="spacing">
     <number>6</number>
    </property>
-   <item row="4" column="0">
-    <widget class="QLineEdit" name="lineEdit1"/>
+   <item row="0" column="0">
+    <widget class="QLabel" name="textLabel1">
+     <property name="text">
+      <string>Text:</string>
+     </property>
+    </widget>
    </item>
-   <item row="2" column="0">
+   <item row="1" column="0">
+    <widget class="QTextEdit" name="textEdit1"/>
+   </item>
+  <item row="2" column="0">
     <layout class="QHBoxLayout">
      <property name="spacing">
       <number>6</number>
@@ -62,6 +69,16 @@
       </widget>
      </item>
     </layout>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="textLabel2">
+     <property name="text">
+      <string>Regular Expression:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLineEdit" name="lineEdit1"/>
    </item>
    <item row="5" column="0">
     <layout class="QHBoxLayout">
@@ -129,24 +146,7 @@
      </item>
     </layout>
    </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="textLabel2">
-     <property name="text">
-      <string>Regular Expression:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="textLabel1">
-     <property name="text">
-      <string>Text:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QTextEdit" name="textEdit1"/>
-   </item>
-  </layout>
+   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
  <tabstops>


### PR DESCRIPTION
This is step 2 and step 3 of the UI normalzation procedure started in #4306. These changes will influence the generated c++ code. But the changes only affect tab order, and only if tab order has not been explicitly defined.

Normalize *.ui XML files throughout the code base. These changes has been made by a script from here:
https://github.com/davidosterberg/Qt-UI-file-sorter

Forum discussion
https://forum.freecadweb.org/viewtopic.php?f=10&t=54503

```sh
#!/bin/sh

git fetch upstream
git reset --hard upstream/master

find . -type f -name "*.ui" -print | xargs ../Qt-UI-file-sorter/sort_ui --no-sort-qgridlayout --no-remove-stdset
git add *.ui
git commit -m "Normalize *.ui files, step 2: remove native=true"

find . -type f -name "*.ui" -print | xargs ../Qt-UI-file-sorter/sort_ui --no-remove-stdset --no-remove-native
git add *.ui
git commit -m "Normalize *.ui files, step 3: sort child items of QGridLayout by row-column"

```


