### PR TITLE
AddonManager: Fixed minor logic glitch affecting non-github addons

### DIFF
--- a/src/Mod/AddonManager/addonmanager_workers.py
+++ b/src/Mod/AddonManager/addonmanager_workers.py
@@ -421,7 +421,7 @@ class ShowWorker(QtCore.QThread):
                         p = p.decode("utf-8")
                     u.close()
                     desc = utils.fix_relative_links(p, readmeurl.rsplit("/README.md")[0])
-                    if NOMARKDOWN or not have_markdown:
+                    if not NOMARKDOWN and have_markdown:
                         desc = markdown.markdown(desc, extensions=["md_in_html"])
                     else:
                         message = """


### PR DESCRIPTION
If a non-github repository is added to the addon manager, the intention was to use the markdown library to render the README.md if available; otherwise it reverts to displaying it in plain text. (See the discussion in https://github.com/FreeCAD/FreeCAD/pull/3868 )

However it seems that during a reformatting in commit dde64d4a0a4db04804297ee539b461bf7f01151f  this logic was inadvertently reversed, and now it tries to use the markdown library only if it was not found. This is fixed in this pull request.


- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [ ]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [x]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [X]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`
