### PR TITLE
[PD] add missing include to get rid of MSVC error

### DIFF
--- a/src/Mod/PartDesign/App/FeatureExtrude.h
+++ b/src/Mod/PartDesign/App/FeatureExtrude.h
@@ -24,6 +24,7 @@
 #ifndef PARTDESIGN_FEATURE_EXTRUDE_H
 #define PARTDESIGN_FEATURE_EXTRUDE_H
 
+#include <App/PropertyGeo.h>
 #include <App/PropertyStandard.h>
 #include <App/PropertyUnits.h>
 #include "FeatureSketchBased.h"

--- a/src/Mod/PartDesign/App/FeatureGroove.h
+++ b/src/Mod/PartDesign/App/FeatureGroove.h
@@ -24,6 +24,7 @@
 #ifndef PARTDESIGN_Groove_H
 #define PARTDESIGN_Groove_H
 
+#include <App/PropertyGeo.h>
 #include <App/PropertyUnits.h>
 #include "FeatureSketchBased.h"
 

--- a/src/Mod/PartDesign/App/FeatureHelix.h
+++ b/src/Mod/PartDesign/App/FeatureHelix.h
@@ -24,6 +24,7 @@
 #ifndef PARTDESIGN_Helix_H
 #define PARTDESIGN_Helix_H
 
+#include <App/PropertyGeo.h>
 #include <App/PropertyUnits.h>
 #include "FeatureSketchBased.h"
 #include <TopoDS_Shape.hxx>

--- a/src/Mod/PartDesign/App/FeatureRevolution.h
+++ b/src/Mod/PartDesign/App/FeatureRevolution.h
@@ -24,6 +24,7 @@
 #ifndef PARTDESIGN_Revolution_H
 #define PARTDESIGN_Revolution_H
 
+#include <App/PropertyGeo.h>
 #include <App/PropertyUnits.h>
 #include "FeatureSketchBased.h"
 


### PR DESCRIPTION
since I while I got an "unknown warning" when compiling PD, despite the compilation succeeds.
Today I realized that MSVC cannot find App::PropertyVector.
With this PR the problem is resolved.