### PR TITLE
App: Merge realthunder PR 2862, stage 2

### DIFF
--- a/src/App/DynamicProperty.cpp
+++ b/src/App/DynamicProperty.cpp
@@ -297,6 +297,18 @@ DynamicProperty::PropData DynamicProperty::getDynamicPropertyData(const Property
     return PropData();
 }
 
+bool DynamicProperty::changeDynamicProperty(const Property *prop, const char *group, const char *doc) {
+    auto &index = props.get<1>();
+    auto it = index.find(const_cast<Property*>(prop));
+    if (it == index.end())
+        return false;
+    if(group)
+        it->group = group;
+    if(doc)
+        it->doc = doc;
+    return true;
+}
+
 const char *DynamicProperty::getPropertyName(const Property *prop) const
 {
     auto &index = props.get<1>();

--- a/src/App/DynamicProperty.h
+++ b/src/App/DynamicProperty.h
@@ -149,8 +149,8 @@ public:
         Property* property;
         std::string name;
         const char *pName;
-        std::string group;
-        std::string doc;
+        mutable std::string group;
+        mutable std::string doc;
         short attr;
         bool readonly;
         bool hidden;
@@ -167,6 +167,8 @@ public:
     };
 
     PropData getDynamicPropertyData(const Property* prop) const;
+
+    bool changeDynamicProperty(const Property *prop, const char *group, const char *doc);
 
 private:
     std::string getUniquePropertyName(PropertyContainer &pc, const char *Name) const;

--- a/src/App/Enumeration.cpp
+++ b/src/App/Enumeration.cpp
@@ -38,6 +38,7 @@ Enumeration::Enumeration()
 }
 
 Enumeration::Enumeration(const Enumeration &other)
+    : _EnumArray(NULL), _ownEnumArray(false), _index(0), _maxVal(-1)
 {
     if (other._ownEnumArray) {
         setEnums(other.getEnumVector());

--- a/src/App/Enumeration.cpp
+++ b/src/App/Enumeration.cpp
@@ -82,11 +82,9 @@ Enumeration::~Enumeration()
 void Enumeration::tearDown(void)
 {
     // Ugly...
-    char **plEnums = (char **)_EnumArray;
-
-    // Delete C Strings first
-    while (*plEnums != NULL) {
-        free(*(plEnums++));
+    for(char **plEnums = (char **)_EnumArray; *plEnums != NULL; ++plEnums) {
+        // Delete C Strings first
+        free(*plEnums);
     }
 
     delete [] _EnumArray;
@@ -98,6 +96,9 @@ void Enumeration::tearDown(void)
 
 void Enumeration::setEnums(const char **plEnums)
 {
+    if(plEnums == _EnumArray)
+        return;
+
     std::string oldValue;
     bool preserve = (isValid() && plEnums != NULL);
     if (preserve) {
@@ -118,7 +119,11 @@ void Enumeration::setEnums(const char **plEnums)
     findMaxVal();
 
     // set _index
-    _index = 0;
+    if (_index < 0)
+        _index = 0;
+    else if (_index > _maxVal)
+        _index = _maxVal;
+
     if (preserve) {
         setValue(oldValue);
     }
@@ -311,6 +316,10 @@ Enumeration & Enumeration::operator=(const Enumeration &other)
 
 bool Enumeration::operator==(const Enumeration &other) const
 {
+    if(_index != other._index)
+        return false;
+    if (getCStr() == other.getCStr())
+        return true;
     if (getCStr() == NULL || other.getCStr() == NULL) {
         return false;
     }

--- a/src/App/ExpressionParser.h
+++ b/src/App/ExpressionParser.h
@@ -273,6 +273,7 @@ public:
         MINVERT, // invert matrix/placement/rotation
         CREATE, // create new object of a given type
         STR, // stringify
+        HIDDENREF, // hidden reference that has no dependency check
 
         // Aggregates
         AGGREGATES,
@@ -345,9 +346,7 @@ protected:
     virtual Py::Object _getPyValue() const override;
     virtual void _toString(std::ostream &ss, bool persistent, int indent) const override;
     virtual bool _isIndexable() const override;
-    virtual void _getDeps(ExpressionDeps &) const override;
-    virtual void _getDepObjects(std::set<App::DocumentObject*> &, std::vector<std::string> *) const override;
-    virtual void _getIdentifiers(std::set<App::ObjectIdentifier> &) const override;
+    virtual void _getIdentifiers(std::map<App::ObjectIdentifier,bool> &) const override;
     virtual bool _adjustLinks(const std::set<App::DocumentObject*> &, ExpressionVisitor &) override;
     virtual void _importSubNames(const ObjectIdentifier::SubNameMap &) override;
     virtual void _updateLabelReference(App::DocumentObject *, const std::string &, const char *) override;
@@ -435,7 +434,7 @@ protected:
     virtual Expression * _copy() const override;
     virtual void _toString(std::ostream &ss, bool persistent, int indent) const override;
     virtual Py::Object _getPyValue() const override;
-    virtual void _getDeps(ExpressionDeps &) const override;
+    virtual void _getIdentifiers(std::map<App::ObjectIdentifier,bool> &) const override;
     virtual bool _renameObjectIdentifier(const std::map<ObjectIdentifier,ObjectIdentifier> &,
                                          const ObjectIdentifier &, ExpressionVisitor &) override;
     virtual void _moveCells(const CellAddress &, int, int, ExpressionVisitor &) override;

--- a/src/App/ObjectIdentifier.cpp
+++ b/src/App/ObjectIdentifier.cpp
@@ -33,18 +33,19 @@
 
 /// Here the FreeCAD includes sorted by Base,App,Gui......
 #include <Base/GeometryPyCXX.h>
-#include <App/ComplexGeoData.h>
+#include <Base/Tools.h>
+#include <Base/Interpreter.h>
+#include <Base/QuantityPy.h>
+#include <Base/Console.h>
+#include <App/DocumentObjectPy.h>
+#include "ComplexGeoData.h"
 #include "Property.h"
 #include "Application.h"
 #include "Document.h"
 #include "DocumentObject.h"
 #include "ObjectIdentifier.h"
 #include "ExpressionParser.h"
-#include <Base/Tools.h>
-#include <Base/Interpreter.h>
-#include <Base/QuantityPy.h>
-#include <App/Link.h>
-#include <Base/Console.h>
+#include "Link.h"
 
 FC_LOG_LEVEL_INIT("Expression",true,true)
 
@@ -1086,32 +1087,58 @@ enum PseudoPropertyType {
     PseudoCadquery,
 };
 
-std::pair<DocumentObject*,std::string> ObjectIdentifier::getDep(std::vector<std::string> *labels) const {
+void ObjectIdentifier::getDepLabels(std::vector<std::string> &labels) const {
+    getDepLabels(ResolveResults(*this),labels);
+}
+
+void ObjectIdentifier::getDepLabels(
+        const ResolveResults &result, std::vector<std::string> &labels) const
+{
+    if(documentObjectName.getString().size()) {
+        if(documentObjectName.isRealString())
+            labels.push_back(documentObjectName.getString());
+    } else if(result.propertyIndex == 1)
+        labels.push_back(components[0].name.getString());
+    if(subObjectName.getString().size()) 
+        PropertyLinkBase::getLabelReferences(labels,subObjectName.getString().c_str());
+}
+
+ObjectIdentifier::Dependencies
+ObjectIdentifier::getDep(bool needProps, std::vector<std::string> *labels) const 
+{
+    Dependencies deps;
+    getDep(deps,needProps,labels);
+    return deps;
+}
+
+void ObjectIdentifier::getDep(
+        Dependencies &deps, bool needProps, std::vector<std::string> *labels) const 
+{
     ResolveResults result(*this);
-    if(labels) {
-        if(documentObjectName.getString().size()) {
-            if(documentObjectName.isRealString())
-                labels->push_back(documentObjectName.getString());
-        } else if(result.propertyIndex == 1)
-            labels->push_back(components[0].name.getString());
-        if(subObjectName.getString().size())
-            PropertyLinkBase::getLabelReferences(*labels,subObjectName.getString().c_str());
+    if(labels) 
+        getDepLabels(result,*labels);
+
+    if(!result.resolvedDocumentObject)
+       return;
+
+    if(!needProps) {
+        deps[result.resolvedDocumentObject];
+        return;
     }
-    if(subObjectName.getString().empty()) {
-        if(result.propertyType==PseudoNone) {
-            CellAddress addr;
-            if(addr.parseAbsoluteAddress(result.propertyName.c_str()))
-                return std::make_pair(result.resolvedDocumentObject,addr.toString(true));
-            return std::make_pair(result.resolvedDocumentObject,result.propertyName);
-        }else if(result.propertyType == PseudoSelf
-                    && result.resolvedDocumentObject
-                    && result.propertyIndex+1 < (int)components.size())
-        {
-            return std::make_pair(result.resolvedDocumentObject,
-                    components[result.propertyIndex+1].getName());
-        }
+
+    if(!result.resolvedProperty) {
+        if(result.propertyName.size())
+            deps[result.resolvedDocumentObject].insert(result.propertyName);
+        return;
     }
-    return std::make_pair(result.resolvedDocumentObject,std::string());
+
+    Base::PyGILStateLocker lock;
+    try {
+        access(result,0,&deps);
+    }catch(Py::Exception &) {
+        Base::PyException e;
+    }catch(...){
+    }
 }
 
 /**
@@ -1241,7 +1268,7 @@ Property *ObjectIdentifier::resolveProperty(const App::DocumentObject *obj,
     if(!obj)
         return 0;
 
-    static std::map<std::string,int> _props = {
+    static std::unordered_map<const char*,int,CStringHasher,CStringHasher> _props = {
         {"_shape",PseudoShape},
         {"_pla",PseudoPlacement},
         {"_matrix",PseudoMatrix},
@@ -1270,23 +1297,8 @@ Property *ObjectIdentifier::resolveProperty(const App::DocumentObject *obj,
         }
         return &const_cast<App::DocumentObject*>(obj)->Label; //fake the property
     }
-
-    auto prop = obj->getPropertyByName(propertyName);
-    if(prop && !prop->testStatus(Property::Hidden) && !(prop->getType() & PropertyType::Prop_Hidden))
-        return prop;
-
-    auto linked = obj->getLinkedObject(true);
-    if(!linked || linked==obj) {
-        auto ext = obj->getExtensionByType<App::LinkBaseExtension>(true);
-        if(!ext)
-            return prop;
-        linked = ext->getTrueLinkedObject(true);
-        if(!linked || linked==obj)
-            return prop;
-    }
-
-    auto linkedProp = linked->getPropertyByName(propertyName);
-    return linkedProp?linkedProp:prop;
+    
+    return obj->getPropertyByName(propertyName);
 }
 
 
@@ -1503,7 +1515,8 @@ void ObjectIdentifier::String::checkImport(const App::DocumentObject *owner,
     }
 }
 
-Py::Object ObjectIdentifier::access(const ResolveResults &result, Py::Object *value) const
+Py::Object ObjectIdentifier::access(const ResolveResults &result,
+        Py::Object *value, Dependencies *deps) const
 {
     if(!result.resolvedDocumentObject || !result.resolvedProperty ||
        (subObjectName.getString().size() && !result.resolvedSubObject))
@@ -1647,13 +1660,65 @@ Py::Object ObjectIdentifier::access(const ResolveResults &result, Py::Object *va
             break;
         }}}
     }
+
+    auto setPropDep = [deps](DocumentObject *obj, Property *prop, const char *propName) {
+        if(!deps || !obj)
+            return;
+        if(prop && prop->getContainer()!=obj) {
+            auto linkTouched = Base::freecad_dynamic_cast<PropertyBool>(
+                    obj->getPropertyByName("_LinkTouched"));
+            if(linkTouched) 
+                propName = linkTouched->getName();
+            else {
+                auto propOwner = Base::freecad_dynamic_cast<DocumentObject>(prop->getContainer());
+                if(propOwner) 
+                    obj = propOwner;
+                else 
+                    propName = 0;
+            }
+        }
+        auto &propset = (*deps)[obj];
+        // inserting a null name in the propset indicates the dependency is
+        // on all properties of the corresponding object.
+        if(propset.size()!=1 || propset.begin()->size()) {
+            if(!propName)
+                propset.clear();
+            propset.insert(propName);
+        }
+        return;
+    };
+
+    App::DocumentObject *lastObj = result.resolvedDocumentObject;
+    if(result.resolvedSubObject) {
+        setPropDep(lastObj,0,0);
+        lastObj = result.resolvedSubObject;
+    }
+    if(ptype == PseudoNone)
+        setPropDep(lastObj, result.resolvedProperty, result.resolvedProperty->getName());
+    else
+        setPropDep(lastObj,0,0);
+    lastObj = 0;
+
     if(components.empty())
         return pyobj;
+
     size_t count = components.size();
     if(value) --count;
     assert(idx<=count);
-    for(;idx<count;++idx)
+
+    for(;idx<count;++idx)  {
+        if(PyObject_TypeCheck(*pyobj, &DocumentObjectPy::Type))
+            lastObj = static_cast<DocumentObjectPy*>(*pyobj)->getDocumentObjectPtr();
+        else if(lastObj) {
+            const char *attr = components[idx].getName().c_str();
+            auto prop = lastObj->getPropertyByName(attr);
+            if(!prop && pyobj.hasAttr(attr))
+                attr = 0;
+            setPropDep(lastObj,prop,attr);
+            lastObj = 0;
+        }
         pyobj = components[idx].get(pyobj);
+    }
     if(value) {
         components[idx].set(pyobj,*value);
         return Py::Object();

--- a/src/App/ObjectIdentifier.h
+++ b/src/App/ObjectIdentifier.h
@@ -342,7 +342,45 @@ public:
 
     bool relabeledDocument(ExpressionVisitor &v, const std::string &oldLabel, const std::string &newLabel);
 
-    std::pair<App::DocumentObject*,std::string> getDep(std::vector<std::string> *labels=0) const;
+    /** Type for storing dependency of an ObjectIdentifier
+     *
+     * The dependency is a map from document object to a set of property names.
+     * An object identifier may references multiple objects using syntax like
+     * 'Part.Group[0].Width'. 
+     *
+     * Also, we use set of string instead of set of Property pointer, because
+     * the property may not exist at the time this ObjectIdentifier is
+     * constructed.
+     */
+    typedef std::map<App::DocumentObject *, std::set<std::string> > Dependencies;
+
+    /** Get dependencies of this object identifier
+     *
+     * @param needProps: whether need property dependencies.
+     * @param labels: optional return of any label references.
+     *
+     * In case of multi-object references, like 'Part.Group[0].Width', if no
+     * property dependency is required, then this function will only return the
+     * first referred object dependency. Or else, all object and property
+     * dependencies will be returned.
+     */
+    Dependencies getDep(bool needProps, std::vector<std::string> *labels=0) const;
+
+    /** Get dependencies of this object identifier
+     *
+     * @param deps: returns the depdenencies.
+     * @param needProps: whether need property dependencies.
+     * @param labels: optional return of any label references.
+     *
+     * In case of multi-object references, like 'Part.Group[0].Width', if no
+     * property dependency is required, then this function will only return the
+     * first referred object dependency. Or else, all object and property
+     * dependencies will be returned.
+     */
+    void getDep(Dependencies &deps, bool needProps, std::vector<std::string> *labels=0) const;
+    
+    /// Returns all label references
+    void getDepLabels(std::vector<std::string> &labels) const;
 
     App::Document *getDocument(String name = String(), bool *ambiguous=0) const;
 
@@ -422,13 +460,16 @@ protected:
 
     void getSubPathStr(std::ostream &ss, const ResolveResults &result, bool toPython=false) const;
 
-    Py::Object access(const ResolveResults &rs, Py::Object *value=0) const;
+    Py::Object access(const ResolveResults &rs,
+            Py::Object *value=0, Dependencies *deps=0) const;
 
     void resolve(ResolveResults & results) const;
     void resolveAmbiguity(ResolveResults &results);
 
     static App::DocumentObject *getDocumentObject(
             const App::Document *doc, const String &name, std::bitset<32> &flags);
+
+    void getDepLabels(const ResolveResults &result, std::vector<std::string> &labels) const;
 
     App::DocumentObject * owner;
     String  documentName;

--- a/src/App/Property.cpp
+++ b/src/App/Property.cpp
@@ -71,6 +71,8 @@ std::string Property::getFullName() const {
     if(myName) {
         if(father)
             name = father->getFullName() + ".";
+        else
+            name = "?.";
         name += myName;
     }else
         return "?";

--- a/src/App/PropertyContainer.h
+++ b/src/App/PropertyContainer.h
@@ -200,6 +200,10 @@ public:
       return dynamicProps.getDynamicPropertyData(prop);
   }
 
+  bool changeDynamicProperty(const Property *prop, const char *group, const char *doc) {
+      return dynamicProps.changeDynamicProperty(prop,group,doc);
+  }
+
   virtual bool removeDynamicProperty(const char* name) {
       return dynamicProps.removeDynamicProperty(name);
   }

--- a/src/App/PropertyContainerPy.xml
+++ b/src/App/PropertyContainerPy.xml
@@ -68,6 +68,11 @@ If the list contains 'Hidden' then the item even doesn't appear in the property 
 			  <UserDocu>Return the name of the group which the property belongs to in this class. The properties sorted in different named groups for convenience.</UserDocu>
 		  </Documentation>
 	  </Methode>
+      <Methode Name="setGroupOfProperty">
+		  <Documentation>
+			  <UserDocu>Set the name of the group of a dynamic property.</UserDocu>
+		  </Documentation>
+	  </Methode>
       <Methode Name="setPropertyStatus">
             <Documentation>
                 <UserDocu>
@@ -95,6 +100,11 @@ text names of the status.
 	  <Methode Name="getDocumentationOfProperty">
 		  <Documentation>
 			  <UserDocu>Return the documentation string of the property of this class.</UserDocu>
+		  </Documentation>
+	  </Methode>
+	  <Methode Name="setDocumentationOfProperty">
+		  <Documentation>
+			  <UserDocu>Set the documentation string of a dynamic property of this class.</UserDocu>
 		  </Documentation>
 	  </Methode>
 	  <Methode Name="getEnumerationsOfProperty">

--- a/src/App/PropertyContainerPyImp.cpp
+++ b/src/App/PropertyContainerPyImp.cpp
@@ -339,6 +339,25 @@ PyObject*  PropertyContainerPy::getGroupOfProperty(PyObject *args)
         return Py::new_reference_to(Py::String(""));
 }
 
+PyObject*  PropertyContainerPy::setGroupOfProperty(PyObject *args)
+{
+    char *pstr;
+    char *group;
+    if (!PyArg_ParseTuple(args, "ss", &pstr, &group))     // convert args: Python->C
+        return NULL;                             // NULL triggers exception
+
+    PY_TRY {
+        Property* prop = getPropertyContainerPtr()->getDynamicPropertyByName(pstr);
+        if (!prop) {
+            PyErr_Format(PyExc_AttributeError, "Property container has no dynamic property '%s'", pstr);
+            return 0;
+        }
+        prop->getContainer()->changeDynamicProperty(prop,group,0);
+        Py_Return;
+    } PY_CATCH
+}
+
+
 PyObject*  PropertyContainerPy::getDocumentationOfProperty(PyObject *args)
 {
     char *pstr;
@@ -356,6 +375,24 @@ PyObject*  PropertyContainerPy::getDocumentationOfProperty(PyObject *args)
         return Py::new_reference_to(Py::String(Group));
     else
         return Py::new_reference_to(Py::String(""));
+}
+
+PyObject*  PropertyContainerPy::setDocumentationOfProperty(PyObject *args)
+{
+    char *pstr;
+    char *doc;
+    if (!PyArg_ParseTuple(args, "ss", &pstr, &doc))     // convert args: Python->C
+        return NULL;                             // NULL triggers exception
+
+    PY_TRY {
+        Property* prop = getPropertyContainerPtr()->getDynamicPropertyByName(pstr);
+        if (!prop) {
+            PyErr_Format(PyExc_AttributeError, "Property container has no dynamic property '%s'", pstr);
+            return 0;
+        }
+        prop->getContainer()->changeDynamicProperty(prop,0,doc);
+        Py_Return;
+    } PY_CATCH
 }
 
 PyObject*  PropertyContainerPy::getEnumerationsOfProperty(PyObject *args)

--- a/src/App/PropertyExpressionEngine.cpp
+++ b/src/App/PropertyExpressionEngine.cpp
@@ -37,6 +37,7 @@
 #include <boost/bind/bind.hpp>
 #include <boost/graph/graph_traits.hpp>
 
+FC_LOG_LEVEL_INIT("App",true);
 
 using namespace App;
 using namespace Base;
@@ -69,6 +70,15 @@ void PropertyExpressionContainer::slotRelabelDocument(const App::Document &doc) 
             prop->onRelabeledDocument(doc);
     }
 }
+
+///////////////////////////////////////////////////////////////////////////////////////
+
+struct PropertyExpressionEngine::Private {
+    // For some reason, MSVC has trouble with vector of scoped_connection if
+    // defined in header, hence the private structure here.
+    std::vector<boost::signals2::scoped_connection> conns;
+    std::unordered_map<std::string, std::vector<ObjectIdentifier> > propMap;
+};
 
 ///////////////////////////////////////////////////////////////////////////////////////
 
@@ -125,7 +135,7 @@ void PropertyExpressionEngine::hasSetValue()
         return;
     }
 
-    std::set<App::DocumentObject*> deps;
+    std::map<App::DocumentObject*,bool> deps;
     std::vector<std::string> labels;
     unregisterElementReference();
     UpdateElementReferenceExpressionVisitor<PropertyExpressionEngine> v(*this);
@@ -141,7 +151,93 @@ void PropertyExpressionEngine::hasSetValue()
 
     updateDeps(std::move(deps));
 
+    if(pimpl) {
+        pimpl->conns.clear();
+        pimpl->propMap.clear();
+    }
+    // check if there is any hidden references
+    bool hasHidden = false;
+    for(auto &v : _Deps) {
+        if(v.second) {
+            hasHidden = true;
+            break;
+        }
+    }
+    if(hasHidden) {
+        if(!pimpl)
+            pimpl.reset(new Private);
+        for(auto &e : expressions) {
+            auto expr = e.second.expression;
+            if(!expr) continue;
+            for(auto &dep : expr->getIdentifiers()) {
+                if(!dep.second)
+                    continue;
+                const ObjectIdentifier &var = dep.first;
+                for(auto &vdep : var.getDep(true)) {
+                    auto obj = vdep.first;
+                    auto objName = obj->getFullName() + ".";
+                    for(auto &propName : vdep.second) {
+                        std::string key = objName + propName;
+                        auto &propDeps = pimpl->propMap[key];
+                        if(propDeps.empty()) {
+                            if(propName.size()) 
+                                pimpl->conns.push_back(obj->signalChanged.connect(boost::bind(
+                                            &PropertyExpressionEngine::slotChangedProperty,this,_1,_2)));
+                            else
+                                pimpl->conns.push_back(obj->signalChanged.connect(boost::bind(
+                                            &PropertyExpressionEngine::slotChangedObject,this,_1,_2)));
+                        }
+                        propDeps.push_back(e.first);
+                    }
+                }
+            }
+        }
+    }
+
     PropertyExpressionContainer::hasSetValue();
+}
+
+void PropertyExpressionEngine::updateHiddenReference(const std::string &key) {
+    if(!pimpl)
+        return;
+    auto it = pimpl->propMap.find(key);
+    if(it == pimpl->propMap.end())
+        return;
+    for(auto &var : it->second) {
+        auto it = expressions.find(var);
+        if(it == expressions.end() || it->second.busy)
+            continue;
+        Property *myProp = var.getProperty();
+        if(!myProp)
+            continue;
+        Base::StateLocker guard(it->second.busy);
+        App::any value;
+        try {
+            value = it->second.expression->getValueAsAny();
+            if(!isAnyEqual(value, myProp->getPathValue(var)))
+                myProp->setPathValue(var, value);
+        }catch(Base::Exception &e) {
+            e.ReportException();
+            FC_ERR("Failed to evaluate property binding "
+                    << myProp->getFullName() << " on change of " << key);
+        }catch(std::bad_cast &) {
+            FC_ERR("Invalid type '" << value.type().name()
+                    << "' in property binding " << myProp->getFullName()
+                    << " on change of " << key);
+        }catch(std::exception &e) {
+            FC_ERR(e.what());
+            FC_ERR("Failed to evaluate property binding "
+                    << myProp->getFullName() << " on change of " << key);
+        }
+    }
+}
+
+void PropertyExpressionEngine::slotChangedObject(const App::DocumentObject &obj, const App::Property &) {
+    updateHiddenReference(obj.getFullName());
+}
+
+void PropertyExpressionEngine::slotChangedProperty(const App::DocumentObject &, const App::Property &prop) {
+    updateHiddenReference(prop.getFullName());
 }
 
 void PropertyExpressionEngine::Paste(const Property &from)
@@ -562,17 +658,17 @@ DocumentObjectExecReturn *App::PropertyExpressionEngine::execute(ExecuteOption o
             prop->setPathValue(*it, value);
         }catch(Base::Exception &e) {
             std::ostringstream ss;
-            ss << e.what() << std::endl << "in property binding '" << prop->getName() << "'";
+            ss << e.what() << std::endl << "in property binding '" << prop->getFullName() << "'";
             e.setMessage(ss.str());
             throw;
         }catch(std::bad_cast &) {
             std::ostringstream ss;
             ss << "Invalid type '" << value.type().name() << "'";
-            ss << "\nin property binding '" << prop->getName() << "'";
+            ss << "\nin property binding '" << prop->getFullName() << "'";
             throw Base::TypeError(ss.str().c_str());
         }catch(std::exception &e) {
             std::ostringstream ss;
-            ss << e.what() << "\nin property binding '" << prop->getName() << "'";
+            ss << e.what() << "\nin property binding '" << prop->getFullName() << "'";
             throw Base::RuntimeError(ss.str().c_str());
         }
     }
@@ -610,9 +706,11 @@ void PropertyExpressionEngine::getPathsToDocumentObject(DocumentObject* obj,
 
 bool PropertyExpressionEngine::depsAreTouched() const
 {
-    for(auto obj : _Deps)
-        if(obj->isTouched())
+    for(auto &v : _Deps) {
+        // v.second inidcates if it is a hidden reference
+        if(!v.second && v.first->isTouched())
             return true;
+    }
     return false;
 }
 
@@ -639,8 +737,9 @@ std::string PropertyExpressionEngine::validateExpression(const ObjectIdentifier 
     assert(pathDocObj);
 
     auto inList = pathDocObj->getInListEx(true);
-    for(auto docObj : expr->getDepObjects()) {
-        if(inList.count(docObj)) {
+    for(auto &v : expr->getDepObjects()) {
+        auto docObj = v.first;
+        if(!v.second && inList.count(docObj)) {
             std::stringstream ss;
             ss << "cyclic reference to " << docObj->getFullName();
             return ss.str();
@@ -765,8 +864,8 @@ bool PropertyExpressionEngine::adjustLink(const std::set<DocumentObject*> &inLis
     if(!owner)
         return false;
     bool found = false;
-    for(auto obj : _Deps) {
-        if(inList.count(obj)) {
+    for(auto &v : _Deps) {
+        if(inList.count(v.first)) {
             found = true;
             break;
         }

--- a/src/App/PropertyExpressionEngine.cpp
+++ b/src/App/PropertyExpressionEngine.cpp
@@ -42,6 +42,7 @@ FC_LOG_LEVEL_INIT("App",true);
 using namespace App;
 using namespace Base;
 using namespace boost;
+using namespace boost::placeholders;
 
 TYPESYSTEM_SOURCE_ABSTRACT(App::PropertyExpressionContainer , App::PropertyXLinkContainer)
 

--- a/src/App/PropertyExpressionEngine.h
+++ b/src/App/PropertyExpressionEngine.h
@@ -85,9 +85,11 @@ public:
 
     struct ExpressionInfo {
         std::shared_ptr<App::Expression> expression; /**< The actual expression tree */
+        bool busy;
 
         ExpressionInfo(std::shared_ptr<App::Expression> expression = std::shared_ptr<App::Expression>()) {
             this->expression = expression;
+            this->busy = false;
         }
 
         ExpressionInfo(const ExpressionInfo & other) {
@@ -186,6 +188,10 @@ private:
                 boost::unordered_map<int, App::ObjectIdentifier> &revNodes, 
                 DiGraph &g, ExecuteOption option=ExecuteAll) const;
 
+    void slotChangedObject(const App::DocumentObject &obj, const App::Property &prop);
+    void slotChangedProperty(const App::DocumentObject &obj, const App::Property &prop);
+    void updateHiddenReference(const std::string &key);
+
     bool running; /**< Boolean used to avoid loops */
     bool restoring = false;
 
@@ -200,6 +206,9 @@ private:
     };
     /**< Expressions are read from file to this map first before they are validated and inserted into the actual map */
     std::unique_ptr<std::vector<RestoredExpression> > restoredExpressions;
+
+    struct Private;
+    std::unique_ptr<Private> pimpl;
 
     friend class AtomicPropertyChange;
 

--- a/src/App/PropertyLinks.cpp
+++ b/src/App/PropertyLinks.cpp
@@ -4453,7 +4453,7 @@ void PropertyXLinkContainer::afterRestore() {
             if(info.docLabel != obj->getDocument()->Label.getValue())
                 _DocMap[App::quote(info.docLabel)] = obj->getDocument()->Label.getValue();
         }
-        if(_Deps.insert(obj).second)
+        if(_Deps.insert(std::make_pair(obj,info.xlink->getScope()==LinkScope::Hidden)).second)
             _XLinks[obj->getFullName()] = std::move(info.xlink);
     }
     _XLinkRestores.reset();
@@ -4466,24 +4466,27 @@ void PropertyXLinkContainer::breakLink(App::DocumentObject *obj, bool clear) {
     if(!owner || !owner->getNameInDocument())
         return;
     if(!clear || obj!=owner) {
-        if(!_Deps.erase(obj))
+        auto it = _Deps.find(obj);
+        if(it == _Deps.end())
             return;
         aboutToSetValue();
         onBreakLink(obj);
-        if(obj->getDocument() == owner->getDocument())
-            obj->_removeBackLink(owner);
-        else
+        if (obj->getDocument() != owner->getDocument())
             _XLinks.erase(obj->getFullName());
+        else if (!it->second)
+            obj->_removeBackLink(owner);
+        _Deps.erase(it);
         hasSetValue();
         return;
     }
     if(obj!=owner)
         return;
-    for(auto obj : _Deps) {
+    for(auto &v : _Deps) {
+        auto obj = v.first;
         if(!obj || !obj->getNameInDocument())
             continue;
         onBreakLink(obj);
-        if(obj->getDocument()==owner->getDocument())
+        if(!v.second && obj->getDocument()==owner->getDocument())
             obj->_removeBackLink(owner);
     }
     _XLinks.clear();
@@ -4523,6 +4526,19 @@ void PropertyXLinkContainer::Save (Base::Writer &writer) const {
             writer.Stream() << "\" docs=\"" << docSet.size();
     }
 
+    std::ostringstream ss;
+    int hidden = 0;
+    int i=-1;
+    for(auto &v : _XLinks) {
+        ++i;
+        if(v.second->getScope() == LinkScope::Hidden) {
+            ss << i << ' ';
+            ++hidden;
+        }
+    }
+    if(hidden)
+        writer.Stream() << "\" hidden=\"" << ss.str();
+
     writer.Stream() << "\">" << std::endl;
     writer.incInd();
 
@@ -4545,6 +4561,15 @@ void PropertyXLinkContainer::Restore(Base::XMLReader &reader) {
     auto count = reader.getAttributeAsUnsigned("count");
     _XLinkRestores.reset(new std::vector<RestoreInfo>(count));
 
+    if(reader.hasAttribute("hidden")) {
+        std::istringstream iss(reader.getAttribute("hidden"));
+        int index;
+        while(iss >> index) {
+            if(index>=0 && index<static_cast<int>(count))
+                _XLinkRestores->at(index).hidden = true;
+        }
+    }
+
     if(reader.hasAttribute("docs")) {
         auto docCount = reader.getAttributeAsUnsigned("docs");
         _DocMap.clear();
@@ -4563,6 +4588,8 @@ void PropertyXLinkContainer::Restore(Base::XMLReader &reader) {
 
     for(auto &info : *_XLinkRestores) {
         info.xlink.reset(createXLink());
+        if(info.hidden)
+            info.xlink->setScope(LinkScope::Hidden);
         info.xlink->Restore(reader);
     }
     reader.readEndElement("XLinks");
@@ -4594,16 +4621,23 @@ bool PropertyXLinkContainer::isLinkedToDocument(const App::Document &doc) const 
     return false;
 }
 
-void PropertyXLinkContainer::updateDeps(std::set<DocumentObject*> &&newDeps) {
+void PropertyXLinkContainer::updateDeps(std::map<DocumentObject*,bool> &&newDeps) {
     auto owner = Base::freecad_dynamic_cast<App::DocumentObject>(getContainer());
     if(!owner || !owner->getNameInDocument())
         return;
     newDeps.erase(owner);
 
-    for(auto obj : newDeps) {
+    for(auto &v : newDeps) {
+        auto obj = v.first;
         if(obj && obj->getNameInDocument()) {
             auto it = _Deps.find(obj);
             if(it != _Deps.end()) {
+                if(v.second != it->second) {
+                    if(v.second)
+                        obj->_removeBackLink(owner);
+                    else
+                        obj->_addBackLink(owner);
+                }
                 _Deps.erase(it);
                 continue;
             }
@@ -4613,21 +4647,21 @@ void PropertyXLinkContainer::updateDeps(std::set<DocumentObject*> &&newDeps) {
                     xlink.reset(createXLink());
                     xlink->setValue(obj);
                 }
+                xlink->setScope(v.second?LinkScope::Hidden:LinkScope::Global);
             }
-#ifndef USE_OLD_DAG
-            else
+            else if(!v.second)
                 obj->_addBackLink(owner);
-#endif
+
             onAddDep(obj);
         }
     }
-    for(auto obj : _Deps) {
+    for(auto &v : _Deps) {
+        auto obj = v.first;
         if(!obj || !obj->getNameInDocument())
             continue;
         if(obj->getDocument()==owner->getDocument()) {
-#ifndef USE_OLD_DAG
-            obj->_removeBackLink(owner);
-#endif
+            if(!v.second)
+                obj->_removeBackLink(owner);
         }else
             _XLinks.erase(obj->getFullName());
         onRemoveDep(obj);
@@ -4651,8 +4685,9 @@ void PropertyXLinkContainer::clearDeps() {
         return;
 #ifndef USE_OLD_DAG
     if (!owner->testStatus(ObjectStatus::Destroy)) {
-        for(auto obj : _Deps) {
-            if(obj && obj->getNameInDocument() && obj->getDocument()==owner->getDocument())
+        for(auto &v : _Deps) {
+            auto obj = v.first;
+            if(!v.second && obj && obj->getNameInDocument() && obj->getDocument()==owner->getDocument())
                 obj->_removeBackLink(owner);
         }
     }
@@ -4662,8 +4697,11 @@ void PropertyXLinkContainer::clearDeps() {
     _LinkRestored = false;
 }
 
-void PropertyXLinkContainer::getLinks(std::vector<App::DocumentObject *> &objs,
-        bool, std::vector<std::string> * /*subs*/, bool /*newStyle*/) const
+void PropertyXLinkContainer::getLinks(std::vector<App::DocumentObject *> &objs, 
+        bool all, std::vector<std::string> * /*subs*/, bool /*newStyle*/) const
 {
-    objs.insert(objs.end(),_Deps.begin(),_Deps.end());
+    for(auto &v : _Deps) {
+        if(all || !v.second)
+            objs.push_back(v.first);
+    }
 }

--- a/src/App/PropertyLinks.h
+++ b/src/App/PropertyLinks.h
@@ -1338,11 +1338,11 @@ protected:
     virtual void onBreakLink(App::DocumentObject *obj);
     virtual void onAddDep(App::DocumentObject *) {}
     virtual void onRemoveDep(App::DocumentObject *) {}
-    void updateDeps(std::set<DocumentObject*> &&newDeps);
+    void updateDeps(std::map<DocumentObject*,bool> &&newDeps);
     void clearDeps();
 
 protected:
-    std::set<App::DocumentObject*> _Deps;
+    std::map<App::DocumentObject*,bool> _Deps;
     std::map<std::string, std::unique_ptr<PropertyXLink> > _XLinks;
     std::map<std::string, std::string> _DocMap;
     bool _LinkRestored;
@@ -1352,6 +1352,7 @@ private:
         std::unique_ptr<PropertyXLink> xlink;
         std::string docName;
         std::string docLabel;
+        bool hidden=false;
     };
     std::unique_ptr<std::vector<RestoreInfo> > _XLinkRestores;
 };

--- a/src/App/PropertyStandard.cpp
+++ b/src/App/PropertyStandard.cpp
@@ -375,7 +375,7 @@ const char * PropertyEnumeration::getValueAsString() const
     return _enum.getCStr();
 }
 
-Enumeration PropertyEnumeration::getEnum() const
+const Enumeration & PropertyEnumeration::getEnum() const
 {
     return _enum;
 }

--- a/src/App/PropertyStandard.h
+++ b/src/App/PropertyStandard.h
@@ -186,11 +186,13 @@ public:
     const char * getValueAsString(void) const;
 
     /// Returns Enumeration object
-    Enumeration getEnum(void) const;
+    const Enumeration &getEnum(void) const;
 
     /// get all possible enum values as vector of strings
     std::vector<std::string> getEnumVector(void) const;
 
+    /// set enum values as vector of strings
+    void setEnumVector(const std::vector<std::string> &);
     /// get the pointer to the enum list
     const char ** getEnums(void) const;
 
@@ -211,7 +213,9 @@ public:
     virtual void Paste(const Property &from);
 
     virtual void setPathValue(const App::ObjectIdentifier & path, const boost::any & value);
-    virtual const boost::any getPathValue(const App::ObjectIdentifier & /*path*/) const { return _enum; }
+    virtual bool setPyPathValue(const App::ObjectIdentifier & path, const Py::Object &value);
+    virtual const boost::any getPathValue(const App::ObjectIdentifier & /*path*/) const;
+    virtual bool getPyPathValue(const ObjectIdentifier &path, Py::Object &r) const;
 
 private:
     Enumeration _enum;

--- a/src/App/Range.h
+++ b/src/App/Range.h
@@ -120,6 +120,12 @@ public:
     /** Current column */
     inline int column() const { return col_curr; }
 
+    /** Row count */
+    inline int rowCount() const { return row_end - row_begin + 1; }
+
+    /** Column count */
+    inline int colCount() const { return col_end - col_begin + 1; }
+
     /** Position of start of range */
     inline CellAddress from() const { return CellAddress(row_begin, col_begin); }
 

--- a/src/Gui/ViewProviderDocumentObject.cpp
+++ b/src/Gui/ViewProviderDocumentObject.cpp
@@ -96,6 +96,7 @@ ViewProviderDocumentObject::ViewProviderDocumentObject()
 ViewProviderDocumentObject::~ViewProviderDocumentObject()
 {
     // Make sure that the property class does not destruct our string list
+    DisplayMode.setContainer(nullptr);
     DisplayMode.setEnums(0);
 }
 
@@ -675,5 +676,5 @@ ViewProviderDocumentObject *ViewProviderDocumentObject::getLinkedViewProvider(
 std::string ViewProviderDocumentObject::getFullName() const {
     if(pcObject)
         return pcObject->getFullName() + ".ViewObject";
-    return std::string();
+    return std::string("?");
 }

--- a/src/Gui/propertyeditor/PropertyEditor.cpp
+++ b/src/Gui/propertyeditor/PropertyEditor.cpp
@@ -31,7 +31,10 @@
 # include <QDialog>
 # include <QMessageBox>
 # include <QCheckBox>
+# include <QInputDialog>
 #endif
+
+#include <boost/algorithm/string/predicate.hpp>
 
 #include <Base/Console.h>
 #include <Base/Tools.h>
@@ -57,6 +60,7 @@ PropertyEditor::PropertyEditor(QWidget *parent)
     , committing(false)
     , delaybuild(false)
     , binding(false)
+    , checkDocument(false)
 {
     propertyModel = new PropertyModel(this);
     setModel(propertyModel);
@@ -362,8 +366,10 @@ void PropertyEditor::drawBranches(QPainter *painter, const QRect &rect, const QM
     //painter->setPen(savedPen);
 }
 
-void PropertyEditor::buildUp(PropertyModel::PropertyList &&props, bool checkDocument)
+void PropertyEditor::buildUp(PropertyModel::PropertyList &&props, bool _checkDocument)
 {
+    checkDocument = _checkDocument;
+
     if (committing) {
         Base::Console().Warning("While committing the data to the property the selection has changed.\n");
         delaybuild = true;
@@ -493,6 +499,7 @@ enum MenuAction {
     MA_Expression,
     MA_RemoveProp,
     MA_AddProp,
+    MA_EditPropGroup,
     MA_Transient,
     MA_Output,
     MA_NoRecompute,
@@ -532,8 +539,20 @@ void PropertyEditor::contextMenuEvent(QContextMenuEvent *) {
             }
         }
 
-        if(props.size())
+        if(props.size()) {
             menu.addAction(tr("Add property"))->setData(QVariant(MA_AddProp));
+            unsigned count = 0;
+            for(auto prop : props) {
+                if(prop->testStatus(App::Property::PropDynamic)
+                        && !boost::starts_with(prop->getName(),prop->getGroup()))
+                {
+                    ++count;
+                } else
+                    break;
+            }
+            if(count == props.size())
+                menu.addAction(tr("Rename property group"))->setData(QVariant(MA_EditPropGroup));
+        }
 
         bool canRemove = !props.empty();
         unsigned long propType = 0;
@@ -643,6 +662,22 @@ void PropertyEditor::contextMenuEvent(QContextMenuEvent *) {
         Gui::Dialog::DlgAddProperty dlg(
                 Gui::getMainWindow(),std::move(containers));
         dlg.exec();
+        return;
+    }
+    case MA_EditPropGroup: {
+        // This operation is not undoable yet.
+        const char *groupName = (*props.begin())->getGroup();
+        if(!groupName)
+            groupName = "Base";
+        QString res = QInputDialog::getText(Gui::getMainWindow(),
+                tr("Rename property group"), tr("Group name:"),
+                QLineEdit::Normal, QString::fromUtf8(groupName));
+        if(res.size()) {
+            std::string group = res.toUtf8().constData();
+            for(auto prop : props)
+                prop->getContainer()->changeDynamicProperty(prop,group.c_str(),0);
+            buildUp(PropertyModel::PropertyList(propList),checkDocument);
+        }
         return;
     }
     case MA_RemoveProp: {

--- a/src/Gui/propertyeditor/PropertyEditor.h
+++ b/src/Gui/propertyeditor/PropertyEditor.h
@@ -124,6 +124,7 @@ private:
     bool committing;
     bool delaybuild;
     bool binding;
+    bool checkDocument;
 
     int transactionID = 0;
 

--- a/src/Gui/propertyeditor/PropertyItem.cpp
+++ b/src/Gui/propertyeditor/PropertyItem.cpp
@@ -770,7 +770,7 @@ QVariant PropertyFontItem::value(const App::Property* prop) const
 
 void PropertyFontItem::setValue(const QVariant& value)
 {
-    if (!value.canConvert(QVariant::String))
+    if (hasExpression() || !value.canConvert(QVariant::String))
         return;
     QString val = value.toString();
     QString data = QString::fromLatin1("\"%1\"").arg(val);
@@ -1270,7 +1270,7 @@ QVariant PropertyBoolItem::value(const App::Property* prop) const
 
 void PropertyBoolItem::setValue(const QVariant& value)
 {
-    if (!value.canConvert(QVariant::Bool))
+    if (hasExpression() || !value.canConvert(QVariant::Bool))
         return;
     bool val = value.toBool();
     QString data = (val ? QLatin1String("True") : QLatin1String("False"));
@@ -1377,7 +1377,7 @@ QVariant PropertyVectorItem::value(const App::Property* prop) const
 
 void PropertyVectorItem::setValue(const QVariant& value)
 {
-    if (!value.canConvert<Base::Vector3d>())
+    if (hasExpression() || !value.canConvert<Base::Vector3d>())
         return;
     const Base::Vector3d& val = value.value<Base::Vector3d>();
     QString data = QString::fromLatin1("(%1, %2, %3)")
@@ -1652,7 +1652,7 @@ QVariant PropertyVectorDistanceItem::value(const App::Property* prop) const
 
 void PropertyVectorDistanceItem::setValue(const QVariant& variant)
 {
-    if (!variant.canConvert<Base::Vector3d>())
+    if (hasExpression() || !variant.canConvert<Base::Vector3d>())
         return;
     const Base::Vector3d& value = variant.value<Base::Vector3d>();
 
@@ -1869,7 +1869,7 @@ QVariant PropertyMatrixItem::toolTip(const App::Property* prop) const
 
 void PropertyMatrixItem::setValue(const QVariant& value)
 {
-    if (!value.canConvert<Base::Matrix4D>())
+    if (hasExpression() || !value.canConvert<Base::Matrix4D>())
         return;
     const Base::Matrix4D& val = value.value<Base::Matrix4D>();
     const int decimals=16;
@@ -2644,7 +2644,7 @@ QVariant PropertyPlacementItem::toString(const QVariant& prop) const
 
 void PropertyPlacementItem::setValue(const QVariant& value)
 {
-    if (!value.canConvert<Base::Placement>())
+    if (hasExpression() || !value.canConvert<Base::Placement>())
         return;
     // Accept this only if the user changed the axis, angle or position but
     // not if >this< item loses focus
@@ -2711,7 +2711,37 @@ void PropertyPlacementItem::propertyBound()
 PROPERTYITEM_SOURCE(Gui::PropertyEditor::PropertyEnumItem)
 
 PropertyEnumItem::PropertyEnumItem()
+    :m_enum(0)
 {
+    if(PropertyView::showAll()) {
+        m_enum = static_cast<PropertyStringListItem*>(PropertyStringListItem::create());
+        m_enum->setParent(this);
+        m_enum->setPropertyName(QLatin1String(QT_TRANSLATE_NOOP("App::Property", "Enum")));
+        this->appendChild(m_enum);
+    }
+}
+
+void PropertyEnumItem::propertyBound()
+{
+    if (m_enum && isBound()) 
+        m_enum->bind(App::ObjectIdentifier(getPath())<<App::ObjectIdentifier::String("Enum"));
+}
+
+void PropertyEnumItem::setEnum(QStringList values)
+{
+    setData(values);
+}
+
+QStringList PropertyEnumItem::getEnum() const
+{
+    QStringList res;
+    auto prop = getFirstProperty();
+    if (prop && prop->getTypeId().isDerivedFrom(App::PropertyEnumeration::getClassTypeId())) {
+        const App::PropertyEnumeration* prop_enum = static_cast<const App::PropertyEnumeration*>(prop);
+        for(int i=0,last=prop_enum->getEnum().maxValue();i<=last;++i)
+            res.push_back(QString::fromUtf8(prop_enum->getEnums()[i]));
+    }
+    return res;
 }
 
 QVariant PropertyEnumItem::value(const App::Property* prop) const
@@ -2719,25 +2749,40 @@ QVariant PropertyEnumItem::value(const App::Property* prop) const
     assert(prop && prop->getTypeId().isDerivedFrom(App::PropertyEnumeration::getClassTypeId()));
 
     const App::PropertyEnumeration* prop_enum = static_cast<const App::PropertyEnumeration*>(prop);
-    const std::vector<std::string>& value = prop_enum->getEnumVector();
-    long currentItem = prop_enum->getValue();
-
-    if (currentItem < 0 || currentItem >= static_cast<long>(value.size()))
+    if(!prop_enum->isValid())
         return QVariant(QString());
-    return QVariant(QString::fromUtf8(value[currentItem].c_str()));
+    return QVariant(QString::fromUtf8(prop_enum->getValueAsString()));
 }
 
 void PropertyEnumItem::setValue(const QVariant& value)
 {
-    if (!value.canConvert(QVariant::StringList))
+    if (hasExpression())
         return;
-    QStringList items = value.toStringList();
-    if (!items.isEmpty()) {
-        QByteArray val = items.front().toUtf8();
-        std::string str = Base::Tools::escapedUnicodeFromUtf8(val);
-        QString data = QString::fromLatin1("u\"%1\"").arg(QString::fromStdString(str));
-        setPropertyValue(data);
+
+    QString data;
+
+    if (value.type() == QVariant::StringList) {
+        QStringList values = value.toStringList();
+        QTextStream str(&data);
+        str << "[";
+        for (QStringList::Iterator it = values.begin(); it != values.end(); ++it) {
+            QString text(*it);
+            text.replace(QString::fromUtf8("'"),QString::fromUtf8("\\'"));
+
+            std::string pystr = Base::Tools::escapedUnicodeFromUtf8(text.toUtf8());
+            pystr = Base::Interpreter().strToPython(pystr.c_str());
+            str << "u\"" << pystr.c_str() << "\", ";
+        }
+        str << "]";
     }
+    else if (value.canConvert(QVariant::String)) {
+        QByteArray val = value.toString().toUtf8();
+        std::string str = Base::Tools::escapedUnicodeFromUtf8(val);
+        data = QString::fromLatin1("u\"%1\"").arg(QString::fromStdString(str));
+    }
+    else
+        return;
+    setPropertyValue(data);
 }
 
 QWidget* PropertyEnumItem::createEditor(QWidget* parent, const QObject* receiver, const char* method) const
@@ -2851,7 +2896,7 @@ QVariant PropertyStringListItem::value(const App::Property* prop) const
 
 void PropertyStringListItem::setValue(const QVariant& value)
 {
-    if (!value.canConvert(QVariant::StringList))
+    if (hasExpression() || !value.canConvert(QVariant::StringList))
         return;
     QStringList values = value.toStringList();
     QString data;
@@ -2928,7 +2973,7 @@ QVariant PropertyFloatListItem::value(const App::Property* prop) const
 
 void PropertyFloatListItem::setValue(const QVariant& value)
 {
-    if (!value.canConvert(QVariant::StringList))
+    if (hasExpression() || !value.canConvert(QVariant::StringList))
         return;
     QStringList values = value.toStringList();
     QString data;
@@ -3003,7 +3048,7 @@ QVariant PropertyIntegerListItem::value(const App::Property* prop) const
 
 void PropertyIntegerListItem::setValue(const QVariant& value)
 {
-    if (!value.canConvert(QVariant::StringList))
+    if (hasExpression() || !value.canConvert(QVariant::StringList))
         return;
     QStringList values = value.toStringList();
     QString data;
@@ -3055,7 +3100,7 @@ QVariant PropertyColorItem::value(const App::Property* prop) const
 
 void PropertyColorItem::setValue(const QVariant& value)
 {
-    if (!value.canConvert<QColor>())
+    if (hasExpression() || !value.canConvert<QColor>())
         return;
     QColor col = value.value<QColor>();
     App::Color val; val.setValue<QColor>(col);
@@ -3347,7 +3392,7 @@ QVariant PropertyMaterialItem::value(const App::Property* prop) const
 
 void PropertyMaterialItem::setValue(const QVariant& value)
 {
-    if (!value.canConvert<Material>())
+    if (hasExpression() || !value.canConvert<Material>())
         return;
 
     Material mat = value.value<Material>();
@@ -3779,7 +3824,7 @@ QVariant PropertyMaterialListItem::value(const App::Property* prop) const
 
 void PropertyMaterialListItem::setValue(const QVariant& value)
 {
-    if (!value.canConvert<QVariantList>())
+    if (hasExpression() || !value.canConvert<QVariantList>())
         return;
 
     QVariantList list = value.toList();
@@ -3900,7 +3945,7 @@ QVariant PropertyFileItem::value(const App::Property* prop) const
 
 void PropertyFileItem::setValue(const QVariant& value)
 {
-    if (!value.canConvert(QVariant::String))
+    if (hasExpression() || !value.canConvert(QVariant::String))
         return;
     QString val = value.toString();
     QString data = QString::fromLatin1("\"%1\"").arg(val);
@@ -3957,7 +4002,7 @@ QVariant PropertyPathItem::value(const App::Property* prop) const
 
 void PropertyPathItem::setValue(const QVariant& value)
 {
-    if (!value.canConvert(QVariant::String))
+    if (hasExpression() || !value.canConvert(QVariant::String))
         return;
     QString val = value.toString();
     QString data = QString::fromLatin1("\"%1\"").arg(val);
@@ -4009,7 +4054,7 @@ QVariant PropertyTransientFileItem::value(const App::Property* prop) const
 
 void PropertyTransientFileItem::setValue(const QVariant& value)
 {
-    if (!value.canConvert(QVariant::String))
+    if (hasExpression() || !value.canConvert(QVariant::String))
         return;
     QString val = value.toString();
     QString data = QString::fromLatin1("\"%1\"").arg(val);
@@ -4267,7 +4312,6 @@ PropertyLinkListItem::PropertyLinkListItem()
 {
 }
 
-// --------------------------------------------------------------------
 
 PropertyItemEditorFactory::PropertyItemEditorFactory()
 {

--- a/src/Gui/propertyeditor/PropertyItem.h
+++ b/src/Gui/propertyeditor/PropertyItem.h
@@ -778,6 +778,8 @@ private:
     PropertyVectorDistanceItem* m_p;
 };
 
+class PropertyStringListItem;
+
 /**
  * Edit properties of enum type. 
  * \author Werner Mayer
@@ -785,18 +787,26 @@ private:
 class GuiExport PropertyEnumItem: public PropertyItem
 {
     Q_OBJECT
+    Q_PROPERTY(QStringList Enum READ getEnum WRITE setEnum DESIGNABLE true USER true)
     PROPERTYITEM_HEADER
 
     virtual QWidget* createEditor(QWidget* parent, const QObject* receiver, const char* method) const;
     virtual void setEditorData(QWidget *editor, const QVariant& data) const;
     virtual QVariant editorData(QWidget *editor) const;
 
+    QStringList getEnum() const;
+    void setEnum(QStringList);
+
 protected:
     virtual QVariant value(const App::Property*) const;
     virtual void setValue(const QVariant&);
+    virtual void propertyBound();
 
 protected:
     PropertyEnumItem();
+
+private:
+    PropertyStringListItem* m_enum;
 };
 
 /**

--- a/src/Mod/Spreadsheet/App/PropertySheet.cpp
+++ b/src/Mod/Spreadsheet/App/PropertySheet.cpp
@@ -1023,38 +1023,39 @@ void PropertySheet::addDependencies(CellAddress key)
     if (expression == 0)
         return;
 
-    for(auto &dep : expression->getDeps()) {
+    for(auto &var : expression->getIdentifiers()) {
+        for(auto &dep : var.first.getDep(true)) {
+            App::DocumentObject *docObj = dep.first;
+            App::Document *doc = docObj->getDocument();
 
-        App::DocumentObject *docObj = dep.first;
-        App::Document *doc = docObj->getDocument();
+            std::string docObjName = docObj->getFullName();
 
-        std::string docObjName = docObj->getFullName();
+            owner->observeDocument(doc);
 
-        owner->observeDocument(doc);
+            documentObjectToCellMap[docObjName].insert(key);
+            cellToDocumentObjectMap[key].insert(docObjName);
+            ++updateCount;
 
-        documentObjectToCellMap[docObjName].insert(key);
-        cellToDocumentObjectMap[key].insert(docObjName);
-        ++updateCount;
+            for(auto &name : dep.second) {
+                std::string propName = docObjName + "." + name;
+                FC_LOG("dep " << key.toString() << " -> " << name);
 
-        for(auto &props : dep.second) {
-            std::string propName = docObjName + "." + props.first;
-            FC_LOG("dep " << key.toString() << " -> " << propName);
+                // Insert into maps
+                propertyNameToCellMap[propName].insert(key);
+                cellToPropertyNameMap[key].insert(propName);
 
-            // Insert into maps
-            propertyNameToCellMap[propName].insert(key);
-            cellToPropertyNameMap[key].insert(propName);
+                // Also an alias?
+                if (docObj==owner && name.size()) {
+                    auto j = revAliasProp.find(name);
 
-            // Also an alias?
-            if (docObj==owner && props.first.size()) {
-                std::map<std::string, CellAddress>::const_iterator j = revAliasProp.find(props.first);
+                    if (j != revAliasProp.end()) {
+                        propName = docObjName + "." + j->second.toString();
+                        FC_LOG("dep " << key.toString() << " -> " << propName);
 
-                if (j != revAliasProp.end()) {
-                    propName = docObjName + "." + j->second.toString();
-                    FC_LOG("dep " << key.toString() << " -> " << propName);
-
-                    // Insert into maps
-                    propertyNameToCellMap[propName].insert(key);
-                    cellToPropertyNameMap[key].insert(propName);
+                        // Insert into maps
+                        propertyNameToCellMap[propName].insert(key);
+                        cellToPropertyNameMap[key].insert(propName);
+                    }
                 }
             }
         }
@@ -1123,6 +1124,16 @@ void PropertySheet::removeDependencies(CellAddress key)
 
 void PropertySheet::recomputeDependants(const App::DocumentObject *owner, const char *propName)
 {
+    auto itD = _Deps.find(const_cast<App::DocumentObject*>(owner));
+    if(itD!=_Deps.end() && itD->second) {
+        // Check for hidden reference. Because a hidden reference is not
+        // protected by cyclic dependency checking, we need to take special
+        // care to prevent it from misbehave.
+        Sheet *sheet = Base::freecad_dynamic_cast<Sheet>(getContainer());
+        if(!sheet || sheet->testStatus(App::ObjectStatus::Recompute2))
+            return;
+    }
+
     // First, search without actual property name for sub-object/link
     // references, i.e indirect references. The dependencies of these
     // references are too complex to track exactly, so we only track the
@@ -1135,7 +1146,7 @@ void PropertySheet::recomputeDependants(const App::DocumentObject *owner, const 
             setDirty(cell);
     }
 
-    if (propName) {
+    if (propName && *propName) {
         // Now, we check for direct property references
         it = propertyNameToCellMap.find(fullName + propName);
         if (it != propertyNameToCellMap.end()) {
@@ -1302,7 +1313,7 @@ void PropertySheet::hasSetValue()
 
     updateCount = 0;
 
-    std::set<App::DocumentObject*> deps;
+    std::map<App::DocumentObject*,bool> deps;
     std::vector<std::string> labels;
     unregisterElementReference();
     UpdateElementReferenceExpressionVisitor<PropertySheet> v(*this);
@@ -1384,8 +1395,9 @@ bool PropertySheet::adjustLink(const std::set<DocumentObject*> &inList) {
             continue;
         try {
             bool need_adjust = false;
-            for(auto docObj : expr->getDepObjects()) {
-                if (docObj && docObj != owner && inList.count(docObj)) {
+            for(auto &v : expr->getDepObjects()) {
+                auto docObj = v.first;
+                if (v.second && docObj && docObj!=owner && inList.count(docObj)) {
                     need_adjust = true;
                     break;
                 }


### PR DESCRIPTION
This is the second stage of cherry-picking commits from @realthunder's PR #2862 -- Configuration Table using Spreadsheet. The main work of this set of commits is to introduce the `HIDDENREF()` function (formerly the `HREF()` function). To borrow from [realthunder's documentation](https://github.com/realthunder/FreeCAD_assembly3/wiki/Expression-and-Spreadsheet#href):

> `hiddenref()` stands for hidden reference, which accepts a single argument containing an property reference. This function hides any object reference inside the argument to work around cyclic dependency error. You need to be careful when using `hiddenref()` because skipping dependency checking may result in unstable recomputing order, and thus given unexpected result. As a rule of thumb, it will be safe if `hiddenref()` is referring (directly or indirectly) to some property that will only be changed by user instead of calculated by the object (e.g. with other expressions). When used right, `hiddenref()` can be a powerful tool. You can, for example, expose module parameters in a parent container (such as an `App::Part` or `PartDesign::Body`), and refer to these parameters inside any child features, e.g. `hiddenref(Part001.Length)`.