### PR TITLE
[PartDesign::Scripts::Spring.py] update old example script

### DIFF
--- a/src/Mod/PartDesign/Scripts/Spring.py
+++ b/src/Mod/PartDesign/Scripts/Spring.py
@@ -32,8 +32,8 @@ class MySpring:
       c.Radius = barradius
       p = c.toShape()
       section = Part.Wire([p])
-      makeSolid = 1  # change to 1 to make a solid
-      isFrenet = 1
+      makeSolid = True
+      isFrenet = True
       myspring = Part.Wire(myhelix).makePipeShell([section], makeSolid, isFrenet)
       fp.Shape = myspring
 


### PR DESCRIPTION
Part.Wire.makePipeShell() now takes boolean arguments instead of integer arguments.

To use the script: in the python console enter:

```
from Scripts import Spring
Spring.makeMySpring()
```