### PR TITLE
Mouse navigation: change unnecesary warnings to messages

### DIFF
--- a/src/Gui/GestureNavigationStyle.cpp
+++ b/src/Gui/GestureNavigationStyle.cpp
@@ -1010,7 +1010,7 @@ void GestureNavigationStyle::onSetRotationCenter(SbVec2s cursor){
     SbBool ret = NavigationStyle::lookAtPoint(cursor);
     if(!ret){
         this->interactiveCountDec(); //this was in original gesture nav. Not sure what is it needed for --DeepSOIC
-        Base::Console().Warning(
+        Base::Console().Message(
             "No object under cursor! Can't set new center of rotation.\n");
     }
 

--- a/src/Gui/MayaGestureNavigationStyle.cpp
+++ b/src/Gui/MayaGestureNavigationStyle.cpp
@@ -295,7 +295,7 @@ SbBool MayaGestureNavigationStyle::processSoEvent(const SoEvent * const ev)
                 SbBool ret = NavigationStyle::lookAtPoint(event->getPosition());
                 if(!ret){
                     this->interactiveCountDec();
-                    Base::Console().Warning(
+                    Base::Console().Message(
                         "No object under cursor! Can't set new center of rotation.\n");
                 }
             }
@@ -413,7 +413,7 @@ SbBool MayaGestureNavigationStyle::processSoEvent(const SoEvent * const ev)
                     SbBool ret = NavigationStyle::lookAtPoint(event->getPosition());
                     if(!ret){
                         this->interactiveCountDec();
-                        Base::Console().Warning(
+                        Base::Console().Message(
                             "No object under cursor! Can't set new center of rotation.\n");
                     }
                 }


### PR DESCRIPTION
Sent when trying to set rotation center without an object under the cursor and can be annoying if report view is set to show with warnings. Would it be ok to just remove the message entirely? I think other navigation modes (besides gesture and maya that are adressed in this PR) don't show it. Also, why do we even need an object under the cursor?