### PR TITLE
Part: Auto-add primitives to active Part

### DIFF
--- a/src/Mod/Part/BasicShapes/CommandShapes.py
+++ b/src/Mod/Part/BasicShapes/CommandShapes.py
@@ -53,6 +53,9 @@ class CommandTube:
         tube = FreeCAD.ActiveDocument.addObject("Part::FeaturePython","Tube")
         Shapes.TubeFeature(tube)
         vp = ViewProviderShapes.ViewProviderTube(tube.ViewObject)
+        activePart = FreeCADGui.activeView().getActiveObject('part')
+        if activePart:
+            activePart.addObject(tube)
         FreeCAD.ActiveDocument.recompute()
         vp.startDefaultEditMode(tube.ViewObject)
 

--- a/src/Mod/Part/Gui/CommandParametric.cpp
+++ b/src/Mod/Part/Gui/CommandParametric.cpp
@@ -30,9 +30,27 @@
 # include <QLineEdit>
 #endif
 
+#include <App/Part.h>
 #include <Gui/Application.h>
 #include <Gui/Command.h>
 #include <Gui/MainWindow.h>
+#include <Gui/Document.h>
+
+//===========================================================================
+// Utils
+//===========================================================================
+QString getAutoGroupCommandStr()
+// Helper class to get the python code to add the newly created object to the active Part object if present
+{
+    App::Part* activePart = Gui::Application::Instance->activeView()->getActiveObject<App::Part*>("part");
+    if (activePart) {
+        QString activePartName = QString::fromLatin1(activePart->getNameInDocument());
+        return QString::fromLatin1("App.ActiveDocument.getObject('%1\')."
+            "addObject(App.ActiveDocument.ActiveObject)\n")
+            .arg(activePartName);
+    }
+    return QString::fromLatin1("# Object created at document root.");
+}
 
 //===========================================================================
 // Part_Cylinder
@@ -62,6 +80,7 @@ void CmdPartCylinder::activated(int iMsg)
     cmd = QString::fromLatin1("App.ActiveDocument.ActiveObject.Label = \"%1\"")
         .arg(qApp->translate("CmdPartCylinder","Cylinder"));
     runCommand(Doc,cmd.toUtf8());
+    runCommand(Doc, getAutoGroupCommandStr().toUtf8());
     commitCommand();
     updateActive();
     runCommand(Gui, "Gui.SendMsgToActiveView(\"ViewFit\")");
@@ -103,6 +122,7 @@ void CmdPartBox::activated(int iMsg)
     cmd = QString::fromLatin1("App.ActiveDocument.ActiveObject.Label = \"%1\"")
         .arg(qApp->translate("CmdPartBox","Cube"));
     runCommand(Doc,cmd.toUtf8());
+    runCommand(Doc, getAutoGroupCommandStr().toUtf8());
     commitCommand();
     updateActive();
     runCommand(Gui, "Gui.SendMsgToActiveView(\"ViewFit\")");
@@ -144,6 +164,7 @@ void CmdPartSphere::activated(int iMsg)
     cmd = QString::fromLatin1("App.ActiveDocument.ActiveObject.Label = \"%1\"")
         .arg(qApp->translate("CmdPartSphere","Sphere"));
     runCommand(Doc,cmd.toUtf8());
+    runCommand(Doc, getAutoGroupCommandStr().toUtf8());
     commitCommand();
     updateActive();
     runCommand(Gui, "Gui.SendMsgToActiveView(\"ViewFit\")");
@@ -185,6 +206,7 @@ void CmdPartCone::activated(int iMsg)
     cmd = QString::fromLatin1("App.ActiveDocument.ActiveObject.Label = \"%1\"")
         .arg(qApp->translate("CmdPartCone","Cone"));
     runCommand(Doc,cmd.toUtf8());
+    runCommand(Doc, getAutoGroupCommandStr().toUtf8());
     commitCommand();
     updateActive();
     runCommand(Gui, "Gui.SendMsgToActiveView(\"ViewFit\")");
@@ -226,6 +248,7 @@ void CmdPartTorus::activated(int iMsg)
     cmd = QString::fromLatin1("App.ActiveDocument.ActiveObject.Label = \"%1\"")
         .arg(qApp->translate("CmdPartTorus","Torus"));
     runCommand(Doc,cmd.toUtf8());
+    runCommand(Doc, getAutoGroupCommandStr().toUtf8());
     commitCommand();
     updateActive();
     runCommand(Gui, "Gui.SendMsgToActiveView(\"ViewFit\")");

--- a/src/Mod/Part/Gui/DlgPrimitives.cpp
+++ b/src/Mod/Part/Gui/DlgPrimitives.cpp
@@ -43,6 +43,7 @@
 #include <Base/Tools.h>
 #include <Base/UnitsApi.h>
 #include <App/Application.h>
+#include <App/Part.h>
 #include <App/Document.h>
 #include <Gui/Application.h>
 #include <Gui/Document.h>
@@ -63,6 +64,20 @@
 using namespace PartGui;
 
 namespace PartGui {
+
+    QString getAutoGroupCommandStr(QString objectName)
+        // Helper class to get the python code to add the newly created object to the active Part object if present
+    {
+        App::Part* activePart = Gui::Application::Instance->activeView()->getActiveObject<App::Part*>("part");
+        if (activePart) {
+            QString activeObjectName = QString::fromLatin1(activePart->getNameInDocument());
+            return QString::fromLatin1("App.ActiveDocument.getObject('%1\')."
+                "addObject(App.ActiveDocument.getObject('%2\'))\n")
+                .arg(activeObjectName)
+                .arg(objectName);
+        }
+        return QString::fromLatin1("# Object %1 created at document root").arg(objectName);
+    }
 
 const char* gce_ErrorStatusText(gce_ErrorType et)
 {
@@ -1107,6 +1122,7 @@ void DlgPrimitives::createPrimitive(const QString& placement)
         QString prim = tr("Create %1").arg(ui->PrimitiveTypeCB->currentText());
         Gui::Application::Instance->activeDocument()->openCommand(prim.toUtf8());
         Gui::Command::runCommand(Gui::Command::Doc, cmd.toUtf8());
+        Gui::Command::runCommand(Gui::Command::Doc, getAutoGroupCommandStr(name).toUtf8());
         Gui::Application::Instance->activeDocument()->commitCommand();
         Gui::Command::runCommand(Gui::Command::Doc, "App.ActiveDocument.recompute()");
         Gui::Command::runCommand(Gui::Command::Gui, "Gui.SendMsgToActiveView(\"ViewFit\")");


### PR DESCRIPTION
Modified DlgPrimitives.cpp to allow auto adding the newly created object to active Std_Part if present.


Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [ ]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [ ]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
