### PR TITLE
[Core] exit() can prevent core dumping, use abort() instead on debug mode

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -1631,7 +1631,11 @@ void segmentation_fault_handler(int sig)
     (void)sig;
     std::cerr << "Program received signal SIGSEGV, Segmentation fault.\n";
     printBacktrace(2);
+#if defined(FC_DEBUG)
+    abort();
+#else
     exit(1);
+#endif
 #else
     switch (sig) {
         case SIGSEGV:


### PR DESCRIPTION
Use of "exit()" function can prevent the core dump handler to be activated on Linux when crashing (especially with segmentation fault).
This is nice for normal user but it definitely needed for coders, so this PR uses "abort()" instead -- only when compiling in debug mode -- so a core dump is correctly generated.

- [X]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [X]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [X]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [X]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [X]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`