### PR TITLE
[PD] Pocket: add missing apply code

### DIFF
--- a/src/Mod/PartDesign/Gui/TaskPocketParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPocketParameters.cpp
@@ -203,7 +203,12 @@ void TaskPocketParameters::apply()
     ui->lengthEdit->apply();
     ui->lengthEdit2->apply();
 
-    FCMD_OBJ_CMD(obj,"Type = " << getMode());
+    FCMD_OBJ_CMD(obj, "UseCustomVector = " << (getCustom() ? 1 : 0));
+    FCMD_OBJ_CMD(obj, "Direction = ("
+        << getXDirection() << ", " << getYDirection() << ", " << getZDirection() << ")");
+    FCMD_OBJ_CMD(obj, "ReferenceAxis = " << getReferenceAxis());
+    FCMD_OBJ_CMD(obj, "AlongSketchNormal = " << (getAlongSketchNormal() ? 1 : 0));
+    FCMD_OBJ_CMD(obj, "Type = " << getMode());
     QString facename = QString::fromLatin1("None");
     if (static_cast<Modes>(getMode()) == Modes::ToFace) {
         facename = getFaceName();


### PR DESCRIPTION
adds apply code that Pad has but not also Pocket

It seems this was forgotten when the direction feature was added to Pocket or it was lost during the Pad-Pocket code refactoring.

Nevertheless I wonder why the missing code has no visible effect with my test files. Werner, since you did the Pad-Pocket code refactoring, could you please have a look if this PR is necessary?