### PR TITLE
[Draft] Enable Transform context menu item

### DIFF
--- a/src/Mod/Draft/draftviewproviders/view_base.py
+++ b/src/Mod/Draft/draftviewproviders/view_base.py
@@ -383,13 +383,19 @@ class ViewProviderDraft(object):
 
         Returns
         -------
-        bool
+        bool or None
             It is `True` if `mode` is 0, and `Draft_Edit` ran successfully.
+            None if mode is not zero.
             It is `False` otherwise.
         """
         if mode == 0 and App.GuiUp: #remove guard after splitting every viewprovider
             Gui.runCommand("Draft_Edit")
             return True
+        elif mode != 0:
+            # Act like this function doesn't even exist, so the command falls back to Part (e.g. in the
+            # case of an unrecognized context menu action)
+            return None 
+
         return False
 
     def unsetEdit(self, vobj, mode=0):


### PR DESCRIPTION
The "Transform" and "Set Colors..." context menu items did not work on most Draft objects because the base Draft View Provider has a `setEdit()` function, which overrides any edit action provided at a higher level (e.g. by Part). This commit checks the mode of the edit, and if it is not zero, behaves as though the `setEdit()` function does not exist, allowing Part to provide the required context menu behavior. This can be overridden by subclasses if needed.

---

- [X]  One module
- [X]  Discussed on forum: [Draft Array Transformation](https://forum.freecadweb.org/viewtopic.php?f=23&t=56895)
- [X]  Rebased on upstream
- [X]  Draft GUI unit tests pass
- [X]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/)
- [X]  Pull request is well written and has a good description
- [X]  No tracker ticket