### PR TITLE
Draft: Fix Part_Line offset issue

### DIFF
--- a/src/Mod/Draft/draftfunctions/offset.py
+++ b/src/Mod/Draft/draftfunctions/offset.py
@@ -44,8 +44,8 @@ from draftmake.make_bspline import makeBSpline
 
 def offset(obj, delta, copy=False, bind=False, sym=False, occ=False):
     """offset(object,delta,[copymode],[bind])
-    
-    Offset the given wire by applying the given delta Vector to its first 
+
+    Offset the given wire by applying the given delta Vector to its first
     vertex.
 
     Parameters
@@ -63,7 +63,7 @@ def offset(obj, delta, copy=False, bind=False, sym=False, occ=False):
     copy : bool
         If bind is True, and provided the wire is open, the original
         and the offset wires will be bound by their endpoints, forming a face.
-    
+
     sym : bool
         if sym is True, bind must be true too, and the offset is made on both
         sides, the total width being the given delta length.
@@ -203,10 +203,10 @@ def offset(obj, delta, copy=False, bind=False, sym=False, occ=False):
                     newobj.Closed = obj.Shape.isClosed()
             except Part.OCCError:
                 pass
-            if not(newobj) and newwire:
+            if (not newobj) and newwire:
                 newobj = App.ActiveDocument.addObject("Part::Feature","Offset")
                 newobj.Shape = newwire
-            else:
+            if not newobj:
                 print("Draft.offset: Unable to create an offset")
         if newobj:
             gui_utils.formatObject(newobj,obj)

--- a/src/Mod/Draft/draftgeoutils/offsets.py
+++ b/src/Mod/Draft/draftgeoutils/offsets.py
@@ -212,6 +212,8 @@ def offsetWire(wire, dvec, bind=False, occ=False,
         # thus need to sort its edges same order 
         edges = Part.__sortEdges__(wire.Edges)
         #edges = wire.Edges
+    elif isinstance(wire, Part.Edge):
+        edges = [wire]
     elif isinstance(wire, list):
         if isinstance(wire[0], Part.Edge):
             edges = wire.copy()


### PR DESCRIPTION
The Draft_Offset command did not work with Part_Lines.

Additionally (offset.py):
`"Draft.offset: Unable to create an offset"` message was printed even if `newobj` was created.

Forum topic:
https://forum.freecadweb.org/viewtopic.php?f=23&t=64346