### PR TITLE
TechDraw: convert source files from iso-8859 to utf-8

### DIFF
--- a/src/Mod/TechDraw/App/DrawViewDimension.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDimension.cpp
@@ -792,7 +792,7 @@ std::string DrawViewDimension::formatValue(qreal value, QString qFormatSpec, int
         }
 
         // qUserString is the value + unit with default decimals, so extract the unit
-        // we cannot just use unit.getString() because this would convert '°' to 'deg'
+        // we cannot just use unit.getString() because this would convert 'Â°' to 'deg'
         QRegExp rxUnits(QString::fromUtf8(" \\D*$")); // space + any non digits at end of string
         int pos = 0;
         if ((pos = rxUnits.indexIn(qUserString, 0)) != -1) {
@@ -948,7 +948,7 @@ std::string DrawViewDimension::getFormattedDimensionValue(int partial)
         if ((Type.isValue("Angle")) || (Type.isValue("Angle3Pt"))) {
             result = labelText + unitText + QString::fromUtf8(" \xC2\xB1 ") + tolerance;
         } else {
-            // add the tolerance to the dimension using the ± sign
+            // add the tolerance to the dimension using the Â± sign
             result = labelText + QString::fromUtf8(" \xC2\xB1 ") + tolerance;
         }
         if (partial == 2) {

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawAnnotationImp.cpp
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawAnnotationImp.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   Copyright (c) 2020 FreeCAD Developers                                 *
- *   Author: Uwe Stöhr <uwestoehr@lyx.org>                                 *
+ *   Author: Uwe StÃ¶hr <uwestoehr@lyx.org>                                 *
  *   Based on src/Mod/FEM/Gui/DlgSettingsFEMImp.cpp                        *
  *                                                                         *
  *   This file is part of the FreeCAD CAx development system.              *

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawAnnotationImp.h
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawAnnotationImp.h
@@ -1,6 +1,6 @@
  /**************************************************************************
  *   Copyright (c) 2020 FreeCAD Developers                                 *
- *   Author: Uwe Stöhr <uwestoehr@lyx.org>                                 *
+ *   Author: Uwe StÃ¶hr <uwestoehr@lyx.org>                                 *
  *                                                                         *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawColorsImp.cpp
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawColorsImp.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   Copyright (c) 2020 FreeCAD Developers                                 *
- *   Author: Uwe Stöhr <uwestoehr@lyx.org>                                 *
+ *   Author: Uwe StÃ¶hr <uwestoehr@lyx.org>                                 *
  *   Based on src/Mod/FEM/Gui/DlgSettingsFEMImp.cpp                        *
  *                                                                         *
  *   This file is part of the FreeCAD CAx development system.              *

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawColorsImp.h
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawColorsImp.h
@@ -1,6 +1,6 @@
  /**************************************************************************
  *   Copyright (c) 2020 FreeCAD Developers                                 *
- *   Author: Uwe Stöhr <uwestoehr@lyx.org>                                 *
+ *   Author: Uwe StÃ¶hr <uwestoehr@lyx.org>                                 *
  *                                                                         *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *

--- a/src/Mod/TechDraw/Gui/TaskDimension.cpp
+++ b/src/Mod/TechDraw/Gui/TaskDimension.cpp
@@ -1,5 +1,5 @@
 /***************************************************************************
- *   Copyright (c) 2021 Uwe Stöhr <uwestoehr@lyx.org>                      *
+ *   Copyright (c) 2021 Uwe StÃ¶hr <uwestoehr@lyx.org>                      *
  *                                                                         *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *

--- a/src/Mod/TechDraw/Gui/TaskHatch.cpp
+++ b/src/Mod/TechDraw/Gui/TaskHatch.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   Copyright (c) 2020 FreeCAD Developers                                 *
- *   Author: Uwe Stöhr <uwestoehr@lyx.org>                                 *
+ *   Author: Uwe StÃ¶hr <uwestoehr@lyx.org>                                 *
  *                                                                         *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *

--- a/src/Mod/TechDraw/Gui/TaskHatch.h
+++ b/src/Mod/TechDraw/Gui/TaskHatch.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   Copyright (c) 2020 FreeCAD Developers                                 *
- *   Author: Uwe Stöhr <uwestoehr@lyx.org>                                 *
+ *   Author: Uwe StÃ¶hr <uwestoehr@lyx.org>                                 *
  *                                                                         *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *


### PR DESCRIPTION
All other source files are either plain ascii or utf-8, this converts the last few iso-8859 files to utf-8.

---

- [x] Your pull request is confined strictly to a single module.
- [x] Small change or has a link to a forum post
- [x] Your branch is rebased on latest master git pull --rebase upstream master
- [x] All FreeCAD unit tests are confirmed to pass by running ./bin/FreeCAD --run-test 0
- [x] All commit messages are well-written ex: Fixes typo in Draft Move command text
- [x] Your pull request is well written and has a good description, and its title starts with the module name, ex: Draft: Fixed typos
- [x] Commit message includes ticket if available