### PR TITLE
[MainWindow] Add toolbar name as toolbar's  tooltip

### DIFF
--- a/src/Gui/ToolBarManager.cpp
+++ b/src/Gui/ToolBarManager.cpp
@@ -205,10 +205,10 @@ void ToolBarManager::setup(ToolBarItem* toolBarItems)
                                         toolbarName.c_str())); // i18n
             toolbar->setObjectName(name);
             if (nameAsToolTip){
-                std::ostringstream tooltip;
-
-                tooltip << "[" << toolbarName << "]";
-                toolbar->setToolTip(QApplication::translate("Workbench", tooltip.str().c_str()));
+                auto tooltip = QChar::fromLatin1('[')
+                    + QApplication::translate("Workbench", toolbarName.c_str())
+                    + QChar::fromLatin1(']');
+                toolbar->setToolTip(tooltip);
             }
             toolbar->setVisible(visible);
             toolbar_added = true;

--- a/src/Gui/ToolBarManager.cpp
+++ b/src/Gui/ToolBarManager.cpp
@@ -186,6 +186,8 @@ void ToolBarManager::setup(ToolBarItem* toolBarItems)
 
     ParameterGrp::handle hPref = App::GetApplication().GetUserParameter().GetGroup("BaseApp")
                                ->GetGroup("MainWindow")->GetGroup("Toolbars");
+    bool nameAsToolTip = App::GetApplication().GetUserParameter().GetGroup("BaseApp")
+            ->GetGroup("Preferences")->GetGroup("MainWindow")->GetBool("ToolBarNameAsToolTip",true);
     QList<ToolBarItem*> items = toolBarItems->getItems();
     QList<QToolBar*> toolbars = toolBars();
     for (QList<ToolBarItem*>::ConstIterator it = items.begin(); it != items.end(); ++it) {
@@ -202,6 +204,12 @@ void ToolBarManager::setup(ToolBarItem* toolBarItems)
                 QApplication::translate("Workbench",
                                         toolbarName.c_str())); // i18n
             toolbar->setObjectName(name);
+            if (nameAsToolTip){
+                std::ostringstream tooltip;
+
+                tooltip << "[" << toolbarName << "]";
+                toolbar->setToolTip(QApplication::translate("Workbench", tooltip.str().c_str()));
+            }
             toolbar->setVisible(visible);
             toolbar_added = true;
         }


### PR DESCRIPTION
forum topic:
https://forum.freecadweb.org/viewtopic.php?f=34&t=64528

Adds the name of the toolbar as a tooltip to the toolbar in between braces.  Example, if toolbar name is File, then the tooltip is [File].  Can be disabled in user parameters:  BaseApp/Preferences/MainWindow/ToolBarNameAsToolTip (boolean, default = true).