### PR TITLE
[PD] some fixes for the new pad length feature

### DIFF
--- a/src/Mod/PartDesign/App/FeaturePad.h
+++ b/src/Mod/PartDesign/App/FeaturePad.h
@@ -45,7 +45,7 @@ public:
     App::PropertyLength      Length2;
     App::PropertyBool        UseCustomVector;
     App::PropertyVector      Direction;
-    App::PropertyBool        AlongCustomVector;
+    App::PropertyBool        AlongSketchNormal;
     App::PropertyLength      Offset;
 
     /** @name methods override feature */

--- a/src/Mod/PartDesign/Gui/TaskPadParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPadParameters.cpp
@@ -75,7 +75,7 @@ TaskPadParameters::TaskPadParameters(ViewProviderPad *PadView, QWidget *parent, 
     PartDesign::Pad* pcPad = static_cast<PartDesign::Pad*>(vp->getObject());
     Base::Quantity l = pcPad->Length.getQuantityValue();
     Base::Quantity l2 = pcPad->Length2.getQuantityValue();
-    bool alongCustom = pcPad->AlongCustomVector.getValue();
+    bool alongCustom = pcPad->AlongSketchNormal.getValue();
     bool useCustom = pcPad->UseCustomVector.getValue();
     double xs = pcPad->Direction.getValue().x;
     double ys = pcPad->Direction.getValue().y;
@@ -157,7 +157,7 @@ TaskPadParameters::TaskPadParameters(ViewProviderPad *PadView, QWidget *parent, 
     connect(ui->lengthEdit2, SIGNAL(valueChanged(double)),
             this, SLOT(onLength2Changed(double)));
     connect(ui->checkBoxAlongDirection, SIGNAL(toggled(bool)),
-        this, SLOT(onAlongDirectionChanged(bool)));
+        this, SLOT(onAlongSketchNormalChanged(bool)));
     connect(ui->groupBoxDirection, SIGNAL(toggled(bool)),
         this, SLOT(onDirectionToggled(bool)));
     connect(ui->XDirectionEdit, SIGNAL(valueChanged(double)),
@@ -310,10 +310,10 @@ void TaskPadParameters::onLength2Changed(double len)
     recomputeFeature();
 }
 
-void TaskPadParameters::onAlongDirectionChanged(bool on)
+void TaskPadParameters::onAlongSketchNormalChanged(bool on)
 {
     PartDesign::Pad* pcPad = static_cast<PartDesign::Pad*>(vp->getObject());
-    pcPad->AlongCustomVector.setValue(on);
+    pcPad->AlongSketchNormal.setValue(on);
     recomputeFeature();
 }
 
@@ -466,7 +466,7 @@ double TaskPadParameters::getLength2(void) const
     return ui->lengthEdit2->value().getValue();
 }
 
-bool   TaskPadParameters::getAlongCustom(void) const
+bool   TaskPadParameters::getAlongSketchNormal(void) const
 {
     return ui->checkBoxAlongDirection->isChecked();
 }
@@ -602,7 +602,7 @@ void TaskPadParameters::apply()
     FCMD_OBJ_CMD(obj, "UseCustomVector = " << (getCustom() ? 1 : 0));
     FCMD_OBJ_CMD(obj, "Direction = ("
         << getXDirection() << ", " << getYDirection() << ", " << getZDirection() << ")");
-    FCMD_OBJ_CMD(obj, "AlongCustomVector = " << (getAlongCustom() ? 1 : 0));
+    FCMD_OBJ_CMD(obj, "AlongSketchNormal = " << (getAlongSketchNormal() ? 1 : 0));
     FCMD_OBJ_CMD(obj,"Type = " << getMode());
     QString facename = getFaceName();
     FCMD_OBJ_CMD(obj,"UpToFace = " << facename.toLatin1().data());

--- a/src/Mod/PartDesign/Gui/TaskPadParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskPadParameters.h
@@ -58,7 +58,7 @@ public:
 private Q_SLOTS:
     void onLengthChanged(double);
     void onLength2Changed(double);
-    void onAlongDirectionChanged(bool);
+    void onAlongSketchNormalChanged(bool);
     void onDirectionToggled(bool);
     void onXDirectionEditChanged(double);
     void onYDirectionEditChanged(double);
@@ -76,7 +76,7 @@ protected:
 private:
     double getLength(void) const;
     double getLength2(void) const;
-    bool   getAlongCustom(void) const;
+    bool   getAlongSketchNormal(void) const;
     bool   getCustom(void) const;
     double getXDirection(void) const;
     double getYDirection(void) const;


### PR DESCRIPTION
- disable 2 properties when no custom direction is used
- rename a property because its name is the opposite of what it is doing