### PR TITLE
Draft: Check special characters using focused input field

### DIFF
--- a/src/Mod/Draft/DraftGui.py
+++ b/src/Mod/Draft/DraftGui.py
@@ -286,6 +286,14 @@ class DraftToolBar:
         self.autogroup = None
         self.isCenterPlane = False
         self.lastMode = None
+        self.input_fields = {
+            "xValue":{"value":"x","unit":"Length"},
+            "yValue":{"value":"y","unit":"Length"},
+            "zValue":{"value":"z","unit":"Length"},
+            "lengthValue":{"value":"lvalue","unit":"Length"},
+            "radiusValue":{"value":"radius","unit":"Length"},
+            "angleValue":{"value":"avalue","unit":"Angle"}
+        }
 
         if self.taskmode:
             # add only a dummy widget, since widgets are created on demand
@@ -580,6 +588,7 @@ class DraftToolBar:
         QtCore.QObject.connect(self.zValue,QtCore.SIGNAL("textEdited(QString)"),self.checkSpecialChars)
         QtCore.QObject.connect(self.lengthValue,QtCore.SIGNAL("textEdited(QString)"),self.checkSpecialChars)
         QtCore.QObject.connect(self.radiusValue,QtCore.SIGNAL("textEdited(QString)"),self.checkSpecialChars)
+        QtCore.QObject.connect(self.angleValue,QtCore.SIGNAL("textEdited(QString)"),self.checkSpecialChars)
         QtCore.QObject.connect(self.zValue,QtCore.SIGNAL("returnPressed()"),self.validatePoint)
         QtCore.QObject.connect(self.pointButton,QtCore.SIGNAL("clicked()"),self.validatePoint)
         QtCore.QObject.connect(self.radiusValue,QtCore.SIGNAL("returnPressed()"),self.validatePoint)
@@ -1682,7 +1691,8 @@ class DraftToolBar:
             if self.closeButton.isVisible():
                 self.closeLine()
         elif txt.upper().startswith(inCommandShortcuts["SetWP"][0]):
-            self.orientWP()
+            if self.orientWPButton.isVisible():
+                self.orientWP()
             spec = True
         elif txt.upper().startswith(inCommandShortcuts["Copy"][0]):
             if self.isCopy.isVisible():
@@ -1693,27 +1703,14 @@ class DraftToolBar:
                 self.isSubelementMode.setChecked(not self.isSubelementMode.isChecked())
             spec = True
         if spec:
-            for i,k in enumerate([self.xValue,self.yValue,self.zValue,self.lengthValue,self.angleValue]):
-                if (k.property("text") == txt):
-                    #print "debug:matching:",k.property("text")
-                    if i == 0:
-                        v = FreeCAD.Units.Quantity(self.x,FreeCAD.Units.Length)\
-                            .getUserPreferred()[0]
-                    elif i == 1:
-                        v = FreeCAD.Units.Quantity(self.y,FreeCAD.Units.Length)\
-                            .getUserPreferred()[0]
-                    elif i == 2:
-                        v = FreeCAD.Units.Quantity(self.z,FreeCAD.Units.Length)\
-                            .getUserPreferred()[0]
-                    elif i == 3:
-                        v = FreeCAD.Units.Quantity(self.lvalue,FreeCAD.Units.Length)\
-                            .getUserPreferred()[0]
-                    else:
-                        v = FreeCAD.Units.Quantity(self.avalue,FreeCAD.Units.Angle)\
-                            .getUserPreferred()[0]
-                    k.setProperty("text",v)
-                    k.setFocus()
-                    k.selectAll()
+            widget = self.baseWidget.focusWidget()
+            field = self.input_fields[widget.objectName()]
+            value = getattr(self, field["value"])
+            unit = getattr(FreeCAD.Units, field["unit"])
+            v = FreeCAD.Units.Quantity(value, unit).getUserPreferred()[0]
+            widget.setProperty("text",v)
+            widget.setFocus()
+            widget.selectAll()
         self.updateSnapper()
 
     def updateSnapper(self):


### PR DESCRIPTION
Currently, the method for checking special characters uses a list of specific input fields.
With this change, the input field used is the one focused inside the base widget "draftToolBar". The attributes to modify and their units are read from the input_fields attribute dictionary. In this way, other workbenches that use other input fields within draftToolBar can use the method to check characters by simply adding the name of the widget and the corresponding attribute to the input_fields dictionary and connecting the Qt signal.
See https://forum.freecadweb.org/viewtopic.php?f=23&t=59352&sid=cf698f878b1630039b741ffe49a14188


Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
