### PR TITLE
[Path] Fix for inactive ramp dressup base operation

### DIFF
--- a/src/Mod/Path/PathScripts/PathDressupRampEntry.py
+++ b/src/Mod/Path/PathScripts/PathDressupRampEntry.py
@@ -32,7 +32,8 @@ from PySide import QtCore
 
 # lazily loaded modules
 from lazy_loader.lazy_loader import LazyLoader
-Part = LazyLoader('Part', globals(), 'Part')
+
+Part = LazyLoader("Part", globals(), "Part")
 
 if FreeCAD.GuiUp:
     import FreeCADGui
@@ -47,18 +48,67 @@ PathLog.setLevel(PathLog.Level.INFO, PathLog.thisModule())
 
 
 class ObjectDressup:
-
     def __init__(self, obj):
         self.obj = obj
-        obj.addProperty("App::PropertyLink", "Base", "Path", QtCore.QT_TRANSLATE_NOOP("Path_DressupRampEntry", "The base path to modify"))
-        obj.addProperty("App::PropertyAngle", "Angle", "Path", QtCore.QT_TRANSLATE_NOOP("Path_DressupRampEntry", "Angle of ramp."))
-        obj.addProperty("App::PropertyEnumeration", "Method", "Path", QtCore.QT_TRANSLATE_NOOP("App::Property", "Ramping Method"))
-        obj.addProperty("App::PropertyEnumeration", "RampFeedRate", "FeedRate", QtCore.QT_TRANSLATE_NOOP("App::Property", "Which feed rate to use for ramping"))
-        obj.addProperty("App::PropertySpeed", "CustomFeedRate", "FeedRate", QtCore.QT_TRANSLATE_NOOP("App::Property", "Custom feed rate"))
-        obj.addProperty("App::PropertyBool", "UseStartDepth", "StartDepth", QtCore.QT_TRANSLATE_NOOP("App::Property", "Should the dressup ignore motion commands above DressupStartDepth"))
-        obj.addProperty("App::PropertyDistance", "DressupStartDepth", "StartDepth", QtCore.QT_TRANSLATE_NOOP("App::Property", "The depth where the ramp dressup is enabled. Above this ramps are not generated, but motion commands are passed through as is."))
-        obj.Method = ['RampMethod1', 'RampMethod2', 'RampMethod3', 'Helix']
-        obj.RampFeedRate = ['Horizontal Feed Rate', 'Vertical Feed Rate', 'Ramp Feed Rate', 'Custom']
+        obj.addProperty(
+            "App::PropertyLink",
+            "Base",
+            "Path",
+            QtCore.QT_TRANSLATE_NOOP(
+                "Path_DressupRampEntry", "The base path to modify"
+            ),
+        )
+        obj.addProperty(
+            "App::PropertyAngle",
+            "Angle",
+            "Path",
+            QtCore.QT_TRANSLATE_NOOP("Path_DressupRampEntry", "Angle of ramp."),
+        )
+        obj.addProperty(
+            "App::PropertyEnumeration",
+            "Method",
+            "Path",
+            QtCore.QT_TRANSLATE_NOOP("App::Property", "Ramping Method"),
+        )
+        obj.addProperty(
+            "App::PropertyEnumeration",
+            "RampFeedRate",
+            "FeedRate",
+            QtCore.QT_TRANSLATE_NOOP(
+                "App::Property", "Which feed rate to use for ramping"
+            ),
+        )
+        obj.addProperty(
+            "App::PropertySpeed",
+            "CustomFeedRate",
+            "FeedRate",
+            QtCore.QT_TRANSLATE_NOOP("App::Property", "Custom feed rate"),
+        )
+        obj.addProperty(
+            "App::PropertyBool",
+            "UseStartDepth",
+            "StartDepth",
+            QtCore.QT_TRANSLATE_NOOP(
+                "App::Property",
+                "Should the dressup ignore motion commands above DressupStartDepth",
+            ),
+        )
+        obj.addProperty(
+            "App::PropertyDistance",
+            "DressupStartDepth",
+            "StartDepth",
+            QtCore.QT_TRANSLATE_NOOP(
+                "App::Property",
+                "The depth where the ramp dressup is enabled. Above this ramps are not generated, but motion commands are passed through as is.",
+            ),
+        )
+        obj.Method = ["RampMethod1", "RampMethod2", "RampMethod3", "Helix"]
+        obj.RampFeedRate = [
+            "Horizontal Feed Rate",
+            "Vertical Feed Rate",
+            "Ramp Feed Rate",
+            "Custom",
+        ]
         obj.Proxy = self
         self.setEditorProperties(obj)
 
@@ -82,16 +132,16 @@ class ObjectDressup:
             self.setEditorProperties(obj)
 
     def setEditorProperties(self, obj):
-        if hasattr(obj, 'UseStartDepth'):
+        if hasattr(obj, "UseStartDepth"):
             if obj.UseStartDepth:
-                obj.setEditorMode('DressupStartDepth', 0)
+                obj.setEditorMode("DressupStartDepth", 0)
             else:
-                obj.setEditorMode('DressupStartDepth', 2)
+                obj.setEditorMode("DressupStartDepth", 2)
 
-        if obj.RampFeedRate == 'Custom':
-            obj.setEditorMode('CustomFeedRate', 0)
+        if obj.RampFeedRate == "Custom":
+            obj.setEditorMode("CustomFeedRate", 0)
         else:
-            obj.setEditorMode('CustomFeedRate', 2)
+            obj.setEditorMode("CustomFeedRate", 2)
 
     def onDocumentRestored(self, obj):
         self.setEditorProperties(obj)
@@ -130,7 +180,7 @@ class ObjectDressup:
         self.angle = obj.Angle
         self.method = obj.Method
         self.wire, self.rapids = PathGeom.wireForPath(obj.Base.Path)
-        if self.method in ['RampMethod1', 'RampMethod2', 'RampMethod3']:
+        if self.method in ["RampMethod1", "RampMethod2", "RampMethod3"]:
             self.outedges = self.generateRamps()
         else:
             self.outedges = self.generateHelix()
@@ -149,7 +199,12 @@ class ObjectDressup:
                 p0 = edge.Vertexes[0].Point
                 p1 = edge.Vertexes[1].Point
                 rampangle = self.angle
-                if bb.XLength < 1e-6 and bb.YLength < 1e-6 and bb.ZLength > 0 and p0.z > p1.z:
+                if (
+                    bb.XLength < 1e-6
+                    and bb.YLength < 1e-6
+                    and bb.ZLength > 0
+                    and p0.z > p1.z
+                ):
 
                     # check if above ignoreAbove parameter - do not generate ramp if it is
                     newEdge, cont = self.checkIgnoreAbove(edge)
@@ -160,9 +215,15 @@ class ObjectDressup:
                         continue
 
                     plungelen = abs(p0.z - p1.z)
-                    projectionlen = plungelen * math.tan(math.radians(rampangle))  # length of the forthcoming ramp projected to XY plane
-                    PathLog.debug("Found plunge move at X:{} Y:{} From Z:{} to Z{}, length of ramp: {}".format(p0.x, p0.y, p0.z, p1.z, projectionlen))
-                    if self.method == 'RampMethod3':
+                    projectionlen = plungelen * math.tan(
+                        math.radians(rampangle)
+                    )  # length of the forthcoming ramp projected to XY plane
+                    PathLog.debug(
+                        "Found plunge move at X:{} Y:{} From Z:{} to Z{}, length of ramp: {}".format(
+                            p0.x, p0.y, p0.z, p1.z, projectionlen
+                        )
+                    )
+                    if self.method == "RampMethod3":
                         projectionlen = projectionlen / 2
 
                     # next need to determine how many edges in the path after
@@ -188,34 +249,58 @@ class ObjectDressup:
                         if i >= len(edges):
                             break
                     if len(rampedges) == 0:
-                        PathLog.debug("No suitable edges for ramping, plunge will remain as such")
+                        PathLog.debug(
+                            "No suitable edges for ramping, plunge will remain as such"
+                        )
                         outedges.append(edge)
                     else:
                         if not covered:
-                            if (not allowBounce) or self.method == 'RampMethod2':
+                            if (not allowBounce) or self.method == "RampMethod2":
                                 l = 0
                                 for redge in rampedges:
                                     l = l + redge.Length
-                                if self.method == 'RampMethod3':
-                                    rampangle = math.degrees(math.atan(l / (plungelen / 2)))
+                                if self.method == "RampMethod3":
+                                    rampangle = math.degrees(
+                                        math.atan(l / (plungelen / 2))
+                                    )
                                 else:
                                     rampangle = math.degrees(math.atan(l / plungelen))
-                                PathLog.warning("Cannot cover with desired angle, tightening angle to: {}".format(rampangle))
+                                PathLog.warning(
+                                    "Cannot cover with desired angle, tightening angle to: {}".format(
+                                        rampangle
+                                    )
+                                )
 
                         # PathLog.debug("Doing ramp to edges: {}".format(rampedges))
-                        if self.method == 'RampMethod1':
-                            outedges.extend(self.createRampMethod1(rampedges, p0, projectionlen, rampangle))
-                        elif self.method == 'RampMethod2':
-                            outedges.extend(self.createRampMethod2(rampedges, p0, projectionlen, rampangle))
+                        if self.method == "RampMethod1":
+                            outedges.extend(
+                                self.createRampMethod1(
+                                    rampedges, p0, projectionlen, rampangle
+                                )
+                            )
+                        elif self.method == "RampMethod2":
+                            outedges.extend(
+                                self.createRampMethod2(
+                                    rampedges, p0, projectionlen, rampangle
+                                )
+                            )
                         else:
                             # if the ramp cannot be covered with Method3, revert to Method1
                             # because Method1 support going back-and-forth and thus results in same path as Method3 when
                             # length of the ramp is smaller than needed for single ramp.
                             if (not covered) and allowBounce:
                                 projectionlen = projectionlen * 2
-                                outedges.extend(self.createRampMethod1(rampedges, p0, projectionlen, rampangle))
+                                outedges.extend(
+                                    self.createRampMethod1(
+                                        rampedges, p0, projectionlen, rampangle
+                                    )
+                                )
                             else:
-                                outedges.extend(self.createRampMethod3(rampedges, p0, projectionlen, rampangle))
+                                outedges.extend(
+                                    self.createRampMethod3(
+                                        rampedges, p0, projectionlen, rampangle
+                                    )
+                                )
                 else:
                     outedges.append(edge)
             else:
@@ -238,9 +323,18 @@ class ObjectDressup:
                 bb = edge.BoundBox
                 p0 = edge.Vertexes[0].Point
                 p1 = edge.Vertexes[1].Point
-                if bb.XLength < 1e-6 and bb.YLength < 1e-6 and bb.ZLength > 0 and p0.z > p1.z:
+                if (
+                    bb.XLength < 1e-6
+                    and bb.YLength < 1e-6
+                    and bb.ZLength > 0
+                    and p0.z > p1.z
+                ):
                     # plungelen = abs(p0.z-p1.z)
-                    PathLog.debug("Found plunge move at X:{} Y:{} From Z:{} to Z{}, Searching for closed loop".format(p0.x, p0.y, p0.z, p1.z))
+                    PathLog.debug(
+                        "Found plunge move at X:{} Y:{} From Z:{} to Z{}, Searching for closed loop".format(
+                            p0.x, p0.y, p0.z, p1.z
+                        )
+                    )
                     # check if above ignoreAbove parameter - do not generate helix if it is
                     newEdge, cont = self.checkIgnoreAbove(edge)
                     if newEdge is not None:
@@ -291,11 +385,18 @@ class ObjectDressup:
         if self.ignoreAboveEnabled:
             p0 = edge.Vertexes[0].Point
             p1 = edge.Vertexes[1].Point
-            if p0.z > self.ignoreAbove and (p1.z > self.ignoreAbove or PathGeom.isRoughly(p1.z, self.ignoreAbove.Value)):
+            if p0.z > self.ignoreAbove and (
+                p1.z > self.ignoreAbove
+                or PathGeom.isRoughly(p1.z, self.ignoreAbove.Value)
+            ):
                 PathLog.debug("Whole plunge move above 'ignoreAbove', ignoring")
                 return (edge, True)
-            elif p0.z > self.ignoreAbove and not PathGeom.isRoughly(p0.z, self.ignoreAbove.Value):
-                PathLog.debug("Plunge move partially above 'ignoreAbove', splitting into two")
+            elif p0.z > self.ignoreAbove and not PathGeom.isRoughly(
+                p0.z, self.ignoreAbove.Value
+            ):
+                PathLog.debug(
+                    "Plunge move partially above 'ignoreAbove', splitting into two"
+                )
                 newPoint = FreeCAD.Base.Vector(p0.x, p0.y, self.ignoreAbove)
                 return (Part.makeLine(p0, newPoint), False)
             else:
@@ -314,7 +415,11 @@ class ObjectDressup:
         for i, redge in enumerate(rampedges):
             if i < len(rampedges) - 1:
                 deltaZ = redge.Length / math.tan(rampangle_rad)
-                newPoint = FreeCAD.Base.Vector(redge.valueAt(redge.LastParameter).x, redge.valueAt(redge.LastParameter).y, curPoint.z - deltaZ)
+                newPoint = FreeCAD.Base.Vector(
+                    redge.valueAt(redge.LastParameter).x,
+                    redge.valueAt(redge.LastParameter).y,
+                    curPoint.z - deltaZ,
+                )
                 outedges.append(self.createRampEdge(redge, curPoint, newPoint))
                 curPoint = newPoint
             else:
@@ -325,10 +430,15 @@ class ObjectDressup:
 
     def createRampEdge(self, originalEdge, startPoint, endPoint):
         # PathLog.debug("Create edge from [{},{},{}] to [{},{},{}]".format(startPoint.x,startPoint.y, startPoint.z, endPoint.x, endPoint.y, endPoint.z))
-        if type(originalEdge.Curve) == Part.Line or type(originalEdge.Curve) == Part.LineSegment:
+        if (
+            type(originalEdge.Curve) == Part.Line
+            or type(originalEdge.Curve) == Part.LineSegment
+        ):
             return Part.makeLine(startPoint, endPoint)
         elif type(originalEdge.Curve) == Part.Circle:
-            arcMid = originalEdge.valueAt((originalEdge.FirstParameter + originalEdge.LastParameter) / 2)
+            arcMid = originalEdge.valueAt(
+                (originalEdge.FirstParameter + originalEdge.LastParameter) / 2
+            )
             arcMid.z = (startPoint.z + endPoint.z) / 2
             return Part.Arc(startPoint, arcMid, endPoint).toShape()
         else:
@@ -391,22 +501,38 @@ class ObjectDressup:
                     p1 = self.getSplitPoint(redge, rampremaining)
                     splitEdge = PathGeom.splitEdgeAt(redge, p1)
                     PathLog.debug("Ramp remaining: {}".format(rampremaining))
-                    PathLog.debug("Got split edge (index: {}) (total len: {}) with lengths: {}, {}".format(i, redge.Length, splitEdge[0].Length, splitEdge[1].Length))
+                    PathLog.debug(
+                        "Got split edge (index: {}) (total len: {}) with lengths: {}, {}".format(
+                            i, redge.Length, splitEdge[0].Length, splitEdge[1].Length
+                        )
+                    )
                     # ramp ends to the last point of first edge
                     p1 = splitEdge[0].valueAt(splitEdge[0].LastParameter)
                     outedges.append(self.createRampEdge(splitEdge[0], curPoint, p1))
                     # now we have reached the end of the ramp. Go back to plunge position with constant Z
                     # start that by going to the beginning of this splitEdge
                     if goingForward:
-                        outedges.append(self.createRampEdge(splitEdge[0], p1, redge.valueAt(redge.FirstParameter)))
+                        outedges.append(
+                            self.createRampEdge(
+                                splitEdge[0], p1, redge.valueAt(redge.FirstParameter)
+                            )
+                        )
                     else:
                         # if we were reversing, we continue to the same direction as the ramp
-                        outedges.append(self.createRampEdge(splitEdge[0], p1, redge.valueAt(redge.LastParameter)))
+                        outedges.append(
+                            self.createRampEdge(
+                                splitEdge[0], p1, redge.valueAt(redge.LastParameter)
+                            )
+                        )
                     done = True
                     break
                 else:
                     deltaZ = redge.Length / math.tan(math.radians(rampangle))
-                    newPoint = FreeCAD.Base.Vector(redge.valueAt(redge.LastParameter).x, redge.valueAt(redge.LastParameter).y, curPoint.z - deltaZ)
+                    newPoint = FreeCAD.Base.Vector(
+                        redge.valueAt(redge.LastParameter).x,
+                        redge.valueAt(redge.LastParameter).y,
+                        curPoint.z - deltaZ,
+                    )
                     outedges.append(self.createRampEdge(redge, curPoint, newPoint))
                     curPoint = newPoint
                     rampremaining = rampremaining - redge.Length
@@ -427,7 +553,7 @@ class ObjectDressup:
         else:
             # if the ramp was already reversing, the edges needed for return are the ones
             # which were not covered in ramp
-            returnedges = rampedges[(i + 1):]
+            returnedges = rampedges[(i + 1) :]
 
         # add the return edges:
         outedges.extend(returnedges)
@@ -457,7 +583,11 @@ class ObjectDressup:
                     # will reach end of ramp within this edge, needs to be split
                     p1 = self.getSplitPoint(redge, rampremaining)
                     splitEdge = PathGeom.splitEdgeAt(redge, p1)
-                    PathLog.debug("Got split edge (index: {}) with lengths: {}, {}".format(i, splitEdge[0].Length, splitEdge[1].Length))
+                    PathLog.debug(
+                        "Got split edge (index: {}) with lengths: {}, {}".format(
+                            i, splitEdge[0].Length, splitEdge[1].Length
+                        )
+                    )
                     # ramp ends to the last point of first edge
                     p1 = splitEdge[0].valueAt(splitEdge[0].LastParameter)
                     deltaZ = splitEdge[0].Length / math.tan(math.radians(rampangle))
@@ -478,13 +608,21 @@ class ObjectDressup:
                     p1.z = curPoint.z - deltaZ
                     outedges.append(self.createRampEdge(redge, curPoint, p1))
                     # and go back that edge
-                    newPoint = FreeCAD.Base.Vector(redge.valueAt(redge.FirstParameter).x, redge.valueAt(redge.FirstParameter).y, p1.z - deltaZ)
+                    newPoint = FreeCAD.Base.Vector(
+                        redge.valueAt(redge.FirstParameter).x,
+                        redge.valueAt(redge.FirstParameter).y,
+                        p1.z - deltaZ,
+                    )
                     outedges.append(self.createRampEdge(redge, p1, newPoint))
                     curPoint = newPoint
                     done = True
                 else:
                     deltaZ = redge.Length / math.tan(math.radians(rampangle))
-                    newPoint = FreeCAD.Base.Vector(redge.valueAt(redge.LastParameter).x, redge.valueAt(redge.LastParameter).y, curPoint.z - deltaZ)
+                    newPoint = FreeCAD.Base.Vector(
+                        redge.valueAt(redge.LastParameter).x,
+                        redge.valueAt(redge.LastParameter).y,
+                        curPoint.z - deltaZ,
+                    )
                     outedges.append(self.createRampEdge(redge, curPoint, newPoint))
                     curPoint = newPoint
                     rampremaining = rampremaining - redge.Length
@@ -494,7 +632,11 @@ class ObjectDressup:
         # ramp backwards to the plunge position
         for i, redge in enumerate(returnedges):
             deltaZ = redge.Length / math.tan(math.radians(rampangle))
-            newPoint = FreeCAD.Base.Vector(redge.valueAt(redge.LastParameter).x, redge.valueAt(redge.LastParameter).y, curPoint.z - deltaZ)
+            newPoint = FreeCAD.Base.Vector(
+                redge.valueAt(redge.LastParameter).x,
+                redge.valueAt(redge.LastParameter).y,
+                curPoint.z - deltaZ,
+            )
             if i == len(rampedges) - 1:
                 # make sure that the last point of the ramps ends to the original position
                 newPoint = redge.valueAt(redge.LastParameter)
@@ -516,15 +658,24 @@ class ObjectDressup:
         outedges = []
         rampremaining = projectionlen
         curPoint = p0  # start from the upper point of plunge
-        if PathGeom.pointsCoincide(PathGeom.xy(p0), PathGeom.xy(rampedges[-1].valueAt(rampedges[-1].LastParameter))):
-            PathLog.debug("The ramp forms a closed wire, needless to move on original Z height")
+        if PathGeom.pointsCoincide(
+            PathGeom.xy(p0),
+            PathGeom.xy(rampedges[-1].valueAt(rampedges[-1].LastParameter)),
+        ):
+            PathLog.debug(
+                "The ramp forms a closed wire, needless to move on original Z height"
+            )
         else:
             for i, redge in enumerate(rampedges):
                 if redge.Length >= rampremaining:
                     # this edge needs to be split
                     p1 = self.getSplitPoint(redge, rampremaining)
                     splitEdge = PathGeom.splitEdgeAt(redge, p1)
-                    PathLog.debug("Got split edges with lengths: {}, {}".format(splitEdge[0].Length, splitEdge[1].Length))
+                    PathLog.debug(
+                        "Got split edges with lengths: {}, {}".format(
+                            splitEdge[0].Length, splitEdge[1].Length
+                        )
+                    )
                     # ramp starts at the last point of first edge
                     p1 = splitEdge[0].valueAt(splitEdge[0].LastParameter)
                     p1.z = p0.z
@@ -532,7 +683,11 @@ class ObjectDressup:
                     # now we have reached the beginning of the ramp.
                     # start that by going to the beginning of this splitEdge
                     deltaZ = splitEdge[0].Length / math.tan(math.radians(rampangle))
-                    newPoint = FreeCAD.Base.Vector(splitEdge[0].valueAt(splitEdge[0].FirstParameter).x, splitEdge[0].valueAt(splitEdge[0].FirstParameter).y, p1.z - deltaZ)
+                    newPoint = FreeCAD.Base.Vector(
+                        splitEdge[0].valueAt(splitEdge[0].FirstParameter).x,
+                        splitEdge[0].valueAt(splitEdge[0].FirstParameter).y,
+                        p1.z - deltaZ,
+                    )
                     outedges.append(self.createRampEdge(splitEdge[0], p1, newPoint))
                     curPoint = newPoint
                 elif i == len(rampedges) - 1:
@@ -544,13 +699,21 @@ class ObjectDressup:
                     outedges.append(self.createRampEdge(redge, curPoint, p1))
                     # and go back that edge
                     deltaZ = redge.Length / math.tan(math.radians(rampangle))
-                    newPoint = FreeCAD.Base.Vector(redge.valueAt(redge.FirstParameter).x, redge.valueAt(redge.FirstParameter).y, p1.z - deltaZ)
+                    newPoint = FreeCAD.Base.Vector(
+                        redge.valueAt(redge.FirstParameter).x,
+                        redge.valueAt(redge.FirstParameter).y,
+                        p1.z - deltaZ,
+                    )
                     outedges.append(self.createRampEdge(redge, p1, newPoint))
                     curPoint = newPoint
 
                 else:
                     # we are traveling on start depth
-                    newPoint = FreeCAD.Base.Vector(redge.valueAt(redge.LastParameter).x, redge.valueAt(redge.LastParameter).y, p0.z)
+                    newPoint = FreeCAD.Base.Vector(
+                        redge.valueAt(redge.LastParameter).x,
+                        redge.valueAt(redge.LastParameter).y,
+                        p0.z,
+                    )
                     outedges.append(self.createRampEdge(redge, curPoint, newPoint))
                     curPoint = newPoint
                     rampremaining = rampremaining - redge.Length
@@ -560,7 +723,11 @@ class ObjectDressup:
         # ramp backwards to the plunge position
         for i, redge in enumerate(reversed(rampedges)):
             deltaZ = redge.Length / math.tan(math.radians(rampangle))
-            newPoint = FreeCAD.Base.Vector(redge.valueAt(redge.FirstParameter).x, redge.valueAt(redge.FirstParameter).y, curPoint.z - deltaZ)
+            newPoint = FreeCAD.Base.Vector(
+                redge.valueAt(redge.FirstParameter).x,
+                redge.valueAt(redge.FirstParameter).y,
+                curPoint.z - deltaZ,
+            )
             if i == len(rampedges) - 1:
                 # make sure that the last point of the ramps ends to the original position
                 newPoint = redge.valueAt(redge.FirstParameter)
@@ -578,11 +745,11 @@ class ObjectDressup:
                     israpid = True
             if israpid:
                 v = edge.valueAt(edge.LastParameter)
-                commands.append(Path.Command('G0', {'X': v.x, 'Y': v.y, 'Z': v.z}))
+                commands.append(Path.Command("G0", {"X": v.x, "Y": v.y, "Z": v.z}))
             else:
                 commands.extend(PathGeom.cmdsForEdge(edge))
 
-        lastCmd = Path.Command('G0', {'X': 0.0, 'Y': 0.0, 'Z': 0.0})
+        lastCmd = Path.Command("G0", {"X": 0.0, "Y": 0.0, "Z": 0.0})
 
         outCommands = []
 
@@ -595,7 +762,7 @@ class ObjectDressup:
             rampFeed = tc.HorizFeed.Value
         elif obj.RampFeedRate == "Vertical Feed Rate":
             rampFeed = tc.VertFeed.Value
-        elif obj.RampFeedRate == 'Ramp Feed Rate':
+        elif obj.RampFeedRate == "Ramp Feed Rate":
             rampFeed = math.sqrt(pow(tc.VertFeed.Value, 2) + pow(tc.HorizFeed.Value, 2))
         else:
             rampFeed = obj.CustomFeedRate.Value
@@ -605,35 +772,37 @@ class ObjectDressup:
 
         for cmd in commands:
             params = cmd.Parameters
-            zVal = params.get('Z', None)
-            zVal2 = lastCmd.Parameters.get('Z', None)
+            zVal = params.get("Z", None)
+            zVal2 = lastCmd.Parameters.get("Z", None)
 
-            xVal = params.get('X', None)
-            xVal2 = lastCmd.Parameters.get('X', None)
+            xVal = params.get("X", None)
+            xVal2 = lastCmd.Parameters.get("X", None)
 
-            yVal2 = lastCmd.Parameters.get('Y', None)
-            yVal = params.get('Y', None)
+            yVal2 = lastCmd.Parameters.get("Y", None)
+            yVal = params.get("Y", None)
 
             zVal = zVal and round(zVal, 8)
             zVal2 = zVal2 and round(zVal2, 8)
 
-            if cmd.Name in ['G1', 'G2', 'G3', 'G01', 'G02', 'G03']:
+            if cmd.Name in ["G1", "G2", "G3", "G01", "G02", "G03"]:
                 if zVal is not None and zVal2 != zVal:
-                    if PathGeom.isRoughly(xVal, xVal2) and PathGeom.isRoughly(yVal, yVal2):
+                    if PathGeom.isRoughly(xVal, xVal2) and PathGeom.isRoughly(
+                        yVal, yVal2
+                    ):
                         # this is a straight plunge
-                        params['F'] = vertFeed
+                        params["F"] = vertFeed
                     else:
                         # this is a ramp
-                        params['F'] = rampFeed
+                        params["F"] = rampFeed
                 else:
-                    params['F'] = horizFeed
+                    params["F"] = horizFeed
                 lastCmd = cmd
 
-            elif cmd.Name in ['G0', 'G00']:
+            elif cmd.Name in ["G0", "G00"]:
                 if zVal is not None and zVal2 != zVal:
-                    params['F'] = vertRapid
+                    params["F"] = vertRapid
                 else:
-                    params['F'] = horizRapid
+                    params["F"] = horizRapid
                 lastCmd = cmd
 
             outCommands.append(Path.Command(cmd.Name, params))
@@ -642,7 +811,6 @@ class ObjectDressup:
 
 
 class ViewProviderDressup:
-
     def __init__(self, vobj):
         self.obj = vobj.Object
 
@@ -663,7 +831,7 @@ class ViewProviderDressup:
         return [self.obj.Base]
 
     def onDelete(self, arg1=None, arg2=None):
-        '''this makes sure that the base operation is added back to the project and visible'''
+        """this makes sure that the base operation is added back to the project and visible"""
         # pylint: disable=unused-argument
         PathLog.debug("Deleting Dressup")
         if arg1.Object and arg1.Object.Base:
@@ -685,9 +853,16 @@ class CommandPathDressupRampEntry:
     # pylint: disable=no-init
 
     def GetResources(self):
-        return {'Pixmap': 'Path_Dressup',
-                'MenuText': QtCore.QT_TRANSLATE_NOOP("Path_DressupRampEntry", "RampEntry Dress-up"),
-                'ToolTip': QtCore.QT_TRANSLATE_NOOP("Path_DressupRampEntry", "Creates a Ramp Entry Dress-up object from a selected path")}
+        return {
+            "Pixmap": "Path_Dressup",
+            "MenuText": QtCore.QT_TRANSLATE_NOOP(
+                "Path_DressupRampEntry", "RampEntry Dress-up"
+            ),
+            "ToolTip": QtCore.QT_TRANSLATE_NOOP(
+                "Path_DressupRampEntry",
+                "Creates a Ramp Entry Dress-up object from a selected path",
+            ),
+        }
 
     def IsActive(self):
         op = PathDressup.selection()
@@ -714,21 +889,29 @@ class CommandPathDressupRampEntry:
         FreeCAD.ActiveDocument.openTransaction(translate("Create RampEntry Dress-up"))
         FreeCADGui.addModule("PathScripts.PathDressupRampEntry")
         FreeCADGui.addModule("PathScripts.PathUtils")
-        FreeCADGui.doCommand('obj = FreeCAD.ActiveDocument.addObject("Path::FeaturePython", "RampEntryDressup")')
-        FreeCADGui.doCommand('dbo = PathScripts.PathDressupRampEntry.ObjectDressup(obj)')
-        FreeCADGui.doCommand('base = FreeCAD.ActiveDocument.' + selection[0].Name)
-        FreeCADGui.doCommand('job = PathScripts.PathUtils.findParentJob(base)')
-        FreeCADGui.doCommand('obj.Base = base')
-        FreeCADGui.doCommand('job.Proxy.addOperation(obj, base)')
-        FreeCADGui.doCommand('obj.ViewObject.Proxy = PathScripts.PathDressupRampEntry.ViewProviderDressup(obj.ViewObject)')
-        FreeCADGui.doCommand('Gui.ActiveDocument.getObject(base.Name).Visibility = False')
-        FreeCADGui.doCommand('dbo.setup(obj)')
+        FreeCADGui.doCommand(
+            'obj = FreeCAD.ActiveDocument.addObject("Path::FeaturePython", "RampEntryDressup")'
+        )
+        FreeCADGui.doCommand(
+            "dbo = PathScripts.PathDressupRampEntry.ObjectDressup(obj)"
+        )
+        FreeCADGui.doCommand("base = FreeCAD.ActiveDocument." + selection[0].Name)
+        FreeCADGui.doCommand("job = PathScripts.PathUtils.findParentJob(base)")
+        FreeCADGui.doCommand("obj.Base = base")
+        FreeCADGui.doCommand("job.Proxy.addOperation(obj, base)")
+        FreeCADGui.doCommand(
+            "obj.ViewObject.Proxy = PathScripts.PathDressupRampEntry.ViewProviderDressup(obj.ViewObject)"
+        )
+        FreeCADGui.doCommand(
+            "Gui.ActiveDocument.getObject(base.Name).Visibility = False"
+        )
+        FreeCADGui.doCommand("dbo.setup(obj)")
         FreeCAD.ActiveDocument.commitTransaction()
         FreeCAD.ActiveDocument.recompute()
 
 
 if FreeCAD.GuiUp:
     # register the FreeCAD command
-    FreeCADGui.addCommand('Path_DressupRampEntry', CommandPathDressupRampEntry())
+    FreeCADGui.addCommand("Path_DressupRampEntry", CommandPathDressupRampEntry())
 
 PathLog.notice("Loading Path_DressupRampEntry... done\n")

--- a/src/Mod/Path/PathScripts/PathDressupRampEntry.py
+++ b/src/Mod/Path/PathScripts/PathDressupRampEntry.py
@@ -109,12 +109,18 @@ class ObjectDressup:
             return
         if not obj.Base.Path:
             return
+
+        if not obj.Base.Active:
+            path = Path.Path("(inactive operation)")
+            obj.Path = path
+            return
+
         if obj.Angle >= 90:
             obj.Angle = 89.9
         elif obj.Angle <= 0:
             obj.Angle = 0.1
 
-        if hasattr(obj, 'UseStartDepth'):
+        if hasattr(obj, "UseStartDepth"):
             self.ignoreAboveEnabled = obj.UseStartDepth
             self.ignoreAbove = obj.DressupStartDepth
         else:


### PR DESCRIPTION
This PR has two commits.
- The first fixes the issue.  It adds a `Base.Active` check to determine if the Base is Active.  If the Base is Inactive, the new code sets the `obj.Path` property to the same inactive message used in PathOp module and the `execution()` method returns immediately, stopping further execution.
- The second is purely a Black code formatting application, which makes the PR much larger than the actual fix.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
