### PR TITLE
[OpenSCAD] Add scale parameter to linear_extrude

### DIFF
--- a/src/Mod/OpenSCAD/OpenSCADTest/app/test_importCSG.py
+++ b/src/Mod/OpenSCAD/OpenSCADTest/app/test_importCSG.py
@@ -246,13 +246,20 @@ polyhedron(
 
         doc = self.utility_create_scad("linear_extrude(height = 20, scale = 0.2) square([20, 10], center = true);", "linear_extrude_scale")
         object = doc.ActiveObject
-        # Not actually supported - this does not create a frustum, but a cube: scale does nothing
+        self.assertTrue (object is not None)
+        self.assertAlmostEqual (object.Shape.Volume, 1945.2745, 3)
         FreeCAD.closeDocument(doc.Name)
 
         doc = self.utility_create_scad("linear_extrude(height = 20, twist = 90) square([20, 10], center = true);", "linear_extrude_twist")
         object = doc.ActiveObject
         self.assertTrue (object is not None)
         self.assertAlmostEqual (object.Shape.Volume, 3999.9961, 3)
+        FreeCAD.closeDocument(doc.Name)
+
+        doc = self.utility_create_scad("linear_extrude(height = 40, twist = 180, scale=0.25) square([20, 10], center = true);", "linear_extrude_twist")
+        object = doc.ActiveObject
+        self.assertTrue (object is not None)
+        self.assertAlmostEqual (object.Shape.Volume, 4144.9071, 3)
         FreeCAD.closeDocument(doc.Name)
 
     def test_import_rotate_extrude_file(self):

--- a/src/Mod/OpenSCAD/importCSG.py
+++ b/src/Mod/OpenSCAD/importCSG.py
@@ -376,7 +376,7 @@ def p_operation(p):
               | intersection_action
               | union_action
               | rotate_extrude_action
-              | linear_extrude_with_twist
+              | linear_extrude_with_transform
               | rotate_extrude_file
               | import_file1
               | resize_action
@@ -728,9 +728,9 @@ def process_linear_extrude(obj,h) :
         newobj.ViewObject.hide()
     return(mylinear)
 
-def process_linear_extrude_with_twist(base,height,twist) :   
-    newobj=doc.addObject("Part::FeaturePython",'twist_extrude')
-    Twist(newobj,base,height,-twist) #base is an FreeCAD Object, height and twist are floats
+def process_linear_extrude_with_transform(base,height,twist,scale) :   
+    newobj=doc.addObject("Part::FeaturePython",'transform_extrude')
+    Twist(newobj,base,height,-twist,scale) #base is an FreeCAD Object, height and twist are floats, scale is a two-component vector of floats
     if gui:
         if FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/OpenSCAD").\
             GetBool('useViewProviderTree'):
@@ -742,17 +742,18 @@ def process_linear_extrude_with_twist(base,height,twist) :
     #ViewProviderTree(obj.ViewObject)
     return(newobj)
 
-def p_linear_extrude_with_twist(p):
-    'linear_extrude_with_twist : linear_extrude LPAREN keywordargument_list RPAREN OBRACE block_list EBRACE'
-    if printverbose: print("Linear Extrude With Twist")
+def p_linear_extrude_with_transform(p):
+    'linear_extrude_with_transform : linear_extrude LPAREN keywordargument_list RPAREN OBRACE block_list EBRACE'
+    if printverbose: print("Linear Extrude With Transform")
     h = float(p[3]['height'])
+    s = 1.0
+    t = 0.0
     if printverbose: print("Twist : ",p[3])
     if 'scale' in p[3]:
-        FreeCAD.Console.PrintWarning('WARNING: "scale" option to linear_extrude is not supported. Ignoring.\n')
+        s = [float(p[3]['scale'][0]), float(p[3]['scale'][1])]
+        print ("Scale: " + str(s))
     if 'twist' in p[3]:
         t = float(p[3]['twist'])
-    else:
-        t = 0
     # Test if null object like from null text
     if (len(p[6]) == 0) :
         p[0] = []
@@ -761,14 +762,14 @@ def p_linear_extrude_with_twist(p):
         obj = fuse(p[6],"Linear Extrude Union")
     else :
         obj = p[6][0]
-    if t:
-        newobj = process_linear_extrude_with_twist(obj,h,t)
+    if t != 0.0 or s != 1.0:
+        newobj = process_linear_extrude_with_transform(obj,h,t,s)
     else:
         newobj = process_linear_extrude(obj,h)
     if p[3]['center']=='true' :
        center(newobj,0,0,h)
     p[0] = [newobj]
-    if printverbose: print("End Linear Extrude with twist")
+    if printverbose: print("End Linear Extrude with Transform")
 
 def p_import_file1(p):
     'import_file1 : import LPAREN keywordargument_list RPAREN SEMICOL'


### PR DESCRIPTION
OpenSCAD's linear_extrude function accepts both a twist angle and a scale parameter -- prior to this commit the scale was unimplemented. This adds it by repurposing the twist code and making a small modification to include the closing section in the pipe creation, and scaling that section. This commit includes a unit test to identify future regressions. 

---

- [X]  Your pull request is confined strictly to a single module.
- [X]  Small feature
- [X]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master
- [X]  All OpenSCAD unit tests are confirmed to pass
- [X]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) 
- [X]  Your pull request is well written and has a good description
- [X]  No tracker ticket