### PR TITLE
Gui: Revert PR #4626 (c62239d0b) Tree View Reorder

### DIFF
--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -3684,6 +3684,10 @@ void StdTreeDrag::activated(int)
     }
 }
 
+
+/*
+* Commented out until discussion is resolved: https://forum.freecadweb.org/viewtopic.php?f=3&t=63744
+
 //===========================================================================
 // Std_GroupMoveUp
 //===========================================================================
@@ -3793,6 +3797,7 @@ bool StdGroupMoveDown::isActive(void)
 
     return tree->allowMoveDownInGroup(selected);
 }
+*/
 
 //======================================================================
 // Std_TreeViewActions
@@ -3829,10 +3834,13 @@ public:
         addCommand(new StdTreeDrag(),cmds.size());
         addCommand(new StdTreeSelection(),cmds.size());
 
+        /*
+        * Commented out until discussion is resolved: https://forum.freecadweb.org/viewtopic.php?f=3&t=63744
         addCommand();
 
         addCommand(new StdGroupMoveUp());
         addCommand(new StdGroupMoveDown());
+        */
     };
     virtual const char* className() const {return "StdCmdTreeViewActions";}
 };

--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -728,7 +728,10 @@ void Document::slotNewObject(const App::DocumentObject& Obj)
         }
 
         // If no tree rank was assigned, do it now, otherwise keep the current one
+        /*
+        * Commented out until discussion is resolved: https://forum.freecadweb.org/viewtopic.php?f=3&t=63744
         pcProvider->TreeRank.setValue(pcProvider->TreeRank.getValue());
+        */
 
         // adding to the tree
         signalNewObject(*pcProvider);
@@ -1433,10 +1436,13 @@ void Document::RestoreDocFile(Base::Reader &reader)
                 }
             }
 
+            /*
+            * Commented out until discussion is resolved: https://forum.freecadweb.org/viewtopic.php?f=3&t=63744
             int rank = 0;
             if (localreader->hasAttribute("rank")) {
                 rank = localreader->getAttributeAsInteger("rank");
             }
+            */
 
             ViewProvider* pObj = getViewProviderByName(name.c_str());
             if (pObj) // check if this feature has been registered
@@ -1444,11 +1450,15 @@ void Document::RestoreDocFile(Base::Reader &reader)
 
             ViewProviderDocumentObject *vpdo = dynamic_cast<ViewProviderDocumentObject *>(pObj);
             if (vpdo) {
+
+                /*
+                * Commented out until discussion is resolved: https://forum.freecadweb.org/viewtopic.php?f=3&t=63744
                 if (rank <= 0 ) {
                     // For backward compatibility, use object ID as tree rank
                     rank = vpdo->getObject()->getID();
                 }
                 vpdo->TreeRank.setValue(rank);
+                */
 
                 if (expanded) {
                     this->signalExpandObject(*vpdo, TreeItemMode::ExpandItem, 0, 0);
@@ -1574,10 +1584,13 @@ void Document::SaveDocFile (Base::Writer &writer) const
         if (obj->hasExtensions())
             writer.Stream() << " Extensions=\"True\"";
 
+        /*
+        * Commented out until discussion is resolved: https://forum.freecadweb.org/viewtopic.php?f=3&t=63744
         ViewProviderDocumentObject *vpdo = dynamic_cast<ViewProviderDocumentObject *>(obj);
         if (vpdo && vpdo->TreeRank.getValue()) {
             writer.Stream() << " rank=\"" << vpdo->TreeRank.getValue() << "\"";
         }
+        */
 
         writer.Stream() << ">" << std::endl;
         obj->Save(writer);

--- a/src/Gui/Tree.h
+++ b/src/Gui/Tree.h
@@ -356,7 +356,11 @@ protected:
                     QTreeWidgetItem *parent=0, int index=-1,
                     DocumentObjectDataPtr ptrs = DocumentObjectDataPtr());
 
+    /*
+    * Reverted until discussion is resolved: https://forum.freecadweb.org/viewtopic.php?f=3&t=63744
     int findRootIndex(const ViewProviderDocumentObject *childObj) const;
+    */
+    int findRootIndex(App::DocumentObject* childObj);
 
     DocumentObjectItem *findItemByObject(bool sync,
             App::DocumentObject *obj, const char *subname, bool select=false);


### PR DESCRIPTION
Users on the forums have identified some serious issues with PR #4626: this commit comments out the key changes so that the original author can look into the issues. When necessary the original code is also restored. Note that a standard `git revert` was unsuccessful due to intervening changes to the codebase, so this was created manually.

See https://forum.freecadweb.org/viewtopic.php?p=548606



