### PR TITLE
[GUI] Tweak wording and translatability of Credits

### DIFF
--- a/src/Gui/Splashscreen.cpp
+++ b/src/Gui/Splashscreen.cpp
@@ -568,14 +568,25 @@ void AboutDialog::showCredits()
     textField->setOpenLinks(false);
     hlayout->addWidget(textField);
 
-    QString creditsHTML = QString::fromLatin1("<html><body><h1>Credits</h1><p>FreeCAD would not be possible without the contributions of:</p><ul>");
+    QString creditsHTML = QString::fromLatin1("<html><body><h1>");
+    //: Header for the Credits tab of the About screen
+    creditsHTML += tr("Credits");
+    creditsHTML += QString::fromLatin1("</h1><p>");
+    creditsHTML += tr("FreeCAD would not be possible without the contributions of");
+    creditsHTML += QString::fromLatin1(":</p><h2>"); 
+    //: Header for the list of individual people in the Credits list.
+    creditsHTML += tr("Individuals");
+    creditsHTML += QString::fromLatin1("</h2><ul>");
 
     QTextStream stream(&creditsFile);
     QString line;
     while (stream.readLineInto(&line)) {
         if (!line.isEmpty()) {
             if (line == QString::fromLatin1("Firms")) {
-                creditsHTML += QString::fromLatin1("</ul><h2>Firms</h2><ul>");
+                creditsHTML += QString::fromLatin1("</ul><h2>");
+                //: Header for the list of companies/organizations in the Credits list.
+                creditsHTML += tr("Organizations");
+                creditsHTML += QString::fromLatin1("</h2><ul>");
             } 
             else {
                 creditsHTML += QString::fromLatin1("<li>") + line + QString::fromLatin1("</li>");


### PR DESCRIPTION
As suggested by FreeCAD forums member neildarlow, this modifies the wording of the Credits screen to use the words "Individuals" and "Organizations". It also exposes the three necessary strings to translation (omitting any formatting marks).

See discussion: https://forum.freecadweb.org/viewtopic.php?f=21&t=56233

---

- [X]  Your pull request is confined strictly to a single module.
- [X]  Discussed on the FreeCAD forum
- [X]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [X]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/)
- [X]  Your pull request is well written and has a good description, and its title starts with the module name
- [X]  No tracker ticket