### PR TITLE
[Spreadsheet] Refactor keyboard handling

### DIFF
--- a/src/Mod/Spreadsheet/App/PropertySheet.cpp
+++ b/src/Mod/Spreadsheet/App/PropertySheet.cpp
@@ -982,6 +982,14 @@ void PropertySheet::getSpans(CellAddress address, int & rows, int & cols) const
     }
 }
 
+App::CellAddress Spreadsheet::PropertySheet::getAnchor(App::CellAddress address) const
+{
+    if (auto anchor = mergedCells.find(address); anchor != mergedCells.end())
+        return anchor->second;
+    else
+        return address;
+}
+
 bool PropertySheet::isMergedCell(CellAddress address) const
 {
     return mergedCells.find(address) != mergedCells.end();

--- a/src/Mod/Spreadsheet/App/PropertySheet.h
+++ b/src/Mod/Spreadsheet/App/PropertySheet.h
@@ -148,6 +148,8 @@ public:
 
     void getSpans(App::CellAddress address, int &rows, int &cols) const;
 
+    App::CellAddress getAnchor(App::CellAddress address) const;
+
     bool isMergedCell(App::CellAddress address) const;
 
     bool isHidden(App::CellAddress address) const;

--- a/src/Mod/Spreadsheet/App/Sheet.cpp
+++ b/src/Mod/Spreadsheet/App/Sheet.cpp
@@ -1063,6 +1063,11 @@ bool Sheet::isMergedCell(CellAddress address) const
     return cells.isMergedCell(address);
 }
 
+App::CellAddress Spreadsheet::Sheet::getAnchor(App::CellAddress address) const
+{
+    return cells.getAnchor(address);
+}
+
 /**
  * @brief Set column with of column \a col to \a width-
  * @param col   Index of column.

--- a/src/Mod/Spreadsheet/App/Sheet.h
+++ b/src/Mod/Spreadsheet/App/Sheet.h
@@ -110,6 +110,8 @@ public:
 
     bool isMergedCell(App::CellAddress address) const;
 
+    App::CellAddress getAnchor(App::CellAddress address) const;
+
     void setColumnWidth(int col, int width);
 
     int getColumnWidth(int col) const;

--- a/src/Mod/Spreadsheet/Gui/LineEdit.cpp
+++ b/src/Mod/Spreadsheet/Gui/LineEdit.cpp
@@ -26,68 +26,58 @@
 # include <QKeyEvent>
 #endif
 
+#include <QCoreApplication>
+
 #include "LineEdit.h"
 
 using namespace SpreadsheetGui;
 
 LineEdit::LineEdit(QWidget *parent)
     : Gui::ExpressionLineEdit(parent, false, true)
-    , current()
-    , deltaCol(0)
-    , deltaRow(0)
+    , lastKeyPressed(0)
+    , lastModifiers(0)
 {
+    setFocusPolicy(Qt::FocusPolicy::ClickFocus);
+}
+
+bool LineEdit::eventFilter(QObject* object, QEvent* event)
+{
+    if (event && event->type() == QEvent::KeyPress) {
+        QKeyEvent* keyEvent = static_cast<QKeyEvent*>(event);
+        if (keyEvent->key() == Qt::Key_Tab) {
+            // Special tab handling -- must be done via a QApplication event filter, otherwise the widget
+            // system will always grab the tab events
+            if (completerActive()) {
+                hideCompleter();
+                event->accept();
+                return true; // To make sure this tab press doesn't do anything else
+            }
+            else {
+                lastKeyPressed = keyEvent->key();
+                lastModifiers = keyEvent->modifiers();
+            }
+        }
+    }
+    return false; // We don't usually actually "handle" the tab event, we just keep track of it
 }
 
 bool LineEdit::event(QEvent *event)
 {
-    if (event && event->type() == QEvent::KeyPress) {
+    if (event && event->type() == QEvent::FocusIn) {
+        qApp->installEventFilter(this);
+    }
+    else if (event && event->type() == QEvent::FocusOut) {
+        qApp->removeEventFilter(this);
+        if (lastKeyPressed)
+            Q_EMIT finishedWithKey(lastKeyPressed, lastModifiers);
+        lastKeyPressed = 0;
+    }
+    else if (event && event->type() == QEvent::KeyPress && !completerActive()) {
         QKeyEvent * kevent = static_cast<QKeyEvent*>(event);
-
-        if (kevent->key() == Qt::Key_Tab) {
-            if (kevent->modifiers() == 0) {
-                deltaCol = 1;
-                deltaRow = 0;
-                Q_EMIT returnPressed();
-                return true;
-            }
-        }
-        else if (kevent->key() == Qt::Key_Backtab) {
-            if (kevent->modifiers() == Qt::ShiftModifier) {
-                deltaCol = -1;
-                deltaRow = 0;
-                Q_EMIT returnPressed();
-                return true;
-            }
-        }
-        else if (kevent->key() == Qt::Key_Enter || kevent->key() == Qt::Key_Return) {
-            if (kevent->modifiers() == 0) {
-                deltaCol = 0;
-                deltaRow = 1;
-                Q_EMIT returnPressed();
-                return true;
-            }
-            else if (kevent->modifiers() == Qt::ShiftModifier) {
-                deltaCol = 0;
-                deltaRow = -1;
-                Q_EMIT returnPressed();
-                return true;
-            }
-        }
+        lastKeyPressed = kevent->key();
+        lastModifiers = kevent->modifiers(); 
     }
     return Gui::ExpressionLineEdit::event(event);
-}
-
-void LineEdit::setIndex(QModelIndex _current)
-{
-    current = _current;
-}
-
-QModelIndex LineEdit::next() const
-{
-    const QAbstractItemModel * m = current.model();
-
-    return m->index(qMin(qMax(0, current.row() + deltaRow), m->rowCount() - 1 ),
-                    qMin(qMax(0, current.column() + deltaCol), m->columnCount() - 1 ) );
 }
 
 #include "moc_LineEdit.cpp"

--- a/src/Mod/Spreadsheet/Gui/LineEdit.h
+++ b/src/Mod/Spreadsheet/Gui/LineEdit.h
@@ -36,13 +36,17 @@ public:
     explicit LineEdit(QWidget *parent = 0);
 
     bool event(QEvent *event);
-    void setIndex(QModelIndex _current);
-    QModelIndex next() const;
+
+Q_SIGNALS:
+    void finishedWithKey(int key, Qt::KeyboardModifiers modifiers);
 
 private:
-    QModelIndex current;
-    int deltaCol;
-    int deltaRow;
+    bool eventFilter(QObject* object, QEvent* event);
+
+
+private:
+    int lastKeyPressed;
+    Qt::KeyboardModifiers lastModifiers;
 };
 
 }

--- a/src/Mod/Spreadsheet/Gui/SheetTableView.h
+++ b/src/Mod/Spreadsheet/Gui/SheetTableView.h
@@ -62,6 +62,9 @@ public:
     void copySelection();
     void cutSelection();
     void pasteClipboard();
+    void finishEditWithMove(int keyPressed, Qt::KeyboardModifiers modifiers, bool handleTabMotion = false);
+
+    void ModifyBlockSelection(int targetRow, int targetColumn);
 
 protected Q_SLOTS:
     void commitData(QWidget *editor);
@@ -77,8 +80,10 @@ protected:
     bool edit(const QModelIndex &index, EditTrigger trigger, QEvent *event);
     bool event(QEvent *event);
     void closeEditor(QWidget *editor, QAbstractItemDelegate::EndEditHint hint);
+    void mousePressEvent(QMouseEvent* event);
 
     QModelIndex currentEditIndex;
+    int tabCounter;
     Spreadsheet::Sheet * sheet;
 
     boost::signals2::scoped_connection cellSpanChangedConnection;

--- a/src/Mod/Spreadsheet/Gui/SpreadsheetDelegate.cpp
+++ b/src/Mod/Spreadsheet/Gui/SpreadsheetDelegate.cpp
@@ -47,26 +47,9 @@ QWidget *SpreadsheetDelegate::createEditor(QWidget *parent,
                                           const QModelIndex &index) const
 {
     SpreadsheetGui::LineEdit *editor = new SpreadsheetGui::LineEdit(parent);
-    editor->setIndex(index);
-
     editor->setDocumentObject(sheet);
-    connect(editor, SIGNAL(returnPressed()), this, SLOT(commitAndCloseEditor()));
+    connect(editor, &SpreadsheetGui::LineEdit::finishedWithKey, this, &SpreadsheetDelegate::on_editorFinishedWithKey);
     return editor;
-}
-
-void SpreadsheetDelegate::commitAndCloseEditor()
-{
-    Gui::ExpressionLineEdit *editor = qobject_cast<Gui::ExpressionLineEdit *>(sender());
-    if (editor->completerActive()) {
-        editor->hideCompleter();
-        return;
-    }
-
-    // See https://forum.freecadweb.org/viewtopic.php?f=3&t=41694
-    // It looks like the slot commitAndCloseEditor() is not needed any more and even
-    // causes a crash when doing so because the LineEdit is still accessed after its destruction.
-    //Q_EMIT commitData(editor);
-    //Q_EMIT closeEditor(editor);
 }
 
 void SpreadsheetDelegate::setEditorData(QWidget *editor,
@@ -87,6 +70,11 @@ void SpreadsheetDelegate::setModelData(QWidget *editor,
         model->setData(index, edit->text());
         return;
     }
+}
+
+void SpreadsheetDelegate::on_editorFinishedWithKey(int key, Qt::KeyboardModifiers modifiers)
+{
+    Q_EMIT finishedWithKey(key, modifiers);
 }
 
 QSize SpreadsheetDelegate::sizeHint(const QStyleOptionViewItem & option, const QModelIndex & index) const

--- a/src/Mod/Spreadsheet/Gui/SpreadsheetDelegate.h
+++ b/src/Mod/Spreadsheet/Gui/SpreadsheetDelegate.h
@@ -45,8 +45,10 @@ public:
                       const QModelIndex &index) const;
 
     QSize sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const;
+Q_SIGNALS:
+    void finishedWithKey(int key, Qt::KeyboardModifiers modifiers);
 private Q_SLOTS:
-    void commitAndCloseEditor();
+    void on_editorFinishedWithKey(int key, Qt::KeyboardModifiers modifiers);
 private:
     Spreadsheet::Sheet * sheet;
 };

--- a/src/Mod/Spreadsheet/Gui/SpreadsheetView.h
+++ b/src/Mod/Spreadsheet/Gui/SpreadsheetView.h
@@ -82,8 +82,10 @@ public:
     virtual void deleteSelf();
 
 protected Q_SLOTS:
-    void editingFinished();
+    void editingFinishedWithKey(int key, Qt::KeyboardModifiers modifiers);
+    void confirmAliasChanged(const QString& text);
     void aliasChanged(const QString& text);
+    void confirmContentChanged(const QString& text);
     void currentChanged( const QModelIndex & current, const QModelIndex & previous );
     void columnResized(int col, int oldSize, int newSize);
     void rowResized(int row, int oldSize, int newSize);
@@ -94,7 +96,6 @@ protected:
     void updateContentLine();
     void updateAliasLine();
     void setCurrentCell(QString str);
-    void keyPressEvent(QKeyEvent *event);
     void resizeColumn(int col, int newSize);
     void resizeRow(int col, int newSize);
 


### PR DESCRIPTION
LineEdit no longer actually handles motion, it simply indicates which action was taken to cause it to lose focus (e.g. which key was pressed). It's up to the client code to determine what this means. This allows significant consolidation of keyboard-handling logic, and the implementation of more extensive keyboard navigation features.

New keyboard shortcuts include a tab counter to implement auto-return, plus Ctrl->Arrow, End, Home, Ctrl-End, and Ctrl-Home, matching the behavior of OpenOffice, LibreOffice, etc.

Testers: please in particular ensure that keyboard navigation when entering and updating data is correct, and that the alias- and expression-completer appears and disappears as expected.