### PR TITLE
Gui: Make DlgSettingsNavigation methods conform to naming standard 

### DIFF
--- a/src/Gui/DlgSettingsNavigation.cpp
+++ b/src/Gui/DlgSettingsNavigation.cpp
@@ -91,7 +91,7 @@ void DlgSettingsNavigation::saveSettings()
     ui->checkBoxInvertZoom->onSave();
     ui->checkBoxDisableTilt->onSave();
     ui->spinBoxZoomStep->onSave();
-    ui->CheckBox_UseAutoRotation->onSave();
+    ui->checkBoxUseAutoRotation->onSave();
     ui->qspinNewDocScale->onSave();
     ui->prefStepByTurn->onSave();
     ui->naviCubeToNearest->onSave();
@@ -117,7 +117,7 @@ void DlgSettingsNavigation::loadSettings()
     ui->checkBoxInvertZoom->onRestore();
     ui->checkBoxDisableTilt->onRestore();
     ui->spinBoxZoomStep->onRestore();
-    ui->CheckBox_UseAutoRotation->onRestore();
+    ui->checkBoxUseAutoRotation->onRestore();
     ui->qspinNewDocScale->onRestore();
     ui->prefStepByTurn->onRestore();
     ui->naviCubeToNearest->onRestore();

--- a/src/Gui/DlgSettingsNavigation.ui
+++ b/src/Gui/DlgSettingsNavigation.ui
@@ -404,7 +404,7 @@ The value is the diameter of the sphere to fit on the screen.</string>
          </widget>
         </item>
         <item row="5" column="0">
-         <widget class="Gui::PrefCheckBox" name="CheckBox_UseAutoRotation">
+         <widget class="Gui::PrefCheckBox" name="checkBoxUseAutoRotation">
           <property name="enabled">
            <bool>true</bool>
           </property>


### PR DESCRIPTION
Renamed `CheckBox_UseAutoRotation` to `checkBoxUseAutoRotation` to match the preexisting naming syntax