### PR TITLE
[OpenSCAD] Minor bug fixes in importing CSG

### DIFF
--- a/src/Mod/OpenSCAD/OpenSCADFeatures.py
+++ b/src/Mod/OpenSCAD/OpenSCADFeatures.py
@@ -431,7 +431,17 @@ class Twist:
                         left_handed = True
                     else:
                         left_handed = False
+
                     auxiliary_spine = Part.makeHelix(pitch, height, radius, 0.0, left_handed)
+
+                    # OCC versions before 7.5 had a problem with using a helix as the auxilliary spine, so approximate
+                    # it piecewise
+                    occ_version = Part.OCC_VERSION.split(".")
+                    if int(occ_version[0]) <= 7 and int(occ_version[1]) < 5:
+                        num_points = int(max(3,num_revolutions * 36)) # Every ten degrees is adequate
+                        wire = auxiliary_spine.Wires[0]
+                        points = wire.discretize(Number=num_points)
+                        auxiliary_spine = Part.makePolygon(points)
                     
                 faces = [lower_face,upper_face]
                 for wire1,wire2 in zip(lower_face.Wires,upper_face.Wires):

--- a/src/Mod/OpenSCAD/importCSG.py
+++ b/src/Mod/OpenSCAD/importCSG.py
@@ -463,13 +463,14 @@ def p_minkowski_action(p):
 def p_resize_action(p):
     '''
     resize_action : resize LPAREN keywordargument_list RPAREN OBRACE block_list EBRACE '''
-    import Draft
     print(p[3])
     new_size = p[3]['newsize']
     auto    = p[3]['auto'] 
     print(new_size)
     print(auto)
     p[6][0].recompute()
+    if p[6][0].Shape.isNull():
+        doc.recompute()
     old_bbox = p[6][0].Shape.BoundBox
     print ("Old bounding box: " + str(old_bbox))
     old_size = [old_bbox.XLength, old_bbox.YLength, old_bbox.ZLength]
@@ -482,7 +483,6 @@ def p_resize_action(p):
 
     # Calculate a transform matrix from the current bounding box to the new one:
     transform_matrix = FreeCAD.Matrix()
-    #new_part.Shape = part.Shape.transformGeometry(transform_matrix) 
 
     scale = FreeCAD.Vector(float(new_size[0])/old_size[0], 
                            float(new_size[1])/old_size[1], 
@@ -978,10 +978,10 @@ def p_multmatrix_action(p):
             part.ViewObject.hide()
     else :
         if printverbose: print("Transform Geometry")
-#       Need to recompute to stop transformGeometry causing a crash        
-        doc.recompute()
+        part.recompute()
+        if part.Shape.isNull():
+            doc.recompute()
         new_part = doc.addObject("Part::Feature","Matrix Deformation")
-      #  new_part.Shape = part.Base.Shape.transformGeometry(transform_matrix)
         new_part.Shape = part.Shape.transformGeometry(transform_matrix) 
         if gui:
             part.ViewObject.hide()


### PR DESCRIPTION
b18caba forces a full-document recompute prior to applying a matrix transformation if the part being transformed is still null after a simple object recompute.

fbd6b04 is an attempt to fix a bug reported by @wwmayer where the linear_extrude() with a rotation angle was failing with OCC 7.3. This restores a bit of the logic of the older version of the code, using a piecewise-linear approximation to the helix as the auxiliary spine. @wwmayer, please let me know if this resolves the issue for you (running the OpenSCADApp test suite should tell us) -- if not I'll install OCC 7.3 locally and do some more debugging. Thanks!

---

- [X]  Single module
- [X]  Minor changes only
- [X]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master
- [X]  OpenSCADApp unit tests pass
- [X]  Commit messages are [well-written](https://chris.beams.io/posts/git-commit/) 
- [X]  Pull request is well written
- [X]  No tracker ticket