### PR TITLE
[PD] use same helix angle step as for other features

### DIFF
--- a/src/Mod/PartDesign/App/FeatureHelix.cpp
+++ b/src/Mod/PartDesign/App/FeatureHelix.cpp
@@ -73,7 +73,7 @@ PROPERTY_SOURCE(PartDesign::Helix, PartDesign::ProfileBased)
 
 // we purposely use not FLT_MAX because this would not be computable
 const App::PropertyFloatConstraint::Constraints floatTurns = { Precision::Confusion(), INT_MAX, 1.0 };
-const App::PropertyAngle::Constraints floatAngle = { -89.0, 89.0, 5.0 };
+const App::PropertyAngle::Constraints floatAngle = { -89.0, 89.0, 1.0 };
 
 Helix::Helix()
 {


### PR DESCRIPTION
All other PD features use a step size of 1.0 for angles.

(Personally also for me a step of 5 is not convenient)

@davidosterberg , OK for you as well?