### PR TITLE
Draft: Fix wrong tree icon for Draft_PointArray

### DIFF
--- a/src/Mod/Draft/draftviewproviders/view_array.py
+++ b/src/Mod/Draft/draftviewproviders/view_array.py
@@ -44,9 +44,9 @@ class ViewProviderDraftArray(ViewProviderDraft):
                 return ":/icons/Draft_PolarArray.svg"
             elif self.Object.ArrayType == 'circular':
                 return ":/icons/Draft_CircularArray.svg"
-        elif hasattr(self.Object, "PointList"):
+        elif hasattr(self.Object, "PointObject"):
             return ":/icons/Draft_PointArray.svg"
-        elif self.Object.Proxy.Type == "PathTwistedArray":
+        elif hasattr(self.Object, "RotationFactor"):
             return ":/icons/Draft_PathTwistedArray.svg"
         else:
             return ":/icons/Draft_PathArray.svg"


### PR DESCRIPTION
The code wrongly used the PointList property to detect a Draft_PointArray. PointObject should be used instead.

For consistency also changed the code to detect a Draft_PathTwistedArray to use the RotationFactor property.