### PR TITLE
[FEM] add GMSH mesh order setting to dialog

### DIFF
--- a/src/Mod/Fem/Gui/Resources/ui/MeshGmsh.ui
+++ b/src/Mod/Fem/Gui/Resources/ui/MeshGmsh.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>439</height>
+    <height>475</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -41,14 +41,14 @@
         <item row="1" column="1">
          <widget class="QComboBox" name="cb_dimension"/>
         </item>
-        <item row="2" column="0">
+        <item row="3" column="0">
          <widget class="QLabel" name="l_max">
           <property name="text">
            <string>Max element size (0.0 = Auto):</string>
           </property>
          </widget>
         </item>
-        <item row="2" column="1">
+        <item row="3" column="1">
          <widget class="Gui::InputField" name="if_max">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -85,14 +85,14 @@
           </property>
          </widget>
         </item>
-        <item row="3" column="0">
+        <item row="4" column="0">
          <widget class="QLabel" name="l_min">
           <property name="text">
            <string>Min element size (0.0 = Auto):</string>
           </property>
          </widget>
         </item>
-        <item row="3" column="1">
+        <item row="4" column="1">
          <widget class="Gui::InputField" name="if_min">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -129,6 +129,16 @@
           </property>
          </widget>
         </item>
+        <item row="2" column="1">
+         <widget class="QComboBox" name="cb_order"/>
+        </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="I_order">
+          <property name="text">
+           <string>Mesh order</string>
+          </property>
+         </widget>
+        </item>
        </layout>
       </item>
      </layout>
@@ -153,6 +163,13 @@
         </property>
         <item row="1" column="1">
          <layout class="QGridLayout" name="gl_actions">
+          <item row="0" column="0">
+           <widget class="QTextEdit" name="te_output">
+            <property name="lineWrapMode">
+             <enum>QTextEdit::NoWrap</enum>
+            </property>
+           </widget>
+          </item>
           <item row="5" column="0">
            <widget class="QLabel" name="l_time">
             <property name="font">
@@ -162,26 +179,6 @@
             </property>
             <property name="text">
              <string>Time:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0">
-           <widget class="QTextEdit" name="te_output">
-            <property name="lineWrapMode">
-             <enum>QTextEdit::NoWrap</enum>
-            </property>
-           </widget>
-          </item>
-          <item row="7" column="0">
-           <widget class="QPushButton" name="pb_get_gmsh_version">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Gmsh version</string>
             </property>
            </widget>
           </item>
@@ -198,7 +195,20 @@
             </property>
            </spacer>
           </item>
-         </layout>
+         <item row="7" column="0">
+           <widget class="QPushButton" name="pb_get_gmsh_version">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Gmsh version</string>
+            </property>
+           </widget>
+          </item>
+          </layout>
         </item>
        </layout>
       </item>

--- a/src/Mod/Fem/femobjects/mesh_gmsh.py
+++ b/src/Mod/Fem/femobjects/mesh_gmsh.py
@@ -141,7 +141,7 @@ class MeshGmsh(base_fempythonobject.BaseFemPythonObject):
                 "Order of mesh elements"
             )
             obj.ElementOrder = MeshGmsh.known_element_orders
-            obj.ElementOrder = "2nd"
+            obj.ElementOrder = "1st"
 
         if not hasattr(obj, "OptimizeStd"):
             obj.addProperty(

--- a/src/Mod/Fem/femtaskpanels/task_mesh_gmsh.py
+++ b/src/Mod/Fem/femtaskpanels/task_mesh_gmsh.py
@@ -78,6 +78,11 @@ class _TaskPanel:
             self.choose_dimension
         )
         QtCore.QObject.connect(
+            self.form.cb_order,
+            QtCore.SIGNAL("activated(int)"),
+            self.choose_order
+        )
+        QtCore.QObject.connect(
             self.Timer,
             QtCore.SIGNAL("timeout()"),
             self.update_timer_text
@@ -90,6 +95,10 @@ class _TaskPanel:
 
         self.form.cb_dimension.addItems(
             mesh_gmsh.MeshGmsh.known_element_dimensions
+        )
+
+        self.form.cb_order.addItems(
+            mesh_gmsh.MeshGmsh.known_element_orders
         )
 
         self.get_mesh_params()
@@ -126,11 +135,13 @@ class _TaskPanel:
         self.clmax = self.mesh_obj.CharacteristicLengthMax
         self.clmin = self.mesh_obj.CharacteristicLengthMin
         self.dimension = self.mesh_obj.ElementDimension
+        self.order = self.mesh_obj.ElementOrder
 
     def set_mesh_params(self):
         self.mesh_obj.CharacteristicLengthMax = self.clmax
         self.mesh_obj.CharacteristicLengthMin = self.clmin
         self.mesh_obj.ElementDimension = self.dimension
+        self.mesh_obj.ElementOrder = self.order
 
     def update(self):
         "fills the widgets"
@@ -138,6 +149,8 @@ class _TaskPanel:
         self.form.if_min.setText(self.clmin.UserString)
         index_dimension = self.form.cb_dimension.findText(self.dimension)
         self.form.cb_dimension.setCurrentIndex(index_dimension)
+        index_order = self.form.cb_order.findText(self.order)
+        self.form.cb_order.setCurrentIndex(index_order)
 
     def console_log(self, message="", color="#000000"):
         if (not isinstance(message, bytes)) and (sys.version_info.major < 3):
@@ -167,6 +180,12 @@ class _TaskPanel:
             return
         self.form.cb_dimension.setCurrentIndex(index)
         self.dimension = str(self.form.cb_dimension.itemText(index))  # form returns unicode
+
+    def choose_order(self, index):
+        if index < 0:
+            return
+        self.form.cb_order.setCurrentIndex(index)
+        self.order = str(self.form.cb_order.itemText(index))  # form returns unicode
 
     def get_gmsh_version(self):
         from femmesh import gmshtools


### PR DESCRIPTION
- also set default to 1st order mesh

The PR is with the code from user johnwang: https://forum.freecadweb.org/viewtopic.php?f=18&t=55608#p454510
I just updated it to the latest master.

I change the default to 1st order since in many cases it is important to get a mesh at all. You can increase the order now quickly/directly in the dialog.

