### PR TITLE
[GUI] Refactoring and cleanup of the About window

### DIFF
--- a/src/Doc/LICENSE.html
+++ b/src/Doc/LICENSE.html
@@ -575,7 +575,9 @@ DAMAGES.
 
 <h4>END OF TERMS AND CONDITIONS</h4>
 
-<h2>3D Mouse Support</h2>
-<p>Development tools and related technology provided under license from 3Dconnexion.(c) 1992 - 2012 3Dconnexion. All rights reserved.</p>
+<hr/>
+
+<!--PLACEHOLDER_FOR_ADDITIONAL_LICENSE_INFORMATION-->
+
 </body>
 </html>

--- a/src/Gui/AboutApplication.ui
+++ b/src/Gui/AboutApplication.ui
@@ -146,7 +146,7 @@
             <number>6</number>
            </property>
            <item row="6" column="1">
-            <widget class="QLabel" name="labelBuildHash">
+            <widget class="Gui::UrlLabel" name="labelBuildHash">
              <property name="text">
               <string notr="true">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=" font-family: MS Shell Dlg 2; font-weight:600;"&gt;Unknown&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
              </property>

--- a/src/Gui/Splashscreen.h
+++ b/src/Gui/Splashscreen.h
@@ -103,6 +103,7 @@ protected:
     void setupLabels();
     void showCredits();
     void showLicenseInformation();
+    QString getAdditionalLicenseInformation() const;
     void showLibraryInformation();
     void showCollectionInformation();
     void showOrHideImage(const QRect& rect);


### PR DESCRIPTION
Removes old Qt code, restores the conditional inclusion of the 3Dconnexion license information, shortens the displayed hash, and links the hash to its repo.

---

- [X]  Confined strictly to a single module
- [X]  Discussed on the FreeCAD forum
- [X]  [Rebased](https://git-scm.com/docs/git-rebase) on latest master
- [X]  Unit tests pass
- [X]  Commit messages are [well-written](https://chris.beams.io/posts/git-commit/)
- [X]  Pull request is well written
- [X]  No tracker ticket