### PR TITLE
Crowdin: fix Draft mirror code typo

### DIFF
--- a/src/Mod/Draft/draftfunctions/mirror.py
+++ b/src/Mod/Draft/draftfunctions/mirror.py
@@ -110,7 +110,7 @@ def mirror(objlist, p1, p2):
 
     for obj in objlist:
         mir = App.ActiveDocument.addObject("Part::Mirroring", "mirror")
-        mir.Label = obj.Label + " (" + translate("draft","mirrored" + ")")
+        mir.Label = obj.Label + " (" + translate("draft","mirrored") + ") "
         mir.Source = obj
         mir.Base = p1
         mir.Normal = pnorm


### PR DESCRIPTION
Removes closing parenthesis from the string.  
Please review the code since I have not compiled to test this change. Thx!

ref: https://crowdin.com/translate/freecad/548/en-en?filter=basic&value=2#6587132