### PR TITLE
TechDraw - Edit annotations via double-click

### DIFF
--- a/src/Gui/Widgets.h
+++ b/src/Gui/Widgets.h
@@ -373,7 +373,7 @@ private:
 
 // ----------------------------------------------------------------------
 
-class PropertyListEditor : public QPlainTextEdit
+class GuiExport PropertyListEditor : public QPlainTextEdit
 {
     Q_OBJECT
 

--- a/src/Mod/TechDraw/Gui/QGIRichAnno.cpp
+++ b/src/Mod/TechDraw/Gui/QGIRichAnno.cpp
@@ -43,6 +43,7 @@
 #include <QTextFrame>
 #include <QTextBlock>
 #include <QTextCursor>
+#include <QDialog>
 
 
 # include <math.h>
@@ -80,6 +81,7 @@
 #include "QGCustomRect.h"
 
 #include "QGIRichAnno.h"
+#include "mrichtextedit.h"
 
 using namespace TechDraw;
 using namespace TechDrawGui;
@@ -358,6 +360,38 @@ double QGIRichAnno::prefPointSize(void)
     
     double ptsSize = round(fontSize * mmToPts);
     return ptsSize;
+}
+
+void QGIRichAnno::mouseDoubleClickEvent(QGraphicsSceneMouseEvent* event) {
+    Q_UNUSED(event);
+
+    TechDraw::DrawRichAnno *annotation = dynamic_cast<TechDraw::DrawRichAnno *>(getViewObject());
+    if (annotation == nullptr) {
+        return;
+    }
+
+    QString text = QString::fromUtf8(annotation->AnnoText.getValue());
+
+    QDialog dialog(0);
+    dialog.setWindowTitle(QObject::tr("Rich text editor"));
+    dialog.setMinimumWidth(400);
+    dialog.setMinimumHeight(400);
+
+    MRichTextEdit richEdit(&dialog, text);
+    QGridLayout gridLayout(&dialog);
+    gridLayout.addWidget(&richEdit, 0, 0, 1, 1);
+
+    connect(&richEdit, SIGNAL(saveText(QString)), &dialog, SLOT(accept()));
+    connect(&richEdit, SIGNAL(editorFinished(void)), &dialog, SLOT(reject()));
+
+    if (dialog.exec()) {
+        QString newText = richEdit.toHtml();
+        if (newText != text) {
+            App::GetApplication().setActiveTransaction("Set Rich Annotation Text");
+            annotation->AnnoText.setValue(newText.toStdString());
+            App::GetApplication().closeActiveTransaction();
+        }
+    }
 }
 
 #include <Mod/TechDraw/Gui/moc_QGIRichAnno.cpp>

--- a/src/Mod/TechDraw/Gui/QGIRichAnno.h
+++ b/src/Mod/TechDraw/Gui/QGIRichAnno.h
@@ -98,6 +98,8 @@ protected:
     double prefPointSize(void);
     QFont prefFont(void);
 
+    virtual void mouseDoubleClickEvent(QGraphicsSceneMouseEvent *event) override;
+
     bool m_isExporting;
     QGCustomText* m_text;
     bool m_hasHover;

--- a/src/Mod/TechDraw/Gui/QGIViewAnnotation.h
+++ b/src/Mod/TechDraw/Gui/QGIViewAnnotation.h
@@ -56,6 +56,8 @@ protected:
     void drawAnnotation();
     QVariant itemChange(GraphicsItemChange change, const QVariant &value) override;
 
+    virtual void mouseDoubleClickEvent(QGraphicsSceneMouseEvent *event) override;
+
     QGCustomText *m_textItem;
     QColor m_colNormal;
     QColor m_colSel;

--- a/src/Mod/TechDraw/Gui/mrichtextedit.cpp
+++ b/src/Mod/TechDraw/Gui/mrichtextedit.cpp
@@ -317,6 +317,15 @@ void MRichTextEdit::focusInEvent(QFocusEvent *) {
     f_textedit->setFocus(Qt::TabFocusReason);
 }
 
+void MRichTextEdit::keyPressEvent(QKeyEvent *event) {
+    if (event->key() == Qt::Key_Return && event->modifiers() == Qt::ControlModifier) {
+        onSave();
+        return;
+    }
+
+    QWidget::keyPressEvent(event);
+}
+
 
 void MRichTextEdit::textUnderline() {
     QTextCharFormat fmt;

--- a/src/Mod/TechDraw/Gui/mrichtextedit.h
+++ b/src/Mod/TechDraw/Gui/mrichtextedit.h
@@ -94,6 +94,7 @@ Q_SIGNALS:
     void list(bool checked, QTextListFormat::Style style);
     void indent(int delta);
     void focusInEvent(QFocusEvent *event);
+    void keyPressEvent(QKeyEvent *event);
     bool hasMultipleSizes(void);
 
     void addFontSize(QString fs);


### PR DESCRIPTION
This pull request adds a way to invoke simple and rich text annotation editors by double-click on the view items. Also gives a possibility to store rich text editor changes by pressing Ctrl+Enter as string list property editor already does.