### PR TITLE
[Macros Dialog] Add 2 new parameters: DuplicateIgnoreExtraNote and Du…

### DIFF
--- a/src/Gui/DlgMacroExecuteImp.cpp
+++ b/src/Gui/DlgMacroExecuteImp.cpp
@@ -350,8 +350,16 @@ void DlgMacroExecuteImp::on_editButton_clicked()
 void DlgMacroExecuteImp::on_createButton_clicked()
 {
     // query file name
+    bool replaceSpaces = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Macro")->GetBool("ReplaceSpaces", true);
+    App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Macro")->SetBool("ReplaceSpaces", replaceSpaces); //create parameter
+
     QString fn = QInputDialog::getText(this, tr("Macro file"), tr("Enter a file name, please:"),
         QLineEdit::Normal, QString(), nullptr, Qt::MSWindowsFixedSizeDialogHint);
+
+    if(replaceSpaces){
+        fn = fn.replace(QString::fromStdString(" "),QString::fromStdString("_"));
+    }
+
     if (!fn.isEmpty())
     {
         QString suffix = QFileInfo(fn).suffix().toLower();
@@ -674,6 +682,9 @@ void DlgMacroExecuteImp::on_renameButton_clicked()
     if (!item)
         return;
 
+    bool replaceSpaces = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Macro")->GetBool("ReplaceSpaces", true);
+    App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Macro")->SetBool("ReplaceSpaces", replaceSpaces); //create parameter
+
     QString oldName = item->text(0);
     QFileInfo oldfi(dir, oldName);
     QFile oldfile(oldfi.absoluteFilePath());
@@ -681,6 +692,11 @@ void DlgMacroExecuteImp::on_renameButton_clicked()
     // query new name
     QString fn = QInputDialog::getText(this, tr("Renaming Macro File"),
         tr("Enter new name:"), QLineEdit::Normal, oldName, nullptr, Qt::MSWindowsFixedSizeDialogHint);
+
+    if(replaceSpaces){
+        fn = fn.replace(QString::fromStdString(" "),QString::fromStdString("_"));
+    }
+
     if (!fn.isEmpty() && fn != oldName) {
         QString suffix = QFileInfo(fn).suffix().toLower();
         if (suffix != QLatin1String("fcmacro") && suffix != QLatin1String("py"))
@@ -729,8 +745,8 @@ void DlgMacroExecuteImp::on_duplicateButton_clicked()
 
     //when creating a note it will be convenient to convert spaces to underscores if the user desires this behavior
 
-    bool replaceSpaces = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Macro")->GetBool("DuplicateReplaceSpaces", false);
-    App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Macro")->SetBool("DuplicateReplaceSpaces", replaceSpaces); //create parameter
+    bool replaceSpaces = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Macro")->GetBool("ReplaceSpaces", true);
+    App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Macro")->SetBool("ReplaceSpaces", replaceSpaces); //create parameter
 
     int index = ui->tabMacroWidget->currentIndex();
     if (index == 0) { //user-specific

--- a/src/Gui/DlgMacroExecuteImp.cpp
+++ b/src/Gui/DlgMacroExecuteImp.cpp
@@ -718,6 +718,20 @@ void DlgMacroExecuteImp::on_duplicateButton_clicked()
 
     bool from001 = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Macro")->GetBool("DuplicateFrom001", false);
     App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Macro")->SetBool("DuplicateFrom001", from001); //create parameter
+
+    //A user may wish to add a note to end of the filename when duplicating
+    //example: mymacro@005.fix_bug_in_dialog.FCMacro
+    //and then when duplicating to have the extra note removed so the suggested new name is:
+    //mymacro@006.FCMacro instead of mymacro@006.fix_bug_in_dialog.FCMacro since the new duplicate will be given a new note
+
+    bool ignoreExtra = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Macro")->GetBool("DuplicateIgnoreExtraNote", false);
+    App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Macro")->SetBool("DuplicateIgnoreExtraNote", ignoreExtra); //create parameter
+
+    //when creating a note it will be convenient to convert spaces to underscores if the user desires this behavior
+
+    bool replaceSpaces = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Macro")->GetBool("DuplicateReplaceSpaces", false);
+    App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Macro")->SetBool("DuplicateReplaceSpaces", replaceSpaces); //create parameter
+
     int index = ui->tabMacroWidget->currentIndex();
     if (index == 0) { //user-specific
         item = ui->userMacroListBox->currentItem();
@@ -732,6 +746,7 @@ void DlgMacroExecuteImp::on_duplicateButton_clicked()
     QFileInfo oldfi(dir, oldName);
     QFile oldfile(oldfi.absoluteFilePath());
     QString completeSuffix = oldfi.completeSuffix(); //everything after the first "."
+    QString extraNote = completeSuffix.left(completeSuffix.size()-oldfi.suffix().size());
     QString baseName = oldfi.baseName(); //everything before first "."
     QString neutralSymbol = QString::fromStdString("@");
     QString last3 = baseName.right(3);
@@ -752,14 +767,28 @@ void DlgMacroExecuteImp::on_duplicateButton_clicked()
     }
     //at this point baseName = the base name without any digits, e.g. "MyMacro"
     //neutralSymbol = "@"
-    //last3 is a string representing 3 digits, always "001" at this time
+    //last3 is a string representing 3 digits, always "001"
     //unless from001 = false, in which case we begin with previous numbers
     //completeSuffix = FCMacro or py or FCMacro.py or else suffix will become FCMacro below
+    //if ignoreExtra any extra notes added between @NN. and .FCMacro will be ignored
+    //when suggesting a new filename
+
+    if(ignoreExtra && !extraNote.isEmpty()){
+        nLast3++;
+        last3 = QString::number(nLast3);
+        while (last3.size()<3){
+            last3.prepend(QString::fromStdString("0")); //pad 0's if needed
+        }
+    }
+
 
     QString oldNameDigitized = baseName+neutralSymbol+last3+QString::fromStdString(".")+completeSuffix;
     QFileInfo fi(dir, oldNameDigitized);
+
+
     // increment until we find available name with smallest digits
     // test from "001" through "999", then give up and let user enter name of choice
+
     while (fi.exists()) {
         nLast3 = last3.toInt()+1;
         if (nLast3 >=1000){ //avoid infinite loop, 999 files will have to be enough
@@ -773,10 +802,17 @@ void DlgMacroExecuteImp::on_duplicateButton_clicked()
         fi = QFileInfo(dir,oldNameDigitized);
     }
 
+    if(ignoreExtra && !extraNote.isEmpty()){
+        oldNameDigitized = oldNameDigitized.remove(extraNote);
+    }
+
     // give user a chance to pick a different name from digitized name suggested
     QString fn = QInputDialog::getText(this, tr("Duplicate Macro"),
         tr("Enter new name:"), QLineEdit::Normal, oldNameDigitized, 
         nullptr, Qt::MSWindowsFixedSizeDialogHint);
+    if (replaceSpaces){
+        fn = fn.replace(QString::fromStdString(" "),QString::fromStdString("_"));
+    }
     if (!fn.isEmpty() && fn != oldName) {
         QString suffix = QFileInfo(fn).suffix().toLower();
         if (suffix != QLatin1String("fcmacro") && suffix != QLatin1String("py")){


### PR DESCRIPTION
…plicateReplaceSpaces

2 more changes, also requested by Mario.

DuplicateIgnoreExtraNote (default = false to keep current behavior by default)

A user may wish to add an extra note to the file name indicating the changes made.

Example: mymacro@005.fix_dialog_font.FCMacro

and have that note ignored in the suggested file name when duplicating this file, so the suggested new name becomes:

mymacro@006.FCMacro instead of mymacro@006.fix_dialog_font.FCMacro

Note: Consider the following list of macro names:

mymacro.FCMacro
mymacro@001.add_cancel_button.FCMacro
mymacro@002.fix_bug_in_object_creation.FCMacro
mymacro@003.resize_dialog.FCMacro

If we duplicate mymacro@002.fix_bug_in_object_creation.FCMacro the suggested name will be mymacro@003.FCMacro and not mymacro@004.FCMacro.  I think this is good because the revisions made in @003 are being tossed out by duplicating the @002 version instead of the @003 version.

Note2: to be recognized as such extra notes must be delimited by decimal (.) after the @NN and before the FCMacro as in:

mymacro@004.some_note.FCMacro

mymacro@004some_note.FCMacro will not be recognized as an extra note and the suggested name is going to be:

mymacro@004some_note@001.FCMacro (which might desired for some users in some cases, similar to branching from a branch)

The other new parameter is DuplicateReplaceSpaces (default = false to keep current behavior by default)

This only happens during the creation of the new duplicate file, not during new macro creation or renaming.  Hence the name, DuplicateReplaceSpaces instead of ReplaceSpaces.  It is for convenience of user to be able to enter spaces instead of harder-to-type underscores.  If true, the spaces entered for the extra note are converted to underscores.  If the user edits the suggested file name by adding a note and the new file name is:

mymacro@004. some extra note.FCMacro

what will be actually used is:

mymacro@004._some_extra_note.FCMacro

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [ ]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [ ]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [ ]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [ ]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
