### PR TITLE
[Path] Fix Waterline error due to invalid arguments in `getOffsetArea()` calls

### DIFF
--- a/src/Mod/Path/PathScripts/PathWaterline.py
+++ b/src/Mod/Path/PathScripts/PathWaterline.py
@@ -1290,8 +1290,7 @@ class ObjectWaterline(PathOp.ObjectOp):
                 self.showDebugObject(activeArea, 'ActiveArea_{}'.format(caCnt))
                 ofstArea = PathUtils.getOffsetArea(activeArea,
                                                    ofst,
-                                                   self.wpc,
-                                                   makeComp=False)
+                                                   self.wpc)
                 if not ofstArea:
                     data = FreeCAD.Units.Quantity(csHght, FreeCAD.Units.Length).UserString
                     PathLog.debug('No offset area returned for cut area depth at {}.'.format(data))
@@ -1467,8 +1466,7 @@ class ObjectWaterline(PathOp.ObjectOp):
         while cont:
             ofstArea = PathUtils.getOffsetArea(shape,
                                                ofst,
-                                               self.wpc,
-                                               makeComp=True)
+                                               self.wpc)
             if not ofstArea:
                 break
             for F in ofstArea.Faces:


### PR DESCRIPTION
This commit fixes the error reported in the forum at [Re: Waterline milling update](https://forum.freecadweb.org/viewtopic.php?f=15&t=33121&start=50#p537787).

This error was introduced when a contributor replaced the `extractFaceOffset()` method from the PathSurfaceSupport.py module with an improved `getOffsetArea()` function in the PathUtils.py module.  The two instances of the improved `getOffsetArea()` calls here in this fix did not get corrected (updated argument lists) when that improvement was originally made.  This fix corrects the argument lists in the two function calls.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
