### PR TITLE
[PD] allow negative helix growth

### DIFF
--- a/src/Mod/PartDesign/App/FeatureHelix.cpp
+++ b/src/Mod/PartDesign/App/FeatureHelix.cpp
@@ -134,13 +134,12 @@ App::DocumentObjectExecReturn *Helix::execute(void)
         if (Turns.getValue() < Precision::Confusion())
             return new App::DocumentObjectExecReturn("Error: turns too small!");
         if ((Height.getValue() < Precision::Confusion())
-            && (Growth.getValue() < Precision::Confusion()))
+            && (abs(Growth.getValue()) < Precision::Confusion()))
             return new App::DocumentObjectExecReturn("Error: either height or growth must not be zero!");
         Pitch.setValue(Height.getValue()/Turns.getValue());
     } else {
         return new App::DocumentObjectExecReturn("Error: unsupported mode");
     }
-
 
     TopoDS_Shape sketchshape;
     try {
@@ -407,7 +406,7 @@ TopoDS_Shape Helix::generateHelixPath(void)
     bool growthMode = std::string(Mode.getValueAsString()).find("growth") != std::string::npos;
     double radiusTop;
     if (growthMode)
-        radiusTop = radius + turns*growth;
+        radiusTop = radius + turns * growth;
     else
         radiusTop = radius + height * tan(Base::toRadians(angle));
 
@@ -533,6 +532,13 @@ void Helix::handleChangedPropertyType(Base::XMLReader& reader, const char* TypeN
         // restore the PropertyFloat to be able to set its value
         TurnsProperty.Restore(reader);
         Turns.setValue(TurnsProperty.getValue());
+    }
+    // property Growth had the App::PropertyLength and was changed to App::PropertyDistance
+    else if (prop == &Growth && strcmp(TypeName, "App::PropertyLength") == 0) {
+        App::PropertyLength GrowthProperty;
+        // restore the PropertyLength to be able to set its value
+        GrowthProperty.Restore(reader);
+        Growth.setValue(GrowthProperty.getValue());
     }
     else {
         ProfileBased::handleChangedPropertyType(reader, TypeName, prop);

--- a/src/Mod/PartDesign/App/FeatureHelix.h
+++ b/src/Mod/PartDesign/App/FeatureHelix.h
@@ -52,7 +52,7 @@ public:
     App::PropertyFloatConstraint   Turns;
     App::PropertyBool        LeftHanded;
     App::PropertyAngle       Angle;
-    App::PropertyLength      Growth;
+    App::PropertyDistance    Growth;
     App::PropertyEnumeration Mode;
     App::PropertyBool        Outside;
     App::PropertyBool        HasBeenEdited;

--- a/src/Mod/PartDesign/Gui/TaskHelixParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskHelixParameters.h
@@ -95,7 +95,7 @@ protected:
     App::PropertyBool*        propReversed;
     App::PropertyLinkSub*     propReferenceAxis;
     App::PropertyAngle*       propAngle;
-    App::PropertyLength*      propGrowth;
+    App::PropertyDistance*    propGrowth;
     App::PropertyEnumeration* propMode;
     App::PropertyBool*        propOutside;
 


### PR DESCRIPTION
Helices that become smaller with every turn are geometrically perfectly valid. Therefore we cannot forbid this.

(For example when creating a helix from a face you often cannot move it so that you can apply a positive growth.)

Here is a use case: [Helix-Tests.zip](https://github.com/FreeCAD/FreeCAD/files/7614657/Helix-Tests.zip)

![FreeCAD_m8ocjYwv0D](https://user-images.githubusercontent.com/1828501/143791464-c6f41b0b-6c48-4e0e-a436-6431652fc4f1.png)


