### PR TITLE
[PartDesign] for chamfer and fillet, add SelectAllEdges option in the…

### DIFF
--- a/src/Mod/PartDesign/Gui/TaskChamferParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskChamferParameters.cpp
@@ -96,6 +96,9 @@ TaskChamferParameters::TaskChamferParameters(ViewProviderDressUp *DressUpView, Q
     createDeleteAction(ui->listWidgetReferences, ui->buttonRefRemove);
     connect(deleteAction, SIGNAL(triggered()), this, SLOT(onRefDeleted()));
 
+    createAddAllEdgesAction(ui->listWidgetReferences);
+    connect(addAllEdgesAction, &QAction::triggered, this, &TaskChamferParameters::onAddAllEdges);
+
     connect(ui->listWidgetReferences, SIGNAL(currentItemChanged(QListWidgetItem*, QListWidgetItem*)),
         this, SLOT(setSelection(QListWidgetItem*)));
     connect(ui->listWidgetReferences, SIGNAL(itemClicked(QListWidgetItem*)),
@@ -244,6 +247,12 @@ void TaskChamferParameters::onRefDeleted(void)
         ui->buttonRefRemove->setEnabled(false);
         ui->buttonRefRemove->setToolTip(tr("There must be at least one item"));
     }
+}
+
+void TaskChamferParameters::onAddAllEdges(void)
+{
+    TaskDressUpParameters::addAllEdges(ui->listWidgetReferences);
+    ui->buttonRefRemove->setEnabled(true);
 }
 
 void TaskChamferParameters::onTypeChanged(int index)

--- a/src/Mod/PartDesign/Gui/TaskChamferParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskChamferParameters.h
@@ -51,6 +51,7 @@ private Q_SLOTS:
     void onAngleChanged(double);
     void onFlipDirection(bool);
     void onRefDeleted(void);
+    void onAddAllEdges(void);
 
 protected:
     virtual void clearButtons(const selectionModes notThis);

--- a/src/Mod/PartDesign/Gui/TaskDressUpParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskDressUpParameters.h
@@ -71,6 +71,7 @@ protected Q_SLOTS:
     void itemClickedTimeout();
     virtual void onRefDeleted(void) = 0;
     void createDeleteAction(QListWidget* parentList, QWidget* parentButton);
+    void createAddAllEdgesAction(QListWidget* parentList);
 
 protected:
     void exitSelectionMode();
@@ -78,7 +79,7 @@ protected:
     bool wasDoubleClicked = false;
     bool KeyEvent(QEvent *e);
     void hideOnError();
-
+    void addAllEdges(QListWidget* listWidget);
 protected:
     enum selectionModes { none, refAdd, refRemove, plane, line };
     virtual void clearButtons(const selectionModes notThis) = 0;
@@ -91,6 +92,7 @@ protected:
     QWidget* proxy;
     ViewProviderDressUp *DressUpView;
     QAction* deleteAction;
+    QAction* addAllEdgesAction;
 
     bool allowFaces, allowEdges;
     selectionModes selectionMode;    

--- a/src/Mod/PartDesign/Gui/TaskFilletParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskFilletParameters.cpp
@@ -90,6 +90,9 @@ TaskFilletParameters::TaskFilletParameters(ViewProviderDressUp *DressUpView, QWi
     createDeleteAction(ui->listWidgetReferences, ui->buttonRefRemove);
     connect(deleteAction, SIGNAL(triggered()), this, SLOT(onRefDeleted()));
 
+    createAddAllEdgesAction(ui->listWidgetReferences);
+    connect(addAllEdgesAction, &QAction::triggered, this, &TaskFilletParameters::onAddAllEdges);
+
     connect(ui->listWidgetReferences, SIGNAL(currentItemChanged(QListWidgetItem*, QListWidgetItem*)),
         this, SLOT(setSelection(QListWidgetItem*)));
     connect(ui->listWidgetReferences, SIGNAL(itemClicked(QListWidgetItem*)),
@@ -199,6 +202,12 @@ void TaskFilletParameters::onRefDeleted(void)
         ui->buttonRefRemove->setEnabled(false);
         ui->buttonRefRemove->setToolTip(tr("There must be at least one item"));
     }
+}
+
+void TaskFilletParameters::onAddAllEdges(void)
+{
+    TaskDressUpParameters::addAllEdges(ui->listWidgetReferences);
+    ui->buttonRefRemove->setEnabled(true);
 }
 
 void TaskFilletParameters::onLengthChanged(double len)

--- a/src/Mod/PartDesign/Gui/TaskFilletParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskFilletParameters.h
@@ -44,6 +44,7 @@ public:
 private Q_SLOTS:
     void onLengthChanged(double);
     void onRefDeleted(void);
+    void onAddAllEdges(void);
 
 protected:
     double getLength(void) const;


### PR DESCRIPTION
… context menu while in add or remove mode
![Snip macro screenshot-41f19f](https://user-images.githubusercontent.com/39143564/146627797-71e5ba56-b829-4464-a5ec-0663eab40df3.png)

If not in add or remove mode the shortcut is disabled.  When it is selected all the edges of the base object are selected, emulating what would happen if the user selected them all manually.