### PR TITLE
[GUI] Update GUI Application.cpp for 0.20

### DIFF
--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -26,10 +26,10 @@
 #ifndef _PreComp_
 # include "InventorAll.h"
 # include <boost_signals2.hpp>
-# include <boost_bind_bind.hpp>
 # include <sstream>
 # include <stdexcept>
 # include <iostream>
+# include <functional>
 # include <QCloseEvent>
 # include <QDir>
 # include <QFileInfo>
@@ -138,7 +138,7 @@
 using namespace Gui;
 using namespace Gui::DockWnd;
 using namespace std;
-namespace bp = boost::placeholders;
+namespace sp = std::placeholders;
 
 
 Application* Application::Instance = 0L;
@@ -309,12 +309,12 @@ Application::Application(bool GUIenabled)
 {
     //App::GetApplication().Attach(this);
     if (GUIenabled) {
-        App::GetApplication().signalNewDocument.connect(boost::bind(&Gui::Application::slotNewDocument, this, bp::_1, bp::_2));
-        App::GetApplication().signalDeleteDocument.connect(boost::bind(&Gui::Application::slotDeleteDocument, this, bp::_1));
-        App::GetApplication().signalRenameDocument.connect(boost::bind(&Gui::Application::slotRenameDocument, this, bp::_1));
-        App::GetApplication().signalActiveDocument.connect(boost::bind(&Gui::Application::slotActiveDocument, this, bp::_1));
-        App::GetApplication().signalRelabelDocument.connect(boost::bind(&Gui::Application::slotRelabelDocument, this, bp::_1));
-        App::GetApplication().signalShowHidden.connect(boost::bind(&Gui::Application::slotShowHidden, this, bp::_1));
+        App::GetApplication().signalNewDocument.connect(std::bind(&Gui::Application::slotNewDocument, this, sp::_1, sp::_2));
+        App::GetApplication().signalDeleteDocument.connect(std::bind(&Gui::Application::slotDeleteDocument, this, sp::_1));
+        App::GetApplication().signalRenameDocument.connect(std::bind(&Gui::Application::slotRenameDocument, this, sp::_1));
+        App::GetApplication().signalActiveDocument.connect(std::bind(&Gui::Application::slotActiveDocument, this, sp::_1));
+        App::GetApplication().signalRelabelDocument.connect(std::bind(&Gui::Application::slotRelabelDocument, this, sp::_1));
+        App::GetApplication().signalShowHidden.connect(std::bind(&Gui::Application::slotShowHidden, this, sp::_1));
 
 
         // install the last active language
@@ -766,13 +766,13 @@ void Application::slotNewDocument(const App::Document& Doc, bool isMainDoc)
     d->documents[&Doc] = pDoc;
 
     // connect the signals to the application for the new document
-    pDoc->signalNewObject.connect(boost::bind(&Gui::Application::slotNewObject, this, bp::_1));
-    pDoc->signalDeletedObject.connect(boost::bind(&Gui::Application::slotDeletedObject, this, bp::_1));
-    pDoc->signalChangedObject.connect(boost::bind(&Gui::Application::slotChangedObject, this, bp::_1, bp::_2));
-    pDoc->signalRelabelObject.connect(boost::bind(&Gui::Application::slotRelabelObject, this, bp::_1));
-    pDoc->signalActivatedObject.connect(boost::bind(&Gui::Application::slotActivatedObject, this, bp::_1));
-    pDoc->signalInEdit.connect(boost::bind(&Gui::Application::slotInEdit, this, bp::_1));
-    pDoc->signalResetEdit.connect(boost::bind(&Gui::Application::slotResetEdit, this, bp::_1));
+    pDoc->signalNewObject.connect(std::bind(&Gui::Application::slotNewObject, this, sp::_1));
+    pDoc->signalDeletedObject.connect(std::bind(&Gui::Application::slotDeletedObject, this, sp::_1));
+    pDoc->signalChangedObject.connect(std::bind(&Gui::Application::slotChangedObject, this, sp::_1, sp::_2));
+    pDoc->signalRelabelObject.connect(std::bind(&Gui::Application::slotRelabelObject, this, sp::_1));
+    pDoc->signalActivatedObject.connect(std::bind(&Gui::Application::slotActivatedObject, this, sp::_1));
+    pDoc->signalInEdit.connect(std::bind(&Gui::Application::slotInEdit, this, sp::_1));
+    pDoc->signalResetEdit.connect(std::bind(&Gui::Application::slotResetEdit, this, sp::_1));
 
     signalNewDocument(*pDoc, isMainDoc);
     if (isMainDoc)

--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -35,9 +35,7 @@
 # include <QFileInfo>
 # include <QLocale>
 # include <QMessageBox>
-#if QT_VERSION >= 0x050000
 # include <QMessageLogContext>
-#endif
 # include <QPointer>
 # include <QSessionManager>
 # include <QStatusBar>
@@ -287,59 +285,8 @@ FreeCADGui_getSoDBVersion(PyObject * /*self*/, PyObject *args)
 {
     if (!PyArg_ParseTuple(args, ""))
         return NULL;
-#if PY_MAJOR_VERSION >= 3
     return PyUnicode_FromString(SoDB::getVersion());
-#else
-    return PyString_FromString(SoDB::getVersion());
-#endif
 }
-
-// Copied from https://github.com/python/cpython/blob/master/Objects/moduleobject.c
-#if PY_MAJOR_VERSION >= 3
-#if PY_MINOR_VERSION <= 4
-static int
-_add_methods_to_object(PyObject *module, PyObject *name, PyMethodDef *functions)
-{
-    PyObject *func;
-    PyMethodDef *fdef;
-
-    for (fdef = functions; fdef->ml_name != NULL; fdef++) {
-        if ((fdef->ml_flags & METH_CLASS) ||
-            (fdef->ml_flags & METH_STATIC)) {
-            PyErr_SetString(PyExc_ValueError,
-                            "module functions cannot set"
-                            " METH_CLASS or METH_STATIC");
-            return -1;
-        }
-        func = PyCFunction_NewEx(fdef, (PyObject*)module, name);
-        if (func == NULL) {
-            return -1;
-        }
-        if (PyObject_SetAttrString(module, fdef->ml_name, func) != 0) {
-            Py_DECREF(func);
-            return -1;
-        }
-        Py_DECREF(func);
-    }
-
-    return 0;
-}
-
-int
-PyModule_AddFunctions(PyObject *m, PyMethodDef *functions)
-{
-    int res;
-    PyObject *name = PyModule_GetNameObject(m);
-    if (name == NULL) {
-        return -1;
-    }
-
-    res = _add_methods_to_object(m, name, functions);
-    Py_DECREF(name);
-    return res;
-}
-#endif
-#endif
 
 struct PyMethodDef FreeCADGui_methods[] = {
     {"subgraphFromObject",FreeCADGui_subgraphFromObject,METH_VARARGS,
@@ -418,7 +365,6 @@ Application::Application(bool GUIenabled)
             "workbenches."
             );
 
-#if PY_MAJOR_VERSION >= 3
         // if this returns a valid pointer then the 'FreeCADGui' Python module was loaded,
         // otherwise the executable was launched
         PyObject* modules = PyImport_GetModuleDict();
@@ -438,9 +384,6 @@ Application::Application(bool GUIenabled)
             // extend the method list
             PyModule_AddFunctions(module, Application::Methods);
         }
-#else
-        PyObject* module = Py_InitModule3("FreeCADGui", Application::Methods, FreeCADGui_doc);
-#endif
         Py::Module(module).setAttr(std::string("ActiveDocument"),Py::None());
 
         UiLoaderPy::init_type();
@@ -457,7 +400,6 @@ Application::Application(bool GUIenabled)
             module,"ExpressionBinding");
 
         //insert Selection module
-#if PY_MAJOR_VERSION >= 3
         static struct PyModuleDef SelectionModuleDef = {
             PyModuleDef_HEAD_INIT,
             "Selection", "Selection module", -1,
@@ -465,9 +407,6 @@ Application::Application(bool GUIenabled)
             NULL, NULL, NULL, NULL
         };
         PyObject* pSelectionModule = PyModule_Create(&SelectionModuleDef);
-#else
-        PyObject* pSelectionModule = Py_InitModule3("Selection", SelectionSingleton::Methods,"Selection module");
-#endif
         Py_INCREF(pSelectionModule);
         PyModule_AddObject(module, "Selection", pSelectionModule);
 
@@ -1608,11 +1547,7 @@ QStringList Application::workbenches(void) const
     // insert all items
     while (PyDict_Next(_pcWorkbenchDictionary, &pos, &key, &value)) {
         /* do something interesting with the values... */
-#if PY_MAJOR_VERSION >= 3
         const char* wbName = PyUnicode_AsUTF8(key);
-#else
-        const char* wbName = PyString_AsString(key);
-#endif
         // add only allowed workbenches
         bool ok = true;
         if (!extra.isEmpty()&&ok) {
@@ -1684,23 +1619,16 @@ CommandManager &Application::commandManager(void)
 //**************************************************************************
 // Init, Destruct and singleton
 
-#if QT_VERSION >= 0x050000
 typedef void (*_qt_msg_handler_old)(QtMsgType, const QMessageLogContext &, const QString &);
-#else
-typedef void (*_qt_msg_handler_old)(QtMsgType type, const char *msg);
-#endif
 _qt_msg_handler_old old_qtmsg_handler = 0;
 
-#if QT_VERSION >= 0x050000
 void messageHandler(QtMsgType type, const QMessageLogContext &context, const QString &msg)
 {
     Q_UNUSED(context);
 #ifdef FC_DEBUG
     switch (type)
     {
-#if QT_VERSION >= 0x050500
     case QtInfoMsg:
-#endif
     case QtDebugMsg:
         Base::Console().Message("%s\n", msg.toUtf8().constData());
         break;
@@ -1724,36 +1652,6 @@ void messageHandler(QtMsgType type, const QMessageLogContext &context, const QSt
     Base::Console().Log("%s\n", msg.toUtf8().constData());
 #endif
 }
-#else
-void messageHandler(QtMsgType type, const char *msg)
-{
-#ifdef FC_DEBUG
-    switch (type)
-    {
-    case QtDebugMsg:
-        Base::Console().Message("%s\n", msg);
-        break;
-    case QtWarningMsg:
-        Base::Console().Warning("%s\n", msg);
-        break;
-    case QtCriticalMsg:
-        Base::Console().Error("%s\n", msg);
-        break;
-    case QtFatalMsg:
-        Base::Console().Error("%s\n", msg);
-        abort();                    // deliberately core dump
-    }
-#ifdef FC_OS_WIN32
-    if (old_qtmsg_handler)
-        (*old_qtmsg_handler)(type, msg);
-#endif
-#else
-    // do not stress user with Qt internals but write to log file if enabled
-    Q_UNUSED(type);
-    Base::Console().Log("%s\n", msg);
-#endif
-}
-#endif
 
 #ifdef FC_DEBUG // redirect Coin messages to FreeCAD
 void messageHandlerCoin(const SoError * error, void * /*userdata*/)
@@ -1775,11 +1673,7 @@ void messageHandlerCoin(const SoError * error, void * /*userdata*/)
         }
 #ifdef FC_OS_WIN32
     if (old_qtmsg_handler)
-#if QT_VERSION >=0x050000
         (*old_qtmsg_handler)(QtDebugMsg, QMessageLogContext(), QString::fromLatin1(msg));
-#else
-        (*old_qtmsg_handler)(QtDebugMsg, msg);
-#endif
 #endif
     }
     else if (error) {
@@ -1810,11 +1704,7 @@ void Application::initApplication(void)
         initTypes();
         new Base::ScriptProducer( "FreeCADGuiInit", FreeCADGuiInit );
         init_resources();
-#if QT_VERSION >=0x050000
         old_qtmsg_handler = qInstallMessageHandler(messageHandler);
-#else
-        old_qtmsg_handler = qInstallMsgHandler(messageHandler);
-#endif
         init = true;
     }
     catch (...) {
@@ -1910,21 +1800,13 @@ void Application::runApplication(void)
     const std::map<std::string,std::string>& cfg = App::Application::Config();
     std::map<std::string,std::string>::const_iterator it;
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 9, 0))
     QCoreApplication::setAttribute(Qt::AA_ShareOpenGLContexts);
-#elif defined(QTWEBENGINE) && defined(Q_OS_LINUX)
-    // Avoid warning of 'Qt WebEngine seems to be initialized from a plugin...'
-    // QTWEBENGINE is defined in src/Gui/CMakeLists.txt, currently only enabled
-    // when build with Conda.
-    QCoreApplication::setAttribute(Qt::AA_ShareOpenGLContexts);
-#endif
 
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 12, 0))
     QCoreApplication::setAttribute(Qt::AA_UseDesktopOpenGL);
 #endif
 
     // Automatic scaling for legacy apps (disable once all parts of GUI are aware of HiDpi)
-#if QT_VERSION >= 0x050600
     ParameterGrp::handle hDPI = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/HighDPI");
     bool disableDpiScaling = hDPI->GetBool("DisableDpiScaling", false);
     if (disableDpiScaling) {
@@ -1937,21 +1819,16 @@ void Application::runApplication(void)
         // Enable automatic scaling based on pixel density of display (added in Qt 5.6)
         QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
     }
-#endif // QT_VERSION >= 0x050600
 
-#if QT_VERSION >= 0x050100
     //Enable support for highres images (added in Qt 5.1, but off by default)
     QCoreApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
-#endif
 
     // Use software rendering for OpenGL
-#if QT_VERSION >= 0x050400
     ParameterGrp::handle hOpenGL = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/OpenGL");
     bool useSoftwareOpenGL = hOpenGL->GetBool("UseSoftwareOpenGL", false);
     if (useSoftwareOpenGL) {
         QApplication::setAttribute(Qt::AA_UseSoftwareOpenGL);
     }
-#endif // QT_VERSION >= 0x050400
 
     // A new QApplication
     Base::Console().Log("Init: Creating Gui::Application and QApplication\n");
@@ -2430,21 +2307,6 @@ void Application::setStyleSheet(const QString& qssFile, bool tiledBackground)
             qApp->sendEvent(getMainWindow(), &e);
             mdi->setBackground(QBrush(QColor(160,160,160)));
         }
-#if QT_VERSION == 0x050600 && defined(Q_OS_WIN32)
-        // Under Windows the tree indicator branch gets corrupted after a while.
-        // For more details see also https://bugreports.qt.io/browse/QTBUG-52230
-        // and https://codereview.qt-project.org/#/c/154357/2//ALL,unified
-        // A workaround for Qt 5.6.0 is to set a minimal style sheet.
-        QString qss = QString::fromLatin1(
-               "QTreeView::branch:closed:has-children  {\n"
-               "    image: url(:/icons/style/windows_branch_closed.png);\n"
-               "}\n"
-               "\n"
-               "QTreeView::branch:open:has-children  {\n"
-               "    image: url(:/icons/style/windows_branch_open.png);\n"
-               "}\n");
-        qApp->setStyleSheet(qss);
-#endif
     }
 
     // At startup time unpolish() mustn't be executed because otherwise the QSint widget


### PR DESCRIPTION
The first commit removes any code that was `#ifdef`-protected and required Qt <5.9 or Python<3.6. The second migrates from `boost::bind` to `std::bind`.

Note that one of the `#ifdef`s referred to Qt 5.10, but this was actually a mistake, and should have referred to Qt 5.1 -- it was a minor issue related to an anti-aliasing feature.

---

- [X]  Your pull request is confined strictly to a single module.
- [X]  Small fixes only
- [X]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [X]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [X]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [X]  No tracker ticket