### PR TITLE
[Draft] Eliminate required GUI for importDXF

### DIFF
--- a/src/Mod/Draft/importDXF.py
+++ b/src/Mod/Draft/importDXF.py
@@ -55,7 +55,7 @@ import six
 import FreeCAD
 import Part, Draft, Mesh
 import DraftVecUtils, DraftGeomUtils, WorkingPlane
-from Draft import _Dimension, _ViewProviderDimension
+from Draft import _Dimension
 from FreeCAD import Vector
 from FreeCAD import Console as FCC
 
@@ -2573,7 +2573,9 @@ def processdxf(document, filename, getShapes=False, reComputeFlag=True):
                     newob = doc.addObject("App::FeaturePython", "Dimension")
                     lay.addObject(newob)
                     _Dimension(newob)
-                    _ViewProviderDimension(newob.ViewObject)
+                    if FreeCAD.GuiUp:
+                        from Draft import _ViewProviderDimension
+                        _ViewProviderDimension(newob.ViewObject)
                     newob.Start = p1
                     newob.End = p2
                     newob.Dimline = pt


### PR DESCRIPTION
Bug reported by forums member tarrox -- the importDXF code assumes the existence of the GUI, but does not actually need it (a `FreeCAD.GuiUp` check suffices to protect the one line of code that was using the view provider).

---

- [X]  Single module
- [X]  Discussed in forum: [[BUG] Error using importDXF without GUI](https://forum.freecadweb.org/viewtopic.php?f=23&t=56711)
- [X]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master
- [X]  Draft unit tests pass
- [X]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) 
- [X]  Your pull request is well written and has a good description
- [X]  No tracker ticket