### PR TITLE
[PD] Support adding solid faces for loft and pipe sections

### DIFF
--- a/src/Mod/PartDesign/App/FeatureLoft.h
+++ b/src/Mod/PartDesign/App/FeatureLoft.h
@@ -40,9 +40,9 @@ class PartDesignExport Loft : public ProfileBased
 public:
     Loft();
 
-    App::PropertyLinkList Sections;
-    App::PropertyBool     Ruled;
-    App::PropertyBool     Closed;    
+    App::PropertyXLinkSubList Sections;
+    App::PropertyBool Ruled;
+    App::PropertyBool Closed;
 
     /** @name methods override feature */
     //@{
@@ -60,14 +60,14 @@ private:
 };
 
 class PartDesignExport AdditiveLoft : public Loft {
-    
+
     PROPERTY_HEADER(PartDesign::AdditiveLoft);
 public:
     AdditiveLoft();
 };
 
 class PartDesignExport SubtractiveLoft : public Loft {
-    
+
     PROPERTY_HEADER(PartDesign::SubtractiveLoft);
 public:
     SubtractiveLoft();

--- a/src/Mod/PartDesign/App/FeaturePipe.h
+++ b/src/Mod/PartDesign/App/FeaturePipe.h
@@ -39,16 +39,16 @@ public:
     Pipe();
 
 
-    App::PropertyLinkSub     Spine;
-    App::PropertyBool        SpineTangent;
-    App::PropertyLinkSub     AuxillerySpine;
-    App::PropertyBool        AuxillerySpineTangent;
-    App::PropertyBool        AuxilleryCurvelinear;
+    App::PropertyLinkSub Spine;
+    App::PropertyBool SpineTangent;
+    App::PropertyLinkSub AuxillerySpine;
+    App::PropertyBool AuxillerySpineTangent;
+    App::PropertyBool AuxilleryCurvelinear;
     App::PropertyEnumeration Mode;
-    App::PropertyVector      Binormal;
+    App::PropertyVector Binormal;
     App::PropertyEnumeration Transition;
     App::PropertyEnumeration Transformation;
-    App::PropertyLinkList    Sections;
+    App::PropertyXLinkSubList Sections;
 
     App::DocumentObjectExecReturn *execute(void);
     short mustExecute() const;

--- a/src/Mod/PartDesign/Gui/TaskLoftParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskLoftParameters.cpp
@@ -212,6 +212,8 @@ bool TaskLoftParameters::referenceSelected(const Gui::SelectionChanges& msg) con
             }
             else if (selectionMode == refRemove) {
                 if (f != refs.end())
+                    // Removing just the object this way instead of `refs.erase` and
+                    // `setValues(ref)` cleanly ensures subnames are preserved.
                     loft->Sections.removeValue(obj);
                 else
                     return false;
@@ -250,8 +252,9 @@ void TaskLoftParameters::onDeleteSection()
         App::DocumentObject* obj = loft->getDocument()->getObject(data.constData());
         std::vector<App::DocumentObject*>::iterator f = std::find(refs.begin(), refs.end(), obj);
         if (f != refs.end()) {
-            refs.erase(f);
-            loft->Sections.setValues(refs);
+            // Removing just the object this way instead of `refs.erase` and
+            // `setValues(ref)` cleanly ensures subnames are preserved.
+            loft->Sections.removeValue(obj);
 
             //static_cast<ViewProviderLoft*>(vp)->highlightReferences(false, true);
             recomputeFeature();

--- a/src/Mod/PartDesign/Gui/TaskPipeParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPipeParameters.cpp
@@ -1042,6 +1042,8 @@ bool TaskPipeScaling::referenceSelected(const SelectionChanges& msg) const {
         }
         else {
             if (f != refs.end())
+                // Removing just the object this way instead of `refs.erase` and
+                // `setValues(ref)` cleanly ensures subnames are preserved.
                 pipe->Sections.removeValue(obj);
             else
                 return false;
@@ -1082,8 +1084,9 @@ void TaskPipeScaling::onDeleteSection()
 
         // if something was found, delete it and update the section list
         if (f != refs.end()) {
-            refs.erase(f);
-            pipe->Sections.setValues(refs);
+            // Removing just the object this way instead of `refs.erase` and
+            // `setValues(ref)` cleanly ensures subnames are preserved.
+            pipe->Sections.removeValue(obj);
             clearButtons();
             recomputeFeature();
         }

--- a/src/Mod/PartDesign/Gui/TaskSketchBasedParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskSketchBasedParameters.cpp
@@ -220,6 +220,20 @@ QString TaskSketchBasedParameters::getFaceReference(const QString& obj, const QS
             .arg(QString::fromLatin1(doc->getName()), o, sub);
 }
 
+QString TaskSketchBasedParameters::make2DLabel(const App::DocumentObject* section,
+                                               const std::vector<std::string>& subValues)
+{
+    if(section->isDerivedFrom(Part::Part2DObject::getClassTypeId()))
+        return QString::fromUtf8(section->Label.getValue());
+    else {
+        if(subValues.empty())
+            throw Base::ValueError("No valid subelement linked in Part::Feature");
+
+        return QString::fromUtf8((std::string(section->getNameInDocument())
+                                  + ":" + subValues[0]).c_str());
+    }
+}
+
 TaskSketchBasedParameters::~TaskSketchBasedParameters()
 {
     Gui::Selection().rmvSelectionGate();

--- a/src/Mod/PartDesign/Gui/TaskSketchBasedParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskSketchBasedParameters.h
@@ -61,6 +61,10 @@ protected:
     QVariant objectNameByLabel(const QString& label, const QVariant& suggest) const;
 
     QString getFaceReference(const QString& obj, const QString& sub) const;
+    /// Create a label for the 2D feature: the objects name if it's already 2D,
+    /// or the subelement's name if the object is a solid.
+    QString make2DLabel(const App::DocumentObject* section,
+                        const std::vector<std::string>& subValues);
 };
 
 class TaskDlgSketchBasedParameters : public PartDesignGui::TaskDlgFeatureParameters


### PR DESCRIPTION
With these changes, one face per solid can be added as either the first
"profile" or subsequent sections in loft and pipe.

These changes depend on `App::PropertyXLinkSubList` preserving the order in which
sections are added.

A minor change this also adds is that when a solid's face is selected that face
is mentioned in the fields instead of the solid (eg `Box:Face1` instead of
`Box`).