### PR TITLE
Draft: fix array issue with Draft_Point and Part_Vertex.

### DIFF
--- a/src/Mod/Draft/draftobjects/draftlink.py
+++ b/src/Mod/Draft/draftobjects/draftlink.py
@@ -187,8 +187,9 @@ class DraftLink(DraftObject):
                             "from '{}'\n".format(obj.Label, obj.Base.Label))
                 raise RuntimeError(_err_msg)
             else:
-                shape = shape.copy()
-                shape.Placement = App.Placement()
+                # Resetting the Placement of the copied shape does not work for
+                # Part_Vertex and Draft_Point objects, we need to transform:
+                shape = shape.transformGeometry(shape.Placement.Matrix.inverse())
                 base = []
                 for i, pla in enumerate(pls):
                     vis = getattr(obj, 'VisibilityList', [])


### PR DESCRIPTION
When the shape of a Draft_Point or Part_Vertex is copied the Placement of the copy does not match that of the original shape. Resetting the Placement is then problematic. We need to use transformGeometry.

Forum topics:
https://forum.freecadweb.org/viewtopic.php?f=3&t=63591
https://forum.freecadweb.org/viewtopic.php?f=22&t=63672

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
