### PR TITLE
[Sketch] add new sketch object rounded rectangle

### DIFF
--- a/src/Mod/Sketcher/Gui/CommandAlterGeometry.cpp
+++ b/src/Mod/Sketcher/Gui/CommandAlterGeometry.cpp
@@ -82,7 +82,7 @@ CmdSketcherToggleConstruction::CmdSketcherToggleConstruction()
     // list of toggle construction commands
     Gui::CommandManager &rcCmdMgr = Gui::Application::Instance->commandManager();
     rcCmdMgr.addCommandMode("ToggleConstruction", "Sketcher_CreateLine");
-    rcCmdMgr.addCommandMode("ToggleConstruction", "Sketcher_CreateRectangle");
+    rcCmdMgr.addCommandMode("ToggleConstruction", "Sketcher_CompCreateRectangles");
     rcCmdMgr.addCommandMode("ToggleConstruction", "Sketcher_CreatePolyline");
     rcCmdMgr.addCommandMode("ToggleConstruction", "Sketcher_CreateSlot");
     rcCmdMgr.addCommandMode("ToggleConstruction", "Sketcher_CompCreateArc");

--- a/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
+++ b/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
@@ -6436,7 +6436,7 @@ public:
             float dx = onSketchPos.x - StartPos.x;
             float dy = onSketchPos.y - StartPos.y;
 
-            lx=0;ly=0;a=0;
+            lx = 0; ly = 0; a = 0;
             double rev = 0;
             if (fabs(dx) > fabs(dy)) {
                 lx = dx;
@@ -6450,16 +6450,15 @@ public:
                 rev = Base::sgn(dy);
             }
 
-            for (int i=0; i < 17; i++) {
-                double angle = (i+a)*M_PI/16.0;
-                double rx = -fabs(r)* rev * sin(angle) ;
-                double ry = fabs(r) * rev *cos(angle) ;
+            for (int i = 0; i < 17; i++) {
+                double angle = (i + a) * M_PI / 16.0;
+                double rx = -fabs(r) * rev * sin(angle);
+                double ry = fabs(r) * rev * cos(angle);
                 EditCurve[i] = Base::Vector2d(StartPos.x + rx, StartPos.y + ry);
-                EditCurve[18+i] = Base::Vector2d(StartPos.x - rx+lx, StartPos.y - ry+ly);
+                EditCurve[18 + i] = Base::Vector2d(StartPos.x - rx + lx, StartPos.y - ry + ly);
             }
             EditCurve[17] = EditCurve[16] + Base::Vector2d(lx,ly);
             EditCurve[35] = EditCurve[0] ;
-            //EditCurve[34] = EditCurve[0];
 
             SbString text;
             text.sprintf(" (%.1fR %.1fL)", r,lx);
@@ -6497,14 +6496,15 @@ public:
             int firstCurve = getHighestCurveIndex() + 1;
             // add the geometry to the sketch
             double start, end;
-            if(fabs(lx)>fabs(ly)){
-                start = M_PI/2;
-                end = -M_PI/2;
-            }else{
+            if (fabs(lx) > fabs(ly)) {
+                start = M_PI / 2;
+                end = -M_PI / 2;
+            }
+            else {
                 start = 0;
                 end = M_PI;
             }
-            if(ly>0 || lx <0){
+            if (ly > 0 || lx < 0) {
                 double temp = start;
                 start = end;
                 end = temp;
@@ -6514,35 +6514,35 @@ public:
                 Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Add slot"));
                 Gui::Command::doCommand(Gui::Command::Doc,
                     "geoList = []\n"
-                    "geoList.append(Part.ArcOfCircle(Part.Circle(App.Vector(%f,%f,0),App.Vector(0,0,1),%f),%f,%f))\n"
-                    "geoList.append(Part.ArcOfCircle(Part.Circle(App.Vector(%f,%f,0),App.Vector(0,0,1),%f),%f,%f))\n"
-                    "geoList.append(Part.LineSegment(App.Vector(%f,%f,0),App.Vector(%f,%f,0)))\n"
-                    "geoList.append(Part.LineSegment(App.Vector(%f,%f,0),App.Vector(%f,%f,0)))\n"
-                    "%s.addGeometry(geoList,%s)\n"
+                    "geoList.append(Part.ArcOfCircle(Part.Circle(App.Vector(%f, %f, 0), App.Vector(0, 0, 1), %f), %f, %f))\n"
+                    "geoList.append(Part.ArcOfCircle(Part.Circle(App.Vector(%f, %f, 0), App.Vector(0, 0, 1), %f), %f, %f))\n"
+                    "geoList.append(Part.LineSegment(App.Vector(%f, %f, 0), App.Vector(%f, %f, 0)))\n"
+                    "geoList.append(Part.LineSegment(App.Vector(%f, %f, 0), App.Vector(%f, %f, 0)))\n"
+                    "%s.addGeometry(geoList, %s)\n"
                     "conList = []\n"
-                    "conList.append(Sketcher.Constraint('Tangent',%i,1,%i,1))\n"
-                    "conList.append(Sketcher.Constraint('Tangent',%i,2,%i,1))\n"
-                    "conList.append(Sketcher.Constraint('Tangent',%i,2,%i,1))\n"
-                    "conList.append(Sketcher.Constraint('Tangent',%i,2,%i,2))\n"
-                    "conList.append(Sketcher.Constraint('%s',%i))\n"
-                    "conList.append(Sketcher.Constraint('Equal',%i,%i))\n"
+                    "conList.append(Sketcher.Constraint('Tangent', %i, 1, %i, 1))\n"
+                    "conList.append(Sketcher.Constraint('Tangent', %i, 2, %i, 1))\n"
+                    "conList.append(Sketcher.Constraint('Tangent', %i, 2, %i, 1))\n"
+                    "conList.append(Sketcher.Constraint('Tangent', %i, 2, %i, 2))\n"
+                    "conList.append(Sketcher.Constraint('%s', %i))\n"
+                    "conList.append(Sketcher.Constraint('Equal', %i, %i))\n"
                     "%s.addConstraint(conList)\n",
-                    StartPos.x,StartPos.y,  // center of the  arc1
+                    StartPos.x, StartPos.y,  // center of the  arc1
                     fabs(r),                  // radius arc1
-                    start,end,                 // start and end angle of arc1
-                    StartPos.x+lx,StartPos.y+ly,    // center of the arc2
+                    start, end,                 // start and end angle of arc1
+                    StartPos.x + lx, StartPos.y + ly,    // center of the arc2
                     fabs(r),                          // radius arc2
-                    end,start,                         // start and end angle of arc2
-                    EditCurve[16].x,EditCurve[16].y,EditCurve[17].x,EditCurve[17].y, // line1
-                    EditCurve[0].x,EditCurve[0].y,EditCurve[34].x,EditCurve[34].y, // line2
+                    end, start,                         // start and end angle of arc2
+                    EditCurve[16].x, EditCurve[16].y, EditCurve[17].x, EditCurve[17].y, // line1
+                    EditCurve[0].x, EditCurve[0].y, EditCurve[34].x, EditCurve[34].y, // line2
                     Gui::Command::getObjectCmd(sketchgui->getObject()).c_str(), // the sketch
-                    geometryCreationMode==Construction?"True":"False", // geometry as construction or not
-                    firstCurve,firstCurve+3, // tangent1
-                    firstCurve,firstCurve+2, // tangent2
-                    firstCurve+2,firstCurve+1, // tangent3
-                    firstCurve+3,firstCurve+1, // tangent4
-                    (fabs(lx)>fabs(ly))?"Horizontal":"Vertical", firstCurve+2, // vertical or horizontal constraint
-                    firstCurve,firstCurve+1, // equal constraint
+                    geometryCreationMode == Construction ? "True" : "False", // geometry as construction or not
+                    firstCurve, firstCurve + 3, // tangent1
+                    firstCurve, firstCurve + 2, // tangent2
+                    firstCurve + 2, firstCurve + 1, // tangent3
+                    firstCurve + 3, firstCurve + 1, // tangent4
+                    (fabs(lx) > fabs(ly)) ? "Horizontal" : "Vertical", firstCurve + 2, // vertical or horizontal constraint
+                    firstCurve, firstCurve + 1, // equal constraint
                     Gui::Command::getObjectCmd(sketchgui->getObject()).c_str()); // the sketch
 
                 Gui::Command::commitCommand();
@@ -6570,9 +6570,9 @@ public:
             ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher");
             bool continuousMode = hGrp->GetBool("ContinuousCreationMode",true);
 
-            if(continuousMode){
+            if (continuousMode) {
                 // This code enables the continuous creation mode.
-                Mode=STATUS_SEEK_First;
+                Mode = STATUS_SEEK_First;
                 EditCurve.clear();
                 sketchgui->drawEdit(EditCurve);
                 EditCurve.resize(36);
@@ -6582,7 +6582,7 @@ public:
                 * handler is destroyed by the quit() method on pressing the
                 * right button of the mouse */
             }
-            else{
+            else {
                 sketchgui->purgeHandler(); // no code after this line, Handler get deleted in ViewProvider
             }
         }
@@ -6591,7 +6591,7 @@ public:
 protected:
     BoxMode Mode;
     Base::Vector2d StartPos;
-    double lx,ly,r,a;
+    double lx, ly, r, a;
     std::vector<Base::Vector2d> EditCurve;
     std::vector<AutoConstraint> sugConstr1, sugConstr2;
 };
@@ -6615,7 +6615,7 @@ CmdSketcherCreateSlot::CmdSketcherCreateSlot()
 void CmdSketcherCreateSlot::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-    ActivateHandler(getActiveGuiDocument(),new DrawSketchHandlerSlot() );
+    ActivateHandler(getActiveGuiDocument(), new DrawSketchHandlerSlot());
 }
 
 void CmdSketcherCreateSlot::updateAction(int mode)
@@ -6633,6 +6633,431 @@ void CmdSketcherCreateSlot::updateAction(int mode)
 }
 
 bool CmdSketcherCreateSlot::isActive(void)
+{
+    return isCreateGeoActive(getActiveGuiDocument());
+}
+
+
+/**
+ * Create rounded oblong
+ */
+class DrawSketchHandlerOblong : public DrawSketchHandler
+{
+public:
+    DrawSketchHandlerOblong()
+        : Mode(STATUS_SEEK_First)
+        , lengthX(0), lengthY(0), radius(0), signX(1), signY(1)
+        , EditCurve(37)
+    {
+    }
+    virtual ~DrawSketchHandlerOblong() {}
+    /// mode table
+    enum BoxMode {
+        STATUS_SEEK_First,      /**< enum value ----. */
+        STATUS_SEEK_Second,     /**< enum value ----. */
+        STATUS_End
+    };
+
+    virtual void activated(ViewProviderSketch*)
+    {
+        setCrosshairCursor("Sketcher_Pointer_Oblong");
+    }
+
+    virtual void mouseMove(Base::Vector2d onSketchPos)
+    {
+
+        if (Mode == STATUS_SEEK_First) {
+            setPositionText(onSketchPos);
+            if (seekAutoConstraint(sugConstr1, onSketchPos, Base::Vector2d(0.f, 0.f))) {
+                renderSuggestConstraintsCursor(sugConstr1);
+                return;
+            }
+        }
+        else if (Mode == STATUS_SEEK_Second) {
+            float distanceX = onSketchPos.x - StartPos.x;
+            float distanceY = onSketchPos.y - StartPos.y;
+
+            lengthX = distanceX; lengthY = distanceY;
+            signX = Base::sgn(distanceX);
+            signY = Base::sgn(distanceY);
+            if (fabs(distanceX) > fabs(distanceY)) {
+                radius = fabs(distanceY) / 4; // we use a fourth of the smaller distance as default radius
+            }
+            else {
+                radius = fabs(distanceX) / 4;
+            }
+
+            // we draw the lines with 36 segments, 8 for each arc and 4 lines
+            // draw the arcs
+            for (int i = 0; i < 8; i++) {
+                // calculate the x,y positions forming the the arc
+                double angle = i * M_PI / 16.0;
+                double x_i = -radius * sin(angle);
+                double y_i = -radius * cos(angle);
+                // we are drawing clockwise starting with the arc that is besides StartPos
+                if (signX == signY) {
+                    EditCurve[i] = Base::Vector2d(StartPos.x + signX * (radius + x_i), StartPos.y + signY * (radius + y_i));
+                    EditCurve[9 + i] = Base::Vector2d(StartPos.x + signY * (radius + y_i), StartPos.y + lengthY - signX * (radius + x_i));
+                    EditCurve[18 + i] = Base::Vector2d(StartPos.x + lengthX - signX * (radius + x_i), StartPos.y + lengthY - signY * (radius + y_i));
+                    EditCurve[27 + i] = Base::Vector2d(StartPos.x + lengthX - signY * (radius + y_i), StartPos.y + signX * (radius + x_i));
+                }
+                else {
+                    EditCurve[i] = Base::Vector2d(StartPos.x - signY * (radius + y_i), StartPos.y - signX * (radius + x_i));
+                    EditCurve[9 + i] = Base::Vector2d(StartPos.x + lengthX - signX * (radius + x_i), StartPos.y + signY * (radius + y_i));
+                    EditCurve[18 + i] = Base::Vector2d(StartPos.x + lengthX + signY * (radius + y_i), StartPos.y + lengthY + signX * (radius + x_i));
+                    EditCurve[27 + i] = Base::Vector2d(StartPos.x + signX * (radius + x_i), StartPos.y + lengthY - signY * (radius + y_i));
+                }
+            }
+            // draw the lines
+            if (signX == signY) {
+                EditCurve[8] = Base::Vector2d(StartPos.x, StartPos.y + (signY * radius));
+                EditCurve[17] = Base::Vector2d(StartPos.x + (signX * radius), StartPos.y + lengthY);
+                EditCurve[26] = Base::Vector2d(StartPos.x + lengthX, StartPos.y + lengthY - (signY * radius));
+                EditCurve[35] = Base::Vector2d(StartPos.x + lengthX - (signX * radius), StartPos.y);
+            }
+            else {
+                EditCurve[8] = Base::Vector2d(StartPos.x + (signX * radius), StartPos.y);
+                EditCurve[17] = Base::Vector2d(StartPos.x + lengthX, StartPos.y + (signY * radius));
+                EditCurve[26] = Base::Vector2d(StartPos.x + lengthX - (signX * radius), StartPos.y + lengthY);
+                EditCurve[35] = Base::Vector2d(StartPos.x, StartPos.y + lengthY - (signY * radius));
+            }
+            // close the curve
+            EditCurve[36] = EditCurve[0];
+
+            SbString text;
+            text.sprintf(" (%.1fR %.1fX %.1fY)", radius, lengthX, lengthY);
+            setPositionText(onSketchPos, text);
+
+            sketchgui->drawEdit(EditCurve);
+            if (seekAutoConstraint(sugConstr2, onSketchPos, Base::Vector2d(0.f, 0.f))) {
+                renderSuggestConstraintsCursor(sugConstr2);
+                return;
+            }
+        }
+        applyCursor();
+    }
+
+    virtual bool pressButton(Base::Vector2d onSketchPos)
+    {
+        if (Mode == STATUS_SEEK_First) {
+            StartPos = onSketchPos;
+            Mode = STATUS_SEEK_Second;
+        }
+        else {
+            EndPos = onSketchPos;
+            Mode = STATUS_End;
+        }
+        return true;
+    }
+
+    virtual bool releaseButton(Base::Vector2d onSketchPos)
+    {
+        Q_UNUSED(onSketchPos);
+        if (Mode == STATUS_End) {
+            unsetCursor();
+            resetPositionText();
+
+            int firstCurve = getHighestCurveIndex() + 1;
+            // add the geometry to the sketch
+            // first determine the angles for the first arc
+            double start = 0;
+            double end = M_PI / 2;
+            if (signX > 0 && signY > 0) {
+                start = -2 * end;
+                end = -1 * end;
+            }
+            else if (signX > 0 && signY < 0) {
+                start = end;
+                end = 2 * end;
+            }
+            else if (signX < 0 && signY > 0) {
+                start = -1 * end;
+                end = 0;
+            }
+
+            try {
+                Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Add rounded rectangle"));
+                Gui::Command::doCommand(Gui::Command::Doc,
+                    // syntax for arcs: Part.ArcOfCircle(Part.Circle(center, axis, radius), startangle, endangle)
+                    "geoList = []\n"
+                    "geoList.append(Part.ArcOfCircle(Part.Circle(App.Vector(%f, %f, 0), App.Vector(0, 0, 1), %f), %f, %f))\n"
+                    "geoList.append(Part.LineSegment(App.Vector(%f, %f, 0), App.Vector(%f, %f, 0)))\n"
+                    "geoList.append(Part.ArcOfCircle(Part.Circle(App.Vector(%f, %f, 0), App.Vector(0, 0, 1), %f), %f, %f))\n"
+                    "geoList.append(Part.LineSegment(App.Vector(%f, %f, 0), App.Vector(%f, %f, 0)))\n"
+                    "geoList.append(Part.ArcOfCircle(Part.Circle(App.Vector(%f, %f, 0), App.Vector(0, 0, 1), %f), %f, %f))\n"
+                    "geoList.append(Part.LineSegment(App.Vector(%f, %f, 0), App.Vector(%f, %f, 0)))\n"
+                    "geoList.append(Part.ArcOfCircle(Part.Circle(App.Vector(%f, %f, 0), App.Vector(0, 0, 1), %f), %f, %f))\n"
+                    "geoList.append(Part.LineSegment(App.Vector(%f, %f, 0), App.Vector(%f, %f, 0)))\n"
+                    "%s.addGeometry(geoList, %s)\n"
+                    "conList = []\n"
+                    "conList.append(Sketcher.Constraint('Tangent', %i, 1, %i, 1))\n"
+                    "conList.append(Sketcher.Constraint('Tangent', %i, 2, %i, 2))\n"
+                    "conList.append(Sketcher.Constraint('Tangent', %i, 1, %i, 1))\n"
+                    "conList.append(Sketcher.Constraint('Tangent', %i, 2, %i, 2))\n"
+                    "conList.append(Sketcher.Constraint('Tangent', %i, 1, %i, 1))\n"
+                    "conList.append(Sketcher.Constraint('Tangent', %i, 2, %i, 2))\n"
+                    "conList.append(Sketcher.Constraint('Tangent', %i, 1, %i, 1))\n"
+                    "conList.append(Sketcher.Constraint('Tangent', %i, 2, %i, 2))\n"
+                    "conList.append(Sketcher.Constraint('Horizontal', %i))\n"
+                    "conList.append(Sketcher.Constraint('Horizontal', %i))\n"
+                    "conList.append(Sketcher.Constraint('Vertical', %i))\n"
+                    "conList.append(Sketcher.Constraint('Vertical', %i))\n"
+                    "conList.append(Sketcher.Constraint('Equal', %i, %i))\n"
+                    "conList.append(Sketcher.Constraint('Equal', %i, %i))\n"
+                    "conList.append(Sketcher.Constraint('Equal', %i, %i))\n"
+                    "%s.addConstraint(conList)\n",
+                    StartPos.x + (signX * radius), StartPos.y + (signY * radius), // center of the  arc 1
+                    radius,
+                    start, end,                 // start and end angle of arc1
+                    EditCurve[8].x, EditCurve[8].y, EditCurve[9].x, EditCurve[9].y, // line 1
+                    signX == signY ? StartPos.x + (signX * radius) : StartPos.x + lengthX - (signX * radius), // center of the arc 2
+                    signX == signY ? StartPos.y + lengthY - (signY * radius) : StartPos.y + (signY * radius),
+                    radius,
+                    // start and end angle of arc 2
+                    // the logic is that end is start + M_PI / 2 and start is the previous end - M_PI
+                    end - M_PI,
+                    end - 0.5 * M_PI,
+                    EditCurve[17].x, EditCurve[17].y, EditCurve[18].x, EditCurve[18].y, // line 2
+                    StartPos.x + lengthX - (signX * radius), StartPos.y + lengthY - (signY * radius),  // center of the arc 3
+                    radius,
+                    end - 1.5 * M_PI,
+                    end - M_PI,
+                    EditCurve[26].x, EditCurve[26].y, EditCurve[27].x, EditCurve[27].y, // line 3
+                    signX == signY ? StartPos.x + lengthX - (signX * radius) : StartPos.x + (signX * radius), // center of the arc 4
+                    signX == signY ? StartPos.y + (signY * radius) : StartPos.y + lengthY - (signY * radius),
+                    radius,
+                    end - 2 * M_PI,
+                    end - 1.5 * M_PI,
+                    EditCurve[35].x, EditCurve[35].y, EditCurve[36].x, EditCurve[36].y, // line 4
+                    Gui::Command::getObjectCmd(sketchgui->getObject()).c_str(), // the sketch
+                    geometryCreationMode == Construction ? "True" : "False", // geometry as construction or not
+                    firstCurve, firstCurve + 1,     // tangent 1
+                    firstCurve + 1, firstCurve + 2, // tangent 2
+                    firstCurve + 2, firstCurve + 3, // tangent 3
+                    firstCurve + 3, firstCurve + 4, // tangent 4
+                    firstCurve + 4, firstCurve + 5, // tangent 5
+                    firstCurve + 5, firstCurve + 6, // tangent 6
+                    firstCurve + 6, firstCurve + 7, // tangent 7
+                    firstCurve + 7, firstCurve,     // tangent 8
+                    signX == signY ? firstCurve + 3 : firstCurve + 1, // horizontal constraint
+                    signX == signY ? firstCurve + 7 : firstCurve + 5, // horizontal constraint
+                    signX == signY ? firstCurve + 1 : firstCurve + 3, // vertical constraint
+                    signX == signY ? firstCurve + 5 : firstCurve + 7, // vertical constraint
+                    firstCurve, firstCurve + 2,     // equal  1
+                    firstCurve + 2, firstCurve + 4, // equal  2
+                    firstCurve + 4, firstCurve + 6, // equal  3
+                    Gui::Command::getObjectCmd(sketchgui->getObject()).c_str()); // the sketch
+
+                // now add contruction geometry - two points used to take suggested constraints
+                Gui::Command::doCommand(Gui::Command::Doc,
+                    "geoList = []\n"
+                    "geoList.append(Part.Point(App.Vector(%f, %f, 0)))\n"
+                    "geoList.append(Part.Point(App.Vector(%f, %f, 0)))\n"
+                    "%s.addGeometry(geoList, True)\n" // geometry as construction
+                    "conList = []\n"
+                    "conList.append(Sketcher.Constraint('PointOnObject', %i, 1, %i, ))\n"
+                    "conList.append(Sketcher.Constraint('PointOnObject', %i, 1, %i, ))\n"
+                    "conList.append(Sketcher.Constraint('PointOnObject', %i, 1, %i, ))\n"
+                    "conList.append(Sketcher.Constraint('PointOnObject', %i, 1, %i, ))\n"
+                    "%s.addConstraint(conList)\n",
+                    StartPos.x, StartPos.y, // point at StartPos
+                    EndPos.x, EndPos.y,     // point at EndPos
+                    Gui::Command::getObjectCmd(sketchgui->getObject()).c_str(), // the sketch
+                    firstCurve + 8, firstCurve + 1, // point on object constraint
+                    firstCurve + 8, firstCurve + 7, // point on object constraint
+                    firstCurve + 9, firstCurve + 3, // point on object constraint
+                    firstCurve + 9, firstCurve + 5, // point on object constraint
+                    Gui::Command::getObjectCmd(sketchgui->getObject()).c_str()); // the sketch
+
+                Gui::Command::commitCommand();
+
+                // add auto constraints at the StartPos auxiliar point
+                if (sugConstr1.size() > 0) {
+                    createAutoConstraints(sugConstr1, getHighestCurveIndex() - 1, Sketcher::start);
+                    sugConstr1.clear();
+                }
+
+                // add auto constraints at the EndPos auxiliar point
+                if (sugConstr2.size() > 0) {
+                    createAutoConstraints(sugConstr2, getHighestCurveIndex(), Sketcher::start);
+                    sugConstr2.clear();
+                }
+
+                tryAutoRecomputeIfNotSolve(static_cast<Sketcher::SketchObject*>(sketchgui->getObject()));
+            }
+            catch (const Base::Exception& e) {
+                Base::Console().Error("Failed to add rounded rectangle: %s\n", e.what());
+                Gui::Command::abortCommand();
+
+                tryAutoRecompute(static_cast<Sketcher::SketchObject*>(sketchgui->getObject()));
+            }
+            ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher");
+            bool continuousMode = hGrp->GetBool("ContinuousCreationMode", true);
+
+            if (continuousMode) {
+                // This code enables the continuous creation mode.
+                Mode = STATUS_SEEK_First;
+                EditCurve.clear();
+                sketchgui->drawEdit(EditCurve);
+                EditCurve.resize(37);
+                applyCursor();
+                /* this is ok not to call to purgeHandler
+                * in continuous creation mode because the
+                * handler is destroyed by the quit() method on pressing the
+                * right button of the mouse */
+            }
+            else {
+                sketchgui->purgeHandler(); // no code after this line, Handler get deleted in ViewProvider
+            }
+        }
+        return true;
+    }
+protected:
+    BoxMode Mode;
+    Base::Vector2d StartPos, EndPos;
+    double lengthX, lengthY, radius;
+    float signX, signY;
+    std::vector<Base::Vector2d> EditCurve;
+    std::vector<AutoConstraint> sugConstr1, sugConstr2;
+};
+
+DEF_STD_CMD_AU(CmdSketcherCreateOblong)
+
+CmdSketcherCreateOblong::CmdSketcherCreateOblong()
+    : Command("Sketcher_CreateOblong")
+{
+    sAppModule = "Sketcher";
+    sGroup = QT_TR_NOOP("Sketcher");
+    sMenuText = QT_TR_NOOP("Create rounded rectangle");
+    sToolTipText = QT_TR_NOOP("Create a rounded rectangle in the sketch");
+    sWhatsThis = "Sketcher_CreateOblong";
+    sStatusTip = sToolTipText;
+    sPixmap = "Sketcher_CreateOblong";
+    sAccel = "";
+    eType = ForEdit;
+}
+
+void CmdSketcherCreateOblong::activated(int iMsg)
+{
+    Q_UNUSED(iMsg);
+    ActivateHandler(getActiveGuiDocument(), new DrawSketchHandlerOblong());
+}
+
+void CmdSketcherCreateOblong::updateAction(int mode)
+{
+    switch (mode) {
+    case Normal:
+        if (getAction())
+            getAction()->setIcon(Gui::BitmapFactory().iconFromTheme("Sketcher_CreateOblong"));
+        break;
+    case Construction:
+        if (getAction())
+            getAction()->setIcon(Gui::BitmapFactory().iconFromTheme("Sketcher_CreateOblong_Constr"));
+        break;
+    }
+}
+
+bool CmdSketcherCreateOblong::isActive(void)
+{
+    return isCreateGeoActive(getActiveGuiDocument());
+}
+
+
+DEF_STD_CMD_ACLU(CmdSketcherCompCreateRectangles)
+
+CmdSketcherCompCreateRectangles::CmdSketcherCompCreateRectangles()
+    : Command("Sketcher_CompCreateRectangles")
+{
+    sAppModule = "Sketcher";
+    sGroup = QT_TR_NOOP("Sketcher");
+    sMenuText = QT_TR_NOOP("Create rectangles");
+    sToolTipText = QT_TR_NOOP("Creates a rectangle in the sketch");
+    sWhatsThis = "Sketcher_CompCreateRectangles";
+    sStatusTip = sToolTipText;
+    eType = ForEdit;
+}
+
+void CmdSketcherCompCreateRectangles::activated(int iMsg)
+{
+    if (iMsg == 0)
+        ActivateHandler(getActiveGuiDocument(), new DrawSketchHandlerBox());
+    else if (iMsg == 1)
+        ActivateHandler(getActiveGuiDocument(), new DrawSketchHandlerOblong());
+    else
+        return;
+
+    // Since the default icon is reset when enabling/disabling the command we have
+    // to explicitly set the icon of the used command.
+    Gui::ActionGroup* pcAction = qobject_cast<Gui::ActionGroup*>(_pcAction);
+    QList<QAction*> a = pcAction->actions();
+
+    assert(iMsg < a.size());
+    pcAction->setIcon(a[iMsg]->icon());
+}
+
+Gui::Action* CmdSketcherCompCreateRectangles::createAction(void)
+{
+    Gui::ActionGroup* pcAction = new Gui::ActionGroup(this, Gui::getMainWindow());
+    pcAction->setDropDownMenu(true);
+    applyCommandData(this->className(), pcAction);
+
+    QAction* arc1 = pcAction->addAction(QString());
+    arc1->setIcon(Gui::BitmapFactory().iconFromTheme("Sketcher_CreateRectangle"));
+    QAction* arc2 = pcAction->addAction(QString());
+    arc2->setIcon(Gui::BitmapFactory().iconFromTheme("Sketcher_CreateOblong"));
+
+    _pcAction = pcAction;
+    languageChange();
+
+    pcAction->setIcon(arc1->icon());
+    int defaultId = 0;
+    pcAction->setProperty("defaultAction", QVariant(defaultId));
+
+    return pcAction;
+}
+
+void CmdSketcherCompCreateRectangles::updateAction(int mode)
+{
+    Gui::ActionGroup* pcAction = qobject_cast<Gui::ActionGroup*>(getAction());
+    if (!pcAction)
+        return;
+
+    QList<QAction*> a = pcAction->actions();
+    int index = pcAction->property("defaultAction").toInt();
+    switch (mode) {
+    case Normal:
+        a[0]->setIcon(Gui::BitmapFactory().iconFromTheme("Sketcher_CreateRectangle"));
+        a[1]->setIcon(Gui::BitmapFactory().iconFromTheme("Sketcher_CreateOblong"));
+        getAction()->setIcon(a[index]->icon());
+        break;
+    case Construction:
+        a[0]->setIcon(Gui::BitmapFactory().iconFromTheme("Sketcher_CreateRectangle_Constr"));
+        a[1]->setIcon(Gui::BitmapFactory().iconFromTheme("Sketcher_CreateOblong_Constr"));
+        getAction()->setIcon(a[index]->icon());
+        break;
+    }
+}
+
+void CmdSketcherCompCreateRectangles::languageChange()
+{
+    Command::languageChange();
+
+    if (!_pcAction)
+        return;
+    Gui::ActionGroup* pcAction = qobject_cast<Gui::ActionGroup*>(_pcAction);
+    QList<QAction*> a = pcAction->actions();
+
+    QAction* rectangle1 = a[0];
+    rectangle1->setText(QApplication::translate("CmdSketcherCompCreateRectangles", "Rectangle"));
+    rectangle1->setToolTip(QApplication::translate("Sketcher_CreateRectangle", "Create a rectangle"));
+    rectangle1->setStatusTip(rectangle1->toolTip());
+    QAction* rectangle2 = a[1];
+    rectangle2->setText(QApplication::translate("CmdSketcherCompCreateRectangles", "Rounded rectangle"));
+    rectangle2->setToolTip(QApplication::translate("Sketcher_CreateOblong", "Create a rounded rectangle"));
+    rectangle2->setStatusTip(rectangle2->toolTip());
+}
+
+bool CmdSketcherCompCreateRectangles::isActive(void)
 {
     return isCreateGeoActive(getActiveGuiDocument());
 }
@@ -7172,7 +7597,9 @@ void CreateSketcherCommandsCreateGeo(void)
     rcCmdMgr.addCommand(new CmdSketcherCreateHeptagon());
     rcCmdMgr.addCommand(new CmdSketcherCreateOctagon());
     rcCmdMgr.addCommand(new CmdSketcherCreateRegularPolygon());
+    rcCmdMgr.addCommand(new CmdSketcherCompCreateRectangles());
     rcCmdMgr.addCommand(new CmdSketcherCreateSlot());
+    rcCmdMgr.addCommand(new CmdSketcherCreateOblong());
     rcCmdMgr.addCommand(new CmdSketcherCompCreateFillets());
     rcCmdMgr.addCommand(new CmdSketcherCreateFillet());
     rcCmdMgr.addCommand(new CmdSketcherCreatePointFillet());

--- a/src/Mod/Sketcher/Gui/Resources/Sketcher.qrc
+++ b/src/Mod/Sketcher/Gui/Resources/Sketcher.qrc
@@ -137,6 +137,8 @@
         <file>icons/geometry/Sketcher_CreateHyperbolic_Arc_Constr.svg</file>
         <file>icons/geometry/Sketcher_CreateLine.svg</file>
         <file>icons/geometry/Sketcher_CreateLine_Constr.svg</file>
+        <file>icons/geometry/Sketcher_CreateOblong.svg</file>
+        <file>icons/geometry/Sketcher_CreateOblong_Constr.svg</file>
         <file>icons/geometry/Sketcher_CreateOctagon.svg</file>
         <file>icons/geometry/Sketcher_CreateOctagon_Constr.svg</file>
         <file>icons/geometry/Sketcher_CreateParabolic_Arc.svg</file>
@@ -194,6 +196,7 @@
         <file>icons/pointers/Sketcher_Pointer_Create_Point.svg</file>
         <file>icons/pointers/Sketcher_Pointer_Extension.svg</file>
         <file>icons/pointers/Sketcher_Pointer_External.svg</file>
+        <file>icons/pointers/Sketcher_Pointer_Oblong.svg</file>
         <file>icons/pointers/Sketcher_Pointer_Regular_Polygon.svg</file>
         <file>icons/pointers/Sketcher_Pointer_Slot.svg</file>
         <file>icons/pointers/Sketcher_Pointer_Splitting.svg</file>

--- a/src/Mod/Sketcher/Gui/Resources/icons/geometry/Sketcher_CreateOblong.svg
+++ b/src/Mod/Sketcher/Gui/Resources/icons/geometry/Sketcher_CreateOblong.svg
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg width="64" height="64" viewBox="0 0 16.933333 16.933334" version="1.1" id="svg3401" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg">
+  <defs id="defs3398">
+    <radialGradient xlink:href="#linearGradient3144-3" id="radialGradient4572" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)" cx="225.26402" cy="672.79736" fx="225.26402" fy="672.79736" r="34.345188" />
+    <linearGradient id="linearGradient3144-3">
+      <stop style="stop-color:#ffffff;stop-opacity:1" offset="0" id="stop3146-7" />
+      <stop style="stop-color:#ffffff;stop-opacity:0" offset="1" id="stop3148-0" />
+    </linearGradient>
+    <radialGradient xlink:href="#linearGradient3144-3" id="radialGradient4574" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)" cx="225.26402" cy="672.79736" fx="225.26402" fy="672.79736" r="34.345188" />
+    <radialGradient xlink:href="#linearGradient3144-3" id="radialGradient3846" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)" cx="225.26402" cy="672.79736" fx="225.26402" fy="672.79736" r="34.345188" />
+    <radialGradient xlink:href="#linearGradient3144-3" id="radialGradient3848" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)" cx="225.26402" cy="672.79736" fx="225.26402" fy="672.79736" r="34.345188" />
+    <linearGradient id="linearGradient3836-0-6-4">
+      <stop style="stop-color:#a40000;stop-opacity:1" offset="0" id="stop3838-2-7-0" />
+      <stop style="stop-color:#ef2929;stop-opacity:1" offset="1" id="stop3840-5-5-9" />
+    </linearGradient>
+    <radialGradient xlink:href="#linearGradient3144-3" id="radialGradient2229" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)" cx="225.26402" cy="672.79736" fx="225.26402" fy="672.79736" r="34.345188" />
+    <radialGradient xlink:href="#linearGradient3144-3" id="radialGradient2215" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)" cx="225.26402" cy="672.79736" fx="225.26402" fy="672.79736" r="34.345188" />
+    <linearGradient xlink:href="#linearGradient3836-0-6-4" id="linearGradient3801-1" gradientUnits="userSpaceOnUse" x1="-18" y1="18" x2="-22" y2="5" />
+    <linearGradient xlink:href="#linearGradient3836-0-6-4" id="linearGradient923" gradientUnits="userSpaceOnUse" x1="-18" y1="18" x2="-22" y2="5" />
+  </defs>
+  <g id="layer1">
+    <g id="g3527-3" transform="matrix(0.03329214,0,0,0.03613385,102.28583,68.953983)">
+      <path style="fill:none;stroke:white;stroke-width:14.6231;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="M -2643.7484,-1825.2061 H -2985.4831 V -1510.3467" id="path3040" />
+      <path style="fill:none;stroke:white;stroke-width:15.2568;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" d="M -2957.5086,-1532.2705 L -2667.3461,-1532.0352 L -2667.857,-1796.1918" id="path3042" />
+      <g id="g5444" transform="translate(-4561.1243,-2394.5536)">
+        <rect style="fill:none;fill-opacity:1;stroke:#2e3436;stroke-width:61.1235;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect3579" width="320.34793" height="290.3475" x="1581.9229" y="577.53864" ry="72.587051" />
+        <rect style="fill:none;fill-opacity:1;stroke:white;stroke-width:15.2809;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect3579-9-4" width="334.35117" height="306.85471" x="1574.9211" y="569.28497" ry="76.713875" />
+        <rect style="fill:none;fill-opacity:1;stroke:#d3d7cf;stroke-width:15.2809;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect3579-9" width="308.51923" height="283.05432" x="1587.837" y="581.18518" ry="70.763763" />
+      </g>
+    </g>
+    <g transform="matrix(0.26458329,0,0,0.26458329,8.9666435,-8.9215957)" id="g3827-1">
+      <g transform="translate(31.322131,40.570289)" id="g3797-9">
+        <path style="fill:none;stroke:#280000;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="path4250-71" d="M -26.156204,5.582626 A 8.993818,8.9934077 0.02042283 1 1 -12.493793,17.282241 A 8.993818,8.9934077 0.02042283 1 1 -26.156204,5.582626 Z" />
+        <path style="fill:url(#linearGradient923);fill-opacity:1;stroke:#ef2929;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="path4250-7-3" d="M -24.633588,6.893588 A 6.9999997,7.0000001 0 1 1 -14,16 A 6.9999997,7.0000001 0 0 1 -24.633588,6.893588 Z" />
+      </g>
+    </g>
+    <g transform="matrix(0.26458329,0,0,0.26458329,1.5536196,-1.5086603)" id="g3827-1-3-7">
+      <g transform="translate(31.322131,40.570289)" id="g3797-9-5-1">
+        <path style="fill:none;stroke:#280000;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="path4250-71-6-9" d="M -26.156204,5.582626 A 8.993818,8.9934077 0.02042283 1 1 -12.493793,17.282241 A 8.993818,8.9934077 0.02042283 1 1 -26.156204,5.582626 Z" />
+        <path style="fill:url(#linearGradient3801-1);fill-opacity:1;stroke:#ef2929;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="path4250-7-3-2-0" d="M -24.633588,6.893588 A 6.9999997,7.0000001 0 1 1 -14,16 A 6.9999997,7.0000001 0 0 1 -24.633588,6.893588 Z" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/src/Mod/Sketcher/Gui/Resources/icons/geometry/Sketcher_CreateOblong_Constr.svg
+++ b/src/Mod/Sketcher/Gui/Resources/icons/geometry/Sketcher_CreateOblong_Constr.svg
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg width="64" height="64" viewBox="0 0 16.933333 16.933334" version="1.1" id="svg3401" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg">
+  <defs id="defs3398">
+    <radialGradient xlink:href="#linearGradient3144-3" id="radialGradient4572" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)" cx="225.26402" cy="672.79736" fx="225.26402" fy="672.79736" r="34.345188" />
+    <linearGradient id="linearGradient3144-3">
+      <stop style="stop-color:#ffffff;stop-opacity:1" offset="0" id="stop3146-7" />
+      <stop style="stop-color:#ffffff;stop-opacity:0" offset="1" id="stop3148-0" />
+    </linearGradient>
+    <radialGradient xlink:href="#linearGradient3144-3" id="radialGradient4574" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)" cx="225.26402" cy="672.79736" fx="225.26402" fy="672.79736" r="34.345188" />
+    <radialGradient xlink:href="#linearGradient3144-3" id="radialGradient3846" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)" cx="225.26402" cy="672.79736" fx="225.26402" fy="672.79736" r="34.345188" />
+    <radialGradient xlink:href="#linearGradient3144-3" id="radialGradient3848" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)" cx="225.26402" cy="672.79736" fx="225.26402" fy="672.79736" r="34.345188" />
+    <linearGradient id="linearGradient3836-0-6-4">
+      <stop style="stop-color:#a40000;stop-opacity:1" offset="0" id="stop3838-2-7-0" />
+      <stop style="stop-color:#ef2929;stop-opacity:1" offset="1" id="stop3840-5-5-9" />
+    </linearGradient>
+    <radialGradient xlink:href="#linearGradient3144-3" id="radialGradient2229" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)" cx="225.26402" cy="672.79736" fx="225.26402" fy="672.79736" r="34.345188" />
+    <radialGradient xlink:href="#linearGradient3144-3" id="radialGradient2215" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)" cx="225.26402" cy="672.79736" fx="225.26402" fy="672.79736" r="34.345188" />
+    <linearGradient xlink:href="#linearGradient3836-0-6-4" id="linearGradient3801-1" gradientUnits="userSpaceOnUse" x1="-18" y1="18" x2="-22" y2="5" />
+    <linearGradient xlink:href="#linearGradient3836-0-6-4" id="linearGradient923" gradientUnits="userSpaceOnUse" x1="-18" y1="18" x2="-22" y2="5" />
+  </defs>
+  <g id="layer1">
+    <g id="g3527-3" transform="matrix(0.03329214,0,0,0.03613385,102.28583,68.953983)">
+      <path style="fill:none;stroke:white;stroke-width:14.6231;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="M -2643.7484,-1825.2061 H -2985.4831 V -1510.3467" id="path3040" />
+      <path style="fill:none;stroke:white;stroke-width:15.2568;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" d="M -2957.5086,-1532.2705 L -2667.3461,-1532.0352 L -2667.857,-1796.1918" id="path3042" />
+      <g id="g5444" transform="translate(-4561.1243,-2394.5536)">
+        <rect style="fill:none;fill-opacity:1;stroke:#2e3436;stroke-width:61.1235;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect3579" width="320.34793" height="290.3475" x="1581.9229" y="577.53864" ry="72.587051" />
+        <rect style="fill:none;fill-opacity:1;stroke:#5c8ac0;stroke-width:15.2809;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect3579-9-4" width="334.35117" height="306.85471" x="1574.9211" y="569.28497" ry="76.713875" />
+        <rect style="fill:none;fill-opacity:1;stroke:#3667a5;stroke-width:15.2809;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect3579-9" width="308.51923" height="283.05432" x="1587.837" y="581.18518" ry="70.763763" />
+      </g>
+    </g>
+    <g transform="matrix(0.26458329,0,0,0.26458329,8.9666435,-8.9215957)" id="g3827-1">
+      <g transform="translate(31.322131,40.570289)" id="g3797-9">
+        <path style="fill:none;stroke:#280000;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="path4250-71" d="M -26.156204,5.582626 A 8.993818,8.9934077 0.02042283 1 1 -12.493793,17.282241 A 8.993818,8.9934077 0.02042283 1 1 -26.156204,5.582626 Z" />
+        <path style="fill:url(#linearGradient923);fill-opacity:1;stroke:#ef2929;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="path4250-7-3" d="M -24.633588,6.893588 A 6.9999997,7.0000001 0 1 1 -14,16 A 6.9999997,7.0000001 0 0 1 -24.633588,6.893588 Z" />
+      </g>
+    </g>
+    <g transform="matrix(0.26458329,0,0,0.26458329,1.5536196,-1.5086603)" id="g3827-1-3-7">
+      <g transform="translate(31.322131,40.570289)" id="g3797-9-5-1">
+        <path style="fill:none;stroke:#280000;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="path4250-71-6-9" d="M -26.156204,5.582626 A 8.993818,8.9934077 0.02042283 1 1 -12.493793,17.282241 A 8.993818,8.9934077 0.02042283 1 1 -26.156204,5.582626 Z" />
+        <path style="fill:url(#linearGradient3801-1);fill-opacity:1;stroke:#ef2929;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="path4250-7-3-2-0" d="M -24.633588,6.893588 A 6.9999997,7.0000001 0 1 1 -14,16 A 6.9999997,7.0000001 0 0 1 -24.633588,6.893588 Z" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/src/Mod/Sketcher/Gui/Resources/icons/pointers/Sketcher_Pointer_Oblong.svg
+++ b/src/Mod/Sketcher/Gui/Resources/icons/pointers/Sketcher_Pointer_Oblong.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg version="1.1" width="64" height="64" id="svg12" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg">
+  <defs id="defs16" />
+  <g style="stroke:#feffff;stroke-width:2.5;stroke-linecap:round;stroke-linejoin:miter;fill:maroon;stroke-opacity:1" id="g10">
+    <path d="m 16,3 v 9 m 0,8 v 9 M 3,16 h 9 m 8,0 h 9" id="path8" style="fill:maroon;stroke:#feffff;stroke-opacity:1" />
+  </g>
+  <rect style="fill:none;fill-opacity:1;stroke:#c00;stroke-width:3.02362205;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" id="rect1303" width="30.236221" height="22.677166" x="18.897638" y="34.015747" ry="7.5590539" />
+</svg>

--- a/src/Mod/Sketcher/Gui/Workbench.cpp
+++ b/src/Mod/Sketcher/Gui/Workbench.cpp
@@ -233,6 +233,21 @@ inline void SketcherAddWorkspaceRegularPolygon<Gui::ToolBarItem>(Gui::ToolBarIte
     geom    << "Sketcher_CompCreateRegularPolygon";
 }
 
+template <typename T>
+void SketcherAddWorkspaceRectangles(T& geom);
+
+template <>
+inline void SketcherAddWorkspaceRectangles<Gui::MenuItem>(Gui::MenuItem& geom)
+{
+    geom    << "Sketcher_CreateRectangle"
+            << "Sketcher_CreateOblong";
+}
+
+template <>
+inline void SketcherAddWorkspaceRectangles<Gui::ToolBarItem>(Gui::ToolBarItem& geom)
+{
+    geom << "Sketcher_CompCreateRectangles";
+}
 
 template <typename T>
 void SketcherAddWorkspaceFillets(T& geom);
@@ -257,8 +272,8 @@ inline void SketcherAddWorkbenchGeometries(T& geom)
             << "Sketcher_CreateLine";
     SketcherAddWorkspaceArcs(geom);
     geom    << "Separator"
-            << "Sketcher_CreatePolyline"
-            << "Sketcher_CreateRectangle";
+            << "Sketcher_CreatePolyline";
+    SketcherAddWorkspaceRectangles(geom);
     SketcherAddWorkspaceRegularPolygon(geom);
     geom    << "Sketcher_CreateSlot"
             << "Separator";


### PR DESCRIPTION
while constructing I miss often that one cannot insert directly rounded rectangles. As it is, one needs first to insert a rectangle, then go to fillet mode, then click 8 times, then set equal constraint, then often also replace the vertical/horizontal constraints since a rectangle must not necessarily be parallel to a sketch axis

As solution this PR adds rounded rectangles in one step. This saves a lot of time since this object is e.g. often used for milled rectangular pockets, for 3D-printed pads etc.

Since the slot is a special case of a rounded rectangle and the use cases are similar as well, I grouped the lot and rounded rectangle.

Here is a screencast how I implemented it:

![d6Lnbwl4UD](https://user-images.githubusercontent.com/1828501/120948023-8306e180-c741-11eb-9bae-58796ad606db.gif)

Forum thread: https://forum.freecadweb.org/viewtopic.php?f=17&t=59210

(The code beautification in this PR of existing code was kindly done automatically be MSVC.)