### PR TITLE
fix source comment typos [skip ci]

### DIFF
--- a/src/Mod/Part/App/Part2DObject.h
+++ b/src/Mod/Part/App/Part2DObject.h
@@ -73,7 +73,7 @@ public:
       * indexes geometryIndex1 and geometryIndex2 specify the corresponding curves that intersect
       * the curve geometryIndex.
       *
-      * If intersection is found, the associated geometryIndex1 or geometryIndex2 retuns -1.
+      * If intersection is found, the associated geometryIndex1 or geometryIndex2 returns -1.
       */
     static bool seekTrimPoints(const std::vector<Geometry *> &geomlist,
                                int geometryIndex, const Base::Vector3d &point,

--- a/src/Mod/Path/PathScripts/post/uccnc_post.py
+++ b/src/Mod/Path/PathScripts/post/uccnc_post.py
@@ -54,7 +54,7 @@ UCCNC_post.export(object,"/path/to/file.ncc","")
 This postprocessor was tested on UC-CNC v1.2111, an UC100 and a Stepcraft 420.
 It was tested on FreeCAD v0.17, v0.18 and v0.19
 
-Other (Stepcraft) machines using UC-CNC and UC* controlers should be easy to adapt.
+Other (Stepcraft) machines using UC-CNC and UC* controllers should be easy to adapt.
 '''
 
 # PREAMBLE_ possible values:
@@ -144,7 +144,7 @@ OUTPUT_HEADER = True
 #                set with --no-comment
 OUTPUT_COMMENTS = True
 
-# OUTPUT_LINE_NUMBERS posible values:
+# OUTPUT_LINE_NUMBERS possible values:
 #    bool      (Dont) use line numbers in output
 #    True        Add a line number to each output line.
 #    False       Do not add a line number.
@@ -188,7 +188,7 @@ MODAL = False
 #                set with --repeat
 REPEAT_ARGUMENTS = False
 
-# USE_TLO posible values:
+# USE_TLO possible values:
 #   bool        Set tool length offset.
 #    True        G43 will be output following tool changes
 #    False       No G43 used.
@@ -287,7 +287,7 @@ COMMAND_SPACE = " "
 UNIT_DEFAULT_CHANGED = False
 
 # counting warnings and problems.
-# Each warning/problem will apear as a WARNING:/PROBLEM: comment in the GCode output.
+# Each warning/problem will appear as a WARNING:/PROBLEM: comment in the GCode output.
 warnings_count = 0
 problems_count = 0
 
@@ -313,7 +313,7 @@ def processArguments(argstring):
     global UNIT_FORMAT              # Text with specific units
     global UNIT_SPEED_FORMAT        # Text with specific units over time units
     global UNIT_DEFAULT_CHANGED     # tracing changes in UNIT settings.
-    global REPEAT_ARGUMENTS         # Repeat or surpress axis values if the same as previous line.
+    global REPEAT_ARGUMENTS         # Repeat or suppress axis values if the same as previous line.
 
     try:
         UNIT_DEFAULT_CHANGED = False

--- a/src/Mod/Sketcher/App/SketchObject.h
+++ b/src/Mod/Sketcher/App/SketchObject.h
@@ -147,7 +147,7 @@ public:
     /** deletes a group of constraints at once, if norecomputes is active, the default behaviour is that
      * it will solve the sketch.
      *
-     * If updating the Geometry property as a consequence of a (sucessful) solve() is not wanted, updategeometry=false,
+     * If updating the Geometry property as a consequence of a (successful) solve() is not wanted, updategeometry=false,
      * prevents the update. This allows to update the solve status (e.g. dof), without updating the geometry (i.e. make it
      * move to fulfil the constraints).
      */


### PR DESCRIPTION
Found via  codespell v2.1.dev0
```
codespell -q 3 -L aci,ake,aline,alle,alledges,alocation,als,ang,anid,apoints,ba,beginn,behaviour,bloaded,byteorder,calculater,cancelled,cancelling,cas,cascade,centimetre,childs,colour,colours,commen,connexion,currenty,dof,doubleclick,dum,eiter,elemente,ende,feld,finde,findf,freez,hist,iff,indicies,initialisation,initialise,initialised,initialises,initialisiert,ist,kilometre,lod,mantatory,methode,metres,millimetre,modell,nd,noe,normale,normaly,nto,numer,oder,orgin,orginx,orginy,ot,pard,parms,pres,programm,que,recurrance,rougly,seperator,serie,sinc,strack,substraction,te,thist,thru,tread,uint,unter,vertexes,wallthickness,whitespaces -S ./.git,*.po,*.ts,./ChangeLog.txt,./src/3rdParty,./src/Mod/Assembly/App/opendcm,./src/CXX,./src/zipios++,./src/Base/swig*,./src/Mod/Robot/App/kdl_cp,./src/Mod/Import/App/SCL,./src/WindowsInstaller,./src/Doc/FreeCAD.uml,./build/doc/SourceDocu
```