### PR TITLE
[PD] handle changed property for loft and pipe

### DIFF
--- a/src/Mod/PartDesign/App/FeatureLoft.cpp
+++ b/src/Mod/PartDesign/App/FeatureLoft.cpp
@@ -256,3 +256,14 @@ PROPERTY_SOURCE(PartDesign::SubtractiveLoft, PartDesign::Loft)
 SubtractiveLoft::SubtractiveLoft() {
     addSubType = Subtractive;
 }
+
+void Loft::handleChangedPropertyType(Base::XMLReader& reader, const char* TypeName, App::Property* prop)
+{
+    // property Sections had the App::PropertyLinkList and was changed to App::PropertyXLinkSubList
+    if (prop == &Sections && strcmp(TypeName, "App::PropertyLinkList") == 0) {
+        Sections.upgrade(reader, TypeName);
+    }
+    else {
+        ProfileBased::handleChangedPropertyType(reader, TypeName, prop);
+    }
+}

--- a/src/Mod/PartDesign/App/FeatureLoft.h
+++ b/src/Mod/PartDesign/App/FeatureLoft.h
@@ -54,6 +54,10 @@ public:
     }
     //@}
 
+protected:
+    // handle changed property
+    virtual void handleChangedPropertyType(Base::XMLReader& reader, const char* TypeName, App::Property* prop);
+
 private:
     //static const char* TypeEnums[];
     //static const char* SideEnums[];

--- a/src/Mod/PartDesign/App/FeaturePipe.cpp
+++ b/src/Mod/PartDesign/App/FeaturePipe.cpp
@@ -518,8 +518,6 @@ void Pipe::buildPipePath(const Part::TopoShape& shape, const std::vector< std::s
     }
 }
 
-
-
 PROPERTY_SOURCE(PartDesign::AdditivePipe, PartDesign::Pipe)
 AdditivePipe::AdditivePipe() {
     addSubType = Additive;
@@ -528,4 +526,15 @@ AdditivePipe::AdditivePipe() {
 PROPERTY_SOURCE(PartDesign::SubtractivePipe, PartDesign::Pipe)
 SubtractivePipe::SubtractivePipe() {
     addSubType = Subtractive;
+}
+
+void Pipe::handleChangedPropertyType(Base::XMLReader& reader, const char* TypeName, App::Property* prop)
+{
+    // property Sections had the App::PropertyLinkList and was changed to App::PropertyXLinkSubList
+    if (prop == &Sections && strcmp(TypeName, "App::PropertyLinkList") == 0) {
+        Sections.upgrade(reader, TypeName);
+    }
+    else {
+        ProfileBased::handleChangedPropertyType(reader, TypeName, prop);
+    }
 }

--- a/src/Mod/PartDesign/App/FeaturePipe.h
+++ b/src/Mod/PartDesign/App/FeaturePipe.h
@@ -38,7 +38,6 @@ class PartDesignExport Pipe : public ProfileBased
 public:
     Pipe();
 
-
     App::PropertyLinkSub Spine;
     App::PropertyBool SpineTangent;
     App::PropertyLinkSub AuxillerySpine;
@@ -56,13 +55,14 @@ public:
     const char* getViewProviderName(void) const {
         return "PartDesignGui::ViewProviderPipe";
     }
-    //@}
 
 protected:
-    ///get the given edges and all their tangent ones
+    /// get the given edges and all their tangent ones
     void getContinuousEdges(Part::TopoShape TopShape, std::vector< std::string >& SubNames);
     void buildPipePath(const Part::TopoShape& input, const  std::vector<std::string>& edges, TopoDS_Shape& result);
     void setupAlgorithm(BRepOffsetAPI_MakePipeShell& mkPipeShell, TopoDS_Shape& auxshape);
+    /// handle changed property
+    virtual void handleChangedPropertyType(Base::XMLReader& reader, const char* TypeName, App::Property* prop);
 
 private:
     static const char* TypeEnums[];


### PR DESCRIPTION
- this was missing in PR #5155

This should be correct, but it crashes FreeCAD. The reason for the crash is line https://github.com/FreeCAD/FreeCAD/blob/master/src/App/PropertyLinks.cpp#L4322
When I uncomment it, it does not crash, but it does also not to the property value restoration.

@realthunder Can you please have a look? I cannot find the cause.