### PR TITLE
[Path] Fix `Face Region` boundary shape usage and LGTM cleanup

### DIFF
--- a/src/Mod/Path/PathScripts/PathMillFace.py
+++ b/src/Mod/Path/PathScripts/PathMillFace.py
@@ -257,6 +257,8 @@ class ObjectFace(PathPocketBase.ObjectPocket):
         return False
 
     def getAllIncludedFaces(self, base, env, faceZ):
+        '''getAllIncludedFaces(base, env, faceZ)...
+        Return all `base` faces extending above `faceZ` whose boundboxes overlap with the `env` boundbox.'''
         included = []
 
         eXMin = env.BoundBox.XMin
@@ -272,6 +274,7 @@ class ObjectFace(PathPocketBase.ObjectPocket):
             return False
 
         for fi in range(0, len(base.Shape.Faces)):
+            # Check all faces of `base` shape
             incl = False
             face = base.Shape.Faces[fi]
             fXMin = face.BoundBox.XMin
@@ -281,8 +284,9 @@ class ObjectFace(PathPocketBase.ObjectPocket):
             fZMax = face.BoundBox.ZMax
 
             if fZMax > eZMin:
-                if isOverlap(fXMin, fXMax, eXMin, eXMax):
-                    if isOverlap(fYMin, fYMax, eYMin, eYMax):
+                # Include face if its boundbox overlaps envelope boundbox
+                if isOverlap(fXMin, fXMax, eXMin, eXMax):  # check X values
+                    if isOverlap(fYMin, fYMax, eYMin, eYMax):  # check Y values
                         incl = True
             if incl:
                 included.append(face)

--- a/src/Mod/Path/PathScripts/PathMillFace.py
+++ b/src/Mod/Path/PathScripts/PathMillFace.py
@@ -194,16 +194,20 @@ class ObjectFace(PathPocketBase.ObjectPocket):
         elif obj.BoundaryShape == 'Face Region':
             baseShape = oneBase[0].Shape
             psZMin = planeshape.BoundBox.ZMin
-            ofstShape = PathUtils.getOffsetArea(planeshape,
-                                                self.tool.Diameter * 1.1,
-                                                plane=planeshape)
+            ofst = 0.0
+            if obj.ClearEdges:
+                ofst = self.tool.Diameter * 0.51
+            ofstShape = PathUtils.getOffsetArea(planeshape, ofst, plane=planeshape)
             ofstShape.translate(FreeCAD.Vector(0.0, 0.0, psZMin - ofstShape.BoundBox.ZMin))
 
             # Calculate custom depth params for removal shape envelope, with start and final depth buffers
             custDepthparams = self._customDepthParams(obj, obj.StartDepth.Value + 0.2, obj.FinalDepth.Value - 0.1)  # only an envelope
             ofstShapeEnv = PathUtils.getEnvelope(partshape=ofstShape, depthparams=custDepthparams)
-            env = ofstShapeEnv.cut(baseShape)
-            env.translate(FreeCAD.Vector(0.0, 0.0, -0.000001))  # lower removal shape into buffer zone
+            if obj.ExcludeRaisedAreas: 
+                env = ofstShapeEnv.cut(baseShape)
+                env.translate(FreeCAD.Vector(0.0, 0.0, -0.00001))  # lower removal shape into buffer zone
+            else:
+                env = ofstShapeEnv
 
         if holeShape:
             PathLog.debug("Processing holes and face ...")

--- a/src/Mod/Path/PathScripts/PathMillFace.py
+++ b/src/Mod/Path/PathScripts/PathMillFace.py
@@ -265,16 +265,9 @@ class ObjectFace(PathPocketBase.ObjectPocket):
         eYMax = env.BoundBox.YMax
         eZMin = faceZ
 
-        def isOverlap(fMn, fMx, eMn, eMx):
-            if fMx > eMn:
-                if fMx <= eMx:
-                    return True
-                elif fMx >= eMx and fMn <= eMx:
-                    return True
-            if fMn < eMx:
-                if fMn >= eMn:
-                    return True
-                elif fMn <= eMn and fMx >= eMn:
+        def isOverlap(faceMin, faceMax, envMin, envMax):
+            if faceMax > envMin:
+                if faceMin <= envMax or faceMin == envMin:
                     return True
             return False
 

--- a/src/Mod/Path/PathScripts/PathMillFace.py
+++ b/src/Mod/Path/PathScripts/PathMillFace.py
@@ -192,7 +192,6 @@ class ObjectFace(PathPocketBase.ObjectPocket):
             else:
                 env = PathUtils.getEnvelope(partshape=planeshape, depthparams=self.depthparams)
         elif obj.BoundaryShape == 'Face Region':
-            import PathScripts.PathSurfaceSupport as PathSurfaceSupport
             baseShape = oneBase[0].Shape
             psZMin = planeshape.BoundBox.ZMin
             ofstShape = PathUtils.getOffsetArea(planeshape,


### PR DESCRIPTION
The four included commits are well organized and defined.  This PR fixes usage of `Face Region` boundary shape paths, leaving an existing collision problem intact.  The fix addresses application of `Clear Edges` toggle and `Exclude Raised Areas` when using `Face Region` as the boundary shape.  Other commits are LGTM and documentation purposed.

This PR is initiated by a prompt from @luzpaz  in the gitter.im/FreeCAD/Path chatroom about LGTM cleanup for the module.  While addressing the LGTM, I addressed the `Face Region` problem identified and added some documentation in the code.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
