### PR TITLE
[0.19][Web] Remove HiDPI fix when using QTWEBVIEW

### DIFF
--- a/src/Mod/Web/Gui/BrowserView.cpp
+++ b/src/Mod/Web/Gui/BrowserView.cpp
@@ -239,6 +239,7 @@ Py::Object BrowserViewPy::setHtml(const Py::Tuple& args)
 WebView::WebView(QWidget *parent)
     : QWEBVIEW(parent)
 {
+#ifdef QTWEBKIT
     // Increase html font size for high DPI displays
 #if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
     QRect mainScreenSize = QApplication::primaryScreen()->geometry();
@@ -248,6 +249,7 @@ WebView::WebView(QWidget *parent)
     if (mainScreenSize.width() > 1920){
         setTextSizeMultiplier (mainScreenSize.width()/1920.0);
     }
+#endif
 }
 
 #ifdef QTWEBENGINE


### PR DESCRIPTION
The screen scale adjustment code here should not be necessary when using the Chromium-based QtWebView widget, which correctly handles logical vs. device px units. The scaling causes poor font size choice when used on ultrawide monitors, as reported in https://forum.freecadweb.org/viewtopic.php?p=485431

---

- [X]  Confined strictly to a single module.
- [X]  Discussed in the forum
- [X]  Branch is [rebased](https://git-scm.com/docs/git-rebase) on 0.19 release branch
- [X]  Unit tests pass
- [X]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/)
- [X]  Your pull request is well written and has a good description, and its title starts with the module name
- [X]  No tracker ticket