### PR TITLE
Path: Fixed incorrect usage of isDirty() in the accept button call back.

### DIFF
--- a/src/Mod/Path/PathScripts/PathOpGui.py
+++ b/src/Mod/Path/PathScripts/PathOpGui.py
@@ -1113,7 +1113,7 @@ class TaskPanel(object):
     def accept(self, resetEdit=True):
         '''accept() ... callback invoked when user presses the task panel OK button.'''
         self.preCleanup()
-        if self.isDirty:
+        if self.isDirty():
             self.panelGetFields()
         FreeCAD.ActiveDocument.commitTransaction()
         self.cleanup(resetEdit)


### PR DESCRIPTION
Path operations were being recalculated even if the panel was opened and closed without any modification. 
This caused avoidable delays particularly with complex 3D surface operations.

The accept call back was checking "isDirty" which always returned "True".
It was changed to call "isDirty()" instead which correct reflects the isdirty state of the pages.

--------------------------

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [ ]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [x]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`


---
