### PR TITLE
[PartDesign] inverse for substractive features / remove outside

### DIFF
--- a/src/Mod/PartDesign/App/FeatureGroove.h
+++ b/src/Mod/PartDesign/App/FeatureGroove.h
@@ -40,6 +40,7 @@ public:
     App::PropertyVector Base;
     App::PropertyVector Axis;
     App::PropertyAngle  Angle;
+    App::PropertyBool   Outside;
 
     /** if this property is set to a valid link, both Axis and Base properties
      *  are calculated according to the linked line

--- a/src/Mod/PartDesign/App/FeatureHelix.cpp
+++ b/src/Mod/PartDesign/App/FeatureHelix.cpp
@@ -92,7 +92,7 @@ Helix::Helix()
     Angle.setConstraints(&floatAngle);
     ADD_PROPERTY_TYPE(ReferenceAxis, (0), "Helix", App::Prop_None, "Reference axis of revolution");
     ADD_PROPERTY_TYPE(Mode, (long(0)), "Helix", App::Prop_None, "Helix input mode");
-    ADD_PROPERTY_TYPE(Outside, (long(0)), "Helix", App::Prop_None, "Outside");
+    ADD_PROPERTY_TYPE(Outside, (long(0)), "Helix", App::Prop_None, "Remove outside of profile");
     ADD_PROPERTY_TYPE(HasBeenEdited, (long(0)), "Helix", App::Prop_None, "HasBeenEdited");
     Mode.setEnums(ModeEnums);
 }

--- a/src/Mod/PartDesign/App/FeatureLoft.h
+++ b/src/Mod/PartDesign/App/FeatureLoft.h
@@ -42,7 +42,8 @@ public:
 
     App::PropertyLinkList Sections;
     App::PropertyBool     Ruled;
-    App::PropertyBool     Closed;    
+    App::PropertyBool     Closed;
+    App::PropertyBool     Outside;
 
     /** @name methods override feature */
     //@{

--- a/src/Mod/PartDesign/App/FeaturePipe.h
+++ b/src/Mod/PartDesign/App/FeaturePipe.h
@@ -49,6 +49,7 @@ public:
     App::PropertyEnumeration Transition;
     App::PropertyEnumeration Transformation;
     App::PropertyLinkList    Sections;
+    App::PropertyBool        Outside;
 
     App::DocumentObjectExecReturn *execute(void);
     short mustExecute() const;

--- a/src/Mod/PartDesign/App/FeaturePocket.cpp
+++ b/src/Mod/PartDesign/App/FeaturePocket.cpp
@@ -69,7 +69,7 @@ Pocket::Pocket()
     ADD_PROPERTY_TYPE(Length2,(100.0),"Pocket",App::Prop_None,"P");
     ADD_PROPERTY_TYPE(UpToFace,(0),"Pocket",App::Prop_None,"Face where pocket will end");
     ADD_PROPERTY_TYPE(Offset,(0.0),"Pocket",App::Prop_None,"Offset from face in which pocket will end");
-    ADD_PROPERTY_TYPE(Inverse,(false),"Pocket",App::Prop_None,"Invert the pocket-operation");
+    ADD_PROPERTY_TYPE(Outside,(false),"Pocket",App::Prop_None,"Remove outside of profile");
     static const App::PropertyQuantityConstraint::Constraints signedLengthConstraint = {-DBL_MAX, DBL_MAX, 1.0};
     Offset.setConstraints ( &signedLengthConstraint );
 
@@ -221,7 +221,7 @@ App::DocumentObjectExecReturn *Pocket::execute(void)
             this->AddSubShape.setValue(prism);
 
             TopoDS_Shape result;
-            if (!Inverse.getValue()) {
+            if (!Outside.getValue()) {
                 // Cut the SubShape out of the base feature
                 BRepAlgoAPI_Cut mkCut(base, prism);
                 if (!mkCut.IsDone())

--- a/src/Mod/PartDesign/App/FeaturePocket.cpp
+++ b/src/Mod/PartDesign/App/FeaturePocket.cpp
@@ -69,6 +69,7 @@ Pocket::Pocket()
     ADD_PROPERTY_TYPE(Length2,(100.0),"Pocket",App::Prop_None,"P");
     ADD_PROPERTY_TYPE(UpToFace,(0),"Pocket",App::Prop_None,"Face where pocket will end");
     ADD_PROPERTY_TYPE(Offset,(0.0),"Pocket",App::Prop_None,"Offset from face in which pocket will end");
+    ADD_PROPERTY_TYPE(Inverse,(false),"Pocket",App::Prop_None,"Invert the pocket-operation");
     static const App::PropertyQuantityConstraint::Constraints signedLengthConstraint = {-DBL_MAX, DBL_MAX, 1.0};
     Offset.setConstraints ( &signedLengthConstraint );
 
@@ -219,11 +220,20 @@ App::DocumentObjectExecReturn *Pocket::execute(void)
             prism = refineShapeIfActive(prism);
             this->AddSubShape.setValue(prism);
 
-            // Cut the SubShape out of the base feature
-            BRepAlgoAPI_Cut mkCut(base, prism);
-            if (!mkCut.IsDone())
-                return new App::DocumentObjectExecReturn("Pocket: Cut out of base feature failed");
-            TopoDS_Shape result = mkCut.Shape();
+            TopoDS_Shape result;
+            if (!Inverse.getValue()) {
+                // Cut the SubShape out of the base feature
+                BRepAlgoAPI_Cut mkCut(base, prism);
+                if (!mkCut.IsDone())
+                    return new App::DocumentObjectExecReturn("Pocket: Cut out of base feature failed");
+                result = mkCut.Shape();
+            } else {
+                // Cut the base feature to SubShape
+                BRepAlgoAPI_Common mkCommon(base, prism);
+                if (!mkCommon.IsDone())
+                    return new App::DocumentObjectExecReturn("Pocket: Cut out of base feature failed");
+                result = mkCommon.Shape();
+            }
             // we have to get the solids (fuse sometimes creates compounds)
             TopoDS_Shape solRes = this->getSolid(result);
             if (solRes.IsNull())

--- a/src/Mod/PartDesign/App/FeaturePocket.h
+++ b/src/Mod/PartDesign/App/FeaturePocket.h
@@ -41,7 +41,7 @@ public:
     App::PropertyLength         Length;
     App::PropertyLength         Length2;
     App::PropertyLength         Offset;
-    App::PropertyBool           Inverse;
+    App::PropertyBool           Outside;
 
     /** @name methods override feature */
     //@{

--- a/src/Mod/PartDesign/App/FeaturePocket.h
+++ b/src/Mod/PartDesign/App/FeaturePocket.h
@@ -41,6 +41,7 @@ public:
     App::PropertyLength         Length;
     App::PropertyLength         Length2;
     App::PropertyLength         Offset;
+    App::PropertyBool           Inverse;
 
     /** @name methods override feature */
     //@{

--- a/src/Mod/PartDesign/App/FeaturePrimitive.h
+++ b/src/Mod/PartDesign/App/FeaturePrimitive.h
@@ -52,6 +52,7 @@ public:
     
     FeaturePrimitive();
     
+    App::PropertyBool   Outside;
     virtual const char* getViewProviderName(void) const override {
         return "PartDesignGui::ViewProviderPrimitive";
     }

--- a/src/Mod/PartDesign/Gui/TaskLoftParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskLoftParameters.cpp
@@ -76,6 +76,8 @@ TaskLoftParameters::TaskLoftParameters(ViewProviderLoft *LoftView,bool /*newObj*
             this, SLOT(onClosed(bool)));
     connect(ui->checkBoxUpdateView, SIGNAL(toggled(bool)),
             this, SLOT(onUpdateView(bool)));
+    connect(ui->checkBoxOutside, SIGNAL(toggled(bool)),
+            this, SLOT(onOutsideChanged(bool)));
 
     // Create context menu
     QAction* remove = new QAction(tr("Remove"), this);
@@ -117,9 +119,12 @@ TaskLoftParameters::TaskLoftParameters(ViewProviderLoft *LoftView,bool /*newObj*
         ui->listWidgetReferences->addItem(item);
     }
 
+    ui->checkBoxOutside->setVisible(loft->getAddSubType() == PartDesign::FeatureAddSub::Subtractive);
+
     // get options
     ui->checkBoxRuled->setChecked(loft->Ruled.getValue());
     ui->checkBoxClosed->setChecked(loft->Closed.getValue());
+    ui->checkBoxOutside->setChecked(loft->Outside.getValue());
 
     if (!loft->Sections.getValues().empty()) {
         LoftView->makeTemporaryVisible(true);
@@ -295,6 +300,12 @@ void TaskLoftParameters::exitSelectionMode() {
 
 void TaskLoftParameters::changeEvent(QEvent * /*e*/)
 {
+}
+
+void TaskLoftParameters::onOutsideChanged(bool val)
+{
+    static_cast<PartDesign::Loft*>(vp->getObject())->Outside.setValue(val);
+    recomputeFeature();
 }
 
 void TaskLoftParameters::onClosed(bool val) {

--- a/src/Mod/PartDesign/Gui/TaskLoftParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskLoftParameters.h
@@ -61,6 +61,7 @@ private Q_SLOTS:
     void onRuled(bool);
     void onDeleteSection();
     void indexesMoved();
+    void onOutsideChanged(bool);
 
 protected:
     void changeEvent(QEvent *e);

--- a/src/Mod/PartDesign/Gui/TaskLoftParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskLoftParameters.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>262</width>
-    <height>270</height>
+    <height>337</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -25,6 +25,13 @@
     <widget class="QCheckBox" name="checkBoxClosed">
      <property name="text">
       <string>Closed</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="checkBoxOutside">
+     <property name="text">
+      <string>Remove outside of loft</string>
      </property>
     </widget>
    </item>

--- a/src/Mod/PartDesign/Gui/TaskPipeParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPipeParameters.cpp
@@ -90,6 +90,8 @@ TaskPipeParameters::TaskPipeParameters(ViewProviderPipe *PipeView, bool /*newObj
             this, SLOT(onButtonRefRemove(bool)));
     connect(ui->buttonSpineBase, SIGNAL(toggled(bool)),
             this, SLOT(onBaseButton(bool)));
+    connect(ui->checkBoxOutside, SIGNAL(toggled(bool)),
+            this, SLOT(onOutsideChanged(bool)));
 
     // Create context menu
     QAction* remove = new QAction(tr("Remove"), this);
@@ -135,6 +137,9 @@ TaskPipeParameters::TaskPipeParameters(ViewProviderPipe *PipeView, bool /*newObj
     }
 
     ui->comboBoxTransition->setCurrentIndex(pipe->Transition.getValue());
+
+    ui->checkBoxOutside->setVisible(pipe->getAddSubType() == PartDesign::FeatureAddSub::Subtractive);
+    ui->checkBoxOutside->setChecked(pipe->Outside.getValue());
 
     updateUI();
 }
@@ -232,6 +237,12 @@ void TaskPipeParameters::onSelectionChanged(const Gui::SelectionChanges& msg)
         clearButtons();
         exitSelectionMode();
     }
+}
+
+void TaskPipeParameters::onOutsideChanged(bool on)
+{
+    static_cast<PartDesign::Pipe*>(vp->getObject())->Outside.setValue(on);
+    recomputeFeature();
 }
 
 void TaskPipeParameters::onTransitionChanged(int idx) {

--- a/src/Mod/PartDesign/Gui/TaskPipeParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskPipeParameters.h
@@ -66,6 +66,7 @@ private Q_SLOTS:
     void onBaseButton(bool checked);
     void onProfileButton(bool checked);
     void onDeleteEdge();
+    void onOutsideChanged(bool);
   
 protected:
     enum selectionModes { none, refAdd, refRemove, refObjAdd, refProfile };

--- a/src/Mod/PartDesign/Gui/TaskPipeParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskPipeParameters.ui
@@ -15,6 +15,13 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>
+    <widget class="QCheckBox" name="checkBoxOutside">
+     <property name="text">
+      <string>Remove outside of sweep</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QGroupBox" name="groupprofile">
      <property name="title">
       <string>Profile</string>

--- a/src/Mod/PartDesign/Gui/TaskPocketParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPocketParameters.cpp
@@ -78,6 +78,7 @@ TaskPocketParameters::TaskPocketParameters(ViewProviderPocket *PocketView,QWidge
     Base::Quantity off = pcPocket->Offset.getQuantityValue();
     bool midplane = pcPocket->Midplane.getValue();
     bool reversed = pcPocket->Reversed.getValue();
+    bool inverse = pcPocket->Inverse.getValue();
     int index = pcPocket->Type.getValue(); // must extract value here, clear() kills it!
     App::DocumentObject* obj =  pcPocket->UpToFace.getValue();
     std::vector<std::string> subStrings = pcPocket->UpToFace.getSubValues();
@@ -95,6 +96,7 @@ TaskPocketParameters::TaskPocketParameters(ViewProviderPocket *PocketView,QWidge
     ui->offsetEdit->setValue(off);
     ui->checkBoxMidplane->setChecked(midplane);
     ui->checkBoxReversed->setChecked(reversed);
+    ui->checkBoxInverse->setChecked(inverse);
 
     // Set object labels
     if (obj && PartDesign::Feature::isDatum(obj)) {
@@ -140,6 +142,8 @@ TaskPocketParameters::TaskPocketParameters(ViewProviderPocket *PocketView,QWidge
             this, SLOT(onMidplaneChanged(bool)));
     connect(ui->checkBoxReversed, SIGNAL(toggled(bool)),
             this, SLOT(onReversedChanged(bool)));
+    connect(ui->checkBoxInverse, SIGNAL(toggled(bool)),
+            this, SLOT(onInverseChanged(bool)));
     connect(ui->changeMode, SIGNAL(currentIndexChanged(int)),
             this, SLOT(onModeChanged(int)));
     connect(ui->buttonFace, SIGNAL(clicked()),
@@ -173,6 +177,7 @@ void TaskPocketParameters::updateUI(int index)
     bool isOffsetEditEnabled  = true;
     bool isMidplateEnabled    = false;
     bool isReversedEnabled    = false;
+    bool isInverseEnabled     = false;
     bool isFaceEditEnabled    = false;
 
     // dimension
@@ -186,6 +191,7 @@ void TaskPocketParameters::updateUI(int index)
         isMidplateEnabled = true;
         // Reverse only makes sense if Midplane is not true
         isReversedEnabled = !ui->checkBoxMidplane->isChecked();
+        isInverseEnabled = true;
     }
     // through all
     else if (index == 1) {
@@ -193,6 +199,7 @@ void TaskPocketParameters::updateUI(int index)
         isOffsetEditEnabled = false; // offset may have some meaning for through all but it doesn't work
         isMidplateEnabled = true;
         isReversedEnabled = !ui->checkBoxMidplane->isChecked();
+        isInverseEnabled = true;
     }
     // up to first
     else if (index == 2) {
@@ -201,6 +208,7 @@ void TaskPocketParameters::updateUI(int index)
             // It may work not quite as expected but useful if sketch oriented upside-down.
             // (may happen in bodies)
             // FIXME: Fix probably lies somewhere in IF block on line 125 of FeaturePocket.cpp
+        isInverseEnabled = false;
     }
     // up to face
     else if (index == 3) {
@@ -211,6 +219,7 @@ void TaskPocketParameters::updateUI(int index)
         // Go into reference selection mode if no face has been selected yet
         if (ui->lineFaceName->property("FeatureName").isNull())
             onButtonFace(true);
+        isInverseEnabled = false;
     }
     // two dimensions
     else {
@@ -234,6 +243,8 @@ void TaskPocketParameters::updateUI(int index)
     ui->checkBoxMidplane->setEnabled( isMidplateEnabled );
 
     ui->checkBoxReversed->setEnabled( isReversedEnabled );
+
+    ui->checkBoxInverse->setEnabled( isInverseEnabled );
 
     ui->buttonFace->setEnabled( isFaceEditEnabled );
     ui->lineFaceName->setEnabled( isFaceEditEnabled );
@@ -303,6 +314,13 @@ void TaskPocketParameters::onReversedChanged(bool on)
 {
     PartDesign::Pocket* pcPocket = static_cast<PartDesign::Pocket*>(vp->getObject());
     pcPocket->Reversed.setValue(on);
+    recomputeFeature();
+}
+
+void TaskPocketParameters::onInverseChanged(bool on)
+{
+    PartDesign::Pocket* pcPocket = static_cast<PartDesign::Pocket*>(vp->getObject());
+    pcPocket->Inverse.setValue(on);
     recomputeFeature();
 }
 
@@ -404,6 +422,11 @@ bool   TaskPocketParameters::getMidplane(void) const
     return ui->checkBoxMidplane->isChecked();
 }
 
+bool   TaskPocketParameters::getInverse(void) const
+{
+    return ui->checkBoxInverse->isChecked();
+}
+
 int TaskPocketParameters::getMode(void) const
 {
     return ui->changeMode->currentIndex();
@@ -497,6 +520,7 @@ void TaskPocketParameters::apply()
     FCMD_OBJ_CMD(obj,"UpToFace = " << facename.toLatin1().data());
     FCMD_OBJ_CMD(obj,"Reversed = " << (getReversed()?1:0));
     FCMD_OBJ_CMD(obj,"Midplane = " << (getMidplane()?1:0));
+    FCMD_OBJ_CMD(obj,"Inverse = " << (getInverse()?1:0));
     FCMD_OBJ_CMD(obj,"Offset = " << getOffset());
 }
 

--- a/src/Mod/PartDesign/Gui/TaskPocketParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskPocketParameters.h
@@ -61,6 +61,7 @@ private Q_SLOTS:
     void onOffsetChanged(double);
     void onMidplaneChanged(bool);
     void onReversedChanged(bool);
+    void onInverseChanged(bool);
     void onButtonFace(const bool pressed = true);
     void onFaceName(const QString& text);
     void onModeChanged(int);
@@ -75,6 +76,7 @@ private:
     int    getMode(void) const;
     bool   getMidplane(void) const;
     bool   getReversed(void) const;
+    bool   getInverse(void) const;
     QString getFaceName(void) const;
 
     void onSelectionChanged(const Gui::SelectionChanges& msg) override;

--- a/src/Mod/PartDesign/Gui/TaskPocketParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskPocketParameters.h
@@ -61,7 +61,7 @@ private Q_SLOTS:
     void onOffsetChanged(double);
     void onMidplaneChanged(bool);
     void onReversedChanged(bool);
-    void onInverseChanged(bool);
+    void onOutsideChanged(bool);
     void onButtonFace(const bool pressed = true);
     void onFaceName(const QString& text);
     void onModeChanged(int);
@@ -76,7 +76,7 @@ private:
     int    getMode(void) const;
     bool   getMidplane(void) const;
     bool   getReversed(void) const;
-    bool   getInverse(void) const;
+    bool   getOutside(void) const;
     QString getFaceName(void) const;
 
     void onSelectionChanged(const Gui::SelectionChanges& msg) override;

--- a/src/Mod/PartDesign/Gui/TaskPocketParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskPocketParameters.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>193</width>
-    <height>272</height>
+    <width>282</width>
+    <height>354</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -83,6 +83,13 @@
     </widget>
    </item>
    <item>
+    <widget class="QCheckBox" name="checkBoxInverse">
+     <property name="text">
+      <string>Inverse</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <layout class="QHBoxLayout" name="horizontalLayout_4">
      <item>
       <widget class="QLabel" name="labelLength2">
@@ -151,6 +158,7 @@
   <tabstop>offsetEdit</tabstop>
   <tabstop>checkBoxMidplane</tabstop>
   <tabstop>checkBoxReversed</tabstop>
+  <tabstop>checkBoxInverse</tabstop>
   <tabstop>lengthEdit2</tabstop>
   <tabstop>buttonFace</tabstop>
   <tabstop>lineFaceName</tabstop>

--- a/src/Mod/PartDesign/Gui/TaskPocketParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskPocketParameters.ui
@@ -83,9 +83,9 @@
     </widget>
    </item>
    <item>
-    <widget class="QCheckBox" name="checkBoxInverse">
+    <widget class="QCheckBox" name="checkBoxOutside">
      <property name="text">
-      <string>Inverse</string>
+      <string>Remove outside of profile</string>
      </property>
     </widget>
    </item>
@@ -158,7 +158,7 @@
   <tabstop>offsetEdit</tabstop>
   <tabstop>checkBoxMidplane</tabstop>
   <tabstop>checkBoxReversed</tabstop>
-  <tabstop>checkBoxInverse</tabstop>
+  <tabstop>checkBoxOutside</tabstop>
   <tabstop>lengthEdit2</tabstop>
   <tabstop>buttonFace</tabstop>
   <tabstop>lineFaceName</tabstop>

--- a/src/Mod/PartDesign/Gui/TaskPrimitiveParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPrimitiveParameters.cpp
@@ -275,6 +275,12 @@ TaskBoxPrimitives::TaskBoxPrimitives(ViewProviderPrimitive* vp, QWidget* parent)
         }
     }
 
+    PartDesign::FeaturePrimitive* prim = static_cast<PartDesign::FeaturePrimitive*>(vp->getObject());
+    ui->checkBoxOutside->setVisible(prim->getAddSubType() == PartDesign::FeatureAddSub::Subtractive);
+    ui->checkBoxOutside->setChecked(prim->Outside.getValue());
+
+    connect(ui->checkBoxOutside, SIGNAL(toggled(bool)), this, SLOT(onOutsideChanged(bool)));
+
     // box
     connect(ui->boxLength, SIGNAL(valueChanged(double)), this, SLOT(onBoxLengthChanged(double)));
     connect(ui->boxWidth, SIGNAL(valueChanged(double)), this, SLOT(onBoxWidthChanged(double)));
@@ -357,6 +363,13 @@ void TaskBoxPrimitives::slotDeletedObject(const Gui::ViewProviderDocumentObject&
 {
     if (this->vp == &Obj)
         this->vp = nullptr;
+}
+
+void TaskBoxPrimitives::onOutsideChanged(bool on)
+{
+    PartDesign::FeaturePrimitive* prim = static_cast<PartDesign::FeaturePrimitive*>(vp->getObject());
+    prim->Outside.setValue(on);
+    vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
 }
 
 void TaskBoxPrimitives::onBoxHeightChanged(double v) {

--- a/src/Mod/PartDesign/Gui/TaskPrimitiveParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskPrimitiveParameters.h
@@ -100,6 +100,7 @@ public Q_SLOTS:
     void onWedgeX2minChanged(double);
     void onWedgeZ2maxChanged(double);
     void onWedgeZ2minChanged(double);
+    void onOutsideChanged(bool); 
 
 private:
     /** Notifies when the object is about to be removed. */

--- a/src/Mod/PartDesign/Gui/TaskPrimitiveParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskPrimitiveParameters.ui
@@ -2346,6 +2346,13 @@ If zero, it is equal to Radius2</string>
      </widget>
     </widget>
    </item>
+   <item>
+    <widget class="QCheckBox" name="checkBoxOutside">
+     <property name="text">
+      <string>Remove outside of primitive</string>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>

--- a/src/Mod/PartDesign/Gui/TaskRevolutionParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskRevolutionParameters.cpp
@@ -84,7 +84,10 @@ TaskRevolutionParameters::TaskRevolutionParameters(PartDesignGui::ViewProvider* 
         this->propReferenceAxis = &(rev->ReferenceAxis);
         this->propReversed = &(rev->Reversed);
         ui->revolveAngle->bind(rev->Angle);
+        ui->checkBoxOutside->setChecked(rev->Outside.getValue());
     }
+
+    ui->checkBoxOutside->setVisible(pcFeat->isDerivedFrom(PartDesign::Groove::getClassTypeId()));
 
     ui->checkBoxMidplane->setChecked(propMidPlane->getValue());
     ui->checkBoxReversed->setChecked(propReversed->getValue());
@@ -207,6 +210,8 @@ void TaskRevolutionParameters::connectSignals()
             this, SLOT(onReversed(bool)));
     connect(ui->checkBoxUpdateView, SIGNAL(toggled(bool)),
             this, SLOT(onUpdateView(bool)));
+    connect(ui->checkBoxOutside, SIGNAL(toggled(bool)),
+            this, SLOT(onOutsideChanged(bool)));
 }
 
 void TaskRevolutionParameters::updateUI()
@@ -312,6 +317,13 @@ void TaskRevolutionParameters::onMidplane(bool on)
 void TaskRevolutionParameters::onReversed(bool on)
 {
     propReversed->setValue(on);
+    recomputeFeature();
+}
+
+void TaskRevolutionParameters::onOutsideChanged(bool on)
+{
+    PartDesign::Groove* rev = static_cast<PartDesign::Groove*>(vp->getObject());
+    rev->Outside.setValue(on);
     recomputeFeature();
 }
 

--- a/src/Mod/PartDesign/Gui/TaskRevolutionParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskRevolutionParameters.h
@@ -70,6 +70,7 @@ private Q_SLOTS:
     void onAxisChanged(int);
     void onMidplane(bool);
     void onReversed(bool);
+    void onOutsideChanged(bool); 
 
 protected:
     void onSelectionChanged(const Gui::SelectionChanges& msg) override;

--- a/src/Mod/PartDesign/Gui/TaskRevolutionParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskRevolutionParameters.ui
@@ -110,6 +110,13 @@
     </widget>
    </item>
    <item>
+    <widget class="QCheckBox" name="checkBoxOutside">
+     <property name="text">
+      <string>Remove outside profile</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="Line" name="line">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>


### PR DESCRIPTION
This adds an “inverse” option for PartDesign pocket feature and other additive features.
Essentially this cuts away anything that is **not** covered by the
sketch. (boolean common instead of cut.)

https://forum.freecadweb.org/viewtopic.php?style=5&f=19&t=59116
https://forum.freecadweb.org/viewtopic.php?style=5&f=13&t=59115

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [x]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
