### PR TITLE
[build]: Fix generation and build of python classes for 3.9

### DIFF
--- a/src/Base/PyObjectBase.cpp
+++ b/src/Base/PyObjectBase.cpp
@@ -105,7 +105,11 @@ static PyTypeObject PyBaseProxyType = {
     sizeof(PyBaseProxy),                                    /*tp_basicsize*/
     0,                                                      /*tp_itemsize*/
     PyBaseProxy_dealloc,                                    /*tp_dealloc*/
+#if PY_VERSION_HEX >= 0x03090000
+    0,                                                      /*tp_vectorcall_offset*/
+#else
     nullptr,                                                /*tp_print*/
+#endif
     nullptr,                                                /*tp_getattr*/
     nullptr,                                                /*tp_setattr*/
     nullptr,                                                /*tp_compare*/
@@ -164,7 +168,11 @@ PyTypeObject PyObjectBase::Type = {
     0,                                                      /*tp_itemsize*/
     /* --- methods ---------------------------------------------- */
     PyDestructor,                                           /*tp_dealloc*/
+#if PY_VERSION_HEX >= 0x03090000
+    0,                                                      /*tp_vectorcall_offset*/
+#else
     nullptr,                                                /*tp_print*/
+#endif
     nullptr,                                                /*tp_getattr*/
     nullptr,                                                /*tp_setattr*/
     nullptr,                                                /*tp_compare*/

--- a/src/Tools/generateTemplates/templateClassPyExport.py
+++ b/src/Tools/generateTemplates/templateClassPyExport.py
@@ -285,7 +285,11 @@ PyTypeObject @self.export.Name@::Type = {
     0,                                                /*tp_itemsize*/
     /* methods */
     PyDestructor,                                     /*tp_dealloc*/
+#if PY_VERSION_HEX >= 0x03090000
+    0,                                                /*tp_vectorcall_offset*/
+#else
     nullptr,                                          /*tp_print*/
+#endif
     nullptr,                                          /*tp_getattr*/
     nullptr,                                          /*tp_setattr*/
     nullptr,                                          /*tp_compare*/


### PR DESCRIPTION
seems python changed the object slots again and replaced a pointer with an offset ...