### PR TITLE
Draft: Fix regression on WP and fixes #0004562

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_base_original.py
+++ b/src/Mod/Draft/draftguitools/gui_base_original.py
@@ -180,6 +180,7 @@ class DraftTool:
             self.ui.sourceCmd = None
         if self.planetrack:
             self.planetrack.finalize()
+        App.DraftWorkingPlane.restore()
         if hasattr(Gui, "Snapper"):
             Gui.Snapper.off()
         if self.call:
@@ -302,4 +303,9 @@ class Modifier(DraftTool):
         super(Modifier, self).__init__()
         self.copymode = False
 
+    def Activated(self, name="None", noplanesetup=False, is_subtool=False):
+        super(Modifier, self).Activated(name, noplanesetup, is_subtool)
+        # call DraftWorkingPlane.save to sync with
+        # DraftWorkingPlane.restore called in finish method
+        App.DraftWorkingPlane.save()
 ## @}

--- a/src/Mod/Draft/draftguitools/gui_selectplane.py
+++ b/src/Mod/Draft/draftguitools/gui_selectplane.py
@@ -127,6 +127,9 @@ class Draft_SelectPlane:
         self.taskd.form.fieldGridExtension.valueChanged.connect(self.onSetExtension)
         self.taskd.form.fieldSnapRadius.valueChanged.connect(self.onSetSnapRadius)
 
+        # save previous WP to ensure back to the last used when restored
+        FreeCAD.DraftWorkingPlane.save()
+
         # Try to find a WP from the current selection
         if FreeCADGui.Selection.getSelectionEx(FreeCAD.ActiveDocument.Name):
             if self.handle():
@@ -161,7 +164,6 @@ class Draft_SelectPlane:
 
         # Reset everything else
         FreeCADGui.Control.closeDialog()
-        FreeCAD.DraftWorkingPlane.restore()
         FreeCADGui.ActiveDocument.resetEdit()
         return True
 


### PR DESCRIPTION
First commit:
The modifications imposed in https://github.com/FreeCAD/FreeCAD/pull/4492/commits/76c7aa314d253f49814f8e5f851b897e89158791 generate a regression in the functioning of the working plane since by eliminating the call to DraftWorkingPlane.restore in the finish method of the commands, and because the next call of the working plane dialog run the restore method, the working plane returns to the previous working plane used.
To reproduce this bug:
1.Run any Creator command (Line, Polyline, Circle, etc).
2.Change the working plane using the working plane setup dialog.
3.Run again any Creator command.
Result: the working plane return to the previous plane.

To solve this, the DraftWorkingPlane.restore method is reenabled in finish method.

Now, back to solve the original bug: https://tracker.freecadweb.org/view.php?id=4562
Since using a BuildingPart saves the last working plane, when the edit command (or any class Modifier command) is used and this command is finish, the restore method is called. So the working plane return to the previous working plane. This dont happen with class Creator commands since this objects call the DraftWorkingPlane.save method on the current working plane via the gui_tool_utils.get_support function used in the Activated method.
To solve this, a call to WorkingPlane.save is added also in the Activated method of the class Modifier.
In this way, both Modifier and Creator commands save the current WP and call the restore method in finish.
Note: Using restore method whitout sync with save method is error prone.

The second commit deal with the next situation:
Another bug occurs due to desynchronization between save and restore methods:
1.Create an ArchBuildingPart
2.Set the WP to the BuildingPart.
3. Set another WP using the working plane setup dialog.
Result: the WP is change correctly on the 3D view, but internally the working plane is restore to the initial working plane, as is showed on the command line using FreeCAD.DraftWorkingPlane.position and FreeCAD.DraftWorkingPlane.axis.

This happens beacause BuildingParts call the save method to store the previous working plane, and the finish method of the Draft_SelectPlane class call DraftWorkingPlane.restore without a previous call to the DraftWorkingPlane.save method, so the working plane return to the value saved by the BuildingPart object.
To solve this, the call to restore in Draft_SelectPlane.finish is removed and is added a call to DraftWorkingPlane.save in Draft_SelectPlane.Activated, thus every time the Draft_SelectPlane object is activated, the previous working plane is saved.
Note: Don't saving the previous working plane can lead to unexpected results.


- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [ ]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [x]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
