### PR TITLE
[Spreadsheet] Remove deprecated Qt < 5.9 code

### DIFF
--- a/src/Mod/Spreadsheet/Gui/SheetTableView.h
+++ b/src/Mod/Spreadsheet/Gui/SheetTableView.h
@@ -37,11 +37,7 @@ public:
     SheetViewHeader(QTableView *owner, Qt::Orientation o) 
         : QHeaderView(o),owner(owner) 
     {
-#if QT_VERSION >= 0x050000
         setSectionsClickable(true);
-#else
-        setClickable(true);
-#endif
     }
 Q_SIGNALS:
     void resizeFinished();

--- a/src/Mod/Spreadsheet/Gui/qtcolorpicker.cpp
+++ b/src/Mod/Spreadsheet/Gui/qtcolorpicker.cpp
@@ -64,9 +64,7 @@
 #include <QtGui/QMouseEvent>
 #include <math.h>
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
-# include <QScreen>
-#endif
+#include <QScreen>
 
 #include "qtcolorpicker.h"
 
@@ -316,11 +314,8 @@ void QtColorPicker::buttonPressed(bool toggled)
     if (!toggled)
         return;
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
     const QRect desktop = QApplication::primaryScreen()->geometry();
-#else
-    const QRect desktop = QApplication::desktop()->geometry();
-#endif
+
     // Make sure the popup is inside the desktop.
     QPoint pos = mapToGlobal(rect().bottomLeft());
     if (pos.x() < desktop.left())


### PR DESCRIPTION
This PR removes any code from the Spreadsheet module that was only included for Qt < 5.9, the current minimum required version. 

---

- [X]  Single module
- [X]  Small change
- [X]  [Rebased](https://git-scm.com/docs/git-rebase) on latest master
- [X]  Spreadsheet unit tests are confirmed to pass
- [X]  Commit messages are [well-written](https://chris.beams.io/posts/git-commit/)
- [X]  Pull request is well written
- [X]  No tracker ticket