### PR TITLE
Revert "Start: Properly hash thumbnail filenames"

### DIFF
--- a/src/Mod/Start/StartPage/StartPage.py
+++ b/src/Mod/Start/StartPage/StartPage.py
@@ -109,8 +109,8 @@ def getInfo(filename):
             import gnomevfs
         except Exception:
             # alternative method
-            import hashlib, urllib
-            fhash = hashlib.md5(urllib.quote("file://"+path,safe=":/")).hexdigest()
+            import hashlib
+            fhash = hashlib.md5(("file://"+path).encode("utf8")).hexdigest()
             thumb = os.path.join(os.path.expanduser("~"),".thumbnails","normal",fhash+".png")
         else:
             uri = gnomevfs.get_uri_from_local_path(path)


### PR DESCRIPTION
Reverts FreeCAD/FreeCAD#4931 -- in Python 3 `quote` is now located in the `urllib.parse` module, and not directly in `urllib`. It also takes an optional `encoding` parameter, which I think is necessary in this case since the hash function requires unicode be encoded prior to execution.