### PR TITLE
[Sketcher] Fix 'Reference' checkbox not working for radius/diameter

### DIFF
--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -4982,6 +4982,7 @@ void CmdSketcherConstrainRadius::activated(int iMsg)
     if (geoIdRadiusMap.empty() && externalGeoIdRadiusMap.empty()) {
         QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
             QObject::tr("Select one or more arcs or circles from the sketch."));
+        return;
     }
 
     if(poles && nonpoles) {
@@ -5040,28 +5041,20 @@ void CmdSketcherConstrainRadius::activated(int iMsg)
 
     if(!geoIdRadiusMap.empty())
     {
-        bool constrainEqual = false;
         if (geoIdRadiusMap.size() > 1 && constraintCreationMode==Driving) {
-            int ret = QMessageBox::question(Gui::getMainWindow(), QObject::tr("Constrain equal"),
-                QObject::tr("Do you want to share the same radius for all selected elements?"),
-                QMessageBox::Yes, QMessageBox::No, QMessageBox::Cancel);
-            // use an equality constraint
-            if (ret == QMessageBox::Yes) {
-                constrainEqual = true;
-            }
-            else if (ret == QMessageBox::Cancel) {
-                // do nothing
-                return;
-            }
-        }
 
-        if (constrainEqual) {
-            // Create the one radius constraint now
             int refGeoId = geoIdRadiusMap.front().first;
             double radius = geoIdRadiusMap.front().second;
 
             if(!commandopened)
                 openCommand(QT_TRANSLATE_NOOP("Command", "Add radius constraint"));
+            
+            // Add the equality constraints
+            for (std::vector< std::pair<int, double> >::iterator it = geoIdRadiusMap.begin()+1; it != geoIdRadiusMap.end(); ++it) {
+                Gui::cmdAppObjectArgs(selection[0].getObject(),
+                    "addConstraint(Sketcher.Constraint('Equal',%d,%d)) ",
+                    refGeoId,it->first);
+            }
 
             if(nonpoles)
                 Gui::cmdAppObjectArgs(selection[0].getObject(), "addConstraint(Sketcher.Constraint('Radius',%d,%f)) ",
@@ -5069,13 +5062,6 @@ void CmdSketcherConstrainRadius::activated(int iMsg)
             else
                 Gui::cmdAppObjectArgs(selection[0].getObject(), "addConstraint(Sketcher.Constraint('Weight',%d,%f)) ",
                     refGeoId,radius);
-
-            // Add the equality constraints
-            for (std::vector< std::pair<int, double> >::iterator it = geoIdRadiusMap.begin()+1; it != geoIdRadiusMap.end(); ++it) {
-                Gui::cmdAppObjectArgs(selection[0].getObject(),
-                    "addConstraint(Sketcher.Constraint('Equal',%d,%d)) ",
-                    refGeoId,it->first);
-            }
         }
         else {
             // Create the radius constraints now
@@ -5113,88 +5099,8 @@ void CmdSketcherConstrainRadius::activated(int iMsg)
             vp->draw(false,false); // Redraw
         }
 
-        ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher");
-        bool show = hGrp->GetBool("ShowDialogOnDistanceConstraint", true);
-        // Ask for the value of the radius immediately
-        if (show && constraintCreationMode==Driving) {
-            QDialog dlg(Gui::getMainWindow());
-            Ui::InsertDatum ui_Datum;
-            ui_Datum.setupUi(&dlg);
-            Base::Quantity init_val;
-            init_val.setValue(geoIdRadiusMap.front().second);
-
-            if(poles) {
-                dlg.setWindowTitle(EditDatumDialog::tr("Change weight"));
-                ui_Datum.label->setText(EditDatumDialog::tr("Weight:"));
-
-            }
-            else{
-                dlg.setWindowTitle(EditDatumDialog::tr("Change radius"));
-                ui_Datum.label->setText(EditDatumDialog::tr("Radius:"));
-                init_val.setUnit(Base::Unit::Length);
-            }
-
-            ui_Datum.labelEdit->setValue(init_val);
-            ui_Datum.labelEdit->selectNumber();
-            if (constrainEqual || geoIdRadiusMap.size() == 1)
-                ui_Datum.labelEdit->bind(Obj->Constraints.createPath(indexConstr));
-            else
-                ui_Datum.name->setDisabled(true);
-
-            if (dlg.exec() == QDialog::Accepted) {
-                Base::Quantity newQuant = ui_Datum.labelEdit->value();
-                double newRadius = newQuant.getValue();
-
-                try {
-                    if (constrainEqual || geoIdRadiusMap.size() == 1) {
-                        Gui::cmdAppObjectArgs(Obj, "setDatum(%i,App.Units.Quantity('%f %s'))",
-                                    indexConstr, newRadius, (const char*)newQuant.getUnit().getString().toUtf8());
-
-                        QString constraintName = ui_Datum.name->text().trimmed();
-                        if (Base::Tools::toStdString(constraintName) != Obj->Constraints[indexConstr]->Name) {
-                            std::string escapedstr = Base::Tools::escapedUnicodeFromUtf8(constraintName.toUtf8().constData());
-                            Gui::cmdAppObjectArgs(Obj, "renameConstraint(%d, u'%s')",
-                                                    indexConstr, escapedstr.c_str());
-                        }
-                    }
-                    else {
-                        for (std::size_t i=0; i<geoIdRadiusMap.size();i++) {
-                            Gui::cmdAppObjectArgs(Obj, "setDatum(%i,App.Units.Quantity('%f %s'))",
-                                        indexConstr+i, newRadius, (const char*)newQuant.getUnit().getString().toUtf8());
-                        }
-                    }
-
-                    commitCommand();
-
-                    if (Obj->noRecomputes && Obj->ExpressionEngine.depsAreTouched()) {
-                        Obj->ExpressionEngine.execute();
-                        Obj->solve();
-                    }
-
-                    tryAutoRecompute(Obj);
-
-                    commitNeeded=false;
-                    updateNeeded=false;
-                }
-                catch (const Base::Exception& e) {
-                    QMessageBox::critical(qApp->activeWindow(), QObject::tr("Dimensional constraint"), QString::fromUtf8(e.what()));
-                    abortCommand();
-
-                    tryAutoRecomputeIfNotSolve(Obj); // we have to update the solver after this aborted addition.
-                }
-            }
-            else {
-                // command canceled
-                abortCommand();
-
-                updateNeeded=true;
-            }
-        }
-        else {
-            // now dialog was shown so commit the command
-            commitCommand();
-            commitNeeded=false;
-        }
+        finishDistanceConstraint(this, Obj, constraintCreationMode==Driving);
+        
         //updateActive();
         getSelection().clearSelection();
     }
@@ -5251,7 +5157,6 @@ void CmdSketcherConstrainRadius::applyConstraint(std::vector<SelIdPair> &selSeq,
 
         const std::vector<Sketcher::Constraint *> &ConStr = Obj->Constraints.getValues();
 
-        int indexConstr = ConStr.size() - 1;
         bool fixed = isPointOrSegmentFixed(Obj,GeoId);
         if(fixed || constraintCreationMode==Reference) {
             Gui::cmdAppObjectArgs(Obj, "setDriving(%i,%s)",
@@ -5272,78 +5177,9 @@ void CmdSketcherConstrainRadius::applyConstraint(std::vector<SelIdPair> &selSeq,
             vp->draw(); // Redraw
         }
 
-        ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher");
-        bool show = hGrp->GetBool("ShowDialogOnDistanceConstraint", true);
-        // Ask for the value of the radius immediately
-        if (show && constraintCreationMode==Driving && !fixed) {
-            QDialog dlg(Gui::getMainWindow());
-            Ui::InsertDatum ui_Datum;
-            ui_Datum.setupUi(&dlg);
-            Base::Quantity init_val;
-
-            if(ispole) {
-                dlg.setWindowTitle(EditDatumDialog::tr("Change weight"));
-                ui_Datum.label->setText(EditDatumDialog::tr("Weight:"));
-
-            }
-            else{
-                dlg.setWindowTitle(EditDatumDialog::tr("Change radius"));
-                ui_Datum.label->setText(EditDatumDialog::tr("Radius:"));
-                init_val.setUnit(Base::Unit::Length);
-            }
-
-            init_val.setValue(radius);
-
-            ui_Datum.labelEdit->setValue(init_val);
-            ui_Datum.labelEdit->selectNumber();
-            ui_Datum.labelEdit->bind(Obj->Constraints.createPath(indexConstr));
-
-            if (dlg.exec() == QDialog::Accepted) {
-                Base::Quantity newQuant = ui_Datum.labelEdit->value();
-                double newRadius = newQuant.getValue();
-
-                try {
-                    Gui::cmdAppObjectArgs(Obj, "setDatum(%i,App.Units.Quantity('%f %s'))",
-                                indexConstr, newRadius, (const char*)newQuant.getUnit().getString().toUtf8());
-
-                    QString constraintName = ui_Datum.name->text().trimmed();
-                    if (Base::Tools::toStdString(constraintName) != Obj->Constraints[indexConstr]->Name) {
-                        std::string escapedstr = Base::Tools::escapedUnicodeFromUtf8(constraintName.toUtf8().constData());
-                        Gui::cmdAppObjectArgs(Obj, "renameConstraint(%d, u'%s')",
-                                              indexConstr, escapedstr.c_str());
-                    }
-
-                    commitCommand();
-
-                    if (Obj->noRecomputes && Obj->ExpressionEngine.depsAreTouched()) {
-                        Obj->ExpressionEngine.execute();
-                        Obj->solve();
-                    }
-
-                    tryAutoRecompute(Obj);
-
-                    commitNeeded=false;
-                    updateNeeded=false;
-                }
-                catch (const Base::Exception& e) {
-                    QMessageBox::critical(qApp->activeWindow(), QObject::tr("Dimensional constraint"), QString::fromUtf8(e.what()));
-                    abortCommand();
-
-                    tryAutoRecomputeIfNotSolve(Obj); // we have to update the solver after this aborted addition.
-                }
-            }
-            else {
-                // command canceled
-                abortCommand();
-
-                updateNeeded=true;
-            }
-        }
-        else {
-            // now dialog was shown so commit the command
-            commitCommand();
-            commitNeeded=false;
-        }
+        if(!fixed)
+            finishDistanceConstraint(this, Obj, constraintCreationMode==Driving);
+        
         //updateActive();
         getSelection().clearSelection();
 


### PR DESCRIPTION
As a consequence :
Remove message box when several arcs/circles are selected and enforce creation of equality constraints in this case
Former existing option of adding a dimensional constraint to each circle encouraged improper constraining

[Forum thread](https://forum.freecadweb.org/viewtopic.php?f=3&t=57584)
I made the minimal changes. I saw other things that may be discussed but will poll community and do another PR if needed.

- [X]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [X]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [X]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [X]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0` **=> Just checked Sketcher/PartDesign tests are OK**
- [X]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [X]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`