### PR TITLE
[Sketch] fix a typo in preferences dialog

### DIFF
--- a/src/Mod/Sketcher/Gui/SketcherSettingsDisplay.ui
+++ b/src/Mod/Sketcher/Gui/SketcherSettingsDisplay.ui
@@ -6,27 +6,14 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>602</width>
-    <height>608</height>
+    <width>500</width>
+    <height>463</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Display</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_3">
-   <item row="2" column="0">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
    <item row="0" column="0">
     <widget class="QGroupBox" name="groupBox">
      <property name="title">
@@ -65,7 +52,7 @@
          <string>Current constraint creation tool will remain active after creation</string>
         </property>
         <property name="text">
-         <string>Constraint creation "Continue Mode"</string>
+         <string>Constraint creation &quot;Continue Mode&quot;</string>
         </property>
         <property name="checked">
          <bool>true</bool>
@@ -111,7 +98,7 @@ Supports all unit systems except 'US customary' and 'Building US/Euro'.</string>
          <string>Use Diameter as default constraint for arcs and circles instead of Radius.</string>
         </property>
         <property name="text">
-         <string>Use Diameter as default constraint for arcs and circles</string>
+         <string>Use diameter as default constraint for arcs and circles</string>
         </property>
         <property name="prefEntry" stdset="0">
          <cstring>DefaultDiaConstraint</cstring>
@@ -312,7 +299,7 @@ Supports all unit systems except 'US customary' and 'Building US/Euro'.</string>
          <string>Current sketcher creation tool will remain active after creation</string>
         </property>
         <property name="text">
-         <string>Geometry creation "Continue Mode"</string>
+         <string>Geometry creation &quot;Continue Mode&quot;</string>
         </property>
         <property name="checked">
          <bool>true</bool>
@@ -397,6 +384,19 @@ Supports all unit systems except 'US customary' and 'Building US/Euro'.</string>
       </item>
      </layout>
     </widget>
+   </item>
+   <item row="2" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
- all other option text use consequently lowercase letters
- also set dialog to a more sensible sensible size
- the other changes were automagically done by Qt Creator