### PR TITLE
[Base] Remove deprecated Qt < 5.9 code

### DIFF
--- a/src/Base/TimeInfo.cpp
+++ b/src/Base/TimeInfo.cpp
@@ -79,18 +79,8 @@ void TimeInfo::setTime_t (uint64_t seconds)
 
 std::string TimeInfo::currentDateTimeString()
 {
-#if (QT_VERSION >= 0x050300)
     return QDateTime::currentDateTime().toTimeSpec(Qt::OffsetFromUTC)
         .toString(Qt::ISODate).toStdString();
-#else
-    QDateTime local = QDateTime::currentDateTime();
-    QDateTime utc = local.toUTC();
-    utc.setTimeSpec(Qt::LocalTime);
-    int utcOffset = utc.secsTo(local);
-    local.setUtcOffset(utcOffset);
-    QString dm = local.toString(Qt::ISODate);
-    return dm.toStdString();
-#endif
 }
 
 std::string TimeInfo::diffTime(const TimeInfo &timeStart,const TimeInfo &timeEnd )

--- a/src/Base/Tools.h
+++ b/src/Base/Tools.h
@@ -34,41 +34,6 @@
 #include <QString>
 #include <QObject>
 
-#if (QT_VERSION < 0x050300)
-class QSignalBlocker
-{
-public:
-    QSignalBlocker(QObject *object)
-      : object(object)
-      , blocked(object && object->blockSignals(true))
-      , inhibited(false)
-    {
-    }
-    ~QSignalBlocker()
-    {
-        if (object && !inhibited)
-            object->blockSignals(blocked);
-    }
-    void reblock()
-    {
-        if (object)
-            object->blockSignals(true);
-        inhibited = false;
-    }
-    void unblock()
-    {
-        if (object)
-            object->blockSignals(blocked);
-        inhibited = true;
-    }
-
-private:
-    QObject *object;
-    bool blocked;
-    bool inhibited;
-};
-#endif
-
 // ----------------------------------------------------------------------------
 
 namespace Base

--- a/src/Base/Translate.cpp
+++ b/src/Base/Translate.cpp
@@ -79,12 +79,7 @@ Py::Object Translate::translate(const Py::Tuple& args)
     if (!PyArg_ParseTuple(args.ptr(), "ss|si", &context, &source, &disambiguation, &n))
         throw Py::Exception();
 
-#if (QT_VERSION >= 0x050000)
     QString str = QCoreApplication::translate(context, source, disambiguation, n);
-#else
-    QString str = QCoreApplication::translate(context, source, disambiguation,
-                                              QCoreApplication::UnicodeUTF8, n);
-#endif
     return Py::asObject(PyUnicode_FromString(str.toUtf8()));
 }
 


### PR DESCRIPTION
This PR removes any code from the base module that was only included for Qt < 5.9, the current minimum required version. 

---

- [X]  Single module
- [X]  Small change
- [X]  [Rebased](https://git-scm.com/docs/git-rebase) on latest master
- [X]  Unit tests are confirmed to pass
- [X]  Commit messages are [well-written](https://chris.beams.io/posts/git-commit/)
- [X]  Pull request is well written
- [X]  No tracker ticket