### PR TITLE
[PD] add feature to set direction for pockets

### DIFF
--- a/src/Mod/PartDesign/App/FeaturePocket.h
+++ b/src/Mod/PartDesign/App/FeaturePocket.h
@@ -37,10 +37,14 @@ class PartDesignExport Pocket : public ProfileBased
 public:
     Pocket();
 
-    App::PropertyEnumeration    Type;
-    App::PropertyLength         Length;
-    App::PropertyLength         Length2;
-    App::PropertyLength         Offset;
+    App::PropertyEnumeration Type;
+    App::PropertyLength      Length;
+    App::PropertyLength      Length2;
+    App::PropertyLength      Offset;
+    App::PropertyBool        UseCustomVector;
+    App::PropertyVector      Direction;
+    App::PropertyBool        AlongSketchNormal;
+    App::PropertyLinkSub     ReferenceAxis;
 
     /** @name methods override feature */
     //@{

--- a/src/Mod/PartDesign/Gui/TaskPocketParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskPocketParameters.h
@@ -55,10 +55,19 @@ public:
     virtual void saveHistory() override;
     virtual void apply() override;
 
+    void fillDirectionCombo();
+    void addAxisToCombo(App::DocumentObject* linkObj, std::string linkSubname, QString itemText);
+
 private Q_SLOTS:
     void onLengthChanged(double);
     void onLength2Changed(double);
     void onOffsetChanged(double);
+    void onDirectionCBChanged(int);
+    void onAlongSketchNormalChanged(bool);
+    void onDirectionToggled(bool);
+    void onXDirectionEditChanged(double);
+    void onYDirectionEditChanged(double);
+    void onZDirectionEditChanged(double);
     void onMidplaneChanged(bool);
     void onReversedChanged(bool);
     void onButtonFace(const bool pressed = true);
@@ -67,11 +76,19 @@ private Q_SLOTS:
 
 protected:
     void changeEvent(QEvent *e) override;
+    App::PropertyLinkSub* propReferenceAxis;
+    void getReferenceAxis(App::DocumentObject*& obj, std::vector<std::string>& sub) const;
 
 private:
     double getLength(void) const;
     double getLength2(void) const;
     double getOffset(void) const;
+    bool   getAlongSketchNormal(void) const;
+    bool   getCustom(void) const;
+    std::string getReferenceAxis(void) const;
+    double getXDirection(void) const;
+    double getYDirection(void) const;
+    double getZDirection(void) const;
     int    getMode(void) const;
     bool   getMidplane(void) const;
     bool   getReversed(void) const;
@@ -79,11 +96,14 @@ private:
 
     void onSelectionChanged(const Gui::SelectionChanges& msg) override;
     void updateUI(int index);
+    void updateDirectionEdits(void);
 
 private:
     QWidget* proxy;
     std::unique_ptr<Ui_TaskPocketParameters> ui;
     double oldLength;
+    bool selectionFace;
+    std::vector<std::unique_ptr<App::PropertyLinkSub>> axesInList;
 };
 
 /// simulation dialog for the TaskView

--- a/src/Mod/PartDesign/Gui/TaskPocketParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskPocketParameters.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>193</width>
-    <height>272</height>
+    <width>300</width>
+    <height>436</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -64,6 +64,179 @@
       </widget>
      </item>
     </layout>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Direction</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_4">
+      <item row="0" column="0">
+       <layout class="QGridLayout" name="gridLayout_3">
+        <item row="0" column="0">
+         <widget class="QLabel" name="labelEdge">
+          <property name="text">
+           <string>Direction/edge:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QComboBox" name="directionCB">
+          <property name="toolTip">
+           <string>Set a direction or select an edge
+from the model as reference</string>
+          </property>
+          <item>
+           <property name="text">
+            <string>Sketch normal</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Select reference...</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Custom direction</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="1" column="0">
+       <widget class="QCheckBox" name="checkBoxDirection">
+        <property name="text">
+         <string>Show direction</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QGroupBox" name="groupBoxDirection">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="toolTip">
+         <string>Use custom vector for pad direction, otherwise
+the sketch plane's normal vector will be used</string>
+        </property>
+        <property name="checkable">
+         <bool>false</bool>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_2">
+         <item row="0" column="1">
+          <widget class="Gui::DoubleSpinBox" name="XDirectionEdit">
+           <property name="toolTip">
+            <string>x-component of direction vector</string>
+           </property>
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
+           <property name="minimum">
+            <double>-100.000000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>100.000000000000000</double>
+           </property>
+           <property name="singleStep">
+            <double>0.100000000000000</double>
+           </property>
+           <property name="unit" stdset="0">
+            <string notr="true"/>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="labelZSkew">
+           <property name="text">
+            <string>z</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="Gui::DoubleSpinBox" name="YDirectionEdit">
+           <property name="toolTip">
+            <string>y-component of direction vector</string>
+           </property>
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
+           <property name="minimum">
+            <double>-100.000000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>100.000000000000000</double>
+           </property>
+           <property name="singleStep">
+            <double>0.100000000000000</double>
+           </property>
+           <property name="unit" stdset="0">
+            <string notr="true"/>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="labelYSkew">
+           <property name="text">
+            <string>y</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="Gui::DoubleSpinBox" name="ZDirectionEdit">
+           <property name="toolTip">
+            <string>z-component of direction vector</string>
+           </property>
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
+           <property name="minimum">
+            <double>-100.000000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>100.000000000000000</double>
+           </property>
+           <property name="singleStep">
+            <double>0.100000000000000</double>
+           </property>
+           <property name="value">
+            <double>1.000000000000000</double>
+           </property>
+           <property name="unit" stdset="0">
+            <string notr="true"/>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="0">
+          <widget class="QLabel" name="labelXSkew">
+           <property name="text">
+            <string>x</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QCheckBox" name="checkBoxAlongDirection">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="toolTip">
+         <string>If unchecked, the length will be
+measured along the specified direction</string>
+        </property>
+        <property name="text">
+         <string>Length along sketch normal</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
    </item>
    <item>
     <widget class="QCheckBox" name="checkBoxMidplane">
@@ -138,6 +311,11 @@
    <class>Gui::QuantitySpinBox</class>
    <extends>QWidget</extends>
    <header>Gui/QuantitySpinBox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>Gui::DoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>Gui/SpinBox.h</header>
   </customwidget>
   <customwidget>
    <class>Gui::PrefQuantitySpinBox</class>


### PR DESCRIPTION
This PR adds the functionality of pads to pad along either a custom direction or along an edge to pockets.

So with this PR Pad and Pocket are on the same level of functionality.

Here is a screencast of what packet can now do:
![MSJAOB41G2](https://user-images.githubusercontent.com/1828501/141048160-1c2d5e59-35cb-4006-a9b0-47cecb5bd725.gif)