### PR TITLE
TopoShape::analyze() SetRunParallel(true) to do the bopcheck in paral…

### DIFF
--- a/src/Mod/Part/App/TopoShape.cpp
+++ b/src/Mod/Part/App/TopoShape.cpp
@@ -1661,6 +1661,7 @@ bool TopoShape::analyze(bool runBopCheck, std::ostream& str) const
 #endif
 #if OCC_VERSION_HEX >= 0x060900
             BOPCheck.SetParallelMode(true); //this doesn't help for speed right now(occt 6.9.1).
+            BOPCheck.SetRunParallel(true); //performance boost, use all available cores
             BOPCheck.TangentMode() = true; //these 4 new tests add about 5% processing time.
             BOPCheck.MergeVertexMode() = true;
             BOPCheck.CurveOnSurfaceMode() = true;


### PR DESCRIPTION
…lel mode

This should improve performance of running check(True) on a shape, such as:

`obj.Shape.check(True)`

from the Python console.  In a test with a difficult file without running in parallel mode, it took about 40.5 seconds, in parallel mode only 30.8 seconds.