### PR TITLE
Draft: Fix offsets.py problem with direction if precision=6

### DIFF
--- a/src/Mod/Draft/draftgeoutils/offsets.py
+++ b/src/Mod/Draft/draftgeoutils/offsets.py
@@ -295,13 +295,14 @@ def offsetWire(wire, dvec, bind=False, occ=False,
         # check against dvec provided for the offset direction
         # would not know if dvec is vector of width (Left/Right Align)
         # or width/2 (Center Align)
-        dvec0 = DraftVecUtils.scaleTo(v0, dvec.Length)
-        if DraftVecUtils.equals(dvec0, dvec):
+        v0.normalize()
+        v1 = App.Vector(dvec).normalize()
+        if v0.isEqual(v1, 0.0001):
             # "Left Offset" (Left Align or 'left offset' in Centre Align)
             firstDir = 1
             firstAlign = 'Left'
             alignListC.append('Left')
-        elif DraftVecUtils.equals(dvec0, dvec.negative()):
+        elif v0.isEqual(v1.negative(), 0.0001):
             # "Right Offset" (Right Align or 'right offset' in Centre Align)
             firstDir = -1
             firstAlign = 'Right'


### PR DESCRIPTION
The direction of the offset could be faulty if Draft precision=6. Since we are only interested in the side the pointer is on, working with a high precision does not make sense.

Forum topic:
https://forum.freecadweb.org/viewtopic.php?f=23&t=59052

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [*]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [*]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [*]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [ ]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
