### PR TITLE
Path: check for empty before using - fixes #4645

### DIFF
--- a/src/Mod/Path/PathScripts/PathJob.py
+++ b/src/Mod/Path/PathScripts/PathJob.py
@@ -171,7 +171,7 @@ class ObjectJob:
             obj.Stock.ViewObject.Visibility = False
 
     def setupSetupSheet(self, obj):
-        if not hasattr(obj, 'SetupSheet'):
+        if not getattr(obj, 'SetupSheet', None):
             obj.addProperty('App::PropertyLink', 'SetupSheet', 'Base', QtCore.QT_TRANSLATE_NOOP('PathJob', 'SetupSheet holding the settings for this job'))
             obj.SetupSheet = PathSetupSheet.Create()
             if obj.SetupSheet.ViewObject:
@@ -223,53 +223,58 @@ class ObjectJob:
         PathLog.track(obj.Label, arg2)
         doc = obj.Document
 
-        # the first to tear down are the ops, they depend on other resources
-        PathLog.debug('taking down ops: %s' % [o.Name for o in self.allOperations()])
-        while obj.Operations.Group:
-            op = obj.Operations.Group[0]
-            if not op.ViewObject or not hasattr(op.ViewObject.Proxy, 'onDelete') or op.ViewObject.Proxy.onDelete(op.ViewObject, ()):
-                PathUtil.clearExpressionEngine(op)
-                doc.removeObject(op.Name)
-        obj.Operations.Group = []
-        doc.removeObject(obj.Operations.Name)
-        obj.Operations = None
+        if getattr(obj, 'Operations', None):
+            # the first to tear down are the ops, they depend on other resources
+            PathLog.debug('taking down ops: %s' % [o.Name for o in self.allOperations()])
+            while obj.Operations.Group:
+                op = obj.Operations.Group[0]
+                if not op.ViewObject or not hasattr(op.ViewObject.Proxy, 'onDelete') or op.ViewObject.Proxy.onDelete(op.ViewObject, ()):
+                    PathUtil.clearExpressionEngine(op)
+                    doc.removeObject(op.Name)
+            obj.Operations.Group = []
+            doc.removeObject(obj.Operations.Name)
+            obj.Operations = None
 
         # stock could depend on Model, so delete it first
-        if obj.Stock:
+        if getattr(obj, 'Stock', None):
             PathLog.debug('taking down stock')
             PathUtil.clearExpressionEngine(obj.Stock)
             doc.removeObject(obj.Stock.Name)
             obj.Stock = None
 
         # base doesn't depend on anything inside job
-        for base in obj.Model.Group:
-            PathLog.debug("taking down base %s" % base.Label)
-            self.removeBase(obj, base, False)
-        obj.Model.Group = []
-        doc.removeObject(obj.Model.Name)
-        obj.Model = None
+        if getattr(obj, 'Model', None):
+            for base in obj.Model.Group:
+                PathLog.debug("taking down base %s" % base.Label)
+                self.removeBase(obj, base, False)
+            obj.Model.Group = []
+            doc.removeObject(obj.Model.Name)
+            obj.Model = None
 
         # Tool controllers might refer to either legacy tool or toolbit
-        PathLog.debug('taking down tool controller')
-        for tc in obj.Tools.Group:
-            if hasattr(tc.Tool, "Proxy"):
-                PathUtil.clearExpressionEngine(tc.Tool)
-                doc.removeObject(tc.Tool.Name)
-            PathUtil.clearExpressionEngine(tc)
-            tc.Proxy.onDelete(tc)
-            doc.removeObject(tc.Name)
-        obj.Tools.Group = []
-        doc.removeObject(obj.Tools.Name)
-        obj.Tools = None
+        if getattr(obj, 'Tools', None):
+            PathLog.debug('taking down tool controller')
+            for tc in obj.Tools.Group:
+                if hasattr(tc.Tool, "Proxy"):
+                    PathUtil.clearExpressionEngine(tc.Tool)
+                    doc.removeObject(tc.Tool.Name)
+                PathUtil.clearExpressionEngine(tc)
+                tc.Proxy.onDelete(tc)
+                doc.removeObject(tc.Name)
+            obj.Tools.Group = []
+            doc.removeObject(obj.Tools.Name)
+            obj.Tools = None
 
         # SetupSheet
-        PathUtil.clearExpressionEngine(obj.SetupSheet)
-        doc.removeObject(obj.SetupSheet.Name)
-        obj.SetupSheet = None
+        if getattr(obj, 'SetupSheet', None):
+            PathUtil.clearExpressionEngine(obj.SetupSheet)
+            doc.removeObject(obj.SetupSheet.Name)
+            obj.SetupSheet = None
+
         return True
 
     def fixupOperations(self, obj):
-        if obj.Operations.ViewObject:
+        if getattr(obj.Operations, 'ViewObject', None):
             try:
                 obj.Operations.ViewObject.DisplayMode
             except Exception:  # pylint: disable=broad-except
@@ -409,7 +414,7 @@ class ObjectJob:
         return None
 
     def execute(self, obj):
-        if hasattr(obj, 'Operations'):
+        if getattr(obj, 'Operations', None):
             obj.Path = obj.Operations.Path
             self.getCycleTime()
 
@@ -479,8 +484,11 @@ class ObjectJob:
                     ops.append(op)
                     for sub in op.Group:
                         collectBaseOps(sub)
-        for op in self.obj.Operations.Group:
-            collectBaseOps(op)
+
+        if getattr(self.obj, 'Operations', None) and getattr(self.obj.Operations, 'Group', None):
+            for op in self.obj.Operations.Group:
+                collectBaseOps(op)
+
         return ops
 
     def setCenterOfRotation(self, center):


### PR DESCRIPTION
In a few locations, python objects are used without checking if they exist and are non-null, which throws missing attribute exceptions. The` fix is to simply check first. This fixes [Issue 4645](https://tracker.freecadweb.org/view.php?id=4645).

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  ~~All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`~~ (relying on CI for tests)
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [x]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`