### PR TITLE
[Gui] Issue #3923 - Add arbitrary Tree View item ordering

### DIFF
--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -3684,6 +3684,116 @@ void StdTreeDrag::activated(int)
     }
 }
 
+//===========================================================================
+// Std_GroupMoveUp
+//===========================================================================
+DEF_STD_CMD_A(StdGroupMoveUp)
+
+StdGroupMoveUp::StdGroupMoveUp()
+  : Command("Std_GroupMoveUp")
+{
+    sGroup       = QT_TR_NOOP("TreeView");
+    sMenuText    = QT_TR_NOOP("Move up in group");
+    sToolTipText = QT_TR_NOOP("Move object one place higher in its group");
+    sStatusTip   = sToolTipText;
+    sWhatsThis   = "Std_GroupMoveUp";
+    sPixmap      = "button_up";
+    sAccel       = "Alt+Up";
+    eType        = 0;
+}
+
+void StdGroupMoveUp::activated(int iMsg)
+{
+    Q_UNUSED(iMsg);
+
+    TreeWidget *tree = TreeWidget::instance();
+    if (!tree) {
+        return;
+    }
+
+    std::vector<DocumentObjectItem *> selected;
+    if (!tree->getSelectedSiblingObjectItems(selected)) {
+        return;
+    }
+
+    DocumentObjectItem *previous;
+    if (!tree->allowMoveUpInGroup(selected, &previous)) {
+        return;
+    }
+
+    TreeWidget::moveSiblings(selected, previous, -1);
+}
+
+bool StdGroupMoveUp::isActive(void)
+{
+    TreeWidget *tree = TreeWidget::instance();
+    if (!tree) {
+        return false;
+    }
+
+    std::vector<DocumentObjectItem *> selected;
+    if (!tree->getSelectedSiblingObjectItems(selected)) {
+        return false;
+    }
+
+    return tree->allowMoveUpInGroup(selected);
+}
+
+//===========================================================================
+// Std_GroupMoveDown
+//===========================================================================
+DEF_STD_CMD_A(StdGroupMoveDown)
+
+StdGroupMoveDown::StdGroupMoveDown()
+  : Command("Std_GroupMoveDown")
+{
+    sGroup       = QT_TR_NOOP("TreeView");
+    sMenuText    = QT_TR_NOOP("Move down in group");
+    sToolTipText = QT_TR_NOOP("Move object one place lower in its group");
+    sStatusTip   = sToolTipText;
+    sWhatsThis   = "Std_GroupMoveDown";
+    sPixmap      = "button_down";
+    sAccel       = "Alt+Down";
+    eType        = 0;
+}
+
+void StdGroupMoveDown::activated(int iMsg)
+{
+    Q_UNUSED(iMsg);
+
+    TreeWidget *tree = TreeWidget::instance();
+    if (!tree) {
+        return;
+    }
+
+    std::vector<DocumentObjectItem *> selected;
+    if (!tree->getSelectedSiblingObjectItems(selected)) {
+        return;
+    }
+
+    DocumentObjectItem *next ;
+    if (!tree->allowMoveDownInGroup(selected, &next)) {
+        return;
+    }
+
+    TreeWidget::moveSiblings(selected, next, +1);
+}
+
+bool StdGroupMoveDown::isActive(void)
+{
+    TreeWidget *tree = TreeWidget::instance();
+    if (!tree) {
+        return false;
+    }
+
+    std::vector<DocumentObjectItem *> selected;
+    if (!tree->getSelectedSiblingObjectItems(selected)) {
+        return false;
+    }
+
+    return tree->allowMoveDownInGroup(selected);
+}
+
 //======================================================================
 // Std_TreeViewActions
 //===========================================================================
@@ -3718,6 +3828,11 @@ public:
 
         addCommand(new StdTreeDrag(),cmds.size());
         addCommand(new StdTreeSelection(),cmds.size());
+
+        addCommand();
+
+        addCommand(new StdGroupMoveUp());
+        addCommand(new StdGroupMoveDown());
     };
     virtual const char* className() const {return "StdCmdTreeViewActions";}
 };

--- a/src/Gui/ViewProviderDocumentObject.cpp
+++ b/src/Gui/ViewProviderDocumentObject.cpp
@@ -66,6 +66,8 @@ FC_LOG_LEVEL_INIT("Gui",true,true)
 using namespace Gui;
 
 
+int ViewProviderDocumentObject::lastTreeRank = 0;
+
 PROPERTY_SOURCE(Gui::ViewProviderDocumentObject, Gui::ViewProvider)
 
 ViewProviderDocumentObject::ViewProviderDocumentObject()
@@ -89,6 +91,8 @@ ViewProviderDocumentObject::ViewProviderDocumentObject()
             "Object: On top only if the whole object is selected\n"
             "Element: On top only if some sub-element of the object is selected");
     OnTopWhenSelected.setEnums(OnTopEnum);
+
+    ADD_PROPERTY_TYPE(TreeRank, (0), dogroup, App::PropertyType(App::Prop_Hidden|App::Prop_NoPersist), "Tree view item ordering key");
 
     sPixmap = "Feature";
 }
@@ -212,6 +216,14 @@ void ViewProviderDocumentObject::onChanged(const App::Property* prop)
         if(getRoot()->isOfType(SoFCSelectionRoot::getClassTypeId())) {
             static_cast<SoFCSelectionRoot*>(getRoot())->selectionStyle = SelectionStyle.getValue()
                 ? SoFCSelectionRoot::Box : SoFCSelectionRoot::Full;
+        }
+    }
+    else if (prop == &TreeRank) {
+        if (this->TreeRank.getValue() <= 0) {
+            this->TreeRank.setValue(++ViewProviderDocumentObject::lastTreeRank);
+        }
+        else if (this->TreeRank.getValue() > ViewProviderDocumentObject::lastTreeRank) {
+            ViewProviderDocumentObject::lastTreeRank = this->TreeRank.getValue();
         }
     }
 
@@ -666,4 +678,16 @@ std::string ViewProviderDocumentObject::getFullName() const {
     if(pcObject)
         return pcObject->getFullName() + ".ViewObject";
     return std::string();
+}
+
+bool ViewProviderDocumentObject::allowTreeOrderSwap(const App::DocumentObject *child1, const App::DocumentObject *child2) const
+{
+    std::vector<ViewProviderExtension *> extensions = getExtensionsDerivedFromType<ViewProviderExtension>();
+    for (ViewProviderExtension *ext : extensions) {
+        if (!ext->extensionAllowTreeOrderSwap(child1, child2)) {
+            return false;
+        }
+    }
+
+    return true;
 }

--- a/src/Gui/ViewProviderDocumentObject.h
+++ b/src/Gui/ViewProviderDocumentObject.h
@@ -64,6 +64,9 @@ public:
     App::PropertyEnumeration OnTopWhenSelected;
     App::PropertyEnumeration SelectionStyle;
 
+    // Hidden properties
+    App::PropertyInteger TreeRank;
+
     virtual void attach(App::DocumentObject *pcObject);
     virtual void reattach(App::DocumentObject *);
     virtual void update(const App::Property*) override;
@@ -155,6 +158,8 @@ public:
     void setShowable(bool enable);
     bool isShowable() const;
 
+    virtual bool allowTreeOrderSwap(const App::DocumentObject *child1, const App::DocumentObject *child2) const;
+
 protected:
     /*! Get the active mdi view of the document this view provider is part of.
       @note The returned mdi view doesn't need to be a 3d view but can be e.g.
@@ -206,6 +211,8 @@ protected:
 protected:
     App::DocumentObject *pcObject;
     Gui::Document* pcDocument;
+
+    static int lastTreeRank;
 
 private:
     bool _Showable = true;

--- a/src/Gui/ViewProviderExtension.h
+++ b/src/Gui/ViewProviderExtension.h
@@ -110,6 +110,8 @@ public:
     virtual bool extensionGetElementPicked(const SoPickedPoint *, std::string &) const {return false;}
     virtual bool extensionGetDetailPath(const char *, SoFullPath *, SoDetail *&) const {return false;}
 
+    virtual bool extensionAllowTreeOrderSwap(const App::DocumentObject *, const App::DocumentObject *) const { return true; }
+
 private:
     bool m_ignoreOverlayIcon = false;
   //Gui::ViewProviderDocumentObject* m_viewBase = nullptr;

--- a/src/Gui/ViewProviderOrigin.h
+++ b/src/Gui/ViewProviderOrigin.h
@@ -74,6 +74,8 @@ public:
         return false;
     }
 
+    virtual bool allowTreeOrderSwap(const App::DocumentObject *, const App::DocumentObject *) const { return false; }
+
     /// Returns default size. Use this if it is not possible to determine appropriate size by other means
     static double defaultSize();
 protected:

--- a/src/Gui/ViewProviderOriginGroupExtension.h
+++ b/src/Gui/ViewProviderOriginGroupExtension.h
@@ -48,6 +48,8 @@ public:
 
     void updateOriginSize();
 
+    virtual bool extensionAllowTreeOrderSwap(const App::DocumentObject *, const App::DocumentObject *) const { return false; }
+    
 protected:
     void slotChangedObjectApp ( const App::DocumentObject& obj );
     void slotChangedObjectGui ( const Gui::ViewProviderDocumentObject& obj );

--- a/src/Mod/Part/Gui/ViewProviderBoolean.h
+++ b/src/Mod/Part/Gui/ViewProviderBoolean.h
@@ -44,6 +44,9 @@ public:
     QIcon getIcon(void) const;
     void updateData(const App::Property*);
     bool onDelete(const std::vector<std::string> &);
+    
+    virtual bool allowTreeOrderSwap(const App::DocumentObject *, const App::DocumentObject *) const { return false; }
+    
 };
 
 /// ViewProvider for the MultiFuse feature

--- a/src/Mod/Part/Gui/ViewProviderMirror.h
+++ b/src/Mod/Part/Gui/ViewProviderMirror.h
@@ -126,6 +126,8 @@ public:
     /// grouping handling 
     std::vector<App::DocumentObject*> claimChildren(void)const;
     bool onDelete(const std::vector<std::string> &);
+
+    virtual bool allowTreeOrderSwap(const App::DocumentObject *, const App::DocumentObject *) const { return false; }
 };
 
 class ViewProviderSweep : public ViewProviderPart
@@ -141,6 +143,8 @@ public:
     /// grouping handling 
     std::vector<App::DocumentObject*> claimChildren(void)const;
     bool onDelete(const std::vector<std::string> &);
+
+    virtual bool allowTreeOrderSwap(const App::DocumentObject *, const App::DocumentObject *) const { return false; }
 };
 
 class ViewProviderOffset : public ViewProviderPart
@@ -187,6 +191,8 @@ public:
     std::vector<App::DocumentObject*> claimChildren(void)const;
     void setupContextMenu(QMenu*, QObject*, const char*);
     bool onDelete(const std::vector<std::string> &);
+
+    virtual bool allowTreeOrderSwap(const App::DocumentObject *, const App::DocumentObject *) const { return false; }
 
 protected:
     virtual bool setEdit(int ModNum);

--- a/src/Mod/PartDesign/Gui/ViewProviderLoft.h
+++ b/src/Mod/PartDesign/Gui/ViewProviderLoft.h
@@ -45,7 +45,9 @@ public:
 
     virtual bool onDelete(const std::vector<std::string> &);
     void highlightReferences(const bool on, bool auxiliary);
-    
+
+    virtual bool allowTreeOrderSwap(const App::DocumentObject *, const App::DocumentObject *) const { return false; }
+
 protected:
     virtual bool setEdit(int ModNum);
     virtual void unsetEdit(int ModNum);

--- a/src/Mod/PartDesign/Gui/ViewProviderPipe.h
+++ b/src/Mod/PartDesign/Gui/ViewProviderPipe.h
@@ -53,7 +53,9 @@ public:
 
     virtual bool onDelete(const std::vector<std::string> &);
     void highlightReferences(Reference mode, bool on);
-    
+
+    virtual bool allowTreeOrderSwap(const App::DocumentObject *, const App::DocumentObject *) const { return false; }
+
 protected:
     virtual QIcon getIcon(void) const;
     virtual bool setEdit(int ModNum);

--- a/src/Mod/Test/CMakeLists.txt
+++ b/src/Mod/Test/CMakeLists.txt
@@ -13,6 +13,7 @@ SET(Test_SRCS
     unittestgui.py
     testmakeWireString.py
     TestPythonSyntax.py
+    TreeView.py
 )
 SOURCE_GROUP("" FILES ${Test_SRCS})
 

--- a/src/Mod/Test/InitGui.py
+++ b/src/Mod/Test/InitGui.py
@@ -77,4 +77,5 @@ Gui.addWorkbench(TestWorkbench())
 FreeCAD.__unit_test__ += [ "Workbench",
                            "Menu",
                            "Menu.MenuDeleteCases",
-                           "Menu.MenuCreateCases" ]
+                           "Menu.MenuCreateCases",
+                           "TreeView"]

--- a/src/Mod/Test/TreeView.py
+++ b/src/Mod/Test/TreeView.py
@@ -1,0 +1,244 @@
+
+# TreeView test module
+
+import os
+import time
+import tempfile
+import unittest
+import FreeCAD
+
+from PySide import QtCore, QtGui
+import FreeCADGui
+
+
+class TreeViewTestCase(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def getTreeWidget(self):
+        mainWnd = FreeCADGui.getMainWindow()
+        treeDock = mainWnd.findChild(QtGui.QDockWidget, "Tree View")
+        if treeDock is None:
+            treeDock = mainWnd.findChild(QtGui.QDockWidget, "Combo View")
+            if not treeDock is None:
+                tabWidget = treeDock.findChild(QtGui.QTabWidget, "combiTab")
+                if not tabWidget is None:
+                    tabWidget.setCurrentIndex(0)
+        self.assertTrue(not treeDock is None, "No Tree View docks available")
+
+        treeView = treeDock.findChild(QtGui.QTreeWidget)
+        self.assertTrue(not treeView is None, "No Tree View widget found")
+
+        return treeView
+
+    def waitForTreeViewSync(self):
+        start = time.time()
+        while time.time() < start + 0.5:
+            FreeCADGui.updateGui()
+
+    def selectDocItem(self, docItem):
+
+        treeView = self.getTreeWidget()
+
+        if docItem.TypeId == "App::Document":
+            appNode = treeView.topLevelItem(0)
+            self.assertTrue(not appNode is None, "No Application top level node")
+
+            docNode = next((appNode.child(i) for i in range(appNode.childCount())
+                                             if appNode.child(i).text(0) == docItem.Label), None)
+            self.assertTrue(not docNode is None, "No test Document node")
+            treeView.setCurrentItem(docNode)
+        else:
+            FreeCADGui.Selection.clearSelection()
+            FreeCADGui.Selection.addSelection(docItem)
+            self.waitForTreeViewSync()
+
+    def trySwapOuterTreeViewItems(self, docItem, transposable):
+
+        self.selectDocItem(docItem)
+        treeView = self.getTreeWidget()
+
+        selected = treeView.selectedItems()
+        self.assertTrue(len(selected) == 1,
+                        "Unexpected count of selected items: " + str(len(selected)))
+        selected = selected[0]
+
+        originalState = [ selected.child(i).text(0) for i in range(selected.childCount()) ]
+        self.assertTrue(len(originalState) >= 1,
+                        "No children found in item " + selected.text(0))
+
+        targetState = originalState.copy()
+        if transposable:
+            targetState[0], targetState[-1] = targetState[-1], targetState[0]
+
+        treeView.setCurrentItem(selected.child(0))
+        self.waitForTreeViewSync()
+
+        # One move down attempt more to test boundary behaviour
+        for i in range(len(originalState)):
+            FreeCADGui.runCommand("Std_GroupMoveDown")
+            self.waitForTreeViewSync()
+
+        treeView.setCurrentItem(selected.child(len(originalState) - 2 if len(originalState) > 1 else 0))
+        self.waitForTreeViewSync()
+
+        # One move up attempt more to test boundary behaviour
+        for i in range(len(originalState) - 1):
+            FreeCADGui.runCommand("Std_GroupMoveUp")
+            self.waitForTreeViewSync()
+
+        finalState = [ selected.child(i).text(0) for i in range(selected.childCount()) ]
+        self.assertTrue(targetState == finalState,
+                        "Unexpected final state: %s\nExpected: %s" % (finalState, targetState))
+
+    def getChildrenOf(self, docItem):
+
+        self.selectDocItem(docItem)
+        treeView = self.getTreeWidget()
+
+        selected = treeView.selectedItems()
+        self.assertTrue(len(selected) == 1,
+                        "Unexpected count of selected items: " + str(len(selected)))
+        selected = selected[0]
+
+        return [ selected.child(i).text(0) for i in range(selected.childCount()) ]
+
+
+    def testMoveTransposableItems(self):
+        # Makes sense only if Gui is shown
+        if not FreeCAD.GuiUp:
+            return
+
+        FreeCAD.TestEnvironment = True
+
+        doc = FreeCAD.newDocument("TreeViewTest1")
+        FreeCAD.setActiveDocument(doc.Name)
+
+        box = doc.addObject("Part::Box", "Box")
+        cyl = doc.addObject("Part::Cylinder", "Cylinder")
+        sph = doc.addObject("Part::Sphere", "Sphere")
+        con = doc.addObject("Part::Cone", "Cone")
+        doc.recompute()
+
+        self.trySwapOuterTreeViewItems(doc, True)
+
+        grp = doc.addObject("App::DocumentObjectGroup", "Group")
+        grp.addObjects([ box, cyl, sph, con ])
+        doc.recompute()
+
+        self.trySwapOuterTreeViewItems(grp, True)
+
+        del FreeCAD.TestEnvironment
+
+
+    def testMoveUnmovableItems(self):
+        # Makes sense only if Gui is shown
+        if not FreeCAD.GuiUp:
+            return
+
+        FreeCAD.TestEnvironment = True
+
+        doc = FreeCAD.newDocument("TreeViewTest2")
+        FreeCAD.setActiveDocument(doc.Name)
+
+        sph = doc.addObject("Part::Sphere", "Sphere")
+        con = doc.addObject("Part::Cone", "Cone")
+        doc.recompute()
+
+        cut = doc.addObject("Part::Cut", "Cut")
+        cut.Base = sph
+        cut.Tool = con
+        doc.recompute()
+
+        self.trySwapOuterTreeViewItems(cut, False)
+
+        bdy = doc.addObject("PartDesign::Body", "Body")
+        box = doc.addObject("PartDesign::AdditiveBox", "Box")
+        bdy.addObject(box)
+        doc.recompute()
+
+        FreeCADGui.Selection.clearSelection()
+        FreeCADGui.Selection.addSelection(bdy)
+        self.waitForTreeViewSync()
+
+        treeView = self.getTreeWidget()
+        treeView.selectedItems()[0].setExpanded(True)
+        self.waitForTreeViewSync()
+
+        FreeCADGui.Selection.clearSelection()
+        FreeCADGui.Selection.addSelection(doc.Name, bdy.Name, box.Name + ".Face6")
+        self.waitForTreeViewSync()
+
+        cha = bdy.newObject("PartDesign::Chamfer", "Chamfer")
+        cha.Base = (box, ["Face6"])
+        doc.recompute()
+
+        cyl = doc.addObject("PartDesign::SubtractiveCylinder", "Cylinder")
+        bdy.addObject(cyl)
+        doc.recompute()
+
+        self.trySwapOuterTreeViewItems(bdy, False)
+
+        del FreeCAD.TestEnvironment
+
+
+    def testItemOrderSaveAndRestore(self):
+        # Makes sense only if Gui is shown
+        if not FreeCAD.GuiUp:
+            return
+
+        FreeCAD.TestEnvironment = True
+
+        doc = FreeCAD.newDocument("TreeViewTest3")
+        FreeCAD.setActiveDocument(doc.Name)
+
+        grp = doc.addObject("App::DocumentObjectGroup", "Group")
+        box = doc.addObject("Part::Box", "Box")
+        cyl = doc.addObject("Part::Cylinder", "Cylinder")
+        sph = doc.addObject("Part::Sphere", "Sphere")
+        con = doc.addObject("Part::Cone", "Cone")
+        doc.recompute()
+
+        origOrder = self.getChildrenOf(doc)
+        self.assertTrue(origOrder == ["Group", "Box", "Cylinder", "Sphere", "Cone"])
+
+        origOrderFile = tempfile.gettempdir() + os.sep + "TreeViewTest3_1.fcstd"
+        doc.saveAs(origOrderFile)
+
+        FreeCADGui.Selection.clearSelection()
+        FreeCADGui.Selection.addSelection(con)
+        FreeCADGui.Selection.addSelection(cyl)
+        self.waitForTreeViewSync()
+
+        FreeCADGui.runCommand("Std_GroupMoveUp")
+        self.waitForTreeViewSync()
+
+        FreeCADGui.Selection.clearSelection()
+        FreeCADGui.Selection.addSelection(grp)
+        FreeCADGui.Selection.addSelection(box)
+        self.waitForTreeViewSync()
+
+        FreeCADGui.runCommand("Std_GroupMoveDown")
+        self.waitForTreeViewSync()
+
+        newOrder = self.getChildrenOf(doc)
+        self.assertTrue(newOrder == ["Cylinder", "Cone", "Sphere", "Group", "Box"])
+
+        newOrderFile = tempfile.gettempdir() + os.sep + "TreeViewTest3_2.fcstd"
+        doc.saveAs(newOrderFile)
+
+        FreeCAD.closeDocument(doc.Name)
+        self.waitForTreeViewSync()
+
+        doc = FreeCAD.open(origOrderFile)
+        order = self.getChildrenOf(doc)
+        self.assertTrue(order == origOrder)
+
+        doc = FreeCAD.open(newOrderFile)
+        order = self.getChildrenOf(doc)
+        self.assertTrue(order == newOrder)
+
+        del FreeCAD.TestEnvironment


### PR DESCRIPTION
This pull request gives the user a possibility to reorder the document tree view items.

For more implementation details please see my contribution to the dedicated forum topic:

[Ticket #3923 - change order in tree view](https://forum.freecadweb.org/viewtopic.php?f=3&t=35316)
