### PR TITLE
[PD] allow to move sweep sections

### DIFF
--- a/src/Mod/PartDesign/Gui/TaskPipeParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskPipeParameters.h
@@ -145,6 +145,7 @@ private Q_SLOTS:
     void onButtonRefRemove(bool checked);
     void updateUI(int idx);
     void onDeleteSection();
+    void indexesMoved();
 
 protected:
     enum selectionModes { none, refAdd, refRemove };

--- a/src/Mod/PartDesign/Gui/TaskPipeScaling.ui
+++ b/src/Mod/PartDesign/Gui/TaskPipeScaling.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>353</width>
-    <height>407</height>
+    <width>262</width>
+    <height>270</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -97,7 +97,14 @@
         </layout>
        </item>
        <item>
-        <widget class="QListWidget" name="listWidgetReferences"/>
+        <widget class="QListWidget" name="listWidgetReferences">
+         <property name="toolTip">
+          <string>List can be reordered by dragging</string>
+         </property>
+         <property name="dragDropMode">
+          <enum>QAbstractItemView::InternalMove</enum>
+         </property>
+        </widget>
        </item>
       </layout>
      </widget>


### PR DESCRIPTION
Now that we have the feature that sweeps can have vertices as end or begin of a sweep, there is the need for the feature to move sections. For example vertices may only be the last section.

Here is a use case:
![t35WnSwed6](https://user-images.githubusercontent.com/1828501/143785511-d20e5411-eb47-4771-a3ab-177f0b801c7e.gif)

