### PR TITLE
[Sketcher] Change diameter symbol used in presentation string, fixes #4779

### DIFF
--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -3239,10 +3239,10 @@ QString ViewProviderSketch::getPresentationString(const Constraint *constraint)
     }
 
     if (constraint->Type == Sketcher::Diameter){
-        valueStr.insert(0, QChar(8960)); // Diameter sign
+        valueStr.prepend(QChar(216)); // Diameter sign
     }
     else if (constraint->Type == Sketcher::Radius){
-        valueStr.insert(0, QChar(82)); // Capital letter R
+        valueStr.prepend(QChar(82)); // Capital letter R
     }
 
     /**


### PR DESCRIPTION
 Standard symbol \u2300 currently used generates text misalignment/cutout on some environments
 Replaced with \uD8 (capital O with stroke) that solves the issue -- and looks better

https://forum.freecadweb.org/viewtopic.php?f=10&t=63041&start=10#p547303