### PR TITLE
TechDraw: Renames submenu command + exposes to translation

### DIFF
--- a/src/Mod/TechDraw/Gui/Workbench.cpp
+++ b/src/Mod/TechDraw/Gui/Workbench.cpp
@@ -47,6 +47,7 @@ using namespace TechDrawGui;
     qApp->translate("Workbench", "TechDraw Decoration");
     qApp->translate("Workbench", "TechDraw Annotation");
     qApp->translate("Workbench", "Views");
+    qApp->translate("Workbench", "Extensions: Centerlines/Threading");
 #endif
 
 TYPESYSTEM_SOURCE(TechDrawGui::Workbench, Gui::StdWorkbench)
@@ -82,7 +83,7 @@ Gui::MenuItem* Workbench::setupMenuBar() const
 
     // toolattributes
     Gui::MenuItem* toolattrib = new Gui::MenuItem;
-    toolattrib->setCommand("Extensions: centerlines and threading");
+    toolattrib->setCommand("Extensions: Centerlines/Threading");
     *toolattrib << "TechDraw_ExtensionCircleCenterLines";
     *toolattrib << "TechDraw_ExtensionThreadHoleSide";
     *toolattrib << "TechDraw_ExtensionThreadBoltSide";


### PR DESCRIPTION
Fixes https://github.com/FreeCAD/FreeCAD-translations/issues/82  
The dropdown `TechDraw > Extensions: centerlines and threading` (submenu) is too long and superfluous. Renamed to: `Extensions: Centerlines/Threading`. Also exposed to translation.