### PR TITLE
Path: vcarve - Fix depth calculation

### DIFF
--- a/src/Mod/Path/PathScripts/PathVcarve.py
+++ b/src/Mod/Path/PathScripts/PathVcarve.py
@@ -186,7 +186,7 @@ class _Geometry(object):
 def _calculate_depth(MIC, geom):
     # given a maximum inscribed circle (MIC) and tool angle,
     # return depth of cut relative to zStart.
-    depth = geom.start - round(MIC / geom.scale, 4)
+    depth = geom.start - round(MIC * geom.scale, 4)
     PathLog.debug('zStart value: {} depth: {}'.format(geom.start, depth))
 
     return max(depth, geom.stop)


### PR DESCRIPTION
Depths were being calculated incorrectly due to MIC distance getting
divided by scaling factor rather than multiplied by it.

The scaling factor is the inverse of the tan of half the cutting tool
angle, so for a 30 degree bit (say), the scaling factor would be
1 / tan(30/2), or 3.7320.

When given an MIC (which is a radius) of 3.175 (say), and cutting to the
same width with a 30 degree bit, the depth should be 3.175 * 3.7320
(11..849), not 3.175 / 3.7320 (0.8509) as it is currently.

My apologies if I haven't complied with the expected PR standards. I have not built the code, but have checked that the calculated depths are correct by modifying the .py file in the version of code running on my system.
It appears that the existing tests check that the 'scale' factor is correct, but they don't appear to test any cut depths, so I woudlnt' expect the existing tests to break.
