### PR TITLE
[Gui] Fix app quitting despite failing to save project

### DIFF
--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -1161,6 +1161,7 @@ bool Document::save(void)
         catch (const Base::Exception& e) {
             QMessageBox::critical(getMainWindow(), QObject::tr("Saving document failed"),
                 QString::fromLatin1(e.what()));
+            return false;
         }
         return true;
     }


### PR DESCRIPTION
Currently, a failure during a document save can return `true` in some cases, which among other possible problems, can cause the App to exit despite not successfully saving the document, resulting in data loss (eg [Issue 4098](https://tracker.freecadweb.org/view.php?id=4098)). This change causes the method to return `false` to properly communicate the failure, which the app-quit process already handles by aborting. 

Steps to reproduce / verify fix:

1. Create a document in its own dir & save it
2. Without closing the document or the app, delete the containing dir
3. Quit the app

**Before this change**: app asks you to save, which fails, but the app exits anyway
**After this change**: app asks you to save, which fails, but the app aborts exit, giving you the chance to "save as" somewhere else

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  ~~All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`~~ (relying on CI to verify tests. is that ok?)
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [x]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`
