### PR TITLE
Draft: fix 2 edit mode issues

### DIFF
--- a/src/Mod/Draft/draftviewproviders/view_base.py
+++ b/src/Mod/Draft/draftviewproviders/view_base.py
@@ -388,15 +388,15 @@ class ViewProviderDraft(object):
             None if mode is not zero.
             It is `False` otherwise.
         """
-        if mode == 0 and App.GuiUp: #remove guard after splitting every viewprovider
+        if mode != 0:
+            return None
+        elif App.GuiUp and "Draft_Edit" in Gui.listCommands(): # remove App.GuiUp guard after splitting every viewprovider
             Gui.runCommand("Draft_Edit")
             return True
-        elif mode != 0:
-            # Act like this function doesn't even exist, so the command falls back to Part (e.g. in the
-            # case of an unrecognized context menu action)
-            return None 
-
-        return False
+        else:
+            _wrn = "Please load the Draft Workbench to enable editing this object"
+            App.Console.PrintWarning(QT_TRANSLATE_NOOP("Draft", _wrn))
+            return False
 
     def unsetEdit(self, vobj, mode=0):
         """Terminate the edit mode of the object.
@@ -423,7 +423,7 @@ class ViewProviderDraft(object):
             This is `obj.ViewObject`.
 
         mode : int, optional
-            It defaults to 0. It is not used.
+            It defaults to 0.
             It indicates the type of edit in the underlying C++ code.
 
         Returns
@@ -432,6 +432,8 @@ class ViewProviderDraft(object):
             This method always returns `False` so it passes
             control to the base class to finish the edit mode.
         """
+        if mode != 0:
+            return False
         if App.activeDraftCommand:
             App.activeDraftCommand.finish()
         if App.GuiUp: # remove guard after splitting every viewprovider

--- a/src/Mod/Draft/draftviewproviders/view_base.py
+++ b/src/Mod/Draft/draftviewproviders/view_base.py
@@ -389,6 +389,8 @@ class ViewProviderDraft(object):
             It is `False` otherwise.
         """
         if mode != 0:
+            # Act like this function doesn't even exist, so the command falls back to Part (e.g. in the
+            # case of an unrecognized context menu action)
             return None
         elif App.GuiUp and "Draft_Edit" in Gui.listCommands(): # remove App.GuiUp guard after splitting every viewprovider
             Gui.runCommand("Draft_Edit")


### PR DESCRIPTION
2 edit mode issues were fixed:
1. Double clicking a Draft object in the Tree would result in an error if the Draft WB was not loaded. Now there is a warning.
2. The introduction of Std_UserEditMode means that edit mode can be non-zero. This required a modification of the unsetEdit function.

Forum discussion about issue 1: https://forum.freecadweb.org/viewtopic.php?f=23&t=59179

@0penBrain Can you have a look at the unsetEdit function? Maybe there is a better way to do this?

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
