### PR TITLE
Github: Automatically label new pull requests based on the paths of files being changed

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,42 @@
+# Add 'source' label to any change to src files within the source dir EXCEPT for the docs sub-folder
+# source:
+# - any: ['src/**/*', '!src/docs/*']
+
+
+🛤️ Path:
+- 'src/Mod/Path/**/*'
+
+🏛 Arch:
+- 'src/Mod/Arch/**/*'
+
+AddonManager:
+- 'src/Mod/AddonManager/**/*'
+
+🚜 PartDesign:
+- 'src/Mod/PartDesign/**/*'
+
+':pencil2: Sketcher':
+- 'src/Mod/Sketcher/**/*'
+
+📐 Draft:
+- 'src/Mod/Draft/**/*'
+
+🧪 FEM:
+- 'src/Mod/Fem/**/*'
+
+⚙ TechDraw:
+- 'src/Mod/TechDraw/**/*'
+
+🧱 Part:  
+- 'src/Mod/Part/**/*'
+
+🥅Mesh:
+- 'src/Mod/Mesh/**/*'
+
+Spreadsheet:
+- 'src/Mod/Spreadsheet/**/*'
+
+Core:
+- 'src/App/**/*'
+- 'src/Base/**/*'
+- 'src/Gui/**/*'

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -9,9 +9,6 @@
 🏛 Arch:
 - 'src/Mod/Arch/**/*'
 
-AddonManager:
-- 'src/Mod/AddonManager/**/*'
-
 🚜 PartDesign:
 - 'src/Mod/PartDesign/**/*'
 

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -6,7 +6,7 @@
 
 name: Labeler
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened]
 
 jobs:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,24 @@
+# This workflow will triage pull requests and apply a label based on the
+# paths that are modified in the pull request.
+#
+# For more information, see:
+# https://github.com/actions/labeler
+
+name: Labeler
+on:
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+    - uses: actions/labeler@v3
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        configuration-path: ".github/labels.yml"
+        sync-labels: false 


### PR DESCRIPTION
This workflow will triage newly created or reopened PR and apply the label(s) based on the paths that are modified in the PR.

![Bildschirmfoto von 2022-01-01 14-49-54](https://user-images.githubusercontent.com/8532323/147852242-6a6367a2-9151-4a92-9b5e-f4270ead73fe.png)

The Labels are defined in the `.github/labels.yml` file.

For more information, see: https://github.com/actions/labeler

It can be tested in my Github Repo https://github.com/Floriansimmer/FreeCAD