### PR TITLE
Set default keycodes for 3dconnexion SpacePilot Pro

### DIFF
--- a/src/Gui/3Dconnexion/3DConnexion.xml
+++ b/src/Gui/3Dconnexion/3DConnexion.xml
@@ -64,35 +64,36 @@
 <ButtonMap DeviceName="SpacePilot Pro">
    <Mapping>
       <Map Description="Menu"          KeyCode="0"  DownTime="short" Command=""/>
-      <Map Description="Fit"           KeyCode="1"  DownTime="short" Command=""/>
+      <Map Description="Fit"           KeyCode="1"  DownTime="short" Command="Std_ViewFitAll"/>
       <Map Description="Top"           KeyCode="2"  DownTime="short" Command="Std_ViewTop"/>
-      <Map Description="Bottom"        KeyCode="2"  DownTime="long"  Command="Std_ViewBottom"/>
+      <Map Description="Left"          KeyCode="3"  DownTime="long"  Command="Std_ViewLeft"/>
       <Map Description="Right"         KeyCode="4"  DownTime="short" Command="Std_ViewRight"/>
-      <Map Description="Left"          KeyCode="4"  DownTime="long"  Command="Std_ViewLeft"/>
       <Map Description="Front"         KeyCode="5"  DownTime="short" Command="Std_ViewFront"/>
-      <Map Description="Rear"          KeyCode="5"  DownTime="long"  Command="Std_ViewRear"/>
-      <Map Description="Clockwise"     KeyCode="8"  DownTime="short" Command=""/>
-      <Map Description="AntiClockwise" KeyCode="8"  DownTime="long"  Command=""/>
-      <Map Description="ISO1"          KeyCode="10" DownTime="short" Command="Std_OrthographicCamera"/>
-      <Map Description="ISO2"          KeyCode="10" DownTime="long"  Command=""/>
+      <Map Description="Bottom"        KeyCode="6"  DownTime="long"  Command="Std_ViewBottom"/>
+      <Map Description="Rear"          KeyCode="7"  DownTime="long"  Command="Std_ViewRear"/>
+      <Map Description="Clockwise"     KeyCode="8"  DownTime="short" Command="Std_ViewRotateRight"/>
+      <Map Description="AntiClockwise" KeyCode="9"  DownTime="long"  Command="Std_ViewRotateLeft"/>
+      <Map Description="ISO1"          KeyCode="10" DownTime="short" Command="Std_ViewIsometric"/>
+      <Map Description="ISO2"          KeyCode="11" DownTime="long"  Command="Std_ViewDimetric"/>
       <Map Description="1"             KeyCode="12" DownTime="short" Command=""/>
-      <Map Description="6"             KeyCode="12" DownTime="long"  Command=""/>
       <Map Description="2"             KeyCode="13" DownTime="short" Command=""/>
-      <Map Description="7"             KeyCode="13" DownTime="long"  Command=""/>
       <Map Description="3"             KeyCode="14" DownTime="short" Command=""/>
-      <Map Description="8"             KeyCode="14" DownTime="long"  Command=""/>
       <Map Description="4"             KeyCode="15" DownTime="short" Command=""/>
-      <Map Description="9"             KeyCode="15" DownTime="long"  Command=""/>
       <Map Description="5"             KeyCode="16" DownTime="short" Command=""/>
-      <Map Description="10"            KeyCode="16" DownTime="long"  Command=""/>
+      <Map Description="6"             KeyCode="17" DownTime="long"  Command=""/>
+      <Map Description="7"             KeyCode="18" DownTime="long"  Command=""/>
+      <Map Description="8"             KeyCode="19" DownTime="long"  Command=""/>
+      <Map Description="9"             KeyCode="20" DownTime="long"  Command=""/>
+      <Map Description="10"            KeyCode="21" DownTime="long"  Command=""/>
       <Map Description="ESC"           KeyCode="22" DownTime="short" Command=""/>
       <Map Description="ALT"           KeyCode="23" DownTime="short" Command=""/>
       <Map Description="SHIFT"         KeyCode="24" DownTime="short" Command=""/>
       <Map Description="CTRL"          KeyCode="25" DownTime="short" Command=""/>
-      <Map Description="ROTZ"          KeyCode="26" DownTime="short" Command=""/>
-      <Map Description="AXIS"          KeyCode="27" DownTime="short" Command=""/>
-      <Map Description="FIT"           KeyCode="28" DownTime="short" Command=""/>
-      <Map Description="PlusMinus"     KeyCode="30" DownTime="short" Command=""/>
+      <Map Description="Dominant"      KeyCode="26" DownTime="short" Command=""/>
+      <Map Description="PanAndZoom"    KeyCode="27" DownTime="short" Command=""/>
+      <Map Description="Rotation"      KeyCode="28" DownTime="short" Command=""/>
+      <Map Description="Plus"          KeyCode="29" DownTime="short" Command=""/>
+      <Map Description="Minus"         KeyCode="30" DownTime="short" Command=""/>
    </Mapping>
 </ButtonMap>
 

--- a/src/Gui/3Dconnexion/3DConnexion.xml
+++ b/src/Gui/3Dconnexion/3DConnexion.xml
@@ -89,9 +89,9 @@
       <Map Description="ALT"           KeyCode="23" DownTime="short" Command=""/>
       <Map Description="SHIFT"         KeyCode="24" DownTime="short" Command=""/>
       <Map Description="CTRL"          KeyCode="25" DownTime="short" Command=""/>
-      <Map Description="Dominant"      KeyCode="26" DownTime="short" Command=""/>
+      <Map Description="Rotation"      KeyCode="26" DownTime="short" Command=""/>
       <Map Description="PanAndZoom"    KeyCode="27" DownTime="short" Command=""/>
-      <Map Description="Rotation"      KeyCode="28" DownTime="short" Command=""/>
+      <Map Description="Dominant"      KeyCode="28" DownTime="short" Command=""/>
       <Map Description="Plus"          KeyCode="29" DownTime="short" Command=""/>
       <Map Description="Minus"         KeyCode="30" DownTime="short" Command=""/>
    </Mapping>


### PR DESCRIPTION
These keycodes matches what my device generate using
spacenavd in Fedora 33.

The old xml definition define two operations on the same KeyCode, one
for short press and one for long press. That doesn't work at all on my
system and the SpacePilot Pro device generate separate KeyCodes for
short presses and long presses.

https://forum.freecadweb.org/viewtopic.php?f=8&t=60265