### PR TITLE
Start: Properly hash thumbnail filenames

### DIFF
--- a/src/Mod/Fem/Gui/Resources/ui/Material.ui
+++ b/src/Mod/Fem/Gui/Resources/ui/Material.ui
@@ -246,7 +246,7 @@
            <double>2.000000000000000</double>
           </property>
           <property name="maximum" stdset="0">
-           <double>2000000000.000000000000000</double>
+           <double>90000000000.000000000000000</double>
           </property>
           <property name="unit" stdset="0">
            <string notr="true">Pa</string>

--- a/src/Mod/Fem/Gui/Resources/ui/Material.ui
+++ b/src/Mod/Fem/Gui/Resources/ui/Material.ui
@@ -246,7 +246,7 @@
            <double>2.000000000000000</double>
           </property>
           <property name="maximum" stdset="0">
-           <double>90000000000.000000000000000</double>
+           <double>2000000000.000000000000000</double>
           </property>
           <property name="unit" stdset="0">
            <string notr="true">Pa</string>

--- a/src/Mod/Start/StartPage/StartPage.py
+++ b/src/Mod/Start/StartPage/StartPage.py
@@ -109,8 +109,8 @@ def getInfo(filename):
             import gnomevfs
         except Exception:
             # alternative method
-            import hashlib
-            fhash = hashlib.md5(("file://"+path).encode("utf8")).hexdigest()
+            import hashlib, urllib
+            fhash = hashlib.md5(urllib.quote("file://"+path,safe=":/")).hexdigest()
             thumb = os.path.join(os.path.expanduser("~"),".thumbnails","normal",fhash+".png")
         else:
             uri = gnomevfs.get_uri_from_local_path(path)


### PR DESCRIPTION
Image filenames should be encoded as URI before being hashed.

Also assume that filenames are already utf8 because the community has been advertiseing utf8 usage since the beginning of this centry AFAIK.

Calling .encode("utf8") on strings that are already in utf8 simply raises exception:
```
  UnicodeDecodeError: 'ascii' codec can't decode byte ...
for non-ascii (already utf8) strings.
```

It's in fact impossible to precisely determine pathname encoding because different components within the path may have different encodings, e.g. a utf8 directory name followed by an mbcs filename is valid on Linux native filesystems. It's the user's responsibility to keep the iocharset consistent.