### PR TITLE
Replace boost::tuple with std::tuple

### DIFF
--- a/src/App/Expression.cpp
+++ b/src/App/Expression.cpp
@@ -3258,16 +3258,16 @@ static void initParser(const App::DocumentObject *owner)
     }
 }
 
-std::vector<boost::tuple<int, int, std::string> > tokenize(const std::string &str)
+std::vector<std::tuple<int, int, std::string> > tokenize(const std::string &str)
 {
     ExpressionParser::YY_BUFFER_STATE buf = ExpressionParser_scan_string(str.c_str());
-    std::vector<boost::tuple<int, int, std::string> > result;
+    std::vector<std::tuple<int, int, std::string> > result;
     int token;
 
     column = 0;
     try {
         while ( (token  = ExpressionParserlex()) != 0)
-            result.push_back(boost::make_tuple(token, ExpressionParser::last_column, yytext));
+            result.push_back(std::make_tuple(token, ExpressionParser::last_column, yytext));
     }
     catch (...) {
         // Ignore all exceptions

--- a/src/App/Expression.h
+++ b/src/App/Expression.h
@@ -24,7 +24,7 @@
 #define EXPRESSION_H
 
 #include <string>
-#include <boost/tuple/tuple.hpp>
+#include <tuple>
 #include <Base/Exception.h>
 #include <Base/Unit.h>
 #include <App/PropertyLinks.h>

--- a/src/App/ExpressionParser.h
+++ b/src/App/ExpressionParser.h
@@ -451,7 +451,7 @@ AppExport UnitExpression * parseUnit(const App::DocumentObject *owner, const cha
 AppExport ObjectIdentifier parsePath(const App::DocumentObject *owner, const char* buffer);
 AppExport bool isTokenAnIndentifier(const std::string & str);
 AppExport bool isTokenAUnit(const std::string & str);
-AppExport std::vector<boost::tuple<int, int, std::string> > tokenize(const std::string & str);
+AppExport std::vector<std::tuple<int, int, std::string> > tokenize(const std::string & str);
 
 /// Convenient class to mark begin of importing
 class AppExport ExpressionImporter {

--- a/src/App/PreCompiled.h
+++ b/src/App/PreCompiled.h
@@ -78,13 +78,13 @@
 #include <unordered_map>
 #include <iterator>
 #include <functional>
+#include <tuple>
 
 // Boost
 #include <boost_signals2.hpp>
 #include <boost/bind/bind.hpp>
 #include <boost/regex.hpp>
 
-#include <boost/tuple/tuple.hpp>
 #include <boost/utility.hpp>
 #include <boost_graph_adjacency_list.hpp>
 

--- a/src/Gui/ExpressionCompleter.cpp
+++ b/src/Gui/ExpressionCompleter.cpp
@@ -454,7 +454,6 @@ void ExpressionCompleter::slotUpdate(const QString & prefix, int pos)
 {
     init();
 
-    using namespace boost::tuples;
     std::string completionPrefix;
 
     // Compute start; if prefix starts with =, start parsing from offset 1.
@@ -469,7 +468,7 @@ void ExpressionCompleter::slotUpdate(const QString & prefix, int pos)
     std::string expression = Base::Tools::toStdString(prefix.mid(start));
 
     // Tokenize prefix
-    std::vector<boost::tuple<int, int, std::string> > tokens = ExpressionParser::tokenize(expression);
+    std::vector<std::tuple<int, int, std::string> > tokens = ExpressionParser::tokenize(expression);
 
     // No tokens
     if (tokens.size() == 0) {

--- a/src/Gui/PreCompiled.h
+++ b/src/Gui/PreCompiled.h
@@ -77,12 +77,12 @@
 #include <bitset>
 #include <unordered_set>
 #include <unordered_map>
+#include <tuple>
 
 // Boost
 #include <boost_signals2.hpp>
 #include <boost/bind/bind.hpp>
 #include <boost/program_options.hpp>
-#include <boost/tuple/tuple.hpp>
 #include <boost/utility.hpp>
 #include <boost_graph_adjacency_list.hpp>
 #include <boost/filesystem/path.hpp>

--- a/src/Mod/Part/App/PreCompiled.h
+++ b/src/Mod/Part/App/PreCompiled.h
@@ -68,6 +68,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <stdexcept>
+#include <tuple>
 
 #include <cmath>
 #include <ctime>
@@ -79,7 +80,6 @@
 #include <boost_signals2.hpp>
 #include <boost/bind/bind.hpp>
 
-#include <boost/tuple/tuple.hpp>
 #include <boost/utility.hpp>
 #include <boost_graph_adjacency_list.hpp>
 

--- a/src/Mod/Part/Gui/TaskCheckGeometry.cpp
+++ b/src/Mod/Part/Gui/TaskCheckGeometry.cpp
@@ -829,9 +829,9 @@ void TaskCheckGeometryResults::dispatchError(ResultEntry *entry, const BRepCheck
     std::vector<FunctionMapType>::iterator mapIt;
     for (mapIt = functionMap.begin(); mapIt != functionMap.end(); ++mapIt)
     {
-        if ((*mapIt).get<0>() == entry->shape.ShapeType() && (*mapIt).get<1>() == stat)
+        if (std::get<0>(*mapIt) == entry->shape.ShapeType() && std::get<1>(*mapIt) == stat)
         {
-            ((*mapIt).get<2>())(entry);
+            (std::get<2>(*mapIt))(entry);
             return;
         }
     }

--- a/src/Mod/Part/Gui/TaskCheckGeometry.h
+++ b/src/Mod/Part/Gui/TaskCheckGeometry.h
@@ -23,7 +23,7 @@
 #ifndef TASKCHECKGEOMETRY_H
 #define TASKCHECKGEOMETRY_H
 
-#include <boost/tuple/tuple.hpp>
+#include <tuple>
 #include <BRepCheck_Analyzer.hxx>
 #include <BRepCheck_Status.hxx>
 #include <Message_ProgressIndicator.hxx>
@@ -73,7 +73,7 @@ void goSetupResultInvalidSameParameterFlag(ResultEntry *entry);
 void goSetupResultUnorientableShapeFace(ResultEntry *entry);
 
 typedef boost::function<void (ResultEntry *entry)> ResultFunction;
-typedef boost::tuple<TopAbs_ShapeEnum, BRepCheck_Status, ResultFunction> FunctionMapType;
+typedef std::tuple<TopAbs_ShapeEnum, BRepCheck_Status, ResultFunction> FunctionMapType;
 
 class ResultModel : public QAbstractItemModel
 {


### PR DESCRIPTION
std::tuple was introduced in c++11 from boost.
This removes yet another boost dependency

---

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [ ]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [x]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
-  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
