### PR TITLE
[UI] Replace SVG icons for Sketcher commands

### DIFF
--- a/src/Mod/Sketcher/Gui/Resources/icons/splines/Sketcher_BSplineDecreaseDegree.svg
+++ b/src/Mod/Sketcher/Gui/Resources/icons/splines/Sketcher_BSplineDecreaseDegree.svg
@@ -1,141 +1,457 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width="64px" height="64px" id="svg2918" sodipodi:version="0.32" inkscape:version="0.48.5 r10040" sodipodi:docname="Sketcher_BSplineDecreaseDegree.svg" inkscape:output_extension="org.inkscape.output.svg.inkscape" version="1.1" inkscape:export-filename="/home/user/Downloads/cad/mystuff/icons/sketcher/Sketcher_CreateCircle_from_3points_2_16px.png" inkscape:export-xdpi="22.5" inkscape:export-ydpi="22.5">
-  <defs id="defs2920">
-    <linearGradient inkscape:collect="always" id="linearGradient3144">
-      <stop style="stop-color:#ffffff;stop-opacity:1;" offset="0" id="stop3146"/>
-      <stop style="stop-color:#ffffff;stop-opacity:0;" offset="1" id="stop3148"/>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   width="64px"
+   height="64px"
+   id="svg2918"
+   version="1.1">
+  <title
+     id="title931">Sketcher_BSplineDecreaseDegree</title>
+  <defs
+     id="defs2920">
+    <linearGradient
+       id="linearGradient3144">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop3146" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop3148" />
     </linearGradient>
-    <inkscape:perspective sodipodi:type="inkscape:persp3d" inkscape:vp_x="0 : 32 : 1" inkscape:vp_y="0 : 1000 : 0" inkscape:vp_z="64 : 32 : 1" inkscape:persp3d-origin="32 : 21.333333 : 1" id="perspective2926"/>
-    <linearGradient inkscape:collect="always" id="linearGradient3144-3">
-      <stop style="stop-color:#ffffff;stop-opacity:1;" offset="0" id="stop3146-1"/>
-      <stop style="stop-color:#ffffff;stop-opacity:0;" offset="1" id="stop3148-5"/>
+    <linearGradient
+       id="linearGradient3144-3">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop3146-1" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop3148-5" />
     </linearGradient>
-    <radialGradient inkscape:collect="always" xlink:href="#linearGradient3144" id="radialGradient3958" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)" cx="225.26402" cy="672.79736" fx="225.26402" fy="672.79736" r="34.345188"/>
-    <radialGradient inkscape:collect="always" xlink:href="#linearGradient3144-3" id="radialGradient3960" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)" cx="225.26402" cy="672.79736" fx="225.26402" fy="672.79736" r="34.345188"/>
-    <radialGradient inkscape:collect="always" xlink:href="#linearGradient3144" id="radialGradient3042" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)" cx="225.26402" cy="672.79736" fx="225.26402" fy="672.79736" r="34.345188"/>
-    <radialGradient inkscape:collect="always" xlink:href="#linearGradient3144" id="radialGradient3068" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)" cx="225.26402" cy="672.79736" fx="225.26402" fy="672.79736" r="34.345188"/>
-    <radialGradient inkscape:collect="always" xlink:href="#linearGradient3144" id="radialGradient3880" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)" cx="225.26402" cy="672.79736" fx="225.26402" fy="672.79736" r="34.345188"/>
-    <radialGradient inkscape:collect="always" xlink:href="#linearGradient3144" id="radialGradient4654" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)" cx="225.26402" cy="672.79736" fx="225.26402" fy="672.79736" r="34.345188"/>
-    <radialGradient inkscape:collect="always" xlink:href="#linearGradient3144" id="radialGradient4693" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)" cx="225.26402" cy="672.79736" fx="225.26402" fy="672.79736" r="34.345188"/>
-    <linearGradient y2="5" x2="-22" y1="18" x1="-18" gradientUnits="userSpaceOnUse" id="linearGradient3131-2" xlink:href="#linearGradient3836-9-3-9" inkscape:collect="always"/>
-    <linearGradient id="linearGradient3836-9-3-9">
-      <stop style="stop-color:#a40000;stop-opacity:1" offset="0" id="stop3838-8-5-1"/>
-      <stop style="stop-color:#ef2929;stop-opacity:1" offset="1" id="stop3840-1-6-2"/>
+    <radialGradient
+       xlink:href="#linearGradient3144"
+       id="radialGradient3958"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
+       cx="225.26402"
+       cy="672.79736"
+       fx="225.26402"
+       fy="672.79736"
+       r="34.345188" />
+    <radialGradient
+       xlink:href="#linearGradient3144-3"
+       id="radialGradient3960"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
+       cx="225.26402"
+       cy="672.79736"
+       fx="225.26402"
+       fy="672.79736"
+       r="34.345188" />
+    <radialGradient
+       xlink:href="#linearGradient3144"
+       id="radialGradient3042"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
+       cx="225.26402"
+       cy="672.79736"
+       fx="225.26402"
+       fy="672.79736"
+       r="34.345188" />
+    <radialGradient
+       xlink:href="#linearGradient3144"
+       id="radialGradient3068"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
+       cx="225.26402"
+       cy="672.79736"
+       fx="225.26402"
+       fy="672.79736"
+       r="34.345188" />
+    <radialGradient
+       xlink:href="#linearGradient3144"
+       id="radialGradient3880"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
+       cx="225.26402"
+       cy="672.79736"
+       fx="225.26402"
+       fy="672.79736"
+       r="34.345188" />
+    <radialGradient
+       xlink:href="#linearGradient3144"
+       id="radialGradient4654"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
+       cx="225.26402"
+       cy="672.79736"
+       fx="225.26402"
+       fy="672.79736"
+       r="34.345188" />
+    <radialGradient
+       xlink:href="#linearGradient3144"
+       id="radialGradient4693"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
+       cx="225.26402"
+       cy="672.79736"
+       fx="225.26402"
+       fy="672.79736"
+       r="34.345188" />
+    <linearGradient
+       y2="5"
+       x2="-22"
+       y1="18"
+       x1="-18"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3131-2"
+       xlink:href="#linearGradient3836-9-3-9" />
+    <linearGradient
+       id="linearGradient3836-9-3-9">
+      <stop
+         style="stop-color:#a40000;stop-opacity:1"
+         offset="0"
+         id="stop3838-8-5-1" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1"
+         offset="1"
+         id="stop3840-1-6-2" />
     </linearGradient>
-    <linearGradient y2="5" x2="-22" y1="18" x1="-18" gradientUnits="userSpaceOnUse" id="linearGradient3171-7" xlink:href="#linearGradient3836-9-3-6-0" inkscape:collect="always"/>
-    <linearGradient id="linearGradient3836-9-3-6-0">
-      <stop style="stop-color:#a40000;stop-opacity:1" offset="0" id="stop3838-8-5-7-9"/>
-      <stop style="stop-color:#ef2929;stop-opacity:1" offset="1" id="stop3840-1-6-5-3"/>
+    <linearGradient
+       y2="5"
+       x2="-22"
+       y1="18"
+       x1="-18"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3171-7"
+       xlink:href="#linearGradient3836-9-3-6-0" />
+    <linearGradient
+       id="linearGradient3836-9-3-6-0">
+      <stop
+         style="stop-color:#a40000;stop-opacity:1"
+         offset="0"
+         id="stop3838-8-5-7-9" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1"
+         offset="1"
+         id="stop3840-1-6-5-3" />
     </linearGradient>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3836-9-3" id="linearGradient3262" gradientUnits="userSpaceOnUse" x1="-18" y1="18" x2="-22" y2="5"/>
-    <linearGradient id="linearGradient3836-9-3">
-      <stop style="stop-color:#a40000;stop-opacity:1" offset="0" id="stop3838-8-5"/>
-      <stop style="stop-color:#ef2929;stop-opacity:1" offset="1" id="stop3840-1-6"/>
+    <linearGradient
+       xlink:href="#linearGradient3836-9-3"
+       id="linearGradient3262"
+       gradientUnits="userSpaceOnUse"
+       x1="-18"
+       y1="18"
+       x2="-22"
+       y2="5" />
+    <linearGradient
+       id="linearGradient3836-9-3">
+      <stop
+         style="stop-color:#a40000;stop-opacity:1"
+         offset="0"
+         id="stop3838-8-5" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1"
+         offset="1"
+         id="stop3840-1-6" />
     </linearGradient>
-    <linearGradient id="linearGradient3836-9-3-6">
-      <stop style="stop-color:#a40000;stop-opacity:1" offset="0" id="stop3838-8-5-7"/>
-      <stop style="stop-color:#ef2929;stop-opacity:1" offset="1" id="stop3840-1-6-5"/>
+    <linearGradient
+       id="linearGradient3836-9-3-6">
+      <stop
+         style="stop-color:#a40000;stop-opacity:1"
+         offset="0"
+         id="stop3838-8-5-7" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1"
+         offset="1"
+         id="stop3840-1-6-5" />
     </linearGradient>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3836-9-3-6-7" id="linearGradient3264-1" gradientUnits="userSpaceOnUse" x1="-18" y1="18" x2="-22" y2="5" gradientTransform="matrix(0.93724177,0,0,0.93725692,-1.2227671,0.70650014)"/>
-    <linearGradient id="linearGradient3836-9-3-6-7">
-      <stop style="stop-color:#a40000;stop-opacity:1" offset="0" id="stop3838-8-5-7-4"/>
-      <stop style="stop-color:#ef2929;stop-opacity:1" offset="1" id="stop3840-1-6-5-0"/>
+    <linearGradient
+       xlink:href="#linearGradient3836-9-3-6-7"
+       id="linearGradient3264-1"
+       gradientUnits="userSpaceOnUse"
+       x1="-18"
+       y1="18"
+       x2="-22"
+       y2="5"
+       gradientTransform="matrix(0.93724177,0,0,0.93725692,-1.2227671,0.70650014)" />
+    <linearGradient
+       id="linearGradient3836-9-3-6-7">
+      <stop
+         style="stop-color:#a40000;stop-opacity:1"
+         offset="0"
+         id="stop3838-8-5-7-4" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1"
+         offset="1"
+         id="stop3840-1-6-5-0" />
     </linearGradient>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3836-9-3-6-4" id="linearGradient3264-9" gradientUnits="userSpaceOnUse" x1="-18" y1="18" x2="-22" y2="5" gradientTransform="matrix(0.93724177,0,0,0.93725692,-1.2227671,0.70650014)"/>
-    <linearGradient id="linearGradient3836-9-3-6-4">
-      <stop style="stop-color:#a40000;stop-opacity:1" offset="0" id="stop3838-8-5-7-8"/>
-      <stop style="stop-color:#ef2929;stop-opacity:1" offset="1" id="stop3840-1-6-5-8"/>
+    <linearGradient
+       xlink:href="#linearGradient3836-9-3-6-4"
+       id="linearGradient3264-9"
+       gradientUnits="userSpaceOnUse"
+       x1="-18"
+       y1="18"
+       x2="-22"
+       y2="5"
+       gradientTransform="matrix(0.93724177,0,0,0.93725692,-1.2227671,0.70650014)" />
+    <linearGradient
+       id="linearGradient3836-9-3-6-4">
+      <stop
+         style="stop-color:#a40000;stop-opacity:1"
+         offset="0"
+         id="stop3838-8-5-7-8" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1"
+         offset="1"
+         id="stop3840-1-6-5-8" />
     </linearGradient>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3836-9-3-6-1" id="linearGradient3264-17" gradientUnits="userSpaceOnUse" x1="-18" y1="18" x2="-22" y2="5" gradientTransform="matrix(0.93724177,0,0,0.93725692,-1.2227671,0.70650014)"/>
-    <linearGradient id="linearGradient3836-9-3-6-1">
-      <stop style="stop-color:#a40000;stop-opacity:1" offset="0" id="stop3838-8-5-7-1"/>
-      <stop style="stop-color:#ef2929;stop-opacity:1" offset="1" id="stop3840-1-6-5-5"/>
+    <linearGradient
+       xlink:href="#linearGradient3836-9-3-6-1"
+       id="linearGradient3264-17"
+       gradientUnits="userSpaceOnUse"
+       x1="-18"
+       y1="18"
+       x2="-22"
+       y2="5"
+       gradientTransform="matrix(0.93724177,0,0,0.93725692,-1.2227671,0.70650014)" />
+    <linearGradient
+       id="linearGradient3836-9-3-6-1">
+      <stop
+         style="stop-color:#a40000;stop-opacity:1"
+         offset="0"
+         id="stop3838-8-5-7-1" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1"
+         offset="1"
+         id="stop3840-1-6-5-5" />
     </linearGradient>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3836-9-3-6-2" id="linearGradient3264-3" gradientUnits="userSpaceOnUse" x1="-18" y1="18" x2="-22" y2="5" gradientTransform="matrix(0.93724177,0,0,0.93725692,-1.2227671,0.70650014)"/>
-    <linearGradient id="linearGradient3836-9-3-6-2">
-      <stop style="stop-color:#a40000;stop-opacity:1" offset="0" id="stop3838-8-5-7-2"/>
-      <stop style="stop-color:#ef2929;stop-opacity:1" offset="1" id="stop3840-1-6-5-1"/>
+    <linearGradient
+       xlink:href="#linearGradient3836-9-3-6-2"
+       id="linearGradient3264-3"
+       gradientUnits="userSpaceOnUse"
+       x1="-18"
+       y1="18"
+       x2="-22"
+       y2="5"
+       gradientTransform="matrix(0.93724177,0,0,0.93725692,-1.2227671,0.70650014)" />
+    <linearGradient
+       id="linearGradient3836-9-3-6-2">
+      <stop
+         style="stop-color:#a40000;stop-opacity:1"
+         offset="0"
+         id="stop3838-8-5-7-2" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1"
+         offset="1"
+         id="stop3840-1-6-5-1" />
     </linearGradient>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3836-9-3-3" id="linearGradient3262-5" gradientUnits="userSpaceOnUse" x1="-18" y1="18" x2="-22" y2="5"/>
-    <linearGradient id="linearGradient3836-9-3-3">
-      <stop style="stop-color:#a40000;stop-opacity:1" offset="0" id="stop3838-8-5-5"/>
-      <stop style="stop-color:#ef2929;stop-opacity:1" offset="1" id="stop3840-1-6-6"/>
+    <linearGradient
+       xlink:href="#linearGradient3836-9-3-3"
+       id="linearGradient3262-5"
+       gradientUnits="userSpaceOnUse"
+       x1="-18"
+       y1="18"
+       x2="-22"
+       y2="5" />
+    <linearGradient
+       id="linearGradient3836-9-3-3">
+      <stop
+         style="stop-color:#a40000;stop-opacity:1"
+         offset="0"
+         id="stop3838-8-5-5" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1"
+         offset="1"
+         id="stop3840-1-6-6" />
     </linearGradient>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3836-9-3-6-29" id="linearGradient3264" gradientUnits="userSpaceOnUse" x1="-18" y1="18" x2="-22" y2="5"/>
-    <linearGradient id="linearGradient3836-9-3-6-29">
-      <stop style="stop-color:#a40000;stop-opacity:1" offset="0" id="stop3838-8-5-7-12"/>
-      <stop style="stop-color:#ef2929;stop-opacity:1" offset="1" id="stop3840-1-6-5-7"/>
+    <linearGradient
+       xlink:href="#linearGradient3836-9-3-6-29"
+       id="linearGradient3264"
+       gradientUnits="userSpaceOnUse"
+       x1="-18"
+       y1="18"
+       x2="-22"
+       y2="5" />
+    <linearGradient
+       id="linearGradient3836-9-3-6-29">
+      <stop
+         style="stop-color:#a40000;stop-opacity:1"
+         offset="0"
+         id="stop3838-8-5-7-12" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1"
+         offset="1"
+         id="stop3840-1-6-5-7" />
     </linearGradient>
-    <linearGradient y2="5" x2="-22" y1="18" x1="-18" gradientUnits="userSpaceOnUse" id="linearGradient3131-2-0" xlink:href="#linearGradient3836-9-3-9-9" inkscape:collect="always"/>
-    <linearGradient id="linearGradient3836-9-3-9-9">
-      <stop style="stop-color:#a40000;stop-opacity:1" offset="0" id="stop3838-8-5-1-3"/>
-      <stop style="stop-color:#ef2929;stop-opacity:1" offset="1" id="stop3840-1-6-2-6"/>
+    <linearGradient
+       y2="5"
+       x2="-22"
+       y1="18"
+       x1="-18"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3131-2-0"
+       xlink:href="#linearGradient3836-9-3-9-9" />
+    <linearGradient
+       id="linearGradient3836-9-3-9-9">
+      <stop
+         style="stop-color:#a40000;stop-opacity:1"
+         offset="0"
+         id="stop3838-8-5-1-3" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1"
+         offset="1"
+         id="stop3840-1-6-2-6" />
     </linearGradient>
-    <linearGradient y2="5" x2="-22" y1="18" x1="-18" gradientUnits="userSpaceOnUse" id="linearGradient3171-7-0" xlink:href="#linearGradient3836-9-3-6-0-6" inkscape:collect="always"/>
-    <linearGradient id="linearGradient3836-9-3-6-0-6">
-      <stop style="stop-color:#a40000;stop-opacity:1" offset="0" id="stop3838-8-5-7-9-2"/>
-      <stop style="stop-color:#ef2929;stop-opacity:1" offset="1" id="stop3840-1-6-5-3-6"/>
+    <linearGradient
+       y2="5"
+       x2="-22"
+       y1="18"
+       x1="-18"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3171-7-0"
+       xlink:href="#linearGradient3836-9-3-6-0-6" />
+    <linearGradient
+       id="linearGradient3836-9-3-6-0-6">
+      <stop
+         style="stop-color:#a40000;stop-opacity:1"
+         offset="0"
+         id="stop3838-8-5-7-9-2" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1"
+         offset="1"
+         id="stop3840-1-6-5-3-6" />
     </linearGradient>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3836-9-3-6-29" id="linearGradient3931" gradientUnits="userSpaceOnUse" x1="-18" y1="18" x2="-22" y2="5" gradientTransform="matrix(0.71441909,0,0,0.71408544,-5.531259,3.2604792)"/>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3836-9-3-6-29" id="linearGradient3937" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.71441909,0,0,0.71408544,-5.531259,3.2604792)" x1="-18" y1="18" x2="-22" y2="5"/>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3836-9-3-6-29-8" id="linearGradient3937-1" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.71441909,0,0,0.71408544,-5.531259,3.2604792)" x1="-18" y1="18" x2="-22" y2="5"/>
-    <linearGradient id="linearGradient3836-9-3-6-29-8">
-      <stop style="stop-color:#a40000;stop-opacity:1" offset="0" id="stop3838-8-5-7-12-7"/>
-      <stop style="stop-color:#ef2929;stop-opacity:1" offset="1" id="stop3840-1-6-5-7-9"/>
+    <linearGradient
+       xlink:href="#linearGradient3836-9-3-6-29"
+       id="linearGradient3931"
+       gradientUnits="userSpaceOnUse"
+       x1="-18"
+       y1="18"
+       x2="-22"
+       y2="5"
+       gradientTransform="matrix(0.71441909,0,0,0.71408544,-5.531259,3.2604792)" />
+    <linearGradient
+       xlink:href="#linearGradient3836-9-3-6-29-8"
+       id="linearGradient3937-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.71441909,0,0,0.71408544,-5.531259,3.2604792)"
+       x1="-18"
+       y1="18"
+       x2="-22"
+       y2="5" />
+    <linearGradient
+       id="linearGradient3836-9-3-6-29-8">
+      <stop
+         style="stop-color:#a40000;stop-opacity:1"
+         offset="0"
+         id="stop3838-8-5-7-12-7" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1"
+         offset="1"
+         id="stop3840-1-6-5-7-9" />
     </linearGradient>
-    <linearGradient y2="5" x2="-22" y1="18" x1="-18" gradientTransform="matrix(0.71441909,0,0,0.71408544,-5.531259,3.2604792)" gradientUnits="userSpaceOnUse" id="linearGradient3956" xlink:href="#linearGradient3836-9-3-6-29-8" inkscape:collect="always"/>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3836-9-3-6-29-7" id="linearGradient3937-3" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.71441909,0,0,0.71408544,-5.531259,3.2604792)" x1="-18" y1="18" x2="-22" y2="5"/>
-    <linearGradient id="linearGradient3836-9-3-6-29-7">
-      <stop style="stop-color:#a40000;stop-opacity:1" offset="0" id="stop3838-8-5-7-12-5"/>
-      <stop style="stop-color:#ef2929;stop-opacity:1" offset="1" id="stop3840-1-6-5-7-92"/>
+    <linearGradient
+       id="linearGradient3836-9-3-6-29-7">
+      <stop
+         style="stop-color:#a40000;stop-opacity:1"
+         offset="0"
+         id="stop3838-8-5-7-12-5" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1"
+         offset="1"
+         id="stop3840-1-6-5-7-92" />
     </linearGradient>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3836-9-3-6-29-1" id="linearGradient3937-36" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.71441909,0,0,0.71408544,-5.531259,3.2604792)" x1="-18" y1="18" x2="-22" y2="5"/>
-    <linearGradient id="linearGradient3836-9-3-6-29-1">
-      <stop style="stop-color:#a40000;stop-opacity:1" offset="0" id="stop3838-8-5-7-12-2"/>
-      <stop style="stop-color:#ef2929;stop-opacity:1" offset="1" id="stop3840-1-6-5-7-93"/>
+    <linearGradient
+       id="linearGradient3836-9-3-6-29-1">
+      <stop
+         style="stop-color:#a40000;stop-opacity:1"
+         offset="0"
+         id="stop3838-8-5-7-12-2" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1"
+         offset="1"
+         id="stop3840-1-6-5-7-93" />
     </linearGradient>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3836" id="linearGradient3850" x1="164.4444" y1="161.22015" x2="154.4444" y2="131.22015" gradientUnits="userSpaceOnUse"/>
-    <linearGradient id="linearGradient3836">
-      <stop style="stop-color:#3465a4;stop-opacity:1;" offset="0" id="stop3838"/>
-      <stop style="stop-color:#729fcf;stop-opacity:1;" offset="1" id="stop3840"/>
+    <linearGradient
+       xlink:href="#linearGradient3836"
+       id="linearGradient3850"
+       x1="164.4444"
+       y1="161.22015"
+       x2="154.4444"
+       y2="131.22015"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3836">
+      <stop
+         style="stop-color:#3465a4;stop-opacity:1;"
+         offset="0"
+         id="stop3838" />
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1;"
+         offset="1"
+         id="stop3840" />
     </linearGradient>
-    <linearGradient gradientTransform="translate(-188.44439,-101.22016)" y2="131.22015" x2="154.4444" y1="161.22015" x1="164.4444" gradientUnits="userSpaceOnUse" id="linearGradient3167" xlink:href="#linearGradient3836" inkscape:collect="always"/>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3836" id="linearGradient3112" gradientUnits="userSpaceOnUse" gradientTransform="translate(-188.44439,-101.22016)" x1="164.4444" y1="161.22015" x2="154.4444" y2="131.22015"/>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3836-6" id="linearGradient3850-3" x1="160.4444" y1="149.22015" x2="158.4444" y2="143.22015" gradientUnits="userSpaceOnUse"/>
-    <linearGradient id="linearGradient3836-6">
-      <stop style="stop-color:#3465a4;stop-opacity:1;" offset="0" id="stop3838-7"/>
-      <stop style="stop-color:#729fcf;stop-opacity:1;" offset="1" id="stop3840-5"/>
+    <linearGradient
+       xlink:href="#linearGradient3836-6"
+       id="linearGradient3850-3"
+       x1="160.4444"
+       y1="149.22015"
+       x2="158.4444"
+       y2="143.22015"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3836-6">
+      <stop
+         style="stop-color:#3465a4;stop-opacity:1;"
+         offset="0"
+         id="stop3838-7" />
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1;"
+         offset="1"
+         id="stop3840-5" />
     </linearGradient>
-    <linearGradient gradientTransform="translate(-141.44439,-128.22016)" y2="143.22015" x2="158.4444" y1="149.22015" x1="160.4444" gradientUnits="userSpaceOnUse" id="linearGradient3185" xlink:href="#linearGradient3836-6" inkscape:collect="always"/>
+    <linearGradient
+       gradientTransform="translate(-141.44439,-136.22016)"
+       y2="143.22015"
+       x2="158.4444"
+       y1="149.22015"
+       x1="160.4444"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3185"
+       xlink:href="#linearGradient3836-6" />
   </defs>
-  <sodipodi:namedview id="base" pagecolor="#ffffff" bordercolor="#666666" borderopacity="1.0" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:zoom="9.3695575" inkscape:cx="21.677859" inkscape:cy="24.907463" inkscape:current-layer="layer1" showgrid="true" inkscape:document-units="px" inkscape:grid-bbox="true" inkscape:window-width="1600" inkscape:window-height="834" inkscape:window-x="0" inkscape:window-y="27" inkscape:window-maximized="1" inkscape:snap-global="true" inkscape:snap-bbox="true" inkscape:snap-nodes="true" showguides="true" inkscape:guide-bbox="true">
-    <inkscape:grid type="xygrid" id="grid3058" empspacing="2" visible="true" enabled="true" snapvisiblegridlinesonly="true"/>
-    <sodipodi:guide orientation="1,0" position="28,22" id="guide3917"/>
-    <sodipodi:guide orientation="0,1" position="12,32" id="guide3919"/>
-    <sodipodi:guide orientation="0,1" position="60,16" id="guide3921"/>
-    <sodipodi:guide orientation="1,0" position="52,8" id="guide3923"/>
-  </sodipodi:namedview>
-  <metadata id="metadata2923">
+  <metadata
+     id="metadata2923">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Sketcher_BSplineDecreaseDegree</dc:title>
         <dc:creator>
           <cc:Agent>
-            <dc:title>[agryson] Alexander Gryson</dc:title>
+            <dc:title>[bitacovir]</dc:title>
           </cc:Agent>
         </dc:creator>
         <dc:title>Sketcher_Create_Periodic_BSpline</dc:title>
-        <dc:date>2017-02-15</dc:date>
+        <dc:date>22-03-2021</dc:date>
         <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>
           </cc:Agent>
         </dc:publisher>
-        <dc:identifier>FreeCAD/src/Mod/Sketcher/Gui/Resources/icons/Sketcher_Toggle_BSpline_Information.svg</dc:identifier>
+        <dc:identifier></dc:identifier>
         <dc:rights>
           <cc:Agent>
             <dc:title>FreeCAD LGPL2+</dc:title>
@@ -144,47 +460,73 @@
         <cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license>
         <dc:contributor>
           <cc:Agent>
-            <dc:title>[agryson] Alexander Gryson</dc:title>
+            <dc:title></dc:title>
           </cc:Agent>
         </dc:contributor>
+        <dc:subject>
+          <rdf:Bag />
+        </dc:subject>
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g id="layer1" inkscape:label="Layer 1" inkscape:groupmode="layer">
-    <path style="fill:none;stroke:#2e3436;stroke-width:8;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="M 55.999976,26.000003 C 58,48 32,32 29.999975,52.000002" id="path3266" inkscape:connector-curvature="0" sodipodi:nodetypes="cc"/>
-    <path style="fill:none;stroke:#d3d7cf;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="M 55.999976,26.000003 C 56,48 32,32 29.999975,52.000002" id="path3266-9" inkscape:connector-curvature="0" sodipodi:nodetypes="cc"/>
-    <path style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="M 54.999975,26.000003 C 56,47 32,31 28.999974,52.000002" id="path3266-9-2" inkscape:connector-curvature="0" sodipodi:nodetypes="cc"/>
-    <g inkscape:export-ydpi="7.2934141" inkscape:export-xdpi="7.2934141" inkscape:export-filename="/home/yorik/Documents/Lab/Draft/icons/circle.png" transform="matrix(-0.14137236,0.07774155,-0.01888492,-0.10633123,99.823869,75.569613)" id="g3177"/>
-    <g inkscape:export-ydpi="7.2934141" inkscape:export-xdpi="7.2934141" inkscape:export-filename="/home/yorik/Documents/Lab/Draft/icons/circle.png" transform="matrix(-0.14109247,0.07923086,-0.02087339,-0.10522619,77.138226,86.686164)" id="g3185"/>
-    <g transform="matrix(0.59988397,0,0,0.60016354,23.595637,49.138672)" id="g3797-7-2-3">
-      <g id="g3933" transform="translate(30.005802,0)">
-        <path d="m -25.658702,6.015909 a 8.3321309,8.3277776 0 1 1 12.65725,10.83369 8.3321309,8.3277776 0 1 1 -12.65725,-10.83369 z" id="path4250-6-9-5" style="fill:#ef2929;stroke:#280000;stroke-width:3.33320141;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" inkscape:connector-curvature="0"/>
-        <path d="m -23.129965,8.18309 a 5.0009335,4.9985982 0 1 1 7.596839,6.502756 5.0009335,4.9985982 0 0 1 -7.596839,-6.502756 z" id="path4250-7-0-1-6" style="fill:url(#linearGradient3937);fill-opacity:1;stroke:#ef2929;stroke-width:3.33320141;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" inkscape:connector-curvature="0"/>
-      </g>
+  <g
+     id="layer1">
+    <g
+       id="g968"
+       transform="translate(-84.071948,8.3392731)">
+      <path
+         id="path3266"
+         d="M 139.77785,-0.05417361 C 141.425,41.34376 101.53964,20.796643 92.391237,47.259112"
+         style="fill:none;stroke:#2e3436;stroke-width:12.5366;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         id="path3266-9"
+         d="M 139.77785,-0.05417361 C 142.13538,40.080959 101.33659,21.264448 92.391237,47.259112"
+         style="fill:none;stroke:#d3d7cf;stroke-width:6.2683;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         id="path3266-9-2"
+         d="M 138.15266,-0.05417361 C 141.74262,38.472557 99.308595,19.394149 90.766053,47.410049"
+         style="fill:none;stroke:#ffffff;stroke-width:3.13415;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <g id="g3933-2" transform="matrix(0.59988397,0,0,0.60016354,67.595636,19.138672)">
-      <path d="m -25.658702,6.015909 a 8.3321309,8.3277776 0 1 1 12.65725,10.83369 8.3321309,8.3277776 0 1 1 -12.65725,-10.83369 z" id="path4250-6-9-5-0" style="fill:#ef2929;stroke:#280000;stroke-width:3.33320141;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" inkscape:connector-curvature="0"/>
-      <path d="m -23.129965,8.18309 a 5.0009335,4.9985982 0 1 1 7.596839,6.502756 5.0009335,4.9985982 0 0 1 -7.596839,-6.502756 z" id="path4250-7-0-1-6-2" style="fill:url(#linearGradient3956);fill-opacity:1;stroke:#ef2929;stroke-width:3.33320141;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" inkscape:connector-curvature="0"/>
+    <g
+       transform="matrix(-0.14137236,0.07774155,-0.01888492,-0.10633123,99.823869,75.569613)"
+       id="g3177" />
+    <g
+       transform="matrix(-0.14109247,0.07923086,-0.02087339,-0.10522619,77.138226,86.686164)"
+       id="g3185" />
+    <path
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3185);fill-opacity:1;fill-rule:evenodd;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="M 13,5 V 5 H 3 v 10 h 10 v 0 h 10 v 0 H 33 V 5 H 23 v 0 z"
+       id="rect3558-3" />
+    <path
+       style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 5,7 h 10 v 0 h 6 v 0 h 10 v 6 H 21 v 0 h -6 v 0 H 5 Z"
+       id="path3826-5" />
+    <g
+       id="g985">
+      <path
+         style="fill:none;stroke:#172a04;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 50.429651,58.951026 2.631579,-25 M 33.982283,51.714184 h 25"
+         id="path3047-3-6-3-2" />
+      <path
+         style="fill:none;stroke:#172a04;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 41.219125,33.951026 -2.631579,25 M 58.982283,41.187868 h -25"
+         id="path3047-3-6-2" />
+      <path
+         style="fill:none;stroke:#4e9a06;stroke-width:2.63158;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+         d="m 41.219125,33.951026 -2.631579,25 M 58.982283,41.187868 h -25"
+         id="path3047-4" />
+      <path
+         style="fill:none;stroke:#4e9a06;stroke-width:2.63158;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+         d="m 50.429651,58.951026 2.631579,-25 M 33.982283,51.714184 h 25"
+         id="path3047-6-7" />
+      <path
+         style="fill:none;stroke:#8ae234;stroke-width:1.31579;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+         d="m 49.771757,58.951026 2.631579,-25 M 33.982283,51.056289 h 25"
+         id="path3047-3-7-6" />
+      <path
+         style="fill:none;stroke:#8ae234;stroke-width:1.31579;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+         d="m 40.56123,33.951026 -2.631579,25 M 58.982283,40.529973 h -25"
+         id="path3047-3-4" />
     </g>
-    <g transform="matrix(0.59988397,0,0,0.60016354,25.595637,25.138672)" id="g3797-7-2-3-2">
-      <g id="g3933-8" transform="translate(30.005802,0)">
-        <path d="m -25.658702,6.015909 a 8.3321309,8.3277776 0 1 1 12.65725,10.83369 8.3321309,8.3277776 0 1 1 -12.65725,-10.83369 z" id="path4250-6-9-5-9" style="fill:#ef2929;stroke:#280000;stroke-width:3.33320141;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" inkscape:connector-curvature="0"/>
-        <path d="m -23.129965,8.18309 a 5.0009335,4.9985982 0 1 1 7.596839,6.502756 5.0009335,4.9985982 0 0 1 -7.596839,-6.502756 z" id="path4250-7-0-1-6-7" style="fill:url(#linearGradient3937-3);fill-opacity:1;stroke:#ef2929;stroke-width:3.33320141;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" inkscape:connector-curvature="0"/>
-      </g>
-    </g>
-    <g transform="matrix(0.59988397,0,0,0.60016354,49.595637,41.138672)" id="g3797-7-2-3-1">
-      <g id="g3933-9" transform="translate(30.005802,0)">
-        <path d="m -25.658702,6.015909 a 8.3321309,8.3277776 0 1 1 12.65725,10.83369 8.3321309,8.3277776 0 1 1 -12.65725,-10.83369 z" id="path4250-6-9-5-4" style="fill:#ef2929;stroke:#280000;stroke-width:3.33320141;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" inkscape:connector-curvature="0"/>
-        <path d="m -23.129965,8.18309 a 5.0009335,4.9985982 0 1 1 7.596839,6.502756 5.0009335,4.9985982 0 0 1 -7.596839,-6.502756 z" id="path4250-7-0-1-6-78" style="fill:url(#linearGradient3937-36);fill-opacity:1;stroke:#ef2929;stroke-width:3.33320141;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" inkscape:connector-curvature="0"/>
-      </g>
-    </g>
-    <path style="fill:none;stroke:#172a04;stroke-width:8;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" d="M 31,44 35,6 M 6,33 44,33" id="path3047-3-6-3" inkscape:connector-curvature="0" sodipodi:nodetypes="cccc"/>
-    <path style="fill:none;stroke:#172a04;stroke-width:8;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" d="M 17,6 13,44 M 44,17 6,17" id="path3047-3-6" inkscape:connector-curvature="0" sodipodi:nodetypes="cccc"/>
-    <path style="fill:none;stroke:#4e9a06;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" d="M 17,6 13,44 M 44,17 6,17" id="path3047" inkscape:connector-curvature="0" sodipodi:nodetypes="cccc"/>
-    <path style="fill:none;stroke:#4e9a06;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" d="M 31,44 35,6 M 6,33 44,33" id="path3047-6" inkscape:connector-curvature="0" sodipodi:nodetypes="cccc"/>
-    <path style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" d="M 30,44 34,6 M 6,32 44,32" id="path3047-3-7" inkscape:connector-curvature="0" sodipodi:nodetypes="cccc"/>
-    <path style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" d="M 16,6 12,44 M 44,16 6,16" id="path3047-3" inkscape:connector-curvature="0" sodipodi:nodetypes="cccc"/>
-    <path style="color:#000000;fill:url(#linearGradient3185);fill-opacity:1;fill-rule:evenodd;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" d="m 13,13 0,0 -10,0 0,10 10,0 0,0 10,0 0,0 10,0 0,-10 -10,0 0,0 z" id="rect3558-3" inkscape:connector-curvature="0" sodipodi:nodetypes="ccccccccccccc"/>
-    <path style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="m 5,15 10,0 0,0 6,0 0,0 10,0 0,6 -10,0 0,0 -6,0 0,0 -10,0 z" id="path3826-5" inkscape:connector-curvature="0" sodipodi:nodetypes="ccccccccccccc"/>
   </g>
 </svg>

--- a/src/Mod/Sketcher/Gui/Resources/icons/splines/Sketcher_BSplineDecreaseKnotMultiplicity.svg
+++ b/src/Mod/Sketcher/Gui/Resources/icons/splines/Sketcher_BSplineDecreaseKnotMultiplicity.svg
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
@@ -8,23 +6,15 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="64px"
    height="64px"
    id="svg2918"
-   sodipodi:version="0.32"
-   inkscape:version="0.92.1 unknown"
-   sodipodi:docname="Sketcher_BSplineDecreaseKnotMultiplicity.svg"
-   inkscape:output_extension="org.inkscape.output.svg.inkscape"
-   version="1.1"
-   inkscape:export-filename="/home/user/Downloads/cad/mystuff/icons/sketcher/Sketcher_CreateCircle_from_3points_2_16px.png"
-   inkscape:export-xdpi="22.5"
-   inkscape:export-ydpi="22.5">
+   version="1.1">
+  <title
+     id="title934">Sketcher_BSplineDecreaseKnotMultiplicity</title>
   <defs
      id="defs2920">
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient3144">
       <stop
          style="stop-color:#ffffff;stop-opacity:1;"
@@ -35,15 +25,7 @@
          offset="1"
          id="stop3148" />
     </linearGradient>
-    <inkscape:perspective
-       sodipodi:type="inkscape:persp3d"
-       inkscape:vp_x="0 : 32 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_z="64 : 32 : 1"
-       inkscape:persp3d-origin="32 : 21.333333 : 1"
-       id="perspective2926" />
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient3144-3">
       <stop
          style="stop-color:#ffffff;stop-opacity:1;"
@@ -55,7 +37,6 @@
          id="stop3148-5" />
     </linearGradient>
     <radialGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3144"
        id="radialGradient3958"
        gradientUnits="userSpaceOnUse"
@@ -66,7 +47,6 @@
        fy="672.79736"
        r="34.345188" />
     <radialGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3144-3"
        id="radialGradient3960"
        gradientUnits="userSpaceOnUse"
@@ -77,7 +57,6 @@
        fy="672.79736"
        r="34.345188" />
     <radialGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3144"
        id="radialGradient3042"
        gradientUnits="userSpaceOnUse"
@@ -88,7 +67,6 @@
        fy="672.79736"
        r="34.345188" />
     <radialGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3144"
        id="radialGradient3068"
        gradientUnits="userSpaceOnUse"
@@ -99,7 +77,6 @@
        fy="672.79736"
        r="34.345188" />
     <radialGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3144"
        id="radialGradient3880"
        gradientUnits="userSpaceOnUse"
@@ -110,7 +87,6 @@
        fy="672.79736"
        r="34.345188" />
     <radialGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3144"
        id="radialGradient4654"
        gradientUnits="userSpaceOnUse"
@@ -121,7 +97,6 @@
        fy="672.79736"
        r="34.345188" />
     <radialGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3144"
        id="radialGradient4693"
        gradientUnits="userSpaceOnUse"
@@ -138,8 +113,7 @@
        x1="-18"
        gradientUnits="userSpaceOnUse"
        id="linearGradient3131-2"
-       xlink:href="#linearGradient3836-9-3-9"
-       inkscape:collect="always" />
+       xlink:href="#linearGradient3836-9-3-9" />
     <linearGradient
        id="linearGradient3836-9-3-9">
       <stop
@@ -158,8 +132,7 @@
        x1="-18"
        gradientUnits="userSpaceOnUse"
        id="linearGradient3171-7"
-       xlink:href="#linearGradient3836-9-3-6-0"
-       inkscape:collect="always" />
+       xlink:href="#linearGradient3836-9-3-6-0" />
     <linearGradient
        id="linearGradient3836-9-3-6-0">
       <stop
@@ -172,7 +145,6 @@
          id="stop3840-1-6-5-3" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3836-9-3"
        id="linearGradient3262"
        gradientUnits="userSpaceOnUse"
@@ -203,7 +175,6 @@
          id="stop3840-1-6-5" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3836-9-3-6-7"
        id="linearGradient3264-1"
        gradientUnits="userSpaceOnUse"
@@ -224,7 +195,6 @@
          id="stop3840-1-6-5-0" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3836-9-3-6-4"
        id="linearGradient3264-9"
        gradientUnits="userSpaceOnUse"
@@ -245,7 +215,6 @@
          id="stop3840-1-6-5-8" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3836-9-3-6-1"
        id="linearGradient3264-17"
        gradientUnits="userSpaceOnUse"
@@ -266,7 +235,6 @@
          id="stop3840-1-6-5-5" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3836-9-3-6-2"
        id="linearGradient3264-3"
        gradientUnits="userSpaceOnUse"
@@ -287,7 +255,6 @@
          id="stop3840-1-6-5-1" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3836-9-3-3"
        id="linearGradient3262-5"
        gradientUnits="userSpaceOnUse"
@@ -307,7 +274,6 @@
          id="stop3840-1-6-6" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3836-9-3-6-29"
        id="linearGradient3264"
        gradientUnits="userSpaceOnUse"
@@ -333,8 +299,7 @@
        x1="-18"
        gradientUnits="userSpaceOnUse"
        id="linearGradient3131-2-0"
-       xlink:href="#linearGradient3836-9-3-9-9"
-       inkscape:collect="always" />
+       xlink:href="#linearGradient3836-9-3-9-9" />
     <linearGradient
        id="linearGradient3836-9-3-9-9">
       <stop
@@ -353,8 +318,7 @@
        x1="-18"
        gradientUnits="userSpaceOnUse"
        id="linearGradient3171-7-0"
-       xlink:href="#linearGradient3836-9-3-6-0-6"
-       inkscape:collect="always" />
+       xlink:href="#linearGradient3836-9-3-6-0-6" />
     <linearGradient
        id="linearGradient3836-9-3-6-0-6">
       <stop
@@ -367,27 +331,6 @@
          id="stop3840-1-6-5-3-6" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3836-9-3-6-29"
-       id="linearGradient3931"
-       gradientUnits="userSpaceOnUse"
-       x1="-18"
-       y1="18"
-       x2="-22"
-       y2="5"
-       gradientTransform="matrix(0.71441909,0,0,0.71408544,-5.531259,3.2604792)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3836-9-3-6-29"
-       id="linearGradient3937"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.71441909,0,0,0.71408544,-5.531259,3.2604792)"
-       x1="-18"
-       y1="18"
-       x2="-22"
-       y2="5" />
-    <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3836-9-3-6-29-8"
        id="linearGradient3937-1"
        gradientUnits="userSpaceOnUse"
@@ -408,26 +351,6 @@
          id="stop3840-1-6-5-7-9" />
     </linearGradient>
     <linearGradient
-       y2="5"
-       x2="-22"
-       y1="18"
-       x1="-18"
-       gradientTransform="matrix(0.71441909,0,0,0.71408544,-5.531259,3.2604792)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3956"
-       xlink:href="#linearGradient3836-9-3-6-29-8"
-       inkscape:collect="always" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3836-9-3-6-29-7"
-       id="linearGradient3937-3"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.71441909,0,0,0.71408544,-5.531259,3.2604792)"
-       x1="-18"
-       y1="18"
-       x2="-22"
-       y2="5" />
-    <linearGradient
        id="linearGradient3836-9-3-6-29-7">
       <stop
          style="stop-color:#a40000;stop-opacity:1"
@@ -438,16 +361,6 @@
          offset="1"
          id="stop3840-1-6-5-7-92" />
     </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3836-9-3-6-29-1"
-       id="linearGradient3937-36"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.71441909,0,0,0.71408544,-5.531259,3.2604792)"
-       x1="-18"
-       y1="18"
-       x2="-22"
-       y2="5" />
     <linearGradient
        id="linearGradient3836-9-3-6-29-1">
       <stop
@@ -460,7 +373,6 @@
          id="stop3840-1-6-5-7-93" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3836"
        id="linearGradient3850"
        x1="164.4444"
@@ -487,10 +399,8 @@
        x1="164.4444"
        gradientUnits="userSpaceOnUse"
        id="linearGradient3167"
-       xlink:href="#linearGradient3836"
-       inkscape:collect="always" />
+       xlink:href="#linearGradient3836" />
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3836"
        id="linearGradient3112"
        gradientUnits="userSpaceOnUse"
@@ -500,7 +410,6 @@
        x2="154.4444"
        y2="131.22015" />
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3836-6"
        id="linearGradient3850-3"
        x1="160.4444"
@@ -520,68 +429,15 @@
          id="stop3840-5" />
     </linearGradient>
     <linearGradient
-       gradientTransform="translate(-141.44439,-128.22016)"
+       gradientTransform="translate(-141.44439,-136.22016)"
        y2="143.22015"
        x2="158.4444"
        y1="149.22015"
        x1="160.4444"
        gradientUnits="userSpaceOnUse"
        id="linearGradient3185"
-       xlink:href="#linearGradient3836-6"
-       inkscape:collect="always" />
+       xlink:href="#linearGradient3836-6" />
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="7.3108168"
-     inkscape:cx="41.931335"
-     inkscape:cy="35.208556"
-     inkscape:current-layer="layer1"
-     showgrid="true"
-     inkscape:document-units="px"
-     inkscape:grid-bbox="true"
-     inkscape:window-width="1920"
-     inkscape:window-height="993"
-     inkscape:window-x="0"
-     inkscape:window-y="28"
-     inkscape:window-maximized="1"
-     inkscape:snap-global="true"
-     inkscape:snap-bbox="true"
-     inkscape:snap-nodes="true"
-     showguides="true"
-     inkscape:guide-bbox="true">
-    <inkscape:grid
-       type="xygrid"
-       id="grid3058"
-       empspacing="2"
-       visible="true"
-       enabled="true"
-       snapvisiblegridlinesonly="true" />
-    <sodipodi:guide
-       orientation="1,0"
-       position="28,22"
-       id="guide3917"
-       inkscape:locked="false" />
-    <sodipodi:guide
-       orientation="0,1"
-       position="12,32"
-       id="guide3919"
-       inkscape:locked="false" />
-    <sodipodi:guide
-       orientation="0,1"
-       position="60,16"
-       id="guide3921"
-       inkscape:locked="false" />
-    <sodipodi:guide
-       orientation="1,0"
-       position="52,8"
-       id="guide3923"
-       inkscape:locked="false" />
-  </sodipodi:namedview>
   <metadata
      id="metadata2923">
     <rdf:RDF>
@@ -590,21 +446,21 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:title>Sketcher_BSplineDecreaseKnotMultiplicity</dc:title>
         <dc:creator>
           <cc:Agent>
-            <dc:title>[agryson] Alexander Gryson</dc:title>
+            <dc:title>[bitacovir]</dc:title>
           </cc:Agent>
         </dc:creator>
         <dc:title>Sketcher_Create_Periodic_BSpline</dc:title>
-        <dc:date>2017-02-15</dc:date>
+        <dc:date>22-03-2021</dc:date>
         <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>
           </cc:Agent>
         </dc:publisher>
-        <dc:identifier>FreeCAD/src/Mod/Sketcher/Gui/Resources/icons/Sketcher_Toggle_BSpline_Information.svg</dc:identifier>
+        <dc:identifier></dc:identifier>
         <dc:rights>
           <cc:Agent>
             <dc:title>FreeCAD LGPL2+</dc:title>
@@ -613,175 +469,80 @@
         <cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license>
         <dc:contributor>
           <cc:Agent>
-            <dc:title>[agryson] Alexander Gryson</dc:title>
+            <dc:title></dc:title>
           </cc:Agent>
         </dc:contributor>
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1"
-     inkscape:label="Layer 1"
-     inkscape:groupmode="layer">
-    <path
-       style="fill:none;stroke:#2e3436;stroke-width:8;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="M 55.999976,26.000003 C 58,48 32,32 29.999975,52.000002"
-       id="path3266"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
-    <path
-       style="fill:none;stroke:#d3d7cf;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="M 55.999976,26.000003 C 56,48 32,32 29.999975,52.000002"
-       id="path3266-9"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
-    <path
-       style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="M 54.999975,26.000003 C 56,47 32,31 28.999974,52.000002"
-       id="path3266-9-2"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
+     id="layer1">
     <g
-       inkscape:export-ydpi="7.2934141"
-       inkscape:export-xdpi="7.2934141"
-       inkscape:export-filename="/home/yorik/Documents/Lab/Draft/icons/circle.png"
        transform="matrix(-0.14137236,0.07774155,-0.01888492,-0.10633123,99.823869,75.569613)"
        id="g3177" />
     <g
-       inkscape:export-ydpi="7.2934141"
-       inkscape:export-xdpi="7.2934141"
-       inkscape:export-filename="/home/yorik/Documents/Lab/Draft/icons/circle.png"
        transform="matrix(-0.14109247,0.07923086,-0.02087339,-0.10522619,77.138226,86.686164)"
        id="g3185" />
-    <g
-       transform="matrix(0.59988397,0,0,0.60016354,23.595637,49.138672)"
-       id="g3797-7-2-3">
-      <g
-         id="g3933"
-         transform="translate(30.005802,0)">
-        <path
-           d="m -25.658702,6.015909 a 8.3321309,8.3277776 0 1 1 12.65725,10.83369 8.3321309,8.3277776 0 1 1 -12.65725,-10.83369 z"
-           id="path4250-6-9-5"
-           style="fill:#ef2929;stroke:#280000;stroke-width:3.33320141;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-           inkscape:connector-curvature="0" />
-        <path
-           d="m -23.129965,8.18309 a 5.0009335,4.9985982 0 1 1 7.596839,6.502756 5.0009335,4.9985982 0 0 1 -7.596839,-6.502756 z"
-           id="path4250-7-0-1-6"
-           style="fill:url(#linearGradient3937);fill-opacity:1;stroke:#ef2929;stroke-width:3.33320141;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-           inkscape:connector-curvature="0" />
-      </g>
-    </g>
-    <g
-       id="g3933-2"
-       transform="matrix(0.59988397,0,0,0.60016354,67.595636,19.138672)">
-      <path
-         d="m -25.658702,6.015909 a 8.3321309,8.3277776 0 1 1 12.65725,10.83369 8.3321309,8.3277776 0 1 1 -12.65725,-10.83369 z"
-         id="path4250-6-9-5-0"
-         style="fill:#ef2929;stroke:#280000;stroke-width:3.33320141;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m -23.129965,8.18309 a 5.0009335,4.9985982 0 1 1 7.596839,6.502756 5.0009335,4.9985982 0 0 1 -7.596839,-6.502756 z"
-         id="path4250-7-0-1-6-2"
-         style="fill:url(#linearGradient3956);fill-opacity:1;stroke:#ef2929;stroke-width:3.33320141;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-         inkscape:connector-curvature="0" />
-    </g>
-    <g
-       transform="matrix(0.59988397,0,0,0.60016354,25.595637,25.138672)"
-       id="g3797-7-2-3-2">
-      <g
-         id="g3933-8"
-         transform="translate(30.005802,0)">
-        <path
-           d="m -25.658702,6.015909 a 8.3321309,8.3277776 0 1 1 12.65725,10.83369 8.3321309,8.3277776 0 1 1 -12.65725,-10.83369 z"
-           id="path4250-6-9-5-9"
-           style="fill:#ef2929;stroke:#280000;stroke-width:3.33320141;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-           inkscape:connector-curvature="0" />
-        <path
-           d="m -23.129965,8.18309 a 5.0009335,4.9985982 0 1 1 7.596839,6.502756 5.0009335,4.9985982 0 0 1 -7.596839,-6.502756 z"
-           id="path4250-7-0-1-6-7"
-           style="fill:url(#linearGradient3937-3);fill-opacity:1;stroke:#ef2929;stroke-width:3.33320141;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-           inkscape:connector-curvature="0" />
-      </g>
-    </g>
-    <g
-       transform="matrix(0.59988397,0,0,0.60016354,49.595637,41.138672)"
-       id="g3797-7-2-3-1">
-      <g
-         id="g3933-9"
-         transform="translate(30.005802,0)">
-        <path
-           d="m -25.658702,6.015909 a 8.3321309,8.3277776 0 1 1 12.65725,10.83369 8.3321309,8.3277776 0 1 1 -12.65725,-10.83369 z"
-           id="path4250-6-9-5-4"
-           style="fill:#ef2929;stroke:#280000;stroke-width:3.33320141;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-           inkscape:connector-curvature="0" />
-        <path
-           d="m -23.129965,8.18309 a 5.0009335,4.9985982 0 1 1 7.596839,6.502756 5.0009335,4.9985982 0 0 1 -7.596839,-6.502756 z"
-           id="path4250-7-0-1-6-78"
-           style="fill:url(#linearGradient3937-36);fill-opacity:1;stroke:#ef2929;stroke-width:3.33320141;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-           inkscape:connector-curvature="0" />
-      </g>
-    </g>
     <path
-       style="fill:none;stroke:#172a04;stroke-width:8;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
-       d="M 31,44 35,6 M 6,33 44,33"
-       id="path3047-3-6-3"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccc" />
-    <path
-       style="fill:none;stroke:#172a04;stroke-width:8;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
-       d="M 17,6 13,44 M 44,17 6,17"
-       id="path3047-3-6"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccc" />
-    <path
-       style="fill:none;stroke:#4e9a06;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
-       d="M 17,6 13,44 M 44,17 6,17"
-       id="path3047"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccc" />
-    <g
-       id="g958"
-       transform="translate(32.279658,-18.049864)">
-      <path
-         inkscape:connector-curvature="0"
-         style="fill:#ef2929;stroke:#280000;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="path4250-6-9-5-3"
-         d="m 8.203393,54.749201 a 4.9983118,4.9980285 0 1 1 7.592881,6.501986 4.9983118,4.9980285 0 1 1 -7.592881,-6.501986 z" />
-      <path
-         inkscape:connector-curvature="0"
-         style="fill:#99cc33;fill-opacity:1;stroke:#669900;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="path4250-7-0-1-6-5"
-         d="M 9.7203418,56.049864 A 2.9999798,2.9999764 0 1 1 14.277564,59.952581 2.9999798,2.9999764 0 0 1 9.7203418,56.049864 Z" />
-    </g>
-    <path
-       style="fill:none;stroke:#4e9a06;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
-       d="M 31,44 35,6 M 6,33 44,33"
-       id="path3047-6"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccc" />
-    <path
-       style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
-       d="M 30,44 34,6 M 6,32 44,32"
-       id="path3047-3-7"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccc" />
-    <path
-       style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
-       d="M 16,6 12,44 M 44,16 6,16"
-       id="path3047-3"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccc" />
-    <path
-       style="color:#000000;fill:url(#linearGradient3185);fill-opacity:1;fill-rule:evenodd;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       d="m 13,13 0,0 -10,0 0,10 10,0 0,0 10,0 0,0 10,0 0,-10 -10,0 0,0 z"
-       id="rect3558-3"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="ccccccccccccc" />
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3185);fill-opacity:1;fill-rule:evenodd;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="M 13,5 V 5 H 3 v 10 h 10 v 0 h 10 v 0 H 33 V 5 H 23 v 0 z"
+       id="rect3558-3" />
     <path
        style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="m 5,15 10,0 0,0 6,0 0,0 10,0 0,6 -10,0 0,0 -6,0 0,0 -10,0 z"
-       id="path3826-5"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="ccccccccccccc" />
+       d="m 5,7 h 10 v 0 h 6 v 0 h 10 v 6 H 21 v 0 h -6 v 0 H 5 Z"
+       id="path3826-5" />
+    <path
+       id="path3266"
+       d="M 55.708085,12.979883 C 54.199158,48.108567 17.100307,30.198606 8.319289,55.598385"
+       style="fill:none;stroke:#2e3436;stroke-width:12.5366;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       id="path3266-9"
+       d="M 55.705902,8.2850995 C 58.063432,48.420232 17.264642,29.603721 8.319289,55.598385"
+       style="fill:none;stroke:#d3d7cf;stroke-width:6.2683;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       id="path3266-9-2"
+       d="M 54.080712,8.2850995 C 57.670672,46.81183 15.236647,27.733422 6.694105,55.749322"
+       style="fill:none;stroke:#ffffff;stroke-width:3.13415;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+    <g
+       id="g985">
+      <path
+         style="fill:none;stroke:#172a04;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 50.429651,58.951026 2.631579,-25 M 33.982283,51.714184 h 25"
+         id="path3047-3-6-3-2" />
+      <path
+         style="fill:none;stroke:#172a04;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 41.219125,33.951026 -2.631579,25 M 58.982283,41.187868 h -25"
+         id="path3047-3-6-2" />
+      <path
+         style="fill:none;stroke:#4e9a06;stroke-width:2.63158;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+         d="m 41.219125,33.951026 -2.631579,25 M 58.982283,41.187868 h -25"
+         id="path3047-4" />
+      <path
+         style="fill:none;stroke:#4e9a06;stroke-width:2.63158;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+         d="m 50.429651,58.951026 2.631579,-25 M 33.982283,51.714184 h 25"
+         id="path3047-6-7" />
+      <path
+         style="fill:none;stroke:#8ae234;stroke-width:1.31579;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+         d="m 49.771757,58.951026 2.631579,-25 M 33.982283,51.056289 h 25"
+         id="path3047-3-7-6" />
+      <path
+         style="fill:none;stroke:#8ae234;stroke-width:1.31579;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+         d="m 40.56123,33.951026 -2.631579,25 M 58.982283,40.529973 h -25"
+         id="path3047-3-4" />
+    </g>
+    <circle
+       r="13.203125"
+       cy="15.203125"
+       cx="49.796875"
+       id="path945"
+       style="fill:#ffffff;fill-rule:evenodd;stroke:none;stroke-width:1.3629;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;paint-order:markers stroke fill" />
+    <path
+       style="fill:#ef2929;stroke:#4e9a06;stroke-width:3.89444;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path4250-6-9-5-3-3"
+       d="M 42.449361,8.9063962 A 9.7328242,9.7322726 0 1 1 57.234388,21.567208 9.7328242,9.7322726 0 1 1 42.449361,8.9063962 Z" />
+    <path
+       style="fill:#172a04;fill-opacity:1;stroke:#73d216;stroke-width:3.89444;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path4250-7-0-1-6-5-4"
+       d="m 45.403197,11.439076 a 5.8416276,5.8416209 0 1 1 8.873925,7.599458 5.8416276,5.8416209 0 0 1 -8.873925,-7.599458 z" />
   </g>
 </svg>

--- a/src/Mod/Sketcher/Gui/Resources/icons/splines/Sketcher_BSplineDegree.svg
+++ b/src/Mod/Sketcher/Gui/Resources/icons/splines/Sketcher_BSplineDegree.svg
@@ -1,128 +1,401 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width="64px" height="64px" id="svg2918" sodipodi:version="0.32" inkscape:version="0.48.5 r10040" sodipodi:docname="Sketcher_BSplineDegree.svg" inkscape:output_extension="org.inkscape.output.svg.inkscape" version="1.1" inkscape:export-filename="/home/user/Downloads/cad/mystuff/icons/sketcher/Sketcher_CreateCircle_from_3points_2_16px.png" inkscape:export-xdpi="22.5" inkscape:export-ydpi="22.5">
-  <defs id="defs2920">
-    <linearGradient inkscape:collect="always" id="linearGradient3144">
-      <stop style="stop-color:#ffffff;stop-opacity:1;" offset="0" id="stop3146"/>
-      <stop style="stop-color:#ffffff;stop-opacity:0;" offset="1" id="stop3148"/>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   width="64px"
+   height="64px"
+   id="svg2918"
+   version="1.1">
+  <title
+     id="title917">Sketcher_BSplineDegree</title>
+  <defs
+     id="defs2920">
+    <linearGradient
+       id="linearGradient3144">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop3146" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop3148" />
     </linearGradient>
-    <inkscape:perspective sodipodi:type="inkscape:persp3d" inkscape:vp_x="0 : 32 : 1" inkscape:vp_y="0 : 1000 : 0" inkscape:vp_z="64 : 32 : 1" inkscape:persp3d-origin="32 : 21.333333 : 1" id="perspective2926"/>
-    <linearGradient inkscape:collect="always" id="linearGradient3144-3">
-      <stop style="stop-color:#ffffff;stop-opacity:1;" offset="0" id="stop3146-1"/>
-      <stop style="stop-color:#ffffff;stop-opacity:0;" offset="1" id="stop3148-5"/>
+    <linearGradient
+       id="linearGradient3144-3">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop3146-1" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop3148-5" />
     </linearGradient>
-    <radialGradient inkscape:collect="always" xlink:href="#linearGradient3144" id="radialGradient3958" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)" cx="225.26402" cy="672.79736" fx="225.26402" fy="672.79736" r="34.345188"/>
-    <radialGradient inkscape:collect="always" xlink:href="#linearGradient3144-3" id="radialGradient3960" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)" cx="225.26402" cy="672.79736" fx="225.26402" fy="672.79736" r="34.345188"/>
-    <radialGradient inkscape:collect="always" xlink:href="#linearGradient3144" id="radialGradient3042" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)" cx="225.26402" cy="672.79736" fx="225.26402" fy="672.79736" r="34.345188"/>
-    <radialGradient inkscape:collect="always" xlink:href="#linearGradient3144" id="radialGradient3068" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)" cx="225.26402" cy="672.79736" fx="225.26402" fy="672.79736" r="34.345188"/>
-    <radialGradient inkscape:collect="always" xlink:href="#linearGradient3144" id="radialGradient3880" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)" cx="225.26402" cy="672.79736" fx="225.26402" fy="672.79736" r="34.345188"/>
-    <radialGradient inkscape:collect="always" xlink:href="#linearGradient3144" id="radialGradient4654" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)" cx="225.26402" cy="672.79736" fx="225.26402" fy="672.79736" r="34.345188"/>
-    <radialGradient inkscape:collect="always" xlink:href="#linearGradient3144" id="radialGradient4693" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)" cx="225.26402" cy="672.79736" fx="225.26402" fy="672.79736" r="34.345188"/>
-    <linearGradient y2="5" x2="-22" y1="18" x1="-18" gradientUnits="userSpaceOnUse" id="linearGradient3131-2" xlink:href="#linearGradient3836-9-3-9" inkscape:collect="always"/>
-    <linearGradient id="linearGradient3836-9-3-9">
-      <stop style="stop-color:#a40000;stop-opacity:1" offset="0" id="stop3838-8-5-1"/>
-      <stop style="stop-color:#ef2929;stop-opacity:1" offset="1" id="stop3840-1-6-2"/>
+    <radialGradient
+       xlink:href="#linearGradient3144"
+       id="radialGradient3958"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
+       cx="225.26402"
+       cy="672.79736"
+       fx="225.26402"
+       fy="672.79736"
+       r="34.345188" />
+    <radialGradient
+       xlink:href="#linearGradient3144-3"
+       id="radialGradient3960"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
+       cx="225.26402"
+       cy="672.79736"
+       fx="225.26402"
+       fy="672.79736"
+       r="34.345188" />
+    <radialGradient
+       xlink:href="#linearGradient3144"
+       id="radialGradient3042"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
+       cx="225.26402"
+       cy="672.79736"
+       fx="225.26402"
+       fy="672.79736"
+       r="34.345188" />
+    <radialGradient
+       xlink:href="#linearGradient3144"
+       id="radialGradient3068"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
+       cx="225.26402"
+       cy="672.79736"
+       fx="225.26402"
+       fy="672.79736"
+       r="34.345188" />
+    <radialGradient
+       xlink:href="#linearGradient3144"
+       id="radialGradient3880"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
+       cx="225.26402"
+       cy="672.79736"
+       fx="225.26402"
+       fy="672.79736"
+       r="34.345188" />
+    <radialGradient
+       xlink:href="#linearGradient3144"
+       id="radialGradient4654"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
+       cx="225.26402"
+       cy="672.79736"
+       fx="225.26402"
+       fy="672.79736"
+       r="34.345188" />
+    <radialGradient
+       xlink:href="#linearGradient3144"
+       id="radialGradient4693"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
+       cx="225.26402"
+       cy="672.79736"
+       fx="225.26402"
+       fy="672.79736"
+       r="34.345188" />
+    <linearGradient
+       y2="5"
+       x2="-22"
+       y1="18"
+       x1="-18"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3131-2"
+       xlink:href="#linearGradient3836-9-3-9" />
+    <linearGradient
+       id="linearGradient3836-9-3-9">
+      <stop
+         style="stop-color:#a40000;stop-opacity:1"
+         offset="0"
+         id="stop3838-8-5-1" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1"
+         offset="1"
+         id="stop3840-1-6-2" />
     </linearGradient>
-    <linearGradient y2="5" x2="-22" y1="18" x1="-18" gradientUnits="userSpaceOnUse" id="linearGradient3171-7" xlink:href="#linearGradient3836-9-3-6-0" inkscape:collect="always"/>
-    <linearGradient id="linearGradient3836-9-3-6-0">
-      <stop style="stop-color:#a40000;stop-opacity:1" offset="0" id="stop3838-8-5-7-9"/>
-      <stop style="stop-color:#ef2929;stop-opacity:1" offset="1" id="stop3840-1-6-5-3"/>
+    <linearGradient
+       y2="5"
+       x2="-22"
+       y1="18"
+       x1="-18"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3171-7"
+       xlink:href="#linearGradient3836-9-3-6-0" />
+    <linearGradient
+       id="linearGradient3836-9-3-6-0">
+      <stop
+         style="stop-color:#a40000;stop-opacity:1"
+         offset="0"
+         id="stop3838-8-5-7-9" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1"
+         offset="1"
+         id="stop3840-1-6-5-3" />
     </linearGradient>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3836-9-3" id="linearGradient3262" gradientUnits="userSpaceOnUse" x1="-18" y1="18" x2="-22" y2="5"/>
-    <linearGradient id="linearGradient3836-9-3">
-      <stop style="stop-color:#a40000;stop-opacity:1" offset="0" id="stop3838-8-5"/>
-      <stop style="stop-color:#ef2929;stop-opacity:1" offset="1" id="stop3840-1-6"/>
+    <linearGradient
+       xlink:href="#linearGradient3836-9-3"
+       id="linearGradient3262"
+       gradientUnits="userSpaceOnUse"
+       x1="-18"
+       y1="18"
+       x2="-22"
+       y2="5" />
+    <linearGradient
+       id="linearGradient3836-9-3">
+      <stop
+         style="stop-color:#a40000;stop-opacity:1"
+         offset="0"
+         id="stop3838-8-5" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1"
+         offset="1"
+         id="stop3840-1-6" />
     </linearGradient>
-    <linearGradient id="linearGradient3836-9-3-6">
-      <stop style="stop-color:#a40000;stop-opacity:1" offset="0" id="stop3838-8-5-7"/>
-      <stop style="stop-color:#ef2929;stop-opacity:1" offset="1" id="stop3840-1-6-5"/>
+    <linearGradient
+       id="linearGradient3836-9-3-6">
+      <stop
+         style="stop-color:#a40000;stop-opacity:1"
+         offset="0"
+         id="stop3838-8-5-7" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1"
+         offset="1"
+         id="stop3840-1-6-5" />
     </linearGradient>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3836-9-3-6-7" id="linearGradient3264-1" gradientUnits="userSpaceOnUse" x1="-18" y1="18" x2="-22" y2="5" gradientTransform="matrix(0.93724177,0,0,0.93725692,-1.2227671,0.70650014)"/>
-    <linearGradient id="linearGradient3836-9-3-6-7">
-      <stop style="stop-color:#a40000;stop-opacity:1" offset="0" id="stop3838-8-5-7-4"/>
-      <stop style="stop-color:#ef2929;stop-opacity:1" offset="1" id="stop3840-1-6-5-0"/>
+    <linearGradient
+       xlink:href="#linearGradient3836-9-3-6-7"
+       id="linearGradient3264-1"
+       gradientUnits="userSpaceOnUse"
+       x1="-18"
+       y1="18"
+       x2="-22"
+       y2="5"
+       gradientTransform="matrix(0.93724177,0,0,0.93725692,-1.2227671,0.70650014)" />
+    <linearGradient
+       id="linearGradient3836-9-3-6-7">
+      <stop
+         style="stop-color:#a40000;stop-opacity:1"
+         offset="0"
+         id="stop3838-8-5-7-4" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1"
+         offset="1"
+         id="stop3840-1-6-5-0" />
     </linearGradient>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3836-9-3-6-4" id="linearGradient3264-9" gradientUnits="userSpaceOnUse" x1="-18" y1="18" x2="-22" y2="5" gradientTransform="matrix(0.93724177,0,0,0.93725692,-1.2227671,0.70650014)"/>
-    <linearGradient id="linearGradient3836-9-3-6-4">
-      <stop style="stop-color:#a40000;stop-opacity:1" offset="0" id="stop3838-8-5-7-8"/>
-      <stop style="stop-color:#ef2929;stop-opacity:1" offset="1" id="stop3840-1-6-5-8"/>
+    <linearGradient
+       xlink:href="#linearGradient3836-9-3-6-4"
+       id="linearGradient3264-9"
+       gradientUnits="userSpaceOnUse"
+       x1="-18"
+       y1="18"
+       x2="-22"
+       y2="5"
+       gradientTransform="matrix(0.93724177,0,0,0.93725692,-1.2227671,0.70650014)" />
+    <linearGradient
+       id="linearGradient3836-9-3-6-4">
+      <stop
+         style="stop-color:#a40000;stop-opacity:1"
+         offset="0"
+         id="stop3838-8-5-7-8" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1"
+         offset="1"
+         id="stop3840-1-6-5-8" />
     </linearGradient>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3836-9-3-6-1" id="linearGradient3264-17" gradientUnits="userSpaceOnUse" x1="-18" y1="18" x2="-22" y2="5" gradientTransform="matrix(0.93724177,0,0,0.93725692,-1.2227671,0.70650014)"/>
-    <linearGradient id="linearGradient3836-9-3-6-1">
-      <stop style="stop-color:#a40000;stop-opacity:1" offset="0" id="stop3838-8-5-7-1"/>
-      <stop style="stop-color:#ef2929;stop-opacity:1" offset="1" id="stop3840-1-6-5-5"/>
+    <linearGradient
+       xlink:href="#linearGradient3836-9-3-6-1"
+       id="linearGradient3264-17"
+       gradientUnits="userSpaceOnUse"
+       x1="-18"
+       y1="18"
+       x2="-22"
+       y2="5"
+       gradientTransform="matrix(0.93724177,0,0,0.93725692,-1.2227671,0.70650014)" />
+    <linearGradient
+       id="linearGradient3836-9-3-6-1">
+      <stop
+         style="stop-color:#a40000;stop-opacity:1"
+         offset="0"
+         id="stop3838-8-5-7-1" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1"
+         offset="1"
+         id="stop3840-1-6-5-5" />
     </linearGradient>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3836-9-3-6-2" id="linearGradient3264-3" gradientUnits="userSpaceOnUse" x1="-18" y1="18" x2="-22" y2="5" gradientTransform="matrix(0.93724177,0,0,0.93725692,-1.2227671,0.70650014)"/>
-    <linearGradient id="linearGradient3836-9-3-6-2">
-      <stop style="stop-color:#a40000;stop-opacity:1" offset="0" id="stop3838-8-5-7-2"/>
-      <stop style="stop-color:#ef2929;stop-opacity:1" offset="1" id="stop3840-1-6-5-1"/>
+    <linearGradient
+       xlink:href="#linearGradient3836-9-3-6-2"
+       id="linearGradient3264-3"
+       gradientUnits="userSpaceOnUse"
+       x1="-18"
+       y1="18"
+       x2="-22"
+       y2="5"
+       gradientTransform="matrix(0.93724177,0,0,0.93725692,-1.2227671,0.70650014)" />
+    <linearGradient
+       id="linearGradient3836-9-3-6-2">
+      <stop
+         style="stop-color:#a40000;stop-opacity:1"
+         offset="0"
+         id="stop3838-8-5-7-2" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1"
+         offset="1"
+         id="stop3840-1-6-5-1" />
     </linearGradient>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3836-9-3-3" id="linearGradient3262-5" gradientUnits="userSpaceOnUse" x1="-18" y1="18" x2="-22" y2="5"/>
-    <linearGradient id="linearGradient3836-9-3-3">
-      <stop style="stop-color:#a40000;stop-opacity:1" offset="0" id="stop3838-8-5-5"/>
-      <stop style="stop-color:#ef2929;stop-opacity:1" offset="1" id="stop3840-1-6-6"/>
+    <linearGradient
+       xlink:href="#linearGradient3836-9-3-3"
+       id="linearGradient3262-5"
+       gradientUnits="userSpaceOnUse"
+       x1="-18"
+       y1="18"
+       x2="-22"
+       y2="5" />
+    <linearGradient
+       id="linearGradient3836-9-3-3">
+      <stop
+         style="stop-color:#a40000;stop-opacity:1"
+         offset="0"
+         id="stop3838-8-5-5" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1"
+         offset="1"
+         id="stop3840-1-6-6" />
     </linearGradient>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3836-9-3-6-29" id="linearGradient3264" gradientUnits="userSpaceOnUse" x1="-18" y1="18" x2="-22" y2="5"/>
-    <linearGradient id="linearGradient3836-9-3-6-29">
-      <stop style="stop-color:#a40000;stop-opacity:1" offset="0" id="stop3838-8-5-7-12"/>
-      <stop style="stop-color:#ef2929;stop-opacity:1" offset="1" id="stop3840-1-6-5-7"/>
+    <linearGradient
+       xlink:href="#linearGradient3836-9-3-6-29"
+       id="linearGradient3264"
+       gradientUnits="userSpaceOnUse"
+       x1="-18"
+       y1="18"
+       x2="-22"
+       y2="5" />
+    <linearGradient
+       id="linearGradient3836-9-3-6-29">
+      <stop
+         style="stop-color:#a40000;stop-opacity:1"
+         offset="0"
+         id="stop3838-8-5-7-12" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1"
+         offset="1"
+         id="stop3840-1-6-5-7" />
     </linearGradient>
-    <linearGradient y2="5" x2="-22" y1="18" x1="-18" gradientUnits="userSpaceOnUse" id="linearGradient3131-2-0" xlink:href="#linearGradient3836-9-3-9-9" inkscape:collect="always"/>
-    <linearGradient id="linearGradient3836-9-3-9-9">
-      <stop style="stop-color:#a40000;stop-opacity:1" offset="0" id="stop3838-8-5-1-3"/>
-      <stop style="stop-color:#ef2929;stop-opacity:1" offset="1" id="stop3840-1-6-2-6"/>
+    <linearGradient
+       y2="5"
+       x2="-22"
+       y1="18"
+       x1="-18"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3131-2-0"
+       xlink:href="#linearGradient3836-9-3-9-9" />
+    <linearGradient
+       id="linearGradient3836-9-3-9-9">
+      <stop
+         style="stop-color:#a40000;stop-opacity:1"
+         offset="0"
+         id="stop3838-8-5-1-3" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1"
+         offset="1"
+         id="stop3840-1-6-2-6" />
     </linearGradient>
-    <linearGradient y2="5" x2="-22" y1="18" x1="-18" gradientUnits="userSpaceOnUse" id="linearGradient3171-7-0" xlink:href="#linearGradient3836-9-3-6-0-6" inkscape:collect="always"/>
-    <linearGradient id="linearGradient3836-9-3-6-0-6">
-      <stop style="stop-color:#a40000;stop-opacity:1" offset="0" id="stop3838-8-5-7-9-2"/>
-      <stop style="stop-color:#ef2929;stop-opacity:1" offset="1" id="stop3840-1-6-5-3-6"/>
+    <linearGradient
+       y2="5"
+       x2="-22"
+       y1="18"
+       x1="-18"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3171-7-0"
+       xlink:href="#linearGradient3836-9-3-6-0-6" />
+    <linearGradient
+       id="linearGradient3836-9-3-6-0-6">
+      <stop
+         style="stop-color:#a40000;stop-opacity:1"
+         offset="0"
+         id="stop3838-8-5-7-9-2" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1"
+         offset="1"
+         id="stop3840-1-6-5-3-6" />
     </linearGradient>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3836-9-3-6-29" id="linearGradient3931" gradientUnits="userSpaceOnUse" x1="-18" y1="18" x2="-22" y2="5" gradientTransform="matrix(0.71441909,0,0,0.71408544,-5.531259,3.2604792)"/>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3836-9-3-6-29" id="linearGradient3937" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.71441909,0,0,0.71408544,-5.531259,3.2604792)" x1="-18" y1="18" x2="-22" y2="5"/>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3836-9-3-6-29-8" id="linearGradient3937-1" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.71441909,0,0,0.71408544,-5.531259,3.2604792)" x1="-18" y1="18" x2="-22" y2="5"/>
-    <linearGradient id="linearGradient3836-9-3-6-29-8">
-      <stop style="stop-color:#a40000;stop-opacity:1" offset="0" id="stop3838-8-5-7-12-7"/>
-      <stop style="stop-color:#ef2929;stop-opacity:1" offset="1" id="stop3840-1-6-5-7-9"/>
+    <linearGradient
+       xlink:href="#linearGradient3836-9-3-6-29-8"
+       id="linearGradient3937-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.71441909,0,0,0.71408544,-5.531259,3.2604792)"
+       x1="-18"
+       y1="18"
+       x2="-22"
+       y2="5" />
+    <linearGradient
+       id="linearGradient3836-9-3-6-29-8">
+      <stop
+         style="stop-color:#a40000;stop-opacity:1"
+         offset="0"
+         id="stop3838-8-5-7-12-7" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1"
+         offset="1"
+         id="stop3840-1-6-5-7-9" />
     </linearGradient>
-    <linearGradient y2="5" x2="-22" y1="18" x1="-18" gradientTransform="matrix(0.71441909,0,0,0.71408544,-5.531259,3.2604792)" gradientUnits="userSpaceOnUse" id="linearGradient3956" xlink:href="#linearGradient3836-9-3-6-29-8" inkscape:collect="always"/>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3836-9-3-6-29-7" id="linearGradient3937-3" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.71441909,0,0,0.71408544,-5.531259,3.2604792)" x1="-18" y1="18" x2="-22" y2="5"/>
-    <linearGradient id="linearGradient3836-9-3-6-29-7">
-      <stop style="stop-color:#a40000;stop-opacity:1" offset="0" id="stop3838-8-5-7-12-5"/>
-      <stop style="stop-color:#ef2929;stop-opacity:1" offset="1" id="stop3840-1-6-5-7-92"/>
+    <linearGradient
+       id="linearGradient3836-9-3-6-29-7">
+      <stop
+         style="stop-color:#a40000;stop-opacity:1"
+         offset="0"
+         id="stop3838-8-5-7-12-5" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1"
+         offset="1"
+         id="stop3840-1-6-5-7-92" />
     </linearGradient>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3836-9-3-6-29-1" id="linearGradient3937-36" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.71441909,0,0,0.71408544,-5.531259,3.2604792)" x1="-18" y1="18" x2="-22" y2="5"/>
-    <linearGradient id="linearGradient3836-9-3-6-29-1">
-      <stop style="stop-color:#a40000;stop-opacity:1" offset="0" id="stop3838-8-5-7-12-2"/>
-      <stop style="stop-color:#ef2929;stop-opacity:1" offset="1" id="stop3840-1-6-5-7-93"/>
+    <linearGradient
+       id="linearGradient3836-9-3-6-29-1">
+      <stop
+         style="stop-color:#a40000;stop-opacity:1"
+         offset="0"
+         id="stop3838-8-5-7-12-2" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1"
+         offset="1"
+         id="stop3840-1-6-5-7-93" />
     </linearGradient>
   </defs>
-  <sodipodi:namedview id="base" pagecolor="#ffffff" bordercolor="#666666" borderopacity="1.0" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:zoom="9.3695575" inkscape:cx="-13.382495" inkscape:cy="34.299582" inkscape:current-layer="layer1" showgrid="true" inkscape:document-units="px" inkscape:grid-bbox="true" inkscape:window-width="1600" inkscape:window-height="834" inkscape:window-x="0" inkscape:window-y="27" inkscape:window-maximized="1" inkscape:snap-global="true" inkscape:snap-bbox="true" inkscape:snap-nodes="true" showguides="true" inkscape:guide-bbox="true">
-    <inkscape:grid type="xygrid" id="grid3058" empspacing="2" visible="true" enabled="true" snapvisiblegridlinesonly="true"/>
-    <sodipodi:guide orientation="1,0" position="28,22" id="guide3917"/>
-    <sodipodi:guide orientation="0,1" position="12,32" id="guide3919"/>
-    <sodipodi:guide orientation="0,1" position="60,16" id="guide3921"/>
-    <sodipodi:guide orientation="1,0" position="52,8" id="guide3923"/>
-  </sodipodi:namedview>
-  <metadata id="metadata2923">
+  <metadata
+     id="metadata2923">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Sketcher_BSplineDegree</dc:title>
         <dc:creator>
           <cc:Agent>
-            <dc:title>[agryson] Alexander Gryson</dc:title>
+            <dc:title>[bitacovir]</dc:title>
           </cc:Agent>
         </dc:creator>
         <dc:title>Sketcher_Create_Periodic_BSpline</dc:title>
-        <dc:date>2017-02-15</dc:date>
+        <dc:date>22-03-2021</dc:date>
         <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>
           </cc:Agent>
         </dc:publisher>
-        <dc:identifier>FreeCAD/src/Mod/Sketcher/Gui/Resources/icons/Sketcher_Toggle_BSpline_Information.svg</dc:identifier>
+        <dc:identifier></dc:identifier>
         <dc:rights>
           <cc:Agent>
             <dc:title>FreeCAD LGPL2+</dc:title>
@@ -131,45 +404,55 @@
         <cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license>
         <dc:contributor>
           <cc:Agent>
-            <dc:title>[agryson] Alexander Gryson</dc:title>
+            <dc:title></dc:title>
           </cc:Agent>
         </dc:contributor>
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g id="layer1" inkscape:label="Layer 1" inkscape:groupmode="layer">
-    <path style="fill:none;stroke:#2e3436;stroke-width:8;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="M 55.999976,26.000003 C 58,48 32,32 29.999975,52.000002" id="path3266" inkscape:connector-curvature="0" sodipodi:nodetypes="cc"/>
-    <path style="fill:none;stroke:#d3d7cf;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="M 55.999976,26.000003 C 56,48 32,32 29.999975,52.000002" id="path3266-9" inkscape:connector-curvature="0" sodipodi:nodetypes="cc"/>
-    <path style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="M 54.999975,26.000003 C 56,47 32,31 28.999974,52.000002" id="path3266-9-2" inkscape:connector-curvature="0" sodipodi:nodetypes="cc"/>
-    <g inkscape:export-ydpi="7.2934141" inkscape:export-xdpi="7.2934141" inkscape:export-filename="/home/yorik/Documents/Lab/Draft/icons/circle.png" transform="matrix(-0.14137236,0.07774155,-0.01888492,-0.10633123,99.823869,75.569613)" id="g3177"/>
-    <g inkscape:export-ydpi="7.2934141" inkscape:export-xdpi="7.2934141" inkscape:export-filename="/home/yorik/Documents/Lab/Draft/icons/circle.png" transform="matrix(-0.14109247,0.07923086,-0.02087339,-0.10522619,77.138226,86.686164)" id="g3185"/>
-    <g transform="matrix(0.59988397,0,0,0.60016354,23.595637,49.138672)" id="g3797-7-2-3">
-      <g id="g3933" transform="translate(30.005802,0)">
-        <path d="m -25.658702,6.015909 a 8.3321309,8.3277776 0 1 1 12.65725,10.83369 8.3321309,8.3277776 0 1 1 -12.65725,-10.83369 z" id="path4250-6-9-5" style="fill:#ef2929;stroke:#280000;stroke-width:3.33320141;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" inkscape:connector-curvature="0"/>
-        <path d="m -23.129965,8.18309 a 5.0009335,4.9985982 0 1 1 7.596839,6.502756 5.0009335,4.9985982 0 0 1 -7.596839,-6.502756 z" id="path4250-7-0-1-6" style="fill:url(#linearGradient3937);fill-opacity:1;stroke:#ef2929;stroke-width:3.33320141;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" inkscape:connector-curvature="0"/>
-      </g>
-    </g>
-    <g id="g3933-2" transform="matrix(0.59988397,0,0,0.60016354,67.595636,19.138672)">
-      <path d="m -25.658702,6.015909 a 8.3321309,8.3277776 0 1 1 12.65725,10.83369 8.3321309,8.3277776 0 1 1 -12.65725,-10.83369 z" id="path4250-6-9-5-0" style="fill:#ef2929;stroke:#280000;stroke-width:3.33320141;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" inkscape:connector-curvature="0"/>
-      <path d="m -23.129965,8.18309 a 5.0009335,4.9985982 0 1 1 7.596839,6.502756 5.0009335,4.9985982 0 0 1 -7.596839,-6.502756 z" id="path4250-7-0-1-6-2" style="fill:url(#linearGradient3956);fill-opacity:1;stroke:#ef2929;stroke-width:3.33320141;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" inkscape:connector-curvature="0"/>
-    </g>
-    <g transform="matrix(0.59988397,0,0,0.60016354,25.595637,25.138672)" id="g3797-7-2-3-2">
-      <g id="g3933-8" transform="translate(30.005802,0)">
-        <path d="m -25.658702,6.015909 a 8.3321309,8.3277776 0 1 1 12.65725,10.83369 8.3321309,8.3277776 0 1 1 -12.65725,-10.83369 z" id="path4250-6-9-5-9" style="fill:#ef2929;stroke:#280000;stroke-width:3.33320141;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" inkscape:connector-curvature="0"/>
-        <path d="m -23.129965,8.18309 a 5.0009335,4.9985982 0 1 1 7.596839,6.502756 5.0009335,4.9985982 0 0 1 -7.596839,-6.502756 z" id="path4250-7-0-1-6-7" style="fill:url(#linearGradient3937-3);fill-opacity:1;stroke:#ef2929;stroke-width:3.33320141;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" inkscape:connector-curvature="0"/>
-      </g>
-    </g>
-    <g transform="matrix(0.59988397,0,0,0.60016354,49.595637,41.138672)" id="g3797-7-2-3-1">
-      <g id="g3933-9" transform="translate(30.005802,0)">
-        <path d="m -25.658702,6.015909 a 8.3321309,8.3277776 0 1 1 12.65725,10.83369 8.3321309,8.3277776 0 1 1 -12.65725,-10.83369 z" id="path4250-6-9-5-4" style="fill:#ef2929;stroke:#280000;stroke-width:3.33320141;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" inkscape:connector-curvature="0"/>
-        <path d="m -23.129965,8.18309 a 5.0009335,4.9985982 0 1 1 7.596839,6.502756 5.0009335,4.9985982 0 0 1 -7.596839,-6.502756 z" id="path4250-7-0-1-6-78" style="fill:url(#linearGradient3937-36);fill-opacity:1;stroke:#ef2929;stroke-width:3.33320141;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" inkscape:connector-curvature="0"/>
-      </g>
-    </g>
-    <path style="fill:none;stroke:#172a04;stroke-width:8;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" d="M 31,44 35,6 M 6,33 44,33" id="path3047-3-6-3" inkscape:connector-curvature="0" sodipodi:nodetypes="cccc"/>
-    <path style="fill:none;stroke:#172a04;stroke-width:8;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" d="M 17,6 13,44 M 44,17 6,17" id="path3047-3-6" inkscape:connector-curvature="0" sodipodi:nodetypes="cccc"/>
-    <path style="fill:none;stroke:#4e9a06;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" d="M 17,6 13,44 M 44,17 6,17" id="path3047" inkscape:connector-curvature="0" sodipodi:nodetypes="cccc"/>
-    <path style="fill:none;stroke:#4e9a06;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" d="M 31,44 35,6 M 6,33 44,33" id="path3047-6" inkscape:connector-curvature="0" sodipodi:nodetypes="cccc"/>
-    <path style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" d="M 30,44 34,6 M 6,32 44,32" id="path3047-3-7" inkscape:connector-curvature="0" sodipodi:nodetypes="cccc"/>
-    <path style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" d="M 16,6 12,44 M 44,16 6,16" id="path3047-3" inkscape:connector-curvature="0" sodipodi:nodetypes="cccc"/>
+  <g
+     id="layer1">
+    <path
+       style="fill:none;stroke:#2e3436;stroke-width:9;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 57.2462,31.371316 C 59.246224,53.371313 33.246224,37.371313 31.246199,57.371315"
+       id="path3266" />
+    <path
+       style="fill:none;stroke:#d3d7cf;stroke-width:4;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 57.2462,31.371316 c 2.4e-5,21.999997 -23.999976,5.999997 -26.000001,25.999999"
+       id="path3266-9" />
+    <path
+       style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 56.246199,31.371316 C 57.246224,52.371313 33.246224,36.371313 30.246198,57.371315"
+       id="path3266-9-2" />
+    <g
+       transform="matrix(-0.14137236,0.07774155,-0.01888492,-0.10633123,99.823869,75.569613)"
+       id="g3177" />
+    <g
+       transform="matrix(-0.14109247,0.07923086,-0.02087339,-0.10522619,77.138226,86.686164)"
+       id="g3185" />
+    <path
+       style="fill:none;stroke:#172a04;stroke-width:8;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+       d="M 31,44 35,6 M 6,33 h 38"
+       id="path3047-3-6-3" />
+    <path
+       style="fill:none;stroke:#172a04;stroke-width:8;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+       d="M 17,6 13,44 M 44,17 H 6"
+       id="path3047-3-6" />
+    <path
+       style="fill:none;stroke:#4e9a06;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+       d="M 17,6 13,44 M 44,17 H 6"
+       id="path3047" />
+    <path
+       style="fill:none;stroke:#4e9a06;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+       d="M 31,44 35,6 M 6,33 h 38"
+       id="path3047-6" />
+    <path
+       style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+       d="M 30,44 34,6 M 6,32 h 38"
+       id="path3047-3-7" />
+    <path
+       style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+       d="M 16,6 12,44 M 44,16 H 6"
+       id="path3047-3" />
   </g>
 </svg>

--- a/src/Mod/Sketcher/Gui/Resources/icons/splines/Sketcher_BSplineIncreaseDegree.svg
+++ b/src/Mod/Sketcher/Gui/Resources/icons/splines/Sketcher_BSplineIncreaseDegree.svg
@@ -1,135 +1,438 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width="64px" height="64px" id="svg2918" sodipodi:version="0.32" inkscape:version="0.48.5 r10040" sodipodi:docname="Sketcher_BSplineIncreaseDegree.svg" inkscape:output_extension="org.inkscape.output.svg.inkscape" version="1.1" inkscape:export-filename="/home/user/Downloads/cad/mystuff/icons/sketcher/Sketcher_CreateCircle_from_3points_2_16px.png" inkscape:export-xdpi="22.5" inkscape:export-ydpi="22.5">
-  <defs id="defs2920">
-    <linearGradient inkscape:collect="always" id="linearGradient3144">
-      <stop style="stop-color:#ffffff;stop-opacity:1;" offset="0" id="stop3146"/>
-      <stop style="stop-color:#ffffff;stop-opacity:0;" offset="1" id="stop3148"/>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.1"
+   id="svg2918"
+   height="64px"
+   width="64px">
+  <title
+     id="title927">Sketcher_BSplineIncreaseDegree</title>
+  <defs
+     id="defs2920">
+    <linearGradient
+       id="linearGradient3144">
+      <stop
+         id="stop3146"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop3148"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
     </linearGradient>
-    <inkscape:perspective sodipodi:type="inkscape:persp3d" inkscape:vp_x="0 : 32 : 1" inkscape:vp_y="0 : 1000 : 0" inkscape:vp_z="64 : 32 : 1" inkscape:persp3d-origin="32 : 21.333333 : 1" id="perspective2926"/>
-    <linearGradient inkscape:collect="always" id="linearGradient3144-3">
-      <stop style="stop-color:#ffffff;stop-opacity:1;" offset="0" id="stop3146-1"/>
-      <stop style="stop-color:#ffffff;stop-opacity:0;" offset="1" id="stop3148-5"/>
+    <linearGradient
+       id="linearGradient3144-3">
+      <stop
+         id="stop3146-1"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop3148-5"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
     </linearGradient>
-    <radialGradient inkscape:collect="always" xlink:href="#linearGradient3144" id="radialGradient3958" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)" cx="225.26402" cy="672.79736" fx="225.26402" fy="672.79736" r="34.345188"/>
-    <radialGradient inkscape:collect="always" xlink:href="#linearGradient3144-3" id="radialGradient3960" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)" cx="225.26402" cy="672.79736" fx="225.26402" fy="672.79736" r="34.345188"/>
-    <radialGradient inkscape:collect="always" xlink:href="#linearGradient3144" id="radialGradient3042" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)" cx="225.26402" cy="672.79736" fx="225.26402" fy="672.79736" r="34.345188"/>
-    <radialGradient inkscape:collect="always" xlink:href="#linearGradient3144" id="radialGradient3068" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)" cx="225.26402" cy="672.79736" fx="225.26402" fy="672.79736" r="34.345188"/>
-    <radialGradient inkscape:collect="always" xlink:href="#linearGradient3144" id="radialGradient3880" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)" cx="225.26402" cy="672.79736" fx="225.26402" fy="672.79736" r="34.345188"/>
-    <radialGradient inkscape:collect="always" xlink:href="#linearGradient3144" id="radialGradient4654" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)" cx="225.26402" cy="672.79736" fx="225.26402" fy="672.79736" r="34.345188"/>
-    <radialGradient inkscape:collect="always" xlink:href="#linearGradient3144" id="radialGradient4693" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)" cx="225.26402" cy="672.79736" fx="225.26402" fy="672.79736" r="34.345188"/>
-    <linearGradient y2="5" x2="-22" y1="18" x1="-18" gradientUnits="userSpaceOnUse" id="linearGradient3131-2" xlink:href="#linearGradient3836-9-3-9" inkscape:collect="always"/>
-    <linearGradient id="linearGradient3836-9-3-9">
-      <stop style="stop-color:#a40000;stop-opacity:1" offset="0" id="stop3838-8-5-1"/>
-      <stop style="stop-color:#ef2929;stop-opacity:1" offset="1" id="stop3840-1-6-2"/>
+    <radialGradient
+       r="34.345188"
+       fy="672.79736"
+       fx="225.26402"
+       cy="672.79736"
+       cx="225.26402"
+       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3958"
+       xlink:href="#linearGradient3144" />
+    <radialGradient
+       r="34.345188"
+       fy="672.79736"
+       fx="225.26402"
+       cy="672.79736"
+       cx="225.26402"
+       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3960"
+       xlink:href="#linearGradient3144-3" />
+    <radialGradient
+       r="34.345188"
+       fy="672.79736"
+       fx="225.26402"
+       cy="672.79736"
+       cx="225.26402"
+       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3042"
+       xlink:href="#linearGradient3144" />
+    <radialGradient
+       r="34.345188"
+       fy="672.79736"
+       fx="225.26402"
+       cy="672.79736"
+       cx="225.26402"
+       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3068"
+       xlink:href="#linearGradient3144" />
+    <radialGradient
+       r="34.345188"
+       fy="672.79736"
+       fx="225.26402"
+       cy="672.79736"
+       cx="225.26402"
+       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3880"
+       xlink:href="#linearGradient3144" />
+    <radialGradient
+       r="34.345188"
+       fy="672.79736"
+       fx="225.26402"
+       cy="672.79736"
+       cx="225.26402"
+       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4654"
+       xlink:href="#linearGradient3144" />
+    <radialGradient
+       r="34.345188"
+       fy="672.79736"
+       fx="225.26402"
+       cy="672.79736"
+       cx="225.26402"
+       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4693"
+       xlink:href="#linearGradient3144" />
+    <linearGradient
+       xlink:href="#linearGradient3836-9-3-9"
+       id="linearGradient3131-2"
+       gradientUnits="userSpaceOnUse"
+       x1="-18"
+       y1="18"
+       x2="-22"
+       y2="5" />
+    <linearGradient
+       id="linearGradient3836-9-3-9">
+      <stop
+         id="stop3838-8-5-1"
+         offset="0"
+         style="stop-color:#a40000;stop-opacity:1" />
+      <stop
+         id="stop3840-1-6-2"
+         offset="1"
+         style="stop-color:#ef2929;stop-opacity:1" />
     </linearGradient>
-    <linearGradient y2="5" x2="-22" y1="18" x1="-18" gradientUnits="userSpaceOnUse" id="linearGradient3171-7" xlink:href="#linearGradient3836-9-3-6-0" inkscape:collect="always"/>
-    <linearGradient id="linearGradient3836-9-3-6-0">
-      <stop style="stop-color:#a40000;stop-opacity:1" offset="0" id="stop3838-8-5-7-9"/>
-      <stop style="stop-color:#ef2929;stop-opacity:1" offset="1" id="stop3840-1-6-5-3"/>
+    <linearGradient
+       xlink:href="#linearGradient3836-9-3-6-0"
+       id="linearGradient3171-7"
+       gradientUnits="userSpaceOnUse"
+       x1="-18"
+       y1="18"
+       x2="-22"
+       y2="5" />
+    <linearGradient
+       id="linearGradient3836-9-3-6-0">
+      <stop
+         id="stop3838-8-5-7-9"
+         offset="0"
+         style="stop-color:#a40000;stop-opacity:1" />
+      <stop
+         id="stop3840-1-6-5-3"
+         offset="1"
+         style="stop-color:#ef2929;stop-opacity:1" />
     </linearGradient>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3836-9-3" id="linearGradient3262" gradientUnits="userSpaceOnUse" x1="-18" y1="18" x2="-22" y2="5"/>
-    <linearGradient id="linearGradient3836-9-3">
-      <stop style="stop-color:#a40000;stop-opacity:1" offset="0" id="stop3838-8-5"/>
-      <stop style="stop-color:#ef2929;stop-opacity:1" offset="1" id="stop3840-1-6"/>
+    <linearGradient
+       y2="5"
+       x2="-22"
+       y1="18"
+       x1="-18"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3262"
+       xlink:href="#linearGradient3836-9-3" />
+    <linearGradient
+       id="linearGradient3836-9-3">
+      <stop
+         id="stop3838-8-5"
+         offset="0"
+         style="stop-color:#a40000;stop-opacity:1" />
+      <stop
+         id="stop3840-1-6"
+         offset="1"
+         style="stop-color:#ef2929;stop-opacity:1" />
     </linearGradient>
-    <linearGradient id="linearGradient3836-9-3-6">
-      <stop style="stop-color:#a40000;stop-opacity:1" offset="0" id="stop3838-8-5-7"/>
-      <stop style="stop-color:#ef2929;stop-opacity:1" offset="1" id="stop3840-1-6-5"/>
+    <linearGradient
+       id="linearGradient3836-9-3-6">
+      <stop
+         id="stop3838-8-5-7"
+         offset="0"
+         style="stop-color:#a40000;stop-opacity:1" />
+      <stop
+         id="stop3840-1-6-5"
+         offset="1"
+         style="stop-color:#ef2929;stop-opacity:1" />
     </linearGradient>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3836-9-3-6-7" id="linearGradient3264-1" gradientUnits="userSpaceOnUse" x1="-18" y1="18" x2="-22" y2="5" gradientTransform="matrix(0.93724177,0,0,0.93725692,-1.2227671,0.70650014)"/>
-    <linearGradient id="linearGradient3836-9-3-6-7">
-      <stop style="stop-color:#a40000;stop-opacity:1" offset="0" id="stop3838-8-5-7-4"/>
-      <stop style="stop-color:#ef2929;stop-opacity:1" offset="1" id="stop3840-1-6-5-0"/>
+    <linearGradient
+       gradientTransform="matrix(0.93724177,0,0,0.93725692,-1.2227671,0.70650014)"
+       y2="5"
+       x2="-22"
+       y1="18"
+       x1="-18"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3264-1"
+       xlink:href="#linearGradient3836-9-3-6-7" />
+    <linearGradient
+       id="linearGradient3836-9-3-6-7">
+      <stop
+         id="stop3838-8-5-7-4"
+         offset="0"
+         style="stop-color:#a40000;stop-opacity:1" />
+      <stop
+         id="stop3840-1-6-5-0"
+         offset="1"
+         style="stop-color:#ef2929;stop-opacity:1" />
     </linearGradient>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3836-9-3-6-4" id="linearGradient3264-9" gradientUnits="userSpaceOnUse" x1="-18" y1="18" x2="-22" y2="5" gradientTransform="matrix(0.93724177,0,0,0.93725692,-1.2227671,0.70650014)"/>
-    <linearGradient id="linearGradient3836-9-3-6-4">
-      <stop style="stop-color:#a40000;stop-opacity:1" offset="0" id="stop3838-8-5-7-8"/>
-      <stop style="stop-color:#ef2929;stop-opacity:1" offset="1" id="stop3840-1-6-5-8"/>
+    <linearGradient
+       gradientTransform="matrix(0.93724177,0,0,0.93725692,-1.2227671,0.70650014)"
+       y2="5"
+       x2="-22"
+       y1="18"
+       x1="-18"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3264-9"
+       xlink:href="#linearGradient3836-9-3-6-4" />
+    <linearGradient
+       id="linearGradient3836-9-3-6-4">
+      <stop
+         id="stop3838-8-5-7-8"
+         offset="0"
+         style="stop-color:#a40000;stop-opacity:1" />
+      <stop
+         id="stop3840-1-6-5-8"
+         offset="1"
+         style="stop-color:#ef2929;stop-opacity:1" />
     </linearGradient>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3836-9-3-6-1" id="linearGradient3264-17" gradientUnits="userSpaceOnUse" x1="-18" y1="18" x2="-22" y2="5" gradientTransform="matrix(0.93724177,0,0,0.93725692,-1.2227671,0.70650014)"/>
-    <linearGradient id="linearGradient3836-9-3-6-1">
-      <stop style="stop-color:#a40000;stop-opacity:1" offset="0" id="stop3838-8-5-7-1"/>
-      <stop style="stop-color:#ef2929;stop-opacity:1" offset="1" id="stop3840-1-6-5-5"/>
+    <linearGradient
+       gradientTransform="matrix(0.93724177,0,0,0.93725692,-1.2227671,0.70650014)"
+       y2="5"
+       x2="-22"
+       y1="18"
+       x1="-18"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3264-17"
+       xlink:href="#linearGradient3836-9-3-6-1" />
+    <linearGradient
+       id="linearGradient3836-9-3-6-1">
+      <stop
+         id="stop3838-8-5-7-1"
+         offset="0"
+         style="stop-color:#a40000;stop-opacity:1" />
+      <stop
+         id="stop3840-1-6-5-5"
+         offset="1"
+         style="stop-color:#ef2929;stop-opacity:1" />
     </linearGradient>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3836-9-3-6-2" id="linearGradient3264-3" gradientUnits="userSpaceOnUse" x1="-18" y1="18" x2="-22" y2="5" gradientTransform="matrix(0.93724177,0,0,0.93725692,-1.2227671,0.70650014)"/>
-    <linearGradient id="linearGradient3836-9-3-6-2">
-      <stop style="stop-color:#a40000;stop-opacity:1" offset="0" id="stop3838-8-5-7-2"/>
-      <stop style="stop-color:#ef2929;stop-opacity:1" offset="1" id="stop3840-1-6-5-1"/>
+    <linearGradient
+       gradientTransform="matrix(0.93724177,0,0,0.93725692,-1.2227671,0.70650014)"
+       y2="5"
+       x2="-22"
+       y1="18"
+       x1="-18"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3264-3"
+       xlink:href="#linearGradient3836-9-3-6-2" />
+    <linearGradient
+       id="linearGradient3836-9-3-6-2">
+      <stop
+         id="stop3838-8-5-7-2"
+         offset="0"
+         style="stop-color:#a40000;stop-opacity:1" />
+      <stop
+         id="stop3840-1-6-5-1"
+         offset="1"
+         style="stop-color:#ef2929;stop-opacity:1" />
     </linearGradient>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3836-9-3-3" id="linearGradient3262-5" gradientUnits="userSpaceOnUse" x1="-18" y1="18" x2="-22" y2="5"/>
-    <linearGradient id="linearGradient3836-9-3-3">
-      <stop style="stop-color:#a40000;stop-opacity:1" offset="0" id="stop3838-8-5-5"/>
-      <stop style="stop-color:#ef2929;stop-opacity:1" offset="1" id="stop3840-1-6-6"/>
+    <linearGradient
+       y2="5"
+       x2="-22"
+       y1="18"
+       x1="-18"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3262-5"
+       xlink:href="#linearGradient3836-9-3-3" />
+    <linearGradient
+       id="linearGradient3836-9-3-3">
+      <stop
+         id="stop3838-8-5-5"
+         offset="0"
+         style="stop-color:#a40000;stop-opacity:1" />
+      <stop
+         id="stop3840-1-6-6"
+         offset="1"
+         style="stop-color:#ef2929;stop-opacity:1" />
     </linearGradient>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3836-9-3-6-29" id="linearGradient3264" gradientUnits="userSpaceOnUse" x1="-18" y1="18" x2="-22" y2="5"/>
-    <linearGradient id="linearGradient3836-9-3-6-29">
-      <stop style="stop-color:#a40000;stop-opacity:1" offset="0" id="stop3838-8-5-7-12"/>
-      <stop style="stop-color:#ef2929;stop-opacity:1" offset="1" id="stop3840-1-6-5-7"/>
+    <linearGradient
+       y2="5"
+       x2="-22"
+       y1="18"
+       x1="-18"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3264"
+       xlink:href="#linearGradient3836-9-3-6-29" />
+    <linearGradient
+       id="linearGradient3836-9-3-6-29">
+      <stop
+         id="stop3838-8-5-7-12"
+         offset="0"
+         style="stop-color:#a40000;stop-opacity:1" />
+      <stop
+         id="stop3840-1-6-5-7"
+         offset="1"
+         style="stop-color:#ef2929;stop-opacity:1" />
     </linearGradient>
-    <linearGradient y2="5" x2="-22" y1="18" x1="-18" gradientUnits="userSpaceOnUse" id="linearGradient3131-2-0" xlink:href="#linearGradient3836-9-3-9-9" inkscape:collect="always"/>
-    <linearGradient id="linearGradient3836-9-3-9-9">
-      <stop style="stop-color:#a40000;stop-opacity:1" offset="0" id="stop3838-8-5-1-3"/>
-      <stop style="stop-color:#ef2929;stop-opacity:1" offset="1" id="stop3840-1-6-2-6"/>
+    <linearGradient
+       xlink:href="#linearGradient3836-9-3-9-9"
+       id="linearGradient3131-2-0"
+       gradientUnits="userSpaceOnUse"
+       x1="-18"
+       y1="18"
+       x2="-22"
+       y2="5" />
+    <linearGradient
+       id="linearGradient3836-9-3-9-9">
+      <stop
+         id="stop3838-8-5-1-3"
+         offset="0"
+         style="stop-color:#a40000;stop-opacity:1" />
+      <stop
+         id="stop3840-1-6-2-6"
+         offset="1"
+         style="stop-color:#ef2929;stop-opacity:1" />
     </linearGradient>
-    <linearGradient y2="5" x2="-22" y1="18" x1="-18" gradientUnits="userSpaceOnUse" id="linearGradient3171-7-0" xlink:href="#linearGradient3836-9-3-6-0-6" inkscape:collect="always"/>
-    <linearGradient id="linearGradient3836-9-3-6-0-6">
-      <stop style="stop-color:#a40000;stop-opacity:1" offset="0" id="stop3838-8-5-7-9-2"/>
-      <stop style="stop-color:#ef2929;stop-opacity:1" offset="1" id="stop3840-1-6-5-3-6"/>
+    <linearGradient
+       xlink:href="#linearGradient3836-9-3-6-0-6"
+       id="linearGradient3171-7-0"
+       gradientUnits="userSpaceOnUse"
+       x1="-18"
+       y1="18"
+       x2="-22"
+       y2="5" />
+    <linearGradient
+       id="linearGradient3836-9-3-6-0-6">
+      <stop
+         id="stop3838-8-5-7-9-2"
+         offset="0"
+         style="stop-color:#a40000;stop-opacity:1" />
+      <stop
+         id="stop3840-1-6-5-3-6"
+         offset="1"
+         style="stop-color:#ef2929;stop-opacity:1" />
     </linearGradient>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3836-9-3-6-29" id="linearGradient3931" gradientUnits="userSpaceOnUse" x1="-18" y1="18" x2="-22" y2="5" gradientTransform="matrix(0.71441909,0,0,0.71408544,-5.531259,3.2604792)"/>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3836-9-3-6-29" id="linearGradient3937" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.71441909,0,0,0.71408544,-5.531259,3.2604792)" x1="-18" y1="18" x2="-22" y2="5"/>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3836-9-3-6-29-8" id="linearGradient3937-1" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.71441909,0,0,0.71408544,-5.531259,3.2604792)" x1="-18" y1="18" x2="-22" y2="5"/>
-    <linearGradient id="linearGradient3836-9-3-6-29-8">
-      <stop style="stop-color:#a40000;stop-opacity:1" offset="0" id="stop3838-8-5-7-12-7"/>
-      <stop style="stop-color:#ef2929;stop-opacity:1" offset="1" id="stop3840-1-6-5-7-9"/>
+    <linearGradient
+       gradientTransform="matrix(0.71441909,0,0,0.71408544,-5.531259,3.2604792)"
+       y2="5"
+       x2="-22"
+       y1="18"
+       x1="-18"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3931"
+       xlink:href="#linearGradient3836-9-3-6-29" />
+    <linearGradient
+       y2="5"
+       x2="-22"
+       y1="18"
+       x1="-18"
+       gradientTransform="matrix(0.71441909,0,0,0.71408544,-5.531259,3.2604792)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3937-1"
+       xlink:href="#linearGradient3836-9-3-6-29-8" />
+    <linearGradient
+       id="linearGradient3836-9-3-6-29-8">
+      <stop
+         id="stop3838-8-5-7-12-7"
+         offset="0"
+         style="stop-color:#a40000;stop-opacity:1" />
+      <stop
+         id="stop3840-1-6-5-7-9"
+         offset="1"
+         style="stop-color:#ef2929;stop-opacity:1" />
     </linearGradient>
-    <linearGradient y2="5" x2="-22" y1="18" x1="-18" gradientTransform="matrix(0.71441909,0,0,0.71408544,-5.531259,3.2604792)" gradientUnits="userSpaceOnUse" id="linearGradient3956" xlink:href="#linearGradient3836-9-3-6-29-8" inkscape:collect="always"/>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3836-9-3-6-29-7" id="linearGradient3937-3" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.71441909,0,0,0.71408544,-5.531259,3.2604792)" x1="-18" y1="18" x2="-22" y2="5"/>
-    <linearGradient id="linearGradient3836-9-3-6-29-7">
-      <stop style="stop-color:#a40000;stop-opacity:1" offset="0" id="stop3838-8-5-7-12-5"/>
-      <stop style="stop-color:#ef2929;stop-opacity:1" offset="1" id="stop3840-1-6-5-7-92"/>
+    <linearGradient
+       id="linearGradient3836-9-3-6-29-7">
+      <stop
+         id="stop3838-8-5-7-12-5"
+         offset="0"
+         style="stop-color:#a40000;stop-opacity:1" />
+      <stop
+         id="stop3840-1-6-5-7-92"
+         offset="1"
+         style="stop-color:#ef2929;stop-opacity:1" />
     </linearGradient>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3836-9-3-6-29-1" id="linearGradient3937-36" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.71441909,0,0,0.71408544,-5.531259,3.2604792)" x1="-18" y1="18" x2="-22" y2="5"/>
-    <linearGradient id="linearGradient3836-9-3-6-29-1">
-      <stop style="stop-color:#a40000;stop-opacity:1" offset="0" id="stop3838-8-5-7-12-2"/>
-      <stop style="stop-color:#ef2929;stop-opacity:1" offset="1" id="stop3840-1-6-5-7-93"/>
+    <linearGradient
+       id="linearGradient3836-9-3-6-29-1">
+      <stop
+         id="stop3838-8-5-7-12-2"
+         offset="0"
+         style="stop-color:#a40000;stop-opacity:1" />
+      <stop
+         id="stop3840-1-6-5-7-93"
+         offset="1"
+         style="stop-color:#ef2929;stop-opacity:1" />
     </linearGradient>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3836" id="linearGradient3850" x1="164.4444" y1="161.22015" x2="154.4444" y2="131.22015" gradientUnits="userSpaceOnUse"/>
-    <linearGradient id="linearGradient3836">
-      <stop style="stop-color:#3465a4;stop-opacity:1;" offset="0" id="stop3838"/>
-      <stop style="stop-color:#729fcf;stop-opacity:1;" offset="1" id="stop3840"/>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="131.22015"
+       x2="154.4444"
+       y1="161.22015"
+       x1="164.4444"
+       id="linearGradient3850"
+       xlink:href="#linearGradient3836" />
+    <linearGradient
+       id="linearGradient3836">
+      <stop
+         id="stop3838"
+         offset="0"
+         style="stop-color:#3465a4;stop-opacity:1;" />
+      <stop
+         id="stop3840"
+         offset="1"
+         style="stop-color:#729fcf;stop-opacity:1;" />
     </linearGradient>
-    <linearGradient gradientTransform="translate(-188.44439,-101.22016)" y2="131.22015" x2="154.4444" y1="161.22015" x1="164.4444" gradientUnits="userSpaceOnUse" id="linearGradient3167" xlink:href="#linearGradient3836" inkscape:collect="always"/>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3836" id="linearGradient3112" gradientUnits="userSpaceOnUse" gradientTransform="translate(-188.44439,-101.22016)" x1="164.4444" y1="161.22015" x2="154.4444" y2="131.22015"/>
+    <linearGradient
+       y2="131.22015"
+       x2="154.4444"
+       y1="161.22015"
+       x1="164.4444"
+       gradientTransform="translate(-188.44439,-101.22016)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3112"
+       xlink:href="#linearGradient3836" />
   </defs>
-  <sodipodi:namedview id="base" pagecolor="#ffffff" bordercolor="#666666" borderopacity="1.0" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:zoom="9.3695575" inkscape:cx="21.677859" inkscape:cy="33.445753" inkscape:current-layer="layer1" showgrid="true" inkscape:document-units="px" inkscape:grid-bbox="true" inkscape:window-width="1600" inkscape:window-height="834" inkscape:window-x="0" inkscape:window-y="27" inkscape:window-maximized="1" inkscape:snap-global="true" inkscape:snap-bbox="true" inkscape:snap-nodes="true" showguides="true" inkscape:guide-bbox="true">
-    <inkscape:grid type="xygrid" id="grid3058" empspacing="2" visible="true" enabled="true" snapvisiblegridlinesonly="true"/>
-    <sodipodi:guide orientation="1,0" position="28,22" id="guide3917"/>
-    <sodipodi:guide orientation="0,1" position="12,32" id="guide3919"/>
-    <sodipodi:guide orientation="0,1" position="60,16" id="guide3921"/>
-    <sodipodi:guide orientation="1,0" position="52,8" id="guide3923"/>
-  </sodipodi:namedview>
-  <metadata id="metadata2923">
+  <metadata
+     id="metadata2923">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Sketcher_BSplineIncreaseDegree</dc:title>
         <dc:creator>
           <cc:Agent>
-            <dc:title>[agryson] Alexander Gryson</dc:title>
+            <dc:title>[bitacovir]</dc:title>
           </cc:Agent>
         </dc:creator>
         <dc:title>Sketcher_Create_Periodic_BSpline</dc:title>
-        <dc:date>2017-02-16</dc:date>
+        <dc:date>22-03-2021</dc:date>
         <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>
           </cc:Agent>
         </dc:publisher>
-        <dc:identifier>FreeCAD/src/Mod/Sketcher/Gui/Resources/icons/Sketcher_Toggle_BSpline_Information.svg</dc:identifier>
+        <dc:identifier></dc:identifier>
         <dc:rights>
           <cc:Agent>
             <dc:title>FreeCAD LGPL2+</dc:title>
@@ -138,49 +441,71 @@
         <cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license>
         <dc:contributor>
           <cc:Agent>
-            <dc:title>[agryson] Alexander Gryson</dc:title>
+            <dc:title></dc:title>
           </cc:Agent>
         </dc:contributor>
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g id="layer1" inkscape:label="Layer 1" inkscape:groupmode="layer">
-    <path style="fill:none;stroke:#2e3436;stroke-width:8;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="M 55.999976,26.000003 C 58,48 32,32 29.999975,52.000002" id="path3266" inkscape:connector-curvature="0" sodipodi:nodetypes="cc"/>
-    <path style="fill:none;stroke:#d3d7cf;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="M 55.999976,26.000003 C 56,48 32,32 29.999975,52.000002" id="path3266-9" inkscape:connector-curvature="0" sodipodi:nodetypes="cc"/>
-    <path style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="M 54.999975,26.000003 C 56,47 32,31 28.999974,52.000002" id="path3266-9-2" inkscape:connector-curvature="0" sodipodi:nodetypes="cc"/>
-    <g inkscape:export-ydpi="7.2934141" inkscape:export-xdpi="7.2934141" inkscape:export-filename="/home/yorik/Documents/Lab/Draft/icons/circle.png" transform="matrix(-0.14137236,0.07774155,-0.01888492,-0.10633123,99.823869,75.569613)" id="g3177"/>
-    <g inkscape:export-ydpi="7.2934141" inkscape:export-xdpi="7.2934141" inkscape:export-filename="/home/yorik/Documents/Lab/Draft/icons/circle.png" transform="matrix(-0.14109247,0.07923086,-0.02087339,-0.10522619,77.138226,86.686164)" id="g3185"/>
-    <g transform="matrix(0.59988397,0,0,0.60016354,23.595637,49.138672)" id="g3797-7-2-3">
-      <g id="g3933" transform="translate(30.005802,0)">
-        <path d="m -25.658702,6.015909 a 8.3321309,8.3277776 0 1 1 12.65725,10.83369 8.3321309,8.3277776 0 1 1 -12.65725,-10.83369 z" id="path4250-6-9-5" style="fill:#ef2929;stroke:#280000;stroke-width:3.33320141;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" inkscape:connector-curvature="0"/>
-        <path d="m -23.129965,8.18309 a 5.0009335,4.9985982 0 1 1 7.596839,6.502756 5.0009335,4.9985982 0 0 1 -7.596839,-6.502756 z" id="path4250-7-0-1-6" style="fill:url(#linearGradient3937);fill-opacity:1;stroke:#ef2929;stroke-width:3.33320141;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" inkscape:connector-curvature="0"/>
-      </g>
+  <g
+     id="layer1">
+    <path
+       id="path3266"
+       d="M 55.641578,8.1868685 C 57.288732,49.584802 17.403372,29.037685 8.2549696,55.500154"
+       style="fill:none;stroke:#2e3436;stroke-width:12.5366;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       id="path3266-9"
+       d="M 55.641578,8.1868685 C 57.999108,48.322001 17.200318,29.50549 8.2549696,55.500154"
+       style="fill:none;stroke:#d3d7cf;stroke-width:6.2683;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       id="path3266-9-2"
+       d="M 54.016393,8.1868685 C 57.606356,46.713599 15.172328,27.635191 6.6297851,55.651091"
+       style="fill:none;stroke:#ffffff;stroke-width:3.13415;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+    <g
+       id="g3177"
+       transform="matrix(-0.14137236,0.07774155,-0.01888492,-0.10633123,99.823869,75.569613)" />
+    <g
+       id="g3185"
+       transform="matrix(-0.14109247,0.07923086,-0.02087339,-0.10522619,77.138226,86.686164)" />
+    <g
+       transform="translate(47,-27)"
+       id="g3108">
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3112);fill-opacity:1;fill-rule:evenodd;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+         d="m -34,30 v 10 h -10 v 10 h 10 v 10 h 10 V 50 h 10 V 40 H -24 V 30 Z"
+         id="rect3558" />
+      <path
+         style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m -42,42 h 10 V 32 h 6 v 10 h 10 v 6 h -10 v 10 h -6 V 48 h -10 z"
+         id="path3826" />
     </g>
-    <g id="g3933-2" transform="matrix(0.59988397,0,0,0.60016354,67.595636,19.138672)">
-      <path d="m -25.658702,6.015909 a 8.3321309,8.3277776 0 1 1 12.65725,10.83369 8.3321309,8.3277776 0 1 1 -12.65725,-10.83369 z" id="path4250-6-9-5-0" style="fill:#ef2929;stroke:#280000;stroke-width:3.33320141;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" inkscape:connector-curvature="0"/>
-      <path d="m -23.129965,8.18309 a 5.0009335,4.9985982 0 1 1 7.596839,6.502756 5.0009335,4.9985982 0 0 1 -7.596839,-6.502756 z" id="path4250-7-0-1-6-2" style="fill:url(#linearGradient3956);fill-opacity:1;stroke:#ef2929;stroke-width:3.33320141;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" inkscape:connector-curvature="0"/>
-    </g>
-    <g transform="matrix(0.59988397,0,0,0.60016354,25.595637,25.138672)" id="g3797-7-2-3-2">
-      <g id="g3933-8" transform="translate(30.005802,0)">
-        <path d="m -25.658702,6.015909 a 8.3321309,8.3277776 0 1 1 12.65725,10.83369 8.3321309,8.3277776 0 1 1 -12.65725,-10.83369 z" id="path4250-6-9-5-9" style="fill:#ef2929;stroke:#280000;stroke-width:3.33320141;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" inkscape:connector-curvature="0"/>
-        <path d="m -23.129965,8.18309 a 5.0009335,4.9985982 0 1 1 7.596839,6.502756 5.0009335,4.9985982 0 0 1 -7.596839,-6.502756 z" id="path4250-7-0-1-6-7" style="fill:url(#linearGradient3937-3);fill-opacity:1;stroke:#ef2929;stroke-width:3.33320141;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" inkscape:connector-curvature="0"/>
-      </g>
-    </g>
-    <g transform="matrix(0.59988397,0,0,0.60016354,49.595637,41.138672)" id="g3797-7-2-3-1">
-      <g id="g3933-9" transform="translate(30.005802,0)">
-        <path d="m -25.658702,6.015909 a 8.3321309,8.3277776 0 1 1 12.65725,10.83369 8.3321309,8.3277776 0 1 1 -12.65725,-10.83369 z" id="path4250-6-9-5-4" style="fill:#ef2929;stroke:#280000;stroke-width:3.33320141;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" inkscape:connector-curvature="0"/>
-        <path d="m -23.129965,8.18309 a 5.0009335,4.9985982 0 1 1 7.596839,6.502756 5.0009335,4.9985982 0 0 1 -7.596839,-6.502756 z" id="path4250-7-0-1-6-78" style="fill:url(#linearGradient3937-36);fill-opacity:1;stroke:#ef2929;stroke-width:3.33320141;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" inkscape:connector-curvature="0"/>
-      </g>
-    </g>
-    <path style="fill:none;stroke:#172a04;stroke-width:8;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" d="M 31,44 35,6 M 6,33 44,33" id="path3047-3-6-3" inkscape:connector-curvature="0" sodipodi:nodetypes="cccc"/>
-    <path style="fill:none;stroke:#172a04;stroke-width:8;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" d="M 17,6 13,44 M 44,17 6,17" id="path3047-3-6" inkscape:connector-curvature="0" sodipodi:nodetypes="cccc"/>
-    <path style="fill:none;stroke:#4e9a06;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" d="M 17,6 13,44 M 44,17 6,17" id="path3047" inkscape:connector-curvature="0" sodipodi:nodetypes="cccc"/>
-    <path style="fill:none;stroke:#4e9a06;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" d="M 31,44 35,6 M 6,33 44,33" id="path3047-6" inkscape:connector-curvature="0" sodipodi:nodetypes="cccc"/>
-    <path style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" d="M 30,44 34,6 M 6,32 44,32" id="path3047-3-7" inkscape:connector-curvature="0" sodipodi:nodetypes="cccc"/>
-    <path style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" d="M 16,6 12,44 M 44,16 6,16" id="path3047-3" inkscape:connector-curvature="0" sodipodi:nodetypes="cccc"/>
-    <g id="g3108" transform="translate(47,-27)">
-      <path sodipodi:nodetypes="ccccccccccccc" inkscape:connector-curvature="0" id="rect3558" d="m -34,30 0,10 -10,0 0,10 10,0 0,10 10,0 0,-10 10,0 0,-10 -10,0 0,-10 z" style="color:#000000;fill:url(#linearGradient3112);fill-opacity:1;fill-rule:evenodd;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-      <path inkscape:connector-curvature="0" id="path3826" d="m -42,42 10,0 0,-10 6,0 0,10 10,0 0,6 -10,0 0,10 -6,0 0,-10 -10,0 z" style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"/>
+    <g
+       transform="translate(-0.37734268,-0.30187414)"
+       id="g1043">
+      <path
+         id="path3047-3-6-3-2"
+         d="m 50.806996,59.2529 2.631579,-25 M 34.359628,52.016058 h 25"
+         style="fill:none;stroke:#172a04;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         id="path3047-3-6-2"
+         d="m 41.59647,34.2529 -2.631579,25 M 59.359628,41.489742 h -25"
+         style="fill:none;stroke:#172a04;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         id="path3047-4"
+         d="m 41.59647,34.2529 -2.631579,25 M 59.359628,41.489742 h -25"
+         style="fill:none;stroke:#4e9a06;stroke-width:2.63158;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+      <path
+         id="path3047-6-7"
+         d="m 50.806996,59.2529 2.631579,-25 M 34.359628,52.016058 h 25"
+         style="fill:none;stroke:#4e9a06;stroke-width:2.63158;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+      <path
+         id="path3047-3-7-6"
+         d="m 50.149102,59.2529 2.631579,-25 M 34.359628,51.358163 h 25"
+         style="fill:none;stroke:#8ae234;stroke-width:1.31579;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+      <path
+         id="path3047-3-4"
+         d="m 40.938575,34.2529 -2.631579,25 M 59.359628,40.831847 h -25"
+         style="fill:none;stroke:#8ae234;stroke-width:1.31579;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
     </g>
   </g>
 </svg>

--- a/src/Mod/Sketcher/Gui/Resources/icons/splines/Sketcher_BSplineIncreaseKnotMultiplicity.svg
+++ b/src/Mod/Sketcher/Gui/Resources/icons/splines/Sketcher_BSplineIncreaseKnotMultiplicity.svg
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
@@ -8,23 +6,15 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="64px"
    height="64px"
    id="svg2918"
-   sodipodi:version="0.32"
-   inkscape:version="0.92.1 unknown"
-   sodipodi:docname="Sketcher_BSplineIncreaseKnotMultiplicity.svg"
-   inkscape:output_extension="org.inkscape.output.svg.inkscape"
-   version="1.1"
-   inkscape:export-filename="/home/user/Downloads/cad/mystuff/icons/sketcher/Sketcher_CreateCircle_from_3points_2_16px.png"
-   inkscape:export-xdpi="22.5"
-   inkscape:export-ydpi="22.5">
+   version="1.1">
+  <title
+     id="title928">Sketcher_BSplineIncreaseKnotMultiplicity</title>
   <defs
      id="defs2920">
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient3144">
       <stop
          style="stop-color:#ffffff;stop-opacity:1;"
@@ -35,15 +25,7 @@
          offset="1"
          id="stop3148" />
     </linearGradient>
-    <inkscape:perspective
-       sodipodi:type="inkscape:persp3d"
-       inkscape:vp_x="0 : 32 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_z="64 : 32 : 1"
-       inkscape:persp3d-origin="32 : 21.333333 : 1"
-       id="perspective2926" />
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient3144-3">
       <stop
          style="stop-color:#ffffff;stop-opacity:1;"
@@ -55,7 +37,6 @@
          id="stop3148-5" />
     </linearGradient>
     <radialGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3144"
        id="radialGradient3958"
        gradientUnits="userSpaceOnUse"
@@ -66,7 +47,6 @@
        fy="672.79736"
        r="34.345188" />
     <radialGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3144-3"
        id="radialGradient3960"
        gradientUnits="userSpaceOnUse"
@@ -77,7 +57,6 @@
        fy="672.79736"
        r="34.345188" />
     <radialGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3144"
        id="radialGradient3042"
        gradientUnits="userSpaceOnUse"
@@ -88,7 +67,6 @@
        fy="672.79736"
        r="34.345188" />
     <radialGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3144"
        id="radialGradient3068"
        gradientUnits="userSpaceOnUse"
@@ -99,7 +77,6 @@
        fy="672.79736"
        r="34.345188" />
     <radialGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3144"
        id="radialGradient3880"
        gradientUnits="userSpaceOnUse"
@@ -110,7 +87,6 @@
        fy="672.79736"
        r="34.345188" />
     <radialGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3144"
        id="radialGradient4654"
        gradientUnits="userSpaceOnUse"
@@ -121,7 +97,6 @@
        fy="672.79736"
        r="34.345188" />
     <radialGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3144"
        id="radialGradient4693"
        gradientUnits="userSpaceOnUse"
@@ -138,8 +113,7 @@
        x1="-18"
        gradientUnits="userSpaceOnUse"
        id="linearGradient3131-2"
-       xlink:href="#linearGradient3836-9-3-9"
-       inkscape:collect="always" />
+       xlink:href="#linearGradient3836-9-3-9" />
     <linearGradient
        id="linearGradient3836-9-3-9">
       <stop
@@ -158,8 +132,7 @@
        x1="-18"
        gradientUnits="userSpaceOnUse"
        id="linearGradient3171-7"
-       xlink:href="#linearGradient3836-9-3-6-0"
-       inkscape:collect="always" />
+       xlink:href="#linearGradient3836-9-3-6-0" />
     <linearGradient
        id="linearGradient3836-9-3-6-0">
       <stop
@@ -172,7 +145,6 @@
          id="stop3840-1-6-5-3" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3836-9-3"
        id="linearGradient3262"
        gradientUnits="userSpaceOnUse"
@@ -203,7 +175,6 @@
          id="stop3840-1-6-5" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3836-9-3-6-7"
        id="linearGradient3264-1"
        gradientUnits="userSpaceOnUse"
@@ -224,7 +195,6 @@
          id="stop3840-1-6-5-0" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3836-9-3-6-4"
        id="linearGradient3264-9"
        gradientUnits="userSpaceOnUse"
@@ -245,7 +215,6 @@
          id="stop3840-1-6-5-8" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3836-9-3-6-1"
        id="linearGradient3264-17"
        gradientUnits="userSpaceOnUse"
@@ -266,7 +235,6 @@
          id="stop3840-1-6-5-5" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3836-9-3-6-2"
        id="linearGradient3264-3"
        gradientUnits="userSpaceOnUse"
@@ -287,7 +255,6 @@
          id="stop3840-1-6-5-1" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3836-9-3-3"
        id="linearGradient3262-5"
        gradientUnits="userSpaceOnUse"
@@ -307,7 +274,6 @@
          id="stop3840-1-6-6" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3836-9-3-6-29"
        id="linearGradient3264"
        gradientUnits="userSpaceOnUse"
@@ -333,8 +299,7 @@
        x1="-18"
        gradientUnits="userSpaceOnUse"
        id="linearGradient3131-2-0"
-       xlink:href="#linearGradient3836-9-3-9-9"
-       inkscape:collect="always" />
+       xlink:href="#linearGradient3836-9-3-9-9" />
     <linearGradient
        id="linearGradient3836-9-3-9-9">
       <stop
@@ -353,8 +318,7 @@
        x1="-18"
        gradientUnits="userSpaceOnUse"
        id="linearGradient3171-7-0"
-       xlink:href="#linearGradient3836-9-3-6-0-6"
-       inkscape:collect="always" />
+       xlink:href="#linearGradient3836-9-3-6-0-6" />
     <linearGradient
        id="linearGradient3836-9-3-6-0-6">
       <stop
@@ -367,27 +331,6 @@
          id="stop3840-1-6-5-3-6" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3836-9-3-6-29"
-       id="linearGradient3931"
-       gradientUnits="userSpaceOnUse"
-       x1="-18"
-       y1="18"
-       x2="-22"
-       y2="5"
-       gradientTransform="matrix(0.71441909,0,0,0.71408544,-5.531259,3.2604792)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3836-9-3-6-29"
-       id="linearGradient3937"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.71441909,0,0,0.71408544,-5.531259,3.2604792)"
-       x1="-18"
-       y1="18"
-       x2="-22"
-       y2="5" />
-    <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3836-9-3-6-29-8"
        id="linearGradient3937-1"
        gradientUnits="userSpaceOnUse"
@@ -408,26 +351,6 @@
          id="stop3840-1-6-5-7-9" />
     </linearGradient>
     <linearGradient
-       y2="5"
-       x2="-22"
-       y1="18"
-       x1="-18"
-       gradientTransform="matrix(0.71441909,0,0,0.71408544,-5.531259,3.2604792)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3956"
-       xlink:href="#linearGradient3836-9-3-6-29-8"
-       inkscape:collect="always" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3836-9-3-6-29-7"
-       id="linearGradient3937-3"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.71441909,0,0,0.71408544,-5.531259,3.2604792)"
-       x1="-18"
-       y1="18"
-       x2="-22"
-       y2="5" />
-    <linearGradient
        id="linearGradient3836-9-3-6-29-7">
       <stop
          style="stop-color:#a40000;stop-opacity:1"
@@ -438,16 +361,6 @@
          offset="1"
          id="stop3840-1-6-5-7-92" />
     </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3836-9-3-6-29-1"
-       id="linearGradient3937-36"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.71441909,0,0,0.71408544,-5.531259,3.2604792)"
-       x1="-18"
-       y1="18"
-       x2="-22"
-       y2="5" />
     <linearGradient
        id="linearGradient3836-9-3-6-29-1">
       <stop
@@ -460,7 +373,6 @@
          id="stop3840-1-6-5-7-93" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3836"
        id="linearGradient3850"
        x1="164.4444"
@@ -480,17 +392,6 @@
          id="stop3840" />
     </linearGradient>
     <linearGradient
-       gradientTransform="translate(-188.44439,-101.22016)"
-       y2="131.22015"
-       x2="154.4444"
-       y1="161.22015"
-       x1="164.4444"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3167"
-       xlink:href="#linearGradient3836"
-       inkscape:collect="always" />
-    <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3836"
        id="linearGradient3112"
        gradientUnits="userSpaceOnUse"
@@ -500,58 +401,6 @@
        x2="154.4444"
        y2="131.22015" />
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="7.3108168"
-     inkscape:cx="34.159114"
-     inkscape:cy="47.567447"
-     inkscape:current-layer="layer1"
-     showgrid="true"
-     inkscape:document-units="px"
-     inkscape:grid-bbox="true"
-     inkscape:window-width="1920"
-     inkscape:window-height="993"
-     inkscape:window-x="0"
-     inkscape:window-y="28"
-     inkscape:window-maximized="1"
-     inkscape:snap-global="true"
-     inkscape:snap-bbox="true"
-     inkscape:snap-nodes="true"
-     showguides="true"
-     inkscape:guide-bbox="true">
-    <inkscape:grid
-       type="xygrid"
-       id="grid3058"
-       empspacing="2"
-       visible="true"
-       enabled="true"
-       snapvisiblegridlinesonly="true" />
-    <sodipodi:guide
-       orientation="1,0"
-       position="28,22"
-       id="guide3917"
-       inkscape:locked="false" />
-    <sodipodi:guide
-       orientation="0,1"
-       position="12,32"
-       id="guide3919"
-       inkscape:locked="false" />
-    <sodipodi:guide
-       orientation="0,1"
-       position="60,16"
-       id="guide3921"
-       inkscape:locked="false" />
-    <sodipodi:guide
-       orientation="1,0"
-       position="52,8"
-       id="guide3923"
-       inkscape:locked="false" />
-  </sodipodi:namedview>
   <metadata
      id="metadata2923">
     <rdf:RDF>
@@ -560,21 +409,21 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:title>Sketcher_BSplineIncreaseKnotMultiplicity</dc:title>
         <dc:creator>
           <cc:Agent>
-            <dc:title>[agryson] Alexander Gryson</dc:title>
+            <dc:title>[bitacovir]</dc:title>
           </cc:Agent>
         </dc:creator>
         <dc:title>Sketcher_Create_Periodic_BSpline</dc:title>
-        <dc:date>2017-02-16</dc:date>
+        <dc:date>22-03-2021</dc:date>
         <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>
           </cc:Agent>
         </dc:publisher>
-        <dc:identifier>FreeCAD/src/Mod/Sketcher/Gui/Resources/icons/Sketcher_Toggle_BSpline_Information.svg</dc:identifier>
+        <dc:identifier></dc:identifier>
         <dc:rights>
           <cc:Agent>
             <dc:title>FreeCAD LGPL2+</dc:title>
@@ -583,178 +432,84 @@
         <cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license>
         <dc:contributor>
           <cc:Agent>
-            <dc:title>[agryson] Alexander Gryson</dc:title>
+            <dc:title></dc:title>
           </cc:Agent>
         </dc:contributor>
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1"
-     inkscape:label="Layer 1"
-     inkscape:groupmode="layer">
+     id="layer1">
     <path
-       style="fill:none;stroke:#2e3436;stroke-width:8;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="M 55.999976,26.000003 C 58,48 32,32 29.999975,52.000002"
        id="path3266"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
+       d="M 55.618776,14.550317 C 53.081884,47.579198 16.970778,30.589727 8.323225,55.603448"
+       style="fill:none;stroke:#2e3436;stroke-width:12.5366;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
     <path
-       style="fill:none;stroke:#d3d7cf;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="M 55.999976,26.000003 C 56,48 32,32 29.999975,52.000002"
        id="path3266-9"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
+       d="M 55.709838,8.2901619 C 58.067368,48.425294 17.268578,29.608783 8.323225,55.603448"
+       style="fill:none;stroke:#d3d7cf;stroke-width:6.2683;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
     <path
-       style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="M 54.999975,26.000003 C 56,47 32,31 28.999974,52.000002"
        id="path3266-9-2"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
+       d="M 54.084648,8.2901619 C 57.674608,46.816893 15.240583,27.738484 6.698041,55.754384"
+       style="fill:none;stroke:#ffffff;stroke-width:3.13415;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
     <g
-       inkscape:export-ydpi="7.2934141"
-       inkscape:export-xdpi="7.2934141"
-       inkscape:export-filename="/home/yorik/Documents/Lab/Draft/icons/circle.png"
        transform="matrix(-0.14137236,0.07774155,-0.01888492,-0.10633123,99.823869,75.569613)"
        id="g3177" />
     <g
-       inkscape:export-ydpi="7.2934141"
-       inkscape:export-xdpi="7.2934141"
-       inkscape:export-filename="/home/yorik/Documents/Lab/Draft/icons/circle.png"
        transform="matrix(-0.14109247,0.07923086,-0.02087339,-0.10522619,77.138226,86.686164)"
        id="g3185" />
     <g
-       transform="matrix(0.59988397,0,0,0.60016354,23.595637,49.138672)"
-       id="g3797-7-2-3">
-      <g
-         id="g3933"
-         transform="translate(30.005802,0)">
-        <path
-           d="m -25.658702,6.015909 a 8.3321309,8.3277776 0 1 1 12.65725,10.83369 8.3321309,8.3277776 0 1 1 -12.65725,-10.83369 z"
-           id="path4250-6-9-5"
-           style="fill:#ef2929;stroke:#280000;stroke-width:3.33320141;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-           inkscape:connector-curvature="0" />
-        <path
-           d="m -23.129965,8.18309 a 5.0009335,4.9985982 0 1 1 7.596839,6.502756 5.0009335,4.9985982 0 0 1 -7.596839,-6.502756 z"
-           id="path4250-7-0-1-6"
-           style="fill:url(#linearGradient3937);fill-opacity:1;stroke:#ef2929;stroke-width:3.33320141;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-           inkscape:connector-curvature="0" />
-      </g>
-    </g>
-    <g
-       id="g3933-2"
-       transform="matrix(0.59988397,0,0,0.60016354,67.595636,19.138672)">
+       id="g985">
       <path
-         d="m -25.658702,6.015909 a 8.3321309,8.3277776 0 1 1 12.65725,10.83369 8.3321309,8.3277776 0 1 1 -12.65725,-10.83369 z"
-         id="path4250-6-9-5-0"
-         style="fill:#ef2929;stroke:#280000;stroke-width:3.33320141;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-         inkscape:connector-curvature="0" />
+         id="path3047-3-6-3-2"
+         d="m 50.429651,58.951026 2.631579,-25 M 33.982283,51.714184 h 25"
+         style="fill:none;stroke:#172a04;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       <path
-         d="m -23.129965,8.18309 a 5.0009335,4.9985982 0 1 1 7.596839,6.502756 5.0009335,4.9985982 0 0 1 -7.596839,-6.502756 z"
-         id="path4250-7-0-1-6-2"
-         style="fill:url(#linearGradient3956);fill-opacity:1;stroke:#ef2929;stroke-width:3.33320141;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-         inkscape:connector-curvature="0" />
-    </g>
-    <g
-       transform="matrix(0.59988397,0,0,0.60016354,25.595637,25.138672)"
-       id="g3797-7-2-3-2">
-      <g
-         id="g3933-8"
-         transform="translate(30.005802,0)">
-        <path
-           d="m -25.658702,6.015909 a 8.3321309,8.3277776 0 1 1 12.65725,10.83369 8.3321309,8.3277776 0 1 1 -12.65725,-10.83369 z"
-           id="path4250-6-9-5-9"
-           style="fill:#ef2929;stroke:#280000;stroke-width:3.33320141;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-           inkscape:connector-curvature="0" />
-        <path
-           d="m -23.129965,8.18309 a 5.0009335,4.9985982 0 1 1 7.596839,6.502756 5.0009335,4.9985982 0 0 1 -7.596839,-6.502756 z"
-           id="path4250-7-0-1-6-7"
-           style="fill:url(#linearGradient3937-3);fill-opacity:1;stroke:#ef2929;stroke-width:3.33320141;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-           inkscape:connector-curvature="0" />
-      </g>
-    </g>
-    <g
-       transform="matrix(0.59988397,0,0,0.60016354,49.595637,41.138672)"
-       id="g3797-7-2-3-1">
-      <g
-         id="g3933-9"
-         transform="translate(30.005802,0)">
-        <path
-           d="m -25.658702,6.015909 a 8.3321309,8.3277776 0 1 1 12.65725,10.83369 8.3321309,8.3277776 0 1 1 -12.65725,-10.83369 z"
-           id="path4250-6-9-5-4"
-           style="fill:#ef2929;stroke:#280000;stroke-width:3.33320141;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-           inkscape:connector-curvature="0" />
-        <path
-           d="m -23.129965,8.18309 a 5.0009335,4.9985982 0 1 1 7.596839,6.502756 5.0009335,4.9985982 0 0 1 -7.596839,-6.502756 z"
-           id="path4250-7-0-1-6-78"
-           style="fill:url(#linearGradient3937-36);fill-opacity:1;stroke:#ef2929;stroke-width:3.33320141;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-           inkscape:connector-curvature="0" />
-      </g>
-    </g>
-    <path
-       style="fill:none;stroke:#172a04;stroke-width:8;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
-       d="M 31,44 35,6 M 6,33 44,33"
-       id="path3047-3-6-3"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccc" />
-    <path
-       style="fill:none;stroke:#172a04;stroke-width:8;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
-       d="M 17,6 13,44 M 44,17 6,17"
-       id="path3047-3-6"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccc" />
-    <path
-       style="fill:none;stroke:#4e9a06;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
-       d="M 17,6 13,44 M 44,17 6,17"
-       id="path3047"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccc" />
-    <g
-       id="g958"
-       transform="translate(32.279658,-18.049864)">
+         id="path3047-3-6-2"
+         d="m 41.219125,33.951026 -2.631579,25 M 58.982283,41.187868 h -25"
+         style="fill:none;stroke:#172a04;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       <path
-         inkscape:connector-curvature="0"
-         style="fill:#ef2929;stroke:#280000;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="path4250-6-9-5-3"
-         d="m 8.203393,54.749201 a 4.9983118,4.9980285 0 1 1 7.592881,6.501986 4.9983118,4.9980285 0 1 1 -7.592881,-6.501986 z" />
+         id="path3047-4-7"
+         d="m 41.219125,33.951026 -2.631579,25 M 58.982283,41.187868 h -25"
+         style="fill:none;stroke:#4e9a06;stroke-width:2.63158;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
       <path
-         inkscape:connector-curvature="0"
-         style="fill:#99cc33;fill-opacity:1;stroke:#669900;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="path4250-7-0-1-6-5"
-         d="M 9.7203418,56.049864 A 2.9999798,2.9999764 0 1 1 14.277564,59.952581 2.9999798,2.9999764 0 0 1 9.7203418,56.049864 Z" />
+         id="path3047-6-7"
+         d="m 50.429651,58.951026 2.631579,-25 M 33.982283,51.714184 h 25"
+         style="fill:none;stroke:#4e9a06;stroke-width:2.63158;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+      <path
+         id="path3047-3-7-6"
+         d="m 49.771757,58.951026 2.631579,-25 M 33.982283,51.056289 h 25"
+         style="fill:none;stroke:#8ae234;stroke-width:1.31579;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+      <path
+         id="path3047-3-4"
+         d="m 40.56123,33.951026 -2.631579,25 M 58.982283,40.529973 h -25"
+         style="fill:none;stroke:#8ae234;stroke-width:1.31579;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
     </g>
-    <path
-       style="fill:none;stroke:#4e9a06;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
-       d="M 31,44 35,6 M 6,33 44,33"
-       id="path3047-6"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccc" />
-    <path
-       style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
-       d="M 30,44 34,6 M 6,32 44,32"
-       id="path3047-3-7"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccc" />
-    <path
-       style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
-       d="M 16,6 12,44 M 44,16 6,16"
-       id="path3047-3"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccc" />
     <g
        id="g3108"
        transform="translate(47,-27)">
       <path
-         sodipodi:nodetypes="ccccccccccccc"
-         inkscape:connector-curvature="0"
          id="rect3558"
-         d="m -34,30 0,10 -10,0 0,10 10,0 0,10 10,0 0,-10 10,0 0,-10 -10,0 0,-10 z"
-         style="color:#000000;fill:url(#linearGradient3112);fill-opacity:1;fill-rule:evenodd;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         d="m -34,30 v 10 h -10 v 10 h 10 v 10 h 10 V 50 h 10 V 40 H -24 V 30 Z"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3112);fill-opacity:1;fill-rule:evenodd;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
       <path
-         inkscape:connector-curvature="0"
          id="path3826"
-         d="m -42,42 10,0 0,-10 6,0 0,10 10,0 0,6 -10,0 0,10 -6,0 0,-10 -10,0 z"
+         d="m -42,42 h 10 V 32 h 6 v 10 h 10 v 6 h -10 v 10 h -6 V 48 h -10 z"
          style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
+    <circle
+       r="13.203125"
+       cy="15.206594"
+       cx="49.803802"
+       id="path945"
+       style="fill:#ffffff;fill-rule:evenodd;stroke:none;stroke-width:1.3629;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;paint-order:markers stroke fill" />
+    <path
+       style="fill:#ef2929;stroke:#4e9a06;stroke-width:3.89444;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path4250-6-9-5-3-3"
+       d="M 42.456289,8.909865 A 9.7328242,9.7322726 0 1 1 57.241316,21.570677 9.7328242,9.7322726 0 1 1 42.456289,8.909865 Z" />
+    <path
+       style="fill:#172a04;fill-opacity:1;stroke:#73d216;stroke-width:3.89444;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path4250-7-0-1-6-5-4"
+       d="m 45.410125,11.442545 a 5.8416276,5.8416209 0 1 1 8.873925,7.599458 5.8416276,5.8416209 0 0 1 -8.873925,-7.599458 z" />
   </g>
 </svg>

--- a/src/Mod/Sketcher/Gui/Resources/icons/splines/Sketcher_BSplineKnotMultiplicity.svg
+++ b/src/Mod/Sketcher/Gui/Resources/icons/splines/Sketcher_BSplineKnotMultiplicity.svg
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
@@ -8,23 +6,15 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="64px"
    height="64px"
    id="svg2918"
-   sodipodi:version="0.32"
-   inkscape:version="0.92.1 unknown"
-   sodipodi:docname="Sketcher_BSplineKnotMultiplicity.svg"
-   inkscape:output_extension="org.inkscape.output.svg.inkscape"
-   version="1.1"
-   inkscape:export-filename="/home/user/Downloads/cad/mystuff/icons/sketcher/Sketcher_CreateCircle_from_3points_2_16px.png"
-   inkscape:export-xdpi="22.5"
-   inkscape:export-ydpi="22.5">
+   version="1.1">
+  <title
+     id="title928">Sketcher_BSplineKnotMultiplicity</title>
   <defs
      id="defs2920">
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient3144">
       <stop
          style="stop-color:#ffffff;stop-opacity:1;"
@@ -35,15 +25,7 @@
          offset="1"
          id="stop3148" />
     </linearGradient>
-    <inkscape:perspective
-       sodipodi:type="inkscape:persp3d"
-       inkscape:vp_x="0 : 32 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_z="64 : 32 : 1"
-       inkscape:persp3d-origin="32 : 21.333333 : 1"
-       id="perspective2926" />
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient3144-3">
       <stop
          style="stop-color:#ffffff;stop-opacity:1;"
@@ -55,7 +37,6 @@
          id="stop3148-5" />
     </linearGradient>
     <radialGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3144"
        id="radialGradient3958"
        gradientUnits="userSpaceOnUse"
@@ -66,7 +47,6 @@
        fy="672.79736"
        r="34.345188" />
     <radialGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3144-3"
        id="radialGradient3960"
        gradientUnits="userSpaceOnUse"
@@ -77,7 +57,6 @@
        fy="672.79736"
        r="34.345188" />
     <radialGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3144"
        id="radialGradient3042"
        gradientUnits="userSpaceOnUse"
@@ -88,7 +67,6 @@
        fy="672.79736"
        r="34.345188" />
     <radialGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3144"
        id="radialGradient3068"
        gradientUnits="userSpaceOnUse"
@@ -99,7 +77,6 @@
        fy="672.79736"
        r="34.345188" />
     <radialGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3144"
        id="radialGradient3880"
        gradientUnits="userSpaceOnUse"
@@ -110,7 +87,6 @@
        fy="672.79736"
        r="34.345188" />
     <radialGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3144"
        id="radialGradient4654"
        gradientUnits="userSpaceOnUse"
@@ -121,7 +97,6 @@
        fy="672.79736"
        r="34.345188" />
     <radialGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3144"
        id="radialGradient4693"
        gradientUnits="userSpaceOnUse"
@@ -138,8 +113,7 @@
        x1="-18"
        gradientUnits="userSpaceOnUse"
        id="linearGradient3131-2"
-       xlink:href="#linearGradient3836-9-3-9"
-       inkscape:collect="always" />
+       xlink:href="#linearGradient3836-9-3-9" />
     <linearGradient
        id="linearGradient3836-9-3-9">
       <stop
@@ -158,8 +132,7 @@
        x1="-18"
        gradientUnits="userSpaceOnUse"
        id="linearGradient3171-7"
-       xlink:href="#linearGradient3836-9-3-6-0"
-       inkscape:collect="always" />
+       xlink:href="#linearGradient3836-9-3-6-0" />
     <linearGradient
        id="linearGradient3836-9-3-6-0">
       <stop
@@ -172,7 +145,6 @@
          id="stop3840-1-6-5-3" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3836-9-3"
        id="linearGradient3262"
        gradientUnits="userSpaceOnUse"
@@ -203,7 +175,6 @@
          id="stop3840-1-6-5" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3836-9-3-6-7"
        id="linearGradient3264-1"
        gradientUnits="userSpaceOnUse"
@@ -224,7 +195,6 @@
          id="stop3840-1-6-5-0" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3836-9-3-6-4"
        id="linearGradient3264-9"
        gradientUnits="userSpaceOnUse"
@@ -245,7 +215,6 @@
          id="stop3840-1-6-5-8" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3836-9-3-6-1"
        id="linearGradient3264-17"
        gradientUnits="userSpaceOnUse"
@@ -266,7 +235,6 @@
          id="stop3840-1-6-5-5" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3836-9-3-6-2"
        id="linearGradient3264-3"
        gradientUnits="userSpaceOnUse"
@@ -287,7 +255,6 @@
          id="stop3840-1-6-5-1" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3836-9-3-3"
        id="linearGradient3262-5"
        gradientUnits="userSpaceOnUse"
@@ -307,7 +274,6 @@
          id="stop3840-1-6-6" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3836-9-3-6-29"
        id="linearGradient3264"
        gradientUnits="userSpaceOnUse"
@@ -333,8 +299,7 @@
        x1="-18"
        gradientUnits="userSpaceOnUse"
        id="linearGradient3131-2-0"
-       xlink:href="#linearGradient3836-9-3-9-9"
-       inkscape:collect="always" />
+       xlink:href="#linearGradient3836-9-3-9-9" />
     <linearGradient
        id="linearGradient3836-9-3-9-9">
       <stop
@@ -353,8 +318,7 @@
        x1="-18"
        gradientUnits="userSpaceOnUse"
        id="linearGradient3171-7-0"
-       xlink:href="#linearGradient3836-9-3-6-0-6"
-       inkscape:collect="always" />
+       xlink:href="#linearGradient3836-9-3-6-0-6" />
     <linearGradient
        id="linearGradient3836-9-3-6-0-6">
       <stop
@@ -367,7 +331,6 @@
          id="stop3840-1-6-5-3-6" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3836-9-3-6-29"
        id="linearGradient3937"
        gradientUnits="userSpaceOnUse"
@@ -377,7 +340,6 @@
        x2="-22"
        y2="5" />
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3836-9-3-6-29-8"
        id="linearGradient3937-1"
        gradientUnits="userSpaceOnUse"
@@ -405,18 +367,7 @@
        gradientTransform="matrix(0.71441909,0,0,0.71408544,-5.531259,3.2604792)"
        gradientUnits="userSpaceOnUse"
        id="linearGradient3956"
-       xlink:href="#linearGradient3836-9-3-6-29-8"
-       inkscape:collect="always" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3836-9-3-6-29-7"
-       id="linearGradient3937-3"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.71441909,0,0,0.71408544,-5.531259,3.2604792)"
-       x1="-18"
-       y1="18"
-       x2="-22"
-       y2="5" />
+       xlink:href="#linearGradient3836-9-3-6-29-8" />
     <linearGradient
        id="linearGradient3836-9-3-6-29-7">
       <stop
@@ -429,7 +380,6 @@
          id="stop3840-1-6-5-7-92" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3836-9-3-6-29-1"
        id="linearGradient3937-36"
        gradientUnits="userSpaceOnUse"
@@ -450,58 +400,6 @@
          id="stop3840-1-6-5-7-93" />
     </linearGradient>
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="7.3108168"
-     inkscape:cx="-1.5801036"
-     inkscape:cy="16.822168"
-     inkscape:current-layer="layer1"
-     showgrid="true"
-     inkscape:document-units="px"
-     inkscape:grid-bbox="true"
-     inkscape:window-width="1920"
-     inkscape:window-height="993"
-     inkscape:window-x="0"
-     inkscape:window-y="28"
-     inkscape:window-maximized="1"
-     inkscape:snap-global="true"
-     inkscape:snap-bbox="true"
-     inkscape:snap-nodes="true"
-     showguides="true"
-     inkscape:guide-bbox="true">
-    <inkscape:grid
-       type="xygrid"
-       id="grid3058"
-       empspacing="2"
-       visible="true"
-       enabled="true"
-       snapvisiblegridlinesonly="true" />
-    <sodipodi:guide
-       orientation="1,0"
-       position="28,22"
-       id="guide3917"
-       inkscape:locked="false" />
-    <sodipodi:guide
-       orientation="0,1"
-       position="12,32"
-       id="guide3919"
-       inkscape:locked="false" />
-    <sodipodi:guide
-       orientation="0,1"
-       position="60,16"
-       id="guide3921"
-       inkscape:locked="false" />
-    <sodipodi:guide
-       orientation="1,0"
-       position="52,8"
-       id="guide3923"
-       inkscape:locked="false" />
-  </sodipodi:namedview>
   <metadata
      id="metadata2923">
     <rdf:RDF>
@@ -510,21 +408,21 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:title>Sketcher_BSplineKnotMultiplicity</dc:title>
         <dc:creator>
           <cc:Agent>
-            <dc:title>[agryson] Alexander Gryson</dc:title>
+            <dc:title>[bitacovir]</dc:title>
           </cc:Agent>
         </dc:creator>
         <dc:title>Sketcher_Create_Periodic_BSpline</dc:title>
-        <dc:date>2017-02-15</dc:date>
+        <dc:date>22-03-2021</dc:date>
         <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>
           </cc:Agent>
         </dc:publisher>
-        <dc:identifier>FreeCAD/src/Mod/Sketcher/Gui/Resources/icons/Sketcher_Toggle_BSpline_Information.svg</dc:identifier>
+        <dc:identifier></dc:identifier>
         <dc:rights>
           <cc:Agent>
             <dc:title>FreeCAD LGPL2+</dc:title>
@@ -533,44 +431,18 @@
         <cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license>
         <dc:contributor>
           <cc:Agent>
-            <dc:title>[agryson] Alexander Gryson</dc:title>
+            <dc:title></dc:title>
           </cc:Agent>
         </dc:contributor>
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1"
-     inkscape:label="Layer 1"
-     inkscape:groupmode="layer">
-    <path
-       style="fill:none;stroke:#2e3436;stroke-width:8;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="M 55.999976,26.000003 C 58,48 32,32 29.999975,52.000002"
-       id="path3266"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
-    <path
-       style="fill:none;stroke:#d3d7cf;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="M 55.999976,26.000003 C 56,48 32,32 29.999975,52.000002"
-       id="path3266-9"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
-    <path
-       style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="M 54.999975,26.000003 C 56,47 32,31 28.999974,52.000002"
-       id="path3266-9-2"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
+     id="layer1">
     <g
-       inkscape:export-ydpi="7.2934141"
-       inkscape:export-xdpi="7.2934141"
-       inkscape:export-filename="/home/yorik/Documents/Lab/Draft/icons/circle.png"
        transform="matrix(-0.14137236,0.07774155,-0.01888492,-0.10633123,99.823869,75.569613)"
        id="g3177" />
     <g
-       inkscape:export-ydpi="7.2934141"
-       inkscape:export-xdpi="7.2934141"
-       inkscape:export-filename="/home/yorik/Documents/Lab/Draft/icons/circle.png"
        transform="matrix(-0.14109247,0.07923086,-0.02087339,-0.10522619,77.138226,86.686164)"
        id="g3185" />
     <g
@@ -578,17 +450,15 @@
        id="g3797-7-2-3">
       <g
          id="g3933"
-         transform="translate(30.005802,0)">
+         transform="translate(30.005802)">
         <path
            d="m -25.658702,6.015909 a 8.3321309,8.3277776 0 1 1 12.65725,10.83369 8.3321309,8.3277776 0 1 1 -12.65725,-10.83369 z"
            id="path4250-6-9-5"
-           style="fill:#ef2929;stroke:#280000;stroke-width:3.33320141;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-           inkscape:connector-curvature="0" />
+           style="fill:#ef2929;stroke:#280000;stroke-width:3.3332;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
         <path
            d="m -23.129965,8.18309 a 5.0009335,4.9985982 0 1 1 7.596839,6.502756 5.0009335,4.9985982 0 0 1 -7.596839,-6.502756 z"
            id="path4250-7-0-1-6"
-           style="fill:url(#linearGradient3937);fill-opacity:1;stroke:#ef2929;stroke-width:3.33320141;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-           inkscape:connector-curvature="0" />
+           style="fill:url(#linearGradient3937);fill-opacity:1;stroke:#ef2929;stroke-width:3.3332;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       </g>
     </g>
     <g
@@ -597,99 +467,51 @@
       <path
          d="m -25.658702,6.015909 a 8.3321309,8.3277776 0 1 1 12.65725,10.83369 8.3321309,8.3277776 0 1 1 -12.65725,-10.83369 z"
          id="path4250-6-9-5-0"
-         style="fill:#ef2929;stroke:#280000;stroke-width:3.33320141;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-         inkscape:connector-curvature="0" />
+         style="fill:#ef2929;stroke:#280000;stroke-width:3.3332;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       <path
          d="m -23.129965,8.18309 a 5.0009335,4.9985982 0 1 1 7.596839,6.502756 5.0009335,4.9985982 0 0 1 -7.596839,-6.502756 z"
          id="path4250-7-0-1-6-2"
-         style="fill:url(#linearGradient3956);fill-opacity:1;stroke:#ef2929;stroke-width:3.33320141;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-         inkscape:connector-curvature="0" />
-    </g>
-    <g
-       transform="matrix(0.59988397,0,0,0.60016354,25.595637,25.138672)"
-       id="g3797-7-2-3-2">
-      <g
-         id="g3933-8"
-         transform="translate(30.005802,0)">
-        <path
-           d="m -25.658702,6.015909 a 8.3321309,8.3277776 0 1 1 12.65725,10.83369 8.3321309,8.3277776 0 1 1 -12.65725,-10.83369 z"
-           id="path4250-6-9-5-9"
-           style="fill:#ef2929;stroke:#280000;stroke-width:3.33320141;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-           inkscape:connector-curvature="0" />
-        <path
-           d="m -23.129965,8.18309 a 5.0009335,4.9985982 0 1 1 7.596839,6.502756 5.0009335,4.9985982 0 0 1 -7.596839,-6.502756 z"
-           id="path4250-7-0-1-6-7"
-           style="fill:url(#linearGradient3937-3);fill-opacity:1;stroke:#ef2929;stroke-width:3.33320141;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-           inkscape:connector-curvature="0" />
-      </g>
+         style="fill:url(#linearGradient3956);fill-opacity:1;stroke:#ef2929;stroke-width:3.3332;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     </g>
     <g
        transform="matrix(0.59988397,0,0,0.60016354,49.595637,41.138672)"
        id="g3797-7-2-3-1">
       <g
          id="g3933-9"
-         transform="translate(30.005802,0)">
+         transform="translate(30.005802)">
         <path
            d="m -25.658702,6.015909 a 8.3321309,8.3277776 0 1 1 12.65725,10.83369 8.3321309,8.3277776 0 1 1 -12.65725,-10.83369 z"
            id="path4250-6-9-5-4"
-           style="fill:#ef2929;stroke:#280000;stroke-width:3.33320141;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-           inkscape:connector-curvature="0" />
+           style="fill:#ef2929;stroke:#280000;stroke-width:3.3332;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
         <path
            d="m -23.129965,8.18309 a 5.0009335,4.9985982 0 1 1 7.596839,6.502756 5.0009335,4.9985982 0 0 1 -7.596839,-6.502756 z"
            id="path4250-7-0-1-6-78"
-           style="fill:url(#linearGradient3937-36);fill-opacity:1;stroke:#ef2929;stroke-width:3.33320141;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-           inkscape:connector-curvature="0" />
+           style="fill:url(#linearGradient3937-36);fill-opacity:1;stroke:#ef2929;stroke-width:3.3332;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       </g>
     </g>
     <path
        style="fill:none;stroke:#172a04;stroke-width:8;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
-       d="M 31,44 35,6 M 6,33 44,33"
-       id="path3047-3-6-3"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccc" />
+       d="M 31,44 35,6 M 6,33 h 38"
+       id="path3047-3-6-3" />
     <path
        style="fill:none;stroke:#172a04;stroke-width:8;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
-       d="M 17,6 13,44 M 44,17 6,17"
-       id="path3047-3-6"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccc" />
+       d="M 17,6 13,44 M 44,17 H 6"
+       id="path3047-3-6" />
     <path
        style="fill:none;stroke:#4e9a06;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
-       d="M 17,6 13,44 M 44,17 6,17"
-       id="path3047"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccc" />
-    <g
-       id="g958"
-       transform="translate(30.279658,-18.049864)">
-      <path
-         inkscape:connector-curvature="0"
-         style="fill:#ef2929;stroke:#280000;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="path4250-6-9-5-3"
-         d="m 8.203393,54.749201 a 4.9983118,4.9980285 0 1 1 7.592881,6.501986 4.9983118,4.9980285 0 1 1 -7.592881,-6.501986 z" />
-      <path
-         inkscape:connector-curvature="0"
-         style="fill:#99cc33;fill-opacity:1;stroke:#669900;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="path4250-7-0-1-6-5"
-         d="M 9.7203418,56.049864 A 2.9999798,2.9999764 0 1 1 14.277564,59.952581 2.9999798,2.9999764 0 0 1 9.7203418,56.049864 Z" />
-    </g>
+       d="M 17,6 13,44 M 44,17 H 6"
+       id="path3047" />
     <path
        style="fill:none;stroke:#4e9a06;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
-       d="M 31,44 35,6 M 6,33 44,33"
-       id="path3047-6"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccc" />
+       d="M 31,44 35,6 M 6,33 h 38"
+       id="path3047-6" />
     <path
        style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
-       d="M 30,44 34,6 M 6,32 44,32"
-       id="path3047-3-7"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccc" />
+       d="M 30,44 34,6 M 6,32 h 38"
+       id="path3047-3-7" />
     <path
        style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
-       d="M 16,6 12,44 M 44,16 6,16"
-       id="path3047-3"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccc" />
+       d="M 16,6 12,44 M 44,16 H 6"
+       id="path3047-3" />
   </g>
 </svg>


### PR DESCRIPTION
Some icons of Sketcher WB are too similar and under small resolution are difficult to identify. A design improvement was requested.
Sketcher_BSplineDegree
Sketcher_BSplineKnotMultiplicity
Sketcher_BSplineDecreaseDegree
Sketcher_BSplineDecreaseKnotMultiplicity
Sketcher_BSplineIncreaseDegree
Sketcher_BSplineIncreaseKnotMultiplicity

This commit replaces SVG files with new icons for these commands.

The new SVG icons follow the FreeCAD Artwork Guidelines and were saved as Plain SVG format.

Forum Discussion: https://forum.freecadweb.org/viewtopic.php?f=34&t=56468&sid=697c86a2dfb2cfd944bc8ab91d5c43d8