### PR TITLE
Fix typos in source comments [skip ci]

### DIFF
--- a/src/App/Application.h
+++ b/src/App/Application.h
@@ -597,7 +597,7 @@ private:
     std::deque<std::string> _pendingDocsReopen;
     std::map<std::string,std::vector<std::string> > _pendingDocMap;
 
-    // To prevent infinite recursion of reloading a partial document due a truely
+    // To prevent infinite recursion of reloading a partial document due a truly
     // missing object
     std::map<std::string,std::set<std::string> > _docReloadAttempts;
 

--- a/src/Mod/Fem/femtaskpanels/task_material_common.py
+++ b/src/Mod/Fem/femtaskpanels/task_material_common.py
@@ -549,7 +549,7 @@ class _TaskPanel:
             # for example PoissonRatio
             value = Units.Quantity(inputfield_text).Value
             old_value = Units.Quantity(self.material[matProperty]).Value
-            # value = float(inputfield_text)  # this fails on locale with komma
+            # value = float(inputfield_text)  # this fails on locale with comma
             # https://forum.freecadweb.org/viewtopic.php?f=18&t=56912&p=523313#p523313
         if value:
             if not (1 - variation < float(old_value) / value < 1 + variation):


### PR DESCRIPTION
Found via `codespell -q 3 -L aci,ake,aline,alle,alledges,alocation,als,ang,anid,apoints,ba,beginn,behaviour,bloaded,bottome,byteorder,calculater,cancelled,cancelling,cas,cascade,centimetre,childs,colour,colours,commen,connexion,currenty,dof,doubleclick,dum,eiter,elemente,ende,feld,finde,findf,freez,hist,iff,indicies,initialisation,initialise,initialised,initialises,initialisiert,inout,ist,kilometre,lod,mantatory,methode,metres,millimetre,modell,nd,noe,normale,normaly,nto,numer,oder,ontop,orgin,orginx,orginy,ot,pard,parms,pres,programm,que,recurrance,rougly,seperator,serie,sinc,strack,substraction,te,thist,thru,tread,uint,unter,vertexes,wallthickness,whitespaces -S ./.git,*.po,*.ts,./ChangeLog.txt,./src/3rdParty,./src/Mod/Assembly/App/opendcm,./src/CXX,./src/zipios++,./src/Base/swig*,./src/Mod/Robot/App/kdl_cp,./src/Mod/Import/App/SCL,./src/WindowsInstaller,./src/Doc/FreeCAD.uml,./build/doc/SourceDocu`