### PR TITLE
Draft: fix scale.py copy_scaled_edge

### DIFF
--- a/src/Mod/Draft/draftfunctions/scale.py
+++ b/src/Mod/Draft/draftfunctions/scale.py
@@ -33,6 +33,7 @@ import draftutils.utils as utils
 import draftutils.gui_utils as gui_utils
 import draftfunctions.join as join
 import draftmake.make_copy as make_copy
+import draftmake.make_line as make_line
 
 
 def scale(objectslist, scale=App.Vector(1,1,1),
@@ -187,7 +188,6 @@ def copy_scaled_edge(obj, edge_index, scale, center):
     Needed for SubObjects modifiers.
     Implemented by Dion Moult during 0.19 dev cycle (works only with Draft Wire).
     """
-    import Part
     vertex1 = scaleVectorFromCenter(
         obj.Placement.multVec(obj.Points[edge_index]),
         scale, center)
@@ -199,7 +199,7 @@ def copy_scaled_edge(obj, edge_index, scale, center):
         vertex2 = scaleVectorFromCenter(
             obj.Placement.multVec(obj.Points[edge_index+1]),
             scale, center)
-    return Part.makeLine(vertex1, vertex2)
+    return make_line.make_line(vertex1, vertex2)
 
 
 copyScaledEdge = copy_scaled_edge


### PR DESCRIPTION
The `copy_scaled_edge` function should return a wire, not an edge. The `join_wires` function, called in `copy_scaled_edges`, can only handle wires.

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
