### PR TITLE
Draft: Some shutil don't have the .which method.

### DIFF
--- a/src/Mod/Draft/importDWG.py
+++ b/src/Mod/Draft/importDWG.py
@@ -203,14 +203,15 @@ def convertToDxf(dwgfilename):
     """
     import os, tempfile, subprocess, sys
 
-    import shutil
-    if shutil.which("dwg2dxf"):
+    try:
         outdir = tempfile.mkdtemp()
         basename = os.path.basename(dwgfilename)
         result = outdir + os.sep + os.path.splitext(basename)[0] + ".dxf"
         proc = subprocess.Popen(("dwg2dxf", dwgfilename, "-o", result))
         proc.communicate()
         return result
+    except:
+        pass
 
     teigha = getTeighaConverter()
     if teigha:


### PR DESCRIPTION
Directly calling subprocess.Popen without checking the presence of the
program is the optimal solution because:
1) Avoids race condition, where the program disappears between the
  check and the Popen call.
2) Popen will raise exception if the program is absent anyway,
  no race condition here.
