### PR TITLE
Crowdin: fix mistake in Draft Preferences text [skip ci]

### DIFF
--- a/src/Mod/Draft/Resources/ui/preferences-dxf.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-dxf.ui
@@ -69,8 +69,7 @@ Note: C++ importer is faster, but is not as featureful yet</string>
     <widget class="Gui::PrefCheckBox" name="checkBox_7">
      <property name="toolTip">
       <string>Python exporter is used, otherwise the newer C++ is used.
-Note: C++ importer is faster, but is not as featureful yet
-      </string>
+Note: C++ exporter is faster, but is not as featureful yet</string>
      </property>
      <property name="text">
       <string>Use legacy python exporter</string>


### PR DESCRIPTION
ref: https://crowdin.com/translate/freecad/548/en-en?filter=basic&value=13#6577122