### PR TITLE
Draft: Fixed make_label to accept list of strings for custom_text

### DIFF
--- a/src/Mod/Draft/draftmake/make_label.py
+++ b/src/Mod/Draft/draftmake/make_label.py
@@ -282,12 +282,13 @@ def make_label(target_point=App.Vector(0, 0, 0),
     if not custom_text:
         custom_text = "Label"
     try:
-        utils.type_check([(custom_text, (str, list))])
+        utils.type_check([(custom_text, (str, list))], name=_name)
     except TypeError:
         _err(translate("draft","Wrong input: must be a list of strings or a single string."))
         return None
 
-    if not all(isinstance(element, str) for element in custom_text):
+    if (type(custom_text) is list
+            and not all(isinstance(element, str) for element in custom_text)):
         _err(translate("draft","Wrong input: must be a list of strings or a single string."))
         return None
 

--- a/src/Mod/Draft/draftmake/make_label.py
+++ b/src/Mod/Draft/draftmake/make_label.py
@@ -119,8 +119,10 @@ def make_label(target_point=App.Vector(0, 0, 0),
         - `'Area'` will show the `Area` of the target object's `Shape`,
           or of the indicated `'FaceN'` in `target`.
 
-    custom_text: str, optional
+    custom_text: str, or list of str, optional
         It defaults to `'Label'`.
+        If it is a list, each element in the list represents a new text line.
+
         It is the text that will be displayed by the label when
         `label_type` is `'Custom'`.
 
@@ -280,10 +282,17 @@ def make_label(target_point=App.Vector(0, 0, 0),
     if not custom_text:
         custom_text = "Label"
     try:
-        utils.type_check([(custom_text, str)], name=_name)
+        utils.type_check([(custom_text, (str, list))])
     except TypeError:
-        _err(translate("draft","Wrong input: must be a string."))
+        _err(translate("draft","Wrong input: must be a list of strings or a single string."))
         return None
+
+    if not all(isinstance(element, str) for element in custom_text):
+        _err(translate("draft","Wrong input: must be a list of strings or a single string."))
+        return None
+
+    if isinstance(custom_text, str):
+        custom_text = [custom_text]
 
     _msg("direction: {}".format(direction))
     if not direction:

--- a/src/Mod/Draft/draftmake/make_label.py
+++ b/src/Mod/Draft/draftmake/make_label.py
@@ -291,9 +291,6 @@ def make_label(target_point=App.Vector(0, 0, 0),
         _err(translate("draft","Wrong input: must be a list of strings or a single string."))
         return None
 
-    if isinstance(custom_text, str):
-        custom_text = [custom_text]
-
     _msg("direction: {}".format(direction))
     if not direction:
         direction = "Horizontal"


### PR DESCRIPTION
The make_label function should accept a list of strings for custom_text. Compare the make_text function. The new code was mostly taken from there.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [ ]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [ ]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [ ]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
