### PR TITLE
[0.19 and master] [Win installer] improve uninstalling

### DIFF
--- a/src/WindowsInstaller/include/declarations.nsh
+++ b/src/WindowsInstaller/include/declarations.nsh
@@ -42,7 +42,13 @@ Configuration and variables of FreeCAD installer
 !define APP_REGNAME_DOC "${APP_NAME}.Document"
 
 !define APP_EXT ".FCStd"
+!define APP_EXT1 ".FCStd1"
 !define APP_MIME_TYPE "application/x-zip-compressed"
+
+!define APP_EXT_BAK ".FCBak"
+!define APP_EXT_MACRO ".FCMacro"
+!define APP_EXT_MAT ".FCMat"
+!define APP_EXT_SCRIPT ".FCScript"
 
 !define APP_UNINST_KEY "Software\Microsoft\Windows\CurrentVersion\Uninstall\${SETUP_UNINSTALLER_KEY}"
 

--- a/src/WindowsInstaller/setup/uninstall.nsh
+++ b/src/WindowsInstaller/setup/uninstall.nsh
@@ -24,10 +24,23 @@ Section "un.FreeCAD" un.SecUnProgramFiles
   ReadRegStr $R0 SHCTX "Software\Classes\${APP_EXT}" ""
   ${if} $R0 == "${APP_REGNAME_DOC}"
    DeleteRegKey SHCTX "Software\Classes\${APP_EXT}"
-   #DeleteRegKey SHCTX "Software\Classes\${APP_REGNAME_DOC}"
   ${endif}
+  DeleteRegKey SHCTX "Software\Microsoft\Windows\CurrentVersion\Explorer\FileExts\${APP_EXT}"
+  
+  # remove further FC-specific file extension
+  DeleteRegKey SHCTX "Software\Classes\${APP_EXT1}" # .FCStd1
+  DeleteRegKey SHCTX "Software\Microsoft\Windows\CurrentVersion\Explorer\FileExts\${APP_EXT1}"
+  DeleteRegKey SHCTX "Software\Classes\${APP_EXT_BAK}" # .FCBak
+  DeleteRegKey SHCTX "Software\Microsoft\Windows\CurrentVersion\Explorer\FileExts\${APP_EXT_BAK}"
+  DeleteRegKey SHCTX "Software\Classes\${APP_EXT_MACRO}" # .FCMacro
+  DeleteRegKey SHCTX "Software\Microsoft\Windows\CurrentVersion\Explorer\FileExts\${APP_EXT_MACRO}"
+  DeleteRegKey SHCTX "Software\Classes\${APP_EXT_MAT}" # .FCMat
+  DeleteRegKey SHCTX "Software\Microsoft\Windows\CurrentVersion\Explorer\FileExts\${APP_EXT_MAT}"
+  DeleteRegKey SHCTX "Software\Classes\${APP_EXT_SCRIPT}" # .FCScript
+  DeleteRegKey SHCTX "Software\Microsoft\Windows\CurrentVersion\Explorer\FileExts\${APP_EXT_SCRIPT}"
+  
   ${if} $MultiUser.Privileges == "Admin"
-   DeleteRegKey HKCR "${APP_NAME}.Document"
+   DeleteRegKey HKCR "${APP_REGNAME_DOC}"
    # see https://nsis.sourceforge.io/Docs/AppendixB.html#library_install for a description of UnInstallLib
    !insertmacro UnInstallLib REGDLL NOTSHARED NOREBOOT_NOTPROTECTED $SYSDIR\FCStdThumbnail.dll
   ${endif}


### PR DESCRIPTION
- fix missing removal of the *.FCStd extension for local users
- FC-specific file extensions might appear in the Windows registry. The aim of the uninstaller is to leave a clear registry without traces of FC.