### PR TITLE
Fixed misc. typos [skip ci]

### DIFF
--- a/src/Mod/Fem/femexamples/elmer_nonguitutorial01_eigenvalue_of_elastic_beam.py
+++ b/src/Mod/Fem/femexamples/elmer_nonguitutorial01_eigenvalue_of_elastic_beam.py
@@ -92,7 +92,7 @@ def setup(doc=None, solvertype="elmer"):
         )[0]
         eq_obj = ObjectsFem.makeEquationElasticity(doc, solver_object)
         eq_obj.LinearSolverType = "Direct"
-        # direct solver was used in the turorial, thus used here too
+        # direct solver was used in the tutorial, thus used here too
         # the iterative is much faster and gives the same results
         eq_obj.DoFrequencyAnalysis = True
         eq_obj.CalculateStresses = True

--- a/src/Mod/Fem/femtaskpanels/task_material_common.py
+++ b/src/Mod/Fem/femtaskpanels/task_material_common.py
@@ -273,7 +273,7 @@ class _TaskPanel:
             return
         self.card_path = self.parameterWidget.cb_materials.itemData(index)  # returns whole path
         FreeCAD.Console.PrintMessage(
-            "Material card choosen:\n"
+            "Material card chosen:\n"
             "    {}\n".format(self.card_path)
         )
         self.material = self.materials[self.card_path]

--- a/src/Mod/PartDesign/App/FeatureHole.cpp
+++ b/src/Mod/PartDesign/App/FeatureHole.cpp
@@ -551,7 +551,7 @@ const char* Hole::ThreadClass_ISOmetricfine_Enums[]  = { "4G", "4H", "5G", "5H",
 
 // ISO 965-1:2013 ISO general purpose metric screw threads - Tolerances - Part 1
 // Table 1 - Fundamentral deviations for internal threads ...
-// reproduced in: https://www.accu.co.uk/en/p/134-iso-metric-thread-tolerances [retrived: 2021-01-11]
+// reproduced in: https://www.accu.co.uk/en/p/134-iso-metric-thread-tolerances [retrieved: 2021-01-11]
 const double Hole::ThreadClass_ISOmetric_data[ThreadClass_ISOmetric_data_size][2] = {
 //  Pitch    G
     {0.2,   0.017},
@@ -939,7 +939,7 @@ double Hole::getThreadClassClearance()
 {
     double pitch = getThreadPitch();
 
-    // Calulate how much clearance to add based on Thread tolerance class and pitch
+    // Calculate how much clearance to add based on Thread tolerance class and pitch
     if (ThreadClass.getValueAsString()[1] == 'G') {
         for(unsigned int i=0; i<ThreadClass_ISOmetric_data_size; i++) {
             double p = ThreadClass_ISOmetric_data[i][0];


### PR DESCRIPTION
Found via
```
codespell -q 3 -L aci,ake,aline,alle,alledges,alocation,als,ang,anid,apoints,ba,beginn,behaviour,bloaded,byteorder,calculater,cancelled,cancelling,cas,cascade,centimetre,childs,colour,colours,commen,connexion,currenty,dof,doubleclick,dum,eiter,elemente,ende,feld,finde,findf,freez,hist,iff,indicies,initialisation,initialise,initialised,initialises,initialisiert,ist,kilometre,lod,mantatory,methode,metres,millimetre,modell,nd,noe,normale,normaly,nto,numer,oder,orgin,orginx,orginy,ot,pard,pres,programm,que,recurrance,rougly,seperator,serie,sinc,strack,substraction,te,thist,thru,tread,uint,unter,vertexes,wallthickness,whitespaces -S ./.git,*.po,*.ts,./ChangeLog.txt,./src/3rdParty,./src/Mod/Assembly/App/opendcm,./src/CXX,./src/zipios++,./src/Base/swig*,./src/Mod/Robot/App/kdl_cp,./src/Mod/Import/App/SCL,./src/WindowsInstaller,./src/Doc/FreeCAD.uml,./build/doc/SourceDocu
```