### PR TITLE
[PD] rename a UI file

### DIFF
--- a/src/Mod/PartDesign/Gui/CMakeLists.txt
+++ b/src/Mod/PartDesign/Gui/CMakeLists.txt
@@ -37,7 +37,7 @@ endif()
 
 set(PartDesignGui_UIC_SRCS
     TaskFeaturePick.ui
-    TaskPadParameters.ui
+    TaskPadPocketParameters.ui
     TaskChamferParameters.ui
     TaskFilletParameters.ui
     TaskDraftParameters.ui
@@ -148,7 +148,7 @@ SET(PartDesignGuiTaskDlgs_SRCS
     TaskSketchBasedParameters.h
     TaskExtrudeParameters.cpp
     TaskExtrudeParameters.h
-    TaskPadParameters.ui
+    TaskPadPocketParameters.ui
     TaskPadParameters.cpp
     TaskPadParameters.h
     TaskPocketParameters.cpp

--- a/src/Mod/PartDesign/Gui/TaskExtrudeParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskExtrudeParameters.cpp
@@ -31,7 +31,7 @@
 # include <QSignalBlocker>
 #endif
 
-#include "ui_TaskPadParameters.h"
+#include "ui_TaskPadPocketParameters.h"
 #include "TaskExtrudeParameters.h"
 #include <Base/UnitsApi.h>
 #include <Mod/PartDesign/App/FeatureExtrude.h>
@@ -46,7 +46,7 @@ using namespace Gui;
 TaskExtrudeParameters::TaskExtrudeParameters(ViewProviderSketchBased *SketchBasedView, QWidget *parent,
                                              const std::string& pixmapname, const QString& parname)
     : TaskSketchBasedParameters(SketchBasedView, parent, pixmapname, parname)
-    , ui(new Ui_TaskPadParameters)
+    , ui(new Ui_TaskPadPocketParameters)
 {
     // we need a separate container widget to add all controls to
     proxy = new QWidget(this);

--- a/src/Mod/PartDesign/Gui/TaskExtrudeParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskExtrudeParameters.h
@@ -31,7 +31,7 @@
 #include "TaskSketchBasedParameters.h"
 #include "ViewProviderSketchBased.h"
 
-class Ui_TaskPadParameters;
+class Ui_TaskPadPocketParameters;
 
 namespace App {
 class Property;
@@ -118,7 +118,7 @@ private:
 
 protected:
     QWidget* proxy;
-    std::unique_ptr<Ui_TaskPadParameters> ui;
+    std::unique_ptr<Ui_TaskPadPocketParameters> ui;
     bool selectionFace;
     std::vector<std::unique_ptr<App::PropertyLinkSub>> axesInList;
 };

--- a/src/Mod/PartDesign/Gui/TaskPadParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPadParameters.cpp
@@ -30,7 +30,7 @@
 # include <Precision.hxx>
 #endif
 
-#include "ui_TaskPadParameters.h"
+#include "ui_TaskPadPocketParameters.h"
 #include "TaskPadParameters.h"
 #include <Gui/Command.h>
 #include <Gui/ViewProvider.h>

--- a/src/Mod/PartDesign/Gui/TaskPadPocketParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskPadPocketParameters.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>PartDesignGui::TaskPadParameters</class>
- <widget class="QWidget" name="PartDesignGui::TaskPadParameters">
+ <class>PartDesignGui::TaskPadPocketParameters</class>
+ <widget class="QWidget" name="PartDesignGui::TaskPadPocketParameters">
   <property name="geometry">
    <rect>
     <x>0</x>

--- a/src/Mod/PartDesign/Gui/TaskPocketParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPocketParameters.cpp
@@ -30,7 +30,7 @@
 # include <Precision.hxx>
 #endif
 
-#include "ui_TaskPadParameters.h"
+#include "ui_TaskPadPocketParameters.h"
 #include "TaskPocketParameters.h"
 #include <Gui/Command.h>
 #include <Gui/ViewProvider.h>


### PR DESCRIPTION
Pad and Pocket share the same UI file therefore change the name to make this clear that changes in that file must be handled for Pad and Pocket