### PR TITLE
Arch: Fix window rendering with mixed rotating and static components

### DIFF
--- a/src/Mod/Arch/ArchWindow.py
+++ b/src/Mod/Arch/ArchWindow.py
@@ -1442,6 +1442,8 @@ class _ArchWindowTaskPanel:
         self.field3.setText('')
         self.field4.setText('')
         self.field5.setText('')
+        self.field6.setText(QtGui.QApplication.translate("Arch", "Get selected edge", None))
+        self.field7.setCurrentIndex(0)
         self.addp4.setChecked(False)
         self.addp5.setChecked(False)
         self.newtitle.setVisible(True)
@@ -1489,6 +1491,8 @@ class _ArchWindowTaskPanel:
             if self.obj:
                 if comp in self.obj.WindowParts:
                     ind = self.obj.WindowParts.index(comp)
+                    self.field6.setText(QtGui.QApplication.translate("Arch", "Get selected edge", None))
+                    self.field7.setCurrentIndex(0)
                     for i in range(5):
                         f = getattr(self,"field"+str(i+1))
                         t = self.obj.WindowParts[ind+i]

--- a/src/Mod/Arch/ArchWindow.py
+++ b/src/Mod/Arch/ArchWindow.py
@@ -615,11 +615,11 @@ class _Window(ArchComponent.Component):
         self.sshapes = []
         self.vshapes = []
         shapes = []
-        rotdata = None
         for i in range(int(len(obj.WindowParts)/5)):
             wires = []
             hinge = None
             omode = None
+            rotdata = None
             ssymbols = []
             vsymbols = []
             wstr = obj.WindowParts[(i*5)+2].split(',')


### PR DESCRIPTION
While rendering each component of a window, the rotdata variable was
not reinitialized for each loop iteration. This means that any component
that does not define any rotation will use the rotation of the previous
component.

This is fixed by first clearing out the rotdata variable for each
component, rather than just once for the entire window.

This probably did not show up for the default windows, since they all
probably define the rotating parts last.

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [ ]  ~~In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum~~
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  ~~All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`~~ Full test was too invasive (cannot run in background), `TestArch` ran succesfully.
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  ~~Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`~~

---

Here is an example file:

[WithAndWithoutRotation.zip](https://github.com/FreeCAD/FreeCAD/files/6223890/WithAndWithoutRotation.zip)

Without this PR applied, this would render like this:

![image](https://user-images.githubusercontent.com/194491/112886366-213b5300-90d2-11eb-9114-2c2b39a32943.png)

