### PR TITLE
[Sketch] save new icons as plain SVG

### DIFF
--- a/src/Mod/Sketcher/Gui/Resources/icons/geometry/Sketcher_CreateRectangle_Center.svg
+++ b/src/Mod/Sketcher/Gui/Resources/icons/geometry/Sketcher_CreateRectangle_Center.svg
@@ -1,121 +1,30 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="64px"
-   height="64px"
-   id="svg2825"
-   version="1.1"
-   sodipodi:docname="Sketcher_CreateRectangle_Center.svg"
-   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)">
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="990"
-     id="namedview32"
-     showgrid="false"
-     inkscape:zoom="3.6875"
-     inkscape:cx="32"
-     inkscape:cy="53.694915"
-     inkscape:window-x="0"
-     inkscape:window-y="33"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg2825" />
-  <defs
-     id="defs2827">
-    <radialGradient
-       xlink:href="#linearGradient3144"
-       id="radialGradient2229"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
-       cx="225.26402"
-       cy="672.79736"
-       fx="225.26402"
-       fy="672.79736"
-       r="34.345188" />
-    <linearGradient
-       id="linearGradient3144">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0"
-         id="stop3146" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1"
-         id="stop3148" />
+<svg width="64px" height="64px" id="svg2825" version="1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs id="defs2827">
+    <radialGradient xlink:href="#linearGradient3144" id="radialGradient2229" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)" cx="225.26402" cy="672.79736" fx="225.26402" fy="672.79736" r="34.345188" />
+    <linearGradient id="linearGradient3144">
+      <stop style="stop-color:#ffffff;stop-opacity:1" offset="0" id="stop3146" />
+      <stop style="stop-color:#ffffff;stop-opacity:0" offset="1" id="stop3148" />
     </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient3144"
-       id="radialGradient2215"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
-       cx="225.26402"
-       cy="672.79736"
-       fx="225.26402"
-       fy="672.79736"
-       r="34.345188" />
-    <linearGradient
-       xlink:href="#linearGradient3836-0"
-       id="linearGradient3801-1"
-       gradientUnits="userSpaceOnUse"
-       x1="-18"
-       y1="18"
-       x2="-22"
-       y2="5" />
-    <linearGradient
-       id="linearGradient3836-0">
-      <stop
-         style="stop-color:#a40000;stop-opacity:1"
-         offset="0"
-         id="stop3838-2" />
-      <stop
-         style="stop-color:#ef2929;stop-opacity:1"
-         offset="1"
-         id="stop3840-5" />
+    <radialGradient xlink:href="#linearGradient3144" id="radialGradient2215" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)" cx="225.26402" cy="672.79736" fx="225.26402" fy="672.79736" r="34.345188" />
+    <linearGradient xlink:href="#linearGradient3836-0" id="linearGradient3801-1" gradientUnits="userSpaceOnUse" x1="-18" y1="18" x2="-22" y2="5" />
+    <linearGradient id="linearGradient3836-0">
+      <stop style="stop-color:#a40000;stop-opacity:1" offset="0" id="stop3838-2" />
+      <stop style="stop-color:#ef2929;stop-opacity:1" offset="1" id="stop3840-5" />
     </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3836-0-6"
-       id="linearGradient3801-1-3"
-       gradientUnits="userSpaceOnUse"
-       x1="-18"
-       y1="18"
-       x2="-22"
-       y2="5" />
-    <linearGradient
-       id="linearGradient3836-0-6">
-      <stop
-         style="stop-color:#a40000;stop-opacity:1"
-         offset="0"
-         id="stop3838-2-7" />
-      <stop
-         style="stop-color:#ef2929;stop-opacity:1"
-         offset="1"
-         id="stop3840-5-5" />
+    <linearGradient xlink:href="#linearGradient3836-0-6" id="linearGradient3801-1-3" gradientUnits="userSpaceOnUse" x1="-18" y1="18" x2="-22" y2="5" />
+    <linearGradient id="linearGradient3836-0-6">
+      <stop style="stop-color:#a40000;stop-opacity:1" offset="0" id="stop3838-2-7" />
+      <stop style="stop-color:#ef2929;stop-opacity:1" offset="1" id="stop3840-5-5" />
     </linearGradient>
   </defs>
-  <metadata
-     id="metadata2830">
+  <metadata id="metadata2830">
     <rdf:RDF>
-      <cc:Work
-         rdf:about="">
+      <cc:Work rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
         <dc:creator>
           <cc:Agent>
             <dc:title>[wmayer]</dc:title>
@@ -143,61 +52,21 @@
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g
-     id="g3527-3"
-     transform="matrix(0.12582859,0,0,0.13656891,-113.21901,-47.81056)">
-    <path
-       id="rect2233"
-       d="M 971.31349,415.98457 V 752.81086 H 1336.8902 V 415.98457 Z m 43.86921,44.36492 274.0236,-0.43105 v 248.95857 l -274.0236,0.0646 z"
-       style="fill:#d3d7cf;fill-opacity:1;stroke:#2e3436;stroke-width:15.25683403;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       inkscape:connector-curvature="0" />
-    <path
-       style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="M 55.913045,10.935149 H 9.1739164 v 43.063378"
-       id="path3040"
-       transform="matrix(7.3115342,0,0,7.3115342,920.13275,350.67648)"
-       inkscape:connector-curvature="0" />
-    <path
-       style="fill:none;stroke:#ffffff;stroke-width:2.08668017;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
-       d="m 13,51 39.685575,0.03219 -0.06987,-36.128755"
-       id="path3042"
-       transform="matrix(7.3115342,0,0,7.3115342,920.13275,350.67648)"
-       inkscape:connector-curvature="0" />
+  <g id="g3527-3" transform="matrix(0.12582859,0,0,0.13656891,-113.21901,-47.81056)">
+    <path id="rect2233" d="M 971.31349,415.98457 V 752.81086 H 1336.8902 V 415.98457 Z m 43.86921,44.36492 274.0236,-0.43105 v 248.95857 l -274.0236,0.0646 z" style="fill:#d3d7cf;fill-opacity:1;stroke:#2e3436;stroke-width:15.25683403;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="M 55.913045,10.935149 H 9.1739164 v 43.063378" id="path3040" transform="matrix(7.3115342,0,0,7.3115342,920.13275,350.67648)" />
+    <path style="fill:none;stroke:#ffffff;stroke-width:2.08668017;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" d="m 13,51 39.685575,0.03219 -0.06987,-36.128755" id="path3042" transform="matrix(7.3115342,0,0,7.3115342,920.13275,350.67648)" />
   </g>
-  <g
-     transform="translate(40.005742,-40.005445)"
-     id="g3827-1">
-    <g
-       transform="translate(31.322131,40.570289)"
-       id="g3797-9">
-      <path
-         style="fill:none;stroke:#280000;stroke-width:1.99999988;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="path4250-71"
-         d="M -26.156204,5.582626 A 8.993818,8.9934077 0.02042283 1 1 -12.493793,17.282241 8.993818,8.9934077 0.02042283 1 1 -26.156204,5.582626 Z"
-         inkscape:connector-curvature="0" />
-      <path
-         style="fill:url(#linearGradient3801-1);fill-opacity:1;stroke:#ef2929;stroke-width:1.99999952;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="path4250-7-3"
-         d="M -24.633588,6.893588 A 6.9999997,7.0000001 0 1 1 -14,16 6.9999997,7.0000001 0 0 1 -24.633588,6.893588 Z"
-         inkscape:connector-curvature="0" />
+  <g transform="translate(40.005742,-40.005445)" id="g3827-1">
+    <g transform="translate(31.322131,40.570289)" id="g3797-9">
+      <path style="fill:none;stroke:#280000;stroke-width:1.99999988;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="path4250-71" d="M -26.156204,5.582626 A 8.993818,8.9934077 0.02042283 1 1 -12.493793,17.282241 8.993818,8.9934077 0.02042283 1 1 -26.156204,5.582626 Z" />
+      <path style="fill:url(#linearGradient3801-1);fill-opacity:1;stroke:#ef2929;stroke-width:1.99999952;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="path4250-7-3" d="M -24.633588,6.893588 A 6.9999997,7.0000001 0 1 1 -14,16 6.9999997,7.0000001 0 0 1 -24.633588,6.893588 Z" />
     </g>
   </g>
-  <g
-     id="g3827-1-3"
-     transform="translate(19.525424,-20.338983)">
-    <g
-       transform="translate(31.322131,40.570289)"
-       id="g3797-9-5">
-      <path
-         style="fill:none;stroke:#280000;stroke-width:1.99999988;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="path4250-71-6"
-         d="M -26.156204,5.582626 A 8.993818,8.9934077 0.02042283 1 1 -12.493793,17.282241 8.993818,8.9934077 0.02042283 1 1 -26.156204,5.582626 Z"
-         inkscape:connector-curvature="0" />
-      <path
-         style="fill:url(#linearGradient3801-1-3);fill-opacity:1;stroke:#ef2929;stroke-width:1.99999952;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="path4250-7-3-2"
-         d="M -24.633588,6.893588 A 6.9999997,7.0000001 0 1 1 -14,16 6.9999997,7.0000001 0 0 1 -24.633588,6.893588 Z"
-         inkscape:connector-curvature="0" />
+  <g id="g3827-1-3" transform="translate(19.525424,-20.338983)">
+    <g transform="translate(31.322131,40.570289)" id="g3797-9-5">
+      <path style="fill:none;stroke:#280000;stroke-width:1.99999988;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="path4250-71-6" d="M -26.156204,5.582626 A 8.993818,8.9934077 0.02042283 1 1 -12.493793,17.282241 8.993818,8.9934077 0.02042283 1 1 -26.156204,5.582626 Z" />
+      <path style="fill:url(#linearGradient3801-1-3);fill-opacity:1;stroke:#ef2929;stroke-width:1.99999952;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="path4250-7-3-2" d="M -24.633588,6.893588 A 6.9999997,7.0000001 0 1 1 -14,16 6.9999997,7.0000001 0 0 1 -24.633588,6.893588 Z" />
     </g>
   </g>
 </svg>

--- a/src/Mod/Sketcher/Gui/Resources/icons/geometry/Sketcher_CreateRectangle_Center_Constr.svg
+++ b/src/Mod/Sketcher/Gui/Resources/icons/geometry/Sketcher_CreateRectangle_Center_Constr.svg
@@ -1,121 +1,30 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="64px"
-   height="64px"
-   id="svg2825"
-   version="1.1"
-   sodipodi:docname="Sketcher_CreateRectangle_Center_Constr.svg"
-   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)">
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="990"
-     id="namedview32"
-     showgrid="false"
-     inkscape:zoom="3.6875"
-     inkscape:cx="32"
-     inkscape:cy="32"
-     inkscape:window-x="0"
-     inkscape:window-y="33"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg2825" />
-  <defs
-     id="defs2827">
-    <radialGradient
-       xlink:href="#linearGradient3144"
-       id="radialGradient2229"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
-       cx="225.26402"
-       cy="672.79736"
-       fx="225.26402"
-       fy="672.79736"
-       r="34.345188" />
-    <linearGradient
-       id="linearGradient3144">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0"
-         id="stop3146" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1"
-         id="stop3148" />
+<svg width="64px" height="64px" id="svg2825" version="1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs id="defs2827">
+    <radialGradient xlink:href="#linearGradient3144" id="radialGradient2229" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)" cx="225.26402" cy="672.79736" fx="225.26402" fy="672.79736" r="34.345188" />
+    <linearGradient id="linearGradient3144">
+      <stop style="stop-color:#ffffff;stop-opacity:1" offset="0" id="stop3146" />
+      <stop style="stop-color:#ffffff;stop-opacity:0" offset="1" id="stop3148" />
     </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient3144"
-       id="radialGradient2215"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
-       cx="225.26402"
-       cy="672.79736"
-       fx="225.26402"
-       fy="672.79736"
-       r="34.345188" />
-    <linearGradient
-       xlink:href="#linearGradient3836-0"
-       id="linearGradient3801-1"
-       gradientUnits="userSpaceOnUse"
-       x1="-18"
-       y1="18"
-       x2="-22"
-       y2="5" />
-    <linearGradient
-       id="linearGradient3836-0">
-      <stop
-         style="stop-color:#a40000;stop-opacity:1"
-         offset="0"
-         id="stop3838-2" />
-      <stop
-         style="stop-color:#ef2929;stop-opacity:1"
-         offset="1"
-         id="stop3840-5" />
+    <radialGradient xlink:href="#linearGradient3144" id="radialGradient2215" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)" cx="225.26402" cy="672.79736" fx="225.26402" fy="672.79736" r="34.345188" />
+    <linearGradient xlink:href="#linearGradient3836-0" id="linearGradient3801-1" gradientUnits="userSpaceOnUse" x1="-18" y1="18" x2="-22" y2="5" />
+    <linearGradient id="linearGradient3836-0">
+      <stop style="stop-color:#a40000;stop-opacity:1" offset="0" id="stop3838-2" />
+      <stop style="stop-color:#ef2929;stop-opacity:1" offset="1" id="stop3840-5" />
     </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3836-0-6"
-       id="linearGradient3801-1-3"
-       gradientUnits="userSpaceOnUse"
-       x1="-18"
-       y1="18"
-       x2="-22"
-       y2="5" />
-    <linearGradient
-       id="linearGradient3836-0-6">
-      <stop
-         style="stop-color:#a40000;stop-opacity:1"
-         offset="0"
-         id="stop3838-2-7" />
-      <stop
-         style="stop-color:#ef2929;stop-opacity:1"
-         offset="1"
-         id="stop3840-5-5" />
+    <linearGradient xlink:href="#linearGradient3836-0-6" id="linearGradient3801-1-3" gradientUnits="userSpaceOnUse" x1="-18" y1="18" x2="-22" y2="5" />
+    <linearGradient id="linearGradient3836-0-6">
+      <stop style="stop-color:#a40000;stop-opacity:1" offset="0" id="stop3838-2-7" />
+      <stop style="stop-color:#ef2929;stop-opacity:1" offset="1" id="stop3840-5-5" />
     </linearGradient>
   </defs>
-  <metadata
-     id="metadata2830">
+  <metadata id="metadata2830">
     <rdf:RDF>
-      <cc:Work
-         rdf:about="">
+      <cc:Work rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
         <dc:creator>
           <cc:Agent>
             <dc:title>[Abdullah Tahiri]</dc:title>
@@ -143,61 +52,21 @@
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g
-     id="g3527-3"
-     transform="matrix(0.12582859,0,0,0.13656891,-113.21901,-47.81056)">
-    <path
-       id="rect2233"
-       d="M 971.31349,415.98457 V 752.81086 H 1336.8902 V 415.98457 Z m 43.86921,44.36492 274.0236,-0.43105 v 248.95857 l -274.0236,0.0646 z"
-       style="fill:#3465a4;fill-opacity:1;stroke:#0b1521;stroke-width:15.25683403;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       inkscape:connector-curvature="0" />
-    <path
-       style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="M 55.913045,10.935149 H 9.1739164 v 43.063378"
-       id="path3040"
-       transform="matrix(7.3115342,0,0,7.3115342,920.13275,350.67648)"
-       inkscape:connector-curvature="0" />
-    <path
-       style="fill:none;stroke:#729fcf;stroke-width:2.08668017;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
-       d="m 13,51 39.685575,0.03219 -0.06987,-36.128755"
-       id="path3042"
-       transform="matrix(7.3115342,0,0,7.3115342,920.13275,350.67648)"
-       inkscape:connector-curvature="0" />
+  <g id="g3527-3" transform="matrix(0.12582859,0,0,0.13656891,-113.21901,-47.81056)">
+    <path id="rect2233" d="M 971.31349,415.98457 V 752.81086 H 1336.8902 V 415.98457 Z m 43.86921,44.36492 274.0236,-0.43105 v 248.95857 l -274.0236,0.0646 z" style="fill:#3465a4;fill-opacity:1;stroke:#0b1521;stroke-width:15.25683403;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="M 55.913045,10.935149 H 9.1739164 v 43.063378" id="path3040" transform="matrix(7.3115342,0,0,7.3115342,920.13275,350.67648)" />
+    <path style="fill:none;stroke:#729fcf;stroke-width:2.08668017;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" d="m 13,51 39.685575,0.03219 -0.06987,-36.128755" id="path3042" transform="matrix(7.3115342,0,0,7.3115342,920.13275,350.67648)" />
   </g>
-  <g
-     transform="translate(40.005742,-40.005445)"
-     id="g3827-1">
-    <g
-       transform="translate(31.322131,40.570289)"
-       id="g3797-9">
-      <path
-         style="fill:none;stroke:#280000;stroke-width:1.99999988;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="path4250-71"
-         d="M -26.156204,5.582626 A 8.993818,8.9934077 0.02042283 1 1 -12.493793,17.282241 8.993818,8.9934077 0.02042283 1 1 -26.156204,5.582626 Z"
-         inkscape:connector-curvature="0" />
-      <path
-         style="fill:url(#linearGradient3801-1);fill-opacity:1;stroke:#ef2929;stroke-width:1.99999952;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="path4250-7-3"
-         d="M -24.633588,6.893588 A 6.9999997,7.0000001 0 1 1 -14,16 6.9999997,7.0000001 0 0 1 -24.633588,6.893588 Z"
-         inkscape:connector-curvature="0" />
+  <g transform="translate(40.005742,-40.005445)" id="g3827-1">
+    <g transform="translate(31.322131,40.570289)" id="g3797-9">
+      <path style="fill:none;stroke:#280000;stroke-width:1.99999988;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="path4250-71" d="M -26.156204,5.582626 A 8.993818,8.9934077 0.02042283 1 1 -12.493793,17.282241 8.993818,8.9934077 0.02042283 1 1 -26.156204,5.582626 Z" />
+      <path style="fill:url(#linearGradient3801-1);fill-opacity:1;stroke:#ef2929;stroke-width:1.99999952;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="path4250-7-3" d="M -24.633588,6.893588 A 6.9999997,7.0000001 0 1 1 -14,16 6.9999997,7.0000001 0 0 1 -24.633588,6.893588 Z" />
     </g>
   </g>
-  <g
-     id="g3827-1-3"
-     transform="translate(19.525424,-20.067797)">
-    <g
-       transform="translate(31.322131,40.570289)"
-       id="g3797-9-5">
-      <path
-         style="fill:none;stroke:#280000;stroke-width:1.99999988;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="path4250-71-6"
-         d="M -26.156204,5.582626 A 8.993818,8.9934077 0.02042283 1 1 -12.493793,17.282241 8.993818,8.9934077 0.02042283 1 1 -26.156204,5.582626 Z"
-         inkscape:connector-curvature="0" />
-      <path
-         style="fill:url(#linearGradient3801-1-3);fill-opacity:1;stroke:#ef2929;stroke-width:1.99999952;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="path4250-7-3-2"
-         d="M -24.633588,6.893588 A 6.9999997,7.0000001 0 1 1 -14,16 6.9999997,7.0000001 0 0 1 -24.633588,6.893588 Z"
-         inkscape:connector-curvature="0" />
+  <g id="g3827-1-3" transform="translate(19.525424,-20.067797)">
+    <g transform="translate(31.322131,40.570289)" id="g3797-9-5">
+      <path style="fill:none;stroke:#280000;stroke-width:1.99999988;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="path4250-71-6" d="M -26.156204,5.582626 A 8.993818,8.9934077 0.02042283 1 1 -12.493793,17.282241 8.993818,8.9934077 0.02042283 1 1 -26.156204,5.582626 Z" />
+      <path style="fill:url(#linearGradient3801-1-3);fill-opacity:1;stroke:#ef2929;stroke-width:1.99999952;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="path4250-7-3-2" d="M -24.633588,6.893588 A 6.9999997,7.0000001 0 1 1 -14,16 6.9999997,7.0000001 0 0 1 -24.633588,6.893588 Z" />
     </g>
   </g>
 </svg>

--- a/src/Mod/Sketcher/Gui/Resources/icons/tools/Sketcher_RemoveAxesAlignment.svg
+++ b/src/Mod/Sketcher/Gui/Resources/icons/tools/Sketcher_RemoveAxesAlignment.svg
@@ -1,275 +1,51 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="64px"
-   height="64px"
-   id="svg2816"
-   version="1.1"
-   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)"
-   sodipodi:docname="Sketcher_RemoveAxesAlignment.svg"
-   inkscape:export-filename="/home/user/Downloads/cad/mystuff/icons/sketcher/context_menu_some/Sketcher_SelectOrigin_3_32px.png"
-   inkscape:export-xdpi="45"
-   inkscape:export-ydpi="45">
-  <defs
-     id="defs2818">
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient3890">
-      <stop
-         style="stop-color:#204a87;stop-opacity:1"
-         offset="0"
-         id="stop3892" />
-      <stop
-         style="stop-color:#729fcf;stop-opacity:1"
-         offset="1"
-         id="stop3894" />
+<svg width="64px" height="64px" id="svg2816" version="1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs id="defs2818">
+    <linearGradient id="linearGradient3890">
+      <stop style="stop-color:#204a87;stop-opacity:1" offset="0" id="stop3892" />
+      <stop style="stop-color:#729fcf;stop-opacity:1" offset="1" id="stop3894" />
     </linearGradient>
-    <linearGradient
-       id="linearGradient3602">
-      <stop
-         style="stop-color:#ff2600;stop-opacity:1;"
-         offset="0"
-         id="stop3604" />
-      <stop
-         style="stop-color:#ff5f00;stop-opacity:1;"
-         offset="1"
-         id="stop3606" />
+    <linearGradient id="linearGradient3602">
+      <stop style="stop-color:#ff2600;stop-opacity:1" offset="0" id="stop3604" />
+      <stop style="stop-color:#ff5f00;stop-opacity:1" offset="1" id="stop3606" />
     </linearGradient>
-    <inkscape:perspective
-       sodipodi:type="inkscape:persp3d"
-       inkscape:vp_x="0 : 32 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_z="64 : 32 : 1"
-       inkscape:persp3d-origin="32 : 21.333333 : 1"
-       id="perspective2824" />
-    <inkscape:perspective
-       id="perspective3618"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3602-7"
-       id="linearGradient3608-5"
-       x1="3.909091"
-       y1="14.363636"
-       x2="24.81818"
-       y2="14.363636"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient3602-7">
-      <stop
-         style="stop-color:#c51900;stop-opacity:1;"
-         offset="0"
-         id="stop3604-1" />
-      <stop
-         style="stop-color:#ff5f00;stop-opacity:1;"
-         offset="1"
-         id="stop3606-3" />
+    <linearGradient xlink:href="#linearGradient3602-7" id="linearGradient3608-5" x1="3.909091" y1="14.363636" x2="24.81818" y2="14.363636" gradientUnits="userSpaceOnUse" />
+    <linearGradient id="linearGradient3602-7">
+      <stop style="stop-color:#c51900;stop-opacity:1" offset="0" id="stop3604-1" />
+      <stop style="stop-color:#ff5f00;stop-opacity:1" offset="1" id="stop3606-3" />
     </linearGradient>
-    <inkscape:perspective
-       id="perspective3677"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3602-5"
-       id="linearGradient3608-1"
-       x1="3.909091"
-       y1="14.363636"
-       x2="24.81818"
-       y2="14.363636"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient3602-5">
-      <stop
-         style="stop-color:#c51900;stop-opacity:1;"
-         offset="0"
-         id="stop3604-9" />
-      <stop
-         style="stop-color:#ff5f00;stop-opacity:1;"
-         offset="1"
-         id="stop3606-9" />
+    <linearGradient xlink:href="#linearGradient3602-5" id="linearGradient3608-1" x1="3.909091" y1="14.363636" x2="24.81818" y2="14.363636" gradientUnits="userSpaceOnUse" />
+    <linearGradient id="linearGradient3602-5">
+      <stop style="stop-color:#c51900;stop-opacity:1" offset="0" id="stop3604-9" />
+      <stop style="stop-color:#ff5f00;stop-opacity:1" offset="1" id="stop3606-9" />
     </linearGradient>
-    <linearGradient
-       y2="14.363636"
-       x2="24.81818"
-       y1="14.363636"
-       x1="3.909091"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3686"
-       xlink:href="#linearGradient3602-5"
-       inkscape:collect="always" />
-    <inkscape:perspective
-       id="perspective3717"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3602-58"
-       id="linearGradient3608-8"
-       x1="3.909091"
-       y1="14.363636"
-       x2="24.81818"
-       y2="14.363636"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient3602-58">
-      <stop
-         style="stop-color:#c51900;stop-opacity:1;"
-         offset="0"
-         id="stop3604-2" />
-      <stop
-         style="stop-color:#ff5f00;stop-opacity:1;"
-         offset="1"
-         id="stop3606-2" />
+    <linearGradient y2="14.363636" x2="24.81818" y1="14.363636" x1="3.909091" gradientUnits="userSpaceOnUse" id="linearGradient3686" xlink:href="#linearGradient3602-5" />
+    <linearGradient xlink:href="#linearGradient3602-58" id="linearGradient3608-8" x1="3.909091" y1="14.363636" x2="24.81818" y2="14.363636" gradientUnits="userSpaceOnUse" />
+    <linearGradient id="linearGradient3602-58">
+      <stop style="stop-color:#c51900;stop-opacity:1" offset="0" id="stop3604-2" />
+      <stop style="stop-color:#ff5f00;stop-opacity:1" offset="1" id="stop3606-2" />
     </linearGradient>
-    <linearGradient
-       y2="14.363636"
-       x2="24.81818"
-       y1="14.363636"
-       x1="3.909091"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3726"
-       xlink:href="#linearGradient3602-58"
-       inkscape:collect="always" />
-    <inkscape:perspective
-       id="perspective4410"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective4944"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective4966"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective5009"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective5165"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3786-7"
-       id="linearGradient3792-1"
-       x1="22"
-       y1="27"
-       x2="9"
-       y2="30"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient3786-7">
-      <stop
-         style="stop-color:#a40000;stop-opacity:1"
-         offset="0"
-         id="stop3788-4" />
-      <stop
-         style="stop-color:#ef2929;stop-opacity:1"
-         offset="1"
-         id="stop3790-0" />
+    <linearGradient y2="14.363636" x2="24.81818" y1="14.363636" x1="3.909091" gradientUnits="userSpaceOnUse" id="linearGradient3726" xlink:href="#linearGradient3602-58" />
+    <linearGradient xlink:href="#linearGradient3786-7" id="linearGradient3792-1" x1="22" y1="27" x2="9" y2="30" gradientUnits="userSpaceOnUse" />
+    <linearGradient id="linearGradient3786-7">
+      <stop style="stop-color:#a40000;stop-opacity:1" offset="0" id="stop3788-4" />
+      <stop style="stop-color:#ef2929;stop-opacity:1" offset="1" id="stop3790-0" />
     </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3890"
-       id="linearGradient3896"
-       x1="20.785244"
-       y1="58.824768"
-       x2="12.00527"
-       y2="36.247696"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.35819329,0,0,0.35819329,3.9171843,36.248204)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3786-7"
-       id="linearGradient3792-1-3"
-       x1="22"
-       y1="27"
-       x2="9"
-       y2="30"
-       gradientUnits="userSpaceOnUse" />
+    <linearGradient xlink:href="#linearGradient3890" id="linearGradient3896" x1="20.785244" y1="58.824768" x2="12.00527" y2="36.247696" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.35819329,0,0,0.35819329,3.9171843,36.248204)" />
+    <linearGradient xlink:href="#linearGradient3786-7" id="linearGradient3792-1-3" x1="22" y1="27" x2="9" y2="30" gradientUnits="userSpaceOnUse" />
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="8.625"
-     inkscape:cx="37.697009"
-     inkscape:cy="25.638212"
-     inkscape:current-layer="layer1"
-     showgrid="true"
-     inkscape:document-units="px"
-     inkscape:grid-bbox="true"
-     inkscape:window-width="1920"
-     inkscape:window-height="990"
-     inkscape:window-x="0"
-     inkscape:window-y="33"
-     inkscape:window-maximized="1"
-     inkscape:snap-bbox="false"
-     inkscape:snap-nodes="true">
-    <inkscape:grid
-       type="xygrid"
-       id="grid3014"
-       empspacing="2"
-       visible="true"
-       enabled="true"
-       snapvisiblegridlinesonly="true" />
-  </sodipodi:namedview>
-  <metadata
-     id="metadata2821">
+  <metadata id="metadata2821">
     <rdf:RDF>
-      <cc:Work
-         rdf:about="">
+      <cc:Work rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
         <dc:creator>
           <cc:Agent>
             <dc:title>[wmayer]</dc:title>
           </cc:Agent>
         </dc:creator>
-        <dc:title>Sketcher_SelectVerticalAxis</dc:title>
         <dc:date>2014-08-04</dc:date>
         <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
         <dc:publisher>
@@ -292,83 +68,23 @@
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g
-     id="layer1"
-     inkscape:label="Layer 1"
-     inkscape:groupmode="layer">
-    <g
-       transform="matrix(0,0.58333333,-1,0,64,45.25)"
-       id="g3812-9">
-      <path
-         sodipodi:nodetypes="cccccccc"
-         id="rect8776-4"
-         d="M 21,51 V 17 h 6 L 15,3 3,17 h 6 v 34 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3792-1);fill-opacity:1;fill-rule:nonzero;stroke:#280000;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         inkscape:connector-curvature="0" />
-      <path
-         sodipodi:nodetypes="ccccccc"
-         inkscape:connector-curvature="0"
-         id="path3784-8"
-         d="M 11,39 V 15 H 7.4 L 15,6.1 22.6,15 H 19 v 24"
-         style="fill:none;stroke:#ef2929;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  <g id="layer1">
+    <g transform="matrix(0,0.58333333,-1,0,64,45.25)" id="g3812-9">
+      <path id="rect8776-4" d="M 21,51 V 17 h 6 L 15,3 3,17 h 6 v 34 z" style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3792-1);fill-opacity:1;fill-rule:nonzero;stroke:#280000;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate" />
+      <path id="path3784-8" d="M 11,39 V 15 H 7.4 L 15,6.1 22.6,15 H 19 v 24" style="fill:none;stroke:#ef2929;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <g
-       transform="matrix(0.58333333,0,0,1,0.58333337,0)"
-       id="g3812-9-5">
-      <path
-         sodipodi:nodetypes="cccccccc"
-         id="rect8776-4-3"
-         d="M 21,51 V 17 h 6 L 15,3 3,17 h 6 v 34 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3792-1-3);fill-opacity:1;fill-rule:nonzero;stroke:#280000;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         inkscape:connector-curvature="0" />
-      <path
-         sodipodi:nodetypes="ccccccc"
-         inkscape:connector-curvature="0"
-         id="path3784-8-5"
-         d="M 11,39 V 15 H 7.4 L 15,6.1 22.6,15 H 19 v 24"
-         style="fill:none;stroke:#ef2929;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <g transform="matrix(0.58333333,0,0,1,0.58333337,0)" id="g3812-9-5">
+      <path id="rect8776-4-3" d="M 21,51 V 17 h 6 L 15,3 3,17 h 6 v 34 z" style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3792-1-3);fill-opacity:1;fill-rule:nonzero;stroke:#280000;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate" />
+      <path id="path3784-8-5" d="M 11,39 V 15 H 7.4 L 15,6.1 22.6,15 H 19 v 24" style="fill:none;stroke:#ef2929;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <g
-       id="g4595">
-      <circle
-         r="5.8405795"
-         cy="53.275368"
-         cx="9.565218"
-         id="path3870"
-         style="fill:#729fcf;fill-opacity:1;stroke:#0b1521;stroke-width:0.89855069;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:2.03999996;stroke-opacity:1" />
-      <circle
-         r="4.942029"
-         cy="53.275368"
-         cx="9.565218"
-         id="path3870-2"
-         style="fill:url(#linearGradient3896);fill-opacity:1;stroke:#729fcf;stroke-width:0.89855075;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:2.03999996;stroke-opacity:1" />
+    <g id="g4595">
+      <circle r="5.8405795" cy="53.275368" cx="9.565218" id="path3870" style="fill:#729fcf;fill-opacity:1;stroke:#0b1521;stroke-width:0.89855069;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:2.03999996;stroke-opacity:1" />
+      <circle r="4.942029" cy="53.275368" cx="9.565218" id="path3870-2" style="fill:url(#linearGradient3896);fill-opacity:1;stroke:#729fcf;stroke-width:0.89855075;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:2.03999996;stroke-opacity:1" />
     </g>
-    <g
-       inkscape:export-ydpi="6.5895667"
-       inkscape:export-xdpi="6.5895667"
-       inkscape:export-filename="/home/yorik/Documents/Lab/Draft/icons/rectangle.png"
-       id="g3527-3"
-       transform="matrix(0.08501554,0.02272129,-0.02472425,0.092035,-44.92451,-56.434526)">
-      <path
-         id="rect2233"
-         d="M 971.31349,415.98457 V 752.81086 H 1336.8902 V 415.98457 Z m 43.86921,44.36492 274.0236,-0.43105 v 248.95857 l -274.0236,0.0646 z"
-         style="fill:#d3d7cf;fill-opacity:1;stroke:#2e3436;stroke-width:16.55097198;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccccccc" />
-      <path
-         style="fill:none;stroke:#ffffff;stroke-width:2.16964698;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="M 55.830146,11.067962 9.1739164,10.935149 9.143254,53.893093"
-         id="path3040-3"
-         inkscape:connector-curvature="0"
-         transform="matrix(7.3115342,0,0,7.3115342,920.13275,350.67648)"
-         sodipodi:nodetypes="ccc" />
-      <path
-         style="fill:none;stroke:#ffffff;stroke-width:2.26367974;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
-         d="m 13,51 39.685575,0.03219 -0.06987,-36.128755"
-         id="path3042-6"
-         inkscape:connector-curvature="0"
-         transform="matrix(7.3115342,0,0,7.3115342,920.13275,350.67648)"
-         sodipodi:nodetypes="ccc" />
+    <g id="g3527-3" transform="matrix(0.08501554,0.02272129,-0.02472425,0.092035,-44.92451,-56.434526)">
+      <path id="rect2233" d="M 971.31349,415.98457 V 752.81086 H 1336.8902 V 415.98457 Z m 43.86921,44.36492 274.0236,-0.43105 v 248.95857 l -274.0236,0.0646 z" style="fill:#d3d7cf;fill-opacity:1;stroke:#2e3436;stroke-width:16.55097198;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path style="fill:none;stroke:#ffffff;stroke-width:2.16964698;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="M 55.830146,11.067962 9.1739164,10.935149 9.143254,53.893093" id="path3040-3" transform="matrix(7.3115342,0,0,7.3115342,920.13275,350.67648)" />
+      <path style="fill:none;stroke:#ffffff;stroke-width:2.26367974;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" d="m 13,51 39.685575,0.03219 -0.06987,-36.128755" id="path3042-6" transform="matrix(7.3115342,0,0,7.3115342,920.13275,350.67648)" />
     </g>
   </g>
 </svg>


### PR DESCRIPTION
As the title says.
To assure that every browser and SVG display program can display the SVGs correctly, we should remove the Inkscape-specials by saving the SVG strictly according to the SVG specifications