### PR TITLE
Do not auto rename when adding dynamic property

### DIFF
--- a/src/App/DynamicProperty.cpp
+++ b/src/App/DynamicProperty.cpp
@@ -37,7 +37,7 @@
 #include <Base/Exception.h>
 #include <Base/Tools.h>
 
-FC_LOG_LEVEL_INIT("DynamicProperty",true,true)
+FC_LOG_LEVEL_INIT("Property",true,true)
 
 
 using namespace App;
@@ -149,23 +149,45 @@ const char* DynamicProperty::getPropertyDocumentation(const char *name) const
 Property* DynamicProperty::addDynamicProperty(PropertyContainer &pc, const char* type,
         const char* name, const char* group, const char* doc, short attr, bool ro, bool hidden)
 {
+    if(!type)
+        type = "<null>";
+
+    std::string _name;
+
+    static ParameterGrp::handle hGrp = GetApplication().GetParameterGroupByPath(
+            "User parameter:BaseApp/Preferences/Document");
+    if(hGrp->GetBool("AutoNameDynamicProperty",false)) {
+        if(!name || !name[0])
+            name = type;
+        _name = getUniquePropertyName(pc,name);
+        if(_name != name) {
+            FC_WARN(pc.getFullName() << " rename dynamic property from '"
+                    << name << "' to '" << _name << "'");
+        }
+        name = _name.c_str();
+    } else if(!name)
+        name = "<null>"; // setting a bad name to trigger exception
+
+    auto prop = pc.getPropertyByName(name);
+    if(prop && prop->getContainer()==&pc)
+        FC_THROWM(Base::NameError, "Property " << pc.getFullName() << '.' << name << " already exists");
+
+    if(Base::Tools::getIdentifier(name) != name) 
+        FC_THROWM(Base::NameError, "Invalid property name '" << name << "'");
+
     Base::BaseClass* base = static_cast<Base::BaseClass*>(Base::Type::createInstanceByName(type,true));
-    if (!base)
-        return 0;
+    if (!base) 
+        FC_THROWM(Base::RuntimeError, "Failed to create property " 
+                << pc.getFullName() << '.' << name << " of type " << type);
     if (!base->getTypeId().isDerivedFrom(Property::getClassTypeId())) {
         delete base;
-        std::stringstream str;
-        str << "'" << type << "' is not a property type";
-        throw Base::ValueError(str.str());
+        FC_THROWM(Base::ValueError, "Invalid type " << type << " for property " << pc.getFullName() << '.' << name);
     }
 
     // get unique name
     Property* pcProperty = static_cast<Property*>(base);
-    if (!name || !name[0])
-        name = type;
 
-    auto res = props.get<0>().emplace(pcProperty,
-            getUniquePropertyName(pc,name), nullptr, group, doc, attr, ro, hidden);
+    auto res = props.get<0>().emplace(pcProperty,name, nullptr, group, doc, attr, ro, hidden);
 
     pcProperty->setContainer(&pc);
     pcProperty->myName = res.first->name.c_str();

--- a/src/App/PropertyContainer.cpp
+++ b/src/App/PropertyContainer.cpp
@@ -332,21 +332,21 @@ void PropertyContainer::Restore(Base::XMLReader &reader)
         reader.readElement("Property");
         std::string PropName = reader.getAttribute("name");
         std::string TypeName = reader.getAttribute("type");
-        auto prop = dynamicProps.restore(*this,PropName.c_str(),TypeName.c_str(),reader);
-        if(!prop)
-            prop = getPropertyByName(PropName.c_str());
-
-        decltype(Property::StatusBits) status;
-        if(reader.hasAttribute("status")) {
-            status = decltype(status)(reader.getAttributeAsUnsigned("status"));
-            if(prop)
-                prop->setStatusValue(status.to_ulong());
-        }
         // NOTE: We must also check the type of the current property because a
         // subclass of PropertyContainer might change the type of a property but
         // not its name. In this case we would force to read-in a wrong property
         // type and the behaviour would be undefined.
         try {
+            auto prop = getPropertyByName(PropName.c_str());
+            if(!prop)
+                prop = dynamicProps.restore(*this,PropName.c_str(),TypeName.c_str(),reader);
+
+            decltype(Property::StatusBits) status;
+            if(reader.hasAttribute("status")) {
+                status = decltype(status)(reader.getAttributeAsUnsigned("status"));
+                if(prop)
+                    prop->setStatusValue(status.to_ulong());
+            }
             // name and type match
             if (prop && strcmp(prop->getTypeId().getName(), TypeName.c_str()) == 0) {
                 if (!prop->testStatus(Property::Transient) 

--- a/src/Mod/Path/PathTests/TestPathStock.py
+++ b/src/Mod/Path/PathTests/TestPathStock.py
@@ -45,7 +45,6 @@ class TestPathStock(PathTestBase):
         model = FreeCAD.ActiveDocument.addObject("App::DocumentObjectGroup", "Model")
         model.addObject(self.base)
         self.job.Model = model
-        self.job.addProperty('App::PropertyLink', 'Proxy')
         self.job.Proxy = FakeJobProxy()
 
     def tearDown(self):

--- a/src/Mod/Test/Document.py
+++ b/src/Mod/Test/Document.py
@@ -1325,7 +1325,7 @@ class DocumentPropertyCases(unittest.TestCase):
     # testing the up and downstream stuff
     props=self.Obj.supportedProperties()
     for i in props:
-        self.Obj.addProperty(i,i)
+        self.Obj.addProperty(i,i.replace(':','_'))
     tempPath = tempfile.gettempdir()
     tempFile = tempPath + os.sep + "PropertyTests.FCStd"
     self.Doc.saveAs(tempFile)


### PR DESCRIPTION
Do not auto rename when adding dynamic property with an invalid or existing name, but throw exception instead, because there is no easy way for Python code to find out the auto selected name. Parameter `BaseApp/Preferences/Document/AutoNameDynamicProperty` can be used to revert back to old behavior.

@chennes This is splitted out from #2758. I'll see if I can split out others.