### PR TITLE
[Sketcher] Make constraint label smaller and styleable

### DIFF
--- a/src/Gui/Stylesheets/Behave-dark.qss
+++ b/src/Gui/Stylesheets/Behave-dark.qss
@@ -2276,3 +2276,34 @@ QPushButton#NavigationIndicator::menu-indicator {
     image: none;
     width: 0px;
 }
+
+/*==================================================================================================
+SKETCHER
+==================================================================================================*/
+
+Gui--StatefulLabel[state="empty_sketch"] {
+    color : rgba(255,255,255,127);
+}
+Gui--StatefulLabel[state="under_constrained"] {
+    color : rgba(255,255,255,255);
+}
+Gui--StatefulLabel[state="conflicting_constraints"] {
+    color : rgba(255,50,50,255);
+}
+Gui--StatefulLabel[state="malformed_constraints"] {
+    color : rgba(255,50,50,255);
+}
+Gui--StatefulLabel[state="redundant_constraints"] {
+    color : rgba(255,0,100,255);
+}
+Gui--StatefulLabel[state="partially_redundant_constraints"] {
+    color : rgba(255,25,100,255);
+}
+Gui--StatefulLabel[state="solver_failed"] {
+    color : rgba(255,0,0,255);
+    font-weight: bold;
+}
+Gui--StatefulLabel[state="fully_constrained"] {
+    color : rgba(0,255,0,255);
+    font-weight: bold;
+}

--- a/src/Gui/Widgets.h
+++ b/src/Gui/Widgets.h
@@ -273,6 +273,65 @@ private:
   QString _url;
 };
 
+
+/**
+ * A text label whose appearance can change based on a specified state. 
+ *
+ * The state is an arbitrary string exposed as a Qt Property (and thus available for selection via 
+ * a stylesheet). This is intended for things like messages to the user, where a message that is an 
+ * "error" might be colored differently than one that is a "warning" or a "message".
+ * 
+ * In order of style precedence for a given state: User preference > Stylesheet > Default
+ * 
+ * @author Chris Hennes
+ */
+class GuiExport StatefulLabel : public QLabel
+{
+    Q_OBJECT
+        Q_PROPERTY( QString state READ state WRITE setState)
+
+public:
+    StatefulLabel(QWidget* parent = nullptr);
+    virtual ~StatefulLabel();
+
+    QString state() const;
+
+    /** If an unrecognized state is set, use this style */
+    void setDefaultStyle(const QString &defaultStyle);
+
+    /** Register a state and its corresponding style (optionally attached to a user preference) */
+    void registerState(const QString &state, const QString &styleCSS, 
+        const std::string& preferenceLocation = std::string(), 
+        const std::string& preferenceName = std::string());
+
+    /** For convenience, allow simple color-only states via QColor (optionally attached to a user preference) */
+    void registerState(const QString& state, const QColor& color, 
+        const std::string& preferenceLocation = std::string(), 
+        const std::string& preferenceName = std::string());
+
+    /** For convenience, allow simple color-only states via QColor (optionally attached to a user preference) */
+    void registerState(const QString& state, const QColor& foreground, const QColor &background,
+        const std::string& preferenceLocation = std::string(),
+        const std::string& preferenceName = std::string());
+
+public Q_SLOTS:
+    void setState(const QString &state);
+
+private:
+    QString _state;
+
+    struct StateData {
+        QColor foregroundColor;
+        QColor backgroundColor;
+        QString defaultCSS;
+        std::string preferenceLocation;
+        std::string preferenceString;
+    };
+
+    std::map<QString, StateData> _availableStates;
+    QString _defaultStyle;
+};
+
 // ----------------------------------------------------------------------
 
 /**

--- a/src/Gui/resource.cpp
+++ b/src/Gui/resource.cpp
@@ -111,6 +111,7 @@ WidgetFactorySupplier::WidgetFactorySupplier()
     new WidgetProducer<Gui::ActionSelector>;
     new WidgetProducer<Gui::ColorButton>;
     new WidgetProducer<Gui::UrlLabel>;
+    new WidgetProducer<Gui::StatefulLabel>;
     new WidgetProducer<Gui::FileChooser>;
     new WidgetProducer<Gui::UIntSpinBox>;
     new WidgetProducer<Gui::IntSpinBox>;

--- a/src/Mod/Sketcher/Gui/TaskSketcherMessages.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherMessages.cpp
@@ -59,8 +59,8 @@ TaskSketcherMessages::TaskSketcherMessages(ViewProviderSketch *sketchView) :
 
     this->groupLayout()->addWidget(proxy);
 
-    connectionSetUp = sketchView->signalSetUp.connect(boost::bind(&SketcherGui::TaskSketcherMessages::slotSetUp, this, bp::_1));
-    connectionSolved = sketchView->signalSolved.connect(boost::bind(&SketcherGui::TaskSketcherMessages::slotSolved, this, bp::_1));
+    connectionSetUp = sketchView->signalSetUp.connect(boost::bind(&SketcherGui::TaskSketcherMessages::slotSetUp, this, bp::_1, bp::_2));
+    connectionSolved = sketchView->signalSolved.connect(boost::bind(&SketcherGui::TaskSketcherMessages::slotSolved, this, bp::_1, bp::_2));
 
     ui->labelConstrainStatus->setOpenExternalLinks(false);
 
@@ -71,6 +71,20 @@ TaskSketcherMessages::TaskSketcherMessages(ViewProviderSketch *sketchView) :
         sketchView->getSketchObject()->noRecomputes=false;
     else
         sketchView->getSketchObject()->noRecomputes=true;
+
+    // Set up the possible state values for the solver status label
+    const std::string paramGroup ("User parameter:BaseApp/Preferences/Mod/Sketcher");
+    ui->labelConstrainStatus->registerState(QString::fromUtf8("empty_sketch"), QColor("black"), paramGroup, "emptySketchMessageColor");
+    ui->labelConstrainStatus->registerState(QString::fromUtf8("under_constrained"), QColor("black"), paramGroup, "underconstrainedMessageColor");
+    ui->labelConstrainStatus->registerState(QString::fromUtf8("malformed_constraints"), QColor("red"), paramGroup, "malformedConstraintMessageColor");
+    ui->labelConstrainStatus->registerState(QString::fromUtf8("conflicting_constraints"), QColor("orangered"), paramGroup, "conflictingConstraintMessageColor");
+    ui->labelConstrainStatus->registerState(QString::fromUtf8("redundant_constraints"), QColor("red"), paramGroup, "redundantConstraintMessageColor");
+    ui->labelConstrainStatus->registerState(QString::fromUtf8("partially_redundant_constraints"), QColor("royalblue"), paramGroup, "partiallyRedundantConstraintMessageColor");
+    ui->labelConstrainStatus->registerState(QString::fromUtf8("fully_constrained"), QColor("green"), paramGroup, "fullyConstrainedMessageColor");
+
+    ui->labelSolverStatus->registerState(QString::fromUtf8("good"), QColor("green"), QColor(255, 255, 255, 50), paramGroup, "solverGoodMessageColor");
+    ui->labelSolverStatus->registerState(QString::fromUtf8("bad"), QColor("red"), QColor(255, 255, 255, 50), paramGroup, "solverBadMessageColor");
+    ui->labelSolverStatus->registerState(QString::fromUtf8("neutral"), QColor("black"), paramGroup, "solverNeutralMessageColor");
 
     /*QObject::connect(
         ui->labelConstrainStatus, SIGNAL(linkActivated(const QString &)),
@@ -92,13 +106,15 @@ TaskSketcherMessages::~TaskSketcherMessages()
     connectionSolved.disconnect();
 }
 
-void TaskSketcherMessages::slotSetUp(QString msg)
+void TaskSketcherMessages::slotSetUp(const QString &state, const QString &msg)
 {
+    ui->labelConstrainStatus->setState(state);
     ui->labelConstrainStatus->setText(msg);
 }
 
-void TaskSketcherMessages::slotSolved(QString msg)
+void TaskSketcherMessages::slotSolved(const QString& state, const QString& msg)
 {
+    ui->labelSolverStatus->setState(state);
     ui->labelSolverStatus->setText(msg);
 }
 
@@ -115,7 +131,7 @@ void TaskSketcherMessages::on_labelConstrainStatus_linkActivated(const QString &
     else
     if( str == QString::fromLatin1("#malformed"))
         Gui::Application::Instance->commandManager().runCommandByName("Sketcher_SelectMalformedConstraints");
-        else
+    else
     if( str == QString::fromLatin1("#partiallyredundant"))
         Gui::Application::Instance->commandManager().runCommandByName("Sketcher_SelectPartiallyRedundantConstraints");
 

--- a/src/Mod/Sketcher/Gui/TaskSketcherMessages.h
+++ b/src/Mod/Sketcher/Gui/TaskSketcherMessages.h
@@ -47,11 +47,10 @@ public:
     TaskSketcherMessages(ViewProviderSketch *sketchView);
     ~TaskSketcherMessages();
 
-    void slotSetUp(const QString &state, const QString &msg);
-    void slotSolved(const QString& state, const QString &msg);
+    void slotSetUp(const QString &state, const QString &msg, const QString& link, const QString& linkText);
 
 private Q_SLOTS:
-    void on_labelConstrainStatus_linkActivated(const QString &);
+    void on_labelConstrainStatusLink_linkClicked(const QString &);
     void on_autoUpdate_stateChanged(int state);
     void on_autoRemoveRedundants_stateChanged(int state);
     void on_manualUpdate_clicked(bool checked);
@@ -59,7 +58,6 @@ private Q_SLOTS:
 protected:
     ViewProviderSketch *sketchView;
     Connection connectionSetUp;
-    Connection connectionSolved;
 
 private:
     QWidget* proxy;

--- a/src/Mod/Sketcher/Gui/TaskSketcherMessages.h
+++ b/src/Mod/Sketcher/Gui/TaskSketcherMessages.h
@@ -47,8 +47,8 @@ public:
     TaskSketcherMessages(ViewProviderSketch *sketchView);
     ~TaskSketcherMessages();
 
-    void slotSetUp(QString msg);
-    void slotSolved(QString msg);
+    void slotSetUp(const QString &state, const QString &msg);
+    void slotSolved(const QString& state, const QString &msg);
 
 private Q_SLOTS:
     void on_labelConstrainStatus_linkActivated(const QString &);

--- a/src/Mod/Sketcher/Gui/TaskSketcherMessages.ui
+++ b/src/Mod/Sketcher/Gui/TaskSketcherMessages.ui
@@ -15,7 +15,7 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QLabel" name="labelConstrainStatus">
+    <widget class="Gui::StatefulLabel" name="labelConstrainStatus">
      <property name="text">
       <string>Undefined degrees of freedom</string>
      </property>
@@ -25,7 +25,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QLabel" name="labelSolverStatus">
+    <widget class="Gui::StatefulLabel" name="labelSolverStatus">
      <property name="text">
       <string>Not solved yet</string>
      </property>
@@ -94,6 +94,11 @@
    <extends>QCheckBox</extends>
    <header>Gui/PrefWidgets.h</header>
   </customwidget>
+   <customwidget>
+     <class>Gui::StatefulLabel</class>
+     <extends>QLabel</extends>
+     <header>Gui/Widgets.h</header>
+   </customwidget>
  </customwidgets>
  <resources/>
  <connections/>

--- a/src/Mod/Sketcher/Gui/TaskSketcherMessages.ui
+++ b/src/Mod/Sketcher/Gui/TaskSketcherMessages.ui
@@ -15,24 +15,35 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="Gui::StatefulLabel" name="labelConstrainStatus">
-     <property name="text">
-      <string>Undefined degrees of freedom</string>
-     </property>
-     <property name="wordWrap">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="Gui::StatefulLabel" name="labelSolverStatus">
-     <property name="text">
-      <string>Not solved yet</string>
-     </property>
-     <property name="wordWrap">
-      <bool>true</bool>
-     </property>
-    </widget>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <widget class="Gui::StatefulLabel" name="labelConstrainStatus">
+       <property name="text">
+        <string>DOF</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="Gui::UrlLabel" name="labelConstrainStatusLink">
+       <property name="text">
+        <string>Link</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
    </item>
    <item>
     <widget class="Gui::PrefCheckBox" name="autoRemoveRedundants">
@@ -94,11 +105,16 @@
    <extends>QCheckBox</extends>
    <header>Gui/PrefWidgets.h</header>
   </customwidget>
-   <customwidget>
-     <class>Gui::StatefulLabel</class>
-     <extends>QLabel</extends>
-     <header>Gui/Widgets.h</header>
-   </customwidget>
+  <customwidget>
+   <class>Gui::StatefulLabel</class>
+   <extends>QLabel</extends>
+   <header>Gui/Widgets.h</header>
+  </customwidget>
+  <customwidget>
+   <class>Gui::UrlLabel</class>
+   <extends>QLabel</extends>
+   <header>Gui/Widgets.h</header>
+  </customwidget>
  </customwidgets>
  <resources/>
  <connections/>

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -1312,10 +1312,6 @@ bool ViewProviderSketch::mouseMove(const SbVec2s &cursorPos, Gui::View3DInventor
                     if (getSketchObject()->moveTemporaryPoint(GeoId, PosId, vec, false) == 0) {
                         setPositionText(Base::Vector2d(x,y));
                         draw(true,false);
-                        signalSolved(QString::fromUtf8("neutral"), QString::fromLatin1("Solved in %1 sec").arg(getSolvedSketch().getSolveTime()));
-                    } else {
-                        signalSolved(QString::fromUtf8("bad"), QString::fromLatin1("Unsolved (%1 sec)").arg(getSolvedSketch().getSolveTime()));
-                        //Base::Console().Log("Error solving:%d\n",ret);
                     }
                 }
             }
@@ -1353,9 +1349,6 @@ bool ViewProviderSketch::mouseMove(const SbVec2s &cursorPos, Gui::View3DInventor
                 if (getSketchObject()->moveTemporaryPoint(edit->DragCurve, Sketcher::none, vec, relative) == 0) {
                     setPositionText(Base::Vector2d(x,y));
                     draw(true,false);
-                    signalSolved(QString::fromUtf8("neutral"), QString::fromLatin1("Solved in %1 sec").arg(getSolvedSketch().getSolveTime()));
-                } else {
-                    signalSolved(QString::fromUtf8("bad"), QString::fromLatin1("Unsolved (%1 sec)").arg(getSolvedSketch().getSolveTime()));
                 }
             }
             return true;
@@ -6584,6 +6577,29 @@ QString ViewProviderSketch::appendConstraintMsg(const QString & singularmsg,
     return msg;
 }
 
+inline QString intListHelper(const std::vector<int> &ints) 
+{
+    QString results;
+    if (ints.size() < 8) { // The 8 is a bit heuristic... more than that and we shift formats
+        for (const auto i : ints) {
+            if (results.isEmpty())
+                results.append(QString::fromUtf8("%1").arg(i));
+            else
+                results.append(QString::fromUtf8(", %1").arg(i));
+        }
+    }
+    else {
+        const int numToShow = 3;
+        int more = ints.size() - numToShow;
+        for (int i = 0; i < numToShow; ++i) {
+            results.append(QString::fromUtf8("%1, ").arg(ints[i]));
+        }
+        results.append(QCoreApplication::translate("ViewProviderSketch","and %1 more").arg(more));
+    }
+    std::string testString = results.toStdString();
+    return results;
+}
+
 void ViewProviderSketch::UpdateSolverInformation()
 {
     // Updates Solver Information with the Last solver execution at SketchObject level
@@ -6594,82 +6610,48 @@ void ViewProviderSketch::UpdateSolverInformation()
     bool hasMalformed    = getSketchObject()->getLastHasMalformedConstraints();
 
     if (getSketchObject()->Geometry.getSize() == 0) {
-        signalSetUp(QString::fromUtf8("empty_sketch"), tr("Empty sketch"));
-        signalSolved(QString::fromUtf8("neutral"), QString());
+        signalSetUp(QString::fromUtf8("empty_sketch"), tr("Empty sketch"), QString(), QString());
     }
-    else if (dofs < 0) { // over-constrained sketch
-        std::string msg;
-        SketchObject::appendConflictMsg(getSketchObject()->getLastConflicting(), msg);
-        signalSetUp(QString::fromUtf8("conflicting_constraints"), 
-                    QString::fromLatin1("%1 <a href=\"#conflicting\"><span style=\" text-decoration: underline; color:#0000ff; background-color: #F8F8FF;\">%2</span></a><br/>%3<br/>")
-                    .arg(tr("Over-constrained sketch"))
-                    .arg(tr("(click to select)"))
-                    .arg(QString::fromStdString(msg)));
-        signalSolved(QString::fromUtf8("neutral"), QString());
+    else if (dofs < 0 || hasConflicts) { // over-constrained sketch
+        signalSetUp(QString::fromUtf8("conflicting_constraints"),
+            tr("Over-constrained: "),
+            QString::fromUtf8("#conflicting"),
+            QString::fromUtf8("(%1)").arg(intListHelper(getSketchObject()->getLastConflicting())));
     }
     else if (hasMalformed) { // malformed constraints
-        signalSetUp(QString::fromUtf8("malformed_constraints"), 
-                    QString::fromLatin1("%1 <a href=\"#malformed\"><span style=\" text-decoration: underline; color:#0000ff; background-color: #F8F8FF;\">%2</span></a><br/>%3<br/>")
-                    .arg(tr("Sketch contains malformed constraints"))
-                    .arg(tr("(click to select)"))
-                    .arg(appendMalformedMsg(getSketchObject()->getLastMalformedConstraints())));
-        signalSolved(QString::fromUtf8("neutral"), QString());
+        signalSetUp(QString::fromUtf8("malformed_constraints"),
+            tr("Malformed constraints: "),
+            QString::fromUtf8("#malformed"),
+            QString::fromUtf8("(%1)").arg(intListHelper(getSketchObject()->getLastMalformedConstraints())));
     }
-    else if (hasConflicts) { // conflicting constraints
-        signalSetUp(QString::fromUtf8("conflicting_constraints"), 
-                    QString::fromLatin1("%1 <a href=\"#conflicting\"><span style=\" text-decoration: underline; color:#0000ff; background-color: #F8F8FF;\">%2</span></a><br/>%3<br/>")
-                    .arg(tr("Sketch contains conflicting constraints"))
-                    .arg(tr("(click to select)"))
-                    .arg(appendConflictMsg(getSketchObject()->getLastConflicting())));
-        signalSolved(QString::fromUtf8("neutral"), QString());
+    else if (hasRedundancies) {
+        signalSetUp(QString::fromUtf8("redundant_constraints"),
+            tr("Redundant constraints:"),
+            QString::fromUtf8("#redundant"),
+            QString::fromUtf8("(%1)").arg(intListHelper(getSketchObject()->getLastRedundant())));
+    }
+    else if (hasPartiallyRedundant) {
+        signalSetUp(QString::fromUtf8("partially_redundant_constraints"),
+            tr("Partially redundant:"),
+            QString::fromUtf8("#partiallyredundant"),
+            QString::fromUtf8("(%1)").arg(intListHelper(getSketchObject()->getLastPartiallyRedundant())));
+    }
+    else if (getSketchObject()->getLastSolverStatus() != 0) {
+        signalSetUp(QString::fromUtf8("solver_failed"),
+            tr("Solver failed to converge"),
+            QString::fromUtf8(""),
+            QString::fromUtf8(""));
+    } else if (dofs > 0) {
+        signalSetUp(QString::fromUtf8("under_constrained"),
+            tr("Under constrained:"),
+            QString::fromUtf8("#dofs"),
+            QString::fromUtf8("%1 %2").arg(dofs).arg(tr("DoF")));
     }
     else {
-        if (hasRedundancies) { // redundant constraints
-            signalSetUp(QString::fromUtf8("redundant_constraints"), 
-                        QString::fromLatin1("%1 <a href=\"#redundant\"><span style=\" text-decoration: underline; color:#0000ff; background-color: #F8F8FF;\">%2</span></a><br/>%3<br/>")
-                        .arg(tr("Sketch contains redundant constraints"))
-                        .arg(tr("(click to select)"))
-                        .arg(appendRedundantMsg(getSketchObject()->getLastRedundant())));
-        }
-
-        QString partiallyRedundantString;
-
-        if(hasPartiallyRedundant) {
-            partiallyRedundantString = QString::fromLatin1("<br/><span style=\"background-color: rgba(255,255,255,50) ;\">%1 <a href=\"#partiallyredundant\"><span style=\" text-decoration:  underline; color:#0000ff; background-color: #F8F8FF;\">%2</span></a><br/>%3</span><br/>")
-                                .arg(tr("Sketch contains partially redundant constraints"))
-                                .arg(tr("(click to select)"))
-                                .arg(appendPartiallyRedundantMsg(getSketchObject()->getLastPartiallyRedundant()));
-        }
-
-        if (getSketchObject()->getLastSolverStatus() == 0) {
-            if (dofs == 0) {
-                // color the sketch as fully constrained if it has geometry (other than the axes)
-                if(getSolvedSketch().getGeometrySize()>2)
-                    edit->FullyConstrained = true;
-
-                if (!hasRedundancies) {
-                    signalSetUp(QString::fromUtf8("fully_constrained"),
-                        partiallyRedundantString + tr("Fully constrained sketch"));
-                }
-            }
-            else if (!hasRedundancies) {
-                QString infoString;
-                if (dofs == 1)
-                    signalSetUp(QString::fromUtf8("under_constrained"), 
-                                tr("Under-constrained sketch with <a href=\"#dofs\"><span style=\" text-decoration: underline; color:#0000ff; background-color: #F8F8FF;\">1 degree</span></a> of freedom. %1")
-                        .arg(partiallyRedundantString));
-                else
-                    signalSetUp(QString::fromUtf8("under_constrained"), 
-                                tr("Under-constrained sketch with <a href=\"#dofs\"><span style=\" text-decoration: underline; color:#0000ff; background-color: #F8F8FF;\">%1 degrees</span></a> of freedom. %2")
-                        .arg(dofs)
-                        .arg(partiallyRedundantString));
-            }
-
-            signalSolved(QString::fromUtf8("good"), tr("Solved in %1 sec").arg(getSketchObject()->getLastSolveTime()));
-        }
-        else {
-            signalSolved(QString::fromUtf8("bad"), tr("Unsolved (%1 sec)").arg(getSketchObject()->getLastSolveTime()));
-        }
+        signalSetUp(QString::fromUtf8("fully_constrained"), tr("Fully constrained"), QString(), QString());
+        // color the sketch as fully constrained if it has geometry (other than the axes)
+        if(getSolvedSketch().getGeometrySize()>2)
+            edit->FullyConstrained = true;
     }
 }
 

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -402,6 +402,9 @@ ViewProviderSketch::ViewProviderSketch()
     //rubberband selection
     rubberband = new Gui::Rubberband();
 
+    // Status message states:
+    
+
     subscribeToParameters();
 }
 
@@ -1309,9 +1312,9 @@ bool ViewProviderSketch::mouseMove(const SbVec2s &cursorPos, Gui::View3DInventor
                     if (getSketchObject()->moveTemporaryPoint(GeoId, PosId, vec, false) == 0) {
                         setPositionText(Base::Vector2d(x,y));
                         draw(true,false);
-                        signalSolved(QString::fromLatin1("Solved in %1 sec").arg(getSolvedSketch().getSolveTime()));
+                        signalSolved(QString::fromUtf8("neutral"), QString::fromLatin1("Solved in %1 sec").arg(getSolvedSketch().getSolveTime()));
                     } else {
-                        signalSolved(QString::fromLatin1("Unsolved (%1 sec)").arg(getSolvedSketch().getSolveTime()));
+                        signalSolved(QString::fromUtf8("bad"), QString::fromLatin1("Unsolved (%1 sec)").arg(getSolvedSketch().getSolveTime()));
                         //Base::Console().Log("Error solving:%d\n",ret);
                     }
                 }
@@ -1350,9 +1353,9 @@ bool ViewProviderSketch::mouseMove(const SbVec2s &cursorPos, Gui::View3DInventor
                 if (getSketchObject()->moveTemporaryPoint(edit->DragCurve, Sketcher::none, vec, relative) == 0) {
                     setPositionText(Base::Vector2d(x,y));
                     draw(true,false);
-                    signalSolved(QString::fromLatin1("Solved in %1 sec").arg(getSolvedSketch().getSolveTime()));
+                    signalSolved(QString::fromUtf8("neutral"), QString::fromLatin1("Solved in %1 sec").arg(getSolvedSketch().getSolveTime()));
                 } else {
-                    signalSolved(QString::fromLatin1("Unsolved (%1 sec)").arg(getSolvedSketch().getSolveTime()));
+                    signalSolved(QString::fromUtf8("bad"), QString::fromLatin1("Unsolved (%1 sec)").arg(getSolvedSketch().getSolveTime()));
                 }
             }
             return true;
@@ -6591,35 +6594,39 @@ void ViewProviderSketch::UpdateSolverInformation()
     bool hasMalformed    = getSketchObject()->getLastHasMalformedConstraints();
 
     if (getSketchObject()->Geometry.getSize() == 0) {
-        signalSetUp(tr("Empty sketch"));
-        signalSolved(QString());
+        signalSetUp(QString::fromUtf8("empty_sketch"), tr("Empty sketch"));
+        signalSolved(QString::fromUtf8("neutral"), QString());
     }
     else if (dofs < 0) { // over-constrained sketch
         std::string msg;
         SketchObject::appendConflictMsg(getSketchObject()->getLastConflicting(), msg);
-        signalSetUp(QString::fromLatin1("<font color='red'>%1 <a href=\"#conflicting\"><span style=\" text-decoration: underline; color:#0000ff; background-color: #F8F8FF;\">%2</span></a><br/>%3</font><br/>")
+        signalSetUp(QString::fromUtf8("conflicting_constraints"), 
+                    QString::fromLatin1("%1 <a href=\"#conflicting\"><span style=\" text-decoration: underline; color:#0000ff; background-color: #F8F8FF;\">%2</span></a><br/>%3<br/>")
                     .arg(tr("Over-constrained sketch"))
                     .arg(tr("(click to select)"))
                     .arg(QString::fromStdString(msg)));
-        signalSolved(QString());
+        signalSolved(QString::fromUtf8("neutral"), QString());
     }
     else if (hasMalformed) { // malformed constraints
-        signalSetUp(QString::fromLatin1("<font color='red'>%1 <a href=\"#malformed\"><span style=\" text-decoration: underline; color:#0000ff; background-color: #F8F8FF;\">%2</span></a><br/>%3</font><br/>")
+        signalSetUp(QString::fromUtf8("malformed_constraints"), 
+                    QString::fromLatin1("%1 <a href=\"#malformed\"><span style=\" text-decoration: underline; color:#0000ff; background-color: #F8F8FF;\">%2</span></a><br/>%3<br/>")
                     .arg(tr("Sketch contains malformed constraints"))
                     .arg(tr("(click to select)"))
                     .arg(appendMalformedMsg(getSketchObject()->getLastMalformedConstraints())));
-        signalSolved(QString());
+        signalSolved(QString::fromUtf8("neutral"), QString());
     }
     else if (hasConflicts) { // conflicting constraints
-        signalSetUp(QString::fromLatin1("<font color='red'>%1 <a href=\"#conflicting\"><span style=\" text-decoration: underline; color:#0000ff; background-color: #F8F8FF;\">%2</span></a><br/>%3</font><br/>")
+        signalSetUp(QString::fromUtf8("conflicting_constraints"), 
+                    QString::fromLatin1("%1 <a href=\"#conflicting\"><span style=\" text-decoration: underline; color:#0000ff; background-color: #F8F8FF;\">%2</span></a><br/>%3<br/>")
                     .arg(tr("Sketch contains conflicting constraints"))
                     .arg(tr("(click to select)"))
                     .arg(appendConflictMsg(getSketchObject()->getLastConflicting())));
-        signalSolved(QString());
+        signalSolved(QString::fromUtf8("neutral"), QString());
     }
     else {
         if (hasRedundancies) { // redundant constraints
-            signalSetUp(QString::fromLatin1("<font color='orangered'>%1 <a href=\"#redundant\"><span style=\" text-decoration: underline; color:#0000ff; background-color: #F8F8FF;\">%2</span></a><br/>%3</font><br/>")
+            signalSetUp(QString::fromUtf8("redundant_constraints"), 
+                        QString::fromLatin1("%1 <a href=\"#redundant\"><span style=\" text-decoration: underline; color:#0000ff; background-color: #F8F8FF;\">%2</span></a><br/>%3<br/>")
                         .arg(tr("Sketch contains redundant constraints"))
                         .arg(tr("(click to select)"))
                         .arg(appendRedundantMsg(getSketchObject()->getLastRedundant())));
@@ -6628,7 +6635,7 @@ void ViewProviderSketch::UpdateSolverInformation()
         QString partiallyRedundantString;
 
         if(hasPartiallyRedundant) {
-            partiallyRedundantString = QString::fromLatin1("<br/><font color='royalblue'><span style=\"background-color: #ececec;\">%1 <a href=\"#partiallyredundant\"><span style=\" text-decoration:  underline; color:#0000ff; background-color: #F8F8FF;\">%2</span></a><br/>%3</span></font><br/>")
+            partiallyRedundantString = QString::fromLatin1("<br/><span style=\"background-color: rgba(255,255,255,50) ;\">%1 <a href=\"#partiallyredundant\"><span style=\" text-decoration:  underline; color:#0000ff; background-color: #F8F8FF;\">%2</span></a><br/>%3</span><br/>")
                                 .arg(tr("Sketch contains partially redundant constraints"))
                                 .arg(tr("(click to select)"))
                                 .arg(appendPartiallyRedundantMsg(getSketchObject()->getLastPartiallyRedundant()));
@@ -6641,25 +6648,27 @@ void ViewProviderSketch::UpdateSolverInformation()
                     edit->FullyConstrained = true;
 
                 if (!hasRedundancies) {
-                    signalSetUp(QString::fromLatin1("<font color='green'><span style=\"color:#008000; background-color: #ececec;\">%1</font></span> %2").arg(tr("Fully constrained sketch")).arg(partiallyRedundantString));
+                    signalSetUp(QString::fromUtf8("fully_constrained"),
+                        partiallyRedundantString + tr("Fully constrained sketch"));
                 }
             }
             else if (!hasRedundancies) {
                 QString infoString;
-
                 if (dofs == 1)
-                    signalSetUp(tr("Under-constrained sketch with <a href=\"#dofs\"><span style=\" text-decoration: underline; color:#0000ff; background-color: #F8F8FF;\">1 degree</span></a> of freedom. %1")
+                    signalSetUp(QString::fromUtf8("under_constrained"), 
+                                tr("Under-constrained sketch with <a href=\"#dofs\"><span style=\" text-decoration: underline; color:#0000ff; background-color: #F8F8FF;\">1 degree</span></a> of freedom. %1")
                         .arg(partiallyRedundantString));
                 else
-                    signalSetUp(tr("Under-constrained sketch with <a href=\"#dofs\"><span style=\" text-decoration: underline; color:#0000ff; background-color: #F8F8FF;\">%1 degrees</span></a> of freedom. %2")
+                    signalSetUp(QString::fromUtf8("under_constrained"), 
+                                tr("Under-constrained sketch with <a href=\"#dofs\"><span style=\" text-decoration: underline; color:#0000ff; background-color: #F8F8FF;\">%1 degrees</span></a> of freedom. %2")
                         .arg(dofs)
                         .arg(partiallyRedundantString));
             }
 
-            signalSolved(QString::fromLatin1("<font color='green'><span style=\"color:#008000; background-color: #ececec;\">%1</font></span>").arg(tr("Solved in %1 sec").arg(getSketchObject()->getLastSolveTime())));
+            signalSolved(QString::fromUtf8("good"), tr("Solved in %1 sec").arg(getSketchObject()->getLastSolveTime()));
         }
         else {
-            signalSolved(QString::fromLatin1("<font color='red'>%1</font>").arg(tr("Unsolved (%1 sec)").arg(getSketchObject()->getLastSolveTime())));
+            signalSolved(QString::fromUtf8("bad"), tr("Unsolved (%1 sec)").arg(getSketchObject()->getLastSolveTime()));
         }
     }
 }

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.h
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.h
@@ -273,9 +273,7 @@ public:
     /// signals if the constraints list has changed
     boost::signals2::signal<void ()> signalConstraintsChanged;
     /// signals if the sketch has been set up
-    boost::signals2::signal<void (const QString &state, const QString &msg)> signalSetUp;
-    /// signals if the sketch has been solved
-    boost::signals2::signal<void (const QString &state, const QString &msg)> signalSolved;
+    boost::signals2::signal<void (const QString &state, const QString &msg, const QString &url, const QString &linkText)> signalSetUp;
     /// signals if the elements list has changed
     boost::signals2::signal<void ()> signalElementsChanged;
 

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.h
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.h
@@ -273,9 +273,9 @@ public:
     /// signals if the constraints list has changed
     boost::signals2::signal<void ()> signalConstraintsChanged;
     /// signals if the sketch has been set up
-    boost::signals2::signal<void (QString msg)> signalSetUp;
+    boost::signals2::signal<void (const QString &state, const QString &msg)> signalSetUp;
     /// signals if the sketch has been solved
-    boost::signals2::signal<void (QString msg)> signalSolved;
+    boost::signals2::signal<void (const QString &state, const QString &msg)> signalSolved;
     /// signals if the elements list has changed
     boost::signals2::signal<void ()> signalElementsChanged;
 


### PR DESCRIPTION
As [discussed in the FreeCAD forums](https://forum.freecadweb.org/viewtopic.php?p=538161), this PR exposes the Sketcher Constraint Status Label to user-configurable styling via both preferences (no GUI, just settable in user.cfg) and via the Qt stylesheet. This is accomplished by creating a new widget called StatefulLabel. This widget has a Q_PROPERTY called "state" which can be dynamically altered at runtime. When the state is changed, the user preferences are optionally scanned for an entry as specified by the label creation code, then the stylesheet is checked, and finally, the default values are used as a fallback.

This PR also significantly reduces the verbosity of the message, eliminates the possibility of multiple overlapping messages (e.g. "redundant" and also "partially redundant"), and moves the clickable portion of the label to its own UrlLabel (which can be styled, unlike an embedded <a> element). 