### PR TITLE
Draft: gui_utils wrongly used a hard-coded name for construction group

### DIFF
--- a/src/Mod/Draft/draftutils/gui_utils.py
+++ b/src/Mod/Draft/draftutils/gui_utils.py
@@ -350,7 +350,7 @@ def format_object(target, origin=None):
     if ui:
         doc = App.ActiveDocument
         if ui.isConstructionMode():
-            lcol = fcol = ui.getDefaultColor("constr")
+            lcol = ui.getDefaultColor("constr")
             tcol = lcol
             fcol = lcol
 

--- a/src/Mod/Draft/draftutils/gui_utils.py
+++ b/src/Mod/Draft/draftutils/gui_utils.py
@@ -353,10 +353,13 @@ def format_object(target, origin=None):
             lcol = fcol = ui.getDefaultColor("constr")
             tcol = lcol
             fcol = lcol
-            grp = doc.getObject("Draft_Construction")
+
+            # Get the construction group or create it if it doesn't exist
+            gname = utils.get_param("constructiongroupname", "Construction")
+            grp = doc.getObject(gname)
             if not grp:
-                grp = doc.addObject("App::DocumentObjectGroup", "Draft_Construction")
-                grp.Label = utils.get_param("constructiongroupname", "Construction")
+                grp = doc.addObject("App::DocumentObjectGroup", gname)
+
             grp.addObject(target)
             if hasattr(obrep, "Transparency"):
                 obrep.Transparency = 80


### PR DESCRIPTION
gui_utils wrongly used a hard-coded name for the construction group. This could lead to two construction groups in the same file. See: https://forum.freecadweb.org/viewtopic.php?f=3&t=59055

- [*]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [*]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [*]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [*]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`