### PR TITLE
[OpenSCAD] Fix projection for OCCT 7.3

### DIFF
--- a/src/Mod/OpenSCAD/OpenSCADFeatures.py
+++ b/src/Mod/OpenSCAD/OpenSCADFeatures.py
@@ -434,15 +434,6 @@ class Twist:
 
                     auxiliary_spine = Part.makeHelix(pitch, height, radius, 0.0, left_handed)
 
-                    # OCC versions before 7.5 had a problem with using a helix as the auxilliary spine, so approximate
-                    # it piecewise
-                    occ_version = Part.OCC_VERSION.split(".")
-                    if int(occ_version[0]) <= 7 and int(occ_version[1]) < 5:
-                        num_points = int(max(3,num_revolutions * 36)) # Every ten degrees is adequate
-                        wire = auxiliary_spine.Wires[0]
-                        points = wire.discretize(Number=num_points)
-                        auxiliary_spine = Part.makePolygon(points)
-                    
                 faces = [lower_face,upper_face]
                 for wire1,wire2 in zip(lower_face.Wires,upper_face.Wires):
                     pipe_shell = Part.BRepOffsetAPI.MakePipeShell(spine)


### PR DESCRIPTION
OCCT 7.3 did not work well when using a very large projection plane, so this commit reduces the plane size to the minimum required for the cut operation. It also performs some minor refactoring in anticipation of the implementation of the true projection feature, and it removes the previous attempted fix, which proved unnecessary.

See further details in the discussion on https://github.com/FreeCAD/FreeCAD/pull/4635

---

- [X]  Single module
- [X]  Small change
- [X]  [Rebased](https://git-scm.com/docs/git-rebase) on latest master
- [X]  OpenSCAD unit tests pass under OCC7.5 and OCC7.3
- [X]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) 
- [X]  Pull request is well written
- [X]  No tracker ticket