### PR TITLE
Gui: remove Py2 code from several src/Gui .cpp files

### DIFF
--- a/src/Gui/ApplicationPy.cpp
+++ b/src/Gui/ApplicationPy.cpp
@@ -737,11 +737,7 @@ PyObject* Application::sGetLocale(PyObject * /*self*/, PyObject *args)
         return NULL;
 
     std::string locale = Translator::instance()->activeLanguage();
-#if PY_MAJOR_VERSION >= 3
     return PyUnicode_FromString(locale.c_str());
-#else
-    return PyString_FromString(locale.c_str());
-#endif
 }
 
 PyObject* Application::sSetLocale(PyObject * /*self*/, PyObject *args)
@@ -819,11 +815,7 @@ PyObject* Application::sAddPreferencePage(PyObject * /*self*/, PyObject *args)
 
     PyObject* dlg;
     // old style classes
-#if PY_MAJOR_VERSION >= 3
     if (PyArg_ParseTuple(args, "O!s", &PyType_Type, &dlg, &grp)) {
-#else
-    if (PyArg_ParseTuple(args, "O!s", &PyClass_Type, &dlg, &grp)) {
-#endif
         // add to the preferences dialog
         new PrefPagePyProducer(Py::Object(dlg), grp);
 

--- a/src/Gui/CommandPyImp.cpp
+++ b/src/Gui/CommandPyImp.cpp
@@ -77,11 +77,7 @@ PyObject* CommandPy::listAll(PyObject *args)
     PyObject* pyList = PyList_New(cmds.size());
     int i=0;
     for ( std::vector<Command*>::iterator it = cmds.begin(); it != cmds.end(); ++it ) {
-#if PY_MAJOR_VERSION >= 3
         PyObject* str = PyUnicode_FromString((*it)->getName());
-#else
-        PyObject* str = PyString_FromString((*it)->getName());
-#endif
         PyList_SetItem(pyList, i++, str);
     }
     return pyList;
@@ -123,11 +119,7 @@ PyObject* CommandPy::listByShortcut(PyObject *args)
     PyObject* pyList = PyList_New(matches.size());
     int i=0;
     for (std::string match : matches) {
-#if PY_MAJOR_VERSION >= 3
         PyObject* str = PyUnicode_FromString(match.c_str());
-#else
-        PyObject* str = PyString_FromString(match.c_str());
-#endif
         PyList_SetItem(pyList, i++, str);
     }
     return pyList;
@@ -178,11 +170,7 @@ PyObject* CommandPy::getShortcut(PyObject *args)
 
     Command* cmd = this->getCommandPtr();
     if (cmd) {
-#if PY_MAJOR_VERSION >= 3
         PyObject* str = PyUnicode_FromString(cmd->getAction() ? cmd->getAction()->shortcut().toString().toStdString().c_str() : "");
-#else
-        PyObject* str = PyString_FromString(cmd->getAction() ? cmd->getAction()->shortcut().toString().toStdString().c_str() : "");
-#endif
         return str;
     }
     else {
@@ -283,21 +271,12 @@ PyObject* CommandPy::getInfo(PyObject *args)
         if (action)
             shortcutTxt = action->shortcut().toString().toStdString();
 
-#if PY_MAJOR_VERSION >= 3
         PyObject* strMenuTxt = PyUnicode_FromString(menuTxt ? menuTxt : "");
         PyObject* strTooltipTxt = PyUnicode_FromString(tooltipTxt ? tooltipTxt : "");
         PyObject* strWhatsThisTxt = PyUnicode_FromString(whatsThisTxt ? whatsThisTxt : "");
         PyObject* strStatustipTxt = PyUnicode_FromString(statustipTxt ? statustipTxt : "");
         PyObject* strPixMapTxt = PyUnicode_FromString(pixMapTxt ? pixMapTxt : "");
         PyObject* strShortcutTxt = PyUnicode_FromString(!shortcutTxt.empty() ? shortcutTxt.c_str() : "");
-#else
-        PyObject* strMenuTxt = PyString_FromString(menuTxt ? menuTxt : "");
-        PyObject* strTooltipTxt = PyString_FromString(tooltipTxt ? tooltipTxt : "");
-        PyObject* strWhatsThisTxt = PyString_FromString(whatsThisTxt ? whatsThisTxt : "");
-        PyObject* strStatustipTxt = PyString_FromString(statustipTxt ? statustipTxt : "");
-        PyObject* strPixMapTxt = PyString_FromString(pixMapTxt ? pixMapTxt : "");
-        PyObject* strShortcutTxt = PyString_FromString(!shortcutTxt.empty() ? shortcutTxt.c_str() : "");
-#endif
         PyList_SetItem(pyList, 0, strMenuTxt);
         PyList_SetItem(pyList, 1, strTooltipTxt);
         PyList_SetItem(pyList, 2, strWhatsThisTxt);

--- a/src/Gui/OnlineDocumentation.cpp
+++ b/src/Gui/OnlineDocumentation.cpp
@@ -169,11 +169,7 @@ QByteArray PythonOnlineHelp::loadResource(const QString& filename) const
         if (result) {
             Py_DECREF(result);
             result = PyDict_GetItemString(dict, "htmldocument");
-#if PY_MAJOR_VERSION >= 3
             const char* contents = PyUnicode_AsUTF8(result);
-#else
-            const char* contents = PyString_AsString(result);
-#endif
             res.append("HTTP/1.0 200 OK\n");
             res.append("Content-type: text/html\n");
             res.append(contents);
@@ -204,11 +200,7 @@ QByteArray PythonOnlineHelp::loadResource(const QString& filename) const
         if (result) {
             Py_DECREF(result);
             result = PyDict_GetItemString(dict, "page");
-#if PY_MAJOR_VERSION >= 3
             const char* page = PyUnicode_AsUTF8(result);
-#else
-            const char* page = PyString_AsString(result);
-#endif
             res.append("HTTP/1.0 200 OK\n");
             res.append("Content-type: text/html\n");
             res.append(page);

--- a/src/Gui/PythonConsole.cpp
+++ b/src/Gui/PythonConsole.cpp
@@ -171,17 +171,9 @@ void InteractiveInterpreter::setPrompt()
     Base::PyGILStateLocker lock;
     d->sysmodule = PyImport_ImportModule("sys");
     if (!PyObject_HasAttrString(d->sysmodule, "ps1"))
-#if PY_MAJOR_VERSION >= 3
         PyObject_SetAttrString(d->sysmodule, "ps1", PyUnicode_FromString(">>> "));
-#else
-        PyObject_SetAttrString(d->sysmodule, "ps1", PyString_FromString(">>> "));
-#endif
     if (!PyObject_HasAttrString(d->sysmodule, "ps2"))
-#if PY_MAJOR_VERSION >= 3
         PyObject_SetAttrString(d->sysmodule, "ps2", PyUnicode_FromString("... "));
-#else
-        PyObject_SetAttrString(d->sysmodule, "ps2", PyString_FromString("... "));
-#endif
 }
 
 /**
@@ -323,11 +315,7 @@ void InteractiveInterpreter::runCode(PyCodeObject* code) const
         throw Base::PyException();                 /* not incref'd */
 
     // It seems that the return value is always 'None' or Null
-#if PY_MAJOR_VERSION >= 3
     presult = PyEval_EvalCode((PyObject*)code, dict, dict); /* run compiled bytecode */
-#else
-    presult = PyEval_EvalCode(code, dict, dict); /* run compiled bytecode */
-#endif
     Py_XDECREF(code);                            /* decref the code object */
     if (!presult) {
         if (PyErr_ExceptionMatches(PyExc_SystemExit)) {
@@ -359,11 +347,7 @@ void InteractiveInterpreter::runCode(PyCodeObject* code) const
                     }
 
                     std::string err = str.str();
-#if PY_MAJOR_VERSION >= 3
                     errdata = PyUnicode_FromString(err.c_str());
-#else
-                    errdata = PyString_FromString(err.c_str());
-#endif
                 }
             }
             PyErr_Restore(errobj, errdata, errtraceback);
@@ -474,13 +458,8 @@ PythonConsole::PythonConsole(QWidget *parent)
     d->_stdin  = PySys_GetObject("stdin");
     PySys_SetObject("stdin", d->_stdinPy);
 
-#if PY_MAJOR_VERSION >= 3
     const char* version  = PyUnicode_AsUTF8(PySys_GetObject("version"));
     const char* platform = PyUnicode_AsUTF8(PySys_GetObject("platform"));
-#else
-    const char* version  = PyString_AsString(PySys_GetObject("version"));
-    const char* platform = PyString_AsString(PySys_GetObject("platform"));
-#endif
     d->info = QString::fromLatin1("Python %1 on %2\n"
     "Type 'help', 'copyright', 'credits' or 'license' for more information.")
     .arg(QString::fromLatin1(version), QString::fromLatin1(platform));
@@ -837,12 +816,11 @@ void PythonConsole::runSource(const QString& line)
         setFocus(); // if focus was lost
     }
     catch (const Base::SystemExitException&) {
-#if PY_MAJOR_VERSION >= 3
         // In Python the exception must be cleared because when the message box below appears
         // callable Python objects can be invoked and due to a failing assert the application
         // will be aborted.
         PyErr_Clear();
-#endif
+
         ParameterGrp::handle hPrefGrp = getWindowParameter();
         bool check = hPrefGrp->GetBool("CheckSystemExit",true);
         int ret = QMessageBox::Yes;

--- a/src/Gui/PythonConsolePy.cpp
+++ b/src/Gui/PythonConsolePy.cpp
@@ -80,15 +80,9 @@ Py::Object PythonStdout::write(const Py::Tuple& args)
     try {
         Py::Object output(args[0]);
         if (PyUnicode_Check(output.ptr())) {
-#if PY_MAJOR_VERSION >= 3
             PyObject* unicode = PyUnicode_AsEncodedString(output.ptr(), "utf-8", 0);
             if (unicode) {
                 const char* string = PyBytes_AsString(unicode);
-#else
-            PyObject* unicode = PyUnicode_AsEncodedObject(output.ptr(), "utf-8", "strict");
-            if (unicode) {
-                const char* string = PyString_AsString(unicode);
-#endif
                 int maxlen = qstrlen(string) > 10000 ? 10000 : -1;
                 pyConsole->insertPythonOutput(QString::fromUtf8(string, maxlen));
                 Py_DECREF(unicode);
@@ -163,15 +157,9 @@ Py::Object PythonStderr::write(const Py::Tuple& args)
     try {
         Py::Object output(args[0]);
         if (PyUnicode_Check(output.ptr())) {
-#if PY_MAJOR_VERSION >= 3
             PyObject* unicode = PyUnicode_AsEncodedString(output.ptr(), "utf-8", 0);
             if (unicode) {
                 const char* string = PyBytes_AsString(unicode);
-#else
-            PyObject* unicode = PyUnicode_AsEncodedObject(output.ptr(), "utf-8", "strict");
-            if (unicode) {
-                const char* string = PyString_AsString(unicode);
-#endif
                 int maxlen = qstrlen(string) > 10000 ? 10000 : -1;
                 pyConsole->insertPythonError(QString::fromUtf8(string, maxlen));
                 Py_DECREF(unicode);
@@ -245,15 +233,9 @@ Py::Object OutputStdout::write(const Py::Tuple& args)
     try {
         Py::Object output(args[0]);
         if (PyUnicode_Check(output.ptr())) {
-#if PY_MAJOR_VERSION >= 3
             PyObject* unicode = PyUnicode_AsEncodedString(output.ptr(), "utf-8", 0);
             if (unicode) {
                 const char* string = PyBytes_AsString(unicode);
-#else
-            PyObject* unicode = PyUnicode_AsEncodedObject(output.ptr(), "utf-8", "strict");
-            if (unicode) {
-                const char* string = PyString_AsString(unicode);
-#endif
                 Base::Console().Message("%s",string);
                 Py_DECREF(unicode);
             }
@@ -326,15 +308,9 @@ Py::Object OutputStderr::write(const Py::Tuple& args)
     try {
         Py::Object output(args[0]);
         if (PyUnicode_Check(output.ptr())) {
-#if PY_MAJOR_VERSION >= 3
             PyObject* unicode = PyUnicode_AsEncodedString(output.ptr(), "utf-8", 0);
             if (unicode) {
                 const char* string = PyBytes_AsString(unicode);
-#else
-            PyObject* unicode = PyUnicode_AsEncodedObject(output.ptr(), "utf-8", "strict");
-            if (unicode) {
-                const char* string = PyString_AsString(unicode);
-#endif
                 Base::Console().Error("%s",string);
                 Py_DECREF(unicode);
             }

--- a/src/Gui/PythonDebugger.cpp
+++ b/src/Gui/PythonDebugger.cpp
@@ -437,11 +437,7 @@ void PythonDebugger::runFile(const QString& fn)
         dict = PyModule_GetDict(module);
         dict = PyDict_Copy(dict);
         if (PyDict_GetItemString(dict, "__file__") == NULL) {
-#if PY_MAJOR_VERSION >= 3
             PyObject *f = PyUnicode_FromString((const char*)pxFileName);
-#else
-            PyObject *f = PyString_FromString((const char*)pxFileName);
-#endif
             if (f == NULL) {
                 fclose(fp);
                 return;
@@ -580,11 +576,7 @@ int PythonDebugger::tracer_callback(PyObject *obj, PyFrameObject *frame, int wha
 
     //no = frame->f_tstate->recursion_depth;
     //std::string funcname = PyString_AsString(frame->f_code->co_name);
-#if PY_MAJOR_VERSION >= 3
     QString file = QString::fromUtf8(PyUnicode_AsUTF8(frame->f_code->co_filename));
-#else
-    QString file = QString::fromUtf8(PyString_AsString(frame->f_code->co_filename));
-#endif
     switch (what) {
     case PyTrace_CALL:
         self->depth++;

--- a/src/Gui/Selection.cpp
+++ b/src/Gui/Selection.cpp
@@ -2067,11 +2067,7 @@ PyObject *SelectionSingleton::sCountObjectsOfType(PyObject * /*self*/, PyObject 
         return NULL;
 
     unsigned int count = Selection().countObjectsOfType(objecttype, document, resolve);
-#if PY_MAJOR_VERSION < 3
     return PyInt_FromLong(count);
-#else
-    return PyLong_FromLong(count);
-#endif
 }
 
 PyObject *SelectionSingleton::sGetSelection(PyObject * /*self*/, PyObject *args)
@@ -2340,15 +2336,9 @@ PyObject *SelectionSingleton::sSetVisible(PyObject * /*self*/, PyObject *args)
         if(visible == Py_None) {
             vis = -1;
         }
-#if PY_MAJOR_VERSION < 3
         else if(PyInt_Check(visible)) {
             vis = PyInt_AsLong(visible);
         }
-#else
-        else if(PyLong_Check(visible)) {
-            vis = PyLong_AsLong(visible);
-        }
-#endif
         else {
             vis = PyObject_IsTrue(visible)?1:0;
         }

--- a/src/Gui/Selection.cpp
+++ b/src/Gui/Selection.cpp
@@ -2067,7 +2067,7 @@ PyObject *SelectionSingleton::sCountObjectsOfType(PyObject * /*self*/, PyObject 
         return NULL;
 
     unsigned int count = Selection().countObjectsOfType(objecttype, document, resolve);
-    return PyInt_FromLong(count);
+    return PyLong_FromLong(count);
 }
 
 PyObject *SelectionSingleton::sGetSelection(PyObject * /*self*/, PyObject *args)
@@ -2336,8 +2336,8 @@ PyObject *SelectionSingleton::sSetVisible(PyObject * /*self*/, PyObject *args)
         if(visible == Py_None) {
             vis = -1;
         }
-        else if(PyInt_Check(visible)) {
-            vis = PyInt_AsLong(visible);
+        else if(PyLong_Check(visible)) {
+            vis = PyLong_AsLong(visible);
         }
         else {
             vis = PyObject_IsTrue(visible)?1:0;

--- a/src/Gui/WidgetFactory.cpp
+++ b/src/Gui/WidgetFactory.cpp
@@ -324,25 +324,14 @@ bool PythonWrapper::toCString(const Py::Object& pyobject, std::string& str)
 {
     if (PyUnicode_Check(pyobject.ptr())) {
         PyObject* unicode = PyUnicode_AsUTF8String(pyobject.ptr());
-#if PY_MAJOR_VERSION >= 3
         str = PyBytes_AsString(unicode);
-#else
-        str = PyString_AsString(unicode);
-#endif
         Py_DECREF(unicode);
         return true;
     }
-#if PY_MAJOR_VERSION >= 3
     else if (PyBytes_Check(pyobject.ptr())) {
         str = PyBytes_AsString(pyobject.ptr());
         return true;
     }
-#else
-    else if (PyString_Check(pyobject.ptr())) {
-        str = PyString_AsString(pyobject.ptr());
-        return true;
-    }
-#endif
 #if defined (HAVE_SHIBOKEN) && defined(HAVE_PYSIDE)
     if (Shiboken::String::check(pyobject.ptr())) {
         const char* s = Shiboken::String::toCString(pyobject.ptr());
@@ -1002,16 +991,7 @@ Py::Object UiLoaderPy::createWidget(const Py::Tuple& args)
     // 1st argument
     Py::String str(args[0]);
     std::string className;
-#if PY_MAJOR_VERSION >= 3
     className = str.as_std_string("utf-8");
-#else
-    if (str.isUnicode()) {
-        className = str.as_std_string("utf-8");
-    }
-    else {
-        className = (std::string)str;
-    }
-#endif
     // 2nd argument
     QWidget* parent = 0;
     if (wrap.loadCoreModule() && args.size() > 1) {
@@ -1024,16 +1004,7 @@ Py::Object UiLoaderPy::createWidget(const Py::Tuple& args)
     std::string objectName;
     if (args.size() > 2) {
         Py::String str(args[2]);
-#if PY_MAJOR_VERSION >= 3
         objectName = str.as_std_string("utf-8");
-#else
-        if (str.isUnicode()) {
-            objectName = str.as_std_string("utf-8");
-        }
-        else {
-            objectName = (std::string)str;
-        }
-#endif
     }
 
     QWidget* widget = loader.createWidget(QString::fromLatin1(className.c_str()), parent,
@@ -1484,24 +1455,9 @@ Py::Object PyResource::setValue(const Py::Tuple& args)
 
     QVariant v;
     if (PyUnicode_Check(psValue)) {
-#if PY_MAJOR_VERSION >= 3
         v = QString::fromUtf8(PyUnicode_AsUTF8(psValue));
-#else
-        PyObject* unicode = PyUnicode_AsUTF8String(psValue);
-        v = QString::fromUtf8(PyString_AsString(unicode));
-        Py_DECREF(unicode);
-    }
-    else if (PyString_Check(psValue)) {
-        v = QString::fromLatin1(PyString_AsString(psValue));
-#endif
 
     }
-#if PY_MAJOR_VERSION < 3
-    else if (PyInt_Check(psValue)) {
-        int val = PyInt_AsLong(psValue);
-        v = val;
-    }
-#endif
     else if (PyLong_Check(psValue)) {
         unsigned int val = PyLong_AsLong(psValue);
         v = val;
@@ -1514,17 +1470,9 @@ Py::Object PyResource::setValue(const Py::Tuple& args)
         int nSize = PyList_Size(psValue);
         for (int i=0; i<nSize;++i) {
             PyObject* item = PyList_GetItem(psValue, i);
-#if PY_MAJOR_VERSION >= 3
             if (!PyUnicode_Check(item))
-#else
-            if (!PyString_Check(item))
-#endif
                 continue;
-#if PY_MAJOR_VERSION >= 3
             const char* pItem = PyUnicode_AsUTF8(item);
-#else
-            char* pItem = PyString_AsString(item);
-#endif
             str.append(QString::fromUtf8(pItem));
         }
 

--- a/src/Main/FreeCADGuiPy.cpp
+++ b/src/Main/FreeCADGuiPy.cpp
@@ -377,7 +377,6 @@ PyMOD_INIT_FUNC(FreeCADGui)
         // is started in command mode
         if (Base::Type::fromName("Gui::BaseView").isBad())
             Gui::Application::initApplication();
-#if PY_MAJOR_VERSION >= 3
         static struct PyModuleDef FreeCADGuiModuleDef = {
             PyModuleDef_HEAD_INIT,
             "FreeCADGui", "FreeCAD GUI module\n", -1,
@@ -386,9 +385,6 @@ PyMOD_INIT_FUNC(FreeCADGui)
         };
         PyObject* module = PyModule_Create(&FreeCADGuiModuleDef);
         return module;
-#else
-        Py_InitModule3("FreeCADGui", FreeCADGui_methods, "FreeCAD GUI module\n");
-#endif
     }
     catch (const Base::Exception& e) {
         PyErr_Format(PyExc_ImportError, "%s\n", e.what());
@@ -396,8 +392,6 @@ PyMOD_INIT_FUNC(FreeCADGui)
     catch (...) {
         PyErr_SetString(PyExc_ImportError, "Unknown runtime error occurred");
     }
-#if PY_MAJOR_VERSION >= 3
     return 0;
-#endif
 }
 

--- a/src/Main/MainPy.cpp
+++ b/src/Main/MainPy.cpp
@@ -109,19 +109,11 @@ PyMOD_INIT_FUNC(FreeCAD)
     putenv("LC_ALL=C");
     // get whole path of the library
     Dl_info info;
-#if PY_MAJOR_VERSION >= 3
     int ret = dladdr((void*)PyInit_FreeCAD, &info);
-#else
-    int ret = dladdr((void*)initFreeCAD, &info);
-#endif
     if ((ret == 0) || (!info.dli_fname)) {
         free(argv);
         PyErr_SetString(PyExc_ImportError, "Cannot get path of the FreeCAD module!");
-#if PY_MAJOR_VERSION >= 3
         return 0;
-#else
-        return;
-#endif
     }
 
     argv[0] = (char*)malloc(PATH_MAX);
@@ -145,31 +137,14 @@ PyMOD_INIT_FUNC(FreeCAD)
         // backwards since the FreeCAD path was likely appended just before
         // we were imported.
         for (i = PyList_Size(pySysPath) - 1; i >= 0 ; --i) {
-#if PY_MAJOR_VERSION >= 3
             const char *basePath;
-#else
-            char *basePath;
-#endif
             PyObject *pyPath = PyList_GetItem(pySysPath, i);
             long sz = 0;
 
-#if PY_MAJOR_VERSION >= 3
             if ( PyUnicode_Check(pyPath) ) {
                 // Python 3 string
                 basePath = PyUnicode_AsUTF8AndSize(pyPath, &sz);
             }
-#else
-            if ( PyString_Check(pyPath) ) {
-                // Python 2 string type
-                PyString_AsStringAndSize(pyPath, &basePath, &sz);
-            }
-            else if ( PyUnicode_Check(pyPath) ) {
-                // Python 2 unicode type - explicitly use UTF-8 codec
-                PyObject *fromUnicode = PyUnicode_AsUTF8String(pyPath);
-                PyString_AsStringAndSize(fromUnicode, &basePath, &sz);
-                Py_XDECREF(fromUnicode);
-            }
-#endif // #if/else PY_MAJOR_VERSION >= 3
             else {
                 continue;
             }
@@ -201,11 +176,7 @@ PyMOD_INIT_FUNC(FreeCAD)
 
     if (buf == NULL) {
         PyErr_SetString(PyExc_ImportError, "Cannot get path of the FreeCAD module!");
-#if PY_MAJOR_VERSION >= 3
         return 0;
-#else
-        return;
-#endif
     }
 
     argv[0] = buf;
@@ -239,7 +210,6 @@ PyMOD_INIT_FUNC(FreeCAD)
     std::clog.rdbuf(&stdclog);
     std::cerr.rdbuf(&stdcerr);
 
-#if PY_MAJOR_VERSION >= 3
     //PyObject* module = _PyImport_FindBuiltin("FreeCAD");
     PyObject* modules = PyImport_GetModuleDict();
     PyObject* module = PyDict_GetItemString(modules, "FreeCAD");
@@ -247,6 +217,5 @@ PyMOD_INIT_FUNC(FreeCAD)
         PyErr_SetString(PyExc_ImportError, "Failed to load FreeCAD module!");
     }
     return module;
-#endif
 }
 


### PR DESCRIPTION
`ApplicationPy.cpp`, `CommandPyImp.cpp`, `OnlineDocumentation.cpp`, `PythonConsole.cpp`, `PythonConsolePy.cpp`, `PythonDebugger.cpp`