### PR TITLE
[Spreadsheet][Bugfix] Solves issue when changing alignment of merged cells

### DIFF
--- a/src/Mod/Spreadsheet/App/PropertySheet.cpp
+++ b/src/Mod/Spreadsheet/App/PropertySheet.cpp
@@ -477,39 +477,43 @@ Cell * PropertySheet::nonNullCellAt(CellAddress address)
 void PropertySheet::setContent(CellAddress address, const char *value)
 {
     Cell * cell = nonNullCellAt(address);
-
     assert(cell != 0);
-
     cell->setContent(value);
 }
 
 void PropertySheet::setAlignment(CellAddress address, int _alignment)
 {
-    nonNullCellAt(address)->setAlignment(_alignment);
+    Cell * cell = nonNullCellAt(address);
+    assert(cell != 0);
+    cell->setAlignment(_alignment);
 }
 
 void PropertySheet::setStyle(CellAddress address, const std::set<std::string> &_style)
 {
-    assert(nonNullCellAt(address) != 0);
-    nonNullCellAt(address)->setStyle(_style);
+    Cell * cell = nonNullCellAt(address);
+    assert(cell != 0);
+    cell->setStyle(_style);
 }
 
 void PropertySheet::setForeground(CellAddress address, const App::Color &color)
 {
-    assert(nonNullCellAt(address) != 0);
-    nonNullCellAt(address)->setForeground(color);
+    Cell * cell = nonNullCellAt(address);
+    assert(cell != 0);
+    cell->setForeground(color);
 }
 
 void PropertySheet::setBackground(CellAddress address, const App::Color &color)
 {
-    assert(nonNullCellAt(address) != 0);
-    nonNullCellAt(address)->setBackground(color);
+    Cell * cell = nonNullCellAt(address);
+    assert(cell != 0);
+    cell->setBackground(color);
 }
 
 void PropertySheet::setDisplayUnit(CellAddress address, const std::string &unit)
 {
-    assert(nonNullCellAt(address) != 0);
-    nonNullCellAt(address)->setDisplayUnit(unit);
+    Cell * cell = nonNullCellAt(address);
+    assert(cell != 0);
+    cell->setDisplayUnit(unit);
 }
 
 
@@ -561,14 +565,16 @@ void PropertySheet::setAlias(CellAddress address, const std::string &alias)
 
 void PropertySheet::setComputedUnit(CellAddress address, const Base::Unit &unit)
 {
-    assert(nonNullCellAt(address) != 0);
-    nonNullCellAt(address)->setComputedUnit(unit);
+    Cell * cell = nonNullCellAt(address);
+    assert(cell != 0);
+    cell->setComputedUnit(unit);
 }
 
 void PropertySheet::setSpans(CellAddress address, int rows, int columns)
 {
-    assert(nonNullCellAt(address) != 0);
-    nonNullCellAt(address)->setSpans(rows, columns);
+    Cell * cell = nonNullCellAt(address);
+    assert(cell != 0);
+    cell->setSpans(rows, columns);
 }
 
 void PropertySheet::clearAlias(CellAddress address)

--- a/src/Mod/Spreadsheet/App/PropertySheet.cpp
+++ b/src/Mod/Spreadsheet/App/PropertySheet.cpp
@@ -485,6 +485,7 @@ void PropertySheet::setAlignment(CellAddress address, int _alignment)
 {
     Cell * cell = nonNullCellAt(address);
     assert(cell != 0);
+    if (cell->address != address) return; //Reject alignment change for merged cell except top-left one
     cell->setAlignment(_alignment);
 }
 

--- a/src/Mod/Spreadsheet/App/PropertySheet.cpp
+++ b/src/Mod/Spreadsheet/App/PropertySheet.cpp
@@ -524,11 +524,10 @@ void PropertySheet::setAlias(CellAddress address, const std::string &alias)
 
     const Cell * aliasedCell = getValueFromAlias(alias);
     Cell * cell = nonNullCellAt(address);
+    assert(cell != 0);
 
     if (aliasedCell != 0 && cell != aliasedCell)
         throw Base::ValueError("Alias already defined.");
-
-    assert(cell != 0);
 
     /* Mark cells depending on this cell dirty; they need to be resolved when an alias changes or disappears */
     std::string fullName = owner->getFullName() + "." + address.toString();


### PR DESCRIPTION
This PR contains 3 commits :
* First 2 are small fixes/improvements not directly related to bug
* Last one is the real, that solves the issue by rejecting alignment change on merge cells (except primary top-left one)
This is done according community poll : https://forum.freecadweb.org/viewtopic.php?f=3&t=62925

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [x]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [x]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`