### PR TITLE
Start: fix bug when custom folder doesn't exist

### DIFF
--- a/src/Mod/Start/StartPage/StartPage.py
+++ b/src/Mod/Start/StartPage/StartPage.py
@@ -415,15 +415,18 @@ def handle():
         for cfolder in cfolders.split(";;"): # allow several paths separated by ;;
             if not os.path.isdir(cfolder):
                 cfolder = os.path.dirname(cfolder)
-            SECTION_CUSTOM += encode("<h2>"+os.path.basename(os.path.normpath(cfolder))+"</h2>")
-            SECTION_CUSTOM += "<ul>"
-            for basename in os.listdir(cfolder):
-                filename = os.path.join(cfolder,basename)
-                SECTION_CUSTOM += encode(buildCard(filename,method="LoadCustom.py?filename="+str(dn)+"_"))
-            SECTION_CUSTOM += "</ul>"
-            # hide the custom section tooltip if custom section is set (users know about it if they enabled it)
-            HTML = HTML.replace("id=\"customtip\"","id=\"customtip\" style=\"display:none;\"")
-            dn += 1
+            if not os.path.exists(cfolder):
+                FreeCAD.Console.PrintWarning("Custom folder not found: %s" % cfolder)
+            else:
+                SECTION_CUSTOM += encode("<h2>"+os.path.basename(os.path.normpath(cfolder))+"</h2>")
+                SECTION_CUSTOM += "<ul>"
+                for basename in os.listdir(cfolder):
+                    filename = os.path.join(cfolder,basename)
+                    SECTION_CUSTOM += encode(buildCard(filename,method="LoadCustom.py?filename="+str(dn)+"_"))
+                SECTION_CUSTOM += "</ul>"
+                # hide the custom section tooltip if custom section is set (users know about it if they enabled it)
+                HTML = HTML.replace("id=\"customtip\"","id=\"customtip\" style=\"display:none;\"")
+                dn += 1
     HTML = HTML.replace("SECTION_CUSTOM",SECTION_CUSTOM)
 
     # build IMAGE_SRC paths


### PR DESCRIPTION
A small code bug in the Start workbench causes it to fail to load in the case that there is a "custom folder" configured which doesn't exist. This change simply checks before using it, reports a warning if it doesn't, and continues loading the workbench either way.

---

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum (it's a small bug fix, but I made a forum post anyway: https://forum.freecadweb.org/viewtopic.php?p=502998)
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  ~~All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`~~ (will use CI for testing. is that alright?)
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  ~~Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`~~
