### PR TITLE
App: Refactor the setup of UserAppData path

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -42,6 +42,7 @@
 # include <ctime>
 # include <csignal>
 # include <boost/program_options.hpp>
+# include <boost/filesystem.hpp>
 #endif
 
 #ifdef FC_OS_WIN32
@@ -2835,57 +2836,38 @@ void Application::ExtractUserPath()
         mConfig["UserHomePath"] = userHome.toUtf8().data();
     }
 
-    std::string appData = pwd->pw_dir;
-    if (!userData.isEmpty()) {
+    boost::filesystem::path appData(pwd->pw_dir);
+    if (!userData.isEmpty())
         appData = userData.toUtf8().data();
-    }
-    appData += PATHSEP;
-    appData += "Library";
-    appData += PATHSEP;
-    appData += "Preferences";
-    Base::FileInfo fi(appData.c_str());
-    if (!fi.exists()) {
+
+    appData = appData / "Library" / "Preferences";
+
+    if (!boost::filesystem::exists(appData)) {
         // This should never ever happen
-        std::stringstream str;
-        str << "Application data directory " << appData << " does not exist!";
-        throw Base::FileSystemError(str.str());
+        throw Base::FileSystemError("Application data directory " + appData.string() + " does not exist!");
     }
 
-    // In order to write to our data path, we must create some directories, first.
-    // If 'AppDataSkipVendor' is defined the value of 'ExeVendor' must not be part of
+    // If 'AppDataSkipVendor' is defined, the value of 'ExeVendor' must not be part of
     // the path.
-    appData += PATHSEP;
     if (mConfig.find("AppDataSkipVendor") == mConfig.end()) {
-        appData += mConfig["ExeVendor"];
-        fi.setFile(appData.c_str());
-        if (!fi.exists() && !Py_IsInitialized()) {
-            if (!fi.createDirectory()) {
-                std::string error = "Cannot create directory ";
-                error += appData;
-                // Want more details on console
-                std::cerr << error << std::endl;
-                throw Base::FileSystemError(error);
-            }
-        }
-        appData += PATHSEP;
+        appData /= mConfig["ExeVendor"];
     }
+    appData /= mConfig["ExeName"];
 
-    appData += mConfig["ExeName"];
-    fi.setFile(appData.c_str());
-    if (!fi.exists() && !Py_IsInitialized()) {
-        if (!fi.createDirectory()) {
-            std::string error = "Cannot create directory ";
-            error += appData;
-            // Want more details on console
-            std::cerr << error << std::endl;
-            throw Base::FileSystemError(error);
-        }
-    }
 
     // Actually the name of the directory where the parameters are stored should be the name of
     // the application due to branding reasons.
-    appData += PATHSEP;
-    mConfig["UserAppData"] = appData;
+        
+    // In order to write to our data path, we must create some directories, first.
+    if (!boost::filesystem::exists(appData) && !Py_IsInitialized()) {
+        try {
+            boost::filesystem::create_directories(appData);
+        } catch (const boost::filesystem::filesystem_error& e) {
+            throw Base::FileSystemError("Could not create app data directories. Failed with: " + e.code().message());
+        }
+    }
+
+    mConfig["UserAppData"] = appData.string() + PATHSEP;
 
 #elif defined(FC_OS_WIN32)
     WCHAR szPath[MAX_PATH];

--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -2875,64 +2875,43 @@ void Application::ExtractUserPath()
         // convert to UTF8
         WideCharToMultiByte(CP_UTF8, 0, szPath, -1,dest, 256, NULL, NULL);
 
-        std::string appData = dest;
-        if (!userData.isEmpty()) {
+        boost::filesystem::path appData(dest);
+        if (!userData.isEmpty())
             appData = userData.toUtf8().data();
-        }
-        Base::FileInfo fi(appData.c_str());
-        if (!fi.exists()) {
+
+        if (!boost::filesystem::exists(appData)) {
             // This should never ever happen
-            std::stringstream str;
-            str << "Application data directory " << appData << " does not exist!";
-            throw Base::FileSystemError(str.str());
+            throw Base::FileSystemError("Application data directory " + appData.string() + " does not exist!");
         }
 
-        // In order to write to our data path we must create some directories first.
-        // If 'AppDataSkipVendor' is defined the value of 'ExeVendor' must not be part of
+        // If 'AppDataSkipVendor' is defined, the value of 'ExeVendor' must not be part of
         // the path.
         if (mConfig.find("AppDataSkipVendor") == mConfig.end()) {
-            appData += PATHSEP;
-            appData += mConfig["ExeVendor"];
-            fi.setFile(appData.c_str());
-            if (!fi.exists() && !Py_IsInitialized()) {
-                if (!fi.createDirectory()) {
-                    std::string error = "Cannot create directory ";
-                    error += appData;
-                    // Want more details on console
-                    std::cerr << error << std::endl;
-                    throw Base::FileSystemError(error);
-                }
-            }
+            appData /= mConfig["ExeVendor"];
         }
-
-        appData += PATHSEP;
-        appData += mConfig["ExeName"];
-        fi.setFile(appData.c_str());
-        if (!fi.exists() && !Py_IsInitialized()) {
-            if (!fi.createDirectory()) {
-                std::string error = "Cannot create directory ";
-                error += appData;
-                // Want more details on console
-                std::cerr << error << std::endl;
-                throw Base::FileSystemError(error);
-            }
-        }
+        appData /= mConfig["ExeName"];
 
         // Actually the name of the directory where the parameters are stored should be the name of
         // the application due to branding reasons.
-        appData += PATHSEP;
-        mConfig["UserAppData"] = appData;
+            
+        // In order to write to our data path, we must create some directories, first.
+        if (!boost::filesystem::exists(appData) && !Py_IsInitialized()) {
+            try {
+                boost::filesystem::create_directories(appData);
+            } catch (const boost::filesystem::filesystem_error& e) {
+                throw Base::FileSystemError("Could not create app data directories. Failed with: " + e.code().message());
+            }
+        }
+
+        mConfig["UserAppData"] = appData.string() + PATHSEP;
 
         // Create the default macro directory
-        fi.setFile(getUserMacroDir());
-        if (!fi.exists() && !Py_IsInitialized()) {
-            if (!fi.createDirectory()) {
-                // If the creation fails only write an error but do not raise an
-                // exception because it doesn't prevent FreeCAD from working
-                std::string error = "Cannot create directory ";
-                error += fi.fileName();
-                // Want more details on console
-                std::cerr << error << std::endl;
+        auto macroDir = getUserMacroDir();
+        if (!boost::filesystem::exists(macroDir) && !Py_IsInitialized()) {
+            try {
+                boost::filesystem::create_directories(macroDir);
+            } catch (const boost::filesystem::filesystem_error& e) {
+                throw Base::FileSystemError("Could not create macro directory. Failed with: " + e.code().message());
             }
         }
     }


### PR DESCRIPTION
Disclaimer:
This branch has, at this time, only been tested on macos.
I'm waiting on results for windows and linux, which is also why it is marked as a draft and not ready for review.

---

This refactors the `UserAppData` setup code to use `boost::filesystem` for paths and creating directories.
The motivation behind this change was to simplify the code to make it easier to add migration for the `UserAppData` path change proposed in #4620.
To make maintenance easier I also changed the code paths for windows and *nix platforms.

Even though `std::filesystem` is part of c++17, it isn't implemented in macos 10.14 (which is still supported by Apple).
However `boost::filesystem` is mostly compatible and when 10.14 support is dropped we will be able to change from `boost::filesystem` to `std::filesystem` with a simple search and replace. 

---

- [x] Your pull request is confined strictly to a single module.
- [x] Small change or has a link to a forum post
- [x] Your branch is rebased on latest master git pull --rebase upstream master
- [x] All FreeCAD unit tests are confirmed to pass by running ./bin/FreeCAD --run-test 0
- [x] All commit messages are well-written ex: Fixes typo in Draft Move command text
- [x] Your pull request is well written and has a good description, and its title starts with the module name, ex: Draft: Fixed typos
- [x] Commit message includes ticket if available