### PR TITLE
[Stylesheet] ProDark: major bugfix for add-ons and hi-contrast outlines for all buttons 

### DIFF
--- a/src/Gui/Stylesheets/ProDark.qss
+++ b/src/Gui/Stylesheets/ProDark.qss
@@ -74,10 +74,23 @@ QToolBar * {
     padding: 0px;
 }
 
+/*==================================================================================================
+Style Links
+==================================================================================================*/
+QLabel[haslink="true"] {
+    color: #55aaff;
+}
+
+Gui--UrlLabel {
+    color: #55aaff;
+}
 
 /*==================================================================================================
 Main window
 ==================================================================================================*/
+QWidget {
+    background-color: #333333;
+}
 QMainWindow,
 QDialog,
 QDockWidget,
@@ -271,7 +284,7 @@ QToolBar::separator:vertical {
 Group box
 ==================================================================================================*/
 QGroupBox {
-    color: rgba(255,255,255,120);
+    color: #bcbcbc;
     border:1px solid rgba(255,255,255,20); /* lighter than its own border-color */;
     border-radius: 2px;
     margin-top: 10px;
@@ -300,7 +313,7 @@ Tooltip
 ==================================================================================================*/
 QToolTip {
     color: #ffffff;
-    background-color: #1e1e1e;
+    background-color: #2a2a2a;
     /*opacity: 90%; doesn't correctly work */
     padding: 4px;
     border-radius: 2px; /* has no effect */
@@ -319,10 +332,10 @@ QDockWidget {
 
 QDockWidget::title {
     text-align: center;
-    background-color: rgba(0,0,0,40);
-    border: 4px solid #333333; /* fix to simulate margin between this :title and tabs */ /* same as main background color */
-    border-radius: 6px; /* bigger than normal due to previous border fix */
-    padding: 4px 0px; /* also needed because of previous border fix */
+    background-color: #2a2a2a;
+    border-bottom: 4px solid #333333; /* fix to simulate margin between this :title and tabs */ /* same as main background color */
+    margin-left: 7px;
+    margin-right: 7px;
 }
 
 QDockWidget::close-button,
@@ -344,17 +357,18 @@ QDockWidget::float-button {
 
 QDockWidget::close-button:hover,
 QDockWidget::float-button:hover {
-    background-color: rgba(0,0,0,60);
+    background-color: #557bb6;
 }
 
 QDockWidget::close-button:pressed,
 QDockWidget::float-button:pressed {
-    background-color: rgba(0,0,0,120);
+    background-color: #42608d;
+    border: 2px solid #76acfd
 }
 
 /* fix for Python Console (probably there is a smarter way to arrive to it) */
 QDockWidget > QFrame {
-    background-color: #3C3C3C;
+    background-color: #3c3c3c;
 
     border: 6px solid #333333;
 }
@@ -366,6 +380,7 @@ Progress bar
 QProgressBar,
 QProgressBar:horizontal {
     color: white;
+    min-height: 24px;
     background-color: rgba(0,0,0,70);
     text-align: center;
     border: 1px solid rgba(0,0,0,140);
@@ -374,7 +389,7 @@ QProgressBar:horizontal {
 }
 QProgressBar::chunk,
 QProgressBar::chunk:horizontal {
-    background-color: qlineargradient(spread:pad, x1:1, y1:0.545, x2:1, y2:0, stop:0 #3874f2, stop:1 #557BB6);
+    background-color: #557BB6;
     border-radius: 2px;
 }
 
@@ -435,11 +450,13 @@ QScrollBar::add-line:horizontal {
 QScrollBar::sub-line:horizontal:hover,
 QScrollBar::sub-line:horizontal:on {
     border-image: url(qss:images_dark-light/left_arrow_lighter.svg);
+    background-color: #557BB6;
 }
 
 QScrollBar::add-line:horizontal:hover,
 QScrollBar::add-line:horizontal:on {
     border-image: url(qss:images_dark-light/right_arrow_lighter.svg);
+    background-color: #557BB6;
 }
 
 QScrollBar::up-arrow:horizontal,
@@ -485,11 +502,13 @@ QScrollBar::add-line:vertical {
 QScrollBar::sub-line:vertical:hover,
 QScrollBar::sub-line:vertical:on {
     border-image: url(qss:images_dark-light/up_arrow_lighter.svg);
+    background-color: #557BB6;
 }
 
 QScrollBar::add-line:vertical:hover,
 QScrollBar::add-line:vertical:on {
     border-image: url(qss:images_dark-light/down_arrow_lighter.svg);
+    background-color: #557BB6;
 }
 
 QScrollBar::up-arrow:vertical,
@@ -507,7 +526,7 @@ QScrollBar::sub-page:vertical {
 Tab bar
 ==================================================================================================*/
 QTabWidget::pane {
-    background-color: #333333; /* temporal (transparent background) */ /* tab content background color */ /* was transparent. fixes no color undocked Combo View */
+    background-color: transparent; /* temporal (transparent background) */ /* tab content background color */ /* was transparent. fixes no color undocked Combo View */
     position: absolute;
 }
 
@@ -543,7 +562,7 @@ QTabWidget::tab-bar:right {
 
 QTabBar {
     qproperty-drawBase: 0; /* important */
-    background-color: #333333; /* Hack for Undocked white background - was transparent*/ 
+    background-color: transparent; /* Hack for Undocked white background - was transparent*/ 
 }
 
 /* Workaround for QTabBars created from docked QDockWidgets which don't draw the border if not set and reset as follows: */
@@ -642,7 +661,8 @@ QDialog#Gui__Dialog__DlgPreferences QTabWidget::pane {
 
 /* hack to correctly align Preferences icon list on OSX */
 QDialog#Gui__Dialog__DlgPreferences > QListView {
-    min-width: 130px;
+    min-width: 108px; /* narrowed for new smaller icons - was 130px*/
+    max-width: 108px;
 }
 
 /* unique styles for sections inside Preferences */
@@ -820,8 +840,8 @@ Gui--PropertyEditor--PropertyEditor QAbstractSpinBox:disabled {
 
 /* hack to hide weird redundant information inside cells with links and no editable data (but editable via "..." button) */
 Gui--PropertyEditor--PropertyEditor > QWidget > QWidget > QLabel {
-	color: #557BB6;
-	background-color: #696969; /* same as focused background color */
+	color: #949494;
+	background-color: #2a2a2a; /* same as focused background color */
 }
 
 /* hack to disable margin inside Property values to following elements */
@@ -1057,7 +1077,7 @@ Text/Python editor (macros, etc...)
 ==================================================================================================*/
 QPlainTextEdit,
 QPlainTextEdit:focus {
-    background-color: #3C3C3C; /* Python Console */
+    background-color: #3c3c3c; /* Python Console */
     selection-color: #f5f5f5;
     selection-background-color: #557BB6;
     border: 6px solid #333333;
@@ -1181,12 +1201,12 @@ QSint--ActionGroup QFrame[class="content"] > QWidget > QPushButton {
     margin: 0px;
 }
 
-/* Fix for lists inside task panels */
+/* Fix for lists inside task panels */ /* sketcher constraints list */ 
 QSint--ActionGroup QFrame[class="content"] QTreeView,
 QSint--ActionGroup QFrame[class="content"] QListView,
 QSint--ActionGroup QFrame[class="content"] QTableView {
     color: #f5f5f5;
-    background-color: #3C3C3C;
+    background-color: #494949;
 }
 
 
@@ -1194,6 +1214,24 @@ QSint--ActionGroup QFrame[class="content"] QTableView {
 Buttons
 ==================================================================================================*/
 /* Common */
+QToolBar > Gui--WorkbenchComboBox  {
+    color: #f5f5f5;
+    background-color: #2a2a2a;  /* workbench picker and drop-down */
+    selection-color: #ffffff;
+    selection-background-color: #2a2a2a;
+    border: 1px solid #2a2a2a;
+    border-radius: 2px;
+    min-width: 50px; /* it ensures the default value is correctly displayed */
+    min-height: 16px; /* important to be a pair number in order to up/down buttons to be divisible by two (if not set could create a blank line in Ubuntu. Its downside is that it's needed to reset it (min-width: 0px) on following elements that can't have it such as fields inside QToolBar and inside QTreeView (Property editor) */
+    padding: 1px 2px; /* temporal: could don't be compatible with elements inside Tree/List view */
+}
+
+QToolBar > Gui--WorkbenchComboBox:!editable {
+    color: #f5f5f5;
+    font-weight: bold;
+    background-color: #557bb6;  /* workbench disabled color */
+}
+
 QComboBox,
 QAbstractSpinBox,
 QSpinBox,
@@ -1204,13 +1242,13 @@ QTimeEdit,
 QDateEdit,
 QDateTimeEdit {
     color: #f5f5f5;
-    background-color: #696969;
+    background-color: #494949;  /* lineedits and drop-downs */
     selection-color: #ffffff;
-    selection-background-color: #557BB6;
+    selection-background-color: #2a2a2a;
     border: 0px solid #2a2a2a;
     border-radius: 2px;
     min-width: 50px; /* it ensures the default value is correctly displayed */
-    min-height: 20px; /* important to be a pair number in order to up/down buttons to be divisible by two (if not set could create a blank line in Ubuntu. Its downside is that it's needed to reset it (min-width: 0px) on following elements that can't have it such as fields inside QToolBar and inside QTreeView (Property editor) */
+    min-height: 16px; /* important to be a pair number in order to up/down buttons to be divisible by two (if not set could create a blank line in Ubuntu. Its downside is that it's needed to reset it (min-width: 0px) on following elements that can't have it such as fields inside QToolBar and inside QTreeView (Property editor) */
     padding: 1px 2px; /* temporal: could don't be compatible with elements inside Tree/List view */
 }
 
@@ -1234,7 +1272,7 @@ QDateTimeEdit {
 QTextEdit:!editable,
 QTextEdit:!editable:focus {
     color: #f5f5f5;
-    background-color: #3C3C3C;
+    background-color: #3c3c3c;
     border: 6px  solid #333333;
     border-radius: 0px;
     margin: 0px;
@@ -1252,10 +1290,10 @@ QDateEdit:focus,
 QDateTimeEdit:focus {
     font-weight: bold;
     color: #f5f5f5;
-    border-color: #3c3c3c;
+    border-color: #333333;
     border: 1px;
     border-right-color: #557BB6; /* same as up/down or drop-down button color */
-    background-color: #696969;
+    background-color: #557bb6;
 }
 
 QComboBox:disabled,
@@ -1267,8 +1305,8 @@ QTextEdit:disabled,
 QTimeEdit:disabled,
 QDateEdit:disabled,
 QDateTimeEdit:disabled {
-    color: #f5f5f5;
-    background-color: #696969; /* same as enabled color */
+    color: #696969;
+    background-color: #494949; /* same as enabled color */
     border-color: #2a2a2a; /* same as enabled color */
 }
 
@@ -1315,7 +1353,7 @@ QDoubleSpinBox:up-button:focus,
 QTimeEdit:up-button:focus,
 QDateEdit:up-button:focus,
 QDateTimeEdit:up-button:focus {
-    background-color: #557BB6;
+    background-color: #2a2a2a;
 }
 
 QAbstractSpinBox:down-button:focus,
@@ -1324,7 +1362,7 @@ QDoubleSpinBox:down-button:focus,
 QTimeEdit:down-button:focus,
 QDateEdit:down-button:focus,
 QDateTimeEdit:down-button:focus {
-    background-color: #557BB6;
+    background-color: #2a2a2a;
 }
 
 QAbstractSpinBox:up-button:disabled,
@@ -1429,7 +1467,7 @@ QComboBox::drop-down {
 
 QComboBox::drop-down:on,
 QComboBox::drop-down:focus {
-    background-color: #557BB6;
+    background-color: #2a2a2a;
 }
 
 QComboBox::down-arrow {
@@ -1454,7 +1492,7 @@ QComboBox {
 
 QComboBox QAbstractItemView {
     color: #bebebe; /* same as regular QComboBox color */
-    background-color: #2a2a2a; /* was transparent */
+    background-color: transparent; /* was transparent */
     selection-color: #f5f5f5;
     selection-background-color: #557BB6;
     border-width: 5px 0px 5px 0px;
@@ -1467,41 +1505,109 @@ QComboBox QAbstractItemView {
 /*==================================================================================================
 Push button
 ==================================================================================================*/
+QPushButton#inspectButton {
+    background-color: #2a2a2a;
+    border-bottom: 2px solid #1e1e1e;
+    min-height: 16px;
+}
+
+QPushButton:focus#inspectButton,
+QPushButton:hover#inspectButton {
+    background-color: #557bb6;
+    border: -2px solid #557bb6;
+}
+
+QPushButton:checked#inspectButton {
+    background-color: #557bb6;
+    border-bottom: solid #557bb6;
+}
+
+QPushButton:pressed#inspectButton {
+    background-color: #557bb6;
+    border-bottom: 1px solid #3c3c3c;
+}
+
+QPushButton#NavigationIndicator {
+    background-color: #557bb6;
+    min-height: 16px;
+    border: 2px solid #557bb6;
+}
+
+QPushButton:hover#NavigationIndicator {
+    border: -2px solid #557bb6;
+}
+
+QPushButton#buttonAddLevel {
+    margin-left:10px;
+}
+
+QPushButton#buttonRename {
+    margin-right:10px;
+}
+
+QPushButton#buttonAddLevel,
+QPushButton#buttonAddProxy,
+QPushButton#buttonDelete,
+QPushButton#buttonToggle,
+QPushButton#buttonIsolate,
+QPushButton#buttonSaveView,
+QPushButton#buttonRename {
+    color: #f5f5f5;
+    max-width: 100%;
+    min-width: 16px;
+    min-height: 24px;
+    padding: 4px;
+    background-color: #333333;
+    border: 1px #557bb6; 
+}
+
+QPushButton:hover#buttonAddLevel,
+QPushButton:hover#buttonAddProxy,
+QPushButton:hover#buttonDelete,
+QPushButton:hover#buttonToggle,
+QPushButton:hover#buttonIsolate,
+QPushButton:hover#buttonSaveView,
+QPushButton:hover#buttonRename {
+    color: #cbd8e6;
+    background-color: #557BB6;
+}  
+
 QPushButton {
     color: #e0e0e0;
     text-align: center;
-    background-color: qlineargradient(spread:pad, x1:0, y1:0.3, x2:0, y2:1, stop:0 #696969, stop:1 #696961); /* Middle Mouse Navigation Button and Ok Cancel Apply Help Preferences Buttons */
-    border: 2px;
-    border-color: #2a2a2a;
-    padding: 4px 20px;
+    min-width: 70px;
+    background-color: #2a2a2a; /* Middle Mouse Navigation Button and Ok Cancel Apply Help Preferences Buttons */
+    border: 2px solid #2a2a2a;
+    border-bottom-color: #1e1e1e; /* simulates shadow under the button */
+    padding: 2px 2px;
     margin: 2px 2px;
-    margin-right: 5px;
-    min-height: 20px; /* same as QTabBar QPushButton min-width */
-    border-radius: 2px;
+    min-height: 16px; /* same as QTabBar QPushButton min-width */
+    border-radius: 1px;
 
 }
 
 QPushButton:hover,
 QPushButton:focus {
     color: #cbd8e6;
-    border-color: #2a2a2a;
+    border: -2px solid #333333;
     background-color: #557BB6;
 }
 
 QPushButton:disabled,
 QPushButton:disabled:checked {
-    color: #2a2a2a;
-    background-color: #696969; /* same as enabled color */
+    color: #f5f5f5;
+    background-color: #2a2a2a; /* same as enabled color */
     border-color: #2a2a2a; /* same as enabled color */
 }
 
 QPushButton:pressed {
     background-color: #557BB6;
+    border: 1px solid #3c3c3c;
 }
 
 QPushButton:checked {
-    background-color: #696969;
-    border-color: #557BB6;
+    background-color: #557BB6;
+    border: solid #557BB6;
 }
 
 /* Color Buttons */
@@ -1552,8 +1658,8 @@ Gui--PropertyEditor--PropertyEditor > QWidget > QWidget > QWidget > QWidget > QF
 }
 
 QPushButton:checked {
-    background-color: #696969;
-    border-color: #696969;
+    background-color: #3c3c3c;
+    border-color: #3c3c3c;
 }
 
 
@@ -1617,7 +1723,7 @@ QSint--ActionGroup QFrame[class="content"] QToolButton:focus {
 
 QSint--ActionGroup QFrame[class="content"] QToolButton:disabled,
 QSint--ActionGroup QFrame[class="content"] QToolButton:disabled:checked {
-    color: #333333;
+    color: #f5f5f5;
     border-color: #424242;
     background-color: #424242;
 }
@@ -1639,7 +1745,7 @@ QSint--ActionGroup QFrame[class="content"] QMenu::item {
 }
 
 QSint--ActionGroup QFrame[class="content"] QComboBox QAbstractItemView {
-    background-color: #696969;
+    background-color: #333333;
 }
 
 
@@ -1918,10 +2024,10 @@ QToolBar > QDateTimeEdit {
 }
 
 QToolBar > QPushButton {
-    padding: 4px;
+    padding: 2px;
     margin: 0px; /* doesn't work with :left, :right:, :top or :bottom sub-controls */
     min-width: 24px; /* could not be larger due to switchable Preferences "Size of toolbar icons" */
-    min-height: 20px; /* could not be larger due to switchable Preferences "Size of toolbar icons" */
+    min-height: 24px; /* could not be larger due to switchable Preferences "Size of toolbar icons" */
     border-radius: 2px; /* same as regular QPushButton */ 
 }
 
@@ -2058,14 +2164,14 @@ QToolBar QToolButton#qt_toolbar_ext_button:on {
 Tables (spreadsheets)
 ==================================================================================================*/
 QTableView {
-    gridline-color: #696969;
+    gridline-color: #a8a8a8;
     selection-color: #ffffff;
-    selection-background-color: #2D5C9A; /* Default Spreadsheet cell selection background color */
-    background-color: #a0a0a0; /* Default Spreadsheet cell background color */
+    selection-background-color: #557bb6; /* Default Spreadsheet cell selection background color */
+    background-color: #cecece; /* Default Spreadsheet cell background color */
 }
 
 QTableView::item:hover  {
-    background-color: rgba(0,0,0,10);  /* temporal: is it displayed in Linux or Windows? on OSX it isn't */
+    background-color: #557bb6;  /* temporal: is it displayed in Linux or Windows? on OSX it isn't */
 }
 
 QTableView::item:disabled  {
@@ -2074,7 +2180,7 @@ QTableView::item:disabled  {
 
 QTableView::item:selected  {
     color: #a0a0a0;
-    border-color: #cbd8e6; /* same as focused background color */
+    border-color: #cecece; /* same as focused background color */
     border-bottom-color: #557BB6; /* same as focused border color */
 }
 
@@ -2114,7 +2220,7 @@ QTableView > QWidget > QTextEdit,
 QTableView > QWidget > QTimeEdit,
 QTableView > QWidget > QDateEdit,
 QTableView > QWidget > QDateTimeEdit {
-    color: black;
+    color: #f5f5f5;
     background-color: transparent;
     border-color: transparent;
 }
@@ -2145,11 +2251,11 @@ QTableView > QWidget > QTextEdit:focus,
 QTableView > QWidget > QTimeEdit:focus,
 QTableView > QWidget > QDateEdit:focus,
 QTableView > QWidget > QDateTimeEdit:focus {
-    color: #2a2a2a;
-    selection-color: white;
+    color: #000000;
+    selection-color: #f5f5f5;
     selection-background-color: #557BB6;
-    border-color: #cbd8e6;
-    background-color: #cbd8e6;
+    border-color: #3c3c3c;
+    background-color: #cecece;
 }
 
 QTableView > QWidget > QComboBox:disabled,
@@ -2161,7 +2267,7 @@ QTableView > QWidget > QTextEdit:disabled,
 QTableView > QWidget > QTimeEdit:disabled,
 QTableView > QWidget > QDateEdit:disabled,
 QTableView > QWidget > QDateTimeEdit:disabled {
-    color: rgba(0,0,0,120);
+    color: #f5f5f5;
     background-color: transparent;
     border-color: transparent;
 }
@@ -2175,7 +2281,7 @@ QTableView > QWidget > QTextEdit:read-only,
 QTableView > QWidget > QTimeEdit:read-only,
 QTableView > QWidget > QDateEdit:read-only,
 QTableView > QWidget > QDateTimeEdit:read-only {
-    color: black;
+    color: #f5f5f5;
     background-color: transparent;
     border-color: transparent;
 }

--- a/src/Gui/Stylesheets/ProDark.qss
+++ b/src/Gui/Stylesheets/ProDark.qss
@@ -24,7 +24,9 @@ INSTALLATION
     WINDOWS = C:/[INSTALLATION_PATH]/FreeCAD/data/Gui/Stylesheets/
     LINUX = /home/[YOUR_USER_NAME]/.FreeCAD/Gui/Stylesheets/
 
-============================================================================================================  
+============================================================================================================ 
+THESE COLOURS WERE USED AS TEMP SCRATCHPAD FOR DESIGNING. PLEASE DISREGARD!
+ 
     BACKGROUND (darker to lighter)
         black
         #1e1e1e
@@ -143,6 +145,10 @@ QToolBox::tab:hover
 /*==================================================================================================
 QStatusBar
 ==================================================================================================*/
+QStatusBar > QLabel {
+    margin-left: 4px;
+}
+
 
 QStatusBar::item {
     border: 1px solid #333333;
@@ -220,7 +226,7 @@ QMenu QToolButton:pressed,
 QMenu QPushButton:selected,
 QMenu QToolButton:selected {
     color: white;
-    background-color: #696969; /* same as QMenu::item:selected and QMenu::item:pressed */
+    background-color: #557bb6; /* same as QMenu::item:selected and QMenu::item:pressed */
 }
 
 QMenu QRadioButton:disabled,
@@ -286,7 +292,7 @@ Group box
 QGroupBox {
     color: #bcbcbc;
     border:1px solid rgba(255,255,255,20); /* lighter than its own border-color */;
-    border-radius: 2px;
+    border-radius: 1px;
     margin-top: 10px;
     padding: 6px;
     background-color: rgba(255,255,255,0);
@@ -316,7 +322,7 @@ QToolTip {
     background-color: #2a2a2a;
     /*opacity: 90%; doesn't correctly work */
     padding: 4px;
-    border-radius: 2px; /* has no effect */
+    border-radius: 1px; /* has no effect */
 }
 
 
@@ -342,7 +348,7 @@ QDockWidget::close-button,
 QDockWidget::float-button {
     border: none;
     background: transparent;
-    border-radius: 2px;
+    border-radius: 1px;
     subcontrol-origin: padding;
     subcontrol-position: right center;
 }
@@ -385,12 +391,12 @@ QProgressBar:horizontal {
     text-align: center;
     border: 1px solid rgba(0,0,0,140);
     padding: 1px;
-    border-radius: 2px;
+    border-radius: 1px;
 }
 QProgressBar::chunk,
 QProgressBar::chunk:horizontal {
     background-color: #557BB6;
-    border-radius: 2px;
+    border-radius: 1px;
 }
 
 
@@ -398,7 +404,7 @@ QProgressBar::chunk:horizontal {
 Scroll
 ==================================================================================================*/
 QAbstractScrollArea {
-    border-radius: 2px;
+    border-radius: 1px;
     background-color: transparent;
 }
 
@@ -425,7 +431,7 @@ QScrollBar::handle:horizontal:hover {
 
 QScrollBar::handle:horizontal {
     min-width: 5px;
-    border-radius: 2px;
+    border-radius: 1px;
     margin: 4px 15px;
 }
 
@@ -477,7 +483,7 @@ QScrollBar:vertical {
 
 QScrollBar::handle:vertical {
     min-height: 24px;
-    border-radius: 2px;
+    border-radius: 1px;
     margin: 15px 4px;
 }
 
@@ -667,7 +673,7 @@ QDialog#Gui__Dialog__DlgPreferences > QListView {
 
 /* unique styles for sections inside Preferences */
 QDialog#Gui__Dialog__DlgPreferences > QListView::item {
-    border-radius: 2px;
+    border-radius: 1px;
 }
 
 QDialog#Gui__Dialog__DlgPreferences > QListView::item:hover { /* Preference left icons*/
@@ -687,7 +693,7 @@ Tab bar buttons
 QTabBar::close-button {
     subcontrol-origin: margin;
     subcontrol-position: center right; /* only works for Qt 4.6 and newer */;
-    border-radius: 2px;
+    border-radius: 1px;
     background-image: url(qss:images_dark-light/close_light.svg);
     background-position: center center;
     background-repeat: none;
@@ -790,7 +796,7 @@ QTableView {
     selection-color: #ffffff;
     selection-background-color: #557BB6; /* should be similar to QListView::item selected background-color */
     show-decoration-selected: 1; /* make the selection span the entire width of the view */
-    border-radius: 2px;
+    border-radius: 1px;
 }
 
 QListView::item:hover,
@@ -821,7 +827,7 @@ Gui--PropertyEditor--PropertyEditor > QWidget > QWidget > QLabel:disabled {
     color: transparent;
     background-color: transparent;
     border: none;
-    border-radius: 2px;
+    border-radius: 1px;
     margin: 0px;
     padding: 0px;
 }
@@ -894,7 +900,7 @@ QTreeView > QWidget > QTimeEdit:down-button,
 QTreeView > QWidget > QDateEdit:down-button,
 QTreeView > QWidget > QDateTimeEdit:down-button,
 QTreeView > QWidget > Gui--ColorButton {
-    border-radius: 2px;
+    border-radius: 1px;
 }
 
 /* set focus colors to best viewing the editable fields */
@@ -927,7 +933,7 @@ QTreeView > QWidget > QDateTimeEdit:read-only {
 /* Fix to correctly (not totally) draw QTextEdit on OSX at Page properties: "Page result", "Template" and "Editable Texts" */
 Gui--PropertyEditor--PropertyEditor > QWidget > QWidget > QWidget {
     min-height: 14px;
-    border-radius: 2px; /* reset */
+    border-radius: 1px; /* reset */
 }
 
 
@@ -937,8 +943,8 @@ Header of tree and list views
 QHeaderView {
     color: #d2d2d2;
     background-color: #2a2a2a;
-    border-top-left-radius: 2px; /* 1px less than its container */
-    border-top-right-radius: 2px; /* 1px less than its container */
+    border-top-left-radius: 1px; /* 1px less than its container */
+    border-top-right-radius: 1px; /* 1px less than its container */
     border-bottom-left-radius: 0px;
     border-bottom-right-radius: 0px;
 }
@@ -1220,7 +1226,7 @@ QToolBar > Gui--WorkbenchComboBox  {
     selection-color: #ffffff;
     selection-background-color: #2a2a2a;
     border: 1px solid #2a2a2a;
-    border-radius: 2px;
+    border-radius: 1px;
     min-width: 50px; /* it ensures the default value is correctly displayed */
     min-height: 16px; /* important to be a pair number in order to up/down buttons to be divisible by two (if not set could create a blank line in Ubuntu. Its downside is that it's needed to reset it (min-width: 0px) on following elements that can't have it such as fields inside QToolBar and inside QTreeView (Property editor) */
     padding: 1px 2px; /* temporal: could don't be compatible with elements inside Tree/List view */
@@ -1246,7 +1252,7 @@ QDateTimeEdit {
     selection-color: #ffffff;
     selection-background-color: #2a2a2a;
     border: 0px solid #2a2a2a;
-    border-radius: 2px;
+    border-radius: 1px;
     min-width: 50px; /* it ensures the default value is correctly displayed */
     min-height: 16px; /* important to be a pair number in order to up/down buttons to be divisible by two (if not set could create a blank line in Ubuntu. Its downside is that it's needed to reset it (min-width: 0px) on following elements that can't have it such as fields inside QToolBar and inside QTreeView (Property editor) */
     padding: 1px 2px; /* temporal: could don't be compatible with elements inside Tree/List view */
@@ -1461,8 +1467,8 @@ QComboBox::drop-down {
     subcontrol-origin: border; /* important */
     subcontrol-position: top right;
     width: 20px;
-    border-top-right-radius: 2px;
-    border-bottom-right-radius: 2px;
+    border-top-right-radius: 1px;
+    border-bottom-right-radius: 1px;
 }
 
 QComboBox::drop-down:on,
@@ -1505,44 +1511,88 @@ QComboBox QAbstractItemView {
 /*==================================================================================================
 Push button
 ==================================================================================================*/
+QPushButton {
+    color: #e0e0e0;
+    text-align: center;
+    background-color: #2a2a2a;
+    padding: 4px 20px;
+    border: 1px solid #1e1e1e;
+    margin: 2px;
+    border-radius: 1px;
+}
+
+QPushButton:hover,
+QPushButton:focus {
+    color: #ffffff;
+    background-color: #557bb6;
+    border: 1px solid #f5f5f5;
+}
+
+QPushButton:disabled,
+QPushButton:disabled:checked {
+    color: #f5f5f5;
+    background-color: #2a2a2a; /* same as enabled color */
+    border: 1px solid #2a2a2a; /* same as enabled color */
+}
+
+QPushButton:pressed {
+    color: #ffffff;
+    background-color: #48699a;
+    border: 1px solid #3c3c3c;
+}
+
+QPushButton:checked {
+    background-color: #557BB6;
+    border: 1px solid #557BB6;
+}
+
 QPushButton#inspectButton {
     background-color: #2a2a2a;
-    border-bottom: 2px solid #1e1e1e;
+    border-bottom: 1px solid #1e1e1e;
     min-height: 16px;
+    margin: 0px;
 }
 
 QPushButton:focus#inspectButton,
 QPushButton:hover#inspectButton {
+    color: #ffffff;
     background-color: #557bb6;
-    border: -2px solid #557bb6;
+    border: 1px solid #f5f5f5;
+    border-bottom: 1px solid #f5f5f5;
 }
 
 QPushButton:checked#inspectButton {
     background-color: #557bb6;
+    border: 1px solid #557bb6;
     border-bottom: solid #557bb6;
+
 }
 
 QPushButton:pressed#inspectButton {
     background-color: #557bb6;
-    border-bottom: 1px solid #3c3c3c;
+    border: 1px solid #557bb6;
+    border-bottom: solid #557bb6;
 }
 
 QPushButton#NavigationIndicator {
     background-color: #557bb6;
-    min-height: 16px;
-    border: 2px solid #557bb6;
+    padding: 2px;
+    margin: 0px;
+    border: 1px solid #333333;
+    border-radius: 1px;
+    min-width: 90px;
+    min-height: 24px;
 }
 
 QPushButton:hover#NavigationIndicator {
-    border: -2px solid #557bb6;
+    color: #ffffff;
+    border: 1px solid #f5f5f5;
 }
 
-QPushButton#buttonAddLevel {
-    margin-left:10px;
-}
-
-QPushButton#buttonRename {
-    margin-right:10px;
+QPushButton:pressed#NavigationIndicator {
+    color: #ffffff;
+    background-color: #557bb6;
+    border: 1px solid #557bb6;
 }
 
 QPushButton#buttonAddLevel,
@@ -1552,13 +1602,23 @@ QPushButton#buttonToggle,
 QPushButton#buttonIsolate,
 QPushButton#buttonSaveView,
 QPushButton#buttonRename {
-    color: #f5f5f5;
+    background-color: #333333;
+    padding: 4px 2px;
+    border: 1px solid #3c3c3c;
+    border-radius: 1px;
+    margin: 2px;
+    margin-bottom: 8px;
     max-width: 100%;
     min-width: 16px;
     min-height: 24px;
-    padding: 4px;
-    background-color: #333333;
-    border: 1px #557bb6; 
+}
+
+QPushButton#buttonAddLevel {
+    margin-left: 10px;
+}
+
+QPushButton#buttonRename {
+    margin-right: 10px;
 }
 
 QPushButton:hover#buttonAddLevel,
@@ -1568,46 +1628,68 @@ QPushButton:hover#buttonToggle,
 QPushButton:hover#buttonIsolate,
 QPushButton:hover#buttonSaveView,
 QPushButton:hover#buttonRename {
-    color: #cbd8e6;
+    border: 1px solid #f5f5f5;
     background-color: #557BB6;
 }  
 
-QPushButton {
+QPushButton:pressed#buttonAddLevel,
+QPushButton:pressed#buttonAddProxy,
+QPushButton:pressed#buttonDelete,
+QPushButton:pressed#buttonToggle,
+QPushButton:pressed#buttonIsolate,
+QPushButton:pressed#buttonSaveView,
+QPushButton:pressed#buttonRename {
+    border: 1px solid #557bb6;
+    background-color: #557BB6;
+}  
+
+QPushButton#manualUpdate {
+    padding: 4px;
+    margin: 0px;
+    border: 1px solid #f5f5f5;
+}
+
+QPushButton:pressed#manualUpdate {
+    color: #ffffff;
+    border: 1px solid #3c3c3c;
+    background-color: #48699a;
+}
+
+QPushButton#buttonUninstall,
+QPushButton#buttonInstall,
+QPushButton#buttonUpdateAll,
+QPushButton#buttonClose {
+    padding: 4px;
+    margin: 0px;
+    border: 1px solid #f5f5f5;
+}
+
+QPushButton:pressed#buttonUninstall,
+QPushButton:pressed#buttonInstall,
+QPushButton:pressed#buttonUpdateAll,
+QPushButton:pressed#buttonClose {
+    color: #ffffff;
+    border: 1px solid #3c3c3c;
+    background-color: #48699a;
+}
+
+QPushButton#buttonUninstall {
+    margin-left: 16px;
+}
+
+QPushButton#buttonClose {
+    margin-right: 8px;
+}
+
+QDialogButtonBox > QPushButton {
     color: #e0e0e0;
     text-align: center;
-    min-width: 70px;
-    background-color: #2a2a2a; /* Middle Mouse Navigation Button and Ok Cancel Apply Help Preferences Buttons */
-    border: 2px solid #2a2a2a;
-    border-bottom-color: #1e1e1e; /* simulates shadow under the button */
-    padding: 2px 2px;
-    margin: 2px 2px;
+    background-color: #2a2a2a; /* Ok Cancel Apply Help Preferences Buttons */
+    border: 1px solid #f5f5f5;
+    padding: 4px;
+    margin: 4px;
+    width: 60px;
     min-height: 16px; /* same as QTabBar QPushButton min-width */
-    border-radius: 1px;
-
-}
-
-QPushButton:hover,
-QPushButton:focus {
-    color: #cbd8e6;
-    border: -2px solid #333333;
-    background-color: #557BB6;
-}
-
-QPushButton:disabled,
-QPushButton:disabled:checked {
-    color: #f5f5f5;
-    background-color: #2a2a2a; /* same as enabled color */
-    border-color: #2a2a2a; /* same as enabled color */
-}
-
-QPushButton:pressed {
-    background-color: #557BB6;
-    border: 1px solid #3c3c3c;
-}
-
-QPushButton:checked {
-    background-color: #557BB6;
-    border: solid #557BB6;
 }
 
 /* Color Buttons */
@@ -1644,7 +1726,7 @@ Gui--PropertyEditor--PropertyEditor > QWidget > QWidget > QPushButton {
     background-color: #2a2a2a;
     border: 1px solid #1e1e1e;
     min-width: 16px; /* reset it due to larger value on regular QPushButton, same or bigger value as regular QPushButton min-height */
-    border-radius: 2px;
+    border-radius: 1px;
     margin: 0px; /* reset */
     padding: 0px; /* reset */
 }
@@ -1653,7 +1735,7 @@ Gui--PropertyEditor--PropertyEditor > QWidget > QWidget > QPushButton {
 Gui--PropertyEditor--PropertyEditor > QWidget > QWidget > QWidget > QWidget > QFrame {
     background-color: #333333; /* main background color */
     border: 1px solid #333333;
-    border-radius: 2px;
+    border-radius: 1px;
     padding: 2px 6px;
 }
 
@@ -1676,7 +1758,7 @@ QDialog QToolButton {
     padding: 0px; /* different than regular QPushButton */
     margin: 2px; /* different than regular QPushButton */
     min-height: 16px; /* same as QTabBar QPushButton min-width */
-    border-radius: 2px;
+    border-radius: 1px;
 }
 
 QDialog QToolButton:hover,
@@ -1711,7 +1793,7 @@ QSint--ActionGroup QFrame[class="content"] QToolButton {
     padding: 2px 6px; /* different than regular QPushButton */
     margin: 2px; /* different than regular QPushButton */
     min-height: 16px; /* same as QTabBar QPushButton min-width */
-    border-radius: 2px;
+    border-radius: 1px;
 }
 
 QSint--ActionGroup QFrame[class="content"] QToolButton:hover,
@@ -1779,7 +1861,7 @@ QRadioButton:disabled {
 QRadioButton::indicator {
     width: 12px;
     height: 12px;
-    border-radius: 2px;
+    border-radius: 1px;
 }
 
 QRadioButton::indicator:pressed {
@@ -1944,7 +2026,7 @@ QSlider:vertical {
 QSlider::groove {
     background-color: #2a2a2a;
     border: 2px solid #3c3c3c;
-    border-radius: 2px;
+    border-radius: 1px;
     margin: 4px 0px;
 }
 
@@ -1968,7 +2050,7 @@ QSlider::handle:vertical {
     border: 1px solid #2a2a2a;
     width: 16px;
     height: 16px;
-    border-radius: 2px;
+    border-radius: 1px;
 }
 
 QSlider::handle:horizontal {
@@ -2028,35 +2110,44 @@ QToolBar > QPushButton {
     margin: 0px; /* doesn't work with :left, :right:, :top or :bottom sub-controls */
     min-width: 24px; /* could not be larger due to switchable Preferences "Size of toolbar icons" */
     min-height: 24px; /* could not be larger due to switchable Preferences "Size of toolbar icons" */
-    border-radius: 2px; /* same as regular QPushButton */ 
+    border-radius: 1px; /* same as regular QPushButton */
 }
 
 QToolBar > QPushButton:checked {
-    border: 1px solid #333333;
+    border: 1px solid #3c3c3c;
     background-color: #557BB6;
+}
+
+/* Hack to avoid QPushButton text partially hidden under menu-indicator */
+QToolBar > QPushButton::menu-indicator:!checked {
+    image: none;
+    width: 0px;
 }
 
 QToolBar > QPushButton:!checked {
     background-color: #333333; /* Current Working Plane and Nudge */
-    border: 1px solid #333333;
-    text-align: left;
+    padding: 2px 4px;
+    border: 1px solid #3c3c3c;
+    margin: 0px 2px;
 }
 
 QToolBar > QPushButton:checked:hover {
-    border-color: #557BB6;
+    border: 1px solid #f5f5f5;
 }
 
 QToolBar > QPushButton:!checked:hover {
     color: #ffffff;
     background-color: #557BB6;
-    border-color: #557BB6;
+    border: 1px solid #f5f5f5;
 }
 
 QToolBar > QPushButton:checked:pressed {
+    border: 1px solid #557bb6;
     background-color: solid #557BB6;
 }
 
 QToolBar > QPushButton:!checked:pressed {
+    border: 1px solid #557bb6;
     background-color: #557BB6;
 }
 
@@ -2069,43 +2160,60 @@ QToolBar > QPushButton:!checked:disabled {
 QToolBar > QToolButton {
     margin: 2px;
     padding: 2px;
-    border-radius: 2px;
+    border-radius: 1px;
+    border: 1px solid transparent;
 }
 
 QToolBar > QToolButton:hover {
     background-color: #557BB6;
+    border: 1px solid #f5f5f5;
 }
 
 QToolBar > QToolButton:pressed {
     background-color: #557BB6;
+    border: 1px solid #557bb6;
 }
 
 /* ToolBar menu buttons (buttons with drop-down menu) */
 QToolBar > QToolButton#qt_toolbutton_menubutton {
     padding-right: 20px; /* Hack to add more width to buttons with menu */
-    border: 1px solid transparent;
-    border-radius: 2px;
-}
-
-QToolBar > QToolButton#qt_toolbutton_menubutton:hover,
-QToolBar > QToolButton#qt_toolbutton_menubutton:pressed,
-QToolBar > QToolButton#qt_toolbutton_menubutton:open {
-    border: 1px solid #557BB6;
+    border: 1px solid #333333;
+    border-radius: 1px;
 }
 
 QToolBar QToolButton::menu-button,
 QToolBar > QToolButton#qt_toolbutton_menubutton::menu-button {
     border: none;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-top-right-radius: 1px;
+    border-bottom-right-radius: 1px;
     width: 16px; /* 16px width + 4px for border = 20px allocated above */
     outline: none;
     background-color: transparent;
 }
 
-QToolBar > QToolButton#qt_toolbutton_menubutton::menu-button:hover,
+QToolBar > QToolButton#qt_toolbutton_menubutton::menu-button:hover {
+    border-top: 1px solid #f5f5f5;
+    border-bottom: 1px solid #f5f5f5;
+    border-right: 1px solid #f5f5f5;
+    background-color: #557BB6;
+}
+
+QToolBar > QToolButton#qt_toolbutton_menubutton:pressed,
+QToolBar > QToolButton#qt_toolbutton_menubutton:open {
+    background-color: #557BB6;
+    border: 1px solid #557BB6;
+}
+
+QToolBar > QToolButton#qt_toolbutton_menubutton:hover {
+    background-color: #557BB6;
+    border: 1px solid #f5f5f5;
+}
+
 QToolBar > QToolButton#qt_toolbutton_menubutton::menu-button:pressed,
 QToolBar > QToolButton#qt_toolbutton_menubutton::menu-button:open {
+    border-top: 1px solid #557bb6;
+    border-bottom: 1px solid #557bb6;
+    border-right: 1px solid #557bb6;
     background-color: #557BB6;
 }
 
@@ -2208,7 +2316,7 @@ QTableView > QWidget > QTimeEdit:down-button,
 QTableView > QWidget > QDateEdit:down-button,
 QTableView > QWidget > QDateTimeEdit:down-button,
 QTableView > QWidget > Gui--ColorButton {
-    border-radius: 2px;
+    border-radius: 1px;
 }
 
 QTableView > QWidget > QComboBox,
@@ -2334,7 +2442,7 @@ QToolBar#Selector QToolButton {
     border: none;
     margin: 0px;
     padding: 2px 6px;
-    border-radius: 2px;
+    border-radius: 1px;
 }
 
 /* Active tab */


### PR DESCRIPTION
Fixed overlapping QPushButton showstopper bug in all Add-ons that use a fixed grid (not responsive design) Themed all toolbar buttons with Hi Contrast border while hovering and focus. Styled Open/Close buutons accordingly the same Hi Contrast border statically. Very easy to use with or without eye disabilities.

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
