### PR TITLE
[Part] Remove deprecated Qt < 5.9 code

### DIFF
--- a/src/Mod/Part/Gui/DlgFilletEdges.cpp
+++ b/src/Mod/Part/Gui/DlgFilletEdges.cpp
@@ -281,15 +281,9 @@ DlgFilletEdges::DlgFilletEdges(FilletType type, Part::FilletBase* fillet, QWidge
     ui->treeView->setModel(model);
 
     QHeaderView* header = ui->treeView->header();
-#if QT_VERSION >= 0x050000
     header->setSectionResizeMode(0, QHeaderView::Stretch);
     header->setDefaultAlignment(Qt::AlignLeft);
     header->setSectionsMovable(false);
-#else
-    header->setResizeMode(0, QHeaderView::Stretch);
-    header->setDefaultAlignment(Qt::AlignLeft);
-    header->setMovable(false);
-#endif
     on_filletType_activated(0);
     findShapes();
 }

--- a/src/Mod/Part/Gui/TaskCheckGeometry.cpp
+++ b/src/Mod/Part/Gui/TaskCheckGeometry.cpp
@@ -356,17 +356,11 @@ QVariant ResultModel::headerData(int section, Qt::Orientation orientation, int r
 
 void ResultModel::setResults(ResultEntry *resultsIn)
 {
-#if QT_VERSION >= 0x040600
     this->beginResetModel();
-#endif
     if (root)
         delete root;
     root = resultsIn;
-#if QT_VERSION >= 0x040600
     this->endResetModel();
-#else
-    this->reset();
-#endif
 }
 
 ResultEntry* ResultModel::getEntry(const QModelIndex &index)


### PR DESCRIPTION
This PR removes any code from the Part module that was only included for Qt < 5.9, the current minimum required version. 

---

- [X]  Single module
- [X]  Small change
- [X]  [Rebased](https://git-scm.com/docs/git-rebase) on latest master
- [X]  Unit tests are confirmed to pass
- [X]  Commit messages are [well-written](https://chris.beams.io/posts/git-commit/)
- [X]  Pull request is well written
- [X]  No tracker ticket