### PR TITLE
[skip ci] [FEM] fix typo

### DIFF
--- a/src/Mod/Fem/Gui/Resources/ui/MeshGmsh.ui
+++ b/src/Mod/Fem/Gui/Resources/ui/MeshGmsh.ui
@@ -34,7 +34,7 @@
         <item row="1" column="0">
          <widget class="QLabel" name="l_dimension">
           <property name="text">
-           <string>Mesh element dimension:</string>
+           <string>Element dimension:</string>
           </property>
          </widget>
         </item>
@@ -135,7 +135,7 @@
         <item row="2" column="0">
          <widget class="QLabel" name="I_order">
           <property name="text">
-           <string>Mesh order</string>
+           <string>Element order:</string>
           </property>
          </widget>
         </item>
@@ -195,7 +195,7 @@
             </property>
            </spacer>
           </item>
-         <item row="7" column="0">
+          <item row="7" column="0">
            <widget class="QPushButton" name="pb_get_gmsh_version">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -208,7 +208,7 @@
             </property>
            </widget>
           </item>
-          </layout>
+         </layout>
         </item>
        </layout>
       </item>


### PR DESCRIPTION
- the property has the name "Element order" thus the dialog should use the same name to avoid confusions

- also uniform naming for the element dimension and remove the redundant "Mesh" (is already in the UI groupBox heading