### PR TITLE
[PD] Add missing translation calls

### DIFF
--- a/src/Mod/PartDesign/Gui/Workbench.cpp
+++ b/src/Mod/PartDesign/Gui/Workbench.cpp
@@ -490,33 +490,33 @@ Gui::MenuItem* Workbench::setupMenuBar() const
 
     // datums
     Gui::MenuItem* datums = new Gui::MenuItem;
-    datums->setCommand("Create a datum");
+    datums->setCommand(QT_TR_NOOP("Create a datum"));
     *datums << "PartDesign_Point" << "PartDesign_Line"
         << "PartDesign_Plane";
 
     // additives
     Gui::MenuItem* additives = new Gui::MenuItem;
-    additives->setCommand("Create an additive feature");
+    additives->setCommand(QT_TR_NOOP("Create an additive feature"));
     *additives << "PartDesign_Pad" << "PartDesign_Revolution"
         << "PartDesign_AdditiveLoft" << "PartDesign_AdditivePipe" << "PartDesign_AdditiveHelix";
 
     // subtractives
     Gui::MenuItem* subtractives = new Gui::MenuItem;
-    subtractives->setCommand("Create a subtractive feature");
+    subtractives->setCommand(QT_TR_NOOP("Create a subtractive feature"));
     *subtractives << "PartDesign_Pocket" << "PartDesign_Hole"
         << "PartDesign_Groove" << "PartDesign_SubtractiveLoft"
         << "PartDesign_SubtractivePipe" << "PartDesign_SubtractiveHelix";
 
     // transformations
     Gui::MenuItem* transformations = new Gui::MenuItem;
-    transformations->setCommand("Apply a pattern");
+    transformations->setCommand(QT_TR_NOOP("Apply a pattern"));
     *transformations << "PartDesign_Mirrored" << "PartDesign_LinearPattern"
         << "PartDesign_PolarPattern" << "PartDesign_MultiTransform";
         //<< "PartDesign_Scaled"
 
     // dressups
     Gui::MenuItem* dressups = new Gui::MenuItem;
-    dressups->setCommand("Apply a dress-up feature");
+    dressups->setCommand(QT_TR_NOOP("Apply a dress-up feature"));
     *dressups << "PartDesign_Fillet" << "PartDesign_Chamfer"
         << "PartDesign_Draft" << "PartDesign_Thickness";
 


### PR DESCRIPTION
The items in the PartDesign menu that have submenus are not implemented using the standard Command architecture (which implements the translation strings internally). This commit adds explicit `QT_TR_NOOP` calls around those strings.

Fixes #0004583. Suitable for back-porting if desired.
https://tracker.freecadweb.org/view.php?id=4583

---

- [X]  Your pull request is confined strictly to a single module.
- [X]  Small change
- [X]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [X]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [X]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [X]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`