### PR TITLE
[Path] Remove `Side` assignment to `Outside` for full model profiles

### DIFF
--- a/src/Mod/Path/PathScripts/PathProfile.py
+++ b/src/Mod/Path/PathScripts/PathProfile.py
@@ -380,7 +380,6 @@ class ObjectProfile(PathAreaOp.ObjectOp):
         else:  # Try to build targets from the job models
             # No base geometry selected, so treating operation like a exterior contour operation
             self.opUpdateDepths(obj)
-            obj.Side = 'Outside'  # Force outside for whole model profile
 
             if 1 == len(self.model) and hasattr(self.model[0], "Proxy"):
                 if isinstance(self.model[0].Proxy, ArchPanel.PanelSheet):  # process the sheet


### PR DESCRIPTION
The profile operation is forcing  cut side to `Outside` when profiling whole models.  This change in code also allows for profiling `Inside` of entire models.  Apart from limiting profiling capabilities of entire models, this override could cause problems with profiling in very specific use cases.  Also, this fix removes the property assignment of a key control property within the execution code, which should not happen, apart from feedback properties.

Tracker bug 4433 occurred some time ago and was deemed to be resolved with PR #3861.  However, the single line of code removed in this PR likely needed to be removed with that original PR.

The forum user that originally identified bug 4433 has recently bumped the original forum post, [Ticket #4433 - profile operation cut side reset](https://forum.freecadweb.org/viewtopic.php?f=15&t=49459), stating it is recurring again.  While the single line of code addressed in this PR is not problematic in most situations, it is possible that it would cause a problem with very specific use cases. A part of the problem is that the Gui Task Panel property value is not synced with the operation property value in certain cases, misleading users.

The line of code is also problematic because it makes an assignment to a control property within the execution code - this property should be read-only in the execution code.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
