### PR TITLE
Fix typos

### DIFF
--- a/src/Mod/Fem/femtest/app/test_object.py
+++ b/src/Mod/Fem/femtest/app/test_object.py
@@ -87,7 +87,7 @@ class TestObjectCreate(unittest.TestCase):
         # solver children: equations --> 6
         # gmsh mesh children: group, region, boundary layer --> 3
         # resule children: mesh result --> 1
-        # post pipeline childeren: region, scalar, cut, wrap --> 4
+        # post pipeline children: region, scalar, cut, wrap --> 4
         # analysis itself is not in analysis group --> 1
         # thus: -14
 

--- a/src/Mod/PartDesign/App/Body.cpp
+++ b/src/Mod/PartDesign/App/Body.cpp
@@ -181,7 +181,7 @@ bool Body::isAfterInsertPoint(App::DocumentObject* feature) {
 
     if (feature == nextSolid) {
         return true;
-    } else if (!nextSolid) { // the tip is last solid, we can't be plased after it
+    } else if (!nextSolid) { // the tip is last solid, we can't be placed after it
         return false;
     } else {
         return isAfter ( feature, nextSolid );

--- a/src/Mod/Path/App/ParamsHelper.h
+++ b/src/Mod/Path/App/ParamsHelper.h
@@ -800,7 +800,7 @@
 #define PARAM_PY_KWDS_(_param) \
     PARAM_TYPED(PARAM_PYARG_,_param)
 
-/** Generate a format string for kewords based argument
+/** Generate a format string for keywords based argument
  * \ingroup ParamPy
  */
 #define PARAM_PY_KWDS(_seq) \


### PR DESCRIPTION
Found via `codespell -q 3 -L aci,ake,aline,alle,alledges,alocation,als,ang,anid,apoints,ba,beginn,behaviour,bloaded,bottome,byteorder,calculater,cancelled,cancelling,cas,cascade,centimetre,childs,colour,colours,commen,connexion,currenty,dof,doubleclick,dum,eiter,elemente,ende,feld,finde,findf,freez,hist,iff,indicies,initialisation,initialise,initialised,initialises,initialisiert,inout,ist,kilometre,lod,mantatory,methode,metres,millimetre,modell,nd,noe,normale,normaly,nto,numer,oder,ontop,orgin,orginx,orginy,ot,pard,parms,pres,programm,que,recurrance,rougly,seperator,serie,sinc,strack,substraction,te,thist,thru,tread,uint,unter,vertexes,wallthickness,whitespaces -S ./.git,*.po,*.ts,./ChangeLog.txt,./src/3rdParty,./src/Mod/Assembly/App/opendcm,./src/CXX,./src/zipios++,./src/Base/swig*,./src/Mod/Robot/App/kdl_cp,./src/Mod/Import/App/SCL,./src/WindowsInstaller,./src/Doc/FreeCAD.uml,./build/doc/SourceDocu`