### PR TITLE
Draft: Commands acting on subelements did not load the Draft module

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_move.py
+++ b/src/Mod/Draft/draftguitools/gui_move.py
@@ -197,6 +197,7 @@ class Move(gui_base_original.Modifier):
 
     def move_subelements(self, is_copy):
         """Move the subelements."""
+        Gui.addModule("Draft")
         try:
             if is_copy:
                 self.commit(translate("draft", "Copy"),

--- a/src/Mod/Draft/draftguitools/gui_rotate.py
+++ b/src/Mod/Draft/draftguitools/gui_rotate.py
@@ -271,6 +271,7 @@ class Rotate(gui_base_original.Modifier):
 
     def rotate_subelements(self, is_copy):
         """Rotate the subelements."""
+        Gui.addModule("Draft")
         try:
             if is_copy:
                 self.commit(translate("draft", "Copy"),

--- a/src/Mod/Draft/draftguitools/gui_scale.py
+++ b/src/Mod/Draft/draftguitools/gui_scale.py
@@ -192,6 +192,7 @@ class Scale(gui_base_original.Modifier):
         the selected object is not a rectangle or another object
         that can't be used with `scaleVertex` and `scaleEdge`.
         """
+        Gui.addModule("Draft")
         try:
             if self.task.isCopy.isChecked():
                 self.commit(translate("draft", "Copy"),


### PR DESCRIPTION
Commands when acting on subelements did not load the Draft module. This would lead to an error of the Draft module was not already loaded by another command.

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
