### PR TITLE
[TechDraw] prevent crash where user has duplicated page without depen…

### DIFF
--- a/src/Mod/TechDraw/Gui/MDIViewPage.cpp
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.cpp
@@ -485,7 +485,7 @@ void MDIViewPage::fixOrphans(bool force)
              * if the user duplicated the page without duplicating dependencies
              */
             int numParentPages = qv->getViewObject()->countParentPages();
-            if (thisPage != pp && numParentPages == 1) {
+            if (thisPage != pp && numParentPages == 0) {
                m_view->removeQView(qv);
             }
         }


### PR DESCRIPTION
…dencies and then tries to remove a view from one of the pages by editing the Views property

This PR prevents the crash where the user edits the Views property of a TechDraw page to remove a view that also exists in another page.

Note: this also provides a means for a user who has duplicated a page without also duplicating the views, dimensions, template, etc. to delete the duplicate page without also deleting all of its content (which also deletes it from all duplicate pages).  The way to do this is to edit the Views property of the page to remove the views from that page before deleting that page.  Ditto for the Template property.

Let's say the original document has:

```
Page
    ->Template
    -> View
        -> Dimension
```
A duplicate is made without dependencies, so now you also have:
```
Page001
    ->Template
    -> View
        -> Dimension
```
Prior to this PR if you edit either page's Views property to remove the View or the Dimension or both, you get a crash.  After the PR if a user wishes to remove Dimension from Page or Page001 and still retain it in the other page he can do so by editing the Views property.

Normally, the way you would remove a Dimension is to simply delete it, but if you do this and it also exists in a duplicate page it gets removed from both pages.  This would be consistent with behavior in other workbenches.  For example, if you have a Cut object made from a Cylinder and a Cube and you duplicate the Cut without dependencies, and then you delete the Cube form the Cut001 object you also delete it from the original Cut and indeed the Cube is deleted from the document.  But the difference is if you delete Cut001 made in this manner it does not also delete Cube and Cylinder, which doesn't break original Cut object.  In TechDraw if you delete Page001 in the above example it also deletes Template, View, and Dimension from the document, breaking Page (or at least deleting all of its content, which might be the desired behavior in some cases).  IMO, deleting Page001 should not also delete all of its content if that content also exists in another page, but I haven't worked out yet how to accomplish this.  Right now, I'm satisfied to just prevent a crash.


Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [ ]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [ ]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [ ]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [ ]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
