### PR TITLE
Fix FEM and Material typos

### DIFF
--- a/src/Mod/Fem/femsolver/writerbase.py
+++ b/src/Mod/Fem/femsolver/writerbase.py
@@ -233,7 +233,7 @@ class FemInputWriter():
         self.get_constraints_displacement_nodes()
         self.get_constraints_planerotation_nodes()
 
-        # constraints suface sets getter
+        # constraints surface sets getter
         self.get_constraints_contact_faces()
         self.get_constraints_tie_faces()
         self.get_constraints_sectionprint_faces()
@@ -529,7 +529,7 @@ class FemInputWriter():
         if not self.sectionprint_objects:
             return
         # TODO: use meshtools to get the surfaces
-        # see constraint contact or constrint tie
+        # see constraint contact or constraint tie
         for femobj in self.sectionprint_objects:
             # femobj --> dict, FreeCAD document object is femobj["Object"]
             sectionprint_obj = femobj["Object"]
@@ -563,7 +563,7 @@ class FemInputWriter():
                     else:
                         # in Gui only Faces can be added
                         FreeCAD.Console.PrintError(
-                            "Wrong reference shapt type for {} "
+                            "Wrong reference shape type for {} "
                             "Only Faces are allowed, but a {} was found.\n"
                             .format(sectionprint_obj.Name, ref_shape.ShapeType)
                         )
@@ -572,7 +572,7 @@ class FemInputWriter():
         if not self.heatflux_objects:
             return
         # TODO: use meshtools to get the surfaces (or move to mesh tools)
-        # see constraint contact or constrint tie and constraint force
+        # see constraint contact or constraint tie and constraint force
         # heatflux_obj_face_table: see force_obj_node_load_table
         #     [
         #         ("refshape_name:elemname", face_table),
@@ -1131,7 +1131,7 @@ def get_ccx_elset_name_short(names):
     else:
         error = (
             "FEM: Trouble in ccx input file, because an"
-            "beam elset name is longer than 20 character! {}\n"
+            "beam elset name is longer than 20 characters! {}\n"
             .format(ccx_elset_name)
         )
         raise Exception(error)

--- a/src/Mod/Material/importFCMat.py
+++ b/src/Mod/Material/importFCMat.py
@@ -23,7 +23,7 @@
 
 __title__ = "FreeCAD material card importer"
 __author__ = "Juergen Riegel"
-__url__ = "http://www.freecadweb.org"
+__url__ = "https://www.freecadweb.org"
 
 
 import os
@@ -119,7 +119,7 @@ def read(filename):
         # https://forum.freecadweb.org/viewtopic.php?f=18&t=56912#p489721
         # older FreeCAD do not write utf-8 for special character on windows
         # I have seen "ISO-8859-15" or "windows-1252"
-        # explizit utf-8 writing, https://github.com/FreeCAD/FreeCAD/commit/9a564dd906f
+        # explicit utf-8 writing, https://github.com/FreeCAD/FreeCAD/commit/9a564dd906f
         FreeCAD.Console.PrintError("Error on card loading. File might not utf-8.")
         return {}
     d = {}


### PR DESCRIPTION
Found via `codespell -q 3 -L aci,ake,aline,alle,alledges,alocation,als,ang,anid,apoints,ba,beginn,behaviour,bloaded,bottome,byteorder,calculater,cancelled,cancelling,cas,cascade,centimetre,childs,colour,colours,commen,connexion,currenty,dof,doubleclick,dum,eiter,elemente,ende,feld,finde,findf,freez,hist,iff,indicies,initialisation,initialise,initialised,initialises,initialisiert,inout,ist,kilometre,lod,mantatory,methode,metres,millimetre,modell,nd,noe,normale,normaly,nto,numer,oder,ontop,orgin,orginx,orginy,ot,pard,parms,pres,programm,que,recurrance,rougly,seperator,serie,sinc,strack,substraction,te,thist,thru,tread,uint,unter,vertexes,wallthickness,whitespaces -S ./.git,*.po,*.ts,./ChangeLog.txt,./src/3rdParty,./src/Mod/Assembly/App/opendcm,./src/CXX,./src/zipios++,./src/Base/swig*,./src/Mod/Robot/App/kdl_cp,./src/Mod/Import/App/SCL,./src/WindowsInstaller,./src/Doc/FreeCAD.uml,./build/doc/SourceDocu`