### PR TITLE
[skip ci] [FEM] don't hide Gmsh mesh by default

### DIFF
--- a/src/Mod/Fem/femviewprovider/view_mesh_gmsh.py
+++ b/src/Mod/Fem/femviewprovider/view_mesh_gmsh.py
@@ -96,10 +96,9 @@ class VPMeshGmsh:
         )
     """
 
-    # overwrite unsetEdit, hide mesh object on task panel exit
+    # overwrite unsetEdit
     def unsetEdit(self, vobj, mode):
         FreeCADGui.Control.closeDialog()
-        self.ViewObject.hide()
         return True
 
     def doubleClicked(self, vobj):


### PR DESCRIPTION
it is very annoying that the mesh is hided when closing the task dialog because one often has to play with the Gmsh properties and need to see the mesh.
See also https://forum.freecadweb.org/viewtopic.php?f=18&t=56401&start=10#p489734