### PR TITLE
[TD] Remove deprecated Qt < 5.9 code

### DIFF
--- a/src/Mod/TechDraw/App/DrawViewDimension.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDimension.cpp
@@ -818,12 +818,8 @@ std::string DrawViewDimension::formatValue(qreal value, QString qFormatSpec, int
         // we reformat the value
         // the user can overwrite the decimal settings, so we must in every case use the formatSpecifier
         // the default is: if useDecimals(), then formatSpecifier = global decimals, otherwise it is %.2f
-#if QT_VERSION >= 0x050000
         formattedValue = QString::asprintf(Base::Tools::toStdString(formatSpecifier).c_str(), userVal);
-#else
-        QString qs2;
-        formattedValue = qs2.sprintf(Base::Tools::toStdString(formatSpecifier).c_str(), userVal);
-#endif
+
         // if abs(1 - userVal / formattedValue) > 0.1 we know that we make an error greater than 10%
         // then we need more digits
         if (abs(userVal - formattedValue.toDouble()) > 0.1 * abs(userVal)) {
@@ -975,12 +971,7 @@ QStringList DrawViewDimension::getPrefixSuffixSpec(QString fSpec)
     int pos = 0;
     if ((pos = rxFormat.indexIn(fSpec, 0)) != -1)  {
         match = rxFormat.cap(0);                                          //entire capture of rx
-//#if QT_VERSION >= 0x050000
 //        formatted = QString::asprintf(Base::Tools::toStdString(match).c_str(),value);
-//#else
-//        QString qs2;
-//        formatted = qs2.sprintf(Base::Tools::toStdString(match).c_str(),value);
-//#endif
         formatPrefix = fSpec.left(pos);
         result.append(formatPrefix);
         formatSuffix = fSpec.right(fSpec.size() - pos - match.size());

--- a/src/Mod/TechDraw/Gui/Grabber3d.cpp
+++ b/src/Mod/TechDraw/Gui/Grabber3d.cpp
@@ -26,9 +26,7 @@
 
 #endif
 
-//#if QT_VERSION >= 0x050000
 //#include <QGuiApplication>
-//#endif
 
 #include <QImage>
 #include <QPixmap>
@@ -317,18 +315,9 @@ double Grabber3d::getViewerScale(Gui::View3DInventorViewer* viewer)
 
     //accurate dpmm for screen is not easily acquired!
 //    double qtpxmm = 96;
-//#if QT_VERSION >=050000
 //    QScreen *screen = QGuiApplication::primaryScreen();
 //    double qtppi = screen->physicalDotsPerInch();  //~111 dpi
 //    qtpxmm       = qtppi / 25.4; 
-//#else
-////    QSize widgetSize = viewer->size();
-////    int qtDpiXLog = viewer->logicalDpiX();
-////    int qtDpiYLog = viewer->logicalDpiY();
-//    int qtDpiXPhys = viewer->physicalDpiX();
-//    int qtDpiYPhys = viewer->physicalDpiY();
-//    qtpxmm = ((qtDpiXPhys + qtDpiYPhys) / 2.0) / 25.4;
-//#endif
 
     SbViewportRegion vpRegion = viewer->getSoRenderManager()->getViewportRegion();
     SbVec2s winSizePx = vpRegion.getWindowSize();                //pixel coords
@@ -361,18 +350,9 @@ double Grabber3d::getPaperScale(Gui::View3DInventorViewer* viewer,
 
     //accurate dpmm for screen is not easily acquired!
 //    double qtpxmm = 96;
-//#if QT_VERSION >=050000
 //    QScreen *screen = QGuiApplication::primaryScreen();
 //    double qtppi = screen->physicalDotsPerInch();  //~111 dpi
 //    qtpxmm       = qtppi / 25.4; 
-//#else
-////    QSize widgetSize = viewer->size();
-////    int qtDpiXLog = viewer->logicalDpiX();
-////    int qtDpiYLog = viewer->logicalDpiY();
-//    int qtDpiXPhys = viewer->physicalDpiX();
-//    int qtDpiYPhys = viewer->physicalDpiY();
-//    qtpxmm = ((qtDpiXPhys + qtDpiYPhys) / 2.0) / 25.4;
-//#endif
 
     SbViewportRegion vpRegion = viewer->getSoRenderManager()->getViewportRegion();
     SbVec2s winSizePx = vpRegion.getWindowSize();                //pixel coords

--- a/src/Mod/TechDraw/Gui/MDIViewPage.cpp
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.cpp
@@ -117,13 +117,8 @@ TYPESYSTEM_SOURCE_ABSTRACT(TechDrawGui::MDIViewPage, Gui::MDIView)
 
 MDIViewPage::MDIViewPage(ViewProviderPage *pageVp, Gui::Document* doc, QWidget* parent)
   : Gui::MDIView(doc, parent),
-#if QT_VERSION >= 0x050300
     m_orientation(QPageLayout::Landscape),
     m_paperSize(QPageSize::A4),
-#else
-    m_orientation(QPrinter::Landscape),
-    m_paperSize(QPrinter::A4),
-#endif
     pagewidth(0.0),
     pageheight(0.0),
     m_vpPage(pageVp)
@@ -316,23 +311,11 @@ void MDIViewPage::attachTemplate(TechDraw::DrawTemplate *obj)
     m_view->setPageTemplate(obj);
     pagewidth  =  obj->Width.getValue();
     pageheight =  obj->Height.getValue();
-#if QT_VERSION >= 0x050300
     m_paperSize = QPageSize::id(QSizeF(pagewidth, pageheight), QPageSize::Millimeter, QPageSize::FuzzyOrientationMatch);
-#else
-    m_paperSize = getPaperSize(int(round(pagewidth)), int(round(pageheight)));
-#endif
     if (pagewidth > pageheight) {
-#if QT_VERSION >= 0x050300
         m_orientation = QPageLayout::Landscape;
-#else
-        m_orientation = QPrinter::Landscape;
-#endif
     } else {
-#if QT_VERSION >= 0x050300
         m_orientation = QPageLayout::Portrait;
-#else
-        m_orientation = QPrinter::Portrait;
-#endif
     }
 }
 
@@ -673,29 +656,16 @@ void MDIViewPage::printPdf(std::string file)
     printer.setFullPage(true);
     printer.setOutputFileName(filename);
 
-#if QT_VERSION >= 0x050300
     if (m_paperSize == QPageSize::Ledger)  {
         printer.setPageOrientation((QPageLayout::Orientation) (1 - m_orientation));  //reverse 0/1
-#else
-    if (m_paperSize == QPrinter::Ledger)  {
-        printer.setOrientation((QPrinter::Orientation) (1 - m_orientation));  //reverse 0/1
-#endif
     } else {
-#if QT_VERSION >= 0x050300
         printer.setPageOrientation(m_orientation);
-#else
-        printer.setOrientation(m_orientation);
-#endif
     }
-#if QT_VERSION >= 0x050300
     if (m_paperSize == QPageSize::Custom) {
         printer.setPageSize(QPageSize(QSizeF(pagewidth, pageheight), QPageSize::Millimeter));
     } else {
         printer.setPageSize(QPageSize(m_paperSize));
     }
-#else
-    printer.setPaperSize(m_paperSize);
-#endif
     print(&printer);
 }
 
@@ -703,17 +673,13 @@ void MDIViewPage::print()
 {
     QPrinter printer(QPrinter::HighResolution);
     printer.setFullPage(true);
-#if QT_VERSION >= 0x050300
     if (m_paperSize == QPageSize::Custom) {
         printer.setPageSize(QPageSize(QSizeF(pagewidth, pageheight), QPageSize::Millimeter));
     } else {
         printer.setPageSize(QPageSize(m_paperSize));
     }
     printer.setPageOrientation(m_orientation);
-#else
-    printer.setPaperSize(m_paperSize);
-    printer.setOrientation(m_orientation);
-#endif
+
     QPrintDialog dlg(&printer, this);
     if (dlg.exec() == QDialog::Accepted) {
         print(&printer);
@@ -724,17 +690,12 @@ void MDIViewPage::printPreview()
 {
     QPrinter printer(QPrinter::HighResolution);
     printer.setFullPage(true);
-#if QT_VERSION >= 0x050300
     if (m_paperSize == QPageSize::Custom) {
         printer.setPageSize(QPageSize(QSizeF(pagewidth, pageheight), QPageSize::Millimeter));
     } else {
         printer.setPageSize(QPageSize(m_paperSize));
     }
     printer.setPageOrientation(m_orientation);
-#else
-    printer.setPaperSize(m_paperSize);
-    printer.setOrientation(m_orientation);
-#endif
 
     QPrintPreviewDialog dlg(&printer, this);
     connect(&dlg, SIGNAL(paintRequested (QPrinter *)),
@@ -758,21 +719,13 @@ void MDIViewPage::print(QPrinter* printer)
     // a certain scaling effect can be observed and the content becomes smaller.
     QPaintEngine::Type paintType = printer->paintEngine()->type();
     if (printer->outputFormat() == QPrinter::NativeFormat) {
-#if QT_VERSION >= 0x050300
         QPageSize::PageSizeId psPrtSetting = printer->pageLayout().pageSize().id();
-#else
-        QPrinter::PaperSize psPrtSetting = printer->paperSize();
-#endif
 
         // for the preview a 'Picture' paint engine is used which we don't
         // care if it uses wrong printer settings
         bool doPrint = paintType != QPaintEngine::Picture;
 
-#if QT_VERSION >= 0x050300
         if (doPrint && printer->pageLayout().orientation() != m_orientation) {
-#else
-        if (doPrint && printer->orientation() != m_orientation) {
-#endif
             int ret = QMessageBox::warning(this, tr("Different orientation"),
                 tr("The printer uses a different orientation  than the drawing.\n"
                    "Do you want to continue?"),
@@ -799,20 +752,15 @@ void MDIViewPage::print(QPrinter* printer)
         return;
     }
 
-#if QT_VERSION >= 0x050300
     QRect targetRect = printer->pageLayout().fullRectPixels(printer->resolution());
-#else
-    QRect targetRect = printer->paperRect();
-#endif
+
 #ifdef Q_OS_WIN32
     // On Windows the preview looks broken when using paperRect as render area.
     // Although the picture is scaled when using pageRect, it looks just fine.
     if (paintType == QPaintEngine::Picture)
-#if QT_VERSION >= 0x050300
+        // FIXME: This is unused in this context, its scope is wrong. Drop the "QRect" from the next 
+        // line and test it.  -- CH 3/31/2021
         QRect targetRect = printer->pageLayout().paintRectPixels(printer->resolution());
-#else
-        QRect targetRect = printer->pageRect();
-#endif
 #endif
 
     //bool block =
@@ -845,66 +793,6 @@ void MDIViewPage::print(QPrinter* printer)
     //bool block =
     static_cast<void> (blockConnection(false));
 }
-
-#if QT_VERSION < 0x050300
-QPrinter::PaperSize MDIViewPage::getPaperSize(int w, int h) const
-{
-    static const float paperSizes[][2] = {
-        {210, 297}, // A4
-        {176, 250}, // B5
-        {215.9f, 279.4f}, // Letter
-        {215.9f, 355.6f}, // Legal
-        {190.5f, 254}, // Executive
-        {841, 1189}, // A0
-        {594, 841}, // A1
-        {420, 594}, // A2
-        {297, 420}, // A3
-        {148, 210}, // A5
-        {105, 148}, // A6
-        {74, 105}, // A7
-        {52, 74}, // A8
-        {37, 52}, // A8
-        {1000, 1414}, // B0
-        {707, 1000}, // B1
-        {31, 44}, // B10
-        {500, 707}, // B2
-        {353, 500}, // B3
-        {250, 353}, // B4
-        {125, 176}, // B6
-        {88, 125}, // B7
-        {62, 88}, // B8
-        {33, 62}, // B9
-        {163, 229}, // C5E
-        {105, 241}, // US Common
-        {110, 220}, // DLE
-        {210, 330}, // Folio
-        {431.8f, 279.4f}, // Ledger (28)   note, two names for same size paper (ANSI B)
-        {279.4f, 431.8f} // Tabloid (29)   causes trouble with orientation on PDF export
-    };
-
-    QPrinter::PaperSize ps = QPrinter::Custom;
-    for (int i=0; i<30; i++) {
-        if (std::abs(paperSizes[i][0]-w) <= 1 &&
-            std::abs(paperSizes[i][1]-h) <= 1) {
-            ps = static_cast<QPrinter::PaperSize>(i);
-            break;
-        }
-        else                                          //handle landscape & portrait w/h
-        if (std::abs(paperSizes[i][0]-h) <= 1 &&
-            std::abs(paperSizes[i][1]-w) <= 1) {
-            ps = static_cast<QPrinter::PaperSize>(i);
-            break;
-        }
-    }
-    if (ps == QPrinter::Ledger)  {                    //check if really Tabloid
-        if (w < 431) {
-            ps = QPrinter::Tabloid;
-        }
-    }
-
-    return ps;
-}
-#endif
 
 PyObject* MDIViewPage::getPyObject()
 {

--- a/src/Mod/TechDraw/Gui/MDIViewPage.h
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.h
@@ -128,9 +128,6 @@ protected:
 
     void contextMenuEvent(QContextMenuEvent *event);
     void closeEvent(QCloseEvent*);
-#if QT_VERSION < 0x050300
-    QPrinter::PaperSize getPaperSize(int w, int h) const;
-#endif
 
     void setDimensionGroups(void);
     void setBalloonGroups(void);
@@ -162,13 +159,8 @@ private:
     QTimer *m_timer;
 
     QString m_currentPath;
-#if QT_VERSION >= 0x050300
     QPageLayout::Orientation m_orientation;
     QPageSize::PageSizeId m_paperSize;
-#else
-    QPrinter::Orientation m_orientation;
-    QPrinter::PaperSize m_paperSize;
-#endif
     qreal pagewidth, pageheight;
     ViewProviderPage *m_vpPage;
 

--- a/src/Mod/TechDraw/Gui/QGVPage.cpp
+++ b/src/Mod/TechDraw/Gui/QGVPage.cpp
@@ -1027,11 +1027,7 @@ void QGVPage::wheelEvent(QWheelEvent *event)
     }
 
     QPointF center = mapToScene(viewport()->rect().center());
-#if QT_VERSION >= QT_VERSION_CHECK(5,0,0)
     int delta = event->angleDelta().y();
-#else
-    int delta = event->delta();
-#endif
     qreal factor = std::pow(mouseBase, delta / mouseAdjust);
     scale(factor, factor);
 

--- a/src/Mod/TechDraw/Gui/TaskRichAnno.cpp
+++ b/src/Mod/TechDraw/Gui/TaskRichAnno.cpp
@@ -239,9 +239,7 @@ void TaskRichAnno::setUiPrimary()
     ui->teAnnoText->setFontPointSize(mre.getDefFontSizeNum());
     // set a placeholder text to inform the user
     // (QTextEdit has no placeholderText property in Qt4)
-#if QT_VERSION >= 0x050200
     ui->teAnnoText->setPlaceholderText(tr("Input the annotation text directly or start the rich text editor"));
-#endif
 }
 
 void TaskRichAnno::enableTextUi(bool b)

--- a/src/Mod/TechDraw/Gui/TemplateTextField.cpp
+++ b/src/Mod/TechDraw/Gui/TemplateTextField.cpp
@@ -69,11 +69,7 @@ void TemplateTextField::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
         //WF: why is this escaped?
         //    "<" is converted elsewhere and no other characters cause problems.
         //    escaping causes "&" to appear as "&amp;" etc
-//#if QT_VERSION >= 0x050000
 //            QString qsClean = ui.getFieldContent().toHtmlEscaped();
-//#else
-//            QString qsClean = Qt::escape( ui.getFieldContent() );
-//#endif
             QString qsClean = ui.getFieldContent();
             std::string utf8Content = qsClean.toUtf8().constData();
             tmplte->EditableTexts.setValue(fieldNameStr, utf8Content);


### PR DESCRIPTION
This PR removes any code from the TechDraw module that was only included for Qt < 5.9, the current minimum required version. 

NOTE: While working on this PR I ran across a bug in `MDIViewPage::printPdf(std::string file)`, around src/Mod/TechDraw/Gui/MDIViewPage.cpp line 811 in the original code. There is an unused local variable there -- I believe its scope is wrong. A fix for that seemed inappropriate to include in this PR, so I left a note there that should be revisited once this is merged.

---

- [X]  Single module
- [X]  Small change
- [X]  [Rebased](https://git-scm.com/docs/git-rebase) on latest master
- [X]  TD unit tests are confirmed to pass
- [X]  Commit messages are [well-written](https://chris.beams.io/posts/git-commit/)
- [X]  Pull request is well written
- [X]  No tracker ticket