### PR TITLE
PD: Fix bug in FeatureTransformed

### DIFF
--- a/src/Mod/PartDesign/App/FeatureTransformed.cpp
+++ b/src/Mod/PartDesign/App/FeatureTransformed.cpp
@@ -20,7 +20,6 @@
  *                                                                            *
  ******************************************************************************/
 
-
 #include "PreCompiled.h"
 #ifndef _PreComp_
 # include <BRepBuilderAPI_Transform.hxx>
@@ -267,7 +266,10 @@ App::DocumentObjectExecReturn *Transformed::execute(void)
         bool overlapping = false;
 
         std::vector<gp_Trsf>::const_iterator t = transformations.begin();
-        bool first = true;
+
+        // First transformation is skipped since it should not be part of the toolShape.
+        t++;
+
         for (; t != transformations.end(); ++t) {
             // Make an explicit copy of the shape because the "true" parameter to BRepBuilderAPI_Transform
             // seems to be pretty broken
@@ -283,14 +285,13 @@ App::DocumentObjectExecReturn *Transformed::execute(void)
             shapes.emplace_back(shape);
             builder.Add(compShape, shape);
 
-            if (overlapDetectionMode && !first)
+            if (overlapDetectionMode)
                 overlapping =  overlapping || (countSolids(TopoShape(origShape).fuse(shape))==1);
 
-            if (first)
-                first = false;
         }
 
         TopoDS_Shape toolShape;
+
 
 #ifndef FC_DEBUG
         if (overlapping || overlapMode == "Overlap mode")
@@ -300,7 +301,7 @@ App::DocumentObjectExecReturn *Transformed::execute(void)
 #endif
 
         if (overlapping || overlapMode == "Overlap mode")
-            toolShape = TopoShape(origShape).fuse(shapes, Precision::Confusion());
+            toolShape = TopoShape(shape).fuse(shapes, Precision::Confusion());
         else
             toolShape = compShape;
 


### PR DESCRIPTION
This fixes the bug identified in
https://forum.freecadweb.org/viewtopic.php?f=3&t=64900

The original was mistakenly included in the pattern. It is important to not include the original in the pattern because the original might not be at the tip of the feature tree. Including the original will interfere with changes that occur further down in the feature tree



