### PR TITLE
[Test] Remove deprecated Qt < 5.9 code

### DIFF
--- a/src/Mod/Test/Gui/UnitTestImp.cpp
+++ b/src/Mod/Test/Gui/UnitTestImp.cpp
@@ -85,11 +85,6 @@ UnitTestDialog::UnitTestDialog(QWidget* parent, Qt::WindowFlags f)
   , ui(new Ui_UnitTest)
 {
     ui->setupUi(this);
-#if QT_VERSION < 0x050000
-    // As it doesn't seem to be able to change the "Highlight" color for the active colorgroup
-    // we force e.g. the "Motif" style only for the progressbar to change the color to green or red.
-    ui->progressBar->setStyle(QStyleFactory::create(QString::fromLatin1("Motif")));
-#endif
     setProgressColor(QColor(40,210,43)); // a darker green
     ui->progressBar->setAlignment(Qt::AlignCenter);
 
@@ -111,7 +106,6 @@ UnitTestDialog::~UnitTestDialog()
  */
 void UnitTestDialog::setProgressColor(const QColor& col)
 {
-#if QT_VERSION >= 0x050000
     QString qss = QString::fromLatin1(
         "QProgressBar {\n"
         "    border: 2px solid grey;\n"
@@ -123,12 +117,6 @@ void UnitTestDialog::setProgressColor(const QColor& col)
         "}"
     ).arg(col.name());
     ui->progressBar->setStyleSheet(qss);
-#else
-    QPalette pl = ui->progressBar->palette();
-    pl.setColor(QPalette::Active, QPalette::Highlight, col);
-    pl.setColor(QPalette::Inactive, QPalette::Highlight, col);
-    ui->progressBar->setPalette(pl);
-#endif
 }
 
 /**


### PR DESCRIPTION
This PR removes any code from the Unit Test module that was only included for Qt < 5.9, the current minimum required version. 

---

- [X]  Single module
- [X]  Small change
- [X]  [Rebased](https://git-scm.com/docs/git-rebase) on latest master
- [ ]  The Test module doesn't have any tests of itself
- [X]  Commit messages are [well-written](https://chris.beams.io/posts/git-commit/)
- [X]  Pull request is well written
- [X]  No tracker ticket