### PR TITLE
Fix various typos

### DIFF
--- a/src/Mod/Draft/Resources/ui/preferences-dwg.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-dwg.ui
@@ -38,7 +38,7 @@
         <item>
          <widget class="Gui::PrefComboBox" name="comboBox">
           <property name="toolTip">
-           <string>This is the method FreeCAD will use to convert DWG files to DXF. If &quot;Automatic&quot; is chosen, FreeCAD will try to find one of the following convertors in the same order as they are shown here. If FreeCAD is unable to find any, you might need to choose a specific convertor and indicate its path here under. Choose the &quot;dwg2dxf&quot; utility if using LibreDWG, &quot;ODAFileConverter&quot; if using the ODA file converter, or the &quot;dwg2dwg&quot; utility if using the pro version of QCAD.</string>
+           <string>This is the method FreeCAD will use to convert DWG files to DXF. If &quot;Automatic&quot; is chosen, FreeCAD will try to find one of the following converters in the same order as they are shown here. If FreeCAD is unable to find any, you might need to choose a specific converter and indicate its path here under. Choose the &quot;dwg2dxf&quot; utility if using LibreDWG, &quot;ODAFileConverter&quot; if using the ODA file converter, or the &quot;dwg2dwg&quot; utility if using the pro version of QCAD.</string>
           </property>
           <property name="prefEntry" stdset="0">
            <cstring>DWGConversion</cstring>

--- a/src/Mod/Draft/draftgeoutils/wires.py
+++ b/src/Mod/Draft/draftgeoutils/wires.py
@@ -354,7 +354,7 @@ def removeInterVertices(wire):
 
 
 def cleanProjection(shape, tessellate=True, seglength=0.05):
-    """Return a compound of edges, optionally tesselate ellipses, splines
+    """Return a compound of edges, optionally tessellate ellipses, splines
     and bezcurves.
 
     The function was formerly used to workaround bugs in the projection

--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -7137,7 +7137,7 @@ bool CmdSketcherConstrainSnellsLaw::isActive(void)
 DEF_STD_CMD_A(CmdSketcherConstrainInternalAlignment)
 
 // NOTE: This command is deprecated. Nobody seriously uses today manual creation of an internal alignment constraint
-// The only reason this code remains is the extremelly unlikely scenario that some user macro may rely on it.
+// The only reason this code remains is the extremely unlikely scenario that some user macro may rely on it.
 CmdSketcherConstrainInternalAlignment::CmdSketcherConstrainInternalAlignment()
     :Command("Sketcher_ConstrainInternalAlignment")
 {

--- a/src/Mod/Sketcher/Gui/TaskSketcherConstrains.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstrains.cpp
@@ -1002,7 +1002,7 @@ void TaskSketcherConstrains::onSelectionChanged(const Gui::SelectionChanges& msg
                     if(geoid != Sketcher::Constraint::GeoUndef && pointpos == Sketcher::none){
                         // It is not possible to update on single addition/removal of a geometric element,
                         // as one removal may imply removing a constraint that should be added by a different element
-                        // that is still selected. The necessary checks outweight a full rebuild of the filter.
+                        // that is still selected. The necessary checks outweigh a full rebuild of the filter.
                         updateAssociatedConstraintsFilter();
                     }
                 }

--- a/src/Mod/Spreadsheet/App/SheetPy.xml
+++ b/src/Mod/Spreadsheet/App/SheetPy.xml
@@ -176,7 +176,7 @@
 recomputeCells(from, to=None)
 
 Manually recompute cells in the given range with the given order without
-following depedency order.
+following dependency order.
         </UserDocu>
       </Documentation>
     </Methode>


### PR DESCRIPTION
Found via `codespell -q 3 -L aci,ake,aline,alle,alledges,alocation,als,ang,anid,apoints,ba,beginn,behaviour,bloaded,bottome,byteorder,calculater,cancelled,cancelling,cas,cascade,centimetre,childs,colour,colours,commen,connexion,currenty,dof,doubleclick,dum,eiter,elemente,ende,feld,finde,findf,freez,hist,iff,indicies,initialisation,initialise,initialised,initialises,initialisiert,inout,ist,kilometre,lod,mantatory,methode,metres,millimetre,modell,nd,noe,normale,normaly,nto,numer,oder,ontop,orgin,orginx,orginy,ot,pard,parms,pres,programm,que,recurrance,rougly,seperator,serie,sinc,strack,substraction,te,thist,thru,tread,uint,unter,vertexes,wallthickness,whitespaces -S ./.git,*.po,*.ts,./ChangeLog.txt,./src/3rdParty,./src/Mod/Assembly/App/opendcm,./src/CXX,./src/zipios++,./src/Base/swig*,./src/Mod/Robot/App/kdl_cp,./src/Mod/Import/App/SCL,./src/WindowsInstaller,./src/Doc/FreeCAD.uml,./build/doc/SourceDocu`