### PR TITLE
AddonManager cannot download anything if working dir is on ecryptfs (aka ubuntu's encrypted home)

### DIFF
--- a/src/Mod/AddonManager/addonmanager_workers.py
+++ b/src/Mod/AddonManager/addonmanager_workers.py
@@ -600,8 +600,8 @@ class ShowWorker(QtCore.QThread):
                 name = path.split("/")[-1]
                 if name and path.startswith("http"):
                     storename = os.path.join(store, name)
-                    if len(storename) >= fscharlimit:
-                        remainChars = (fscharlimit - 1) - (len(store) + len(wbName) + 1)
+                    if len(storename) >= 260:
+                        remainChars = 259 - (len(store) + len(wbName) + 1)
                         storename = os.path.join(store, wbName+name[-remainChars:])
                     if not os.path.exists(storename):
                         try:

--- a/src/Mod/AddonManager/addonmanager_workers.py
+++ b/src/Mod/AddonManager/addonmanager_workers.py
@@ -600,8 +600,8 @@ class ShowWorker(QtCore.QThread):
                 name = path.split("/")[-1]
                 if name and path.startswith("http"):
                     storename = os.path.join(store, name)
-                    if len(storename) >= 260:
-                        remainChars = 259 - (len(store) + len(wbName) + 1)
+                    if len(storename) >= fscharlimit:
+                        remainChars = (fscharlimit - 1) - (len(store) + len(wbName) + 1)
                         storename = os.path.join(store, wbName+name[-remainChars:])
                     if not os.path.exists(storename):
                         try:
@@ -611,13 +611,17 @@ class ShowWorker(QtCore.QThread):
                         except Exception:
                             print("AddonManager: Debug: Error retrieving image from", path)
                         else:
-                            f = open(storename, "wb")
-                            f.write(imagedata)
-                            f.close()
-
-                            # resize the image to 300x300px if needed
-                            img = QtGui.QImage(storename)
-                            if (img.width() > 300) or (img.height() > 300):
+			    try:
+                        	f = open(storename, "wb")
+			    except OSError:
+				# ecryptfs (and probably not only ecryptfs) has lower length limit for path
+				storename = storename[-140:]
+				f = open(storename, "wb")
+                    	    f.write(imagedata)
+                	    f.close()
+                    	    # resize the image to 300x300px if needed
+                    	    img = QtGui.QImage(storename)
+                    	    if (img.width() > 300) or (img.height() > 300):
                                 pix = QtGui.QPixmap()
                                 pix = pix.fromImage(img.scaled(300, 300,
                                                                QtCore.Qt.KeepAspectRatio,

--- a/src/Mod/AddonManager/addonmanager_workers.py
+++ b/src/Mod/AddonManager/addonmanager_workers.py
@@ -611,17 +611,17 @@ class ShowWorker(QtCore.QThread):
                         except Exception:
                             print("AddonManager: Debug: Error retrieving image from", path)
                         else:
-			    try:
-                        	f = open(storename, "wb")
-			    except OSError:
-				# ecryptfs (and probably not only ecryptfs) has lower length limit for path
-				storename = storename[-140:]
-				f = open(storename, "wb")
-                    	    f.write(imagedata)
-                	    f.close()
-                    	    # resize the image to 300x300px if needed
-                    	    img = QtGui.QImage(storename)
-                    	    if (img.width() > 300) or (img.height() > 300):
+                            try:
+                                f = open(storename, "wb")
+                            except OSError:
+                                # ecryptfs (and probably not only ecryptfs) has lower length limit for path
+                                storename = storename[-140:]
+                                f = open(storename, "wb")
+                            f.write(imagedata)
+                            f.close()
+                            # resize the image to 300x300px if needed
+                            img = QtGui.QImage(storename)
+                            if (img.width() > 300) or (img.height() > 300):
                                 pix = QtGui.QPixmap()
                                 pix = pix.fromImage(img.scaled(300, 300,
                                                                QtCore.Qt.KeepAspectRatio,


### PR DESCRIPTION
This pull request fixes AddonManager to work with encrypted Ubuntu home dir with ecryptfs. Ecryptfs has internal limitation of path lenght to 140 characters only, but AddonManager respects only 260 chars limitation of normal filesystems.
