### PR TITLE
PD: Enhance the helix property docs

### DIFF
--- a/src/Mod/PartDesign/App/FeatureHelix.cpp
+++ b/src/Mod/PartDesign/App/FeatureHelix.cpp
@@ -77,22 +77,42 @@ Helix::Helix()
 {
     addSubType = FeatureAddSub::Additive;
 
-    ADD_PROPERTY_TYPE(Base, (Base::Vector3d(0.0, 0.0, 0.0)), "Helix", App::Prop_ReadOnly, "Base");
-    ADD_PROPERTY_TYPE(Axis, (Base::Vector3d(0.0, 1.0, 0.0)), "Helix", App::Prop_ReadOnly, "Axis");
-    ADD_PROPERTY_TYPE(Pitch, (10.), "Helix", App::Prop_None, "Pitch");
-    ADD_PROPERTY_TYPE(Height, (30.0), "Helix", App::Prop_None, "Height");
-    ADD_PROPERTY_TYPE(Turns, (3.0), "Helix", App::Prop_None, "Turns");
+    const char* group = "Helix";
+    ADD_PROPERTY_TYPE(Base, (Base::Vector3d(0.0, 0.0, 0.0)), group, App::Prop_ReadOnly,
+        "The center point of the helix' start.");
+    ADD_PROPERTY_TYPE(Axis, (Base::Vector3d(0.0, 1.0, 0.0)), group, App::Prop_ReadOnly,
+        "The helix' direction.");
+    ADD_PROPERTY_TYPE(Pitch, (10.), group, App::Prop_None,
+        "The axial distance between two turns.");
+    ADD_PROPERTY_TYPE(Height, (30.0), group, App::Prop_None,
+        "The height of the helix' path, not accounting for the extent of the profile.");
+    ADD_PROPERTY_TYPE(Turns, (3.0), group, App::Prop_None,
+        "The number of turns in the helix.");
     Turns.setConstraints(&floatTurns);
-    ADD_PROPERTY_TYPE(LeftHanded, (long(0)), "Helix", App::Prop_None, "LeftHanded");
-    ADD_PROPERTY_TYPE(Reversed, (long(0)), "Helix", App::Prop_None, "Reversed");
-    ADD_PROPERTY_TYPE(Angle, (0.0), "Helix", App::Prop_None, "Angle");
-    ADD_PROPERTY_TYPE(Growth, (0.0), "Helix", App::Prop_None, "Growth");
+    ADD_PROPERTY_TYPE(LeftHanded, (long(0)), group, App::Prop_None,
+        "Sets the turning direction to left handed,\n"
+        "i.e. counter-clockwise when moving along its axis.");
+    ADD_PROPERTY_TYPE(Reversed, (long(0)), group, App::Prop_None,
+        "Determines whether the helix points in the opposite direction of the axis.");
+    ADD_PROPERTY_TYPE(Angle, (0.0), group, App::Prop_None,
+        "The angle of the cone that forms a hull around the helix.\n"
+        "Non-zero values turn the helix into a conical spiral.\n"
+        "Positive values make the radius grow, nevatige shrink.");
     Angle.setConstraints(&floatAngle);
-    ADD_PROPERTY_TYPE(ReferenceAxis, (0), "Helix", App::Prop_None, "Reference axis of revolution");
-    ADD_PROPERTY_TYPE(Mode, (long(0)), "Helix", App::Prop_None, "Helix input mode");
-    ADD_PROPERTY_TYPE(Outside, (long(0)), "Helix", App::Prop_None, "Outside");
-    ADD_PROPERTY_TYPE(HasBeenEdited, (long(0)), "Helix", App::Prop_None, "HasBeenEdited");
+    ADD_PROPERTY_TYPE(Growth, (0.0), group, App::Prop_None,
+        "The growth of the helix' radius per turn.\n"
+        "Non-zero values turn the helix into a conical spiral.");
+    ADD_PROPERTY_TYPE(ReferenceAxis, (0), group, App::Prop_None,
+        "The reference axis of the helix.");
+    ADD_PROPERTY_TYPE(Mode, (long(0)), group, App::Prop_None,
+        "The helix input mode specifies which properties are set by the user.\n"
+        "Dependent properties are then calculated.");
     Mode.setEnums(ModeEnums);
+    ADD_PROPERTY_TYPE(Outside, (long(0)), group, App::Prop_None,
+        "If set, the result will be the intersection of the profile and the preexisting body.");
+    ADD_PROPERTY_TYPE(HasBeenEdited, (long(0)), group, App::Prop_None,
+        "If false, the tool will propose an initial value for the pitch based on the profile bounding box,\n"
+        "so that self intersection is avoided.");
 }
 
 short Helix::mustExecute() const


### PR DESCRIPTION
Up to now the property descriptions (e.g. shown as tool tip in the property grid) just repeat the property's name, which was not very helpful. With this PR most strings are based on descriptions from the [wiki](https://wiki.freecadweb.org/PartDesign_AdditiveHelix). Some have been extended where I saw need (once accepted, I can adapt the wiki, too). Note that I'm not a native speaker, though.

I also plan to make those property descriptions [translatable](https://tracker.freecadweb.org/view.php?id=0002524) and use them as tooltip in the helix' task panel. As you seem to prefer several smaller PRs I did not include this here. It may also requires some more discussion.