### PR TITLE
[Doc] update weblink to Coin3D

### DIFF
--- a/src/Doc/ThirdPartyLibraries.html
+++ b/src/Doc/ThirdPartyLibraries.html
@@ -56,7 +56,7 @@ DEALINGS IN THE SOFTWARE.
 <hr>
 
 <h3><a name="_TocCoin3D"></a>Coin3D</h3>
-<p>Web site: <a href="https://bitbucket.org/Coin3D/coin/">https://bitbucket.org/Coin3D/coin/</a></p>
+<p>Web site: <a href="https://coin3d.github.io">https://coin3d.github.io</a></p>
 <p>Copyright: Coin is copyright (C) 1998-2013 Kongsberg Oil & Gas Technologies AS</p>
 <p>License: BSD-3-clause</p>
 <pre>

--- a/src/Gui/Splashscreen.cpp
+++ b/src/Gui/Splashscreen.cpp
@@ -505,14 +505,14 @@ void AboutDialog::showLibraryInformation()
     // Coin3D
     li.name = QLatin1String("Coin3D");
     li.href = baseurl + QLatin1String("#_TocCoin3D");
-    li.url = QLatin1String("https://bitbucket.org/Coin3D/coin/");
+    li.url = QLatin1String("https://coin3d.github.io");
     li.version = QLatin1String(COIN_VERSION);
     libInfo << li;
 
     // Eigen3
     li.name = QLatin1String("Eigen3");
     li.href = baseurl + QLatin1String("#_TocEigen3");
-    li.url = QLatin1String("http://eigen.tuxfamily.org/");
+    li.url = QLatin1String("http://eigen.tuxfamily.org");
     li.version = QString::fromLatin1(FC_EIGEN3_VERSION);
     libInfo << li;
 


### PR DESCRIPTION
* Coin3D is no longer available via bitbucket, therefore update the new dead links
* change a weblink so that it is the same in all our code