### PR TITLE
[PartDesign] Remove useless function overriding

### DIFF
--- a/src/Mod/PartDesign/Gui/ViewProviderLoft.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderLoft.cpp
@@ -81,11 +81,6 @@ void ViewProviderLoft::setupContextMenu(QMenu* menu, QObject* receiver, const ch
     PartDesignGui::ViewProvider::setupContextMenu(menu, receiver, member);
 }
 
-bool ViewProviderLoft::doubleClicked(void)
-{
-    return PartDesignGui::setEdit(pcObject);
-}
-
 bool ViewProviderLoft::setEdit(int ModNum)
 {
     if (ModNum == ViewProvider::Default)

--- a/src/Mod/PartDesign/Gui/ViewProviderLoft.h
+++ b/src/Mod/PartDesign/Gui/ViewProviderLoft.h
@@ -41,7 +41,6 @@ public:
     /// grouping handling 
     std::vector<App::DocumentObject*> claimChildren(void)const;
     void setupContextMenu(QMenu*, QObject*, const char*);
-    bool doubleClicked();
 
     virtual bool onDelete(const std::vector<std::string> &);
     void highlightReferences(const bool on, bool auxiliary);

--- a/src/Mod/PartDesign/Gui/ViewProviderPipe.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderPipe.cpp
@@ -89,11 +89,6 @@ void ViewProviderPipe::setupContextMenu(QMenu* menu, QObject* receiver, const ch
     PartDesignGui::ViewProvider::setupContextMenu(menu, receiver, member);
 }
 
-bool ViewProviderPipe::doubleClicked(void)
-{
-    return PartDesignGui::setEdit(pcObject);
-}
-
 bool ViewProviderPipe::setEdit(int ModNum) {
     if (ModNum == ViewProvider::Default )
         setPreviewDisplayMode(true);

--- a/src/Mod/PartDesign/Gui/ViewProviderPipe.h
+++ b/src/Mod/PartDesign/Gui/ViewProviderPipe.h
@@ -49,7 +49,6 @@ public:
     /// grouping handling 
     std::vector<App::DocumentObject*> claimChildren(void)const;
     void setupContextMenu(QMenu*, QObject*, const char*);
-    bool doubleClicked();
 
     virtual bool onDelete(const std::vector<std::string> &);
     void highlightReferences(Reference mode, bool on);


### PR DESCRIPTION
 Double-click is already handled by PartDesign::ViewProvider::doubleClicked()
 Overridings in Loft & Pipe brings no specific behavior
 By removing overridings, behavioral consistency is improved both in ...
 ... undo commands & body activation management when PartDesign items ...
 ... are double-clicked

- [X]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [X]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [X]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [x]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [X]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [X]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`
