### PR TITLE
Draft: Improve alignToSelection method on WorkingPlane

### DIFF
--- a/src/Mod/Draft/WorkingPlane.py
+++ b/src/Mod/Draft/WorkingPlane.py
@@ -34,10 +34,16 @@ YZ, and XZ planes.
 #  in FreeCAD and a couple of utility functions.
 
 import math
+import lazy_loader.lazy_loader as lz
 
 import FreeCAD
 import DraftVecUtils
 from FreeCAD import Vector
+from draftutils.translate import translate
+
+DraftGeomUtils = lz.LazyLoader("DraftGeomUtils", globals(), "DraftGeomUtils")
+Part = lz.LazyLoader("Part", globals(), "Part")
+FreeCADGui = lz.LazyLoader("FreeCADGui", globals(), "FreeCADGui")
 
 __title__ = "FreeCAD Working Plane utility"
 __author__ = "Ken Cline"
@@ -603,12 +609,6 @@ class Plane:
         """Align the plane to a selection if it defines a plane.
 
         If the selection uniquely defines a plane it will be used.
-        Currently it only works with one object selected, a `'Face'`.
-        It extracts the shape of the object or subobject
-        and then calls `alignToFace(shape, offset)`.
-
-        This method only works when `FreeCAD.GuiUp` is `True`,
-        that is, when the graphical interface is loaded.
 
         Parameter
         ---------
@@ -621,42 +621,100 @@ class Plane:
         bool
             `True` if the operation was successful, and `False` otherwise.
             It returns `False` if the selection has no elements,
-            or if it has more than one element,
             or if the object is not derived from `'Part::Feature'`
             or if the object doesn't have a `Shape`.
-
-        To do
-        -----
-        The method returns `False` if the selection list has more than
-        one element.
-        The method should search the list for objects like faces, points,
-        edges, wires, etc., and call the appropriate aligning submethod.
-
-        The method could work for curves (`'Edge'`  or `'Wire'`) but
-        `alignToCurve()` isn't fully implemented.
-
-        When the interface is not loaded it should fail and print
-        a message, `FreeCAD.Console.PrintError()`.
 
         See Also
         --------
         alignToFace, alignToCurve
         """
-        import FreeCADGui
-        sex = FreeCADGui.Selection.getSelectionEx(FreeCAD.ActiveDocument.Name)
-        if len(sex) == 0:
+        sel_ex = FreeCADGui.Selection.getSelectionEx(FreeCAD.ActiveDocument.Name)
+        if not sel_ex:
             return False
-        elif len(sex) == 1:
-            if (not sex[0].Object.isDerivedFrom("Part::Feature")
-                    or not sex[0].Object.Shape):
+
+        shapes = list()
+        names = list()
+        for obj in sel_ex:
+            # check that the geometric property is a Part.Shape object
+            geom_is_shape = False
+            if isinstance(obj.Object, FreeCAD.GeoFeature):
+                geom = obj.Object.getPropertyOfGeometry()
+                if isinstance(geom, Part.Shape):
+                    geom_is_shape = True
+            if not geom_is_shape:
+                FreeCAD.Console.PrintError(translate(
+                    "draft",
+                    "Object without Part.Shape geometry:'{}'\n".format(
+                        obj.ObjectName)))
                 return False
-            return (self.alignToFace(sex[0].Object.Shape, offset)
-                    or (len(sex[0].SubObjects) == 1
-                        and self.alignToFace(sex[0].SubObjects[0], offset))
-                    or self.alignToCurve(sex[0].Object.Shape, offset))
+            if geom.isNull():
+                FreeCAD.Console.PrintError(translate(
+                    "draft",
+                    "Object with null Part.Shape geometry:'{}'\n".format(
+                        obj.ObjectName)))
+                return False
+            if obj.HasSubObjects:
+                shapes.extend(obj.SubObjects)
+                names.extend([obj.ObjectName + "." + n for n in obj.SubElementNames])
+            else:
+                shapes.append(geom)
+                names.append(obj.ObjectName)
+
+        normal = None
+        for n in range(len(shapes)):
+            if not DraftGeomUtils.is_planar(shapes[n]):
+                FreeCAD.Console.PrintError(translate(
+                   "draft","'{}' object is not planar\n".format(names[n])))
+                return False
+            if not normal:
+                normal = DraftGeomUtils.get_normal(shapes[n])
+                shape_ref = n
+
+        # test if all shapes are coplanar
+        if normal:
+            for n in range(len(shapes)):
+                if not DraftGeomUtils.are_coplanar(shapes[shape_ref], shapes[n]):
+                    FreeCAD.Console.PrintError(translate(
+                        "draft","{} and {} aren't coplanar\n".format(
+                        names[shape_ref],names[n])))
+                    return False
         else:
-            # len(sex) > 2, look for point and line, three points, etc.
+            # suppose all geometries are straight lines or points
+            points = [vertex.Point for shape in shapes for vertex in shape.Vertexes]
+            if len(points) >= 3:
+                poly = Part.makePolygon(points)
+                if not DraftGeomUtils.is_planar(poly):
+                    FreeCAD.Console.PrintError(translate(
+                        "draft","All Shapes must be coplanar\n"))
+                    return False
+                normal = DraftGeomUtils.get_normal(poly)
+            else:
+                normal = None
+
+        if not normal:
+            FreeCAD.Console.PrintError(translate(
+                "draft","Selected Shapes must define a plane\n"))
             return False
+
+        # set center of mass
+        ctr_mass = FreeCAD.Vector(0,0,0)
+        ctr_pts = FreeCAD.Vector(0,0,0)
+        mass = 0
+        for shape in shapes:
+            if hasattr(shape, "CenterOfMass"):
+                ctr_mass += shape.CenterOfMass*shape.Mass
+                mass += shape.Mass
+            else:
+                ctr_pts += shape.Point
+        if mass > 0:
+            ctr_mass /= mass
+        # all shapes are vertexes
+        else:
+            ctr_mass = ctr_pts/len(shapes)
+
+        self.alignToPointAndAxis(ctr_mass, normal, offset)
+
+        return True
 
     def setup(self, direction=None, point=None, upvec=None, force=False):
         """Set up the working plane if it exists but is undefined.

--- a/src/Mod/Draft/draftgeoutils/geometry.py
+++ b/src/Mod/Draft/draftgeoutils/geometry.py
@@ -199,6 +199,9 @@ def findDistance(point, edge, strict=False):
 def get_spline_normal(edge, tol=-1):
     """Find the normal of a BSpline edge."""
 
+    if edge.isNull():
+        return None
+
     if is_straight_line(shape, tol):
         return None
 
@@ -230,9 +233,11 @@ def get_normal(shape, tol=-1):
                 return None
 
     # for shapes
-    if is_straight_line(shape, tol):
+    if shape.isNull():
         return None
 
+    if is_straight_line(shape, tol):
+        return None
     else:
         plane = find_plane(shape, tol)
         if plane:
@@ -273,6 +278,7 @@ def is_planar(shape, tol=-1):
             poly = Part.makePolygon(shape)
             if is_straight_line(poly, tol):
                 return True
+
             plane = poly.findPlane(tol)
             if plane:
                 return True
@@ -280,6 +286,9 @@ def is_planar(shape, tol=-1):
                 return False
 
     # for shapes
+    if shape.isNull():
+        return False
+
     # because Part.Shape.findPlane return None for Vertex and straight edges
     if shape.ShapeType == "Vertex":
         return True
@@ -299,6 +308,9 @@ def is_straight_line(shape, tol=-1):
     function used in other methods because Part.Shape.findPlane assign a
     plane and normal to straight wires creating privileged directions
     and to deal with straight wires with overlapped edges."""
+
+    if shape.isNull():
+        return False
 
     if len(shape.Faces) != 0:
         return False
@@ -331,6 +343,9 @@ def is_straight_line(shape, tol=-1):
 
 def are_coplanar(shape_a, shape_b, tol=-1):
     """Return True if exist a plane containing both shapes."""
+
+    if shape_a.isNull() or shape_b.isNull():
+        return False
 
     if not is_planar(shape_a, tol) or not is_planar(shape_b, tol):
         return False
@@ -391,6 +406,9 @@ def get_spline_surface_normal(shape, tol=-1):
     """Check if shape formed by BSpline surfaces is planar and get normal.
     If shape is not planar return None."""
 
+    if shape.isNull():
+        return None
+
     if len(shape.Faces) == 0:
         return None
 
@@ -430,6 +448,9 @@ def find_plane(shape, tol=-1):
     """Find the plane containing the shape if possible.
     Use this function as a workaround due Part.Shape.findPlane
     fail to find plane on BSpline surfaces."""
+
+    if shape.isNull():
+        return None
 
     if shape.ShapeType == "Vertex":
         return None

--- a/src/Mod/Draft/draftguitools/gui_selectplane.py
+++ b/src/Mod/Draft/draftguitools/gui_selectplane.py
@@ -75,6 +75,10 @@ class Draft_SelectPlane:
 
     def Activated(self):
         """Execute when the command is called."""
+        # finish active Draft command if any
+        if FreeCAD.activeDraftCommand is not None:
+            FreeCAD.activeDraftCommand.finish()
+
         # Reset variables
         self.view = Draft.get3DView()
         self.wpButton = FreeCADGui.draftToolBar.wplabel
@@ -84,9 +88,6 @@ class Draft_SelectPlane:
         if not self.states:
             p = FreeCAD.DraftWorkingPlane
             self.states.append([p.u, p.v, p.axis, p.position])
-
-        m = translate("draft", "Pick a face, 3 vertices or a WP Proxy to define the drawing plane")
-        _msg(m)
 
         # Create task panel
         FreeCADGui.Control.closeDialog()
@@ -127,18 +128,20 @@ class Draft_SelectPlane:
         self.taskd.form.fieldSnapRadius.valueChanged.connect(self.onSetSnapRadius)
 
         # Try to find a WP from the current selection
-        if self.handle():
-            return
+        if FreeCADGui.Selection.getSelectionEx(FreeCAD.ActiveDocument.Name):
+            if self.handle():
+                pass
+            # Try another method
+            elif FreeCAD.DraftWorkingPlane.alignToSelection():
+                FreeCADGui.Selection.clearSelection()
+                self.display(FreeCAD.DraftWorkingPlane.axis)
+            return None
 
-        # Try another method
-        if FreeCAD.DraftWorkingPlane.alignToSelection():
-            FreeCADGui.Selection.clearSelection()
-            self.display(FreeCAD.DraftWorkingPlane.axis)
-            self.finish()
-            return
-
-        # Execute the actual task panel
-        FreeCADGui.Control.showDialog(self.taskd)
+        # Execute the actual task panel delayed to catch posible active Draft command
+        todo.delay(FreeCADGui.Control.showDialog, self.taskd)
+        _msg(translate(
+                "draft",
+                "Pick a face, 3 vertices or a WP Proxy to define the drawing plane"))
         self.call = self.view.addEventCallback("SoEvent", self.action)
 
     def finish(self, close=False):


### PR DESCRIPTION
Currently, alignToSelection works only on a face object. With this changes, the method works on any list of Part.Shape objects.
If this objects define a plane, the working plane is set to it even if the list exceeds the number of objects needed to define the plane.
First, the method check the geometric property of the selection according to https://forum.freecadweb.org/viewtopic.php?f=10&t=49939&p=429457#p429469. Then, checks coplanarity, set the WorkingPlane's normal and the position at the center of mass of the selection objects.
With the changes on gui_selectplane.py, the methods handle and alignToSelection are only executed if a list of objects is selected. If not, the task panel is launched. Also, checks if there is a active draft command and finish it when the SelectPlane button is pressed.



Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [ ]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
