### PR TITLE
Crowdin: remove superfluous whitespace from translation 

### DIFF
--- a/src/Mod/Draft/draftmake/make_arc_3points.py
+++ b/src/Mod/Draft/draftmake/make_arc_3points.py
@@ -156,7 +156,7 @@ def make_arc_3points(points, placement=None, face=False,
     try:
         _edge = Part.Arc(p1, p2, p3)
     except Part.OCCError as error:
-        _err(translate("draft","Cannot generate shape: ") + "{}".format(error))
+        _err(translate("draft","Cannot generate shape:") + " " + "{}".format(error))
         return None
 
     edge = _edge.toShape()


### PR DESCRIPTION
ref: https://crowdin.com/translate/freecad/548/en-en?filter=basic&value=2#6587168