### PR TITLE
Draft: fix issues with _tr

### DIFF
--- a/src/Mod/Draft/draftutils/gui_utils.py
+++ b/src/Mod/Draft/draftutils/gui_utils.py
@@ -43,7 +43,7 @@ import FreeCAD as App
 import draftutils.utils as utils
 
 from draftutils.messages import _msg, _wrn, _err
-from draftutils.translate import _tr, translate
+from draftutils.translate import translate
 
 if App.GuiUp:
     import FreeCADGui as Gui
@@ -78,7 +78,7 @@ def get_3d_view():
             if v:
                 return v[0]
 
-    _wrn(_tr("No graphical interface"))
+    _wrn(translate("draft", "No graphical interface"))
     return None
 
 
@@ -155,7 +155,7 @@ def autogroup(obj):
                 return
             matrix = parent.getSubObject(sub, retType=4)
             if matrix.hasScale() == 1:
-                err = translate("Draft",
+                err = translate("draft",
                                 "Unable to insert new object into "
                                 "a scaled part")
                 App.Console.PrintMessage(err)
@@ -264,7 +264,7 @@ def dim_symbol(symbol=None, invert=False):
     elif symbol == 4:
         return dim_dash((-1.5, -1.5, 0), (1.5, 1.5, 0))
     else:
-        _wrn(_tr("Symbol not implemented. Use a default symbol."))
+        _wrn(translate("draft", "Symbol not implemented. Using a default symbol."))
         return coin.SoSphere()
 
 
@@ -330,7 +330,7 @@ def remove_hidden(objectslist):
         if obj.ViewObject:
             if not obj.ViewObject.isVisible():
                 newlist.remove(obj)
-                _msg(_tr("Visibility off; removed from list: ") + obj.Label)
+                _msg(translate("draft", "Visibility off; removed from list: ") + obj.Label)
     return newlist
 
 
@@ -600,13 +600,13 @@ def load_texture(filename, size=None, gui=App.GuiUp):
             p = QtGui.QImage(filename)
 
             if p.isNull():
-                _wrn("load_texture: " + _tr("image is Null"))
+                _wrn("load_texture: " + translate("draft", "image is Null"))
 
                 if not os.path.exists(filename):
                     raise FileNotFoundError(-1,
-                                            _tr("filename does not exist "
-                                                "on the system or "
-                                                "on the resource file"),
+                                            translate("draft", "filename does not exist "
+                                                               "on the system or "
+                                                               "in the resource file"),
                                             filename)
 
             # This is buggy so it was de-activated.
@@ -665,7 +665,7 @@ def load_texture(filename, size=None, gui=App.GuiUp):
             return None
         except Exception as exc:
             _wrn(str(exc))
-            _wrn("load_texture: " + _tr("unable to load texture"))
+            _wrn("load_texture: " + translate("draft", "unable to load texture"))
             return None
         else:
             return img
@@ -717,7 +717,7 @@ def get_bbox(obj, debug=False):
 
     found, doc = utils.find_doc(App.activeDocument())
     if not found:
-        _err(_tr("No active document. Aborting."))
+        _err(translate("draft", "No active document. Aborting."))
         return None
 
     if isinstance(obj, str):
@@ -726,7 +726,7 @@ def get_bbox(obj, debug=False):
     found, obj = utils.find_object(obj, doc)
     if not found:
         _msg("obj: {}".format(obj_str))
-        _err(_tr("Wrong input: object not in document."))
+        _err(translate("draft", "Wrong input: object not in document."))
         return None
 
     if debug:
@@ -735,7 +735,7 @@ def get_bbox(obj, debug=False):
     if (not hasattr(obj, "ViewObject")
             or not obj.ViewObject
             or not hasattr(obj.ViewObject, "RootNode")):
-        _err(_tr("Does not have 'ViewObject.RootNode'."))
+        _err(translate("draft", "Does not have 'ViewObject.RootNode'."))
 
     # For Draft Dimensions
     # node = obj.ViewObject.Proxy.node

--- a/src/Mod/Draft/draftutils/utils.py
+++ b/src/Mod/Draft/draftutils/utils.py
@@ -41,7 +41,7 @@ import PySide.QtCore as QtCore
 import FreeCAD as App
 
 from draftutils.messages import _msg, _wrn, _err, _log
-from draftutils.translate import _tr
+from draftutils.translate import translate
 
 # TODO: move the functions that require the graphical interface
 # This module should not import any graphical commands; those should be
@@ -647,20 +647,20 @@ def print_shape(shape):
     shape : Part::TopoShape
         Any topological shape in an object, usually obtained from `obj.Shape`.
     """
-    _msg(_tr("Solids:") + " {}".format(len(shape.Solids)))
-    _msg(_tr("Faces:") + " {}".format(len(shape.Faces)))
-    _msg(_tr("Wires:") + " {}".format(len(shape.Wires)))
-    _msg(_tr("Edges:") + " {}".format(len(shape.Edges)))
-    _msg(_tr("Vertices:") + " {}".format(len(shape.Vertexes)))
+    _msg(translate("draft", "Solids:") + " {}".format(len(shape.Solids)))
+    _msg(translate("draft", "Faces:") + " {}".format(len(shape.Faces)))
+    _msg(translate("draft", "Wires:") + " {}".format(len(shape.Wires)))
+    _msg(translate("draft", "Edges:") + " {}".format(len(shape.Edges)))
+    _msg(translate("draft", "Vertices:") + " {}".format(len(shape.Vertexes)))
 
     if shape.Faces:
         for f in range(len(shape.Faces)):
-            _msg(_tr("Face") + " {}:".format(f))
+            _msg(translate("draft", "Face") + " {}:".format(f))
             for v in shape.Faces[f].Vertexes:
                 _msg("    {}".format(v.Point))
     elif shape.Wires:
         for w in range(len(shape.Wires)):
-            _msg(_tr("Wire") + " {}:".format(w))
+            _msg(translate("draft", "Wire") + " {}:".format(w))
             for v in shape.Wires[w].Vertexes:
                 _msg("    {}".format(v.Point))
     else:
@@ -692,11 +692,11 @@ def compare_objects(obj1, obj2):
     if obj1.TypeId != obj2.TypeId:
         _msg("'{0}' ({1}), '{2}' ({3}): ".format(obj1.Name, obj1.TypeId,
                                                  obj2.Name, obj2.TypeId)
-             + _tr("different types") + " (TypeId)")
+             + translate("draft", "different types") + " (TypeId)")
     elif getType(obj1) != getType(obj2):
         _msg("'{0}' ({1}), '{2}' ({3}): ".format(obj1.Name, get_type(obj1),
                                                  obj2.Name, get_type(obj2))
-             + _tr("different types") + " (Proxy.Type)")
+             + translate("draft", "different types") + " (Proxy.Type)")
     else:
         for p in obj1.PropertiesList:
             if p in obj2.PropertiesList:
@@ -704,15 +704,15 @@ def compare_objects(obj1, obj2):
                     pass
                 elif p == "Placement":
                     delta = obj1.Placement.Base.sub(obj2.Placement.Base)
-                    text = _tr("Objects have different placements. "
-                               "Distance between the two base points: ")
+                    text = translate("draft", "Objects have different placements. "
+                                              "Distance between the two base points: ")
                     _msg(text + str(delta.Length))
                 else:
                     if getattr(obj1, p) != getattr(obj2, p):
-                        _msg("'{}' ".format(p) + _tr("has a different value"))
+                        _msg("'{}' ".format(p) + translate("draft", "has a different value"))
             else:
                 _msg("{} ".format(p)
-                     + _tr("doesn't exist in one of the objects"))
+                     + translate("draft", "doesn't exist in one of the objects"))
 
 
 compareObjects = compare_objects
@@ -824,13 +824,13 @@ def filter_objects_for_modifiers(objects, isCopied=False):
                 if parent.isDerivedFrom("Part::Feature"):
                     parents.append(parent.Name)
             if len(parents) > 1:
-                warningMessage = _tr("%s shares a base with %d other objects. Please check if you want to modify this.") % (obj.Name,len(parents) - 1)
+                warningMessage = translate("draft", "%s shares a base with %d other objects. Please check if you want to modify this.") % (obj.Name,len(parents) - 1)
                 App.Console.PrintError(warningMessage)
                 if App.GuiUp:
                     Gui.getMainWindow().showMessage(warningMessage, 0)
             filteredObjects.append(obj.Base)
         elif hasattr(obj,"Placement") and obj.getEditorMode("Placement") == ["ReadOnly"] and not isCopied:
-            App.Console.PrintError(_tr("%s cannot be modified because its placement is readonly.") % obj.Name)
+            App.Console.PrintError(translate("draft", "%s cannot be modified because its placement is readonly.") % obj.Name)
             continue
         else:
             filteredObjects.append(obj)
@@ -974,7 +974,7 @@ def find_doc(doc=None):
             doc = App.getDocument(doc)
         except NameError:
             _msg("document: {}".format(doc))
-            _err(_tr("Wrong input: unknown document."))
+            _err(translate("draft", "Wrong input: unknown document."))
             return not FOUND, None
 
     return FOUND, doc
@@ -1011,7 +1011,7 @@ def find_object(obj, doc=None):
 
     found, doc = find_doc(doc)
     if not found:
-        _err(_tr("No active document. Aborting."))
+        _err(translate("draft", "No active document. Aborting."))
         return not FOUND, None
 
     if isinstance(obj, str):
@@ -1050,15 +1050,12 @@ def use_instead(function, version=""):
         If we don't know when this command will be deprecated
         then we should not give a version.
     """
-    text = "This function will be deprecated in "
-    text2 = "This function will be deprecated. "
-    text3 = "Please use "
-
     if version:
-        _wrn(_tr(text) + "{}. ".format(version)
-             + _tr(text3) + "'{}'.".format(function))
+        _wrn(translate("draft", "This function will be deprecated in ")
+             + "{}. ".format(version)
+             + translate("draft", "Please use ") + "'{}'.".format(function))
     else:
-        _wrn(_tr(text2)
-             + _tr(text3) + "'{}'.".format(function))
+        _wrn(translate("draft", "This function will be deprecated. ")
+             + translate("draft", "Please use ") + "'{}'.".format(function))
 
 ## @}


### PR DESCRIPTION
Removed calls to the `_tr` function from two remaining Draft files. Also fixed some issues with the use of the `translate` function in those files.

The `_tr` function is still used in `gui_groups.py`, but this previous PR already takes care of that: https://github.com/FreeCAD/FreeCAD/pull/5301

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

---
