### PR TITLE
Draft: Sync input fields in task panel

### DIFF
--- a/src/Mod/Draft/DraftGui.py
+++ b/src/Mod/Draft/DraftGui.py
@@ -273,11 +273,13 @@ class DraftToolBar:
         self.fillmode = Draft.getParam("fillmode",False)
         self.mask = None
         self.alock = False
-        self.angle = None
-        self.avalue = None
         self.x = 0
         self.y = 0
         self.z = 0
+        self.lvalue = 0
+        self.pvalue = 90
+        self.avalue = 0
+        self.angle = None
         self.radius = 0
         self.offset = 0
         self.uiloader = FreeCADGui.UiLoader()
@@ -835,11 +837,7 @@ class DraftToolBar:
 
     def taskUi(self,title="Draft",extra=None,icon="Draft_Draft"):
         # reset InputField values
-        self.x = 0
-        self.y = 0
-        self.z = 0
-        self.radius = 0
-        self.offset = 0
+        self.reset_ui_values()
         if self.taskmode:
             self.isTaskOn = True
             todo.delay(FreeCADGui.Control.closeDialog,None)
@@ -1577,7 +1575,6 @@ class DraftToolBar:
 
     def wipeLine(self):
         """wipes existing segments of a line"""
-        FreeCAD.Console.PrintMessage("el de wipe\n")
         self.sourceCmd.wipe()
 
     def orientWP(self):
@@ -1791,16 +1788,18 @@ class DraftToolBar:
 
         # set length and angle
         if last and dp and plane:
-            self.lengthValue.setText(displayExternal(dp.Length,None,'Length'))
-            a = math.degrees(-DraftVecUtils.angle(dp,plane.u,plane.axis))
-            if not self.angleLock.isChecked():
-                self.angleValue.setText(displayExternal(a,None,'Angle'))
+            length, theta, phi = DraftVecUtils.get_spherical_coords(*dp)
+            theta = math.degrees(theta)
+            phi = math.degrees(phi)
+            self.lengthValue.setText(displayExternal(length,None,'Length'))
+            #if not self.angleLock.isChecked():
+            self.angleValue.setText(displayExternal(phi,None,'Angle'))
             if not mask:
-                # automask, a is rounded to identify one of the below cases
-                a = round(a, Draft.getParam("precision"))
-                if a in [0,180,-180]:
+                # automask, phi is rounded to identify one of the below cases
+                phi = round(phi, Draft.getParam("precision"))
+                if phi in [0,180,-180]:
                     mask = "x"
-                elif a in [90,270,-90,-270]:
+                elif phi in [90,270,-90,-270]:
                     mask = "y"
 
         # set masks
@@ -2108,12 +2107,21 @@ class DraftToolBar:
 
     def changeXValue(self,d):
         self.x = d
+        if not self.xValue.hasFocus():
+            return None
+        self.update_spherical_coords()
 
     def changeYValue(self,d):
         self.y = d
+        if not self.yValue.hasFocus():
+            return None
+        self.update_spherical_coords()
 
     def changeZValue(self,d):
         self.z = d
+        if not self.zValue.hasFocus():
+            return None
+        self.update_spherical_coords()
 
     def changeRadiusValue(self,d):
         self.radius = d
@@ -2126,29 +2134,15 @@ class DraftToolBar:
 
     def changeLengthValue(self,d):
         self.lvalue = d
-        v = FreeCAD.Vector(self.x,self.y,self.z)
-        if not v.Length:
-            if self.angle:
-                v = FreeCAD.Vector(self.angle)
-            else:
-                v = FreeCAD.Vector(FreeCAD.DraftWorkingPlane.u)
-                if self.avalue:
-                    v = DraftVecUtils.rotate(v,math.radians(d),FreeCAD.DraftWorkingPlane.axis)
-        v = DraftVecUtils.scaleTo(v,d)
-        self.xValue.setText(displayExternal(v.x,None,'Length'))
-        self.yValue.setText(displayExternal(v.y,None,'Length'))
-        self.zValue.setText(displayExternal(v.z,None,'Length'))
+        if not self.lengthValue.hasFocus():
+            return None
+        self.update_cartesian_coords()
 
     def changeAngleValue(self,d):
         self.avalue = d
-        v = FreeCAD.Vector(self.x,self.y,self.z)
-        a = DraftVecUtils.angle(v,FreeCAD.DraftWorkingPlane.u,FreeCAD.DraftWorkingPlane.axis)
-        a = math.radians(d)+a
-        v = DraftVecUtils.rotate(v,a,FreeCAD.DraftWorkingPlane.axis)
-        self.angle = v
-        self.xValue.setText(displayExternal(v.x,None,'Length'))
-        self.yValue.setText(displayExternal(v.y,None,'Length'))
-        self.zValue.setText(displayExternal(v.z,None,'Length'))
+        if not self.angleValue.hasFocus():
+            return None
+        self.update_cartesian_coords()
         if self.angleLock.isChecked():
             FreeCADGui.Snapper.setAngle(self.angle)
 
@@ -2160,6 +2154,25 @@ class DraftToolBar:
             FreeCADGui.Snapper.setAngle()
             self.angle = None
 
+    def update_spherical_coords(self):
+        length, theta, phi = DraftVecUtils.get_spherical_coords(
+            self.x,self.y,self.z)
+        self.lvalue = length
+        self.pvalue = math.degrees(theta)
+        self.avalue = math.degrees(phi)
+        self.angle = FreeCAD.Vector(DraftVecUtils.get_cartesian_coords(
+            1, theta, phi))
+        self.lengthValue.setText(displayExternal(self.lvalue,None,'Length'))
+        self.angleValue.setText(displayExternal(self.avalue,None,'Angle'))
+
+    def update_cartesian_coords(self):
+        self.x, self.y, self.z = DraftVecUtils.get_cartesian_coords(
+            self.lvalue,math.radians(self.pvalue),math.radians(self.avalue))
+        self.angle = FreeCAD.Vector(DraftVecUtils.get_cartesian_coords(
+            1, math.radians(self.pvalue), math.radians(self.avalue)))
+        self.xValue.setText(displayExternal(self.x,None,'Length'))
+        self.yValue.setText(displayExternal(self.y,None,'Length'))
+        self.zValue.setText(displayExternal(self.z,None,'Length'))
 
 #---------------------------------------------------------------------------
 # TaskView operations
@@ -2234,6 +2247,18 @@ class DraftToolBar:
         else: # self.taskmode == 0  Draft toolbar is obsolete and has been disabled (February 2020)
             self.draftWidget.setVisible(False)
             self.draftWidget.toggleViewAction().setVisible(False)
+
+    def reset_ui_values(self):
+        """Method to reset task panel values"""
+        self.x = 0
+        self.y = 0
+        self.z = 0
+        self.lvalue = 0
+        self.pvalue = 90
+        self.avalue = 0
+        self.angle = None
+        self.radius = 0
+        self.offset = 0
 
 
 class FacebinderTaskPanel:

--- a/src/Mod/Draft/DraftVecUtils.py
+++ b/src/Mod/Draft/DraftVecUtils.py
@@ -829,4 +829,76 @@ def removeDoubles(vlist):
     nlist.append(vlist[-1])
     return nlist
 
+def get_spherical_coords(x, y, z):
+    """Get the Spherical coordinates of the vector represented
+    by Cartesian coordinates (x, y, z).
+
+    Parameters
+    ----------
+    vector : Base::Vector3
+        The input vector.
+
+    Returns
+    -------
+    tuple of float
+        Tuple (radius, theta, phi) with the Spherical coordinates.
+        Radius is the radial coordinate, theta the polar angle and
+        phi the azimuthal angle in radians.
+
+    Notes
+    -----
+    The vector (0, 0, 0) has undefined values for theta and phi, while
+    points on the z axis has undefined value for phi. The following
+    conventions are used (useful in DraftToolBar methods):
+    (0, 0, 0) -> (0, pi/2, 0)
+    (0, 0, z) -> (radius, theta, 0)
+    """
+
+    v = Vector(x,y,z)
+    x_axis = Vector(1,0,0)
+    z_axis = Vector(0,0,1)
+    y_axis = Vector(0,1,0)
+    rad = v.Length
+
+    if not bool(round(rad, precision())):
+        return (0, math.pi/2, 0)
+
+    theta = v.getAngle(z_axis)
+    v.projectToPlane(Vector(0,0,0), z_axis)
+    phi = v.getAngle(x_axis)
+    if math.isnan(phi):
+        return (rad, theta, 0)
+    # projected vector is on 3rd or 4th quadrant
+    if v.dot(Vector(y_axis)) < 0:
+        phi = -1*phi
+
+    return (rad, theta, phi)
+
+
+def get_cartesian_coords(radius, theta, phi):
+    """Get the three-dimensional Cartesian coordinates of the vector
+    represented by Spherical coordinates (radius, theta, phi).
+
+    Parameters
+    ----------
+    radius : float, int
+        Radial coordinate of the vector.
+    theta : float, int
+        Polar coordinate of the vector in radians.
+    phi : float, int
+        Azimuthal coordinate of the vector in radians.
+
+    Returns
+    -------
+    tuple of float :
+        Tuple (x, y, z) with the Cartesian coordinates.
+    """
+
+    x = radius*math.sin(theta)*math.cos(phi)
+    y = radius*math.sin(theta)*math.sin(phi)
+    z = radius*math.cos(theta)
+
+    return (x, y, z)
+
+
 ##  @}


### PR DESCRIPTION
There are three bug report on the forum:
https://forum.freecadweb.org/viewtopic.php?f=23&t=57302
https://forum.freecadweb.org/viewtopic.php?f=23&t=57303
https://forum.freecadweb.org/viewtopic.php?f=23&t=57306
The first is solved reseting the coordinates-related attributes on each call to the commands.
The second and third are solved syncing the input fields on the task panel and updating the coordinates-related attributes (x, y, z, avalue, lvalue). The new attribute pvalue is intended to be used in future pull request as the polar angle theta while avalue will be the azimuthal angle phi.
To reduce the number of calls to the coordinate update functions, these are called only once when the input field is in focus. 
Two new functions are added to DraftVectUtils.py to transform from Cartesian coordinates to polar coordinates and vice versa.


- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [ ]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
