### PR TITLE
Draft: improve get_group_contents function in groups.py

### DIFF
--- a/src/Mod/Draft/draftutils/groups.py
+++ b/src/Mod/Draft/draftutils/groups.py
@@ -37,7 +37,7 @@ the objects created with this workbench work like groups.
 import FreeCAD as App
 import draftutils.utils as utils
 
-from draftutils.translate import _tr
+from draftutils.translate import translate
 from draftutils.messages import _msg, _err
 
 
@@ -58,15 +58,16 @@ def is_group(obj):
         a `'LayerContainer'`.
 
         Or the object is of the type `'Project'`, `'Site'`, `'Building'`,
-        `'Floor'` or `'BuildingPart'` from the Arch Workbench.
+        `'Floor'`, `'BuildingPart'` or `'Space'` from the Arch Workbench.
+        Note that `'Floor'` and `'Building'` are obsolete types.
 
         Otherwise returns `False`.
     """
-
+    typ = utils.get_type(obj)
     return ((obj.isDerivedFrom("App::DocumentObjectGroup")
-                and obj.Name != "LayerContainer")
-            or utils.get_type(obj) in ("Project", "Site", "Building",
-                                       "Floor", "BuildingPart"))
+                and typ != "LayerContainer")
+            or typ in ("Project", "Site", "Building",
+                       "Floor", "BuildingPart", "Space"))
 
 
 def get_group_names(doc=None):
@@ -91,7 +92,7 @@ def get_group_names(doc=None):
         found, doc = utils.find_doc(App.activeDocument())
 
     if not found:
-        _err(_tr("No active document. Aborting."))
+        _err(translate("draft", "No active document. Aborting."))
         return []
 
     glist = []
@@ -128,7 +129,7 @@ def ungroup(obj):
     found, obj = utils.find_object(obj, doc=App.activeDocument())
     if not found:
         _msg("obj: {}".format(obj_str))
-        _err(_tr("Wrong input: object not in document."))
+        _err(translate("draft", "Wrong input: object not in document."))
         return None
 
     doc = obj.Document
@@ -200,12 +201,9 @@ def get_group_contents(objectslist,
     Parameters
     ----------
     objectslist: list
-        If any object in the list is a group, its contents (`obj.Group`)
-        are extracted and added to the output list.
-
-        The "groups" are objects derived from `App::DocumentObjectGroup`,
-        but they can also be `'App::Part'`, or `'Building'`, `'BuildingPart'`,
-        `'Space'`, and `'Site'` from the Arch Workbench.
+        If any object in the list is considered a group, see the `is_group`
+        function, its contents (`obj.Group`) are extracted and added to the
+        output list.
 
         Single items that aren't groups are added to the output list
         as is.
@@ -242,28 +240,16 @@ def get_group_contents(objectslist,
 
     for obj in objectslist:
         if obj:
-            if (obj.isDerivedFrom("App::DocumentObjectGroup")
-                    or (utils.get_type(obj) in ("Building", "BuildingPart",
-                                                "Space", "Site")
-                        and hasattr(obj, "Group"))):
-                if utils.get_type(obj) == "Site":
-                    if obj.Shape:
-                        newlist.append(obj)
-                if obj.isDerivedFrom("Drawing::FeaturePage"):
-                    # Skip if the group is a Drawing page
-                    # Note: the Drawing workbench is obsolete
+            if is_group(obj):
+                if addgroups or (spaces
+                                 and utils.get_type(obj) == "Space"):
                     newlist.append(obj)
-                else:
-                    if addgroups or (spaces
-                                     and utils.get_type(obj) == "Space"):
-                        newlist.append(obj)
-                    if (noarchchild
-                            and utils.get_type(obj) in ("Building",
-                                                        "BuildingPart")):
-                        pass
-                    else:
-                        newlist.extend(get_group_contents(obj.Group,
-                                                          walls, addgroups))
+                if not (noarchchild
+                        and utils.get_type(obj) in ("Building",
+                                                    "BuildingPart")):
+                    newlist.extend(get_group_contents(obj.Group,
+                                                      walls, addgroups,
+                                                      spaces, noarchchild))
             else:
                 # print("adding ", obj.Name)
                 newlist.append(obj)


### PR DESCRIPTION
For consistency the `get_group_contents` function should use `is_group` to identify groups. The code dedicated to Site objects and Drawing pages was removed. Site objects should be handled the same as other groups and the Drawing workbench is obsolete.

Additionally:
1. The recursive call to `get_group_contents` did not receive all arguments from the initial call. This made no sense.
2. Updated the `is_group` function: Space objects should also be considered groups (they can contain equipment f.e.). And identifying LayerContainers by their 'type' is more reliable.
3. Fixed issues with `_tr`.

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
