### PR TITLE
Spreadsheet: Realthunder sheetbind stage4

### DIFF
--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -127,6 +127,7 @@ recompute path. Also, it enables more complicated dependencies beyond trees.
 #include "Origin.h"
 #include "OriginGroupExtension.h"
 #include "Link.h"
+#include "DocumentObserver.h"
 #include "GeoFeature.h"
 
 FC_LOG_LEVEL_INIT("App", true, true, true)
@@ -174,6 +175,7 @@ struct DocumentP
     std::unordered_map<std::string,DocumentObject*> objectMap;
     std::unordered_map<long,DocumentObject*> objectIdMap;
     std::unordered_map<std::string, bool> partialLoadObjects;
+    std::vector<DocumentObjectT> pendingRemove;
     long lastObjectId;
     DocumentObject* activeObject;
     Transaction *activeUndoTransaction;
@@ -3558,16 +3560,22 @@ int Document::recompute(const std::vector<App::DocumentObject*> &objs, bool forc
             continue;
         obj->setStatus(ObjectStatus::PendingRecompute,false);
         obj->setStatus(ObjectStatus::Recompute2,false);
-        if(obj->testStatus(ObjectStatus::PendingRemove))
-            obj->getDocument()->removeObject(obj->getNameInDocument());
     }
 
     signalRecomputed(*this,topoSortedObjects);
 
     FC_TIME_LOG(t,"Recompute total");
 
-    if (d->_RecomputeLog.size())
-        Base::Console().Log("Recompute failed! Please check report view.\n");
+    if(d->_RecomputeLog.size()) {
+        d->pendingRemove.clear();
+        Base::Console().Error("Recompute failed! Please check report view.\n");
+    } else {
+        for(auto &o : d->pendingRemove) {
+            auto obj = o.getObject();
+            if(obj)
+                obj->getDocument()->removeObject(obj->getNameInDocument());
+        }
+    }
 
     return objectCount;
 }
@@ -4097,7 +4105,7 @@ void Document::removeObject(const char* sName)
     if (pos->second->testStatus(ObjectStatus::PendingRecompute)) {
         // TODO: shall we allow removal if there is active undo transaction?
         FC_LOG("pending remove of " << sName << " after recomputing document " << getName());
-        pos->second->setStatus(ObjectStatus::PendingRemove,true);
+        d->pendingRemove.emplace_back(pos->second);
         return;
     }
 

--- a/src/App/DocumentObject.h
+++ b/src/App/DocumentObject.h
@@ -58,7 +58,6 @@ enum ObjectStatus {
     Recompute2 = 9, // set when the object is being recomputed in the second pass
     PartialObject = 10,
     PendingRecompute = 11, // set by Document, indicating the object is in recomputation queue
-    PendingRemove = 12, // set by Document, indicating the object is in pending for remove after recompute
     ObjImporting = 13, // Mark the object as importing
     NoTouch = 14, // no touch on any property change
     GeoExcluded = 15, // mark as a member but not claimed by GeoFeatureGroup

--- a/src/App/DocumentObject.h
+++ b/src/App/DocumentObject.h
@@ -65,6 +65,7 @@ enum ObjectStatus {
     NoAutoExpand = 17, // disable tree item auto expand on selection for this object
     PendingTransactionUpdate = 18, // mark that the object expects a call to onUndoRedoFinished() after transaction is finished.
     RecomputeExtension = 19, // mark the object to recompute its extensions
+    TouchOnColorChange = 20, // inform view provider touch object on color change
 };
 
 /** Return object for feature execution

--- a/src/App/DynamicProperty.cpp
+++ b/src/App/DynamicProperty.cpp
@@ -65,6 +65,12 @@ void DynamicProperty::getPropertyList(std::vector<Property*> &List) const
         List.push_back(v.property);
 }
 
+void DynamicProperty::getPropertyNamedList(std::vector<std::pair<const char*, Property*> > &List) const
+{
+    for (auto &v : props.get<0>())
+        List.emplace_back(v.getName(),v.property);
+}
+
 void DynamicProperty::getPropertyMap(std::map<std::string,Property*> &Map) const
 {
     for (auto &v : props.get<0>())

--- a/src/App/DynamicProperty.h
+++ b/src/App/DynamicProperty.h
@@ -75,6 +75,8 @@ public:
     //@{
     /// Get all properties of the class (including parent)
     void getPropertyList(std::vector<Property*> &List) const;
+    /// get all properties with their names
+    void getPropertyNamedList(std::vector<std::pair<const char*,Property*> > &List) const;
     /// Get all properties of the class (including parent)
     void getPropertyMap(std::map<std::string,Property*> &Map) const;
     /// Find a dynamic property by its name

--- a/src/App/Expression.cpp
+++ b/src/App/Expression.cpp
@@ -1140,12 +1140,13 @@ Expression* Expression::eval() const {
     return expressionFromPy(owner,getPyValue());
 }
 
-bool Expression::isSame(const Expression &other) const {
+bool Expression::isSame(const Expression &other, bool checkComment) const {
     if(&other == this)
         return true;
     if(getTypeId()!=other.getTypeId())
         return false;
-    return comment==other.comment && toString(true,true) == other.toString(true,true);
+    return (!checkComment || comment==other.comment)
+        && toString(true,true) == other.toString(true,true);
 }
 
 std::string Expression::toString(bool persistent, bool checkPriority, int indent) const {

--- a/src/App/Expression.cpp
+++ b/src/App/Expression.cpp
@@ -2710,12 +2710,18 @@ void VariableExpression::_offsetCells(int rowOffset, int colOffset, ExpressionVi
     if(!addr.isValid() || (addr.isAbsoluteCol() && addr.isAbsoluteRow()))
         return;
 
-    v.aboutToChange();
     if(!addr.isAbsoluteCol())
         addr.setCol(addr.col()+colOffset);
     if(!addr.isAbsoluteRow())
         addr.setRow(addr.row()+rowOffset);
-    var.setComponent(idx,ObjectIdentifier::SimpleComponent(addr.toString()));
+    if(!addr.isValid()) {
+        FC_WARN("Not changing relative cell reference '"
+                << comp.getName() << "' due to invalid offset "
+                << '(' << colOffset << ", " << rowOffset << ')');
+    } else {
+        v.aboutToChange();
+        var.setComponent(idx,ObjectIdentifier::SimpleComponent(addr.toString()));
+    }
 }
 
 void VariableExpression::setPath(const ObjectIdentifier &path)

--- a/src/App/Expression.cpp
+++ b/src/App/Expression.cpp
@@ -1748,6 +1748,7 @@ FunctionExpression::FunctionExpression(const DocumentObject *_owner, Function _f
     case MINVERT:
     case STR:
     case HIDDENREF:
+    case HREF:
         if (args.size() != 1)
             EXPR_THROW("Invalid number of arguments: exactly one required.");
         break;
@@ -2099,7 +2100,7 @@ Py::Object FunctionExpression::evaluate(const Expression *expr, int f, const std
         return res;
     } else if (f == STR) {
         return Py::String(args[0]->getPyValue().as_string());
-    } else if (f == HIDDENREF) {
+    } else if (f == HIDDENREF || f == HREF) {
         return args[0]->getPyValue();
     }
 
@@ -2437,6 +2438,8 @@ void FunctionExpression::_toString(std::ostream &ss, bool persistent,int) const
         ss << "str("; break;;
     case HIDDENREF:
         ss << "hiddenref("; break;;
+    case HREF:
+        ss << "href("; break;;
     default:
         ss << fname << "("; break;;
     }
@@ -2470,7 +2473,7 @@ void FunctionExpression::_visit(ExpressionVisitor &v)
 {
     std::vector<Expression*>::const_iterator i = args.begin();
 
-    HiddenReference ref(f == HIDDENREF);
+    HiddenReference ref(f == HIDDENREF || f == HREF);
     while (i != args.end()) {
         (*i)->visit(v);
         ++i;
@@ -3252,6 +3255,7 @@ static void initParser(const App::DocumentObject *owner)
         registered_functions["create"] = FunctionExpression::CREATE;
         registered_functions["str"] = FunctionExpression::STR;
         registered_functions["hiddenref"] = FunctionExpression::HIDDENREF;
+        registered_functions["href"] = FunctionExpression::HREF;
 
         // Aggregates
         registered_functions["sum"] = FunctionExpression::SUM;

--- a/src/App/Expression.h
+++ b/src/App/Expression.h
@@ -185,7 +185,7 @@ public:
 
     Py::Object getPyValue() const;
 
-    bool isSame(const Expression &other) const;
+    bool isSame(const Expression &other, bool checkComment=true) const;
 
     friend ExpressionVisitor;
 

--- a/src/App/ExpressionParser.h
+++ b/src/App/ExpressionParser.h
@@ -301,6 +301,9 @@ public:
 
     static Py::Object evaluate(const Expression *owner, int type, const std::vector<Expression*> &args);
 
+    Function getFunction() const {return f;}
+    const std::vector<Expression*> &getArgs() const {return args;}
+
 protected:
     static Py::Object evalAggregate(const Expression *owner, int type, const std::vector<Expression*> &args);
     virtual Py::Object _getPyValue() const override;

--- a/src/App/ExpressionParser.h
+++ b/src/App/ExpressionParser.h
@@ -274,6 +274,7 @@ public:
         CREATE, // create new object of a given type
         STR, // stringify
         HIDDENREF, // hidden reference that has no dependency check
+        HREF, // deprecated alias of HIDDENREF
 
         // Aggregates
         AGGREGATES,

--- a/src/App/Link.cpp
+++ b/src/App/Link.cpp
@@ -28,6 +28,7 @@
 
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/preprocessor/stringize.hpp>
+#include <Base/Tools.h>
 #include "Application.h"
 #include "Document.h"
 #include "GroupExtension.h"
@@ -53,7 +54,7 @@ namespace bp = boost::placeholders;
 EXTENSION_PROPERTY_SOURCE(App::LinkBaseExtension, App::DocumentObjectExtension)
 
 LinkBaseExtension::LinkBaseExtension(void)
-    :enableLabelCache(false),hasOldSubElement(false)
+    :enableLabelCache(false),hasOldSubElement(false),hasCopyOnChange(true)
 {
     initExtensionType(LinkBaseExtension::getExtensionClassTypeId());
     EXTENSION_ADD_PROPERTY_TYPE(_LinkTouched, (false), " Link",
@@ -139,7 +140,15 @@ void LinkBaseExtension::setProperty(int idx, Property *prop) {
         if(!propLinkMode->getEnums())
             propLinkMode->setEnums(linkModeEnums);
         break;
-    } case PropLinkTransform:
+    }
+    case PropLinkCopyOnChange: {
+        static const char *enums[] = {"Disabled","Enabled","Owned",0};
+        auto propEnum = freecad_dynamic_cast<PropertyEnumeration>(prop);
+        if(!propEnum->getEnums())
+            propEnum->setEnums(enums);
+        break;
+    }
+    case PropLinkTransform:
     case PropLinkPlacement:
     case PropPlacement:
         if(getLinkTransformProperty() &&
@@ -181,6 +190,8 @@ void LinkBaseExtension::setProperty(int idx, Property *prop) {
     }
 }
 
+static const char _GroupPrefix[] = "Configuration (";
+
 App::DocumentObjectExecReturn *LinkBaseExtension::extensionExecute(void) {
     // The actual value of LinkRecompouted is not important, just to notify view
     // provider that the link (in fact, its dependents, i.e. linked ones) have
@@ -193,6 +204,24 @@ App::DocumentObjectExecReturn *LinkBaseExtension::extensionExecute(void) {
             return new App::DocumentObjectExecReturn("Link broken");
 
         App::DocumentObject *container = getContainer();
+        setupCopyOnChange(container);
+
+        if(hasCopyOnChange && getLinkCopyOnChangeValue()==0) {
+            hasCopyOnChange = false;
+            std::vector<Property*> props;
+            container->getPropertyList(props);
+            for(auto prop : props) {
+                if(isCopyOnChangeProperty(container, *prop)) {
+                    try {
+                        container->removeDynamicProperty(prop->getName());
+                    } catch (Base::Exception &e) {
+                        e.ReportException();
+                    } catch (...) {
+                    }
+                }
+            }
+        }
+
         PropertyPythonObject *proxy = 0;
         if(getLinkExecuteProperty()
                 && !boost::iequals(getLinkExecuteValue(), "none")
@@ -251,6 +280,165 @@ short LinkBaseExtension::extensionMustExecute(void) {
     auto link = getLink();
     if(!link) return 0;
     return link->mustExecute();
+}
+
+bool LinkBaseExtension::isCopyOnChangeProperty(DocumentObject *obj, const App::Property &prop) {
+    if(obj!=prop.getContainer() || !prop.testStatus(App::Property::PropDynamic))
+        return false;
+    auto group = prop.getGroup();
+    return group && boost::starts_with(group,_GroupPrefix);
+}
+
+void LinkBaseExtension::setupCopyOnChange(DocumentObject *parent) {
+    copyOnChangeConns.clear();
+
+    auto linked = getTrueLinkedObject(false);
+    if(!linked || getLinkCopyOnChangeValue()==0)
+        return;
+
+    hasCopyOnChange = setupCopyOnChange(parent,linked,&copyOnChangeConns,hasCopyOnChange);
+}
+
+bool LinkBaseExtension::setupCopyOnChange(DocumentObject *parent, DocumentObject *linked,
+        std::vector<boost::signals2::scoped_connection> *copyOnChangeConns, bool checkExisting)
+{
+    if(!parent || !linked)
+        return false;
+
+    bool res = false;
+
+    std::unordered_map<Property*, Property*> newProps;
+    std::vector<Property*> props;
+    linked->getPropertyList(props);
+    for(auto prop : props) {
+        if(!prop->testStatus(Property::CopyOnChange)
+                || prop->getContainer()!=linked)
+            continue;
+
+        res = true;
+
+        const char* linkedGroupName = prop->getGroup();
+        if(!linkedGroupName || !linkedGroupName[0])
+            linkedGroupName = "Base";
+
+        std::string groupName;
+        groupName = _GroupPrefix;
+        if(boost::starts_with(linkedGroupName,_GroupPrefix))
+            groupName += linkedGroupName + sizeof(_GroupPrefix)-1;
+        else {
+            groupName += linkedGroupName;
+            groupName += ")";
+        }
+
+        auto p = parent->getPropertyByName(prop->getName());
+        if(p) {
+            if(p->getContainer()!=parent)
+                p = 0;
+            else {
+                const char* otherGroupName = p->getGroup();
+                if(!otherGroupName || !boost::starts_with(otherGroupName, _GroupPrefix)) {
+                    FC_WARN(p->getFullName() << " shadows another CopyOnChange property "
+                            << prop->getFullName());
+                    continue;
+                }
+                if(p->getTypeId() != prop->getTypeId() || groupName != otherGroupName) {
+                    parent->removeDynamicProperty(p->getName());
+                    p = 0;
+                }
+            }
+        }
+        if(!p) {
+            p = parent->addDynamicProperty(prop->getTypeId().getName(),
+                    prop->getName(), groupName.c_str(), prop->getDocumentation());
+            std::unique_ptr<Property> pcopy(prop->Copy());
+            Base::ObjectStatusLocker<Property::Status,Property> guard(Property::User3, p);
+            if(pcopy) {
+                p->Paste(*pcopy);
+            }
+            p->setStatusValue(prop->getStatus());
+        }
+        newProps[p] = prop;
+    }
+
+    if(checkExisting) {
+        props.clear();
+        parent->getPropertyList(props);
+        for(auto prop : props) {
+            if(prop->getContainer()!=parent)
+                continue;
+            auto gname = prop->getGroup();
+            if(!gname || !boost::starts_with(gname, _GroupPrefix))
+                continue;
+            if(!newProps.count(prop))
+                parent->removeDynamicProperty(prop->getName());
+        }
+    }
+
+    if(!copyOnChangeConns)
+        return res;
+
+    for(auto &v : newProps) {
+        // sync configuration properties
+        copyOnChangeConns->push_back(v.second->signalChanged.connect([parent](const Property &prop) {
+            if(!prop.testStatus(Property::CopyOnChange))
+                return;
+            auto p = parent->getPropertyByName(prop.getName());
+            if(p && p->getTypeId()==prop.getTypeId()) {
+                std::unique_ptr<Property> pcopy(prop.Copy());
+                // temperoray set Output to prevent touching
+                p->setStatus(Property::Output, true);
+                // temperoray block copy on change
+                Base::ObjectStatusLocker<Property::Status,Property> guard(Property::User3, p);
+                if(pcopy)
+                    p->Paste(*pcopy);
+                p->setStatusValue(prop.getStatus());
+            }
+        }));
+    }
+
+    return res;
+}
+
+void LinkBaseExtension::checkCopyOnChange(
+        App::DocumentObject *parent, const App::Property &prop) 
+{
+    if(parent->getDocument()->isPerformingTransaction())
+        return;
+
+    auto linked = getTrueLinkedObject(false);
+    if(!linked || getLinkCopyOnChangeValue()==0
+               || !isCopyOnChangeProperty(parent,prop))
+        return;
+
+    if(getLinkCopyOnChangeValue()==2) {
+        auto p = linked->getPropertyByName(prop.getName());
+        if(p && p->getTypeId()==prop.getTypeId()) {
+            std::unique_ptr<Property> pcopy(prop.Copy());
+            if(pcopy)
+                p->Paste(*pcopy);
+        }
+        return;
+    }
+
+    auto linkedProp = linked->getPropertyByName(prop.getName());
+    if(!linkedProp || linkedProp->getTypeId()!=prop.getTypeId() || linkedProp->isSame(prop))
+        return;
+
+    auto objs = parent->getDocument()->copyObject({linked},true);
+    if(objs.empty())
+        return;
+
+    linked = objs.back();
+    linked->Visibility.setValue(false);
+    linkedProp = linked->getPropertyByName(prop.getName());
+    if(linkedProp && linkedProp->getTypeId()==prop.getTypeId()) {
+        std::unique_ptr<Property> pcopy(prop.Copy());
+        if(pcopy)
+            linkedProp->Paste(*pcopy);
+    }
+    getLinkCopyOnChangeProperty()->setValue((long)0);
+    getLinkedObjectProperty()->setValue(linked);
+    getLinkCopyOnChangeProperty()->setValue(2);
 }
 
 App::GroupExtension *LinkBaseExtension::linkedPlainGroup() const {
@@ -1098,6 +1286,15 @@ void LinkBaseExtension::update(App::DocumentObject *parent, const Property *prop
             _ChildCache.setValue();
         parseSubName();
         syncElementList();
+
+        if(getLinkCopyOnChangeValue()==2)
+            getLinkCopyOnChangeProperty()->setValue(1);
+        else
+            setupCopyOnChange(parent);
+
+    }else if(prop == getLinkCopyOnChangeProperty()) {
+        setupCopyOnChange(parent);
+
     }else if(prop == getLinkTransformProperty()) {
         auto linkPlacement = getLinkPlacementProperty();
         auto placement = getPlacementProperty();
@@ -1107,6 +1304,9 @@ void LinkBaseExtension::update(App::DocumentObject *parent, const Property *prop
             linkPlacement->setStatus(Property::Hidden,!transform);
         }
         syncElementList();
+
+    } else {
+        checkCopyOnChange(parent, *prop);
     }
 }
 
@@ -1156,6 +1356,8 @@ void LinkBaseExtension::syncElementList() {
 
         element->LinkedObject.setStatus(Property::Hidden,link!=0);
         element->LinkedObject.setStatus(Property::Immutable,link!=0);
+        if(element->LinkCopyOnChange.getValue()==2)
+            continue;
         if(xlink) {
             if(element->LinkedObject.getValue()!=xlink->getValue() ||
                element->LinkedObject.getSubValues()!=xlink->getSubValues())

--- a/src/App/Link.h
+++ b/src/App/Link.h
@@ -96,6 +96,14 @@ public:
     (LinkTransform, bool, App::PropertyBool, false, \
       "Set to false to override linked object's placement", ##__VA_ARGS__)
 
+#define LINK_PARAM_COPY_ON_CHANGE(...) \
+    (LinkCopyOnChange, long, App::PropertyEnumeration, ((long)0), \
+      "Disabled: disable copy on change\n"\
+      "Enabled: enable copy linked object on change of any of its propert marked as CopyOnChange\n"\
+      "Owned: indicate the linked object has been copied and is own owned by the link. And the\n"\
+      "       the link will try to sync any change of the original linked object back to the copy.",\
+      ##__VA_ARGS__)
+
 #define LINK_PARAM_SCALE(...) \
     (Scale, double, App::PropertyFloat, 1.0, "Scale factor", ##__VA_ARGS__)
 
@@ -162,6 +170,7 @@ public:
     LINK_PARAM(MODE)\
     LINK_PARAM(LINK_EXECUTE)\
     LINK_PARAM(COLORED_ELEMENTS)\
+    LINK_PARAM(COPY_ON_CHANGE)\
 
     enum PropIndex {
 #define LINK_PINDEX_DEFINE(_1,_2,_param) LINK_PINDEX(_param),
@@ -293,11 +302,18 @@ public:
 
     void cacheChildLabel(int enable=-1) const;
 
+    static bool setupCopyOnChange(App::DocumentObject *obj, App::DocumentObject *linked,
+            std::vector<boost::signals2::scoped_connection> *copyOnChangeConns, bool checkExisting);
+
+    static bool isCopyOnChangeProperty(App::DocumentObject *obj, const Property &prop);
+
 protected:
     void _handleChangedPropertyName(Base::XMLReader &reader,
             const char * TypeName, const char *PropName);
     void parseSubName() const;
     void update(App::DocumentObject *parent, const Property *prop);
+    void checkCopyOnChange(App::DocumentObject *parent, const App::Property &prop);
+    void setupCopyOnChange(App::DocumentObject *parent);
     void syncElementList();
     void detachElement(App::DocumentObject *obj);
     void checkGeoElementMap(const App::DocumentObject *obj,
@@ -318,10 +334,12 @@ protected:
 
     mutable std::unordered_map<std::string,int> myLabelCache; // for label based subname lookup
     mutable bool enableLabelCache;
-
     bool hasOldSubElement;
 
     mutable bool checkingProperty = false;
+
+    std::vector<boost::signals2::scoped_connection> copyOnChangeConns;
+    bool hasCopyOnChange;
 };
 
 ///////////////////////////////////////////////////////////////////////////
@@ -456,6 +474,7 @@ public:
     LINK_PARAM_EXT_TYPE(COUNT,App::PropertyIntegerConstraint)\
     LINK_PARAM_EXT(LINK_EXECUTE)\
     LINK_PARAM_EXT_ATYPE(COLORED_ELEMENTS,App::Prop_Hidden)\
+    LINK_PARAM_EXT(COPY_ON_CHANGE)\
 
     LINK_PROPS_DEFINE(LINK_PARAMS_LINK)
 
@@ -495,6 +514,7 @@ public:
     LINK_PARAM_EXT(TRANSFORM) \
     LINK_PARAM_EXT(LINK_PLACEMENT)\
     LINK_PARAM_EXT(PLACEMENT)\
+    LINK_PARAM_EXT(COPY_ON_CHANGE)\
 
     // defines the actual properties
     LINK_PROPS_DEFINE(LINK_PARAMS_ELEMENT)

--- a/src/App/Property.cpp
+++ b/src/App/Property.cpp
@@ -256,7 +256,8 @@ void Property::setStatusValue(unsigned long status) {
         |(1<<PropReadOnly)
         |(1<<PropTransient)
         |(1<<PropOutput)
-        |(1<<PropHidden);
+        |(1<<PropHidden)
+        |(1<<Busy);
 
     status &= ~mask;
     status |= StatusBits.to_ulong() & mask;

--- a/src/App/Property.cpp
+++ b/src/App/Property.cpp
@@ -257,6 +257,7 @@ void Property::setStatusValue(unsigned long status) {
         |(1<<PropTransient)
         |(1<<PropOutput)
         |(1<<PropHidden)
+        |(1<<PropNoPersist)
         |(1<<Busy);
 
     status &= ~mask;

--- a/src/App/Property.cpp
+++ b/src/App/Property.cpp
@@ -276,6 +276,17 @@ void Property::setStatus(Status pos, bool on) {
     bits.set(pos,on);
     setStatusValue(bits.to_ulong());
 }
+
+bool Property::isSame(const Property &other) const {
+    if(other.getTypeId() != getTypeId() || getMemSize() != other.getMemSize())
+        return false;
+
+    Base::StringWriter writer,writer2;
+    Save(writer);
+    other.Save(writer2);
+    return writer.getString() == writer2.getString();
+}
+
 //**************************************************************************
 //**************************************************************************
 // PropertyListsBase

--- a/src/App/Property.h
+++ b/src/App/Property.h
@@ -77,6 +77,7 @@ public:
         EvalOnRestore = 14, // In case of expression binding, evaluate the
                             // expression on restore and touch the object on value change.
         Busy = 15, // internal use to avoid recursive signaling
+        CopyOnChange = 16, // for Link to copy the linked object on change of the property with this flag
 
         // The following bits are corresponding to PropertyType set when the
         // property added. These types are meant to be static, and cannot be

--- a/src/App/Property.h
+++ b/src/App/Property.h
@@ -236,6 +236,9 @@ public:
     /// Called before a child property changing value
     virtual void aboutToSetChildValue(Property &) {}
 
+    /// Compare if this property has the same content as the given one
+    virtual bool isSame(const Property &other) const;
+
     friend class PropertyContainer;
     friend struct PropertyData;
     friend class DynamicProperty;
@@ -491,6 +494,11 @@ public:
     const ListT &getValue(void) const{return getValues();}
 
     const_reference operator[] (int idx) const {return _lValueList[idx];} 
+
+    virtual bool isSame(const Property &other) const override {
+        return this->getTypeId() == other.getTypeId()
+            && this->getValue() == static_cast<decltype(this)>(&other)->getValue();
+    }
 
     virtual void setPyObject(PyObject *value) override {
         try {

--- a/src/App/PropertyContainer.cpp
+++ b/src/App/PropertyContainer.cpp
@@ -101,6 +101,12 @@ void PropertyContainer::getPropertyList(std::vector<Property*> &List) const
     getPropertyData().getPropertyList(this,List);
 }
 
+void PropertyContainer::getPropertyNamedList(std::vector<std::pair<const char*, Property*> > &List) const
+{
+    dynamicProps.getPropertyNamedList(List);
+    getPropertyData().getPropertyNamedList(this,List);
+}
+
 void PropertyContainer::setPropertyStatus(unsigned char bit,bool value)
 {
     std::vector<Property*> List;
@@ -584,6 +590,18 @@ void PropertyData::getPropertyList(OffsetBase offsetBase,std::vector<Property*> 
     List.reserve(base+propertyData.size());
     for (auto &spec : propertyData.get<0>())
         List.push_back((Property *) (spec.Offset + offsetBase.getOffset()));
+}
+
+void PropertyData::getPropertyNamedList(OffsetBase offsetBase,
+        std::vector<std::pair<const char*,Property*> > &List) const
+{
+    merge();
+    size_t base = List.size();
+    List.reserve(base+propertyData.size());
+    for (auto &spec : propertyData.get<0>()) {
+        auto prop = (Property *) (spec.Offset + offsetBase.getOffset());
+        List.emplace_back(prop->getName(),prop);
+    }
 }
 
 

--- a/src/App/PropertyContainer.cpp
+++ b/src/App/PropertyContainer.cpp
@@ -358,7 +358,7 @@ void PropertyContainer::Restore(Base::XMLReader &reader)
                 if (!prop->testStatus(Property::Transient) 
                         && !status.test(Property::Transient)
                         && !status.test(Property::PropTransient)
-                        && !(getPropertyType(prop) & Prop_Transient))
+                        && !prop->testStatus(Property::PropTransient))
                 {
                     FC_TRACE("restore property '" << prop->getName() << "'");
                     prop->Restore(reader);

--- a/src/App/PropertyContainer.h
+++ b/src/App/PropertyContainer.h
@@ -130,6 +130,7 @@ struct AppExport PropertyData
   Property *getPropertyByName(OffsetBase offsetBase,const char* name) const;
   void getPropertyMap(OffsetBase offsetBase,std::map<std::string,Property*> &Map) const;
   void getPropertyList(OffsetBase offsetBase,std::vector<Property*> &List) const;
+  void getPropertyNamedList(OffsetBase offsetBase, std::vector<std::pair<const char*,Property*> > &List) const;
 
   void merge(PropertyData *other=0) const;
   void split(PropertyData *other);
@@ -168,6 +169,8 @@ public:
   virtual void getPropertyMap(std::map<std::string,Property*> &Map) const;
   /// get all properties of the class (including properties of the parent)
   virtual void getPropertyList(std::vector<Property*> &List) const;
+  /// get all properties with their names
+  virtual void getPropertyNamedList(std::vector<std::pair<const char*,Property*> > &List) const;
   /// set the Status bit of all properties at once
   void setPropertyStatus(unsigned char bit,bool value);
 

--- a/src/App/PropertyContainer.h
+++ b/src/App/PropertyContainer.h
@@ -169,7 +169,7 @@ public:
   virtual void getPropertyMap(std::map<std::string,Property*> &Map) const;
   /// get all properties of the class (including properties of the parent)
   virtual void getPropertyList(std::vector<Property*> &List) const;
-  /// get all properties with their names
+  /// get all properties with their names, may contain duplicates and aliases
   virtual void getPropertyNamedList(std::vector<std::pair<const char*,Property*> > &List) const;
   /// set the Status bit of all properties at once
   void setPropertyStatus(unsigned char bit,bool value);

--- a/src/App/PropertyContainerPyImp.cpp
+++ b/src/App/PropertyContainerPyImp.cpp
@@ -55,7 +55,7 @@ PyObject*  PropertyContainerPy::getPropertyByName(PyObject *args)
     char *pstr;
     int checkOwner=0;
     if (!PyArg_ParseTuple(args, "s|i", &pstr, &checkOwner))     // convert args: Python->C
-        return NULL;                             // NULL triggers exception
+        return nullptr;                             // nullptr triggers exception
     App::Property* prop = getPropertyContainerPtr()->getPropertyByName(pstr);
     if (prop) {
         if(!checkOwner || (checkOwner==1 && prop->getContainer()==getPropertyContainerPtr()))
@@ -65,14 +65,14 @@ PyObject*  PropertyContainerPy::getPropertyByName(PyObject *args)
         return Py::new_reference_to(res);
     }
     PyErr_Format(PyExc_AttributeError, "Property container has no property '%s'", pstr);
-    return NULL;
+    return nullptr;
 }
 
 PyObject*  PropertyContainerPy::getPropertyTouchList(PyObject *args)
 {
     char *pstr;
     if (!PyArg_ParseTuple(args, "s", &pstr))     // convert args: Python->C
-        return NULL;                             // NULL triggers exception
+        return nullptr;                             // nullptr triggers exception
     App::Property* prop = getPropertyContainerPtr()->getPropertyByName(pstr);
     if (prop && prop->isDerivedFrom(PropertyLists::getClassTypeId())) {
         const auto &touched = static_cast<PropertyLists*>(prop)->getTouchList();
@@ -86,7 +86,7 @@ PyObject*  PropertyContainerPy::getPropertyTouchList(PyObject *args)
         PyErr_Format(PyExc_AttributeError, "Property container has no property '%s'", pstr);
     else
         PyErr_Format(PyExc_AttributeError, "Property '%s' is not of list type", pstr);
-    return NULL;
+    return nullptr;
 }
 
 PyObject*  PropertyContainerPy::getTypeOfProperty(PyObject *args)
@@ -94,12 +94,12 @@ PyObject*  PropertyContainerPy::getTypeOfProperty(PyObject *args)
     Py::List ret;
     char *pstr;
     if (!PyArg_ParseTuple(args, "s", &pstr))     // convert args: Python->C
-        return NULL;                             // NULL triggers exception
+        return nullptr;                             // nullptr triggers exception
 
     Property* prop =  getPropertyContainerPtr()->getPropertyByName(pstr);
     if (!prop) {
         PyErr_Format(PyExc_AttributeError, "Property container has no property '%s'", pstr);
-        return 0;
+        return nullptr;
     }
 
     short Type =  prop->getType();
@@ -121,12 +121,12 @@ PyObject*  PropertyContainerPy::getTypeIdOfProperty(PyObject *args)
 {
     char *pstr;
     if (!PyArg_ParseTuple(args, "s", &pstr))     // convert args: Python->C
-        return NULL;                             // NULL triggers exception
+        return nullptr;                             // nullptr triggers exception
 
     Property* prop =  getPropertyContainerPtr()->getPropertyByName(pstr);
     if (!prop) {
         PyErr_Format(PyExc_AttributeError, "Property container has no property '%s'", pstr);
-        return 0;
+        return nullptr;
     }
 
     Py::String str(prop->getTypeId().getName());
@@ -141,7 +141,7 @@ PyObject*  PropertyContainerPy::setEditorMode(PyObject *args)
         App::Property* prop = getPropertyContainerPtr()->getPropertyByName(name);
         if (!prop) {
             PyErr_Format(PyExc_AttributeError, "Property container has no property '%s'", name);
-            return 0;
+            return nullptr;
         }
 
         std::bitset<32> status(prop->getStatus());
@@ -160,7 +160,7 @@ PyObject*  PropertyContainerPy::setEditorMode(PyObject *args)
             App::Property* prop = getPropertyContainerPtr()->getPropertyByName(name);
             if (!prop) {
                 PyErr_Format(PyExc_AttributeError, "Property container has no property '%s'", name);
-                return 0;
+                return nullptr;
             }
 
             // reset all bits first
@@ -181,7 +181,7 @@ PyObject*  PropertyContainerPy::setEditorMode(PyObject *args)
     }
 
     PyErr_SetString(PyExc_TypeError, "First argument must be str, second can be int, list or tuple");
-    return 0;
+    return nullptr;
 }
 
 static const std::map<std::string, int> &getStatusMap() {
@@ -208,11 +208,11 @@ PyObject*  PropertyContainerPy::setPropertyStatus(PyObject *args)
     char* name;
     PyObject *pyValue;
     if (!PyArg_ParseTuple(args, "sO", &name, &pyValue))
-        return 0;
+        return nullptr;
     App::Property* prop = getPropertyContainerPtr()->getPropertyByName(name);
     if (!prop) {
         PyErr_Format(PyExc_AttributeError, "Property container has no property '%s'", name);
-        return 0;
+        return nullptr;
     }
     auto linkProp = Base::freecad_dynamic_cast<App::PropertyLinkBase>(prop);
 
@@ -244,7 +244,7 @@ PyObject*  PropertyContainerPy::setPropertyStatus(PyObject *args)
                     continue;
                 }
                 PyErr_Format(PyExc_ValueError, "Unknown property status '%s'", v.c_str());
-                return 0;
+                return nullptr;
             }
             status.set(it->second,value);
         }else if(item.isNumeric()) {
@@ -258,7 +258,7 @@ PyObject*  PropertyContainerPy::setPropertyStatus(PyObject *args)
             status.set(v,value);
         } else {
             PyErr_SetString(PyExc_TypeError, "Expects status type to be Int or String");
-            return 0;
+            return nullptr;
         }
     }
 
@@ -270,7 +270,7 @@ PyObject*  PropertyContainerPy::getPropertyStatus(PyObject *args)
 {
     char* name = "";
     if (!PyArg_ParseTuple(args, "|s", &name))     // convert args: Python->C
-        return NULL;                             // NULL triggers exception
+        return nullptr;                             // nullptr triggers exception
 
     Py::List ret;
     const auto &statusMap = getStatusMap();
@@ -308,7 +308,7 @@ PyObject*  PropertyContainerPy::getEditorMode(PyObject *args)
 {
     char* name;
     if (!PyArg_ParseTuple(args, "s", &name))     // convert args: Python->C
-        return NULL;                             // NULL triggers exception
+        return nullptr;                             // nullptr triggers exception
 
     App::Property* prop = getPropertyContainerPtr()->getPropertyByName(name);
     Py::List ret;
@@ -326,12 +326,12 @@ PyObject*  PropertyContainerPy::getGroupOfProperty(PyObject *args)
 {
     char *pstr;
     if (!PyArg_ParseTuple(args, "s", &pstr))     // convert args: Python->C
-        return NULL;                             // NULL triggers exception
+        return nullptr;                             // nullptr triggers exception
 
     Property* prop = getPropertyContainerPtr()->getPropertyByName(pstr);
     if (!prop) {
         PyErr_Format(PyExc_AttributeError, "Property container has no property '%s'", pstr);
-        return 0;
+        return nullptr;
     }
 
     const char* Group = getPropertyContainerPtr()->getPropertyGroup(prop);
@@ -346,13 +346,13 @@ PyObject*  PropertyContainerPy::setGroupOfProperty(PyObject *args)
     char *pstr;
     char *group;
     if (!PyArg_ParseTuple(args, "ss", &pstr, &group))     // convert args: Python->C
-        return NULL;                             // NULL triggers exception
+        return nullptr;                             // nullptr triggers exception
 
     PY_TRY {
         Property* prop = getPropertyContainerPtr()->getDynamicPropertyByName(pstr);
         if (!prop) {
             PyErr_Format(PyExc_AttributeError, "Property container has no dynamic property '%s'", pstr);
-            return 0;
+            return nullptr;
         }
         prop->getContainer()->changeDynamicProperty(prop,group,0);
         Py_Return;
@@ -364,12 +364,12 @@ PyObject*  PropertyContainerPy::getDocumentationOfProperty(PyObject *args)
 {
     char *pstr;
     if (!PyArg_ParseTuple(args, "s", &pstr))     // convert args: Python->C
-        return NULL;                             // NULL triggers exception
+        return nullptr;                             // nullptr triggers exception
 
     Property* prop = getPropertyContainerPtr()->getPropertyByName(pstr);
     if (!prop) {
         PyErr_Format(PyExc_AttributeError, "Property container has no property '%s'", pstr);
-        return 0;
+        return nullptr;
     }
 
     const char* Group = getPropertyContainerPtr()->getPropertyDocumentation(prop);
@@ -384,13 +384,13 @@ PyObject*  PropertyContainerPy::setDocumentationOfProperty(PyObject *args)
     char *pstr;
     char *doc;
     if (!PyArg_ParseTuple(args, "ss", &pstr, &doc))     // convert args: Python->C
-        return NULL;                             // NULL triggers exception
+        return nullptr;                             // nullptr triggers exception
 
     PY_TRY {
         Property* prop = getPropertyContainerPtr()->getDynamicPropertyByName(pstr);
         if (!prop) {
             PyErr_Format(PyExc_AttributeError, "Property container has no dynamic property '%s'", pstr);
-            return 0;
+            return nullptr;
         }
         prop->getContainer()->changeDynamicProperty(prop,0,doc);
         Py_Return;
@@ -401,12 +401,12 @@ PyObject*  PropertyContainerPy::getEnumerationsOfProperty(PyObject *args)
 {
     char *pstr;
     if (!PyArg_ParseTuple(args, "s", &pstr))     // convert args: Python->C
-        return NULL;                             // NULL triggers exception
+        return nullptr;                             // nullptr triggers exception
 
     Property* prop = getPropertyContainerPtr()->getPropertyByName(pstr);
     if (!prop) {
         PyErr_Format(PyExc_AttributeError, "Property container has no property '%s'", pstr);
-        return 0;
+        return nullptr;
     }
 
     PropertyEnumeration *enumProp = dynamic_cast<PropertyEnumeration*>(prop);
@@ -442,16 +442,16 @@ PyObject* PropertyContainerPy::dumpPropertyContent(PyObject *args, PyObject *kwd
 {
     int compression = 3;
     char* property;
-    static char* kwds_def[] = {"Property", "Compression",NULL};
+    static char* kwds_def[] = {"Property", "Compression",nullptr};
     PyErr_Clear();
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "s|i", kwds_def, &property, &compression)) {
-        return NULL;
+        return nullptr;
     }
 
     Property* prop = getPropertyContainerPtr()->getPropertyByName(property);
     if (!prop) {
         PyErr_Format(PyExc_AttributeError, "Property container has no property '%s'", property);
-        return 0;
+        return nullptr;
     }
 
     //setup the stream. the in flag is needed to make "read" work
@@ -461,22 +461,22 @@ PyObject* PropertyContainerPy::dumpPropertyContent(PyObject *args, PyObject *kwd
     }
     catch (...) {
        PyErr_SetString(PyExc_IOError, "Unable parse content into binary representation");
-       return NULL;
+       return nullptr;
     }
 
     //build the byte array with correct size
     if (!stream.seekp(0, stream.end)) {
         PyErr_SetString(PyExc_IOError, "Unable to find end of stream");
-        return NULL;
+        return nullptr;
     }
 
     std::stringstream::pos_type offset = stream.tellp();
     if (!stream.seekg(0, stream.beg)) {
         PyErr_SetString(PyExc_IOError, "Unable to find begin of stream");
-        return NULL;
+        return nullptr;
     }
 
-    PyObject* ba = PyByteArray_FromStringAndSize(NULL, offset);
+    PyObject* ba = PyByteArray_FromStringAndSize(nullptr, offset);
 
     //use the buffer protocol to access the underlying array and write into it
     Py_buffer buf = Py_buffer();
@@ -484,14 +484,14 @@ PyObject* PropertyContainerPy::dumpPropertyContent(PyObject *args, PyObject *kwd
     try {
         if(!stream.read((char*)buf.buf, offset)) {
             PyErr_SetString(PyExc_IOError, "Error copying data into byte array");
-            return NULL;
+            return nullptr;
         }
         PyBuffer_Release(&buf);
     }
     catch (...) {
         PyBuffer_Release(&buf);
         PyErr_SetString(PyExc_IOError, "Error copying data into byte array");
-        return NULL;
+        return nullptr;
     }
 
     return ba;
@@ -502,27 +502,27 @@ PyObject* PropertyContainerPy::restorePropertyContent(PyObject *args)
     PyObject* buffer;
     char* property;
     if( !PyArg_ParseTuple(args, "sO", &property, &buffer) )
-        return NULL;
+        return nullptr;
 
     Property* prop = getPropertyContainerPtr()->getPropertyByName(property);
     if (!prop) {
         PyErr_Format(PyExc_AttributeError, "Property container has no property '%s'", property);
-        return 0;
+        return nullptr;
     }
 
     //check if it really is a buffer
     if( !PyObject_CheckBuffer(buffer) ) {
         PyErr_SetString(PyExc_TypeError, "Must be a buffer object");
-        return NULL;
+        return nullptr;
     }
 
     Py_buffer buf;
     if(PyObject_GetBuffer(buffer, &buf, PyBUF_SIMPLE) < 0)
-        return NULL;
+        return nullptr;
 
     if(!PyBuffer_IsContiguous(&buf, 'C')) {
         PyErr_SetString(PyExc_TypeError, "Buffer must be contiguous");
-        return NULL;
+        return nullptr;
     }
 
     //check if it really is a buffer
@@ -533,7 +533,7 @@ PyObject* PropertyContainerPy::restorePropertyContent(PyObject *args)
     }
     catch(...) {
         PyErr_SetString(PyExc_IOError, "Unable to restore content");
-        return NULL;
+        return nullptr;
     }
 
     Py_Return;
@@ -597,7 +597,7 @@ PyObject *PropertyContainerPy::getCustomAttributes(const char* attr) const
         }
     }
 
-    return 0;
+    return nullptr;
 }
 
 int PropertyContainerPy::setCustomAttributes(const char* attr, PyObject *obj)

--- a/src/App/PropertyContainerPyImp.cpp
+++ b/src/App/PropertyContainerPyImp.cpp
@@ -197,6 +197,8 @@ static const std::map<std::string, int> &getStatusMap() {
         statusMap["LockDynamic"] = Property::LockDynamic;
         statusMap["NoModify"] = Property::NoModify;
         statusMap["PartialTrigger"] = Property::PartialTrigger;
+        statusMap["NoRecompute"] = Property::NoRecompute;
+        statusMap["CopyOnChange"] = Property::CopyOnChange;
     }
     return statusMap;
 }

--- a/src/App/PropertyExpressionEngine.h
+++ b/src/App/PropertyExpressionEngine.h
@@ -176,7 +176,8 @@ private:
 
     typedef boost::adjacency_list< boost::listS, boost::vecS, boost::directedS > DiGraph;
     typedef std::pair<int, int> Edge;
-    typedef boost::unordered_map<const App::ObjectIdentifier, ExpressionInfo> ExpressionMap;
+    // Note: use std::map instead of unordered_map to keep the binding order stable
+    typedef std::map<const App::ObjectIdentifier, ExpressionInfo> ExpressionMap;
 
     std::vector<App::ObjectIdentifier> computeEvaluationOrder(ExecuteOption option);
 

--- a/src/App/PropertyFile.h
+++ b/src/App/PropertyFile.h
@@ -103,6 +103,13 @@ public:
     virtual void Paste(const Property &from);
     virtual unsigned int getMemSize (void) const;
 
+    virtual bool isSame(const Property &other) const {
+        return getTypeId() == other.getTypeId()
+            && _BaseFileName == static_cast<decltype(this)>(&other)->_BaseFileName
+            && _OriginalName == static_cast<decltype(this)>(&other)->_OriginalName
+            && _cValue == static_cast<decltype(this)>(&other)->_cValue;
+    }
+
     /** get a temp file name in the transient path of the document.
       * Using this file for new Version of the file and set 
       * this file with setValue() is the fastest way to change

--- a/src/App/PropertyGeo.h
+++ b/src/App/PropertyGeo.h
@@ -108,6 +108,11 @@ public:
         return Base::Unit();
     }
 
+    virtual bool isSame(const Property &other) const override {
+        return getTypeId() == other.getTypeId()
+            && getValue() == static_cast<decltype(this)>(&other)->getValue();
+    }
+
 private:
     Base::Vector3d _cVec;
 };
@@ -278,6 +283,11 @@ public:
         return sizeof(Base::Matrix4D);
     }
 
+    virtual bool isSame(const Property &other) const {
+        return getTypeId() == other.getTypeId()
+            && getValue() == static_cast<decltype(this)>(&other)->getValue();
+    }
+
 private:
     Base::Matrix4D _cMat;
 };
@@ -343,6 +353,11 @@ public:
 
     virtual unsigned int getMemSize (void) const override {
         return sizeof(Base::Placement);
+    }
+
+    virtual bool isSame(const Property &other) const override {
+        return getTypeId() == other.getTypeId()
+            && getValue() == static_cast<decltype(this)>(&other)->getValue();
     }
 
     static const Placement Null;

--- a/src/App/PropertyLinks.cpp
+++ b/src/App/PropertyLinks.cpp
@@ -84,6 +84,27 @@ void PropertyLinkBase::hasSetValue() {
     Property::hasSetValue();
 }
 
+bool PropertyLinkBase::isSame(const Property &other) const
+{
+    if(other.isDerivedFrom(PropertyLinkBase::getClassTypeId())
+        || getScope() != static_cast<const PropertyLinkBase*>(&other)->getScope())
+        return false;
+
+    static std::vector<App::DocumentObject*> ret;
+    static std::vector<std::string> subs;
+    static std::vector<App::DocumentObject*> ret2;
+    static std::vector<std::string> subs2;
+
+    ret.clear();
+    subs.clear();
+    ret2.clear();
+    subs2.clear();
+    getLinks(ret,true,&subs,false);
+    static_cast<const PropertyLinkBase *>(&other)->getLinks(ret2,true,&subs2,true);
+
+    return ret==ret2 && subs==subs2;
+}
+
 void PropertyLinkBase::unregisterElementReference() {
 }
 

--- a/src/App/PropertyLinks.h
+++ b/src/App/PropertyLinks.h
@@ -93,8 +93,8 @@ public:
      * Retrieve what kind of links are allowed. Only in the Local GeoFeatureGroup, in this and
      * all Childs or to all objects within the Glocal scope.
      */
-    LinkScope getScope() {return _pcScope;};
-
+    LinkScope getScope() const {return _pcScope;};
+    
 protected:
     LinkScope _pcScope = LinkScope::Local;
 };
@@ -287,6 +287,8 @@ public:
         return ret;
     }
     //@}
+
+    virtual bool isSame(const Property &other) const override;
 
     /** Enable/disable temporary holding external object without throwing exception
      *

--- a/src/App/PropertyStandard.cpp
+++ b/src/App/PropertyStandard.cpp
@@ -207,7 +207,7 @@ void PropertyPath::setValue(const char * Path)
     hasSetValue();
 }
 
-boost::filesystem::path PropertyPath::getValue() const
+const boost::filesystem::path &PropertyPath::getValue(void) const
 {
     return _cValue;
 }

--- a/src/App/PropertyStandard.h
+++ b/src/App/PropertyStandard.h
@@ -81,6 +81,11 @@ public:
     virtual void setPathValue(const App::ObjectIdentifier & path, const boost::any & value);
     virtual const boost::any getPathValue(const App::ObjectIdentifier & /*path*/) const { return _lValue; }
 
+    virtual bool isSame(const Property &other) const {
+        return getTypeId() == other.getTypeId()
+            && getValue() == static_cast<decltype(this)>(&other)->getValue();
+    }
+
 protected:
     long _lValue;
 };
@@ -107,7 +112,7 @@ public:
 
     /** This method returns a string representation of the property
      */
-    boost::filesystem::path getValue(void) const;
+    const boost::filesystem::path &getValue(void) const;
 
     virtual const char* getEditorName(void) const { return "Gui::PropertyEditor::PropertyPathItem"; }
 
@@ -121,6 +126,11 @@ public:
     virtual void Paste(const Property &from);
 
     virtual unsigned int getMemSize (void) const;
+
+    virtual bool isSame(const Property &other) const {
+        return getTypeId() == other.getTypeId()
+            && getValue() == static_cast<decltype(this)>(&other)->getValue();
+    }
 
 protected:
     boost::filesystem::path _cValue;
@@ -216,6 +226,11 @@ public:
     virtual bool setPyPathValue(const App::ObjectIdentifier & path, const Py::Object &value);
     virtual const boost::any getPathValue(const App::ObjectIdentifier & /*path*/) const;
     virtual bool getPyPathValue(const ObjectIdentifier &path, Py::Object &r) const;
+
+    virtual bool isSame(const Property &other) const {
+        return getTypeId() == other.getTypeId()
+            && getEnum() == static_cast<decltype(this)>(&other)->getEnum();
+    }
 
 private:
     Enumeration _enum;
@@ -391,6 +406,10 @@ public:
     virtual void Paste(const Property &from);
     virtual unsigned int getMemSize (void) const;
 
+    virtual bool isSame(const Property &other) const {
+        return getTypeId() == other.getTypeId()
+            && getValues() == static_cast<decltype(this)>(&other)->getValues();
+    }
 private:
     std::set<long> _lValueSet;
 };
@@ -444,7 +463,11 @@ public:
     virtual void Paste(const Property &from);
 
     virtual unsigned int getMemSize (void) const;
-
+    
+    virtual bool isSame(const Property &other) const {
+        return getTypeId() == other.getTypeId()
+            && getValues() == static_cast<decltype(this)>(&other)->getValues();
+    }
 
 private:
     std::map<std::string,std::string> _lValueList;
@@ -494,6 +517,11 @@ public:
 
     void setPathValue(const App::ObjectIdentifier &path, const boost::any &value);
     const boost::any getPathValue(const App::ObjectIdentifier &path) const;
+
+    virtual bool isSame(const Property &other) const {
+        return getTypeId() == other.getTypeId()
+            && getValue() == static_cast<decltype(this)>(&other)->getValue();
+    }
 
 protected:
     double _dValue;
@@ -679,6 +707,11 @@ public:
     void setPathValue(const App::ObjectIdentifier &path, const boost::any &value);
     const boost::any getPathValue(const App::ObjectIdentifier &path) const;
 
+    virtual bool isSame(const Property &other) const {
+        return getTypeId() == other.getTypeId()
+            && getStrValue() == static_cast<decltype(this)>(&other)->getStrValue();
+    }
+
 protected:
     std::string _cValue;
 };
@@ -722,6 +755,11 @@ public:
     virtual void Paste(const Property &from);
     virtual unsigned int getMemSize (void) const;
 
+    virtual bool isSame(const Property &other) const {
+        return getTypeId() == other.getTypeId()
+            && _uuid.getValue() == static_cast<decltype(this)>(&other)->_uuid.getValue();
+    }
+
 private:
     Base::Uuid _uuid;
 };
@@ -738,6 +776,11 @@ public:
     virtual ~PropertyFont();
     virtual const char* getEditorName(void) const
     { return "Gui::PropertyEditor::PropertyFontItem"; }
+
+    virtual bool isSame(const Property &other) const {
+        return getTypeId() == other.getTypeId()
+            && getValue() == static_cast<decltype(this)>(&other)->getValue();
+    }
 };
 
 class AppExport PropertyStringList: public PropertyListsT<std::string>
@@ -819,6 +862,11 @@ public:
     void setPathValue(const App::ObjectIdentifier &path, const boost::any &value);
     const boost::any getPathValue(const App::ObjectIdentifier &path) const;
 
+    virtual bool isSame(const Property &other) const {
+        return getTypeId() == other.getTypeId()
+            && getValue() == static_cast<decltype(this)>(&other)->getValue();
+    }
+
 private:
     bool _lValue;
 };
@@ -892,7 +940,11 @@ public:
     virtual void Paste(const Property &from);
 
     virtual unsigned int getMemSize (void) const{return sizeof(Color);}
-
+    
+    virtual bool isSame(const Property &other) const {
+        return getTypeId() == other.getTypeId()
+            && getValue() == static_cast<decltype(this)>(&other)->getValue();
+    }
 
 private:
     Color _cCol;
@@ -979,6 +1031,11 @@ public:
     virtual void Paste(const Property &from);
 
     virtual unsigned int getMemSize (void) const{return sizeof(_cMat);}
+    
+    virtual bool isSame(const Property &other) const {
+        return getTypeId() == other.getTypeId()
+            && getValue() == static_cast<decltype(this)>(&other)->getValue();
+    }
 
 private:
     Material _cMat;

--- a/src/App/PropertyUnits.h
+++ b/src/App/PropertyUnits.h
@@ -71,6 +71,12 @@ public:
     virtual void setPathValue(const App::ObjectIdentifier &path, const boost::any &value);
     virtual const boost::any getPathValue(const App::ObjectIdentifier &path) const;
 
+    virtual bool isSame(const Property &other) const {
+        return getTypeId() == other.getTypeId()
+            && getValue() == static_cast<decltype(this)>(&other)->getValue()
+            && _Unit == static_cast<decltype(this)>(&other)->_Unit;
+    }
+
 protected:
     Base::Quantity createQuantityFromPy(PyObject *value);
     Base::Unit _Unit;

--- a/src/App/Range.cpp
+++ b/src/App/Range.cpp
@@ -149,7 +149,7 @@ int App::validRow(const std::string &rowstr)
     char * end;
     int i = strtol(rowstr.c_str(), &end, 10);
 
-    if (i <0 || i >= CellAddress::MAX_ROWS || *end)
+    if (i <=0 || i > CellAddress::MAX_ROWS || *end)
         return -1;
 
     return i - 1;
@@ -234,24 +234,28 @@ App::CellAddress App::stringToAddress(const char * strAddress, bool silent)
   * @returns Address given as a string.
   */
 
-std::string App::CellAddress::toString(bool noAbsolute) const
+std::string App::CellAddress::toString(bool noAbsolute, bool r, bool c) const
 {
     std::stringstream s;
 
-    if(_absCol && !noAbsolute)
-        s << '$';
-    if (col() < 26)
-        s << (char)('A' + col());
-    else {
-        int colnum = col() - 26;
+    if(c) {
+        if(_absCol && !noAbsolute)
+            s << '$';
+        if (col() < 26)
+            s << (char)('A' + col());
+        else {
+            int colnum = col() - 26;
 
-        s << (char)('A' + (colnum / 26));
-        s << (char)('A' + (colnum % 26));
+            s << (char)('A' + (colnum / 26));
+            s << (char)('A' + (colnum % 26));
+        }
     }
 
-    if(_absRow && !noAbsolute)
-        s << '$';
-    s << (row() + 1);
+    if(r) {
+        if(_absRow && !noAbsolute)
+            s << '$';
+        s << (row() + 1);
+    }
 
     return s.str();
 }

--- a/src/App/Range.h
+++ b/src/App/Range.h
@@ -64,6 +64,8 @@ struct AppExport CellAddress {
 
     inline bool operator<(const CellAddress & other) const { return asInt() < other.asInt(); }
 
+    inline bool operator>(const CellAddress & other) const { return asInt() > other.asInt(); }
+
     inline bool operator==(const CellAddress & other) const { return asInt() == other.asInt(); }
 
     inline bool operator!=(const CellAddress & other) const { return asInt() != other.asInt(); }
@@ -147,6 +149,14 @@ public:
     }
 
     CellAddress operator*() const { return CellAddress(row_curr, col_curr); }
+
+    inline bool operator<(const Range & other) const { 
+        if(from() < other.from())
+            return true;
+        if(from() > other.from())
+            return false;
+        return to() < other.to();
+    }
 
     /** Number of elements in range */
     inline int size() const { return (row_end - row_begin + 1) * (col_end - col_begin + 1); }

--- a/src/App/Range.h
+++ b/src/App/Range.h
@@ -58,9 +58,9 @@ struct AppExport CellAddress {
 
     inline int col() const { return _col; }
 
-    void setRow(int r) { _row = r; }
+    void setRow(int r, bool clip=false) { _row = (clip && r>=MAX_ROWS) ? MAX_ROWS-1 : r; }
 
-    void setCol(int c) { _col = c; }
+    void setCol(int c, bool clip=false) { _col = (clip && c>=MAX_COLUMNS) ? MAX_COLUMNS-1 : c; }
 
     inline bool operator<(const CellAddress & other) const { return asInt() < other.asInt(); }
 
@@ -74,7 +74,7 @@ struct AppExport CellAddress {
 
     inline bool isAbsoluteCol() const { return _absCol; }
 
-    std::string toString(bool noAbsolute=false) const;
+    std::string toString(bool noAbsolute=false, bool row=true, bool col=true) const;
 
     // Static members
 

--- a/src/Base/Uuid.h
+++ b/src/Base/Uuid.h
@@ -50,6 +50,9 @@ public:
     const std::string& getValue(void) const;
     static std::string createUuid(void);
 
+    bool operator==(const Uuid &other) const {return _uuid == other._uuid;}
+    bool operator<(const Uuid &other) const {return _uuid < other._uuid;}
+
 private:
     std::string _uuid;
 };

--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -1989,6 +1989,9 @@ bool Document::canClose (bool checkModify, bool checkLink)
     if (checkLink && App::PropertyXLink::getDocumentInList(getDocument()).size())
         return true;
 
+    if (getDocument()->testStatus(App::Document::TempDoc))
+        return true;
+
     bool ok = true;
     if (checkModify && isModified() && !getDocument()->testStatus(App::Document::PartialDoc)) {
         const char *docName = getDocument()->Label.getValue();

--- a/src/Gui/ExpressionCompleter.cpp
+++ b/src/Gui/ExpressionCompleter.cpp
@@ -159,10 +159,10 @@ public:
         int docSize = (int)docs.size()*2;
         int objSize = 0;
         int propSize = 0;
-        std::vector<App::Property*> props;
+        std::vector<std::pair<const char*, App::Property*> > props;
         App::Document *doc = 0;
         App::DocumentObject *obj = 0;
-        App::Property *prop = 0;
+        const char *propName = nullptr;
         if(idx>=0 && idx<docSize)
             doc = docs[idx/2];
         else {
@@ -184,13 +184,13 @@ public:
                     idx -= objSize;
                     if(info.d.doc<0)
                         row = idx;
-                    cobj->getPropertyList(props);
+                    cobj->getPropertyNamedList(props);
                     propSize = (int)props.size();
                     if(idx >= propSize)
                         return;
                     if(idx>=0) {
                         obj = cobj;
-                        prop = props[idx];
+                        propName = props[idx].first;
                     }
                 }
             }
@@ -200,8 +200,8 @@ public:
                 *count = docSize + objSize + propSize;
             if(idx>=0 && v) {
                 QString res;
-                if(prop)
-                    res = QString::fromLatin1(prop->getName());
+                if(propName)
+                    res = QString::fromLatin1(propName);
                 else if(obj) {
                     if(idx & 1)
                         res = QString::fromUtf8(quote(obj->Label.getStrValue()).c_str());
@@ -248,18 +248,18 @@ public:
 
         if(noProperty)
             return;
-        if(!prop) {
+        if(!propName) {
             idx = row;
-            obj->getPropertyList(props);
+            obj->getPropertyNamedList(props);
             propSize = (int)props.size();
             if(idx<0 || idx>=propSize)
                 return;
-            prop = props[idx];
+            propName = props[idx].first;
             if(count)
                 *count = propSize;
         }
-        if(v)
-            *v = QString::fromLatin1(prop->getName());
+        if(v) 
+            *v = QString::fromLatin1(propName);
         return;
     }
 

--- a/src/Gui/ExpressionCompleter.h
+++ b/src/Gui/ExpressionCompleter.h
@@ -50,8 +50,8 @@ class GuiExport ExpressionCompleter : public QCompleter
 {
     Q_OBJECT
 public:
-    ExpressionCompleter(const App::DocumentObject * currentDocObj,
-            QObject *parent = nullptr, bool noProperty = false);
+    ExpressionCompleter(const App::DocumentObject * currentDocObj, 
+            QObject *parent = nullptr, bool noProperty = false, bool checkInList = true);
 
     void getPrefixRange(int &start, int &end) const {
         start = prefixStart;
@@ -62,10 +62,9 @@ public:
         prefixEnd = end;
     }
 
-    void setDocumentObject(const App::DocumentObject*);
+    void setDocumentObject(const App::DocumentObject*, bool checkInList=true);
 
     void setNoProperty(bool enabled=true);
-    void setRequireLeadingEqualSign(bool enabled);
 
 public Q_SLOTS:
     void slotUpdate(const QString &prefix, int pos);
@@ -77,18 +76,19 @@ private:
 
     int prefixStart = 0;
     int prefixEnd = 0;
-    bool requireLeadingEqualSign = false;
 
     App::DocumentObjectT currentObj;
     bool noProperty;
-
+    bool checkInList;
 };
 
 class GuiExport ExpressionLineEdit : public QLineEdit {
     Q_OBJECT
 public:
-    ExpressionLineEdit(QWidget *parent = nullptr, bool noProperty = false, bool requireLeadingEqualSign = false);
-    void setDocumentObject(const App::DocumentObject *currentDocObj);
+    ExpressionLineEdit(QWidget *parent = 0, bool noProperty=false,
+            char checkPrefix=0, bool checkInList=true);
+    void setDocumentObject(const App::DocumentObject *currentDocObj, bool checkInList=true);
+    void setPrefix(char prefix);
     bool completerActive() const;
     void hideCompleter();
     void setNoProperty(bool enabled=true);
@@ -106,7 +106,8 @@ private:
     bool block;
     bool noProperty;
     bool exactMatch;
-    bool requireLeadingEqualSign;
+    bool checkInList;
+    char checkPrefix;
 };
 
 class GuiExport ExpressionTextEdit : public QPlainTextEdit {

--- a/src/Gui/MDIView.cpp
+++ b/src/Gui/MDIView.cpp
@@ -183,6 +183,9 @@ bool MDIView::onHasMsg(const char* pMsg) const
 
 bool MDIView::canClose(void)
 {
+    if (getAppDocument() && getAppDocument()->testStatus(App::Document::TempDoc))
+        return true;
+
     if (!bIsPassive && getGuiDocument() && getGuiDocument()->isLastView()) {
         this->setFocus(); // raises the view to front
         return (getGuiDocument()->canClose(true,true));

--- a/src/Gui/ViewProviderGeometryObject.cpp
+++ b/src/Gui/ViewProviderGeometryObject.cpp
@@ -157,6 +157,8 @@ void ViewProviderGeometryObject::onChanged(const App::Property* prop)
         }
     }
     else if (prop == &ShapeMaterial) {
+        if (getObject() && getObject()->testStatus(App::ObjectStatus::TouchOnColorChange))
+            getObject()->touch(true);
         const App::Material& Mat = ShapeMaterial.getValue();
         long value = (long)(100*Mat.transparency);
         if (value != Transparency.getValue())

--- a/src/Gui/propertyeditor/PropertyEditor.cpp
+++ b/src/Gui/propertyeditor/PropertyEditor.cpp
@@ -525,21 +525,36 @@ void PropertyEditor::contextMenuEvent(QContextMenuEvent *) {
     auto contextIndex = currentIndex();
 
     std::unordered_set<App::Property*> props;
-
-    if(PropertyView::showAll()) {
-        for(auto index : selectedIndexes()) {
-            auto item = static_cast<PropertyItem*>(index.internalPointer());
-            if(item->isSeparator())
-                continue;
-            for(auto parent=item;parent;parent=parent->parent()) {
-                const auto &ps = parent->getPropertyData();
-                if(ps.size()) {
-                    props.insert(ps.begin(),ps.end());
-                    break;
-                }
+    for(auto index : selectedIndexes()) {
+        auto item = static_cast<PropertyItem*>(index.internalPointer());
+        if(item->isSeparator())
+            continue;
+        for(auto parent=item;parent;parent=parent->parent()) {
+            const auto &ps = parent->getPropertyData();
+            if(ps.size()) {
+                props.insert(ps.begin(),ps.end());
+                break;
             }
         }
+    }
 
+    if(props.size() == 1) {
+        auto item = static_cast<PropertyItem*>(contextIndex.internalPointer());
+        auto prop = *props.begin();
+        if(item->isBound() 
+            && !prop->isDerivedFrom(App::PropertyExpressionEngine::getClassTypeId())
+            && !prop->isReadOnly() 
+            && !prop->testStatus(App::Property::Immutable)
+            && !(prop->getType() & App::Prop_ReadOnly))
+        {
+            contextIndex = propertyModel->buddy(contextIndex);
+            setCurrentIndex(contextIndex);
+            menu.addSeparator();
+            menu.addAction(tr("Expression..."))->setData(QVariant(MA_Expression));
+        }
+    }
+
+    if(PropertyView::showAll()) {
         if(props.size()) {
             menu.addAction(tr("Add property"))->setData(QVariant(MA_AddProp));
             unsigned count = 0;
@@ -569,21 +584,6 @@ void PropertyEditor::contextMenuEvent(QContextMenuEvent *) {
         }
         if(canRemove)
             menu.addAction(tr("Remove property"))->setData(QVariant(MA_RemoveProp));
-
-        if(props.size() == 1) {
-            auto item = static_cast<PropertyItem*>(contextIndex.internalPointer());
-            auto prop = *props.begin();
-            if(item->isBound() 
-                && !prop->isDerivedFrom(App::PropertyExpressionEngine::getClassTypeId())
-                && !prop->isReadOnly() 
-                && !(prop->getType() & App::Prop_ReadOnly))
-            {
-                contextIndex = propertyModel->buddy(contextIndex);
-                setCurrentIndex(contextIndex);
-                menu.addSeparator();
-                menu.addAction(tr("Expression..."))->setData(QVariant(MA_Expression));
-            }
-        }
 
         if(props.size()) {
             menu.addSeparator();

--- a/src/Gui/propertyeditor/PropertyEditor.cpp
+++ b/src/Gui/propertyeditor/PropertyEditor.cpp
@@ -507,6 +507,7 @@ enum MenuAction {
     MA_Hidden,
     MA_Touched,
     MA_EvalOnRestore,
+    MA_CopyOnChange,
 };
 
 void PropertyEditor::contextMenuEvent(QContextMenuEvent *) {
@@ -612,6 +613,7 @@ void PropertyEditor::contextMenuEvent(QContextMenuEvent *) {
             ACTION_SETUP(Transient);
             _ACTION_SETUP(Touched);
             _ACTION_SETUP(EvalOnRestore);
+            _ACTION_SETUP(CopyOnChange);
         }
     }
 
@@ -638,6 +640,7 @@ void PropertyEditor::contextMenuEvent(QContextMenuEvent *) {
     ACTION_CHECK(Output);
     ACTION_CHECK(Hidden);
     ACTION_CHECK(EvalOnRestore);
+    ACTION_CHECK(CopyOnChange);
     case MA_Touched:
         for(auto prop : props) {
             if(action->isChecked())

--- a/src/Gui/propertyeditor/PropertyEditor.cpp
+++ b/src/Gui/propertyeditor/PropertyEditor.cpp
@@ -557,17 +557,13 @@ void PropertyEditor::contextMenuEvent(QContextMenuEvent *) {
     if(PropertyView::showAll()) {
         if(props.size()) {
             menu.addAction(tr("Add property"))->setData(QVariant(MA_AddProp));
-            unsigned count = 0;
-            for(auto prop : props) {
-                if(prop->testStatus(App::Property::PropDynamic)
-                        && !boost::starts_with(prop->getName(),prop->getGroup()))
-                {
-                    ++count;
-                } else
-                    break;
-            }
-            if(count == props.size())
+            if (std::all_of(props.begin(), props.end(), [](auto prop) {
+                    return prop->testStatus(App::Property::PropDynamic)
+                        && !boost::starts_with(prop->getName(),prop->getGroup());
+               }))
+            {
                 menu.addAction(tr("Rename property group"))->setData(QVariant(MA_EditPropGroup));
+            }
         }
 
         bool canRemove = !props.empty();

--- a/src/Gui/propertyeditor/PropertyItem.cpp
+++ b/src/Gui/propertyeditor/PropertyItem.cpp
@@ -350,10 +350,8 @@ QVariant PropertyItem::toString(const QVariant& prop) const
     std::ostringstream ss;
     Base::PyGILStateLocker lock;
     try {
-        Base::PyGILStateLocker lock;
-        Py::Object pyobj(propertyItems[0]->getPyObject(), true);
-        std::ostringstream ss;
-        if (pyobj.isNone()) {
+        Py::Object pyobj(propertyItems[0]->getPyObject(),true);
+        if(pyobj.isNone()) {
             ss << "<None>";
         }
         else if(pyobj.isSequence()) {
@@ -393,6 +391,7 @@ QVariant PropertyItem::toString(const QVariant& prop) const
         }
         else
             ss << pyobj.as_string();
+
     } catch (Py::Exception &) {
         Base::PyException e;
         ss.str("");

--- a/src/Gui/propertyeditor/PropertyItem.cpp
+++ b/src/Gui/propertyeditor/PropertyItem.cpp
@@ -552,7 +552,10 @@ QVariant PropertyItem::data(int column, int role) const
 {
     // property name
     if (column == 0) {
-        if (role == Qt::BackgroundRole || role == Qt::ForegroundRole) {
+        if (role == Qt::TextColorRole && linked)
+            return QVariant::fromValue(QColor(0x20,0xaa,0x20));
+
+        if (role == Qt::BackgroundRole || role == Qt::TextColorRole) {
             if(PropertyView::showAll()
                 && propertyItems.size() == 1
                 && propertyItems.front()->testStatus(App::Property::PropDynamic)

--- a/src/Gui/propertyeditor/PropertyItem.cpp
+++ b/src/Gui/propertyeditor/PropertyItem.cpp
@@ -2740,7 +2740,7 @@ QStringList PropertyEnumItem::getEnum() const
     auto prop = getFirstProperty();
     if (prop && prop->getTypeId().isDerivedFrom(App::PropertyEnumeration::getClassTypeId())) {
         const App::PropertyEnumeration* prop_enum = static_cast<const App::PropertyEnumeration*>(prop);
-        for(int i=0,last=prop_enum->getEnum().maxValue();i<=last;++i)
+        for(int i=0; i<prop_enum->getEnum().maxValue(); ++i)
             res.push_back(QString::fromUtf8(prop_enum->getEnums()[i]));
     }
     return res;

--- a/src/Mod/Draft/draftobjects/draftlink.py
+++ b/src/Mod/Draft/draftobjects/draftlink.py
@@ -93,6 +93,14 @@ class DraftLink(DraftObject):
         """Set up the link properties on attachment."""
         obj.configLinkProperty('Placement', LinkedObject='Base')
 
+        if not hasattr(obj, 'AlwaysSyncPlacement'):
+            _tip = QT_TRANSLATE_NOOP("App::Property",
+                'Force sync pattern placements even when array elements are expanded')
+            obj.addProperty("App::PropertyBool",
+                            "AlwaysSyncPlacement",
+                            "Draft",
+                            _tip)
+
         if hasattr(obj, 'ShowElement'):
             # Rename 'ShowElement' property to 'ExpandArray' to avoid conflict
             # with native App::Link
@@ -128,7 +136,13 @@ class DraftLink(DraftObject):
                             ' Link')
             obj.setPropertyStatus('ColoredElements', 'Hidden')
 
-        obj.configLinkProperty('LinkTransform', 'ColoredElements')
+        if not hasattr(obj,'LinkCopyOnChange'):
+            obj.addProperty("App::PropertyEnumeration","LinkCopyOnChange"," Link")
+
+        obj.configLinkProperty('LinkCopyOnChange','LinkTransform','ColoredElements')
+
+        if not getattr(obj, 'Fuse', False):
+            obj.setPropertyStatus('Shape', 'Transient')
 
     def getViewProviderName(self, _obj):
         """Override the view provider name."""
@@ -170,13 +184,15 @@ class DraftLink(DraftObject):
     def buildShape(self, obj, pl, pls):
         """Build the shape of the link object."""
         if self.use_link:
-            if not getattr(obj, 'ExpandArray', True) or obj.Count != len(pls):
+            if not getattr(obj, 'ExpandArray', False) or obj.Count != len(pls):
                 obj.setPropertyStatus('PlacementList', '-Immutable')
                 obj.PlacementList = pls
                 obj.setPropertyStatus('PlacementList', 'Immutable')
                 obj.Count = len(pls)
-        elif hasattr(obj, 'Count') and obj.Count != len(pls): # required for regular pointarrays
-            obj.Count = len(pls)
+            if getattr(obj, 'ExpandArray', False) \
+                    and getattr(obj, 'AlwaysSyncPlacement', False):
+                for pla,child in zip(pls,obj.ElementList):
+                    child.Placement = pla
 
         if obj.Base:
             shape = getattr(obj.Base, 'Shape', None)
@@ -198,10 +214,7 @@ class DraftLink(DraftObject):
                     if len(vis) > i and not vis[i]:
                         continue
 
-                    # 'I' is a prefix for disambiguation
-                    # when mapping element names
-                    base.append(shape.transformed(pla.toMatrix(),
-                                                  op='I{}'.format(i)))
+                    base.append(shape.transformed(pla.toMatrix()))
 
                 if getattr(obj, 'Fuse', False) and len(base) > 1:
                     obj.Shape = base[0].multiFuse(base[1:]).removeSplitter()

--- a/src/Mod/Part/Gui/ViewProviderExt.cpp
+++ b/src/Mod/Part/Gui/ViewProviderExt.cpp
@@ -624,6 +624,9 @@ std::vector<Base::Vector3d> ViewProviderPartExt::getSelectionShape(const char* /
 
 void ViewProviderPartExt::setHighlightedFaces(const std::vector<App::Color>& colors)
 {
+    if (getObject() && getObject()->testStatus(App::ObjectStatus::TouchOnColorChange))
+        getObject()->touch(true);
+
     Gui::SoUpdateVBOAction action;
     action.apply(this->faceset);
 
@@ -779,6 +782,8 @@ void ViewProviderPartExt::unsetHighlightedFaces()
 
 void ViewProviderPartExt::setHighlightedEdges(const std::vector<App::Color>& colors)
 {
+    if (getObject() && getObject()->testStatus(App::ObjectStatus::TouchOnColorChange))
+        getObject()->touch(true);
     int size = static_cast<int>(colors.size());
     if (size > 1) {
         // Although indexed lineset is used the material binding must be PER_FACE!
@@ -814,6 +819,8 @@ void ViewProviderPartExt::unsetHighlightedEdges()
 
 void ViewProviderPartExt::setHighlightedPoints(const std::vector<App::Color>& colors)
 {
+    if (getObject() && getObject()->testStatus(App::ObjectStatus::TouchOnColorChange))
+        getObject()->touch(true);
     int size = static_cast<int>(colors.size());
     if (size > 1) {
 #if 0

--- a/src/Mod/PartDesign/App/AppPartDesign.cpp
+++ b/src/Mod/PartDesign/App/AppPartDesign.cpp
@@ -123,6 +123,7 @@ PyMOD_INIT_FUNC(_PartDesign)
     PartDesign::SubtractiveHelix            ::init();
     PartDesign::ShapeBinder                 ::init();
     PartDesign::SubShapeBinder              ::init();
+    PartDesign::SubShapeBinderPython        ::init();
     PartDesign::Plane                       ::init();
     PartDesign::Line                        ::init();
     PartDesign::Point                       ::init();

--- a/src/Mod/PartDesign/App/ShapeBinder.cpp
+++ b/src/Mod/PartDesign/App/ShapeBinder.cpp
@@ -907,3 +907,13 @@ void SubShapeBinder::handleChangedPropertyType(
    }
 }
 
+////////////////////////////////////////////////////////////////////////////////////////
+
+namespace App {
+PROPERTY_SOURCE_TEMPLATE(PartDesign::SubShapeBinderPython, PartDesign::SubShapeBinder)
+template<> const char* PartDesign::SubShapeBinderPython::getViewProviderName(void) const {
+    return "PartDesignGui::ViewProviderSubShapeBinderPython";
+}
+template class PartDesignExport FeaturePythonT<PartDesign::SubShapeBinder>;
+}
+

--- a/src/Mod/PartDesign/App/ShapeBinder.h
+++ b/src/Mod/PartDesign/App/ShapeBinder.h
@@ -28,6 +28,7 @@
 #include <boost_signals2.hpp>
 #include <App/PropertyLinks.h>
 #include <App/DocumentObserver.h>
+#include <App/FeaturePython.h>
 #include <Mod/Part/App/DatumFeature.h>
 #include <Mod/PartDesign/PartDesignGlobal.h>
 
@@ -145,6 +146,8 @@ protected:
     App::PropertyXLinkSub _CopiedLink;
     std::vector<App::DocumentObjectT> _CopiedObjs;
 };
+
+typedef App::FeaturePythonT<SubShapeBinder> SubShapeBinderPython;
 
 } //namespace PartDesign
 

--- a/src/Mod/PartDesign/App/ShapeBinder.h
+++ b/src/Mod/PartDesign/App/ShapeBinder.h
@@ -27,6 +27,7 @@
 #include <QString>
 #include <boost_signals2.hpp>
 #include <App/PropertyLinks.h>
+#include <App/DocumentObserver.h>
 #include <Mod/Part/App/DatumFeature.h>
 #include <Mod/PartDesign/PartDesignGlobal.h>
 
@@ -81,6 +82,8 @@ public:
     typedef Part::Feature inherited;
 
     SubShapeBinder();
+    ~SubShapeBinder();
+
     const char* getViewProviderName(void) const override {
         return "PartDesignGui::ViewProviderSubShapeBinder";
     }
@@ -96,6 +99,7 @@ public:
     App::PropertyBool PartialLoad;
     App::PropertyXLink Context;
     App::PropertyInteger _Version;
+    App::PropertyEnumeration BindCopyOnChange;
 
     enum UpdateOption {
         UpdateNone = 0,
@@ -123,13 +127,23 @@ protected:
     virtual void onDocumentRestored() override;
     virtual void setupObject() override;
 
+    void setupCopyOnChange();
+    void checkCopyOnChange(const App::Property &prop);
+    void clearCopiedObjects();
+
     void checkPropertyStatus();
 
     void slotRecomputedObject(const App::DocumentObject& Obj);
 
     typedef boost::signals2::scoped_connection Connection;
     Connection connRecomputedObj;
-    App::Document *contextDoc=0;
+    App::Document *contextDoc = 0;
+
+    std::vector<Connection> copyOnChangeConns;
+    bool hasCopyOnChange = true;
+
+    App::PropertyXLinkSub _CopiedLink;
+    std::vector<App::DocumentObjectT> _CopiedObjs;
 };
 
 } //namespace PartDesign

--- a/src/Mod/PartDesign/Gui/AppPartDesignGui.cpp
+++ b/src/Mod/PartDesign/Gui/AppPartDesignGui.cpp
@@ -152,6 +152,7 @@ PyMOD_INIT_FUNC(PartDesignGui)
     PartDesignGui::ViewProviderDatumCoordinateSystem::init();
     PartDesignGui::ViewProviderShapeBinder   ::init();
     PartDesignGui::ViewProviderSubShapeBinder::init();
+    PartDesignGui::ViewProviderSubShapeBinderPython::init();
     PartDesignGui::ViewProviderBoolean       ::init();
     PartDesignGui::ViewProviderAddSub        ::init();
     PartDesignGui::ViewProviderPrimitive     ::init();

--- a/src/Mod/PartDesign/Gui/ViewProviderShapeBinder.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderShapeBinder.cpp
@@ -416,3 +416,10 @@ std::vector<App::DocumentObject*> ViewProviderSubShapeBinder::claimChildren(void
     return ret;
 }
 
+////////////////////////////////////////////////////////////////////////////////////////
+
+namespace Gui {
+PROPERTY_SOURCE_TEMPLATE(PartDesignGui::ViewProviderSubShapeBinderPython,
+                         PartDesignGui::ViewProviderSubShapeBinder)
+template class PartDesignGuiExport ViewProviderPythonFeatureT<ViewProviderSubShapeBinder>;
+}

--- a/src/Mod/PartDesign/Gui/ViewProviderShapeBinder.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderShapeBinder.cpp
@@ -367,7 +367,11 @@ void ViewProviderSubShapeBinder::updatePlacement(bool transaction) {
     if(!transaction) {
         if(relative)
             self->Context.setValue(parent,parentSub.c_str());
-        self->update(PartDesign::SubShapeBinder::UpdateForced);
+        try {
+            self->update(PartDesign::SubShapeBinder::UpdateForced);
+        } catch (Base::Exception &e) {
+            e.ReportException();
+        }
         return;
     }
 

--- a/src/Mod/PartDesign/Gui/ViewProviderShapeBinder.h
+++ b/src/Mod/PartDesign/Gui/ViewProviderShapeBinder.h
@@ -24,6 +24,7 @@
 #ifndef PARTGUI_ViewProviderShapeBinder_H
 #define PARTGUI_ViewProviderShapeBinder_H
 
+#include <Gui/ViewProviderPythonFeature.h>
 #include <Mod/Part/Gui/ViewProvider.h>
 #include <Mod/PartDesign/PartDesignGlobal.h>
 
@@ -83,6 +84,8 @@ private:
     };
     void updatePlacement(bool transaction);
 };
+
+typedef Gui::ViewProviderPythonFeatureT<ViewProviderSubShapeBinder> ViewProviderSubShapeBinderPython;
 
 } // namespace PartDesignGui
 

--- a/src/Mod/PartDesign/Gui/ViewProviderShapeBinder.h
+++ b/src/Mod/PartDesign/Gui/ViewProviderShapeBinder.h
@@ -57,6 +57,7 @@ class PartDesignGuiExport ViewProviderSubShapeBinder : public PartGui::ViewProvi
     PROPERTY_HEADER_WITH_OVERRIDE(PartDesignGui::ViewProviderShapeBinder);
 
 public:
+    App::PropertyBool UseBinderStyle;
 
     /// Constructor
     ViewProviderSubShapeBinder();
@@ -72,6 +73,8 @@ public:
     virtual bool doubleClicked() override;
     virtual void setupContextMenu(QMenu* menu, QObject* receiver, const char* member) override;
     virtual bool setEdit(int ModNum) override;
+    virtual void attach(App::DocumentObject *obj) override;
+    virtual void onChanged(const App::Property *prop) override;
 
 private:
     enum {

--- a/src/Mod/Spreadsheet/App/Cell.cpp
+++ b/src/Mod/Spreadsheet/App/Cell.cpp
@@ -131,12 +131,12 @@ Cell::Cell(PropertySheet *_owner, const Cell &other)
     , foregroundColor(other.foregroundColor)
     , backgroundColor(other.backgroundColor)
     , displayUnit(other.displayUnit)
-    , alias(other.alias)
     , computedUnit(other.computedUnit)
     , rowSpan(other.rowSpan)
     , colSpan(other.colSpan)
 {
     setUsed(MARK_SET, false);
+    setAlias(other.alias);
     setDirty();
 }
 

--- a/src/Mod/Spreadsheet/App/PropertySheet.cpp
+++ b/src/Mod/Spreadsheet/App/PropertySheet.cpp
@@ -399,7 +399,7 @@ void PropertySheet::pasteCells(XMLReader &reader, Range dstRange) {
         Range range(from,to);
 
         CellAddress addr(dstFrom);
-        if(!ri) {
+        if(ri == 0) {
             roffset = addr.row() - from.row();
             coffset = addr.col() - from.col();
         }
@@ -410,10 +410,10 @@ void PropertySheet::pasteCells(XMLReader &reader, Range dstRange) {
             ccount = 1;
         } else {
             rcount = dstRows/range.rowCount();
-            if(!rcount)
+            if(rcount == 0)
                 rcount = 1;
             ccount = dstCols/range.colCount();
-            if(!ccount)
+            if(ccount == 0)
                 ccount = 1;
         }
         for(int ci=0; ci < cellCount; ++ci) {
@@ -482,7 +482,7 @@ void PropertySheet::pasteCells(XMLReader &reader, Range dstRange) {
                 }
             }
         }
-        if(!cellCount || range.next()) {
+        if(cellCount == 0 || range.next()) {
             do {
                 for(int r=0; r < rcount; ++r) {
                     for(int c=0; c < ccount; ++c) {
@@ -1400,7 +1400,7 @@ void PropertySheet::recomputeDependencies(CellAddress key)
 
 void PropertySheet::hasSetValue()
 {
-    if(!updateCount || 
+    if(updateCount == 0 || 
        !owner || !owner->getNameInDocument() || owner->isRestoring() ||
        this!=&owner->cells ||
        testFlag(LinkDetached)) 

--- a/src/Mod/Spreadsheet/App/PropertySheet.cpp
+++ b/src/Mod/Spreadsheet/App/PropertySheet.cpp
@@ -100,6 +100,15 @@ const Cell *PropertySheet::getValue(CellAddress key) const
         return i->second;
 }
 
+Cell * PropertySheet::getValueFromAlias(const std::string &alias)
+{
+    std::map<std::string, CellAddress>::const_iterator it = revAliasProp.find(alias);
+
+    if (it != revAliasProp.end())
+        return getValue(it->second);
+    else
+        return 0;
+}
 
 const Cell * PropertySheet::getValueFromAlias(const std::string &alias) const
 {
@@ -109,7 +118,6 @@ const Cell * PropertySheet::getValueFromAlias(const std::string &alias) const
         return getValue(it->second);
     else
         return 0;
-
 }
 
 bool PropertySheet::isValidAlias(const std::string &candidate)
@@ -1448,7 +1456,7 @@ PyObject *PropertySheet::getPyValue(PyObject *key) {
             Py_Return;
         }
 
-        Range range = getRange(Py::Object(key).as_string().c_str());
+        Range range = getRange(Py::Object(key).as_string().c_str(), false);
         if(!range.from().isValid() || !range.to().isValid())
             return Py::new_reference_to(Py::Tuple());
 
@@ -1796,10 +1804,10 @@ void PropertySheet::setPathValue(const ObjectIdentifier &path, const boost::any 
                         << " in " << getFullName());
 
             App::CellAddress targetFrom = other->getCellAddress(
-                Py::Object(seq[1].ptr()).as_string().c_str());
+                Py::Object(seq[1].ptr()).as_string().c_str(), false);
 
             App::CellAddress targetTo = other->getCellAddress(
-                Py::Object(seq[2].ptr()).as_string().c_str());
+                Py::Object(seq[2].ptr()).as_string().c_str(), false);
 
             App::Range range(from,to);
             App::Range rangeTarget(targetFrom,targetTo);

--- a/src/Mod/Spreadsheet/App/PropertySheet.cpp
+++ b/src/Mod/Spreadsheet/App/PropertySheet.cpp
@@ -120,17 +120,6 @@ const Cell * PropertySheet::getValueFromAlias(const std::string &alias) const
         return 0;
 }
 
-Cell * PropertySheet::getValueFromAlias(const std::string &alias)
-{
-    std::map<std::string, CellAddress>::const_iterator it = revAliasProp.find(alias);
-
-    if (it != revAliasProp.end())
-        return getValue(it->second);
-    else
-        return 0;
-
-}
-
 bool PropertySheet::isValidAlias(const std::string &candidate)
 {
     static const boost::regex gen("^[A-Za-z][_A-Za-z0-9]*$");

--- a/src/Mod/Spreadsheet/App/PropertySheet.cpp
+++ b/src/Mod/Spreadsheet/App/PropertySheet.cpp
@@ -1216,7 +1216,8 @@ void PropertySheet::recomputeDependants(const App::DocumentObject *owner, const 
         // protected by cyclic dependency checking, we need to take special
         // care to prevent it from misbehave.
         Sheet *sheet = Base::freecad_dynamic_cast<Sheet>(getContainer());
-        if(!sheet || sheet->testStatus(App::ObjectStatus::Recompute2))
+        if(!sheet || sheet->testStatus(App::ObjectStatus::Recompute2)
+                || !owner || owner->testStatus(App::ObjectStatus::Recompute2))
             return;
     }
 
@@ -1434,6 +1435,36 @@ void PropertySheet::setPyObject(PyObject *obj) {
         Paste(*static_cast<PropertySheetPy*>(obj)->getPropertySheetPtr());
 }
 
+PyObject *PropertySheet::getPyValue(PyObject *key) {
+    assert(key);
+
+    PY_TRY {
+        std::string addr = Py::Object(key).as_string();
+        CellAddress caddr = getCellAddress(addr.c_str(),true);
+        if(caddr.isValid()) {
+            auto prop = owner->getPropertyByName(caddr.toString().c_str());
+            if(prop)
+                return prop->getPyObject();
+            Py_Return;
+        }
+
+        Range range = getRange(Py::Object(key).as_string().c_str());
+        if(!range.from().isValid() || !range.to().isValid())
+            return Py::new_reference_to(Py::Tuple());
+
+        Py::Tuple res(range.size());
+        int i = 0;
+        do {
+            addr = range.address();
+            auto prop = owner->getPropertyByName(addr.c_str());
+            res.setItem(i++,prop?Py::asObject(prop->getPyObject()):Py::Object());
+        } while(range.next());
+
+        return Py::new_reference_to(res);
+
+    } PY_CATCH
+}
+
 void PropertySheet::afterRestore()
 {
     Base::FlagToggler<bool> flag(restoring);
@@ -1620,4 +1651,232 @@ void PropertySheet::setExpressions(
             cell->setExpression(std::move(v.second));
     }
     signaller.tryInvoke();
+}
+
+App::CellAddress PropertySheet::getCellAddress(const char *addr, bool silent) const {
+    assert(addr);
+    CellAddress caddr;
+    const Cell * cell = getValueFromAlias(addr);
+    if(cell)
+        return cell->getAddress();
+    else
+        return stringToAddress(addr,silent);
+}
+
+App::Range PropertySheet::getRange(const char *range, bool silent) const {
+    assert(range);
+    const char *sep = strchr(range,':');
+    CellAddress from,to;
+    if(!sep) 
+        from = to = getCellAddress(range,silent);
+    else {
+        std::string addr(range,sep);
+
+        auto findCell = [this, &addr](CellAddress caddr, int r, int c) -> CellAddress {
+            if(!getValue(caddr))
+                return CellAddress();
+            if(addr == "-")
+                r = 0;
+            else
+                c = 0;
+            for(;;) {
+                caddr.setRow(caddr.row()+r);
+                caddr.setCol(caddr.col()+c);
+                if(!caddr.isValid() || !getValue(caddr)) 
+                    break;
+            }
+            caddr.setRow(caddr.row()-r);
+            caddr.setCol(caddr.col()-c);
+            return caddr;
+        };
+
+        if(addr == "-" || addr == "|") {
+            to = getCellAddress(sep+1,silent);
+            return Range(findCell(to,-1,-1), from);
+        } else {
+            from = getCellAddress(addr.c_str(),silent);
+            addr = sep+1;
+            if(addr == "-" || addr == "|")
+                return Range(from, findCell(from,1,1));
+            to = getCellAddress(addr.c_str(),silent);
+        } 
+    }
+
+    if(!from.isValid() || !to.isValid())
+        return App::Range(App::CellAddress(),App::CellAddress());
+    return App::Range(from,to);
+}
+
+bool PropertySheet::isBindingPath(const ObjectIdentifier &path,
+        CellAddress *from, CellAddress *to, bool *href) const
+{
+    const auto &comps = path.getComponents();
+    if (comps.size()!=4 
+            || !comps[2].isSimple()
+            || !comps[3].isSimple()
+            || (comps[1].getName()!="Bind"
+                && comps[1].getName()!="BindHREF"
+                && comps[1].getName()!="BindHiddenRef")
+            || path.getProperty() != this)
+    {
+        return false;
+    }
+    if(href)
+        *href = (comps[1].getName()=="BindHREF" || comps[1].getName()=="BindHiddenRef");
+    if(from)
+        *from = CellAddress(comps[2].getName());
+    if(to)
+        *to = CellAddress(comps[3].getName());
+    return true;
+}
+
+PropertySheet::BindingType PropertySheet::getBinding(
+        const Range &range, ExpressionPtr *pStart, ExpressionPtr *pEnd) const
+{
+    if(!owner)
+        return BindingNone;
+
+    for(int href=0;href<2;++href) {
+        ObjectIdentifier path(*this);
+        path << ObjectIdentifier::SimpleComponent(href?"BindHiddenRef":"Bind");
+        path << ObjectIdentifier::SimpleComponent(range.from().toString().c_str());
+        path << ObjectIdentifier::SimpleComponent(range.to().toString().c_str());
+        auto res = owner->getExpression(path);
+        if(res.expression && res.expression->isDerivedFrom(FunctionExpression::getClassTypeId()))
+        {
+            auto expr = static_cast<FunctionExpression*>(res.expression.get());
+            if(href) {
+                if((expr->getFunction()!=FunctionExpression::HIDDENREF
+                            && expr->getFunction()!=FunctionExpression::HREF)
+                        || expr->getArgs().size()!=1 
+                        || !expr->getArgs().front()->isDerivedFrom(FunctionExpression::getClassTypeId()))
+                    continue;
+                expr = static_cast<FunctionExpression*>(expr->getArgs().front());
+            }
+
+            if(expr->getFunction() == FunctionExpression::TUPLE && expr->getArgs().size()==3) {
+                if(pStart)
+                    pStart->reset(expr->getArgs()[1]->copy());
+                if(pEnd)
+                    pEnd->reset(expr->getArgs()[2]->copy());
+                return href?BindingHiddenRef:BindingNormal;
+            }
+        }
+    }
+    return BindingNone;
+}
+
+void PropertySheet::setPathValue(const ObjectIdentifier &path, const boost::any &value)
+{
+    if(!owner)
+        FC_THROWM(Base::RuntimeError, "Invalid state");
+
+    bool href = false;
+    CellAddress from,to;
+    if(!isBindingPath(path,&from,&to,&href)) {
+        FC_THROWM(Base::IndexError, "Invalid binding of '" << path.toString()
+                << "' in " << getFullName());
+    }
+
+    Base::PyGILStateLocker lock;
+    Py::Object pyValue = pyObjectFromAny(value);
+
+    if(pyValue.isSequence()) {
+        Py::Sequence seq(pyValue);
+        if(seq.size()==3 
+                && PyObject_TypeCheck(seq[0].ptr(),&PropertySheetPy::Type)
+                && Py::Object(seq[1].ptr()).isString()
+                && Py::Object(seq[2].ptr()).isString())
+        {
+            AtomicPropertyChange signaller(*this,false);
+            auto other = static_cast<PropertySheetPy*>(seq[0].ptr())->getPropertySheetPtr();
+            auto otherOwner = Base::freecad_dynamic_cast<App::DocumentObject>(other->getContainer());
+            if(!otherOwner)
+                FC_THROWM(Base::RuntimeError, "Invalid binding of '" << other->getFullName()
+                        << " in " << getFullName());
+
+            App::CellAddress targetFrom = other->getCellAddress(
+                Py::Object(seq[1].ptr()).as_string().c_str());
+
+            App::CellAddress targetTo = other->getCellAddress(
+                Py::Object(seq[2].ptr()).as_string().c_str());
+
+            App::Range range(from,to);
+            App::Range rangeTarget(targetFrom,targetTo);
+
+            std::string expr(href?"href(":"");
+            if(other != this) {
+                if(otherOwner->getDocument() == owner->getDocument())
+                    expr = otherOwner->getNameInDocument();
+                else
+                    expr = otherOwner->getFullName();
+            }
+            expr += ".";
+            std::size_t exprSize = expr.size();
+
+            do {
+                CellAddress target(*rangeTarget);
+                CellAddress source(*range);
+                if(other == this && source.row() >= targetFrom.row()
+                        && source.row() <= targetTo.row()
+                        && source.col() >= targetFrom.col()
+                        && source.col() <= targetTo.col())
+                    continue;
+
+                Cell *dst = other->getValue(target);
+                Cell *src = getValue(source);
+                if(!dst) {
+                    if(src) {
+                        signaller.aboutToChange();
+                        owner->clear(source);
+                        owner->cellUpdated(source);
+                    }
+                    continue;
+                }
+
+                if(!src) {
+                    signaller.aboutToChange();
+                    src = createCell(source);
+                }
+
+                std::string alias;
+                if(this!=other && dst->getAlias(alias)) {
+                    auto *oldCell = getValueFromAlias(alias);
+                    if(oldCell && oldCell!=dst) {
+                        signaller.aboutToChange();
+                        oldCell->setAlias("");
+                    }
+                    std::string oldAlias;
+                    if(!src->getAlias(oldAlias) || oldAlias!=alias) {
+                        signaller.aboutToChange();
+                        setAlias(source,alias);
+                    }
+                }
+
+                expr.resize(exprSize);
+                expr += rangeTarget.address();
+                if(href)
+                    expr += ")";
+                auto e = App::ExpressionPtr(App::Expression::parse(owner,expr));
+                auto e2 = src->getExpression();
+                if(!e2 || !e->isSame(*e2,false)) {
+                    signaller.aboutToChange();
+                    src->setExpression(std::move(e));
+                }
+
+            } while(range.next() && rangeTarget.next());
+            owner->rangeUpdated(range);
+            signaller.tryInvoke();
+            return;
+        }
+    }
+
+    FC_THROWM(Base::TypeError, "Invalid path value '"
+            << "' for " << getFullName());
+}
+
+const boost::any PropertySheet::getPathValue(const App::ObjectIdentifier & path) const {
+    if(isBindingPath(path))
+        return boost::any();
+    return path.getValue();
 }

--- a/src/Mod/Spreadsheet/App/PropertySheet.cpp
+++ b/src/Mod/Spreadsheet/App/PropertySheet.cpp
@@ -44,6 +44,7 @@
 #include <PropertySheetPy.h>
 #include <App/ExpressionVisitors.h>
 #include <App/ExpressionParser.h>
+
 FC_LOG_LEVEL_INIT("Spreadsheet", true, true)
 
 using namespace App;
@@ -368,45 +369,124 @@ void PropertySheet::copyCells(Base::Writer& writer, const std::vector<Range>& ra
     writer.Stream() << "</Cells>" << std::endl;
 }
 
-void PropertySheet::pasteCells(XMLReader& reader, const CellAddress& addr) {
-    AtomicPropertyChange signaller(*this);
-
-    bool first = true;
-    int roffset = 0, coffset = 0;
-
+void PropertySheet::pasteCells(XMLReader &reader, Range dstRange) {
     reader.readElement("Cells");
-    for (int rangeCount = reader.getAttributeAsInteger("count"); rangeCount > 0; --rangeCount) {
+    int rangeCount = reader.getAttributeAsInteger("count");
+    if(rangeCount<=0)
+        return;
+
+    int dstRows = dstRange.rowCount();
+    int dstCols = dstRange.colCount();
+    CellAddress dstFrom = dstRange.from();
+
+    int roffset,coffset;
+
+    AtomicPropertyChange signaller(*this);
+    for(int ri=0; ri < rangeCount; ++ri) {
         reader.readElement("Range");
         CellAddress from(reader.getAttribute("from"));
         CellAddress to(reader.getAttribute("to"));
-        Range range(from, to);
-        for (int cellCount = reader.getAttributeAsInteger("count"); cellCount > 0; --cellCount) {
-            if (first) {
-                first = false;
-                roffset = addr.row() - from.row();
-                coffset = addr.col() - from.col();
-            }
+        int cellCount = reader.getAttributeAsInteger("count");
+
+        Range range(from,to);
+
+        CellAddress addr(dstFrom);
+        if(!ri) {
+            roffset = addr.row() - from.row();
+            coffset = addr.col() - from.col();
+        }
+
+        int rcount,ccount;
+        if(rangeCount>1) {
+            rcount = 1;
+            ccount = 1;
+        } else {
+            rcount = dstRows/range.rowCount();
+            if(!rcount)
+                rcount = 1;
+            ccount = dstCols/range.colCount();
+            if(!ccount)
+                ccount = 1;
+        }
+        for(int ci=0; ci < cellCount; ++ci) {
             reader.readElement("Cell");
             CellAddress src(reader.getAttribute("address"));
-            CellAddress dst(src.row() + roffset, src.col() + coffset);
-            owner->clear(dst);
-            owner->cellUpdated(dst);
 
-            auto cell = owner->getNewCell(dst);
-            cell->setSpans(-1, -1);
-            cell->restore(reader, true);
-            int rows, cols;
-            if (cell->getSpans(rows, cols) && (rows > 1 || cols > 1))
-                mergeCells(dst, CellAddress(dst.row() + rows - 1, dst.col() + cols - 1));
+            if(ci)
+                range.next();
 
-            if (roffset || coffset) {
-                OffsetCellsExpressionVisitor<PropertySheet> visitor(*this, roffset, coffset);
-                cell->visit(visitor);
-                if (visitor.changed())
-                    recomputeDependencies(dst);
+            while(src!=*range) {
+                for(int r=0; r < rcount; ++r) {
+                    for(int c=0; c < ccount; ++c) {
+                        CellAddress dst(range.row()+roffset+r*range.rowCount(),
+                                        range.column()+coffset+c*range.colCount());
+                        if(!dst.isValid())
+                            continue;
+                        owner->clear(dst);
+                        owner->cellUpdated(dst);
+                    }
+                }
+                range.next();
             }
-            dirty.insert(dst);
-            owner->cellUpdated(dst);
+
+            CellAddress newCellAddr;
+            for(int r=0; r < rcount; ++r) {
+                for(int c=0; c < ccount; ++c) {
+                    CellAddress dst(src.row()+roffset+r*range.rowCount(),
+                                    src.col()+coffset+c*range.colCount());
+                    if(!dst.isValid())
+                        continue;
+
+                    auto cell = owner->getNewCell(dst);
+                    cell->setSpans(-1,-1);
+
+                    int roffset_cur, coffset_cur;
+                    if(!newCellAddr.isValid()) {
+                        roffset_cur = roffset;
+                        coffset_cur = coffset;
+                        newCellAddr = dst;
+                        cell->restore(reader,true);
+                    } else {
+                        roffset_cur = r*range.rowCount();
+                        coffset_cur = c*range.colCount();
+                        auto newCell = owner->getCell(newCellAddr);
+                        const Expression *expr;
+                        if(!newCell || !(expr=newCell->getExpression(true))) {
+                            FC_THROWM(Base::RuntimeError, "Failed to copy cell "
+                                    << getFullName() << '.' << dst.toString()
+                                    << " from " << newCellAddr.toString());
+                        }
+                        cell->setExpression(ExpressionPtr(expr->copy()));
+                    }
+
+                    int rows, cols;
+                    if (cell->getSpans(rows, cols) && (rows > 1 || cols > 1)) 
+                        mergeCells(dst, CellAddress(dst.row() + rows - 1, dst.col() + cols - 1));
+
+                    if(roffset_cur || coffset_cur) {
+                        OffsetCellsExpressionVisitor<PropertySheet> visitor(*this, roffset_cur, coffset_cur);
+                        cell->visit(visitor);
+                        if(visitor.changed())
+                            recomputeDependencies(dst);
+                    }
+                    dirty.insert(dst);
+                    owner->cellUpdated(dst);
+                }
+            }
+        }
+        if(!cellCount || range.next()) {
+            do {
+                for(int r=0; r < rcount; ++r) {
+                    for(int c=0; c < ccount; ++c) {
+                        CellAddress dst(range.row()+roffset+r*range.rowCount(),
+                                        range.column()+coffset+c*range.colCount());
+                        if(!dst.isValid())
+                            continue;
+                        owner->clear(dst);
+                        owner->cellUpdated(dst);
+                    }
+                }
+            }while(range.next());
         }
     }
     signaller.tryInvoke();

--- a/src/Mod/Spreadsheet/App/PropertySheet.cpp
+++ b/src/Mod/Spreadsheet/App/PropertySheet.cpp
@@ -120,6 +120,17 @@ const Cell * PropertySheet::getValueFromAlias(const std::string &alias) const
         return 0;
 }
 
+Cell * PropertySheet::getValueFromAlias(const std::string &alias)
+{
+    std::map<std::string, CellAddress>::const_iterator it = revAliasProp.find(alias);
+
+    if (it != revAliasProp.end())
+        return getValue(it->second);
+    else
+        return 0;
+
+}
+
 bool PropertySheet::isValidAlias(const std::string &candidate)
 {
     static const boost::regex gen("^[A-Za-z][_A-Za-z0-9]*$");
@@ -615,8 +626,13 @@ void PropertySheet::setAlias(CellAddress address, const std::string &alias)
     Cell * cell = nonNullCellAt(address);
     assert(cell != 0);
 
-    if (aliasedCell != 0 && cell != aliasedCell)
+    if(aliasedCell == cell)
+        return;
+
+    if (aliasedCell)
         throw Base::ValueError("Alias already defined.");
+
+    AtomicPropertyChange signaller(*this);
 
     /* Mark cells depending on this cell dirty; they need to be resolved when an alias changes or disappears */
     std::string fullName = owner->getFullName() + "." + address.toString();
@@ -632,23 +648,21 @@ void PropertySheet::setAlias(CellAddress address, const std::string &alias)
     }
 
     std::string oldAlias;
-
-    if (cell->getAlias(oldAlias))
-        owner->aliasRemoved(address, oldAlias);
-
+    cell->getAlias(oldAlias);
     cell->setAlias(alias);
 
-    if (oldAlias.size() > 0 && alias.size() > 0) {
+    if (oldAlias.size() > 0) {
         std::map<App::ObjectIdentifier, App::ObjectIdentifier> m;
 
         App::ObjectIdentifier key(owner, oldAlias);
-        App::ObjectIdentifier value(owner, alias);
+        App::ObjectIdentifier value(owner, alias.empty()?address.toString():alias);
 
         m[key] = value;
 
         owner->getDocument()->renameObjectIdentifiers(m);
     }
 
+    signaller.tryInvoke();
 }
 
 void PropertySheet::setComputedUnit(CellAddress address, const Base::Unit &unit)

--- a/src/Mod/Spreadsheet/App/PropertySheet.h
+++ b/src/Mod/Spreadsheet/App/PropertySheet.h
@@ -74,7 +74,7 @@ public:
 
     void copyCells(Base::Writer &writer, const std::vector<App::Range> &ranges) const;
 
-    void pasteCells(Base::XMLReader &reader, const App::CellAddress &addr);
+    void pasteCells(Base::XMLReader &reader, App::Range dstRange);
 
     Cell *createCell(App::CellAddress address);
 

--- a/src/Mod/Spreadsheet/App/PropertySheet.h
+++ b/src/Mod/Spreadsheet/App/PropertySheet.h
@@ -48,6 +48,8 @@ public:
 
     virtual std::map<App::ObjectIdentifier, const App::Expression*> getExpressions() const override;
     virtual void setExpressions(std::map<App::ObjectIdentifier, App::ExpressionPtr> &&exprs) override;
+    App::CellAddress getCellAddress(const char *addr, bool silent) const;
+    App::Range getRange(const char *range, bool silent) const;
     virtual void onRelabeledDocument(const App::Document &doc) override;
 
     virtual void updateElementReference(
@@ -105,6 +107,8 @@ public:
     Cell * getValue(App::CellAddress key);
 
     const Cell * getValue(App::CellAddress key) const;
+
+    Cell * getValueFromAlias(const std::string &alias);
 
     const Cell * getValueFromAlias(const std::string &alias) const;
 

--- a/src/Mod/Spreadsheet/App/PropertySheet.h
+++ b/src/Mod/Spreadsheet/App/PropertySheet.h
@@ -163,6 +163,8 @@ public:
     PyObject *getPyObject(void) override;
     void setPyObject(PyObject *) override;
 
+    PyObject *getPyValue(PyObject *key);
+
     void invalidateDependants(const App::DocumentObject *docObj);
 
     void renamedDocumentObject(const App::DocumentObject *docObj);
@@ -175,6 +177,22 @@ public:
     std::string getRow(int offset=0) const;
 
     std::string getColumn(int offset=0) const;
+
+    virtual void setPathValue(const App::ObjectIdentifier & path, const boost::any & value) override;
+    virtual const boost::any getPathValue(const App::ObjectIdentifier & path) const override;
+
+    unsigned getBindingBorder(App::CellAddress address) const;
+
+    bool isBindingPath(const App::ObjectIdentifier &path,
+            App::CellAddress *from=0, App::CellAddress *to=0, bool *href=0) const;
+
+    enum BindingType {
+        BindingNone,
+        BindingNormal,
+        BindingHiddenRef,
+    };
+    BindingType getBinding(const App::Range &range,
+            App::ExpressionPtr *pStart=0, App::ExpressionPtr *pEnd=0) const;
 
 protected:
     virtual void hasSetValue() override;

--- a/src/Mod/Spreadsheet/App/PropertySheet.h
+++ b/src/Mod/Spreadsheet/App/PropertySheet.h
@@ -48,8 +48,6 @@ public:
 
     virtual std::map<App::ObjectIdentifier, const App::Expression*> getExpressions() const override;
     virtual void setExpressions(std::map<App::ObjectIdentifier, App::ExpressionPtr> &&exprs) override;
-    App::CellAddress getCellAddress(const char *addr, bool silent) const;
-    App::Range getRange(const char *range, bool silent) const;
     virtual void onRelabeledDocument(const App::Document &doc) override;
 
     virtual void updateElementReference(
@@ -111,8 +109,6 @@ public:
     Cell * getValueFromAlias(const std::string &alias);
 
     const Cell * getValueFromAlias(const std::string &alias) const;
-
-    Cell * getValueFromAlias(const std::string &alias);
 
     bool isValidAlias(const std::string &candidate);
 

--- a/src/Mod/Spreadsheet/App/PropertySheet.h
+++ b/src/Mod/Spreadsheet/App/PropertySheet.h
@@ -112,6 +112,8 @@ public:
 
     const Cell * getValueFromAlias(const std::string &alias) const;
 
+    Cell * getValueFromAlias(const std::string &alias);
+
     bool isValidAlias(const std::string &candidate);
 
     std::set<App::CellAddress> getUsedCells() const;
@@ -177,6 +179,9 @@ public:
     void deletedDocumentObject(const App::DocumentObject *docObj);
 
     void documentSet();
+
+    App::CellAddress getCellAddress(const char *addr, bool silent=false) const;
+    App::Range getRange(const char *range, bool silent=false) const;
 
     std::string getRow(int offset=0) const;
 

--- a/src/Mod/Spreadsheet/App/PropertySheetPyImp.cpp
+++ b/src/Mod/Spreadsheet/App/PropertySheetPyImp.cpp
@@ -23,13 +23,30 @@
 
 #include "PreCompiled.h"
 
-#include "PropertySheet.h"
+#include "Mod/Spreadsheet/App/PropertySheet.h"
 
 // inclusion of the generated files (generated out of PropertySheetPy.xml)
 #include "PropertySheetPy.h"
 #include "PropertySheetPy.cpp"
 
 using namespace Spreadsheet;
+
+struct PropertySheetPyInit {
+
+    PyMappingMethods methods;
+
+    PropertySheetPyInit() {
+        methods.mp_length = 0;
+        methods.mp_ass_subscript = 0;
+        methods.mp_subscript = [](PyObject *o, PyObject *key) {
+            return static_cast<PropertySheetPy*>(o)->getPropertySheetPtr()->getPyValue(key);
+        };
+
+        PropertySheetPy::Type.tp_as_mapping = &methods;
+    }
+};
+
+static PropertySheetPyInit _PropertySheetPyInit;
 
 // returns a string which represents the object e.g. when printed in python
 std::string PropertySheetPy::representation(void) const

--- a/src/Mod/Spreadsheet/App/Sheet.cpp
+++ b/src/Mod/Spreadsheet/App/Sheet.cpp
@@ -432,7 +432,7 @@ PyObject *Sheet::getPyObject(void)
 
 Property * Sheet::getProperty(CellAddress key) const
 {
-    return props.getDynamicPropertyByName(key.toString().c_str());
+    return props.getDynamicPropertyByName(key.toString(true).c_str());
 }
 
 /**
@@ -512,15 +512,16 @@ void Sheet::onSettingDocument()
 
 Property * Sheet::setFloatProperty(CellAddress key, double value)
 {
-    Property * prop = props.getDynamicPropertyByName(key.toString().c_str());
+    std::string name = key.toString(true);
+    Property * prop = props.getDynamicPropertyByName(name.c_str());
     PropertyFloat * floatProp;
 
     if (!prop || prop->getTypeId() != PropertyFloat::getClassTypeId()) {
         if (prop) {
-            this->removeDynamicProperty(key.toString().c_str());
+            this->removeDynamicProperty(name.c_str());
             propAddress.erase(prop);
         }
-        floatProp = freecad_dynamic_cast<PropertyFloat>(addDynamicProperty("App::PropertyFloat", key.toString().c_str(), 0, 0, Prop_ReadOnly | Prop_Hidden | Prop_NoPersist));
+        floatProp = freecad_dynamic_cast<PropertyFloat>(addDynamicProperty("App::PropertyFloat", name.c_str(), 0, 0, Prop_ReadOnly | Prop_Hidden | Prop_NoPersist));
     }
     else
         floatProp = static_cast<PropertyFloat*>(prop);
@@ -533,16 +534,17 @@ Property * Sheet::setFloatProperty(CellAddress key, double value)
 
 Property * Sheet::setIntegerProperty(CellAddress key, long value)
 {
-    Property * prop = props.getDynamicPropertyByName(key.toString().c_str());
+    std::string name = key.toString(true);
+    Property * prop = props.getDynamicPropertyByName(name.c_str());
     PropertyInteger * intProp;
 
     if (!prop || prop->getTypeId() != PropertyInteger::getClassTypeId()) {
         if (prop) {
-            this->removeDynamicProperty(key.toString().c_str());
+            this->removeDynamicProperty(name.c_str());
             propAddress.erase(prop);
         }
         intProp = freecad_dynamic_cast<PropertyInteger>(addDynamicProperty(
-                    "App::PropertyInteger", key.toString().c_str(), 0, 0, 
+                    "App::PropertyInteger", name.c_str(), 0, 0, 
                     Prop_ReadOnly | Prop_Hidden | Prop_NoPersist));
     }
     else
@@ -567,15 +569,16 @@ Property * Sheet::setIntegerProperty(CellAddress key, long value)
 
 Property * Sheet::setQuantityProperty(CellAddress key, double value, const Base::Unit & unit)
 {
-    Property * prop = props.getDynamicPropertyByName(key.toString().c_str());
+    std::string name = key.toString(true);
+    Property * prop = props.getDynamicPropertyByName(name.c_str());
     PropertySpreadsheetQuantity * quantityProp;
 
     if (!prop || prop->getTypeId() != PropertySpreadsheetQuantity::getClassTypeId()) {
         if (prop) {
-            this->removeDynamicProperty(key.toString().c_str());
+            this->removeDynamicProperty(name.c_str());
             propAddress.erase(prop);
         }
-        Property * p = addDynamicProperty("Spreadsheet::PropertySpreadsheetQuantity", key.toString().c_str(), 0, 0, Prop_ReadOnly | Prop_Hidden | Prop_NoPersist);
+        Property * p = addDynamicProperty("Spreadsheet::PropertySpreadsheetQuantity", name.c_str(), 0, 0, Prop_ReadOnly | Prop_Hidden | Prop_NoPersist);
         quantityProp = freecad_dynamic_cast<PropertySpreadsheetQuantity>(p);
     }
     else
@@ -601,15 +604,16 @@ Property * Sheet::setQuantityProperty(CellAddress key, double value, const Base:
 
 Property * Sheet::setStringProperty(CellAddress key, const std::string & value)
 {
-    Property * prop = props.getDynamicPropertyByName(key.toString().c_str());
+    std::string name = key.toString(true);
+    Property * prop = props.getDynamicPropertyByName(name.c_str());
     PropertyString * stringProp = freecad_dynamic_cast<PropertyString>(prop);
 
     if (!stringProp) {
         if (prop) {
-            this->removeDynamicProperty(key.toString().c_str());
+            this->removeDynamicProperty(name.c_str());
             propAddress.erase(prop);
         }
-        stringProp = freecad_dynamic_cast<PropertyString>(addDynamicProperty("App::PropertyString", key.toString().c_str(), 0, 0, Prop_ReadOnly | Prop_Hidden | Prop_NoPersist));
+        stringProp = freecad_dynamic_cast<PropertyString>(addDynamicProperty("App::PropertyString", name.c_str(), 0, 0, Prop_ReadOnly | Prop_Hidden | Prop_NoPersist));
     }
 
     propAddress[stringProp] = key;
@@ -620,15 +624,16 @@ Property * Sheet::setStringProperty(CellAddress key, const std::string & value)
 
 Property * Sheet::setObjectProperty(CellAddress key, Py::Object object)
 {
-    Property * prop = props.getDynamicPropertyByName(key.toString().c_str());
+    std::string name = key.toString(true);
+    Property * prop = props.getDynamicPropertyByName(name.c_str());
     PropertyPythonObject * pyProp = freecad_dynamic_cast<PropertyPythonObject>(prop);
 
     if (!pyProp) {
         if (prop) {
-            this->removeDynamicProperty(key.toString().c_str());
+            this->removeDynamicProperty(name.c_str());
             propAddress.erase(prop);
         }
-        pyProp = freecad_dynamic_cast<PropertyPythonObject>(addDynamicProperty("App::PropertyPythonObject", key.toString().c_str(), 0, 0, Prop_ReadOnly | Prop_Hidden | Prop_NoPersist));
+        pyProp = freecad_dynamic_cast<PropertyPythonObject>(addDynamicProperty("App::PropertyPythonObject", name.c_str(), 0, 0, Prop_ReadOnly | Prop_Hidden | Prop_NoPersist));
     }
 
     propAddress[pyProp] = key;

--- a/src/Mod/Spreadsheet/App/Sheet.cpp
+++ b/src/Mod/Spreadsheet/App/Sheet.cpp
@@ -120,7 +120,6 @@ void Sheet::clearAll()
     cellErrors.clear();
     columnWidths.clear();
     rowHeights.clear();
-    removedAliases.clear();
 
     for (ObserverMap::iterator i = observers.begin(); i != observers.end(); ++i)
         delete i->second;
@@ -464,6 +463,14 @@ bool Sheet::getCellAddress(const Property *prop, CellAddress & address)
     return false;
 }
 
+App::CellAddress Sheet::getCellAddress(const char *name, bool silent) const {
+    return cells.getCellAddress(name,silent);
+}
+
+App::Range Sheet::getRange(const char *name, bool silent) const {
+    return cells.getRange(name,silent);
+}
+
 /**
  * @brief Get a map with column indices and widths.
  * @return Map with results.
@@ -484,22 +491,6 @@ std::map<int, int> Sheet::getRowHeights() const
     return rowHeights.getValues();
 }
 
-
-/**
- * @brief Remove all aliases.
- *
- */
-
-void Sheet::removeAliases()
-{
-    std::map<CellAddress, std::string>::iterator i = removedAliases.begin();
-
-    while (i != removedAliases.end()) {
-        this->removeDynamicProperty(i->second.c_str());
-        ++i;
-    }
-    removedAliases.clear();
-}
 
 /**
  * Update internal structure when document is set for this property.
@@ -646,42 +637,6 @@ Property * Sheet::setObjectProperty(CellAddress key, Py::Object object)
     return pyProp;
 }
 
-/**
- * @brief Update the alias for the cell at \a key.
- * @param key Cell to update.
- */
-
-void Sheet::updateAlias(CellAddress key)
-{
-    std::string alias;
-    Property * prop = props.getDynamicPropertyByName(key.toString().c_str());
-
-    if (!prop)
-        return;
-
-    Cell * cell = getCell(key);
-
-    if (cell && cell->getAlias(alias)) {
-        Property * aliasProp = props.getDynamicPropertyByName(alias.c_str());
-
-        /* Update or create alias? */
-        if (aliasProp) {
-            // Type of alias and property must always be the same
-            if (aliasProp->getTypeId() != prop->getTypeId()) {
-                this->removeDynamicProperty(alias.c_str());
-                aliasProp = 0;
-            }
-        }
-
-        if (!aliasProp) {
-            aliasProp = addDynamicProperty(prop->getTypeId().getName(), alias.c_str(), 0, 0, Prop_ReadOnly | Prop_NoPersist);
-            aliasProp->setStatus(App::Property::Hidden,true);
-        }
-
-        aliasProp->Paste(*prop);
-    }
-}
-
 struct CurrentAddressLock {
     CurrentAddressLock(int &r, int &c, const CellAddress &addr)
         :row(r),col(c)
@@ -772,18 +727,35 @@ void Sheet::updateProperty(CellAddress key)
 
 Property *Sheet::getPropertyByName(const char* name) const
 {
-    std::string _name;
-    CellAddress addr;
-    if(addr.parseAbsoluteAddress(name)) {
-        _name = addr.toString(true);
-        name = _name.c_str();
-    }
-    Property * prop = getProperty(name);
-
+    CellAddress addr = getCellAddress(name,true);
+    Property *prop = 0;
+    if(addr.isValid())
+        prop = getProperty(addr);
     if (prop)
         return prop;
     else
         return DocumentObject::getPropertyByName(name);
+}
+
+Property *Sheet::getDynamicPropertyByName(const char* name) const {
+    CellAddress addr = getCellAddress(name,true);
+    Property *prop = 0;
+    if(addr.isValid())
+        prop = getProperty(addr);
+    if (prop)
+        return prop;
+    else
+        return DocumentObject::getDynamicPropertyByName(name);
+}
+
+void Sheet::getPropertyNamedList(std::vector<std::pair<const char*,Property*> > &List) const {
+    DocumentObject::getPropertyNamedList(List);
+    List.reserve(List.size()+cells.aliasProp.size());
+    for(auto &v : cells.aliasProp) {
+        auto prop = getProperty(v.first);
+        if(prop)
+            List.emplace_back(v.second.c_str(),prop);
+    }
 }
 
 void Sheet::touchCells(Range range) {
@@ -837,8 +809,6 @@ void Sheet::recomputeCell(CellAddress p)
         if(e.isDerivedFrom(Base::AbortException::getClassTypeId()))
             throw;
     }
-
-    updateAlias(p);
 
     if (!cell || cell->spansChanged())
         cellSpanChanged(p);
@@ -897,8 +867,6 @@ unsigned Sheet::getCellBindingBorder(App::CellAddress address) const {
 
 DocumentObjectExecReturn *Sheet::execute(void)
 {
-    // Remove all aliases first
-    removeAliases();
     boundRanges.clear();
     for(auto &v : ExpressionEngine.getExpressions()) {
         CellAddress from,to;
@@ -1441,17 +1409,6 @@ bool Sheet::isValidAlias(const std::string & candidate)
 void Sheet::setSpans(CellAddress address, int rows, int columns)
 {
     cells.setSpans(address, rows, columns);
-}
-
-/**
- * @brief Called when alias \a alias at \a address is removed.
- * @param address Address of alias.
- * @param alias Removed alias.
- */
-
-void Sheet::aliasRemoved(CellAddress address, const std::string & alias)
-{
-    removedAliases[address] = alias;
 }
 
 /**

--- a/src/Mod/Spreadsheet/App/Sheet.h
+++ b/src/Mod/Spreadsheet/App/Sheet.h
@@ -98,6 +98,18 @@ public:
 
     Cell *getNewCell(App::CellAddress address);
 
+    enum Border {
+        BorderTop = 1,
+        BorderLeft = 2,
+        BorderBottom = 4,
+        BorderRight = 8,
+        BorderAll = 15,
+    };
+    unsigned getCellBindingBorder(App::CellAddress address) const;
+
+    PropertySheet::BindingType getCellBinding(App::Range &range,
+            App::ExpressionPtr *pStart=0, App::ExpressionPtr *pEnd=0) const;
+
     void setCell(const char *address, const char *value);
 
     void setCell(App::CellAddress address, const char *value);
@@ -185,6 +197,8 @@ public:
 
     boost::signals2::signal<void (App::CellAddress)> cellUpdated;
 
+    boost::signals2::signal<void (App::Range)> rangeUpdated;
+
     boost::signals2::signal<void (App::CellAddress)> cellSpanChanged;
 
     boost::signals2::signal<void (int, int)> columnWidthChanged;
@@ -258,6 +272,8 @@ protected:
 
     int currentRow = -1;
     int currentCol = -1;
+
+    std::vector<App::Range> boundRanges;
 
     friend class SheetObserver;
 

--- a/src/Mod/Spreadsheet/App/Sheet.h
+++ b/src/Mod/Spreadsheet/App/Sheet.h
@@ -175,11 +175,19 @@ public:
 
     App::Property *getPropertyByName(const char *name) const;
 
+    App::Property *getDynamicPropertyByName(const char* name) const;
+
+    virtual void getPropertyNamedList(std::vector<std::pair<const char*,App::Property*> > &List) const;
+
     virtual short mustExecute(void) const;
 
     App::DocumentObjectExecReturn *execute(void);
 
     bool getCellAddress(const App::Property *prop, App::CellAddress &address);
+
+    App::CellAddress getCellAddress(const char *name, bool silent=false) const;
+
+    App::Range getRange(const char *name, bool silent=false) const;
 
     std::map<int, int> getColumnWidths() const;
 
@@ -223,8 +231,6 @@ protected:
 
     App::Property *getProperty(const char * addr) const;
 
-    void updateAlias(App::CellAddress key);
-
     void updateProperty(App::CellAddress key);
 
     App::Property *setStringProperty(App::CellAddress key, const std::string & value) ;
@@ -237,10 +243,6 @@ protected:
 
     App::Property *setQuantityProperty(App::CellAddress key, double value, const Base::Unit &unit);
 
-    void aliasRemoved(App::CellAddress address, const std::string &alias);
-
-    void removeAliases();
-
     virtual void onSettingDocument();
 
     /* Properties for used cells */
@@ -248,9 +250,6 @@ protected:
 
     /* Mapping of properties to cell position */
     std::map<const App::Property*, App::CellAddress > propAddress;
-
-    /* Removed (unprocessed) aliases */
-    std::map<App::CellAddress, std::string> removedAliases;
 
     /* Set of cells with errors */
     std::set<App::CellAddress> cellErrors;

--- a/src/Mod/Spreadsheet/App/Sheet.h
+++ b/src/Mod/Spreadsheet/App/Sheet.h
@@ -217,7 +217,13 @@ public:
 
     virtual void renameObjectIdentifiers(const std::map<App::ObjectIdentifier, App::ObjectIdentifier> & paths);
 
+    void setCopyOrCutRanges(const std::vector<App::Range> &ranges, bool copy=true);
+    const std::vector<App::Range> &getCopyOrCutRange(bool copy=true) const;
+    unsigned getCopyOrCutBorder(App::CellAddress address, bool copy=true) const;
+
 protected:
+
+    virtual void onChanged(const App::Property *prop);
 
     void updateColumnsOrRows(bool horizontal, int section, int count) ;
 
@@ -244,6 +250,8 @@ protected:
     App::Property *setQuantityProperty(App::CellAddress key, double value, const Base::Unit &unit);
 
     virtual void onSettingDocument();
+
+    void updateBindings();
 
     /* Properties for used cells */
     App::DynamicProperty &props;
@@ -273,6 +281,9 @@ protected:
     int currentCol = -1;
 
     std::vector<App::Range> boundRanges;
+
+    std::vector<App::Range> copyCutRanges;
+    bool hasCopyRange = false;
 
     friend class SheetObserver;
 

--- a/src/Mod/Spreadsheet/Gui/CMakeLists.txt
+++ b/src/Mod/Spreadsheet/Gui/CMakeLists.txt
@@ -51,6 +51,7 @@ endif()
 set(SpreadsheetGui_UIC_SRCS
    Sheet.ui
    PropertiesDialog.ui
+   DlgBindSheet.ui
 )
 
 if(BUILD_QT5)
@@ -89,6 +90,8 @@ SET(SpreadsheetGui_SRCS
     qtcolorpicker.cpp
     PropertiesDialog.h
     PropertiesDialog.cpp
+    DlgBindSheet.h
+    DlgBindSheet.cpp
     ${SpreadsheetGui_UIC_HDRS}
 )
 

--- a/src/Mod/Spreadsheet/Gui/CMakeLists.txt
+++ b/src/Mod/Spreadsheet/Gui/CMakeLists.txt
@@ -52,6 +52,7 @@ set(SpreadsheetGui_UIC_SRCS
    Sheet.ui
    PropertiesDialog.ui
    DlgBindSheet.ui
+   DlgSheetConf.ui
 )
 
 if(BUILD_QT5)
@@ -92,6 +93,8 @@ SET(SpreadsheetGui_SRCS
     PropertiesDialog.cpp
     DlgBindSheet.h
     DlgBindSheet.cpp
+    DlgSheetConf.h
+    DlgSheetConf.cpp
     ${SpreadsheetGui_UIC_HDRS}
 )
 

--- a/src/Mod/Spreadsheet/Gui/DlgBindSheet.cpp
+++ b/src/Mod/Spreadsheet/Gui/DlgBindSheet.cpp
@@ -1,0 +1,202 @@
+/****************************************************************************
+ *   Copyright (c) 2019 Zheng, Lei (realthunder) <realthunder.dev@gmail.com>*
+ *                                                                          *
+ *   This file is part of the FreeCAD CAx development system.               *
+ *                                                                          *
+ *   This library is free software; you can redistribute it and/or          *
+ *   modify it under the terms of the GNU Library General Public            *
+ *   License as published by the Free Software Foundation; either           *
+ *   version 2 of the License, or (at your option) any later version.       *
+ *                                                                          *
+ *   This library  is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *   GNU Library General Public License for more details.                   *
+ *                                                                          *
+ *   You should have received a copy of the GNU Library General Public      *
+ *   License along with this library; see the file COPYING.LIB. If not,     *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,          *
+ *   Suite 330, Boston, MA  02111-1307, USA                                 *
+ *                                                                          *
+ ****************************************************************************/
+
+#include "PreCompiled.h"
+#include <boost/algorithm/string/predicate.hpp>
+#include <QMessageBox>
+#include "DlgBindSheet.h"
+#include <Base/Tools.h>
+#include <App/Range.h>
+#include <App/Document.h>
+#include <App/Application.h>
+#include <App/ExpressionParser.h>
+#include <Gui/CommandT.h>
+#include "ui_DlgBindSheet.h"
+
+using namespace App;
+using namespace Spreadsheet;
+using namespace SpreadsheetGui;
+
+DlgBindSheet::DlgBindSheet(Sheet *sheet, const std::vector<Range> &ranges, QWidget *parent)
+    : QDialog(parent), sheet(sheet), range(ranges.front()), ui(new Ui::DlgBindSheet)
+{
+    ui->setupUi(this);
+
+    std::string toStart,toEnd;
+    ExpressionPtr pStart, pEnd;
+    PropertySheet::BindingType type = sheet->getCellBinding(range,&pStart,&pEnd);
+    if(type == PropertySheet::BindingNone) {
+        if(ranges.size()>1) {
+            toStart = ranges.back().from().toString();
+            toEnd = ranges.back().to().toString();
+        } else {
+            CellAddress target(range.to().row()?0:range.to().row()+1,range.from().col());
+            toStart = target.toString();
+            target.setRow(target.row() + range.to().row() - range.from().row());
+            target.setCol(target.col() + range.to().col() - range.from().col());
+            toEnd = target.toString();
+        }
+    } else {
+        ui->lineEditFromStart->setReadOnly(true);
+        ui->lineEditFromEnd->setReadOnly(true);
+        ui->checkBoxHREF->setChecked(type==PropertySheet::BindingHiddenRef);
+        assert(pStart && pEnd);
+        if(!pStart->hasComponent() && pStart->isDerivedFrom(StringExpression::getClassTypeId()))
+            toStart = static_cast<StringExpression*>(pStart.get())->getText();
+        else {
+            toStart = "=";
+            toStart += pStart->toString();
+        }
+        if(!pEnd->hasComponent() && pEnd->isDerivedFrom(StringExpression::getClassTypeId()))
+            toEnd = static_cast<StringExpression*>(pEnd.get())->getText();
+        else {
+            toEnd = "=";
+            toEnd += pEnd->toString();
+        }
+    }
+
+    ui->lineEditFromStart->setText(QString::fromLatin1(range.from().toString().c_str()));
+    ui->lineEditFromEnd->setText(QString::fromLatin1(range.to().toString().c_str()));
+
+    ui->lineEditToStart->setDocumentObject(sheet,false);
+    ui->lineEditToStart->setPrefix('=');
+    ui->lineEditToEnd->setDocumentObject(sheet,false);
+    ui->lineEditToEnd->setPrefix('=');
+
+    ui->lineEditToStart->setText(QLatin1String(toStart.c_str()));
+    ui->lineEditToEnd->setText(QLatin1String(toEnd.c_str()));
+
+    ui->comboBox->addItem(QString::fromLatin1(". (%1)").arg(
+                QString::fromUtf8(sheet->Label.getValue())), QByteArray(""));
+
+    for(auto obj : sheet->getDocument()->getObjectsOfType<Sheet>()) {
+        if(obj == sheet)
+            continue;
+        QString label;
+        if(obj->Label.getStrValue() != obj->getNameInDocument())
+            label = QString::fromLatin1("%1 (%2)").arg(
+                                QString::fromLatin1(obj->getNameInDocument()),
+                                QString::fromUtf8(obj->Label.getValue()));
+        else
+            label = QLatin1String(obj->getNameInDocument());
+        ui->comboBox->addItem(label, QByteArray(obj->getNameInDocument()));
+    }
+    for(auto doc : GetApplication().getDocuments()) {
+        if(doc == sheet->getDocument())
+            continue;
+        for(auto obj : sheet->getDocument()->getObjectsOfType<Sheet>()) {
+            if(obj == sheet)
+                continue;
+            std::string fullname = obj->getFullName();
+            QString label;
+            if(obj->Label.getStrValue() != obj->getNameInDocument())
+                label = QString::fromLatin1("%1 (%2)").arg(
+                                    QString::fromLatin1(fullname.c_str()),
+                                    QString::fromUtf8(obj->Label.getValue()));
+            else
+                label = QLatin1String(fullname.c_str());
+            ui->comboBox->addItem(label, QByteArray(fullname.c_str()));
+        }
+    }
+
+    connect(ui->btnDiscard, SIGNAL(clicked()), this, SLOT(onDiscard()));
+}
+
+DlgBindSheet::~DlgBindSheet()
+{
+    delete ui;
+}
+
+void DlgBindSheet::accept()
+{
+    bool commandActive = false;
+    try {
+        const char *ref = ui->comboBox->itemData(ui->comboBox->currentIndex()).toByteArray().constData();
+        auto obj = sheet;
+        if(ref[0]) {
+            const char *sep = strchr(ref,'#');
+            if(sep) {
+                std::string docname(ref,sep);
+                auto doc = GetApplication().getDocument(docname.c_str());
+                if(!doc)
+                    FC_THROWM(Base::RuntimeError, "Cannot find document " << docname);
+                obj = Base::freecad_dynamic_cast<Sheet>(doc->getObject(sep+1));
+            } else 
+                obj = Base::freecad_dynamic_cast<Sheet>(sheet->getDocument()->getObject(ref));
+            if(!obj)
+                FC_THROWM(Base::RuntimeError, "Cannot find Spreadsheet '" << ref << "'");
+        }
+
+        std::string fromStart(ui->lineEditFromStart->text().trimmed().toLatin1().constData());
+        std::string fromEnd(ui->lineEditFromEnd->text().trimmed().toLatin1().constData());
+
+        std::string toStart(ui->lineEditToStart->text().trimmed().toLatin1().constData());
+        if(boost::starts_with(toStart,"=")) 
+            toStart.erase(toStart.begin());
+        else
+            toStart = std::string("<<") + toStart + ">>";
+
+        std::string toEnd(ui->lineEditToEnd->text().trimmed().toLatin1().constData());
+        if(boost::starts_with(toEnd,"=")) 
+            toEnd.erase(toEnd.begin());
+        else
+            toEnd = std::string("<<") + toEnd + ">>";
+
+        Gui::Command::openCommand("Bind cells");
+        commandActive = true;
+
+        if(ui->checkBoxHREF->isChecked())
+            Gui::cmdAppObjectArgs(sheet,
+                    "setExpression('.cells.BindHiddenRef.%s.%s', 'hiddenref(tuple(%s.cells, %s, %s))')",
+                    fromStart, fromEnd, ref, toStart, toEnd);
+        else
+            Gui::cmdAppObjectArgs(sheet,
+                    "setExpression('.cells.Bind.%s.%s', 'tuple(%s.cells, %s, %s)')",
+                    fromStart, fromEnd, ref, toStart, toEnd);
+        Gui::Command::doCommand(Gui::Command::Doc, "App.ActiveDocument.recompute()");
+        Gui::Command::commitCommand();
+        QDialog::accept();
+    } catch(Base::Exception &e) {
+        e.ReportException();
+        QMessageBox::critical(this, tr("Bind cells"), QString::fromUtf8(e.what()));
+        if(commandActive)
+            Gui::Command::abortCommand();
+    }
+}
+
+void DlgBindSheet::onDiscard() {
+    try {
+        std::string fromStart(ui->lineEditFromStart->text().trimmed().toLatin1().constData());
+        std::string fromEnd(ui->lineEditFromEnd->text().trimmed().toLatin1().constData());
+        Gui::Command::openCommand("Unbind cells");
+        Gui::cmdAppObjectArgs(sheet, "setExpression('.cells.Bind.%s.%s', None)", fromStart, fromEnd);
+        Gui::Command::doCommand(Gui::Command::Doc, "App.ActiveDocument.recompute()");
+        Gui::Command::commitCommand();
+        reject();
+    } catch(Base::Exception &e) {
+        e.ReportException();
+        QMessageBox::critical(this, tr("Unbind cells"), QString::fromUtf8(e.what()));
+        Gui::Command::abortCommand();
+    }
+}
+
+#include "moc_DlgBindSheet.cpp"

--- a/src/Mod/Spreadsheet/Gui/DlgBindSheet.h
+++ b/src/Mod/Spreadsheet/Gui/DlgBindSheet.h
@@ -1,0 +1,56 @@
+/****************************************************************************
+ *   Copyright (c) 2019 Zheng, Lei (realthunder) <realthunder.dev@gmail.com>*
+ *                                                                          *
+ *   This file is part of the FreeCAD CAx development system.               *
+ *                                                                          *
+ *   This library is free software; you can redistribute it and/or          *
+ *   modify it under the terms of the GNU Library General Public            *
+ *   License as published by the Free Software Foundation; either           *
+ *   version 2 of the License, or (at your option) any later version.       *
+ *                                                                          *
+ *   This library  is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *   GNU Library General Public License for more details.                   *
+ *                                                                          *
+ *   You should have received a copy of the GNU Library General Public      *
+ *   License along with this library; see the file COPYING.LIB. If not,     *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,          *
+ *   Suite 330, Boston, MA  02111-1307, USA                                 *
+ *                                                                          *
+ ****************************************************************************/
+
+#ifndef DLG_BINDSHEET_H
+#define DLG_BINDSHEET_H
+
+#include <QDialog>
+#include <Mod/Spreadsheet/App/Sheet.h>
+
+namespace Ui {
+class DlgBindSheet;
+}
+
+namespace SpreadsheetGui {
+
+class DlgBindSheet : public QDialog
+{
+    Q_OBJECT
+    
+public:
+    explicit DlgBindSheet(Spreadsheet::Sheet *sheet, const std::vector<App::Range> &range, QWidget *parent = 0);
+    ~DlgBindSheet();
+    
+    void accept();
+
+public Q_SLOTS:
+    void onDiscard();
+
+private:
+    Spreadsheet::Sheet * sheet;
+    App::Range range;
+    Ui::DlgBindSheet *ui;
+};
+
+}
+
+#endif // DLG_BINDSHEET_H

--- a/src/Mod/Spreadsheet/Gui/DlgBindSheet.ui
+++ b/src/Mod/Spreadsheet/Gui/DlgBindSheet.ui
@@ -1,0 +1,169 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>DlgBindSheet</class>
+ <widget class="QDialog" name="DlgBindSheet">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>387</width>
+    <height>176</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Bind Spreadsheet Cells</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>From cells:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QLineEdit" name="lineEditFromStart">
+     <property name="toolTip">
+      <string>Binding cell range start</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="2">
+    <widget class="QLineEdit" name="lineEditFromEnd">
+     <property name="toolTip">
+      <string>Binding cell range end
+</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_3">
+     <property name="text">
+      <string>To cells:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="Gui::ExpressionLineEdit" name="lineEditToStart">
+     <property name="toolTip">
+      <string>Starting cell address to bind to. Type '=' if you want to use expression.
+The expression must evaluates to a string of some cell address.</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="2">
+    <widget class="Gui::ExpressionLineEdit" name="lineEditToEnd">
+     <property name="toolTip">
+      <string>Ending cell address to bind to. Type '=' if you want to use expression.
+The expression must evaluates to a string of some cell address.</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Sheet:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1" colspan="2">
+    <widget class="QCheckBox" name="checkBoxHREF">
+     <property name="toolTip">
+      <string>Use hidden reference not avoid creating a depdenecy with the referenced object. Use with caution!</string>
+     </property>
+     <property name="text">
+      <string>Use hidden reference</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1" colspan="2">
+    <layout class="QHBoxLayout" name="horizontalLayout_5">
+     <item>
+      <widget class="QPushButton" name="btnDiscard">
+       <property name="text">
+        <string>Unbind</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btnCancel">
+       <property name="text">
+        <string>Cancel</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btnOk">
+       <property name="text">
+        <string>OK</string>
+       </property>
+       <property name="default">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="2" column="1" colspan="2">
+    <widget class="QComboBox" name="comboBox">
+     <property name="toolTip">
+      <string>Select which spread sheet to bind to.</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>Gui::ExpressionLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header location="global">Gui/ExpressionCompleter.h</header>
+  </customwidget>
+ </customwidgets>
+ <tabstops>
+  <tabstop>lineEditFromStart</tabstop>
+  <tabstop>lineEditFromEnd</tabstop>
+  <tabstop>lineEditToStart</tabstop>
+  <tabstop>lineEditToEnd</tabstop>
+  <tabstop>comboBox</tabstop>
+  <tabstop>checkBoxHREF</tabstop>
+  <tabstop>btnOk</tabstop>
+  <tabstop>btnCancel</tabstop>
+  <tabstop>btnDiscard</tabstop>
+ </tabstops>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>btnOk</sender>
+   <signal>clicked()</signal>
+   <receiver>DlgBindSheet</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>334</x>
+     <y>152</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>193</x>
+     <y>87</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>btnCancel</sender>
+   <signal>clicked()</signal>
+   <receiver>DlgBindSheet</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>243</x>
+     <y>152</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>193</x>
+     <y>87</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/Mod/Spreadsheet/Gui/DlgSheetConf.cpp
+++ b/src/Mod/Spreadsheet/Gui/DlgSheetConf.cpp
@@ -1,0 +1,297 @@
+/****************************************************************************
+ *   Copyright (c) 2019 Zheng, Lei (realthunder) <realthunder.dev@gmail.com>*
+ *                                                                          *
+ *   This file is part of the FreeCAD CAx development system.               *
+ *                                                                          *
+ *   This library is free software; you can redistribute it and/or          *
+ *   modify it under the terms of the GNU Library General Public            *
+ *   License as published by the Free Software Foundation; either           *
+ *   version 2 of the License, or (at your option) any later version.       *
+ *                                                                          *
+ *   This library  is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *   GNU Library General Public License for more details.                   *
+ *                                                                          *
+ *   You should have received a copy of the GNU Library General Public      *
+ *   License along with this library; see the file COPYING.LIB. If not,     *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,          *
+ *   Suite 330, Boston, MA  02111-1307, USA                                 *
+ *                                                                          *
+ ****************************************************************************/
+
+#include "PreCompiled.h"
+#include <boost/algorithm/string/predicate.hpp>
+#include <QMessageBox>
+#include "DlgSheetConf.h"
+#include <Base/Tools.h>
+#include <App/Range.h>
+#include <App/Document.h>
+#include <App/Application.h>
+#include <App/ExpressionParser.h>
+#include <App/AutoTransaction.h>
+#include <Gui/CommandT.h>
+#include "ui_DlgSheetConf.h"
+
+using namespace App;
+using namespace Spreadsheet;
+using namespace SpreadsheetGui;
+
+DlgSheetConf::DlgSheetConf(Sheet *sheet, Range range, QWidget *parent)
+    : QDialog(parent), sheet(sheet), ui(new Ui::DlgSheetConf)
+{
+    ui->setupUi(this);
+
+    if(range.colCount()==1) {
+        auto to = range.to();
+        to.setCol(CellAddress::MAX_COLUMNS-1);
+        range = Range(range.from(),to);
+    }
+
+    ui->lineEditStart->setText(QString::fromLatin1(range.from().toString().c_str()));
+    ui->lineEditEnd->setText(QString::fromLatin1(range.to().toString().c_str()));
+
+    ui->lineEditProp->setDocumentObject(sheet,false);
+
+    connect(ui->btnDiscard, SIGNAL(clicked()), this, SLOT(onDiscard()));
+
+    CellAddress from,to;
+    std::string rangeConf;
+    ObjectIdentifier path;
+    auto prop = prepare(from,to,rangeConf,path,true);
+    if(prop) {
+        ui->lineEditProp->setText(QString::fromUtf8(path.toString().c_str()));
+        if (auto group = prop->getGroup())
+            ui->lineEditGroup->setText(QString::fromUtf8(group));
+    }
+
+    ui->lineEditStart->setText(QString::fromLatin1(from.toString().c_str()));
+    ui->lineEditEnd->setText(QString::fromLatin1(to.toString().c_str()));
+}
+
+DlgSheetConf::~DlgSheetConf()
+{
+    delete ui;
+}
+
+App::Property *DlgSheetConf::prepare(CellAddress &from, CellAddress &to,
+    std::string &rangeConf, ObjectIdentifier &path, bool init)
+{
+    from = sheet->getCellAddress(
+            ui->lineEditStart->text().trimmed().toLatin1().constData());
+    to = sheet->getCellAddress(
+            ui->lineEditEnd->text().trimmed().toLatin1().constData());
+
+    if(from.col()>=to.col())
+        FC_THROWM(Base::RuntimeError, "Invalid cell range");
+
+    // Setup row as parameters, and column as configurations
+    to.setRow(from.row());
+
+    CellAddress confFrom(from.row()+1,from.col());
+    rangeConf = confFrom.toString();
+    // rangeConf is supposed to hold the range of string cells, each
+    // holding the name of a configuration. The '|' below indicates a
+    // growing but continuous column, so that we can auto include new
+    // configurations. We'll bind the string list to a
+    // PropertyEnumeration for dynamical switching of the
+    // configuration.
+    rangeConf += ":|";
+
+    if(!init) {
+        std::string exprTxt(ui->lineEditProp->text().trimmed().toUtf8().constData());
+        ExpressionPtr expr;
+        try {
+            expr.reset(App::Expression::parse(sheet,exprTxt));
+        } catch (Base::Exception &e) {
+            e.ReportException();
+            FC_THROWM(Base::RuntimeError, "Failed to parse expression for property");
+        }
+        if(expr->hasComponent() || !expr->isDerivedFrom(App::VariableExpression::getClassTypeId())) 
+            FC_THROWM(Base::RuntimeError, "Invalid property expression: " << expr->toString());
+
+        path = static_cast<App::VariableExpression*>(expr.get())->getPath();
+        auto obj = path.getDocumentObject();
+        if(!obj) 
+            FC_THROWM(Base::RuntimeError, "Invalid object referenced in: " << expr->toString());
+
+        int pseudoType;
+        auto prop = path.getProperty(&pseudoType);
+        if(pseudoType || (prop && (!prop->isDerivedFrom(App::PropertyEnumeration::getClassTypeId())
+                                    || !prop->testStatus(App::Property::PropDynamic))))
+        {
+            FC_THROWM(Base::RuntimeError, "Invalid property referenced in: " << expr->toString());
+        }
+        return prop;
+    }
+
+    Cell *cell = sheet->getCell(from);
+    if(cell && cell->getExpression()) {
+        auto expr = cell->getExpression();
+        if(expr->isDerivedFrom(FunctionExpression::getClassTypeId())) {
+            auto fexpr = Base::freecad_dynamic_cast<FunctionExpression>(cell->getExpression());
+            if(fexpr && (fexpr->getFunction()==FunctionExpression::HREF
+                            || fexpr->getFunction()==FunctionExpression::HIDDENREF)
+                     && fexpr->getArgs().size()==1)
+                expr = fexpr->getArgs().front();
+        }
+        auto vexpr = Base::freecad_dynamic_cast<VariableExpression>(expr);
+        if(vexpr) {
+            auto prop = Base::freecad_dynamic_cast<PropertyEnumeration>(
+                                vexpr->getPath().getProperty());
+            if(prop) {
+                auto obj = Base::freecad_dynamic_cast<DocumentObject>(prop->getContainer());
+                if(obj) {
+                    path = ObjectIdentifier(sheet);
+                    path.setDocumentObjectName(obj,true);
+                    path << ObjectIdentifier::SimpleComponent(prop->getName());
+                    return prop;
+                }
+            }
+        }
+    }
+    return 0;
+}
+
+void DlgSheetConf::accept()
+{
+    bool commandActive = false;
+    try {
+        std::string rangeConf;
+        CellAddress from,to;
+        ObjectIdentifier path;
+        App::Property *prop = prepare(from,to,rangeConf,path,false);
+
+        Range range(from,to);
+
+        // check rangeConf, make sure it is a sequence of string only
+        Range r(sheet->getRange(rangeConf.c_str()));
+        do {
+            auto cell = sheet->getCell(*r);
+            if(cell && cell->getExpression()) {
+                ExpressionPtr expr(cell->getExpression()->eval());
+                if(expr->isDerivedFrom(StringExpression::getClassTypeId()))
+                    continue;
+            }
+            FC_THROWM(Base::RuntimeError, "Expects cell "
+                    << r.address() << " evaluates to string.\n"
+                    << rangeConf << " is supposed to contain a list of configuration names");
+        } while(r.next());
+
+        std::string exprTxt(ui->lineEditProp->text().trimmed().toUtf8().constData());
+        App::ExpressionPtr expr(App::Expression::parse(sheet,exprTxt));
+        if(expr->hasComponent() || !expr->isDerivedFrom(App::VariableExpression::getClassTypeId())) 
+            FC_THROWM(Base::RuntimeError, "Invalid property expression: " << expr->toString());
+
+        AutoTransaction guard("Setup conf table");
+        commandActive = true;
+
+        // unbind any previous binding
+        int count = range.rowCount() * range.colCount();
+        for (int i=0; i<count; ++i) {
+            auto r = range;
+            auto binding = sheet->getCellBinding(r);
+            if(!binding)
+                break;
+            Gui::cmdAppObjectArgs(sheet, "setExpression('.cells.%s.%s.%s', None)",
+                    binding==PropertySheet::BindingNormal?"Bind":"BindHiddenRef",
+                    r.from().toString(), r.to().toString());
+        }
+
+        auto obj = path.getDocumentObject();
+        if(!obj)
+            FC_THROWM(Base::RuntimeError, "Object not found");
+
+        // Add a dynamic PropertyEnumeration for user to switch the configuration
+        std::string propName = path.getPropertyName();
+        QString groupName = ui->lineEditGroup->text().trimmed();
+        if(!prop) {
+            prop = obj->addDynamicProperty("App::PropertyEnumeration", propName.c_str(),
+                                groupName.toUtf8().constData());
+        } else if (groupName.size())
+            obj->changeDynamicProperty(prop, groupName.toUtf8().constData(), nullptr);
+        prop->setStatus(App::Property::CopyOnChange,true);
+
+        // Bind the enumeration items to the column of configuration names
+        Gui::cmdAppObjectArgs(obj, "setExpression('%s.Enum', '%s.cells[<<%s>>]')",
+                propName, sheet->getFullName(), rangeConf);
+
+        Gui::cmdAppObjectArgs(obj, "recompute()");
+
+        // Bind the first cell to string value of the PropertyEnumeration. We
+        // could have just bind the entire row as below, but binding the first
+        // cell separately using a simpler expression can make it easy for us
+        // to extract the name of the PropertyEnumeration for editing or unsetup.
+        Gui::cmdAppObjectArgs(sheet, "set('%s', '=hiddenref(%s.String)')",
+                from.toString(true), prop->getFullName());
+
+        // Adjust the range to skip the first cell
+        range = Range(from.row(),from.col()+1,to.row(),to.col());
+
+        // Formulate expression to calculate the row binding using
+        // PropertyEnumeration
+        Gui::cmdAppObjectArgs(sheet, "setExpression('.cells.Bind.%s.%s', "
+            "'tuple(.cells, <<%s>> + str(hiddenref(%s)+%d), <<%s>> + str(hiddenref(%s)+%d))')",
+            range.from().toString(true), range.to().toString(true),
+            range.from().toString(true,false,true), prop->getFullName(), from.row()+2,
+            range.to().toString(true,false,true), prop->getFullName(), from.row()+2);
+
+        Gui::Command::doCommand(Gui::Command::Doc, "App.ActiveDocument.recompute()");
+        Gui::Command::commitCommand();
+        QDialog::accept();
+    } catch(Base::Exception &e) {
+        e.ReportException();
+        QMessageBox::critical(this, tr("Setup configuration table"), QString::fromUtf8(e.what()));
+        if(commandActive)
+            Gui::Command::abortCommand();
+    }
+}
+
+void DlgSheetConf::onDiscard() {
+    bool commandActive = false;
+    try {
+        std::string rangeConf;
+        CellAddress from,to;
+        ObjectIdentifier path;
+        auto prop = prepare(from,to,rangeConf,path,true);
+
+        Range range(from,to);
+
+        AutoTransaction guard("Unsetup conf table");
+        commandActive = true;
+
+        // unbind any previous binding
+        int count = range.rowCount() * range.colCount();
+        for (int i=0; i<count; ++i) {
+            auto r = range;
+            auto binding = sheet->getCellBinding(r);
+            if(!binding)
+                break;
+            Gui::cmdAppObjectArgs(sheet, "setExpression('.cells.%s.%s.%s', None)",
+                    binding==PropertySheet::BindingNormal?"Bind":"BindHiddenRef",
+                    r.from().toString(), r.to().toString());
+        }
+
+        Gui::cmdAppObjectArgs(sheet, "clear('%s')", from.toString(true));
+
+        if(prop && prop->getName()) {
+            auto obj = path.getDocumentObject();
+            if(!obj)
+                FC_THROWM(Base::RuntimeError, "Object not found");
+            Gui::cmdAppObjectArgs(obj, "setExpression('%s.Enum', None)", prop->getName());
+            if(prop->testStatus(Property::PropDynamic))
+                Gui::cmdAppObjectArgs(obj, "removeProperty('%s')", prop->getName());
+        }
+
+        Gui::Command::doCommand(Gui::Command::Doc, "App.ActiveDocument.recompute()");
+        Gui::Command::commitCommand();
+        QDialog::accept();
+    } catch(Base::Exception &e) {
+        e.ReportException();
+        QMessageBox::critical(this, tr("Unsetup configuration table"), QString::fromUtf8(e.what()));
+        if(commandActive)
+            Gui::Command::abortCommand();
+    }
+}
+
+#include "moc_DlgSheetConf.cpp"

--- a/src/Mod/Spreadsheet/Gui/DlgSheetConf.h
+++ b/src/Mod/Spreadsheet/Gui/DlgSheetConf.h
@@ -1,0 +1,58 @@
+/****************************************************************************
+ *   Copyright (c) 2019 Zheng, Lei (realthunder) <realthunder.dev@gmail.com>*
+ *                                                                          *
+ *   This file is part of the FreeCAD CAx development system.               *
+ *                                                                          *
+ *   This library is free software; you can redistribute it and/or          *
+ *   modify it under the terms of the GNU Library General Public            *
+ *   License as published by the Free Software Foundation; either           *
+ *   version 2 of the License, or (at your option) any later version.       *
+ *                                                                          *
+ *   This library  is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *   GNU Library General Public License for more details.                   *
+ *                                                                          *
+ *   You should have received a copy of the GNU Library General Public      *
+ *   License along with this library; see the file COPYING.LIB. If not,     *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,          *
+ *   Suite 330, Boston, MA  02111-1307, USA                                 *
+ *                                                                          *
+ ****************************************************************************/
+
+#ifndef DLG_SHEETCONF_H
+#define DLG_SHEETCONF_H
+
+#include <QDialog>
+#include <Mod/Spreadsheet/App/Sheet.h>
+
+namespace Ui {
+class DlgSheetConf;
+}
+
+namespace SpreadsheetGui {
+
+class DlgSheetConf : public QDialog
+{
+    Q_OBJECT
+    
+public:
+    explicit DlgSheetConf(Spreadsheet::Sheet *sheet, App::Range range, QWidget *parent = 0);
+    ~DlgSheetConf();
+    
+    void accept();
+
+    App::Property *prepare(App::CellAddress &from, App::CellAddress &to,
+                std::string &rangeConf, App::ObjectIdentifier &path, bool init);
+
+public Q_SLOTS:
+    void onDiscard();
+
+private:
+    Spreadsheet::Sheet * sheet;
+    Ui::DlgSheetConf *ui;
+};
+
+}
+
+#endif // DLG_SHEETCONF_H

--- a/src/Mod/Spreadsheet/Gui/DlgSheetConf.ui
+++ b/src/Mod/Spreadsheet/Gui/DlgSheetConf.ui
@@ -1,0 +1,155 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>DlgSheetConf</class>
+ <widget class="QDialog" name="DlgSheetConf">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>366</width>
+    <height>146</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Setup Configuration Table</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>Property:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="2">
+    <widget class="QLineEdit" name="lineEditEnd">
+     <property name="toolTip">
+      <string>Ending cell address.
+
+The first column of the range is assumed to contain a list of configuration
+names, which will be used to generate a string list and bind to the given
+property for user to dynamically switch configuration.
+
+The first row of the range will be bound to whatever row (indirectly) selected
+by that property.
+</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Cell range:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QLineEdit" name="lineEditStart">
+     <property name="toolTip">
+      <string>Starting cell address.
+
+The first column of the range is assumed to contain a list of configuration
+names, which will be used to generate a string list and bind to the given
+property for user to dynamically switch configuration.
+
+The first row of the range will be bound to whatever row (indirectly) selected
+by that property.
+</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1" colspan="2">
+    <widget class="Gui::ExpressionLineEdit" name="lineEditProp">
+     <property name="toolTip">
+      <string>Type in an expression to specify the object and property name to dynamically
+switch the design configuration. The property will be created if not exist.</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1" colspan="2">
+    <widget class="QLineEdit" name="lineEditGroup">
+     <property name="toolTip">
+      <string>Optional property group name.</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_3">
+     <property name="text">
+      <string>Group:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1" colspan="2">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QPushButton" name="btnDiscard">
+       <property name="text">
+        <string>Unsetup</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="bthCancel">
+       <property name="text">
+        <string>Cancel</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btnOk">
+       <property name="text">
+        <string>OK</string>
+       </property>
+       <property name="default">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>Gui::ExpressionLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header location="global">Gui/ExpressionCompleter.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>btnOk</sender>
+   <signal>clicked()</signal>
+   <receiver>DlgSheetConf</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>313</x>
+     <y>122</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>182</x>
+     <y>72</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>bthCancel</sender>
+   <signal>clicked()</signal>
+   <receiver>DlgSheetConf</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>222</x>
+     <y>122</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>182</x>
+     <y>72</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/Mod/Spreadsheet/Gui/SheetModel.cpp
+++ b/src/Mod/Spreadsheet/Gui/SheetModel.cpp
@@ -50,6 +50,7 @@ SheetModel::SheetModel(Sheet *_sheet, QObject *parent)
     , sheet(_sheet)
 {
     cellUpdatedConnection = sheet->cellUpdated.connect(bind(&SheetModel::cellUpdated, this, bp::_1));
+    rangeUpdatedConnection = sheet->rangeUpdated.connect(bind(&SheetModel::rangeUpdated, this, bp::_1));
 
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Spreadsheet");
     aliasBgColor = QColor(Base::Tools::fromStdString(hGrp->GetASCII("AliasedCellBackgroundColor", "#feff9e")));
@@ -61,6 +62,7 @@ SheetModel::SheetModel(Sheet *_sheet, QObject *parent)
 SheetModel::~SheetModel()
 {
     cellUpdatedConnection.disconnect();
+    rangeUpdatedConnection.disconnect();
 }
 
 int SheetModel::rowCount(const QModelIndex &parent) const
@@ -592,6 +594,14 @@ void SheetModel::cellUpdated(CellAddress address)
     QModelIndex i = index(address.row(), address.col());
 
     dataChanged(i, i);
+}
+
+void SheetModel::rangeUpdated(const Range &range)
+{
+    QModelIndex i = index(range.from().row(), range.from().col());
+    QModelIndex j = index(range.to().row(), range.to().col());
+
+    dataChanged(i, j);
 }
 
 #include "moc_SheetModel.cpp"

--- a/src/Mod/Spreadsheet/Gui/SheetModel.h
+++ b/src/Mod/Spreadsheet/Gui/SheetModel.h
@@ -50,8 +50,10 @@ public:
 
 private:
     void cellUpdated(App::CellAddress address);
+    void rangeUpdated(const App::Range &range);
 
     boost::signals2::scoped_connection cellUpdatedConnection;
+    boost::signals2::scoped_connection rangeUpdatedConnection;
     Spreadsheet::Sheet * sheet;
     QColor aliasBgColor;
     QColor textFgColor;

--- a/src/Mod/Spreadsheet/Gui/SheetTableView.cpp
+++ b/src/Mod/Spreadsheet/Gui/SheetTableView.cpp
@@ -48,6 +48,7 @@
 #include "LineEdit.h"
 #include "PropertiesDialog.h"
 #include "DlgBindSheet.h"
+#include "DlgSheetConf.h"
 
 using namespace SpreadsheetGui;
 using namespace Spreadsheet;
@@ -183,6 +184,10 @@ SheetTableView::SheetTableView(QWidget *parent)
     connect(actionBind, SIGNAL(triggered()), this, SLOT(onBind()));
     contextMenu->addAction(actionBind);
 
+    QAction *actionConf = new QAction(tr("Configuration table..."),this);
+    connect(actionConf, SIGNAL(triggered()), this, SLOT(onConfSetup()));
+    contextMenu->addAction(actionConf);
+
     horizontalHeader()->addAction(actionBind);
     verticalHeader()->addAction(actionBind);
 
@@ -220,6 +225,14 @@ void SheetTableView::onBind() {
         DlgBindSheet dlg(sheet,ranges,this);
         dlg.exec();
     }
+}
+
+void SheetTableView::onConfSetup() {
+    auto ranges = selectedRanges();
+    if(ranges.empty())
+        return;
+    DlgSheetConf dlg(sheet,ranges.back(),this);
+    dlg.exec();
 }
 
 void SheetTableView::cellProperties()

--- a/src/Mod/Spreadsheet/Gui/SheetTableView.cpp
+++ b/src/Mod/Spreadsheet/Gui/SheetTableView.cpp
@@ -500,6 +500,9 @@ bool SheetTableView::event(QEvent* event)
         case Qt::Key_Delete:
             deleteSelection();
             return true;
+        case Qt::Key_Escape:
+            sheet->setCopyOrCutRanges({});
+            return true;
         default:
             break;
         }
@@ -570,8 +573,8 @@ void SheetTableView::deleteSelection()
             Gui::Command::doCommand(Gui::Command::Doc,"App.ActiveDocument.%s.clear('%s')", sheet->getNameInDocument(),
                                     i->rangeString().c_str());
         }
-        Gui::Command::commitCommand();
         Gui::Command::doCommand(Gui::Command::Doc, "App.ActiveDocument.recompute()");
+        Gui::Command::commitCommand();
     }
 }
 
@@ -579,18 +582,20 @@ static const QLatin1String _SheetMime("application/x-fc-spreadsheet");
 
 void SheetTableView::copySelection()
 {
-    QModelIndexList selection = selectionModel()->selectedIndexes();
+    _copySelection(selectedRanges(), true);
+}
+
+void SheetTableView::_copySelection(const std::vector<App::Range> &ranges, bool copy)
+{
     int minRow = INT_MAX;
     int maxRow = 0;
     int minCol = INT_MAX;
     int maxCol = 0;
-    for (auto it : selection) {
-        int row = it.row();
-        int col = it.column();
-        minRow = std::min(minRow, row);
-        maxRow = std::max(maxRow, row);
-        minCol = std::min(minCol, col);
-        maxCol = std::max(maxCol, col);
+    for (auto &range : ranges) {
+        minRow = std::min(minRow, range.from().row());
+        maxRow = std::max(maxRow, range.to().row());
+        minCol = std::min(minCol, range.from().col());
+        maxCol = std::max(maxCol, range.to().col());
     }
 
     QString selectedText;
@@ -607,33 +612,51 @@ void SheetTableView::copySelection()
     }
 
     Base::StringWriter writer;
-    sheet->getCells()->copyCells(writer,selectedRanges());
+    sheet->getCells()->copyCells(writer,ranges);
     QMimeData *mime = new QMimeData();
     mime->setText(selectedText);
     mime->setData(_SheetMime,QByteArray(writer.getString().c_str()));
     QApplication::clipboard()->setMimeData(mime);
+
+    sheet->setCopyOrCutRanges(std::move(ranges), copy);
 }
 
 void SheetTableView::cutSelection()
 {
-    copySelection();
-    deleteSelection();
+    _copySelection(selectedRanges(), false);
 }
 
 void SheetTableView::pasteClipboard()
 {
-    const QMimeData* mimeData = QApplication::clipboard()->mimeData();
-    if(!mimeData || !mimeData->hasText())
-        return;
-
-    auto ranges = selectedRanges();
-    if(ranges.empty())
-        return;
-
-    Range range = ranges.back();
-
     App::AutoTransaction committer("Paste cell");
     try {
+        bool copy = true;
+        auto ranges = sheet->getCopyOrCutRange(copy);
+        if(ranges.empty()) {
+            copy = false;
+            ranges = sheet->getCopyOrCutRange(copy);
+        }
+
+        if(ranges.size())
+            _copySelection(ranges, copy);
+
+        const QMimeData* mimeData = QApplication::clipboard()->mimeData();
+        if(!mimeData || !mimeData->hasText())
+            return;
+
+        if(!copy) {
+            for(auto range : ranges) {
+                do {
+                    sheet->clear(*range);
+                } while (range.next());
+            }
+        }
+
+        ranges = selectedRanges();
+        if(ranges.empty())
+            return;
+
+        Range range = ranges.back();
         if (!mimeData->hasFormat(_SheetMime)) {
             CellAddress current = range.from();
             QStringList cells;

--- a/src/Mod/Spreadsheet/Gui/SheetTableView.cpp
+++ b/src/Mod/Spreadsheet/Gui/SheetTableView.cpp
@@ -47,6 +47,7 @@
 #include "SheetTableView.h"
 #include "LineEdit.h"
 #include "PropertiesDialog.h"
+#include "DlgBindSheet.h"
 
 using namespace SpreadsheetGui;
 using namespace Spreadsheet;
@@ -178,6 +179,13 @@ SheetTableView::SheetTableView(QWidget *parent)
     connect(recompute, SIGNAL(triggered()), this, SLOT(onRecompute()));
     contextMenu->addAction(recompute);
 
+    actionBind = new QAction(tr("Bind..."),this);
+    connect(actionBind, SIGNAL(triggered()), this, SLOT(onBind()));
+    contextMenu->addAction(actionBind);
+
+    horizontalHeader()->addAction(actionBind);
+    verticalHeader()->addAction(actionBind);
+
     contextMenu->addSeparator();
     actionMerge = contextMenu->addAction(tr("Merge cells"));
     connect(actionMerge,SIGNAL(triggered()), this, SLOT(mergeCells()));
@@ -204,6 +212,14 @@ void SheetTableView::onRecompute() {
                 range.fromCellString(), range.toCellString());
     }
     Gui::Command::commitCommand();
+}
+
+void SheetTableView::onBind() {
+    auto ranges = selectedRanges();
+    if(ranges.size()>=1 && ranges.size()<=2) {
+        DlgBindSheet dlg(sheet,ranges,this);
+        dlg.exec();
+    }
 }
 
 void SheetTableView::cellProperties()
@@ -908,6 +924,9 @@ void SheetTableView::contextMenuEvent(QContextMenuEvent *)
         actionSplit->setEnabled(true);
         actionMerge->setEnabled(true);
     }
+
+    auto ranges = selectedRanges();
+    actionBind->setEnabled(ranges.size()>=1 && ranges.size()<=2);
 
     contextMenu->exec(QCursor::pos());
 }

--- a/src/Mod/Spreadsheet/Gui/SheetTableView.cpp
+++ b/src/Mod/Spreadsheet/Gui/SheetTableView.cpp
@@ -597,18 +597,16 @@ void SheetTableView::pasteClipboard()
     if(!mimeData || !mimeData->hasText())
         return;
 
-    if(selectionModel()->selectedIndexes().size()>1) {
-        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Spreadsheet"),
-                QObject::tr("Spreadsheet does not support range selection when pasting.\n"
-                            "Please select one cell only."));
+    auto ranges = selectedRanges();
+    if(ranges.empty())
         return;
-    }
 
-    QModelIndex current = currentIndex();
+    Range range = ranges.back();
 
     App::AutoTransaction committer("Paste cell");
     try {
         if (!mimeData->hasFormat(_SheetMime)) {
+            CellAddress current = range.from();
             QStringList cells;
             QString text = mimeData->text();
             int i=0;
@@ -616,7 +614,7 @@ void SheetTableView::pasteClipboard()
                 QStringList cols = it.split(QLatin1Char('\t'));
                 int j=0;
                 for (auto jt : cols) {
-                    QModelIndex index = model()->index(current.row()+i, current.column()+j);
+                    QModelIndex index = model()->index(current.row()+i, current.col()+j);
                     model()->setData(index, jt);
                     j++;
                 }
@@ -628,7 +626,7 @@ void SheetTableView::pasteClipboard()
             std::istream in(0);
             in.rdbuf(&buf);
             Base::XMLReader reader("<memory>", in);
-            sheet->getCells()->pasteCells(reader,CellAddress(current.row(),current.column()));
+            sheet->getCells()->pasteCells(reader,range);
         }
 
         GetApplication().getActiveDocument()->recompute();
@@ -637,7 +635,9 @@ void SheetTableView::pasteClipboard()
         e.ReportException();
         QMessageBox::critical(Gui::getMainWindow(), QObject::tr("Copy & Paste failed"),
                 QString::fromLatin1(e.what()));
+        return;
     }
+    clearSelection();
 }
 
 void SheetTableView::finishEditWithMove(int keyPressed, Qt::KeyboardModifiers modifiers, bool handleTabMotion)

--- a/src/Mod/Spreadsheet/Gui/SheetTableView.h
+++ b/src/Mod/Spreadsheet/Gui/SheetTableView.h
@@ -82,6 +82,7 @@ protected Q_SLOTS:
     void cellProperties();
     void onRecompute();
     void onBind();
+    void onConfSetup();
 
 protected:
     bool edit(const QModelIndex &index, EditTrigger trigger, QEvent *event);

--- a/src/Mod/Spreadsheet/Gui/SheetTableView.h
+++ b/src/Mod/Spreadsheet/Gui/SheetTableView.h
@@ -92,6 +92,8 @@ protected:
 
     void contextMenuEvent (QContextMenuEvent * e);
 
+    void _copySelection(const std::vector<App::Range> &ranges, bool copy);
+
     QModelIndex currentEditIndex;
     Spreadsheet::Sheet * sheet;
     int tabCounter;

--- a/src/Mod/Spreadsheet/Gui/SheetTableView.h
+++ b/src/Mod/Spreadsheet/Gui/SheetTableView.h
@@ -81,6 +81,7 @@ protected Q_SLOTS:
     void removeColumns();
     void cellProperties();
     void onRecompute();
+    void onBind();
 
 protected:
     bool edit(const QModelIndex &index, EditTrigger trigger, QEvent *event);
@@ -102,6 +103,7 @@ protected:
     QAction *actionPaste;
     QAction *actionCut;
     QAction *actionDel;
+    QAction *actionBind;
 
     boost::signals2::scoped_connection cellSpanChangedConnection;
 };

--- a/src/Mod/Spreadsheet/Gui/SpreadsheetDelegate.cpp
+++ b/src/Mod/Spreadsheet/Gui/SpreadsheetDelegate.cpp
@@ -28,6 +28,7 @@
 # include <QPainter>
 #endif
 
+#include <Base/Console.h>
 #include "SpreadsheetDelegate.h"
 #include "LineEdit.h"
 #include <Base/Console.h>
@@ -96,31 +97,41 @@ QSize SpreadsheetDelegate::sizeHint(const QStyleOptionViewItem & option, const Q
     return QSize();
 }
 
+static inline void drawBorder(QPainter *painter, const QStyleOptionViewItem &option,
+        unsigned flags, QColor color, Qt::PenStyle style)
+{
+    if(!flags)
+        return;
+    QPen pen(color);
+    pen.setWidth(2);
+    pen.setStyle(style);
+    painter->setPen(pen);
+
+    QRect rect = option.rect.adjusted(1,1,0,0);
+    if(flags == Sheet::BorderAll) {
+        painter->drawRect(rect);
+        return;
+    }
+    if(flags & Sheet::BorderLeft) 
+        painter->drawLine(rect.topLeft(), rect.bottomLeft());
+    if(flags & Sheet::BorderTop) 
+        painter->drawLine(rect.topLeft(), rect.topRight());
+    if(flags & Sheet::BorderRight) 
+        painter->drawLine(rect.topRight(), rect.bottomRight());
+    if(flags & Sheet::BorderBottom) 
+        painter->drawLine(rect.bottomLeft(), rect.bottomRight());
+}
+
 void SpreadsheetDelegate::paint(QPainter *painter,
         const QStyleOptionViewItem &option, const QModelIndex &index ) const
 {
     QStyledItemDelegate::paint(painter, option, index);
     if(!sheet)
         return;
-    unsigned flags = sheet->getCellBindingBorder(App::CellAddress(index.row(),index.column()));
-    if(!flags)
-        return;
-    QPen pen(Qt::blue);
-    pen.setWidth(1);
-    pen.setStyle(Qt::SolidLine);
-    painter->setPen(pen);
-    if(flags == Sheet::BorderAll) {
-        painter->drawRect(option.rect);
-        return;
-    }
-    if(flags & Sheet::BorderLeft) 
-        painter->drawLine(option.rect.topLeft(), option.rect.bottomLeft());
-    if(flags & Sheet::BorderTop) 
-        painter->drawLine(option.rect.topLeft(), option.rect.topRight());
-    if(flags & Sheet::BorderRight) 
-        painter->drawLine(option.rect.topRight(), option.rect.bottomRight());
-    if(flags & Sheet::BorderBottom) 
-        painter->drawLine(option.rect.bottomLeft(), option.rect.bottomRight());
+    App::CellAddress addr(index.row(), index.column());
+    drawBorder(painter, option, sheet->getCellBindingBorder(addr), Qt::blue, Qt::SolidLine);
+    drawBorder(painter, option, sheet->getCopyOrCutBorder(addr,true), Qt::green, Qt::DashLine);
+    drawBorder(painter, option, sheet->getCopyOrCutBorder(addr,false), Qt::red, Qt::DashLine);
 }
 
 #include "moc_SpreadsheetDelegate.cpp"

--- a/src/Mod/Spreadsheet/Gui/SpreadsheetDelegate.cpp
+++ b/src/Mod/Spreadsheet/Gui/SpreadsheetDelegate.cpp
@@ -30,10 +30,13 @@
 
 #include "SpreadsheetDelegate.h"
 #include "LineEdit.h"
+#include <Base/Console.h>
 #include <App/DocumentObject.h>
 #include <Mod/Spreadsheet/App/Sheet.h>
 #include <Gui/ExpressionCompleter.h>
 #include "DlgBindSheet.h"
+
+FC_LOG_LEVEL_INIT("Spreadsheet",true,true)
 
 using namespace Spreadsheet;
 using namespace SpreadsheetGui;

--- a/src/Mod/Spreadsheet/Gui/SpreadsheetDelegate.cpp
+++ b/src/Mod/Spreadsheet/Gui/SpreadsheetDelegate.cpp
@@ -24,8 +24,8 @@
 
 #include "PreCompiled.h"
 #ifndef _PreComp_
-#include <QItemDelegate>
-#include <QLineEdit>
+# include <QLineEdit>
+# include <QPainter>
 #endif
 
 #include "SpreadsheetDelegate.h"
@@ -33,11 +33,13 @@
 #include <App/DocumentObject.h>
 #include <Mod/Spreadsheet/App/Sheet.h>
 #include <Gui/ExpressionCompleter.h>
+#include "DlgBindSheet.h"
 
+using namespace Spreadsheet;
 using namespace SpreadsheetGui;
 
 SpreadsheetDelegate::SpreadsheetDelegate(Spreadsheet::Sheet * _sheet, QWidget *parent)
-    : QItemDelegate(parent)
+    : QStyledItemDelegate(parent)
     , sheet(_sheet)
 {
 }
@@ -46,7 +48,13 @@ QWidget *SpreadsheetDelegate::createEditor(QWidget *parent,
                                           const QStyleOptionViewItem &,
                                           const QModelIndex &index) const
 {
-    Q_UNUSED(index)
+    App::CellAddress addr(index.row(),index.column());
+    App::Range range(addr,addr);
+    if(sheet && sheet->getCellBinding(range)) {
+        FC_ERR("Bound cell " << addr.toString() << " cannot be edited");
+        return 0;
+    }
+
     SpreadsheetGui::LineEdit *editor = new SpreadsheetGui::LineEdit(parent);
     editor->setDocumentObject(sheet);
     connect(editor, &SpreadsheetGui::LineEdit::finishedWithKey, this, &SpreadsheetDelegate::on_editorFinishedWithKey);
@@ -83,6 +91,33 @@ QSize SpreadsheetDelegate::sizeHint(const QStyleOptionViewItem & option, const Q
     Q_UNUSED(option);
     Q_UNUSED(index);
     return QSize();
+}
+
+void SpreadsheetDelegate::paint(QPainter *painter,
+        const QStyleOptionViewItem &option, const QModelIndex &index ) const
+{
+    QStyledItemDelegate::paint(painter, option, index);
+    if(!sheet)
+        return;
+    unsigned flags = sheet->getCellBindingBorder(App::CellAddress(index.row(),index.column()));
+    if(!flags)
+        return;
+    QPen pen(Qt::blue);
+    pen.setWidth(1);
+    pen.setStyle(Qt::SolidLine);
+    painter->setPen(pen);
+    if(flags == Sheet::BorderAll) {
+        painter->drawRect(option.rect);
+        return;
+    }
+    if(flags & Sheet::BorderLeft) 
+        painter->drawLine(option.rect.topLeft(), option.rect.bottomLeft());
+    if(flags & Sheet::BorderTop) 
+        painter->drawLine(option.rect.topLeft(), option.rect.topRight());
+    if(flags & Sheet::BorderRight) 
+        painter->drawLine(option.rect.topRight(), option.rect.bottomRight());
+    if(flags & Sheet::BorderBottom) 
+        painter->drawLine(option.rect.bottomLeft(), option.rect.bottomRight());
 }
 
 #include "moc_SpreadsheetDelegate.cpp"

--- a/src/Mod/Spreadsheet/Gui/SpreadsheetDelegate.h
+++ b/src/Mod/Spreadsheet/Gui/SpreadsheetDelegate.h
@@ -25,7 +25,7 @@
 #ifndef SPREADSHEETDELEGATE_H
 #define SPREADSHEETDELEGATE_H
 
-#include <QItemDelegate>
+#include <QStyledItemDelegate>
 
 namespace Spreadsheet {
 class Sheet;
@@ -33,7 +33,7 @@ class Sheet;
 
 namespace SpreadsheetGui {
 
-class SpreadsheetDelegate : public QItemDelegate
+class SpreadsheetDelegate : public QStyledItemDelegate
 {
     Q_OBJECT
 public:
@@ -45,8 +45,11 @@ public:
                       const QModelIndex &index) const;
 
     QSize sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const;
+    void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index ) const;
+
 Q_SIGNALS:
     void finishedWithKey(int key, Qt::KeyboardModifiers modifiers);
+
 private Q_SLOTS:
     void on_editorFinishedWithKey(int key, Qt::KeyboardModifiers modifiers);
 private:


### PR DESCRIPTION
This is the penultimate of the merge PRs for @realthunder's PR "Configuration Table using Spreadsheet" (#2862). The main features implemented in this batch are cell binding and improved cut-copy-and-paste UI. Most needed right now are simply testers for those two features on various operating systems. The cell binding mechanism is found in the context menu and will open a dialog box. Copy and paste are accessed through the usual mechanisms.