### PR TITLE
Draft: Draft_Trimex: Fix wrong angle units in task panel

### DIFF
--- a/src/Mod/Draft/DraftGui.py
+++ b/src/Mod/Draft/DraftGui.py
@@ -1095,7 +1095,7 @@ class DraftToolBar:
         self.taskUi(title, icon="Draft_Trimex")
         self.radiusUi()
         self.labelRadius.setText(translate("draft","Distance"))
-        self.radiusValue.setToolTip(translate("draft", "Trim distance"))
+        self.radiusValue.setToolTip(translate("draft", "Offset distance"))
         self.radiusValue.setText(FreeCAD.Units.Quantity(0,FreeCAD.Units.Length).UserString)
         todo.delay(self.radiusValue.setFocus,None)
         self.radiusValue.selectAll()

--- a/src/Mod/Draft/draftguitools/gui_trimex.py
+++ b/src/Mod/Draft/draftguitools/gui_trimex.py
@@ -203,9 +203,21 @@ class Trimex(gui_base_original.Modifier):
             if self.extrudeMode:
                 dist = self.extrude(self.shift)
             else:
-                dist = self.redraw(self.point, self.snapped,
-                                   self.shift, self.alt)
-            self.ui.setRadiusValue(dist, unit="Length")
+                # If the geomType of the edge is "Line" ang will be None,
+                # else dist will be None.
+                dist, ang = self.redraw(self.point, self.snapped,
+                                        self.shift, self.alt)
+
+            if dist:
+                self.ui.labelRadius.setText(translate("draft", "Distance"))
+                self.ui.radiusValue.setToolTip(translate("draft",
+                                                         "Offset distance"))
+                self.ui.setRadiusValue(dist, unit="Length")
+            else:
+                self.ui.labelRadius.setText(translate("draft", "Angle"))
+                self.ui.radiusValue.setToolTip(translate("draft",
+                                                         "Offset angle"))
+                self.ui.setRadiusValue(ang, unit="Angle")
             self.ui.radiusValue.setFocus()
             self.ui.radiusValue.selectAll()
             gui_tool_utils.redraw3DView()
@@ -301,6 +313,7 @@ class Trimex(gui_base_original.Modifier):
 
         # modifying active edge
         if DraftGeomUtils.geomType(edge) == "Line":
+            ang = None
             ve = DraftGeomUtils.vec(edge)
             chord = v1.sub(point)
             n = ve.cross(chord)
@@ -313,9 +326,6 @@ class Trimex(gui_base_original.Modifier):
             dist = v1.sub(self.newpoint).Length
             ghost.p1(self.newpoint)
             ghost.p2(v2)
-            self.ui.labelRadius.setText(translate("draft", "Distance"))
-            self.ui.radiusValue.setToolTip(translate("draft",
-                                                     "The offset distance"))
             if real:
                 if self.force:
                     ray = self.newpoint.sub(v1)
@@ -323,16 +333,14 @@ class Trimex(gui_base_original.Modifier):
                     self.newpoint = App.Vector.add(v1, ray)
                 newedges.append(Part.LineSegment(self.newpoint, v2).toShape())
         else:
+            dist = None
             center = edge.Curve.Center
             rad = edge.Curve.Radius
             ang1 = DraftVecUtils.angle(v2.sub(center))
             ang2 = DraftVecUtils.angle(point.sub(center))
             _rot_rad = DraftVecUtils.rotate(App.Vector(rad, 0, 0), -ang2)
             self.newpoint = App.Vector.add(center, _rot_rad)
-            self.ui.labelRadius.setText(translate("draft", "Angle"))
-            self.ui.radiusValue.setToolTip(translate("draft",
-                                                     "The offset angle"))
-            dist = math.degrees(-ang2)
+            ang = math.degrees(-ang2)
             # if ang1 > ang2:
             #     ang1, ang2 = ang2, ang1
             # print("last calculated:",
@@ -384,7 +392,7 @@ class Trimex(gui_base_original.Modifier):
         if real:
             return newedges
         else:
-            return dist
+            return [dist, ang]
 
     def trimObject(self):
         """Trim the actual object."""


### PR DESCRIPTION
gui_trimex:
The redraw function was changed to return a list [dist, ang] if the real argument is not True. With this list the action function 'knows' which units to display. This also made it possible to move the "self.ui." related stuff that was in the redraw function to the action function.
I have also changed two tooltip texts by removing the article "The". This is more in keeping with other tooltips.

DraftGui.py
The tooltip text in this file was changed to match one of the tooltips in gui_trimex.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
