### PR TITLE
Revert "[Core] (Partially?) Fix data loss on dir rename (#4996)"

### DIFF
--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -66,7 +66,6 @@ recompute path. Also, it enables more complicated dependencies beyond trees.
 # include <climits>
 # include <bitset>
 # include <random>
-# include <boost/filesystem.hpp>
 #endif
 
 #include <boost/algorithm/string.hpp>
@@ -142,8 +141,6 @@ using namespace zipios;
 #if FC_DEBUG
 #  define FC_LOGFEATUREUPDATE
 #endif
-
-namespace fs = boost::filesystem;
 
 // typedef boost::property<boost::vertex_root_t, DocumentObject* > VertexProperty;
 typedef boost::adjacency_list <
@@ -2613,8 +2610,6 @@ bool Document::saveToFile(const char* filename) const
         fn += uuid;
     }
     Base::FileInfo tmp(fn);
-    // In case some folders in the path do not exist
-    fs::create_directories(fs::path(filename).parent_path());
 
     // open extra scope to close ZipWriter properly
     {

--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -1158,25 +1158,6 @@ bool Document::save(void)
                 if(gdoc) gdoc->setModified(false);
             }
         }
-        catch (const Base::FileException& e) {
-            int ret = QMessageBox::question(
-                getMainWindow(),
-                QObject::tr("Could not Save Document"),
-                QObject::tr("There was an issue trying to save the file. "
-                            "This may be because some of the parent folders do not exist, "
-                            "or you do not have sufficient permissions, "
-                            "or for other reasons. Error details:\n\n\"%1\"\n\n"
-                            "Would you like to save the file with a different name?")
-                .arg(QString::fromLatin1(e.what())),
-                QMessageBox::Yes, QMessageBox::No);
-            if (ret == QMessageBox::No) {
-                // TODO: Understand what exactly is supposed to be returned here
-                getMainWindow()->showMessage(QObject::tr("Saving aborted"), 2000);
-                return false;
-            } else if (ret == QMessageBox::Yes) {
-                return saveAs();
-            }
-        }
         catch (const Base::Exception& e) {
             QMessageBox::critical(getMainWindow(), QObject::tr("Saving document failed"),
                 QString::fromLatin1(e.what()));
@@ -1214,25 +1195,6 @@ bool Document::saveAs(void)
             fi.setFile(QString::fromUtf8(d->_pcDocument->FileName.getValue()));
             setModified(false);
             getMainWindow()->appendRecentFile(fi.filePath());
-        }
-        catch (const Base::FileException& e) {
-            int ret = QMessageBox::question(
-                getMainWindow(),
-                QObject::tr("Could not Save Document"),
-                QObject::tr("There was an issue trying to save the file. "
-                            "This may be because some of the parent folders do not exist, "
-                            "or you do not have sufficient permissions, "
-                            "or for other reasons. Error details:\n\n\"%1\"\n\n"
-                            "Would you like to save the file with a different name?")
-                .arg(QString::fromLatin1(e.what())),
-                QMessageBox::Yes, QMessageBox::No);
-            if (ret == QMessageBox::No) {
-                // TODO: Understand what exactly is supposed to be returned here
-                getMainWindow()->showMessage(QObject::tr("Saving aborted"), 2000);
-                return false;
-            } else if (ret == QMessageBox::Yes) {
-                return saveAs();
-            }
         }
         catch (const Base::Exception& e) {
             QMessageBox::critical(getMainWindow(), QObject::tr("Saving document failed"),
@@ -1980,33 +1942,11 @@ bool Document::canClose (bool checkModify, bool checkLink)
 
     bool ok = true;
     if (checkModify && isModified() && !getDocument()->testStatus(App::Document::PartialDoc)) {
-        const char *docName = getDocument()->Label.getValue();
-        int res = getMainWindow()->confirmSave(docName, getActiveView());
-        switch (res)
-        {
-        case MainWindow::ConfirmSaveResult::Cancel:
-            ok = false;
-            break;
-        case MainWindow::ConfirmSaveResult::SaveAll:
-        case MainWindow::ConfirmSaveResult::Save:
+        int res = getMainWindow()->confirmSave(getDocument()->Label.getValue(),getActiveView());
+        if(res>0)
             ok = save();
-            if (!ok) {
-                int ret = QMessageBox::question(
-                    getActiveView(),
-                    QObject::tr("Document not saved"),
-                    QObject::tr("The document%1 could not be saved. Do you want to cancel closing it?")
-                    .arg(docName?(QString::fromUtf8(" ")+QString::fromUtf8(docName)):QString()),
-                    QMessageBox::Discard | QMessageBox::Cancel,
-                    QMessageBox::Discard);
-                if (ret == QMessageBox::Discard)
-                    ok = true;
-            }
-            break;
-        case MainWindow::ConfirmSaveResult::DiscardAll:
-        case MainWindow::ConfirmSaveResult::Discard:
-            ok = true;
-            break;
-        }
+        else
+            ok = res<0;
     }
 
     if (ok) {

--- a/src/Gui/MainWindow.h
+++ b/src/Gui/MainWindow.h
@@ -77,13 +77,6 @@ class GuiExport MainWindow : public QMainWindow
     Q_OBJECT
 
 public:
-    enum ConfirmSaveResult {
-        Cancel = 0,
-        Save,
-        SaveAll,
-        Discard,
-        DiscardAll
-    };
     /**
      * Constructs an empty main window. For default \a parent is 0, as there usually is
      * no toplevel window there.


### PR DESCRIPTION
This reverts commit 820e88f95b5c6d34da09d2152fc3aa3b268e7a95.

Commits from PR #4996 were squashed without saving the texts of individual
commits. Additionally, the single commit affects both `App` and `Gui` modules.

Separate PR's with changes in `App` and `Gui` to follow.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [ ]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [x]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [x]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
