### PR TITLE
FEM: CCX naming of buckling resultfile

### DIFF
--- a/src/Mod/Fem/feminout/importCcxFrdResults.py
+++ b/src/Mod/Fem/feminout/importCcxFrdResults.py
@@ -69,7 +69,8 @@ def insert(
 def importFrd(
     filename,
     analysis=None,
-    result_name_prefix=""
+    result_name_prefix="",
+    result_analysis_type=""
 ):
     import ObjectsFem
     from . import importToolsFem
@@ -111,10 +112,19 @@ def importFrd(
                         .format(result_name_prefix, eigenmode_number)
                     )
                 elif number_of_increments > 1:
-                    results_name = (
-                        "{}Time{}_Results"
-                        .format(result_name_prefix, step_time)
-                    )
+
+                    if result_analysis_type == "buckling":
+
+                        results_name = (
+                            "{}BucklingFactor{}_Results"
+                            .format(result_name_prefix, step_time)
+                        )
+                    else:
+                        results_name = (
+                            "{}Time{}_Results"
+                                .format(result_name_prefix, step_time)
+                        )
+
                 else:
                     results_name = (
                         "{}Results"

--- a/src/Mod/Fem/femtools/ccxtools.py
+++ b/src/Mod/Fem/femtools/ccxtools.py
@@ -784,7 +784,7 @@ class FemToolsCcx(QtCore.QRunnable, QtCore.QObject):
         import feminout.importCcxFrdResults as importCcxFrdResults
         frd_result_file = os.path.splitext(self.inp_file_name)[0] + ".frd"
         if os.path.isfile(frd_result_file):
-            importCcxFrdResults.importFrd(frd_result_file, self.analysis, "CCX_")
+            importCcxFrdResults.importFrd(frd_result_file, self.analysis, "CCX_", self.solver.AnalysisType)
             for m in self.analysis.Group:
                 if m.isDerivedFrom("Fem::FemResultObject"):
                     self.results_present = True


### PR DESCRIPTION
Fixes the naming of the resultfile with solver Calculix when doing a buckle analysis. Instead of displaying 'Time', it displays "BucklingFactor".

What I can see is the resultfile from calculix is very similar when doing a multistep 'Static' analysis and a 'Buckle' analysis.

The way it is now is that when importing the resultfile('.frd') the import function determines what kind of analysis depending on the resultfile. This is not possible for Buckle analysis because of the similarity of the resultfiles.

The easiest way of solving this is to pass the requested AnalysisType when importing the resultfile.

![image](https://user-images.githubusercontent.com/27229796/122643602-f2e97480-d110-11eb-8a6b-d8440596cc6c.png)

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [X ]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [ ]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [ X]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ X]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [ ]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
