### PR TITLE
Crowdin: represent whitespace in code instead of in string

### DIFF
--- a/src/Mod/Arch/ArchStairs.py
+++ b/src/Mod/Arch/ArchStairs.py
@@ -321,13 +321,13 @@ class _Stairs(ArchComponent.Component):
         if not hasattr(obj,"LastSegment"):
             obj.addProperty("App::PropertyLink","LastSegment","Segment and Parts","Last Segment (Flight or Landing) of Arch Stairs connecting to This Segment")
         if not hasattr(obj,"AbsTop"):
-            obj.addProperty("App::PropertyVector","AbsTop","Segment and Parts",QT_TRANSLATE_NOOP("App::Property","The 'absolute' top level of a flight of stairs leads to "))
+            obj.addProperty("App::PropertyVector","AbsTop","Segment and Parts",QT_TRANSLATE_NOOP("App::Property","The 'absolute' top level of a flight of stairs leads to"))
             obj.setEditorMode("AbsTop",1)
         if not hasattr(obj,"OutlineLeft"):
-            obj.addProperty("App::PropertyVectorList","OutlineLeft","Segment and Parts",QT_TRANSLATE_NOOP("App::Property","The 'left outline' of stairs ")) # Used for Outline of Railing
+            obj.addProperty("App::PropertyVectorList","OutlineLeft","Segment and Parts",QT_TRANSLATE_NOOP("App::Property","The 'left outline' of stairs")) # Used for Outline of Railing
             obj.setEditorMode("OutlineLeft",1)
         if not hasattr(obj,"OutlineRight"):
-            obj.addProperty("App::PropertyVectorList","OutlineRight","Segment and Parts",QT_TRANSLATE_NOOP("App::Property","The 'left outline' of stairs "))
+            obj.addProperty("App::PropertyVectorList","OutlineRight","Segment and Parts",QT_TRANSLATE_NOOP("App::Property","The 'left outline' of stairs"))
             obj.setEditorMode("OutlineRight",1)
 
         # Can't accept 'None' in list, need NaN
@@ -364,10 +364,10 @@ class _Stairs(ArchComponent.Component):
                     pass
 
         if not hasattr(obj,"OutlineLeftAll"):
-            obj.addProperty("App::PropertyVectorList","OutlineLeftAll","Segment and Parts",QT_TRANSLATE_NOOP("App::Property","The 'left outline' of all segments of stairs "))
+            obj.addProperty("App::PropertyVectorList","OutlineLeftAll","Segment and Parts",QT_TRANSLATE_NOOP("App::Property","The 'left outline' of all segments of stairs"))
             obj.setEditorMode("OutlineLeftAll",1) # Used for Outline of Railing
         if not hasattr(obj,"OutlineRightAll"):
-            obj.addProperty("App::PropertyVectorList","OutlineRightAll","Segment and Parts",QT_TRANSLATE_NOOP("App::Property","The 'right outline' of all segments of stairs "))
+            obj.addProperty("App::PropertyVectorList","OutlineRightAll","Segment and Parts",QT_TRANSLATE_NOOP("App::Property","The 'right outline' of all segments of stairs"))
             obj.setEditorMode("OutlineRightAll",1)
 
         # Can't accept 'None' in list, need NaN

--- a/src/Mod/Draft/DraftGui.py
+++ b/src/Mod/Draft/DraftGui.py
@@ -2047,7 +2047,7 @@ class DraftToolBar:
                 self.autogroup = value
                 self.autoGroupButton.setText(obj.Label)
                 self.autoGroupButton.setIcon(obj.ViewObject.Icon)
-                self.autoGroupButton.setToolTip(translate("draft", "Autogroup: ")+obj.Label)
+                self.autoGroupButton.setToolTip(translate("draft", "Autogroup:") + " " + obj.Label)
                 self.autoGroupButton.setDown(False)
             else:
                 self.autogroup = None

--- a/src/Mod/Draft/draftguitools/gui_edit.py
+++ b/src/Mod/Draft/draftguitools/gui_edit.py
@@ -930,8 +930,8 @@ class Edit(gui_base_original.Modifier):
         selection = Gui.Selection.getSelection()
         self.edited_objects = []
         if len(selection) > self.maxObjects:
-            _err = translate("draft", "Too many objects selected, max number set to: ")
-            App.Console.PrintMessage(_err + str(self.maxObjects) + "\n")
+            _err = translate("draft", "Too many objects selected, max number set to:")
+            App.Console.PrintMessage(_err + " " + str(self.maxObjects) + "\n")
             return None
 
         for obj in selection:

--- a/src/Mod/Draft/draftguitools/gui_scale.py
+++ b/src/Mod/Draft/draftguitools/gui_scale.py
@@ -330,10 +330,12 @@ class Scale(gui_base_original.Modifier):
                 bads.append(obj)
         if bads:
             if len(bads) == 1:
-                m = translate("draft", "Unable to scale object: ")
+                m = translate("draft", "Unable to scale object:")
+                m += " "
                 m += bads[0].Label
             else:
-                m = translate("draft", "Unable to scale objects: ")
+                m = translate("draft", "Unable to scale objects:")
+                m += " "
                 m += ", ".join([o.Label for o in bads])
             m += " - " + translate("draft","This object type cannot be scaled directly. Please use the clone method.")
             _err(m)

--- a/src/Mod/Draft/draftmake/make_arc_3points.py
+++ b/src/Mod/Draft/draftmake/make_arc_3points.py
@@ -135,7 +135,7 @@ def make_arc_3points(points, placement=None, face=False,
         try:
             utils.type_check([(placement, App.Placement)], name=_name)
         except TypeError:
-            _err(translate("draft","Placement: ") + "{}".format(placement))
+            _err(translate("draft","Placement:") + " {}".format(placement))
             _err(translate("draft","Wrong input: incorrect type of placement."))
             return None
 

--- a/src/Mod/Draft/draftmake/make_arc_3points.py
+++ b/src/Mod/Draft/draftmake/make_arc_3points.py
@@ -122,12 +122,12 @@ def make_arc_3points(points, placement=None, face=False,
     try:
         utils.type_check([(points, (list, tuple))], name=_name)
     except TypeError:
-        _err(translate("draft","Points: ") + "{}".format(points))
+        _err(translate("draft","Points:") + " {}".format(points))
         _err(translate("draft","Wrong input: must be list or tuple of three points exactly."))
         return None
 
     if len(points) != 3:
-        _err(translate("draft","Points: ") + "{}".format(points))
+        _err(translate("draft","Points:") + " {}".format(points))
         _err(translate("draft","Wrong input: must be list or tuple of three points exactly."))
         return None
 

--- a/src/Mod/Draft/importDWG.py
+++ b/src/Mod/Draft/importDWG.py
@@ -219,8 +219,8 @@ def convertToDxf(dwgfilename):
         basename = os.path.basename(dwgfilename)
         cmdline = ('"%s" "%s" "%s" "ACAD2000" "DXF" "0" "1" "%s"'
                    % (teigha, indir, outdir, basename))
-        FCC.PrintMessage(translate("ImportDWG", "Converting: ")
-                         + cmdline + "\n")
+        FCC.PrintMessage(translate("ImportDWG", "Converting:")
+                         + " " + cmdline + "\n")
         if six.PY2:
             if isinstance(cmdline, six.text_type):
                 encoding = sys.getfilesystemencoding()
@@ -272,8 +272,8 @@ def convertToDwg(dxffilename, dwgfilename):
         basename = os.path.basename(dxffilename)
         cmdline = ('"%s" "%s" "%s" "ACAD2000" "DWG" "0" "1" "%s"'
                    % (teigha, indir, outdir, basename))
-        FCC.PrintMessage(translate("ImportDWG", "Converting: ")
-                         + cmdline + "\n")
+        FCC.PrintMessage(translate("ImportDWG", "Converting:")
+                         + " " + cmdline + "\n")
         subprocess.call(cmdline, shell=True)  # os.system(cmdline)
         return dwgfilename
     return None

--- a/src/Mod/Draft/importDXF.py
+++ b/src/Mod/Draft/importDXF.py
@@ -3862,7 +3862,7 @@ def export(objectslist, filename, nospline=False, lwPoly=False):
                     filename = filename.encode("utf8")
             dxf.saveas(filename)
 
-        FCC.PrintMessage("successfully exported " + filename + "\n")
+        FCC.PrintMessage("successfully exported" + " " + filename + "\n")
 
     else:
         errorDXFLib(gui)

--- a/src/Mod/Draft/importOCA.py
+++ b/src/Mod/Draft/importOCA.py
@@ -488,5 +488,5 @@ def export(exportList, filename):
     # closing
     oca.close()
     FCC.PrintMessage(translate("importOCA",
-                               "successfully exported ")
-                     + filename + "\n")
+                               "successfully exported")
+                     + " " + filename + "\n")

--- a/src/Mod/Fem/femguiutils/selection_widgets.py
+++ b/src/Mod/Fem/femguiutils/selection_widgets.py
@@ -271,7 +271,7 @@ class GeometryElementsSelection(QtGui.QWidget):
     def initUI(self):
         # auch ArchPanel ist coded ohne ui-file
         # title
-        self.setWindowTitle(self.tr("Geometry reference selector for a ") + self.sel_elem_text)
+        self.setWindowTitle(self.tr("Geometry reference selector for a") + " " + self.sel_elem_text)
         # button
         self.pushButton_Add = QtGui.QPushButton(self.tr("Add"))
         # label

--- a/src/Mod/OpenSCAD/exportCSG.py
+++ b/src/Mod/OpenSCAD/exportCSG.py
@@ -269,4 +269,4 @@ def export(exportList,filename):
     csg.write("}\n}\n")
     # close file              
     csg.close()
-    FreeCAD.Console.PrintMessage("successfully exported "+filename)
+    FreeCAD.Console.PrintMessage("successfully exported" + " " + filename)

--- a/src/Mod/Part/Gui/TaskCheckGeometry.cpp
+++ b/src/Mod/Part/Gui/TaskCheckGeometry.cpp
@@ -149,7 +149,7 @@ QString checkStatusToString(const int &index)
     }
     if (index > 33 || index < 0)
     {
-        QString message(QObject::tr("Out Of Enum Range:") + " ");
+        QString message(QObject::tr("Out Of Enum Range:") + QString::fromLatin1(" "));
         QString number;
         number.setNum(index);
         message += number;

--- a/src/Mod/Part/Gui/TaskCheckGeometry.cpp
+++ b/src/Mod/Part/Gui/TaskCheckGeometry.cpp
@@ -149,7 +149,7 @@ QString checkStatusToString(const int &index)
     }
     if (index > 33 || index < 0)
     {
-        QString message(QObject::tr("Out Of Enum Range: "));
+        QString message(QObject::tr("Out Of Enum Range:") + " ");
         QString number;
         number.setNum(index);
         message += number;

--- a/src/Mod/Path/Gui/Resources/translations/Path.ts
+++ b/src/Mod/Path/Gui/Resources/translations/Path.ts
@@ -794,11 +794,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="PathEngrave.py" line="65"/>
-        <source>The description of the tool </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="PathEngrave.py" line="70"/>
         <source>Rapid Safety Height between locations.</source>
         <translation type="unfinished"></translation>

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -6546,21 +6546,24 @@ void ViewProviderSketch::UpdateSolverInformation()
         std::string msg;
         SketchObject::appendConflictMsg(getSketchObject()->getLastConflicting(), msg);
         signalSetUp(QString::fromLatin1("<font color='red'>%1<a href=\"#conflicting\"><span style=\" text-decoration: underline; color:#0000ff; background-color: #F8F8FF;\">%2</span></a><br/>%3</font><br/>")
-                    .arg(tr("Over-constrained sketch "))
+                    .arg(tr("Over-constrained sketch"))
+                    .arg(" ")
                     .arg(tr("(click to select)"))
                     .arg(QString::fromStdString(msg)));
         signalSolved(QString());
     }
     else if (hasMalformed) { // malformed constraints
         signalSetUp(QString::fromLatin1("<font color='red'>%1<a href=\"#malformed\"><span style=\" text-decoration: underline; color:#0000ff; background-color: #F8F8FF;\">%2</span></a><br/>%3</font><br/>")
-                    .arg(tr("Sketch contains malformed constraints "))
+                    .arg(tr("Sketch contains malformed constraints"))
+                    .arg(" ")
                     .arg(tr("(click to select)"))
                     .arg(appendMalformedMsg(getSketchObject()->getLastMalformedConstraints())));
         signalSolved(QString());
     }
     else if (hasConflicts) { // conflicting constraints
         signalSetUp(QString::fromLatin1("<font color='red'>%1<a href=\"#conflicting\"><span style=\" text-decoration: underline; color:#0000ff; background-color: #F8F8FF;\">%2</span></a><br/>%3</font><br/>")
-                    .arg(tr("Sketch contains conflicting constraints "))
+                    .arg(tr("Sketch contains conflicting constraints"))
+                    .arg(" ")
                     .arg(tr("(click to select)"))
                     .arg(appendConflictMsg(getSketchObject()->getLastConflicting())));
         signalSolved(QString());
@@ -6568,7 +6571,8 @@ void ViewProviderSketch::UpdateSolverInformation()
     else {
         if (hasRedundancies) { // redundant constraints
             signalSetUp(QString::fromLatin1("<font color='orangered'>%1<a href=\"#redundant\"><span style=\" text-decoration: underline; color:#0000ff; background-color: #F8F8FF;\">%2</span></a><br/>%3</font><br/>")
-                        .arg(tr("Sketch contains redundant constraints "))
+                        .arg(tr("Sketch contains redundant constraints"))
+                        .arg(" ")
                         .arg(tr("(click to select)"))
                         .arg(appendRedundantMsg(getSketchObject()->getLastRedundant())));
         }
@@ -6577,7 +6581,8 @@ void ViewProviderSketch::UpdateSolverInformation()
 
         if(hasPartiallyRedundant) {
             partiallyRedundantString = QString::fromLatin1("<br/><font color='royalblue'><span style=\"background-color: #ececec;\">%1<a href=\"#partiallyredundant\"><span style=\" text-decoration:  underline; color:#0000ff; background-color: #F8F8FF;\">%2</span></a><br/>%3</span></font><br/>")
-                                .arg(tr("Sketch contains partially redundant constraints "))
+                                .arg(tr("Sketch contains partially redundant constraints"))
+                                .arg(" ")
                                 .arg(tr("(click to select)"))
                                 .arg(appendPartiallyRedundantMsg(getSketchObject()->getLastPartiallyRedundant()));
         }

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -6545,34 +6545,30 @@ void ViewProviderSketch::UpdateSolverInformation()
     else if (dofs < 0) { // over-constrained sketch
         std::string msg;
         SketchObject::appendConflictMsg(getSketchObject()->getLastConflicting(), msg);
-        signalSetUp(QString::fromLatin1("<font color='red'>%1<a href=\"#conflicting\"><span style=\" text-decoration: underline; color:#0000ff; background-color: #F8F8FF;\">%2</span></a><br/>%3</font><br/>")
+        signalSetUp(QString::fromLatin1("<font color='red'>%1 <a href=\"#conflicting\"><span style=\" text-decoration: underline; color:#0000ff; background-color: #F8F8FF;\">%2</span></a><br/>%3</font><br/>")
                     .arg(tr("Over-constrained sketch"))
-                    .arg(" ")
                     .arg(tr("(click to select)"))
                     .arg(QString::fromStdString(msg)));
         signalSolved(QString());
     }
     else if (hasMalformed) { // malformed constraints
-        signalSetUp(QString::fromLatin1("<font color='red'>%1<a href=\"#malformed\"><span style=\" text-decoration: underline; color:#0000ff; background-color: #F8F8FF;\">%2</span></a><br/>%3</font><br/>")
+        signalSetUp(QString::fromLatin1("<font color='red'>%1 <a href=\"#malformed\"><span style=\" text-decoration: underline; color:#0000ff; background-color: #F8F8FF;\">%2</span></a><br/>%3</font><br/>")
                     .arg(tr("Sketch contains malformed constraints"))
-                    .arg(" ")
                     .arg(tr("(click to select)"))
                     .arg(appendMalformedMsg(getSketchObject()->getLastMalformedConstraints())));
         signalSolved(QString());
     }
     else if (hasConflicts) { // conflicting constraints
-        signalSetUp(QString::fromLatin1("<font color='red'>%1<a href=\"#conflicting\"><span style=\" text-decoration: underline; color:#0000ff; background-color: #F8F8FF;\">%2</span></a><br/>%3</font><br/>")
+        signalSetUp(QString::fromLatin1("<font color='red'>%1 <a href=\"#conflicting\"><span style=\" text-decoration: underline; color:#0000ff; background-color: #F8F8FF;\">%2</span></a><br/>%3</font><br/>")
                     .arg(tr("Sketch contains conflicting constraints"))
-                    .arg(" ")
                     .arg(tr("(click to select)"))
                     .arg(appendConflictMsg(getSketchObject()->getLastConflicting())));
         signalSolved(QString());
     }
     else {
         if (hasRedundancies) { // redundant constraints
-            signalSetUp(QString::fromLatin1("<font color='orangered'>%1<a href=\"#redundant\"><span style=\" text-decoration: underline; color:#0000ff; background-color: #F8F8FF;\">%2</span></a><br/>%3</font><br/>")
+            signalSetUp(QString::fromLatin1("<font color='orangered'>%1 <a href=\"#redundant\"><span style=\" text-decoration: underline; color:#0000ff; background-color: #F8F8FF;\">%2</span></a><br/>%3</font><br/>")
                         .arg(tr("Sketch contains redundant constraints"))
-                        .arg(" ")
                         .arg(tr("(click to select)"))
                         .arg(appendRedundantMsg(getSketchObject()->getLastRedundant())));
         }
@@ -6580,9 +6576,8 @@ void ViewProviderSketch::UpdateSolverInformation()
         QString partiallyRedundantString;
 
         if(hasPartiallyRedundant) {
-            partiallyRedundantString = QString::fromLatin1("<br/><font color='royalblue'><span style=\"background-color: #ececec;\">%1<a href=\"#partiallyredundant\"><span style=\" text-decoration:  underline; color:#0000ff; background-color: #F8F8FF;\">%2</span></a><br/>%3</span></font><br/>")
+            partiallyRedundantString = QString::fromLatin1("<br/><font color='royalblue'><span style=\"background-color: #ececec;\">%1 <a href=\"#partiallyredundant\"><span style=\" text-decoration:  underline; color:#0000ff; background-color: #F8F8FF;\">%2</span></a><br/>%3</span></font><br/>")
                                 .arg(tr("Sketch contains partially redundant constraints"))
-                                .arg(" ")
                                 .arg(tr("(click to select)"))
                                 .arg(appendPartiallyRedundantMsg(getSketchObject()->getLastPartiallyRedundant()));
         }

--- a/src/Mod/Start/Gui/Resources/translations/StartPage.ts
+++ b/src/Mod/Start/Gui/Resources/translations/StartPage.ts
@@ -344,11 +344,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgStartPreferences.ui" line="289"/>
-        <source>If this is checked, if a style sheet is specified in General preferences, it will be used and override the colors below</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../DlgStartPreferences.ui" line="308"/>
         <source>Page background color</source>
         <translation type="unfinished"></translation>

--- a/src/Mod/TechDraw/Gui/Command.cpp
+++ b/src/Mod/TechDraw/Gui/Command.cpp
@@ -1380,7 +1380,7 @@ void CmdTechDrawExportPageDXF::activated(int iMsg)
 //WF? allow more than one TD Page per Dxf file??  1 TD page = 1 DXF file = 1 drawing?
     QString defaultDir;
     QString fileName = Gui::FileDialog::getSaveFileName(Gui::getMainWindow(),
-                                                   QString::fromUtf8(QT_TR_NOOP("Save Dxf File ")),
+                                                   QString::fromUtf8(QT_TR_NOOP("Save Dxf File")),
                                                    defaultDir,
                                                    QString::fromUtf8(QT_TR_NOOP("Dxf (*.dxf)")));
 

--- a/src/Mod/TechDraw/Gui/MDIViewPage.cpp
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.cpp
@@ -854,7 +854,7 @@ void MDIViewPage::saveDXF()
 {
     QString defaultDir;
     QString fileName = Gui::FileDialog::getSaveFileName(Gui::getMainWindow(),
-                                                   QString::fromUtf8(QT_TR_NOOP("Save Dxf File ")),
+                                                   QString::fromUtf8(QT_TR_NOOP("Save Dxf File")),
                                                    defaultDir,
                                                    QString::fromUtf8(QT_TR_NOOP("Dxf (*.dxf)")));
     if (fileName.isEmpty()) {

--- a/src/Mod/TechDraw/Gui/mrichtextedit.cpp
+++ b/src/Mod/TechDraw/Gui/mrichtextedit.cpp
@@ -102,7 +102,7 @@ MRichTextEdit::MRichTextEdit(QWidget *parent, QString textIn) : QWidget(parent) 
                         << tr("Heading 3")
                         << tr("Heading 4")
                         << tr("Monospace")
-                        << tr(" ");
+                        << QString::fromUtf8(" ");
     f_paragraph->addItems(m_paragraphItems);
 
     connect(f_paragraph, SIGNAL(activated(int)),


### PR DESCRIPTION
Removing possible whitespace from strings lead to more accurate translations