### PR TITLE
App: Bugfix for NULL-Pointer dereference of Property->getName()

### DIFF
--- a/src/App/Property.cpp
+++ b/src/App/Property.cpp
@@ -62,6 +62,8 @@ Property::~Property()
 
 const char* Property::getName(void) const
 {
+    if (myName == NULL)
+        return "?";
     return myName;
 }
 


### PR DESCRIPTION
Some parts of FreeCAD use prop->getName() without testing
for NULL first, e.g.:

src/Mod/PartDesign/Gui/ViewProviderAddSub.cpp:258
 ViewProviderAddSub::updateData()
src/Mod/PartDesign/Gui/ViewProviderDatumCS.cpp:193
 ViewProviderDatumCoordinateSystem::updateData()

See also:
https://forum.freecadweb.org/viewtopic.php?f=3&t=58603

I modified Property::getName() to return "?" if name is NULL, but I feel
not familiar enough to judge wether this is safe.

- [o]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [o]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [ ]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`


---
