### PR TITLE
[OpenSCAD] Fix missing hide() on linear extrude

### DIFF
--- a/src/Mod/OpenSCAD/importCSG.py
+++ b/src/Mod/OpenSCAD/importCSG.py
@@ -806,6 +806,8 @@ def p_linear_extrude_with_transform(p):
     if p[3]['center']=='true' :
        center(newobj,0,0,h)
     p[0] = [newobj]
+    if gui:
+        obj.ViewObject.hide()
     if printverbose: print("End Linear Extrude with Transform")
 
 def p_import_file1(p):


### PR DESCRIPTION
Extruded 2d geometry was not being hidden, per forums discussion https://forum.freecadweb.org/viewtopic.php?f=8&t=57410&start=30

---

- [X]  Your pull request is confined strictly to a single module
- [X]  Small bug fix
- [X]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master
- [X]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/)
- [X]  Your pull request is well written and has a good description
- [X]  No tracker ticket