### PR TITLE
[TD]Improve Handling of View in Multiple Pages

### DIFF
--- a/src/Mod/TechDraw/App/DrawPagePy.xml
+++ b/src/Mod/TechDraw/App/DrawPagePy.xml
@@ -43,6 +43,11 @@
         <UserDocu>Return the orientation of this page</UserDocu>
       </Documentation>
     </Methode>
+    <Methode Name="requestPaint">
+      <Documentation>
+        <UserDocu>Ask the Gui to redraw this page</UserDocu>
+      </Documentation>
+    </Methode>
     <CustomAttributes />
   </PythonExport>
 </GenerateModel>

--- a/src/Mod/TechDraw/App/DrawPagePyImp.cpp
+++ b/src/Mod/TechDraw/App/DrawPagePyImp.cpp
@@ -93,6 +93,16 @@ PyObject* DrawPagePy::getAllViews(PyObject* args)
     return Py::new_reference_to(ret);
 }
 
+PyObject* DrawPagePy::requestPaint(PyObject* args)
+{
+    (void) args;
+    DrawPage* page = getDrawPagePtr();
+    page->requestPaint();
+    Py_INCREF(Py_None);
+    return Py_None;
+}
+
+
 //    double getPageWidth() const;
 PyObject* DrawPagePy::getPageWidth(PyObject *)
 {

--- a/src/Mod/TechDraw/App/DrawProjGroupItem.cpp
+++ b/src/Mod/TechDraw/App/DrawProjGroupItem.cpp
@@ -349,6 +349,38 @@ void DrawProjGroupItem::unsetupObject()
     DrawViewPart::unsetupObject();
 }
 
+//DPGIs have DPG as parent, not Page, so we need to ask the DPG how many Pages own it.
+int DrawProjGroupItem::countParentPages() const
+{
+    DrawProjGroup* dpg = getPGroup();
+    if (dpg != nullptr) {
+        int count = dpg->countParentPages();
+        return count;
+    }
+    return 0;
+}
+
+DrawPage* DrawProjGroupItem::findParentPage() const
+{
+    DrawProjGroup* dpg = getPGroup();
+    if (dpg != nullptr) {
+        DrawPage* dp = dpg->findParentPage();
+        return dp;
+    }
+    return nullptr;
+}
+
+std::vector<DrawPage*> DrawProjGroupItem::findAllParentPages() const
+{
+    DrawProjGroup* dpg = getPGroup();
+    if (dpg != nullptr) {
+        std::vector<DrawPage*> dps = dpg->findAllParentPages();
+        return dps;
+    }
+    std::vector<DrawPage*> empty;
+    return empty;
+}
+
 PyObject *DrawProjGroupItem::getPyObject(void)
 {
     if (PythonObject.is(Py::_None())) {

--- a/src/Mod/TechDraw/App/DrawProjGroupItem.h
+++ b/src/Mod/TechDraw/App/DrawProjGroupItem.h
@@ -89,6 +89,10 @@ public:
     virtual bool checkFit(void) const override { return true; }
     virtual bool checkFit(DrawPage*) const override { return true; }
 
+    virtual int countParentPages() const override;
+    virtual DrawPage* findParentPage() const override;
+    virtual std::vector<DrawPage*> findAllParentPages() const override;
+
 protected:
     void onChanged(const App::Property* prop) override;
     virtual bool isLocked(void) const override;

--- a/src/Mod/TechDraw/App/DrawView.cpp
+++ b/src/Mod/TechDraw/App/DrawView.cpp
@@ -246,6 +246,7 @@ void DrawView::onDocumentRestored()
  * in case it is also a child of another duplicate page
  * @return
  */
+//note this won't find parent pages for DrawProjItem since their parent is DrawProjGroup!
 int DrawView::countParentPages() const
 {
     int count = 0;
@@ -260,6 +261,9 @@ int DrawView::countParentPages() const
     return count;
 }
 
+//finds the first DrawPage in this Document that claims to own this DrawView
+//note that it is possible to manipulate the Views property of DrawPage so that
+//more than 1 DrawPage claims a DrawView.
 DrawPage* DrawView::findParentPage() const
 {
     // Get Feature Page
@@ -282,6 +286,33 @@ DrawPage* DrawView::findParentPage() const
 
     return page;
 }
+
+
+std::vector<DrawPage*> DrawView::findAllParentPages() const
+{
+    // Get Feature Page
+    std::vector<DrawPage*> result;
+    DrawPage *page = 0;
+    DrawViewCollection *collection = 0;
+    std::vector<App::DocumentObject*> parent = getInList();
+    for (std::vector<App::DocumentObject*>::iterator it = parent.begin(); it != parent.end(); ++it) {
+        if ((*it)->getTypeId().isDerivedFrom(DrawPage::getClassTypeId())) {
+            page = static_cast<TechDraw::DrawPage *>(*it);
+        }
+
+        if ((*it)->getTypeId().isDerivedFrom(DrawViewCollection::getClassTypeId())) {
+            collection = static_cast<TechDraw::DrawViewCollection *>(*it);
+            page = collection->findParentPage();
+        }
+
+        if(page) {
+            result.emplace_back(page);
+        }
+    }
+
+    return result;
+}
+
 
 bool DrawView::isInClip()
 {

--- a/src/Mod/TechDraw/App/DrawView.h
+++ b/src/Mod/TechDraw/App/DrawView.h
@@ -23,6 +23,8 @@
 #ifndef _DrawView_h_
 #define _DrawView_h_
 
+#include <Mod/TechDraw/TechDrawGlobal.h>
+
 #include <boost_signals2.hpp>
 
 #include <QCoreApplication>
@@ -85,6 +87,7 @@ public:
     virtual PyObject *getPyObject(void) override;
 
     virtual DrawPage* findParentPage() const;
+    virtual std::vector<DrawPage*> findAllParentPages() const;
     virtual int countParentPages() const;
     virtual QRectF getRect() const;                      //must be overridden by derived class
     virtual double autoScale(void) const;


### PR DESCRIPTION
Although not intended in the design, it is possible for a user to assign a View to multiple Pages by using Std_Copy/Std_Paste and/or Duplicate_Selection.  In the past this caused issues with multiple deletes of QGraphicsItems.

https://github.com/FreeCAD/FreeCAD/pull/5013 and https://github.com/FreeCAD/FreeCAD/pull/5016 solved the multiple delete problem for many cases.  This PR extends that work to handle more cases.

[Additional background here](https://www.forum.freecadweb.org/viewtopic.php?p=559781#p559781)


Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [ ]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [ ]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [ ]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [ ]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
