### PR TITLE
[GUI] don't show report view on warnings by default

### DIFF
--- a/src/Gui/DlgReportView.ui
+++ b/src/Gui/DlgReportView.ui
@@ -134,9 +134,6 @@ on-screen while displaying the warning</string>
         <property name="text">
          <string>Show report view on warning</string>
         </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
         <property name="prefEntry" stdset="0">
          <cstring>checkShowReportViewOnWarning</cstring>
         </property>
@@ -304,7 +301,7 @@ on-screen while displaying the log message</string>
           <property name="text">
            <string/>
           </property>
-          <property name="color" stdset="0">
+          <property name="color">
            <color>
             <red>0</red>
             <green>0</green>
@@ -362,7 +359,7 @@ on-screen while displaying the log message</string>
           <property name="text">
            <string/>
           </property>
-          <property name="color" stdset="0">
+          <property name="color">
            <color>
             <red>0</red>
             <green>0</green>
@@ -420,7 +417,7 @@ on-screen while displaying the log message</string>
           <property name="text">
            <string/>
           </property>
-          <property name="color" stdset="0">
+          <property name="color">
            <color>
             <red>255</red>
             <green>170</green>
@@ -478,7 +475,7 @@ on-screen while displaying the log message</string>
           <property name="text">
            <string/>
           </property>
-          <property name="color" stdset="0">
+          <property name="color">
            <color>
             <red>255</red>
             <green>0</green>

--- a/src/Gui/ReportView.cpp
+++ b/src/Gui/ReportView.cpp
@@ -261,7 +261,7 @@ bool ReportOutputObserver::eventFilter(QObject *obj, QEvent *event)
                     GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("OutputWindow");
             ReportHighlighter::Paragraph msgType = cr->messageType();
             if (msgType == ReportHighlighter::Warning){
-                if (group->GetBool("checkShowReportViewOnWarning", true)) {
+                if (group->GetBool("checkShowReportViewOnWarning", false)) {
                     showReportView();
                 }
             } else if (msgType == ReportHighlighter::Error){
@@ -485,10 +485,10 @@ void ReportOutput::changeEvent(QEvent *ev)
 void ReportOutput::contextMenuEvent ( QContextMenuEvent * e )
 {
     ParameterGrp::handle hGrp = WindowParameter::getDefaultParameter()->GetGroup("OutputWindow");
-    bool bShowOnLog = hGrp->GetBool("checkShowReportViewOnLogMessage",false);
-    bool bShowOnNormal = hGrp->GetBool("checkShowReportViewOnNormalMessage",false);
-    bool bShowOnWarn = hGrp->GetBool("checkShowReportViewOnWarning",true);
-    bool bShowOnError = hGrp->GetBool("checkShowReportViewOnError",true);
+    bool bShowOnLog = hGrp->GetBool("checkShowReportViewOnLogMessage", false);
+    bool bShowOnNormal = hGrp->GetBool("checkShowReportViewOnNormalMessage", false);
+    bool bShowOnWarn = hGrp->GetBool("checkShowReportViewOnWarning", false);
+    bool bShowOnError = hGrp->GetBool("checkShowReportViewOnError", true);
 
     QMenu* menu = new QMenu(this);
     QMenu* optionMenu = new QMenu( menu );
@@ -635,7 +635,7 @@ void ReportOutput::onToggleNormalMessage()
 
 void ReportOutput::onToggleShowReportViewOnWarning()
 {
-    bool show = getWindowParameter()->GetBool("checkShowReportViewOnWarning", true);
+    bool show = getWindowParameter()->GetBool("checkShowReportViewOnWarning", false);
     getWindowParameter()->SetBool("checkShowReportViewOnWarning", !show);
 }
 


### PR DESCRIPTION
I introduced FreeCAD to several people and see that especially newbies are confused with all the warnings they get but cannot understand.
The solution was to change that the report view panel is not automatically shown on every warning.
This PR does this.

More experienced users can anytime enable the option. Thus this PR has not much impact but obviously makes life easier for beginners.