### PR TITLE
[Draft] Fix bug in data entry on scale w/ uniform scaling on

### DIFF
--- a/src/Mod/Draft/drafttaskpanels/task_scale.py
+++ b/src/Mod/Draft/drafttaskpanels/task_scale.py
@@ -119,9 +119,12 @@ class ScaleTaskPanel:
     def setValue(self, val=None):
         """Set the value of the points."""
         if self.lock.isChecked():
-            self.xValue.setValue(val)
-            self.yValue.setValue(val)
-            self.zValue.setValue(val)
+            if not self.xValue.hasFocus():
+                self.xValue.setValue(val)
+            if not self.yValue.hasFocus():
+                self.yValue.setValue(val)
+            if not self.zValue.hasFocus():
+                self.zValue.setValue(val)
         if self.sourceCmd:
             self.sourceCmd.scaleGhost(self.xValue.value(),self.yValue.value(),self.zValue.value(),self.relative.isChecked())
 


### PR DESCRIPTION
When entering a scale factor, if uniform scaling is on, the current code keeps appending zeroes as you type, forcing you to delete them before entering your next digit. This commit fixes that by ensuring that the widget that you are currently editing is not updated continuously.

Fixes [#0004601](https://tracker.freecadweb.org/view.php?id=4601).

---

- [X]  Single module
- [X]  Discussed in forum: [Draft WB, Clone, Data Entry issue](https://forum.freecadweb.org/viewtopic.php?f=3&t=56968)
- [X]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [X]  Draft GUI unit tests pass
- [X]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) 
- [X]  Your pull request is well written and has a good description
- [X]  Commit messages include `issue #<id>` or `fixes #<id>` 