### PR TITLE
Addon Manager: download and display Macro metadata

### DIFF
--- a/src/Mod/AddonManager/AddonManager.py
+++ b/src/Mod/AddonManager/AddonManager.py
@@ -243,7 +243,6 @@ class CommandAddonManager:
         )
         self.dialog.buttonClose.clicked.connect(self.dialog.reject)
         self.dialog.buttonUpdateCache.clicked.connect(self.on_buttonUpdateCache_clicked)
-        self.dialog.buttonShowDetails.clicked.connect(self.toggle_details)
         self.dialog.buttonPauseUpdate.clicked.connect(self.stop_update)
         self.packageList.itemSelected.connect(self.table_row_activated)
         self.packageList.setEnabled(False)
@@ -871,7 +870,6 @@ class CommandAddonManager:
         self.dialog.labelStatusInfo.hide()
         self.dialog.progressBar.hide()
         self.dialog.buttonPauseUpdate.hide()
-        self.dialog.buttonShowDetails.hide()
         self.dialog.labelUpdateInProgress.hide()
         self.packageList.ui.lineEditFilter.setFocus()
 
@@ -879,9 +877,7 @@ class CommandAddonManager:
         if self.dialog.progressBar.isHidden():
             self.dialog.progressBar.show()
             self.dialog.buttonPauseUpdate.show()
-            self.dialog.buttonShowDetails.show()
-            self.dialog.labelStatusInfo.hide()
-            self.dialog.buttonShowDetails.setArrowType(QtCore.Qt.RightArrow)
+            self.dialog.labelStatusInfo.show()
             self.dialog.labelUpdateInProgress.show()
 
     def update_progress_bar(self, current_value: int, max_value: int) -> None:
@@ -901,14 +897,6 @@ class CommandAddonManager:
             value * 10
         )  # Out of 1000 segments, so it moves sort of smoothly
         self.dialog.progressBar.repaint()
-
-    def toggle_details(self) -> None:
-        if self.dialog.labelStatusInfo.isHidden():
-            self.dialog.labelStatusInfo.show()
-            self.dialog.buttonShowDetails.setArrowType(QtCore.Qt.DownArrow)
-        else:
-            self.dialog.labelStatusInfo.hide()
-            self.dialog.buttonShowDetails.setArrowType(QtCore.Qt.RightArrow)
 
     def stop_update(self) -> None:
         self.cleanup_workers()

--- a/src/Mod/AddonManager/AddonManager.py
+++ b/src/Mod/AddonManager/AddonManager.py
@@ -755,6 +755,8 @@ class CommandAddonManager:
                 real_install_succeeded, errors = macro.install(self.macro_repo_dir)
                 if not real_install_succeeded:
                     failed = True
+                else:
+                    utils.update_macro_installation_details(repo)
 
             if not failed:
                 message = translate(

--- a/src/Mod/AddonManager/AddonManager.py
+++ b/src/Mod/AddonManager/AddonManager.py
@@ -24,7 +24,6 @@
 # *                                                                         *
 # ***************************************************************************
 
-from inspect import indentsize
 import os
 import shutil
 import stat
@@ -155,6 +154,8 @@ class CommandAddonManager:
                     "DownloadMacros",
                     warning_dialog.checkBoxDownloadMacroMetadata.isChecked(),
                 )
+                if warning_dialog.checkBoxDownloadMacroMetadata.isChecked():
+                    self.trigger_recache = True
                 selected_proxy_option = warning_dialog.comboBoxProxy.currentIndex()
                 if selected_proxy_option == 0:
                     pref.SetBool("NoProxyCheck", True)
@@ -202,6 +203,8 @@ class CommandAddonManager:
         #  0: Update every launch
         # >0: Update every n days
         self.update_cache = False
+        if hasattr(self, "trigger_recache") and self.trigger_recache:
+            self.update_cache = True
         update_frequency = pref.GetInt("UpdateFrequencyComboEntry", 0)
         if update_frequency == 0:
             days_between_updates = -1

--- a/src/Mod/AddonManager/AddonManager.py
+++ b/src/Mod/AddonManager/AddonManager.py
@@ -29,8 +29,7 @@ import shutil
 import stat
 import tempfile
 from datetime import date, timedelta
-from typing import Dict, Union
-from enum import Enum
+from typing import Dict
 
 from PySide2 import QtGui, QtCore, QtWidgets
 import FreeCADGui

--- a/src/Mod/AddonManager/AddonManager.ui
+++ b/src/Mod/AddonManager/AddonManager.ui
@@ -29,26 +29,6 @@
      <item>
       <layout class="QHBoxLayout" name="horizontalLayout_7">
        <item>
-        <widget class="QToolButton" name="buttonShowDetails">
-         <property name="toolTip">
-          <string>Show details</string>
-         </property>
-         <property name="text">
-          <string>...</string>
-         </property>
-         <property name="arrowType">
-          <enum>Qt::RightArrow</enum>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLabel" name="labelUpdateInProgress">
-         <property name="text">
-          <string>Loading...</string>
-         </property>
-        </widget>
-       </item>
-       <item>
         <widget class="QProgressBar" name="progressBar">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">

--- a/src/Mod/AddonManager/AddonManagerOptions.ui
+++ b/src/Mod/AddonManager/AddonManagerOptions.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>390</width>
-    <height>628</height>
+    <width>388</width>
+    <height>621</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -32,6 +32,19 @@ installed addons will be checked for available updates
      </property>
      <property name="prefPath" stdset="0">
       <cstring>Addons</cstring>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="Gui::PrefCheckBox" name="guiprefcheckboxdownloadmacros">
+     <property name="text">
+      <string>Download Macro metadata (approximately 10MB)</string>
+     </property>
+     <property name="prefEntry" stdset="0">
+      <string>DownloadMacros</string>
+     </property>
+     <property name="prefPath" stdset="0">
+      <string>Addons</string>
      </property>
     </widget>
    </item>

--- a/src/Mod/AddonManager/CMakeLists.txt
+++ b/src/Mod/AddonManager/CMakeLists.txt
@@ -13,6 +13,7 @@ SET(AddonManager_SRCS
     addonmanager_workers.py
     AddonManager.ui
     AddonManagerOptions.ui
+    first_run.ui
     compact_view.py
     expanded_view.py
     package_list.py

--- a/src/Mod/AddonManager/addonmanager_macro.py
+++ b/src/Mod/AddonManager/addonmanager_macro.py
@@ -198,7 +198,10 @@ class Macro(object):
                     return
                 response = ""
                 block = 8192
-                while data := u2.read(block):
+                while True:
+                    data = u2.read(block)
+                    if not data:
+                        break
                     if isinstance(data, bytes):
                         data = data.decode("utf-8")
                     response += data
@@ -232,7 +235,7 @@ class Macro(object):
             FreeCAD.Console.PrintWarning(
                 translate(
                     "AddonsInstaller",
-                    "Unable to retrieve a description for this macro.",
+                    f"Unable to retrieve a description from the wiki for macro {self.name}",
                 )
                 + "\n"
             )

--- a/src/Mod/AddonManager/addonmanager_macro.py
+++ b/src/Mod/AddonManager/addonmanager_macro.py
@@ -66,7 +66,6 @@ class Macro(object):
         self.author = ""
         self.other_files = []
         self.parsed = False
-        self.parse_time = 0.0
 
     def __eq__(self, other):
         return self.filename == other.filename

--- a/src/Mod/AddonManager/addonmanager_utilities.py
+++ b/src/Mod/AddonManager/addonmanager_utilities.py
@@ -127,9 +127,7 @@ def urlopen(url: str) -> Union[None, HTTPResponse]:
         u = urllib.request.urlopen(req, timeout=timeout)
 
     except URLError as e:
-        FreeCAD.Console.PrintError(
-            translate("AddonsInstaller", f"Error loading {url}") + ":\n {e.reason}\n"
-        )
+        FreeCAD.Console.PrintLog(f"Error loading {url}:\n {e.reason}\n")
         return None
     except Exception:
         return None

--- a/src/Mod/AddonManager/addonmanager_utilities.py
+++ b/src/Mod/AddonManager/addonmanager_utilities.py
@@ -300,4 +300,15 @@ def fix_relative_links(text, base_url):
     return new_text
 
 
+def warning_color_string() -> str:
+    warningColorString = "rgb(255,0,0)"
+    if hasattr(QtWidgets.QApplication.instance(), "styleSheet"):
+        # Qt 5.9 doesn't give a QApplication instance, so can't give the stylesheet info
+        if "dark" in QtWidgets.QApplication.instance().styleSheet().lower():
+            warningColorString = "rgb(255,50,50)"
+        else:
+            warningColorString = "rgb(200,0,0)"
+    return warningColorString
+
+
 #  @}

--- a/src/Mod/AddonManager/addonmanager_utilities.py
+++ b/src/Mod/AddonManager/addonmanager_utilities.py
@@ -29,11 +29,13 @@ import sys
 import ctypes
 import tempfile
 import ssl
+from typing import Union
 
 import urllib
 from urllib.request import Request
 from urllib.error import URLError
 from urllib.parse import urlparse
+from http.client import HTTPResponse
 
 from PySide2 import QtGui, QtCore, QtWidgets
 
@@ -94,7 +96,7 @@ def symlink(source, link_name):
                 raise ctypes.WinError()
 
 
-def urlopen(url: str):
+def urlopen(url: str) -> Union[None, HTTPResponse]:
     """Opens an url with urllib and streams it to a temp file"""
 
     timeout = 5

--- a/src/Mod/AddonManager/addonmanager_utilities.py
+++ b/src/Mod/AddonManager/addonmanager_utilities.py
@@ -21,23 +21,18 @@
 # *                                                                         *
 # ***************************************************************************
 
-import codecs
 import os
 import re
-import shutil
-import sys
 import ctypes
-import tempfile
 import ssl
 from typing import Union
 
 import urllib
-from urllib.request import Request
 from urllib.error import URLError
 from urllib.parse import urlparse
 from http.client import HTTPResponse
 
-from PySide2 import QtGui, QtCore, QtWidgets
+from PySide2 import QtCore, QtWidgets
 
 import FreeCAD
 import FreeCADGui

--- a/src/Mod/AddonManager/addonmanager_workers.py
+++ b/src/Mod/AddonManager/addonmanager_workers.py
@@ -286,7 +286,6 @@ class LoadPackagesFromCacheWorker(QtCore.QThread):
 
 class LoadMacrosFromCacheWorker(QtCore.QThread):
     add_macro_signal = QtCore.Signal(object)
-    done = QtCore.Signal()
 
     def __init__(self, cache_file: str):
         QtCore.QThread.__init__(self)
@@ -301,7 +300,6 @@ class LoadMacrosFromCacheWorker(QtCore.QThread):
                     return
                 new_macro = Macro.from_cache(item)
                 self.add_macro_signal.emit(AddonManagerRepo.from_macro(new_macro))
-        self.done.emit()
 
 
 class CheckWorkbenchesForUpdatesWorker(QtCore.QThread):

--- a/src/Mod/AddonManager/addonmanager_workers.py
+++ b/src/Mod/AddonManager/addonmanager_workers.py
@@ -35,7 +35,7 @@ import time
 from datetime import datetime
 from typing import Union, List
 
-from PySide2 import QtCore, QtGui, QtNetwork
+from PySide2 import QtCore, QtNetwork
 
 import FreeCAD
 

--- a/src/Mod/AddonManager/addonmanager_workers.py
+++ b/src/Mod/AddonManager/addonmanager_workers.py
@@ -697,9 +697,14 @@ class CacheMacroCode(QtCore.QThread):
             if terminator and terminator.isActive():
                 terminator.stop()
 
-        FreeCAD.Console.PrintMessage(
-            f"Out of {num_macros} macros, {len(self.failed)} failed"
-        )
+        if len(self.failed) > 0:
+            num_failed = len(self.failed)
+            FreeCAD.Console.PrintWarning(
+                translate(
+                    "AddonsInstaller",
+                    f"Out of {num_macros} macros, {num_failed} timed out while processing",
+                )
+            )
 
     def update_and_advance(self, repo: AddonManagerRepo) -> None:
         if repo is not None:

--- a/src/Mod/AddonManager/first_run.ui
+++ b/src/Mod/AddonManager/first_run.ui
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Dialog</class>
+ <widget class="QDialog" name="Dialog">
+  <property name="windowModality">
+   <enum>Qt::WindowModal</enum>
+  </property>
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>398</width>
+    <height>237</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Welcome to the Addon Manager</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="labelWarning">
+     <property name="text">
+      <string>The addons that can be installed here are not officially part of FreeCAD, and are not reviewed by the FreeCAD team. Make sure you know what you are installing!</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="label_2">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Download Settings</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="checkBoxAutoCheck">
+     <property name="text">
+      <string>Automatically check installed Addons for updates</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="checkBoxDownloadMacroMetadata">
+     <property name="text">
+      <string>Download Macro metadata (approximately 10MB)</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QComboBox" name="comboBoxProxy">
+       <item>
+        <property name="text">
+         <string>No proxy</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>System proxy</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>User-defined proxy:</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="lineEditProxy"/>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QLabel" name="label_3">
+     <property name="text">
+      <string>These and other settings are available in the FreeCAD Preferences window.</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>Dialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>Dialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/Mod/AddonManager/package_details.py
+++ b/src/Mod/AddonManager/package_details.py
@@ -31,11 +31,13 @@ from datetime import date, timedelta
 
 import FreeCAD
 
-from addonmanager_utilities import translate  # this needs to be as is for pylupdate
+import addonmanager_utilities as utils
 from addonmanager_workers import ShowWorker, GetMacroDetailsWorker
 from AddonManagerRepo import AddonManagerRepo
 
 import inspect
+
+translate = FreeCAD.Qt.translate
 
 
 class PackageDetails(QWidget):
@@ -93,31 +95,34 @@ class PackageDetails(QWidget):
             self.ui.buttonExecute.hide()
 
         if repo.update_status != AddonManagerRepo.UpdateStatus.NOT_INSTALLED:
-            installed_version_string = ""
-            if repo.installed_version:
-                installed_version_string = translate("AddonsInstaller", "Version") + " "
-                installed_version_string += repo.installed_version
-            else:
-                installed_version_string = (
-                    translate(
-                        "AddonsInstaller", "Unknown version (no package.xml file found)"
-                    )
-                    + " "
-                )
 
+            version = repo.installed_version
+            date = ""
+            installed_version_string = "<h3>"
             if repo.updated_timestamp:
-                installed_version_string += (
-                    " " + translate("AddonsInstaller", "installed on") + " "
-                )
-                installed_version_string += (
+                date = (
                     QDateTime.fromTime_t(repo.updated_timestamp)
                     .date()
                     .toString(Qt.SystemLocaleShortDate)
                 )
-                installed_version_string += ". "
+            if version and date:
+                installed_version_string += (
+                    translate(
+                        "AddonsInstaller", f"Version {version} installed on {date}"
+                    )
+                    + ". "
+                )
+            elif version:
+                installed_version_string += (
+                    translate("AddonsInstaller", f"Version {version} installed") + ". "
+                )
+            elif date:
+                installed_version_string += (
+                    translate("AddonsInstaller", f"Installed on {date}") + ". "
+                )
             else:
                 installed_version_string += (
-                    translate("AddonsInstaller", "installed") + ". "
+                    translate("AddonsInstaller", "Installed") + ". "
                 )
 
             if repo.update_status == AddonManagerRepo.UpdateStatus.UPDATE_AVAILABLE:
@@ -129,12 +134,20 @@ class PackageDetails(QWidget):
                     )
                     installed_version_string += repo.metadata.Version
                     installed_version_string += ".</b>"
+                elif repo.macro and repo.macro.version:
+                    installed_version_string += (
+                        "<b>"
+                        + translate("AddonsInstaller", "Update available to version")
+                        + " "
+                    )
+                    installed_version_string += repo.macro.version
+                    installed_version_string += ".</b>"
                 else:
                     installed_version_string += (
                         "<b>"
                         + translate(
                             "AddonsInstaller",
-                            "Update available to unknown version (no package.xml file found)",
+                            "An update is available",
                         )
                         + ".</b>"
                     )
@@ -166,19 +179,32 @@ class PackageDetails(QWidget):
                         + "."
                     )
 
-            basedir = FreeCAD.getUserAppDataDir()
-            moddir = os.path.join(basedir, "Mod", repo.name)
-            installed_version_string += (
-                "<br/>"
-                + translate("AddonsInstaller", "Installation location")
-                + ": "
-                + moddir
+            installed_version_string += "</h3>"
+            self.ui.labelPackageDetails.setText(installed_version_string)
+            if repo.update_status == AddonManagerRepo.UpdateStatus.UPDATE_AVAILABLE:
+                self.ui.labelPackageDetails.setStyleSheet(
+                    "color:" + utils.attention_color_string()
+                )
+            else:
+                self.ui.labelPackageDetails.setStyleSheet(
+                    "color:" + utils.bright_color_string()
+                )
+            self.ui.labelPackageDetails.show()
+
+            if repo.macro is not None:
+                moddir = FreeCAD.getUserMacroDir(True)
+            else:
+                basedir = FreeCAD.getUserAppDataDir()
+                moddir = os.path.join(basedir, "Mod", repo.name)
+            installationLocationString = (
+                translate("AddonsInstaller", "Installation location") + ": " + moddir
             )
 
-            self.ui.labelPackageDetails.setText(installed_version_string)
-            self.ui.labelPackageDetails.show()
+            self.ui.labelInstallationLocation.setText(installationLocationString)
+            self.ui.labelInstallationLocation.show()
         else:
             self.ui.labelPackageDetails.hide()
+            self.ui.labelInstallationLocation.hide()
 
         if repo.update_status == AddonManagerRepo.UpdateStatus.NOT_INSTALLED:
             self.ui.buttonInstall.show()
@@ -206,14 +232,6 @@ class PackageDetails(QWidget):
             self.ui.buttonUpdate.hide()
             self.ui.buttonCheckForUpdate.hide()
 
-        warningColorString = "rgb(255,0,0)"
-        if hasattr(QApplication.instance(), "styleSheet"):
-            # Qt 5.9 doesn't give a QApplication instance, so can't give the stylesheet info
-            if "dark" in QApplication.instance().styleSheet().lower():
-                warningColorString = "rgb(255,50,50)"
-            else:
-                warningColorString = "rgb(200,0,0)"
-
         if repo.obsolete:
             self.ui.labelWarningInfo.show()
             self.ui.labelWarningInfo.setText(
@@ -221,7 +239,9 @@ class PackageDetails(QWidget):
                 + translate("AddonsInstaller", "WARNING: This addon is obsolete")
                 + "</h1>"
             )
-            self.ui.labelWarningInfo.setStyleSheet("color:" + warningColorString)
+            self.ui.labelWarningInfo.setStyleSheet(
+                "color:" + utils.warning_color_string()
+            )
         elif repo.python2:
             self.ui.labelWarningInfo.show()
             self.ui.labelWarningInfo.setText(
@@ -229,7 +249,9 @@ class PackageDetails(QWidget):
                 + translate("AddonsInstaller", "WARNING: This addon is Python 2 Only")
                 + "</h1>"
             )
-            self.ui.labelWarningInfo.setStyleSheet("color:" + warningColorString)
+            self.ui.labelWarningInfo.setStyleSheet(
+                "color:" + utils.warning_color_string()
+            )
         else:
             self.ui.labelWarningInfo.hide()
 
@@ -415,6 +437,12 @@ class Ui_PackageDetails(object):
         self.labelPackageDetails.hide()
 
         self.verticalLayout_2.addWidget(self.labelPackageDetails)
+
+        self.labelInstallationLocation = QLabel(PackageDetails)
+        self.labelInstallationLocation.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        self.labelInstallationLocation.hide()
+
+        self.verticalLayout_2.addWidget(self.labelInstallationLocation)
 
         self.labelWarningInfo = QLabel(PackageDetails)
         self.labelWarningInfo.hide()

--- a/src/Mod/AddonManager/package_details.py
+++ b/src/Mod/AddonManager/package_details.py
@@ -207,7 +207,7 @@ class PackageDetails(QWidget):
             self.ui.buttonCheckForUpdate.hide()
 
         warningColorString = "rgb(255,0,0)"
-        if hasattr(QApplication.instance(),"styleSheet"):
+        if hasattr(QApplication.instance(), "styleSheet"):
             # Qt 5.9 doesn't give a QApplication instance, so can't give the stylesheet info
             if "dark" in QApplication.instance().styleSheet().lower():
                 warningColorString = "rgb(255,50,50)"

--- a/src/Mod/AddonManager/package_list.py
+++ b/src/Mod/AddonManager/package_list.py
@@ -358,6 +358,15 @@ class PackageListItemDelegate(QStyledItemDelegate):
                             f"\n{maintainer['name']} <{maintainer['email']}>"
                         )
                 self.widget.ui.labelMaintainer.setText(maintainers_string)
+        elif repo.macro and repo.macro.parsed:
+            if repo.macro.comment:
+                self.widget.ui.labelDescription.setText(repo.macro.comment)
+            elif repo.macro.desc:
+                comment, _, _ = repo.desc.partition("<br")
+                self.widget.ui.labelDescription.setText(comment)
+            self.widget.ui.labelVersion.setText(repo.macro.version)
+            if self.displayStyle == ListDisplayStyle.EXPANDED:
+                self.widget.ui.labelMaintainer.setText(repo.macro.author)
         else:
             self.widget.ui.labelDescription.setText("")
             self.widget.ui.labelVersion.setText("")

--- a/src/Mod/AddonManager/package_list.py
+++ b/src/Mod/AddonManager/package_list.py
@@ -361,6 +361,21 @@ class PackageListItemDelegate(QStyledItemDelegate):
         elif repo.macro and repo.macro.parsed:
             self.widget.ui.labelDescription.setText(repo.macro.comment)
             self.widget.ui.labelVersion.setText(repo.macro.version)
+            if repo.macro.date:
+                if repo.macro.version:
+                    new_label = (
+                        "v"
+                        + repo.macro.version
+                        + ", "
+                        + translate("AddonsInstaller", "updated")
+                        + " "
+                        + repo.macro.date
+                    )
+                else:
+                    new_label = (
+                        translate("AddonsInstaller", "Updated") + " " + repo.macro.date
+                    )
+                self.widget.ui.labelVersion.setText(new_label)
             if self.displayStyle == ListDisplayStyle.EXPANDED:
                 if repo.macro.author:
                     caption = translate("AddonsInstaller", "Author")

--- a/src/Mod/AddonManager/package_list.py
+++ b/src/Mod/AddonManager/package_list.py
@@ -367,6 +367,8 @@ class PackageListItemDelegate(QStyledItemDelegate):
                     self.widget.ui.labelMaintainer.setText(
                         caption + ": " + repo.macro.author
                     )
+                else:
+                    self.widget.ui.labelMaintainer.setText("")
         else:
             self.widget.ui.labelDescription.setText("")
             self.widget.ui.labelVersion.setText("")

--- a/src/Mod/AddonManager/package_list.py
+++ b/src/Mod/AddonManager/package_list.py
@@ -359,14 +359,14 @@ class PackageListItemDelegate(QStyledItemDelegate):
                         )
                 self.widget.ui.labelMaintainer.setText(maintainers_string)
         elif repo.macro and repo.macro.parsed:
-            if repo.macro.comment:
-                self.widget.ui.labelDescription.setText(repo.macro.comment)
-            elif repo.macro.desc:
-                comment, _, _ = repo.desc.partition("<br")
-                self.widget.ui.labelDescription.setText(comment)
+            self.widget.ui.labelDescription.setText(repo.macro.comment)
             self.widget.ui.labelVersion.setText(repo.macro.version)
             if self.displayStyle == ListDisplayStyle.EXPANDED:
-                self.widget.ui.labelMaintainer.setText(repo.macro.author)
+                if repo.macro.author:
+                    caption = translate("AddonsInstaller", "Author")
+                    self.widget.ui.labelMaintainer.setText(
+                        caption + ": " + repo.macro.author
+                    )
         else:
             self.widget.ui.labelDescription.setText("")
             self.widget.ui.labelVersion.setText("")
@@ -541,6 +541,12 @@ class PackageListFilter(QSortFilterProxyModel):
                 if re.match(name).hasMatch():
                     return True
                 if re.match(desc).hasMatch():
+                    return True
+                if (
+                    data.macro
+                    and data.macro.comment
+                    and re.match(data.macro.comment).hasMatch()
+                ):
                     return True
                 return False
             else:


### PR DESCRIPTION
This PR adds an option to download and display macro metadata. Doing so will also make it searchable using the filter box. The first-launch dialog is expanded to display the most important options, including this one. Note that this will make that dialog re-display for everyone, even those who had already seen the old version of the warning.