### PR TITLE
[Stylesheet] Increase behave-dark contrast on input boxes

### DIFF
--- a/src/Gui/Stylesheets/Behave-dark.qss
+++ b/src/Gui/Stylesheets/Behave-dark.qss
@@ -1209,10 +1209,10 @@ QTimeEdit,
 QDateEdit,
 QDateTimeEdit {
     color: #bebebe;
-    background-color: #232932;
+    background-color: #1E2226;
     selection-color: white;
     selection-background-color: #65A2E5;
-    border: 1px solid #232932;
+    border: 1px solid #1E2226;
     border-radius: 3px;
     min-width: 50px; /* it ensures the default value is correctly displayed */
     min-height: 20px; /* important to be a pair number in order to up/down buttons to be divisible by two (if not set could create a blank line in Ubuntu. Its downside is that it's needed to reset it (min-width: 0px) on following elements that can't have it such as fields inside QToolBar and inside QTreeView (Property editor) */


### PR DESCRIPTION
Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [X]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [X]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [X]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [X] [hopefully]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---

Most input boxes were blending in some dialogs since not all dialogs use the same backgrounds. The preferences dialog for example has various hue overlays depending on settings grouping so on some pages the contrast was better than on others. Specifically file dialogs don't have a group overlay at all so the textboxes were blending in fully when not selected:

![Before](https://user-images.githubusercontent.com/39636046/111070532-783a0900-84d2-11eb-8632-e0bec7577913.png)

All inputs like ComboBoxes etc. now use a slightly darker color that is not used anywhere else so it can never vanish fully:

![After](https://user-images.githubusercontent.com/39636046/111070561-943daa80-84d2-11eb-87b0-4bc32bb7bfe1.png)

The change is very small as the same style input fields are used on much lighter backgrounds in grouped tabs and the contrast would be too high there if made darker. Here is how the preferences look now, once on the lighter "groups within groups" and once on the darker single groups:

![image](https://user-images.githubusercontent.com/39636046/111070702-247bef80-84d3-11eb-9317-f87883c76400.png)
![image](https://user-images.githubusercontent.com/39636046/111070710-2ba2fd80-84d3-11eb-8780-4d6c6dbef0a3.png)

