### PR TITLE
[PD] disallow angles <=0 for holes and revolution

### DIFF
--- a/src/Mod/PartDesign/App/FeatureHole.cpp
+++ b/src/Mod/PartDesign/App/FeatureHole.cpp
@@ -645,6 +645,8 @@ const char* Hole::ThreadDirectionEnums[]  = { "Right", "Left", NULL};
 
 PROPERTY_SOURCE(PartDesign::Hole, PartDesign::ProfileBased)
 
+const App::PropertyAngle::Constraints floatAngle = { Base::toDegrees<double>(Precision::Angular()), 360.0, 1.0 };
+
 Hole::Hole()
 {
     addSubType = FeatureAddSub::Subtractive;
@@ -683,6 +685,7 @@ Hole::Hole()
     ADD_PROPERTY_TYPE(HoleCutDepth, (0.0), "Hole", App::Prop_None, "Head cut deth");
 
     ADD_PROPERTY_TYPE(HoleCutCountersinkAngle, (90.0), "Hole", App::Prop_None, "Head cut countersink angle");
+    HoleCutCountersinkAngle.setConstraints(&floatAngle);
 
     ADD_PROPERTY_TYPE(DepthType, (0L), "Hole", App::Prop_None, "Type");
     DepthType.setEnums(DepthTypeEnums);
@@ -693,12 +696,14 @@ Hole::Hole()
     DrillPoint.setEnums(DrillPointEnums);
 
     ADD_PROPERTY_TYPE(DrillPointAngle, (118.0), "Hole", App::Prop_None, "Drill point angle");
+    DrillPointAngle.setConstraints(&floatAngle);
     ADD_PROPERTY_TYPE(DrillForDepth, ((long)0), "Hole", App::Prop_None,
         "The size of the drill point will be taken into\n account for the depth of blind holes");
 
     ADD_PROPERTY_TYPE(Tapered, (false),"Hole",  App::Prop_None, "Tapered");
 
     ADD_PROPERTY_TYPE(TaperedAngle, (90.0), "Hole", App::Prop_None, "Tapered angle");
+    TaperedAngle.setConstraints(&floatAngle);
 
     ADD_PROPERTY_TYPE(ThreadDepthType, (0L), "Hole", App::Prop_None, "Thread depth type");
     ThreadDepthType.setEnums(ThreadDepthTypeEnums);

--- a/src/Mod/PartDesign/App/FeatureHole.cpp
+++ b/src/Mod/PartDesign/App/FeatureHole.cpp
@@ -645,7 +645,7 @@ const char* Hole::ThreadDirectionEnums[]  = { "Right", "Left", NULL};
 
 PROPERTY_SOURCE(PartDesign::Hole, PartDesign::ProfileBased)
 
-const App::PropertyAngle::Constraints floatAngle = { Base::toDegrees<double>(Precision::Angular()), 360.0, 1.0 };
+const App::PropertyAngle::Constraints Hole::floatAngle = { Base::toDegrees<double>(Precision::Angular()), 360.0, 1.0 };
 
 Hole::Hole()
 {

--- a/src/Mod/PartDesign/App/FeatureHole.h
+++ b/src/Mod/PartDesign/App/FeatureHole.h
@@ -109,6 +109,8 @@ public:
 
 protected:
     void onChanged(const App::Property* prop);
+    static const App::PropertyAngle::Constraints floatAngle;
+
 private:
     static const char* DepthTypeEnums[];
     static const char* ThreadDepthTypeEnums[];

--- a/src/Mod/PartDesign/App/FeatureRevolution.cpp
+++ b/src/Mod/PartDesign/App/FeatureRevolution.cpp
@@ -53,7 +53,7 @@ namespace PartDesign {
 
 PROPERTY_SOURCE(PartDesign::Revolution, PartDesign::ProfileBased)
 
-const App::PropertyAngle::Constraints floatAngle = { Base::toDegrees<double>(Precision::Angular()), 360, 1.0 };
+const App::PropertyAngle::Constraints Revolution::floatAngle = { Base::toDegrees<double>(Precision::Angular()), 360.0, 1.0 };
 
 Revolution::Revolution()
 {

--- a/src/Mod/PartDesign/App/FeatureRevolution.cpp
+++ b/src/Mod/PartDesign/App/FeatureRevolution.cpp
@@ -53,6 +53,8 @@ namespace PartDesign {
 
 PROPERTY_SOURCE(PartDesign::Revolution, PartDesign::ProfileBased)
 
+const App::PropertyAngle::Constraints floatAngle = { Base::toDegrees<double>(Precision::Angular()), 360, 1.0 };
+
 Revolution::Revolution()
 {
     addSubType = FeatureAddSub::Additive;
@@ -60,6 +62,7 @@ Revolution::Revolution()
     ADD_PROPERTY_TYPE(Base,(Base::Vector3d(0.0,0.0,0.0)),"Revolution", App::Prop_ReadOnly, "Base");
     ADD_PROPERTY_TYPE(Axis,(Base::Vector3d(0.0,1.0,0.0)),"Revolution", App::Prop_ReadOnly, "Axis");
     ADD_PROPERTY_TYPE(Angle,(360.0),"Revolution", App::Prop_None, "Angle");
+    Angle.setConstraints(&floatAngle);
     ADD_PROPERTY_TYPE(ReferenceAxis,(0),"Revolution",(App::Prop_None),"Reference axis of revolution");
 }
 

--- a/src/Mod/PartDesign/App/FeatureRevolution.h
+++ b/src/Mod/PartDesign/App/FeatureRevolution.h
@@ -68,6 +68,8 @@ public:
 protected:
     /// updates Axis from ReferenceAxis
     void updateAxis(void);
+
+    static const App::PropertyAngle::Constraints floatAngle;
 };
 
 } //namespace PartDesign


### PR DESCRIPTION
neither the taper, drill or countersink angle can be zero or negative for a valid hole, thus set a constraint