### PR TITLE
Draft: fixed Snap behaviour when no document is active.

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_snaps.py
+++ b/src/Mod/Draft/draftguitools/gui_snaps.py
@@ -35,6 +35,7 @@ from PySide.QtCore import QT_TRANSLATE_NOOP
 import FreeCADGui as Gui
 import draftguitools.gui_base as gui_base
 
+from draftutils.messages import _msg, _log
 from draftutils.translate import translate
 
 
@@ -102,8 +103,20 @@ def sync_snap_statusbar_button(button, status):
 
 # SNAP GUI TOOLS ------------------------------------------------------------
 
+class Draft_Snap_Base():
+    def __init__(self, name="None"):
+        self.command_name = name
 
-class Draft_Snap_Lock(gui_base.GuiCommandSimplest):
+    def IsActive(self):
+        return True
+
+    def Activated(self):
+        _log("GuiCommand: {}".format(self.command_name))
+        _msg("{}".format(16*"-"))
+        _msg("GuiCommand: {}".format(self.command_name))
+
+
+class Draft_Snap_Lock(Draft_Snap_Base):
     """GuiCommand for the Draft_Snap_Lock tool.
 
     Activate or deactivate all snap methods at once.
@@ -134,7 +147,7 @@ class Draft_Snap_Lock(gui_base.GuiCommandSimplest):
 Gui.addCommand('Draft_Snap_Lock', Draft_Snap_Lock())
 
 
-class Draft_Snap_Midpoint(gui_base.GuiCommandSimplest):
+class Draft_Snap_Midpoint(Draft_Snap_Base):
     """GuiCommand for the Draft_Snap_Midpoint tool.
 
     Set snapping to the midpoint of an edge.
@@ -164,7 +177,7 @@ class Draft_Snap_Midpoint(gui_base.GuiCommandSimplest):
 Gui.addCommand('Draft_Snap_Midpoint', Draft_Snap_Midpoint())
 
 
-class Draft_Snap_Perpendicular(gui_base.GuiCommandSimplest):
+class Draft_Snap_Perpendicular(Draft_Snap_Base):
     """GuiCommand for the Draft_Snap_Perpendicular tool.
 
     Set snapping to a direction that is perpendicular to an edge.
@@ -194,7 +207,7 @@ class Draft_Snap_Perpendicular(gui_base.GuiCommandSimplest):
 Gui.addCommand('Draft_Snap_Perpendicular', Draft_Snap_Perpendicular())
 
 
-class Draft_Snap_Grid(gui_base.GuiCommandSimplest):
+class Draft_Snap_Grid(Draft_Snap_Base):
     """GuiCommand for the Draft_Snap_Grid tool.
 
     Set snapping to the intersection of grid lines.
@@ -224,7 +237,7 @@ class Draft_Snap_Grid(gui_base.GuiCommandSimplest):
 Gui.addCommand('Draft_Snap_Grid', Draft_Snap_Grid())
 
 
-class Draft_Snap_Intersection(gui_base.GuiCommandSimplest):
+class Draft_Snap_Intersection(Draft_Snap_Base):
     """GuiCommand for the Draft_Snap_Intersection tool.
 
     Set snapping to the intersection of edges.
@@ -254,7 +267,7 @@ class Draft_Snap_Intersection(gui_base.GuiCommandSimplest):
 Gui.addCommand('Draft_Snap_Intersection', Draft_Snap_Intersection())
 
 
-class Draft_Snap_Parallel(gui_base.GuiCommandSimplest):
+class Draft_Snap_Parallel(Draft_Snap_Base):
     """GuiCommand for the Draft_Snap_Parallel tool.
 
     Set snapping to a direction that is parallel to an edge.
@@ -284,7 +297,7 @@ class Draft_Snap_Parallel(gui_base.GuiCommandSimplest):
 Gui.addCommand('Draft_Snap_Parallel', Draft_Snap_Parallel())
 
 
-class Draft_Snap_Endpoint(gui_base.GuiCommandSimplest):
+class Draft_Snap_Endpoint(Draft_Snap_Base):
     """GuiCommand for the Draft_Snap_Endpoint tool.
 
     Set snapping to endpoints of an edge.
@@ -314,7 +327,7 @@ class Draft_Snap_Endpoint(gui_base.GuiCommandSimplest):
 Gui.addCommand('Draft_Snap_Endpoint', Draft_Snap_Endpoint())
 
 
-class Draft_Snap_Angle(gui_base.GuiCommandSimplest):
+class Draft_Snap_Angle(Draft_Snap_Base):
     """GuiCommand for the Draft_Snap_Angle tool.
 
     Set snapping to points in a circular arc located at multiples
@@ -345,7 +358,7 @@ class Draft_Snap_Angle(gui_base.GuiCommandSimplest):
 Gui.addCommand('Draft_Snap_Angle', Draft_Snap_Angle())
 
 
-class Draft_Snap_Center(gui_base.GuiCommandSimplest):
+class Draft_Snap_Center(Draft_Snap_Base):
     """GuiCommand for the Draft_Snap_Center tool.
 
     Set snapping to the center of a circular arc.
@@ -375,7 +388,7 @@ class Draft_Snap_Center(gui_base.GuiCommandSimplest):
 Gui.addCommand('Draft_Snap_Center', Draft_Snap_Center())
 
 
-class Draft_Snap_Extension(gui_base.GuiCommandSimplest):
+class Draft_Snap_Extension(Draft_Snap_Base):
     """GuiCommand for the Draft_Snap_Extension tool.
 
     Set snapping to the extension of an edge.
@@ -405,7 +418,7 @@ class Draft_Snap_Extension(gui_base.GuiCommandSimplest):
 Gui.addCommand('Draft_Snap_Extension', Draft_Snap_Extension())
 
 
-class Draft_Snap_Near(gui_base.GuiCommandSimplest):
+class Draft_Snap_Near(Draft_Snap_Base):
     """GuiCommand for the Draft_Snap_Near tool.
 
     Set snapping to the nearest point of an edge.
@@ -435,7 +448,7 @@ class Draft_Snap_Near(gui_base.GuiCommandSimplest):
 Gui.addCommand('Draft_Snap_Near', Draft_Snap_Near())
 
 
-class Draft_Snap_Ortho(gui_base.GuiCommandSimplest):
+class Draft_Snap_Ortho(Draft_Snap_Base):
     """GuiCommand for the Draft_Snap_Ortho tool.
 
     Set snapping to a direction that is a multiple of 45 degrees
@@ -466,7 +479,7 @@ class Draft_Snap_Ortho(gui_base.GuiCommandSimplest):
 Gui.addCommand('Draft_Snap_Ortho', Draft_Snap_Ortho())
 
 
-class Draft_Snap_Special(gui_base.GuiCommandSimplest):
+class Draft_Snap_Special(Draft_Snap_Base):
     """GuiCommand for the Draft_Snap_Special tool.
 
     Set snapping to the special points defined inside an object.
@@ -496,7 +509,7 @@ class Draft_Snap_Special(gui_base.GuiCommandSimplest):
 Gui.addCommand('Draft_Snap_Special', Draft_Snap_Special())
 
 
-class Draft_Snap_Dimensions(gui_base.GuiCommandSimplest):
+class Draft_Snap_Dimensions(Draft_Snap_Base):
     """GuiCommand for the Draft_Snap_Dimensions tool.
 
     Show temporary linear dimensions when editing an object
@@ -527,7 +540,7 @@ class Draft_Snap_Dimensions(gui_base.GuiCommandSimplest):
 Gui.addCommand('Draft_Snap_Dimensions', Draft_Snap_Dimensions())
 
 
-class Draft_Snap_WorkingPlane(gui_base.GuiCommandSimplest):
+class Draft_Snap_WorkingPlane(Draft_Snap_Base):
     """GuiCommand for the Draft_Snap_WorkingPlane tool.
 
     Restricts snapping to a point in the current working plane.
@@ -560,7 +573,7 @@ class Draft_Snap_WorkingPlane(gui_base.GuiCommandSimplest):
 Gui.addCommand('Draft_Snap_WorkingPlane', Draft_Snap_WorkingPlane())
 
 
-class ShowSnapBar(gui_base.GuiCommandSimplest):
+class ShowSnapBar(Draft_Snap_Base):
     """GuiCommand for the Draft_ShowSnapBar tool.
 
     Show the snap toolbar if it is hidden.

--- a/src/Mod/Draft/draftguitools/gui_snaps.py
+++ b/src/Mod/Draft/draftguitools/gui_snaps.py
@@ -112,8 +112,8 @@ class Draft_Snap_Base():
 
     def Activated(self):
         _log("GuiCommand: {}".format(self.command_name))
-        _msg("{}".format(16*"-"))
-        _msg("GuiCommand: {}".format(self.command_name))
+        #_msg("{}".format(16*"-"))
+        #_msg("GuiCommand: {}".format(self.command_name))
 
 
 class Draft_Snap_Lock(Draft_Snap_Base):


### PR DESCRIPTION
Draft toolbar and statusbar can be activated also when no document is active, because Snap is not related to active document.