### PR TITLE
Draft: Enable multiple selection for dumb task dialog in Modification commands

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_tool_utils.py
+++ b/src/Mod/Draft/draftguitools/gui_tool_utils.py
@@ -72,10 +72,9 @@ def select_object(arg):
         If it is of type Keyboard and the `ESCAPE` key, it runs the `finish`
         method of the active command.
 
-        If it is of type Mouse button and `BUTTON1` press,
-        it captures the position of the cursor (x, y)
-        and the object below that cursor to add it to the active selection;
-        then it runs the `proceed` method of the active command
+        If Ctrl key is pressed, multiple selection is enabled until the
+        button is released.
+        Then it runs the `proceed` method of the active command
         to continue with the command's logic.
     """
     if arg["Type"] == "SoKeyboardEvent":
@@ -83,16 +82,8 @@ def select_object(arg):
             App.activeDraftCommand.finish()
             # TODO: this part raises a coin3D warning about scene traversal.
             # It needs to be fixed.
-    elif arg["Type"] == "SoMouseButtonEvent":
-        if arg["State"] == "DOWN" and arg["Button"] == "BUTTON1":
-            cursor = arg["Position"]
-            snapped = gui_utils.get_3d_view().getObjectInfo((cursor[0],
-                                                             cursor[1]))
-            if snapped:
-                obj = App.ActiveDocument.getObject(snapped['Object'])
-                Gui.Selection.addSelection(obj)
-                App.activeDraftCommand.component = snapped['Component']
-                App.activeDraftCommand.proceed()
+    elif not arg["CtrlDown"] and Gui.Selection.hasSelection():
+        App.activeDraftCommand.proceed()
 
 
 selectObject = select_object


### PR DESCRIPTION
When a modification command is executed without objects selected, a dumb task dialog opens. With these changes it is possible to select/deselect multiple objects by holding down the Ctrl key.

Since the selection of objects is implicitly effective when they are clicked during the execution of the event callback, the use of the Python function Gui.Selection.addSelection is unnecessary. In fact, using this function or Gui.Selection.removeSelection to add/remove objects generates unnecessary multiple calls to the SelectionSingleton::addSelection and SelectionSingleton::rmvSelection functions respectively since these last two are used directly by the selection mechanism.
Also, the definition of the activeDraftCommand.component attribute is removed since it is not used by any command.


Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
