### PR TITLE
Draft: Draft_Label fix label type list

### DIFF
--- a/src/Mod/Draft/DraftGui.py
+++ b/src/Mod/Draft/DraftGui.py
@@ -1016,11 +1016,11 @@ class DraftToolBar:
         w.setWindowTitle(translate("draft","Label type", utf8_decode=True))
         l = QtGui.QVBoxLayout(w)
         combo = QtGui.QComboBox()
-        for s in ["Custom","Name","Label","Position","Length","Area","Volume","Tag","Material"]:
+        from draftobjects.label import get_label_types
+        types = get_label_types()
+        for s in types:
             combo.addItem(s)
-        combo.setCurrentIndex(
-            ["Custom","Name","Label","Position","Length","Area","Volume","Tag","Material"]\
-            .index(Draft.getParam("labeltype","Custom")))
+        combo.setCurrentIndex(types.index(Draft.getParam("labeltype","Custom")))
         l.addWidget(combo)
         QtCore.QObject.connect(combo,QtCore.SIGNAL("currentIndexChanged(int)"),callback)
         self.pointUi(title=title, extra=w, icon="Draft_Label")

--- a/src/Mod/Draft/draftguitools/gui_labels.py
+++ b/src/Mod/Draft/draftguitools/gui_labels.py
@@ -82,8 +82,8 @@ class Label(gui_base_original.Creator):
 
     def setmode(self, i):
         """Set the type of label, if it is associated to an object."""
-        self.labeltype = ["Custom", "Name", "Label", "Position",
-                          "Length", "Area", "Volume", "Tag", "Material"][i]
+        from draftobjects.label import get_label_types
+        self.labeltype = get_label_types()[i]
         utils.setParam("labeltype", self.labeltype)
 
     def finish(self, closed=False, cont=False):

--- a/src/Mod/Draft/draftmake/make_label.py
+++ b/src/Mod/Draft/draftmake/make_label.py
@@ -33,10 +33,10 @@
 import FreeCAD as App
 import draftutils.gui_utils as gui_utils
 import draftutils.utils as utils
+import draftobjects.label as label
 
 from draftutils.messages import _msg, _wrn, _err
 from draftutils.translate import translate
-from draftobjects.label import Label
 
 if App.GuiUp:
     from draftviewproviders.view_label import ViewProviderLabel
@@ -104,9 +104,8 @@ def make_label(target_point=App.Vector(0, 0, 0),
 
     label_type: str, optional
         It defaults to `'Custom'`.
-        It can be `'Custom'`, `'Name'`, `'Label'`, `'Position'`,
-        `'Length'`, `'Area'`, `'Volume'`, `'Tag'`, or `'Material'`.
         It indicates the type of information that will be shown in the label.
+        See the get_label_types function in label.py for supported types.
 
         Only `'Custom'` allows you to manually set the text
         by defining `custom_text`. The other types take their information
@@ -270,12 +269,12 @@ def make_label(target_point=App.Vector(0, 0, 0),
     try:
         utils.type_check([(label_type, str)], name=_name)
     except TypeError:
-        _err(translate("draft","Wrong input: must be a string, 'Custom', 'Name', 'Label', 'Position', 'Length', 'Area', 'Volume', 'Tag', or 'Material'."))
+        _err(translate("draft","Wrong input: label_type must be a string."))
         return None
 
-    if label_type not in ("Custom", "Name", "Label", "Position",
-                          "Length", "Area", "Volume", "Tag", "Material"):
-        _err(translate("draft","Wrong input: must be a string, 'Custom', 'Name', 'Label', 'Position', 'Length', 'Area', 'Volume', 'Tag', or 'Material'."))
+    types = label.get_label_types()
+    if label_type not in types:
+        _err(translate("draft", "Wrong input: label_type must be one of the following: ") + str(types).strip("[]"))
         return None
 
     _msg("custom_text: {}".format(custom_text))
@@ -334,7 +333,7 @@ def make_label(target_point=App.Vector(0, 0, 0),
 
     new_obj = doc.addObject("App::FeaturePython",
                             "dLabel")
-    Label(new_obj)
+    label.Label(new_obj)
 
     new_obj.TargetPoint = target_point
     new_obj.Placement = placement

--- a/src/Mod/Draft/draftobjects/label.py
+++ b/src/Mod/Draft/draftobjects/label.py
@@ -217,12 +217,7 @@ class Label(DraftAnnotation):
                             "LabelType",
                             "Label",
                             _tip)
-            obj.LabelType = ["Custom", "Name", "Label", "Position",
-                             "Length", "Area", "Volume",
-                             "Tag", "Material",
-                             "Label + Position", "Label + Length",
-                             "Label + Area", "Label + Volume",
-                             "Label + Material"]
+            obj.LabelType = get_label_types()
 
     def onDocumentRestored(self, obj):
         """Execute code when the document is restored.
@@ -296,6 +291,23 @@ class Label(DraftAnnotation):
 
 # Alias for compatibility with v0.18 and earlier
 DraftLabel = Label
+
+
+def get_label_types():
+    return ["Custom",
+            "Name",
+            "Label",
+            "Position",
+            "Length",
+            "Area",
+            "Volume",
+            "Tag",
+            "Material",
+            "Label + Position",
+            "Label + Length",
+            "Label + Area",
+            "Label + Volume",
+            "Label + Material"]
 
 
 def return_info(target, typ, subelement=None):


### PR DESCRIPTION
The label type list for Draft_Labels was not consistently implemented. Instead of updating a hard-coded list in several files I have decided to create a function `get_label_types` in `label.py`.

Forum topic:
https://forum.freecadweb.org/viewtopic.php?f=23&t=58234

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---