### PR TITLE
Gui: expose the 'Link Actions' toolbar icon to translation

### DIFF
--- a/src/Gui/Workbench.cpp
+++ b/src/Gui/Workbench.cpp
@@ -514,6 +514,8 @@ std::list<std::string> Workbench::listCommandbars() const
     qApp->translate("Workbench", "Macro");
     qApp->translate("Workbench", "View");
     qApp->translate("Workbench", "Special Ops");
+    // needed for Structure toolbar
+    qApp->translate("Workbench", "Link actions");
 #endif
 
 #if 0 // needed for the application menu on OSX


### PR DESCRIPTION
Related to https://github.com/FreeCAD/FreeCAD-translations/issues/51 and https://github.com/FreeCAD/FreeCAD-translations/issues/16