### PR TITLE
[Spreadsheet] Expose SpreadsheetView::getSheet to Python

### DIFF
--- a/src/Mod/Spreadsheet/Gui/CMakeLists.txt
+++ b/src/Mod/Spreadsheet/Gui/CMakeLists.txt
@@ -8,6 +8,13 @@ include_directories(
     ${XercesC_INCLUDE_DIRS}
 )
 
+generate_from_xml(SpreadsheetViewPy)
+
+# The XML files
+set(SpreadsheetGui_XML_SRCS
+    SpreadsheetViewPy.xml
+)
+
 set(SpreadsheetGui_LIBS
     Spreadsheet
     FreeCADGui
@@ -54,6 +61,7 @@ endif()
 
 SET(SpreadsheetGui_SRCS
     ${SpreadsheetGui_QRC_SRCS}
+    ${SpreadsheetGui_XML_SRCS}
     AppSpreadsheetGui.cpp
     Command.cpp
     LineEdit.h
@@ -63,6 +71,7 @@ SET(SpreadsheetGui_SRCS
     Resources/Spreadsheet.qrc
     SpreadsheetView.cpp
     SpreadsheetView.h
+    SpreadsheetViewPyImp.cpp
     SpreadsheetDelegate.h
     SpreadsheetDelegate.cpp
     SheetTableView.cpp

--- a/src/Mod/Spreadsheet/Gui/SpreadsheetView.cpp
+++ b/src/Mod/Spreadsheet/Gui/SpreadsheetView.cpp
@@ -52,6 +52,7 @@
 #include "qtcolorpicker.h"
 
 #include "SpreadsheetView.h"
+#include "SpreadsheetViewPy.h"
 #include "SpreadsheetDelegate.h"
 #include "ui_Sheet.h"
 
@@ -444,7 +445,11 @@ QModelIndex SheetView::currentIndex() const
 
 PyObject *SheetView::getPyObject()
 {
-    return Gui::MDIView::getPyObject();
+    if (!pythonObject)
+        pythonObject = new SpreadsheetViewPy(this);
+
+    Py_INCREF(pythonObject);
+    return pythonObject;
 }
 
 void SheetView::deleteSelf()

--- a/src/Mod/Spreadsheet/Gui/SpreadsheetViewPy.xml
+++ b/src/Mod/Spreadsheet/Gui/SpreadsheetViewPy.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GenerateModel xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="generateMetaModel_Module.xsd">
+  <PythonExport
+      Father="PyObjectBase"
+      Name="SpreadsheetViewPy" 
+      Twin="SheetView" 
+      TwinPointer="SheetView" 
+      Include="Mod/Spreadsheet/Gui/SpreadsheetView.h" 
+      Namespace="SpreadsheetGui"
+      FatherInclude="Base/PyObjectBase.h"
+      FatherNamespace="Base">
+    <Documentation>
+      <Author Licence="LGPL" Name="openBrain" EMail="" />
+      <UserDocu>SpreadsheetView object</UserDocu>
+    </Documentation>
+    <Methode Name="getSheet">
+      <Documentation>
+        <UserDocu>returns the sheet being displayed</UserDocu>
+      </Documentation>
+    </Methode>
+    <CustomAttributes />
+  </PythonExport>
+</GenerateModel>

--- a/src/Mod/Spreadsheet/Gui/SpreadsheetViewPyImp.cpp
+++ b/src/Mod/Spreadsheet/Gui/SpreadsheetViewPyImp.cpp
@@ -1,0 +1,31 @@
+#include "PreCompiled.h"
+
+#include "SpreadsheetViewPy.h"
+#include "SpreadsheetViewPy.cpp"
+
+#include <Mod/Spreadsheet/App/SheetPy.h>
+
+using namespace SpreadsheetGui;
+
+PyObject*  SpreadsheetViewPy::getSheet(PyObject *args)
+{
+    if (!PyArg_ParseTuple(args, ""))
+        return nullptr;
+    return new Spreadsheet::SheetPy(getSheetViewPtr()->getSheet());
+}
+
+// returns a string which represents the object e.g. when printed in python
+std::string SpreadsheetViewPy::representation(void) const
+{
+    return std::string("<SheetView object>");
+}
+
+PyObject *SpreadsheetViewPy::getCustomAttributes(const char* /*attr*/) const
+{
+    return 0;
+}
+
+int SpreadsheetViewPy::setCustomAttributes(const char* /*attr*/, PyObject* /*obj*/)
+{
+    return 0; 
+}


### PR DESCRIPTION
The goal of the PR is to provide a sure way to get a pointer to a spreadsheet based on its MDIView.
As of today, only guessing from the window (tab) title is possible but it's limited.
Typical usage is `FreeCADGui.ActiveDocument.ActiveView.getSheet()`

ATM it returns a DocumentObject. For consistency, it would probably be better to return a ViewProviderObject, but I'm not sure there is a simple way to achieve this. I'll open a topic in the forum and update the PR if I can find a solution there.

- [X]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [X]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum => N/A
- [X]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [X]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [X]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805` => N/A