### PR TITLE
Draft & Arch: Python code simplifications

### DIFF
--- a/src/Mod/Arch/ArchComponent.py
+++ b/src/Mod/Arch/ArchComponent.py
@@ -737,20 +737,18 @@ class Component(ArchIFC.IfcProduct):
                         base = base.fuse(add)
 
                     elif hasattr(o,'Shape'):
-                        if o.Shape:
-                            if not o.Shape.isNull():
-                                if o.Shape.Solids:
-                                    s = o.Shape.copy()
-                                    if placement:
-                                        s.Placement = s.Placement.multiply(placement)
-                                    if base:
-                                        if base.Solids:
-                                            try:
-                                                base = base.fuse(s)
-                                            except Part.OCCError:
-                                                print("Arch: unable to fuse object ", obj.Name, " with ", o.Name)
-                                    else:
-                                        base = s
+                        if o.Shape and not o.Shape.isNull() and o.Shape.Solids:
+                            s = o.Shape.copy()
+                            if placement:
+                                s.Placement = s.Placement.multiply(placement)
+                            if base:
+                                if base.Solids:
+                                    try:
+                                        base = base.fuse(s)
+                                    except Part.OCCError:
+                                        print("Arch: unable to fuse object ", obj.Name, " with ", o.Name)
+                            else:
+                                base = s
 
         # treat subtractions
         subs = obj.Subtractions
@@ -1420,11 +1418,7 @@ class ViewProviderComponent:
         if hasattr(self,"Object"):
             c = []
             if hasattr(self.Object,"Base"):
-                if Draft.getType(self.Object) != "Wall":
-                    c = [self.Object.Base]
-                elif Draft.getType(self.Object.Base) == "Space":
-                    c = []
-                else:
+                if not (Draft.getType(self.Object) == "Wall" and Draft.getType(self.Object.Base) == "Space"):
                     c = [self.Object.Base]
             if hasattr(self.Object,"Additions"):
                 c.extend(self.Object.Additions)

--- a/src/Mod/Draft/draftobjects/circle.py
+++ b/src/Mod/Draft/draftobjects/circle.py
@@ -79,10 +79,7 @@ class Circle(DraftObject):
 
         if obj.FirstAngle.Value == obj.LastAngle.Value:
             shape = Part.Wire(shape)
-            if hasattr(obj,"MakeFace"):
-                if obj.MakeFace:
-                    shape = Part.Face(shape)
-            else:
+            if getattr(obj,"MakeFace",True):
                 shape = Part.Face(shape)
 
         obj.Shape = shape

--- a/src/Mod/Draft/draftobjects/wire.py
+++ b/src/Mod/Draft/draftobjects/wire.py
@@ -102,10 +102,7 @@ class Wire(DraftObject):
             if obj.Base.isDerivedFrom("Sketcher::SketchObject"):
                 shape = obj.Base.Shape.copy()
                 if obj.Base.Shape.isClosed():
-                    if hasattr(obj,"MakeFace"):
-                        if obj.MakeFace:
-                            shape = Part.Face(shape)
-                    else:
+                    if getattr(obj,"MakeFace",True):
                         shape = Part.Face(shape)
                 obj.Shape = shape
         elif obj.Base and obj.Tool:
@@ -126,21 +123,20 @@ class Wire(DraftObject):
                 obj.Points.pop()
             if obj.Closed and (len(obj.Points) > 2):
                 pts = obj.Points
-                if hasattr(obj,"Subdivisions"):
-                    if obj.Subdivisions > 0:
-                        npts = []
-                        for i in range(len(pts)):
-                            p1 = pts[i]
-                            npts.append(pts[i])
-                            if i == len(pts)-1:
-                                p2 = pts[0]
-                            else:
-                                p2 = pts[i+1]
-                            v = p2.sub(p1)
-                            v = DraftVecUtils.scaleTo(v,v.Length/(obj.Subdivisions+1))
-                            for j in range(obj.Subdivisions):
-                                npts.append(p1.add(App.Vector(v).multiply(j+1)))
-                        pts = npts
+                if getattr(obj,"Subdivisions",0) > 0:
+                    npts = []
+                    for i in range(len(pts)):
+                        p1 = pts[i]
+                        npts.append(pts[i])
+                        if i == len(pts)-1:
+                            p2 = pts[0]
+                        else:
+                            p2 = pts[i+1]
+                        v = p2.sub(p1)
+                        v = DraftVecUtils.scaleTo(v,v.Length/(obj.Subdivisions+1))
+                        for j in range(obj.Subdivisions):
+                            npts.append(p1.add(App.Vector(v).multiply(j+1)))
+                    pts = npts
                 shape = Part.makePolygon(pts+[pts[0]])
                 if "ChamferSize" in obj.PropertiesList:
                     if obj.ChamferSize.Value != 0:
@@ -153,10 +149,7 @@ class Wire(DraftObject):
                         if w:
                             shape = w
                 try:
-                    if hasattr(obj,"MakeFace"):
-                        if obj.MakeFace:
-                            shape = Part.Face(shape)
-                    else:
+                    if getattr(obj,"MakeFace",True):
                         shape = Part.Face(shape)
                 except Part.OCCError:
                     pass
@@ -166,18 +159,15 @@ class Wire(DraftObject):
                 lp = obj.Points[0]
                 for p in pts:
                     if not DraftVecUtils.equals(lp,p):
-                        if hasattr(obj,"Subdivisions"):
-                            if obj.Subdivisions > 0:
-                                npts = []
-                                v = p.sub(lp)
-                                v = DraftVecUtils.scaleTo(v,v.Length/(obj.Subdivisions+1))
-                                edges.append(Part.LineSegment(lp,lp.add(v)).toShape())
-                                lv = lp.add(v)
-                                for j in range(obj.Subdivisions):
-                                    edges.append(Part.LineSegment(lv,lv.add(v)).toShape())
-                                    lv = lv.add(v)
-                            else:
-                                edges.append(Part.LineSegment(lp,p).toShape())
+                        if getattr(obj,"Subdivisions",0) > 0:
+                            npts = []
+                            v = p.sub(lp)
+                            v = DraftVecUtils.scaleTo(v,v.Length/(obj.Subdivisions+1))
+                            edges.append(Part.LineSegment(lp,lp.add(v)).toShape())
+                            lv = lp.add(v)
+                            for j in range(obj.Subdivisions):
+                                edges.append(Part.LineSegment(lv,lv.add(v)).toShape())
+                                lv = lv.add(v)
                         else:
                             edges.append(Part.LineSegment(lp,p).toShape())
                         lp = p


### PR DESCRIPTION
This is a small PR containing a few small simplifications to the draft & arch code, that help readability (and maybe a tiny bit of performance). This is just a pilot PR containing a few such simplifications I noticed while reading the code. If this is welcomed, I might submit more.

This PR makes no changes to FreeCAD's behavior, it only replaces code with simpler but equivalent code.

See also https://forum.freecadweb.org/viewtopic.php?f=10&t=58611 for some previous discussion about these kind of changes.

- [ ]  ~~Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones~~ Nope, I mixed Arch and Draft which seem related enough. Let me know if you prefer splitting.
- [X]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [X]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [x]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [X]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  ~~Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`~~