### PR TITLE
PD: Fix helix property visibility/writability

### DIFF
--- a/src/Mod/PartDesign/App/FeatureHelix.cpp
+++ b/src/Mod/PartDesign/App/FeatureHelix.cpp
@@ -110,7 +110,7 @@ Helix::Helix()
     Mode.setEnums(ModeEnums);
     ADD_PROPERTY_TYPE(Outside, (long(0)), group, App::Prop_None,
         "If set, the result will be the intersection of the profile and the preexisting body.");
-    ADD_PROPERTY_TYPE(HasBeenEdited, (long(0)), group, App::Prop_None,
+    ADD_PROPERTY_TYPE(HasBeenEdited, (long(0)), group, App::Prop_Hidden,
         "If false, the tool will propose an initial value for the pitch based on the profile bounding box,\n"
         "so that self intersection is avoided.");
 }
@@ -609,9 +609,11 @@ void Helix::handleChangedPropertyType(Base::XMLReader& reader, const char* TypeN
 PROPERTY_SOURCE(PartDesign::AdditiveHelix, PartDesign::Helix)
 AdditiveHelix::AdditiveHelix() {
     addSubType = Additive;
+    Outside.setStatus(App::Property::Hidden, true);
 }
 
 PROPERTY_SOURCE(PartDesign::SubtractiveHelix, PartDesign::Helix)
 SubtractiveHelix::SubtractiveHelix() {
     addSubType = Subtractive;
+    Outside.setStatus(App::Property::Hidden, false);
 }

--- a/src/Mod/PartDesign/App/FeatureHelix.cpp
+++ b/src/Mod/PartDesign/App/FeatureHelix.cpp
@@ -80,9 +80,15 @@ Helix::Helix()
 
     const char* group = "Helix";
     ADD_PROPERTY_TYPE(Base, (Base::Vector3d(0.0, 0.0, 0.0)), group, App::Prop_ReadOnly,
-        "The center point of the helix' start.");
+        "The center point of the helix' start; derived from the reference axis.");
     ADD_PROPERTY_TYPE(Axis, (Base::Vector3d(0.0, 1.0, 0.0)), group, App::Prop_ReadOnly,
-        "The helix' direction.");
+        "The helix' direction; derived from the reference axis.");
+    ADD_PROPERTY_TYPE(ReferenceAxis, (0), group, App::Prop_None,
+        "The reference axis of the helix.");
+    ADD_PROPERTY_TYPE(Mode, (long(initialMode)), group, App::Prop_None,
+        "The helix input mode specifies which properties are set by the user.\n"
+        "Dependent properties are then calculated.");
+    Mode.setEnums(ModeEnums);
     ADD_PROPERTY_TYPE(Pitch, (10.), group, App::Prop_None,
         "The axial distance between two turns.");
     ADD_PROPERTY_TYPE(Height, (30.0), group, App::Prop_None,
@@ -90,11 +96,6 @@ Helix::Helix()
     ADD_PROPERTY_TYPE(Turns, (3.0), group, App::Prop_None,
         "The number of turns in the helix.");
     Turns.setConstraints(&floatTurns);
-    ADD_PROPERTY_TYPE(LeftHanded, (long(0)), group, App::Prop_None,
-        "Sets the turning direction to left handed,\n"
-        "i.e. counter-clockwise when moving along its axis.");
-    ADD_PROPERTY_TYPE(Reversed, (long(0)), group, App::Prop_None,
-        "Determines whether the helix points in the opposite direction of the axis.");
     ADD_PROPERTY_TYPE(Angle, (0.0), group, App::Prop_None,
         "The angle of the cone that forms a hull around the helix.\n"
         "Non-zero values turn the helix into a conical spiral.\n"
@@ -103,12 +104,11 @@ Helix::Helix()
     ADD_PROPERTY_TYPE(Growth, (0.0), group, App::Prop_None,
         "The growth of the helix' radius per turn.\n"
         "Non-zero values turn the helix into a conical spiral.");
-    ADD_PROPERTY_TYPE(ReferenceAxis, (0), group, App::Prop_None,
-        "The reference axis of the helix.");
-    ADD_PROPERTY_TYPE(Mode, (long(initialMode)), group, App::Prop_None,
-        "The helix input mode specifies which properties are set by the user.\n"
-        "Dependent properties are then calculated.");
-    Mode.setEnums(ModeEnums);
+    ADD_PROPERTY_TYPE(LeftHanded, (long(0)), group, App::Prop_None,
+        "Sets the turning direction to left handed,\n"
+        "i.e. counter-clockwise when moving along its axis.");
+    ADD_PROPERTY_TYPE(Reversed, (long(0)), group, App::Prop_None,
+        "Determines whether the helix points in the opposite direction of the axis.");
     ADD_PROPERTY_TYPE(Outside, (long(0)), group, App::Prop_None,
         "If set, the result will be the intersection of the profile and the preexisting body.");
     ADD_PROPERTY_TYPE(HasBeenEdited, (long(0)), group, App::Prop_Hidden,

--- a/src/Mod/PartDesign/App/FeatureHelix.h
+++ b/src/Mod/PartDesign/App/FeatureHelix.h
@@ -88,13 +88,19 @@ protected:
     // center of profile bounding box
     Base::Vector3d getProfileCenterPoint();
 
-    // handle changed property
+    // handle changed property types for backward compatibility
     virtual void handleChangedPropertyType(Base::XMLReader& reader, const char* TypeName, App::Property* prop);
+
+    void onChanged(const App::Property* prop);
+
     static const App::PropertyFloatConstraint::Constraints floatTurns;
     static const App::PropertyAngle::Constraints floatAngle;
 
 private:
     static const char* ModeEnums[];
+
+    // Sets the read-only status bit for properties depending on the input mode.
+    void setReadWriteStatusForMode(HelixMode inputMode);
 };
 
 


### PR DESCRIPTION
With this PR minor tweaks are done to the additive/subtractive helix' properties:
- The `HasBeenEdited` property is only used internally to check wether to
  fill certain other parameters with initial values. So there is no need
  show it in the property grid at all.
- The `Outside` property is only used in the subtractive helix and thus
  hidden for the additive helix.
- Those properties which are calculated according to the current input mode (i.e. not directly entered by the user) are now set read-only. Previously they have been writable but their value was ignored and overwritten at the next recompute
- The input mode and reference axis have been placed further up in the list of properties to become more prominent.

This is a bundle of three independent commits, so I suggest to review them independently. They all belong to the same topic and are each rather small, so I've chosen to put them in a single PR -- I hope you don't mind.