### PR TITLE
[PATH] Fix bug with spindle not restarting

### DIFF
--- a/src/Mod/Path/PathScripts/PathJob.py
+++ b/src/Mod/Path/PathScripts/PathJob.py
@@ -296,6 +296,18 @@ class ObjectJob:
             obj.addProperty("App::PropertyString", "CycleTime", "Path", QtCore.QT_TRANSLATE_NOOP("PathOp", "Operations Cycle Time Estimation"))
             obj.setEditorMode('CycleTime', 1)  # read-only
 
+        if not hasattr(obj, "Fixtures"):
+            obj.addProperty("App::PropertyStringList", "Fixtures", "WCS", QtCore.QT_TRANSLATE_NOOP("PathJob", "The Work Coordinate Systems for the Job"))
+            obj.Fixtures = ['G54']
+
+        if not hasattr(obj, "OrderOutputBy"):
+            obj.addProperty("App::PropertyEnumeration", "OrderOutputBy", "WCS", QtCore.QT_TRANSLATE_NOOP("PathJob", "If multiple WCS, order the output this way"))
+            obj.OrderOutputBy = ['Fixture', 'Tool', 'Operation']
+
+        if not hasattr(obj, "SplitOutput"):
+            obj.addProperty("App::PropertyBool", "SplitOutput", "Output", QtCore.QT_TRANSLATE_NOOP("PathJob", "Split output into multiple gcode files"))
+            obj.SplitOutput = False
+
     def onChanged(self, obj, prop):
         if prop == "PostProcessor" and obj.PostProcessor:
             processor = PostProcessor.load(obj.PostProcessor)

--- a/src/Mod/Path/PathScripts/PathPost.py
+++ b/src/Mod/Path/PathScripts/PathPost.py
@@ -236,7 +236,7 @@ class CommandPathPost:
             elif hasattr(sel, "Path"):
                 try:
                     job = PathUtils.findParentJob(sel)
-                except Exception: # pylint: disable=broad-except
+                except Exception:
                     job = None
             else:
                 job = None
@@ -261,22 +261,9 @@ class CommandPathPost:
 
         PathLog.debug("about to postprocess job: {}".format(job.Name))
 
-        # Build up an ordered list of operations and tool changes.
-        # Then post-the ordered list
-        if hasattr(job, "Fixtures"):
-            wcslist = job.Fixtures
-        else:
-            wcslist = ['G54']
-
-        if hasattr(job, "OrderOutputBy"):
-            orderby = job.OrderOutputBy
-        else:
-            orderby = "Operation"
-
-        if hasattr(job, "SplitOutput"):
-            split = job.SplitOutput
-        else:
-            split = False
+        wcslist = job.Fixtures
+        orderby = job.OrderOutputBy
+        split = job.SplitOutput
 
         postlist = []
 
@@ -332,7 +319,7 @@ class CommandPathPost:
             for idx, obj in enumerate(job.Operations.Group):
 
                 # check if the operation is active
-                active =  PathUtil.opProperty(obj, 'Active')
+                active = PathUtil.opProperty(obj, 'Active')
 
                 tc = PathUtil.toolControllerForOp(obj)
                 if tc is None or tc.ToolNumber == currTool and active:
@@ -380,14 +367,14 @@ class CommandPathPost:
                         firstFixture = False
                         tc = PathUtil.toolControllerForOp(obj)
                         if tc is not None:
-                            if tc.ToolNumber != currTool:
+                            if job.SplitOutput or (tc.ToolNumber != currTool):
                                 sublist.append(tc)
                                 currTool = tc.ToolNumber
                         sublist.append(obj)
                     postlist.append(sublist)
 
         fail = True
-        rc = '' # pylint: disable=unused-variable
+        rc = ''
         if split:
             for slist in postlist:
                 (fail, rc, filename) = self.exportObjectsWith(slist, job)


### PR DESCRIPTION
if output is split by operation spindle should restart when next file is loaded

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [x]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
