### PR TITLE
[TechDraw] prevent crash where user duplicates page without also dupl…

### DIFF
--- a/src/Mod/TechDraw/App/DrawView.cpp
+++ b/src/Mod/TechDraw/App/DrawView.cpp
@@ -239,6 +239,26 @@ void DrawView::onDocumentRestored()
     handleXYLock();
     DrawView::execute();
 }
+/**
+ * @brief DrawView::countParentPages
+ * Fixes a crash in TechDraw when user creates duplicate page without dependencies
+ * In fixOrphans() we check how many parent pages an object has before deleting
+ * in case it is also a child of another duplicate page
+ * @return
+ */
+int DrawView::countParentPages() const
+{
+    int count = 0;
+
+    std::vector<App::DocumentObject*> parent = getInList();
+    for (std::vector<App::DocumentObject*>::iterator it = parent.begin(); it != parent.end(); ++it) {
+        if ((*it)->getTypeId().isDerivedFrom(DrawPage::getClassTypeId())) {
+            //page = static_cast<TechDraw::DrawPage *>(*it);
+            count++;
+        }
+    }
+    return count;
+}
 
 DrawPage* DrawView::findParentPage() const
 {

--- a/src/Mod/TechDraw/App/DrawView.h
+++ b/src/Mod/TechDraw/App/DrawView.h
@@ -85,6 +85,7 @@ public:
     virtual PyObject *getPyObject(void) override;
 
     virtual DrawPage* findParentPage() const;
+    virtual int countParentPages() const;
     virtual QRectF getRect() const;                      //must be overridden by derived class
     virtual double autoScale(void) const;
     virtual double autoScale(double w, double h) const;

--- a/src/Mod/TechDraw/Gui/MDIViewPage.cpp
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.cpp
@@ -481,7 +481,11 @@ void MDIViewPage::fixOrphans(bool force)
             m_view->removeQView(qv);
         } else {
             TechDraw::DrawPage* pp = qv->getViewObject()->findParentPage();
-            if (thisPage != pp) {
+            /** avoid crash where a view might have more than one parent page
+             * if the user duplicated the page without duplicating dependencies
+             */
+            int numParentPages = qv->getViewObject()->countParentPages();
+            if (thisPage != pp && numParentPages == 1) {
                m_view->removeQView(qv);
             }
         }


### PR DESCRIPTION
…icating dependencies

This fixes the crash caused when a user duplicates a page using Edit menu -> Duplicate and presses "Use Original Selections" button or simply deselects all of the page's dependencies.  See https://github.com/FreeCAD/FreeCAD/pull/5010

I don't know enough about TechDraw to know what unintended side effects this might have.  It prevents removing the child view if the child view has more than one parent page in fixOrphans() function.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [ ]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [ ]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [ ]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [ ]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
