### PR TITLE
App: fix subname encoding when saving property links

### DIFF
--- a/src/App/PropertyLinks.cpp
+++ b/src/App/PropertyLinks.cpp
@@ -1321,20 +1321,20 @@ void PropertyLinkSub::Save (Base::Writer &writer) const
         writer.Stream() << writer.ind() << "<Sub value=\"";
         if(exporting) {
             std::string exportName;
-            writer.Stream() << exportSubName(exportName,_pcLinkSub,sub.c_str());
+            writer.Stream() << encodeAttribute(exportSubName(exportName,_pcLinkSub,sub.c_str()));
             if(shadow.second.size() && shadow.first == _cSubList[i])
                 writer.Stream() << "\" " ATTR_MAPPED "=\"1";
         } else {
-            writer.Stream() << sub;
+            writer.Stream() << encodeAttribute(sub);
             if(_cSubList[i].size()) {
                 if(sub!=_cSubList[i]) {
                     // Stores the actual value that is shadowed. For new version FC,
                     // we will restore this shadowed value instead.
-                    writer.Stream() << "\" " ATTR_SHADOWED "=\"" << _cSubList[i];
+                    writer.Stream() << "\" " ATTR_SHADOWED "=\"" << encodeAttribute(_cSubList[i]);
                 }else if(shadow.first.size()){
                     // Here means the user set value is old style element name.
                     // We shall then store the shadow somewhere else.
-                    writer.Stream() << "\" " ATTR_SHADOW "=\"" << shadow.first;
+                    writer.Stream() << "\" " ATTR_SHADOW "=\"" << encodeAttribute(shadow.first);
                 }
             }
         }
@@ -2164,20 +2164,20 @@ void PropertyLinkSubList::Save (Base::Writer &writer) const
         writer.Stream() << writer.ind() << "<Link obj=\"" << obj->getExportName() << "\" sub=\"";
         if(exporting) {
             std::string exportName;
-            writer.Stream() << exportSubName(exportName,obj,sub.c_str());
+            writer.Stream() << encodeAttribute(exportSubName(exportName,obj,sub.c_str()));
             if(shadow.second.size() && _lSubList[i]==shadow.first)
                 writer.Stream() << "\" " ATTR_MAPPED "=\"1";
         } else {
-            writer.Stream() << sub;
+            writer.Stream() << encodeAttribute(sub);
             if(_lSubList[i].size()) {
                 if(sub!=_lSubList[i]) {
                     // Stores the actual value that is shadowed. For new version FC,
                     // we will restore this shadowed value instead.
-                    writer.Stream() << "\" " ATTR_SHADOWED "=\"" << _lSubList[i];
+                    writer.Stream() << "\" " ATTR_SHADOWED "=\"" << encodeAttribute(_lSubList[i]);
                 }else if(shadow.first.size()) {
                     // Here means the user set value is old style element name.
                     // We shall then store the shadow somewhere else.
-                    writer.Stream() << "\" " ATTR_SHADOW "=\"" << shadow.first;
+                    writer.Stream() << "\" " ATTR_SHADOW "=\"" << encodeAttribute(shadow.first);
                 }
             }
         }
@@ -3316,16 +3316,17 @@ void PropertyXLink::Save (Base::Writer &writer) const {
         const auto &sub = shadowSub.second.empty()?subName:shadowSub.second;
         if(exporting) {
             std::string exportName;
-            writer.Stream() << "\" sub=\"" << exportSubName(exportName,_pcLink,sub.c_str());
+            writer.Stream() << "\" sub=\"" << 
+                encodeAttribute(exportSubName(exportName,_pcLink,sub.c_str()));
             if(shadowSub.second.size() && shadowSub.first==subName)
                 writer.Stream() << "\" " ATTR_MAPPED "=\"1";
         }else{
-            writer.Stream() << "\" sub=\"" << sub;
+            writer.Stream() << "\" sub=\"" << encodeAttribute(sub);
             if(sub.size()) {
                 if(sub!=subName)
-                    writer.Stream() << "\" " ATTR_SHADOWED "=\"" << subName;
+                    writer.Stream() << "\" " ATTR_SHADOWED "=\"" << encodeAttribute(subName);
                 else if(shadowSub.first.size())
-                    writer.Stream() << "\" " ATTR_SHADOW "=\"" << shadowSub.first;
+                    writer.Stream() << "\" " ATTR_SHADOW "=\"" << encodeAttribute(shadowSub.first);
             }
         }
         writer.Stream() << "\"/>" << std::endl;
@@ -3341,16 +3342,16 @@ void PropertyXLink::Save (Base::Writer &writer) const {
             writer.Stream() << writer.ind() << "<Sub value=\"";
             if(exporting) {
                 std::string exportName;
-                writer.Stream() << exportSubName(exportName,_pcLink,sub.c_str());
+                writer.Stream() << encodeAttribute(exportSubName(exportName,_pcLink,sub.c_str()));
                 if(shadow.second.size() && shadow.first == _SubList[i])
                     writer.Stream() << "\" " ATTR_MAPPED "=\"1";
             } else {
-                writer.Stream() << sub;
+                writer.Stream() << encodeAttribute(sub);
                 if(_SubList[i].size()) {
                     if(sub!=_SubList[i])
-                        writer.Stream() << "\" " ATTR_SHADOWED "=\"" << _SubList[i];
+                        writer.Stream() << "\" " ATTR_SHADOWED "=\"" << encodeAttribute(_SubList[i]);
                     else if(shadow.first.size())
-                        writer.Stream() << "\" " ATTR_SHADOW "=\"" << shadow.first;
+                        writer.Stream() << "\" " ATTR_SHADOW "=\"" << encodeAttribute(shadow.first);
                 }
             }
             writer.Stream()<<"\"/>" << endl;


### PR DESCRIPTION
Problem reported [here](https://github.com/realthunder/FreeCAD_assembly3/issues/928)