### PR TITLE
[Path] Make Job and Operation visibility more natural

### DIFF
--- a/src/Mod/Path/PathScripts/PathJob.py
+++ b/src/Mod/Path/PathScripts/PathJob.py
@@ -282,12 +282,13 @@ class ObjectJob:
 
     def setupOperations(self, obj):
         """setupOperations(obj)... setup the Operations group for the Job object."""
-        ops = FreeCAD.ActiveDocument.addObject(
-            "Path::FeatureCompoundPython", "Operations"
-        )
+        # ops = FreeCAD.ActiveDocument.addObject(
+        #     "Path::FeatureCompoundPython", "Operations"
+        # )
+        ops = FreeCAD.ActiveDocument.addObject("App::DocumentObjectGroup","Operations")
         if ops.ViewObject:
-            ops.ViewObject.Proxy = 0
-            ops.ViewObject.Visibility = False
+            # ops.ViewObject.Proxy = 0
+            ops.ViewObject.Visibility = True
 
         obj.Operations = ops
         obj.setEditorMode("Operations", 2)  # hide
@@ -659,7 +660,7 @@ class ObjectJob:
 
     def execute(self, obj):
         if getattr(obj, "Operations", None):
-            obj.Path = obj.Operations.Path
+            #obj.Path = obj.Operations.Path
             self.getCycleTime()
 
     def getCycleTime(self):
@@ -709,7 +710,7 @@ class ObjectJob:
             else:
                 group.append(op)
             self.obj.Operations.Group = group
-            op.Path.Center = self.obj.Operations.Path.Center
+            # op.Path.Center = self.obj.Operations.Path.Center
 
     def nextToolNumber(self):
         # returns the next available toolnumber in the job
@@ -849,5 +850,6 @@ def Create(name, base, templateFile=None):
     else:
         models = base
     obj = FreeCAD.ActiveDocument.addObject("Path::FeaturePython", name)
+    obj.addExtension("App::GroupExtensionPython")
     obj.Proxy = ObjectJob(obj, models, templateFile)
     return obj

--- a/src/Mod/Path/PathScripts/PathJobGui.py
+++ b/src/Mod/Path/PathScripts/PathJobGui.py
@@ -241,6 +241,7 @@ class ViewProvider:
             self.obj.Stock.ViewObject.Proxy.onEdit(_OpenCloseResourceEditor)
 
     def rememberBaseVisibility(self, obj, base):
+        PathLog.track()
         if base.ViewObject:
             orig = PathUtil.getPublicObject(obj.Proxy.baseObject(obj, base))
             self.baseVisibility[base.Name] = (
@@ -253,6 +254,7 @@ class ViewProvider:
             base.ViewObject.Visibility = True
 
     def forgetBaseVisibility(self, obj, base):
+        PathLog.track()
         if self.baseVisibility.get(base.Name):
             visibility = self.baseVisibility[base.Name]
             visibility[0].ViewObject.Visibility = visibility[1]
@@ -260,6 +262,7 @@ class ViewProvider:
             del self.baseVisibility[base.Name]
 
     def setupEditVisibility(self, obj):
+        PathLog.track()
         self.baseVisibility = {}
         for base in obj.Model.Group:
             self.rememberBaseVisibility(obj, base)
@@ -270,6 +273,7 @@ class ViewProvider:
             self.obj.Stock.ViewObject.Visibility = True
 
     def resetEditVisibility(self, obj):
+        PathLog.track()
         for base in obj.Model.Group:
             self.forgetBaseVisibility(obj, base)
         if obj.Stock and obj.Stock.ViewObject:
@@ -1581,6 +1585,7 @@ def Create(base, template=None):
     try:
         obj = PathJob.Create("Job", base, template)
         obj.ViewObject.Proxy = ViewProvider(obj.ViewObject)
+        obj.ViewObject.addExtension("Gui::ViewProviderGroupExtensionPython")
         FreeCAD.ActiveDocument.commitTransaction()
         obj.Document.recompute()
         obj.ViewObject.Proxy.editObject(obj.Stock)

--- a/src/Mod/Path/PathScripts/PathOpGui.py
+++ b/src/Mod/Path/PathScripts/PathOpGui.py
@@ -221,6 +221,11 @@ class TaskPanelPage(object):
     def _installTCUpdate(self):
         return hasattr(self.form, "toolController")
 
+    def setParent(self, parent):
+        '''setParent() ... used to transfer parent object link to child class.
+        Do not overwrite.'''
+        self.parent = parent
+
     def onDirtyChanged(self, callback):
         """onDirtyChanged(callback) ... set callback when dirty state changes."""
         self.signalDirtyChanged = callback
@@ -1178,6 +1183,7 @@ class TaskPanel(object):
             self.form = forms
 
         self.selectionFactory = selectionFactory
+        self.obj = obj
         self.isdirty = deleteOnReject
         self.visibility = obj.ViewObject.Visibility
         obj.ViewObject.Visibility = True
@@ -1392,7 +1398,7 @@ def Create(res):
         obj = res.objFactory(res.name, obj=None, parentJob=res.job)
         if obj.Proxy:
             obj.ViewObject.Proxy = ViewProvider(obj.ViewObject, res)
-            obj.ViewObject.Visibility = False
+            obj.ViewObject.Visibility = True
             FreeCAD.ActiveDocument.commitTransaction()
 
             obj.ViewObject.Document.setEdit(obj.ViewObject, 0)


### PR DESCRIPTION
This is an attempt to make the visibility of path objects a little more natural. 
Path visualization is removed from the Job node.
Operations node has been changed into a regular group.


- [ ]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [ ]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [ ]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [ ]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
