### PR TITLE
MeshPart: fix header uniformity + remove superfluous whitespace

### DIFF
--- a/src/Mod/MeshPart/App/AppMeshPart.cpp
+++ b/src/Mod/MeshPart/App/AppMeshPart.cpp
@@ -1,5 +1,5 @@
 /***************************************************************************
- *   Copyright (c) 2008 Jürgen Riegel (juergen.riegel@web.de)              *
+ *   Copyright (c) 2008 Jürgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *

--- a/src/Mod/MeshPart/App/AppMeshPartPy.cpp
+++ b/src/Mod/MeshPart/App/AppMeshPartPy.cpp
@@ -1,5 +1,5 @@
 /***************************************************************************
- *   Copyright (c) 2008 Jürgen Riegel (juergen.riegel@web.de)              *
+ *   Copyright (c) 2008 Jürgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *

--- a/src/Mod/MeshPart/App/CurveProjector.cpp
+++ b/src/Mod/MeshPart/App/CurveProjector.cpp
@@ -1,5 +1,5 @@
 /***************************************************************************
- *   Copyright (c) Juergen Riegel         <juergen.riegel@web.de>          *
+ *   Copyright (c) 2008 Juergen Riegel <juergen.riegel@web.de>             *
  *                                                                         *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *

--- a/src/Mod/MeshPart/App/CurveProjector.h
+++ b/src/Mod/MeshPart/App/CurveProjector.h
@@ -1,5 +1,5 @@
 /***************************************************************************
- *   Copyright (c) Juergen Riegel         <juergen.riegel@web.de>          *
+ *   Copyright (c) 2008 Juergen Riegel <juergen.riegel@web.de>             *
  *                                                                         *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *

--- a/src/Mod/MeshPart/App/MeshAlgos.cpp
+++ b/src/Mod/MeshPart/App/MeshAlgos.cpp
@@ -1,5 +1,5 @@
 /***************************************************************************
- *   Copyright (c) Juergen Riegel         <juergen.riegel@web.de>          *
+ *   Copyright (c) 2008 Juergen Riegel <juergen.riegel@web.de>             *
  *                                                                         *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *

--- a/src/Mod/MeshPart/App/MeshAlgos.h
+++ b/src/Mod/MeshPart/App/MeshAlgos.h
@@ -1,5 +1,5 @@
 /***************************************************************************
- *   Copyright (c) Juergen Riegel         <juergen.riegel@web.de>          *
+ *   Copyright (c) 2008 Juergen Riegel <juergen.riegel@web.de>             *
  *                                                                         *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *

--- a/src/Mod/MeshPart/App/PreCompiled.cpp
+++ b/src/Mod/MeshPart/App/PreCompiled.cpp
@@ -1,5 +1,5 @@
 /***************************************************************************
- *   Copyright (c) 2008 Jürgen Riegel (juergen.riegel@web.de)              *
+ *   Copyright (c) 2008 Jürgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *

--- a/src/Mod/MeshPart/App/PreCompiled.h
+++ b/src/Mod/MeshPart/App/PreCompiled.h
@@ -1,5 +1,5 @@
 /***************************************************************************
- *   Copyright (c) 2008 Jürgen Riegel (juergen.riegel@web.de)              *
+ *   Copyright (c) 2008 Jürgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *

--- a/src/Mod/MeshPart/Gui/AppMeshPartGui.cpp
+++ b/src/Mod/MeshPart/Gui/AppMeshPartGui.cpp
@@ -1,5 +1,5 @@
 /***************************************************************************
- *   Copyright (c) 2008 Jürgen Riegel (juergen.riegel@web.de)              *
+ *   Copyright (c) 2008 Jürgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *

--- a/src/Mod/MeshPart/Gui/Command.cpp
+++ b/src/Mod/MeshPart/Gui/Command.cpp
@@ -1,5 +1,5 @@
 /***************************************************************************
- *   Copyright (c) 2008 Jürgen Riegel (juergen.riegel@web.de)              *
+ *   Copyright (c) 2008 Jürgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *

--- a/src/Mod/MeshPart/Gui/MeshFlatteningCommand.py
+++ b/src/Mod/MeshPart/Gui/MeshFlatteningCommand.py
@@ -1,3 +1,25 @@
+#***************************************************************************
+#*   Copyright (c) 2017 Lorenz Lechner                                     *
+#*                                                                         *
+#*   This file is part of the FreeCAD CAx development system.              *
+#*                                                                         *
+#*   This library is free software; you can redistribute it and/or         *
+#*   modify it under the terms of the GNU Library General Public           *
+#*   License as published by the Free Software Foundation; either          *
+#*   version 2 of the License, or (at your option) any later version.      *
+#*                                                                         *
+#*   This library  is distributed in the hope that it will be useful,      *
+#*   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+#*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+#*   GNU Library General Public License for more details.                  *
+#*                                                                         *
+#*   You should have received a copy of the GNU Library General Public     *
+#*   License along with this library; see the file COPYING.LIB. If not,    *
+#*   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+#*   Suite 330, Boston, MA  02111-1307, USA                                *
+#*                                                                         *
+#***************************************************************************/
+
 import Mesh
 import FreeCAD as App
 import FreeCADGui as Gui

--- a/src/Mod/MeshPart/Gui/PreCompiled.cpp
+++ b/src/Mod/MeshPart/Gui/PreCompiled.cpp
@@ -1,5 +1,5 @@
 /***************************************************************************
- *   Copyright (c) 2008 Jürgen Riegel (juergen.riegel@web.de)              *
+ *   Copyright (c) 2008 Jürgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *

--- a/src/Mod/MeshPart/Gui/PreCompiled.h
+++ b/src/Mod/MeshPart/Gui/PreCompiled.h
@@ -1,5 +1,5 @@
 /***************************************************************************
- *   Copyright (c) 2008 Jürgen Riegel (juergen.riegel@web.de)              *
+ *   Copyright (c) 2008 Jürgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *

--- a/src/Mod/MeshPart/Init.py
+++ b/src/Mod/MeshPart/Init.py
@@ -1,8 +1,8 @@
-# FreeCAD init script of the MeshPart module  
+# FreeCAD init script of the MeshPart module
 # (c) 2001 Juergen Riegel
 
 #***************************************************************************
-#*   (c) Juergen Riegel (juergen.riegel@web.de) 2002                       *   
+#*   Copyright (c) 2002 Juergen Riegel <juergen.riegel@web.de>             *
 #*                                                                         *
 #*   This file is part of the FreeCAD CAx development system.              *
 #*                                                                         *
@@ -13,14 +13,13 @@
 #*   for detail see the LICENCE text file.                                 *
 #*                                                                         *
 #*   FreeCAD is distributed in the hope that it will be useful,            *
-#*   but WITHOUT ANY WARRANTY; without even the implied warranty of        * 
+#*   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
 #*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
 #*   GNU Lesser General Public License for more details.                   *
 #*                                                                         *
 #*   You should have received a copy of the GNU Library General Public     *
-#*   License along with FreeCAD; if not, write to the Free Software        * 
+#*   License along with FreeCAD; if not, write to the Free Software        *
 #*   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
 #*   USA                                                                   *
 #*                                                                         *
-#*   Juergen Riegel 2002                                                   *
 #***************************************************************************/

--- a/src/Mod/MeshPart/InitGui.py
+++ b/src/Mod/MeshPart/InitGui.py
@@ -1,4 +1,4 @@
-# MeshPart gui init module  
+# MeshPart gui init module
 # (c) 2003 Juergen Riegel
 #
 # Gathering all the information to start FreeCAD
@@ -6,7 +6,7 @@
 # runs when the gui is up
 
 #***************************************************************************
-#*   (c) Juergen Riegel (juergen.riegel@web.de) 2002                       *
+#*   Copyright (c) 2002 Juergen Riegel <juergen.riegel@web.de>             *
 #*                                                                         *
 #*   This file is part of the FreeCAD CAx development system.              *
 #*                                                                         *
@@ -26,44 +26,46 @@
 #*   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
 #*   USA                                                                   *
 #*                                                                         *
-#*   Juergen Riegel 2002                                                   *
 #***************************************************************************/
 
 
 class MeshPartWorkbench ( Workbench ):
-	"MeshPart workbench object"
-	Icon = """
-			/* XPM */
-			static const char *MeshPart_Box[]={
-			"16 16 3 1",
-			". c None",
-			"# c #000000",
-			"a c #c6c642",
-			"................",
-			".......#######..",
-			"......#aaaaa##..",
-			".....#aaaaa###..",
-			"....#aaaaa##a#..",
-			"...#aaaaa##aa#..",
-			"..#aaaaa##aaa#..",
-			".########aaaa#..",
-			".#aaaaa#aaaaa#..",
-			".#aaaaa#aaaa##..",
-			".#aaaaa#aaa##...",
-			".#aaaaa#aa##....",
-			".#aaaaa#a##... .",
-			".#aaaaa###......",
-			".########.......",
-			"................"};
-			"""
-	MenuText = "MeshPart"
-	ToolTip = "MeshPart workbench"
+    "MeshPart workbench object"
+    Icon = """
+            /* XPM */
+            static const char *MeshPart_Box[]={
+            "16 16 3 1",
+            ". c None",
+            "# c #000000",
+            "a c #c6c642",
+            "................",
+            ".......#######..",
+            "......#aaaaa##..",
+            ".....#aaaaa###..",
+            "....#aaaaa##a#..",
+            "...#aaaaa##aa#..",
+            "..#aaaaa##aaa#..",
+            ".########aaaa#..",
+            ".#aaaaa#aaaaa#..",
+            ".#aaaaa#aaaa##..",
+            ".#aaaaa#aaa##...",
+            ".#aaaaa#aa##....",
+            ".#aaaaa#a##... .",
+            ".#aaaaa###......",
+            ".########.......",
+            "................"};
+            """
+    MenuText = "MeshPart"
+    ToolTip = "MeshPart workbench"
 
-	def Initialize(self):
-		# load the module
-		import MeshPartGui
-		import MeshPart
-	def GetClassName(self):
-		return "MeshPartGui::Workbench"
 
-#Gui.addWorkbench(MeshPartWorkbench())
+def Initialize(self):
+    # load the module
+    import MeshPartGui
+    import MeshPart
+
+
+def GetClassName(self):
+    return "MeshPartGui::Workbench"
+
+# Gui.addWorkbench(MeshPartWorkbench())

--- a/src/Mod/MeshPart/InitGui.py
+++ b/src/Mod/MeshPart/InitGui.py
@@ -59,13 +59,13 @@ class MeshPartWorkbench ( Workbench ):
     ToolTip = "MeshPart workbench"
 
 
-def Initialize(self):
-    # load the module
-    import MeshPartGui
-    import MeshPart
+    def Initialize(self):
+        # load the module
+        import MeshPartGui
+        import MeshPart
 
 
-def GetClassName(self):
-    return "MeshPartGui::Workbench"
+    def GetClassName(self):
+        return "MeshPartGui::Workbench"
 
 # Gui.addWorkbench(MeshPartWorkbench())


### PR DESCRIPTION
Adding some uniformity to the headers of the `src/Mod/MeshPart`. I'm not sure if the `blame` info for some of the files is accurate since the source code wasn't originally on github and some of that history is not available.