### PR TITLE
[PD] Use a custom button group in pipe task to allow no button pressed

### DIFF
--- a/src/Mod/PartDesign/Gui/TaskPipeParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPipeParameters.cpp
@@ -43,15 +43,16 @@
 #include <App/Document.h>
 #include <App/Origin.h>
 #include <App/Part.h>
+#include <Base/Console.h>
 #include <Gui/Application.h>
 #include <Gui/Document.h>
 #include <Gui/BitmapFactory.h>
 #include <Gui/ViewProvider.h>
 #include <Gui/WaitCursor.h>
-#include <Base/Console.h>
 #include <Gui/Selection.h>
 #include <Gui/CommandT.h>
 #include <Gui/MainWindow.h>
+#include <Gui/Widgets.h>
 #include <Mod/PartDesign/App/FeaturePipe.h>
 #include <Mod/Sketcher/App/SketchObject.h>
 #include <Mod/PartDesign/App/Body.h>
@@ -248,7 +249,6 @@ void TaskPipeParameters::onTransitionChanged(int idx)
 void TaskPipeParameters::onButtonRefAdd(bool checked)
 {
     if (checked) {
-        clearButtons(refAdd);
         //hideObject();
         Gui::Selection().clearSelection();
         selectionMode = refAdd;
@@ -256,7 +256,8 @@ void TaskPipeParameters::onButtonRefAdd(bool checked)
     }
     else {
         Gui::Selection().clearSelection();
-        selectionMode = none;
+        if (selectionMode == refAdd)
+            selectionMode = none;
         static_cast<ViewProviderPipe*>(vp)->highlightReferences(ViewProviderPipe::Spine, false);
     }
 }
@@ -264,7 +265,6 @@ void TaskPipeParameters::onButtonRefAdd(bool checked)
 void TaskPipeParameters::onButtonRefRemove(bool checked)
 {
     if (checked) {
-        clearButtons(refRemove);
         //hideObject();
         Gui::Selection().clearSelection();
         selectionMode = refRemove;
@@ -272,7 +272,8 @@ void TaskPipeParameters::onButtonRefRemove(bool checked)
     }
     else {
         Gui::Selection().clearSelection();
-        selectionMode = none;
+        if (selectionMode == refRemove)
+            selectionMode = none;
         static_cast<ViewProviderPipe*>(vp)->highlightReferences(ViewProviderPipe::Spine, false);
     }
 }
@@ -280,7 +281,6 @@ void TaskPipeParameters::onButtonRefRemove(bool checked)
 void TaskPipeParameters::onBaseButton(bool checked)
 {
     if (checked) {
-        clearButtons(refObjAdd);
         //hideObject();
         Gui::Selection().clearSelection();
         selectionMode = refObjAdd;
@@ -288,7 +288,8 @@ void TaskPipeParameters::onBaseButton(bool checked)
     }
     else {
         Gui::Selection().clearSelection();
-        selectionMode = none;
+        if (selectionMode == refObjAdd)
+            selectionMode = none;
         static_cast<ViewProviderPipe*>(vp)->highlightReferences(ViewProviderPipe::Spine, false);
     }
 }
@@ -304,7 +305,6 @@ void TaskPipeParameters::onProfileButton(bool checked)
             pvp->setVisible(true);
         }
 
-        clearButtons(refProfile);
         //hideObject();
         Gui::Selection().clearSelection();
         selectionMode = refProfile;
@@ -312,7 +312,8 @@ void TaskPipeParameters::onProfileButton(bool checked)
     }
     else {
         Gui::Selection().clearSelection();
-        selectionMode = none;
+        if (selectionMode == refProfile)
+            selectionMode = none;
         static_cast<ViewProviderPipe*>(vp)->highlightReferences(ViewProviderPipe::Profile, false);
     }
 }
@@ -700,14 +701,14 @@ void TaskPipeOrientation::exitSelectionMode()
 void TaskPipeOrientation::onButtonRefAdd(bool checked)
 {
     if (checked) {
-        clearButtons(refAdd);
         Gui::Selection().clearSelection();
         selectionMode = refAdd;
         static_cast<ViewProviderPipe*>(vp)->highlightReferences(ViewProviderPipe::AuxiliarySpine, true);
     }
     else {
         Gui::Selection().clearSelection();
-        selectionMode = none;
+        if (selectionMode == refAdd)
+            selectionMode = none;
         static_cast<ViewProviderPipe*>(vp)->highlightReferences(ViewProviderPipe::AuxiliarySpine, false);
     }
 }
@@ -715,14 +716,14 @@ void TaskPipeOrientation::onButtonRefAdd(bool checked)
 void TaskPipeOrientation::onButtonRefRemove(bool checked)
 {
     if (checked) {
-        clearButtons(refRemove);
         Gui::Selection().clearSelection();
         selectionMode = refRemove;
         static_cast<ViewProviderPipe*>(vp)->highlightReferences(ViewProviderPipe::AuxiliarySpine, true);
     }
     else {
         Gui::Selection().clearSelection();
-        selectionMode = none;
+        if (selectionMode == refRemove)
+            selectionMode = none;
         static_cast<ViewProviderPipe*>(vp)->highlightReferences(ViewProviderPipe::AuxiliarySpine, false);
     }
 }
@@ -730,14 +731,14 @@ void TaskPipeOrientation::onButtonRefRemove(bool checked)
 void TaskPipeOrientation::onBaseButton(bool checked)
 {
     if (checked) {
-        clearButtons(refObjAdd);
         Gui::Selection().clearSelection();
         selectionMode = refObjAdd;
         static_cast<ViewProviderPipe*>(vp)->highlightReferences(ViewProviderPipe::AuxiliarySpine, true);
     }
     else {
         Gui::Selection().clearSelection();
-        selectionMode = none;
+        if (selectionMode == refObjAdd)
+            selectionMode = none;
         static_cast<ViewProviderPipe*>(vp)->highlightReferences(ViewProviderPipe::AuxiliarySpine, false);
     }
 }
@@ -1009,14 +1010,14 @@ void TaskPipeScaling::exitSelectionMode()
 void TaskPipeScaling::onButtonRefAdd(bool checked)
 {
     if (checked) {
-        clearButtons(refAdd);
         Gui::Selection().clearSelection();
         selectionMode = refAdd;
         static_cast<ViewProviderPipe*>(vp)->highlightReferences(ViewProviderPipe::Section, true);
     }
     else {
         Gui::Selection().clearSelection();
-        selectionMode = none;
+        if (selectionMode == refAdd)
+            selectionMode = none;
         static_cast<ViewProviderPipe*>(vp)->highlightReferences(ViewProviderPipe::Section, false);
     }
 }
@@ -1024,14 +1025,14 @@ void TaskPipeScaling::onButtonRefAdd(bool checked)
 void TaskPipeScaling::onButtonRefRemove(bool checked)
 {
     if (checked) {
-        clearButtons(refRemove);
         Gui::Selection().clearSelection();
         selectionMode = refRemove;
         static_cast<ViewProviderPipe*>(vp)->highlightReferences(ViewProviderPipe::Section, true);
     }
     else {
         Gui::Selection().clearSelection();
-        selectionMode = none;
+        if (selectionMode == refRemove)
+            selectionMode = none;
         static_cast<ViewProviderPipe*>(vp)->highlightReferences(ViewProviderPipe::Section, false);
     }
 }
@@ -1180,6 +1181,22 @@ TaskDlgPipeParameters::TaskDlgPipeParameters(ViewProviderPipe *PipeView,bool new
     Content.push_back(parameter);
     Content.push_back(orientation);
     Content.push_back(scaling);
+
+
+    buttonGroup = new ButtonGroup(this);
+    buttonGroup->setExclusive(true);
+
+    buttonGroup->addButton(parameter->ui->buttonProfileBase);
+    buttonGroup->addButton(parameter->ui->buttonRefAdd);
+    buttonGroup->addButton(parameter->ui->buttonRefRemove);
+    buttonGroup->addButton(parameter->ui->buttonSpineBase);
+
+    buttonGroup->addButton(orientation->ui->buttonRefAdd);
+    buttonGroup->addButton(orientation->ui->buttonRefRemove);
+    buttonGroup->addButton(orientation->ui->buttonProfileBase);
+
+    buttonGroup->addButton(scaling->ui->buttonRefAdd);
+    buttonGroup->addButton(scaling->ui->buttonRefRemove);
 }
 
 TaskDlgPipeParameters::~TaskDlgPipeParameters()

--- a/src/Mod/PartDesign/Gui/TaskPipeParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskPipeParameters.h
@@ -27,6 +27,7 @@
 #include <Gui/TaskView/TaskView.h>
 #include <Gui/Selection.h>
 #include <Gui/TaskView/TaskDialog.h>
+#include <Gui/Widgets.h>
 
 #include "TaskSketchBasedParameters.h"
 #include "ViewProviderPipe.h"
@@ -91,6 +92,7 @@ private:
 private:
     QWidget* proxy;
     std::unique_ptr<Ui_TaskPipeParameters> ui;
+    friend class TaskDlgPipeParameters;
 };
 
 class TaskPipeOrientation : public TaskSketchBasedParameters
@@ -128,6 +130,7 @@ private:
 private:
     QWidget* proxy;
     std::unique_ptr<Ui_TaskPipeOrientation> ui;
+    friend class TaskDlgPipeParameters;
 };
 
 
@@ -162,6 +165,7 @@ private:
 private:
     QWidget* proxy;
     std::unique_ptr<Ui_TaskPipeScaling> ui;
+    friend class TaskDlgPipeParameters;
 };
 
 
@@ -183,6 +187,8 @@ protected:
     TaskPipeParameters  *parameter;
     TaskPipeOrientation *orientation;
     TaskPipeScaling     *scaling;
+
+    Gui::ButtonGroup *buttonGroup;
 };
 
 } //namespace PartDesignGui

--- a/src/Mod/PartDesign/Gui/TaskPipeParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskPipeParameters.h
@@ -48,6 +48,36 @@ class Ui_TaskPipeParameters;
 class Ui_TaskPipeOrientation;
 class Ui_TaskPipeScaling;
 
+/// Convenience class to maintain states between the various task boxes for pipe
+class StateHandlerTaskPipe
+{
+public:
+    enum SelectionModes {
+        none = 0,
+        refProfile,
+        refSpine,
+        refSpineEdgeAdd,
+        refSpineEdgeRemove,
+        refAuxSpine,
+        refAuxSpineEdgeAdd,
+        refAuxSpineEdgeRemove,
+        refSectionAdd,
+        refSectionRemove
+    };
+
+public:
+    StateHandlerTaskPipe() {selectionMode = SelectionModes::none;}
+    ~StateHandlerTaskPipe() {}
+
+    // only keeping getter because task boxes shouldn't need to change this
+    // and task dialog is already friend
+    enum SelectionModes getSelectionMode() {return selectionMode;}
+
+private:
+    enum SelectionModes selectionMode;
+    friend class TaskDlgPipeParameters;
+};
+
 
 class TaskPipeParameters : public TaskSketchBasedParameters
 {
@@ -62,23 +92,17 @@ public:
 private Q_SLOTS:
     void onTangentChanged(bool checked);
     void onTransitionChanged(int);
-    void onButtonRefAdd(bool checked);
-    void onButtonRefRemove(bool checked);
-    void onBaseButton(bool checked);
     void onProfileButton(bool checked);
     void onDeleteEdge();
 
 protected:
-    enum selectionModes { none, refAdd, refRemove, refObjAdd, refProfile };
-    selectionModes selectionMode = none;
-
     void removeFromListWidget(QListWidget*w, QString name);
     bool referenceSelected(const Gui::SelectionChanges& msg) const;
 
 private:
     void onSelectionChanged(const Gui::SelectionChanges& msg);
     void updateUI();
-    void clearButtons(const selectionModes notThis=none);
+    void clearButtons();
     void exitSelectionMode();
     void setVisibilityOfSpineAndProfile();
 
@@ -92,6 +116,7 @@ private:
 private:
     QWidget* proxy;
     std::unique_ptr<Ui_TaskPipeParameters> ui;
+    StateHandlerTaskPipe *stateHandler;
     friend class TaskDlgPipeParameters;
 };
 
@@ -106,30 +131,25 @@ public:
 
 private Q_SLOTS:
     void onOrientationChanged(int);
-    void onButtonRefAdd(bool checked);
-    void onButtonRefRemove(bool checked);
     void updateUI(int idx);
-    void onBaseButton(bool checked);
     void onClearButton();
     void onCurvelinearChanged(bool checked);
     void onBinormalChanged(double);
     void onDeleteItem();
 
 protected:
-    enum selectionModes { none, refAdd, refRemove, refObjAdd };
-    selectionModes selectionMode = none;
-
     void removeFromListWidget(QListWidget*w, QString name);
     bool referenceSelected(const Gui::SelectionChanges& msg) const;
 
 private:
     void onSelectionChanged(const Gui::SelectionChanges& msg);
-    void clearButtons(const selectionModes notThis=none);
+    void clearButtons();
     void exitSelectionMode();
 
 private:
     QWidget* proxy;
     std::unique_ptr<Ui_TaskPipeOrientation> ui;
+    StateHandlerTaskPipe *stateHandler;
     friend class TaskDlgPipeParameters;
 };
 
@@ -144,30 +164,25 @@ public:
 
 private Q_SLOTS:
     void onScalingChanged(int);
-    void onButtonRefAdd(bool checked);
-    void onButtonRefRemove(bool checked);
     void updateUI(int idx);
     void onDeleteSection();
     void indexesMoved();
 
 protected:
-    enum selectionModes { none, refAdd, refRemove };
-    selectionModes selectionMode = none;
-
     void removeFromListWidget(QListWidget*w, QString name);
     bool referenceSelected(const Gui::SelectionChanges& msg) const;
 
 private:
     void onSelectionChanged(const Gui::SelectionChanges& msg);
-    void clearButtons(const selectionModes notThis=none);
+    void clearButtons();
     void exitSelectionMode();
 
 private:
     QWidget* proxy;
     std::unique_ptr<Ui_TaskPipeScaling> ui;
+    StateHandlerTaskPipe *stateHandler;
     friend class TaskDlgPipeParameters;
 };
-
 
 /// simulation dialog for the TaskView
 class TaskDlgPipeParameters : public TaskDlgSketchBasedParameters
@@ -183,12 +198,16 @@ public:
     virtual bool accept();
     /// is called by the framework if the dialog is rejected (Cancel)
 
+protected Q_SLOTS:
+    void onButtonToggled(QAbstractButton *button, bool checked);
+
 protected:
     TaskPipeParameters  *parameter;
     TaskPipeOrientation *orientation;
     TaskPipeScaling     *scaling;
 
     Gui::ButtonGroup *buttonGroup;
+    StateHandlerTaskPipe *stateHandler;
 };
 
 } //namespace PartDesignGui


### PR DESCRIPTION
Replaces PR #5189 to use `GUI::ButtonGroup` introduced in 792277a848c5bb5d5cfbdf592e8c9991b7fa4889 instead of creating a new one.