### PR TITLE
Arch: Fix section view duplicate rendering of items in groups with only flat objects

### DIFF
--- a/src/Mod/Arch/ArchSectionPlane.py
+++ b/src/Mod/Arch/ArchSectionPlane.py
@@ -375,9 +375,12 @@ def getSVG(source,
                 drafts.append(o)
         elif o.isDerivedFrom("Part::Part2DObject"):
             drafts.append(o)
+        elif o.isDerivedFrom("App::DocumentObjectGroup"):
+            # These will have been expanded by getSectionData already
+            pass
         elif looksLikeDraft(o):
             drafts.append(o)
-        elif not o.isDerivedFrom("App::DocumentObjectGroup"):
+        else:
             nonspaces.append(o)
         if Draft.getType(o.getLinkedObject()) == "Window":  # To support Link of Windows(Doors)
             windows.append(o)

--- a/src/Mod/Draft/draftutils/groups.py
+++ b/src/Mod/Draft/draftutils/groups.py
@@ -197,8 +197,8 @@ def get_group_contents(objectslist,
 
     spaces: bool, optional
         It defaults to `False`.
-        If it is `True`, Arch Spaces are treated as groups,
-        and are added to the output list.
+        If it is `True`, Arch Spaces are added to the output list even
+        when addgroups is False (their contents are always added).
 
     noarchchild: bool, optional
         It defaults to `False`.


### PR DESCRIPTION
- [ ]  ~~Your pull request is confined strictly to a single module.~~ I changed both Arch and Draft, which seem related enough. Also, the Draft commit is a trivial (but related) documentation fix. But if you prefer a separate PR for that, I'm happy to split it.
- [ ]  ~~In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum~~ Just a bugfix
- [ ]  ~~Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`~~ It's a few days old, didn't want to spend the time of rebuilding my entire FreeCAD against current master
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [X]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  ~~Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`~~ No tracker item

I noticed a problem where the draft section view sometimes renders invisible objects when it should not. It turns out that for groups that only contain flat objects, all contained objects are rendered in the section view an additional time, without looking at visibility. This means visible objects are rendered *twice*, and invisible objects are rendered *once*.

Here is a file with a testcase: 
[Flat groups test.FCStd.zip](https://github.com/FreeCAD/FreeCAD/files/6447908/Flat.groups.test.FCStd.zip)


![image](https://user-images.githubusercontent.com/194491/117578457-b75d9280-b0ee-11eb-82e2-606eae4152a2.png)

Which renders like this. Note that the top line is slightly more bold than the bottom one:

![image](https://user-images.githubusercontent.com/194491/117578524-11f6ee80-b0ef-11eb-8cfb-ec7dd7494512.png)

With this PR applied, it renders as expected.

![image](https://user-images.githubusercontent.com/194491/117578367-49b16680-b0ee-11eb-8b88-aa2761e73953.png)

See the commit message for a detailed description of the problem and the fix. I think this is a pragmatic fix with minimal code changes, but I also have the feeling that some parts of the section view code are a bit too complex and some cleanup and refactoring might be appropriate too (but I'm not up for that now).

@yorikvanhavre ping, I suspect this is a PR you'd be interested in.

I've also included a slightly related documentation fix in a separate commit.