### PR TITLE
Gui: Prevent crash when calling stderr.write and stdout.write without arguments

### DIFF
--- a/src/Gui/PythonConsolePy.cpp
+++ b/src/Gui/PythonConsolePy.cpp
@@ -77,27 +77,16 @@ Py::Object PythonStdout::repr()
 
 Py::Object PythonStdout::write(const Py::Tuple& args)
 {
-    try {
-        Py::Object output(args[0]);
-        if (PyUnicode_Check(output.ptr())) {
-            PyObject* unicode = PyUnicode_AsEncodedString(output.ptr(), "utf-8", 0);
-            if (unicode) {
-                const char* string = PyBytes_AsString(unicode);
-                int maxlen = qstrlen(string) > 10000 ? 10000 : -1;
-                pyConsole->insertPythonOutput(QString::fromUtf8(string, maxlen));
-                Py_DECREF(unicode);
-            }
-        }
-        else {
-            Py::String text(args[0]);
-            std::string string = (std::string)text;
-            int maxlen = string.size() > 10000 ? 10000 : -1;
-            pyConsole->insertPythonOutput(QString::fromUtf8(string.c_str(), maxlen));
-        }
-    }
-    catch (Py::Exception& e) {
-        // Do not provoke error messages
-        e.clear();
+    PyObject* output;
+    if (!PyArg_ParseTuple(args.ptr(), "O!",&PyUnicode_Type, &output))
+        throw Py::TypeError("PythonStdout.write() takes exactly one argument of type str");
+
+    PyObject* unicode = PyUnicode_AsEncodedString(output, "utf-8", 0);
+    if (unicode) {
+        const char* string = PyBytes_AsString(unicode);
+        int maxlen = qstrlen(string) > 10000 ? 10000 : -1;
+        pyConsole->insertPythonOutput(QString::fromUtf8(string, maxlen));
+        Py_DECREF(unicode);
     }
 
     return Py::None();
@@ -154,27 +143,16 @@ Py::Object PythonStderr::repr()
 
 Py::Object PythonStderr::write(const Py::Tuple& args)
 {
-    try {
-        Py::Object output(args[0]);
-        if (PyUnicode_Check(output.ptr())) {
-            PyObject* unicode = PyUnicode_AsEncodedString(output.ptr(), "utf-8", 0);
-            if (unicode) {
-                const char* string = PyBytes_AsString(unicode);
-                int maxlen = qstrlen(string) > 10000 ? 10000 : -1;
-                pyConsole->insertPythonError(QString::fromUtf8(string, maxlen));
-                Py_DECREF(unicode);
-            }
-        }
-        else {
-            Py::String text(args[0]);
-            std::string string = (std::string)text;
-            int maxlen = string.size() > 10000 ? 10000 : -1;
-            pyConsole->insertPythonError(QString::fromUtf8(string.c_str(), maxlen));
-        }
-    }
-    catch (Py::Exception& e) {
-        // Do not provoke error messages
-        e.clear();
+    PyObject* output;
+    if (!PyArg_ParseTuple(args.ptr(), "O!",&PyUnicode_Type, &output))
+        throw Py::TypeError("PythonStderr.write() takes exactly one argument of type str");
+
+    PyObject* unicode = PyUnicode_AsEncodedString(output, "utf-8", 0);
+    if (unicode) {
+        const char* string = PyBytes_AsString(unicode);
+        int maxlen = qstrlen(string) > 10000 ? 10000 : -1;
+        pyConsole->insertPythonError(QString::fromUtf8(string, maxlen));
+        Py_DECREF(unicode);
     }
 
     return Py::None();
@@ -230,25 +208,15 @@ Py::Object OutputStdout::repr()
 
 Py::Object OutputStdout::write(const Py::Tuple& args)
 {
-    try {
-        Py::Object output(args[0]);
-        if (PyUnicode_Check(output.ptr())) {
-            PyObject* unicode = PyUnicode_AsEncodedString(output.ptr(), "utf-8", 0);
-            if (unicode) {
-                const char* string = PyBytes_AsString(unicode);
-                Base::Console().Message("%s",string);
-                Py_DECREF(unicode);
-            }
-        }
-        else {
-            Py::String text(args[0]);
-            std::string string = (std::string)text;
-            Base::Console().Message("%s",string.c_str());
-        }
-    }
-    catch (Py::Exception& e) {
-        // Do not provoke error messages
-        e.clear();
+    PyObject* output;
+    if (!PyArg_ParseTuple(args.ptr(), "O!",&PyUnicode_Type, &output))
+        throw Py::TypeError("OutputStdout.write() takes exactly one argument of type str");
+
+    PyObject* unicode = PyUnicode_AsEncodedString(output, "utf-8", 0);
+    if (unicode) {
+        const char* string = PyBytes_AsString(unicode);
+        Base::Console().Message("%s",string);
+        Py_DECREF(unicode);
     }
 
     return Py::None();
@@ -305,25 +273,15 @@ Py::Object OutputStderr::repr()
 
 Py::Object OutputStderr::write(const Py::Tuple& args)
 {
-    try {
-        Py::Object output(args[0]);
-        if (PyUnicode_Check(output.ptr())) {
-            PyObject* unicode = PyUnicode_AsEncodedString(output.ptr(), "utf-8", 0);
-            if (unicode) {
-                const char* string = PyBytes_AsString(unicode);
-                Base::Console().Error("%s",string);
-                Py_DECREF(unicode);
-            }
-        }
-        else {
-            Py::String text(args[0]);
-            std::string string = (std::string)text;
-            Base::Console().Error("%s",string.c_str());
-        }
-    }
-    catch (Py::Exception& e) {
-        // Do not provoke error messages
-        e.clear();
+    PyObject* output;
+    if (!PyArg_ParseTuple(args.ptr(), "O!",&PyUnicode_Type, &output))
+        throw Py::TypeError("OutputStderr.write() takes exactly one argument of type str");
+
+    PyObject* unicode = PyUnicode_AsEncodedString(output, "utf-8", 0);
+    if (unicode) {
+        const char* string = PyBytes_AsString(unicode);
+        Base::Console().Error("%s",string);
+        Py_DECREF(unicode);
     }
 
     return Py::None();


### PR DESCRIPTION
Steps to reproduce the crash:
import sys
sys.stderr.write()
#same using sys.stdout.write()

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
