### PR TITLE
Show green color for linked property

### DIFF
--- a/src/Gui/propertyeditor/PropertyItem.cpp
+++ b/src/Gui/propertyeditor/PropertyItem.cpp
@@ -553,6 +553,9 @@ QVariant PropertyItem::data(int column, int role) const
 {
     // property name
     if (column == 0) {
+        if (role == Qt::ForegroundRole && linked)
+            return QVariant::fromValue(QColor(0,0x80,0));
+
         if (role == Qt::BackgroundRole || role == Qt::ForegroundRole) {
             if(PropertyView::showAll()
                 && propertyItems.size() == 1


### PR DESCRIPTION
To distinguish the property that owned by the Link from those belong to the linked object.

![Screenshot from 2021-11-22 10-25-34](https://user-images.githubusercontent.com/1207888/142792522-4424b52e-03fe-4ba3-951e-4f682d696768.png)
