### PR TITLE
[App] LGTM fix - rename loop variable

### DIFF
--- a/src/App/Link.cpp
+++ b/src/App/Link.cpp
@@ -1322,8 +1322,8 @@ void LinkBaseExtension::setLink(int index, DocumentObject *obj,
 
         auto objs = getElementListValue();
         getElementListProperty()->setValue();
-        for(auto obj : objs)
-            detachElement(obj);
+        for(auto thisObj : objs)
+            detachElement(thisObj);
         return;
     }
 


### PR DESCRIPTION
LGTM complains that the use of "obj" as the loop variable here hides the parameter "obj". To silence the warning, rename the loop variable.