### PR TITLE
Path: Grbl_post: Allow controller-specific/non-standard gcode commands

### DIFF
--- a/src/Mod/Path/PathScripts/post/grbl_post.py
+++ b/src/Mod/Path/PathScripts/post/grbl_post.py
@@ -31,6 +31,7 @@ import argparse
 import datetime
 import shlex
 import PathScripts.PathUtil as PathUtil
+import regex
 
 
 TOOLTIP = """
@@ -577,6 +578,12 @@ def parse(pathobj):
             # prepend a line number and append a newline
             if len(outstring) >= 1:
                 out += linenumber() + format_outstring(outstring) + "\n"
+
+            # Check for comments containing machine-specific commands to pass literally to the controller
+            m = regex.match(r'^\(MC_RUN_COMMAND: ([^)]+)\)$', command)
+            if m:
+                raw_command = m.group(1)
+                out += linenumber() + raw_command + "\n"
 
     return out
 


### PR DESCRIPTION
This PR updates grbl_post to detect machine controller-specific commands in commends, and include them literally in the output.

This is useful for including in a job custom commands that a machine controller supports (but that aren't valid gcode).

Usage: add comments to Custom Ops using the format "(MC_RUN_COMMAND: my-custom-command)". The output file will contain a line with "my-custom-command".