### PR TITLE
Draft: fix Snapper GridSnap not working over a face

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_snapper.py
+++ b/src/Mod/Draft/draftguitools/gui_snapper.py
@@ -475,21 +475,15 @@ class Snapper:
                 # snap to corners of section planes
                 snaps.extend(self.snapToEndpoints(obj.Shape))
 
+        if not snaps:
+            return None
+
         # updating last objects list
         if not self.lastObj[1]:
             self.lastObj[1] = obj.Name
         elif self.lastObj[1] != obj.Name:
             self.lastObj[0] = self.lastObj[1]
             self.lastObj[1] = obj.Name
-
-        if not snaps:
-            self.spoint = self.cstr(lastpoint, constrain, point)
-            self.running = False
-            if self.trackLine and lastpoint:
-                self.trackLine.p2(self.spoint)
-                self.trackLine.color.rgb = Gui.draftToolBar.getDefaultColor("line")
-                self.trackLine.on()
-            return self.spoint
 
         # calculating the nearest snap point
         shortest = 1000000000000000000


### PR DESCRIPTION
ref. https://forum.freecadweb.org/viewtopic.php?f=23&t=62274&sid=4c9d07255e4f0db219b661c345768319

If the cursor is over a Face and no SnapCenter is active, the snapToObject method returns the current cursor point instead of None. Doing so the snap() method does not check for extension and grid snaps.
It seems this is a bug since the snap() already contains the deleted code.

One note: the no snaps case was moved before the lastObj setting, since if no snap point was found, it's not right to set it to a non snapped object.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [x]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [x]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
