### PR TITLE
[Path] Fixes for drilling operation

### DIFF
--- a/src/Mod/Path/PathScripts/PathDrilling.py
+++ b/src/Mod/Path/PathScripts/PathDrilling.py
@@ -87,6 +87,7 @@ class ObjectDrilling(PathCircularHoleBase.ObjectOp):
 
         lastAxis = None
         lastAngle = 0.0
+        parentJob = PathUtils.findParentJob(obj)
 
         self.commandlist.append(Path.Command("(Begin Drilling)"))
 
@@ -151,7 +152,10 @@ class ObjectDrilling(PathCircularHoleBase.ObjectOp):
                 self.opSetDefaultRetractHeight(obj)
                 cmdParams['R'] = obj.RetractHeight.Value
 
+            # move to hole location
             self.commandlist.append(Path.Command('G0', {'X': p['x'], 'Y': p['y'], 'F': self.horizRapid}))
+            startHeight = obj.StartDepth.Value + parentJob.SetupSheet.SafeHeightOffset.Value
+            self.commandlist.append(Path.Command('G0', {'Z': startHeight, 'F': self.vertFeed}))
             self.commandlist.append(Path.Command('G1', {'Z': obj.StartDepth.Value, 'F': self.vertFeed}))
 
             # Update changes to parameters

--- a/src/Mod/Path/PathScripts/PathDrilling.py
+++ b/src/Mod/Path/PathScripts/PathDrilling.py
@@ -187,7 +187,7 @@ class ObjectDrilling(PathCircularHoleBase.ObjectOp):
 
         if hasattr(job.SetupSheet, 'RetractHeight'):
             obj.RetractHeight = job.SetupSheet.RetractHeight
-        elif self.applyExpression(obj, 'RetractHeight', 'OpStartDepth+1mm'):
+        elif self.applyExpression(obj, 'RetractHeight', 'StartDepth+SetupSheet.SafeHeightOffset'):
             if has_job:
                 obj.RetractHeight = 10
             else:

--- a/src/Mod/Path/PathScripts/PathDrilling.py
+++ b/src/Mod/Path/PathScripts/PathDrilling.py
@@ -146,12 +146,13 @@ class ObjectDrilling(PathCircularHoleBase.ObjectOp):
 
                 # Prepare for drilling cycle
                 self.commandlist.append(Path.Command('G0', {axisOfRot: angle, 'F': self.axialRapid}))
-                self.commandlist.append(Path.Command('G0', {'X': p['x'], 'Y': p['y'], 'F': self.horizRapid}))
-                self.commandlist.append(Path.Command('G1', {'Z': obj.StartDepth.Value, 'F': self.vertFeed}))
 
                 # Update retract height due to rotation
                 self.opSetDefaultRetractHeight(obj)
                 cmdParams['R'] = obj.RetractHeight.Value
+
+            self.commandlist.append(Path.Command('G0', {'X': p['x'], 'Y': p['y'], 'F': self.horizRapid}))
+            self.commandlist.append(Path.Command('G1', {'Z': obj.StartDepth.Value, 'F': self.vertFeed}))
 
             # Update changes to parameters
             params.update(cmdParams)

--- a/src/Mod/Path/PathScripts/PathDrilling.py
+++ b/src/Mod/Path/PathScripts/PathDrilling.py
@@ -155,7 +155,7 @@ class ObjectDrilling(PathCircularHoleBase.ObjectOp):
             # move to hole location
             self.commandlist.append(Path.Command('G0', {'X': p['x'], 'Y': p['y'], 'F': self.horizRapid}))
             startHeight = obj.StartDepth.Value + parentJob.SetupSheet.SafeHeightOffset.Value
-            self.commandlist.append(Path.Command('G0', {'Z': startHeight, 'F': self.vertFeed}))
+            self.commandlist.append(Path.Command('G0', {'Z': startHeight, 'F': self.vertRapid}))
             self.commandlist.append(Path.Command('G1', {'Z': obj.StartDepth.Value, 'F': self.vertFeed}))
 
             # Update changes to parameters

--- a/src/Mod/Path/PathScripts/PathUtils.py
+++ b/src/Mod/Path/PathScripts/PathUtils.py
@@ -745,18 +745,29 @@ def guessDepths(objshape, subs=None):
 
 def drillTipLength(tool):
     """returns the length of the drillbit tip."""
-    if not hasattr(tool, 'CuttingEdgeAngle') or tool.CuttingEdgeAngle == 180 or tool.CuttingEdgeAngle == 0.0 or float(tool.Diameter) == 0.0:
+
+    if isinstance(tool, Path.Tool):
+        PathLog.error(translate("Path", "Legacy Tools not supported"))
         return 0.0
-    else:
-        if tool.CuttingEdgeAngle <= 0 or tool.CuttingEdgeAngle >= 180:
-            PathLog.error(translate("Path", "Invalid Cutting Edge Angle %.2f, must be >0° and <=180°") % tool.CuttingEdgeAngle)
-            return 0.0
-        theta = math.radians(tool.CuttingEdgeAngle)
-        length = (float(tool.Diameter) / 2) / math.tan(theta / 2)
-        if length < 0:
-            PathLog.error(translate("Path", "Cutting Edge Angle (%.2f) results in negative tool tip length") % tool.CuttingEdgeAngle)
-            return 0.0
-        return length
+
+    if not hasattr(tool, 'TipAngle'):
+        PathLog.error(translate("Path", "Selected tool is not a drill"))
+        return 0.0
+
+    angle = tool.TipAngle
+
+    if angle <= 0 or angle >= 180:
+        PathLog.error(translate("Path", "Invalid Cutting Edge Angle %.2f, must be >0° and <=180°") % angle)
+        return 0.0
+
+    theta = math.radians(angle)
+    length = (float(tool.Diameter) / 2) / math.tan(theta / 2)
+
+    if length < 0:
+        PathLog.error(translate("Path", "Cutting Edge Angle (%.2f) results in negative tool tip length") % angle)
+        return 0.0
+
+    return length
 
 
 class depth_params(object):


### PR DESCRIPTION
Forum Discussion: https://forum.freecadweb.org/viewtopic.php?f=15&t=58306&sid=1eea82eb33515fc35e70affd64fbbe70

Bug: https://tracker.freecadweb.org/view.php?id=4652

Changes:
- Start drilling operations from OpStartDepth + SafeHeightOffset rather than StockTop + SafeheightOffset
- Enable the use of tipoffset when using toolbits. Display an unsupported warning if using legacy tools. Toolbits FTW!
- Set the retract height relative to the operations startDepth + SafeHeightOffset.