### PR TITLE
[Edit menu -> Copy / Duplicate] Add Use Original Selections button to…

### DIFF
--- a/src/Gui/DlgObjectSelection.h
+++ b/src/Gui/DlgObjectSelection.h
@@ -45,10 +45,14 @@ private Q_SLOTS:
     void onItemChanged(QTreeWidgetItem * item, int);
     void onItemSelectionChanged();
     void onDepSelectionChanged();
+    void onUseOriginalsBtnClicked();
 
 private:
     QTreeWidgetItem *createItem(App::DocumentObject *obj, QTreeWidgetItem *parent);
     App::DocumentObject *objFromItem(QTreeWidgetItem *item);
+    QPushButton *useOriginalsBtn;
+    std::vector<App::DocumentObject*> originalSelections;
+    bool returnOriginals = false;
 
 private:
     struct Info {


### PR DESCRIPTION
… dependency selection dialog

https://forum.freecadweb.org/viewtopic.php?f=3&t=61826&start=40#p530285

The new button enables the user to bypass dependency selection and simply duplicate/copy the objects the user originally selected prior to opening the dialog.  This dialog is used by both the Edit -> Copy command and the Edit -> Duplicate command.  In the current implementation (prior to this PR) the user must manually deselect the dependencies he does not wish to copy, which can be quite cumbersome.  With this PR he can easily bypass that operation and simply proceed with duplicating the objects he originally selected without any dependencies.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [ ]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [ ]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [ ]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [ ]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
