### PR TITLE
[Sketcher] Remove deprecated Qt < 5.9 code

### DIFF
--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -905,14 +905,12 @@ public:
         cursorPainter.end();
         int hotX = 8;
         int hotY = 8;
-#if QT_VERSION >= 0x050000
         cursorPixmap.setDevicePixelRatio(pixelRatio);
         // only X11 needs hot point coordinates to be scaled
         if (qGuiApp->platformName() == QLatin1String("xcb")) {
             hotX *= pixelRatio;
             hotY *= pixelRatio;
         }
-#endif
         setCursor(cursorPixmap, hotX, hotY, false);
     }
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandler.cpp
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandler.cpp
@@ -29,9 +29,7 @@
 # include <Inventor/nodes/SoText2.h>
 # include <Inventor/nodes/SoFont.h>
 # include <QPainter>
-# if QT_VERSION >= 0x050000
 # include <QGuiApplication>
-# endif
 # include <cmath>
 #endif  // #ifndef _PreComp_
 
@@ -119,23 +117,18 @@ void DrawSketchHandler::setSvgCursor(const QString & cursorName, int x, int y, c
     qreal defaultCursorSize = isRatioOne ? 64 : 32;
     qreal hotX = x;
     qreal hotY = y;
-#if QT_VERSION >= 0x050000
 #if !defined(Q_OS_WIN32) && !defined(Q_OS_MAC)
     if (qGuiApp->platformName() == QLatin1String("xcb")) {
         hotX *= pRatio;
         hotY *= pRatio;
     }
 #endif
-#endif
     qreal cursorSize = defaultCursorSize * pRatio;
 
     QPixmap pointer = Gui::BitmapFactory().pixmapFromSvg(cursorName.toStdString().c_str(), QSizeF(cursorSize, cursorSize), colorMapping);
     if (isRatioOne)
         pointer = pointer.scaled(32, 32);
-#if QT_VERSION >= 0x050000
     pointer.setDevicePixelRatio(pRatio);
-#endif
-
     setCursor(pointer, hotX, hotY, false);
 }
 
@@ -151,26 +144,18 @@ void DrawSketchHandler::setCursor(const QPixmap &p,int x,int y, bool autoScale)
         QPixmap p1(p);
         // TODO remove autoScale after all cursors are SVG-based
         if (autoScale) {
-#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
             qreal pRatio = viewer->devicePixelRatio();
-#else
-            qreal pRatio = 1;
-#endif
             int newWidth = p.width()*pRatio;
             int newHeight = p.height()*pRatio;
             p1 = p1.scaled(newWidth, newHeight, Qt::KeepAspectRatio, Qt::SmoothTransformation);
-#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
             p1.setDevicePixelRatio(pRatio);
-#endif
             qreal hotX = x;
             qreal hotY = y;
-#if QT_VERSION >= 0x050000
 #if !defined(Q_OS_WIN32) && !defined(Q_OS_MAC)
             if (qGuiApp->platformName() == QLatin1String("xcb")) {
                 hotX *= pRatio;
                 hotY *= pRatio;
             }
-#endif
 #endif
             cursor = QCursor(p1, hotX, hotY);
         } else {
@@ -190,12 +175,8 @@ void DrawSketchHandler::addCursorTail( std::vector<QPixmap> &pixmaps ) {
     Gui::MDIView* view = Gui::getMainWindow()->activeWindow();
     if (view && view->isDerivedFrom(Gui::View3DInventor::getClassTypeId())) {
         QPixmap baseIcon = QPixmap(actCursorPixmap);
-#if QT_VERSION >= 0x050000
         baseIcon.setDevicePixelRatio(actCursorPixmap.devicePixelRatio());
         qreal pixelRatio = baseIcon.devicePixelRatio();
-#else
-        qreal pixelRatio = 1;
-#endif
         // cursor size in device independent pixels
         qreal baseCursorWidth = baseIcon.width();
         qreal baseCursorHeight = baseIcon.height();
@@ -238,11 +219,7 @@ void DrawSketchHandler::addCursorTail( std::vector<QPixmap> &pixmaps ) {
 
         // Create the new cursor with the icon.
         QPoint p=actCursor.hotSpot();
-
-#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
         newIcon.setDevicePixelRatio(pixelRatio);
-#endif
-
         QCursor newCursor(newIcon, p.x(), p.y());
         applyCursor(newCursor);
     }
@@ -273,13 +250,11 @@ void DrawSketchHandler::unsetCursor(void)
 
 qreal DrawSketchHandler::devicePixelRatio() {
     qreal pixelRatio = 1;
-# if QT_VERSION >= 0x050000
     Gui::MDIView* view = Gui::getMainWindow()->activeWindow();
     if (view && view->isDerivedFrom(Gui::View3DInventor::getClassTypeId())) {
         Gui::View3DInventorViewer* viewer = static_cast<Gui::View3DInventor*>(view)->getViewer();
         pixelRatio = viewer->devicePixelRatio();
     }
-# endif
     return pixelRatio;
 }
 
@@ -313,13 +288,11 @@ std::vector<QPixmap> DrawSketchHandler::suggestedConstraintsPixmaps(
         }
         if (!iconType.isEmpty()) {
             qreal pixelRatio = 1;
-# if QT_VERSION >= 0x050000
             Gui::MDIView* view = Gui::getMainWindow()->activeWindow();
             if (view && view->isDerivedFrom(Gui::View3DInventor::getClassTypeId())) {
                 Gui::View3DInventorViewer* viewer = static_cast<Gui::View3DInventor*>(view)->getViewer();
                 pixelRatio = viewer->devicePixelRatio();
             }
-# endif
             int iconWidth = 16 * pixelRatio;
             QPixmap icon = Gui::BitmapFactory()
                 .pixmapFromSvg(iconType.toStdString().c_str(), QSize(iconWidth, iconWidth));

--- a/src/Mod/Sketcher/Gui/TaskSketcherConstrains.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstrains.cpp
@@ -394,11 +394,7 @@ protected:
     }
 
     void paint ( QPainter * painter, const QStyleOptionViewItem & option, const QModelIndex & index ) const {
-#if QT_VERSION >= 0x050000
         QStyleOptionViewItem options = option;
-#else
-        QStyleOptionViewItemV4 options = option;
-#endif
         initStyleOption(&options, index);
 
         options.widget->style()->drawControl(QStyle::CE_ItemViewItem, &options, painter);

--- a/src/Mod/Sketcher/Gui/TaskSketcherGeneral.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherGeneral.cpp
@@ -49,9 +49,7 @@ SketcherGeneralWidget::SketcherGeneralWidget(QWidget *parent)
   : QWidget(parent), ui(new Ui_TaskSketcherGeneral)
 {
     ui->setupUi(this);
-#if QT_VERSION >= 0x050200
     ui->renderingOrder->setSizeAdjustPolicy(QAbstractScrollArea::AdjustToContents);
-#endif
 
     // connecting the needed signals
     connect(ui->checkBoxShowGrid, SIGNAL(toggled(bool)),

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -1373,11 +1373,7 @@ bool ViewProviderSketch::mouseMove(const SbVec2s &cursorPos, Gui::View3DInventor
         }
         case STATUS_SKETCH_UseRubberBand: {
             // Here we must use the device-pixel-ratio to compute the correct y coordinate (#0003130)
-#if QT_VERSION >= 0x050600
             qreal dpr = viewer->getGLWidget()->devicePixelRatioF();
-#else
-            qreal dpr = 1;
-#endif
             newCursorPos = cursorPos;
             rubberband->setCoords(prvCursorPos.getValue()[0],
                        viewer->getGLWidget()->height()*dpr - prvCursorPos.getValue()[1],


### PR DESCRIPTION
This PR removes any code from the Sketcher module that was only included for Qt < 5.9, the current minimum required version. 

---

- [X]  Single module
- [X]  Small change
- [X]  [Rebased](https://git-scm.com/docs/git-rebase) on latest master
- [X]  Unit tests are confirmed to pass
- [X]  Commit messages are [well-written](https://chris.beams.io/posts/git-commit/)
- [X]  Pull request is well written
- [X]  No tracker ticket