### PR TITLE
[PD] fix property issues

### DIFF
--- a/src/Mod/PartDesign/App/FeatureDraft.cpp
+++ b/src/Mod/PartDesign/App/FeatureDraft.cpp
@@ -67,7 +67,7 @@ using namespace PartDesign;
 
 PROPERTY_SOURCE(PartDesign::Draft, PartDesign::DressUp)
 
-App::PropertyAngle::Constraints Draft::floatAngle = { 0.0, 90.0 - Base::toDegrees<double>(Precision::Angular()), 0.1 };
+const App::PropertyAngle::Constraints Draft::floatAngle = { 0.0, 90.0 - Base::toDegrees<double>(Precision::Angular()), 0.1 };
 
 Draft::Draft()
 {

--- a/src/Mod/PartDesign/App/FeatureDraft.h
+++ b/src/Mod/PartDesign/App/FeatureDraft.h
@@ -58,7 +58,7 @@ public:
 
 private:
     virtual void handleChangedPropertyType(Base::XMLReader &reader, const char * TypeName, App::Property * prop);
-    static App::PropertyAngle::Constraints floatAngle;
+    static const App::PropertyAngle::Constraints floatAngle;
 };
 
 } //namespace PartDesign

--- a/src/Mod/PartDesign/App/FeatureHelix.cpp
+++ b/src/Mod/PartDesign/App/FeatureHelix.cpp
@@ -72,8 +72,8 @@ const char* Helix::ModeEnums[] = {"pitch-height-angle", "pitch-turns-angle", "he
 PROPERTY_SOURCE(PartDesign::Helix, PartDesign::ProfileBased)
 
 // we purposely use not FLT_MAX because this would not be computable
-const App::PropertyFloatConstraint::Constraints floatTurns = { Precision::Confusion(), INT_MAX, 1.0 };
-const App::PropertyAngle::Constraints floatAngle = { -89.0, 89.0, 1.0 };
+const App::PropertyFloatConstraint::Constraints Helix::floatTurns = { Precision::Confusion(), INT_MAX, 1.0 };
+const App::PropertyAngle::Constraints Helix::floatAngle = { -89.0, 89.0, 1.0 };
 
 Helix::Helix()
 {

--- a/src/Mod/PartDesign/App/FeatureHelix.h
+++ b/src/Mod/PartDesign/App/FeatureHelix.h
@@ -90,7 +90,7 @@ protected:
 
     // handle changed property
     virtual void handleChangedPropertyType(Base::XMLReader& reader, const char* TypeName, App::Property* prop);
-    static const App::PropertyFloatConstraint::Constraints Helix::floatTurns;
+    static const App::PropertyFloatConstraint::Constraints floatTurns;
     static const App::PropertyAngle::Constraints floatAngle;
 
 private:

--- a/src/Mod/PartDesign/App/FeatureHelix.h
+++ b/src/Mod/PartDesign/App/FeatureHelix.h
@@ -90,6 +90,8 @@ protected:
 
     // handle changed property
     virtual void handleChangedPropertyType(Base::XMLReader& reader, const char* TypeName, App::Property* prop);
+    static const App::PropertyFloatConstraint::Constraints Helix::floatTurns;
+    static const App::PropertyAngle::Constraints floatAngle;
 
 private:
     static const char* ModeEnums[];

--- a/src/Mod/PartDesign/App/FeatureLinearPattern.cpp
+++ b/src/Mod/PartDesign/App/FeatureLinearPattern.cpp
@@ -32,8 +32,6 @@
 # include <BRepAdaptor_Surface.hxx>
 #endif
 
-
-#include "FeatureLinearPattern.h"
 #include "DatumPlane.h"
 #include "DatumLine.h"
 #include <App/OriginFeature.h>
@@ -42,6 +40,8 @@
 #include <Mod/Part/App/TopoShape.h>
 #include <Mod/Part/App/Part2DObject.h>
 
+#include "FeatureLinearPattern.h"
+
 using namespace PartDesign;
 
 namespace PartDesign {
@@ -49,7 +49,7 @@ namespace PartDesign {
 
 PROPERTY_SOURCE(PartDesign::LinearPattern, PartDesign::Transformed)
 
-const App::PropertyIntegerConstraint::Constraints intOccurrences = { 1, INT_MAX, 1 };
+const App::PropertyIntegerConstraint::Constraints LinearPattern::intOccurrences = { 1, INT_MAX, 1 };
 
 LinearPattern::LinearPattern()
 {

--- a/src/Mod/PartDesign/App/FeatureLinearPattern.h
+++ b/src/Mod/PartDesign/App/FeatureLinearPattern.h
@@ -66,6 +66,7 @@ public:
 
 protected:
     virtual void handleChangedPropertyType(Base::XMLReader& reader, const char* TypeName, App::Property* prop);
+    static const App::PropertyIntegerConstraint::Constraints intOccurrences;
 };
 
 } //namespace PartDesign

--- a/src/Mod/PartDesign/App/FeaturePolarPattern.cpp
+++ b/src/Mod/PartDesign/App/FeaturePolarPattern.cpp
@@ -31,8 +31,6 @@
 # include <BRepAdaptor_Curve.hxx>
 #endif
 
-
-#include "FeaturePolarPattern.h"
 #include "DatumLine.h"
 #include <Base/Axis.h>
 #include <Base/Exception.h>
@@ -40,6 +38,8 @@
 #include <Mod/Part/App/TopoShape.h>
 #include <Mod/Part/App/Part2DObject.h>
 #include <App/OriginFeature.h>
+
+#include "FeaturePolarPattern.h"
 
 using namespace PartDesign;
 

--- a/src/Mod/PartDesign/Gui/TaskHelixParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskHelixParameters.h
@@ -90,7 +90,7 @@ protected:
     //mirrors of helixes's properties
     App::PropertyLength*      propPitch;
     App::PropertyLength*      propHeight;
-    App::PropertyFloat*       propTurns;
+    App::PropertyFloatConstraint*       propTurns;
     App::PropertyBool*        propLeftHanded;
     App::PropertyBool*        propReversed;
     App::PropertyLinkSub*     propReferenceAxis;


### PR DESCRIPTION
- Helix: the property Turns has the App::PropertyFloatConstraint thus also the pointer to it must have the same property

- LinearPattern and Helix: make constraints static class member (forgot this in commit 3704ad68)

- Draft: make the constraint const

- PolarPattern and LinearPattern assure that the header file is loaded at last to avoid potential troubles
