### PR TITLE
[TechDraw] Add 'getPage' Python API ; returns page from view

### DIFF
--- a/src/Mod/TechDraw/Gui/CMakeLists.txt
+++ b/src/Mod/TechDraw/Gui/CMakeLists.txt
@@ -36,6 +36,13 @@ else(BUILD_QT5)
     )
 endif(BUILD_QT5)
 
+generate_from_xml(MDIViewPagePy)
+
+# The XML files
+set(TechDrawGui_XML_SRCS
+    MDIViewPagePy.xml
+)
+
 link_directories(${OCC_LIBRARY_DIR})
 
 set(TechDrawGui_LIBS
@@ -96,6 +103,7 @@ SET(MRTE_SRCS
 SET(TechDrawGui_SRCS
     ${CMAKE_SOURCE_DIR}/src/Mod/TechDraw/InitGui.py
     ${TechDrawGui_SRCS}
+    ${TechDrawGui_XML_SRCS}
     ${MRTE_SRCS}
     AppTechDrawGui.cpp
     AppTechDrawGuiPy.cpp
@@ -197,6 +205,7 @@ SET(TechDrawGui_SRCS
 SET(TechDrawGuiView_SRCS
     MDIViewPage.cpp
     MDIViewPage.h
+    MDIViewPagePyImp.cpp
     QGVPage.cpp
     QGVPage.h
     QGCustomText.cpp

--- a/src/Mod/TechDraw/Gui/MDIViewPage.cpp
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.cpp
@@ -47,6 +47,7 @@
 #include <math.h>
 
 #include "MDIViewPage.h"
+#include "MDIViewPagePy.h"
 
 #include <Base/Stream.h>
 #include <Base/Tools.h>
@@ -794,7 +795,11 @@ void MDIViewPage::print(QPrinter* printer)
 
 PyObject* MDIViewPage::getPyObject()
 {
-    return Gui::MDIView::getPyObject();
+    if (!pythonObject)
+        pythonObject = new MDIViewPagePy(this);
+
+    Py_INCREF(pythonObject);
+    return pythonObject;
 }
 
 void MDIViewPage::contextMenuEvent(QContextMenuEvent *event)

--- a/src/Mod/TechDraw/Gui/MDIViewPage.h
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.h
@@ -24,12 +24,16 @@
 #ifndef TECHDRAWGUI_MDIVIEWPAGE_H
 #define TECHDRAWGUI_MDIVIEWPAGE_H
 
+#include "ViewProviderPage.h"
+
 #include <Gui/MDIView.h>
 #include <Gui/Selection.h>
 
 #include <QPrinter>
 #include <QGraphicsScene>
 #include <QPointF>
+
+#include <Mod/TechDraw/App/DrawPage.h>
 
 QT_BEGIN_NAMESPACE
 class QAction;
@@ -90,6 +94,7 @@ public:
     void setDocumentObject(const std::string&);
     void setDocumentName(const std::string&);
     PyObject* getPyObject();
+    TechDraw::DrawPage * getPage() { return m_vpPage->getDrawPage(); }
 
     QGVPage* getQGVPage(void) {return m_view;};
 

--- a/src/Mod/TechDraw/Gui/MDIViewPagePy.xml
+++ b/src/Mod/TechDraw/Gui/MDIViewPagePy.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GenerateModel xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="generateMetaModel_Module.xsd">
+  <PythonExport
+      Father="PyObjectBase"
+      Name="MDIViewPagePy" 
+      Twin="MDIViewPage" 
+      TwinPointer="MDIViewPage" 
+      Include="Mod/TechDraw/Gui/MDIViewPage.h" 
+      Namespace="TechDrawGui"
+      FatherInclude="Base/PyObjectBase.h"
+      FatherNamespace="Base">
+    <Documentation>
+      <Author Licence="LGPL" Name="openBrain" EMail="" />
+      <UserDocu>MDIViewPage object</UserDocu>
+    </Documentation>
+    <Methode Name="getPage">
+      <Documentation>
+        <UserDocu>returns the page being displayed</UserDocu>
+      </Documentation>
+    </Methode>
+    <CustomAttributes />
+  </PythonExport>
+</GenerateModel>

--- a/src/Mod/TechDraw/Gui/MDIViewPagePyImp.cpp
+++ b/src/Mod/TechDraw/Gui/MDIViewPagePyImp.cpp
@@ -1,0 +1,43 @@
+
+#include "PreCompiled.h"
+
+#include "Mod/TechDraw/Gui/MDIViewPage.h"
+
+// inclusion of the generated files (generated out of MDIViewPagePy.xml)
+#include "MDIViewPagePy.h"
+#include "MDIViewPagePy.cpp"
+
+#include <Mod/TechDraw/App/DrawPagePy.h>
+
+using namespace TechDrawGui;
+
+// returns a string which represents the object e.g. when printed in python
+std::string MDIViewPagePy::representation() const
+{
+    return std::string("<TechDrawView object>");
+}
+
+
+
+PyObject* MDIViewPagePy::getPage(PyObject * args)
+{
+    if (!PyArg_ParseTuple(args, ""))
+        return nullptr;
+    return new TechDraw::DrawPagePy(getMDIViewPagePtr()->getPage());
+}
+
+
+
+
+
+PyObject *MDIViewPagePy::getCustomAttributes(const char* /*attr*/) const
+{
+    return nullptr;
+}
+
+int MDIViewPagePy::setCustomAttributes(const char* /*attr*/, PyObject* /*obj*/)
+{
+    return 0; 
+}
+
+


### PR DESCRIPTION
This PR adds a new 'getPage' functions in TechDraw ViewProviderPage.
It uses this function to add a 'getPage' Python API that returns from a TechDraw MDIView that DrawPage being displayed

- [X]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [X]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum => n/A
- [X]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [X]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [X]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805` => N/A