### PR TITLE
PartDesign: Extend Helix to support flat spirals (and revolutions)

### DIFF
--- a/src/Mod/Part/App/PrimitiveFeature.cpp
+++ b/src/Mod/Part/App/PrimitiveFeature.cpp
@@ -801,6 +801,8 @@ Helix::Helix(void)
     Height.setConstraints(&quantityRange);
     ADD_PROPERTY_TYPE(Radius,(1.0),"Helix",App::Prop_None,"The radius of the helix");
     Radius.setConstraints(&quantityRange);
+    ADD_PROPERTY_TYPE(SegmentLength,(1.0),"Helix",App::Prop_None,"The number of turns of an helix segment");
+    SegmentLength.setConstraints(&quantityRange);
     ADD_PROPERTY_TYPE(Angle,(0.0),"Helix",App::Prop_None,"If angle is != 0 a conical otherwise a cylindircal surface is used");
     Angle.setConstraints(&apexRange);
     ADD_PROPERTY_TYPE(LocalCoord,(long(0)),"Coordinate System",App::Prop_None,"Orientation of the local coordinate system of the helix");
@@ -813,7 +815,8 @@ void Helix::onChanged(const App::Property* prop)
 {
     if (!isRestoring()) {
         if (prop == &Pitch || prop == &Height || prop == &Radius ||
-            prop == &Angle || prop == &LocalCoord || prop == &Style) {
+            prop == &Angle || prop == &LocalCoord || prop == &Style ||
+            prop == &SegmentLength) {
             try {
                 App::DocumentObjectExecReturn *ret = recompute();
                 delete ret;
@@ -851,13 +854,12 @@ App::DocumentObjectExecReturn *Helix::execute(void)
         Standard_Real myAngle  = Angle.getValue();
         Standard_Boolean myLocalCS = LocalCoord.getValue() ? Standard_True : Standard_False;
         Standard_Real nbTurns = myHeight / myPitch;
+        Standard_Real mySegLen = SegmentLength.getValue();
         
         Standard_Real myRadiusTop = myRadius + myHeight * tan(Base::toRadians(myAngle));
         TopoShape spirhelix;
-        // work around for OCC bug #23314 (FC #0954)
-        // the exact conditions for failure are unknown.  building the helix 1 turn at a time
-        // seems to always work.
-        TopoDS_Shape myHelix = spirhelix.makeSpiralHelix(myRadius, myRadiusTop, myHeight, nbTurns, 2, myLocalCS);
+
+        TopoDS_Shape myHelix = spirhelix.makeSpiralHelix(myRadius, myRadiusTop, myHeight, nbTurns, mySegLen, myLocalCS);
         this->Shape.setValue(myHelix);
     }
     catch (Standard_Failure& e) {
@@ -878,12 +880,15 @@ Spiral::Spiral(void)
     Radius.setConstraints(&quantityRange);
     ADD_PROPERTY_TYPE(Rotations,(2.0),"Spiral",App::Prop_None,"The number of rotations");
     Rotations.setConstraints(&quantityRange);
+    ADD_PROPERTY_TYPE(SegmentLength,(1.0),"Spiral",App::Prop_None,"The number of turns of an spiral segment");
+    SegmentLength.setConstraints(&quantityRange);
 }
 
 void Spiral::onChanged(const App::Property* prop)
 {
     if (!isRestoring()) {
-        if (prop == &Growth || prop == &Rotations || prop == &Radius) {
+        if (prop == &Growth || prop == &Rotations || prop == &Radius ||
+            prop == &SegmentLength) {
             try {
                 App::DocumentObjectExecReturn *ret = recompute();
                 delete ret;
@@ -913,6 +918,7 @@ App::DocumentObjectExecReturn *Spiral::execute(void)
         Standard_Real myRadius = Radius.getValue();
         Standard_Real myGrowth = Growth.getValue();
         Standard_Real myRadiusTop = myRadius + myGrowth * myNumRot;
+        Standard_Real mySegLen = SegmentLength.getValue();
         TopoShape spirhelix;
 
         if (myGrowth < Precision::Confusion())
@@ -920,7 +926,7 @@ App::DocumentObjectExecReturn *Spiral::execute(void)
         if (myNumRot < Precision::Confusion())
             Standard_Failure::Raise("Number of rotations too small");
         
-        TopoDS_Shape mySpiral = spirhelix.makeSpiralHelix(myRadius, myRadiusTop, 0, myNumRot, 2, Standard_False);
+        TopoDS_Shape mySpiral = spirhelix.makeSpiralHelix(myRadius, myRadiusTop, 0, myNumRot, mySegLen, Standard_False);
         this->Shape.setValue(mySpiral);
         return Primitive::execute();
     }

--- a/src/Mod/Part/App/PrimitiveFeature.h
+++ b/src/Mod/Part/App/PrimitiveFeature.h
@@ -310,6 +310,7 @@ public:
     App::PropertyLength Height;
     App::PropertyLength Radius;
     App::PropertyAngle Angle;
+    App::PropertyQuantityConstraint SegmentLength;
     App::PropertyEnumeration     LocalCoord;
     App::PropertyEnumeration     Style;
 
@@ -342,6 +343,7 @@ public:
     App::PropertyLength Growth;
     App::PropertyQuantityConstraint Rotations;
     App::PropertyLength Radius;
+    App::PropertyQuantityConstraint SegmentLength;
 
     /** @name methods override feature */
     //@{

--- a/src/Mod/Part/App/TopoShape.cpp
+++ b/src/Mod/Part/App/TopoShape.cpp
@@ -2507,6 +2507,8 @@ TopoDS_Shape TopoShape::makeSpiralHelix(Standard_Real radiusbottom, Standard_Rea
                                   Standard_Real height, Standard_Real nbturns,
                                   Standard_Real breakperiod, Standard_Boolean leftHanded) const
 {
+    // 1000 periods is an OCCT limit. The 3D curve gets truncated
+    // if he 2D curve spans beyond this limit.
     if ((breakperiod < 0) || (breakperiod > 1000))
         Standard_Failure::Raise("Break period must be in [0, 1000]");
     if (breakperiod == 0)

--- a/src/Mod/Part/App/TopoShape.cpp
+++ b/src/Mod/Part/App/TopoShape.cpp
@@ -2505,7 +2505,7 @@ TopoDS_Shape TopoShape::makeLongHelix(Standard_Real pitch, Standard_Real height,
 
 TopoDS_Shape TopoShape::makeSpiralHelix(Standard_Real radiusbottom, Standard_Real radiustop,
                                   Standard_Real height, Standard_Real nbturns,
-                                  Standard_Real breakperiod) const
+                                  Standard_Real breakperiod, Standard_Boolean leftHanded) const
 {
     if ((breakperiod < 0) || (breakperiod > 1000))
         Standard_Failure::Raise("Break period must be in [0, 1000]");
@@ -2514,8 +2514,9 @@ TopoDS_Shape TopoShape::makeSpiralHelix(Standard_Real radiusbottom, Standard_Rea
     if (nbturns <= 0)
         Standard_Failure::Raise("Number of turns must be greater than 0");
 
-    Standard_Real nbFullTurns = floor(nbturns/breakperiod);
-    Standard_Real partTurn = nbturns - nbFullTurns*breakperiod;
+    Standard_Real nbPeriods = nbturns/breakperiod;
+    Standard_Real nbFullPeriods = floor(nbPeriods);
+    Standard_Real partPeriod = nbPeriods - nbFullPeriods;
 
     // A Bezier curve is used below, to get a periodic surface also for spirals.
     TColgp_Array1OfPnt poles(1,2);
@@ -2530,19 +2531,21 @@ TopoDS_Shape TopoShape::makeSpiralHelix(Standard_Real radiusbottom, Standard_Rea
 
     gp_Pnt2d beg(0, 0);
     gp_Pnt2d end(0, 0);
-    gp_Vec2d dir(2.0 * M_PI, height / nbturns);
+    gp_Vec2d dir(breakperiod * 2.0 * M_PI, 1 / nbPeriods);
+    if (leftHanded == Standard_True)
+        dir = gp_Vec2d(-breakperiod * 2.0 * M_PI, 1 / nbPeriods);
     Handle(Geom2d_TrimmedCurve) segm;
     TopoDS_Edge edgeOnSurf;
     BRepBuilderAPI_MakeWire mkWire;
-    for (unsigned long i = 0; i < nbFullTurns; i++) {
+    for (unsigned long i = 0; i < nbFullPeriods; i++) {
         end = beg.Translated(dir);
         segm = GCE2d_MakeSegment(beg , end);
         edgeOnSurf = BRepBuilderAPI_MakeEdge(segm , surf);
         mkWire.Add(edgeOnSurf);
         beg = end;
     }
-    if (partTurn > Precision::Confusion()) {
-        dir.Scale(partTurn);
+    if (partPeriod > Precision::Confusion()) {
+        dir.Scale(partPeriod);
         end = beg.Translated(dir);
         segm = GCE2d_MakeSegment(beg , end);
         edgeOnSurf = BRepBuilderAPI_MakeEdge(segm , surf);

--- a/src/Mod/Part/App/TopoShape.cpp
+++ b/src/Mod/Part/App/TopoShape.cpp
@@ -2503,6 +2503,57 @@ TopoDS_Shape TopoShape::makeLongHelix(Standard_Real pitch, Standard_Real height,
     return TopoDS_Shape(std::move(wire));
 }
 
+TopoDS_Shape TopoShape::makeSpiralHelix(Standard_Real radiusbottom, Standard_Real radiustop,
+                                  Standard_Real height, Standard_Real nbturns,
+                                  Standard_Real breakperiod) const
+{
+    if ((breakperiod < 0) || (breakperiod > 1000))
+        Standard_Failure::Raise("Break period must be in [0, 1000]");
+    if (breakperiod == 0)
+        breakperiod = 1000;
+    if (nbturns <= 0)
+        Standard_Failure::Raise("Number of turns must be greater than 0");
+
+    Standard_Real nbFullTurns = floor(nbturns/breakperiod);
+    Standard_Real partTurn = nbturns - nbFullTurns*breakperiod;
+
+    // A Bezier curve is used below, to get a periodic surface also for spirals.
+    TColgp_Array1OfPnt poles(1,2);
+    poles(1) = gp_Pnt(fabs(radiusbottom), 0, 0);
+    poles(2) = gp_Pnt(fabs(radiustop), 0, height);
+    Handle(Geom_BezierCurve) meridian;
+    meridian = new Geom_BezierCurve(poles);
+
+    gp_Ax1 axis(gp_Pnt(0.0,0.0,0.0) , gp::DZ());
+    Handle(Geom_Surface) surf;
+    surf = new Geom_SurfaceOfRevolution(meridian, axis);
+
+    gp_Pnt2d beg(0, 0);
+    gp_Pnt2d end(0, 0);
+    gp_Vec2d dir(2.0 * M_PI, height / nbturns);
+    Handle(Geom2d_TrimmedCurve) segm;
+    TopoDS_Edge edgeOnSurf;
+    BRepBuilderAPI_MakeWire mkWire;
+    for (unsigned long i = 0; i < nbFullTurns; i++) {
+        end = beg.Translated(dir);
+        segm = GCE2d_MakeSegment(beg , end);
+        edgeOnSurf = BRepBuilderAPI_MakeEdge(segm , surf);
+        mkWire.Add(edgeOnSurf);
+        beg = end;
+    }
+    if (partTurn > Precision::Confusion()) {
+        dir.Scale(partTurn);
+        end = beg.Translated(dir);
+        segm = GCE2d_MakeSegment(beg , end);
+        edgeOnSurf = BRepBuilderAPI_MakeEdge(segm , surf);
+        mkWire.Add(edgeOnSurf);
+    }
+
+    TopoDS_Wire wire = mkWire.Wire();
+    BRepLib::BuildCurves3d(wire, Precision::Confusion(), GeomAbs_Shape::GeomAbs_C1, 14, 10000);
+    return TopoDS_Shape(std::move(wire));
+}
+
 TopoDS_Shape TopoShape::makeThread(Standard_Real pitch,
                                    Standard_Real depth,
                                    Standard_Real height,

--- a/src/Mod/Part/App/TopoShape.h
+++ b/src/Mod/Part/App/TopoShape.h
@@ -258,6 +258,8 @@ public:
     TopoDS_Shape makeLongHelix(Standard_Real pitch, Standard_Real height,
         Standard_Real radius, Standard_Real angle=0,
         Standard_Boolean left=Standard_False) const;
+    TopoDS_Shape makeSpiralHelix(Standard_Real radiusbottom, Standard_Real radiustop,
+        Standard_Real height, Standard_Real nbturns=1, Standard_Real breakperiod=1) const;
     TopoDS_Shape makeThread(Standard_Real pitch, Standard_Real depth,
         Standard_Real height, Standard_Real radius) const;
     TopoDS_Shape makeLoft(const TopTools_ListOfShape& profiles, Standard_Boolean isSolid,

--- a/src/Mod/Part/App/TopoShape.h
+++ b/src/Mod/Part/App/TopoShape.h
@@ -259,7 +259,8 @@ public:
         Standard_Real radius, Standard_Real angle=0,
         Standard_Boolean left=Standard_False) const;
     TopoDS_Shape makeSpiralHelix(Standard_Real radiusbottom, Standard_Real radiustop,
-        Standard_Real height, Standard_Real nbturns=1, Standard_Real breakperiod=1) const;
+        Standard_Real height, Standard_Real nbturns=1, Standard_Real breakperiod=1,
+        Standard_Boolean left=Standard_False) const;
     TopoDS_Shape makeThread(Standard_Real pitch, Standard_Real depth,
         Standard_Real height, Standard_Real radius) const;
     TopoDS_Shape makeLoft(const TopTools_ListOfShape& profiles, Standard_Boolean isSolid,

--- a/src/Mod/PartDesign/App/FeatureHelix.h
+++ b/src/Mod/PartDesign/App/FeatureHelix.h
@@ -45,6 +45,7 @@ public:
     App::PropertyFloatConstraint   Turns;
     App::PropertyBool        LeftHanded;
     App::PropertyAngle       Angle;
+    App::PropertyLength      Growth;
     App::PropertyEnumeration Mode;
     App::PropertyBool        Outside;
     App::PropertyBool        HasBeenEdited;

--- a/src/Mod/PartDesign/Gui/TaskHelixParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskHelixParameters.cpp
@@ -77,6 +77,8 @@ TaskHelixParameters::TaskHelixParameters(PartDesignGui::ViewProviderHelix *Helix
             this, SLOT(onTurnsChanged(double)));
     connect(ui->coneAngle, SIGNAL(valueChanged(double)),
             this, SLOT(onAngleChanged(double)));
+    connect(ui->growth, SIGNAL(valueChanged(double)),
+            this, SLOT(onGrowthChanged(double)));
     connect(ui->axis, SIGNAL(activated(int)),
             this, SLOT(onAxisChanged(int)));
     connect(ui->checkBoxLeftHanded, SIGNAL(toggled(bool)),
@@ -98,6 +100,7 @@ TaskHelixParameters::TaskHelixParameters(PartDesignGui::ViewProviderHelix *Helix
     ui->height->blockSignals(true);
     ui->turns->blockSignals(true);
     ui->coneAngle->blockSignals(true);
+    ui->growth->blockSignals(true);
     ui->checkBoxLeftHanded->blockSignals(true);
     ui->checkBoxReversed->blockSignals(true);
     ui->checkBoxOutside->blockSignals(true);
@@ -113,6 +116,7 @@ TaskHelixParameters::TaskHelixParameters(PartDesignGui::ViewProviderHelix *Helix
     }
 
     this->propAngle = &(rev->Angle);
+    this->propGrowth = &(rev->Growth);
     this->propPitch = &(rev->Pitch);
     this->propHeight = &(rev->Height);
     this->propTurns = &(rev->Turns);
@@ -126,6 +130,7 @@ TaskHelixParameters::TaskHelixParameters(PartDesignGui::ViewProviderHelix *Helix
     double height = propHeight->getValue();
     double turns = propTurns->getValue();
     double angle = propAngle->getValue();
+    double growth = propGrowth->getValue();
     bool leftHanded = propLeftHanded->getValue();
     bool reversed = propReversed->getValue();
     int index = propMode->getValue();
@@ -137,6 +142,7 @@ TaskHelixParameters::TaskHelixParameters(PartDesignGui::ViewProviderHelix *Helix
     ui->coneAngle->setValue(angle);
     ui->coneAngle->setMinimum(propAngle->getMinimum());
     ui->coneAngle->setMaximum(propAngle->getMaximum());
+    ui->growth->setValue(growth);
     ui->checkBoxLeftHanded->setChecked(leftHanded);
     ui->checkBoxReversed->setChecked(reversed);
     ui->inputMode->setCurrentIndex(index);
@@ -150,12 +156,14 @@ TaskHelixParameters::TaskHelixParameters(PartDesignGui::ViewProviderHelix *Helix
     ui->height->bind(static_cast<PartDesign::Helix *>(pcFeat)->Height);
     ui->turns->bind(static_cast<PartDesign::Helix *>(pcFeat)->Turns);
     ui->coneAngle->bind(static_cast<PartDesign::Helix *>(pcFeat)->Angle);
+    ui->growth->bind(static_cast<PartDesign::Helix *>(pcFeat)->Growth);
 
     ui->axis->blockSignals(false);
     ui->pitch->blockSignals(false);
     ui->height->blockSignals(false);
     ui->turns->blockSignals(false);
     ui->coneAngle->blockSignals(false);
+    ui->growth->blockSignals(false);
     ui->checkBoxLeftHanded->blockSignals(false);
     ui->checkBoxReversed->blockSignals(false);
     ui->checkBoxOutside->blockSignals(false);
@@ -273,22 +281,32 @@ void TaskHelixParameters::updateUI()
     bool isHeightVisible = false;
     bool isTurnsVisible  = false;
     bool isOutsideVisible = false;
+    bool isAngleVisible = false;
+    bool isGrowthVisible = false;
 
     if(pcHelix->getAddSubType() == PartDesign::FeatureAddSub::Subtractive)
         isOutsideVisible = true;
 
-    switch (propMode->getValue()) {
-        case 0:
-            isPitchVisible = true;
-            isHeightVisible = true;
-            break;
-        case 1:
-            isPitchVisible = true;
-            isTurnsVisible = true;
-            break;
-        default:
-            isHeightVisible = true;
-            isTurnsVisible = true;
+    std::string mode = propMode->getValueAsString();
+    if (mode == "pitch-height-angle") {
+        isPitchVisible = true;
+        isHeightVisible = true;
+        isAngleVisible = true;
+    } else if (mode == "pitch-turns-angle") {
+        isPitchVisible = true;
+        isTurnsVisible = true;
+        isAngleVisible = true;
+    } else if (mode == "height-turns-angle") {
+        isHeightVisible = true;
+        isTurnsVisible = true;
+        isAngleVisible = true;
+    } else if (mode == "height-turns-growth") {
+        isHeightVisible = true;
+        isTurnsVisible = true;
+        isGrowthVisible = true;
+    } else {
+        status = "Error: unsupported mode";
+        ui->labelMessage->setText(QString::fromUtf8(status.c_str()));
     }
 
     ui->pitch->setVisible(isPitchVisible);
@@ -299,6 +317,12 @@ void TaskHelixParameters::updateUI()
 
     ui->turns->setVisible(isTurnsVisible);
     ui->labelTurns->setVisible(isTurnsVisible);
+
+    ui->coneAngle->setVisible(isAngleVisible);
+    ui->labelConeAngle->setVisible(isAngleVisible);
+
+    ui->growth->setVisible(isGrowthVisible);
+    ui->labelGrowth->setVisible(isGrowthVisible);
 
     ui->checkBoxOutside->setVisible(isOutsideVisible);
 
@@ -343,6 +367,13 @@ void TaskHelixParameters::onTurnsChanged(double len)
 void TaskHelixParameters::onAngleChanged(double len)
 {
     propAngle->setValue(len);
+    recomputeFeature();
+    updateUI();
+}
+
+void TaskHelixParameters::onGrowthChanged(double len)
+{
+    propGrowth->setValue(len);
     recomputeFeature();
     updateUI();
 }
@@ -534,6 +565,7 @@ void TaskHelixParameters::apply()
     FCMD_OBJ_CMD(tobj,"Height = " << propHeight->getValue());
     FCMD_OBJ_CMD(tobj,"Turns = " << propTurns->getValue());
     FCMD_OBJ_CMD(tobj,"Angle = " << propAngle->getValue());
+    FCMD_OBJ_CMD(tobj,"Growth = " << propGrowth->getValue());
     FCMD_OBJ_CMD(tobj,"LeftHanded = " << (propLeftHanded->getValue() ? 1 : 0));
     FCMD_OBJ_CMD(tobj,"Reversed = " << (propReversed->getValue() ? 1 : 0));
 }

--- a/src/Mod/PartDesign/Gui/TaskHelixParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskHelixParameters.h
@@ -71,6 +71,7 @@ private Q_SLOTS:
     void onHeightChanged(double);
     void onTurnsChanged(double);
     void onAngleChanged(double);
+    void onGrowthChanged(double);
     void onAxisChanged(int);
     void onLeftHandedChanged(bool);
     void onReversedChanged(bool);
@@ -94,6 +95,7 @@ protected:
     App::PropertyBool*        propReversed;
     App::PropertyLinkSub*     propReferenceAxis;
     App::PropertyAngle*       propAngle;
+    App::PropertyLength*      propGrowth;
     App::PropertyEnumeration* propMode;
     App::PropertyBool*        propOutside;
 

--- a/src/Mod/PartDesign/Gui/TaskHelixParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskHelixParameters.ui
@@ -93,20 +93,25 @@
       <widget class="QComboBox" name="inputMode">
        <item>
         <property name="text">
-         <string>Pitch-Height</string>
+         <string>Pitch-Height-Angle</string>
         </property>
        </item>
        <item>
         <property name="text">
-         <string>Pitch-Turns</string>
+         <string>Pitch-Turns-Angle</string>
         </property>
        </item>
        <item>
         <property name="text">
-         <string>Height-Turns</string>
+         <string>Height-Turns-Angle</string>
         </property>
        </item>
-      </widget>
+       <item>
+        <property name="text">
+         <string>Height-Turns-Growth</string>
+        </property>
+       </item>
+       </widget>
      </item>
     </layout>
    </item>
@@ -204,7 +209,7 @@
    <item>
     <layout class="QHBoxLayout" name="horizontalLayoutConeAngle">
      <item>
-      <widget class="QLabel" name="label5">
+      <widget class="QLabel" name="labelConeAngle">
        <property name="text">
         <string>Cone angle:</string>
        </property>
@@ -223,6 +228,34 @@
        </property>
        <property name="maximum">
         <double>89.000000000000000</double>
+       </property>
+       <property name="singleStep">
+        <double>5.000000000000000</double>
+       </property>
+       <property name="value">
+        <double>0.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayoutGrowth">
+     <item>
+      <widget class="QLabel" name="labelGrowth">
+       <property name="text">
+        <string>Growth:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="Gui::QuantitySpinBox" name="growth">
+       <property name="keyboardTracking">
+        <bool>false</bool>
+       </property>
+       <property name="unit" stdset="0">
+        <string notr="true">mm</string>
        </property>
        <property name="singleStep">
         <double>5.000000000000000</double>


### PR DESCRIPTION
This PR depends on functionality introduced in  #4582

Forum thread:
https://forum.freecadweb.org/viewtopic.php?f=19&t=56378

Demo:
![helix_spiral2](https://user-images.githubusercontent.com/1278189/110205552-e2223500-7e78-11eb-9ae8-d3247a13a346.gif)
