### PR TITLE
Fix camera position buttons in WebGL export

### DIFF
--- a/src/Mod/Arch/importWebGL.py
+++ b/src/Mod/Arch/importWebGL.py
@@ -326,8 +326,8 @@ def getHTMLTemplate():
                     clippingz: 100,
                     cameraType: cameraType,
                     navright: function() { navChange( [1,0,0] ); },
-                    navtop:   function() { navChange( [0,1,0] ); },
-                    navfront: function() { navChange( [0,0,1] ); }
+                    navtop:   function() { navChange( [0,0,1] ); },
+                    navfront: function() { navChange( [0,-1,0] ); }
                 };
                 
                 // ---- Wires ----


### PR DESCRIPTION
Fix the "View Top" and "View Front" buttons on pages generated with the WebGL exporter to select the same views as the FreeCAD Navigation Cube.

Prior to this change, "View Top" was showing the back and "View Front" was showing the top of the model, as mentioned in the forum thread at https://forum.freecadweb.org/viewtopic.php?f=23&t=56755
