### PR TITLE
App: Prevent crash when trying to delete pointer to BaseClass

### DIFF
--- a/src/App/DynamicProperty.cpp
+++ b/src/App/DynamicProperty.cpp
@@ -181,25 +181,29 @@ Property* DynamicProperty::addDynamicProperty(PropertyContainer &pc, const char*
     if(Base::Tools::getIdentifier(name) != name) 
         FC_THROWM(Base::NameError, "Invalid property name '" << name << "'");
 
-    Base::BaseClass* base = static_cast<Base::BaseClass*>(Base::Type::createInstanceByName(type,true));
-    if (!base) 
-        FC_THROWM(Base::RuntimeError, "Failed to create property " 
-                << pc.getFullName() << '.' << name << " of type " << type);
-    if (!base->getTypeId().isDerivedFrom(Property::getClassTypeId())) {
-        delete base;
-        FC_THROWM(Base::ValueError, "Invalid type " << type << " for property " << pc.getFullName() << '.' << name);
+    Base::Type propType = Base::Type::getTypeIfDerivedFrom(type, App::Property::getClassTypeId(), true);
+    if (propType.isBad()) {
+        FC_THROWM(Base::ValueError, "Invalid type "
+                << type << " for property " << pc.getFullName() << '.' << name);
     }
 
-    // get unique name
-    Property* pcProperty = static_cast<Property*>(base);
+    void* propInstance = propType.createInstance();
+    if (!propInstance) {
+        FC_THROWM(Base::RuntimeError, "Failed to create property "
+                << pc.getFullName() << '.' << name << " of type " << type);
+    }
+
+    Property* pcProperty = static_cast<Property*>(propInstance);
 
     auto res = props.get<0>().emplace(pcProperty,name, nullptr, group, doc, attr, ro, hidden);
 
     pcProperty->setContainer(&pc);
     pcProperty->myName = res.first->name.c_str();
 
-    if(ro) attr |= Prop_ReadOnly;
-    if(hidden) attr |= Prop_Hidden;
+    if(ro)
+        attr |= Prop_ReadOnly;
+    if(hidden)
+        attr |= Prop_Hidden;
 
     pcProperty->syncType(attr);
     pcProperty->StatusBits.set((size_t)Property::PropDynamic);

--- a/src/Base/Type.cpp
+++ b/src/Base/Type.cpp
@@ -234,3 +234,16 @@ int Type::getNumTypes(void)
 {
   return typedata.size();
 }
+
+Type Type::getTypeIfDerivedFrom(const char* name , const Type parent, bool bLoadModule)
+{
+  if (bLoadModule)
+    importModule(name);
+
+  Type type = fromName(name);
+
+  if (type.isDerivedFrom(parent))
+    return type;
+  else
+    return Type::badType();
+}

--- a/src/Base/Type.h
+++ b/src/Base/Type.h
@@ -101,6 +101,8 @@ public:
   bool isDerivedFrom(const Type type) const;
 
   static int getAllDerivedFrom(const Type type, std::vector<Type>& List);
+  /// Returns the given named type if is derived from parent type, otherwise return bad type
+  static Type getTypeIfDerivedFrom(const char* name , const Type parent, bool bLoadModule=false);
 
   static int getNumTypes(void);
 


### PR DESCRIPTION
Attempting to delete through a pointer to Base::BaseClass result in undefined behavior for those classes which don't inherit from Base::BaseClass.
Example for reproduce a crash from Python command line:
App.ActiveDocument.addObject("App::DocumentObjectExtension")
#segmentation fault.

In the Python implementation of Base::Type, calls to getPyObject() from classes that don't have the method also generates segmentation fault, for example:
e = App.Base.TypeId.fromName("App::LinkExtensionPython")
e.createInstance()
#segmentation fault

A new function "Type::getTypeIfDerivedFrom" is created to return the given named type if is derived from the specified class, otherwise return Type::badType.

The strategy to prevent these crashes is as follows:
use getTypeIfDerivedFrom to check the Type. If this happens correctly, check if the generated pointer in the static_cast is null.
(for example, adding a property of the type "App::Property" corresponds to the latter case) 

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [ ]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
