### PR TITLE
[Path] Handle unavailability of Camotics library/module

### DIFF
--- a/src/Mod/Path/PathScripts/PathGuiInit.py
+++ b/src/Mod/Path/PathScripts/PathGuiInit.py
@@ -39,17 +39,17 @@ def Startup():
         PathLog.debug('Initializing PathGui')
         from PathScripts import PathAdaptiveGui
         from PathScripts import PathArray
+        from PathScripts import PathCamoticsGui
         from PathScripts import PathComment
-        # from PathScripts import PathCustom
         from PathScripts import PathCustomGui
         from PathScripts import PathDeburrGui
         from PathScripts import PathDressupAxisMap
         from PathScripts import PathDressupDogbone
         from PathScripts import PathDressupDragknife
-        from PathScripts import PathDressupRampEntry
-        from PathScripts import PathDressupPathBoundaryGui
-        from PathScripts import PathDressupTagGui
         from PathScripts import PathDressupLeadInOut
+        from PathScripts import PathDressupPathBoundaryGui
+        from PathScripts import PathDressupRampEntry
+        from PathScripts import PathDressupTagGui
         from PathScripts import PathDressupZCorrect
         from PathScripts import PathDrillingGui
         from PathScripts import PathEngraveGui
@@ -62,26 +62,20 @@ def Startup():
         from PathScripts import PathPocketShapeGui
         from PathScripts import PathPost
         from PathScripts import PathProbeGui
-        # from PathScripts import PathProfileContourGui
-        # from PathScripts import PathProfileEdgesGui
-        # from PathScripts import PathProfileFacesGui
         from PathScripts import PathProfileGui
         from PathScripts import PathPropertyBagGui
         from PathScripts import PathSanity
         from PathScripts import PathSetupSheetGui
         from PathScripts import PathSimpleCopy
         from PathScripts import PathSimulatorGui
-        from PathScripts import PathCamoticsGui
         from PathScripts import PathSlotGui
         from PathScripts import PathStop
-        # from PathScripts import PathSurfaceGui  # Added in initGui.py due to OCL dependency
         from PathScripts import PathThreadMillingGui
         from PathScripts import PathToolController
         from PathScripts import PathToolControllerGui
-        from PathScripts import PathToolLibraryManager
         from PathScripts import PathToolLibraryEditor
+        from PathScripts import PathToolLibraryManager
         from PathScripts import PathUtilsGui
-        # from PathScripts import PathWaterlineGui  # Added in initGui.py due to OCL dependency
         from PathScripts import PathVcarveGui
         Processed = True
     else:

--- a/src/Mod/Path/PathScripts/PathGuiInit.py
+++ b/src/Mod/Path/PathScripts/PathGuiInit.py
@@ -39,7 +39,13 @@ def Startup():
         PathLog.debug('Initializing PathGui')
         from PathScripts import PathAdaptiveGui
         from PathScripts import PathArray
-        from PathScripts import PathCamoticsGui
+        try:
+            import camotics
+        except ImportError:
+            import FreeCAD
+            FreeCAD.Console.PrintError("Camotics is not available.\n")
+        else:
+            from PathScripts import PathCamoticsGui
         from PathScripts import PathComment
         from PathScripts import PathCustomGui
         from PathScripts import PathDeburrGui


### PR DESCRIPTION
This PR touches one module, PathGuiInit.  It alphabetizes the import list and handles the error created by the unavailability of the  Camotics library/module.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [x]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
