### PR TITLE
[Core] Rotation : improve gimbal lock handling

### DIFF
--- a/src/Base/Rotation.cpp
+++ b/src/Base/Rotation.cpp
@@ -673,13 +673,13 @@ void Rotation::getYawPitchRoll(double& y, double& p, double& r) const
     double qd2 = 2.0*(q13-q02);
 
     // handle gimbal lock
-    if (fabs(qd2-1.0) <= DBL_EPSILON) {
+    if (fabs(qd2-1.0) <= 16 * DBL_EPSILON) { // Tolerance copied from OCC "gp_Quaternion.cxx"
         // north pole
         y = 0.0;
         p = D_PI/2.0;
         r = 2.0 * atan2(quat[0],quat[3]);
     }
-    else if (fabs(qd2+1.0) <= DBL_EPSILON) {
+    else if (fabs(qd2+1.0) <= 16 * DBL_EPSILON) { // Tolerance copied from OCC "gp_Quaternion.cxx"
         // south pole
         y = 0.0;
         p = -D_PI/2.0;


### PR DESCRIPTION
Following PR #5027, some cases are still wrongly handled (see forum discussion on previous PR).
Tolerance used for this PR is the one used in OCC for the same computation. I didn't find any rational for it, nor did I make any incertitude computation to check it.

- [X]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [X]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [X]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [X]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [X]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`