### PR TITLE
[FEM] add mesh algorithms

### DIFF
--- a/src/Mod/Fem/femmesh/gmshtools.py
+++ b/src/Mod/Fem/femmesh/gmshtools.py
@@ -101,6 +101,8 @@ class GmshTools():
             self.algorithm2D = "7"
         elif algo2D == "DelQuad":
             self.algorithm2D = "8"
+        elif algo2D == "Packing Parallelograms":
+            self.algorithm2D = "9"
         else:
             self.algorithm2D = "2"
 
@@ -114,14 +116,12 @@ class GmshTools():
             self.algorithm3D = "2"
         elif algo3D == "Frontal":
             self.algorithm3D = "4"
-        elif algo3D == "Frontal Delaunay":
-            self.algorithm3D = "5"
-        elif algo3D == "Frontal Hex":
-            self.algorithm3D = "6"
         elif algo3D == "MMG3D":
             self.algorithm3D = "7"
         elif algo3D == "R-tree":
             self.algorithm3D = "9"
+        elif algo3D == "HXT":
+            self.algorithm3D = "10"
         else:
             self.algorithm3D = "1"
 
@@ -803,7 +803,7 @@ class GmshTools():
         )
         geo.write(
             "// 2D mesh algorithm (1=MeshAdapt, 2=Automatic, "
-            "5=Delaunay, 6=Frontal, 7=BAMG, 8=DelQuad)\n"
+            "5=Delaunay, 6=Frontal, 7=BAMG, 8=DelQuad, 9=Packing Parallelograms)\n"
         )
         if len(self.bl_setting_list) and self.dimension == 3:
             geo.write("Mesh.Algorithm = " + "DelQuad" + ";\n")  # Frontal/DelQuad are tested
@@ -811,7 +811,7 @@ class GmshTools():
             geo.write("Mesh.Algorithm = " + self.algorithm2D + ";\n")
         geo.write(
             "// 3D mesh algorithm (1=Delaunay, 2=New Delaunay, 4=Frontal, "
-            "5=Frontal Delaunay, 6=Frontal Hex, 7=MMG3D, 9=R-tree)\n"
+            "7=MMG3D, 9=R-tree, 10=HTX)\n"
         )
         geo.write("Mesh.Algorithm3D = " + self.algorithm3D + ";\n")
         geo.write("\n")

--- a/src/Mod/Fem/femobjects/mesh_gmsh.py
+++ b/src/Mod/Fem/femobjects/mesh_gmsh.py
@@ -48,17 +48,17 @@ class MeshGmsh(base_fempythonobject.BaseFemPythonObject):
         "Delaunay",
         "Frontal",
         "BAMG",
-        "DelQuad"
+        "DelQuad",
+        "Packing Parallelograms"
     ]
     known_mesh_algorithm_3D = [
         "Automatic",
         "Delaunay",
         "New Delaunay",
         "Frontal",
-        "Frontal Delaunay",
-        "Frontal Hex",
         "MMG3D",
-        "R-tree"
+        "R-tree",
+        "HXT"
     ]
 
     def __init__(self, obj):
@@ -67,6 +67,9 @@ class MeshGmsh(base_fempythonobject.BaseFemPythonObject):
 
     def onDocumentRestored(self, obj):
         self.add_properties(obj)
+        # refresh the list of known 3D algorithms for existing meshes
+        # since some algos are meanwhile deprecated and new algos are available
+        obj.Algorithm3D = MeshGmsh.known_mesh_algorithm_3D
 
     def add_properties(self, obj):
         if not hasattr(obj, "MeshBoundaryLayerList"):

--- a/src/Mod/Fem/femtest/data/elmer/group_mesh.geo
+++ b/src/Mod/Fem/femtest/data/elmer/group_mesh.geo
@@ -26,9 +26,9 @@ Mesh.ElementOrder = 2;
 Mesh.SecondOrderLinear = 0; // Second order nodes are created by linear interpolation instead by curvilinear
 
 // mesh algorithm, only a few algorithms are usable with 3D boundary layer generation
-// 2D mesh algorithm (1=MeshAdapt, 2=Automatic, 5=Delaunay, 6=Frontal, 7=BAMG, 8=DelQuad)
+// 2D mesh algorithm (1=MeshAdapt, 2=Automatic, 5=Delaunay, 6=Frontal, 7=BAMG, 8=DelQuad, 9=Packing Parallelograms)
 Mesh.Algorithm = 2;
-// 3D mesh algorithm (1=Delaunay, 2=New Delaunay, 4=Frontal, 5=Frontal Delaunay, 6=Frontal Hex, 7=MMG3D, 9=R-tree)
+// 3D mesh algorithm (1=Delaunay, 2=New Delaunay, 4=Frontal, 7=MMG3D, 9=R-tree, 10=HTX)
 Mesh.Algorithm3D = 1;
 
 // meshing


### PR DESCRIPTION
- Gmsh has since a while 2 new mesh algorithms
- on the other hand the two algorithms "Frontal Delaunay" and "Frontal Hex" are deprecated and not listed anymore in the docs: https://gmsh.info/doc/texinfo/gmsh.html#index-Mesh_002eAlgorithm3D
and indeed all attempts with these 2 algorithms fail

Forum thread: https://forum.freecadweb.org/viewtopic.php?f=18&t=56971