### PR TITLE
[Start] Correct TestStart installation location

### DIFF
--- a/src/Mod/Start/CMakeLists.txt
+++ b/src/Mod/Start/CMakeLists.txt
@@ -47,5 +47,5 @@ INSTALL(
     FILES
         ${Start_Tests}
     DESTINATION
-        Mod/Start/testStart
+        Mod/Start/TestStart
 )


### PR DESCRIPTION
Fix bug identified by @PrzemoF -- actual fix by @sgrogan. Case error in the installation location of the Start Page test suite.

---

- [X]  Single module
- [X]  Discussed in [Self test fails on fedora 33 - nightly build](https://forum.freecadweb.org/viewtopic.php?f=10&t=56182)
- [X]  [Rebased](https://git-scm.com/docs/git-rebase) on latest master 
- [X]  Start unit tests pass after installation
- [X]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) 
- [X]  Your pull request is well written and has a good description
- [X]  No tracker ticket