### PR TITLE
[PD] fix sweep visibility bug

### DIFF
--- a/src/Mod/PartDesign/Gui/TaskPipeParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskPipeParameters.h
@@ -53,7 +53,7 @@ class TaskPipeParameters : public TaskSketchBasedParameters
     Q_OBJECT
 
 public:
-    TaskPipeParameters(ViewProviderPipe *PipeView,bool newObj=false,QWidget *parent = 0);
+    TaskPipeParameters(ViewProviderPipe *PipeView, bool newObj=false, QWidget *parent = 0);
     ~TaskPipeParameters();
 
     bool accept();
@@ -84,7 +84,8 @@ private:
     { return static_cast<ViewProviderPipe*>(vp); }
 
     bool spineShow = false;
-
+    bool profileShow = false;
+    
 private:
     QWidget* proxy;
     std::unique_ptr<Ui_TaskPipeParameters> ui;
@@ -95,7 +96,7 @@ class TaskPipeOrientation : public TaskSketchBasedParameters
     Q_OBJECT
 
 public:
-    TaskPipeOrientation(ViewProviderPipe *PipeView,bool newObj=false,QWidget *parent = 0);
+    TaskPipeOrientation(ViewProviderPipe *PipeView, bool newObj=false, QWidget *parent = 0);
     virtual ~TaskPipeOrientation();
 
 


### PR DESCRIPTION
Currently:
- only sweep path is toggled correctly in its visibility, the profile is never shown
- the sections are always shown

This PR fixes this inconsistency reported here: https://forum.freecadweb.org/viewtopic.php?f=19&t=63544