### PR TITLE
[Core] Add checks for conflicting accelerators

### DIFF
--- a/src/Gui/Command.h
+++ b/src/Gui/Command.h
@@ -330,6 +330,7 @@ protected:
     /// Applies the menu text, tool and status tip to the passed action object
     void applyCommandData(const char* context, Action* );
     const char* keySequenceToAccel(int) const;
+    void printConflictingAccelerators() const;
     //@}
 
 public:
@@ -871,6 +872,14 @@ public:
 
     void addCommandMode(const char* sContext, const char* sName);
     void updateCommands(const char* sContext, int mode);
+
+    /** 
+     * Returns a pointer to a conflicting command, or nullptr if there is no conflict.
+     * In the case of multiple conflicts, only the first is returned. 
+     * \param accel The accelerator to check
+     * \param ignore (optional) A command to ignore matches with
+     */
+    const Command* checkAcceleratorForConflicts(const char* accel, const Command *ignore = nullptr) const;
 
 private:
     /// Destroys all commands in the manager and empties the list.


### PR DESCRIPTION
When compiled in debug mode, this PR adds code to check for conflicting accelerator keys when a command is created. This can help developers ensure that their default accelerator key selections don't conflict. The actual check function is publicly accessible from the `CommandManager`, so other code that wants to change or update accelerators can call it to verify that a choice is valid and non-conflicting. This code detects both complete conflicts, as well as "blockers" (that is, a key combination that will prevent another from working).

---

- [X]  Your pull request is confined strictly to a single module
- [X]  Small change
- [X]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master
- [X]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) 
- [X]  Your pull request is well written and has a good description, and its title starts with the module name
- [X] No ticket
