### PR TITLE
[CMake] Add missing backwards-compatibility var

### DIFF
--- a/cMake/FreeCAD_Helpers/SetupPython.cmake
+++ b/cMake/FreeCAD_Helpers/SetupPython.cmake
@@ -142,6 +142,7 @@ macro(SetupPython)
         find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
 
         # For backwards compatibility with old CMake scripts
+        set(PYTHON_EXECUTABLE ${Python3_EXECUTABLE})
         set(PYTHON_LIBRARIES ${Python3_LIBRARIES})
         set(PYTHON_INCLUDE_DIRS ${Python3_INCLUDE_DIRS})
         set(PYTHON_LIBRARY_DIRS ${Python3_LIBRARY_DIRS})


### PR DESCRIPTION
I missed a backwards-compatibility variable in the code handling CMake >=3.12 Python executables. This adds it.

---

- [X]  Your pull request is confined strictly to a single module.
- [X]  Small change
- [X]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [X]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [X]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [X]  No ticket