### PR TITLE
[Path] Fix update of Extensions `Default Length` GUI spin box

### DIFF
--- a/src/Mod/Path/PathScripts/PathPocketShapeGui.py
+++ b/src/Mod/Path/PathScripts/PathPocketShapeGui.py
@@ -222,7 +222,7 @@ class TaskPanelExtensionPage(PathOpGui.TaskPanelPage):
 
         if obj.ExtensionCorners != self.form.extendCorners.isChecked():
             self.form.extendCorners.toggle()
-        self.defaultLength.updateSpinBox()
+        self.updateQuantitySpinBoxes()
         self.extensions = obj.Proxy.getExtensions(obj) # pylint: disable=attribute-defined-outside-init
         self.setExtensions(self.extensions)
 
@@ -341,11 +341,15 @@ class TaskPanelExtensionPage(PathOpGui.TaskPanelPage):
 
         self.form.extensionTree.blockSignals(False)
 
+    def updateQuantitySpinBoxes(self, index = None):
+        self.defaultLength.updateSpinBox()
+
     def updateData(self, obj, prop):
         PathLog.track(obj.Label, prop, self.blockUpdateData)
         if not self.blockUpdateData:
             if prop in ['Base', 'ExtensionLengthDefault']:
                 self.setExtensions(obj.Proxy.getExtensions(obj))
+                self.updateQuantitySpinBoxes()
 
     def restoreSelection(self, selection):
         PathLog.track()
@@ -458,6 +462,7 @@ class TaskPanelExtensionPage(PathOpGui.TaskPanelPage):
         self.form.buttonClear.clicked.connect(self.extensionsClear)
         self.form.buttonDisable.clicked.connect(self.extensionsDisable)
         self.form.buttonEnable.clicked.connect(self.extensionsEnable)
+        self.form.defaultLength.editingFinished.connect(self.updateQuantitySpinBoxes)
 
         self.model.itemChanged.connect(self.updateItemEnabled)
 


### PR DESCRIPTION
Fix the bug hindering update of the Default Length spin box in the Extensions tab after editing and change of focus. 
With the fix, the spin box updates after change of focus, as do other spin boxes in the Path workbench.
Used method found in PathDrillingGui module.

I cannot locate the forum thread(s) where this is mentioned; if I do find one, I will add it here.  I did not find an open mantis ticket.  This has needed to be fixed for a long time.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [ ]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [x]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
