### PR TITLE
[Base] Fix lost filename in err msg

### DIFF
--- a/src/Base/Exception.cpp
+++ b/src/Base/Exception.cpp
@@ -248,17 +248,13 @@ const char* XMLAttributeError::what() const throw()
 FileException::FileException(const char * sMessage, const char * sFileName)
   : Exception( sMessage ),file(sFileName)
 {
-    if (sFileName) {
-        _sErrMsgAndFileName = _sErrMsg + ": ";
-        _sErrMsgAndFileName += sFileName;
-    }
+    setFileName(sFileName);
 }
 
 FileException::FileException(const char * sMessage, const FileInfo& File)
   : Exception( sMessage ),file(File)
 {
-    _sErrMsgAndFileName = _sErrMsg + ": ";
-    _sErrMsgAndFileName += File.fileName();
+    setFileName(File.fileName().c_str());
 }
 
 FileException::FileException()
@@ -272,6 +268,15 @@ FileException::FileException(const FileException &inst)
   , file(inst.file)
   , _sErrMsgAndFileName(inst._sErrMsgAndFileName.c_str())
 {
+}
+
+void FileException::setFileName(const char * sFileName) {
+    file.setFile(sFileName);
+    _sErrMsgAndFileName = _sErrMsg;
+    if (sFileName) {
+        _sErrMsgAndFileName += ": ";
+        _sErrMsgAndFileName += sFileName;
+    }
 }
 
 std::string FileException::getFileName() const
@@ -324,7 +329,7 @@ void FileException::setPyObject( PyObject * pydict)
 
         Py::Dict edict(pydict);
         if (edict.hasKey("filename"))
-            file.setFile(static_cast<std::string>(Py::String(edict.getItem("filename"))));
+            setFileName(Py::String(edict.getItem("filename")).as_std_string("utf-8").c_str());
     }
 }
 

--- a/src/Base/Exception.h
+++ b/src/Base/Exception.h
@@ -262,6 +262,7 @@ protected:
   // necessary   for what() legacy behaviour as it returns a buffer that
   // can not be of a temporary object to be destroyed at end of what()
   std::string _sErrMsgAndFileName;
+  void setFileName(const char * sFileName=0);
 };
 
 /**


### PR DESCRIPTION
In some circumstances, FileExceptions are constructed empty, then have a filename assigned to them, but the error message in these scenarios is left as the default "unknown" one, which is missing both the exception message and the filename.

This change fixes that by re-calculating both when an except is updated with a `PyObject`. In addition, I consolidated that logic into a private method so that construction & later-updating stay consistent over time.

To verify, I tried to save a project after deleting its containing dir. Before this change:

![image](https://user-images.githubusercontent.com/232685/118300721-416f7780-b4b0-11eb-91a0-6b43111c416b.png)

After change:

![image](https://user-images.githubusercontent.com/232685/118300748-47fdef00-b4b0-11eb-9966-89b1230e12e0.png)

This doesn't fix [Issue 4098](https://tracker.freecadweb.org/view.php?id=4098), but it helps with the error msg.

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  ~~All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`~~ (relying on CI to verify tests. Is that ok?)
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [x]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`
