### PR TITLE
[App] Fix LGTM warning decl hides param

### DIFF
--- a/src/App/Expression.cpp
+++ b/src/App/Expression.cpp
@@ -484,11 +484,11 @@ App::any pyObjectToAny(Py::Object value, bool check) {
     if (PyLong_Check(pyvalue))
         return App::any(PyLong_AsLong(pyvalue));
     else if (PyUnicode_Check(pyvalue)) {
-        const char* value = PyUnicode_AsUTF8(pyvalue);
-        if (!value) {
+        const char* utf8value = PyUnicode_AsUTF8(pyvalue);
+        if (!utf8value) {
             FC_THROWM(Base::ValueError, "Invalid unicode string");
         }
-        return App::any(std::string(value));
+        return App::any(std::string(utf8value));
     }
     else {
         return App::any(pyObjectWrap(pyvalue));

--- a/src/App/ObjectIdentifier.cpp
+++ b/src/App/ObjectIdentifier.cpp
@@ -1490,14 +1490,14 @@ void ObjectIdentifier::String::checkImport(const App::DocumentObject *owner,
         else {
             str.resize(str.size()-1);
             auto mapped = reader->getName(str.c_str());
-            auto obj = owner->getDocument()->getObject(mapped);
-            if (!obj) {
+            auto objForMapped = owner->getDocument()->getObject(mapped);
+            if (!objForMapped) {
                 FC_ERR("Cannot find object " << str);
             }
             else {
                 isString = true;
                 forceIdentifier = false;
-                str = obj->Label.getValue();
+                str = objForMapped->Label.getValue();
             }
         }
     }

--- a/src/App/PropertyLinks.cpp
+++ b/src/App/PropertyLinks.cpp
@@ -2729,9 +2729,9 @@ public:
         // potentially unchanged. So we just touch at most one.
         std::set<Document*> docs;
         for(auto link : links) {
-            auto doc = static_cast<DocumentObject*>(link->getContainer())->getDocument();
-            auto ret = docs.insert(doc);
-            if(ret.second && !doc->isTouched())
+            auto linkdoc = static_cast<DocumentObject*>(link->getContainer())->getDocument();
+            auto ret = docs.insert(linkdoc);
+            if(ret.second && !linkdoc->isTouched())
                 link->touch();
         }
     }


### PR DESCRIPTION
In several instances local variables are created whose name is the same as a parameter, which LGTM warns about: this commit renames the local variables with non-conflicting names.