### PR TITLE
Gui: remove superfluous whitespace from translation string

### DIFF
--- a/src/Gui/CommandPyImp.cpp
+++ b/src/Gui/CommandPyImp.cpp
@@ -101,7 +101,7 @@ PyObject* CommandPy::listByShortcut(PyObject *args)
                re.setCaseSensitivity(Qt::CaseInsensitive);
                if (!re.isValid()){
                    std::stringstream str;
-                   str << "Invalid regular expression: " << shortcut_to_find;
+                   str << "Invalid regular expression:" << ' ' << shortcut_to_find;
                    throw Py::RuntimeError(str.str());
                }
 

--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -1081,15 +1081,21 @@ static bool checkCanonicalPath(const std::map<App::Document*, bool> &docs)
                     FC_WARN("  Document: " << docName(d).toUtf8().constData()
                             << ": " << d->FileName.getValue());
                 if (count == 3) {
-                    ts << QObject::tr("\n\nPlease check report view for more...");
+                    ts << "\n\n"
+                    << QObject::tr("Please check report view for more...");
                 } else if (count < 3) {
-                    ts << QObject::tr("\n\nPhysical path: ") << v.first
-                    << QObject::tr("\nDocument: ") << docName(doc)
-                    << QObject::tr("\n  Path: ") << QString::fromUtf8(doc->FileName.getValue());
+                    ts << "\n\n"
+                    << QObject::tr("Physical path:") << ' ' << v.first
+                    << "\n"
+                    << QObject::tr("Document:") << ' ' << docName(doc)
+                    << "\n" << '  '
+                    << QObject::tr("Path:") << ' ' << QString::fromUtf8(doc->FileName.getValue());
                     for (auto d : v.second) {
                         if (d == doc) continue;
-                        ts << QObject::tr("\nDocument: ") << docName(d)
-                        << QObject::tr("\n  Path: ") << QString::fromUtf8(d->FileName.getValue());
+                        ts << "\n" 
+                        << QObject::tr("Document:") << ' ' << docName(d)
+                        << "\n" << '  '
+                        << QObject::tr("Path:") << ' ' << QString::fromUtf8(d->FileName.getValue());
                     }
                 }
                 ++count;


### PR DESCRIPTION
Avoids possible translation mistakes by only exposing non-whitespace strings.