### PR TITLE
[GUI] Enable panning in dependency graph view

### DIFF
--- a/src/Gui/GraphvizView.cpp
+++ b/src/Gui/GraphvizView.cpp
@@ -149,16 +149,16 @@ private:
 };
 
 // Simple wrapper around QGraphicsView to make panning possible
-class GraphVizGraphicsView final : public QGraphicsView
+class GraphvizGraphicsView final : public QGraphicsView
 {
   public:
-    GraphVizGraphicsView(QGraphicsScene* scene, QWidget* parent);
-    ~GraphVizGraphicsView() = default;
+    GraphvizGraphicsView(QGraphicsScene* scene, QWidget* parent);
+    ~GraphvizGraphicsView() = default;
 
-    GraphVizGraphicsView(const GraphVizGraphicsView&) = delete;
-    GraphVizGraphicsView(GraphVizGraphicsView&&) = delete;
-    GraphVizGraphicsView& operator=(const GraphVizGraphicsView&) = delete;
-    GraphVizGraphicsView& operator=(GraphVizGraphicsView&&) = delete;
+    GraphvizGraphicsView(const GraphvizGraphicsView&) = delete;
+    GraphvizGraphicsView(GraphvizGraphicsView&&) = delete;
+    GraphvizGraphicsView& operator=(const GraphvizGraphicsView&) = delete;
+    GraphvizGraphicsView& operator=(GraphvizGraphicsView&&) = delete;
 
   protected:
     void mousePressEvent(QMouseEvent *event) override;
@@ -166,21 +166,21 @@ class GraphVizGraphicsView final : public QGraphicsView
     void mouseReleaseEvent(QMouseEvent *event) override;
 
   private:
-    bool   isPanning_;
-    QPoint panStart_;
+    bool   isPanning;
+    QPoint panStart;
 };
 
-GraphVizGraphicsView::GraphVizGraphicsView(QGraphicsScene* scene, QWidget* parent) : QGraphicsView(scene, parent),
-                                                                     isPanning_(false)
+GraphvizGraphicsView::GraphvizGraphicsView(QGraphicsScene* scene, QWidget* parent) : QGraphicsView(scene, parent),
+                                                                     isPanning(false)
 {
 }
 
-void GraphVizGraphicsView::mousePressEvent(QMouseEvent* e)
+void GraphvizGraphicsView::mousePressEvent(QMouseEvent* e)
 {
   if(e && e->button() == Qt::LeftButton)
   {
-    isPanning_ = true;
-    panStart_ = e->pos();
+    isPanning = true;
+    panStart = e->pos();
     e->accept();
     QApplication::setOverrideCursor(Qt::ClosedHandCursor);
   }
@@ -190,14 +190,14 @@ void GraphVizGraphicsView::mousePressEvent(QMouseEvent* e)
   return;
 }
 
-void GraphVizGraphicsView::mouseMoveEvent(QMouseEvent *e)
+void GraphvizGraphicsView::mouseMoveEvent(QMouseEvent *e)
 {
   if(e == nullptr)
   {
     return;
   }
 
-  if(isPanning_)
+  if(isPanning)
   {
     auto* horizontalScrollbar = horizontalScrollBar();
     auto* verticalScrollbar = verticalScrollBar();
@@ -207,11 +207,11 @@ void GraphVizGraphicsView::mouseMoveEvent(QMouseEvent *e)
       return;
     }
 
-    auto direction = e->pos() - panStart_;
+    auto direction = e->pos() - panStart;
     horizontalScrollbar->setValue(horizontalScrollbar->value() - direction.x());
     verticalScrollbar->setValue(verticalScrollbar->value() - direction.y());
 
-    panStart_ = e->pos();
+    panStart = e->pos();
     e->accept();
   }
 
@@ -220,11 +220,11 @@ void GraphVizGraphicsView::mouseMoveEvent(QMouseEvent *e)
   return;
 }
 
-void GraphVizGraphicsView::mouseReleaseEvent(QMouseEvent* e)
+void GraphvizGraphicsView::mouseReleaseEvent(QMouseEvent* e)
 {
   if(e && e->button() & Qt::LeftButton)
   {
-    isPanning_ = false;
+    isPanning = false;
     QApplication::restoreOverrideCursor();
     e->accept();
   }
@@ -253,7 +253,7 @@ GraphvizView::GraphvizView(App::Document & _doc, QWidget* parent)
     scene->addItem(svgItem);
 
     // Create view and zoomer object
-    view = new GraphVizGraphicsView(scene, this);
+    view = new GraphvizGraphicsView(scene, this);
     zoomer = new GraphicsViewZoom(view);
     zoomer->set_modifiers(Qt::NoModifier);
     view->show();

--- a/src/Gui/GraphvizView.cpp
+++ b/src/Gui/GraphvizView.cpp
@@ -148,7 +148,7 @@ private:
     QByteArray str, flatStr;
 };
 
-// Simple wrapper around QGraphicsView to make dragging possible
+// Simple wrapper around QGraphicsView to make panning possible
 class GraphVizGraphicsView final : public QGraphicsView
 {
   public:


### PR DESCRIPTION
This PR makes it possible to drag the dependency graph using the
left mouse button.

See issue #3896.

Forum discussion:
https://forum.freecadweb.org/viewtopic.php?f=3&t=34791

Note that this PR only implements dragging by the left mouse button, and does not use the navigation mode of the 3D View set by the user. I had a look on some other "2D style" workbenches (Drawing, TechDraw, Image), and none of those seemed to use the 3D navigation modes. There seem to be no easy way to gather the navigation modifiers from those classes that inherit from `Gui::NavigationStyle`, because they seem to be implemented directly in `processEvent(...)`. I am also new to FreeCAD development, so I might be wrong. In this case, let me know and I will adjust accordingly.

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [x]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [x]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`
---
