### PR TITLE
Draft: fix wpproxy view properties group

### DIFF
--- a/src/Mod/Draft/draftviewproviders/view_wpproxy.py
+++ b/src/Mod/Draft/draftviewproviders/view_wpproxy.py
@@ -45,11 +45,11 @@ class ViewProviderWorkingPlaneProxy:
 
         _tip = "The display length of this section plane"
         vobj.addProperty("App::PropertyLength", "DisplaySize",
-                         "Arch", QT_TRANSLATE_NOOP("App::Property", _tip))
+                         "Draft", QT_TRANSLATE_NOOP("App::Property", _tip))
 
         _tip = "The size of the arrows of this section plane"
-        vobj.addProperty("App::PropertyLength","ArrowSize",
-                         "Arch",QT_TRANSLATE_NOOP("App::Property", _tip))
+        vobj.addProperty("App::PropertyLength", "ArrowSize",
+                         "Draft", QT_TRANSLATE_NOOP("App::Property", _tip))
 
         vobj.addProperty("App::PropertyPercent","Transparency","Base","")
 


### PR DESCRIPTION
View properties of a WP proxy should not appear in the "Arch" group. Changed "Arch" to "Draft".

Note that existing WP proxies are not updated. But creating code for that would be over the top IMO.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
