### PR TITLE
[Sketcher] Validate Sketch : UI refactoring to avoid confusion

### DIFF
--- a/src/Mod/Sketcher/Gui/TaskSketcherValidation.ui
+++ b/src/Mod/Sketcher/Gui/TaskSketcherValidation.ui
@@ -22,6 +22,9 @@
      <layout class="QGridLayout" name="gridLayout_4">
       <item row="0" column="0">
        <widget class="QPushButton" name="findReversed">
+        <property name="toolTip">
+         <string>Finds reversed external geometries</string>
+        </property>
         <property name="text">
          <string>Find</string>
         </property>
@@ -29,6 +32,9 @@
       </item>
       <item row="1" column="0">
        <widget class="QPushButton" name="swapReversed">
+        <property name="toolTip">
+         <string>Fixes found reversed external geometries by swapping their endpoints</string>
+        </property>
         <property name="text">
          <string>Swap endpoints in constraints</string>
         </property>
@@ -39,12 +45,18 @@
    </item>
    <item row="1" column="0">
     <widget class="QGroupBox" name="groupBox_1">
+     <property name="toolTip">
+      <string>Fixes found missing coincidences by adding extra coincident constrains</string>
+     </property>
      <property name="title">
       <string>Missing coincidences</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
       <item row="1" column="0" colspan="2">
        <widget class="QCheckBox" name="checkBoxIgnoreConstruction">
+        <property name="toolTip">
+         <string>If checked, construction geometries are ignored in the search</string>
+        </property>
         <property name="text">
          <string>Ignore construction geometry</string>
         </property>
@@ -55,6 +67,10 @@
       </item>
       <item row="2" column="0">
        <widget class="QPushButton" name="findButton">
+        <property name="toolTip">
+         <string>Finds and displays missing coincidences found in the sketch
+This is done by analyzing the sketch geometries and constraints</string>
+        </property>
         <property name="text">
          <string>Find</string>
         </property>
@@ -75,7 +91,11 @@
        </widget>
       </item>
       <item row="0" column="1">
-       <widget class="QComboBox" name="comboBoxTolerance"/>
+       <widget class="QComboBox" name="comboBoxTolerance">
+        <property name="toolTip">
+         <string>Defines the X/Y tolerance inside which missing coincidences are searched.</string>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>
@@ -88,6 +108,9 @@
      <layout class="QGridLayout" name="gridLayout_2">
       <item row="0" column="0">
        <widget class="QPushButton" name="findConstraint">
+        <property name="toolTip">
+         <string>Finds invalid/malformed constrains in the sketch</string>
+        </property>
         <property name="text">
          <string>Find</string>
         </property>
@@ -95,6 +118,9 @@
       </item>
       <item row="0" column="1">
        <widget class="QPushButton" name="fixConstraint">
+        <property name="toolTip">
+         <string>Tries to fix found invalid constraints</string>
+        </property>
         <property name="text">
          <string>Fix</string>
         </property>
@@ -102,6 +128,9 @@
       </item>
       <item row="1" column="0" colspan="2">
        <widget class="QPushButton" name="delConstrExtr">
+        <property name="toolTip">
+         <string>Deletes constrains refering to external geometry</string>
+        </property>
         <property name="text">
          <string>Delete constraints to external geom.</string>
         </property>
@@ -130,6 +159,10 @@
       </property>
       <item row="0" column="0">
        <widget class="QPushButton" name="highlightButton">
+        <property name="toolTip">
+         <string>Highlights open and non-manifold vertexes that could lead to error if sketch is used to generate solids
+This is purely based on topological shape of the sketch and not on its geometry/constrain set.</string>
+        </property>
         <property name="text">
          <string>Highlight troublesome vertexes</string>
         </property>
@@ -146,6 +179,9 @@
      <layout class="QGridLayout" name="gridLayout_6">
       <item row="0" column="0">
        <widget class="QPushButton" name="findDegenerated">
+        <property name="toolTip">
+         <string>Finds degenerated geometries in the sketch</string>
+        </property>
         <property name="text">
          <string>Find</string>
         </property>
@@ -153,6 +189,9 @@
       </item>
       <item row="0" column="1">
        <widget class="QPushButton" name="fixDegenerated">
+        <property name="toolTip">
+         <string>Tries to fix found degenerated geometries</string>
+        </property>
         <property name="text">
          <string>Fix</string>
         </property>
@@ -169,6 +208,9 @@
      <layout class="QGridLayout" name="gridLayout_5">
       <item row="0" column="0">
        <widget class="QPushButton" name="orientLockEnable">
+        <property name="toolTip">
+         <string>Enables/updates constraint orientation locking</string>
+        </property>
         <property name="text">
          <string>Enable/Update</string>
         </property>
@@ -176,6 +218,9 @@
       </item>
       <item row="1" column="0">
        <widget class="QPushButton" name="orientLockDisable">
+        <property name="toolTip">
+         <string>Disables constraint orientation locking</string>
+        </property>
         <property name="text">
          <string>Disable</string>
         </property>

--- a/src/Mod/Sketcher/Gui/TaskSketcherValidation.ui
+++ b/src/Mod/Sketcher/Gui/TaskSketcherValidation.ui
@@ -6,30 +6,43 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>311</width>
-    <height>453</height>
+    <width>266</width>
+    <height>684</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Sketcher validation</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_3">
-   <item row="0" column="0">
-    <widget class="QGroupBox" name="groupBox">
+   <item row="5" column="0">
+    <widget class="QGroupBox" name="groupBox_3">
+     <property name="title">
+      <string>Reversed external geometry</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_4">
+      <item row="0" column="0">
+       <widget class="QPushButton" name="findReversed">
+        <property name="text">
+         <string>Find</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QPushButton" name="swapReversed">
+        <property name="text">
+         <string>Swap endpoints in constraints</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QGroupBox" name="groupBox_1">
      <property name="title">
       <string>Missing coincidences</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
-      <item row="0" column="0">
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Tolerance:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QComboBox" name="comboBoxTolerance"/>
-      </item>
       <item row="1" column="0" colspan="2">
        <widget class="QCheckBox" name="checkBoxIgnoreConstruction">
         <property name="text">
@@ -47,6 +60,13 @@
         </property>
        </widget>
       </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Tolerance:</string>
+        </property>
+       </widget>
+      </item>
       <item row="2" column="1">
        <widget class="QPushButton" name="fixButton">
         <property name="text">
@@ -54,17 +74,13 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="0" colspan="2">
-       <widget class="QPushButton" name="highlightButton">
-        <property name="text">
-         <string>Highlight open vertexes</string>
-        </property>
-       </widget>
+      <item row="0" column="1">
+       <widget class="QComboBox" name="comboBoxTolerance"/>
       </item>
      </layout>
     </widget>
    </item>
-   <item row="1" column="0">
+   <item row="2" column="0">
     <widget class="QGroupBox" name="groupBox_2">
      <property name="title">
       <string>Invalid constraints</string>
@@ -94,7 +110,35 @@
      </layout>
     </widget>
    </item>
-   <item row="2" column="0">
+   <item row="0" column="0">
+    <widget class="QGroupBox" name="groupBox_0">
+     <property name="title">
+      <string>Open and non-manifold vertexes</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_7">
+      <property name="leftMargin">
+       <number>6</number>
+      </property>
+      <property name="topMargin">
+       <number>6</number>
+      </property>
+      <property name="rightMargin">
+       <number>6</number>
+      </property>
+      <property name="bottomMargin">
+       <number>6</number>
+      </property>
+      <item row="0" column="0">
+       <widget class="QPushButton" name="highlightButton">
+        <property name="text">
+         <string>Highlight troublesome vertexes</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="3" column="0">
     <widget class="QGroupBox" name="groupBox_6">
      <property name="title">
       <string>Degenerated geometry</string>
@@ -117,30 +161,7 @@
      </layout>
     </widget>
    </item>
-   <item row="4" column="0">
-    <widget class="QGroupBox" name="groupBox_3">
-     <property name="title">
-      <string>Reversed external geometry</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_4">
-      <item row="0" column="0">
-       <widget class="QPushButton" name="findReversed">
-        <property name="text">
-         <string>Find</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QPushButton" name="swapReversed">
-        <property name="text">
-         <string>Swap endpoints in constraints</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="5" column="0">
+   <item row="6" column="0">
     <widget class="QGroupBox" name="groupBox_4">
      <property name="title">
       <string>Constraint orientation locking</string>


### PR DESCRIPTION
This PR refactors the Validate Sketch UI to avoid confusion regarding 'Highlight open vertexes' following https://forum.freecadweb.org/viewtopic.php?f=8&t=62936&start=10#p540189
Precisely it separates this function from 'Missing coincidences' ones.
Also it adds tooltips so more information is provided to the user

![image](https://user-images.githubusercontent.com/48731257/140383354-e4999fae-311b-423b-8417-42b05966fbae.png)

- [X]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [X]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [X]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [X]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [X]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [X]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

