### PR TITLE
[PD] Check if property is named before `strcmp`

### DIFF
--- a/src/Mod/PartDesign/Gui/ViewProviderAddSub.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderAddSub.cpp
@@ -235,7 +235,7 @@ void ViewProviderAddSub::updateAddSubShapeIndicator() {
 
 void ViewProviderAddSub::updateData(const App::Property* p) {
 
-    if(strcmp(p->getName(), "AddSubShape")==0)
+    if(p->getName() && strcmp(p->getName(), "AddSubShape")==0)
         updateAddSubShapeIndicator();
 
     PartDesignGui::ViewProvider::updateData(p);


### PR DESCRIPTION
`ViewProviderAddSub::updateData` assumed that the property provided was named.