### PR TITLE
AddonManager: parse addonflags.json with json module

### DIFF
--- a/src/Mod/AddonManager/addonmanager_workers.py
+++ b/src/Mod/AddonManager/addonmanager_workers.py
@@ -25,6 +25,7 @@ import os
 import re
 import shutil
 import sys
+import json
 
 from PySide import QtCore, QtGui
 
@@ -107,21 +108,16 @@ class UpdateWorker(QtCore.QThread):
         u = utils.urlopen("https://raw.githubusercontent.com/FreeCAD/FreeCAD-addons/master/addonflags.json")
         if u:
             p = u.read()
-            if sys.version_info.major >= 3 and isinstance(p, bytes):
-                p = p.decode("utf-8")
             u.close()
-            hit = re.findall(r'"obsolete"[^\{]*?{[^\{]*?"Mod":\[(?P<obsolete>[^\[\]]+?)\]}',
-                             p.replace("\n", "").replace(" ", ""))
-            if hit:
-                obsolete = hit[0].replace('"', "").split(",")
-            hit = re.findall(r'"blacklisted"[^\{]*?{[^\{]*?"Macro":\[(?P<blacklisted>[^\[\]]+?)\]}',
-                             p.replace("\n", "").replace(" ", ""))
-            if hit:
-                macros_blacklist = hit[0].replace('"', "").split(",")
-            hit = re.findall(r'"py2only"[^\{]*?{[^\{]*?"Mod":\[(?P<py2only>[^\[\]]+?)\]}',
-                             p.replace("\n", "").replace(" ", ""))
-            if hit:
-                py2only = hit[0].replace('"', "").split(",")
+            j = json.loads(p)
+            if "obsolete" in j and "Mod" in j["obsolete"]:
+                obsolete = j["obsolete"]["Mod"]
+
+            if "blacklisted" in j and "Macro" in j["blacklisted"]:
+                macros_blacklist = j["blacklisted"]["Macro"]
+
+            if "py2only" in j and "Mod" in j["py2only"]:
+                py2only = j["py2only"]["Mod"]
         else:
             print("Debug: addon_flags.json not found")
 


### PR DESCRIPTION
Parses addonflags.json with the python json-module instead of using
regular expressions.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [ ]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [x]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
