### PR TITLE
App: Abort save when unable to finish

### DIFF
--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -2398,8 +2398,8 @@ private:
 
         Base::FileInfo tmp(sourcename);
         if (tmp.renameFile(targetname.c_str()) == false) {
-            Base::Console().Warning("Cannot rename file from '%s' to '%s'\n",
-                                    sourcename.c_str(), targetname.c_str());
+            throw Base::FileException(
+                "Cannot rename tmp save file to project file", targetname);
         }
     }
     void applyTimeStamp(const std::string& sourcename, const std::string& targetname) {
@@ -2531,9 +2531,8 @@ private:
 
         Base::FileInfo tmp(sourcename);
         if (tmp.renameFile(targetname.c_str()) == false) {
-            Base::Console().Error("Save interrupted: Cannot rename file from '%s' to '%s'\n",
-                                  sourcename.c_str(), targetname.c_str());
-            //throw Base::FileException("Save interrupted: Cannot rename temporary file to project file", tmp);
+            throw Base::FileException(
+                "Save interrupted: Cannot rename temporary file to project file", tmp);
         }
 
         if (numberOfFiles <= 0) {


### PR DESCRIPTION
While applying a `BackupPolicy` during a `Document` save, there are two error cases where the project's file will not contain the latest changes, but only a warning was being logged, while the save was considered successful. Not only is that technically incorrect, but it can lead to data loss, such as on app quit.

This fix addresses that by throwing an exception, which will abort the save, inform the user, and give them a chance to take alternate action.

### Steps to Reproduce (Linux)

1. Create a test directory and save a project in there (empty is fine)
2. Make some change in the project, but don't yet save, and leave it open in FreeCAD
3. Set the sticky bit of the dir, and change owner (eg `chmod +t <dir> && sudo chown root <dir>`)
4. Lock the main project file by changing its ownership, while retaining read permissions (`chmod 644 <project.FCStd> && sudo chown root <project.FCStd>`)
5. Try to quit FreeCAD without saving, and choose to save the project when prompted

**Results before this change:** The save is considered successful and FreeCAD exits without actually updating the main project file or indicating to the user that anything went wrong.

**Results after this change:** Currently, the same! However, with the addition of PR #4792, an error dialog is shown to the user, and the app aborts exiting, giving the user a chance to take alternate action.

This is just one way of triggering this issue, but really [any number of errors](https://man7.org/linux/man-pages/man2/renameat2.2.html#ERRORS) can happen to trigger it.

Forum Post: [How to handle failures during Document Save](https://forum.freecadweb.org/viewtopic.php?f=10&t=58645)

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  ~~All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`~~ (relying on CI for testing)
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [x]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`