### PR TITLE
[Gui] add Std_TransformManip to Edit menu

### DIFF
--- a/src/Gui/Workbench.cpp
+++ b/src/Gui/Workbench.cpp
@@ -586,7 +586,7 @@ MenuItem* StdWorkbench::setupMenuBar() const
           << "Std_Paste" << "Std_DuplicateSelection" << "Separator"
           << "Std_Refresh" << "Std_BoxSelection" << "Std_BoxElementSelection"
           << "Std_SelectAll" << "Std_Delete" << "Std_SendToPythonConsole"
-          << "Separator" << "Std_Placement" /*<< "Std_TransformManip"*/ << "Std_Alignment"
+          << "Separator" << "Std_Placement" << "Std_TransformManip" << "Std_Alignment"
           << "Std_Edit" << "Separator" << "Std_DlgPreferences";
 
     MenuItem* axoviews = new MenuItem;


### PR DESCRIPTION
I was wondering why we only offer this tool in the context menu. I tested and cannot see a drawback in having it also in the edit menu.