### PR TITLE
Draft: fix regression draftlink.py

### DIFF
--- a/src/Mod/Draft/draftobjects/draftlink.py
+++ b/src/Mod/Draft/draftobjects/draftlink.py
@@ -187,15 +187,11 @@ class DraftLink(DraftObject):
                             "from '{}'\n".format(obj.Label, obj.Base.Label))
                 raise RuntimeError(_err_msg)
             else:
+                # Resetting the Placement of the copied shape does not work for
+                # Part_Vertex and Draft_Point objects, we need to transform:
                 place = shape.Placement
                 shape = shape.copy()
-                if shape.Placement == place:
-                    shape.Placement = App.Placement()
-                else:
-                    # In some cases the copied shape has a different Placement
-                    # than its original. This happens with Part_Vertex and
-                    # Draft_Point objects. In those cases we need to transform:
-                    shape = shape.transformGeometry(place.Matrix.inverse())
+                shape.transformShape(place.Matrix.inverse())
                 base = []
                 for i, pla in enumerate(pls):
                     vis = getattr(obj, 'VisibilityList', [])

--- a/src/Mod/Draft/draftobjects/draftlink.py
+++ b/src/Mod/Draft/draftobjects/draftlink.py
@@ -187,9 +187,15 @@ class DraftLink(DraftObject):
                             "from '{}'\n".format(obj.Label, obj.Base.Label))
                 raise RuntimeError(_err_msg)
             else:
-                # Resetting the Placement of the copied shape does not work for
-                # Part_Vertex and Draft_Point objects, we need to transform:
-                shape = shape.transformGeometry(shape.Placement.Matrix.inverse())
+                place = shape.Placement
+                shape = shape.copy()
+                if place.__eq__(shape.Placement):
+                    shape.Placement = App.Placement()
+                else:
+                    # In some cases the copied shape has a different Placement.
+                    # This happens with Part_Vertex and Draft_Point objects.
+                    # In those cases we need to transform:
+                    shape = shape.transformGeometry(place.Matrix.inverse())
                 base = []
                 for i, pla in enumerate(pls):
                     vis = getattr(obj, 'VisibilityList', [])

--- a/src/Mod/Draft/draftobjects/draftlink.py
+++ b/src/Mod/Draft/draftobjects/draftlink.py
@@ -189,12 +189,12 @@ class DraftLink(DraftObject):
             else:
                 place = shape.Placement
                 shape = shape.copy()
-                if place.__eq__(shape.Placement):
+                if shape.Placement == place:
                     shape.Placement = App.Placement()
                 else:
-                    # In some cases the copied shape has a different Placement.
-                    # This happens with Part_Vertex and Draft_Point objects.
-                    # In those cases we need to transform:
+                    # In some cases the copied shape has a different Placement
+                    # than its original. This happens with Part_Vertex and
+                    # Draft_Point objects. In those cases we need to transform:
                     shape = shape.transformGeometry(place.Matrix.inverse())
                 base = []
                 for i, pla in enumerate(pls):


### PR DESCRIPTION
This PR fixes a regression introduces with #5180.

See forum topic:
https://forum.freecadweb.org/viewtopic.php?f=3&t=64246

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
