### PR TITLE
PD: Make helix property descriptions translatable and reuse them as task panel tooltips

### DIFF
--- a/src/Mod/PartDesign/App/FeatureHelix.cpp
+++ b/src/Mod/PartDesign/App/FeatureHelix.cpp
@@ -80,40 +80,40 @@ Helix::Helix()
 
     const char* group = "Helix";
     ADD_PROPERTY_TYPE(Base, (Base::Vector3d(0.0, 0.0, 0.0)), group, App::Prop_ReadOnly,
-        "The center point of the helix' start; derived from the reference axis.");
+        QT_TRANSLATE_NOOP("App::Property", "The center point of the helix' start; derived from the reference axis."));
     ADD_PROPERTY_TYPE(Axis, (Base::Vector3d(0.0, 1.0, 0.0)), group, App::Prop_ReadOnly,
-        "The helix' direction; derived from the reference axis.");
+        QT_TRANSLATE_NOOP("App::Property", "The helix' direction; derived from the reference axis."));
     ADD_PROPERTY_TYPE(ReferenceAxis, (0), group, App::Prop_None,
-        "The reference axis of the helix.");
+        QT_TRANSLATE_NOOP("App::Property", "The reference axis of the helix."));
     ADD_PROPERTY_TYPE(Mode, (long(initialMode)), group, App::Prop_None,
-        "The helix input mode specifies which properties are set by the user.\n"
-        "Dependent properties are then calculated.");
+        QT_TRANSLATE_NOOP("App::Property", "The helix input mode specifies which properties are set by the user.\n"
+            "Dependent properties are then calculated."));
     Mode.setEnums(ModeEnums);
     ADD_PROPERTY_TYPE(Pitch, (10.0), group, App::Prop_None,
-        "The axial distance between two turns.");
+        QT_TRANSLATE_NOOP("App::Property", "The axial distance between two turns."));
     ADD_PROPERTY_TYPE(Height, (30.0), group, App::Prop_None,
-        "The height of the helix' path, not accounting for the extent of the profile.");
+        QT_TRANSLATE_NOOP("App::Property", "The height of the helix' path, not accounting for the extent of the profile."));
     ADD_PROPERTY_TYPE(Turns, (3.0), group, App::Prop_None,
-        "The number of turns in the helix.");
+        QT_TRANSLATE_NOOP("App::Property", "The number of turns in the helix."));
     Turns.setConstraints(&floatTurns);
     ADD_PROPERTY_TYPE(Angle, (0.0), group, App::Prop_None,
-        "The angle of the cone that forms a hull around the helix.\n"
-        "Non-zero values turn the helix into a conical spiral.\n"
-        "Positive values make the radius grow, nevatige shrink.");
+        QT_TRANSLATE_NOOP("App::Property", "The angle of the cone that forms a hull around the helix.\n"
+            "Non-zero values turn the helix into a conical spiral.\n"
+            "Positive values make the radius grow, nevatige shrink."));
     Angle.setConstraints(&floatAngle);
     ADD_PROPERTY_TYPE(Growth, (0.0), group, App::Prop_None,
-        "The growth of the helix' radius per turn.\n"
-        "Non-zero values turn the helix into a conical spiral.");
+        QT_TRANSLATE_NOOP("App::Property", "The growth of the helix' radius per turn.\n"
+            "Non-zero values turn the helix into a conical spiral."));
     ADD_PROPERTY_TYPE(LeftHanded, (false), group, App::Prop_None,
-        "Sets the turning direction to left handed,\n"
-        "i.e. counter-clockwise when moving along its axis.");
+        QT_TRANSLATE_NOOP("App::Property", "Sets the turning direction to left handed,\n"
+            "i.e. counter-clockwise when moving along its axis."));
     ADD_PROPERTY_TYPE(Reversed, (false), group, App::Prop_None,
-        "Determines whether the helix points in the opposite direction of the axis.");
+        QT_TRANSLATE_NOOP("App::Property", "Determines whether the helix points in the opposite direction of the axis."));
     ADD_PROPERTY_TYPE(Outside, (false), group, App::Prop_None,
-        "If set, the result will be the intersection of the profile and the preexisting body.");
+        QT_TRANSLATE_NOOP("App::Property", "If set, the result will be the intersection of the profile and the preexisting body."));
     ADD_PROPERTY_TYPE(HasBeenEdited, (false), group, App::Prop_Hidden,
-        "If false, the tool will propose an initial value for the pitch based on the profile bounding box,\n"
-        "so that self intersection is avoided.");
+        QT_TRANSLATE_NOOP("App::Property", "If false, the tool will propose an initial value for the pitch based on the profile bounding box,\n"
+            "so that self intersection is avoided."));
 
     setReadWriteStatusForMode(initialMode);
 }

--- a/src/Mod/PartDesign/Gui/TaskHelixParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskHelixParameters.cpp
@@ -301,9 +301,13 @@ void TaskHelixParameters::updateStatus()
 void TaskHelixParameters::updateUI()
 {
     fillAxisCombo();
-
+    assignToolTipsFromPropertyDocs();
     updateStatus();
+    adaptVisibilityToMode();
+}
 
+void TaskHelixParameters::adaptVisibilityToMode()
+{
     bool isPitchVisible = false;
     bool isHeightVisible = false;
     bool isTurnsVisible = false;
@@ -356,6 +360,52 @@ void TaskHelixParameters::updateUI()
     ui->labelGrowth->setVisible(isGrowthVisible);
 
     ui->checkBoxOutside->setVisible(isOutsideVisible);
+}
+
+void TaskHelixParameters::assignToolTipsFromPropertyDocs()
+{
+    auto pcHelix = static_cast<PartDesign::Helix*>(vp->getObject());
+    const char* propCategory = "App::Property"; // cf. https://tracker.freecadweb.org/view.php?id=0002524
+    QString toolTip;
+
+    // Beware that "Axis" in the GUI actually represents the property "ReferenceAxis"!
+    // The property "Axis" holds only the directional part of the reference axis and has no corresponding GUI element.
+    toolTip = QApplication::translate(propCategory, pcHelix->ReferenceAxis.getDocumentation());
+    ui->axis->setToolTip(toolTip);
+    ui->labelAxis->setToolTip(toolTip);
+
+    toolTip = QApplication::translate(propCategory, pcHelix->Mode.getDocumentation());
+    ui->inputMode->setToolTip(toolTip);
+    ui->labelInputMode->setToolTip(toolTip);
+
+    toolTip = QApplication::translate(propCategory, pcHelix->Pitch.getDocumentation());
+    ui->pitch->setToolTip(toolTip);
+    ui->labelPitch->setToolTip(toolTip);
+
+    toolTip = QApplication::translate(propCategory, pcHelix->Height.getDocumentation());
+    ui->height->setToolTip(toolTip);
+    ui->labelHeight->setToolTip(toolTip);
+
+    toolTip = QApplication::translate(propCategory, pcHelix->Turns.getDocumentation());
+    ui->turns->setToolTip(toolTip);
+    ui->labelTurns->setToolTip(toolTip);
+
+    toolTip = QApplication::translate(propCategory, pcHelix->Angle.getDocumentation());
+    ui->coneAngle->setToolTip(toolTip);
+    ui->labelConeAngle->setToolTip(toolTip);
+
+    toolTip = QApplication::translate(propCategory, pcHelix->Growth.getDocumentation());
+    ui->growth->setToolTip(toolTip);
+    ui->labelGrowth->setToolTip(toolTip);
+
+    toolTip = QApplication::translate(propCategory, pcHelix->LeftHanded.getDocumentation());
+    ui->checkBoxLeftHanded->setToolTip(toolTip);
+
+    toolTip = QApplication::translate(propCategory, pcHelix->Reversed.getDocumentation());
+    ui->checkBoxReversed->setToolTip(toolTip);
+
+    toolTip = QApplication::translate(propCategory, pcHelix->Outside.getDocumentation());
+    ui->checkBoxOutside->setToolTip(toolTip);
 }
 
 void TaskHelixParameters::onSelectionChanged(const Gui::SelectionChanges& msg)
@@ -529,6 +579,7 @@ void TaskHelixParameters::changeEvent(QEvent* e)
         int axis = ui->axis->currentIndex();
         int mode = ui->inputMode->currentIndex();
         ui->retranslateUi(proxy);
+        assignToolTipsFromPropertyDocs();
 
         // Axes added by the user cannot be restored
         fillAxisCombo(true);

--- a/src/Mod/PartDesign/Gui/TaskHelixParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskHelixParameters.h
@@ -69,6 +69,8 @@ private:
     void addSketchAxes();
     void addPartAxes();
     int addCurrentLink();
+    void assignToolTipsFromPropertyDocs();
+    void adaptVisibilityToMode();
 
 private Q_SLOTS:
     void onPitchChanged(double);

--- a/src/Mod/PartDesign/Gui/TaskHelixParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskHelixParameters.ui
@@ -35,7 +35,7 @@
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
-      <widget class="QLabel" name="label0">
+      <widget class="QLabel" name="labelAxis">
        <property name="text">
         <string>Axis:</string>
        </property>
@@ -88,7 +88,7 @@
    <item>
     <layout class="QHBoxLayout" name="horizontalLayoutMode">
      <item>
-      <widget class="QLabel" name="label4">
+      <widget class="QLabel" name="labelInputMode">
        <property name="text">
         <string>Mode:</string>
        </property>

--- a/src/Mod/PartDesign/Gui/TaskHelixParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskHelixParameters.ui
@@ -43,9 +43,6 @@
      </item>
      <item>
       <widget class="QComboBox" name="axis">
-       <property name="toolTip">
-        <string>Axis the helix winds around</string>
-       </property>
        <item>
         <property name="text">
          <string>Base X axis</string>
@@ -96,9 +93,6 @@
      </item>
      <item>
       <widget class="QComboBox" name="inputMode">
-       <property name="toolTip">
-        <string>Parameter set defining the helix</string>
-       </property>
        <item>
         <property name="text">
          <string>Pitch-Height-Angle</string>
@@ -134,9 +128,6 @@
      </item>
      <item>
       <widget class="Gui::QuantitySpinBox" name="pitch">
-       <property name="toolTip">
-        <string>Axial distance between two turns</string>
-       </property>
        <property name="keyboardTracking">
         <bool>false</bool>
        </property>
@@ -164,9 +155,6 @@
      </item>
      <item>
       <widget class="Gui::QuantitySpinBox" name="height">
-       <property name="toolTip">
-        <string>Height of helix</string>
-       </property>
        <property name="keyboardTracking">
         <bool>false</bool>
        </property>
@@ -194,9 +182,6 @@
      </item>
      <item>
       <widget class="Gui::QuantitySpinBox" name="turns">
-       <property name="toolTip">
-        <string>Number of turns</string>
-       </property>
        <property name="keyboardTracking">
         <bool>false</bool>
        </property>
@@ -221,9 +206,6 @@
      </item>
      <item>
       <widget class="Gui::QuantitySpinBox" name="coneAngle">
-       <property name="toolTip">
-        <string>Angle of the cone that forms a hull around the helix.</string>
-       </property>
        <property name="keyboardTracking">
         <bool>false</bool>
        </property>
@@ -254,9 +236,6 @@
      </item>
      <item>
       <widget class="Gui::QuantitySpinBox" name="growth">
-       <property name="toolTip">
-        <string>Radial growth of helix per turn</string>
-       </property>
        <property name="keyboardTracking">
         <bool>false</bool>
        </property>
@@ -272,9 +251,6 @@
      <property name="enabled">
       <bool>true</bool>
      </property>
-     <property name="toolTip">
-      <string>Sets turning direction to left handed</string>
-     </property>
      <property name="text">
       <string>Left handed</string>
      </property>
@@ -285,9 +261,6 @@
      <property name="enabled">
       <bool>true</bool>
      </property>
-     <property name="toolTip">
-      <string>Reverses the Axis direction</string>
-     </property>
      <property name="text">
       <string>Reversed</string>
      </property>
@@ -295,9 +268,6 @@
    </item>
    <item>
     <widget class="QCheckBox" name="checkBoxOutside">
-     <property name="toolTip">
-      <string>the result will be the intersection of helix and the preexisting body</string>
-     </property>
      <property name="text">
       <string>Remove outside of profile</string>
      </property>


### PR DESCRIPTION
By reusing the property docs as tooltip we avoid maintaining the same information in two places. The property descriptions have been made translatable, too, to ensure a fully translatable UI.

If we agree on this in general, I can adapt the other PartDesign features/taskpanels as well. However, before putting more work into this, I want to hear your comments.

I followed the methodology @wwmayer and @yorikvanhavre have introduced long time ago, cf. [Issue 0002524](https://tracker.freecadweb.org/view.php?id=0002524). It is used at least in the Arch, Draft and Path WBs and I think (not only) the PartDesign WB can benefit from this work, too.

----------
Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [ ]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
