### PR TITLE
Addon manager dependency resolver

### DIFF
--- a/src/Mod/AddonManager/AddonManager.py
+++ b/src/Mod/AddonManager/AddonManager.py
@@ -1081,32 +1081,61 @@ class CommandAddonManager:
 
     def on_update_all_completed(self) -> None:
         self.hide_progress_widgets()
+
+        def get_package_list(
+            message: str, repos: List[AddonManagerRepo], threshold: int
+        ):
+            """To ensure that the list doesn't get too long for the dialog, cut it off at some threshold"""
+            num_updates = len(repos)
+            if num_updates < threshold:
+                result = "".join([repo.name + "\n" for repo in repos])
+            else:
+                result = translate(
+                    "AddonsInstaller", f"{num_updates} total, see Report view for list"
+                )
+                for repo in repos:
+                    FreeCAD.Console.PrintMessage(f"{message}: {repo.name}\n")
+            return result
+
         if not self.subupdates_failed:
             message = (
                 translate(
                     "AddonsInstaller",
-                    "All packages were successfully updated. Packages:",
+                    "All packages were successfully updated",
                 )
-                + "\n"
+                + ": \n"
             )
-            message += "".join([repo.name + "\n" for repo in self.subupdates_succeeded])
+            message += get_package_list(
+                translate("AddonsInstaller", "Succeeded"), self.subupdates_succeeded, 15
+            )
         elif not self.subupdates_succeeded:
             message = (
-                translate("AddonsInstaller", "All packages updates failed. Packages:")
-                + "\n"
+                translate("AddonsInstaller", "All packages updates failed:") + "\n"
             )
-            message += "".join([repo.name + "\n" for repo in self.subupdates_failed])
+            message += get_package_list(
+                translate("AddonsInstaller", "Failed"), self.subupdates_failed, 15
+            )
         else:
             message = (
                 translate(
                     "AddonsInstaller",
-                    "Some packages updates failed. Successful packages:",
+                    "Some packages updates failed.",
                 )
-                + "\n"
+                + "\n\n"
+                + translate(
+                    "AddonsInstaller",
+                    "Succeeded",
+                )
+                + ":\n"
             )
-            message += "".join([repo.name + "\n" for repo in self.subupdates_succeeded])
-            message += translate("AddonsInstaller", "Failed packages:") + "\n"
-            message += "".join([repo.name + "\n" for repo in self.subupdates_failed])
+            message += get_package_list(
+                translate("AddonsInstaller", "Succeeded"), self.subupdates_succeeded, 8
+            )
+            message += "\n\n"
+            message += translate("AddonsInstaller", "Failed") + ":\n"
+            message += get_package_list(
+                translate("AddonsInstaller", "Failed"), self.subupdates_failed, 8
+            )
 
         for installed_repo in self.subupdates_succeeded:
             self.restart_required = True

--- a/src/Mod/AddonManager/AddonManager.py
+++ b/src/Mod/AddonManager/AddonManager.py
@@ -482,6 +482,7 @@ class CommandAddonManager:
             self.update_cache = False
             pref = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Addons")
             pref.SetString("LastCacheUpdate", date.today().isoformat())
+            self.packageList.item_filter.invalidateFilter()
 
     def get_cache_file_name(self, file: str) -> str:
         cache_path = FreeCAD.getUserCachePath()

--- a/src/Mod/AddonManager/AddonManagerRepo.py
+++ b/src/Mod/AddonManager/AddonManagerRepo.py
@@ -23,7 +23,7 @@
 import FreeCAD
 
 import os
-from typing import Dict
+from typing import Dict, Set
 
 from addonmanager_macro import Macro
 
@@ -92,6 +92,14 @@ class AddonManagerRepo:
         self.macro = None  # Bridge to Gaël Écorchard's macro management class
         self.updated_timestamp = None
         self.installed_version = None
+
+        # Each repo is also a node in a directed dependency graph:
+        self.requires: Set[AddonManagerRepo] = set()
+        self.blocks: Set[AddonManagerRepo] = set()
+
+        # And maintains a list of required and optional Python dependencies
+        self.python_requires: Set[str] = set()
+        self.python_optional: Set[str] = set()
 
     def __str__(self) -> str:
         result = f"FreeCAD {self.repo_type}\n"

--- a/src/Mod/AddonManager/AddonManagerRepo.py
+++ b/src/Mod/AddonManager/AddonManagerRepo.py
@@ -73,12 +73,13 @@ class AddonManagerRepo:
                 return "Restart required"
 
     class Dependencies:
-        required_external_addons = dict()
-        blockers = dict()
-        replaces = dict()
-        unrecognized_addons: Set[str] = set()
-        python_required: Set[str] = set()
-        python_optional: Set[str] = set()
+        def __init__(self):
+            self.required_external_addons = dict()
+            self.blockers = dict()
+            self.replaces = dict()
+            self.unrecognized_addons: Set[str] = set()
+            self.python_required: Set[str] = set()
+            self.python_optional: Set[str] = set()
 
     class ResolutionFailed(RuntimeError):
         def __init__(self, msg):

--- a/src/Mod/AddonManager/AddonManagerRepo.py
+++ b/src/Mod/AddonManager/AddonManagerRepo.py
@@ -107,9 +107,10 @@ class AddonManagerRepo:
         self.updated_timestamp = None
         self.installed_version = None
 
-        # Each repo is also a node in a directed dependency graph:
-        self.requires: Set[AddonManagerRepo] = set()
-        self.blocks: Set[AddonManagerRepo] = set()
+        # Each repo is also a node in a directed dependency graph (referenced by name so 
+        # they cen be serialized):
+        self.requires: Set[str] = set()
+        self.blocks: Set[str] = set()
 
         # And maintains a list of required and optional Python dependencies
         self.python_requires: Set[str] = set()
@@ -165,6 +166,13 @@ class AddonManagerRepo:
             )
             if os.path.isfile(cached_package_xml_file):
                 instance.load_metadata_file(cached_package_xml_file)
+
+        if "requires" in cache_dict:
+            instance.requires = set(cache_dict["requires"])
+            instance.blocks = set(cache_dict["blocks"])
+            instance.python_requires = set(cache_dict["python_requires"])
+            instance.python_optional = set(cache_dict["python_optional"])
+
         return instance
 
     def to_cache(self) -> Dict:
@@ -181,6 +189,10 @@ class AddonManagerRepo:
             "python2": self.python2,
             "obsolete": self.obsolete,
             "rejected": self.rejected,
+            "requires": list(self.requires),
+            "blocks": list(self.blocks),
+            "python_requires": list(self.python_requires),
+            "python_optional": list(self.python_optional),
         }
 
     def load_metadata_file(self, file: str) -> None:

--- a/src/Mod/AddonManager/AddonManagerRepo.py
+++ b/src/Mod/AddonManager/AddonManagerRepo.py
@@ -107,7 +107,7 @@ class AddonManagerRepo:
         self.updated_timestamp = None
         self.installed_version = None
 
-        # Each repo is also a node in a directed dependency graph (referenced by name so 
+        # Each repo is also a node in a directed dependency graph (referenced by name so
         # they cen be serialized):
         self.requires: Set[str] = set()
         self.blocks: Set[str] = set()

--- a/src/Mod/AddonManager/CMakeLists.txt
+++ b/src/Mod/AddonManager/CMakeLists.txt
@@ -15,6 +15,7 @@ SET(AddonManager_SRCS
     AddonManagerOptions.ui
     first_run.ui
     compact_view.py
+    dependency_resolution_dialog.ui
     expanded_view.py
     package_list.py
     package_details.py

--- a/src/Mod/AddonManager/addonmanager_metadata.py
+++ b/src/Mod/AddonManager/addonmanager_metadata.py
@@ -199,7 +199,7 @@ class DependencyDownloadWorker(DownloadWorker):
         """Called when the data fetch completed, either with an error, or if it found the metadata file"""
 
         if self.fetch_task.error() == QtNetwork.QNetworkReply.NetworkError.NoError:
-            FreeCAD.Console.PrintMessage(
+            FreeCAD.Console.PrintLog(
                 f"Found a metadata.txt file for {self.repo.name}\n"
             )
             new_deps = self.fetch_task.readAll()
@@ -232,7 +232,7 @@ class DependencyDownloadWorker(DownloadWorker):
                     wb_name = wb.strip()
                     if wb_name:
                         self.repo.requires.add(wb_name)
-                        FreeCAD.Console.PrintMessage(
+                        FreeCAD.Console.PrintLog(
                             f"{self.repo.display_name} requires FreeCAD Addon '{wb_name}'\n"
                         )
 
@@ -241,7 +241,7 @@ class DependencyDownloadWorker(DownloadWorker):
                 for pl in depspy:
                     if pl.strip():
                         self.repo.python_requires.add(pl.strip())
-                        FreeCAD.Console.PrintMessage(
+                        FreeCAD.Console.PrintLog(
                             f"{self.repo.display_name} requires python package '{pl.strip()}'\n"
                         )
             elif line.startswith("optionalpylibs="):
@@ -249,7 +249,7 @@ class DependencyDownloadWorker(DownloadWorker):
                 for pl in opspy:
                     if pl.strip():
                         self.repo.python_optional.add(pl.strip())
-                        FreeCAD.Console.PrintMessage(
+                        FreeCAD.Console.PrintLog(
                             f"{self.repo.display_name} optionally imports python package '{pl.strip()}'\n"
                         )
         self.updated.emit(self.repo)

--- a/src/Mod/AddonManager/addonmanager_metadata.py
+++ b/src/Mod/AddonManager/addonmanager_metadata.py
@@ -22,8 +22,8 @@
 
 import FreeCAD
 
-import tempfile
 import os
+import io
 import hashlib
 from typing import Dict, List
 
@@ -36,34 +36,17 @@ from AddonManagerRepo import AddonManagerRepo
 translate = FreeCAD.Qt.translate
 
 
-class MetadataDownloadWorker(QObject):
-    """A worker for downloading package.xml and associated icon(s)
-
-    To use, instantiate an object of this class and call the start_fetch() function
-    with a QNetworkAccessManager. It is expected that many of these objects will all
-    be created and associated with the same QNAM, which will then handle the actual
-    asynchronous downloads in some Qt-defined number of threads. To monitor progress
-    you should connect to the QNAM's "finished" signal, and ensure it is called the
-    number of times you expect based on how many workers you have enqueued.
-
-    """
-
+class DownloadWorker(QObject):
     updated = QtCore.Signal(AddonManagerRepo)
 
-    def __init__(self, parent, repo: AddonManagerRepo, index: Dict[str, str]):
+    def __init__(self, parent, url: str):
         """repo is an AddonManagerRepo object, and index is a dictionary of SHA1 hashes of the package.xml files in the cache"""
 
         super().__init__(parent)
-        self.repo = repo
-        self.index = index
-        self.store = os.path.join(
-            FreeCAD.getUserCachePath(), "AddonManager", "PackageMetadata"
-        )
-        self.last_sha1 = ""
-        self.url = self.repo.metadata_url
+        self.url = url
 
     def start_fetch(self, network_manager: QtNetwork.QNetworkAccessManager):
-        """Asynchronously begin the network access. Intended as a set-and-forget black box for downloading metadata."""
+        """Asynchronously begin the network access. Intended as a set-and-forget black box for downloading files."""
 
         self.request = QtNetwork.QNetworkRequest(QtCore.QUrl(self.url))
         self.request.setAttribute(
@@ -92,11 +75,35 @@ class MetadataDownloadWorker(QObject):
         for error in errors:
             FreeCAD.Console.PrintWarning(error)
 
+
+class MetadataDownloadWorker(DownloadWorker):
+    """A worker for downloading package.xml and associated icon(s)
+
+    To use, instantiate an object of this class and call the start_fetch() function
+    with a QNetworkAccessManager. It is expected that many of these objects will all
+    be created and associated with the same QNAM, which will then handle the actual
+    asynchronous downloads in some Qt-defined number of threads. To monitor progress
+    you should connect to the QNAM's "finished" signal, and ensure it is called the
+    number of times you expect based on how many workers you have enqueued.
+
+    """
+
+    def __init__(self, parent, repo: AddonManagerRepo, index: Dict[str, str]):
+        """repo is an AddonManagerRepo object, and index is a dictionary of SHA1 hashes of the package.xml files in the cache"""
+
+        super().__init__(parent, repo.metadata_url)
+        self.repo = repo
+        self.index = index
+        self.store = os.path.join(
+            FreeCAD.getUserCachePath(), "AddonManager", "PackageMetadata"
+        )
+        self.last_sha1 = ""
+
     def resolve_fetch(self):
         """Called when the data fetch completed, either with an error, or if it found the metadata file"""
 
         if self.fetch_task.error() == QtNetwork.QNetworkReply.NetworkError.NoError:
-            FreeCAD.Console.PrintLog(f"Found a metadata file for {self.repo.name}\n")
+            FreeCAD.Console.PrintLog(f"Found a package.xml file for {self.repo.name}\n")
             self.repo.repo_type = AddonManagerRepo.RepoType.PACKAGE
             new_xml = self.fetch_task.readAll()
             hasher = hashlib.sha1()
@@ -178,4 +185,64 @@ class MetadataDownloadWorker(QObject):
             with open(cache_file, "wb") as icon_file:
                 icon_file.write(icon_data)
                 self.repo.cached_icon_filename = cache_file
+        self.updated.emit(self.repo)
+
+
+class DependencyDownloadWorker(DownloadWorker):
+    """A worker for downloading metadata.txt"""
+
+    def __init__(self, parent, repo: AddonManagerRepo):
+        super().__init__(parent, repo.metadata_url)
+        self.repo = repo
+        self.store = os.path.join(
+            FreeCAD.getUserCachePath(), "AddonManager", "PackageMetadata"
+        )
+
+    def resolve_fetch(self):
+        """Called when the data fetch completed, either with an error, or if it found the metadata file"""
+
+        if self.fetch_task.error() == QtNetwork.QNetworkReply.NetworkError.NoError:
+            FreeCAD.Console.PrintLog(
+                f"Found a metadata.txt file for {self.repo.name}\n"
+            )
+            new_deps = self.fetch_task.readAll()
+            self.parse_file(new_deps.data().decode("utf8"))
+        elif (
+            self.fetch_task.error()
+            == QtNetwork.QNetworkReply.NetworkError.ContentNotFoundError
+        ):
+            pass
+        elif (
+            self.fetch_task.error()
+            == QtNetwork.QNetworkReply.NetworkError.OperationCanceledError
+        ):
+            pass
+        else:
+            FreeCAD.Console.PrintWarning(
+                translate("AddonsInstaller", "Failed to connect to URL")
+                + f":\n{self.url}\n {self.fetch_task.error()}\n"
+            )
+
+    def parse_file(self, data: str) -> None:
+        f = io.StringIO(data)
+        while True:
+            line = f.readline()
+            if not line:
+                break
+            if line.startswith("workbenches="):
+                depswb = line.split("=")[1].split(",")
+                for wb in depswb:
+                    wb_name = wb.strip()
+                    if wb_name:
+                        self.repo.requires.add(wb_name)
+            elif line.startswith("pylibs="):
+                depspy = line.split("=")[1].split(",")
+                for pl in depspy:
+                    if pl.strip():
+                        self.repo.python_requires.add(pl.strip())
+            elif line.startswith("optionalpylibs="):
+                opspy = line.split("=")[1].split(",")
+                for pl in opspy:
+                    if pl.strip():
+                        self.repo.python_optional.add(pl.strip())
         self.updated.emit(self.repo)

--- a/src/Mod/AddonManager/addonmanager_workers.py
+++ b/src/Mod/AddonManager/addonmanager_workers.py
@@ -94,6 +94,7 @@ NOGIT = False  # for debugging purposes, set this to True to always use http dow
 NOMARKDOWN = False  # for debugging purposes, set this to True to disable Markdown lib
 """Multithread workers for the Addon Manager"""
 
+
 class ConnectionChecker(QtCore.QThread):
 
     success = QtCore.Signal()
@@ -103,24 +104,37 @@ class ConnectionChecker(QtCore.QThread):
         QtCore.QThread.__init__(self)
 
     def run(self):
-        FreeCAD.Console.PrintMessage(translate("AddonsInstaller","Checking network connection...\n"))
+        FreeCAD.Console.PrintMessage(
+            translate("AddonsInstaller", "Checking network connection...\n")
+        )
         url = "https://api.github.com/zen"
         request = utils.urlopen(url)
         if QtCore.QThread.currentThread().isInterruptionRequested():
             return
         if not request:
-            self.failure.emit (translate("AddonsInstaller","Unable to connect to GitHub: check your internet connection and proxy settings and try again."))
+            self.failure.emit(
+                translate(
+                    "AddonsInstaller",
+                    "Unable to connect to GitHub: check your internect connection and proxy settings and try again.",
+                )
+            )
             return
         result = request.read()
         if QtCore.QThread.currentThread().isInterruptionRequested():
             return
         if not result:
-            self.failure.emit (translate("AddonsInstaller","Unable to read data from GitHub: check your internet connection and proxy settings and try again."))
+            self.failure.emit(
+                translate(
+                    "AddonsInstaller",
+                    "Unable to read data from GitHub: check your internet connection and proxy settings and try again.",
+                )
+            )
             return
 
         result = result.decode("utf8")
         FreeCAD.Console.PrintLog(f"GitHub's zen message response: {result}\n")
         self.success.emit()
+
 
 class UpdateWorker(QtCore.QThread):
     """This worker updates the list of available workbenches"""
@@ -1178,11 +1192,15 @@ class InstallWorkbenchWorker(QtCore.QThread):
         wbs = FreeCADGui.listWorkbenches()
         missing_wbs = []
         for dep in deps.unrecognized_addons:
-            if dep not in wbs and dep+"Workbench" not in wbs:
+            if dep not in wbs and dep + "Workbench" not in wbs:
                 missing_wbs.append(dep)
         if missing_wbs:
             FreeCAD.Console.PrintError(
-                translate("AddonsInstaller",f"{self.repo.display_name} requires the following workbenches, but your version of FreeCAD does not appear to have them:") + "\n"
+                translate(
+                    "AddonsInstaller",
+                    f"{self.repo.display_name} requires the following workbenches, but your version of FreeCAD does not appear to have them:",
+                )
+                + "\n"
             )
             for wb in missing_wbs:
                 FreeCAD.Console.PrintError("  * " + wb + "\n")
@@ -1205,7 +1223,6 @@ class InstallWorkbenchWorker(QtCore.QThread):
             for lib in missing_python_requirements:
                 FreeCAD.Console.PrintError("  * " + lib + "\n")
             return
-
 
         if have_git and not NOGIT:
             self.run_git(target_dir)

--- a/src/Mod/AddonManager/dependency_resolution_dialog.ui
+++ b/src/Mod/AddonManager/dependency_resolution_dialog.ui
@@ -9,8 +9,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
-    <height>300</height>
+    <width>455</width>
+    <height>200</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -20,7 +20,7 @@
    <item>
     <widget class="QLabel" name="label">
      <property name="text">
-      <string>This Addon has the following required and optional depdencies. Try to install them?</string>
+      <string>This Addon has the following required and optional depdencies. You must install them before this Addon can be used.</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>
@@ -44,7 +44,7 @@
      <item>
       <widget class="QGroupBox" name="groupBox_2">
        <property name="title">
-        <string>Python modules</string>
+        <string>Required Python modules</string>
        </property>
        <layout class="QVBoxLayout" name="verticalLayout_2">
         <item>
@@ -53,19 +53,19 @@
        </layout>
       </widget>
      </item>
+     <item>
+      <widget class="QGroupBox" name="groupBox_3">
+       <property name="title">
+        <string>Optional Python modules</string>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout_4">
+        <item>
+         <widget class="QListWidget" name="listWidgetPythonOptional"/>
+        </item>
+       </layout>
+      </widget>
+     </item>
     </layout>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="groupBox_3">
-     <property name="title">
-      <string>Optional Python modules (check to install)</string>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout_4">
-      <item>
-       <widget class="QListWidget" name="listWidgetPythonOptional"/>
-      </item>
-     </layout>
-    </widget>
    </item>
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">
@@ -73,7 +73,7 @@
       <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ignore|QDialogButtonBox::Yes</set>
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ignore</set>
      </property>
     </widget>
    </item>

--- a/src/Mod/AddonManager/dependency_resolution_dialog.ui
+++ b/src/Mod/AddonManager/dependency_resolution_dialog.ui
@@ -20,7 +20,7 @@
    <item>
     <widget class="QLabel" name="label">
      <property name="text">
-      <string>This Addon has the following required and optional depdencies. You must install them before this Addon can be used.</string>
+      <string>This Addon has the following required and optional dependencies. You must install them before this Addon can be used.</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>

--- a/src/Mod/AddonManager/dependency_resolution_dialog.ui
+++ b/src/Mod/AddonManager/dependency_resolution_dialog.ui
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>DependencyResolutionDialog</class>
+ <widget class="QDialog" name="DependencyResolutionDialog">
+  <property name="windowModality">
+   <enum>Qt::WindowModal</enum>
+  </property>
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Resolve Dependencies</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_3">
+   <item>
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>This Addon has the following required and optional depdencies. Try to install them?</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QGroupBox" name="groupBox">
+       <property name="title">
+        <string>FreeCAD Addons</string>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout">
+        <item>
+         <widget class="QListWidget" name="listWidgetAddons"/>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
+      <widget class="QGroupBox" name="groupBox_2">
+       <property name="title">
+        <string>Python modules</string>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout_2">
+        <item>
+         <widget class="QListWidget" name="listWidgetPythonRequired"/>
+        </item>
+       </layout>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="groupBox_3">
+     <property name="title">
+      <string>Optional Python modules (check to install)</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_4">
+      <item>
+       <widget class="QListWidget" name="listWidgetPythonOptional"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ignore|QDialogButtonBox::Yes</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>DependencyResolutionDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>DependencyResolutionDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/Mod/AddonManager/package_list.py
+++ b/src/Mod/AddonManager/package_list.py
@@ -658,8 +658,6 @@ class Ui_PackageList(object):
         self.listPackages.setEditTriggers(QAbstractItemView.NoEditTriggers)
         self.listPackages.setProperty("showDropIndicator", False)
         self.listPackages.setSelectionMode(QAbstractItemView.NoSelection)
-        self.listPackages.setLayoutMode(QListView.Batched)
-        self.listPackages.setBatchSize(15)
         self.listPackages.setResizeMode(QListView.Adjust)
         self.listPackages.setUniformItemSizes(False)
         self.listPackages.setAlternatingRowColors(True)


### PR DESCRIPTION
The main work of this PR is to add a basic dependency checker that will tell the user installing a package what missing dependencies they have. It does not currently offer to install them, just presents them in a list that can either be ignored (installing the package anyway) or cancelled (cancelling the installation).

As a secondary function, this PR cleans up various display items:
1) it checks for an internet connection on startup, and presents a (hopefully clear) error message if one is not found
2) The packages list is correctly filtered on the first refresh
3) The packages list should flicker less during its initial load
4) Very long lists of failed and succeeded updates are consolidated so they don't exceed maximum dialog size