### PR TITLE
Fix external document loading

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -55,6 +55,8 @@
 #include <sys/sysctl.h>
 #endif
 
+#include <boost/algorithm/string/predicate.hpp>
+
 #include "Application.h"
 #include "Document.h"
 
@@ -99,6 +101,7 @@
 #include "Document.h"
 #include "DocumentObjectGroup.h"
 #include "DocumentObjectFileIncluded.h"
+#include "DocumentObserver.h"
 #include "InventorObject.h"
 #include "VRMLObject.h"
 #include "Annotation.h"
@@ -487,6 +490,7 @@ bool Application::closeDocument(const char* name)
         setActiveDocument((Document*)0);
     std::unique_ptr<Document> delDoc (pos->second);
     DocMap.erase( pos );
+    DocFileMap.erase(FileInfo(delDoc->FileName.getValue()).filePath());
 
     _objCount = -1;
 
@@ -566,8 +570,10 @@ int Application::addPendingDocument(const char *FileName, const char *objName, b
         return -1;
     assert(FileName && FileName[0]);
     assert(objName && objName[0]);
-    auto ret =  _pendingDocMap.emplace(FileName,std::set<std::string>());
-    ret.first->second.emplace(objName);
+    if(!_docReloadAttempts[FileName].emplace(objName).second)
+        return -1;
+    auto ret =  _pendingDocMap.emplace(FileName,std::vector<std::string>());
+    ret.first->second.push_back(objName);
     if(ret.second) {
         _pendingDocs.push_back(ret.first->first.c_str());
         return 1;
@@ -623,6 +629,41 @@ Document* Application::openDocument(const char * FileName, bool createView) {
     return 0;
 }
 
+Document *Application::getDocumentByPath(const char *path, int checkCanonical) const {
+    if(!path || !path[0])
+        return nullptr;
+    if(DocFileMap.empty()) {
+        for(auto &v : DocMap) {
+            const auto &file = v.second->FileName.getStrValue();
+            if(file.size())
+                DocFileMap[FileInfo(file.c_str()).filePath()] = v.second;
+        }
+    }
+    auto it = DocFileMap.find(FileInfo(path).filePath());
+    if(it != DocFileMap.end())
+        return it->second;
+
+    if (!checkCanonical)
+        return nullptr;
+
+    std::string filepath = FileInfo(path).filePath();
+    QString canonicalPath = QFileInfo(QString::fromUtf8(path)).canonicalFilePath();
+    for (auto &v : DocMap) {
+        QFileInfo fi(QString::fromUtf8(v.second->FileName.getValue()));
+        if (canonicalPath == fi.canonicalFilePath()) {
+            if (checkCanonical == 1)
+                return v.second;
+            bool samePath = (canonicalPath == QString::fromUtf8(filepath.c_str()));
+            FC_WARN("Identical physical path '" << canonicalPath.toUtf8().constData() << "'\n"
+                    << (samePath?"":"  for file '") << (samePath?"":filepath.c_str()) << (samePath?"":"'\n")
+                    << "  with existing document '" << v.second->Label.getValue()
+                    << "' in path: '" << v.second->FileName.getValue() << "'");
+            break;
+        }
+    }
+    return nullptr;
+}
+
 std::vector<Document*> Application::openDocuments(const std::vector<std::string> &filenames,
                                                   const std::vector<std::string> *paths,
                                                   const std::vector<std::string> *labels,
@@ -640,6 +681,7 @@ std::vector<Document*> Application::openDocuments(const std::vector<std::string>
     _pendingDocs.clear();
     _pendingDocsReopen.clear();
     _pendingDocMap.clear();
+    _docReloadAttempts.clear();
 
     signalStartOpenDocument();
 
@@ -649,118 +691,162 @@ std::vector<Document*> Application::openDocuments(const std::vector<std::string>
     for (auto &name : filenames)
         _pendingDocs.push_back(name.c_str());
 
-    std::map<Document *, DocTiming> newDocs;
+    std::map<DocumentT, DocTiming> timings;
 
     FC_TIME_INIT(t);
 
-    for (std::size_t count=0;; ++count) {
-        const char *name = _pendingDocs.front();
-        _pendingDocs.pop_front();
-        bool isMainDoc = count < filenames.size();
+    std::vector<DocumentT> openedDocs;
 
-        try {
-            _objCount = -1;
-            std::set<std::string> objNames;
-            if (_allowPartial) {
-                auto it = _pendingDocMap.find(name);
-                if (it != _pendingDocMap.end())
-                    objNames.swap(it->second);
-            }
+    int pass = 0;
+    do {
+        std::set<App::DocumentT> newDocs;
+        for (std::size_t count=0;; ++count) {
+            std::string name = std::move(_pendingDocs.front());
+            _pendingDocs.pop_front();
+            bool isMainDoc = (pass == 0 && count < filenames.size());
 
-            FC_TIME_INIT(t1);
-            DocTiming timing;
+            try {
+                _objCount = -1;
+                std::vector<std::string> objNames;
+                if (_allowPartial) {
+                    auto it = _pendingDocMap.find(name);
+                    if (it != _pendingDocMap.end()) {
+                        if(isMainDoc)
+                            it->second.clear();
+                        else
+                            objNames.swap(it->second);
+                        _pendingDocMap.erase(it);
+                    }
+                }
 
-            const char *path = name;
-            const char *label = 0;
-            if (isMainDoc) {
-                if (paths && paths->size()>count)
-                    path = (*paths)[count].c_str();
+                FC_TIME_INIT(t1);
+                DocTiming timing;
 
-                if (labels && labels->size()>count)
-                    label = (*labels)[count].c_str();
-            }
+                const char *path = name.c_str();
+                const char *label = 0;
+                if (isMainDoc) {
+                    if (paths && paths->size()>count)
+                        path = (*paths)[count].c_str();
 
-            auto doc = openDocumentPrivate(path, name, label, isMainDoc, createView, objNames);
-            FC_DURATION_PLUS(timing.d1,t1);
-            if (doc)
-                newDocs.emplace(doc,timing);
+                    if (labels && labels->size()>count)
+                        label = (*labels)[count].c_str();
+                }
 
-            if (isMainDoc)
-                res[count] = doc;
-            _objCount = -1;
-        }
-        catch (const Base::Exception &e) {
-            if (!errs && isMainDoc)
-                throw;
-            if (errs && isMainDoc)
-                (*errs)[count] = e.what();
-            else
-                Console().Error("Exception opening file: %s [%s]\n", name, e.what());
-        }
-        catch (const std::exception &e) {
-            if (!errs && isMainDoc)
-                throw;
-            if (errs && isMainDoc)
-                (*errs)[count] = e.what();
-            else
-                Console().Error("Exception opening file: %s [%s]\n", name, e.what());
-        }
-        catch (...) {
-            if (errs) {
+                auto doc = openDocumentPrivate(path, name.c_str(), label, isMainDoc, createView, std::move(objNames));
+                FC_DURATION_PLUS(timing.d1,t1);
+                if (doc) {
+                    timings[doc].d1 += timing.d1;
+                    newDocs.emplace(doc);
+                }
+
                 if (isMainDoc)
-                    (*errs)[count] = "unknown error";
+                    res[count] = doc;
+                _objCount = -1;
             }
-            else {
-                _pendingDocs.clear();
+            catch (const Base::Exception &e) {
+                e.ReportException();
+                if (!errs && isMainDoc)
+                    throw;
+                if (errs && isMainDoc)
+                    (*errs)[count] = e.what();
+                else
+                    Console().Error("Exception opening file: %s [%s]\n", name.c_str(), e.what());
+            }
+            catch (const std::exception &e) {
+                if (!errs && isMainDoc)
+                    throw;
+                if (errs && isMainDoc)
+                    (*errs)[count] = e.what();
+                else
+                    Console().Error("Exception opening file: %s [%s]\n", name.c_str(), e.what());
+            }
+            catch (...) {
+                if (errs) {
+                    if (isMainDoc)
+                        (*errs)[count] = "unknown error";
+                }
+                else {
+                    _pendingDocs.clear();
+                    _pendingDocsReopen.clear();
+                    _pendingDocMap.clear();
+                    throw;
+                }
+            }
+
+            if (_pendingDocs.empty()) {
+                if(_pendingDocsReopen.empty())
+                    break;
+                _pendingDocs = std::move(_pendingDocsReopen);
                 _pendingDocsReopen.clear();
-                _pendingDocMap.clear();
-                throw;
+                for(auto &file : _pendingDocs) {
+                    auto doc = getDocumentByPath(file.c_str());
+                    if(doc)
+                        closeDocument(doc->getName());
+                }
             }
         }
 
-        if (_pendingDocs.empty()) {
-            if (_pendingDocsReopen.empty())
-                break;
-            _allowPartial = false;
-            _pendingDocs.swap(_pendingDocsReopen);
+        ++pass;
+        _pendingDocMap.clear();
+
+        std::vector<Document*> docs;
+        docs.reserve(newDocs.size());
+        for(auto &d : newDocs) {
+            auto doc = d.getDocument();
+            if(!doc)
+                continue;
+            // Notify PropertyXLink to attach newly opened documents and restore
+            // relevant external links
+            PropertyXLink::restoreDocument(*doc);
+            docs.push_back(doc);
         }
-    }
 
-    _pendingDocs.clear();
-    _pendingDocsReopen.clear();
-    _pendingDocMap.clear();
+        Base::SequencerLauncher seq("Postprocessing...", docs.size());
 
-    Base::SequencerLauncher seq("Postprocessing...", newDocs.size());
-
-    std::vector<Document*> docs;
-    docs.reserve(newDocs.size());
-    for (auto &v : newDocs) {
-        // Notify PropertyXLink to attach newly opened documents and restore
-        // relevant external links
-        PropertyXLink::restoreDocument(*v.first);
-        docs.push_back(v.first);
-    }
-
-    // After external links has been restored, we can now sort the document
-    // according to their dependency order.
-    docs = Document::getDependentDocuments(docs, true);
-    for (auto it=docs.begin(); it!=docs.end();) {
-        Document *doc = *it;
-        // It is possible that the newly opened document depends on an existing
-        // document, which will be included with the above call to
-        // Document::getDependentDocuments(). Make sure to exclude that.
-        auto dit = newDocs.find(doc);
-        if (dit == newDocs.end()) {
-            it = docs.erase(it);
-            continue;
+        // After external links has been restored, we can now sort the document
+        // according to their dependency order.
+        try {
+            docs = Document::getDependentDocuments(docs, true);
+        } catch (Base::Exception &e) {
+            e.ReportException();
         }
-        ++it;
-        FC_TIME_INIT(t1);
-        // Finalize document restoring with the correct order
-        doc->afterRestore(true);
-        FC_DURATION_PLUS(dit->second.d2,t1);
-        seq.next();
-    }
+        for(auto it=docs.begin(); it!=docs.end();) {
+            auto doc = *it;
+
+            // It is possible that the newly opened document depends on an existing
+            // document, which will be included with the above call to
+            // Document::getDependentDocuments(). Make sure to exclude that.
+            if(!newDocs.count(doc)) {
+                it = docs.erase(it);
+                continue;
+            }
+
+            auto &timing = timings[doc];
+            FC_TIME_INIT(t1);
+            // Finalize document restoring with the correct order
+            if(doc->afterRestore(true)) {
+                openedDocs.push_back(doc);
+                it = docs.erase(it);
+            } else {
+                ++it;
+                // Here means this is a partial loaded document, and we need to
+                // reload it fully because of touched objects. The reason of
+                // reloading a partial document with touched object is because
+                // partial document is supposed to be readonly, while a
+                // 'touched' object requires recomputation. And an object may
+                // become touched during restoring if externally linked
+                // document time stamp mismatches with the stamp saved.
+                _pendingDocs.push_back(doc->FileName.getValue());
+                _pendingDocMap.erase(doc->FileName.getValue());
+            }
+            FC_DURATION_PLUS(timing.d2,t1);
+            seq.next();
+        }
+        // Close the document for reloading
+        for(auto doc : docs)
+            closeDocument(doc->getName());
+
+    }while(!_pendingDocs.empty());
 
     // Set the active document using the first successfully restored main
     // document (i.e. documents explicitly asked for by caller).
@@ -771,14 +857,14 @@ std::vector<Document*> Application::openDocuments(const std::vector<std::string>
         }
     }
 
-    for (auto doc : docs) {
-        auto &timing = newDocs[doc];
-        FC_DURATION_LOG(timing.d1, doc->getName() << " restore");
-        FC_DURATION_LOG(timing.d2, doc->getName() << " postprocess");
+    for (auto &doc : openedDocs) {
+        auto &timing = timings[doc];
+        FC_DURATION_LOG(timing.d1, doc.getDocumentName() << " restore");
+        FC_DURATION_LOG(timing.d2, doc.getDocumentName() << " postprocess");
     }
     FC_TIME_LOG(t,"total");
-
     _isRestoring = false;
+
     signalFinishOpenDocument();
     return res;
 }
@@ -786,7 +872,7 @@ std::vector<Document*> Application::openDocuments(const std::vector<std::string>
 Document* Application::openDocumentPrivate(const char * FileName,
         const char *propFileName, const char *label,
         bool isMainDoc, bool createView,
-        const std::set<std::string> &objNames)
+        std::vector<std::string> &&objNames)
 {
     FileInfo File(FileName);
 
@@ -797,55 +883,51 @@ Document* Application::openDocumentPrivate(const char * FileName,
     }
 
     // Before creating a new document we check whether the document is already open
-    std::string filepath = File.filePath();
-    QString canonicalPath = QFileInfo(QString::fromUtf8(FileName)).canonicalFilePath();
-    for (std::map<std::string,Document*>::iterator it = DocMap.begin(); it != DocMap.end(); ++it) {
-        // get unique path separators
-        std::string fi = FileInfo(it->second->FileName.getValue()).filePath();
-        if (filepath != fi) {
-            if (canonicalPath == QFileInfo(QString::fromUtf8(fi.c_str())).canonicalFilePath()) {
-                bool samePath = (canonicalPath == QString::fromUtf8(FileName));
-                FC_WARN("Identical physical path '" << canonicalPath.toUtf8().constData() << "'\n"
-                        << (samePath?"":"  for file '") << (samePath?"":FileName) << (samePath?"":"'\n")
-                        << "  with existing document '" << it->second->Label.getValue()
-                        << "' in path: '" << it->second->FileName.getValue() << "'");
-            }
-            continue;
-        }
-        if(it->second->testStatus(App::Document::PartialDoc)
-                || it->second->testStatus(App::Document::PartialRestore)) {
+    auto doc = getDocumentByPath(File.filePath().c_str(), 2);
+    if(doc) {
+        if(doc->testStatus(App::Document::PartialDoc)
+                || doc->testStatus(App::Document::PartialRestore)) {
             // Here means a document is already partially loaded, but the document
             // is requested again, either partial or not. We must check if the
             // document contains the required object
 
             if(isMainDoc) {
                 // Main document must be open fully, so close and reopen
-                closeDocument(it->first.c_str());
-                break;
-            }
-
-            if(_allowPartial) {
+                closeDocument(doc->getName());
+                doc = nullptr;
+            } else if(_allowPartial) {
                 bool reopen = false;
                 for(auto &name : objNames) {
-                    auto obj = it->second->getObject(name.c_str());
+                    auto obj = doc->getObject(name.c_str());
                     if(!obj || obj->testStatus(App::PartialObject)) {
                         reopen = true;
+                        // NOTE: We are about to reload this document with
+                        // extra objects. However, it is possible to repeat
+                        // this process several times, if it is linked by
+                        // multiple documents and each with a different set of
+                        // objects. To partially solve this problem, we do not
+                        // close and reopen the document immediately here, but
+                        // add it to _pendingDocsReopen to delay reloading.
+                        for(auto obj : doc->getObjects())
+                            objNames.push_back(obj->getNameInDocument());
+                        _pendingDocMap[doc->FileName.getValue()] = std::move(objNames);
                         break;
                     }
                 }
                 if(!reopen)
                     return 0;
             }
-            auto &names = _pendingDocMap[FileName];
-            names.clear();
-            _pendingDocsReopen.push_back(FileName);
-            return 0;
+
+            if(doc) {
+                _pendingDocsReopen.emplace_back(FileName);
+                return 0;
+            }
         }
 
         if(!isMainDoc)
             return 0;
-
-        return it->second;
+        else if(doc)
+            return doc;
     }
 
     std::string name;
@@ -867,6 +949,8 @@ Document* Application::openDocumentPrivate(const char * FileName,
     try {
         // read the document
         newDoc->restore(File.filePath().c_str(),true,objNames);
+        if(DocFileMap.size())
+            DocFileMap[FileInfo(newDoc->FileName.getValue()).filePath()] = newDoc;
         return newDoc;
     }
     // if the project file itself is corrupt then
@@ -1463,6 +1547,7 @@ void Application::slotStartSaveDocument(const App::Document& doc, const std::str
 
 void Application::slotFinishSaveDocument(const App::Document& doc, const std::string& filename)
 {
+    DocFileMap.clear();
     this->signalFinishSaveDocument(doc, filename);
 }
 

--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -629,7 +629,7 @@ Document* Application::openDocument(const char * FileName, bool createView) {
     return 0;
 }
 
-Document *Application::getDocumentByPath(const char *path, int checkCanonical) const {
+Document *Application::getDocumentByPath(const char *path, PathMatchMode checkCanonical) const {
     if(!path || !path[0])
         return nullptr;
     if(DocFileMap.empty()) {
@@ -643,7 +643,7 @@ Document *Application::getDocumentByPath(const char *path, int checkCanonical) c
     if(it != DocFileMap.end())
         return it->second;
 
-    if (!checkCanonical)
+    if (checkCanonical == MatchAbsolute)
         return nullptr;
 
     std::string filepath = FileInfo(path).filePath();
@@ -651,7 +651,7 @@ Document *Application::getDocumentByPath(const char *path, int checkCanonical) c
     for (auto &v : DocMap) {
         QFileInfo fi(QString::fromUtf8(v.second->FileName.getValue()));
         if (canonicalPath == fi.canonicalFilePath()) {
-            if (checkCanonical == 1)
+            if (checkCanonical == MatchCanonical)
                 return v.second;
             bool samePath = (canonicalPath == QString::fromUtf8(filepath.c_str()));
             FC_WARN("Identical physical path '" << canonicalPath.toUtf8().constData() << "'\n"
@@ -883,7 +883,7 @@ Document* Application::openDocumentPrivate(const char * FileName,
     }
 
     // Before creating a new document we check whether the document is already open
-    auto doc = getDocumentByPath(File.filePath().c_str(), 2);
+    auto doc = getDocumentByPath(File.filePath().c_str(), MatchCanonicalWarning);
     if(doc) {
         if(doc->testStatus(App::Document::PartialDoc)
                 || doc->testStatus(App::Document::PartialRestore)) {

--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -633,7 +633,7 @@ Document *Application::getDocumentByPath(const char *path, PathMatchMode checkCa
     if(!path || !path[0])
         return nullptr;
     if(DocFileMap.empty()) {
-        for(auto &v : DocMap) {
+        for(const auto &v : DocMap) {
             const auto &file = v.second->FileName.getStrValue();
             if(file.size())
                 DocFileMap[FileInfo(file.c_str()).filePath()] = v.second;
@@ -643,15 +643,15 @@ Document *Application::getDocumentByPath(const char *path, PathMatchMode checkCa
     if(it != DocFileMap.end())
         return it->second;
 
-    if (checkCanonical == MatchAbsolute)
+    if (checkCanonical == PathMatchMode::MatchAbsolute)
         return nullptr;
 
     std::string filepath = FileInfo(path).filePath();
     QString canonicalPath = QFileInfo(QString::fromUtf8(path)).canonicalFilePath();
-    for (auto &v : DocMap) {
+    for (const auto &v : DocMap) {
         QFileInfo fi(QString::fromUtf8(v.second->FileName.getValue()));
         if (canonicalPath == fi.canonicalFilePath()) {
-            if (checkCanonical == MatchCanonical)
+            if (checkCanonical == PathMatchMode::MatchCanonical)
                 return v.second;
             bool samePath = (canonicalPath == QString::fromUtf8(filepath.c_str()));
             FC_WARN("Identical physical path '" << canonicalPath.toUtf8().constData() << "'\n"
@@ -778,7 +778,7 @@ std::vector<Document*> Application::openDocuments(const std::vector<std::string>
                     break;
                 _pendingDocs = std::move(_pendingDocsReopen);
                 _pendingDocsReopen.clear();
-                for(auto &file : _pendingDocs) {
+                for(const auto &file : _pendingDocs) {
                     auto doc = getDocumentByPath(file.c_str());
                     if(doc)
                         closeDocument(doc->getName());
@@ -791,7 +791,7 @@ std::vector<Document*> Application::openDocuments(const std::vector<std::string>
 
         std::vector<Document*> docs;
         docs.reserve(newDocs.size());
-        for(auto &d : newDocs) {
+        for(const auto &d : newDocs) {
             auto doc = d.getDocument();
             if(!doc)
                 continue;
@@ -843,7 +843,7 @@ std::vector<Document*> Application::openDocuments(const std::vector<std::string>
             seq.next();
         }
         // Close the document for reloading
-        for(auto doc : docs)
+        for(const auto doc : docs)
             closeDocument(doc->getName());
 
     }while(!_pendingDocs.empty());
@@ -883,7 +883,7 @@ Document* Application::openDocumentPrivate(const char * FileName,
     }
 
     // Before creating a new document we check whether the document is already open
-    auto doc = getDocumentByPath(File.filePath().c_str(), MatchCanonicalWarning);
+    auto doc = getDocumentByPath(File.filePath().c_str(), PathMatchMode::MatchCanonicalWarning);
     if(doc) {
         if(doc->testStatus(App::Document::PartialDoc)
                 || doc->testStatus(App::Document::PartialRestore)) {
@@ -897,7 +897,7 @@ Document* Application::openDocumentPrivate(const char * FileName,
                 doc = nullptr;
             } else if(_allowPartial) {
                 bool reopen = false;
-                for(auto &name : objNames) {
+                for(const auto &name : objNames) {
                     auto obj = doc->getObject(name.c_str());
                     if(!obj || obj->testStatus(App::PartialObject)) {
                         reopen = true;

--- a/src/App/Application.h
+++ b/src/App/Application.h
@@ -120,16 +120,33 @@ public:
     App::Document* getActiveDocument(void) const;
     /// Retrieve a named document
     App::Document* getDocument(const char *Name) const;
+
+    /// Path matching mode for getDocumentByPath()
+    enum PathMatchMode {
+        /// Match by resolving to absolute file path
+        MatchAbsolute = 0,
+        /** Match by absolute path first. If not found then match by resolving
+         * to canonical file path where any intermediate '.' '..' and symlinks
+         * are resolved.
+         */
+        MatchCanonical = 1,
+        /** Same as MatchCanonical, but if a document is found by canonical
+         * path match, which means the document can be resolved using two
+         * different absolute path, a warning is printed and the found document
+         * is not returned. This is to allow the caller to intentionally load
+         * the same physical file as separate documents.
+         */
+        MatchCanonicalWarning = 2,
+    };
     /** Retrieve a document based on file path
      *
      * @param path: file path
-     * @param checkCanonical: if zero, only match absolute file path. If 1,
-     * then match by canonical file path, where any intermediate '.' and '..'
-     * and symlinks are resolved. If 2, then only print warning message if
-     * there is identical canonical file path found, but will not return the
-     * matched document.
+     * @param checkCanonical: file path matching mode, @sa PathMatchMode.
+     * @return Return the document found by matching with the given path
      */
-    App::Document* getDocumentByPath(const char *path, int checkCanonical=0) const;
+    App::Document* getDocumentByPath(const char *path,
+                                     PathMatchMode checkCanonical = MatchAbsolute) const;
+
     /// gets the (internal) name of the document
     const char * getDocumentName(const App::Document* ) const;
     /// get a list of all documents in the application

--- a/src/App/Application.h
+++ b/src/App/Application.h
@@ -122,7 +122,7 @@ public:
     App::Document* getDocument(const char *Name) const;
 
     /// Path matching mode for getDocumentByPath()
-    enum PathMatchMode {
+    enum class PathMatchMode {
         /// Match by resolving to absolute file path
         MatchAbsolute = 0,
         /** Match by absolute path first. If not found then match by resolving
@@ -145,7 +145,7 @@ public:
      * @return Return the document found by matching with the given path
      */
     App::Document* getDocumentByPath(const char *path,
-                                     PathMatchMode checkCanonical = MatchAbsolute) const;
+                                     PathMatchMode checkCanonical = PathMatchMode::MatchAbsolute) const;
 
     /// gets the (internal) name of the document
     const char * getDocumentName(const App::Document* ) const;

--- a/src/App/Document.h
+++ b/src/App/Document.h
@@ -74,7 +74,8 @@ public:
         PartialDoc = 7,
         AllowPartialRecompute = 8, // allow recomputing editing object if SkipRecompute is set
         TempDoc = 9, // Mark as temporary document without prompt for save
-        RestoreError = 10
+        RestoreError = 10,
+        LinkStampChanged = 11, // Indicates during restore time if any linked document's time stamp has changed
     };
 
     /** @name Properties */
@@ -195,8 +196,8 @@ public:
     bool saveCopy(const char* file) const;
     /// Restore the document from the file in Property Path
     void restore (const char *filename=0,
-            bool delaySignal=false, const std::set<std::string> &objNames={});
-    void afterRestore(bool checkPartial=false);
+            bool delaySignal=false, const std::vector<std::string> &objNames={});
+    bool afterRestore(bool checkPartial=false);
     bool afterRestore(const std::vector<App::DocumentObject *> &, bool checkPartial=false);
     enum ExportStatus {
         NotExporting,

--- a/src/App/Document.h
+++ b/src/App/Document.h
@@ -75,7 +75,7 @@ public:
         AllowPartialRecompute = 8, // allow recomputing editing object if SkipRecompute is set
         TempDoc = 9, // Mark as temporary document without prompt for save
         RestoreError = 10,
-        LinkStampChanged = 11, // Indicates during restore time if any linked document's time stamp has changed
+        LinkStampChanged = 11, // Indicates during restore time if any linked document's time stamp has changed
     };
 
     /** @name Properties */

--- a/src/App/DocumentObserver.h
+++ b/src/App/DocumentObserver.h
@@ -62,6 +62,14 @@ public:
     /*! Assignment operator */
     void operator=(const std::string&);
 
+    bool operator==(const DocumentT &other) const {
+        return document == other.document;
+    }
+
+    bool operator<(const DocumentT &other) const {
+        return document < other.document;
+    }
+
     /*! Get a pointer to the document or 0 if it doesn't exist any more. */
     Document* getDocument() const;
     /*! Get the name of the document. */

--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -1499,7 +1499,7 @@ void Document::slotFinishRestoreDocument(const App::Document& doc)
     }
 
     // reset modified flag
-    setModified(false);
+    setModified(doc.testStatus(App::Document::LinkStampChanged));
 }
 
 void Document::slotShowHidden(const App::Document& doc)

--- a/src/Gui/ViewProviderDocumentObject.cpp
+++ b/src/Gui/ViewProviderDocumentObject.cpp
@@ -196,12 +196,19 @@ void ViewProviderDocumentObject::onChanged(const App::Property* prop)
             // this is undesired behaviour. So, if this change marks the document as
             // modified then it must be be reversed.
             if (!testStatus(Gui::ViewStatus::TouchDocument)) {
-                bool mod = false;
-                if (pcDocument)
-                    mod = pcDocument->isModified();
+                // Note: reverting document modified status like that is not
+                // appropreiate because we can't tell if there is any other
+                // property being changed due to the change of Visibility here.
+                // Temporary setting the Visibility property as 'NoModify' is
+                // the proper way.
+                Base::ObjectStatusLocker<App::Property::Status,App::Property> guard(
+                        App::Property::NoModify, &Visibility);
+                // bool mod = false;
+                // if (pcDocument)
+                //     mod = pcDocument->isModified();
                 getObject()->Visibility.setValue(Visibility.getValue());
-                if (pcDocument)
-                    pcDocument->setModified(mod);
+                // if (pcDocument)
+                //     pcDocument->setModified(mod);
             }
             else {
                 getObject()->Visibility.setValue(Visibility.getValue());
@@ -215,7 +222,10 @@ void ViewProviderDocumentObject::onChanged(const App::Property* prop)
         }
     }
 
-    if (pcDocument && !pcDocument->isModified() && testStatus(Gui::ViewStatus::TouchDocument)) {
+    if (prop && !prop->testStatus(App::Property::NoModify)
+             && pcDocument
+             && !pcDocument->isModified()
+             && testStatus(Gui::ViewStatus::TouchDocument)) {
         if (prop)
             FC_LOG(prop->getFullName() << " changed");
         pcDocument->setModified(true);

--- a/src/Gui/ViewProviderDocumentObject.cpp
+++ b/src/Gui/ViewProviderDocumentObject.cpp
@@ -197,7 +197,7 @@ void ViewProviderDocumentObject::onChanged(const App::Property* prop)
             // modified then it must be be reversed.
             if (!testStatus(Gui::ViewStatus::TouchDocument)) {
                 // Note: reverting document modified status like that is not
-                // appropreiate because we can't tell if there is any other
+                // appropriate because we can't tell if there is any other
                 // property being changed due to the change of Visibility here.
                 // Temporary setting the Visibility property as 'NoModify' is
                 // the proper way.

--- a/src/Mod/Part/Gui/ViewProviderExt.cpp
+++ b/src/Mod/Part/Gui/ViewProviderExt.cpp
@@ -399,7 +399,7 @@ void ViewProviderPartExt::onChanged(const App::Property* prop)
             updateVisual();
             // updateVisual() may not be triggered by any change (e.g.
             // triggered by an external object through forceUpdate()). And
-            // since DiffuseColor is not changed here either, do not falsly set
+            // since DiffuseColor is not changed here either, do not falsely set
             // the document modified status
             Base::ObjectStatusLocker<App::Property::Status,App::Property> guard(
                     App::Property::NoModify, &DiffuseColor);


### PR DESCRIPTION
Forum thread https://forum.freecadweb.org/viewtopic.php?p=495078#p495078

The problem happens when partial loading is enabled. If document A contains a link to some object in document B, it will load B as partial document with only that object and its necessary dependencies. But if document A contains another link to some object in document C which also has a link to some object in document B, the link in document C may not be restored, because document B is partially loaded without the linked object. This patch will check for this case and reload document B for more objects.