### PR TITLE
[Mesh] rename gmsh -> Gmsh

### DIFF
--- a/src/Mod/Mesh/Gui/RemeshGmsh.cpp
+++ b/src/Mod/Mesh/Gui/RemeshGmsh.cpp
@@ -284,7 +284,7 @@ RemeshGmsh::RemeshGmsh(Mesh::Feature* mesh, QWidget* parent, Qt::WindowFlags fl)
   : GmshWidget(parent, fl)
   , d(new Private(mesh))
 {
-    // Copy mesh that is used each time when applying gmsh's remeshing function
+    // Copy mesh that is used each time when applying Gmsh's remeshing function
     d->copy = mesh->Mesh.getValue().getKernel();
     d->stlFile = App::Application::getTempFileName() + "mesh.stl";
     d->geoFile = App::Application::getTempFileName() + "mesh.geo";
@@ -313,15 +313,15 @@ bool RemeshGmsh::writeProject(QString& inpFile, QString& outFile)
         int maxAngle = 120;
         int minAngle = 20;
 
-        // gmsh geo file
+        // Gmsh geo file
         Base::FileInfo geo(d->geoFile);
         Base::ofstream geoOut(geo, std::ios::out);
-        // Examples on how to use gmsh: https://sfepy.org/doc-devel/preprocessing.html
-        // http://gmsh.info//doc/texinfo/gmsh.html
+        // Examples on how to use Gmsh: https://sfepy.org/doc-devel/preprocessing.html
+        // https://gmsh.info//doc/texinfo/gmsh.html
         // https://docs.salome-platform.org/latest/gui/GMSHPLUGIN/gmsh_2d_3d_hypo_page.html
         geoOut << "// geo file for meshing with Gmsh meshing software created by FreeCAD\n"
             << "If(GMSH_MAJOR_VERSION < 4)\n"
-            << "   Error(\"Too old gmsh version %g.%g. At least 4.x is required\", GMSH_MAJOR_VERSION, GMSH_MINOR_VERSION);\n"
+            << "   Error(\"Too old Gmsh version %g.%g. At least 4.x is required\", GMSH_MAJOR_VERSION, GMSH_MINOR_VERSION);\n"
             << "   Exit;\n"
             << "EndIf\n"
             << "Merge \"" << stl.filePath() << "\";\n\n"

--- a/src/Mod/Mesh/Gui/RemeshGmsh.ui
+++ b/src/Mod/Mesh/Gui/RemeshGmsh.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Remesh by gmsh</string>
+   <string>Remesh by Gmsh</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_3">
    <item row="0" column="0">
@@ -48,16 +48,16 @@
         <property name="unit" stdset="0">
          <string notr="true">mm</string>
         </property>
-        <property name="minimum" stdset="0">
+        <property name="minimum">
          <double>0.000000000000000</double>
         </property>
-        <property name="maximum" stdset="0">
+        <property name="maximum">
          <double>1000.000000000000000</double>
         </property>
-        <property name="singleStep" stdset="0">
+        <property name="singleStep">
          <double>0.100000000000000</double>
         </property>
-        <property name="value" stdset="0">
+        <property name="value">
          <double>0.000000000000000</double>
         </property>
        </widget>
@@ -74,16 +74,16 @@
         <property name="unit" stdset="0">
          <string notr="true">mm</string>
         </property>
-        <property name="minimum" stdset="0">
+        <property name="minimum">
          <double>0.000000000000000</double>
         </property>
-        <property name="maximum" stdset="0">
+        <property name="maximum">
          <double>1000.000000000000000</double>
         </property>
-        <property name="singleStep" stdset="0">
+        <property name="singleStep">
          <double>0.100000000000000</double>
         </property>
-        <property name="value" stdset="0">
+        <property name="value">
          <double>0.000000000000000</double>
         </property>
        </widget>
@@ -100,13 +100,13 @@
         <property name="unit" stdset="0">
          <string notr="true">deg</string>
         </property>
-        <property name="minimum" stdset="0">
+        <property name="minimum">
          <double>20.000000000000000</double>
         </property>
-        <property name="maximum" stdset="0">
+        <property name="maximum">
          <double>120.000000000000000</double>
         </property>
-        <property name="value" stdset="0">
+        <property name="value">
          <double>40.000000000000000</double>
         </property>
        </widget>

--- a/src/Mod/MeshPart/Gui/Tessellation.cpp
+++ b/src/Mod/MeshPart/Gui/Tessellation.cpp
@@ -59,7 +59,7 @@ Tessellation::Tessellation(QWidget* parent)
     gmsh = new Mesh2ShapeGmsh(this);
     connect(gmsh, SIGNAL(processed()), this, SLOT(gmshProcessed()));
 
-    ui->stackedWidget->addTab(gmsh, tr("gmsh"));
+    ui->stackedWidget->addTab(gmsh, tr("Gmsh"));
 
     ParameterGrp::handle handle = App::GetApplication().GetParameterGroupByPath
         ("User parameter:BaseApp/Preferences/Mod/Mesh/Meshing/Standard");
@@ -260,7 +260,7 @@ bool Tessellation::accept()
     bool doClose = !ui->checkBoxDontQuit->isChecked();
     int method = ui->stackedWidget->currentIndex();
 
-    // For gmsh the workflow is very different because it uses an executable
+    // For Gmsh the workflow is very different because it uses an executable
     // and therefore things are asynchronous
     if (method == Gmsh) {
         gmsh->process(activeDoc, shapeObjects);
@@ -522,7 +522,7 @@ bool Mesh2ShapeGmsh::writeProject(QString& inpFile, QString& outFile)
                 maxSize = 1.0e22;
             double minSize = getMinSize();
 
-            // gmsh geo file
+            // Gmsh geo file
             Base::FileInfo geo(d->geoFile);
             Base::ofstream geoOut(geo, std::ios::out);
             geoOut << "// geo file for meshing with Gmsh meshing software created by FreeCAD\n"


### PR DESCRIPTION
I was informed that Gmsh names itself with a capital G. I had a look and in FEM it is already named Gmsh, but not in the Mesh WB. Therefore this PR.

(The other UI file changes than the pure renaming were automatically done by Qt's designer.)