### PR TITLE
[Sketcher] Visibility automation : add option to force orthographic view when entering edit mode

### DIFF
--- a/src/Mod/Sketcher/Gui/SketcherSettings.cpp
+++ b/src/Mod/Sketcher/Gui/SketcherSettings.cpp
@@ -156,6 +156,7 @@ void SketcherSettingsDisplay::saveSettings()
     ui->checkBoxTVShowLinks->onSave();
     ui->checkBoxTVShowSupport->onSave();
     ui->checkBoxTVRestoreCamera->onSave();
+    ui->checkBoxTVForceOrtho->onSave();
     ui->checkBoxTVSectionView->onSave();
 
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Part");
@@ -178,6 +179,8 @@ void SketcherSettingsDisplay::loadSettings()
     ui->checkBoxTVShowLinks->onRestore();
     ui->checkBoxTVShowSupport->onRestore();
     ui->checkBoxTVRestoreCamera->onRestore();
+    ui->checkBoxTVForceOrtho->onRestore();
+    this->ui->checkBoxTVForceOrtho->setEnabled(this->ui->checkBoxTVRestoreCamera->isChecked());
     ui->checkBoxTVSectionView->onRestore();
 
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Part");
@@ -211,12 +214,14 @@ void SketcherSettingsDisplay::onBtnTVApplyClicked(bool)
             "        sketch.ViewObject.ShowLinks = %s\n"
             "        sketch.ViewObject.ShowSupport = %s\n"
             "        sketch.ViewObject.RestoreCamera = %s\n"
+            "        sketch.ViewObject.ForceOrtho = %s\n"
             "        sketch.ViewObject.SectionView = %s\n",
             this->ui->checkBoxTVHideDependent->isChecked() ? "True": "False",
             this->ui->checkBoxTVShowLinks->isChecked()     ? "True": "False",
             this->ui->checkBoxTVShowSupport->isChecked()   ? "True": "False",
             this->ui->checkBoxTVRestoreCamera->isChecked() ? "True": "False",
-            this->ui->checkBoxTVSectionView->isChecked() ? "True": "False");
+            this->ui->checkBoxTVForceOrtho->isChecked()    ? "True": "False",
+            this->ui->checkBoxTVSectionView->isChecked()   ? "True": "False");
     } catch (Base::PyException &e){
         Base::Console().Error("SketcherSettings::onBtnTVApplyClicked:\n");
         e.ReportException();

--- a/src/Mod/Sketcher/Gui/SketcherSettingsDisplay.ui
+++ b/src/Mod/Sketcher/Gui/SketcherSettingsDisplay.ui
@@ -231,6 +231,25 @@ Supports all unit systems except 'US customary' and 'Building US/Euro'.</string>
           </widget>
          </item>
          <item>
+          <widget class="Gui::PrefCheckBox" name="checkBoxTVForceOrtho">
+           <property name="toolTip">
+            <string>When entering edit mode, force orthographic view of camera. Operates only with camera restoration enabled.</string>
+           </property>
+           <property name="text">
+            <string>Force orthographic camera when entering edit</string>
+           </property>
+           <property name="checked">
+            <bool>false</bool>
+           </property>
+           <property name="prefEntry" stdset="0">
+            <cstring>ForceOrtho</cstring>
+           </property>
+           <property name="prefPath" stdset="0">
+            <cstring>Mod/Sketcher/General</cstring>
+           </property>
+          </widget>
+         </item>
+         <item>
           <widget class="Gui::PrefCheckBox" name="checkBoxTVSectionView">
            <property name="toolTip">
             <string>By default, open a sketch in Section View mode -- objects are only visible behind sketch plane</string>
@@ -445,8 +464,17 @@ Supports all unit systems except 'US customary' and 'Building US/Euro'.</string>
   <tabstop>checkBoxTVShowLinks</tabstop>
   <tabstop>checkBoxTVShowSupport</tabstop>
   <tabstop>checkBoxTVRestoreCamera</tabstop>
+  <tabstop>checkBoxTVForceOrtho</tabstop>
+  <tabstop>checkBoxTVSectionView</tabstop>
   <tabstop>btnTVApply</tabstop>
  </tabstops>
  <resources/>
- <connections/>
+ <connections>
+   <connection>
+    <sender>checkBoxTVRestoreCamera</sender>
+    <signal>toggled(bool)</signal>
+    <receiver>checkBoxTVForceOrtho</receiver>
+    <slot>setEnabled(bool)</slot>
+  </connection>
+ </connections>
 </ui>

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -335,6 +335,7 @@ ViewProviderSketch::ViewProviderSketch()
     ADD_PROPERTY_TYPE(ShowLinks,(true),"Visibility automation",(App::PropertyType)(App::Prop_None),"If true, all objects used in links to external geometry are shown when opening sketch.");
     ADD_PROPERTY_TYPE(ShowSupport,(true),"Visibility automation",(App::PropertyType)(App::Prop_None),"If true, all objects this sketch is attached to are shown when opening sketch.");
     ADD_PROPERTY_TYPE(RestoreCamera,(true),"Visibility automation",(App::PropertyType)(App::Prop_None),"If true, camera position before entering sketch is remembered, and restored after closing it.");
+    ADD_PROPERTY_TYPE(ForceOrtho,(false),"Visibility automation",(App::PropertyType)(App::Prop_None),"If true, camera type will be forced to orthographic view when entering editing mode.");
     ADD_PROPERTY_TYPE(SectionView,(false),"Visibility automation",(App::PropertyType)(App::Prop_None),"If true, only objects (or part of) located behind the sketch plane are visible.");
     ADD_PROPERTY_TYPE(EditingWorkbench,("SketcherWorkbench"),"Visibility automation",(App::PropertyType)(App::Prop_None),"Name of the workbench to activate when editing this sketch.");
 
@@ -344,6 +345,7 @@ ViewProviderSketch::ViewProviderSketch()
         this->ShowLinks.setValue(hGrp->GetBool("ShowLinks", true));
         this->ShowSupport.setValue(hGrp->GetBool("ShowSupport", true));
         this->RestoreCamera.setValue(hGrp->GetBool("RestoreCamera", true));
+        this->ForceOrtho.setValue(hGrp->GetBool("ForceOrtho", false));
         this->SectionView.setValue(hGrp->GetBool("SectionView", false));
 
         // well it is not visibility automation but a good place nevertheless
@@ -6889,6 +6891,8 @@ void ViewProviderSketch::setEditViewer(Gui::View3DInventorViewer* viewer, int Mo
                         "ActiveSketch = App.getDocument('%1').getObject('%2')\n"
                         "if ActiveSketch.ViewObject.RestoreCamera:\n"
                         "  ActiveSketch.ViewObject.TempoVis.saveCamera()\n"
+                        "  if ActiveSketch.ViewObject.ForceOrtho:\n"
+                        "    ActiveSketch.ViewObject.Document.ActiveView.setCameraType('Orthographic')\n"
                         ).arg(QString::fromLatin1(getDocument()->getDocument()->getName())).arg(
                               QString::fromLatin1(getSketchObject()->getNameInDocument()));
             QByteArray cmdstr_bytearray = cmdstr.toLatin1();

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.h
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.h
@@ -114,6 +114,7 @@ public:
     App::PropertyBool ShowLinks;
     App::PropertyBool ShowSupport;
     App::PropertyBool RestoreCamera;
+    App::PropertyBool ForceOrtho;
     App::PropertyBool SectionView;
     App::PropertyString EditingWorkbench;
 


### PR DESCRIPTION
This is only available & operational when 'Restore camera' is enabled

[Forum discussion](https://forum.freecadweb.org/viewtopic.php?f=22&t=44747)

- [X]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [ ]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum => N/A
- [X]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0` => I only ran functional tests (extensively)
- [X]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [X]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805` => N/A
