### PR TITLE
Fix various typos

### DIFF
--- a/src/Mod/AddonManager/AddonManager.py
+++ b/src/Mod/AddonManager/AddonManager.py
@@ -1258,7 +1258,7 @@ class CommandAddonManager:
         with open(stopfile, "w", encoding="utf8") as f:
             f.write(
                 "This file indicates that a cache operation was interrupted, and "
-                "the cache is in an unkown state. It will be deleted next time "
+                "the cache is in an unknown state. It will be deleted next time "
                 "AddonManager recaches."
             )
 

--- a/src/Mod/Assembly/App/opendcm/core/property.hpp
+++ b/src/Mod/Assembly/App/opendcm/core/property.hpp
@@ -74,7 +74,7 @@ namespace dcm {
  * A property of kind @ref vertex_property will added to vertices, a property of kind @ref object_property to all
  * objects and so on.
  *
- * If the property type is a standart c++ type like int or bool, the defualt value can't be set by using its
+ * If the property type is a standart c++ type like int or bool, the default value can't be set by using its
  * constructor. Therefore a interface for setting default values is added to the property. If you want
  * to assign a default value you just need to add a struct default_value which returns the wanted default
  * value with the operator(). If you don't want a default value, just don't add the struct. The implementation

--- a/src/Mod/Assembly/App/opendcm/core/property.hpp
+++ b/src/Mod/Assembly/App/opendcm/core/property.hpp
@@ -74,7 +74,7 @@ namespace dcm {
  * A property of kind @ref vertex_property will added to vertices, a property of kind @ref object_property to all
  * objects and so on.
  *
- * If the property type is a standart c++ type like int or bool, the default value can't be set by using its
+ * If the property type is a standard c++ type like int or bool, the default value can't be set by using its
  * constructor. Therefore a interface for setting default values is added to the property. If you want
  * to assign a default value you just need to add a struct default_value which returns the wanted default
  * value with the operator(). If you don't want a default value, just don't add the struct. The implementation

--- a/src/Mod/PartDesign/App/FeatureHelix.cpp
+++ b/src/Mod/PartDesign/App/FeatureHelix.cpp
@@ -253,7 +253,7 @@ App::DocumentObjectExecReturn* Helix::execute(void)
             mkPS.SetTransitionMode(BRepBuilderAPI_Transformed);
 
             //mkPS.SetMode(true);  //This is for frenet
-            mkPS.SetMode(TopoDS::Wire(auxpath), true);  // this is for auxilliary
+            mkPS.SetMode(TopoDS::Wire(auxpath), true);  // this is for auxiliary
 
             for (TopoDS_Wire& wire : wires) {
                 wire.Move(invObjLoc);

--- a/src/Mod/Path/PathScripts/PathSlot.py
+++ b/src/Mod/Path/PathScripts/PathSlot.py
@@ -314,7 +314,7 @@ class ObjectSlot(PathOp.ObjectOp):
             obj.OpStartDepth.Value = 10
 
         PathLog.debug('Default OpFinalDepth: {}'.format(obj.OpFinalDepth.Value))
-        PathLog.debug('Defualt OpStartDepth: {}'.format(obj.OpStartDepth.Value))
+        PathLog.debug('Default OpStartDepth: {}'.format(obj.OpStartDepth.Value))
 
     def opApplyPropertyLimits(self, obj):
         '''opApplyPropertyLimits(obj) ... Apply necessary limits to user input property values before performing main operation.'''

--- a/src/Mod/Path/PathScripts/PathSurface.py
+++ b/src/Mod/Path/PathScripts/PathSurface.py
@@ -621,7 +621,7 @@ class ObjectSurface(PathOp.ObjectOp):
             obj.OpStartDepth.Value = 10
 
         PathLog.debug("Default OpFinalDepth: {}".format(obj.OpFinalDepth.Value))
-        PathLog.debug("Defualt OpStartDepth: {}".format(obj.OpStartDepth.Value))
+        PathLog.debug("Default OpStartDepth: {}".format(obj.OpStartDepth.Value))
 
     def opApplyPropertyLimits(self, obj):
         """opApplyPropertyLimits(obj) ... Apply necessary limits to user input property values before performing main operation."""

--- a/src/Mod/Path/PathScripts/PathWaterline.py
+++ b/src/Mod/Path/PathScripts/PathWaterline.py
@@ -597,7 +597,7 @@ class ObjectWaterline(PathOp.ObjectOp):
             obj.OpStartDepth.Value = 10
 
         PathLog.debug("Default OpFinalDepth: {}".format(obj.OpFinalDepth.Value))
-        PathLog.debug("Defualt OpStartDepth: {}".format(obj.OpStartDepth.Value))
+        PathLog.debug("Default OpStartDepth: {}".format(obj.OpStartDepth.Value))
 
     def opApplyPropertyLimits(self, obj):
         """opApplyPropertyLimits(obj) ... Apply necessary limits to user input property values before performing main operation."""

--- a/src/Mod/Robot/App/kdl_cp/frames.inl
+++ b/src/Mod/Robot/App/kdl_cp/frames.inl
@@ -824,7 +824,7 @@ IMETHOD void Vector2::Set3DYZ(const Vector& v)
     data[1]=v(2);
 }
 IMETHOD void Vector2::Set3DZX(const Vector& v)
-// projects v in its XY plane, and and sets *this to these values
+// projects v in its XY plane, and sets *this to these values
 {
     data[0]=v(2);
     data[1]=v(0);

--- a/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
@@ -1267,7 +1267,7 @@ void EditModeConstraintCoinManager::updateConstraintColor(const std::vector<Sket
         Sketcher::Constraint* constraint = constraints[i];
         ConstraintType type = constraint->Type;
 
-        // It may happen that color updates are triggered by programatic selection changes before a command final update. Then
+        // It may happen that color updates are triggered by programmatic selection changes before a command final update. Then
         // constraints may have been changed and the color will be updated as part
         if (type != vConstrType[i])
             break;

--- a/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp
+++ b/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp
@@ -118,8 +118,8 @@ namespace TechDrawGui {
 // TechDraw_ExtensionInsertDiameter
 //===========================================================================
 
-void execInsertPrefixChar(Gui::Command* cmd, std::string praefixChar) {
-    // insert a praefix character into the format specifier
+void execInsertPrefixChar(Gui::Command* cmd, std::string prefixChar) {
+    // insert a prefix character into the format specifier
     std::vector<Gui::SelectionObject> selection;
     if (_checkSelection(cmd, selection, "TechDraw Insert Prefix Character")) {
         Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Insert Prefix Character"));
@@ -128,7 +128,7 @@ void execInsertPrefixChar(Gui::Command* cmd, std::string praefixChar) {
             if (object->isDerivedFrom(TechDraw::DrawViewDimension::getClassTypeId())) {
                 auto dim = dynamic_cast<TechDraw::DrawViewDimension*>(selected.getObject());
                 std::string formatSpec = dim->FormatSpec.getStrValue();
-                formatSpec = praefixChar + formatSpec;
+                formatSpec = prefixChar + formatSpec;
                 dim->FormatSpec.setValue(formatSpec);
             }
         }
@@ -230,10 +230,10 @@ void CmdTechDrawExtensionInsertPrefixGroup::activated(int iMsg)
     Gui::ActionGroup* pcAction = qobject_cast<Gui::ActionGroup*>(_pcAction);
     pcAction->setIcon(pcAction->actions().at(iMsg)->icon());
     switch (iMsg) {
-    case 0:                 //insert "⌀" as praefix
+    case 0:                 //insert "⌀" as prefix
         execInsertPrefixChar(this, "⌀");
         break;
-    case 1:                 //insert "〼" as praefix
+    case 1:                 //insert "〼" as prefix
         execInsertPrefixChar(this, "〼");
         break;
     default:

--- a/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp
+++ b/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp
@@ -958,7 +958,7 @@ CmdTechDrawExtensionCascadeObliqueDimension::CmdTechDrawExtensionCascadeObliqueD
     sMenuText       = QT_TR_NOOP("Cascade Oblique Dimensions");
     sToolTipText    = QT_TR_NOOP("Cascade oblique dimensions\n\
     - select some parallel oblique measures\n\
-    - the first selected maesure defines the position\n\
+    - the first selected measure defines the position\n\
     - click this button");
     sWhatsThis      = "TechDraw_ExtensionCascadeObliqueDimension";
     sStatusTip      = sToolTipText;
@@ -1082,7 +1082,7 @@ void CmdTechDrawExtensionCascadeDimensionGroup::languageChange()
     arc3->setToolTip(QApplication::translate("TechDraw_Extension",
         "Cascade oblique dimensions\n\
     - select some parallel oblique measures\n\
-    - the first selected maesure defines the position\n\
+    - the first selected measure defines the position\n\
     - click this button"));
     arc3->setStatusTip(arc3->toolTip());
 }

--- a/src/Mod/TechDraw/Gui/MDIViewPage.cpp
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.cpp
@@ -520,7 +520,7 @@ void MDIViewPage::fixOrphans(bool force)
                     }
                 }
                 if (!found) {
-                    //none of the parent Pages for View coorespond to this Page
+                    //none of the parent Pages for View correspond to this Page
                     m_view->removeQView(qv);
                 }
             }

--- a/src/Mod/Test/TestApp.py
+++ b/src/Mod/Test/TestApp.py
@@ -71,7 +71,7 @@ def TestText(s):
     # Flushing to make sure the stream is written to the console
     # before the wrapping process stops executing. Without this line
     # executing the tests from command line did not show stats
-    # and proper tarceback in some cases.
+    # and proper traceback in some cases.
     sys.stdout.flush()
     return retval
 


### PR DESCRIPTION
Found via `codespell -q 3 -L aci,ake,aline,alle,alledges,alocation,als,ang,anid,apoints,ba,beginn,behaviour,bloaded,bottome,byteorder,calculater,cancelled,cancelling,cas,cascade,centimetre,childrens,childs,colour,colours,commen,connexion,currenty,dof,doubleclick,dum,eiter,elemente,ende,feld,finde,findf,freez,hist,iff,indicies,initialisation,initialise,initialised,initialises,initialisiert,inout,ist,kilometre,lod,mantatory,methode,metres,millimetre,modell,nd,noe,normale,normaly,nto,numer,oce,oder,ontop,orgin,orginx,orginy,ot,pard,parm,parms,pres,programm,que,rady,recurrance,rougly,seperator,serie,sinc,strack,substraction,te,thist,thru,tread,uint,unter,vertexes,wallthickness,whitespaces -S ./.git,*.po,*.ts,./ChangeLog.txt,./src/3rdParty,./src/Mod/Assembly/App/opendcm,./src/CXX,./src/zipios++,./src/Base/swig*,./src/Mod/Robot/App/kdl_cp,./src/Mod/Import/App/SCL,./src/WindowsInstaller,./src/Doc/FreeCAD.uml,./build/doc/SourceDocu`