### PR TITLE
Use correct name `spacemouse` so it's uniform and searchable in our code

### DIFF
--- a/conda/build.sh
+++ b/conda/build.sh
@@ -31,7 +31,7 @@ if [[ ${HOST} =~ "Darwin" ]]; then
 
   # install space-mouse
   if [ ! -d "/Library/Frameworks/3DconnexionClient.framework" ]; then
-    echo "Installing 3D connexion space mouse drivers."
+    echo "Installing 3D connexion spacemouse drivers."
     curl -o /tmp/3dFW.dmg -L 'https://download.3dconnexion.com/drivers/mac/10-6-6_360DF97D-ED08-4ccf-A55E-0BF905E58476/3DxWareMac_v10-6-6_r3234.dmg'
     hdiutil attach -readonly /tmp/3dFW.dmg
     sudo installer -package /Volumes/3Dconnexion\ Software/Install\ 3Dconnexion\ software.pkg -target /

--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -203,7 +203,7 @@ Action * StdPerspectiveCamera::createAction(void)
 //===========================================================================
 
 // The two commands below are provided for convenience so that they can be bound
-// to a button of a space mouse
+// to a button of a spacemouse
 
 //===========================================================================
 // Std_ViewSaveCamera

--- a/src/Gui/GestureNavigationStyle.cpp
+++ b/src/Gui/GestureNavigationStyle.cpp
@@ -53,7 +53,7 @@
  * So, to avoid entering Tilt mode, the style implements its own tap-and-hold
  * detection, and a special Pan state for the state machine - StickyPanState.
  *
- * This style wasn't tested with space mouse during development (I don't have one).
+ * This style wasn't tested with spacemouse during development (I don't have one).
  *
  * See also GestureNavigationStyle-state-machine-diagram.docx for a crude
  * diagram of the state machine.


### PR DESCRIPTION
Make all mentions of `spacemouse` in the code a single word (with no whitespace) so we can parse the source code more accurately to find mentions of it if necessary. 