### PR TITLE
App: Fix UserAppData dir on macOS

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -2842,7 +2842,7 @@ void Application::ExtractUserPath()
     appData += PATHSEP;
     appData += "Library";
     appData += PATHSEP;
-    appData += "Preferences";
+    appData += "Application Support";
     Base::FileInfo fi(appData.c_str());
     if (!fi.exists()) {
         // This should never ever happen


### PR DESCRIPTION
`UserAppData` dir  on macOS is under `~/Library/Preferences/FreeCAD`, but should be under `~/Library/Application Support` is reserved for entries created by the macOS preferences system.

To migrate from the old behaviour: 

```
$ cd ~/Library/Preferences/
$ mv FreeCAD ../Application\ Support/

```
Fixes #0004596
Forum thread: https://forum.freecadweb.org/viewtopic.php?f=22&t=7104&start=10
