### PR TITLE
Addon Manager: Add version-based Addon deprecation

### DIFF
--- a/src/Mod/AddonManager/addonmanager_workers.py
+++ b/src/Mod/AddonManager/addonmanager_workers.py
@@ -173,6 +173,35 @@ class UpdateWorker(QtCore.QThread):
 
             if "py2only" in j and "Mod" in j["py2only"]:
                 py2only = j["py2only"]["Mod"]
+
+            if "deprecated" in j:
+                fc_major = int(FreeCAD.Version()[0])
+                fc_minor = int(FreeCAD.Version()[1])
+                for item in j["deprecated"]:
+                    if "as_of" in item and "name" in item:
+                        try:
+                            version_components = item["as_of"].split(".")
+                            major = int(version_components[0])
+                            if len(version_components) > 1:
+                                minor = int(version_components[1])
+                            else:
+                                minor = 0
+                            if major < fc_major or (
+                                major == fc_major and minor <= fc_minor
+                            ):
+                                if "kind" not in item or item["kind"] == "mod":
+                                    obsolete.append(item["name"])
+                                elif item["kind"] == "macro":
+                                    macros_reject_list.append(item["name"])
+                                else:
+                                    FreeCAD.Console.PrintMessage(
+                                        f'Unrecognized Addon kind {item["kind"]} in deprecation list.'
+                                    )
+                        except Exception:
+                            FreeCAD.Console.PrintMessage(
+                                f"Exception caught when parsing deprecated Addon {item['name']}, version {item['as_of']}"
+                            )
+
         else:
             message = translate(
                 "AddonsInstaller",


### PR DESCRIPTION
It is possible for an Addon to work in one version of FreeCAD, and not in a later version: to support this idea, the original "Obsolete" list from the FreeCAD-Addons repo was expanded to include a new "Deprecated" list that allows a package to be deprecated "as_of" a particular version of FreeCAD. For example, this enables FreeCAD 0.19 to continue to locate and load the Autoload Addon, but FreeCAD 0.20 won't list it (by default), because that Addon is deprecated in 0.20. 