### PR TITLE
Draft: Fix and clean up ToDo helper class

### DIFF
--- a/src/Mod/Draft/DraftGui.py
+++ b/src/Mod/Draft/DraftGui.py
@@ -855,7 +855,7 @@ class DraftToolBar:
         self.reset_ui_values()
         if self.taskmode:
             self.isTaskOn = True
-            todo.delay(FreeCADGui.Control.closeDialog,None)
+            todo.delay(FreeCADGui.Control.closeDialog)
             self.baseWidget = DraftBaseWidget()
             self.layout = QtGui.QVBoxLayout(self.baseWidget)
             self.setupToolBar(task=True)
@@ -1012,7 +1012,7 @@ class DraftToolBar:
         self.z = 0
         self.pointButton.show()
         if rel: self.isRelative.show()
-        todo.delay(self.setFocus,None)
+        todo.delay(self.setFocus)
         self.xValue.selectAll()
 
     def labelUi(self,title=translate("draft","Label"),callback=None):
@@ -1042,11 +1042,11 @@ class DraftToolBar:
         self.labelRadius.setText(translate("draft","Distance"))
         self.radiusValue.setToolTip(translate("draft", "Offset distance"))
         self.radiusValue.setText(FreeCAD.Units.Quantity(0,FreeCAD.Units.Length).UserString)
-        todo.delay(self.radiusValue.setFocus,None)
+        todo.delay(self.radiusValue.setFocus)
         self.radiusValue.selectAll()
 
     def offUi(self):
-        todo.delay(FreeCADGui.Control.closeDialog,None)
+        todo.delay(FreeCADGui.Control.closeDialog)
         self.cancel = None
         self.sourceCmd = None
         self.pointcallback = None
@@ -1100,7 +1100,7 @@ class DraftToolBar:
         self.labelRadius.setText(translate("draft","Distance"))
         self.radiusValue.setToolTip(translate("draft", "Offset distance"))
         self.radiusValue.setText(FreeCAD.Units.Quantity(0,FreeCAD.Units.Length).UserString)
-        todo.delay(self.radiusValue.setFocus,None)
+        todo.delay(self.radiusValue.setFocus)
         self.radiusValue.selectAll()
 
     def radiusUi(self):
@@ -1110,7 +1110,7 @@ class DraftToolBar:
         self.labelRadius.show()
         self.radiusValue.setText(FreeCAD.Units.Quantity(0,FreeCAD.Units.Length).UserString)
         self.radiusValue.show()
-        todo.delay(self.radiusValue.setFocus,None)
+        todo.delay(self.radiusValue.setFocus)
         self.radiusValue.selectAll()
 
     def textUi(self):
@@ -1118,7 +1118,7 @@ class DraftToolBar:
         self.textValue.show()
         self.textOkButton.show()
         self.textValue.setText('')
-        todo.delay(self.textValue.setFocus,None)
+        todo.delay(self.textValue.setFocus)
         self.textbuffer=[]
         self.textline=0
         self.continueCmd.show()
@@ -1131,7 +1131,7 @@ class DraftToolBar:
         self.labelSString.show()
         self.SStringValue.show()
         self.SStringValue.setText('')
-        todo.delay(self.SStringValue.setFocus,None)
+        todo.delay(self.SStringValue.setFocus)
         self.continueCmd.hide()
 
     def SSizeUi(self):
@@ -1142,7 +1142,7 @@ class DraftToolBar:
         self.labelSSize.show()
         self.SSizeValue.setText(FreeCAD.Units.Quantity(1,FreeCAD.Units.Length).UserString)
         self.SSizeValue.show()
-        todo.delay(self.SSizeValue.setFocus,None)
+        todo.delay(self.SSizeValue.setFocus)
 
     def STrackUi(self):
         ''' set up ui for ShapeString tracking entry '''
@@ -1151,7 +1151,7 @@ class DraftToolBar:
         self.labelSTrack.show()
         self.STrackValue.setText(FreeCAD.Units.Quantity(0,FreeCAD.Units.Length).UserString)
         self.STrackValue.show()
-        todo.delay(self.STrackValue.setFocus,None)
+        todo.delay(self.STrackValue.setFocus)
 
     def SFileUi(self):
         ''' set up UI for ShapeString font file selection '''
@@ -1162,7 +1162,7 @@ class DraftToolBar:
         self.labelFFile.show()
         self.FFileValue.show()
         self.chooserButton.show()
-        todo.delay(self.FFileValue.setFocus,None)
+        todo.delay(self.FFileValue.setFocus)
 
     def switchUi(self,store=True):
         if store:

--- a/src/Mod/Draft/draftguitools/gui_move.py
+++ b/src/Mod/Draft/draftguitools/gui_move.py
@@ -108,7 +108,7 @@ class Move(gui_base_original.Modifier):
             ghost.finalize()
         if cont and self.ui:
             if self.ui.continueMode:
-                todo.ToDo.delayAfter(self.Activated, [])
+                todo.ToDo.delayAfter(self.Activated)
         super(Move, self).finish()
 
     def action(self, arg):

--- a/src/Mod/Draft/draftguitools/gui_rotate.py
+++ b/src/Mod/Draft/draftguitools/gui_rotate.py
@@ -263,7 +263,7 @@ class Rotate(gui_base_original.Modifier):
             ghost.finalize()
         if cont and self.ui:
             if self.ui.continueMode:
-                todo.ToDo.delayAfter(self.Activated, [])
+                todo.ToDo.delayAfter(self.Activated)
         super(Rotate, self).finish()
         if self.doc:
             self.doc.recompute()

--- a/src/Mod/Draft/draftguitools/gui_scale.py
+++ b/src/Mod/Draft/draftguitools/gui_scale.py
@@ -399,8 +399,8 @@ class Scale(gui_base_original.Modifier):
             self.task = task_scale.ScaleTaskPanel()
             self.task.sourceCmd = self
             todo.ToDo.delay(Gui.Control.showDialog, self.task)
-            todo.ToDo.delay(self.task.xValue.selectAll, None)
-            todo.ToDo.delay(self.task.xValue.setFocus, None)
+            todo.ToDo.delay(self.task.xValue.selectAll)
+            todo.ToDo.delay(self.task.xValue.setFocus)
             for ghost in self.ghosts:
                 ghost.on()
         elif len(self.node) == 2:

--- a/src/Mod/Draft/draftguitools/gui_selectplane.py
+++ b/src/Mod/Draft/draftguitools/gui_selectplane.py
@@ -180,7 +180,7 @@ class Draft_SelectPlane:
             if (arg["State"] == "DOWN") and (arg["Button"] == "BUTTON1"):
                 # Coin detection happens before the selection
                 # got a chance of being updated, so we must delay
-                todo.delay(self.checkSelection, None)
+                todo.delay(self.checkSelection)
 
     def checkSelection(self):
         """Check the selection, if there is a handle, finish the command."""

--- a/src/Mod/Draft/draftutils/todo.py
+++ b/src/Mod/Draft/draftutils/todo.py
@@ -76,40 +76,13 @@ class ToDo:
             name()
 
     commitlist: list of tuples
-        Each tuple is of the form `(name, command_list)`.
-        The `name` is a string identifier or description of the commands
-        that will be run, and `command_list` is a list of strings
-        that indicate the Python instructions that will be executed,
-        or a reference to a single function that will be executed.
-
-        If `command_list` is a list, the program opens a transaction,
-        then runs all commands in the list in sequence,
-        and finally commits the transaction.
-        ::
-            command_list = ["command1", "command2", "..."]
-            App.activeDocument().openTransaction(name)
-            Gui.doCommand("command1")
-            Gui.doCommand("command2")
-            Gui.doCommand("...")
-            App.activeDocument().commitTransaction()
-
-        If `command_list` is a reference to a function
-        the function is executed directly.
-        ::
-            command_list = function
-            App.activeDocument().openTransaction(name)
-            function()
-            App.activeDocument().commitTransaction()
+        Each tuple is of the form `(name, func_or_list)`.
+        The `name` is a string identifier, `func_or_list` is a python
+        function or a list of strings with python code to be executed.
 
     afteritinerary: list of tuples
         Each tuple is of the form `(name, arg)`.
         This list is used just like `itinerary`.
-
-    Lists
-    -----
-    The lists contain tuples. Each tuple contains a `name` which is just
-    a string to identify the operation, and a `command_list` which is
-    a list of strings, each string an individual Python instruction.
     """
 
     itinerary = []
@@ -215,13 +188,6 @@ class ToDo:
         Schedule geometry manipulation that would crash Coin if done
         in the event callback.
 
-        If the `itinerary` list is empty, it will call
-        `QtCore.QTimer.singleShot(0, ToDo.doTasks)`
-        to execute the commands in the other lists.
-
-        Finally, it will build the tuple `(f, arg)`
-        and append it to the `itinerary` list.
-
         Parameters
         ----------
         f: function reference
@@ -250,21 +216,22 @@ class ToDo:
         Schedule geometry manipulation that would crash Coin if done
         in the event callback.
 
-        First it calls
-        `QtCore.QTimer.singleShot(0, ToDo.doTasks)`
-        to execute the commands in all lists.
-
-        Then the `cl` list is assigned as the new commit list.
-
         Parameters
         ----------
         cl: list of tuples
-            Each tuple is of the form `(name, command_list)`.
-            The `name` is a string identifier or description of the commands
-            that will be run, and `command_list` is a list of strings
-            that indicate the Python instructions that will be executed.
+            Each tuple is of the form `(name, func_or_list)`.
 
-            See the attributes of the `ToDo` class for more information.
+            The `name` is a string identifier or description of the commands
+            that will be run (used as the name of the transaction), and
+            `func_or_list` indicates what needs to be executed.
+
+            If `func_or_list` is a list, all items must be strings
+            containing python code. The program then opens a transaction,
+            runs each string using Gui.doCommand and finally commits the
+            transaction.
+
+            If `func_or_list` is a reference to a function
+            the function is executed directly (also within a transaction).
         """
         if _DEBUG:
             _msg("Debug: delaying commit.\n"
@@ -282,13 +249,6 @@ class ToDo:
         in the event callback.
 
         Works the same as `delay`.
-
-        If the `afteritinerary` list is empty, it will call
-        `QtCore.QTimer.singleShot(0, ToDo.doTasks)`
-        to execute the commands in the other lists.
-
-        Finally, it will build the tuple `(f, arg)`
-        and append it to the `afteritinerary` list.
         """
         if _DEBUG:
             _msg("Debug: delaying after.\n"

--- a/src/Mod/Draft/draftutils/todo.py
+++ b/src/Mod/Draft/draftutils/todo.py
@@ -34,7 +34,6 @@ to execute the instructions stored in internal lists.
 # \ingroup draftutils
 # \brief Provides the ToDo static class to run commands with a time delay.
 
-import six
 import sys
 import traceback
 import PySide.QtCore as QtCore
@@ -132,9 +131,6 @@ class ToDo:
 
         if commitlist:
             for name, func in commitlist:
-                if six.PY2:
-                    if isinstance(name, six.text_type):
-                        name = name.encode("utf8")
                 if _DEBUG_inner:
                     _msg("Debug: committing.\n"
                          "name: {}\n".format(name))

--- a/src/Mod/Draft/draftutils/todo.py
+++ b/src/Mod/Draft/draftutils/todo.py
@@ -115,6 +115,7 @@ class ToDo:
     itinerary = []
     commitlist = []
     afteritinerary = []
+    timerpending = False
 
     @staticmethod
     def doTasks():
@@ -197,6 +198,7 @@ class ToDo:
                        "in {1}({2})".format(sys.exc_info()[0], f, arg))
                 _wrn(wrn)
         ToDo.afteritinerary = []
+        ToDo.timerpending = False
 
     @staticmethod
     def delay(f, arg):
@@ -228,8 +230,9 @@ class ToDo:
         if _DEBUG:
             _msg("Debug: delaying.\n"
                  "function: {}\n".format(f))
-        if ToDo.itinerary == []:
+        if not ToDo.timerpending:
             QtCore.QTimer.singleShot(0, ToDo.doTasks)
+            ToDo.timerpending = True
         ToDo.itinerary.append((f, arg))
 
     @staticmethod
@@ -258,7 +261,9 @@ class ToDo:
         if _DEBUG:
             _msg("Debug: delaying commit.\n"
                  "commitlist: {}\n".format(cl))
-        QtCore.QTimer.singleShot(0, ToDo.doTasks)
+        if not ToDo.timerpending:
+            QtCore.QTimer.singleShot(0, ToDo.doTasks)
+            ToDo.timerpending = True
         ToDo.commitlist = cl
 
     @staticmethod
@@ -280,8 +285,9 @@ class ToDo:
         if _DEBUG:
             _msg("Debug: delaying after.\n"
                  "function: {}\n".format(f))
-        if ToDo.afteritinerary == []:
+        if not ToDo.timerpending:
             QtCore.QTimer.singleShot(0, ToDo.doTasks)
+            ToDo.timerpending = True
         ToDo.afteritinerary.append((f, arg))
 
 

--- a/src/Mod/Draft/draftutils/todo.py
+++ b/src/Mod/Draft/draftutils/todo.py
@@ -216,7 +216,8 @@ class ToDo:
         if not ToDo.timerpending:
             QtCore.QTimer.singleShot(0, ToDo.doTasks)
             ToDo.timerpending = True
-        ToDo.commitlist = cl
+        for item in cl:
+            ToDo.commitlist.append(item)
 
     @staticmethod
     def delayAfter(f, *args):

--- a/src/Mod/Draft/draftutils/todo.py
+++ b/src/Mod/Draft/draftutils/todo.py
@@ -136,26 +136,26 @@ class ToDo:
                  "afteritinerary: {2}\n".format(itinerary,
                                                 commitlist,
                                                 afteritinerary))
-        try:
-            for f, arg in itinerary:
+        for f, arg in itinerary:
+            try:
+                if _DEBUG_inner:
+                    _msg("Debug: executing.\n"
+                         "function: {}\n".format(f))
+                if arg or (arg is False):
+                    f(arg)
+                else:
+                    f()
+            except Exception:
                 try:
-                    if _DEBUG_inner:
-                        _msg("Debug: executing.\n"
-                             "function: {}\n".format(f))
-                    if arg or (arg is False):
-                        f(arg)
-                    else:
-                        f()
-                except Exception:
                     _log(traceback.format_exc())
                     _err(traceback.format_exc())
                     wrn = ("ToDo.doTasks, Unexpected error:\n"
                            "{0}\n"
                            "in {1}({2})".format(sys.exc_info()[0], f, arg))
                     _wrn(wrn)
-        except ReferenceError:
-            _wrn("Debug: ToDo.doTasks: "
-                 "queue contains a deleted object, skipping")
+                except ReferenceError:
+                    _wrn("Debug: ToDo.doTasks: "
+                         "queue contains a deleted object, skipping")
 
         if commitlist:
             for name, func in commitlist:


### PR DESCRIPTION
This PR fixes an issue with the Draft ToDo class where it would add multiple timers and, when the ToDo items would take long, could cause them to be executed twice, leading to a crash. See the commit messages and [this forum thread](https://forum.freecadweb.org/viewtopic.php?f=23&t=59373) for more details.

In addition to fixing the issue, this PR also cleans up the ToDo class, removing duplicate code, generalizing the code, cleaning up comments and improving the interface. The actual bugfix is in the first commit, so if this is merged, that commit should probably be backported to 0.19 (maybe also the second commit, though I'm not sure if that situation can actually occur, so maybe not needed).

All fixes and cleanups are separated in a small commits, to simplify review and history viewing later. Reviewing this PR is probably best done commit by commit, though because the total change is not too big and mostly contained to the ToDo class, you could also just look at the total diff and see if the resulting code is ok :-)

This PR is still a draft because:
 - I still have to do a proper review myself (but ran out of time for now and did want to share my progress so far).
 - It has been rebased on master, but I have only tested it on a few weeks old version (need some time to compile master again).
 - There is a change that breaks compatibility that probably needs to be fixed first (see below).
 - I still have to do some more thorough testing.

Wrt compatibility, commit abdd48f4e331feeb27500ade852feef2de61563b modifies the interface of the `ToDo.delay` and `ToDo.delayAfter` functions. Previously, you would pass a function and an argument to them, and that function would be called with that argument. If the function does not accept an argument, you could pass any falsey value (e.g. `ToDo.delay(func, None)`) which was handled specially by calling the function with arguments (with one exception: if you passed `False`, it *would* be passed on as-is).

I do not really like this interface, since it is not really clear and predictable (also, you can not pass e.g. `None` to a delayed function now). Also, Python offers better mechanisms for this (variable argument handling), so I changed `ToDo.delay` and `Todo.delayAfter` to accept a function followed by any number of arguments to be passed to that function. This means you could simply pass no arguments if your function needs no arguments (e.g. `ToDo.delay(func)`, but also pass multiple (e.g. `ToDo.delay(func, 1, 2)`), which is nicer and more flexible.

However, this means that existing code that passes a `None` (or `[]` is also used it seems) will now break: `ToDo.delay(func, None)` will end up calling `func(None)` instead of `func()`.

I can think of a few ways to fix this:
 1. Keep the special handling of a single argument that is falsey (but not `False`) and if so, drop that argument. However, this would mean that the surprising handling is kept around (i.e. you cannot pass `None` to a delayed function). Some of this suprise could maybe be avoided by introspecting the function and only applying this special handling if the function accepts no arguments, but that probably makes things even more complex.
 2. Rename these two functions, applying the new interface to the new name and keeping the old interface for the old names. Would be easy without needing to duplicate code, but does require coming up with new names and changing a lot of code (though that could be an opportunity to change `todo` to `ToDo` everywhere as well maybe).
 3. Keep the old interface for e.g. `todo.delay()` and the new interface for `ToDo.delay()`. This would still break existing third-party code that uses `ToDo.delay()`, but that code could then at least be updated to switch back to `todo.delay()` if they need to support 0.19 and before, or use the new interface with `ToDo.delay()` if they're ok with supporting only 0.20 and above.

I think option 2. would be the cleanest, if we can come up with some reasonable alternative names :-)

 -  [X]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [X]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [X]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [X]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  ~~Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`~~
