### PR TITLE
[PD] Use `compare` to compare strings instead of `substr`

### DIFF
--- a/src/Mod/PartDesign/App/FeatureDressUp.cpp
+++ b/src/Mod/PartDesign/App/FeatureDressUp.cpp
@@ -116,7 +116,7 @@ void DressUp::getContinuousEdges(Part::TopoShape TopShape, std::vector< std::str
     {
         std::string aSubName = static_cast<std::string>(SubNames.at(i));
 
-        if (aSubName.size() > 4 && aSubName.substr(0,4) == "Edge") {
+        if (aSubName.compare(0, 4, "Edge") == 0) {
             TopoDS_Edge edge = TopoDS::Edge(TopShape.getSubShape(aSubName.c_str()));
             const TopTools_ListOfShape& los = mapEdgeFace.FindFromKey(edge);
 
@@ -138,7 +138,7 @@ void DressUp::getContinuousEdges(Part::TopoShape TopShape, std::vector< std::str
 
             i++;
         }
-        else if(aSubName.size() > 4 && aSubName.substr(0,4) == "Face") {
+        else if(aSubName.compare(0, 4, "Face") == 0) {
             TopoDS_Face face = TopoDS::Face(TopShape.getSubShape(aSubName.c_str()));
 
             TopTools_IndexedMapOfShape mapOfFaces;

--- a/src/Mod/PartDesign/App/FeatureLinearPattern.cpp
+++ b/src/Mod/PartDesign/App/FeatureLinearPattern.cpp
@@ -98,12 +98,12 @@ const std::list<gp_Trsf> LinearPattern::getTransformations(const std::vector<App
             axis = refSketch->getAxis(Part::Part2DObject::V_Axis);
         else if (subStrings[0] == "N_Axis")
             axis = refSketch->getAxis(Part::Part2DObject::N_Axis);
-        else if (subStrings[0].size() > 4 && subStrings[0].substr(0,4) == "Axis") {
+        else if (subStrings[0].compare(0, 4, "Axis") == 0) {
             int AxId = std::atoi(subStrings[0].substr(4,4000).c_str());
             if (AxId >= 0 && AxId < refSketch->getAxisCount())
                 axis = refSketch->getAxis(AxId);
         }
-        else if (subStrings[0].substr(0,4) == "Edge") {
+        else if (subStrings[0].compare(0, 4, "Edge") == 0) {
             Part::TopoShape refShape = refSketch->Shape.getShape();
             TopoDS_Shape ref = refShape.getSubShape(subStrings[0].c_str());
             TopoDS_Edge refEdge = TopoDS::Edge(ref);

--- a/src/Mod/PartDesign/App/FeatureLoft.cpp
+++ b/src/Mod/PartDesign/App/FeatureLoft.cpp
@@ -85,7 +85,7 @@ App::DocumentObjectExecReturn *Loft::execute(void)
             // only take the entire shape when we have a sketch selected, but
             // not a point of the sketch
             if (feature->isDerivedFrom(Part::Part2DObject::getClassTypeId()) &&
-                !(subName.size() > 6 && subName.substr(0,6) == "Vertex"))
+                subName.compare(0, 6, "Vertex") != 0)
                 return static_cast<Part::Part2DObject*>(feature)->Shape.getValue();
             else {
                 if(subName.empty())

--- a/src/Mod/PartDesign/App/FeatureMirrored.cpp
+++ b/src/Mod/PartDesign/App/FeatureMirrored.cpp
@@ -77,7 +77,7 @@ const std::list<gp_Trsf> Mirrored::getTransformations(const std::vector<App::Doc
             axis = refSketch->getAxis(Part::Part2DObject::H_Axis);
         else if (subStrings[0] == "")
             axis = refSketch->getAxis(Part::Part2DObject::N_Axis);
-        else if (subStrings[0].size() > 4 && subStrings[0].substr(0,4) == "Axis") {
+        else if (subStrings[0].compare(0, 4, "Axis") == 0) {
             int AxId = std::atoi(subStrings[0].substr(4,4000).c_str());
             if (AxId >= 0 && AxId < refSketch->getAxisCount()) {
                 axis = refSketch->getAxis(AxId);

--- a/src/Mod/PartDesign/App/FeaturePipe.cpp
+++ b/src/Mod/PartDesign/App/FeaturePipe.cpp
@@ -123,7 +123,7 @@ App::DocumentObjectExecReturn *Pipe::execute(void)
             // only take the entire shape when we have a sketch selected, but
             // not a point of the sketch
             if (feature->isDerivedFrom(Part::Part2DObject::getClassTypeId()) &&
-                !(subName.compare(0, 6, "Vertex") == 0))
+                subName.compare(0, 6, "Vertex") != 0)
                 return static_cast<Part::Part2DObject*>(feature)->Shape.getValue();
             else {
                 if(subName.empty())
@@ -490,7 +490,7 @@ void Pipe::getContinuousEdges(Part::TopoShape /*TopShape*/, std::vector< std::st
     {
         std::string aSubName = static_cast<std::string>(SubNames.at(i));
 
-        if (aSubName.size() > 4 && aSubName.substr(0, 4) == "Edge") {
+        if (aSubName.compare(0, 4, "Edge") == 0) {
             TopoDS_Edge edge = TopoDS::Edge(TopShape.getSubShape(aSubName.c_str()));
             const TopTools_ListOfShape& los = mapEdgeEdge.FindFromKey(edge);
 

--- a/src/Mod/PartDesign/App/FeaturePolarPattern.cpp
+++ b/src/Mod/PartDesign/App/FeaturePolarPattern.cpp
@@ -115,7 +115,7 @@ const std::list<gp_Trsf> PolarPattern::getTransformations(const std::vector<App:
             axis = refSketch->getAxis(Part::Part2DObject::V_Axis);
         else if (subStrings[0] == "N_Axis")
             axis = refSketch->getAxis(Part::Part2DObject::N_Axis);
-        else if (subStrings[0].size() > 4 && subStrings[0].substr(0,4) == "Axis") {
+        else if (subStrings[0].compare(0, 4, "Axis") == 0) {
             int AxId = std::atoi(subStrings[0].substr(4,4000).c_str());
             if (AxId >= 0 && AxId < refSketch->getAxisCount())
                 axis = refSketch->getAxis(AxId);

--- a/src/Mod/PartDesign/App/FeatureSketchBased.cpp
+++ b/src/Mod/PartDesign/App/FeatureSketchBased.cpp
@@ -842,13 +842,13 @@ void ProfileBased::remapSupportShape(const TopoDS_Shape& newShape)
 
             for (std::vector<std::string>::iterator it = subValues.begin(); it != subValues.end(); ++it) {
                 std::string shapetype;
-                if (it->size() > 4 && it->substr(0,4) == "Face") {
+                if (it->compare(0, 4, "Face") == 0) {
                     shapetype = "Face";
                 }
-                else if (it->size() > 4 && it->substr(0,4) == "Edge") {
+                else if (it->compare(0, 4, "Edge") == 0) {
                     shapetype = "Edge";
                 }
-                else if (it->size() > 6 && it->substr(0,6) == "Vertex") {
+                else if (it->compare(0, 6, "Vertex") == 0) {
                     shapetype = "Vertex";
                 }
                 else {
@@ -1073,7 +1073,7 @@ void ProfileBased::getAxis(const App::DocumentObject *pcReferenceAxis, const std
                 hasValidAxis = true;
                 axis = sketch->getAxis(Part::Part2DObject::N_Axis);
             }
-            else if (subReferenceAxis[0].size() > 4 && subReferenceAxis[0].substr(0, 4) == "Axis") {
+            else if (subReferenceAxis[0].compare(0, 4, "Axis") == 0) {
                 int AxId = std::atoi(subReferenceAxis[0].substr(4, 4000).c_str());
                 if (AxId >= 0 && AxId < sketch->getAxisCount()) {
                     hasValidAxis = true;

--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -1029,9 +1029,9 @@ void prepareProfileBased(PartDesign::Body *pcActiveBody, Gui::Command* cmd, cons
 
             // `ProfileBased::getProfileShape()` and other methods will return
             // just the sub-shapes if they are set. So when whole sketches are
-            // desired, don not set sub-values.
+            // desired, do not set sub-values.
             if (feature->isDerivedFrom(Part::Part2DObject::getClassTypeId()) &&
-                !(subName.size() > 6 && subName.substr(0, 6) == "Vertex"))
+                subName.compare(0, 6, "Vertex") != 0)
                 runProfileCmd();
             else
                 runProfileCmdWithSubs();
@@ -1059,7 +1059,7 @@ void prepareProfileBased(PartDesign::Body *pcActiveBody, Gui::Command* cmd, cons
             // just the sub-shapes if they are set. So when whole sketches are
             // desired, don not set sub-values.
             if (feature->isDerivedFrom(Part::Part2DObject::getClassTypeId()) &&
-                !(subName.size() > 6 && subName.substr(0, 6) == "Vertex"))
+                subName.compare(0, 6, "Vertex") != 0)
                 runProfileCmd();
             else
                 runProfileCmdWithSubs();
@@ -2048,7 +2048,7 @@ void CmdPartDesignDraft::activated(int iMsg)
     {
         std::string aSubName = static_cast<std::string>(SubNames.at(i));
 
-        if (aSubName.size() > 4 && aSubName.substr(0,4) == "Face") {
+        if (aSubName.compare(0, 4, "Face") == 0) {
             // Check for valid face types
             TopoDS_Face face = TopoDS::Face(TopShape.getSubShape(aSubName.c_str()));
             BRepAdaptor_Surface sf(face);
@@ -2104,7 +2104,7 @@ void CmdPartDesignThickness::activated(int iMsg)
     {
         std::string aSubName = static_cast<std::string>(SubNames.at(i));
 
-        if (aSubName.size() > 4 && aSubName.substr(0, 4) != "Face") {
+        if (aSubName.compare(0, 4, "Face") != 0) {
             // empty name or any other sub-element
             SubNames.erase(SubNames.begin()+i);
         }

--- a/src/Mod/PartDesign/Gui/ReferenceSelection.cpp
+++ b/src/Mod/PartDesign/Gui/ReferenceSelection.cpp
@@ -148,7 +148,7 @@ bool ReferenceSelection::allow(App::Document* pDoc, App::DocumentObject* pObj, c
 
     if (pObj && pObj->getTypeId().isDerivedFrom(Part::Feature::getClassTypeId())) {
         std::string subName(sSubName);
-        if (edge && subName.size() > 4 && subName.substr(0,4) == "Edge") {
+        if (edge && subName.compare(0, 4, "Edge") == 0) {
             const Part::TopoShape &shape = static_cast<const Part::Feature*>(pObj)->Shape.getValue();
             TopoDS_Shape sh = shape.getSubShape(subName.c_str());
             const TopoDS_Edge& edgeShape = TopoDS::Edge(sh);
@@ -162,7 +162,7 @@ bool ReferenceSelection::allow(App::Document* pDoc, App::DocumentObject* pObj, c
                 }
             }
         }
-        if (plane && subName.size() > 4 && subName.substr(0,4) == "Face") {
+        if (plane && subName.compare(0, 4, "Face") == 0) {
             const Part::TopoShape &shape = static_cast<const Part::Feature*>(pObj)->Shape.getValue();
             TopoDS_Shape sh = shape.getSubShape(subName.c_str());
             const TopoDS_Face& face = TopoDS::Face(sh);
@@ -176,10 +176,10 @@ bool ReferenceSelection::allow(App::Document* pDoc, App::DocumentObject* pObj, c
                 }
             }
         }
-        if (point && subName.size() > 6 && subName.substr(0,6) == "Vertex") {
+        if (point && subName.compare(0, 6, "Vertex") == 0) {
             return true;
         }
-        if (circle && subName.size() > 4 && subName.substr(0,4) == "Edge") {
+        if (circle && subName.compare(0, 4, "Edge") == 0) {
             const Part::TopoShape &shape = static_cast<const Part::Feature*>(pObj)->Shape.getValue();
             TopoDS_Shape sh = shape.getSubShape(subName.c_str());
             const TopoDS_Edge& edgeShape = TopoDS::Edge(sh);

--- a/src/Mod/PartDesign/Gui/TaskExtrudeParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskExtrudeParameters.cpp
@@ -84,7 +84,7 @@ void TaskExtrudeParameters::setupDialog()
     int faceId = -1;
     if (obj && !subStrings.empty()) {
         upToFace = subStrings.front();
-        if (upToFace.substr(0,4) == "Face")
+        if (upToFace.compare(0, 4, "Face") == 0)
             faceId = std::atoi(&upToFace[4]);
     }
 

--- a/src/Mod/PartDesign/Gui/ViewProviderShapeBinder.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderShapeBinder.cpp
@@ -159,13 +159,13 @@ void ViewProviderShapeBinder::highlightReferences(const bool on, bool /*auxiliar
 
             for (std::string e : subs) {
                 // Note: stoi may throw, but it strictly shouldn't happen
-                if(e.substr(4) == "Edge") {
+                if(e.compare(0, 4, "Edge") == 0) {
                     int idx = std::stoi(e.substr(4)) - 1;
                     assert ( idx>=0 );
                     if ( idx < (ssize_t) lcolors.size() )
                         lcolors[idx] = App::Color(1.0,0.0,1.0); // magenta
                 }
-                else if(e.substr(4) == "Face")  {
+                else if(e.compare(0, 4, "Face") == 0)  {
                     int idx = std::stoi(e.substr(4)) - 1;
                     assert ( idx>=0 );
                     if ( idx < (ssize_t) fcolors.size() )


### PR DESCRIPTION
Used when finding subelements of a feature. Many of the comparisons used to also
check for string lengths, but as far as I can tell they are not strictly
necessary (see https://www.cplusplus.com/reference/string/string/substr/) and
just `substr` can be used without them. However, `compare` explicitly is for
comparing, and does not make a new object that `substr` does.