### PR TITLE
[Web] Remove deprecated Qt < 5.9 code

### DIFF
--- a/src/Mod/Web/App/Server.cpp
+++ b/src/Mod/Web/App/Server.cpp
@@ -114,11 +114,7 @@ AppServer::AppServer(QObject* parent)
 {
 }
 
-#if QT_VERSION >=0x050000
 void AppServer::incomingConnection(qintptr socket)
-#else
-void AppServer::incomingConnection(int socket)
-#endif
 {
     QTcpSocket* s = new QTcpSocket(this);
     connect(s, SIGNAL(readyRead()), this, SLOT(readClient()));

--- a/src/Mod/Web/App/Server.h
+++ b/src/Mod/Web/App/Server.h
@@ -85,11 +85,7 @@ public:
     AppServer(QObject* parent = 0);
     static std::string runPython(const QByteArray&);
 
-#if QT_VERSION >=0x050000
     void incomingConnection(qintptr socket);
-#else
-    void incomingConnection(int socket);
-#endif
 
 protected:
     void customEvent(QEvent* e);

--- a/src/Mod/Web/Gui/BrowserView.h
+++ b/src/Mod/Web/Gui/BrowserView.h
@@ -29,14 +29,10 @@
 #include <Gui/Window.h>
 #include <QLineEdit>
 
-#if QT_VERSION >= 0x050700 && defined(QTWEBENGINE)
 #include <QWebEngineView>
 namespace WebGui {
 class WebEngineUrlRequestInterceptor;
 };
-#elif QT_VERSION >= 0x040400 && defined(QTWEBKIT)
-#include <QWebView>
-#endif
 
 class QUrl;
 class QNetworkRequest;
@@ -45,25 +41,14 @@ class QNetworkReply;
 namespace WebGui {
 class UrlWidget;
 
-#ifdef QTWEBENGINE
 class WebGuiExport WebView : public QWebEngineView
-#else
-class WebGuiExport WebView : public QWebView
-#endif
 {
     Q_OBJECT
 
 public:
     WebView(QWidget *parent = 0);
-#ifdef QTWEBENGINE
-    // reimplement setTextSizeMultiplier
-    void setTextSizeMultiplier(qreal factor);
-#endif
 
 protected:
-#ifdef QTWEBKIT
-    void mousePressEvent(QMouseEvent *event);
-#endif
     void wheelEvent(QWheelEvent *event);
     void contextMenuEvent(QContextMenuEvent *event);
 
@@ -110,17 +95,10 @@ protected Q_SLOTS:
     void onLoadProgress(int);
     void onLoadFinished(bool);
     bool chckHostAllowed(const QString& host);
-#ifdef QTWEBENGINE
     void onDownloadRequested(QWebEngineDownloadItem *request);
     void setWindowIcon(const QIcon &icon);
     void urlFilter(const QUrl &url);
     void onLinkHovered(const QString& url);
-#else
-    void onDownloadRequested(const QNetworkRequest& request);
-    void onUnsupportedContent(QNetworkReply* reply);
-    void onLinkClicked (const QUrl& url);
-    void onLinkHovered(const QString& link, const QString& title, const QString& textContent);
-#endif
     void onViewSource(const QUrl &url);
     void onOpenLinkInExternalBrowser(const QUrl& url);
     void onOpenLinkInNewWindow(const QUrl&);
@@ -129,11 +107,7 @@ private:
     WebView* view;
     bool isLoading;
     UrlWidget *urlWgt;
-#ifdef QTWEBENGINE
     WebEngineUrlRequestInterceptor *interceptLinks;
-#else
-    float textSizeMultiplier;
-#endif
 };
 
 // the URL ardressbar lineedit


### PR DESCRIPTION
This PR removes any code from the Web module that was only included for Qt < 5.9, the current minimum required version. For Web this also implies removing support for Qt WebKit, which was deprecated in Qt 5.5 in favor of Qt WebEngine. The result is that this PR is a more extensive change to the underlying module than the others. Nothing was broken in my testing, but since the unit tests are of limited use in this case, actual user tests would be appreciated!

---

- [X]  Single module
- [X]  Small change
- [X]  [Rebased](https://git-scm.com/docs/git-rebase) on latest master
- [X]  Unit tests are confirmed to pass
- [X]  Commit messages are [well-written](https://chris.beams.io/posts/git-commit/)
- [X]  Pull request is well written
- [X]  No tracker ticket