### PR TITLE
Fix linux build: undefined std:string_view

### DIFF
--- a/src/Mod/Mesh/App/CMakeLists.txt
+++ b/src/Mod/Mesh/App/CMakeLists.txt
@@ -399,6 +399,8 @@ endif ()
 
 add_library(Mesh SHARED ${Core_SRCS} ${WildMagic4_SRCS} ${Mesh_SRCS})
 target_link_libraries(Mesh ${Mesh_LIBS})
+set_target_properties(Mesh PROPERTIES CXX_STANDARD_REQUIRED ON)
+set_target_properties(Mesh PROPERTIES CXX_STANDARD 17)
 
 
 SET_BIN_DIR(Mesh Mesh /Mod/Mesh)

--- a/src/Mod/Mesh/App/Core/MeshIO.cpp
+++ b/src/Mod/Mesh/App/Core/MeshIO.cpp
@@ -46,6 +46,7 @@
 #include <sstream>
 #include <iomanip>
 #include <algorithm>
+#include <string_view>
 #include <boost/regex.hpp>
 #include <boost/algorithm/string.hpp>
 #include <boost/lexical_cast.hpp>

--- a/src/Mod/PartDesign/App/json.hpp
+++ b/src/Mod/PartDesign/App/json.hpp
@@ -43,6 +43,7 @@ SOFTWARE.
 #include <memory> // unique_ptr
 #include <numeric> // accumulate
 #include <string> // string, stoi, to_string
+#include <string_view> // string_view
 #include <utility> // declval, forward, move, pair, swap
 #include <vector> // vector
 


### PR DESCRIPTION
Pop 'mesh' library c++ stranderd to c++17
Add required <string_view> header

Without this `gcc:11` complains about `std:string_view` being an undefined reference:
```cpp
/build/freecad-git/src/FreeCAD/src/Mod/Mesh/App/Core/MeshIO.cpp:1686:35: note: ‘std::string_view’ is only available from C++17 onwards
/build/freecad-git/src/FreeCAD/src/Mod/Mesh/App/Core/MeshIO.cpp:1688:31: error: ‘string_view’ is not a member of ‘std’
1688 |             auto xView = std::string_view(&line[8+16+16], 16);
     |                               ^~~~~~~~~~~   
```

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [x]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`
- [ ] btw. is there any reason source code mixes `Unix` and `Dos` file encoding, it looks somewhat messy when pushing code with two different line end encoding, especially in the same commit ¯\\\_(ツ)\_/¯

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
