### PR TITLE
[PartDesign] Improve edit modes management

### DIFF
--- a/src/Mod/PartDesign/Gui/ViewProvider.h
+++ b/src/Mod/PartDesign/Gui/ViewProvider.h
@@ -78,6 +78,9 @@ protected:
     virtual bool setEdit(int ModNum) override;
     virtual void unsetEdit(int ModNum) override;
 
+    static inline void manageEditMode(int &ModNum) {
+        if (ModNum == ViewProvider::Transform || ModNum == ViewProvider::Cutting) ModNum = ViewProvider::Default; }
+
     virtual bool onDelete(const std::vector<std::string> &) override;
 
     /**

--- a/src/Mod/PartDesign/Gui/ViewProviderBase.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderBase.cpp
@@ -83,6 +83,7 @@ void ViewProviderBase::setupContextMenu(QMenu* menu, QObject* receiver, const ch
 
 bool ViewProviderBase::setEdit(int ModNum)
 {
+    manageEditMode(ModNum);
     PartDesign::FeatureBase* base = static_cast<PartDesign::FeatureBase*>(getObject());
     if (!base->Placement.testStatus(App::Property::Immutable) &&
         !base->Placement.testStatus(App::Property::ReadOnly) &&

--- a/src/Mod/PartDesign/Gui/ViewProviderBoolean.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderBoolean.cpp
@@ -71,6 +71,7 @@ void ViewProviderBoolean::setupContextMenu(QMenu* menu, QObject* receiver, const
 
 bool ViewProviderBoolean::setEdit(int ModNum)
 {
+    manageEditMode(ModNum);
     if (ModNum == ViewProvider::Default ) {
         // When double-clicking on the item for this fillet the
         // object unsets and sets its edit mode without closing

--- a/src/Mod/PartDesign/Gui/ViewProviderDressUp.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderDressUp.cpp
@@ -60,6 +60,7 @@ const std::string & ViewProviderDressUp::featureName() const {
 
 
 bool ViewProviderDressUp::setEdit(int ModNum) {
+    manageEditMode(ModNum);
     if (ModNum == ViewProvider::Default ) {
         // Here we should prevent edit of a Feature with missing base
         // Otherwise it could call unhandled exception.

--- a/src/Mod/PartDesign/Gui/ViewProviderHelix.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderHelix.cpp
@@ -76,6 +76,7 @@ QIcon ViewProviderHelix::getIcon(void) const {
 
 bool ViewProviderHelix::setEdit(int ModNum)
 {
+    manageEditMode(ModNum);
     if (ModNum == ViewProvider::Default ) {
         auto* prim = static_cast<PartDesign::Helix*>(getObject());
         setPreviewDisplayMode(TaskHelixParameters::showPreview(prim));

--- a/src/Mod/PartDesign/Gui/ViewProviderHole.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderHole.cpp
@@ -66,6 +66,7 @@ void ViewProviderHole::setupContextMenu(QMenu* menu, QObject* receiver, const ch
 
 bool ViewProviderHole::setEdit(int ModNum)
 {
+    manageEditMode(ModNum);
     if (ModNum == ViewProvider::Default ) {
         // When double-clicking on the item for this hole the
         // object unsets and sets its edit mode without closing

--- a/src/Mod/PartDesign/Gui/ViewProviderLoft.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderLoft.cpp
@@ -79,6 +79,7 @@ void ViewProviderLoft::setupContextMenu(QMenu* menu, QObject* receiver, const ch
 
 bool ViewProviderLoft::setEdit(int ModNum)
 {
+    manageEditMode(ModNum);
     if (ModNum == ViewProvider::Default)
         setPreviewDisplayMode(true);
 

--- a/src/Mod/PartDesign/Gui/ViewProviderPipe.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderPipe.cpp
@@ -88,6 +88,7 @@ void ViewProviderPipe::setupContextMenu(QMenu* menu, QObject* receiver, const ch
 }
 
 bool ViewProviderPipe::setEdit(int ModNum) {
+    manageEditMode(ModNum);
     if (ModNum == ViewProvider::Default )
         setPreviewDisplayMode(true);
 

--- a/src/Mod/PartDesign/Gui/ViewProviderPrimitive.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderPrimitive.cpp
@@ -78,6 +78,7 @@ void ViewProviderPrimitive::setupContextMenu(QMenu* menu, QObject* receiver, con
 
 bool ViewProviderPrimitive::setEdit(int ModNum)
 {
+    manageEditMode(ModNum);
     if (ModNum == ViewProvider::Default ) {
         // When double-clicking on the item for this fillet the
         // object unsets and sets its edit mode without closing

--- a/src/Mod/PartDesign/Gui/ViewProviderSketchBased.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderSketchBased.cpp
@@ -57,6 +57,10 @@ std::vector<App::DocumentObject*> ViewProviderSketchBased::claimChildren(void) c
     return temp;
 }
 
+bool ViewProviderSketchBased::setEdit(int ModNum) {
+    manageEditMode(ModNum);
+    return ViewProvider::setEdit(ModNum);
+}
 
 bool ViewProviderSketchBased::onDelete(const std::vector<std::string> &s) {
     PartDesign::ProfileBased* feature = static_cast<PartDesign::ProfileBased*>(getObject());

--- a/src/Mod/PartDesign/Gui/ViewProviderSketchBased.h
+++ b/src/Mod/PartDesign/Gui/ViewProviderSketchBased.h
@@ -43,6 +43,8 @@ public:
     /// grouping handling
     std::vector<App::DocumentObject*> claimChildren(void)const;
 
+    virtual bool setEdit(int ModNum);
+
     virtual bool onDelete(const std::vector<std::string> &);
 
 };

--- a/src/Mod/PartDesign/Gui/ViewProviderTransformed.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderTransformed.cpp
@@ -89,6 +89,7 @@ Gui::ViewProvider *ViewProviderTransformed::startEditing(int ModNum) {
 
 bool ViewProviderTransformed::setEdit(int ModNum)
 {
+    manageEditMode(ModNum);
     pcRejectedRoot = new SoSeparator();
     pcRejectedRoot->ref();
 


### PR DESCRIPTION
 Reject Transform+Cutting and instead switch to Default

This mainly improves friendliness with UserEditMode along with PartDesign objects.

https://forum.freecadweb.org/viewtopic.php?f=3&t=64460