### PR TITLE
App: catch Base::Exception in ObjectIdentifier::getDep()

### DIFF
--- a/src/App/ObjectIdentifier.cpp
+++ b/src/App/ObjectIdentifier.cpp
@@ -1138,6 +1138,8 @@ void ObjectIdentifier::getDep(Dependencies &deps, bool needProps, std::vector<st
     catch (Py::Exception& e) {
         e.clear();
     }
+    catch (Base::Exception &) {
+    }
 }
 
 /**


### PR DESCRIPTION
Reported in forum thread [here](https://forum.freecadweb.org/viewtopic.php?f=10&t=64718&sid=a720fe8c793e26c1625f2eab0539cd7f) and [here](https://forum.freecadweb.org/viewtopic.php?f=3&t=64699&start=10)

The exception is thrown by `access()` because it does not support getting value from `Property::getPathValue()`, to prevent recursive (some property overrides `getPathValue()` to call `ObjectIdentifier::getPyValue()` which in turn calls `access()`).