### PR TITLE
[PD] Helix: Offer profile's normal as axis

### DIFF
--- a/src/Mod/PartDesign/Gui/TaskHelixParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskHelixParameters.cpp
@@ -202,6 +202,7 @@ void TaskHelixParameters::fillAxisCombo(bool forceRefill)
         PartDesign::ProfileBased* pcFeat = static_cast<PartDesign::ProfileBased*>(vp->getObject());
         Part::Part2DObject* pcSketch = dynamic_cast<Part::Part2DObject*>(pcFeat->Profile.getValue());
         if (pcSketch){
+            addAxisToCombo(pcSketch,"N_Axis",QObject::tr("Normal sketch axis"));
             addAxisToCombo(pcSketch,"V_Axis",QObject::tr("Vertical sketch axis"));
             addAxisToCombo(pcSketch,"H_Axis",QObject::tr("Horizontal sketch axis"));
             for (int i=0; i < pcSketch->getAxisCount(); i++) {

--- a/src/Mod/PartDesign/Gui/TaskHelixParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskHelixParameters.ui
@@ -72,6 +72,11 @@
        </item>
        <item>
         <property name="text">
+         <string>Normal sketch axis</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
          <string>Select reference...</string>
         </property>
        </item>


### PR DESCRIPTION
Previously, only the vertical and horizontal axis of the profile was
selectable in the task panel of the additive/subtractive helix. Now the
profile's normal axis can be selected, too. This now allows to create
helical extrusions or "twisted pockets".

The order of the GUI entries was chosen to be in line with the order of
axis selection of the multi-transform parameters.
The actual feature's implementation needed adaption for this special case
as in some places a unit vector (`gp_Dir`) was derived from the cross-
product of axis and profile normal -- a null-vector when the axis *is*
the normal. This caused the gp_Dir's ctor to throw.

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).