### PR TITLE
[OpenSCAD] Fixes cut color while importing CSG

### DIFF
--- a/src/Mod/OpenSCAD/importCSG.py
+++ b/src/Mod/OpenSCAD/importCSG.py
@@ -69,7 +69,7 @@ def shallHide(subject):
 def setColorRecursively(obj, color, transp):
     '''
     For some reason a part made by cutting or fusing other parts do not have a color
-    unless it's constituents are also colored. This code sets colors for those
+    unless its constituents are also colored. This code sets colors for those
     constituents unless already set elsewhere.
     '''
     obj.ViewObject.ShapeColor = color
@@ -77,10 +77,10 @@ def setColorRecursively(obj, color, transp):
     # Add any other relevant features to this list
     boolean_features = ["Part::Fuse", "Part::MultiFuse", "Part::Cut",
                         "Part::Common", "Part::MultiCommon"]
-    if (obj.TypeId in boolean_features):
+    if obj.TypeId in boolean_features:
         for currentObject in obj.OutList:
             print(f"Fixing up colors for: {currentObject.FullName}")
-            if(currentObject not in hassetcolor):
+            if currentObject not in hassetcolor:
                 setColorRecursively(currentObject, color, transp)
 
 def fixVisibility():

--- a/src/Mod/OpenSCAD/importCSG.py
+++ b/src/Mod/OpenSCAD/importCSG.py
@@ -66,19 +66,20 @@ def shallHide(subject):
             return True
     return False
 
-def setColorRecursively(obj,color,transp):
-    if(obj.TypeId=="Part::Fuse" or obj.TypeId=="Part::MultiFuse"):
-                for currentObject in obj.OutList:
-                    if (currentObject.TypeId=="Part::Fuse" or currentObject.TypeId=="Part::MultiFuse"):
-                        setColorRecursively(currentObject,color,transp)
-                    else:
-                        print("Fixing up colors for: "+str(currentObject.FullName))
-                    if(currentObject not in hassetcolor):
-                        currentObject.ViewObject.ShapeColor=color
-                        currentObject.ViewObject.Transparency=transp
-                        setColorRecursively(currentObject,color,transp)
-                    else:
-                        setColorRecursively(currentObject,color,transp)
+def setColorRecursively(obj, color, transp):
+    '''
+    For some reason a part made by cutting or fusing other parts do not have a color
+    unless it's constituents are also colored. This code sets colors for those
+    constituents unless already set elsewhere.
+    '''
+    obj.ViewObject.ShapeColor = color
+    obj.ViewObject.Transparency = transp
+    if(obj.TypeId=="Part::Fuse" or obj.TypeId=="Part::MultiFuse" or
+       obj.TypeId=="Part::Cut"):
+        for currentObject in obj.OutList:
+            print(f"Fixing up colors for: {currentObject.FullName}")
+            if(currentObject not in hassetcolor):
+                setColorRecursively(currentObject, color, transp)
 
 def fixVisibility():
     for obj in FreeCAD.ActiveDocument.Objects:
@@ -555,22 +556,7 @@ def p_color_action(p):
                 if "Group" in obj.FullName:
                     obj.ViewObject.Visibility=False
                     alreadyhidden.append(obj)
-                if(obj.TypeId=="Part::Fuse" or obj.TypeId=="Part::MultiFuse"):
-                    for currentObject in obj.OutList:
-                        if (currentObject.TypeId=="Part::Fuse" or   currentObject.TypeId=="Part::MultiFuse"):
-                            setColorRecursively(currentObject,color,transp)
-                        if(currentObject not in hassetcolor):
-                            currentObject.ViewObject.ShapeColor=color
-                            currentObject.ViewObject.Transparency=transp
-                            setColorRecursively(currentObject,color,transp)
-                        else:
-                            setColorRecursively(currentObject,color,transp)
-                else:
-                    obj.ViewObject.ShapeColor =color
-                    obj.ViewObject.Transparency = transp
-            else:
-                obj.ViewObject.ShapeColor =color
-                obj.ViewObject.Transparency = transp
+            setColorRecursively(obj, color, transp)
             hassetcolor.append(obj)
     p[0] = p[6]
 

--- a/src/Mod/OpenSCAD/importCSG.py
+++ b/src/Mod/OpenSCAD/importCSG.py
@@ -74,8 +74,10 @@ def setColorRecursively(obj, color, transp):
     '''
     obj.ViewObject.ShapeColor = color
     obj.ViewObject.Transparency = transp
-    if(obj.TypeId=="Part::Fuse" or obj.TypeId=="Part::MultiFuse" or
-       obj.TypeId=="Part::Cut"):
+    # Add any other relevant features to this list
+    boolean_features = ["Part::Fuse", "Part::MultiFuse", "Part::Cut",
+                        "Part::Common", "Part::MultiCommon"]
+    if (obj.TypeId in boolean_features):
         for currentObject in obj.OutList:
             print(f"Fixing up colors for: {currentObject.FullName}")
             if(currentObject not in hassetcolor):


### PR DESCRIPTION
Fixes #4684.
For some reason colors of "base" and "tool" need to be set in order for the cut
to have colors as well, just like fuse and multifuse.
Also tidied up the relevant code portions a little.
Some testing might be needed.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [x]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
