### PR TITLE
PartDesign: Improve orientation behaviour for conical helices

### DIFF
--- a/src/Mod/PartDesign/App/FeatureHelix.cpp
+++ b/src/Mod/PartDesign/App/FeatureHelix.cpp
@@ -443,7 +443,7 @@ TopoDS_Shape Helix::generateHelixPath(double startOffset0)
 
     // The factor of 100 below ensures that profile size is small compared to the curvature of the helix.
     // This improves the issue reported in https://forum.freecadweb.org/viewtopic.php?f=10&t=65048
-    double axisOffset = 100*(profileCenter * start - b * start);
+    double axisOffset = 100 * (profileCenter * start - b * start);
     double startOffset = startOffset0 + profileCenter * v - b * v;
     double radius = std::fabs(axisOffset);
     bool turned = axisOffset < 0;

--- a/src/Mod/PartDesign/App/FeatureHelix.h
+++ b/src/Mod/PartDesign/App/FeatureHelix.h
@@ -80,7 +80,7 @@ protected:
     void updateAxis(void);
 
     /// generate helix and move it to the right location.
-    TopoDS_Shape generateHelixPath(void);
+    TopoDS_Shape generateHelixPath(double startOffset0=0.0);
 
     // project shape on plane. Used for detecting self intersection.
     TopoDS_Shape projectShape(const TopoDS_Shape& input, const gp_Ax2& plane);

--- a/src/Mod/PartDesign/App/FeatureHelix.h
+++ b/src/Mod/PartDesign/App/FeatureHelix.h
@@ -80,7 +80,7 @@ protected:
     void updateAxis(void);
 
     /// generate helix and move it to the right location.
-    TopoDS_Shape generateHelixPath(double startOffset0=0.0);
+    TopoDS_Shape generateHelixPath(double startOffset0 = 0.0);
 
     // project shape on plane. Used for detecting self intersection.
     TopoDS_Shape projectShape(const TopoDS_Shape& input, const gp_Ax2& plane);


### PR DESCRIPTION
Until now FeatureHelix is using Frenet for orienting the profile along the sweep. 

As identified in the forum
https://forum.freecadweb.org/viewtopic.php?f=3&t=65136
this does not give expected results for helices with cone angle for example when constructing a tapered thread, because the thread profile is not consistent (see example below). 
 
By using an auxiliary helix that is axially offset as a guide we get an improved behavior. 

**Before**
![image](https://user-images.githubusercontent.com/1278189/148691206-4f115844-157c-44ac-9989-49f0329ff236.png)

**After**
![image](https://user-images.githubusercontent.com/1278189/148678021-8eea38ad-2c98-48fd-8ef7-4071fc095d54.png)

**Before**
![image](https://user-images.githubusercontent.com/1278189/148699505-23112179-5440-4426-b24c-4f1aff8870fb.png)

**After**
![image](https://user-images.githubusercontent.com/1278189/148699540-7ccf7ae8-2384-4a52-911f-049ca1a96257.png)

Results will be the same as before when cone angle is 0.
