### PR TITLE
[PD] get rid of a CI compiler warning

### DIFF
--- a/src/Mod/PartDesign/App/FeaturePad.cpp
+++ b/src/Mod/PartDesign/App/FeaturePad.cpp
@@ -100,7 +100,8 @@ App::DocumentObjectExecReturn *Pad::execute()
 
     TopoDS_Shape sketchshape;
     try {
-        Part::Feature* obj = getVerifiedObject();
+        getVerifiedObject();
+
         sketchshape = getVerifiedFace();
     }
     catch (const Base::Exception& e) {

--- a/src/Mod/PartDesign/App/FeaturePad.cpp
+++ b/src/Mod/PartDesign/App/FeaturePad.cpp
@@ -98,10 +98,9 @@ App::DocumentObjectExecReturn *Pad::execute()
     Midplane.setReadOnly(hasReversed);
     Reversed.setReadOnly(hasMidplane);
 
-    Part::Feature* obj = 0;
     TopoDS_Shape sketchshape;
     try {
-        obj = getVerifiedObject();
+        Part::Feature* obj = getVerifiedObject();
         sketchshape = getVerifiedFace();
     }
     catch (const Base::Exception& e) {

--- a/src/Mod/PartDesign/App/FeaturePocket.cpp
+++ b/src/Mod/PartDesign/App/FeaturePocket.cpp
@@ -100,7 +100,8 @@ App::DocumentObjectExecReturn *Pocket::execute()
 
     TopoDS_Shape profileshape;
     try {
-        Part::Feature* obj = getVerifiedObject();
+        getVerifiedObject();
+
         profileshape = getVerifiedFace();
     } catch (const Base::Exception& e) {
         return new App::DocumentObjectExecReturn(e.what());

--- a/src/Mod/PartDesign/App/FeaturePocket.cpp
+++ b/src/Mod/PartDesign/App/FeaturePocket.cpp
@@ -98,10 +98,9 @@ App::DocumentObjectExecReturn *Pocket::execute()
     if ((std::string(Type.getValueAsString()) == "TwoLengths") && (L < Precision::Confusion()))
         return new App::DocumentObjectExecReturn("Pocket: Second length of pocket too small");
 
-    Part::Feature* obj = 0;
     TopoDS_Shape profileshape;
     try {
-        obj = getVerifiedObject();
+        Part::Feature* obj = getVerifiedObject();
         profileshape = getVerifiedFace();
     } catch (const Base::Exception& e) {
         return new App::DocumentObjectExecReturn(e.what());


### PR DESCRIPTION
The CI compiler outputs this warning:
`FeaturePad.cpp:101:20: warning: variable 'obj' set but not used [-Wunused-but-set-variable]`

This PR is to see if the CI compiler warning vanishes.
