### PR TITLE
Part Design: Improved chamfer behaviour when faces are selected and non equal chamfer types are used

### DIFF
--- a/src/Mod/PartDesign/App/FeatureDressUp.cpp
+++ b/src/Mod/PartDesign/App/FeatureDressUp.cpp
@@ -99,6 +99,13 @@ Part::Feature *DressUp::getBaseObject(bool silent) const
 
 void DressUp::getContinuousEdges(Part::TopoShape TopShape, std::vector< std::string >& SubNames) {
 
+    std::vector< std::string > FaceNames;
+
+    getContinuousEdges(TopShape, SubNames, FaceNames);
+}
+
+void DressUp::getContinuousEdges(Part::TopoShape TopShape, std::vector< std::string >& SubNames, std::vector< std::string >& FaceNames) {
+
     TopTools_IndexedMapOfShape mapOfEdges;
     TopTools_IndexedDataMapOfShapeListOfShape mapEdgeFace;
     TopExp::MapShapesAndAncestors(TopShape.getShape(), TopAbs_EDGE, TopAbs_FACE, mapEdgeFace);
@@ -153,6 +160,7 @@ void DressUp::getContinuousEdges(Part::TopoShape TopShape, std::vector< std::str
 
             }
 
+            FaceNames.push_back(aSubName.c_str());
             SubNames.erase(SubNames.begin()+i);
         }
         // empty name or any other sub-element

--- a/src/Mod/PartDesign/App/FeatureDressUp.h
+++ b/src/Mod/PartDesign/App/FeatureDressUp.h
@@ -59,6 +59,8 @@ public:
     /// extracts all edges from the subshapes (including face edges) and furthermore adds
     /// all C0 continuous edges to the vector
     void getContinuousEdges(Part::TopoShape, std::vector< std::string >&);
+    // add argument to return the selected face that edges were derived from
+    void getContinuousEdges(Part::TopoShape, std::vector< std::string >&, std::vector< std::string >&);
 
     virtual void getAddSubShape(Part::TopoShape &addShape, Part::TopoShape &subShape);
 


### PR DESCRIPTION
Improved Part Design chamfer behaviour when faces are selected and non equal chamfer types are used. 
(Distance Distance or Distance Angle)

See  [Forum discussion](https://forum.freecadweb.org/viewtopic.php?f=19&t=62084) for background.

_This is resubmission of #5029 with clean commit history and review feedback addressed._

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [X]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [X]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [X] Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [X]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [X]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [X]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
