### PR TITLE
Draft: fix 3 snap issues

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_snapper.py
+++ b/src/Mod/Draft/draftguitools/gui_snapper.py
@@ -83,7 +83,7 @@ class Snapper:
 
     def __init__(self):
         self.activeview = None
-        self.lastObj = [None, None]
+        self.lastObj = []
         self.maxEdges = 0
         self.radius = 0
         self.constraintAxis = None
@@ -471,15 +471,15 @@ class Snapper:
                 # snap to corners of section planes
                 snaps.extend(self.snapToEndpoints(obj.Shape))
 
+        # updating last objects list
+        if obj.Name in self.lastObj:
+            self.lastObj.remove(obj.Name)
+        self.lastObj.append(obj.Name)
+        if len(self.lastObj) > 8:
+            self.lastObj = self.lastObj[-8:]
+
         if not snaps:
             return None
-
-        # updating last objects list
-        if not self.lastObj[1]:
-            self.lastObj[1] = obj.Name
-        elif self.lastObj[1] != obj.Name:
-            self.lastObj[0] = self.lastObj[1]
-            self.lastObj[1] = obj.Name
 
         # calculating the nearest snap point
         shortest = 1000000000000000000
@@ -610,9 +610,9 @@ class Snapper:
                         self.setCursor(tsnap[1])
                         return tsnap[2], eline
 
-        for o in (self.lastObj[1], self.lastObj[0]):
-            if o and (self.isEnabled('Extension')
-                      or self.isEnabled('Parallel')):
+        for o in self.lastObj:
+            if (self.isEnabled('Extension')
+                    or self.isEnabled('Parallel')):
                 ob = App.ActiveDocument.getObject(o)
                 if not ob:
                     continue
@@ -630,10 +630,10 @@ class Snapper:
                         if DraftGeomUtils.geomType(e) != "Line":
                             continue
                         np = self.getPerpendicular(e,point)
-                        if DraftGeomUtils.isPtOnEdge(np,e):
-                            continue
                         if (np.sub(point)).Length < self.radius:
                             if self.isEnabled('Extension'):
+                                if DraftGeomUtils.isPtOnEdge(np,e):
+                                    continue
                                 if np != e.Vertexes[0].Point:
                                     p0 = e.Vertexes[0].Point
                                     if self.tracker and not self.selectMode:
@@ -664,20 +664,19 @@ class Snapper:
                                                 self.lastExtensions[1] = self.lastExtensions[0]
                                                 self.lastExtensions[0] = ne
                                     return np,ne
-                        else:
-                            if self.isEnabled('Parallel'):
-                                if last:
-                                    ve = DraftGeomUtils.vec(e)
-                                    if not DraftVecUtils.isNull(ve):
-                                        de = Part.LineSegment(last,last.add(ve)).toShape()
-                                        np = self.getPerpendicular(de,point)
-                                        if (np.sub(point)).Length < self.radius:
-                                            if self.tracker and not self.selectMode:
-                                                self.tracker.setCoords(np)
-                                                self.tracker.setMarker(self.mk['parallel'])
-                                                self.tracker.on()
-                                            self.setCursor('parallel')
-                                            return np,de
+                        elif self.isEnabled('Parallel'):
+                            if last:
+                                ve = DraftGeomUtils.vec(e)
+                                if not DraftVecUtils.isNull(ve):
+                                    de = Part.LineSegment(last,last.add(ve)).toShape()
+                                    np = self.getPerpendicular(de,point)
+                                    if (np.sub(point)).Length < self.radius:
+                                        if self.tracker and not self.selectMode:
+                                            self.tracker.setCoords(np)
+                                            self.tracker.setMarker(self.mk['parallel'])
+                                            self.tracker.on()
+                                        self.setCursor('parallel')
+                                        return np,de
         return point,eline
 
 
@@ -995,8 +994,8 @@ class Snapper:
         snaps = []
         if self.isEnabled("Intersection"):
             # get the stored objects to calculate intersections
-            if self.lastObj[0]:
-                obj = App.ActiveDocument.getObject(self.lastObj[0])
+            for o in self.lastObj[:-1]:
+                obj = App.ActiveDocument.getObject(o)
                 if obj:
                     if obj.isDerivedFrom("Part::Feature") or (Draft.getType(obj) == "Axis"):
                         if (not self.maxEdges) or (len(obj.Shape.Edges) <= self.maxEdges):
@@ -1226,6 +1225,7 @@ class Snapper:
         self.selectMode = False
         self.running = False
         self.holdPoints = []
+        self.lastObj = []
 
 
     def setSelectMode(self, mode):


### PR DESCRIPTION
1. Draft_Snap_Parallel only worked beyond the endpoints of the edge.
2. It was very hard to select an edge for Draft_Snap_Parallel if no other snaps were active.
3. Only two snap objects were stored.

Forum topic:
https://forum.freecadweb.org/viewtopic.php?p=547723#p547723

The main change is the last. The `self.lastObj` list now has a length of 0-8 items and is cleared in the `off` function. Having the list hold more than 2 items alleviates the problem where accidentally hovering too long over two random edges would mean that the edge selected for Draft_Snap_Parallel was no longer available. Using 8 as the max. length for the list is debatable, but that can easily be changed later.

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
