### PR TITLE
[GUI] Remove code for Qt < 5.9

### DIFF
--- a/src/Gui/Action.cpp
+++ b/src/Gui/Action.cpp
@@ -37,9 +37,7 @@
 # include <QToolButton>
 #endif
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
-# include <QScreen>
-#endif
+#include <QScreen>
 
 #include <Base/Tools.h>
 #include "Action.h"
@@ -431,11 +429,7 @@ void WorkbenchComboBox::showPopup()
     int rows = count();
     if (rows > 0) {
         int height = view()->sizeHintForRow(0);
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
         int maxHeight = QApplication::primaryScreen()->size().height();
-#else
-        int maxHeight = QApplication::desktop()->height();
-#endif
         view()->setMinimumHeight(qMin(height * rows, maxHeight/2));
     }
 

--- a/src/Gui/BitmapFactory.cpp
+++ b/src/Gui/BitmapFactory.cpp
@@ -37,9 +37,6 @@
 # include <QStyleOption>
 # include <sstream>
 #endif
-#if defined (FC_OS_WIN32) && QT_VERSION < 0x050000
-#define QTWEBKIT
-#endif
 
 #ifdef QTWEBKIT
 #include <QWebView>
@@ -177,9 +174,7 @@ QStringList BitmapFactoryInst::findIconFiles() const
         filters << QString::fromLatin1("*.%1").arg(QString::fromLatin1(*it).toLower());
 
     QStringList paths = QDir::searchPaths(QString::fromLatin1("icons"));
-#if QT_VERSION >= 0x040500
     paths.removeDuplicates();
-#endif
     for (QStringList::ConstIterator pt = paths.begin(); pt != paths.end(); ++pt) {
         QDir d(*pt);
         d.setNameFilters(filters);
@@ -188,9 +183,7 @@ QStringList BitmapFactoryInst::findIconFiles() const
             files << it->absoluteFilePath();
     }
 
-#if QT_VERSION >= 0x040500
     files.removeDuplicates();
-#endif
     return files;
 }
 
@@ -583,13 +576,8 @@ QPixmap BitmapFactoryInst::merge(const QPixmap& p1, const QPixmap& p2, Position 
 {
     // does the similar as the method above except that this method does not resize the resulting pixmap
     int x = 0, y = 0;
-#if QT_VERSION >= 0x050000
     qreal dpr1 = p1.devicePixelRatio();
     qreal dpr2 = p2.devicePixelRatio();
-#else
-    qreal dpr1 = 1;
-    qreal dpr2 = 1;
-#endif
 
     switch (pos)
     {

--- a/src/Gui/CommandDoc.cpp
+++ b/src/Gui/CommandDoc.cpp
@@ -677,9 +677,7 @@ StdCmdSaveAs::StdCmdSaveAs()
   sToolTipText  = QT_TR_NOOP("Save the active document under a new file name");
   sWhatsThis    = "Std_SaveAs";
   sStatusTip    = QT_TR_NOOP("Save the active document under a new file name");
-#if QT_VERSION >= 0x040200
   sPixmap       = "document-save-as";
-#endif
   sAccel        = keySequenceToAccel(QKeySequence::SaveAs);
   eType         = 0;
 }
@@ -819,9 +817,7 @@ StdCmdProjectInfo::StdCmdProjectInfo()
   sToolTipText  = QT_TR_NOOP("Show details of the currently active project");
   sWhatsThis    = "Std_ProjectInfo";
   sStatusTip    = QT_TR_NOOP("Show details of the currently active project");
-#if QT_VERSION >= 0x040200
   sPixmap       = "document-properties";
-#endif
 }
 
 void StdCmdProjectInfo::activated(int iMsg)
@@ -973,9 +969,7 @@ StdCmdQuit::StdCmdQuit()
   sToolTipText  = QT_TR_NOOP("Quits the application");
   sWhatsThis    = "Std_Quit";
   sStatusTip    = QT_TR_NOOP("Quits the application");
-#if QT_VERSION >= 0x040200
   sPixmap       = "application-exit";
-#endif
   sAccel        = "Alt+F4";
   eType         = NoTransaction;
 }
@@ -1278,9 +1272,7 @@ StdCmdSelectAll::StdCmdSelectAll()
     sToolTipText  = QT_TR_NOOP("Select all");
     sWhatsThis    = "Std_SelectAll";
     sStatusTip    = QT_TR_NOOP("Select all");
-#if QT_VERSION >= 0x040200
     sPixmap       = "edit-select-all";
-#endif
     //sAccel        = "Ctrl+A"; // superseeds shortcuts for text edits
 }
 
@@ -1311,9 +1303,7 @@ StdCmdDelete::StdCmdDelete()
   sToolTipText  = QT_TR_NOOP("Deletes the selected objects");
   sWhatsThis    = "Std_Delete";
   sStatusTip    = QT_TR_NOOP("Deletes the selected objects");
-#if QT_VERSION >= 0x040200
   sPixmap       = "edit-delete";
-#endif
   sAccel        = keySequenceToAccel(QKeySequence::Delete);
   eType         = ForEdit;
 }
@@ -1704,9 +1694,7 @@ StdCmdEdit::StdCmdEdit()
     sWhatsThis    = "Std_Edit";
     sStatusTip    = QT_TR_NOOP("Activates or Deactivates the selected object's edit mode");
     sAccel        = "";
-#if QT_VERSION >= 0x040200
     sPixmap       = "edit-edit";
-#endif
     eType         = ForEdit;
 }
 

--- a/src/Gui/CommandStd.cpp
+++ b/src/Gui/CommandStd.cpp
@@ -27,10 +27,8 @@
 # include <QMessageBox>
 # include <QSharedPointer>
 # include <QWhatsThis>
-#if QT_VERSION >= 0x040200
 # include <QDesktopServices>
 # include <QUrl>
-#endif
 #endif
 
 #include <boost/scoped_ptr.hpp>
@@ -245,13 +243,8 @@ Action * StdCmdAbout::createAction(void)
     pcAction->setWhatsThis(QLatin1String(sWhatsThis));
     pcAction->setIcon(QApplication::windowIcon());
     pcAction->setShortcut(QString::fromLatin1(sAccel));
-#if QT_VERSION > 0x050000
     // Needs to have AboutRole set to avoid duplicates if adding the about action more than once on macOS
     pcAction->setMenuRole(QAction::AboutRole);
-#else
-    // With Qt 4.8, having AboutRole set causes it to disappear when readding it: issue #0001485
-    pcAction->setMenuRole(QAction::ApplicationSpecificRole);
-#endif
     return pcAction;
 }
 

--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -1520,9 +1520,7 @@ StdCmdViewFitSelection::StdCmdViewFitSelection()
     sWhatsThis    = "Std_ViewFitSelection";
     sStatusTip    = QT_TR_NOOP("Fits the selected content on the screen");
     sAccel        = "V, S";
-#if QT_VERSION >= 0x040200
     sPixmap       = "zoom-selection";
-#endif
     eType         = Alter3DView;
 }
 
@@ -2494,9 +2492,7 @@ StdViewZoomIn::StdViewZoomIn()
     sToolTipText  = QT_TR_NOOP("Zoom In");
     sWhatsThis    = "Std_ViewZoomIn";
     sStatusTip    = QT_TR_NOOP("Zoom In");
-#if QT_VERSION >= 0x040200
     sPixmap       = "zoom-in";
-#endif
     sAccel        = keySequenceToAccel(QKeySequence::ZoomIn);
     eType         = Alter3DView;
 }
@@ -2529,9 +2525,7 @@ StdViewZoomOut::StdViewZoomOut()
     sToolTipText  = QT_TR_NOOP("Zoom Out");
     sWhatsThis    = "Std_ViewZoomOut";
     sStatusTip    = QT_TR_NOOP("Zoom Out");
-#if QT_VERSION >= 0x040200
     sPixmap       = "zoom-out";
-#endif
     sAccel        = keySequenceToAccel(QKeySequence::ZoomOut);
     eType         = Alter3DView;
 }
@@ -2564,9 +2558,7 @@ StdViewBoxZoom::StdViewBoxZoom()
     sToolTipText  = QT_TR_NOOP("Box zoom");
     sWhatsThis    = "Std_ViewBoxZoom";
     sStatusTip    = QT_TR_NOOP("Box zoom");
-#if QT_VERSION >= 0x040200
     sPixmap       = "zoom-border";
-#endif
     sAccel        = "Ctrl+B";
     eType         = Alter3DView;
 }
@@ -2595,9 +2587,7 @@ StdBoxSelection::StdBoxSelection()
     sToolTipText  = QT_TR_NOOP("Box selection");
     sWhatsThis    = "Std_BoxSelection";
     sStatusTip    = QT_TR_NOOP("Box selection");
-#if QT_VERSION >= 0x040200
     sPixmap       = "edit-select-box";
-#endif
     sAccel        = "Shift+B";
     eType         = AlterSelection;
 }
@@ -2819,9 +2809,7 @@ StdBoxElementSelection::StdBoxElementSelection()
     sToolTipText  = QT_TR_NOOP("Box element selection");
     sWhatsThis    = "Std_BoxElementSelection";
     sStatusTip    = QT_TR_NOOP("Box element selection");
-#if QT_VERSION >= 0x040200
     sPixmap       = "edit-element-select-box";
-#endif
     sAccel        = "Shift+E";
     eType         = AlterSelection;
 }

--- a/src/Gui/DAGView/DAGRectItem.cpp
+++ b/src/Gui/DAGView/DAGRectItem.cpp
@@ -46,11 +46,7 @@ void RectItem::paint(QPainter* painter, const QStyleOptionGraphicsItem* option, 
   Q_UNUSED(widget); 
   painter->save();
 
-#if QT_VERSION >= 0x050000
   QStyleOptionViewItem styleOption;
-#else
-  QStyleOptionViewItemV4 styleOption;
-#endif
 
   styleOption.backgroundBrush = backgroundBrush;
   if (editing)

--- a/src/Gui/DlgActionsImp.cpp
+++ b/src/Gui/DlgActionsImp.cpp
@@ -83,11 +83,7 @@ DlgCustomActionsImp::DlgCustomActionsImp( QWidget* parent )
     ui->actionListWidget->setHeaderLabels(labels);
     ui->actionListWidget->header()->hide();
     ui->actionListWidget->setIconSize(QSize(32, 32));
-#if QT_VERSION >= 0x050000
     ui->actionListWidget->header()->setSectionResizeMode(0, QHeaderView::ResizeToContents);
-#else
-    ui->actionListWidget->header()->setResizeMode(0, QHeaderView::ResizeToContents);
-#endif
 
     showActions();
 }

--- a/src/Gui/DlgCommandsImp.cpp
+++ b/src/Gui/DlgCommandsImp.cpp
@@ -118,11 +118,7 @@ DlgCustomCommandsImp::DlgCustomCommandsImp( QWidget* parent  )
     ui->commandTreeWidget->setHeaderLabels(labels);
     ui->commandTreeWidget->header()->hide();
     ui->commandTreeWidget->setIconSize(QSize(32, 32));
-#if QT_VERSION >= 0x050000
     ui->commandTreeWidget->header()->setSectionResizeMode(0, QHeaderView::ResizeToContents);
-#else
-    ui->commandTreeWidget->header()->setResizeMode(0, QHeaderView::ResizeToContents);
-#endif
 
     ui->categoryTreeWidget->setCurrentItem(ui->categoryTreeWidget->topLevelItem(0));
 }

--- a/src/Gui/DlgCustomizeSpaceball.cpp
+++ b/src/Gui/DlgCustomizeSpaceball.cpp
@@ -783,11 +783,7 @@ void DlgCustomizeSpaceball::goPrint()
 {
     QTableView *view = new QTableView(this);
     PrintModel *model = new PrintModel(this, buttonModel, commandModel);
-#if QT_VERSION >= 0x050000
     view->horizontalHeader()->setSectionResizeMode(QHeaderView::Fixed);
-#else
-    view->horizontalHeader()->setResizeMode(QHeaderView::Fixed);
-#endif
     view->setModel(model);
     view->horizontalHeader()->resizeSection(0, 150);
     view->horizontalHeader()->resizeSection(1, 300);

--- a/src/Gui/DlgExpressionInput.cpp
+++ b/src/Gui/DlgExpressionInput.cpp
@@ -65,11 +65,7 @@ DlgExpressionInput::DlgExpressionInput(const App::ObjectIdentifier & _path,
     }
     else {
         QVariant text = parent->property("text");
-#if QT_VERSION >= 0x050000
         if (text.canConvert(QMetaType::QString)) {
-#else
-        if (text.canConvert(QVariant::String)) {
-#endif
             ui->expression->setText(text.toString());
         }
     }

--- a/src/Gui/DlgGeneralImp.cpp
+++ b/src/Gui/DlgGeneralImp.cpp
@@ -193,7 +193,6 @@ void DlgGeneralImp::loadSettings()
         QByteArray lang = it->first.c_str();
         QString langname = QString::fromLatin1(lang.constData());
 
-#if QT_VERSION >= 0x040800
         QLocale locale(QString::fromLatin1(it->second.c_str()));
         QString native = locale.nativeLanguageName();
         if (!native.isEmpty()) {
@@ -201,7 +200,6 @@ void DlgGeneralImp::loadSettings()
                 native[0] = native[0].toUpper();
             langname = native;
         }
-#endif
 
         ui->Languages->addItem(langname, lang);
         if (language == lang) {

--- a/src/Gui/DlgKeyboardImp.cpp
+++ b/src/Gui/DlgKeyboardImp.cpp
@@ -109,11 +109,7 @@ DlgCustomKeyboardImp::DlgCustomKeyboardImp( QWidget* parent  )
     ui->commandTreeWidget->setHeaderLabels(labels);
     ui->commandTreeWidget->header()->hide();
     ui->commandTreeWidget->setIconSize(QSize(32, 32));
-#if QT_VERSION >= 0x050000
     ui->commandTreeWidget->header()->setSectionResizeMode(0, QHeaderView::ResizeToContents);
-#else
-    ui->commandTreeWidget->header()->setResizeMode(0, QHeaderView::ResizeToContents);
-#endif
 
     ui->assignedTreeWidget->setHeaderLabels(labels);
     ui->assignedTreeWidget->header()->hide();

--- a/src/Gui/DlgObjectSelection.cpp
+++ b/src/Gui/DlgObjectSelection.cpp
@@ -46,19 +46,12 @@ DlgObjectSelection::DlgObjectSelection(
     ui->setupUi(this);
 
     // make sure to show a horizontal scrollbar if needed
-#if QT_VERSION >= 0x050000
     ui->depList->header()->setSectionResizeMode(0, QHeaderView::ResizeToContents);
     ui->depList->header()->setSectionResizeMode(1, QHeaderView::ResizeToContents);
     ui->depList->header()->setSectionResizeMode(2, QHeaderView::ResizeToContents);
     ui->depList->header()->setSectionResizeMode(3, QHeaderView::ResizeToContents);
     ui->treeWidget->header()->setSectionResizeMode(0, QHeaderView::ResizeToContents);
-#else
-    ui->depList->header()->setResizeMode(0, QHeaderView::ResizeToContents);
-    ui->depList->header()->setResizeMode(1, QHeaderView::ResizeToContents);
-    ui->depList->header()->setResizeMode(2, QHeaderView::ResizeToContents);
-    ui->depList->header()->setResizeMode(3, QHeaderView::ResizeToContents);
-    ui->treeWidget->header()->setResizeMode(0, QHeaderView::ResizeToContents);
-#endif
+
     ui->depList->header()->setStretchLastSection(false);
     ui->depList->headerItem()->setText(0, tr("Dependency"));
     ui->depList->headerItem()->setText(1, tr("Document"));

--- a/src/Gui/DlgParameterImp.cpp
+++ b/src/Gui/DlgParameterImp.cpp
@@ -70,25 +70,19 @@ DlgParameterImp::DlgParameterImp( QWidget* parent,  Qt::WindowFlags fl )
     paramGroup = new ParameterGroup(ui->splitter3);
     paramGroup->setHeaderLabels(groupLabels);
     paramGroup->setRootIsDecorated(false);
-#if QT_VERSION >= 0x050000
     paramGroup->setSortingEnabled(true);
     paramGroup->sortByColumn(0, Qt::AscendingOrder);
     paramGroup->header()->setProperty("showSortIndicator", QVariant(true));
-#endif
 
     QStringList valueLabels;
     valueLabels << tr( "Name" ) << tr( "Type" ) << tr( "Value" );
     paramValue = new ParameterValue(ui->splitter3);
     paramValue->setHeaderLabels(valueLabels);
     paramValue->setRootIsDecorated(false);
-#if QT_VERSION >= 0x050000
     paramValue->header()->setSectionResizeMode(0, QHeaderView::Stretch);
     paramValue->setSortingEnabled(true);
     paramValue->sortByColumn(0, Qt::AscendingOrder);
     paramValue->header()->setProperty("showSortIndicator", QVariant(true));
-#else
-    paramValue->header()->setResizeMode(0, QHeaderView::Stretch);
-#endif
 
     QSizePolicy policy = paramValue->sizePolicy();
     policy.setHorizontalStretch(3);
@@ -128,9 +122,7 @@ DlgParameterImp::DlgParameterImp( QWidget* parent,  Qt::WindowFlags fl )
 
     // set a placeholder text to inform the user
     // (QLineEdit has no placeholderText property in Qt4)
-#if QT_VERSION >= 0x050200
     ui->findGroupLE->setPlaceholderText(tr("Search Group"));
-#endif
 }
 
 /**
@@ -238,7 +230,6 @@ void DlgParameterImp::changeEvent(QEvent *e)
 
 void DlgParameterImp::on_checkSort_toggled(bool on)
 {
-#if QT_VERSION >= 0x050000
     paramGroup->setSortingEnabled(on);
     paramGroup->sortByColumn(0, Qt::AscendingOrder);
     paramGroup->header()->setProperty("showSortIndicator", QVariant(on));
@@ -246,9 +237,6 @@ void DlgParameterImp::on_checkSort_toggled(bool on)
     paramValue->setSortingEnabled(on);
     paramValue->sortByColumn(0, Qt::AscendingOrder);
     paramValue->header()->setProperty("showSortIndicator", QVariant(on));
-#else
-    Q_UNUSED(on)
-#endif
 }
 
 void DlgParameterImp::on_closeButton_clicked()
@@ -733,16 +721,12 @@ void ParameterValue::keyPressEvent (QKeyEvent* event)
 
 void ParameterValue::resizeEvent(QResizeEvent* event)
 {
-#if QT_VERSION >= 0x050000
     QHeaderView* hv = header();
     hv->setSectionResizeMode(QHeaderView::Stretch);
-#endif
 
     QTreeWidget::resizeEvent(event);
 
-#if QT_VERSION >= 0x050000
     hv->setSectionResizeMode(QHeaderView::Interactive);
-#endif
 }
 
 void ParameterValue::onChangeSelectedItem(QTreeWidgetItem* item, int col)

--- a/src/Gui/DlgPreferencesImp.cpp
+++ b/src/Gui/DlgPreferencesImp.cpp
@@ -34,9 +34,7 @@
 # include <QScrollBar>
 #endif
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
-# include <QScreen>
-#endif
+#include <QScreen>
 
 #include <Base/Exception.h>
 #include <Base/Console.h>
@@ -410,11 +408,7 @@ void DlgPreferencesImp::resizeEvent(QResizeEvent* ev)
     if (canEmbedScrollArea) {
         // embed the widget stack into a scroll area if the size is
         // bigger than the available desktop
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
         QRect rect = QApplication::primaryScreen()->availableGeometry();
-#else
-        QRect rect = QApplication::desktop()->availableGeometry();
-#endif
         int maxHeight = rect.height() - 60;
         int maxWidth = rect.width();
         if (height() > maxHeight || width() > maxWidth) {

--- a/src/Gui/DlgSettingsImageImp.cpp
+++ b/src/Gui/DlgSettingsImageImp.cpp
@@ -53,9 +53,6 @@ DlgSettingsImageImp::DlgSettingsImageImp( QWidget* parent )
     ui->comboMethod->addItem(tr("Offscreen (Old)"), QByteArray("CoinOffscreenRenderer"));
     ui->comboMethod->addItem(tr("Framebuffer (custom)"), QByteArray("FramebufferObject"));
     ui->comboMethod->addItem(tr("Framebuffer (as is)"), QByteArray("GrabFramebuffer"));
-#if QT_VERSION < 0x050000
-    ui->comboMethod->addItem(tr("Pixel buffer"), QByteArray("PixelBuffer"));
-#endif
 }
 
 /**
@@ -240,12 +237,7 @@ void DlgSettingsImageImp::setMethod(const QByteArray& m)
 
 QByteArray DlgSettingsImageImp::method() const
 {
-#if QT_VERSION < 0x050000
-    int index = ui->comboMethod->currentIndex();
-    return ui->comboMethod->itemData(index).toByteArray();
-#else
     return ui->comboMethod->currentData().toByteArray();
-#endif
 }
 
 void DlgSettingsImageImp::on_comboMethod_activated(int index)

--- a/src/Gui/DlgToolbarsImp.cpp
+++ b/src/Gui/DlgToolbarsImp.cpp
@@ -135,11 +135,7 @@ DlgCustomToolbars::DlgCustomToolbars(DlgCustomToolbars::Type t, QWidget* parent)
     ui->commandTreeWidget->setHeaderLabels(labels);
     ui->commandTreeWidget->header()->hide();
     ui->commandTreeWidget->setIconSize(QSize(32, 32));
-#if QT_VERSION >= 0x050000
     ui->commandTreeWidget->header()->setSectionResizeMode(0, QHeaderView::ResizeToContents);
-#else
-    ui->commandTreeWidget->header()->setResizeMode(0, QHeaderView::ResizeToContents);
-#endif
 
     labels.clear(); labels << tr("Command");
     ui->toolbarTreeWidget->setHeaderLabels(labels);

--- a/src/Gui/DocumentRecovery.cpp
+++ b/src/Gui/DocumentRecovery.cpp
@@ -178,11 +178,7 @@ DocumentRecovery::DocumentRecovery(const QList<QFileInfo>& dirs, QWidget* parent
 {
     d_ptr->ui.setupUi(this);
     d_ptr->ui.buttonBox->button(QDialogButtonBox::Ok)->setText(tr("Start Recovery"));
-#if QT_VERSION >= 0x050000
     d_ptr->ui.treeWidget->header()->setSectionResizeMode(QHeaderView::Stretch);
-#else
-    d_ptr->ui.treeWidget->header()->setResizeMode(QHeaderView::Stretch);
-#endif
 
     d_ptr->recovered = false;
 

--- a/src/Gui/DownloadItem.cpp
+++ b/src/Gui/DownloadItem.cpp
@@ -39,9 +39,7 @@
 #include <QHeaderView>
 #include <QDebug>
 #include <QKeyEvent>
-#if QT_VERSION >= 0x050000
 #include <QStandardPaths>
-#endif
 #include <QTextDocument>
 
 #include <App/Document.h>
@@ -171,11 +169,7 @@ NetworkAccessManager::NetworkAccessManager(QObject *parent)
             SLOT(proxyAuthenticationRequired(const QNetworkProxy&, QAuthenticator*)));
 
     QNetworkDiskCache *diskCache = new QNetworkDiskCache(this);
-#if QT_VERSION >= 0x050000
     QString location = QStandardPaths::writableLocation(QStandardPaths::CacheLocation);
-#else
-    QString location = QDesktopServices::storageLocation(QDesktopServices::CacheLocation);
-#endif
     diskCache->setCacheDirectory(location);
     setCache(diskCache);
 }
@@ -192,11 +186,7 @@ void NetworkAccessManager::authenticationRequired(QNetworkReply *reply, QAuthent
     dialog.adjustSize();
 
     QString introMessage = tr("<qt>Enter username and password for \"%1\" at %2</qt>");
-#if QT_VERSION >= 0x050000
     introMessage = introMessage.arg(QString(reply->url().toString()).toHtmlEscaped(), QString(reply->url().toString()).toHtmlEscaped());
-#else
-    introMessage = introMessage.arg(Qt::escape(reply->url().toString()), Qt::escape(reply->url().toString()));
-#endif
     passwordDialog.siteDescription->setText(introMessage);
     passwordDialog.siteDescription->setWordWrap(true);
 
@@ -218,11 +208,7 @@ void NetworkAccessManager::proxyAuthenticationRequired(const QNetworkProxy &prox
     dialog.adjustSize();
 
     QString introMessage = tr("<qt>Connect to proxy \"%1\" using:</qt>");
-#if QT_VERSION >= 0x050000
     introMessage = introMessage.arg(QString(proxy.hostName()).toHtmlEscaped());
-#else
-    introMessage = introMessage.arg(Qt::escape(proxy.hostName()));
-#endif
     proxyDialog.siteDescription->setText(introMessage);
     proxyDialog.siteDescription->setWordWrap(true);
 
@@ -288,11 +274,7 @@ void DownloadItem::init()
 QString DownloadItem::getDownloadDirectory() const
 {
     QString exe = QString::fromLatin1(App::GetApplication().getExecutableName());
-#if QT_VERSION >= 0x050000
     QString path = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
-#else
-    QString path = QDesktopServices::storageLocation(QDesktopServices::DocumentsLocation);
-#endif
     QString dirPath = QDir(path).filePath(exe);
     Base::Reference<ParameterGrp> hPath = App::GetApplication().GetUserParameter().GetGroup("BaseApp")
                                ->GetGroup("Preferences")->GetGroup("General");
@@ -301,11 +283,7 @@ QString DownloadItem::getDownloadDirectory() const
         dirPath = QString::fromUtf8(dir.c_str());
     }
 
-#if QT_VERSION >= 0x050000
     if (QFileInfo::exists(dirPath) || QDir().mkpath(dirPath)) {
-#else
-    if (QFileInfo(dirPath).exists() || QDir().mkpath(dirPath)) {
-#endif
         return dirPath;
     }
     else {

--- a/src/Gui/DownloadManager.cpp
+++ b/src/Gui/DownloadManager.cpp
@@ -33,12 +33,7 @@
 #include <QMetaEnum>
 #include <QSettings>
 #include <QFileIconProvider>
-#if QT_VERSION < 0x050000
-#include <QWebSettings>
-#endif
-#if QT_VERSION >= 0x050000
 #include <QUrlQuery>
-#endif
 
 #include "DownloadItem.h"
 #include "DownloadManager.h"
@@ -117,7 +112,6 @@ QUrl DownloadManager::redirectUrl(const QUrl& url) const
 {
     QUrl redirectUrl = url;
     if (url.host() == QLatin1String("www.dropbox.com")) {
-#if QT_VERSION >= 0x050000
         QUrlQuery urlQuery(url);
         QList< QPair<QString, QString> > query = urlQuery.queryItems();
         for (QList< QPair<QString, QString> >::iterator it = query.begin(); it != query.end(); ++it) {
@@ -134,22 +128,6 @@ QUrl DownloadManager::redirectUrl(const QUrl& url) const
             }
         }
         redirectUrl.setQuery(urlQuery);
-#else
-        QList< QPair<QString, QString> > query = url.queryItems();
-        for (QList< QPair<QString, QString> >::iterator it = query.begin(); it != query.end(); ++it) {
-            if (it->first == QLatin1String("dl")) {
-                if (it->second == QLatin1String("0\r\n")) {
-                    redirectUrl.removeQueryItem(QLatin1String("dl"));
-                    redirectUrl.addQueryItem(QLatin1String("dl"), QLatin1String("1\r\n"));
-                }
-                else if (it->second == QLatin1String("0")) {
-                    redirectUrl.removeQueryItem(QLatin1String("dl"));
-                    redirectUrl.addQueryItem(QLatin1String("dl"), QLatin1String("1"));
-                }
-                break;
-            }
-        }
-#endif
     }
     else {
         // When the url comes from drag and drop it may end with CR+LF. This may cause problems
@@ -217,13 +195,6 @@ void DownloadManager::updateRow()
     ui->downloadsView->setRowHeight(row, item->minimumSizeHint().height());
 
     bool remove = false;
-#if QT_VERSION < 0x050000
-    QWebSettings *globalSettings = QWebSettings::globalSettings();
-    if (!item->downloading()
-        && globalSettings->testAttribute(QWebSettings::PrivateBrowsingEnabled))
-        remove = true;
-#endif
-
     if (item->downloadedSuccessfully()
         && removePolicy() == DownloadManager::SuccessFullDownload) {
         remove = true;

--- a/src/Gui/ExpressionCompleter.cpp
+++ b/src/Gui/ExpressionCompleter.cpp
@@ -586,10 +586,8 @@ void ExpressionLineEdit::setDocumentObject(const App::DocumentObject * currentDo
         completer->setWidget(this);
         completer->setCaseSensitivity(Qt::CaseInsensitive);
         completer->setRequireLeadingEqualSign(requireLeadingEqualSign);
-#if QT_VERSION>=QT_VERSION_CHECK(5,2,0)
         if (!exactMatch)
             completer->setFilterMode(Qt::MatchContains);
-#endif
         connect(completer, SIGNAL(activated(QString)), this, SLOT(slotCompleteText(QString)));
         connect(completer, SIGNAL(highlighted(QString)), this, SLOT(slotCompleteText(QString)));
         connect(this, SIGNAL(textChanged2(QString,int)), completer, SLOT(slotUpdate(QString,int)));
@@ -604,10 +602,9 @@ void ExpressionLineEdit::setNoProperty(bool enabled) {
 
 void ExpressionLineEdit::setExactMatch(bool enabled) {
     exactMatch = enabled;
-#if QT_VERSION>=QT_VERSION_CHECK(5,2,0)
     if (completer)
         completer->setFilterMode(exactMatch ? Qt::MatchStartsWith : Qt::MatchContains);
-#endif
+
 }
 
 bool ExpressionLineEdit::completerActive() const
@@ -649,7 +646,6 @@ void ExpressionLineEdit::keyPressEvent(QKeyEvent *e) {
 
 void ExpressionLineEdit::contextMenuEvent(QContextMenuEvent *event)
 {
-#if QT_VERSION >= QT_VERSION_CHECK(5,2,0)
     QMenu *menu = createStandardContextMenu();
     menu->addSeparator();
     QAction* match = menu->addAction(tr("Exact match"));
@@ -670,9 +666,6 @@ void ExpressionLineEdit::contextMenuEvent(QContextMenuEvent *event)
     }
 
     delete menu;
-#else
-    QLineEdit::contextMenuEvent(event);
-#endif
 }
 
 
@@ -689,10 +682,8 @@ ExpressionTextEdit::ExpressionTextEdit(QWidget *parent)
 
 void ExpressionTextEdit::setExactMatch(bool enabled) {
     exactMatch = enabled;
-#if QT_VERSION>=QT_VERSION_CHECK(5,2,0)
     if (completer)
         completer->setFilterMode(exactMatch ? Qt::MatchStartsWith : Qt::MatchContains);
-#endif
 }
 
 void ExpressionTextEdit::setDocumentObject(const App::DocumentObject * currentDocObj)
@@ -704,10 +695,8 @@ void ExpressionTextEdit::setDocumentObject(const App::DocumentObject * currentDo
 
     if (currentDocObj != nullptr) {
         completer = new ExpressionCompleter(currentDocObj, this);
-#if QT_VERSION>=QT_VERSION_CHECK(5,2,0)
         if (!exactMatch)
             completer->setFilterMode(Qt::MatchContains);
-#endif
         completer->setWidget(this);
         completer->setCaseSensitivity(Qt::CaseInsensitive);
         connect(completer, SIGNAL(activated(QString)), this, SLOT(slotCompleteText(QString)));
@@ -756,7 +745,6 @@ void ExpressionTextEdit::keyPressEvent(QKeyEvent *e) {
 
 void ExpressionTextEdit::contextMenuEvent(QContextMenuEvent *event)
 {
-#if QT_VERSION >= QT_VERSION_CHECK(5,2,0)
     QMenu *menu = createStandardContextMenu();
     menu->addSeparator();
     QAction* match = menu->addAction(tr("Exact match"));
@@ -777,9 +765,6 @@ void ExpressionTextEdit::contextMenuEvent(QContextMenuEvent *event)
     }
 
     delete menu;
-#else
-    QPlainTextEdit::contextMenuEvent(event);
-#endif
 }
 
 ///////////////////////////////////////////////////////////////////////

--- a/src/Gui/FileDialog.cpp
+++ b/src/Gui/FileDialog.cpp
@@ -173,10 +173,6 @@ QString FileDialog::getSaveFileName (QWidget * parent, const QString & caption, 
     if (windowTitle.isEmpty())
         windowTitle = FileDialog::tr("Save as");
 
-#if QT_VERSION < 0x040800 && defined(FC_OS_MACOSX)
-    options |= QFileDialog::DontUseNativeDialog;
-#endif
-
     // NOTE: We must not change the specified file name afterwards as we may return the name of an already
     // existing file. Hence we must extract the first matching suffix from the filter list and append it
     // before showing the file dialog.
@@ -184,7 +180,6 @@ QString FileDialog::getSaveFileName (QWidget * parent, const QString & caption, 
     if (dontUseNativeDialog()) {
         QList<QUrl> urls;
 
-#if QT_VERSION >= 0x050000
         options |= QFileDialog::DontUseNativeDialog;
         urls << QUrl::fromLocalFile(QStandardPaths::writableLocation(QStandardPaths::DesktopLocation));
         urls << QUrl::fromLocalFile(QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation));
@@ -192,14 +187,6 @@ QString FileDialog::getSaveFileName (QWidget * parent, const QString & caption, 
         urls << QUrl::fromLocalFile(QStandardPaths::writableLocation(QStandardPaths::MusicLocation));
         urls << QUrl::fromLocalFile(QStandardPaths::writableLocation(QStandardPaths::PicturesLocation));
         urls << QUrl::fromLocalFile(QStandardPaths::writableLocation(QStandardPaths::MoviesLocation));
-#else
-        urls << QUrl::fromLocalFile(QDesktopServices::storageLocation(QDesktopServices::DesktopLocation));
-        urls << QUrl::fromLocalFile(QDesktopServices::storageLocation(QDesktopServices::DocumentsLocation));
-        urls << QUrl::fromLocalFile(QDesktopServices::storageLocation(QDesktopServices::HomeLocation));
-        urls << QUrl::fromLocalFile(QDesktopServices::storageLocation(QDesktopServices::MusicLocation));
-        urls << QUrl::fromLocalFile(QDesktopServices::storageLocation(QDesktopServices::PicturesLocation));
-        urls << QUrl::fromLocalFile(QDesktopServices::storageLocation(QDesktopServices::MoviesLocation));
-#endif
         urls << QUrl::fromLocalFile(getWorkingDirectory());
         urls << QUrl::fromLocalFile(restoreLocation());
         urls << QUrl::fromLocalFile(QDir::currentPath());
@@ -228,9 +215,7 @@ QString FileDialog::getSaveFileName (QWidget * parent, const QString & caption, 
     }
     else {
         file = QFileDialog::getSaveFileName(parent, windowTitle, dirName, filter, selectedFilter, options);
-#if QT_VERSION >= 0x040600
         file = QDir::fromNativeSeparators(file);
-#endif
     }
 
     if (!file.isEmpty()) {
@@ -246,9 +231,6 @@ QString FileDialog::getSaveFileName (QWidget * parent, const QString & caption, 
  */
 QString FileDialog::getExistingDirectory( QWidget * parent, const QString & caption, const QString & dir, Options options )
 {
-#if QT_VERSION < 0x040800 && defined(FC_OS_MACOSX)
-    options |= QFileDialog::DontUseNativeDialog;
-#endif
     QString path = QFileDialog::getExistingDirectory(parent, caption, dir, options);
     // valid path was selected
     if ( !path.isEmpty() ) {
@@ -275,15 +257,10 @@ QString FileDialog::getOpenFileName(QWidget * parent, const QString & caption, c
     if (windowTitle.isEmpty())
         windowTitle = FileDialog::tr("Open");
 
-#if QT_VERSION < 0x040800 && defined(FC_OS_MACOSX)
-    options |= QFileDialog::DontUseNativeDialog;
-#endif
-
     QString file;
     if (dontUseNativeDialog()) {
         QList<QUrl> urls;
 
-#if QT_VERSION >= 0x050000
         options |= QFileDialog::DontUseNativeDialog;
         urls << QUrl::fromLocalFile(QStandardPaths::writableLocation(QStandardPaths::DesktopLocation));
         urls << QUrl::fromLocalFile(QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation));
@@ -291,14 +268,6 @@ QString FileDialog::getOpenFileName(QWidget * parent, const QString & caption, c
         urls << QUrl::fromLocalFile(QStandardPaths::writableLocation(QStandardPaths::MusicLocation));
         urls << QUrl::fromLocalFile(QStandardPaths::writableLocation(QStandardPaths::PicturesLocation));
         urls << QUrl::fromLocalFile(QStandardPaths::writableLocation(QStandardPaths::MoviesLocation));
-#else
-        urls << QUrl::fromLocalFile(QDesktopServices::storageLocation(QDesktopServices::DesktopLocation));
-        urls << QUrl::fromLocalFile(QDesktopServices::storageLocation(QDesktopServices::DocumentsLocation));
-        urls << QUrl::fromLocalFile(QDesktopServices::storageLocation(QDesktopServices::HomeLocation));
-        urls << QUrl::fromLocalFile(QDesktopServices::storageLocation(QDesktopServices::MusicLocation));
-        urls << QUrl::fromLocalFile(QDesktopServices::storageLocation(QDesktopServices::PicturesLocation));
-        urls << QUrl::fromLocalFile(QDesktopServices::storageLocation(QDesktopServices::MoviesLocation));
-#endif
         urls << QUrl::fromLocalFile(getWorkingDirectory());
         urls << QUrl::fromLocalFile(restoreLocation());
         urls << QUrl::fromLocalFile(QDir::currentPath());
@@ -323,9 +292,7 @@ QString FileDialog::getOpenFileName(QWidget * parent, const QString & caption, c
     }
     else {
         file = QFileDialog::getOpenFileName(parent, windowTitle, dirName, filter, selectedFilter, options);
-#if QT_VERSION >= 0x040600
         file = QDir::fromNativeSeparators(file);
-#endif
     }
 
     if (!file.isEmpty()) {
@@ -351,15 +318,10 @@ QStringList FileDialog::getOpenFileNames (QWidget * parent, const QString & capt
     if (windowTitle.isEmpty())
         windowTitle = FileDialog::tr("Open");
 
-#if QT_VERSION < 0x040800 && defined(FC_OS_MACOSX)
-    options |= QFileDialog::DontUseNativeDialog;
-#endif
-
     QStringList files;
     if (dontUseNativeDialog()) {
         QList<QUrl> urls;
 
-#if QT_VERSION >= 0x050000
         options |= QFileDialog::DontUseNativeDialog;
         urls << QUrl::fromLocalFile(QStandardPaths::writableLocation(QStandardPaths::DesktopLocation));
         urls << QUrl::fromLocalFile(QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation));
@@ -367,14 +329,6 @@ QStringList FileDialog::getOpenFileNames (QWidget * parent, const QString & capt
         urls << QUrl::fromLocalFile(QStandardPaths::writableLocation(QStandardPaths::MusicLocation));
         urls << QUrl::fromLocalFile(QStandardPaths::writableLocation(QStandardPaths::PicturesLocation));
         urls << QUrl::fromLocalFile(QStandardPaths::writableLocation(QStandardPaths::MoviesLocation));
-#else
-        urls << QUrl::fromLocalFile(QDesktopServices::storageLocation(QDesktopServices::DesktopLocation));
-        urls << QUrl::fromLocalFile(QDesktopServices::storageLocation(QDesktopServices::DocumentsLocation));
-        urls << QUrl::fromLocalFile(QDesktopServices::storageLocation(QDesktopServices::HomeLocation));
-        urls << QUrl::fromLocalFile(QDesktopServices::storageLocation(QDesktopServices::MusicLocation));
-        urls << QUrl::fromLocalFile(QDesktopServices::storageLocation(QDesktopServices::PicturesLocation));
-        urls << QUrl::fromLocalFile(QDesktopServices::storageLocation(QDesktopServices::MoviesLocation));
-#endif
         urls << QUrl::fromLocalFile(getWorkingDirectory());
         urls << QUrl::fromLocalFile(restoreLocation());
         urls << QUrl::fromLocalFile(QDir::currentPath());
@@ -399,11 +353,9 @@ QStringList FileDialog::getOpenFileNames (QWidget * parent, const QString & capt
     }
     else {
         files = QFileDialog::getOpenFileNames(parent, windowTitle, dirName, filter, selectedFilter, options);
-#if QT_VERSION >= 0x040600
         for (QStringList::iterator it = files.begin(); it != files.end(); ++it) {
             *it = QDir::fromNativeSeparators(*it);
         }
-#endif
     }
 
     if (!files.isEmpty()) {
@@ -483,9 +435,7 @@ FileOptionsDialog::FileOptionsDialog( QWidget* parent, Qt::WindowFlags fl )
     extensionButton = new QPushButton( this );
     extensionButton->setText( tr( "Extended" ) );
 
-#if QT_VERSION >= 0x050000
     setOption(QFileDialog::DontUseNativeDialog);
-#endif
 
     // This is an alternative to add the button to the grid layout
     //QDialogButtonBox* box = this->findChild<QDialogButtonBox*>();
@@ -493,11 +443,7 @@ FileOptionsDialog::FileOptionsDialog( QWidget* parent, Qt::WindowFlags fl )
 
     //search for the grid layout and add the new button
     QGridLayout* grid = this->findChild<QGridLayout*>();
-#if QT_VERSION >= 0x040500
     grid->addWidget(extensionButton, 4, 2, Qt::AlignLeft);
-#else
-    grid->addWidget(extensionButton, 4, 5, Qt::AlignLeft);
-#endif
 
     connect(extensionButton, SIGNAL(clicked()), this, SLOT(toggleExtension()));
 }

--- a/src/Gui/GraphicsViewZoom.cpp
+++ b/src/Gui/GraphicsViewZoom.cpp
@@ -79,7 +79,6 @@ bool GraphicsViewZoom::eventFilter(QObject *object, QEvent *event) {
   } else if (event->type() == QEvent::Wheel) {
     QWheelEvent* wheel_event = static_cast<QWheelEvent*>(event);
     if (QApplication::keyboardModifiers() == _modifiers) {
-#if QT_VERSION >= QT_VERSION_CHECK(5,0,0)
       QPoint delta = wheel_event->angleDelta();
       if (qAbs(delta.y()) > qAbs(delta.x())) { // vertical
         double angle = -delta.y();
@@ -89,16 +88,6 @@ bool GraphicsViewZoom::eventFilter(QObject *object, QEvent *event) {
         gentle_zoom(factor);
         return true;
       }
-#else
-      if (wheel_event->orientation() == Qt::Vertical) {
-        double angle = -wheel_event->delta();
-        if (m_invert_zoom)
-          angle = -angle;
-        double factor = qPow(_zoom_factor_base, angle);
-        gentle_zoom(factor);
-        return true;
-      }
-#endif
     }
   }
   Q_UNUSED(object);

--- a/src/Gui/GraphvizView.cpp
+++ b/src/Gui/GraphvizView.cpp
@@ -70,18 +70,12 @@ public:
     GraphvizWorker(QObject * parent = 0)
         : QThread(parent)
     {
-#if QT_VERSION < 0x050000
-        dotProc.moveToThread(this);
-        unflattenProc.moveToThread(this);
-#endif
     }
 
     virtual ~GraphvizWorker()
     {
-#if QT_VERSION >= 0x050000
         dotProc.moveToThread(this);
         unflattenProc.moveToThread(this);
-#endif
     }
 
     void setData(const QByteArray & data)
@@ -90,7 +84,6 @@ public:
     }
 
     void startThread() {
-#if QT_VERSION >= 0x050000
         // This doesn't actually run a thread but calls the function
         // directly in the main thread.
         // This is needed because embedding a QProcess into a QThread
@@ -98,9 +91,6 @@ public:
         run();
         // Can't use the finished() signal of QThread
         emitFinished();
-#else
-        start();
-#endif
     }
 
     void run() {
@@ -268,9 +258,7 @@ GraphvizView::GraphvizView(App::Document & _doc, QWidget* parent)
 
     // Create worker thread
     thread = new GraphvizWorker(this);
-#if QT_VERSION >= 0x050000
     connect(thread, SIGNAL(emitFinished()), this, SLOT(done()));
-#endif
     connect(thread, SIGNAL(finished()), this, SLOT(done()));
     connect(thread, SIGNAL(error()), this, SLOT(error()));
     connect(thread, SIGNAL(svgFileRead(const QByteArray &)), this, SLOT(svgFileRead(const QByteArray &)));
@@ -533,11 +521,7 @@ bool GraphvizView::onHasMsg(const char* pMsg) const
 void GraphvizView::print(QPrinter* printer)
 {
     QPainter p(printer);
-#if QT_VERSION >= 0x050300
     QRect rect = printer->pageLayout().paintRectPixels(printer->resolution());
-#else
-    QRect rect = printer->pageRect();
-#endif
     view->scene()->render(&p, rect);
     //QByteArray buffer = exportGraph(QString::fromLatin1("svg"));
     //QSvgRenderer svg(buffer);
@@ -549,11 +533,7 @@ void GraphvizView::print()
 {
     QPrinter printer(QPrinter::HighResolution);
     printer.setFullPage(true);
-#if QT_VERSION >= 0x050300
     printer.setPageOrientation(QPageLayout::Landscape);
-#else
-    printer.setOrientation(QPrinter::Landscape);
-#endif
     QPrintDialog dlg(&printer, this);
     if (dlg.exec() == QDialog::Accepted) {
         print(&printer);
@@ -583,11 +563,7 @@ void GraphvizView::printPreview()
 {
     QPrinter printer(QPrinter::HighResolution);
     printer.setFullPage(true);
-#if QT_VERSION >= 0x050300
     printer.setPageOrientation(QPageLayout::Landscape);
-#else
-    printer.setOrientation(QPrinter::Landscape);
-#endif
 
     QPrintPreviewDialog dlg(&printer, this);
     connect(&dlg, SIGNAL(paintRequested (QPrinter *)),

--- a/src/Gui/GuiApplication.cpp
+++ b/src/Gui/GuiApplication.cpp
@@ -63,14 +63,9 @@ using namespace Gui;
 GUIApplication::GUIApplication(int & argc, char ** argv)
     : GUIApplicationNativeEventAware(argc, argv)
 {
-#if QT_VERSION > 0x050000
-    // In Qt 4.x 'commitData' is a virtual method
     connect(this, SIGNAL(commitDataRequest(QSessionManager &)),
             SLOT(commitData(QSessionManager &)), Qt::DirectConnection);
-#endif
-#if QT_VERSION >= 0x050600
     setFallbackSessionManagementEnabled(false);
-#endif
 }
 
 GUIApplication::~GUIApplication()

--- a/src/Gui/GuiApplicationNativeEventAware.cpp
+++ b/src/Gui/GuiApplicationNativeEventAware.cpp
@@ -306,11 +306,4 @@ void Gui::GUIApplicationNativeEventAware::importSettings(std::vector<int>& motio
     }
 }
 
-#if defined(SPNAV_FOUND) && defined(SPNAV_USE_X11) && QT_VERSION < 0x050000
-bool Gui::GUIApplicationNativeEventAware::x11EventFilter(XEvent *event)
-{
-  return nativeEvent->x11EventFilter(event);
-}
-#endif
-
 #include "moc_GuiApplicationNativeEventAware.cpp"

--- a/src/Gui/GuiApplicationNativeEventAware.h
+++ b/src/Gui/GuiApplicationNativeEventAware.h
@@ -54,9 +54,6 @@ namespace Gui
       #if defined(_USE_3DCONNEXION_SDK) || defined(SPNAV_FOUND)
         GuiNativeEvent *nativeEvent;
       #endif
-      #if defined(SPNAV_FOUND) && defined(SPNAV_USE_X11) && QT_VERSION < 0x050000
-        bool x11EventFilter(XEvent *event) override final;
-      #endif
     }; // end class GUIApplicationNativeEventAware
 } // end namespace Gui
 

--- a/src/Gui/InputField.cpp
+++ b/src/Gui/InputField.cpp
@@ -692,11 +692,7 @@ void InputField::wheelEvent (QWheelEvent * event)
     }
 
     double factor = event->modifiers() & Qt::ControlModifier ? 10 : 1;
-#if QT_VERSION >= QT_VERSION_CHECK(5,0,0)
     double step = event->angleDelta().y() > 0 ? StepSize : -StepSize;
-#else
-    double step = event->delta() > 0 ? StepSize : -StepSize;
-#endif
     double val = actUnitValue + factor * step;
     if (val > Maximum)
         val = Maximum;

--- a/src/Gui/MDIView.cpp
+++ b/src/Gui/MDIView.cpp
@@ -107,10 +107,6 @@ void MDIView::deleteSelf()
     QWidget* parent = this->parentWidget();
     if (qobject_cast<QMdiSubWindow*>(parent)) {
         // https://forum.freecadweb.org/viewtopic.php?f=22&t=23070
-#if QT_VERSION < 0x050000
-        // With Qt5 this would lead to some annoying flickering
-        getMainWindow()->removeWindow(this);
-#endif
         parent->close();
     }
     else {

--- a/src/Gui/MouseSelection.cpp
+++ b/src/Gui/MouseSelection.cpp
@@ -390,11 +390,7 @@ int PolyPickerSelection::locationEvent(const SoLocation2Event* const, const QPoi
 
     if (polyline.isWorking()) {
         // check the position
-#if QT_VERSION >= 0x050600
         qreal dpr = _pcView3D->getGLWidget()->devicePixelRatioF();
-#else
-        qreal dpr = 1.0;
-#endif
         QRect r = _pcView3D->getGLWidget()->rect();
         if (dpr != 1.0) {
             r.setHeight(r.height()*dpr);
@@ -608,11 +604,7 @@ int FreehandSelection::locationEvent(const SoLocation2Event* const e, const QPoi
 
     if (polyline.isWorking()) {
         // check the position
-#if QT_VERSION >= 0x050600
         qreal dpr = _pcView3D->getGLWidget()->devicePixelRatioF();
-#else
-        qreal dpr = 1.0;
-#endif
         QRect r = _pcView3D->getGLWidget()->rect();
         if (dpr != 1.0) {
             r.setHeight(r.height()*dpr);

--- a/src/Gui/NavigationStyle.h
+++ b/src/Gui/NavigationStyle.h
@@ -99,11 +99,7 @@ public:
         Trackball
     };
 
-#if QT_VERSION < 0x050000
-    enum RotationCenterMode {
-#else
     enum class RotationCenterMode {
-#endif
         WindowCenter       = 0, /**< The center of the window */
         ScenePointAtCursor = 1, /**< Find the point in the scene at the cursor position. If there is no point then the focal plane is used */
         FocalPointAtCursor = 2, /**< Find the point on the focal plane at the cursor position. */

--- a/src/Gui/NetworkRetriever.cpp
+++ b/src/Gui/NetworkRetriever.cpp
@@ -374,12 +374,8 @@ void NetworkRetriever::wgetFinished(int exitCode, QProcess::ExitStatus status)
 bool NetworkRetriever::testWget()
 {
     QProcess proc;
-#if QT_VERSION > 0x050000
     proc.setProgram(QString::fromLatin1("wget"));
     proc.start();
-#else
-    proc.start(QString::fromLatin1("wget"));
-#endif
     bool ok = proc.state() == QProcess::Running;
     proc.kill();
     proc.waitForFinished();

--- a/src/Gui/OnlineDocumentation.cpp
+++ b/src/Gui/OnlineDocumentation.cpp
@@ -293,11 +293,7 @@ HttpServer::HttpServer(QObject* parent)
 {
 }
 
-#if QT_VERSION >=0x050000
 void HttpServer::incomingConnection(qintptr socket)
-#else
-void HttpServer::incomingConnection(int socket)
-#endif
 {
     if (disabled)
         return;

--- a/src/Gui/OnlineDocumentation.h
+++ b/src/Gui/OnlineDocumentation.h
@@ -62,11 +62,7 @@ class HttpServer : public QTcpServer
 public:
     HttpServer(QObject* parent = 0);
 
-#if QT_VERSION >=0x050000
     void incomingConnection(qintptr socket);
-#else
-    void incomingConnection(int socket);
-#endif
     void pause();
     void resume();
 

--- a/src/Gui/ProgressBar.cpp
+++ b/src/Gui/ProgressBar.cpp
@@ -35,9 +35,8 @@
 # include <QTimer>
 #endif
 
-#if QT_VERSION >= 0x050000
-# include <QWindow>
-#endif
+#include <QWindow>
+
 
 #include "ProgressBar.h"
 #include "ProgressDialog.h"
@@ -68,13 +67,11 @@ struct ProgressBarPrivate
     bool isModalDialog(QObject* o) const
     {
         QWidget* parent = qobject_cast<QWidget*>(o);
-#if QT_VERSION >= 0x050000
         if (!parent) {
             QWindow* window = qobject_cast<QWindow*>(o);
             if (window)
                 parent = QWidget::find(window->winId());
         }
-#endif
         while (parent) {
             QMessageBox* dlg = qobject_cast<QMessageBox*>(parent);
             if (dlg && dlg->isModal())

--- a/src/Gui/PropertyPage.cpp
+++ b/src/Gui/PropertyPage.cpp
@@ -116,9 +116,7 @@ PreferenceUiForm::PreferenceUiForm(const QString& fn, QWidget* parent)
   : PreferencePage(parent), form(0)
 {
     UiLoader loader;
-#if QT_VERSION >= 0x040500
     loader.setLanguageChangeEnabled(true);
-#endif
     loader.setWorkingDirectory(QFileInfo(fn).absolutePath());
     QFile file(fn);
     if (file.open(QFile::ReadOnly))

--- a/src/Gui/Qt4All.h
+++ b/src/Gui/Qt4All.h
@@ -161,12 +161,6 @@
 #include <QUiLoader>
 #include <QtDesigner/QFormBuilder>
 
-// QtWebKit
-// Only needed in Web module
-//#include <QWebFrame>
-//#include <QWebView>
-//#include <QWebSettings>
-
 #include "qmath.h"
 #include <QGraphicsView>
 #include <QGraphicsScene>

--- a/src/Gui/Qt4All.h
+++ b/src/Gui/Qt4All.h
@@ -49,9 +49,7 @@
 #include <qtimer.h>
 #include <qtranslator.h>
 #include <QUrl>
-#if QT_VERSION >= 0x050000
 #include <QUrlQuery>
-#endif
 #include <qvariant.h>
 #include <QWaitCondition>
 // QtGui
@@ -69,9 +67,7 @@
 #include <qcolordialog.h>
 #include <qcombobox.h>
 #include <qcursor.h>
-#if QT_VERSION >= 0x040200
 #include <QDesktopServices>
-#endif
 #include <QDesktopWidget>
 #include <QDialogButtonBox>
 #include <QDockWidget>
@@ -103,9 +99,7 @@
 #include <QMainWindow>
 #include <qmenubar.h>
 #include <qmessagebox.h>
-#if QT_VERSION >= 0x050000
 #include <QMessageLogContext>
-#endif
 #include <QMimeData>
 #include <qmovie.h>
 #include <qpainter.h>
@@ -168,12 +162,10 @@
 #include <QtDesigner/QFormBuilder>
 
 // QtWebKit
-#if QT_VERSION >= 0x040400
 // Only needed in Web module
 //#include <QWebFrame>
 //#include <QWebView>
 //#include <QWebSettings>
-#endif
 
 #include "qmath.h"
 #include <QGraphicsView>

--- a/src/Gui/Quarter/EventFilter.cpp
+++ b/src/Gui/Quarter/EventFilter.cpp
@@ -48,9 +48,7 @@
 #include <Quarter/devices/Keyboard.h>
 #include <Quarter/devices/SpaceNavigatorDevice.h>
 
-#if QT_VERSION >= 0x050000
 #include <QGuiApplication>
-#endif
 
 namespace SIM { namespace Coin3D { namespace Quarter {
 
@@ -78,9 +76,7 @@ public:
 
     SbVec2s mousepos(event->pos().x(), this->windowsize[1] - event->pos().y() - 1);
     // the following corrects for high-dpi displays (e.g. mac retina)
-#if QT_VERSION >= 0x050000
     mousepos *= quarterwidget->devicePixelRatio();
-#endif
     foreach(InputDevice * device, this->devices) {
       device->setMousePosition(mousepos);
     }

--- a/src/Gui/Quarter/Mouse.cpp
+++ b/src/Gui/Quarter/Mouse.cpp
@@ -51,16 +51,12 @@
 #include <QtGui/QMouseEvent>
 #include <QtGui/QWheelEvent>
 
-#if QT_VERSION >= 0x050000
 #include <QGuiApplication>
-#endif
 
 #include <Inventor/SbVec2s.h>
 #include <Inventor/events/SoEvents.h>
 #include <Inventor/errors/SoDebugError.h>
-#if QT_VERSION >= 0x050000
 #include <Quarter/QuarterWidget.h>
-#endif
 
 namespace SIM { namespace Coin3D { namespace Quarter {
 
@@ -156,9 +152,7 @@ MouseP::mouseMoveEvent(QMouseEvent * event)
   assert(this->windowsize[1] != -1);
   SbVec2s pos(event->pos().x(), this->windowsize[1] - event->pos().y() - 1);
   // the following corrects for high-dpi displays (e.g. mac retina)
-#if QT_VERSION >= 0x050000
   pos *= publ->quarter->devicePixelRatio();
-#endif
   this->location2->setPosition(pos);
   this->mousebutton->setPosition(pos);
   return this->location2;
@@ -175,9 +169,7 @@ MouseP::mouseWheelEvent(QWheelEvent * event)
   SbVec2s pos(event->pos().x(), PUBLIC(this)->windowsize[1] - event->pos().y() - 1);
 #endif
   // the following corrects for high-dpi displays (e.g. mac retina)
-#if QT_VERSION >= 0x050000
   pos *= publ->quarter->devicePixelRatio();
-#endif
   this->location2->setPosition(pos); //I don't know why location2 is assigned here, I assumed it important  --DeepSOIC
   this->wheel->setPosition(pos);
 
@@ -187,11 +179,7 @@ MouseP::mouseWheelEvent(QWheelEvent * event)
   // value indicates that the wheel was rotated backwards toward the
   // user. A typical wheel click is 120, but values coming from touchpad
   // can be a lot lower
-#if QT_VERSION >= QT_VERSION_CHECK(5,0,0)
   this->wheel->setDelta(event->angleDelta().y());
-#else
-  this->wheel->setDelta(event->delta());
-#endif
 
   return this->wheel;
 }
@@ -202,9 +190,7 @@ MouseP::mouseButtonEvent(QMouseEvent * event)
   PUBLIC(this)->setModifiers(this->mousebutton, event);
   SbVec2s pos(event->pos().x(), PUBLIC(this)->windowsize[1] - event->pos().y() - 1);
   // the following corrects for high-dpi displays (e.g. mac retina)
-#if QT_VERSION >= 0x050000
   pos *= publ->quarter->devicePixelRatio();
-#endif
   this->location2->setPosition(pos);
   this->mousebutton->setPosition(pos);
 

--- a/src/Gui/Quarter/QuarterWidget.cpp
+++ b/src/Gui/Quarter/QuarterWidget.cpp
@@ -1043,11 +1043,7 @@ QuarterWidget::redraw(void)
   // Note that, the recursive repaint is not infinite due to setting
   // 'processdelayqueue = false' above. However, it does cause annoying
   // flickering, and actually crash on Windows.
-#if 1
   this->viewport()->update();
-#else
-
-#endif
 }
 
 /*!

--- a/src/Gui/Quarter/QuarterWidget.cpp
+++ b/src/Gui/Quarter/QuarterWidget.cpp
@@ -99,11 +99,9 @@
 #include "QuarterWidgetP.h"
 #include "QuarterP.h"
 
-#if QT_VERSION >= 0x050000
 #include <QWindow>
 #include <QGuiApplication>
 #include <QMetaObject>
-#endif
 
 
 using namespace SIM::Coin3D::Quarter;
@@ -209,13 +207,11 @@ public:
     }
     void aboutToDestroyGLContext()
     {
-#if QT_VERSION >= 0x050900
         // With Qt 5.9 a signal is emitted while the QuarterWidget is being destroyed.
         // At this state its type is a QWidget, not a QuarterWidget any more.
         QuarterWidget* qw = qobject_cast<QuarterWidget*>(parent());
         if (!qw)
             return;
-#endif
         QMetaObject::invokeMethod(parent(), "aboutToDestroyGLContext",
             Qt::DirectConnection,
             QGenericReturnArgument());
@@ -835,7 +831,6 @@ QuarterWidget::seek(void)
 
 bool
 QuarterWidget::updateDevicePixelRatio(void) {
-#if QT_VERSION >= 0x050000
     qreal dev_pix_ratio = 1.0;
     QWidget* winwidg = window();
     QWindow* win = NULL;
@@ -853,7 +848,6 @@ QuarterWidget::updateDevicePixelRatio(void) {
         emit devicePixelRatioChanged(dev_pix_ratio);
         return true;
     }
-#endif
     return false;
 }
 
@@ -1052,14 +1046,6 @@ QuarterWidget::redraw(void)
 #if 1
   this->viewport()->update();
 #else
-
-// #if QT_VERSION >= 0x050500 && QT_VERSION < 0x050600
-#if 1
-  // With Qt 5.5.x there is a major performance problem
-  this->viewport()->update();
-#else
-  this->viewport()->repaint();
-#endif
 
 #endif
 }
@@ -1355,9 +1341,7 @@ QuarterWidget::setNavigationModeFile(const QUrl & url)
     //navigation systems? - BFG 20090117
     this->setStateCursor("interact", Qt::ArrowCursor);
     this->setStateCursor("idle", Qt::OpenHandCursor);
-#if QT_VERSION >= 0x040200
     this->setStateCursor("rotate", Qt::ClosedHandCursor);
-#endif
     this->setStateCursor("pan", Qt::SizeAllCursor);
     this->setStateCursor("zoom", Qt::SizeVerCursor);
     this->setStateCursor("dolly", Qt::SizeVerCursor);

--- a/src/Gui/SceneInspector.cpp
+++ b/src/Gui/SceneInspector.cpp
@@ -170,13 +170,8 @@ void DlgInspector::setNode(SoNode* node)
     model->setNode(node);
 
     QHeaderView* header = ui->treeView->header();
-#if QT_VERSION >= 0x050000
     header->setSectionResizeMode(0, QHeaderView::Stretch);
     header->setSectionsMovable(false);
-#else
-    header->setResizeMode(0, QHeaderView::Stretch);
-    header->setMovable(false);
-#endif
 }
 
 void DlgInspector::setNodeNames(Gui::Document* doc)

--- a/src/Gui/SelectionView.cpp
+++ b/src/Gui/SelectionView.cpp
@@ -65,9 +65,7 @@ SelectionView::SelectionView(Gui::Document* pcDocument, QWidget *parent)
     vLayout->setMargin (0);
 
     QLineEdit* searchBox = new QLineEdit(this);
-#if QT_VERSION >= 0x040700
     searchBox->setPlaceholderText(tr("Search"));
-#endif
     searchBox->setToolTip(tr("Searches object labels"));
     QHBoxLayout* hLayout = new QHBoxLayout();
     hLayout->setSpacing(2);
@@ -97,10 +95,8 @@ SelectionView::SelectionView(Gui::Document* pcDocument, QWidget *parent)
     pickList->setVisible(false);
     vLayout->addWidget(pickList);
 
-#if QT_VERSION >= 0x040200
     selectionView->setMouseTracking(true); // needed for itemEntered() to work
     pickList->setMouseTracking(true);
-#endif
 
     resize(200, 200);
 

--- a/src/Gui/SoFCOffscreenRenderer.cpp
+++ b/src/Gui/SoFCOffscreenRenderer.cpp
@@ -614,7 +614,6 @@ SoQtOffscreenRenderer::makeFrameBuffer(int width, int height, int samples)
 
     viewport.setWindowSize(width, height);
 
-#if QT_VERSION >= 0x040600
     QtGLFramebufferObjectFormat fmt;
     fmt.setSamples(samples);
     fmt.setAttachment(QtGLFramebufferObject::Depth);
@@ -624,10 +623,6 @@ SoQtOffscreenRenderer::makeFrameBuffer(int width, int height, int samples)
     // format and in the output image search for the above color and
     // replaces it with the color requested by the user.
     fmt.setInternalTextureFormat(this->texFormat);
-#else
-    QtGLFramebufferObject::Attachment fmt;
-    fmt = QtGLFramebufferObject::Depth;
-#endif
 
     framebuffer = new QtGLFramebufferObject(width, height, fmt);
     cache_context = SoGLCacheContextElement::getUniqueCacheContext(); // unique per pixel buffer object, just to be sure

--- a/src/Gui/Splashscreen.cpp
+++ b/src/Gui/Splashscreen.cpp
@@ -652,7 +652,6 @@ void AboutDialog::showCollectionInformation()
 
 void AboutDialog::linkActivated(const QUrl& link)
 {
-//#if defined(Q_OS_WIN) && QT_VERSION < 0x050602
     LicenseView* licenseView = new LicenseView();
     licenseView->setAttribute(Qt::WA_DeleteOnClose);
     licenseView->show();
@@ -665,9 +664,6 @@ void AboutDialog::linkActivated(const QUrl& link)
     licenseView->setWindowTitle(title);
     getMainWindow()->addWindow(licenseView);
     licenseView->setSource(link);
-//#else
-//    QDesktopServices::openUrl(link);
-//#endif
 }
 
 void AboutDialog::on_copyButton_clicked()

--- a/src/Gui/SyntaxHighlighter.cpp
+++ b/src/Gui/SyntaxHighlighter.cpp
@@ -159,13 +159,7 @@ void SyntaxHighlighter::colorChanged(const QString& type, const QColor& col)
 {
     Q_UNUSED(type);
     Q_UNUSED(col);
-  // rehighlight
-#if QT_VERSION >= 0x040200
     rehighlight();
-#else
-    document()->setPlainText(document()->toPlainText());
-    document()->setModified(false);
-#endif
 }
 
 int SyntaxHighlighter::maximumUserState() const

--- a/src/Gui/TaskView/TaskDialogPython.cpp
+++ b/src/Gui/TaskView/TaskDialogPython.cpp
@@ -289,9 +289,7 @@ TaskDialogPython::TaskDialogPython(const Py::Object& o) : dlg(o)
 {
     if (dlg.hasAttr(std::string("ui"))) {
         UiLoader loader;
-#if QT_VERSION >= 0x040500
         loader.setLanguageChangeEnabled(true);
-#endif
         QString fn, icon;
         Py::String ui(dlg.getAttr(std::string("ui")));
         std::string path = (std::string)ui;

--- a/src/Gui/TreeView.cpp
+++ b/src/Gui/TreeView.cpp
@@ -47,10 +47,7 @@ TreeView::TreeView(QWidget* parent)
     this->setDropIndicatorShown(false);
     this->setRootIsDecorated(false);
     this->setSelectionMode(QAbstractItemView::ExtendedSelection);
-#if QT_VERSION >= 0x040200
-    // causes unexpected drop events (possibly only with Qt4.1.x)
     this->setMouseTracking(true); // needed for itemEntered() to work
-#endif
 }
 
 TreeView::~TreeView()

--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -271,13 +271,8 @@ public:
         // Thus, we filter out horizontal scrolling.
         if (event->type() == QEvent::Wheel) {
             QWheelEvent* we = static_cast<QWheelEvent*>(event);
-#if QT_VERSION >= QT_VERSION_CHECK(5,0,0)
             if (qAbs(we->angleDelta().x()) > qAbs(we->angleDelta().y()))
                 return true;
-#else
-            if (we->orientation() == Qt::Horizontal)
-                return true;
-#endif
         }
         else if (event->type() == QEvent::KeyPress) {
             QKeyEvent* ke = static_cast<QKeyEvent*>(event);
@@ -601,10 +596,8 @@ void View3DInventorViewer::init()
 
     //create the cursors
     createStandardCursors(devicePixelRatio());
-#if (QT_VERSION >= 0x050000)
     connect(this, &View3DInventorViewer::devicePixelRatioChanged,
             this, &View3DInventorViewer::createStandardCursors);
-#endif
 
     naviCube = new NaviCube(this);
     naviCubeEnabled = true;

--- a/src/Gui/WaitCursor.cpp
+++ b/src/Gui/WaitCursor.cpp
@@ -33,9 +33,7 @@
 # endif
 #endif
 
-#if QT_VERSION >= 0x050000
-# include <QWindow>
-#endif
+#include <QWindow>
 
 #include "WaitCursor.h"
 
@@ -105,13 +103,11 @@ void WaitCursorP::setIgnoreEvents(WaitCursor::FilterEventsFlags flags)
 bool WaitCursorP::isModalDialog(QObject* o) const
 {
     QWidget* parent = qobject_cast<QWidget*>(o);
-#if QT_VERSION >= 0x050000
     if (!parent) {
         QWindow* window = qobject_cast<QWindow*>(o);
         if (window)
             parent = QWidget::find(window->winId());
     }
-#endif
     while (parent) {
         QMessageBox* dlg = qobject_cast<QMessageBox*>(parent);
         if (dlg && dlg->isModal())

--- a/src/Gui/WidgetFactory.cpp
+++ b/src/Gui/WidgetFactory.cpp
@@ -372,11 +372,6 @@ QObject* PythonWrapper::toQObject(const Py::Object& pyobject)
     return reinterpret_cast<QObject*>(ptr);
 #endif
 
-#if 0 // Unwrapping using sip/PyQt
-    void* ptr = qt_getCppPointer(pyobject, "sip", "unwrapinstance");
-    return reinterpret_cast<QObject*>(ptr);
-#endif
-
     return 0;
 }
 
@@ -455,10 +450,6 @@ Py::Object PythonWrapper::fromQObject(QObject* object, const char* className)
     //
     return qt_wrapInstance<QObject*>(object, className, "shiboken2", "PySide2.QtCore", "wrapInstance");
 #endif
-#if 0 // Unwrapping using sip/PyQt
-    Q_UNUSED(className);
-    return qt_wrapInstance<QObject*>(object, "QObject", "sip", "PyQt5.QtCore", "wrapinstance");
-#endif
 }
 
 Py::Object PythonWrapper::fromQWidget(QWidget* widget, const char* className)
@@ -483,11 +474,6 @@ Py::Object PythonWrapper::fromQWidget(QWidget* widget, const char* className)
     // Access shiboken2/PySide2 via Python
     //
     return qt_wrapInstance<QWidget*>(widget, className, "shiboken2", "PySide2.QtWidgets", "wrapInstance");
-#endif
-
-#if 0 // Unwrapping using sip/PyQt
-    Q_UNUSED(className);
-    return qt_wrapInstance<QWidget*>(widget, "QWidget", "sip", "PyQt5.QtWidgets", "wrapinstance");
 #endif
 }
 

--- a/src/Gui/Widgets.cpp
+++ b/src/Gui/Widgets.cpp
@@ -759,14 +759,10 @@ void ColorButton::onChooseColor()
 {
     if (!d->allowChange)
         return;
-#if QT_VERSION >= 0x040500
     if (d->modal) {
-#endif
         QColor currentColor = d->col;
         QColorDialog cd(d->col, this);
-#if QT_VERSION >= 0x050000
         cd.setOptions(QColorDialog::DontUseNativeDialog);
-#endif
 
         if (d->autoChange) {
             connect(&cd, SIGNAL(currentColorChanged(const QColor &)),
@@ -786,15 +782,12 @@ void ColorButton::onChooseColor()
             setColor(currentColor);
             changed();
         }
-#if QT_VERSION >= 0x040500
     }
     else {
         if (d->cd.isNull()) {
             d->old = d->col;
             d->cd = new QColorDialog(d->col, this);
-#if QT_VERSION >= 0x050000
             d->cd->setOptions(QColorDialog::DontUseNativeDialog);
-#endif
             d->cd->setAttribute(Qt::WA_DeleteOnClose);
             connect(d->cd, SIGNAL(rejected()),
                     this, SLOT(onRejected()));
@@ -803,7 +796,6 @@ void ColorButton::onChooseColor()
         }
         d->cd->show();
     }
-#endif
 }
 
 void ColorButton::onColorChosen(const QColor& c)

--- a/src/Gui/Widgets.h
+++ b/src/Gui/Widgets.h
@@ -157,11 +157,7 @@ private Q_SLOTS:
     void updateClearButton(const QString &text);
 
 private:
-#if QT_VERSION >= 0x050200
     QAction *clearAction;
-#else
-    QToolButton *clearButton;
-#endif
 };
 
 // ------------------------------------------------------------------------------

--- a/src/Gui/WinNativeGestureRecognizers.h
+++ b/src/Gui/WinNativeGestureRecognizers.h
@@ -32,14 +32,6 @@
 #include <QGestureRecognizer>
 #include <QPinchGesture>
 
-#ifdef Q_OS_WIN
-#if QT_VERSION < 0x050000
-#if(WINVER >= 0x0601) // need Windows 7
-#define GESTURE_MESS
-#endif
-#endif // QT_VERSION < 0x050000
-#endif // Q_OS_WIN
-
 #ifdef GESTURE_MESS
 
 /*!

--- a/src/Gui/iisTaskPanel/src/iisiconlabel.cpp
+++ b/src/Gui/iisTaskPanel/src/iisiconlabel.cpp
@@ -127,11 +127,7 @@ void iisIconLabel::paintEvent ( QPaintEvent * event )
         QRect boundingRect;
 
         QFontMetrics fm(fnt);
-#if QT_VERSION >= 0x040203
         QString txt(fm.elidedText(myText, Qt::ElideRight, textRect.width()));
-#else
-        QString txt = myText;
-#endif
 
         p.drawText(textRect, Qt::AlignLeft | Qt::AlignVCenter, txt, &boundingRect);
 

--- a/src/Gui/iisTaskPanel/src/iistaskbox.cpp
+++ b/src/Gui/iisTaskPanel/src/iistaskbox.cpp
@@ -77,11 +77,7 @@ void iisTaskBox::showHide()
 	if (m_foldStep)
 		return;
 
-#if QT_VERSION >= 0x050000
 	m_foldPixmap = myGroup->grab(myGroup->rect());
-#else
-	m_foldPixmap = QPixmap::grabWidget(myGroup, myGroup->rect());
-#endif
 
 	if (myGroup->isVisible()) {
 		m_tempHeight = m_fullHeight = myGroup->height();
@@ -158,12 +154,10 @@ void iisTaskBox::paintEvent ( QPaintEvent * event )
 	QPainter p(this);
 
 	if (myDummy->isVisible()) {
-#if QT_VERSION >= 0x040202
 		if (m_foldDirection < 0)
 			p.setOpacity((double)m_foldStep / myScheme->groupFoldSteps);
 		else
 			p.setOpacity((double)(myScheme->groupFoldSteps-m_foldStep) / myScheme->groupFoldSteps);
-#endif
 
 		p.drawPixmap(myDummy->x(),myDummy->y(),m_foldPixmap);
 

--- a/src/Gui/iisTaskPanel/src/iistaskheader.cpp
+++ b/src/Gui/iisTaskPanel/src/iistaskheader.cpp
@@ -100,10 +100,8 @@ void iisTaskHeader::paintEvent ( QPaintEvent * event )
     Q_UNUSED(event);
     QPainter p(this);
 
-#if QT_VERSION >= 0x040203
     if (myScheme->headerAnimation)
         p.setOpacity(m_opacity+0.7);
-#endif
 
     p.setPen(myScheme->headerBorder);
     p.setBrush(myScheme->headerBackground);


### PR DESCRIPTION
This PR removes any code from the main GUI module that was only included for Qt < 5.9, the current minimum required version. It only addresses explicit dependencies on the Qt version, not implied dependencies like testing for the existence of particular features (e.g. WebKit, etc.).

---

- [X]  Single module
- [X]  "Small" change
- [X]  [Rebased](https://git-scm.com/docs/git-rebase) on latest master
- [X]  GUI unit tests are confirmed to pass
- [X]  Commit messages are [well-written](https://chris.beams.io/posts/git-commit/)
- [X]  Pull request is well written
- [X]  No tracker ticket