### PR TITLE
Gui: Update icon for Sketcher Constraint Block

### DIFF
--- a/src/Mod/Sketcher/Gui/Resources/icons/constraints/Constraint_Block.svg
+++ b/src/Mod/Sketcher/Gui/Resources/icons/constraints/Constraint_Block.svg
@@ -1,15 +1,18 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg xmlns="http://www.w3.org/2000/svg" version="1.1" id="svg2816" height="64px" width="64px">
   <g  id="pale-red" style="fill:none;stroke:#280000;stroke-width:8;" >
+     <path d="M 48,48 L 16,16"/>
      <path d="M 16,48 48,16"  />
      <circle r="26" cy="32" cx="32" />
   </g>    
   <g id="red" style="fill:none;stroke:#cc0000;stroke-width:4;">    
     <circle r="26" cy="32" cx="32" />
-    <path  d="M 14,50 50,14" />
+    <path d="M 50,50 L 14,14"/>
+    <path d="M14,50l36-36" />
   </g>
   <g id="dark" style="fill:none;stroke:#ef2929;stroke-width:1.99999988;">
     <circle  r="27" cy="32"  cx="32" />
-    <path d="M 12,50 50,12" />
+    <path d="M 50,52 L 12,14"/>
+    <path d="M12,50l38-38" />
   </g>
 </svg>


### PR DESCRIPTION
The existing icon for the sketcher constraint for "constraint block" is easily confused with the icon for the diameter constraint. A small modification to add a 2nd cross bar will visually distinguish it (especially at smaller icon sizes).

![icons_proposed](https://user-images.githubusercontent.com/80009653/109880688-4066d200-7c45-11eb-9fce-2a1f8090d705.png)
