### PR TITLE
Fix source comment typos

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_edit_base_object.py
+++ b/src/Mod/Draft/draftguitools/gui_edit_base_object.py
@@ -64,7 +64,7 @@ class GuiTools:
     def get_edit_point_context_menu(self, edit_command, obj, node_idx):
         """ Get the context menu associated to edit points (user is over an editpoint)
 
-        Return a list of tuples containig menu labels and associated functions:
+        Return a list of tuples containing menu labels and associated functions:
             return [
                 ("action label", lambda: self.handle_action_label(edit_command, obj, node_idx)),
             ]
@@ -79,7 +79,7 @@ class GuiTools:
     def get_edit_obj_context_menu(self, edit_command, obj, position):
         """ Get the context menu associated to edited object (user is over the object)
 
-        Return a list of tuples containig menu labels and associated functions:
+        Return a list of tuples containing menu labels and associated functions:
             return [
                 ("action label", lambda: self.handle_action_label(edit_command, obj, position)),
             ]

--- a/src/Mod/Draft/draftguitools/gui_selectplane.py
+++ b/src/Mod/Draft/draftguitools/gui_selectplane.py
@@ -137,7 +137,7 @@ class Draft_SelectPlane:
                 self.display(FreeCAD.DraftWorkingPlane.axis)
             return None
 
-        # Execute the actual task panel delayed to catch posible active Draft command
+        # Execute the actual task panel delayed to catch possible active Draft command
         todo.delay(FreeCADGui.Control.showDialog, self.taskd)
         _msg(translate(
                 "draft",

--- a/src/Mod/Path/PathScripts/PathFeatureExtensions.py
+++ b/src/Mod/Path/PathScripts/PathFeatureExtensions.py
@@ -102,7 +102,7 @@ def extendWire(feature, wire, length):
         off2D = wire.makeOffset2D(length)
     except FreeCAD.Base.FreeCADError as ee:
         return None
-    endPts = endPoints(wire)  # Asumes wire is NOT closed
+    endPts = endPoints(wire)  # Assumes wire is NOT closed
     if endPts:
         edges = [e for e in off2D.Edges if Part.Circle != type(e.Curve) or not includesPoint(e.Curve.Center, endPts)]
         wires = [Part.Wire(e) for e in Part.sortEdges(edges)]
@@ -245,7 +245,7 @@ class Extension(object):
     def getExtensionFaces(self, extensionWire):
         '''getExtensionFace(extensionWire)...
         A public helper method to retrieve the requested extension as a face,
-        rather than a wire becuase some extensions require a face shape
+        rather than a wire because some extensions require a face shape
         for definition that allows for two wires for boundary definition.
         '''
 
@@ -471,7 +471,7 @@ class Extension(object):
 
 
 def initialize_properties(obj):
-    """initialize_properties(obj)... Adds feature propeties to object argument"""
+    """initialize_properties(obj)... Adds feature properties to object argument"""
     if not hasattr(obj, 'ExtensionLengthDefault'):
         obj.addProperty('App::PropertyDistance', 'ExtensionLengthDefault', 'Extension', QtCore.QT_TRANSLATE_NOOP('PathPocketShape', 'Default length of extensions.'))
     if not hasattr(obj, 'ExtensionFeature'):

--- a/src/Mod/Path/PathScripts/PathFeatureExtensionsGui.py
+++ b/src/Mod/Path/PathScripts/PathFeatureExtensionsGui.py
@@ -75,7 +75,7 @@ class _Extension(object):
         crd = coin.SoCoordinate3()
         fce = coin.SoFaceSet()
         hnt = coin.SoShapeHints()
-        numVert = list()  # track number of verticies in each polygon face
+        numVert = list()  # track number of vertices in each polygon face
 
         try:
             wire = ext.getWire()
@@ -285,7 +285,7 @@ class TaskPanelExtensionPage(PathOpGui.TaskPanelPage):
         Subroutine called inside `setFields()` to initialize Extensions efficiently."""
         if self.enabled:
             self.extensions = FeatureExtensions.getExtensions(obj)
-        elif len(obj.ExtensionFeature) > 0:  # latter test loads pre-existing extensions (editting of existing operation)
+        elif len(obj.ExtensionFeature) > 0:  # latter test loads pre-existing extensions (editing of existing operation)
             noEdges = True
             for (__, __, subFeat) in FeatureExtensions.readObjExtensionFeature(obj):
                 if subFeat.startswith("Edge") or subFeat.startswith("Wire"):

--- a/src/Mod/Path/PathScripts/PathGeom.py
+++ b/src/Mod/Path/PathScripts/PathGeom.py
@@ -582,7 +582,7 @@ def combineHorizontalFaces(faces):
     topFace = None
     innerFaces = list()
 
-    # Verify all incomming faces are at Z=0.0
+    # Verify all incoming faces are at Z=0.0
     for f in faces:
         if f.BoundBox.ZMin != 0.0:
             f.translate(FreeCAD.Vector(0.0, 0.0, 0.0 - f.BoundBox.ZMin))


### PR DESCRIPTION
Found via `codespell -q 3 -L aci,ake,aline,alle,alledges,alocation,als,ang,anid,apoints,ba,beginn,behaviour,bloaded,bottome,byteorder,calculater,cancelled,cancelling,cas,cascade,centimetre,childs,colour,colours,commen,connexion,currenty,dof,doubleclick,dum,eiter,elemente,ende,feld,finde,findf,freez,hist,iff,indicies,initialisation,initialise,initialised,initialises,initialisiert,ist,kilometre,lod,mantatory,methode,metres,millimetre,modell,nd,noe,normale,normaly,nto,numer,oder,ontop,orgin,orginx,orginy,ot,pard,parms,pres,programm,que,recurrance,rougly,seperator,serie,sinc,strack,substraction,te,thist,thru,tread,uint,unter,vertexes,wallthickness,whitespaces -S ./.git,*.po,*.ts,./ChangeLog.txt,./src/3rdParty,./src/Mod/Assembly/App/opendcm,./src/CXX,./src/zipios++,./src/Base/swig*,./src/Mod/Robot/App/kdl_cp,./src/Mod/Import/App/SCL,./src/WindowsInstaller,./src/Doc/FreeCAD.uml,./build/doc/SourceDocu`