### PR TITLE
[ViewProvider2DObject=>Sketcher] Fix grid visibility management

### DIFF
--- a/src/Mod/Part/Gui/ViewProvider2DObject.cpp
+++ b/src/Mod/Part/Gui/ViewProvider2DObject.cpp
@@ -274,7 +274,7 @@ void ViewProvider2DObjectGrid::onChanged(const App::Property* prop)
     ViewProviderPart::onChanged(prop);
 
     if (prop == &ShowGrid || prop == &ShowOnlyInEditMode || prop == &Visibility) {
-        if (ShowGrid.getValue() && Visibility.getValue() && !(ShowOnlyInEditMode.getValue() && !this->isEditing()))
+        if (ShowGrid.getValue() && ((Visibility.getValue() && !ShowOnlyInEditMode.getValue()) || this->isEditing()))
             createGrid();
         else
             Gui::coinRemoveAllChildren(GridRoot);

--- a/src/Mod/Part/Gui/ViewProvider2DObject.h
+++ b/src/Mod/Part/Gui/ViewProvider2DObject.h
@@ -21,8 +21,8 @@
  ***************************************************************************/
 
 
-#ifndef PARTGUI_IEWPROVIDER2DOBJECT_H
-#define PARTGUI_IEWPROVIDER2DOBJECT_H
+#ifndef PARTGUI_VIEWPROVIDER2DOBJECT_H
+#define PARTGUI_VIEWPROVIDER2DOBJECT_H
 
 #include "ViewProvider.h"
 #include <App/PropertyUnits.h>
@@ -103,5 +103,5 @@ typedef Gui::ViewProviderPythonFeatureT<ViewProvider2DObject> ViewProvider2DObje
 } // namespace PartGui
 
 
-#endif // PARTGUI_IEWPROVIDER2DOBJECT_H
+#endif // PARTGUI_VIEWPROVIDER2DOBJECT_H
 

--- a/src/Mod/Sketcher/Gui/TaskSketcherGeneral.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherGeneral.cpp
@@ -264,9 +264,6 @@ void TaskSketcherGeneral::onChangedSketchView(const Gui::ViewProvider& vp,
             QSignalBlocker block(widget);
             widget->checkGridView(sketchView->ShowGrid.getValue());
             widget->enableGridSettings(sketchView->ShowGrid.getValue());
-            if (sketchView->ShowGrid.getValue()) {
-                sketchView->createGrid();
-            }
         }
         else if (&sketchView->GridSize == &prop) {
             QSignalBlocker block(widget);
@@ -293,7 +290,6 @@ void TaskSketcherGeneral::onToggleGridView(bool on)
     Base::ConnectionBlocker block(changedSketchView);
     sketchView->ShowGrid.setValue(on);
     widget->enableGridSettings(on);
-    if (on) sketchView->createGrid();
 }
 
 void TaskSketcherGeneral::onSetGridSize(double val)


### PR DESCRIPTION
Problem has been reported [here in the forum](https://forum.freecadweb.org/viewtopic.php?f=10&t=63210)
From user point of view, it makes the sketcher grid disappear when a sketch is saved while in Edit mode.

The reason is that when entering edit mode, the sketch is made not visible so that its "TopoShape" doesn't duplicates the sketch geometry on screen.
However the grid shall always been shown in Edit mode --if enabled-- (and in normal mode, only if ShowOnlyInEditMode is false).

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [x]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [x]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`