### PR TITLE
Fix regex in translation extraction script

### DIFF
--- a/src/Tools/updatets.py
+++ b/src/Tools/updatets.py
@@ -112,7 +112,7 @@ PyCommands = [["src/Mod/Draft",
 
 # add python folders to exclude list
 for c in PyCommands:
-    DirFilter.append(c[0])
+    DirFilter.append(c[0]+"$")
 
 QMAKE = ""
 LUPDATE = ""


### PR DESCRIPTION
The regular expressions that are used to remove the Python directories from the list of Mods was accidentally catching PartDesign in its regex for Part. This one-character patch forces the regex to be at the end of the line.