### PR TITLE
Part: add more options to Shape.reflectLines()

### DIFF
--- a/src/Mod/Part/App/TopoShapePy.xml
+++ b/src/Mod/Part/App/TopoShapePy.xml
@@ -682,7 +682,7 @@ ViewPos(origin) and UpDir(up direction).
 If OnShape is True, the returned edges are the corresponding 3D reflect lines located on the shape.
 EdgeType is a string defining the type of result edges :
 - IsoLine : isoparametric line
-- OutLine : outline (silouhette) edge
+- OutLine : outline (silhouette) edge
 - Rg1Line : smooth edge of G1-continuity between two surfaces
 - RgNLine : sewn edge of CN-continuity on one surface
 - Sharp : sharp edge (of C0-continuity)

--- a/src/Mod/Part/App/TopoShapePy.xml
+++ b/src/Mod/Part/App/TopoShapePy.xml
@@ -673,10 +673,21 @@ makePerspectiveProjection(shape, pnt) -> Shape
     </Methode>
     <Methode Name="reflectLines" Const="true" Keyword="true">
       <Documentation>
-        <UserDocu>Build reflect lines on a shape according to the axes of view.
-reflectLines(ViewDir, ViewPos, UpDir) -> Shape
+        <UserDocu>Build projection or reflect lines of a shape according to a view direction.
+reflectLines(ViewDir, [ViewPos, UpDir, EdgeType, Visible, OnShape]) -> Shape (Compound of edges)
 --
-Reflect lines are represented by edges in 3d.
+This algorithm computes the projection of the shape in the ViewDir direction.
+If OnShape is False(default), the returned edges are flat on the XY plane defined by
+ViewPos(origin) and UpDir(up direction).
+If OnShape is True, the returned edges are the corresponding 3D reflect lines located on the shape.
+EdgeType is a string defining the type of result edges :
+- IsoLine : isoparametric line
+- OutLine : outline (silouhette) edge
+- Rg1Line : smooth edge of G1-continuity between two surfaces
+- RgNLine : sewn edge of CN-continuity on one surface
+- Sharp : sharp edge (of C0-continuity)
+If Visible is True (default), only visible edges are returned.
+If Visible is False, only invisible edges are returned.
         </UserDocu>
       </Documentation>
     </Methode>

--- a/src/Mod/Part/App/TopoShapePyImp.cpp
+++ b/src/Mod/Part/App/TopoShapePyImp.cpp
@@ -2069,7 +2069,7 @@ pos=Gui.ActiveDocument.ActiveView.getCameraNode().position.getValue().getValue()
 pos=App.Vector(*pos)
 
 shape=App.ActiveDocument.ActiveObject.Shape
-reflect=shape.reflectLines(ViewDir=vdir, ViewPos=pos, UpDir=udir)
+reflect=shape.reflectLines(ViewDir=vdir, ViewPos=pos, UpDir=udir, EdgeType="Sharp", Visible=True, OnShape=False)
 Part.show(reflect)
  */
 PyObject* TopoShapePy::reflectLines(PyObject *args, PyObject *kwds)


### PR DESCRIPTION
Related forum topic : https://forum.freecadweb.org/viewtopic.php?f=22&t=57238

The current implementation of HLRAppli_ReflectLines is missing many useful options.
This PR adds options for : 
- choosing between flat 2D projected edges and in-place 3D edges (on the shape)
- switching output between visible and invisible edges
- choosing the type of output edges (IsoLine (no visible effect ?), Outline silouhette, G1-SeamEdge, CN-SeamEdge, SharpEdge)

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [ ]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [x]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
