### PR TITLE
Spreadsheet: Fix trouble with clang and MacOS

### DIFF
--- a/src/App/PropertyExpressionEngine.h
+++ b/src/App/PropertyExpressionEngine.h
@@ -178,7 +178,7 @@ private:
     typedef std::pair<int, int> Edge;
     // Note: use std::map instead of unordered_map to keep the binding order stable
     #ifdef FC_OS_MACOSX
-    typedef boost::unordered_map<const App::ObjectIdentifier, ExpressionInfo> ExpressionMap;
+    typedef std::map<App::ObjectIdentifier, ExpressionInfo> ExpressionMap;
     #else
     typedef std::map<const App::ObjectIdentifier, ExpressionInfo> ExpressionMap;
     #endif

--- a/src/App/PropertyExpressionEngine.h
+++ b/src/App/PropertyExpressionEngine.h
@@ -177,7 +177,11 @@ private:
     typedef boost::adjacency_list< boost::listS, boost::vecS, boost::directedS > DiGraph;
     typedef std::pair<int, int> Edge;
     // Note: use std::map instead of unordered_map to keep the binding order stable
+    #ifdef FC_OS_MACOSX
+    typedef boost::unordered_map<const App::ObjectIdentifier, ExpressionInfo> ExpressionMap;
+    #else
     typedef std::map<const App::ObjectIdentifier, ExpressionInfo> ExpressionMap;
+    #endif
 
     std::vector<App::ObjectIdentifier> computeEvaluationOrder(ExecuteOption option);
 


### PR DESCRIPTION
Since the Spreadsheet: support cell binding commit, I got trouble by building freecad. I didn't find similar reports in install/compile forum. So I will only use the old version of typedef for macos. Better solutions are welcome.

See [trouble details](https://github.com/FreeCAD/FreeCAD/commit/68fca409833ca0c8c3811ad4efddcfcc3e2e4255#commitcomment-62364932)
