### PR TITLE
Draft: Do not move children of App::Link objects

### DIFF
--- a/src/Mod/Draft/draftutils/groups.py
+++ b/src/Mod/Draft/draftutils/groups.py
@@ -297,7 +297,7 @@ def get_movable_children(objectslist, recursive=True):
     for obj in objectslist:
         # Skips some objects that should never move their children
         if utils.get_type(obj) not in ("Clone", "SectionPlane",
-                                       "Facebinder", "BuildingPart"):
+                                       "Facebinder", "BuildingPart", "App::Link"):
             children = obj.OutList
             if (hasattr(obj, "Proxy") and obj.Proxy
                     and hasattr(obj.Proxy, "getSiblings")


### PR DESCRIPTION
This caused the original object to be moved when using the Draft move
tool to move a link object, when the original object has MoveWithHost
set (e.g. a Window). There was already a similar exception for clones,
so it makes sense to extend this for links too.

Note that there seem to be more problems with the "MoveWithHost"
mechanism and fixing them might completely refactor this code, but until
then, this is a simple and targeted fix that at least makes moving
links to windows work as expected.

See https://forum.freecadweb.org/viewtopic.php?f=23&t=57223 for
discussion of this bug, its fix and the additional problems mentioned.

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [x]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`