### PR TITLE
[PartDesign] Fix 'Reversed' no more available in Pad 'toFirst/toLast' + Pocket '2dims'

### DIFF
--- a/src/Mod/PartDesign/Gui/TaskPadParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPadParameters.cpp
@@ -237,6 +237,8 @@ void TaskPadParameters::updateUI(int index)
         // Go into reference selection mode if no face has been selected yet
         if (ui->lineFaceName->property("FeatureName").isNull())
             onButtonFace(true);
+        isReversedEnabled = true;
+        isReversedVisible = true;
     }
     // two dimensions
     else {

--- a/src/Mod/PartDesign/Gui/TaskPadParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPadParameters.cpp
@@ -203,7 +203,8 @@ void TaskPadParameters::updateUI(int index)
     bool isLengthEditVisible  = false;
     bool isLengthEdit2Visible = false;
     bool isOffsetEditVisible  = false;
-    bool isMidplateEnabled    = false;
+    bool isMidplaneEnabled    = false;
+    bool isMidplaneVisible    = false;
     bool isReversedEnabled    = false;
     bool isReversedVisible    = false;
     bool isFaceEditEnabled    = false;
@@ -216,7 +217,8 @@ void TaskPadParameters::updateUI(int index)
         // Calling setFocus() directly doesn't work because the spin box is not
         // yet visible.
         QMetaObject::invokeMethod(ui->lengthEdit, "setFocus", Qt::QueuedConnection);
-        isMidplateEnabled = !ui->checkBoxReversed->isChecked();
+        isMidplaneEnabled = !ui->checkBoxReversed->isChecked();
+        isMidplaneVisible = true;
         // Reverse only makes sense if Midplane is not true
         isReversedEnabled = !ui->checkBoxMidplane->isChecked();
         isReversedVisible = true;
@@ -224,6 +226,8 @@ void TaskPadParameters::updateUI(int index)
     // up to first/last
     else if (index == 1 || index == 2) {
         isOffsetEditVisible = true;
+        isReversedEnabled = true;
+        isReversedVisible = true;
     }
     // up to face
     else if (index == 3) {
@@ -238,7 +242,8 @@ void TaskPadParameters::updateUI(int index)
     else {
         isLengthEditVisible  = true;
         isLengthEdit2Visible = true;
-        isMidplateEnabled    = !ui->checkBoxReversed->isChecked();
+        isMidplaneEnabled    = !ui->checkBoxReversed->isChecked();
+        isMidplaneVisible    = true;
         isReversedEnabled    = !ui->checkBoxMidplane->isChecked();
         isReversedVisible    = true;
     }
@@ -252,7 +257,8 @@ void TaskPadParameters::updateUI(int index)
     ui->offsetEdit->setEnabled( isOffsetEditVisible );
     ui->labelOffset->setVisible( isOffsetEditVisible );
 
-    ui->checkBoxMidplane->setEnabled( isMidplateEnabled );
+    ui->checkBoxMidplane->setEnabled( isMidplaneEnabled );
+    ui->checkBoxMidplane->setVisible( isMidplaneVisible );
 
     ui->checkBoxReversed->setEnabled( isReversedEnabled );
     ui->checkBoxReversed->setVisible( isReversedVisible );

--- a/src/Mod/PartDesign/Gui/TaskPocketParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPocketParameters.cpp
@@ -215,6 +215,7 @@ void TaskPocketParameters::updateUI(int index)
     else {
         isLengthEditVisable = true;
         isLengthEdit2Visable = true;
+        isReversedEnabled = true;
     }    
 
     ui->lengthEdit->setVisible( isLengthEditVisable );

--- a/src/Mod/PartDesign/Gui/TaskPocketParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPocketParameters.cpp
@@ -205,6 +205,7 @@ void TaskPocketParameters::updateUI(int index)
     // up to face
     else if (index == 3) {
         isOffsetEditVisable = true;
+        isReversedEnabled = true;
         isFaceEditEnabled    = true;
         QMetaObject::invokeMethod(ui->lineFaceName, "setFocus", Qt::QueuedConnection);
         // Go into reference selection mode if no face has been selected yet


### PR DESCRIPTION
 While useless 'Midplane' was still visible
 Bug introduced in commit cf11f388, not fixed by commmit b4b1cbed
 Also fixing some typos

- [X]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [X]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [X]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [X]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [X]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`