### PR TITLE
[OpenSCAD] Fix bug in resize code

### DIFF
--- a/src/Mod/OpenSCAD/OpenSCADTest/app/test_importCSG.py
+++ b/src/Mod/OpenSCAD/OpenSCADTest/app/test_importCSG.py
@@ -312,6 +312,18 @@ polyhedron(
         self.assertAlmostEqual (object.Shape.Volume, 8.000000, 6)
         FreeCAD.closeDocument(doc.Name)
 
+        # Make sure to test something that isn't just a box (where the bounding box is trivial)
+        doc = self.utility_create_scad("""
+resize(newsize = [0,0,10], auto = [0,0,0]) {
+    sphere($fn = 96, $fa = 12, $fs = 2, r = 8.5);
+}""", "resize_non_uniform_sphere")
+        object = doc.ActiveObject
+        self.assertTrue (object is not None)
+        self.assertAlmostEqual (object.Shape.BoundBox.XLength, 2*8.5, 1)
+        self.assertAlmostEqual (object.Shape.BoundBox.YLength, 2*8.5, 1)
+        self.assertAlmostEqual (object.Shape.BoundBox.ZLength, 10.0, 1)
+        FreeCAD.closeDocument(doc.Name)
+
     def test_import_surface(self):
         # Workaround for absolute vs. relative path issue
         # Inside the OpenSCAD file an absolute path name to Surface.dat is used

--- a/src/Mod/OpenSCAD/importCSG.py
+++ b/src/Mod/OpenSCAD/importCSG.py
@@ -469,6 +469,7 @@ def p_resize_action(p):
     auto    = p[3]['auto'] 
     print(new_size)
     print(auto)
+    p[6][0].recompute()
     old_bbox = p[6][0].Shape.BoundBox
     print ("Old bounding box: " + str(old_bbox))
     old_size = [old_bbox.XLength, old_bbox.YLength, old_bbox.ZLength]


### PR DESCRIPTION
The resize code must recompute some kinds of objects prior to requesting their bounding box, or the bounding box can be invalid.

---

- [X]  Single module
- [X]  Discussed in forum: [OpenSCAD import error - "Cannot transform null shape"](https://forum.freecadweb.org/viewtopic.php?f=3&t=57018)
- [X]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master
- [X]  All OpenSCADApp unit tests are confirmed to pass
- [X]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) 
- [X]  Your pull request is well written and has a good description
- [X]  No tracker ticket