### PR TITLE
[Part] change icon to math the other Part icon scheme

### DIFF
--- a/src/Mod/Part/Gui/Resources/icons/tools/Part_MakeFace.svg
+++ b/src/Mod/Part/Gui/Resources/icons/tools/Part_MakeFace.svg
@@ -1,109 +1,35 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   width="64px"
-   height="64px"
-   id="svg2825"
-   version="1.1">
-  <title
-     id="title848">Part_MakeFace</title>
-  <defs
-     id="defs2827">
-    <linearGradient
-       id="linearGradient889">
-      <stop
-         style="stop-color:#204a87;stop-opacity:1;"
-         offset="0"
-         id="stop885" />
-      <stop
-         style="stop-color:#729fcf;stop-opacity:1"
-         offset="1"
-         id="stop887" />
+<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="64px" height="64px" id="svg2825" version="1.1">
+  <title id="title848">Part_MakeFace</title>
+  <defs id="defs2827">
+    <linearGradient id="linearGradient889">
+      <stop style="stop-color:#204a87;stop-opacity:1" offset="0" id="stop885" />
+      <stop style="stop-color:#729fcf;stop-opacity:1" offset="1" id="stop887" />
     </linearGradient>
-    <linearGradient
-       id="linearGradient3836-0">
-      <stop
-         style="stop-color:#c4a000;stop-opacity:1;"
-         offset="0"
-         id="stop3838-2" />
-      <stop
-         style="stop-color:#fce94f;stop-opacity:1;"
-         offset="1"
-         id="stop3840-5" />
+    <linearGradient id="linearGradient3836-0">
+      <stop style="stop-color:#c4a000;stop-opacity:1" offset="0" id="stop3838-2" />
+      <stop style="stop-color:#fce94f;stop-opacity:1" offset="1" id="stop3840-5" />
     </linearGradient>
-    <linearGradient
-       id="linearGradient3836-0-6">
-      <stop
-         style="stop-color:#c4a000;stop-opacity:1;"
-         offset="0"
-         id="stop3838-2-7" />
-      <stop
-         style="stop-color:#fce94f;stop-opacity:1;"
-         offset="1"
-         id="stop3840-5-5" />
+    <linearGradient id="linearGradient3836-0-6">
+      <stop style="stop-color:#c4a000;stop-opacity:1" offset="0" id="stop3838-2-7" />
+      <stop style="stop-color:#fce94f;stop-opacity:1" offset="1" id="stop3840-5-5" />
     </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient889"
-       id="linearGradient891"
-       x1="38"
-       y1="51"
-       x2="17"
-       y2="19"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.82608697,0,0,0.82608697,10.434783,10.434782)" />
+    <linearGradient xlink:href="#linearGradient889" id="linearGradient891" x1="38" y1="51" x2="17" y2="19" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.82608697,0,0,0.82608697,10.434783,10.434782)" />
   </defs>
-  <g
-     id="layer1">
-    <g
-       id="g3527"
-       transform="matrix(0.12582859,0,0,0.13656891,-119.21901,-53.81056)">
-      <path
-         id="rect2233"
-         d="M 971.31349,415.98457 V 752.81086 H 1336.8902 V 415.98457 Z m 43.86921,44.36492 274.0236,-0.43105 v 248.95857 l -274.0236,0.0646 z"
-         style="fill:#d3d7cf;fill-opacity:1;stroke:#2e3436;stroke-width:15.2568;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <path
-         style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 55.913045,10.935149 H 9.1739164 v 43.063378"
-         id="path3040"
-         transform="matrix(7.3115342,0,0,7.3115342,920.13275,350.67648)" />
-      <path
-         style="fill:none;stroke:#ffffff;stroke-width:2.08668;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
-         d="m 13,51 39.685575,0.03219 -0.06987,-36.128755"
-         id="path3042"
-         transform="matrix(7.3115342,0,0,7.3115342,920.13275,350.67648)" />
+  <g id="layer1">
+    <g id="g3527" transform="matrix(0.12582859,0,0,0.13656891,-119.21901,-53.81056)">
+      <path id="rect2233" d="M 977.50867,421.69252 V 753.79102 L 1336.8902,752.81086 L 1337.954,421.69252 Z M 1007.5458,449.36739 L 1307.9169,449.36739 L 1307.9169,726.11615 H 1007.5458 Z" style="fill:#ef2929;fill-opacity:1;stroke:#a40000;stroke-width:15.2568;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     </g>
-    <rect
-       style="fill:url(#linearGradient891);fill-opacity:1;fill-rule:evenodd;stroke:#0b1521;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;paint-order:markers stroke fill"
-       id="rect881"
-       width="38"
-       height="36.347828"
-       x="22"
-       y="23.652174" />
-    <rect
-       style="fill:none;fill-rule:evenodd;stroke:#729fcf;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;paint-order:markers stroke fill"
-       id="rect883"
-       width="36.347828"
-       height="34.695652"
-       x="22.826086"
-       y="24.47826"
-       ry="0" />
+    <rect style="fill:url(#linearGradient891);fill-opacity:1;fill-rule:evenodd;stroke:#0b1521;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;paint-order:markers stroke fill" id="rect881" width="38" height="36.347828" x="22" y="23.652174" />
+    <rect style="fill:none;fill-rule:evenodd;stroke:#729fcf;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;paint-order:markers stroke fill" id="rect883" width="36.347828" height="34.695652" x="22.826086" y="24.47826" ry="0" />
   </g>
-  <metadata
-     id="metadata5305">
+  <metadata id="metadata5305">
     <rdf:RDF>
-      <cc:Work
-         rdf:about="">
+      <cc:Work rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
         <dc:title>Part_MakeFace</dc:title>
-        <cc:license
-           rdf:resource="" />
+        <cc:license rdf:resource="" />
         <dc:date>12-01-2021</dc:date>
         <dc:creator>
           <cc:Agent>
@@ -120,14 +46,14 @@
             <dc:title>FreeCAD</dc:title>
           </cc:Agent>
         </dc:publisher>
-        <dc:identifier></dc:identifier>
+        <dc:identifier />
         <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
         <dc:contributor>
           <cc:Agent>
-            <dc:title></dc:title>
+            <dc:title />
           </cc:Agent>
         </dc:contributor>
-        <dc:description></dc:description>
+        <dc:description />
         <dc:subject>
           <rdf:Bag />
         </dc:subject>


### PR DESCRIPTION
The other Part icons have red lines indicating wires, only the new make faces ion does not. The PR changes this to use the same for all icons.