### PR TITLE
[PartDesign Fillet/Chamfer] add UseAllEdges boolean property

### DIFF
--- a/src/Mod/PartDesign/App/FeatureChamfer.cpp
+++ b/src/Mod/PartDesign/App/FeatureChamfer.cpp
@@ -76,7 +76,7 @@ Chamfer::Chamfer()
     Angle.setConstraints(&floatAngle);
 
     ADD_PROPERTY_TYPE(FlipDirection, (false), "Chamfer", App::Prop_None, "Flip direction");
-    ADD_PROPERTY_TYPE(UseAllEdges, (false), "Base", App::Prop_None,
+    ADD_PROPERTY_TYPE(UseAllEdges, (false), "Chamfer", App::Prop_None,
              "Chamfer all edges if true, else use only those edges in Base property.\n"
              "If true, then this overrides any edge changes made to the Base property or in the dialog.\n");
 

--- a/src/Mod/PartDesign/App/FeatureChamfer.cpp
+++ b/src/Mod/PartDesign/App/FeatureChamfer.cpp
@@ -76,6 +76,9 @@ Chamfer::Chamfer()
     Angle.setConstraints(&floatAngle);
 
     ADD_PROPERTY_TYPE(FlipDirection, (false), "Chamfer", App::Prop_None, "Flip direction");
+    ADD_PROPERTY_TYPE(UseAllEdges, (false), "Base", App::Prop_None,
+             "Chamfer all edges if true, else use only those edges in Base property.\n"
+             "If true, then this overrides any edge changes made to the Base property or in the dialog.\n");
 
     updateProperties();
 }
@@ -115,8 +118,20 @@ App::DocumentObjectExecReturn *Chamfer::execute(void)
     }
 
     std::vector<std::string> SubNames = std::vector<std::string>(Base.getSubValues());
+
+    if (UseAllEdges.getValue()){
+        SubNames.clear();
+        std::string edgeTypeName = Part::TopoShape::shapeName(TopAbs_EDGE); //"Edge"
+        int count = TopShape.countSubElements(edgeTypeName.c_str());
+        for (int ii = 0; ii < count; ii++){
+            std::ostringstream edgeName;
+            edgeName << edgeTypeName << ii+1;
+            SubNames.push_back(edgeName.str());
+        }
+    }
+
     std::vector<std::string> FaceNames;
-  
+
     getContinuousEdges(TopShape, SubNames, FaceNames);
 
     if (SubNames.size() == 0)

--- a/src/Mod/PartDesign/App/FeatureChamfer.h
+++ b/src/Mod/PartDesign/App/FeatureChamfer.h
@@ -44,6 +44,7 @@ public:
     App::PropertyQuantityConstraint Size2;
     App::PropertyAngle Angle;
     App::PropertyBool FlipDirection;
+    App::PropertyBool UseAllEdges;
 
     /** @name methods override feature */
     //@{

--- a/src/Mod/PartDesign/App/FeatureFillet.cpp
+++ b/src/Mod/PartDesign/App/FeatureFillet.cpp
@@ -53,10 +53,10 @@ const App::PropertyQuantityConstraint::Constraints floatRadius = {0.0,FLT_MAX,0.
 
 Fillet::Fillet()
 {
-    ADD_PROPERTY(Radius,(1.0));
+    ADD_PROPERTY_TYPE(Radius, (1.0), "Fillet", App::Prop_None, "Fillet radius.");
     Radius.setUnit(Base::Unit::Length);
     Radius.setConstraints(&floatRadius);
-    ADD_PROPERTY_TYPE(UseAllEdges, (false), "Base", App::Prop_None,
+    ADD_PROPERTY_TYPE(UseAllEdges, (false), "Fillet", App::Prop_None,
       "Fillet all edges if true, else use only those edges in Base property.\n"
       "If true, then this overrides any edge changes made to the Base property or in the dialog.\n");
 }

--- a/src/Mod/PartDesign/App/FeatureFillet.cpp
+++ b/src/Mod/PartDesign/App/FeatureFillet.cpp
@@ -56,6 +56,9 @@ Fillet::Fillet()
     ADD_PROPERTY(Radius,(1.0));
     Radius.setUnit(Base::Unit::Length);
     Radius.setConstraints(&floatRadius);
+    ADD_PROPERTY_TYPE(UseAllEdges, (false), "Base", App::Prop_None,
+      "Fillet all edges if true, else use only those edges in Base property.\n"
+      "If true, then this overrides any edge changes made to the Base property or in the dialog.\n");
 }
 
 short Fillet::mustExecute() const
@@ -73,7 +76,19 @@ App::DocumentObjectExecReturn *Fillet::execute(void)
     } catch (Base::Exception& e) {
         return new App::DocumentObjectExecReturn(e.what());
     }
-    std::vector<std::string> SubNames = std::vector<std::string>(Base.getSubValues());
+    std::vector<std::string> SubNames = std::vector<std::string>(Base.getSubValues());  
+
+    if (UseAllEdges.getValue()){
+        SubNames.clear();
+        std::string edgeTypeName = Part::TopoShape::shapeName(TopAbs_EDGE); //"Edge"
+        int count = TopShape.countSubElements(edgeTypeName.c_str());
+        for (int ii = 0; ii < count; ii++){
+            std::ostringstream edgeName;
+            edgeName << edgeTypeName << ii+1;
+            SubNames.push_back(edgeName.str());
+        }
+    }
+
     getContinuousEdges(TopShape, SubNames);
 
     if (SubNames.size() == 0)

--- a/src/Mod/PartDesign/App/FeatureFillet.h
+++ b/src/Mod/PartDesign/App/FeatureFillet.h
@@ -40,6 +40,7 @@ public:
     Fillet();
 
     App::PropertyQuantityConstraint Radius;
+    App::PropertyBool UseAllEdges;
 
     /** @name methods override feature */
     //@{

--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -1913,19 +1913,20 @@ bool dressupGetSelected(Gui::Command* cmd, const std::string& which,
 
     // if 1 Part::Feature object selected, but no subobjects, select all edges for the user
     if (selection[0].getSubNames().size() == 0){
-        int count = TopShape.countSubElements("Edge");
+        std::string edgeTypeName = Part::TopoShape::shapeName(TopAbs_EDGE); //"Edge"
+        int count = TopShape.countSubElements(edgeTypeName.c_str());
         std::string docName = App::GetApplication().getDocumentName(base->getDocument());
         std::string objName = base->getNameInDocument();
         for (int ii = 0; ii < count; ii++){
             std::ostringstream edgeName;
-            edgeName << "Edge" << ii+1;
+            edgeName << edgeTypeName << ii+1;
             Gui::Selection().addSelection(docName.c_str(), objName.c_str(), edgeName.str().c_str());
         }
         selection = cmd->getSelection().getSelectionEx();
         if (selection.size() == 1){
             selected = selection[0];
         }
-    }
+   }
     return true;
 }
 

--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -1861,7 +1861,7 @@ bool CmdPartDesignSubtractiveHelix::isActive(void)
 //===========================================================================
 
 bool dressupGetSelected(Gui::Command* cmd, const std::string& which,
-        Gui::SelectionObject &selected)
+        Gui::SelectionObject &selected, bool &useAllEdges)
 {
     // No PartDesign feature without Body past FreeCAD 0.16
     App::Document *doc = cmd->getDocument();
@@ -1912,7 +1912,9 @@ bool dressupGetSelected(Gui::Command* cmd, const std::string& which,
     }
 
     // if 1 Part::Feature object selected, but no subobjects, select all edges for the user
-    if (selection[0].getSubNames().size() == 0){
+    // but only for fillet and chamfer (not for draft or thickness)
+    if (selection[0].getSubNames().size() == 0 && (which.compare("Fillet") == 0 || which.compare("Chamfer") == 0)){
+        useAllEdges = true;
         std::string edgeTypeName = Part::TopoShape::shapeName(TopAbs_EDGE); //"Edge"
         int count = TopShape.countSubElements(edgeTypeName.c_str());
         std::string docName = App::GetApplication().getDocumentName(base->getDocument());
@@ -1926,12 +1928,12 @@ bool dressupGetSelected(Gui::Command* cmd, const std::string& which,
         if (selection.size() == 1){
             selected = selection[0];
         }
-   }
+    }
     return true;
 }
 
 void finishDressupFeature(const Gui::Command* cmd, const std::string& which,
-        Part::Feature *base, const std::vector<std::string> & SubNames)
+        Part::Feature *base, const std::vector<std::string> & SubNames, const bool useAllEdges)
 {
     if (SubNames.size() == 0) {
         QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
@@ -1954,6 +1956,9 @@ void finishDressupFeature(const Gui::Command* cmd, const std::string& which,
     FCMD_OBJ_CMD(body,"newObject('PartDesign::"<<which<<"','"<<FeatName<<"')");
     auto Feat = body->getDocument()->getObject(FeatName.c_str());
     FCMD_OBJ_CMD(Feat,"Base = " << str.str());
+    if (useAllEdges && (which.compare("Fillet") == 0 || which.compare("Chamfer") == 0)){
+        FCMD_OBJ_CMD(Feat,"UseAllEdges = True");
+    }
     cmd->doCommand(cmd->Gui, "Gui.Selection.clearSelection()");
     finishFeature(cmd, Feat, base);
 
@@ -1969,15 +1974,16 @@ void finishDressupFeature(const Gui::Command* cmd, const std::string& which,
 
 void makeChamferOrFillet(Gui::Command* cmd, const std::string& which)
 {
+    bool useAllEdges = false;
     Gui::SelectionObject selected;
-    if (!dressupGetSelected ( cmd, which, selected))
+    if (!dressupGetSelected ( cmd, which, selected, useAllEdges))
         return;
 
     Part::Feature *base = static_cast<Part::Feature*>(selected.getObject());
 
     std::vector<std::string> SubNames = std::vector<std::string>(selected.getSubNames());
 
-    finishDressupFeature (cmd, which, base, SubNames);
+    finishDressupFeature (cmd, which, base, SubNames, useAllEdges);
 }
 
 //===========================================================================
@@ -2058,7 +2064,8 @@ void CmdPartDesignDraft::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
     Gui::SelectionObject selected;
-    if (!dressupGetSelected ( this, "Draft", selected))
+    bool useAllEdges = false;
+    if (!dressupGetSelected ( this, "Draft", selected, useAllEdges))
         return;
 
     Part::Feature *base = static_cast<Part::Feature*>(selected.getObject());
@@ -2085,7 +2092,7 @@ void CmdPartDesignDraft::activated(int iMsg)
         i++;
     }
 
-    finishDressupFeature (this, "Draft", base, SubNames);
+    finishDressupFeature (this, "Draft", base, SubNames, useAllEdges);
 }
 
 bool CmdPartDesignDraft::isActive(void)
@@ -2115,7 +2122,8 @@ void CmdPartDesignThickness::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
     Gui::SelectionObject selected;
-    if (!dressupGetSelected ( this, "Thickness", selected))
+    bool useAllEdges = false;
+    if (!dressupGetSelected ( this, "Thickness", selected, useAllEdges))
         return;
 
     Part::Feature *base = static_cast<Part::Feature*>(selected.getObject());
@@ -2134,7 +2142,7 @@ void CmdPartDesignThickness::activated(int iMsg)
         i++;
     }
 
-    finishDressupFeature (this, "Thickness", base, SubNames);
+    finishDressupFeature (this, "Thickness", base, SubNames, useAllEdges);
 }
 
 bool CmdPartDesignThickness::isActive(void)

--- a/src/Mod/PartDesign/Gui/TaskChamferParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskChamferParameters.cpp
@@ -67,6 +67,12 @@ TaskChamferParameters::TaskChamferParameters(ViewProviderDressUp *DressUpView, Q
     PartDesign::Chamfer* pcChamfer = static_cast<PartDesign::Chamfer*>(DressUpView->getObject());
 
     setUpUI(pcChamfer);
+
+    bool useAllEdges = pcChamfer->UseAllEdges.getValue();
+    ui->checkBoxUseAllEdges->setChecked(useAllEdges);
+    ui->buttonRefAdd->setEnabled(!useAllEdges);
+    ui->buttonRefRemove->setEnabled(!useAllEdges);
+    ui->listWidgetReferences->setEnabled(!useAllEdges);
     QMetaObject::invokeMethod(ui->chamferSize, "setFocus", Qt::QueuedConnection);
 
     std::vector<std::string> strings = pcChamfer->Base.getSubValues();
@@ -91,6 +97,8 @@ TaskChamferParameters::TaskChamferParameters(ViewProviderDressUp *DressUpView, Q
         this, SLOT(onButtonRefAdd(bool)));
     connect(ui->buttonRefRemove, SIGNAL(toggled(bool)),
         this, SLOT(onButtonRefRemove(bool)));
+    connect(ui->checkBoxUseAllEdges, SIGNAL(toggled(bool)),
+            this, SLOT(onCheckBoxUseAllEdgesToggled(bool)));
 
     // Create context menu
     createDeleteAction(ui->listWidgetReferences, ui->buttonRefRemove);
@@ -147,6 +155,7 @@ void TaskChamferParameters::setUpUI(PartDesign::Chamfer* pcChamfer)
     ui->sizeLabel->setMinimumWidth(minWidth);
     ui->size2Label->setMinimumWidth(minWidth);
     ui->angleLabel->setMinimumWidth(minWidth);
+
 }
 
 void TaskChamferParameters::onSelectionChanged(const Gui::SelectionChanges& msg)
@@ -188,6 +197,16 @@ void TaskChamferParameters::onSelectionChanged(const Gui::SelectionChanges& msg)
             DressUpView->highlightReferences(true);
         }
     }
+}
+
+void TaskChamferParameters::onCheckBoxUseAllEdgesToggled(bool checked)
+{
+    PartDesign::Chamfer* pcChamfer = static_cast<PartDesign::Chamfer*>(DressUpView->getObject());
+    ui->buttonRefRemove->setEnabled(!checked);
+    ui->buttonRefAdd->setEnabled(!checked);
+    ui->listWidgetReferences->setEnabled(!checked);
+    pcChamfer->UseAllEdges.setValue(checked);
+    pcChamfer->getDocument()->recomputeFeature(pcChamfer);
 }
 
 void TaskChamferParameters::clearButtons(const selectionModes notThis)

--- a/src/Mod/PartDesign/Gui/TaskChamferParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskChamferParameters.h
@@ -52,6 +52,7 @@ private Q_SLOTS:
     void onFlipDirection(bool);
     void onRefDeleted(void);
     void onAddAllEdges(void);
+    void onCheckBoxUseAllEdgesToggled(bool checked);
 
 protected:
     virtual void clearButtons(const selectionModes notThis);

--- a/src/Mod/PartDesign/Gui/TaskChamferParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskChamferParameters.ui
@@ -133,6 +133,13 @@ click again to end selection</string>
     </layout>
    </item>
    <item>
+    <widget class="QCheckBox" name="checkBoxUseAllEdges">
+     <property name="text">
+      <string>Use All Edges</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QStackedWidget" name="stackedWidget">
      <property name="currentIndex">
       <number>0</number>

--- a/src/Mod/PartDesign/Gui/TaskDressUpParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskDressUpParameters.cpp
@@ -429,7 +429,6 @@ TaskDlgDressUpParameters::~TaskDlgDressUpParameters()
 bool TaskDlgDressUpParameters::accept()
 {
     getDressUpView()->highlightReferences(false);
-
     std::vector<std::string> refs = parameter->getReferences();
     std::stringstream str;
     str << Gui::Command::getObjectCmd(vp->getObject()) << ".Base = (" 

--- a/src/Mod/PartDesign/Gui/TaskDressUpParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskDressUpParameters.h
@@ -80,6 +80,7 @@ protected:
     bool KeyEvent(QEvent *e);
     void hideOnError();
     void addAllEdges(QListWidget* listWidget);
+
 protected:
     enum selectionModes { none, refAdd, refRemove, plane, line };
     virtual void clearButtons(const selectionModes notThis) = 0;

--- a/src/Mod/PartDesign/Gui/TaskFilletParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskFilletParameters.cpp
@@ -63,6 +63,11 @@ TaskFilletParameters::TaskFilletParameters(ViewProviderDressUp *DressUpView, QWi
     this->groupLayout()->addWidget(proxy);
 
     PartDesign::Fillet* pcFillet = static_cast<PartDesign::Fillet*>(DressUpView->getObject());
+    bool useAllEdges = pcFillet->UseAllEdges.getValue();
+    ui->checkBoxUseAllEdges->setChecked(useAllEdges);
+    ui->buttonRefAdd->setEnabled(!useAllEdges);
+    ui->buttonRefRemove->setEnabled(!useAllEdges);
+    ui->listWidgetReferences->setEnabled(!useAllEdges);
     double r = pcFillet->Radius.getValue();
 
     ui->filletRadius->setUnit(Base::Unit::Length);
@@ -85,6 +90,8 @@ TaskFilletParameters::TaskFilletParameters(ViewProviderDressUp *DressUpView, QWi
         this, SLOT(onButtonRefAdd(bool)));
     connect(ui->buttonRefRemove, SIGNAL(toggled(bool)),
         this, SLOT(onButtonRefRemove(bool)));
+    connect(ui->checkBoxUseAllEdges, SIGNAL(toggled(bool)),
+            this, SLOT(onCheckBoxUseAllEdgesToggled(bool)));
 
     // Create context menu
     createDeleteAction(ui->listWidgetReferences, ui->buttonRefRemove);
@@ -143,6 +150,16 @@ void TaskFilletParameters::onSelectionChanged(const Gui::SelectionChanges& msg)
             DressUpView->highlightReferences(true);
         }
     }
+}
+
+void TaskFilletParameters::onCheckBoxUseAllEdgesToggled(bool checked)
+{
+    PartDesign::Fillet* pcFillet = static_cast<PartDesign::Fillet*>(DressUpView->getObject());
+    ui->buttonRefRemove->setEnabled(!checked);
+    ui->buttonRefAdd->setEnabled(!checked);
+    ui->listWidgetReferences->setEnabled(!checked);
+    pcFillet->UseAllEdges.setValue(checked);
+    pcFillet->getDocument()->recomputeFeature(pcFillet);
 }
 
 void TaskFilletParameters::clearButtons(const selectionModes notThis)

--- a/src/Mod/PartDesign/Gui/TaskFilletParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskFilletParameters.h
@@ -45,6 +45,7 @@ private Q_SLOTS:
     void onLengthChanged(double);
     void onRefDeleted(void);
     void onAddAllEdges(void);
+    void onCheckBoxUseAllEdgesToggled(bool checked);
 
 protected:
     double getLength(void) const;

--- a/src/Mod/PartDesign/Gui/TaskFilletParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskFilletParameters.ui
@@ -75,6 +75,13 @@ click again to end selection</string>
      </item>
     </layout>
    </item>
+   <item>
+    <widget class="QCheckBox" name="checkBoxUseAllEdges">
+     <property name="text">
+      <string>Use All Edges</string>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <customwidgets>


### PR DESCRIPTION
Adds a new boolean property called "UseAllEdges" to Part Design fillets and chamfers.  This will make these features robust against topological naming problem if this property is set to True, because then no matter if the edges of the base object change this dressup feature will still be using all of the edges.

Pros:

- Robust against topological naming if set to True

- Convenient way to fillet/chamfer all edges instead of opening the dialog

Cons:

-If the user has set UseAllEdges to true and then tries to edit the edges in the list, then the changes to the list will have no effect, possibly confusing and frustrating some users.

There is some minor code duplication, but I think it's better not to put the code in FeatureDressup.cpp because that class is also used by Draft and Thickness, which will not get the UseAllEdges property.

We could set this property to true when a new fillet/chamfer is created and the user has not selected any edges instead of populating the Base property with all the edges, but I decided against this for a couple reasons: 1) it will confuse users who will expect to be able to edit the edges in the dialog, but if the user sets the property himself, then this will be less likely; and 2) files created in the new version will still be able to be opened in 0.19, which will know nothing of the UseAllEdges property, but this will not be the case if the Base property is left empty and the UseAllEdges property is set to true.