### PR TITLE
[FEM] speedup large multi-material simulations with CalculiX

### DIFF
--- a/src/Mod/Fem/App/CMakeLists.txt
+++ b/src/Mod/Fem/App/CMakeLists.txt
@@ -198,6 +198,11 @@ endif(FREECAD_USE_PCH)
 add_library(Fem SHARED ${Fem_SRCS})
 target_link_libraries(Fem ${Fem_LIBS} ${VTK_LIBRARIES})
 
+find_package(OpenMP)
+if(OpenMP_CXX_FOUND)
+	target_link_libraries(Fem OpenMP::OpenMP_CXX)
+endif()
+
 # external SMESH doesn't support C++17 yet
 if(FREECAD_USE_EXTERNAL_SMESH)
     set_target_properties(Fem PROPERTIES CXX_STANDARD_REQUIRED ON)

--- a/src/Mod/Fem/App/FemMesh.cpp
+++ b/src/Mod/Fem/App/FemMesh.cpp
@@ -872,9 +872,16 @@ std::set<int> FemMesh::getNodesBySolid(const TopoDS_Solid &solid) const
     // get the current transform of the FemMesh
     const Base::Matrix4D Mtrx(getTransform());
 
+    std::vector<const SMDS_MeshNode*> nodes;
     SMDS_NodeIteratorPtr aNodeIter = myMesh->GetMeshDS()->nodesIterator();
     while (aNodeIter->more()) {
         const SMDS_MeshNode* aNode = aNodeIter->next();
+        nodes.push_back(aNode);
+    }
+
+#pragma omp parallel for schedule(dynamic)
+    for (size_t i = 0; i < nodes.size(); ++i) {
+        const SMDS_MeshNode* aNode = nodes[i];
         Base::Vector3d vec(aNode->X(),aNode->Y(),aNode->Z());
         // Apply the matrix to hold the BoundBox in absolute space.
         vec = Mtrx * vec;
@@ -890,7 +897,10 @@ std::set<int> FemMesh::getNodesBySolid(const TopoDS_Solid &solid) const
                 continue;
 
             if (measure.Value() < limit)
+#pragma omp critical
+            {
                 result.insert(aNode->GetID());
+            }
         }
     }
     return result;
@@ -909,9 +919,16 @@ std::set<int> FemMesh::getNodesByFace(const TopoDS_Face &face) const
     // get the current transform of the FemMesh
     const Base::Matrix4D Mtrx(getTransform());
 
+    std::vector<const SMDS_MeshNode*> nodes;
     SMDS_NodeIteratorPtr aNodeIter = myMesh->GetMeshDS()->nodesIterator();
     while (aNodeIter->more()) {
         const SMDS_MeshNode* aNode = aNodeIter->next();
+        nodes.push_back(aNode);
+    }
+
+#pragma omp parallel for schedule(dynamic)
+    for (size_t i = 0; i < nodes.size(); ++i) {
+        const SMDS_MeshNode* aNode = nodes[i];
         Base::Vector3d vec(aNode->X(),aNode->Y(),aNode->Z());
         // Apply the matrix to hold the BoundBox in absolute space.
         vec = Mtrx * vec;
@@ -927,7 +944,10 @@ std::set<int> FemMesh::getNodesByFace(const TopoDS_Face &face) const
                 continue;
 
             if (measure.Value() < limit)
+#pragma omp critical
+            {
                 result.insert(aNode->GetID());
+            }
         }
     }
 


### PR DESCRIPTION
This pull request fixes some of the biggest pain points I experienced when simulating a bigger multi-material case with CalculiX.

In fact without these patches, I had some tasks in FreeCAD take much more time than the actual solving process in CalculiX, and even after the patches there is still room for improvement.

The pullrequest consists of two commits so far:
- Using numpy to speed up `get_femelement_sets`
- Using OpenMP to parallelize the costly operation of finding nodes in solids or on faces.

TODO: For some reason the tests fail with more than one thread. I.e. `OMP_NUM_THREADS=1 ./bin/FreeCAD --run-test 0` runs flawlessly, whereas `./bin/FreeCAD --run-test 0` fails in the following tests:
```
======================================================================
FAIL: test_thermomech_spine (femtest.app.test_ccxtools.TestCcxTools)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/Philipp/src/FreeCAD/build/Mod/Fem/femtest/app/test_ccxtools.py", line 178, in test_thermomech_spine
    fea = self.input_file_writing_test(
  File "/home/Philipp/src/FreeCAD/build/Mod/Fem/femtest/app/test_ccxtools.py", line 242, in input_file_writing_test
    self.assertFalse(
AssertionError: 'Comparing /home/Philipp/src/FreeCAD/build/Mod/Fem/femtest/data/calculix/thermomech_spine.inp to /tmp/FEM_unittests/ccxtools_thermomech_spine_41c53b3f3c1e/Mesh.inp failed!\n--- \n+++ \n@@ -174 +173,0 @@\n-7,F3,255.3722,0.005678\n@@ -176 +174,0 @@\n-12,F2,255.3722,0.005678\n@@ -180 +177,0 @@\n-4,F4,255.3722,0.005678\n' is not false : ccxtools write_inp_file test failed.
Comparing /home/Philipp/src/FreeCAD/build/Mod/Fem/femtest/data/calculix/thermomech_spine.inp to /tmp/FEM_unittests/ccxtools_thermomech_spine_41c53b3f3c1e/Mesh.inp failed!
--- 
+++ 
@@ -174 +173,0 @@
-7,F3,255.3722,0.005678
@@ -176 +174,0 @@
-12,F2,255.3722,0.005678
@@ -180 +177,0 @@
-4,F4,255.3722,0.005678


======================================================================
FAIL: test_ccxcantilever_nodeload (femtest.app.test_solver_calculix.TestSolverCalculix)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/Philipp/src/FreeCAD/build/Mod/Fem/femtest/app/test_solver_calculix.py", line 120, in test_ccxcantilever_nodeload
    self.input_file_writing_test(get_namefromdef("test_"))
  File "/home/Philipp/src/FreeCAD/build/Mod/Fem/femtest/app/test_solver_calculix.py", line 282, in input_file_writing_test
    self.assertFalse(
AssertionError: 'Comparing /home/Philipp/src/FreeCAD/build/Mod/Fem/femtest/data/calculix/ccxcantilever_nodeload.inp to /tmp/FEM_unittests/solver_calculix_ccxcantilever_nodeload_48cd79bdea8c/Mesh.inp failed!\n--- \n+++ \n@@ -340,0 +341 @@\n+75,\n' is not false : CalculiX write_inp_file for ccxcantilever_nodeload test failed.
Comparing /home/Philipp/src/FreeCAD/build/Mod/Fem/femtest/data/calculix/ccxcantilever_nodeload.inp to /tmp/FEM_unittests/solver_calculix_ccxcantilever_nodeload_48cd79bdea8c/Mesh.inp failed!
--- 
+++ 
@@ -340,0 +341 @@
+75,


======================================================================
FAIL: test_ccxcantilever_prescribeddisplacement (femtest.app.test_solver_calculix.TestSolverCalculix)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/Philipp/src/FreeCAD/build/Mod/Fem/femtest/app/test_solver_calculix.py", line 128, in test_ccxcantilever_prescribeddisplacement
    self.input_file_writing_test(get_namefromdef("test_"))
  File "/home/Philipp/src/FreeCAD/build/Mod/Fem/femtest/app/test_solver_calculix.py", line 282, in input_file_writing_test
    self.assertFalse(
AssertionError: 'Comparing /home/Philipp/src/FreeCAD/build/Mod/Fem/femtest/data/calculix/ccxcantilever_prescribeddisplacement.inp to /tmp/FEM_unittests/solver_calculix_ccxcantilever_prescribeddisplacement_f74ead23a5f0/Mesh.inp failed!\n--- \n+++ \n@@ -357,0 +358 @@\n+48,\n' is not false : CalculiX write_inp_file for ccxcantilever_prescribeddisplacement test failed.
Comparing /home/Philipp/src/FreeCAD/build/Mod/Fem/femtest/data/calculix/ccxcantilever_prescribeddisplacement.inp to /tmp/FEM_unittests/solver_calculix_ccxcantilever_prescribeddisplacement_f74ead23a5f0/Mesh.inp failed!
--- 
+++ 
@@ -357,0 +358 @@
+48,


======================================================================
FAIL: test_constraint_contact_shell_shell (femtest.app.test_solver_calculix.TestSolverCalculix)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/Philipp/src/FreeCAD/build/Mod/Fem/femtest/app/test_solver_calculix.py", line 136, in test_constraint_contact_shell_shell
    self.input_file_writing_test(get_namefromdef("test_"))
  File "/home/Philipp/src/FreeCAD/build/Mod/Fem/femtest/app/test_solver_calculix.py", line 282, in input_file_writing_test
    self.assertFalse(
AssertionError: 'Comparing /home/Philipp/src/FreeCAD/build/Mod/Fem/femtest/data/calculix/constraint_contact_shell_shell.inp to /tmp/FEM_unittests/solver_calculix_constraint_contact_shell_shell_3c6f08c56ed0/Mesh.inp failed!\n--- \n+++ \n@@ -23171,2 +23170,0 @@\n-424,S2\n-425,S2\n@@ -23198 +23195,0 @@\n-451,S2\n@@ -23209 +23205,0 @@\n-462,S2\n@@ -23575 +23570,0 @@\n-828,S2\n@@ -23579 +23573,0 @@\n-832,S2\n@@ -23694 +23687,0 @@\n-947,S2\n@@ -23772,2 +23764,0 @@\n-1025,S2\n-1026,S2\n@@ -24221 +24211,0 @@\n-1474,S2\n@@ -24505 +24494,0 @@\n-1758,S2\n@@ -24517 +24505,0 @@\n-1770,S2\n@@ -24521 +24508,0 @@\n-1774,S2\n@@ -24620 +24606,0 @@\n-1873,S2\n@@ -24670 +24655,0 @@\n-1923,S2\n@@ -24672 +24656,0 @@\n-1925,S2\n@@ -24692 +24675,0 @@\n-1945,S2\n@@ -24770 +24752,0 @@\n-2023,S2\n@@ -24832 +24813,0 @@\n-2085,S2\n@@ -24834 +24814,0 @@\n-2087,S2\n@@ -25175,2 +25154,0 @@\n-2428,S2\n-2429,S2\n@@ -25191 +25168,0 @@\n-2444,S2\n@@ -25219 +25195,0 @@\n-2472,S2\n@@ -25254 +25229,0 @@\n-2507,S2\n@@ -25340 +25314,0 @@\n-2593,S2\n@@ -25769 +25742,0 @@\n-3022,S2\n@@ -25876 +25848,0 @@\n-3129,S2\n@@ -26344 +26315,0 @@\n-3597,S2\n@@ -26408 +26378,0 @@\n-3661,S2\n@@ -26425 +26394,0 @@\n-3678,S2\n@@ -26616 +26584,0 @@\n-3869,S2\n@@ -26640 +26607,0 @@\n-3893,S2\n@@ -26753 +26719,0 @@\n-4006,S2\n@@ -26769 +26734,0 @@\n-4022,S2\n@@ -26889 +26853,0 @@\n-4142,S2\n@@ -27081 +27044,0 @@\n-4334,S2\n@@ -27145 +27107,0 @@\n-4398,S2\n@@ -27168 +27129,0 @@\n-4421,S2\n@@ -27203 +27163,0 @@\n-4456,S2\n@@ -27340 +27299,0 @@\n-4593,S2\n@@ -27499 +27457,0 @@\n-4752,S2\n@@ -27731 +27688,0 @@\n-4984,S2\n@@ -28609 +28565,0 @@\n-5862,S2\n@@ -28641 +28596,0 @@\n-5894,S2\n@@ -28646 +28600,0 @@\n-5899,S2\n@@ -28654 +28607,0 @@\n-5907,S2\n@@ -28688 +28640,0 @@\n-5941,S2\n@@ -28714 +28665,0 @@\n-5967,S2\n@@ -28737 +28687,0 @@\n-5990,S2\n@@ -28760 +28709,0 @@\n-6013,S2\n@@ -28769 +28717,0 @@\n-6022,S2\n@@ -28849 +28796,0 @@\n-6102,S2\n@@ -28994 +28940,0 @@\n-6247,S2\n@@ -29079 +29024,0 @@\n-6332,S2\n@@ -29186 +29130,0 @@\n-6439,S2\n@@ -29320 +29263,0 @@\n-6573,S2\n@@ -29323 +29265,0 @@\n-6576,S2\n@@ -29328 +29269,0 @@\n-6581,S2\n@@ -29382 +29322,0 @@\n-6635,S2\n@@ -29420 +29359,0 @@\n-6673,S2\n@@ -29457,2 +29395,0 @@\n-6710,S2\n-6711,S2\n@@ -29927 +29863,0 @@\n-7180,S2\n@@ -29949,2 +29884,0 @@\n-7202,S2\n-7203,S2\n@@ -29958 +29891,0 @@\n-7211,S2\n@@ -29961,2 +29893,0 @@\n-7214,S2\n-7215,S2\n@@ -30368 +30298,0 @@\n-7621,S2\n@@ -30590 +30519,0 @@\n-7842,S2\n@@ -30683 +30611,0 @@\n-7935,S2\n@@ -30697,2 +30624,0 @@\n-7949,S2\n-7950,S2\n@@ -30861 +30786,0 @@\n-8113,S2\n@@ -30992 +30916,0 @@\n-8244,S2\n@@ -31049 +30972,0 @@\n-8301,S2\n@@ -31282 +31204,0 @@\n-8534,S2\n@@ -31931,2 +31852,0 @@\n-9183,S2\n-9184,S2\n@@ -32313 +32232,0 @@\n-9565,S2\n@@ -32374 +32292,0 @@\n-9626,S2\n@@ -32377 +32294,0 @@\n-9629,S2\n@@ -32520 +32436,0 @@\n-9772,S2\n@@ -32526 +32441,0 @@\n-9778,S2\n@@ -33533 +33447,0 @@\n-10785,S2\n@@ -33839 +33752,0 @@\n-11091,S2\n@@ -33842 +33754,0 @@\n-11094,S2\n@@ -34276,2 +34187,0 @@\n-11528,S2\n-11529,S2\n@@ -34393 +34302,0 @@\n-11645,S2\n@@ -34520 +34428,0 @@\n-11772,S2\n@@ -34529,2 +34436,0 @@\n-11781,S2\n-11782,S2\n@@ -34809 +34714,0 @@\n-12061,S2\n@@ -34811,2 +34715,0 @@\n-12063,S2\n-12064,S2\n@@ -34924 +34826,0 @@\n-12176,S2\n@@ -34966 +34867,0 @@\n-12218,S2\n@@ -35301 +35201,0 @@\n-12553,S2\n@@ -35415 +35314,0 @@\n-12667,S2\n@@ -35481 +35379,0 @@\n-12733,S2\n@@ -35976 +35873,0 @@\n-13228,S2\n@@ -35985 +35881,0 @@\n-13237,S2\n@@ -36321 +36216,0 @@\n-13573,S2\n@@ -36494 +36388,0 @@\n-13746,S2\n@@ -36691 +36584,0 @@\n-13943,S2\n@@ -36842 +36734,0 @@\n-14094,S2\n@@ -36904 +36795,0 @@\n-14156,S2\n' is not false : CalculiX ...

======================================================================
FAIL: test_constraint_sectionprint (femtest.app.test_solver_calculix.TestSolverCalculix)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/Philipp/src/FreeCAD/build/Mod/Fem/femtest/app/test_solver_calculix.py", line 155, in test_constraint_sectionprint
    self.input_file_writing_test(get_namefromdef("test_"))
  File "/home/Philipp/src/FreeCAD/build/Mod/Fem/femtest/app/test_solver_calculix.py", line 282, in input_file_writing_test
    self.assertFalse(
AssertionError: 'Comparing /home/Philipp/src/FreeCAD/build/Mod/Fem/femtest/data/calculix/constraint_sectionprint.inp to /tmp/FEM_unittests/solver_calculix_constraint_sectionprint_925379558c5f/Mesh.inp failed!\n--- \n+++ \n@@ -3363 +3362,0 @@\n-811,S4\n@@ -3367 +3365,0 @@\n-938,S1\n@@ -3370 +3367,0 @@\n-952,S4\n@@ -3380,2 +3376,0 @@\n-1763,S1\n-1781,S1\n@@ -3384 +3378,0 @@\n-1795,S1\n' is not false : CalculiX write_inp_file for constraint_sectionprint test failed.
Comparing /home/Philipp/src/FreeCAD/build/Mod/Fem/femtest/data/calculix/constraint_sectionprint.inp to /tmp/FEM_unittests/solver_calculix_constraint_sectionprint_925379558c5f/Mesh.inp failed!
--- 
+++ 
@@ -3363 +3362,0 @@
-811,S4
@@ -3367 +3365,0 @@
-938,S1
@@ -3370 +3367,0 @@
-952,S4
@@ -3380,2 +3376,0 @@
-1763,S1
-1781,S1
@@ -3384 +3378,0 @@
-1795,S1


======================================================================
FAIL: test_constraint_tie (femtest.app.test_solver_calculix.TestSolverCalculix)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/Philipp/src/FreeCAD/build/Mod/Fem/femtest/app/test_solver_calculix.py", line 171, in test_constraint_tie
    self.input_file_writing_test(get_namefromdef("test_"))
  File "/home/Philipp/src/FreeCAD/build/Mod/Fem/femtest/app/test_solver_calculix.py", line 282, in input_file_writing_test
    self.assertFalse(
AssertionError: 'Comparing /home/Philipp/src/FreeCAD/build/Mod/Fem/femtest/data/calculix/constraint_tie.inp to /tmp/FEM_unittests/solver_calculix_constraint_tie_1bc538195a19/Mesh.inp failed!\n--- \n+++ \n@@ -18558 +18557,0 @@\n-6221,S1\n@@ -18561 +18559,0 @@\n-6364,S1\n@@ -18563 +18560,0 @@\n-7403,S1\n@@ -18574,2 +18570,0 @@\n-4687,S4\n-5445,S3\n@@ -18579 +18573,0 @@\n-6278,S4\n' is not false : CalculiX write_inp_file for constraint_tie test failed.
Comparing /home/Philipp/src/FreeCAD/build/Mod/Fem/femtest/data/calculix/constraint_tie.inp to /tmp/FEM_unittests/solver_calculix_constraint_tie_1bc538195a19/Mesh.inp failed!
--- 
+++ 
@@ -18558 +18557,0 @@
-6221,S1
@@ -18561 +18559,0 @@
-6364,S1
@@ -18563 +18560,0 @@
-7403,S1
@@ -18574,2 +18570,0 @@
-4687,S4
-5445,S3
@@ -18579 +18573,0 @@
-6278,S4


======================================================================
FAIL: test_material_multiple_bendingbeam_fiveboxes (femtest.app.test_solver_calculix.TestSolverCalculix)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/Philipp/src/FreeCAD/build/Mod/Fem/femtest/app/test_solver_calculix.py", line 179, in test_material_multiple_bendingbeam_fiveboxes
    self.input_file_writing_test(get_namefromdef("test_"))
  File "/home/Philipp/src/FreeCAD/build/Mod/Fem/femtest/app/test_solver_calculix.py", line 282, in input_file_writing_test
    self.assertFalse(
AssertionError: 'Comparing /home/Philipp/src/FreeCAD/build/Mod/Fem/femtest/data/calculix/material_multiple_bendingbeam_fiveboxes.inp to /tmp/FEM_unittests/solver_calculix_material_multiple_bendingbeam_fiveboxes_aaa9dfadb13d/Mesh.inp failed!\n--- \n+++ \n@@ -28293 +28292,0 @@\n-89,3,-0.0000000000000E+00\n@@ -28302,2 +28300,0 @@\n-98,3,-5.5694444444400E+00\n-99,3,-5.2616191597367E+00\n@@ -28397,2 +28394 @@\n-1309,3,-1.1138888889082E+01\n-1310,3,-1.1441784274639E+01\n+1309,3,-5.5694444446420E+00\n@@ -28415,3 +28411,2 @@\n-1327,3,-1.0523238319473E+01\n-1328,3,-1.1133958989936E+01\n-1329,3,-1.0326374040205E+01\n+1327,3,-5.2616191597367E+00\n+1329,3,-4.4540342100065E+00\n@@ -28883 +28877,0 @@\n-192,3,-0.0000000000000E+00\n@@ -28887,2 +28880,0 @@\n-196,3,-4.9560604147048E+00\n-197,3,-6.5089699073333E+00\n@@ -29004,2 +28996 @@\n-2536,3,-1.0158241489876E+01\n-2537,3,-8.9897553785120E+00\n+2536,3,-5.2021810751712E+00\n@@ -29009,3 +29000,2 @@\n-2541,3,-1.0542664871141E+01\n-2542,3,-1.1068816115445E+01\n-2543,3,-9.4092147654283E+00\n+2542,3,-4.5598462081112E+00\n+2543,3,-5.3755198016211E+00\n' is not false : CalculiX write_inp_file for material_multiple_bendingbeam_fiveboxes test failed.
Comparing /home/Philipp/src/FreeCAD/build/Mod/Fem/femtest/data/calculix/material_multiple_bendingbeam_fiveboxes.inp to /tmp/FEM_unittests/solver_calculix_material_multiple_bendingbeam_fiveboxes_aaa9dfadb13d/Mesh.inp failed!
--- 
+++ 
@@ -28293 +28292,0 @@
-89,3,-0.0000000000000E+00
@@ -28302,2 +28300,0 @@
-98,3,-5.5694444444400E+00
-99,3,-5.2616191597367E+00
@@ -28397,2 +28394 @@
-1309,3,-1.1138888889082E+01
-1310,3,-1.1441784274639E+01
+1309,3,-5.5694444446420E+00
@@ -28415,3 +28411,2 @@
-1327,3,-1.0523238319473E+01
-1328,3,-1.1133958989936E+01
-1329,3,-1.0326374040205E+01
+1327,3,-5.2616191597367E+00
+1329,3,-4.4540342100065E+00
@@ -28883 +28877,0 @@
-192,3,-0.0000000000000E+00
@@ -28887,2 +28880,0 @@
-196,3,-4.9560604147048E+00
-197,3,-6.5089699073333E+00
@@ -29004,2 +28996 @@
-2536,3,-1.0158241489876E+01
-2537,3,-8.9897553785120E+00
+2536,3,-5.2021810751712E+00
@@ -29009,3 +29000,2 @@
-2541,3,-1.0542664871141E+01
-2542,3,-1.1068816115445E+01
-2543,3,-9.4092147654283E+00
+2542,3,-4.5598462081112E+00
+2543,3,-5.3755198016211E+00


======================================================================
FAIL: test_thermomech_spine (femtest.app.test_solver_calculix.TestSolverCalculix)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/Philipp/src/FreeCAD/build/Mod/Fem/femtest/app/test_solver_calculix.py", line 243, in test_thermomech_spine
    self.input_file_writing_test(get_namefromdef("test_"))
  File "/home/Philipp/src/FreeCAD/build/Mod/Fem/femtest/app/test_solver_calculix.py", line 282, in input_file_writing_test
    self.assertFalse(
AssertionError: 'Comparing /home/Philipp/src/FreeCAD/build/Mod/Fem/femtest/data/calculix/thermomech_spine.inp to /tmp/FEM_unittests/solver_calculix_thermomech_spine_3fd1779a046c/Mesh.inp failed!\n--- \n+++ \n@@ -178,4 +177,0 @@\n-1,F2,255.3722,0.005678\n-2,F4,255.3722,0.005678\n-4,F4,255.3722,0.005678\n-9,F4,255.3722,0.005678\n' is not false : CalculiX write_inp_file for thermomech_spine test failed.
Comparing /home/Philipp/src/FreeCAD/build/Mod/Fem/femtest/data/calculix/thermomech_spine.inp to /tmp/FEM_unittests/solver_calculix_thermomech_spine_3fd1779a046c/Mesh.inp failed!
--- 
+++ 
@@ -178,4 +177,0 @@
-1,F2,255.3722,0.005678
-2,F4,255.3722,0.005678
-4,F4,255.3722,0.005678
-9,F4,255.3722,0.005678


======================================================================
FAIL: test_ccxcantilever_faceload (femtest.app.test_solver_z88.TestSolverZ88)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/Philipp/src/FreeCAD/build/Mod/Fem/femtest/app/test_solver_z88.py", line 84, in test_ccxcantilever_faceload
    self.inputfile_writing_test(get_namefromdef("test_"))
  File "/home/Philipp/src/FreeCAD/build/Mod/Fem/femtest/app/test_solver_z88.py", line 162, in inputfile_writing_test
    self.assertFalse(
AssertionError: 'Comparing /home/Philipp/src/FreeCAD/build/Mod/Fem/femtest/data/z88/ccxcantilever_faceload/z88i2.txt to /tmp/FEM_unittests/solver_z88_ccxcantilever_faceload_4d7d21908468/z88i2.txt failed!\n--- \n+++ \n@@ -1,5 +1 @@\n-52\n-1  3  1  -0.0\n-2  3  1  -0.0\n-3  3  1  -0.0\n-4  3  1  -0.0\n+39\n@@ -18 +13,0 @@\n-49  3  1  -0.0\n@@ -25 +19,0 @@\n-64  3  1  -750000.0000000001\n@@ -29,2 +22,0 @@\n-88  3  1  -750000.0000000001\n-100  3  1  -750000.0000000001\n@@ -34 +25,0 @@\n-102  3  1  -750000.0000000001\n@@ -38,4 +28,0 @@\n-188  3  1  -1500000.0000000002\n-189  3  1  -1500000.0000000002\n-190  3  1  -1500000.0000000002\n-191  3  1  -1500000.0000000002\n' is not false : Z88 write_inp_file for ccxcantilever_faceload test failed.
Comparing /home/Philipp/src/FreeCAD/build/Mod/Fem/femtest/data/z88/ccxcantilever_faceload/z88i2.txt to /tmp/FEM_unittests/solver_z88_ccxcantilever_faceload_4d7d21908468/z88i2.txt failed!
--- 
+++ 
@@ -1,5 +1 @@
-52
-1  3  1  -0.0
-2  3  1  -0.0
-3  3  1  -0.0
-4  3  1  -0.0
+39
@@ -18 +13,0 @@
-49  3  1  -0.0
@@ -25 +19,0 @@
-64  3  1  -750000.0000000001
@@ -29,2 +22,0 @@
-88  3  1  -750000.0000000001
-100  3  1  -750000.0000000001
@@ -34 +25,0 @@
-102  3  1  -750000.0000000001
@@ -38,4 +28,0 @@
-188  3  1  -1500000.0000000002
-189  3  1  -1500000.0000000002
-190  3  1  -1500000.0000000002
-191  3  1  -1500000.0000000002


======================================================================
FAIL: test_ccxcantilever_nodeload (femtest.app.test_solver_z88.TestSolverZ88)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/Philipp/src/FreeCAD/build/Mod/Fem/femtest/app/test_solver_z88.py", line 100, in test_ccxcantilever_nodeload
    self.inputfile_writing_test(get_namefromdef("test_"))
  File "/home/Philipp/src/FreeCAD/build/Mod/Fem/femtest/app/test_solver_z88.py", line 162, in inputfile_writing_test
    self.assertFalse(
AssertionError: 'Comparing /home/Philipp/src/FreeCAD/build/Mod/Fem/femtest/data/z88/ccxcantilever_nodeload/z88i2.txt to /tmp/FEM_unittests/solver_z88_ccxcantilever_nodeload_43cccecbc0bb/z88i2.txt failed!\n--- \n+++ \n@@ -1 +1 @@\n-43\n+46\n@@ -17,0 +18,3 @@\n+49  1  2  0\n+49  2  2  0\n+49  3  2  0\n' is not false : Z88 write_inp_file for ccxcantilever_nodeload test failed.
Comparing /home/Philipp/src/FreeCAD/build/Mod/Fem/femtest/data/z88/ccxcantilever_nodeload/z88i2.txt to /tmp/FEM_unittests/solver_z88_ccxcantilever_nodeload_43cccecbc0bb/z88i2.txt failed!
--- 
+++ 
@@ -1 +1 @@
-43
+46
@@ -17,0 +18,3 @@
+49  1  2  0
+49  2  2  0
+49  3  2  0
```

General checklist:
- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [ ]  ~~In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum~~
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  ~~Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`~~
