### PR TITLE
[0.19][GUI] Limit about max height

### DIFF
--- a/src/Gui/Splashscreen.cpp
+++ b/src/Gui/Splashscreen.cpp
@@ -255,6 +255,7 @@ AboutDialog::AboutDialog(bool showLic, QWidget* parent)
 
         image = image.scaled(width, height);
     }
+    this->setMaximumHeight(0.9*rect.height());
     ui->labelSplashPicture->setPixmap(image);
 //    if (showLic) { // currently disabled. Additional license blocks are always shown.
         QString info(QLatin1String("SUCH DAMAGES.<hr/>"));


### PR DESCRIPTION
As reported in https://forum.freecadweb.org/viewtopic.php?p=485363#p485363, it is possible for the About box to exceed the maximum height of the screen, cutting off the controls to close the window. While pressing Esc still works, it's not obvious. This patch prevents the About window height from exceeding 90% of the screen height.

---

- [X]  Your pull request is confined strictly to a single module
- [X]  Discussed in forum
- [X]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [X]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) 
- [X]  Your pull request is well written and has a good description, and its title starts with the module name
- [X]  No ticket