### PR TITLE
[TechDraw] Use global DontUseNativeColorDialog parameter from BaseApp…

### DIFF
--- a/src/Mod/TechDraw/Gui/mrichtextedit.cpp
+++ b/src/Mod/TechDraw/Gui/mrichtextedit.cpp
@@ -51,9 +51,9 @@
 #include <Base/Console.h>
 #include <Base/Parameter.h>
 #include <Base/Tools.h>
+#include <Gui/FileDialog.h>
 
 #include <App/Application.h>
-
 #include "PreferencesGui.h"
 #include "mrichtextedit.h"
 
@@ -433,7 +433,12 @@ void MRichTextEdit::textStyle(int index) {
 }
 
 void MRichTextEdit::textFgColor() {
-    QColor col = QColorDialog::getColor(f_textedit->textColor(), this);
+    QColor col;
+    if (Gui::DialogOptions::dontUseNativeColorDialog()){
+        col = QColorDialog::getColor(f_textedit->textColor(),this, QLatin1String(""), QColorDialog::DontUseNativeDialog);
+    } else {
+        col = QColorDialog::getColor(f_textedit->textColor(), this);
+    }
     QTextCursor cursor = f_textedit->textCursor();
     if (!cursor.hasSelection()) {
         cursor.select(QTextCursor::WordUnderCursor);
@@ -450,7 +455,12 @@ void MRichTextEdit::textFgColor() {
 }
 
 void MRichTextEdit::textBgColor() {
-    QColor col = QColorDialog::getColor(f_textedit->textBackgroundColor(), this);
+    QColor col;
+    if (Gui::DialogOptions::dontUseNativeColorDialog()){
+        col = QColorDialog::getColor(f_textedit->textBackgroundColor(),this, QLatin1String(""), QColorDialog::DontUseNativeDialog);
+    } else {
+        col = QColorDialog::getColor(f_textedit->textBackgroundColor(), this);
+    }
     QTextCursor cursor = f_textedit->textCursor();
     if (!cursor.hasSelection()) {
         cursor.select(QTextCursor::WordUnderCursor);


### PR DESCRIPTION
…/Preferences/Dialog when opening color dialog

There is now a parameter the user can edit to select whether to have the native color dialog or the qt color dialog.  On Manjaro for some users there is a crash when opening the native color dialog.

https://forum.freecadweb.org/viewtopic.php?f=3&t=64291

https://github.com/FreeCAD/FreeCAD/pull/5289 (merged)

Qt Dialog in Ubuntu:

![Snip macro screenshot-f9953b](https://user-images.githubusercontent.com/39143564/147890427-5385f5aa-f619-4524-a120-9dd07ce792ba.png)

Native Dialog in Ubuntu:

![Snip macro screenshot-87bd31](https://user-images.githubusercontent.com/39143564/147890454-09099bbb-93c7-4a69-a7cc-fcd9bec60134.png)

