### PR TITLE
[GUI] Remove explicit triangle styling from tabs

### DIFF
--- a/src/Gui/PropertyView.cpp
+++ b/src/Gui/PropertyView.cpp
@@ -89,9 +89,6 @@ PropertyView::PropertyView(QWidget *parent)
     tabs = new QTabWidget (this);
     tabs->setObjectName(QString::fromUtf8("propertyTab"));
     tabs->setTabPosition(QTabWidget::South);
-#if defined(Q_OS_WIN32)
-    tabs->setTabShape(QTabWidget::Triangular);
-#endif
     pLayout->addWidget(tabs, 0, 0);
 
     propertyEditorView = new Gui::PropertyEditor::PropertyEditor();


### PR DESCRIPTION
On Windows the lower tabs of the PropertyView were being set to triangular, which breaks stylesheets. This removes that code, so they now take on whatever the standard shape is on the system. Fixes [#0004599](https://tracker.freecadweb.org/view.php?id=4599).

---

- [X]  Single module
- [X]  Forum discussion: [0.19 Release breaks all shipping Stylesheets Tab theming](https://forum.freecadweb.org/viewtopic.php?f=34&t=56875)
- [X]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) 
- [X]  Your pull request is well written and has a good description
- [X]  Commit messages include `issue #<id>` or `fixes #<id>`