### PR TITLE
[Path] Fix GUI issues and minor code cleanup

### DIFF
--- a/src/Mod/Path/PathScripts/PathGui.py
+++ b/src/Mod/Path/PathScripts/PathGui.py
@@ -100,6 +100,7 @@ class QuantitySpinBox:
         self.widget = widget
         self.onBeforeChange = onBeforeChange
         self.prop = None
+        self.obj = obj
         self.attachTo(obj, prop)
 
     def attachTo(self, obj, prop = None):
@@ -139,9 +140,14 @@ class QuantitySpinBox:
         If no value is provided the value of the bound property is used.
         quantity can be of type Quantity or Float.'''
         PathLog.track(self.prop, self.valid)
+
         if self.valid:
+            expr  = self._hasExpression()
             if quantity is None:
-                quantity = PathUtil.getProperty(self.obj, self.prop)
+                if expr:
+                    quantity = FreeCAD.Units.Quantity(self.obj.evalExpression(expr))
+                else:
+                    quantity = PathUtil.getProperty(self.obj, self.prop)
             value = quantity.Value if hasattr(quantity, 'Value') else quantity
             self.widget.setProperty('rawValue', value)
 
@@ -150,4 +156,10 @@ class QuantitySpinBox:
         PathLog.track(self.prop, self.valid)
         if self.valid:
             return updateInputField(self.obj, self.prop, self.widget, self.onBeforeChange)
+        return None
+
+    def _hasExpression(self):
+        for (prop, exp) in self.obj.ExpressionEngine:
+            if prop == self.prop:
+                return exp
         return None

--- a/src/Mod/Path/PathScripts/PathGui.py
+++ b/src/Mod/Path/PathScripts/PathGui.py
@@ -68,10 +68,10 @@ def updateInputField(obj, prop, widget, onBeforeChange=None):
                         isDiff = True
                     break
             if noExpr:
-                widget.setProperty('readonly', False)
+                widget.setReadOnly(False)
                 widget.setStyleSheet("color: black")
             else:
-                widget.setProperty('readonly', True)
+                widget.setReadOnly(True)
                 widget.setStyleSheet("color: gray")
             widget.update()
 

--- a/src/Mod/Path/PathScripts/PathOpGui.py
+++ b/src/Mod/Path/PathScripts/PathOpGui.py
@@ -1203,7 +1203,18 @@ class TaskPanel(object):
                     page.clearBase()
                     page.addBaseGeometry(sel)
 
+        # Update properties based upon expressions in case expression value has changed
+        for (prp, expr) in self.obj.ExpressionEngine:
+            val = FreeCAD.Units.Quantity(self.obj.evalExpression(expr))
+            value = val.Value if hasattr(val, 'Value') else val
+            prop = getattr(self.obj, prp)
+            if hasattr(prop, "Value"):
+                prop.Value = value
+            else:
+                prop = value
+
         self.panelSetFields()
+
         for page in self.featurePages:
             page.pageRegisterSignalHandlers()
 

--- a/src/Mod/Path/PathScripts/PathOpGui.py
+++ b/src/Mod/Path/PathScripts/PathOpGui.py
@@ -214,11 +214,6 @@ class TaskPanelPage(object):
     def _installTCUpdate(self):
         return hasattr(self.form, 'toolController')
 
-    def setParent(self, parent):
-        '''setParent() ... used to transfer parent object link to child class.
-        Do not overwrite.'''
-        self.parent = parent
-
     def onDirtyChanged(self, callback):
         '''onDirtyChanged(callback) ... set callback when dirty state changes.'''
         self.signalDirtyChanged = callback
@@ -1000,8 +995,10 @@ class TaskPanel(object):
     def __init__(self, obj, deleteOnReject, opPage, selectionFactory):
         PathLog.track(obj.Label, deleteOnReject, opPage, selectionFactory)
         FreeCAD.ActiveDocument.openTransaction(translate("Path", "AreaOp Operation"))
+        self.obj = obj
         self.deleteOnReject = deleteOnReject
         self.featurePages = []
+        self.parent = None
 
         # members initialized later
         self.clearanceHeight = None
@@ -1050,9 +1047,9 @@ class TaskPanel(object):
         self.featurePages.append(opPage)
 
         for page in self.featurePages:
+            page.parent = self  # save pointer to this current class as "parent"
             page.initPage(obj)
             page.onDirtyChanged(self.pageDirtyChanged)
-            page.setParent(self)
 
         taskPanelLayout = PathPreferences.defaultTaskPanelLayout()
 
@@ -1092,7 +1089,6 @@ class TaskPanel(object):
             self.form = forms
 
         self.selectionFactory = selectionFactory
-        self.obj = obj
         self.isdirty = deleteOnReject
         self.visibility = obj.ViewObject.Visibility
         obj.ViewObject.Visibility = True

--- a/src/Mod/Path/PathScripts/PathPocketShape.py
+++ b/src/Mod/Path/PathScripts/PathPocketShape.py
@@ -84,6 +84,7 @@ class ObjectPocket(PathPocketBase.ObjectPocket):
     def areaOpShapes(self, obj):
         '''areaOpShapes(obj) ... return shapes representing the solids to be removed.'''
         PathLog.track()
+        self.removalshapes = []
 
         # self.isDebug = True if PathLog.getLevel(PathLog.thisModule()) == 4 else False
         self.removalshapes = []
@@ -162,7 +163,8 @@ class ObjectPocket(PathPocketBase.ObjectPocket):
         #    shape.tessellate(0.05)  # originally 0.1
 
         if self.removalshapes:
-            obj.removalshape = self.removalshapes[0][0]
+            obj.removalshape = Part.makeCompound([tup[0] for tup in self.removalshapes])
+
         return self.removalshapes
 
     # Support methods


### PR DESCRIPTION
Three issues are fixed in this PR that are more ease-of-use fixes (not new features) for behaviors that are expected, but not occurring:
* Fix readonly GUI spin boxes when no expression is used.  Currently when the expression is cleared, the spin box behaves as readonly, forcing the user to enter their new value in the popup expression editor.
* Fix incorrect values in GUI spin boxes in Task Panel upon initial creation of operation.  To reproduce, simply create simple cube 20x20x20.  Select the top face and then create either a Profile or Pocket op.  Look at the values in the Depths and Heights tabs; the values likely do not reflect correct values based on the selected face and stock of the model.  This PR corrects this deceiving behavior.  Currently, the values will be corrected after the user clicks the Apply button to generate the first path data.
* Fix the `obj.removalshape` for the PocketShape op, using a `Part.Compound` shape to contain all possible shapes collectively rather then the first shape in the list of `removalshapes` as is the current implementation.

This PR also has some very minor code cleanup and code simplification changes.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
