### PR TITLE
[Core] Improve decimal point substitution mechanism

### DIFF
--- a/src/Gui/GuiApplication.cpp
+++ b/src/Gui/GuiApplication.cpp
@@ -334,13 +334,13 @@ bool KeyboardFilter::eventFilter(QObject* obj, QEvent* ev)
 {
     if (ev->type() == QEvent::KeyPress || ev->type() == QEvent::KeyRelease) {
         QKeyEvent *kev = static_cast<QKeyEvent *>(ev);
-        QAbstractSpinBox *target = dynamic_cast<QAbstractSpinBox *>(obj);
-        if (kev->key() == Qt::Key_Period && target)
+        Qt::KeyboardModifiers mod = kev->modifiers();
+        int key = kev->key();
+        if ((mod & Qt::KeypadModifier) && (key == Qt::Key_Period || key == Qt::Key_Comma))
         {
-            QChar decimalPoint = QLocale().decimalPoint();
-            QChar groupSeparator = QLocale().groupSeparator();
-            if (decimalPoint != Qt::Key_Period && (groupSeparator != Qt::Key_Period || (kev->modifiers() & Qt::KeypadModifier))) {
-                QKeyEvent modifiedKeyEvent(kev->type(), decimalPoint.digitValue(), kev->modifiers(), QString(decimalPoint), kev->isAutoRepeat(), kev->count());
+            QChar dp = QLocale().decimalPoint();
+            if (key != dp) {
+                QKeyEvent modifiedKeyEvent(kev->type(), dp.digitValue(), mod, QString(dp), kev->isAutoRepeat(), kev->count());
                 qApp->sendEvent(obj, &modifiedKeyEvent);
                 return true;
             }


### PR DESCRIPTION
This PR improves the decimal point substitution mechanism that allows it to be conform to locale settings (introduced in PR #3256), when it is entered from the numerical pad : 
* The PR simplifies the mechanism. The current one is a bit weird because at the time I did it I observed a strange behavior of Qt modifiers() value. It happens that this weirdness comes from the OS, so it doesn't have to be fixed in Qt. Fixes exists in OS
* Following @wwmayer [post here](https://forum.freecadweb.org/viewtopic.php?f=8&t=62546&start=20#p544339), the mechanism has been extended to cope with substitution in a more general way

The algorithm is now simple : 
If comma or period key event coming from numerical keypad, compare with locale decimal point value. If different, tamper the event substituting with locale value.