### PR TITLE
Draft: Fixed 3 gui_*.py files that did not execute Gui.addModule("Draft") if UsePartPrimitives is True

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_arcs.py
+++ b/src/Mod/Draft/draftguitools/gui_arcs.py
@@ -301,6 +301,7 @@ class Arc(gui_base_original.Creator):
             try:
                 # The command to run is built as a series of text strings
                 # to be committed through the `draftutils.todo.ToDo` class.
+                Gui.addModule("Draft")
                 if utils.getParam("UsePartPrimitives", False):
                     # Insert a Part::Primitive object
                     _base = DraftVecUtils.toString(self.center)
@@ -318,7 +319,6 @@ class Arc(gui_base_original.Creator):
                                 _cmd_list)
                 else:
                     # Insert a Draft circle
-                    Gui.addModule("Draft")
                     _base = DraftVecUtils.toString(self.center)
                     _cmd = 'Draft.makeCircle'
                     _cmd += '('

--- a/src/Mod/Draft/draftguitools/gui_ellipses.py
+++ b/src/Mod/Draft/draftguitools/gui_ellipses.py
@@ -104,9 +104,9 @@ class Ellipse(gui_base_original.Creator):
                 rot2 = App.Placement(m)
                 rot2 = rot2.Rotation
                 rot = str((rot1.multiply(rot2)).Q)
+            Gui.addModule("Draft")
             if utils.getParam("UsePartPrimitives", False):
                 # Insert a Part::Primitive object
-                Gui.addModule("Part")
                 _cmd = 'FreeCAD.ActiveDocument.'
                 _cmd += 'addObject("Part::Ellipse", "Ellipse")'
                 _cmd_list = ['ellipse = ' + _cmd,
@@ -122,7 +122,6 @@ class Ellipse(gui_base_original.Creator):
                             _cmd_list)
             else:
                 # Insert a Draft ellipse
-                Gui.addModule("Draft")
                 _cmd = 'Draft.makeEllipse'
                 _cmd += '('
                 _cmd += str(r1) + ', ' + str(r2) + ', '

--- a/src/Mod/Draft/draftguitools/gui_points.py
+++ b/src/Mod/Draft/draftguitools/gui_points.py
@@ -119,6 +119,7 @@ class Point(gui_base_original.Creator):
                 # The command to run is built as a series of text strings
                 # to be committed through the `draftutils.todo.ToDo` class.
                 commitlist = []
+                Gui.addModule("Draft")
                 if utils.getParam("UsePartPrimitives", False):
                     # Insert a Part::Primitive object
                     _cmd = 'FreeCAD.ActiveDocument.'
@@ -133,7 +134,6 @@ class Point(gui_base_original.Creator):
                                        _cmd_list))
                 else:
                     # Insert a Draft point
-                    Gui.addModule("Draft")
                     _cmd = 'Draft.makePoint'
                     _cmd += '('
                     _cmd += str(self.stack[0][0]) + ', '


### PR DESCRIPTION
If UsePartPrimitives is True Draft.autogroup(...) is part of _cmd_list, therefore Draft module must be available. Since the Draft module imports the Part module, there is no need to load the latter separately.