### PR TITLE
Arch: Parse window opening modes with more than one digit

### DIFF
--- a/src/Mod/Arch/ArchWindow.py
+++ b/src/Mod/Arch/ArchWindow.py
@@ -632,7 +632,10 @@ class _Window(ArchComponent.Component):
                 elif "Edge" in s:
                     hinge = int(s[4:])-1
                 elif "Mode" in s:
-                    omode = int(s[-1])
+                    omode = int(s[4:])
+                    if omode >= len(WindowOpeningModes):
+                        # Ignore modes not listed in WindowOpeningModes
+                        omode = None
             if wires:
                 max_length = 0
                 for w in wires:
@@ -1510,7 +1513,11 @@ class _ArchWindowTaskPanel:
                                 elif "Edge" in l:
                                     self.field6.setText(l)
                                 elif "Mode" in l:
-                                    self.field7.setCurrentIndex(int(l[-1]))
+                                    if int(l[4:]) < len(WindowOpeningModes):
+                                        self.field7.setCurrentIndex(int(l[4:]))
+                                    else:
+                                        # Ignore modes not listed in WindowOpeningModes
+                                        self.field7.setCurrentIndex(0)
                             if wires:
                                 f.setText(",".join(wires))
 


### PR DESCRIPTION
Signed-off-by: Łukasz Stelmach <stlman@poczta.fm>

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [ ]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0` (**tested on an installed FreeCAD**)
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
