### PR TITLE
[Sketcher] Display radius/diameter constraints with some angle (+ code cleaning)

### DIFF
--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -102,6 +102,8 @@ void finishDistanceConstraint(Gui::Command* cmd, Sketcher::SketchObject* sketch,
     Gui::Document *doc = cmd->getActiveGuiDocument();
     float sf = 1.f;
     float lp = hGrp->GetFloat("RadiusDiamConstraintDispAngle", 15) * (M_PI / 180); // Get radius/diameter constraint display angle
+    float lprnd = hGrp->GetFloat("RadiusDiamConstraintDispAngleRnd", 0) * (M_PI / 180); // Get randomness
+    if (lprnd != 0) lp = lp + lprnd * (static_cast<float>(std::rand())/static_cast<float>(RAND_MAX) - 0.5);
     if (doc && doc->getInEdit() && doc->getInEdit()->isDerivedFrom(SketcherGui::ViewProviderSketch::getClassTypeId())) {
         SketcherGui::ViewProviderSketch *vp = static_cast<SketcherGui::ViewProviderSketch*>(doc->getInEdit());
         sf = vp->getScaleFactor();

--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -5017,23 +5017,7 @@ void CmdSketcherConstrainRadius::activated(int iMsg)
             Gui::cmdAppObjectArgs(selection[0].getObject(),"setDriving(%i,%s)", constrSize-1,"False");
         }
 
-        const std::vector<Sketcher::Constraint *> &ConStr = Obj->Constraints.getValues();
-
-        std::size_t indexConstr = constrSize - externalGeoIdRadiusMap.size();
-
-        // Guess some reasonable distance for placing the datum text
-        Gui::Document *doc = getActiveGuiDocument();
-        float sf = 1.f;
-        if (doc && doc->getInEdit() && doc->getInEdit()->isDerivedFrom(SketcherGui::ViewProviderSketch::getClassTypeId())) {
-            SketcherGui::ViewProviderSketch *vp = static_cast<SketcherGui::ViewProviderSketch*>(doc->getInEdit());
-            sf = vp->getScaleFactor();
-
-            for (std::size_t i=0; i<externalGeoIdRadiusMap.size();i++) {
-                Sketcher::Constraint *constr = ConStr[indexConstr + i];
-                constr->LabelDistance = 2. * sf;
-            }
-            vp->draw(false,false); // Redraw
-        }
+        finishDistanceConstraint(this, Obj, false);
 
         commitNeeded=true;
         updateNeeded=true;
@@ -5080,23 +5064,6 @@ void CmdSketcherConstrainRadius::activated(int iMsg)
                     Gui::cmdAppObjectArgs(selection[0].getObject(), "setDriving(%i,%s)", ConStr.size()-1,"False");
                 }
             }
-        }
-
-        const std::vector<Sketcher::Constraint *> &ConStr = Obj->Constraints.getValues();
-        std::size_t indexConstr = ConStr.size() - geoIdRadiusMap.size();
-
-        // Guess some reasonable distance for placing the datum text
-        Gui::Document *doc = getActiveGuiDocument();
-        float sf = 1.f;
-        if (doc && doc->getInEdit() && doc->getInEdit()->isDerivedFrom(SketcherGui::ViewProviderSketch::getClassTypeId())) {
-            SketcherGui::ViewProviderSketch *vp = static_cast<SketcherGui::ViewProviderSketch*>(doc->getInEdit());
-            sf = vp->getScaleFactor();
-
-            for (std::size_t i=0; i<geoIdRadiusMap.size();i++) {
-                Sketcher::Constraint *constr = ConStr[indexConstr + i];
-                constr->LabelDistance = 2. * sf;
-            }
-            vp->draw(false,false); // Redraw
         }
 
         finishDistanceConstraint(this, Obj, constraintCreationMode==Driving);
@@ -5165,20 +5132,7 @@ void CmdSketcherConstrainRadius::applyConstraint(std::vector<SelIdPair> &selSeq,
             updateNeeded=true; // We do need to update the solver DoF after setting the constraint driving.
         }
 
-        // Guess some reasonable distance for placing the datum text
-        Gui::Document *doc = getActiveGuiDocument();
-        float sf = 1.f;
-        if (doc && doc->getInEdit() && doc->getInEdit()->isDerivedFrom(SketcherGui::ViewProviderSketch::getClassTypeId())) {
-            SketcherGui::ViewProviderSketch *vp = static_cast<SketcherGui::ViewProviderSketch*>(doc->getInEdit());
-            sf = vp->getScaleFactor();
-
-            Sketcher::Constraint *constr = ConStr[ConStr.size()-1];
-            constr->LabelDistance = 2. * sf;
-            vp->draw(); // Redraw
-        }
-
-        if(!fixed)
-            finishDistanceConstraint(this, Obj, constraintCreationMode==Driving);
+        finishDistanceConstraint(this, Obj, constraintCreationMode==Driving && !fixed);
 
         //updateActive();
         getSelection().clearSelection();
@@ -5348,23 +5302,7 @@ void CmdSketcherConstrainDiameter::activated(int iMsg)
             Gui::cmdAppObjectArgs(Obj,"setDriving(%i,%s)",constrSize-1,"False");
         }
 
-        const std::vector<Sketcher::Constraint *> &ConStr = Obj->Constraints.getValues();
-
-        std::size_t indexConstr = constrSize - externalGeoIdDiameterMap.size();
-
-        // Guess some reasonable distance for placing the datum text
-        Gui::Document *doc = getActiveGuiDocument();
-        float sf = 1.f;
-        if (doc && doc->getInEdit() && doc->getInEdit()->isDerivedFrom(SketcherGui::ViewProviderSketch::getClassTypeId())) {
-            SketcherGui::ViewProviderSketch *vp = static_cast<SketcherGui::ViewProviderSketch*>(doc->getInEdit());
-            sf = vp->getScaleFactor();
-
-            for (std::size_t i=0; i<externalGeoIdDiameterMap.size();i++) {
-                Sketcher::Constraint *constr = ConStr[indexConstr + i];
-                constr->LabelDistance = 2. * sf;
-            }
-            vp->draw(false,false); // Redraw
-        }
+        finishDistanceConstraint(this, Obj, false);
 
         commitNeeded=true;
         updateNeeded=true;
@@ -5406,22 +5344,6 @@ void CmdSketcherConstrainDiameter::activated(int iMsg)
             }
         }
 
-        const std::vector<Sketcher::Constraint *> &ConStr = Obj->Constraints.getValues();
-        std::size_t indexConstr = ConStr.size() - geoIdDiameterMap.size();
-
-        // Guess some reasonable distance for placing the datum text
-        Gui::Document *doc = getActiveGuiDocument();
-        float sf = 1.f;
-        if (doc && doc->getInEdit() && doc->getInEdit()->isDerivedFrom(SketcherGui::ViewProviderSketch::getClassTypeId())) {
-            SketcherGui::ViewProviderSketch *vp = static_cast<SketcherGui::ViewProviderSketch*>(doc->getInEdit());
-            sf = vp->getScaleFactor();
-
-            for (std::size_t i=0; i<geoIdDiameterMap.size();i++) {
-                Sketcher::Constraint *constr = ConStr[indexConstr + i];
-                constr->LabelDistance = 2. * sf;
-            }
-            vp->draw(false,false); // Redraw
-        }
         finishDistanceConstraint(this, Obj, constraintCreationMode==Driving);
 
         //updateActive();
@@ -5485,19 +5407,7 @@ void CmdSketcherConstrainDiameter::applyConstraint(std::vector<SelIdPair> &selSe
                 updateNeeded=true; // We do need to update the solver DoF after setting the constraint driving.
             }
 
-            // Guess some reasonable distance for placing the datum text
-            Gui::Document *doc = getActiveGuiDocument();
-            float sf = 1.f;
-            if (doc && doc->getInEdit() && doc->getInEdit()->isDerivedFrom(SketcherGui::ViewProviderSketch::getClassTypeId())) {
-                SketcherGui::ViewProviderSketch *vp = static_cast<SketcherGui::ViewProviderSketch*>(doc->getInEdit());
-                sf = vp->getScaleFactor();
-
-                Sketcher::Constraint *constr = ConStr[ConStr.size()-1];
-                constr->LabelDistance = 2. * sf;
-                vp->draw(); // Redraw
-            }
-            if(!fixed)
-                finishDistanceConstraint(this, Obj, constraintCreationMode==Driving);
+            finishDistanceConstraint(this, Obj, constraintCreationMode==Driving && !fixed);
 
             //updateActive();
             getSelection().clearSelection();
@@ -5682,23 +5592,7 @@ void CmdSketcherConstrainRadiam::activated(int iMsg)
             Gui::cmdAppObjectArgs(Obj,"setDriving(%i,%s)",constrSize-1,"False");
         }
 
-        const std::vector<Sketcher::Constraint *> &ConStr = Obj->Constraints.getValues();
-
-        std::size_t indexConstr = constrSize - externalGeoIdRadiamMap.size();
-
-        // Guess some reasonable distance for placing the datum text
-        Gui::Document *doc = getActiveGuiDocument();
-        float sf = 1.f;
-        if (doc && doc->getInEdit() && doc->getInEdit()->isDerivedFrom(SketcherGui::ViewProviderSketch::getClassTypeId())) {
-            SketcherGui::ViewProviderSketch *vp = static_cast<SketcherGui::ViewProviderSketch*>(doc->getInEdit());
-            sf = vp->getScaleFactor();
-
-            for (std::size_t i=0; i<externalGeoIdRadiamMap.size();i++) {
-                Sketcher::Constraint *constr = ConStr[indexConstr + i];
-                constr->LabelDistance = 2. * sf;
-            }
-            vp->draw(false,false); // Redraw
-        }
+        finishDistanceConstraint(this, Obj, false);
 
         commitNeeded=true;
         updateNeeded=true;
@@ -5757,22 +5651,6 @@ void CmdSketcherConstrainRadiam::activated(int iMsg)
             }
         }
 
-        const std::vector<Sketcher::Constraint *> &ConStr = Obj->Constraints.getValues();
-        std::size_t indexConstr = ConStr.size() - geoIdRadiamMap.size();
-
-        // Guess some reasonable distance for placing the datum text
-        Gui::Document *doc = getActiveGuiDocument();
-        float sf = 1.f;
-        if (doc && doc->getInEdit() && doc->getInEdit()->isDerivedFrom(SketcherGui::ViewProviderSketch::getClassTypeId())) {
-            SketcherGui::ViewProviderSketch *vp = static_cast<SketcherGui::ViewProviderSketch*>(doc->getInEdit());
-            sf = vp->getScaleFactor();
-
-            for (std::size_t i=0; i<geoIdRadiamMap.size();i++) {
-                Sketcher::Constraint *constr = ConStr[indexConstr + i];
-                constr->LabelDistance = 2. * sf;
-            }
-            vp->draw(false,false); // Redraw
-        }
         finishDistanceConstraint(this, Obj, constraintCreationMode==Driving);
 
         //updateActive();
@@ -5844,19 +5722,7 @@ void CmdSketcherConstrainRadiam::applyConstraint(std::vector<SelIdPair> &selSeq,
                 updateNeeded=true; // We do need to update the solver DoF after setting the constraint driving.
             }
 
-            // Guess some reasonable distance for placing the datum text
-            Gui::Document *doc = getActiveGuiDocument();
-            float sf = 1.f;
-            if (doc && doc->getInEdit() && doc->getInEdit()->isDerivedFrom(SketcherGui::ViewProviderSketch::getClassTypeId())) {
-                SketcherGui::ViewProviderSketch *vp = static_cast<SketcherGui::ViewProviderSketch*>(doc->getInEdit());
-                sf = vp->getScaleFactor();
-
-                Sketcher::Constraint *constr = ConStr[ConStr.size()-1];
-                constr->LabelDistance = 2. * sf;
-                vp->draw(); // Redraw
-            }
-            if(!fixed)
-                finishDistanceConstraint(this, Obj, constraintCreationMode==Driving);
+            finishDistanceConstraint(this, Obj, constraintCreationMode==Driving && !fixed);
 
             //updateActive();
             getSelection().clearSelection();

--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -91,6 +91,9 @@ bool isCreateConstraintActive(Gui::Document *doc)
 // Utility method to avoid repeating the same code over and over again
 void finishDistanceConstraint(Gui::Command* cmd, Sketcher::SketchObject* sketch, bool isDriven=true)
 {
+
+    ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher");
+
     // Get the latest constraint
     const std::vector<Sketcher::Constraint *> &ConStr = sketch->Constraints.getValues();
     Sketcher::Constraint *constr = ConStr[ConStr.size() -1];
@@ -98,15 +101,16 @@ void finishDistanceConstraint(Gui::Command* cmd, Sketcher::SketchObject* sketch,
     // Guess some reasonable distance for placing the datum text
     Gui::Document *doc = cmd->getActiveGuiDocument();
     float sf = 1.f;
+    float lp = hGrp->GetFloat("RadiusDiamConstraintDispAngle", 15) * (M_PI / 180); // Get radius/diameter constraint display angle
     if (doc && doc->getInEdit() && doc->getInEdit()->isDerivedFrom(SketcherGui::ViewProviderSketch::getClassTypeId())) {
         SketcherGui::ViewProviderSketch *vp = static_cast<SketcherGui::ViewProviderSketch*>(doc->getInEdit());
         sf = vp->getScaleFactor();
 
         constr->LabelDistance = 2. * sf;
+        constr->LabelPosition = lp; // Can safely be done for all constraints as ignored by distances & angles
         vp->draw(false,false); // Redraw
     }
 
-    ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher");
     bool show = hGrp->GetBool("ShowDialogOnDistanceConstraint", true);
 
     // Ask for the value of the distance immediately


### PR DESCRIPTION
See https://forum.freecadweb.org/viewtopic.php?f=22&t=60370

1st commit is code cleaning that can be cherry-picked if feature change is rejected
2nd commit is feature change, default angle set to 15°, can be changed by user with 'BaseApp/Preferences/Mod/Sketcher/RadiusDiamConstraintDispAngle' -- will document in wiki once/if PR is merged

https://user-images.githubusercontent.com/48731257/126631504-531e81f7-6e1b-47ec-b073-40d498fc820c.mp4

- [X]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [X]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [X]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [X]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [X]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number]