### PR TITLE
[FEM] Allow modal adding/removal of geometric entities to constraints

### DIFF
--- a/src/Mod/Fem/Gui/CMakeLists.txt
+++ b/src/Mod/Fem/Gui/CMakeLists.txt
@@ -140,6 +140,8 @@ SET(FemGui_DLG_SRCS
     TaskFemConstraint.ui
     TaskFemConstraint.cpp
     TaskFemConstraint.h
+    TaskFemConstraintOnBoundary.cpp
+    TaskFemConstraintOnBoundary.h
     TaskFemConstraintBearing.ui
     TaskFemConstraintBearing.cpp
     TaskFemConstraintBearing.h

--- a/src/Mod/Fem/Gui/TaskFemConstraint.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraint.cpp
@@ -201,6 +201,11 @@ void TaskFemConstraint::onButtonWizCancel()
     onButtonWizOk();
 }
 
+const QString TaskFemConstraint::makeRefText(const std::string& objName, const std::string& subName) const
+{
+    return QString::fromUtf8((objName + ":" + subName).c_str());
+}
+
 const QString TaskFemConstraint::makeRefText(const App::DocumentObject* obj, const std::string& subName) const
 {
     return QString::fromUtf8((std::string(obj->getNameInDocument()) + ":" + subName).c_str());

--- a/src/Mod/Fem/Gui/TaskFemConstraint.h
+++ b/src/Mod/Fem/Gui/TaskFemConstraint.h
@@ -59,12 +59,11 @@ protected Q_SLOTS:
 
 protected:
     virtual void changeEvent(QEvent *e) { TaskBox::changeEvent(e); }
+    const QString makeRefText(const std::string& objName, const std::string& subName) const;
     const QString makeRefText(const App::DocumentObject* obj, const std::string& subName) const;
     virtual void keyPressEvent(QKeyEvent * ke);
     void createDeleteAction(QListWidget* parentList);
     bool KeyEvent(QEvent *e);
-
-private:
     virtual void onSelectionChanged(const Gui::SelectionChanges&) {}
 
 protected:

--- a/src/Mod/Fem/Gui/TaskFemConstraintDisplacement.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintDisplacement.cpp
@@ -54,6 +54,7 @@
 #include <Gui/Selection.h>
 #include <Gui/SelectionFilter.h>
 #include <Mod/Part/App/PartFeature.h>
+#include <Mod/PartDesign/Gui/ReferenceSelection.h>
 
 
 using namespace FemGui;
@@ -62,7 +63,7 @@ using namespace Gui;
 /* TRANSLATOR FemGui::TaskFemConstraintDisplacement */
 
 TaskFemConstraintDisplacement::TaskFemConstraintDisplacement(ViewProviderFemConstraintDisplacement *ConstraintView,QWidget *parent)
-  : TaskFemConstraint(ConstraintView, parent, "FEM_ConstraintDisplacement")
+    : TaskFemConstraintOnBoundary(ConstraintView, parent, "FEM_ConstraintDisplacement")
 {
     proxy = new QWidget(this);
     ui = new Ui_TaskFemConstraintDisplacement();
@@ -197,8 +198,10 @@ TaskFemConstraintDisplacement::TaskFemConstraintDisplacement(ViewProviderFemCons
     ui->rotzfree->blockSignals(false);
 
     //Selection buttons
-    connect(ui->btnAdd, SIGNAL(clicked()),  this, SLOT(addToSelection()));
-    connect(ui->btnRemove, SIGNAL(clicked()),  this, SLOT(removeFromSelection()));
+    connect(ui->btnAdd, SIGNAL(toggled(bool)),
+            this, SLOT(_addToSelection(bool)));
+    connect(ui->btnRemove, SIGNAL(toggled(bool)),
+            this, SLOT(_removeFromSelection(bool)));
 
     updateUI();
 }
@@ -561,6 +564,12 @@ void TaskFemConstraintDisplacement::changeEvent(QEvent *)
 //        ui->retranslateUi(proxy);
 //        ui->if_pressure->blockSignals(false);
 //    }
+}
+
+void TaskFemConstraintDisplacement::clearButtons(const SelectionChangeModes notThis)
+{
+    if (notThis != refAdd) ui->btnAdd->setChecked(false);
+    if (notThis != refRemove) ui->btnRemove->setChecked(false);
 }
 
 //**************************************************************************

--- a/src/Mod/Fem/Gui/TaskFemConstraintDisplacement.h
+++ b/src/Mod/Fem/Gui/TaskFemConstraintDisplacement.h
@@ -33,6 +33,7 @@
 #include <Base/Quantity.h>
 
 #include "TaskFemConstraint.h"
+#include "TaskFemConstraintOnBoundary.h"
 #include "ViewProviderFemConstraintDisplacement.h"
 
 #include <QObject>
@@ -43,7 +44,7 @@
 class Ui_TaskFemConstraintDisplacement;
 
 namespace FemGui {
-class TaskFemConstraintDisplacement : public TaskFemConstraint
+class TaskFemConstraintDisplacement : public TaskFemConstraintOnBoundary
 {
     Q_OBJECT
 
@@ -95,8 +96,9 @@ private Q_SLOTS:
     void removeFromSelection();
 
 protected:
-    bool event(QEvent *e); 
+    bool event(QEvent *e);
     void changeEvent(QEvent *e);
+    void clearButtons(const SelectionChangeModes notThis) override;
 
 private:
     void updateUI();

--- a/src/Mod/Fem/Gui/TaskFemConstraintDisplacement.ui
+++ b/src/Mod/Fem/Gui/TaskFemConstraintDisplacement.ui
@@ -54,16 +54,22 @@
     <item>
      <layout class="QHBoxLayout" name="hLayout1">
       <item>
-       <widget class="QPushButton" name="btnAdd">
+       <widget class="QToolButton" name="btnAdd">
         <property name="text">
          <string>Add</string>
+        </property>
+        <property name="checkable">
+          <bool>true</bool>
         </property>
        </widget>
       </item>
       <item>
-       <widget class="QPushButton" name="btnRemove">
+       <widget class="QToolButton" name="btnRemove">
         <property name="text">
          <string>Remove</string>
+        </property>
+        <property name="checkable">
+          <bool>true</bool>
         </property>
        </widget>
       </item>

--- a/src/Mod/Fem/Gui/TaskFemConstraintFixed.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintFixed.cpp
@@ -60,7 +60,7 @@ using namespace Gui;
 /* TRANSLATOR FemGui::TaskFemConstraintFixed */
 
 TaskFemConstraintFixed::TaskFemConstraintFixed(ViewProviderFemConstraintFixed *ConstraintView,QWidget *parent)
-  : TaskFemConstraint(ConstraintView, parent, "FEM_ConstraintFixed")
+  : TaskFemConstraintOnBoundary(ConstraintView, parent, "FEM_ConstraintFixed")
 { //Note change "Fixed" in line above to new constraint name
     proxy = new QWidget(this);
     ui = new Ui_TaskFemConstraintFixed();
@@ -96,8 +96,10 @@ TaskFemConstraintFixed::TaskFemConstraintFixed(ViewProviderFemConstraintFixed *C
     }
 
     //Selection buttons
-    connect(ui->btnAdd, SIGNAL(clicked()),  this, SLOT(addToSelection()));
-    connect(ui->btnRemove, SIGNAL(clicked()),  this, SLOT(removeFromSelection()));
+    connect(ui->btnAdd, SIGNAL(toggled(bool)),
+            this, SLOT(_addToSelection(bool)));
+    connect(ui->btnRemove, SIGNAL(toggled(bool)),
+            this, SLOT(_removeFromSelection(bool)));
 
     updateUI();
 }
@@ -242,6 +244,12 @@ bool TaskFemConstraintFixed::event(QEvent *e)
 
 void TaskFemConstraintFixed::changeEvent(QEvent *)
 {
+}
+
+void TaskFemConstraintFixed::clearButtons(const SelectionChangeModes notThis)
+{
+    if (notThis != refAdd) ui->btnAdd->setChecked(false);
+    if (notThis != refRemove) ui->btnRemove->setChecked(false);
 }
 
 //**************************************************************************

--- a/src/Mod/Fem/Gui/TaskFemConstraintFixed.h
+++ b/src/Mod/Fem/Gui/TaskFemConstraintFixed.h
@@ -31,6 +31,7 @@
 #include <Base/Quantity.h>
 
 #include "TaskFemConstraint.h"
+#include "TaskFemConstraintOnBoundary.h"
 #include "ViewProviderFemConstraintFixed.h"
 
 #include <QObject>
@@ -40,7 +41,7 @@
 class Ui_TaskFemConstraintFixed;
 
 namespace FemGui {
-class TaskFemConstraintFixed : public TaskFemConstraint
+class TaskFemConstraintFixed : public TaskFemConstraintOnBoundary
 {
     Q_OBJECT
 
@@ -57,6 +58,7 @@ private Q_SLOTS:
 protected:
     bool event(QEvent *e);
     void changeEvent(QEvent *e);
+    void clearButtons(const SelectionChangeModes notThis) override;
 
 private:
     void updateUI();

--- a/src/Mod/Fem/Gui/TaskFemConstraintFixed.ui
+++ b/src/Mod/Fem/Gui/TaskFemConstraintFixed.ui
@@ -24,16 +24,22 @@
    <item>
     <layout class="QHBoxLayout" name="hLayout1">
      <item>
-      <widget class="QPushButton" name="btnAdd">
+      <widget class="QToolButton" name="btnAdd">
        <property name="text">
         <string>Add</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
        </property>
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="btnRemove">
+      <widget class="QToolButton" name="btnRemove">
        <property name="text">
         <string>Remove</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
        </property>
       </widget>
      </item>

--- a/src/Mod/Fem/Gui/TaskFemConstraintFluidBoundary.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintFluidBoundary.cpp
@@ -132,7 +132,7 @@ void initComboBox(QComboBox* combo, const std::vector<std::string>& textItems, c
 
 /* TRANSLATOR FemGui::TaskFemConstraintFluidBoundary */
 TaskFemConstraintFluidBoundary::TaskFemConstraintFluidBoundary(ViewProviderFemConstraintFluidBoundary *ConstraintView,QWidget *parent)
-    : TaskFemConstraint(ConstraintView, parent, "FEM_ConstraintFluidBoundary")
+    : TaskFemConstraintOnBoundary(ConstraintView, parent, "FEM_ConstraintFluidBoundary")
     , dimension(-1)
 {
     // we need a separate container widget to add all controls to
@@ -175,8 +175,10 @@ TaskFemConstraintFluidBoundary::TaskFemConstraintFluidBoundary(ViewProviderFemCo
     ui->checkReverse->blockSignals(true);
 
     //Selection buttons
-    connect(ui->btnAdd, SIGNAL(clicked()), this, SLOT(addToSelection()));
-    connect(ui->btnRemove, SIGNAL(clicked()), this, SLOT(removeFromSelection()));
+    connect(ui->btnAdd, SIGNAL(toggled(bool)),
+            this, SLOT(_addToSelection(bool)));
+    connect(ui->btnRemove, SIGNAL(toggled(bool)),
+            this, SLOT(_removeFromSelection(bool)));
 
     // Get the feature data
     Fem::ConstraintFluidBoundary* pcConstraint = static_cast<Fem::ConstraintFluidBoundary*>(ConstraintView->getObject());
@@ -557,6 +559,9 @@ void TaskFemConstraintFluidBoundary::onButtonDirection(const bool pressed)
     // sets the normal vector of the currently selecteed planar face as direction
 
     Q_UNUSED(pressed)
+
+    clearButtons(none);
+
     //get vector of selected objects of active document
     std::vector<Gui::SelectionObject> selection = Gui::Selection().getSelectionEx();
     if (selection.size() == 0) {
@@ -861,6 +866,12 @@ void TaskFemConstraintFluidBoundary::changeEvent(QEvent *e)
 
         ui->spinBoundaryValue->blockSignals(false);
     }
+}
+
+void TaskFemConstraintFluidBoundary::clearButtons(const SelectionChangeModes notThis)
+{
+    if (notThis != refAdd) ui->btnAdd->setChecked(false);
+    if (notThis != refRemove) ui->btnRemove->setChecked(false);
 }
 
 //**************************************************************************

--- a/src/Mod/Fem/Gui/TaskFemConstraintFluidBoundary.h
+++ b/src/Mod/Fem/Gui/TaskFemConstraintFluidBoundary.h
@@ -31,6 +31,7 @@
 #include <Mod/Fem/App/FemSolverObject.h>
 
 #include "TaskFemConstraint.h"
+#include "TaskFemConstraintOnBoundary.h"
 #include "ViewProviderFemConstraintFluidBoundary.h"
 
 #include <QKeyEvent>
@@ -47,7 +48,7 @@ class ViewProvider;
 
 namespace FemGui {
 
-class TaskFemConstraintFluidBoundary : public TaskFemConstraint
+class TaskFemConstraintFluidBoundary : public TaskFemConstraintOnBoundary
 {
     Q_OBJECT
 
@@ -92,6 +93,7 @@ private Q_SLOTS:
 protected:
     bool event(QEvent *e);
     virtual void changeEvent(QEvent *e);
+    void clearButtons(const SelectionChangeModes notThis) override;
 
 private:
     void updateBoundaryTypeUI();

--- a/src/Mod/Fem/Gui/TaskFemConstraintFluidBoundary.ui
+++ b/src/Mod/Fem/Gui/TaskFemConstraintFluidBoundary.ui
@@ -88,16 +88,22 @@
      <item>
       <layout class="QHBoxLayout" name="horizontalLayout_2">
        <item>
-        <widget class="QPushButton" name="btnAdd">
+        <widget class="QToolButton" name="btnAdd">
          <property name="text">
           <string>Add</string>
+         </property>
+         <property name="checkable">
+           <bool>true</bool>
          </property>
         </widget>
        </item>
        <item>
-        <widget class="QPushButton" name="btnRemove">
+        <widget class="QToolButton" name="btnRemove">
          <property name="text">
           <string>Remove</string>
+         </property>
+         <property name="checkable">
+           <bool>true</bool>
          </property>
         </widget>
        </item>

--- a/src/Mod/Fem/Gui/TaskFemConstraintForce.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintForce.cpp
@@ -70,7 +70,7 @@ using namespace Gui;
 /* TRANSLATOR FemGui::TaskFemConstraintForce */
 
 TaskFemConstraintForce::TaskFemConstraintForce(ViewProviderFemConstraintForce *ConstraintView,QWidget *parent)
-    : TaskFemConstraint(ConstraintView, parent, "FEM_ConstraintForce")
+    : TaskFemConstraintOnBoundary(ConstraintView, parent, "FEM_ConstraintForce")
 {
     // we need a separate container widget to add all controls to
     proxy = new QWidget(this);
@@ -128,8 +128,10 @@ TaskFemConstraintForce::TaskFemConstraintForce(ViewProviderFemConstraintForce *C
     ui->checkReverse->blockSignals(false);
 
     //Selection buttons
-    connect(ui->btnAdd, SIGNAL(clicked()), this, SLOT(addToSelection()));
-    connect(ui->btnRemove, SIGNAL(clicked()), this, SLOT(removeFromSelection()));
+    connect(ui->btnAdd, SIGNAL(toggled(bool)),
+            this, SLOT(_addToSelection(bool)));
+    connect(ui->btnRemove, SIGNAL(toggled(bool)),
+            this, SLOT(_removeFromSelection(bool)));
 
     updateUI();
 }
@@ -315,6 +317,8 @@ void TaskFemConstraintForce::onButtonDirection(const bool pressed)
     // sets the normal vector of the currently selecteed planar face as direction
     Q_UNUSED(pressed)
 
+    clearButtons(none);
+
     auto link = getDirection(Gui::Selection().getSelectionEx());
     if (!link.first) {
         QMessageBox::warning(this, tr("Wrong selection"), tr("Select an edge or a face, please."));
@@ -400,6 +404,12 @@ void TaskFemConstraintForce::changeEvent(QEvent *e)
         ui->retranslateUi(proxy);
         ui->spinForce->blockSignals(false);
     }
+}
+
+void TaskFemConstraintForce::clearButtons(const SelectionChangeModes notThis)
+{
+    if (notThis != refAdd) ui->btnAdd->setChecked(false);
+    if (notThis != refRemove) ui->btnRemove->setChecked(false);
 }
 
 //**************************************************************************

--- a/src/Mod/Fem/Gui/TaskFemConstraintForce.h
+++ b/src/Mod/Fem/Gui/TaskFemConstraintForce.h
@@ -30,6 +30,7 @@
 #include <Gui/TaskView/TaskDialog.h>
 
 #include "TaskFemConstraint.h"
+#include "TaskFemConstraintOnBoundary.h"
 #include "ViewProviderFemConstraintForce.h"
 
 #include <QKeyEvent>
@@ -47,7 +48,7 @@ class ViewProvider;
 
 namespace FemGui {
 
-class TaskFemConstraintForce : public TaskFemConstraint
+class TaskFemConstraintForce : public TaskFemConstraintOnBoundary
 {
     Q_OBJECT
 
@@ -71,6 +72,7 @@ private Q_SLOTS:
 protected:
     bool event(QEvent *e);
     virtual void changeEvent(QEvent *e);
+    void clearButtons(const SelectionChangeModes notThis) override;
 
 private:
     std::pair<App::DocumentObject*, std::string> getDirection(const std::vector<Gui::SelectionObject>&) const;

--- a/src/Mod/Fem/Gui/TaskFemConstraintForce.ui
+++ b/src/Mod/Fem/Gui/TaskFemConstraintForce.ui
@@ -42,16 +42,22 @@
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
-      <widget class="QPushButton" name="btnAdd">
+      <widget class="QToolButton" name="btnAdd">
        <property name="text">
         <string>Add</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
        </property>
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="btnRemove">
+      <widget class="QToolButton" name="btnRemove">
        <property name="text">
         <string>Remove</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
        </property>
       </widget>
      </item>
@@ -94,7 +100,7 @@
    <item>
     <layout class="QHBoxLayout" name="layoutDirection">
      <item>
-      <widget class="QPushButton" name="buttonDirection">
+      <widget class="QToolButton" name="buttonDirection">
        <property name="toolTip">
         <string>Select a planar edge or face, then press this button</string>
        </property>

--- a/src/Mod/Fem/Gui/TaskFemConstraintHeatflux.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintHeatflux.cpp
@@ -59,7 +59,7 @@ using namespace Gui;
 /* TRANSLATOR FemGui::TaskFemConstraintHeatflux */
 
 TaskFemConstraintHeatflux::TaskFemConstraintHeatflux(ViewProviderFemConstraintHeatflux *ConstraintView,QWidget *parent)
-  : TaskFemConstraint(ConstraintView, parent, "FEM_ConstraintHeatflux")
+  : TaskFemConstraintOnBoundary(ConstraintView, parent, "FEM_ConstraintHeatflux")
 {
     proxy = new QWidget(this);
     ui = new Ui_TaskFemConstraintHeatflux();
@@ -130,8 +130,10 @@ TaskFemConstraintHeatflux::TaskFemConstraintHeatflux(ViewProviderFemConstraintHe
     }
 
     //Selection buttons
-    connect(ui->btnAdd, SIGNAL(clicked()),  this, SLOT(addToSelection()));
-    connect(ui->btnRemove, SIGNAL(clicked()),  this, SLOT(removeFromSelection()));
+    connect(ui->btnAdd, SIGNAL(toggled(bool)),
+            this, SLOT(_addToSelection(bool)));
+    connect(ui->btnRemove, SIGNAL(toggled(bool)),
+            this, SLOT(_removeFromSelection(bool)));
 
     ui->if_ambienttemp->blockSignals(false);
     //ui->if_facetemp->blockSignals(false);
@@ -373,6 +375,12 @@ void TaskFemConstraintHeatflux::changeEvent(QEvent *e)
         ui->if_ambienttemp->blockSignals(false);
         ui->if_filmcoef->blockSignals(false);
     }
+}
+
+void TaskFemConstraintHeatflux::clearButtons(const SelectionChangeModes notThis)
+{
+    if (notThis != refAdd) ui->btnAdd->setChecked(false);
+    if (notThis != refRemove) ui->btnRemove->setChecked(false);
 }
 
 //**************************************************************************

--- a/src/Mod/Fem/Gui/TaskFemConstraintHeatflux.h
+++ b/src/Mod/Fem/Gui/TaskFemConstraintHeatflux.h
@@ -33,6 +33,7 @@
 #include <Base/Quantity.h>
 
 #include "TaskFemConstraint.h"
+#include "TaskFemConstraintOnBoundary.h"
 #include "ViewProviderFemConstraintHeatflux.h"
 
 #include <QObject>
@@ -43,7 +44,7 @@
 class Ui_TaskFemConstraintHeatflux;
 
 namespace FemGui {
-class TaskFemConstraintHeatflux : public TaskFemConstraint
+class TaskFemConstraintHeatflux : public TaskFemConstraintOnBoundary
 {
     Q_OBJECT
 
@@ -70,6 +71,7 @@ private Q_SLOTS:
 protected:
     bool event(QEvent *e);
     virtual void changeEvent(QEvent *e);
+    void clearButtons(const SelectionChangeModes notThis) override;
 
 private:
     void updateUI();

--- a/src/Mod/Fem/Gui/TaskFemConstraintHeatflux.ui
+++ b/src/Mod/Fem/Gui/TaskFemConstraintHeatflux.ui
@@ -24,16 +24,22 @@
    <item>
     <layout class="QHBoxLayout" name="hLayout1">
      <item>
-      <widget class="QPushButton" name="btnAdd">
+      <widget class="QToolButton" name="btnAdd">
        <property name="text">
         <string>Add</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
        </property>
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="btnRemove">
+      <widget class="QToolButton" name="btnRemove">
        <property name="text">
         <string>Remove</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
        </property>
       </widget>
      </item>

--- a/src/Mod/Fem/Gui/TaskFemConstraintOnBoundary.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintOnBoundary.cpp
@@ -1,0 +1,128 @@
+/***************************************************************************
+ *   Copyright (c) 2021 FreeCAD Developers                                 *
+ *   Author: Ajinkya Dahale <dahale.a.p@gmail.com>                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#include "PreCompiled.h"
+
+#ifndef _PreComp_
+# include <BRepAdaptor_Curve.hxx>
+# include <BRepAdaptor_Surface.hxx>
+# include <Geom_Line.hxx>
+# include <Geom_Plane.hxx>
+# include <Precision.hxx>
+
+# include <QAction>
+# include <QKeyEvent>
+# include <QMessageBox>
+# include <QRegExp>
+# include <QTextStream>
+
+# include <TopoDS.hxx>
+# include <gp_Ax1.hxx>
+# include <gp_Lin.hxx>
+# include <gp_Pln.hxx>
+# include <sstream>
+#endif
+
+#include "TaskFemConstraintOnBoundary.h"
+#include <App/Application.h>
+#include <Base/Tools.h>
+#include <Gui/Command.h>
+#include <Gui/Selection.h>
+#include <Gui/SelectionFilter.h>
+
+
+using namespace FemGui;
+using namespace Gui;
+
+/* TRANSLATOR FemGui::TaskFemConstraintOnBoundary */
+
+TaskFemConstraintOnBoundary::TaskFemConstraintOnBoundary(ViewProviderFemConstraint *ConstraintView, QWidget *parent, const char* pixmapname)
+    : TaskFemConstraint(ConstraintView, parent, pixmapname)
+{
+}
+
+TaskFemConstraintOnBoundary::~TaskFemConstraintOnBoundary()
+{
+}
+
+void TaskFemConstraintOnBoundary::_addToSelection(bool checked)
+{
+    if (checked)
+    {
+        const auto& selection = Gui::Selection().getSelectionEx(); //gets vector of selected objects of active document
+        if (selection.empty()) {
+            this->clearButtons(refAdd);
+            selChangeMode = refAdd;
+        } else {
+            this->addToSelection();
+            clearButtons(none);
+        }
+    } else {
+        exitSelectionChangeMode();
+    }
+}
+
+void TaskFemConstraintOnBoundary::_removeFromSelection(bool checked)
+{
+    if (checked)
+    {
+        const auto& selection = Gui::Selection().getSelectionEx(); //gets vector of selected objects of active document
+        if (selection.empty()) {
+            this->clearButtons(refRemove);
+            selChangeMode = refRemove;
+        } else {
+            this->removeFromSelection();
+            clearButtons(none);
+        }
+    } else {
+        exitSelectionChangeMode();
+    }
+}
+
+void TaskFemConstraintOnBoundary::onSelectionChanged(const Gui::SelectionChanges&msg)
+{
+    if (msg.Type == Gui::SelectionChanges::AddSelection) {
+        switch (selChangeMode) {
+        case refAdd:
+            // TODO: Optimize to just perform actions on the newly selected item. Suggestion from PartDesign:
+            // ui->lw_references->addItem(makeRefText(msg.pObjectName, msg.pSubName));
+            this->addToSelection();
+            break;
+        case refRemove:
+            this->removeFromSelection();
+            break;
+        case none:
+            return;
+        default:
+            return;
+        }
+    }
+}
+
+void TaskFemConstraintOnBoundary::exitSelectionChangeMode()
+{
+    selChangeMode = none;
+    Gui::Selection().clearSelection();
+}
+
+#include "moc_TaskFemConstraintOnBoundary.cpp"

--- a/src/Mod/Fem/Gui/TaskFemConstraintOnBoundary.h
+++ b/src/Mod/Fem/Gui/TaskFemConstraintOnBoundary.h
@@ -1,0 +1,74 @@
+/***************************************************************************
+ *   Copyright (c) 2021 FreeCAD Developers                                 *
+ *   Author: Ajinkya Dahale <dahale.a.p@gmail.com>                         *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#ifndef GUI_TASKVIEW_TaskFemConstraintOnBoundary_H
+#define GUI_TASKVIEW_TaskFemConstraintOnBoundary_H
+
+#include <Gui/TaskView/TaskView.h>
+#include <Gui/Selection.h>
+#include <Gui/TaskView/TaskDialog.h>
+#include <Base/Quantity.h>
+
+#include "TaskFemConstraint.h"
+
+#include <QObject>
+#include <Base/Console.h>
+#include <App/DocumentObject.h>
+#include <QKeyEvent>
+
+namespace FemGui {
+
+/** @brief Taskbox for FEM constraints that apply on subsets of the domain boundary
+ *
+ *  @detail Convenience superclass for taskboxes setting certain constraints
+ *  that apply on subsets of the boundary (faces/edges/vertices), where one or
+ *  more boundary entities need to be selected.
+ */
+class TaskFemConstraintOnBoundary : public TaskFemConstraint
+{
+    Q_OBJECT
+
+public:
+    TaskFemConstraintOnBoundary(ViewProviderFemConstraint *ConstraintView, QWidget *parent = 0, const char* pixmapname = "");
+    ~TaskFemConstraintOnBoundary();
+
+protected Q_SLOTS:
+    void _addToSelection(bool checked);
+    virtual void addToSelection() = 0;
+    void _removeFromSelection(bool checked);
+    virtual void removeFromSelection() = 0;
+
+protected:
+    enum SelectionChangeModes {none, refAdd, refRemove};
+    virtual void onSelectionChanged(const Gui::SelectionChanges&) override;
+    virtual void clearButtons(const SelectionChangeModes notThis) = 0;
+    void exitSelectionChangeMode();
+
+protected:
+    enum SelectionChangeModes selChangeMode;
+};
+
+} // namespace FemGui
+
+#endif // GUI_TASKVIEW_TaskFemConstraintOnBoundary_H

--- a/src/Mod/Fem/Gui/TaskFemConstraintPressure.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintPressure.cpp
@@ -59,7 +59,7 @@ using namespace Gui;
 /* TRANSLATOR FemGui::TaskFemConstraintPressure */
 
 TaskFemConstraintPressure::TaskFemConstraintPressure(ViewProviderFemConstraintPressure *ConstraintView,QWidget *parent)
-  : TaskFemConstraint(ConstraintView, parent, "FEM_ConstraintPressure")
+    : TaskFemConstraintOnBoundary(ConstraintView, parent, "FEM_ConstraintPressure")
 { //Note change "pressure" in line above to new constraint name
     proxy = new QWidget(this);
     ui = new Ui_TaskFemConstraintPressure();
@@ -105,8 +105,10 @@ TaskFemConstraintPressure::TaskFemConstraintPressure(ViewProviderFemConstraintPr
     }
 
     //Selection buttons
-    connect(ui->btnAdd, SIGNAL(clicked()),  this, SLOT(addToSelection()));
-    connect(ui->btnRemove, SIGNAL(clicked()),  this, SLOT(removeFromSelection()));
+    connect(ui->btnAdd, SIGNAL(toggled(bool)),
+            this, SLOT(_addToSelection(bool)));
+    connect(ui->btnRemove, SIGNAL(toggled(bool)),
+            this, SLOT(_removeFromSelection(bool)));
 
     updateUI();
 }
@@ -259,6 +261,12 @@ bool TaskFemConstraintPressure::event(QEvent *e)
 
 void TaskFemConstraintPressure::changeEvent(QEvent *)
 {
+}
+
+void TaskFemConstraintPressure::clearButtons(const SelectionChangeModes notThis)
+{
+    if (notThis != refAdd) ui->btnAdd->setChecked(false);
+    if (notThis != refRemove) ui->btnRemove->setChecked(false);
 }
 
 //**************************************************************************

--- a/src/Mod/Fem/Gui/TaskFemConstraintPressure.h
+++ b/src/Mod/Fem/Gui/TaskFemConstraintPressure.h
@@ -33,6 +33,7 @@
 #include <Base/Quantity.h>
 
 #include "TaskFemConstraint.h"
+#include "TaskFemConstraintOnBoundary.h"
 #include "ViewProviderFemConstraintPressure.h"
 
 #include <QObject>
@@ -43,7 +44,7 @@
 class Ui_TaskFemConstraintPressure;
 
 namespace FemGui {
-class TaskFemConstraintPressure : public TaskFemConstraint
+class TaskFemConstraintPressure : public TaskFemConstraintOnBoundary
 {
     Q_OBJECT
 
@@ -63,6 +64,7 @@ private Q_SLOTS:
 protected:
     bool event(QEvent *e);
     void changeEvent(QEvent *e);
+    void clearButtons(const SelectionChangeModes notThis) override;
 
 private:
     void updateUI();

--- a/src/Mod/Fem/Gui/TaskFemConstraintPressure.ui
+++ b/src/Mod/Fem/Gui/TaskFemConstraintPressure.ui
@@ -24,16 +24,22 @@
    <item>
     <layout class="QHBoxLayout" name="hLayout1">
      <item>
-      <widget class="QPushButton" name="btnAdd">
+      <widget class="QToolButton" name="btnAdd">
        <property name="text">
         <string>Add</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
        </property>
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="btnRemove">
+      <widget class="QToolButton" name="btnRemove">
        <property name="text">
         <string>Remove</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
        </property>
       </widget>
      </item>

--- a/src/Mod/Fem/Gui/TaskFemConstraintSpring.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintSpring.cpp
@@ -59,8 +59,8 @@ using namespace Gui;
 /* TRANSLATOR FemGui::TaskFemConstraintSpring */
 
 TaskFemConstraintSpring::TaskFemConstraintSpring(ViewProviderFemConstraintSpring *ConstraintView, QWidget *parent)
-  : TaskFemConstraint(ConstraintView, parent, "FEM_ConstraintSpring")
-{ 
+  : TaskFemConstraintOnBoundary(ConstraintView, parent, "FEM_ConstraintSpring")
+{
     proxy = new QWidget(this);
     ui = new Ui_TaskFemConstraintSpring();
     ui->setupUi(proxy);
@@ -95,7 +95,7 @@ TaskFemConstraintSpring::TaskFemConstraintSpring(ViewProviderFemConstraintSpring
     ui->if_tan->setMaximum(FLOAT_MAX);
     Base::Quantity ts = Base::Quantity((pcConstraint->tangentialStiffness.getValue()), Base::Unit::Stiffness);
     ui->if_tan->setValue(ts);
-    
+
 /* */
 
     ui->lw_references->clear();
@@ -107,8 +107,10 @@ TaskFemConstraintSpring::TaskFemConstraintSpring(ViewProviderFemConstraintSpring
     }
 
     //Selection buttons
-    connect(ui->btnAdd, SIGNAL(clicked()),  this, SLOT(addToSelection()));
-    connect(ui->btnRemove, SIGNAL(clicked()),  this, SLOT(removeFromSelection()));
+    connect(ui->btnAdd, SIGNAL(toggled(bool)),
+            this, SLOT(_addToSelection(bool)));
+    connect(ui->btnRemove, SIGNAL(toggled(bool)),
+            this, SLOT(_removeFromSelection(bool)));
 
     updateUI();
 }
@@ -259,6 +261,12 @@ bool TaskFemConstraintSpring::event(QEvent *e)
 
 void TaskFemConstraintSpring::changeEvent(QEvent *)
 {
+}
+
+void TaskFemConstraintSpring::clearButtons(const SelectionChangeModes notThis)
+{
+    if (notThis != refAdd) ui->btnAdd->setChecked(false);
+    if (notThis != refRemove) ui->btnRemove->setChecked(false);
 }
 
 //**************************************************************************

--- a/src/Mod/Fem/Gui/TaskFemConstraintSpring.h
+++ b/src/Mod/Fem/Gui/TaskFemConstraintSpring.h
@@ -31,6 +31,7 @@
 #include <Base/Quantity.h>
 
 #include "TaskFemConstraint.h"
+#include "TaskFemConstraintOnBoundary.h"
 #include "ViewProviderFemConstraintSpring.h"
 
 #include <QObject>
@@ -41,7 +42,7 @@
 class Ui_TaskFemConstraintSpring;
 
 namespace FemGui {
-class TaskFemConstraintSpring : public TaskFemConstraint
+class TaskFemConstraintSpring : public TaskFemConstraintOnBoundary
 {
     Q_OBJECT
 
@@ -60,6 +61,7 @@ private Q_SLOTS:
 protected:
     bool event(QEvent *e);
     void changeEvent(QEvent *e);
+    void clearButtons(const SelectionChangeModes notThis) override;
 
 private:
     void updateUI();

--- a/src/Mod/Fem/Gui/TaskFemConstraintSpring.ui
+++ b/src/Mod/Fem/Gui/TaskFemConstraintSpring.ui
@@ -24,16 +24,22 @@
    <item>
     <layout class="QHBoxLayout" name="hLayout1">
      <item>
-      <widget class="QPushButton" name="btnAdd">
+      <widget class="QToolButton" name="btnAdd">
        <property name="text">
         <string>Add</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
        </property>
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="btnRemove">
+      <widget class="QToolButton" name="btnRemove">
        <property name="text">
         <string>Remove</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
        </property>
       </widget>
      </item>

--- a/src/Mod/Fem/Gui/TaskFemConstraintTemperature.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintTemperature.cpp
@@ -61,7 +61,7 @@ using namespace Gui;
 /* TRANSLATOR FemGui::TaskFemConstraintTemperature */
 
 TaskFemConstraintTemperature::TaskFemConstraintTemperature(ViewProviderFemConstraintTemperature *ConstraintView,QWidget *parent)
-  : TaskFemConstraint(ConstraintView, parent, "FEM_ConstraintTemperature")
+  : TaskFemConstraintOnBoundary(ConstraintView, parent, "FEM_ConstraintTemperature")
 {
     proxy = new QWidget(this);
     ui = new Ui_TaskFemConstraintTemperature();
@@ -120,8 +120,10 @@ TaskFemConstraintTemperature::TaskFemConstraintTemperature(ViewProviderFemConstr
     }
 
     //Selection buttons
-    connect(ui->btnAdd, SIGNAL(clicked()),  this, SLOT(addToSelection()));
-    connect(ui->btnRemove, SIGNAL(clicked()),  this, SLOT(removeFromSelection()));
+    connect(ui->btnAdd, SIGNAL(toggled(bool)),
+            this, SLOT(_addToSelection(bool)));
+    connect(ui->btnRemove, SIGNAL(toggled(bool)),
+            this, SLOT(_removeFromSelection(bool)));
 
     updateUI();
 }
@@ -314,6 +316,12 @@ void TaskFemConstraintTemperature::changeEvent(QEvent *)
 //        ui->retranslateUi(proxy);
 //        ui->if_pressure->blockSignals(false);
 //    }
+}
+
+void TaskFemConstraintTemperature::clearButtons(const SelectionChangeModes notThis)
+{
+    if (notThis != refAdd) ui->btnAdd->setChecked(false);
+    if (notThis != refRemove) ui->btnRemove->setChecked(false);
 }
 
 //**************************************************************************

--- a/src/Mod/Fem/Gui/TaskFemConstraintTemperature.h
+++ b/src/Mod/Fem/Gui/TaskFemConstraintTemperature.h
@@ -33,6 +33,7 @@
 #include <Base/Quantity.h>
 
 #include "TaskFemConstraint.h"
+#include "TaskFemConstraintOnBoundary.h"
 #include "ViewProviderFemConstraintTemperature.h"
 
 #include <QObject>
@@ -43,7 +44,7 @@
 class Ui_TaskFemConstraintTemperature;
 
 namespace FemGui {
-class TaskFemConstraintTemperature : public TaskFemConstraint
+class TaskFemConstraintTemperature : public TaskFemConstraintOnBoundary
 {
     Q_OBJECT
 
@@ -66,6 +67,7 @@ private Q_SLOTS:
 protected:
     bool event(QEvent *e);
     void changeEvent(QEvent *e);
+    void clearButtons(const SelectionChangeModes notThis) override;
 
 private:
     void updateUI();

--- a/src/Mod/Fem/Gui/TaskFemConstraintTemperature.ui
+++ b/src/Mod/Fem/Gui/TaskFemConstraintTemperature.ui
@@ -24,16 +24,22 @@
    <item>
     <layout class="QHBoxLayout" name="hLayout1">
      <item>
-      <widget class="QPushButton" name="btnAdd">
+      <widget class="QToolButton" name="btnAdd">
        <property name="text">
         <string>Add</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
        </property>
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="btnRemove">
+      <widget class="QToolButton" name="btnRemove">
        <property name="text">
         <string>Remove</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
With these changes applied, if nothing is selected while a constraint is being edited, pressing the add/remove button will put the user in an add/remove mode so that on clicking a face/edge in the viewport, that edge/face will be added to/removed from the list of entities to be constrained with the given FEM constraint.

Currently restricted to displacement constraints. I plan to add this to the rest of the constraints and make the behavior consistent with task-views in other workbenches which add/remove boundary entities.
