### PR TITLE
TechDraw - Undo for Cosmetics Vertices and Lines

### DIFF
--- a/src/Mod/TechDraw/App/DrawViewPart.cpp
+++ b/src/Mod/TechDraw/App/DrawViewPart.cpp
@@ -324,7 +324,10 @@ short DrawViewPart::mustExecute() const
                     SeamHidden.isTouched() ||
                     IsoHidden.isTouched() ||
                     IsoCount.isTouched() ||
-                    CoarseView.isTouched());
+                    CoarseView.isTouched() ||
+                    CosmeticVertexes.isTouched() ||
+                    CosmeticEdges.isTouched() ||
+                    CenterLines.isTouched());
     }
 
     if (result) {

--- a/src/Mod/TechDraw/Gui/CommandAnnotate.cpp
+++ b/src/Mod/TechDraw/Gui/CommandAnnotate.cpp
@@ -348,6 +348,8 @@ void execMidpoints(Gui::Command* cmd)
         return;
     }
 
+    Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Add Midpont Vertices"));
+
     const std::vector<TechDraw::BaseGeom*> edges = dvp->getEdgeGeometry();
     double scale = dvp->getScale();
     for (auto& s: selectedEdges) {
@@ -357,6 +359,9 @@ void execMidpoints(Gui::Command* cmd)
         mid = DrawUtil::invertY(mid);
         dvp->addCosmeticVertex(mid / scale);
     }
+
+    Gui::Command::commitCommand();
+
     dvp->recomputeFeature();
 }
 
@@ -371,6 +376,8 @@ void execQuadrants(Gui::Command* cmd)
         return;
     }
 
+    Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Add Quadrant Vertices"));
+
     const std::vector<TechDraw::BaseGeom*> edges = dvp->getEdgeGeometry();
     double scale = dvp->getScale();
     for (auto& s: selectedEdges) {
@@ -382,6 +389,9 @@ void execQuadrants(Gui::Command* cmd)
                 dvp->addCosmeticVertex(iq / scale);
             }
     }
+
+    Gui::Command::commitCommand();
+
     dvp->recomputeFeature();
 }
 

--- a/src/Mod/TechDraw/Gui/TaskCosVertex.cpp
+++ b/src/Mod/TechDraw/Gui/TaskCosVertex.cpp
@@ -161,11 +161,15 @@ void TaskCosVertex::updateUi(void)
 
 void TaskCosVertex::addCosVertex(QPointF qPos)
 {
+    Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Add Cosmetic Vertex"));
+
 //    Base::Console().Message("TCV::addCosVertex(%s)\n", TechDraw::DrawUtil::formatVector(qPos).c_str());
     Base::Vector3d pos(qPos.x(), -qPos.y());
 //    int idx =
     (void) m_baseFeat->addCosmeticVertex(pos);
     m_baseFeat->requestPaint();
+
+    Gui::Command::commitCommand();
 }
 
 

--- a/src/Mod/TechDraw/Gui/TaskCosmeticLine.cpp
+++ b/src/Mod/TechDraw/Gui/TaskCosmeticLine.cpp
@@ -203,6 +203,8 @@ void TaskCosmeticLine::setUiEdit()
 //******************************************************************************
 void TaskCosmeticLine::createCosmeticLine(void)
 {
+    Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Create Cosmetic Line"));
+
     double x = ui->qsbx1->value().getValue();
     double y = ui->qsby1->value().getValue();
     double z = ui->qsbz1->value().getValue();
@@ -227,6 +229,8 @@ void TaskCosmeticLine::createCosmeticLine(void)
 
     m_tag = m_partFeat->addCosmeticEdge(p0, p1);
     m_ce = m_partFeat->getCosmeticEdge(m_tag);
+
+    Gui::Command::commitCommand();
 }
 
 void TaskCosmeticLine::updateCosmeticLine(void)


### PR DESCRIPTION
This pull request fixes missing Undo/Redo for TechDraw's Add Cosmetic Vertex and Add Cosmetic Line functionality, as reported in this TechDraw forum section topic: [https://forum.freecadweb.org/viewtopic.php?f=35&t=59529](https://forum.freecadweb.org/viewtopic.php?f=35&t=59529)