### PR TITLE
[Arch] Add missing inits

### DIFF
--- a/src/Mod/Arch/OfflineRenderingUtils.py
+++ b/src/Mod/Arch/OfflineRenderingUtils.py
@@ -122,7 +122,8 @@ class FreeCADGuiHandler(xml.sax.ContentHandler):
     # plus a GuiCameraSettings key that contains an iv repr of a coin camera
 
     def __init__(self):
-
+        
+        super().__init__()
         self.guidata = {}
         self.current = None
         self.properties = {}

--- a/src/Mod/Arch/importSH3D.py
+++ b/src/Mod/Arch/importSH3D.py
@@ -105,7 +105,8 @@ def read(filename):
 class SH3DHandler(xml.sax.ContentHandler):
 
     def __init__(self,z):
-
+        
+        super().__init__()
         self.makeIndividualWalls = False
         self.z = z
         self.windows = []

--- a/src/Tools/generateBase/generateModel_Module.py
+++ b/src/Tools/generateBase/generateModel_Module.py
@@ -1841,6 +1841,7 @@ class SaxStackElement:
 #
 class SaxGeneratemodelHandler(handler.ContentHandler):
     def __init__(self):
+        super().__init__()
         self.stack = []
         self.root = None
 
@@ -2344,6 +2345,7 @@ def usage():
 #
 class SaxSelectorHandler(handler.ContentHandler):
     def __init__(self):
+        super().__init__()
         self.topElementName = None
     def getTopElementName(self):
         return self.topElementName


### PR DESCRIPTION
LGTM complains about some missing parent class inits -- I've added them in this PR. They don't actually do anything, those parent initializers are empty, but it makes LGTM happy (I hope).

---

- [ ]  Your pull request is confined strictly to a single module (technically two of these are in Tools, not Arch)
- [X]  Small bugs
- [X]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master
- [X]  All FreeCAD unit tests are confirmed to pass
- [X]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/)
- [X]  Your pull request is well written and has a good description
- [X]  No tracker ticket