### PR TITLE
[Main] Remove deprecated Qt < 5.9 code

### DIFF
--- a/src/Main/FreeCADGuiPy.cpp
+++ b/src/Main/FreeCADGuiPy.cpp
@@ -106,9 +106,7 @@ FreeCADGui_showMainWindow(PyObject * /*self*/, PyObject *args)
             std::thread t([]() {
                 static int argc = 0;
                 static char **argv = {0};
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 9, 0))
                 QApplication::setAttribute(Qt::AA_ShareOpenGLContexts);
-#endif
                 // This only works well if the QApplication is the very first created instance
                 // of a QObject. Otherwise the application lives in a different thread than the
                 // main thread which will cause hazardous behaviour.

--- a/src/Main/MainGui.cpp
+++ b/src/Main/MainGui.cpp
@@ -120,13 +120,6 @@ int main( int argc, char ** argv )
     // Make sure to setup the Qt locale system before setting LANG and LC_ALL to C.
     // which is needed to use the system locale settings.
     (void)QLocale::system();
-#if QT_VERSION < 0x050000
-    // http://www.freecadweb.org/tracker/view.php?id=399
-    // Because of setting LANG=C the Qt automagic to use the correct encoding
-    // for file names is broken. This is a workaround to force the use of UTF-8 encoding
-    QFile::setEncodingFunction(myEncoderFunc);
-    QFile::setDecodingFunction(myDecoderFunc);
-#endif
     // See https://forum.freecadweb.org/viewtopic.php?f=18&t=20600
     // See Gui::Application::runApplication()
     putenv("LC_NUMERIC=C");
@@ -189,9 +182,7 @@ int main( int argc, char ** argv )
     App::Application::Config()["SplashTextColor" ] = "#ffffff"; // white
     App::Application::Config()["SplashInfoColor" ] = "#c8c8c8"; // light grey
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 7, 0))
     QGuiApplication::setDesktopFileName(QStringLiteral("org.freecadweb.FreeCAD.desktop"));
-#endif
 
     try {
         // Init phase ===========================================================


### PR DESCRIPTION
This PR removes any code from the main module that was only included for Qt < 5.9, the current minimum required version. 

---

- [X]  Single module
- [X]  Small change
- [X]  [Rebased](https://git-scm.com/docs/git-rebase) on latest master
- [X]  Unit tests are confirmed to pass
- [X]  Commit messages are [well-written](https://chris.beams.io/posts/git-commit/)
- [X]  Pull request is well written
- [X]  No tracker ticket