### PR TITLE
Path: fix various typos and superfluous whitespace

### DIFF
--- a/src/Mod/Path/PathScripts/PathGeom.py
+++ b/src/Mod/Path/PathScripts/PathGeom.py
@@ -343,7 +343,7 @@ def edgeForCmd(cmd, startPoint):
             PathLog.debug("StartPoint:{}".format(startPoint))
             PathLog.debug("MidPoint:{}".format(midPoint))
             PathLog.debug("EndPoint:{}".format(endPoint))
-            
+
             if pointsCoincide(startPoint, endPoint, 0.001):
                 return Part.makeCircle(R, center, FreeCAD.Vector(0, 0, 1))
             else:
@@ -575,7 +575,7 @@ def combineHorizontalFaces(faces):
     '''combineHorizontalFaces(faces)...
     This function successfully identifies and combines multiple connected faces and
     works on multiple independent faces with multiple connected faces within the list.
-    The return value is list of simplifed faces.
+    The return value is a list of simplified faces.
     The Adaptive op is not concerned with which hole edges belong to which face.
 
     Attempts to do the same shape connecting failed with TechDraw.findShapeOutline() and
@@ -611,7 +611,7 @@ def combineHorizontalFaces(faces):
     for i in range(len(extrudedFaces)):
         temp = extrudedFaces.pop().fuse(allFacesSolid)
         allFacesSolid = temp
-    cut = bboxSolid.cut(allFacesSolid)        
+    cut = bboxSolid.cut(allFacesSolid)
 
     # Debug
     # Part.show(cut)

--- a/src/Mod/Path/PathScripts/PathJobDlg.py
+++ b/src/Mod/Path/PathScripts/PathJobDlg.py
@@ -213,7 +213,7 @@ class JobCreate:
     def setupTemplate(self):
         templateFiles = []
         for path in PathPreferences.searchPaths():
-            cleanPaths = [f.replace("\\", "/") for f in self.templateFilesIn(path)]  # Standardize slashes used accross os platforms
+            cleanPaths = [f.replace("\\", "/") for f in self.templateFilesIn(path)]  # Standardize slashes used across os platforms
             templateFiles.extend(cleanPaths)
 
         template = {}

--- a/src/Mod/Path/PathScripts/PathSlot.py
+++ b/src/Mod/Path/PathScripts/PathSlot.py
@@ -524,7 +524,7 @@ class ObjectSlot(PathOp.ObjectOp):
             begExt = obj.ExtendPathStart.Value
             endExt = obj.ExtendPathEnd.Value
             # invert endExt, begExt args to apply extensions to correct ends
-            # XY geom is postitive CCW; Gcode postitive CW
+            # XY geom is positive CCW; Gcode positive CW
             pnts = self._extendArcSlot(p1, p2, self.arcCenter, endExt, begExt)
 
         if not pnts:
@@ -558,8 +558,8 @@ class ObjectSlot(PathOp.ObjectOp):
         CMDS = list()
         PATHS = [(p2, p1, 'G2'), (p1, p2, 'G3')]
         if obj.ReverseDirection :
-            path_index = 1 
-        else : 
+            path_index = 1
+        else :
             path_index = 0
 
         def arcPass(POINTS, depth):
@@ -620,7 +620,7 @@ class ObjectSlot(PathOp.ObjectOp):
                 pnts = self._makePerpendicular(p1, p2, initPerpDist)  # 10.0 offset below
         else:
             # Modify path points if user selected two parallel edges
-            if (featureCnt == 2 and self.shapeType1 == 'Edge' and 
+            if (featureCnt == 2 and self.shapeType1 == 'Edge' and
                     self.shapeType2 == 'Edge'):
                 if self.featureDetails[0] == "arc" and self.featureDetails[1] == "arc":
                     perpZero = False
@@ -725,7 +725,7 @@ class ObjectSlot(PathOp.ObjectOp):
             pnts = False
             norm = shape_1.normalAt(0.0, 0.0)
             PathLog.debug('{}.normalAt(): {}'.format(sub1, norm))
-            
+
             if PathGeom.isRoughly(shape_1.BoundBox.ZMax, shape_1.BoundBox.ZMin):
                 # Horizontal face
                 if norm.z == 1 or norm.z == -1:
@@ -743,7 +743,7 @@ class ObjectSlot(PathOp.ObjectOp):
             else:
                 if len(shape_1.Edges) == 4:
                     pnts = self._processSingleHorizFace(obj, shape_1)
-                else: 
+                else:
                     pnts = self._processSingleComplexFace(obj, shape_1)
 
             if not pnts:
@@ -812,7 +812,7 @@ class ObjectSlot(PathOp.ObjectOp):
         eCnt = len(shape.Edges)
         lstE = eCnt - 1
         for i in range(0, eCnt):  # populate empty parallel edge flag list
-            parallel_edge_flags.append(0)        
+            parallel_edge_flags.append(0)
         for i in range(0, eCnt):  # Cycle through edges to identify parallel pairs
             if i < lstE:
                 ni = i + 1
@@ -976,14 +976,14 @@ class ObjectSlot(PathOp.ObjectOp):
         p1 = FreeCAD.Vector(V1.X, V1.Y, 0.0)
         if len(edge.Vertexes) == 1:   # circle has one virtex
             p2 = FreeCAD.Vector(p1)
-        else :  
+        else :
             V2 = edge.Vertexes[1]
             p2 = FreeCAD.Vector(V2.X, V2.Y, 0.0)
-         
+
         # Process edge based on curve type
         if edge.Curve.TypeId in lineTypes:
             return (p1, p2)
-            
+
         elif edge.Curve.TypeId in curveTypes:
             if len(edge.Vertexes) == 1:
                 # Circle edge
@@ -1009,7 +1009,7 @@ class ObjectSlot(PathOp.ObjectOp):
                 midPnt = edge.valueAt(edge.getParameterByLength(edge.Length / 2.0))
                 if not isHorizontal(V1.Z, V2.Z, midPnt.z):
                     return False
-                    
+
                 midPnt.z = 0.0
                 circleCenter = circumCircleFrom3Points(p1, p2, midPnt)
                 if not circleCenter:
@@ -1025,7 +1025,7 @@ class ObjectSlot(PathOp.ObjectOp):
         else :
             msg = translate('PathSlot','Failed, slot from edge only accepts lines, arcs and circles.')
             FreeCAD.Console.PrintError(msg + '\n')
-           
+
             return False  # not line , not circle
 
     # Methods for processing double geometry
@@ -1089,7 +1089,7 @@ class ObjectSlot(PathOp.ObjectOp):
     def _normalizeVector(self, v):
         """_normalizeVector(v)...
         Returns a copy of the vector received with values rounded to 10 decimal places."""
-        posTol = 0.0000000001  # abitrary, use job Geometry Tolerance ???
+        posTol = 0.0000000001  # arbitrary, use job Geometry Tolerance ???
         negTol = -1 * posTol
         V = FreeCAD.Vector(v.x, v.y, v.z)
         V.normalize()
@@ -1245,7 +1245,7 @@ class ObjectSlot(PathOp.ObjectOp):
         n1 = p1
         n2 = p2
 
-        # Create a chord of the right length, on XY plane, starting on x axis 
+        # Create a chord of the right length, on XY plane, starting on x axis
         def makeChord(rads):
             x = self.newRadius * math.cos(rads)
             y = self.newRadius * math.sin(rads)
@@ -1256,7 +1256,7 @@ class ObjectSlot(PathOp.ObjectOp):
 
         # Convert extension to radians; make a generic chord ( line ) on XY plane from the x axis
         # rotate and shift into place so it has same vertices as the required arc extension
-        # adjust rotation angle to provide +ve or -ve extension as needed 
+        # adjust rotation angle to provide +ve or -ve extension as needed
         origin = FreeCAD.Vector(0.0, 0.0, 0.0)
         if begExt:
             ExtRadians = abs(begExt / self.newRadius)
@@ -1264,19 +1264,19 @@ class ObjectSlot(PathOp.ObjectOp):
 
             beginRadians = self._getVectorAngle(p1.sub(self.arcCenter))
             if begExt < 0:
-                beginRadians += 0  # negative Ext shortens slot so chord endpoint is slot start point 
+                beginRadians += 0  # negative Ext shortens slot so chord endpoint is slot start point
             else :
                 beginRadians -= 2*ExtRadians  # positive Ext lengthens slot so decrease start point angle
-                
+
             # PathLog.debug('begExt angles are: {},  {}'.format(beginRadians, math.degrees(beginRadians)))
 
             chord.rotate(origin, FreeCAD.Vector(0, 0, 1), math.degrees(beginRadians))
             chord.translate(self.arcCenter)
             self._addDebugObject(chord, 'ExtendStart')
-            
+
             v1 = chord.Vertexes[1]
             n1 = FreeCAD.Vector(v1.X, v1.Y, 0.0)
-            
+
         if endExt:
             ExtRadians = abs(endExt / self.newRadius)
             chord = makeChord(ExtRadians)
@@ -1286,13 +1286,13 @@ class ObjectSlot(PathOp.ObjectOp):
                 endRadians += 0  # positive Ext lengthens slot so chord endpoint is good
             else :
                 endRadians -= 2*ExtRadians  # negative Ext shortens slot so decrease end point angle
-                
+
             # PathLog.debug('endExt angles are: {},  {}'.format(endRadians, math.degrees(endRadians)))
 
             chord.rotate(origin, FreeCAD.Vector(0, 0, 1), math.degrees(endRadians))
             chord.translate(self.arcCenter)
             self._addDebugObject(chord, 'ExtendEnd')
-               
+
             v1 = chord.Vertexes[1]
             n2 = FreeCAD.Vector(v1.X, v1.Y, 0.0)
 
@@ -1321,7 +1321,7 @@ class ObjectSlot(PathOp.ObjectOp):
           n2 = p2.add(end.normalize()*endExt)
         else:
             n2 = p2
-        return (n1, n2) 
+        return (n1, n2)
 
     def _getOppMidPoints(self, same):
         """_getOppMidPoints(same)...

--- a/src/Mod/Path/PathScripts/post/nccad_post.py
+++ b/src/Mod/Path/PathScripts/post/nccad_post.py
@@ -53,7 +53,7 @@ TOOL_CHANGE = '''G77      ; Move to release position
 M10 O6.0 ; Stop spindle
 M01 Insert tool TOOL
 G76      ; Move to reference point to ensure correct coordinates after tool change
-M10 O6.1 ; Start spindel'''
+M10 O6.1 ; Start spindle'''
 
 
 # gCode finishing the program

--- a/src/Mod/Path/PathScripts/post/uccnc_post.py
+++ b/src/Mod/Path/PathScripts/post/uccnc_post.py
@@ -80,7 +80,7 @@ G80
 # POSTAMBLE possible values:
 #    Multi line text with gcode. Postable gcode
 #    The postamble text will appear following the last operation.
-POSTAMBLE_DEFAULT = '''M05 (stop spindel)
+POSTAMBLE_DEFAULT = '''M05 (stop spindle)
 G17 (Default: XY-plane)
 G54 (Default: First coordinate system)
 G40 (Default: Cutter radius compensation none)

--- a/src/Mod/Path/PathTests/TestPathAdaptive.py
+++ b/src/Mod/Path/PathTests/TestPathAdaptive.py
@@ -56,7 +56,7 @@ class TestPathAdaptive(PathTestBase):
         if FreeCAD.GuiUp:
             job.ViewObject.Proxy = PathJobGui.ViewProvider(job.ViewObject)
 
-        # Instantiate an Adaptive operation for quering available properties
+        # Instantiate an Adaptive operation for querying available properties
         prototype = PathAdaptive.Create("Adaptive")
         prototype.Base = [(doc.Fusion, ["Face3"])]
         prototype.Label = "Prototype"

--- a/src/Mod/Path/Tools/README.md
+++ b/src/Mod/Path/Tools/README.md
@@ -65,7 +65,7 @@ TechDraw's templates.
 ## How to create a new tool bit Shape
 
 The shape file for a tool bit is expected to contain a PD body which represents the tool as a 3d solid. The PD body
-should be parametric based on a a PropertyBag object so that, when the properties of the PropertyBag are changed the
+should be parametric based on a PropertyBag object so that, when the properties of the PropertyBag are changed the
 solid is updated to the correct representation.
 
 1. Create a new FreeCAD document


### PR DESCRIPTION
Found via `codespell -q 3 -L aci,ake,aline,alle,alledges,alocation,als,ang,anid,apoints,ba,beginn,behaviour,bloaded,bottome,byteorder,calculater,cancelled,cancelling,cas,cascade,centimetre,childs,colour,colours,commen,connexion,currenty,dof,doubleclick,dum,eiter,elemente,ende,feld,finde,findf,freez,hist,iff,indicies,initialisation,initialise,initialised,initialises,initialisiert,inout,ist,kilometre,lod,mantatory,methode,metres,millimetre,modell,nd,noe,normale,normaly,nto,numer,oder,ontop,orgin,orginx,orginy,ot,pard,parms,pres,programm,que,recurrance,rougly,seperator,serie,sinc,strack,substraction,te,thist,thru,tread,uint,unter,vertexes,wallthickness,whitespaces -S ./.git,*.po,*.ts,./ChangeLog.txt,./src/3rdParty,./src/Mod/Assembly/App/opendcm,./src/CXX,./src/zipios++,./src/Base/swig*,./src/Mod/Robot/App/kdl_cp,./src/Mod/Import/App/SCL,./src/WindowsInstaller,./src/Doc/FreeCAD.uml,./build/doc/SourceDocu`