### PR TITLE
[App] Fix regression introduced by PR #4996

### DIFF
--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -2613,9 +2613,8 @@ bool Document::saveToFile(const char* filename) const
     }
     Base::FileInfo tmp(fn);
     // In case some folders in the path do not exist
-    fs::path parent = fs::path(filename).parent_path();
-    if (!parent.empty() && !parent.filename_is_dot() && !parent.filename_is_dot_dot())
-        fs::create_directories(parent);
+    auto parentPath = fs::absolute(fs::path(filename)).parent_path();
+    fs::create_directories(parentPath);
 
     // open extra scope to close ZipWriter properly
     {


### PR DESCRIPTION
Files opened by running `freecad xxxx.FCStd` or similar relative paths could not
be saved because of new code introduced to create parent directories. See
https://github.com/FreeCAD/FreeCAD/pull/4996#issuecomment-922370077 and
https://forum.freecadweb.org/viewtopic.php?f=13&t=62319&p=534156#p534156.

---

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [x]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [x]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
