### PR TITLE
[core] Add new parameter to BaseApp/Preferences/Dialog called DontUse…

### DIFF
--- a/src/Gui/TaskElementColors.cpp
+++ b/src/Gui/TaskElementColors.cpp
@@ -237,6 +237,11 @@ public:
         auto color = item->data(Qt::UserRole).value<QColor>();
         QColorDialog cd(color, parent);
         cd.setOption(QColorDialog::ShowAlphaChannel);
+        ParameterGrp::handle group = App::GetApplication().GetUserParameter().
+              GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Dialog");
+        bool notNativeColorDialog = group->GetBool("DontUseNativeColorDialog", true);
+        if (notNativeColorDialog)
+            cd.setOptions(QColorDialog::DontUseNativeDialog);
         if (cd.exec()!=QDialog::Accepted || color==cd.selectedColor())
             return;
         color = cd.selectedColor();
@@ -426,6 +431,11 @@ void ElementColors::on_addSelection_clicked()
         auto color = d->items.front()->data(Qt::UserRole).value<QColor>();
         QColorDialog cd(color, this);
         cd.setOption(QColorDialog::ShowAlphaChannel);
+        ParameterGrp::handle group = App::GetApplication().GetUserParameter().
+              GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Dialog");
+        bool notNativeColorDialog = group->GetBool("DontUseNativeColorDialog", true);
+        if (notNativeColorDialog)
+            cd.setOptions(QColorDialog::DontUseNativeDialog);
         if (cd.exec()!=QDialog::Accepted)
             return;
         color = cd.selectedColor();

--- a/src/Gui/Widgets.cpp
+++ b/src/Gui/Widgets.cpp
@@ -782,7 +782,11 @@ void ColorButton::onChooseColor()
     if (d->modal) {
         QColor currentColor = d->col;
         QColorDialog cd(d->col, this);
-        cd.setOptions(QColorDialog::DontUseNativeDialog);
+        ParameterGrp::handle group = App::GetApplication().GetUserParameter().
+              GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Dialog");
+        bool notNativeColorDialog = group->GetBool("DontUseNativeColorDialog", true);
+        if (notNativeColorDialog)
+            cd.setOptions(QColorDialog::DontUseNativeDialog);
         cd.setOption(QColorDialog::ColorDialogOption::ShowAlphaChannel, d->allowTransparency);
 
         if (d->autoChange) {
@@ -808,7 +812,11 @@ void ColorButton::onChooseColor()
         if (d->cd.isNull()) {
             d->old = d->col;
             d->cd = new QColorDialog(d->col, this);
-            d->cd->setOptions(QColorDialog::DontUseNativeDialog);
+            ParameterGrp::handle group = App::GetApplication().GetUserParameter().
+                  GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Dialog");
+            bool notNativeColorDialog = group->GetBool("DontUseNativeColorDialog", true);
+            if (notNativeColorDialog)
+                d->cd->setOptions(QColorDialog::DontUseNativeDialog);
             d->cd->setOption(QColorDialog::ColorDialogOption::ShowAlphaChannel, d->allowTransparency);
             d->cd->setAttribute(Qt::WA_DeleteOnClose);
             connect(d->cd, SIGNAL(rejected()),


### PR DESCRIPTION
…NativeColorDialog, defaults to true.

This would hopefully resolve a crash with some systems where the native color dialog causes FreeCAD to crash.

https://forum.freecadweb.org/viewtopic.php?f=3&t=64291

