### PR TITLE
[Gui] Always hide progress bar on finished load

### DIFF
--- a/src/Mod/Web/Gui/BrowserView.cpp
+++ b/src/Mod/Web/Gui/BrowserView.cpp
@@ -693,12 +693,10 @@ void BrowserView::onLoadProgress(int step)
 
 void BrowserView::onLoadFinished(bool ok)
 {
-    if (ok) {
-        QProgressBar* bar = SequencerBar::instance()->getProgressBar();
-        bar->setValue(100);
-        bar->hide();
-        getMainWindow()->showMessage(QString());
-    }
+    QProgressBar* bar = SequencerBar::instance()->getProgressBar();
+    bar->setValue(100);
+    bar->hide();
+    getMainWindow()->showMessage(QString());
     isLoading = false;
 }
 


### PR DESCRIPTION
The `loadFinished` signal from QtWebEngine includes a boolean indicating whether the load was "successful" or not, but no apparent way to determine what error, if any, occurred. Given that we are never displaying any error information to the user, hide the progress bar regardless of the success or failure of the operation.

This was the cause of the never-hidden progress bar when creating a new file from the Start WB: loadFinished is returning with an "ok=false" when that action is executed.