### PR TITLE
3rdParty/E57Lib: Include limits to header

### DIFF
--- a/src/3rdParty/libE57Format/src/E57XmlParser.h
+++ b/src/3rdParty/libE57Format/src/E57XmlParser.h
@@ -27,6 +27,7 @@
 
 #pragma once
 
+#include <limits>
 #include <stack>
 
 #include <xercesc/sax/InputSource.hpp>


### PR DESCRIPTION
Some system have trouble to building the e57 library. Details will you found here: 
[Build failure because of E57XmlParser.cpp](https://forum.freecadweb.org/viewtopic.php?f=4&t=64567)