### PR TITLE
[Tux] fix navigation status bar width

### DIFF
--- a/src/Mod/Tux/NavigationIndicatorGui.py
+++ b/src/Mod/Tux/NavigationIndicatorGui.py
@@ -53,6 +53,7 @@ class IndicatorButton(QtGui.QPushButton):
         if event.type() == QtCore.QEvent.LanguageChange:
             retranslateUi()
             onTooltip()
+            adjustSize()
         return super(IndicatorButton, self).changeEvent(event)
 
 
@@ -74,21 +75,21 @@ def retranslateUi():
     t0 = translate("NavigationIndicator", "Navigation style not recognized.")
 
     global t1
-    t1 = "<p align='center'><b>OpenInventor</b> " + text06 + """</p>
+    t1 = "<p align='center'><b>Blender</b> " + text06 + """</p>
     <table>
      <tr>
       <th><small>""" + text01 + """</small></th>
       <th><small>""" + text02 + """</small></th>
-      <th><small>""" + text02 + """</small></th>
       <th><small>""" + text03 + """</small></th>
+      <th><small>""" + text04 + """</small></th>
       <th><small>""" + text04 + """</small></th>
      </tr>
      <tr>
-      <td align='center'><img src=':/icons/NavigationOpenInventor_Select.svg'></td>
-      <td align='center'><img src=':/icons/NavigationOpenInventor_Zoom.svg'></td>
-      <td align='center'><img src=':/icons/NavigationOpenInventor_ZoomAlt.svg'></td>
-      <td align='center'><img src=':/icons/NavigationOpenInventor_Rotate.svg'></td>
-      <td align='center'><img src=':/icons/NavigationOpenInventor_Pan.svg'></td>
+      <td align='center'><img src=':/icons/NavigationBlender_Select.svg'></td>
+      <td align='center'><img src=':/icons/NavigationBlender_Zoom.svg'></td>
+      <td align='center'><img src=':/icons/NavigationBlender_Rotate.svg'></td>
+      <td align='center'><img src=':/icons/NavigationBlender_Pan.svg'></td>
+      <td align='center'><img src=':/icons/NavigationBlender_PanAlt.svg'></td>
      </tr>
     </table>
     <b>""" + text08 + ":</b> " + text10 + "</small></p>"
@@ -114,122 +115,7 @@ def retranslateUi():
     <b>""" + text08 + ":</b> " + text10 + "</small></p>"
 
     global t3
-    t3 = "<p align='center'><b>Revit</b> " + text06 + """</p>
-    <table>
-     <tr>
-      <th><small>""" + text01 + """</small></th>
-      <th><small>""" + text02 + """</small></th>
-      <th><small>""" + text03 + """</small></th>
-      <th><small>""" + text04 + """</small></th>
-      <th><small>""" + text04 + """</small></th>
-     </tr>
-     <tr>
-      <td align='center'><img src=':/icons/NavigationBlender_Select.svg'></td>
-      <td align='center'><img src=':/icons/NavigationBlender_Zoom.svg'></td>
-      <td align='center'><img src=':/icons/NavigationRevit_Rotate.svg'></td>
-      <td align='center'><img src=':/icons/NavigationRevit_Pan.svg'></td>
-      <td align='center'><img src=':/icons/NavigationBlender_PanAlt.svg'></td>
-     </tr>
-    </table>
-    <b>""" + text08 + ":</b> " + text10 + "</small></p>"
-
-    global t4
-    t4 = "<p align='center'><b>Blender</b> " + text06 + """</p>
-    <table>
-     <tr>
-      <th><small>""" + text01 + """</small></th>
-      <th><small>""" + text02 + """</small></th>
-      <th><small>""" + text03 + """</small></th>
-      <th><small>""" + text04 + """</small></th>
-      <th><small>""" + text04 + """</small></th>
-     </tr>
-     <tr>
-      <td align='center'><img src=':/icons/NavigationBlender_Select.svg'></td>
-      <td align='center'><img src=':/icons/NavigationBlender_Zoom.svg'></td>
-      <td align='center'><img src=':/icons/NavigationBlender_Rotate.svg'></td>
-      <td align='center'><img src=':/icons/NavigationBlender_Pan.svg'></td>
-      <td align='center'><img src=':/icons/NavigationBlender_PanAlt.svg'></td>
-     </tr>
-    </table>
-    <b>""" + text08 + ":</b> " + text10 + "</small></p>"
-
-    global t5
-    t5 = "<p align='center'><b>MayaGesture</b> " + text06 + """</p>
-    <table>
-     <tr>
-      <th><small>""" + text01 + """</small></th>
-      <th><small>""" + text02 + """</small></th>
-      <th><small>""" + text02 + """</small></th>
-      <th><small>""" + text03 + """</small></th>
-      <th><small>""" + text04 + """</small></th>
-      <th><small>""" + text05 + """</small></th>
-     </tr>
-     <tr>
-      <td align='center'><img src=':/icons/NavigationMayaGesture_Select.svg'></td>
-      <td align='center'><img src=':/icons/NavigationMayaGesture_Zoom.svg'></td>
-      <td align='center'><img src=':/icons/NavigationMayaGesture_ZoomAlt.svg'></td>
-      <td align='center'><img src=':/icons/NavigationMayaGesture_Rotate.svg'></td>
-      <td align='center'><img src=':/icons/NavigationMayaGesture_Pan.svg'></td>
-      <td align='center'><img src=':/icons/NavigationMayaGesture_Tilt.svg'></td>
-     </tr>
-     <tr>
-      <th><small>""" + text01 + """</small></th>
-      <th><small>""" + text02 + """</small></th>
-      <th><small>""" + text03 + """</small></th>
-      <th><small>""" + text04 + """</small></th>
-      <th><small>""" + text04 + """</small></th>
-      <th><small>""" + text05 + """</small></th>
-     </tr>
-     <tr>
-      <td align='center'><img src=':/icons/NavigationMayaGesture_SelectTouch.svg'></td>
-      <td align='center'><img src=':/icons/NavigationMayaGesture_ZoomTouch.svg'></td>
-      <td align='center'><img src=':/icons/NavigationMayaGesture_RotateTouch.svg'></td>
-      <td align='center'><img src=':/icons/NavigationMayaGesture_PanTouch.svg'></td>
-      <td align='center'><img src=':/icons/NavigationMayaGesture_PanTouchAlt.svg'></td>
-      <td align='center'><img src=':/icons/NavigationMayaGesture_TiltTouch.svg'></td>
-     </tr>
-    </table>
-    <p><small><b>""" + text02 + ":</b> " + text07 + """<br>
-    <b>""" + text08 + ":</b> " + text09 + "</small></p>"
-
-    global t6
-    t6 = "<p align='center'><b>Touchpad</b> " + text06 + """</p>
-    <table>
-     <tr>
-      <th><small>""" + text01 + """</small></th>
-      <th><small>""" + text02 + """</small></th>
-      <th><small>""" + text02 + """</small></th>
-      <th><small>""" + text03 + """</small></th>
-      <th><small>""" + text03 + """</small></th>
-      <th><small>""" + text04 + """</small></th>
-     </tr>
-     <tr>
-      <td align='center'><img src=':/icons/NavigationTouchpad_Select.svg'></td>
-      <td align='center'><img src=':/icons/NavigationTouchpad_Zoom.svg'></td>
-      <td align='center'><img src=':/icons/NavigationTouchpad_ZoomAlt.svg'></td>
-      <td align='center'><img src=':/icons/NavigationTouchpad_Rotate.svg'></td>
-      <td align='center'><img src=':/icons/NavigationTouchpad_RotateAlt.svg'></td>
-      <td align='center'><img src=':/icons/NavigationTouchpad_Pan.svg'></td>
-     </tr>
-     <tr>
-      <th><small>""" + text01 + """</small></th>
-      <th><small>""" + text02 + """</small></th>
-      <th><small>""" + text03 + """</small></th>
-      <th><small>""" + text03 + """</small></th>
-      <th><small>""" + text04 + """</small></th>
-     </tr>
-     <tr>
-      <td align='center'><img src=':/icons/NavigationTouchpad_SelectTouch.svg'></td>
-      <td align='center'><img src=':/icons/NavigationTouchpad_ZoomTouch.svg'></td>
-      <td align='center'><img src=':/icons/NavigationTouchpad_RotateTouch.svg'></td>
-      <td align='center'><img src=':/icons/NavigationTouchpad_RotateTouchAlt.svg'></td>
-      <td align='center'><img src=':/icons/NavigationTouchpad_PanTouch.svg'></td>
-     </tr>
-    </table>
-    <p><small><b>""" + text02 + ":</b> " + text07 + "</p>"
-
-    global t7
-    t7 = "<p align='center'><b>Gesture</b> " + text06 + """</p>
+    t3 = "<p align='center'><b>Gesture</b> " + text06 + """</p>
     <table>
      <tr>
       <th><small>""" + text01 + """</small></th>
@@ -267,8 +153,47 @@ def retranslateUi():
     <p><small><b>""" + text02 + ":</b> " + text07 + """<br>
     <b>""" + text08 + ":</b> " + text09 + "</small></p>"
 
-    global t8
-    t8 = "<p align='center'><b>OpenCascade</b> " + text06 + """</p>
+    global t4
+    t4 = "<p align='center'><b>MayaGesture</b> " + text06 + """</p>
+    <table>
+     <tr>
+      <th><small>""" + text01 + """</small></th>
+      <th><small>""" + text02 + """</small></th>
+      <th><small>""" + text02 + """</small></th>
+      <th><small>""" + text03 + """</small></th>
+      <th><small>""" + text04 + """</small></th>
+      <th><small>""" + text05 + """</small></th>
+     </tr>
+     <tr>
+      <td align='center'><img src=':/icons/NavigationMayaGesture_Select.svg'></td>
+      <td align='center'><img src=':/icons/NavigationMayaGesture_Zoom.svg'></td>
+      <td align='center'><img src=':/icons/NavigationMayaGesture_ZoomAlt.svg'></td>
+      <td align='center'><img src=':/icons/NavigationMayaGesture_Rotate.svg'></td>
+      <td align='center'><img src=':/icons/NavigationMayaGesture_Pan.svg'></td>
+      <td align='center'><img src=':/icons/NavigationMayaGesture_Tilt.svg'></td>
+     </tr>
+     <tr>
+      <th><small>""" + text01 + """</small></th>
+      <th><small>""" + text02 + """</small></th>
+      <th><small>""" + text03 + """</small></th>
+      <th><small>""" + text04 + """</small></th>
+      <th><small>""" + text04 + """</small></th>
+      <th><small>""" + text05 + """</small></th>
+     </tr>
+     <tr>
+      <td align='center'><img src=':/icons/NavigationMayaGesture_SelectTouch.svg'></td>
+      <td align='center'><img src=':/icons/NavigationMayaGesture_ZoomTouch.svg'></td>
+      <td align='center'><img src=':/icons/NavigationMayaGesture_RotateTouch.svg'></td>
+      <td align='center'><img src=':/icons/NavigationMayaGesture_PanTouch.svg'></td>
+      <td align='center'><img src=':/icons/NavigationMayaGesture_PanTouchAlt.svg'></td>
+      <td align='center'><img src=':/icons/NavigationMayaGesture_TiltTouch.svg'></td>
+     </tr>
+    </table>
+    <p><small><b>""" + text02 + ":</b> " + text07 + """<br>
+    <b>""" + text08 + ":</b> " + text09 + "</small></p>"
+
+    global t5
+    t5 = "<p align='center'><b>OpenCascade</b> " + text06 + """</p>
     <table>
      <tr>
       <th><small>""" + text01 + """</small></th>
@@ -288,8 +213,28 @@ def retranslateUi():
      </tr>
     </table>"""
 
-    global t9
-    t9 = "<p align='center'><b>OpenSCAD</b> " + text06 + """</p>
+    global t6
+    t6 = "<p align='center'><b>OpenInventor</b> " + text06 + """</p>
+    <table>
+     <tr>
+      <th><small>""" + text01 + """</small></th>
+      <th><small>""" + text02 + """</small></th>
+      <th><small>""" + text02 + """</small></th>
+      <th><small>""" + text03 + """</small></th>
+      <th><small>""" + text04 + """</small></th>
+     </tr>
+     <tr>
+      <td align='center'><img src=':/icons/NavigationOpenInventor_Select.svg'></td>
+      <td align='center'><img src=':/icons/NavigationOpenInventor_Zoom.svg'></td>
+      <td align='center'><img src=':/icons/NavigationOpenInventor_ZoomAlt.svg'></td>
+      <td align='center'><img src=':/icons/NavigationOpenInventor_Rotate.svg'></td>
+      <td align='center'><img src=':/icons/NavigationOpenInventor_Pan.svg'></td>
+     </tr>
+    </table>
+    <b>""" + text08 + ":</b> " + text10 + "</small></p>"
+
+    global t7
+    t7 = "<p align='center'><b>OpenSCAD</b> " + text06 + """</p>
     <table>
      <tr>
       <th><small>""" + text01 + """</small></th>
@@ -307,8 +252,28 @@ def retranslateUi():
      </tr>
     </table>"""
 
-    global t10
-    t10 = "<p align='center'><b>TinkerCAD</b> " + text06 + """</p>
+    global t8
+    t8 = "<p align='center'><b>Revit</b> " + text06 + """</p>
+    <table>
+     <tr>
+      <th><small>""" + text01 + """</small></th>
+      <th><small>""" + text02 + """</small></th>
+      <th><small>""" + text03 + """</small></th>
+      <th><small>""" + text04 + """</small></th>
+      <th><small>""" + text04 + """</small></th>
+     </tr>
+     <tr>
+      <td align='center'><img src=':/icons/NavigationBlender_Select.svg'></td>
+      <td align='center'><img src=':/icons/NavigationBlender_Zoom.svg'></td>
+      <td align='center'><img src=':/icons/NavigationRevit_Rotate.svg'></td>
+      <td align='center'><img src=':/icons/NavigationRevit_Pan.svg'></td>
+      <td align='center'><img src=':/icons/NavigationBlender_PanAlt.svg'></td>
+     </tr>
+    </table>
+    <b>""" + text08 + ":</b> " + text10 + "</small></p>"
+
+    global t9
+    t9 = "<p align='center'><b>TinkerCAD</b> " + text06 + """</p>
     <table>
      <tr>
       <th><small>""" + text01 + """</small></th>
@@ -324,6 +289,42 @@ def retranslateUi():
      </tr>
     </table>"""
 
+    global t10
+    t10 = "<p align='center'><b>Touchpad</b> " + text06 + """</p>
+    <table>
+     <tr>
+      <th><small>""" + text01 + """</small></th>
+      <th><small>""" + text02 + """</small></th>
+      <th><small>""" + text02 + """</small></th>
+      <th><small>""" + text03 + """</small></th>
+      <th><small>""" + text03 + """</small></th>
+      <th><small>""" + text04 + """</small></th>
+     </tr>
+     <tr>
+      <td align='center'><img src=':/icons/NavigationTouchpad_Select.svg'></td>
+      <td align='center'><img src=':/icons/NavigationTouchpad_Zoom.svg'></td>
+      <td align='center'><img src=':/icons/NavigationTouchpad_ZoomAlt.svg'></td>
+      <td align='center'><img src=':/icons/NavigationTouchpad_Rotate.svg'></td>
+      <td align='center'><img src=':/icons/NavigationTouchpad_RotateAlt.svg'></td>
+      <td align='center'><img src=':/icons/NavigationTouchpad_Pan.svg'></td>
+     </tr>
+     <tr>
+      <th><small>""" + text01 + """</small></th>
+      <th><small>""" + text02 + """</small></th>
+      <th><small>""" + text03 + """</small></th>
+      <th><small>""" + text03 + """</small></th>
+      <th><small>""" + text04 + """</small></th>
+     </tr>
+     <tr>
+      <td align='center'><img src=':/icons/NavigationTouchpad_SelectTouch.svg'></td>
+      <td align='center'><img src=':/icons/NavigationTouchpad_ZoomTouch.svg'></td>
+      <td align='center'><img src=':/icons/NavigationTouchpad_RotateTouch.svg'></td>
+      <td align='center'><img src=':/icons/NavigationTouchpad_RotateTouchAlt.svg'></td>
+      <td align='center'><img src=':/icons/NavigationTouchpad_PanTouch.svg'></td>
+     </tr>
+    </table>
+    <p><small><b>""" + text02 + ":</b> " + text07 + "</p>"
+
     menuSettings.setTitle(translate("NavigationIndicator", "Settings"))
     menuOrbit.setTitle(translate("NavigationIndicator", "Orbit style"))
     aCompact.setText(translate("NavigationIndicator", "Compact"))
@@ -335,6 +336,7 @@ def retranslateUi():
 
 indicator = IndicatorButton(statusBar)
 indicator.setFlat(True)
+indicator.adjustSize()
 indicator.setObjectName("NavigationIndicator")
 
 menu = QtGui.QMenu(indicator)
@@ -369,68 +371,68 @@ gStyle = QtGui.QActionGroup(menu)
 
 a0 = QtGui.QAction(gStyle)
 a0.setIcon(QtGui.QIcon(":/icons/NavigationUndefined.svg"))
-a0.setData("Undefined")
+a0.setData("Undefined  ")
 a0.setObjectName("Indicator_NavigationUndefined")
 
 a1 = QtGui.QAction(gStyle)
-a1.setIcon(QtGui.QIcon(":/icons/NavigationOpenInventor_dark.svg"))
-a1.setText("OpenInventor")
-a1.setData("Gui::InventorNavigationStyle")
-a1.setObjectName("Indicator_NavigationOpenInventor")
+a1.setIcon(QtGui.QIcon(":/icons/NavigationBlender_dark.svg"))
+a1.setText("Blender  ")
+a1.setData("Gui::BlenderNavigationStyle")
+a1.setObjectName("Indicator_NavigationBlender")
 
 a2 = QtGui.QAction(gStyle)
 a2.setIcon(QtGui.QIcon(':/icons/NavigationCAD_dark.svg'))
-a2.setText("CAD")
+a2.setText("CAD  ")
 a2.setData("Gui::CADNavigationStyle")
 a2.setObjectName("Indicator_NavigationCAD")
 
 a3 = QtGui.QAction(gStyle)
-a3.setIcon(QtGui.QIcon(":/icons/NavigationRevit_dark.svg"))
-a3.setText("Revit")
-a3.setData("Gui::RevitNavigationStyle")
-a3.setObjectName("Indicator_NavigationRevit")
+a3.setIcon(QtGui.QIcon(":/icons/NavigationGesture_dark.svg"))
+a3.setText("Gesture  ")
+a3.setData("Gui::GestureNavigationStyle")
+a3.setObjectName("Indicator_NavigationGesture")
 
 a4 = QtGui.QAction(gStyle)
-a4.setIcon(QtGui.QIcon(":/icons/NavigationBlender_dark.svg"))
-a4.setText("Blender")
-a4.setData("Gui::BlenderNavigationStyle")
-a4.setObjectName("Indicator_NavigationBlender")
+a4.setIcon(QtGui.QIcon(":/icons/NavigationMayaGesture_dark.svg"))
+a4.setText("MayaGesture  ")
+a4.setData("Gui::MayaGestureNavigationStyle")
+a4.setObjectName("Indicator_NavigationMayaGesture")
 
 a5 = QtGui.QAction(gStyle)
-a5.setIcon(QtGui.QIcon(":/icons/NavigationMayaGesture_dark.svg"))
-a5.setText("MayaGesture")
-a5.setData("Gui::MayaGestureNavigationStyle")
-a5.setObjectName("Indicator_NavigationMayaGesture")
+a5.setIcon(QtGui.QIcon(":/icons/NavigationOpenCascade_dark.svg"))
+a5.setText("OpenCascade  ")
+a5.setData("Gui::OpenCascadeNavigationStyle")
+a5.setObjectName("Indicator_NavigationOpenCascade")
 
 a6 = QtGui.QAction(gStyle)
-a6.setIcon(QtGui.QIcon(":/icons/NavigationTouchpad_dark.svg"))
-a6.setText("Touchpad")
-a6.setData("Gui::TouchpadNavigationStyle")
-a6.setObjectName("Indicator_NavigationTouchpad")
+a6.setIcon(QtGui.QIcon(":/icons/NavigationOpenInventor_dark.svg"))
+a6.setText("OpenInventor  ")
+a6.setData("Gui::InventorNavigationStyle")
+a6.setObjectName("Indicator_NavigationOpenInventor")
 
 a7 = QtGui.QAction(gStyle)
-a7.setIcon(QtGui.QIcon(":/icons/NavigationGesture_dark.svg"))
-a7.setText("Gesture")
-a7.setData("Gui::GestureNavigationStyle")
-a7.setObjectName("Indicator_NavigationGesture")
+a7.setIcon(QtGui.QIcon(":/icons/NavigationOpenSCAD_dark.svg"))
+a7.setText("OpenSCAD  ")
+a7.setData("Gui::OpenSCADNavigationStyle")
+a7.setObjectName("Indicator_NavigationOpenSCAD")
 
 a8 = QtGui.QAction(gStyle)
-a8.setIcon(QtGui.QIcon(":/icons/NavigationOpenCascade_dark.svg"))
-a8.setText("OpenCascade")
-a8.setData("Gui::OpenCascadeNavigationStyle")
-a8.setObjectName("Indicator_NavigationOpenCascade")
+a8.setIcon(QtGui.QIcon(":/icons/NavigationRevit_dark.svg"))
+a8.setText("Revit  ")
+a8.setData("Gui::RevitNavigationStyle")
+a8.setObjectName("Indicator_NavigationRevit")
 
 a9 = QtGui.QAction(gStyle)
-a9.setIcon(QtGui.QIcon(":/icons/NavigationOpenSCAD_dark.svg"))
-a9.setText("OpenSCAD")
-a9.setData("Gui::OpenSCADNavigationStyle")
-a9.setObjectName("Indicator_NavigationOpenSCAD")
+a9.setIcon(QtGui.QIcon(":/icons/NavigationTinkerCAD_dark.svg"))
+a9.setText("TinkerCAD  ")
+a9.setData("Gui::TinkerCADNavigationStyle")
+a9.setObjectName("Indicator_NavigationTinkerCAD")
 
 a10 = QtGui.QAction(gStyle)
-a10.setIcon(QtGui.QIcon(":/icons/NavigationTinkerCAD_dark.svg"))
-a10.setText("TinkerCAD")
-a10.setData("Gui::TinkerCADNavigationStyle")
-a10.setObjectName("Indicator_NavigationTinkerCAD")
+a10.setIcon(QtGui.QIcon(":/icons/NavigationTouchpad_dark.svg"))
+a10.setText("Touchpad  ")
+a10.setData("Gui::TouchpadNavigationStyle")
+a10.setObjectName("Indicator_NavigationTouchpad")
 
 menu.addMenu(menuSettings)
 menu.addSeparator()
@@ -465,6 +467,7 @@ def setCompact(action):
         indicator.setText("")
     else:
         indicator.setText(action.text())
+        indicator.adjustSize()
 
 
 def onTooltip():
@@ -557,7 +560,7 @@ def setCurrent():
                 pass
     else:
         s = True
-        setCompact(a2)
+        setCompact(a2) # set to style CAD
         menu.setDefaultAction(a2)
         indicator.setIcon(a2.icon())
         indicator.setToolTip(a2.toolTip())


### PR DESCRIPTION
- the PR adjusts the size of the navigation style status bar so that it is wide enough to contain the text + the space for the combobox button
- also sort the entries since as it is, it just reflects the order the styles were added in the development

With the fix:
![FreeCAD_ft8GCErtQH](https://user-images.githubusercontent.com/1828501/140823671-06cc2f93-6b97-4da2-9275-b2d5c0bd28d5.png)

Without the fix:
![bqxafRJiwA](https://user-images.githubusercontent.com/1828501/140823726-98ee32c0-46c8-4d5b-8475-a4f0fa6d87b0.png)


The size adjustment is done using Qt's adjustSize() command and the space consumed be the combobox dropdown indicator is done by adding two spaces to the button text since on different OSes the necessary space might be different.