### PR TITLE
PD: Expose missing commands to translation in Measure dropdown menu

### DIFF
--- a/src/Mod/PartDesign/Gui/Workbench.cpp
+++ b/src/Mod/PartDesign/Gui/Workbench.cpp
@@ -65,6 +65,8 @@ namespace bp = boost::placeholders;
     qApp->translate("Gui::TaskView::TaskWatcherCommands", "Create Geometry");
     //
     qApp->translate("Workbench", "Measure");
+    qApp->translate("Workbench", "Refresh");
+    qApp->translate("Workbench", "Toggle 3D");
     qApp->translate("Workbench", "Part Design Helper");
     qApp->translate("Workbench", "Part Design Modeling");
 #endif


### PR DESCRIPTION
Fixes https://github.com/FreeCAD/FreeCAD-translations/issues/6

These commands are already translated but for some reason we need to add them again to `Workbench.cpp` so they will be in fact translated.