### PR TITLE
[Path] PathSanity.py now outputs fillename for the report the same as the postprocessor job

### DIFF
--- a/src/Mod/Path/PathScripts/PathSanity.py
+++ b/src/Mod/Path/PathScripts/PathSanity.py
@@ -404,8 +404,8 @@ class CommandPathSanity:
 
         # Save the report
 
-        reportraw = self.outputpath + 'setupreport.asciidoc'
-        reporthtml = self.outputpath + 'setupreport.html'
+        reportraw = self.outputpath + job.PostProcessorOutputFile + '.asciidoc'
+        reporthtml = self.outputpath + job.PostProcessorOutputFile + '.html'
         with open(reportraw, 'w') as fd:
             fd.write(report)
             fd.close()


### PR DESCRIPTION
[Path] PathSanity now outputs fillename for the report the same as the postprocessor job

Output fillename for the report is now the same as the postprocessor job (job.PostProcessorOutputFile), this way the setup file will be autoloaded in LinuxCNC qtDraggon ui and others based on probe-basic.
There is some error checking missing, the check to see if the job.PostProcessorOutputFile is not empty is not there for example. But since the report can/should only be generated when there is a postprocessor file this is not a big problem.