### PR TITLE
Gui: Enable compression of tablet motion events

### DIFF
--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -1833,6 +1833,20 @@ void Application::runApplication(void)
         QApplication::setAttribute(Qt::AA_UseSoftwareOpenGL);
     }
 
+    #if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
+        // By default (on platforms that support it, see docs for
+        // Qt::AA_CompressHighFrequencyEvents) QT applies compression
+        // for high frequency events (mouse move, touch, window resizes)
+        // to keep things smooth even when handling the event takes a
+        // while (e.g. to calculate snapping).
+        // However, tablet pen move events (and mouse move events
+        // synthesised from those) are not compressed by default (to
+        // allow maximum precision when e.g. hand-drawing curves),
+        // leading to unacceptable slowdowns using a tablet pen. Enable
+        // compression for tablet events here to solve that.
+        QCoreApplication::setAttribute(Qt::AA_CompressTabletEvents);
+    #endif
+
     // A new QApplication
     Base::Console().Log("Init: Creating Gui::Application and QApplication\n");
 


### PR DESCRIPTION
By default (on platforms that support it, X11 and Windows currently) QT
applies compression for high frequency events (mouse move, touch, window
resizes) to keep things smooth even when handling the event takes a
while (e.g. to calculate snapping).

However, tablet pen move events (and mouse move events synthesised from
those, which is what FreeCAD uses) are not compressed by default (to
allow maximum precision when e.g. hand-drawing curves), leading to
unacceptable slowdowns using a tablet pen.

This commit enable compression for tablet events here to solve that and
make use of a tablet just as smooth as a mouse with FreeCAD.

This can (and likely will) lead to some movement events being dropped,
but since there is no freeform curve drawing tool, that should not be
problematic (and if it is ever added, it could still work without
compression if the mouse movement event handler is written to be fast
enough).

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [ ] ~~In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum~~ simple bugfix
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0` (waiting for compilation to complete after rebase, patch was manually tested on few days old master)
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  ~~Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`~~ no issue to close

Some additional info:
 - This issue was previously discussed on the forum: https://forum.freecadweb.org/viewtopic.php?f=8&t=45046&p=490962#p490962
 - The QT implementation of compression is [here for X11](https://github.com/qt/qtbase/blob/2801c1988742b18557c581a544a70a02f4faefa1/src/plugins/platforms/xcb/qxcbconnection.cpp#L893) and [here for Windows](https://github.com/qt/qtbase/blob/420e27c9efc1ef1a6400dc287345e897036abc71/src/plugins/platforms/windows/qwindowspointerhandler.cpp#L88).
 - For reference, here's an excerpt from [the relevant QT docs](https://doc.qt.io/qt-5/qt.html#ApplicationAttribute-enum):

Qt::AA_CompressHighFrequencyEvents | Enables compression of certain frequent events. On the X11 windowing system, the default value is true, which means that QEvent::MouseMove, QEvent::TouchUpdate,  and changes in window size and position will be combined whenever they  occur more frequently than the application handles them, so that they  don't accumulate and overwhelm the application later. On Windows 8 and  above the default value is also true, but it only applies to touch  events. Mouse and window events remain unaffected by this flag. On other  platforms, the default is false. (In the future, the compression  feature may be implemented across platforms.) You can test the attribute  to see whether compression is enabled. If your application needs to  handle all events with no compression, you can unset this attribute.  Notice that input events from tablet devices will not be compressed. See  AA_CompressTabletEvents if you want these to be compressed as well.  This value was added in Qt 5.7.
-- | --
Qt::AA_CompressTabletEvents | Enables  compression of input events from tablet devices. Notice that  AA_CompressHighFrequencyEvents must be true for events compression to be  enabled, and that this flag extends the former to tablet events.  Currently supported on the X11 windowing system, Windows 8 and above.  The default value is false. This value was added in Qt 5.10.

