### PR TITLE
Remove deprecated Qt constants and version checks

### DIFF
--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -3133,11 +3133,11 @@ void DocumentItem::slotResetEdit(const Gui::ViewProviderDocumentObject& v)
     FOREACH_ITEM_ALL(item)
         if(tree->editingItem) {
             if(item == tree->editingItem) {
-                item->setData(0, Qt::BackgroundColorRole,QVariant());
+                item->setData(0, Qt::BackgroundRole,QVariant());
                 break;
             }
         }else if(item->object() == &v)
-            item->setData(0, Qt::BackgroundColorRole,QVariant());
+            item->setData(0, Qt::BackgroundRole,QVariant());
     END_FOREACH_ITEM
     tree->editingItem = 0;
 }
@@ -4592,7 +4592,7 @@ void DocumentObjectItem::testStatus(bool resetStatus, QIcon &icon1, QIcon &icon2
 #if QT_VERSION >= 0x040200
         this->setData(0, Qt::ForegroundRole,QVariant());
 #else
-        this->setData(0, Qt::TextColorRole,QVariant());
+        this->setData(0, Qt::ForegroundRole,QVariant());
 #endif
     }
     else { // invisible

--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -518,11 +518,7 @@ TreeWidget::TreeWidget(const char *name, QWidget* parent)
             boost::bind(&TreeWidget::slotChangedViewObject, this, bp::_1, bp::_2));
 
     // make sure to show a horizontal scrollbar if needed
-#if QT_VERSION >= 0x050000
     this->header()->setSectionResizeMode(0, QHeaderView::ResizeToContents);
-#else
-    this->header()->setResizeMode(0, QHeaderView::ResizeToContents);
-#endif
     this->header()->setStretchLastSection(false);
 
     // Add the first main label
@@ -530,10 +526,9 @@ TreeWidget::TreeWidget(const char *name, QWidget* parent)
     this->rootItem->setFlags(Qt::ItemIsEnabled);
     this->expandItem(this->rootItem);
     this->setSelectionMode(QAbstractItemView::ExtendedSelection);
-#if QT_VERSION >= 0x040200
     // causes unexpected drop events (possibly only with Qt4.1.x)
     this->setMouseTracking(true); // needed for itemEntered() to work
-#endif
+
 
     this->preselectTimer = new QTimer(this);
     this->preselectTimer->setSingleShot(true);
@@ -1419,7 +1414,6 @@ void TreeWidget::dragLeaveEvent(QDragLeaveEvent * event)
 
 void TreeWidget::dragMoveEvent(QDragMoveEvent *event)
 {
-#if QT_VERSION >= 0x050000
     // Qt5 does not change drag cursor in response to modifier key press,
     // because QDrag installs a event filter that eats up key event. We install
     // a filter after Qt and generate fake mouse move event in response to key
@@ -1428,7 +1422,6 @@ void TreeWidget::dragMoveEvent(QDragMoveEvent *event)
         _DragEventFilter = true;
         qApp->installEventFilter(this);
     }
-#endif
 
     QTreeWidget::dragMoveEvent(event);
     if (!event->isAccepted())
@@ -2899,9 +2892,7 @@ TreePanel::TreePanel(const char *name, QWidget* parent)
     pLayout->addWidget(this->searchBox);
     this->searchBox->hide();
     this->searchBox->installEventFilter(this);
-#if QT_VERSION >= 0x040700
     this->searchBox->setPlaceholderText(tr("Search"));
-#endif
     connect(this->searchBox, SIGNAL(returnPressed()),
             this, SLOT(accept()));
     connect(this->searchBox, SIGNAL(textChanged(QString)),
@@ -4589,22 +4580,14 @@ void DocumentObjectItem::testStatus(bool resetStatus, QIcon &icon1, QIcon &icon2
         // to black which will lead to unreadable text if the system background
         // hss already a dark color.
         // However, it works if we set the appropriate role to an empty QVariant().
-#if QT_VERSION >= 0x040200
         this->setData(0, Qt::ForegroundRole,QVariant());
-#else
-        this->setData(0, Qt::ForegroundRole,QVariant());
-#endif
     }
     else { // invisible
         QStyleOptionViewItem opt;
         // it can happen that a tree item is not attached to the tree widget (#0003025)
         if (this->treeWidget())
             opt.initFrom(this->treeWidget());
-#if QT_VERSION >= 0x040200
         this->setForeground(0, opt.palette.color(QPalette::Disabled,QPalette::Text));
-#else
-        this->setTextColor(0, opt.palette.color(QPalette::Disabled,QPalette::Text);
-#endif
         mode = QIcon::Disabled;
     }
 
@@ -4735,11 +4718,7 @@ void DocumentObjectItem::displayStatusInfo()
 {
     App::DocumentObject* Obj = object()->getObject();
 
-#if (QT_VERSION >= 0x050000)
     QString info = QApplication::translate(Obj->getTypeId().getName(), Obj->getStatusString());
-#else
-    QString info = QApplication::translate(Obj->getTypeId().getName(), Obj->getStatusString(), 0, QApplication::UnicodeUTF8);
-#endif
 
     if (Obj->mustExecute() == 1 && !Obj->isError())
         info += TreeWidget::tr(" (but must be executed)");

--- a/src/Gui/View3DInventor.cpp
+++ b/src/Gui/View3DInventor.cpp
@@ -513,13 +513,8 @@ void View3DInventor::printPreview()
 {
     QPrinter printer(QPrinter::ScreenResolution);
     printer.setFullPage(true);
-#if QT_VERSION >= 0x050300
     printer.setPageSize(QPageSize(QPageSize::A4));
     printer.setPageOrientation(QPageLayout::Landscape);
-#else
-    printer.setPageSize(QPrinter::A4);
-    printer.setOrientation(QPrinter::Landscape);
-#endif
 
     QPrintPreviewDialog dlg(&printer, this);
     connect(&dlg, SIGNAL(paintRequested (QPrinter *)),
@@ -539,11 +534,7 @@ void View3DInventor::print(QPrinter* printer)
         return;
     }
 
-#if QT_VERSION >= 0x050300
     QRect rect = printer->pageLayout().paintRectPixels(printer->resolution());
-#else
-    QRect rect = printer->pageRect();
-#endif
     QImage img;
     _viewer->imageFromFramebuffer(rect.width(), rect.height(), 8, QColor(255,255,255), img);
     p.drawImage(0,0,img);
@@ -1038,16 +1029,6 @@ void View3DInventor::keyPressEvent (QKeyEvent* e)
     // of an MDI view because it causes rendering problems.
     // The only reliable solution is to clone the MDI view,
     // set its view mode and close the original MDI view.
-#if (QT_VERSION < QT_VERSION_CHECK(5, 0, 0))
-    ViewMode mode = MDIView::currentViewMode();
-    if (mode != Child) {
-        // If the widget is in fullscreen mode then we can return to normal mode either
-        // by pressing the matching accelerator or ESC.
-        if (e->key() == Qt::Key_Escape) {
-            setCurrentViewMode(Child);
-        }
-    }
-#endif
 
     QMainWindow::keyPressEvent(e);
 }

--- a/src/Gui/View3DInventor.cpp
+++ b/src/Gui/View3DInventor.cpp
@@ -530,7 +530,7 @@ void View3DInventor::printPreview()
 void View3DInventor::print(QPrinter* printer)
 {
     QPainter p(printer);
-    p.setRenderHints(QPainter::Antialiasing | QPainter::HighQualityAntialiasing);
+    p.setRenderHints(QPainter::Antialiasing);
     if (!p.isActive() && !printer->outputFileName().isEmpty()) {
         qApp->setOverrideCursor(Qt::ArrowCursor);
         QMessageBox::critical(this, tr("Opening file failed"),

--- a/src/Gui/propertyeditor/PropertyItem.cpp
+++ b/src/Gui/propertyeditor/PropertyItem.cpp
@@ -537,7 +537,7 @@ QVariant PropertyItem::data(int column, int role) const
 {
     // property name
     if (column == 0) {
-        if (role == Qt::BackgroundRole || role == Qt::TextColorRole) {
+        if (role == Qt::BackgroundRole || role == Qt::ForegroundRole) {
             if(PropertyView::showAll()
                 && propertyItems.size() == 1
                 && propertyItems.front()->testStatus(App::Property::PropDynamic)
@@ -587,7 +587,7 @@ QVariant PropertyItem::data(int column, int role) const
                 QVariant val = parent->property(qPrintable(objectName()));
                 return toString(val);
             } 
-            else if (role == Qt::TextColorRole) {
+            else if (role == Qt::ForegroundRole) {
                 if (hasExpression())
                     return QVariant::fromValue(QApplication::palette().color(QPalette::Link));
                 return QVariant();
@@ -607,7 +607,7 @@ QVariant PropertyItem::data(int column, int role) const
         else if (role == Qt::ToolTipRole) {
             return toolTip(propertyItems[0]);
         }
-        else if( role == Qt::TextColorRole) {
+        else if( role == Qt::ForegroundRole) {
             if (hasExpression())
                 return QVariant::fromValue(QApplication::palette().color(QPalette::Link));
             return QVariant();
@@ -3907,11 +3907,11 @@ QVariant PropertyLinkItem::toString(const QVariant& prop) const
 
 QVariant PropertyLinkItem::data(int column, int role) const {
     if(propertyItems.size() && column == 1 
-            && (role == Qt::TextColorRole || role == Qt::ToolTipRole))
+            && (role == Qt::ForegroundRole || role == Qt::ToolTipRole))
     {
         auto propLink = Base::freecad_dynamic_cast<const App::PropertyLinkBase>(propertyItems[0]);
         if(propLink) {
-            if(role==Qt::TextColorRole && propLink->checkRestore()>1)
+            if(role==Qt::ForegroundRole && propLink->checkRestore()>1)
                 return QVariant::fromValue(QColor(0xff,0,0));
             else if(role == Qt::ToolTipRole) {
                 auto xlink = Base::freecad_dynamic_cast<const App::PropertyXLink>(propertyItems[0]);

--- a/src/Gui/propertyeditor/PropertyItem.cpp
+++ b/src/Gui/propertyeditor/PropertyItem.cpp
@@ -3987,7 +3987,6 @@ PropertyItemEditorFactory::~PropertyItemEditorFactory()
 {
 }
 
-#if (QT_VERSION >= 0x050300)
 QWidget * PropertyItemEditorFactory::createEditor (int /*type*/, QWidget * /*parent*/) const
 {
     // do not allow to create any editor widgets because we do that in subclasses of PropertyItem
@@ -3999,19 +3998,6 @@ QByteArray PropertyItemEditorFactory::valuePropertyName (int /*type*/) const
     // do not allow to set properties because we do that in subclasses of PropertyItem
     return "";
 }
-#else
-QWidget * PropertyItemEditorFactory::createEditor (QVariant::Type /*type*/, QWidget * /*parent*/) const
-{
-    // do not allow to create any editor widgets because we do that in subclasses of PropertyItem
-    return 0;
-}
-
-QByteArray PropertyItemEditorFactory::valuePropertyName (QVariant::Type /*type*/) const
-{
-    // do not allow to set properties because we do that in subclasses of PropertyItem
-    return "";
-}
-#endif
 
 #include "moc_PropertyItem.cpp"
 

--- a/src/Mod/Drawing/Gui/DrawingView.cpp
+++ b/src/Mod/Drawing/Gui/DrawingView.cpp
@@ -154,7 +154,7 @@ void SvgView::setRenderer(RendererType type)
 void SvgView::setHighQualityAntialiasing(bool highQualityAntialiasing)
 {
 #ifndef QT_NO_OPENGL
-    setRenderHint(QPainter::HighQualityAntialiasing, highQualityAntialiasing);
+    setRenderHint(QPainter::Antialiasing);
 #else
     Q_UNUSED(highQualityAntialiasing);
 #endif

--- a/src/Mod/Drawing/Gui/DrawingView.cpp
+++ b/src/Mod/Drawing/Gui/DrawingView.cpp
@@ -197,11 +197,7 @@ void SvgView::paintEvent(QPaintEvent *event)
 
 void SvgView::wheelEvent(QWheelEvent *event)
 {
-#if QT_VERSION >= QT_VERSION_CHECK(5,0,0)
     int delta = -event->angleDelta().y();
-#else
-    int delta = -event->delta();
-#endif
     if (m_invertZoom)
         delta = -delta;
     qreal factor = std::pow(1.2, delta / 240.0);
@@ -258,13 +254,8 @@ DrawingView::DrawingView(Gui::Document* doc, QWidget* parent)
 
     setCentralWidget(m_view);
     //setWindowTitle(tr("SVG Viewer"));
-#if QT_VERSION >= 0x050300
     m_orientation = QPageLayout::Landscape;
     m_pageSize = QPageSize::A4;
-#else
-    m_orientation = QPrinter::Landscape;
-    m_pageSize = QPrinter::A4;
-#endif
 
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath
             ("User parameter:BaseApp/Preferences/View");
@@ -306,21 +297,12 @@ void DrawingView::load (const QString & fileName)
 void DrawingView::findPrinterSettings(const QString& fileName)
 {
     if (fileName.indexOf(QLatin1String("Portrait"), Qt::CaseInsensitive) >= 0) {
-#if QT_VERSION >= 0x050300
         m_orientation = QPageLayout::Portrait;
-#else
-        m_orientation = QPrinter::Portrait;
-#endif
     }
     else {
-#if QT_VERSION >= 0x050300
         m_orientation = QPageLayout::Landscape;
-#else
-        m_orientation = QPrinter::Landscape;
-#endif
     }
 
-#if QT_VERSION >= 0x050300
     QMap<QPageSize::PageSizeId, QString> pageSizes;
     pageSizes[QPageSize::A0] = QString::fromLatin1("A0");
     pageSizes[QPageSize::A1] = QString::fromLatin1("A1");
@@ -342,34 +324,7 @@ void DrawingView::findPrinterSettings(const QString& fileName)
     pageSizes[QPageSize::B7] = QString::fromLatin1("B7");
     pageSizes[QPageSize::B8] = QString::fromLatin1("B8");
     pageSizes[QPageSize::B9] = QString::fromLatin1("B9");
-#else
-    QMap<QPrinter::PageSize, QString> pageSizes;
-    pageSizes[QPrinter::A0] = QString::fromLatin1("A0");
-    pageSizes[QPrinter::A1] = QString::fromLatin1("A1");
-    pageSizes[QPrinter::A2] = QString::fromLatin1("A2");
-    pageSizes[QPrinter::A3] = QString::fromLatin1("A3");
-    pageSizes[QPrinter::A4] = QString::fromLatin1("A4");
-    pageSizes[QPrinter::A5] = QString::fromLatin1("A5");
-    pageSizes[QPrinter::A6] = QString::fromLatin1("A6");
-    pageSizes[QPrinter::A7] = QString::fromLatin1("A7");
-    pageSizes[QPrinter::A8] = QString::fromLatin1("A8");
-    pageSizes[QPrinter::A9] = QString::fromLatin1("A9");
-    pageSizes[QPrinter::B0] = QString::fromLatin1("B0");
-    pageSizes[QPrinter::B1] = QString::fromLatin1("B1");
-    pageSizes[QPrinter::B2] = QString::fromLatin1("B2");
-    pageSizes[QPrinter::B3] = QString::fromLatin1("B3");
-    pageSizes[QPrinter::B4] = QString::fromLatin1("B4");
-    pageSizes[QPrinter::B5] = QString::fromLatin1("B5");
-    pageSizes[QPrinter::B6] = QString::fromLatin1("B6");
-    pageSizes[QPrinter::B7] = QString::fromLatin1("B7");
-    pageSizes[QPrinter::B8] = QString::fromLatin1("B8");
-    pageSizes[QPrinter::B9] = QString::fromLatin1("B9");
-#endif
-#if QT_VERSION >= 0x050300
     for (QMap<QPageSize::PageSizeId, QString>::iterator it = pageSizes.begin(); it != pageSizes.end(); ++it) {
-#else
-    for (QMap<QPrinter::PageSize, QString>::iterator it = pageSizes.begin(); it != pageSizes.end(); ++it) {
-#endif
         if (fileName.startsWith(it.value(), Qt::CaseInsensitive)) {
             m_pageSize = it.key();
             break;
@@ -528,7 +483,6 @@ void DrawingView::printPdf()
     formLayout->addWidget(groupBox, 0, 0, 1, 1);
 
     groupBox->setTitle(tr("Page sizes"));
-#if QT_VERSION >= 0x050300
     item = new QListWidgetItem(tr("A0"), listWidget);
     item->setData(Qt::UserRole, QVariant(QPageSize::A0));
     item = new QListWidgetItem(tr("A1"), listWidget);
@@ -541,20 +495,6 @@ void DrawingView::printPdf()
     item->setData(Qt::UserRole, QVariant(QPageSize::A4));
     item = new QListWidgetItem(tr("A5"), listWidget);
     item->setData(Qt::UserRole, QVariant(QPageSize::A5));
-#else
-    item = new QListWidgetItem(tr("A0"), listWidget);
-    item->setData(Qt::UserRole, QVariant(QPrinter::A0));
-    item = new QListWidgetItem(tr("A1"), listWidget);
-    item->setData(Qt::UserRole, QVariant(QPrinter::A1));
-    item = new QListWidgetItem(tr("A2"), listWidget);
-    item->setData(Qt::UserRole, QVariant(QPrinter::A2));
-    item = new QListWidgetItem(tr("A3"), listWidget);
-    item->setData(Qt::UserRole, QVariant(QPrinter::A3));
-    item = new QListWidgetItem(tr("A4"), listWidget);
-    item->setData(Qt::UserRole, QVariant(QPrinter::A4));
-    item = new QListWidgetItem(tr("A5"), listWidget);
-    item->setData(Qt::UserRole, QVariant(QPrinter::A5));
-#endif
     int index = 4; // by default A4
     for (int i=0; i<listWidget->count(); i++) {
         if (listWidget->item(i)->data(Qt::UserRole).toInt() == m_pageSize) {
@@ -572,19 +512,11 @@ void DrawingView::printPdf()
         printer.setFullPage(true);
         printer.setOutputFormat(QPrinter::PdfFormat);
         printer.setOutputFileName(filename);
-#if QT_VERSION >= 0x050300
         printer.setPageOrientation(m_orientation);
-#else
-        printer.setOrientation(m_orientation);
-#endif
         QList<QListWidgetItem*> items = listWidget->selectedItems();
         if (items.size() == 1) {
             int AX = items.front()->data(Qt::UserRole).toInt();
-#if QT_VERSION >= 0x050300
             printer.setPageSize(QPageSize(QPageSize::PageSizeId(AX)));
-#else
-            printer.setPaperSize(QPrinter::PageSize(AX));
-#endif
         }
 
         print(&printer);
@@ -596,13 +528,8 @@ void DrawingView::print()
     QPrinter printer(QPrinter::HighResolution);
     printer.setFullPage(true);
 
-#if QT_VERSION >= 0x050300
     printer.setPageSize(QPageSize(m_pageSize));
     printer.setPageOrientation(m_orientation);
-#else
-    printer.setPageSize(m_pageSize);
-    printer.setOrientation(m_orientation);
-#endif
 
     QPrintDialog dlg(&printer, this);
     if (dlg.exec() == QDialog::Accepted) {
@@ -615,13 +542,8 @@ void DrawingView::printPreview()
     QPrinter printer(QPrinter::HighResolution);
     printer.setFullPage(true);
 
-#if QT_VERSION >= 0x050300
     printer.setPageSize(QPageSize(m_pageSize));
     printer.setPageOrientation(m_orientation);
-#else
-    printer.setPageSize(m_pageSize);
-    printer.setOrientation(m_orientation);
-#endif
 
     QPrintPreviewDialog dlg(&printer, this);
     connect(&dlg, SIGNAL(paintRequested (QPrinter *)),
@@ -646,23 +568,14 @@ void DrawingView::print(QPrinter* printer)
     if (printer->outputFormat() == QPrinter::NativeFormat) {
         int w = printer->widthMM();
         int h = printer->heightMM();
-#if QT_VERSION >= 0x050300
         QPageSize::PageSizeId realPaperSize = getPageSize(w, h);
         QPageSize::PageSizeId curPaperSize = printer->pageLayout().pageSize().id();
-#else
-        QPrinter::PaperSize realPaperSize = getPageSize(w, h);
-        QPrinter::PaperSize curPaperSize = printer->paperSize();
-#endif
 
         // for the preview a 'Picture' paint engine is used which we don't
         // care if it uses wrong printer settings
         bool doPrint = paintType != QPaintEngine::Picture;
 
-#if QT_VERSION >= 0x050300
         if (doPrint && printer->pageLayout().orientation() != this->m_orientation) {
-#else
-        if (doPrint && printer->orientation() != this->m_orientation) {
-#endif
             int ret = QMessageBox::warning(this, tr("Different orientation"),
                 tr("The printer uses a different orientation than the drawing.\n"
                    "Do you want to continue?"),
@@ -696,30 +609,18 @@ void DrawingView::print(QPrinter* printer)
         qApp->restoreOverrideCursor();
         return;
     }
-#if QT_VERSION >= 0x050300
     QRect rect = printer->pageLayout().fullRectPixels(printer->resolution());
-#else
-    QRect rect = printer->paperRect();
-#endif
 #ifdef Q_OS_WIN32
     // On Windows the preview looks broken when using paperRect as render area.
     // Although the picture is scaled when using pageRect, it looks just fine.
     if (paintType == QPaintEngine::Picture)
-#if QT_VERSION >= 0x050300
         QRect rect = printer->pageLayout().paintRectPixels(printer->resolution());
-#else
-        QRect rect = printer->pageRect();
-#endif
 #endif
     this->m_view->scene()->render(&p, rect);
     p.end();
 }
 
-#if QT_VERSION >= 0x050300
 QPageSize::PageSizeId DrawingView::getPageSize(int w, int h) const
-#else
-QPrinter::PageSize DrawingView::getPageSize(int w, int h) const
-#endif
 {
     static const float paperSizes[][2] = {
         {210, 297}, // A4
@@ -754,29 +655,18 @@ QPrinter::PageSize DrawingView::getPageSize(int w, int h) const
         {279.4f, 431.8f} // Tabloid
     };
 
-#if QT_VERSION >= 0x050300
     QPageSize::PageSizeId ps = QPageSize::Custom;
-#else
-    QPrinter::PageSize ps = QPrinter::Custom;
-#endif
     for (int i=0; i<30; i++) {
         if (std::abs(paperSizes[i][0]-w) <= 1 &&
             std::abs(paperSizes[i][1]-h) <= 1) {
-#if QT_VERSION >= 0x050300
             ps = static_cast<QPageSize::PageSizeId>(i);
-#else
-            ps = static_cast<QPrinter::PageSize>(i);
-#endif
             break;
         }
         else
         if (std::abs(paperSizes[i][0]-h) <= 1 &&
             std::abs(paperSizes[i][1]-w) <= 1) {
-#if QT_VERSION >= 0x050300
             ps = static_cast<QPageSize::PageSizeId>(i);
-#else
-            ps = static_cast<QPrinter::PageSize>(i);
-#endif
+
             break;
         }
     }

--- a/src/Mod/Spreadsheet/Gui/SheetModel.cpp
+++ b/src/Mod/Spreadsheet/Gui/SheetModel.cpp
@@ -192,11 +192,7 @@ QVariant SheetModel::data(const QModelIndex &index, int role) const
     if (cell->hasException()) {
         switch (role) {
         case Qt::ToolTipRole: {
-#if QT_VERSION >= 0x050000
             QString txt(Base::Tools::fromStdString(cell->getException()).toHtmlEscaped());
-#else
-            QString txt(Qt::escape(Base::Tools::fromStdString(cell->getException())));
-#endif
             return QVariant(QString::fromLatin1("<pre>%1</pre>").arg(txt));
         }
         case Qt::DisplayRole: {

--- a/src/Mod/Spreadsheet/Gui/SheetModel.cpp
+++ b/src/Mod/Spreadsheet/Gui/SheetModel.cpp
@@ -209,7 +209,7 @@ QVariant SheetModel::data(const QModelIndex &index, int role) const
             return QVariant::fromValue(QString::fromUtf8("#ERR"));
 #endif
         }
-        case Qt::TextColorRole:
+        case Qt::ForegroundRole:
             return QVariant::fromValue(QColor(255.0, 0, 0));
         case Qt::TextAlignmentRole:
             return QVariant(Qt::AlignVCenter | Qt::AlignLeft);
@@ -283,7 +283,7 @@ QVariant SheetModel::data(const QModelIndex &index, int role) const
 
     if (!prop) {
         switch (role) {
-        case  Qt::TextColorRole: {
+        case  Qt::ForegroundRole: {
             return QColor(0, 0, 255.0);
         }
         case Qt::TextAlignmentRole: {
@@ -303,7 +303,7 @@ QVariant SheetModel::data(const QModelIndex &index, int role) const
         const App::PropertyString * stringProp = static_cast<const App::PropertyString*>(prop);
 
         switch (role) {
-        case Qt::TextColorRole: {
+        case Qt::ForegroundRole: {
             Color color;
 
             if (cell->getForeground(color))
@@ -333,7 +333,7 @@ QVariant SheetModel::data(const QModelIndex &index, int role) const
         const App::PropertyQuantity * floatProp = static_cast<const App::PropertyQuantity*>(prop);
 
         switch (role) {
-        case  Qt::TextColorRole: {
+        case  Qt::ForegroundRole: {
             Color color;
 
             if (cell->getForeground(color))
@@ -402,7 +402,7 @@ QVariant SheetModel::data(const QModelIndex &index, int role) const
             d = static_cast<const App::PropertyInteger*>(prop)->getValue();
 
         switch (role) {
-        case  Qt::TextColorRole: {
+        case  Qt::ForegroundRole: {
             Color color;
 
             if (cell->getForeground(color))
@@ -449,7 +449,7 @@ QVariant SheetModel::data(const QModelIndex &index, int role) const
         auto pyProp = static_cast<const App::PropertyPythonObject*>(prop);
 
         switch (role) {
-        case  Qt::TextColorRole: {
+        case  Qt::ForegroundRole: {
             Color color;
 
             if (cell->getForeground(color))

--- a/src/Mod/Spreadsheet/Gui/Workbench.cpp
+++ b/src/Mod/Spreadsheet/Gui/Workbench.cpp
@@ -81,7 +81,7 @@ void Workbench::activated()
                 foregroundColor = new QtColorPicker();
                 foregroundColor->setObjectName(QString::fromLatin1("Spreadsheet_ForegroundColor"));
                 foregroundColor->setStandardColors();
-                foregroundColor->setCurrentColor(palette.color(QPalette::Foreground));
+                foregroundColor->setCurrentColor(palette.color(QPalette::WindowText));
                 QObject::connect(foregroundColor, SIGNAL(colorSet(QColor)), workbenchHelper.get(), SLOT(setForegroundColor(QColor)));
             }
             foregroundColor->setToolTip(QObject::tr("Set cell(s) foreground color"));


### PR DESCRIPTION
Qt has deprecated the following constants, this PR replaces them with their equivalent/replacement:
* `Qt::TextColorRole` -> `Qt::ForegroundRole`
* `Qt::BackgroundColorRole` -> `Qt::BackgroundRole`
* `QPainter::HighQualityAntialiasing` -> `QPainter::Antialiasing`
* `QPalette::Foreground` -> `QPalette::WindowText`

A second commit also removes any no-longer-needed Qt version checks from those files already being modified, since now we require Qt >= 5.9.

- [ ]  Your pull request is confined strictly to a single module
- [X]  Small bugs
- [X]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master
- [X]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) 
- [X]  Your pull request is well written and has a good description, and its title starts with the module name
- [X]  No tracker ticket