### PR TITLE
Draft: Make Edit closed wires consistent with open wires and tracker

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_edit_draft_objects.py
+++ b/src/Mod/Draft/draftguitools/gui_edit_draft_objects.py
@@ -91,12 +91,14 @@ class DraftWireGuiTools(GuiTools):
             App.Console.PrintMessage(_err + "\n")
             return
 
-        if obj.Closed:
-            # DNC: project the new point to the plane of the face if present
-            if hasattr(obj.Shape, "normalAt"):
-                normal = obj.Shape.normalAt(0,0)
-                point_on_plane = obj.Shape.Vertexes[0].Point
-                v.projectToPlane(point_on_plane, normal)
+        # TODO: Make consistent operation with trackers and open wires
+        # See: https://forum.freecadweb.org/viewtopic.php?f=23&t=56661
+        #if obj.Closed:
+        #    # DNC: project the new point to the plane of the face if present
+        #    if hasattr(obj.Shape, "normalAt"):
+        #        normal = obj.Shape.normalAt(0,0)
+        #        point_on_plane = obj.Shape.Vertexes[0].Point
+        #        v.projectToPlane(point_on_plane, normal)
 
         pts[node_idx] = v
         obj.Points = pts


### PR DESCRIPTION
Currently when editing a closed wire, it tries to use the plane defined by the Shape of this object to project the edited point (which is not necessary if the object is on the WorkingPlane). This is not correctly implemented since it does not take into account the difference in coordinates between the Points attribute of the object and the Vertex of the Shape, generating the reported result in https://forum.freecadweb.org/viewtopic.php?f=23&t=56661
In addition, if the edited object is not on the WorkingPlane, the result is inconsistent with the trackers (which projects the points onto the WorkingPlane) and with the behavior of the Edit command on open wires.
The proposal is to disable these lines of code until a consistent implementation is made between closed wires, trackers and the open wires. 


Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [x]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
