### PR TITLE
Path: PathArray: use python library 're' instead of 'regex'

### DIFF
--- a/src/Mod/Path/PathScripts/post/grbl_post.py
+++ b/src/Mod/Path/PathScripts/post/grbl_post.py
@@ -31,7 +31,7 @@ import argparse
 import datetime
 import shlex
 import PathScripts.PathUtil as PathUtil
-import regex
+import re
 
 
 TOOLTIP = """
@@ -580,7 +580,7 @@ def parse(pathobj):
                 out += linenumber() + format_outstring(outstring) + "\n"
 
             # Check for comments containing machine-specific commands to pass literally to the controller
-            m = regex.match(r'^\(MC_RUN_COMMAND: ([^)]+)\)$', command)
+            m = re.match(r'^\(MC_RUN_COMMAND: ([^)]+)\)$', command)
             if m:
                 raw_command = m.group(1)
                 out += linenumber() + raw_command + "\n"


### PR DESCRIPTION
The python standard library includes 're' but not 'regex'.  'regex' has features that don't benefit here but has to be installed separately.  So, prefer 're', since it is available everywhere.