### PR TITLE
[PATH] change discretize value to fix issues

### DIFF
--- a/src/Mod/Path/PathScripts/PathAdaptive.py
+++ b/src/Mod/Path/PathScripts/PathAdaptive.py
@@ -33,6 +33,7 @@ import json
 import math
 import area
 
+from FreeCAD import Units
 from PySide import QtCore
 
 # lazily loaded modules
@@ -104,7 +105,13 @@ def sceneClean():
 
 
 def discretize(edge, flipDirection=False):
-    pts = edge.discretize(Deflection=0.0001)
+    val=Units.Quantity("1mm").getUserPreferred()
+    if len(val)==3 and val[2]=='mm':
+        deflection=0.002
+    else:
+        deflection=0.0001
+
+    pts = edge.discretize(Deflection=deflection)
     if flipDirection:
         pts.reverse()
 

--- a/src/Mod/Path/PathScripts/PathAdaptive.py
+++ b/src/Mod/Path/PathScripts/PathAdaptive.py
@@ -33,7 +33,6 @@ import json
 import math
 import area
 
-from FreeCAD import Units
 from PySide import QtCore
 
 # lazily loaded modules
@@ -105,13 +104,7 @@ def sceneClean():
 
 
 def discretize(edge, flipDirection=False):
-    val=Units.Quantity("1mm").getUserPreferred()
-    if len(val)==3 and val[2]=='mm':
-        deflection=0.002
-    else:
-        deflection=0.0001
-
-    pts = edge.discretize(Deflection=deflection)
+    pts = edge.discretize(Deflection=0.002)
     if flipDirection:
         pts.reverse()
 


### PR DESCRIPTION
Discretize of 0.0001 is okay for inches, but for metric <1microns would be quite small, this fixes some issues when generating paths for curves that look inward.
Since the internal unit is mm 0.0001 must have been set when having inch in mind.

I found following post in the forum: https://forum.freecadweb.org/viewtopic.php?f=15&t=42755
I have experienced similar issues with other curves in my object.
This is a sample where I use bsplines for creating extensions to a face (I also had that issue when generating adaptive paths - with the updated accuracy it does not happen anymore):
https://streamable.com/jfbin6

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [ ]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [ ]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [ ]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [ ]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
