### PR TITLE
Sketcher: fix mislabeled .ui cstring tag 

### DIFF
--- a/src/Mod/Sketcher/Gui/SketcherSettingsDisplay.ui
+++ b/src/Mod/Sketcher/Gui/SketcherSettingsDisplay.ui
@@ -266,7 +266,7 @@ Defaults to: %N = %V
          <string>DimensionalStringFormat</string>
         </property>
         <property name="prefPath" stdset="0">
-         <string>Mod/Sketcher</string>
+         <cstring>Mod/Sketcher</cstring>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
Closes https://github.com/FreeCAD/FreeCAD-translations/issues/59  
Thanks @jakub-swierk for the patch!  

@yorikvanhavre the next crowdin push is tomorrow, this fix should be merged before that. Thanks!