### PR TITLE
Addon manager: install dependencies

### DIFF
--- a/src/App/FreeCADInit.py
+++ b/src/App/FreeCADInit.py
@@ -162,8 +162,14 @@ def InitApplications():
 
 	# also add these directories to the sys.path to
 	# not change the old behaviour. once we have moved to
-	# proper python modules this can eventuelly be removed.
+	# proper python modules this can eventually be removed.
 	sys.path = [ModDir] + libpaths + [ExtDir] + sys.path
+
+    # The AddonManager may install additional Python packages in
+    # this path:
+	additional_packages_path = os.path.join(FreeCAD.getUserAppDataDir(),"AdditionalPythonPackages")
+	if os.path.isdir(additional_packages_path):
+		sys.path.append(additional_packages_path)
 
 	def RunInitPy(Dir):
 		InstallFile = os.path.join(Dir,"Init.py")

--- a/src/Mod/AddonManager/ALLOWED_PYTHON_PACKAGES.txt
+++ b/src/Mod/AddonManager/ALLOWED_PYTHON_PACKAGES.txt
@@ -1,0 +1,19 @@
+# This file lists the Python packages that the Addon Manager allows to be installed
+# automatically via pip. To request that a package be added to this list, submit a 
+# pull reqest to the FreeCAD git repository with the requested package added. Only
+# packages in this list will be processed from the metadata.txt and requirements.txt
+# files specified by an Addon. Note that this is NOT a requirements.txt-format file,
+# no version information may be specified, and no wildcards are supported.
+
+# Allow these packages to be installed:
+ezdxf
+markdown
+numpy
+olefile
+pillow
+pygit2
+requests
+scipy
+xlrd
+xlutils
+xlwt

--- a/src/Mod/AddonManager/ALLOWED_PYTHON_PACKAGES.txt
+++ b/src/Mod/AddonManager/ALLOWED_PYTHON_PACKAGES.txt
@@ -1,18 +1,27 @@
 # This file lists the Python packages that the Addon Manager allows to be installed
 # automatically via pip. To request that a package be added to this list, submit a 
-# pull reqest to the FreeCAD git repository with the requested package added. Only
+# pull request to the FreeCAD git repository with the requested package added. Only
 # packages in this list will be processed from the metadata.txt and requirements.txt
 # files specified by an Addon. Note that this is NOT a requirements.txt-format file,
 # no version information may be specified, and no wildcards are supported.
 
 # Allow these packages to be installed:
 ezdxf
+gmsh
+lxml
 markdown
+matplotlib
 numpy
 olefile
+openpyxl
+pandas
 pillow
+ply
+pycollada
 pygit2
+pynastran
 requests
+rhino3dm
 scipy
 xlrd
 xlutils

--- a/src/Mod/AddonManager/ALLOWED_PYTHON_PACKAGES.txt
+++ b/src/Mod/AddonManager/ALLOWED_PYTHON_PACKAGES.txt
@@ -17,3 +17,4 @@ scipy
 xlrd
 xlutils
 xlwt
+PyYAML

--- a/src/Mod/AddonManager/AddonManager.py
+++ b/src/Mod/AddonManager/AddonManager.py
@@ -1052,8 +1052,7 @@ class CommandAddonManager:
             translate("AddonsInstaller", "Cannot execute Python"),
             translate(
                 "AddonsInstaller",
-                "Failed to automatically locate your Python executable, or the path is set incorrectly. "
-                "Please check the Addon Manager preferences setting for the path to Python.",
+                "Failed to automatically locate your Python executable, or the path is set incorrectly. Please check the Addon Manager preferences setting for the path to Python.",
             )
             + "\n\n"
             + translate(
@@ -1073,9 +1072,7 @@ class CommandAddonManager:
             translate("AddonsInstaller", "Cannot execute pip"),
             translate(
                 "AddonsInstaller",
-                "Failed to execute pip, which may be missing from your Python installation. "
-                "Please ensure your system has pip installed and try again."
-                "The failed command was: ",
+                "Failed to execute pip, which may be missing from your Python installation. Please ensure your system has pip installed and try again. The failed command was: ",
             )
             + f"\n\n{command}\n\n"
             + translate(
@@ -1157,8 +1154,7 @@ class CommandAddonManager:
             if not failed:
                 message = translate(
                     "AddonsInstaller",
-                    "Macro successfully installed. The macro is "
-                    "now available from the Macros dialog.",
+                    "Macro successfully installed. The macro is now available from the Macros dialog.",
                 )
                 self.on_package_installed(repo, message)
             else:

--- a/src/Mod/AddonManager/AddonManager.py
+++ b/src/Mod/AddonManager/AddonManager.py
@@ -976,7 +976,8 @@ class CommandAddonManager:
                 self.dependency_dialog.listWidgetPythonRequired.addItem(mod)
             for mod in missing_python_optionals:
                 item = QtWidgets.QListWidgetItem(mod)
-                item.setFlags(Qt.ItemIsUserCheckable)
+                item.setFlags(item.flags()|QtCore.Qt.ItemIsUserCheckable)
+                item.setCheckState(QtCore.Qt.Unchecked)
                 self.dependency_dialog.listWidgetPythonOptional.addItem(item)
 
             self.dependency_dialog.buttonBox.button(
@@ -1010,7 +1011,7 @@ class CommandAddonManager:
         python_optional = []
         for row in range(self.dependency_dialog.listWidgetPythonOptional.count()):
             item = self.dependency_dialog.listWidgetPythonOptional.item(row)
-            if item.checked():
+            if item.checkState() == QtCore.Qt.Checked:
                 python_optional.append(item.text())
 
         self.dependency_installation_worker = DependencyInstallationWorker(

--- a/src/Mod/AddonManager/AddonManagerOptions.ui
+++ b/src/Mod/AddonManager/AddonManagerOptions.ui
@@ -237,7 +237,7 @@ of the line after a space (e.g. https://github.com/FreeCAD/FreeCAD master).</str
      <item>
       <widget class="QLabel" name="fclabel">
        <property name="text">
-        <string>Python executable:</string>
+        <string>Python executable (optional):</string>
        </property>
       </widget>
      </item>
@@ -256,7 +256,7 @@ of the line after a space (e.g. https://github.com/FreeCAD/FreeCAD master).</str
         </size>
        </property>
        <property name="toolTip">
-        <string>The path to the Python executable for package installation with pip</string>
+        <string>The path to the Python executable for package installation with pip. Autodetected if needed and not specified.</string>
        </property>
        <property name="prefEntry" stdset="0">
         <cstring>PythonExecutableForPip</cstring>

--- a/src/Mod/AddonManager/AddonManagerOptions.ui
+++ b/src/Mod/AddonManager/AddonManagerOptions.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>388</width>
+    <width>757</width>
     <height>621</height>
    </rect>
   </property>
@@ -233,6 +233,42 @@ of the line after a space (e.g. https://github.com/FreeCAD/FreeCAD master).</str
     </widget>
    </item>
    <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <widget class="QLabel" name="fclabel">
+       <property name="text">
+        <string>Python executable:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="Gui::PrefFileChooser" name="gui::preffilechooser" native="true">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>300</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string>The path to the Python executable for package installation with pip</string>
+       </property>
+       <property name="prefEntry" stdset="0">
+        <cstring>PythonExecutableForPip</cstring>
+       </property>
+       <property name="prefPath" stdset="0">
+        <cstring>Addons</cstring>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -271,6 +307,11 @@ of the line after a space (e.g. https://github.com/FreeCAD/FreeCAD master).</str
   <customwidget>
    <class>Gui::PrefLineEdit</class>
    <extends>QLineEdit</extends>
+   <header>Gui/PrefWidgets.h</header>
+  </customwidget>
+  <customwidget>
+   <class>Gui::PrefFileChooser</class>
+   <extends>QWidget</extends>
    <header>Gui/PrefWidgets.h</header>
   </customwidget>
  </customwidgets>

--- a/src/Mod/AddonManager/AddonManagerRepo.py
+++ b/src/Mod/AddonManager/AddonManagerRepo.py
@@ -113,7 +113,7 @@ class AddonManagerRepo:
         self.requires: Set[str] = set()
         self.blocks: Set[str] = set()
 
-        # And maintains a list of required and optional Python dependencies
+        # And maintains a list of required and optional Python dependencies from metadata.txt
         self.python_requires: Set[str] = set()
         self.python_optional: Set[str] = set()
 

--- a/src/Mod/AddonManager/AddonManagerRepo.py
+++ b/src/Mod/AddonManager/AddonManagerRepo.py
@@ -98,9 +98,10 @@ class AddonManagerRepo:
         self.description = None
         from addonmanager_utilities import construct_git_url
 
-        self.metadata_url = (
-            "" if not self.url else construct_git_url(self, "package.xml")
-        )
+        if "github" in self.url or "gitlab" in self.url or "salsa" in self.url:
+            self.metadata_url = construct_git_url(self, "package.xml")
+        else:
+            self.metadata_url = None
         self.metadata = None
         self.icon = None
         self.cached_icon_filename = ""

--- a/src/Mod/AddonManager/CMakeLists.txt
+++ b/src/Mod/AddonManager/CMakeLists.txt
@@ -13,6 +13,7 @@ SET(AddonManager_SRCS
     addonmanager_workers.py
     AddonManager.ui
     AddonManagerOptions.ui
+    ALLOWED_PYTHON_PACKAGES.txt
     first_run.ui
     compact_view.py
     dependency_resolution_dialog.ui

--- a/src/Mod/AddonManager/addonmanager_metadata.py
+++ b/src/Mod/AddonManager/addonmanager_metadata.py
@@ -25,7 +25,7 @@ import FreeCAD
 import os
 import io
 import hashlib
-from typing import Dict, List
+from typing import Dict, List, Set
 
 from PySide2 import QtCore, QtNetwork
 from PySide2.QtCore import QObject
@@ -188,7 +188,7 @@ class MetadataDownloadWorker(DownloadWorker):
         self.updated.emit(self.repo)
 
 
-class DependencyDownloadWorker(DownloadWorker):
+class MetadataTxtDownloadWorker(DownloadWorker):
     """A worker for downloading metadata.txt"""
 
     def __init__(self, parent, repo: AddonManagerRepo):
@@ -239,17 +239,70 @@ class DependencyDownloadWorker(DownloadWorker):
             elif line.startswith("pylibs="):
                 depspy = line.split("=")[1].split(",")
                 for pl in depspy:
-                    if pl.strip():
-                        self.repo.python_requires.add(pl.strip())
+                    dep = pl.strip()
+                    if dep:
+                        self.repo.python_requires.add(dep)
                         FreeCAD.Console.PrintLog(
-                            f"{self.repo.display_name} requires python package '{pl.strip()}'\n"
+                            f"{self.repo.display_name} requires python package '{dep}'\n"
                         )
+
             elif line.startswith("optionalpylibs="):
                 opspy = line.split("=")[1].split(",")
                 for pl in opspy:
-                    if pl.strip():
+                    dep = pl.strip()
+                    if dep:
                         self.repo.python_optional.add(pl.strip())
                         FreeCAD.Console.PrintLog(
                             f"{self.repo.display_name} optionally imports python package '{pl.strip()}'\n"
                         )
+        self.updated.emit(self.repo)
+
+
+class RequirementsTxtDownloadWorker(DownloadWorker):
+    """A worker for downloading requirements.txt"""
+
+    def __init__(self, parent, repo: AddonManagerRepo):
+        super().__init__(parent, utils.construct_git_url(repo, "requirements.txt"))
+        self.repo = repo
+
+    def resolve_fetch(self):
+        """Called when the data fetch completed, either with an error, or if it found the metadata file"""
+
+        if self.fetch_task.error() == QtNetwork.QNetworkReply.NetworkError.NoError:
+            FreeCAD.Console.PrintLog(
+                f"Found a requirements.txt file for {self.repo.name}\n"
+            )
+            new_deps = self.fetch_task.readAll()
+            self.parse_file(new_deps.data().decode("utf8"))
+        elif (
+            self.fetch_task.error()
+            == QtNetwork.QNetworkReply.NetworkError.ContentNotFoundError
+        ):
+            pass
+        elif (
+            self.fetch_task.error()
+            == QtNetwork.QNetworkReply.NetworkError.OperationCanceledError
+        ):
+            pass
+        else:
+            FreeCAD.Console.PrintWarning(
+                translate("AddonsInstaller", "Failed to connect to URL")
+                + f":\n{self.url}\n {self.fetch_task.error()}\n"
+            )
+
+    def parse_file(self, data: str) -> None:
+        f = io.StringIO(data)
+        valid_lines = []
+        while True:
+            line = f.readline()
+            if not line:
+                break
+
+            break_chars = " <>=~!+"
+            for n, c in enumerate(line):
+                if c in break_chars:
+                    package = line[:n].strip()
+                    # We are stripping version information here: there is no direct support in FreeCAD
+                    # for using specific versions of these packages.
+                    self.repo.python_requires.add(package)
         self.updated.emit(self.repo)

--- a/src/Mod/AddonManager/addonmanager_utilities.py
+++ b/src/Mod/AddonManager/addonmanager_utilities.py
@@ -197,7 +197,6 @@ def get_zip_url(repo):
     ):
         # https://framagit.org/freecad-france/mooc-workbench/-/archive/master/mooc-workbench-master.zip
         # https://salsa.debian.org/mess42/pyrate/-/archive/master/pyrate-master.zip
-        reponame = baseurl.strip("/").split("/")[-1]
         return f"{repo.url}/-/archive/{repo.branch}/{repo.name}-{repo.branch}.zip"
     else:
         FreeCAD.Console.PrintLog(
@@ -237,7 +236,7 @@ def get_readme_url(repo):
 def get_metadata_url(url):
     "Returns the location of a package.xml metadata file"
 
-    return construct_git_url(repo, "package.xml")
+    return construct_git_url(url, "package.xml")
 
 
 def get_desc_regex(repo):

--- a/src/Mod/AddonManager/addonmanager_workers.py
+++ b/src/Mod/AddonManager/addonmanager_workers.py
@@ -647,8 +647,7 @@ class FillMacroListWorker(QtCore.QThread):
             FreeCAD.Console.PrintWarning(
                 translate(
                     "AddonsInstaller",
-                    "There appears to be an issue connecting to the Wiki, "
-                    "therefore FreeCAD cannot retrieve the Wiki macro list at this time",
+                    "Error connecting to the Wiki, FreeCAD cannot retrieve the Wiki macro list at this time",
                 )
                 + "\n"
             )
@@ -899,7 +898,7 @@ class ShowWorker(QtCore.QThread):
                 return
         message = desc
         if self.repo.update_status == AddonManagerRepo.UpdateStatus.UNCHECKED:
-            # Addon is installed but we haven't checked it yet, so lets check if it has an update
+            # Addon is installed but we haven't checked it yet, so let's check if it has an update
             upd = False
             # checking for updates
             if not NOGIT and have_git:
@@ -921,49 +920,7 @@ class ShowWorker(QtCore.QThread):
                     AddonManagerRepo.UpdateStatus.NO_UPDATE_AVAILABLE
                 )
             self.update_status.emit(self.repo)
-
-            if QtCore.QThread.currentThread().isInterruptionRequested():
-                return
-
-        # If the Addon is obsolete, let the user know through the Addon UI
-        if self.repo.name in obsolete:
-            message = """
-<div style="width: 100%; text-align:center; background: #FFB3B3;">
-    <strong style="color: #FFFFFF; background: #FF0000;">
-"""
-            message += (
-                translate("AddonsInstaller", "This addon is marked as obsolete")
-                + "</strong><br/><br/>"
-            )
-            message += (
-                translate(
-                    "AddonsInstaller",
-                    "This usually means it is no longer maintained, "
-                    "and some more advanced addon in this list "
-                    "provides the same functionality.",
-                )
-                + "<br/></div><hr/>"
-                + desc
-            )
-
-        # If the Addon is Python 2 only, let the user know through the Addon UI
-        if self.repo.name in py2only:
-            message = """
-<div style="width: 100%; text-align:center; background: #ffe9b3;">
-    <strong style="color: #FFFFFF; background: #ff8000;">
-"""
-            message += (
-                translate("AddonsInstaller", "This addon is marked as Python 2 Only")
-                + "</strong><br/><br/>"
-            )
-            message += translate(
-                "AddonsInstaller",
-                "This workbench may no longer be maintained and "
-                "installing it on a Python 3 system will more than "
-                "likely result in errors at startup or while in use.",
-            )
-            message += "<br/></div><hr/>" + desc
-
+            
         if QtCore.QThread.currentThread().isInterruptionRequested():
             return
         self.readme_updated.emit(message)
@@ -1122,8 +1079,7 @@ class InstallWorkbenchWorker(QtCore.QThread):
                 FreeCAD.Console.PrintError(
                     translate(
                         "AddonsInstaller",
-                        "Your version of Python doesn't appear to support ZIP "
-                        "files. Unable to proceed.",
+                        "Your version of Python doesn't appear to support ZIP files. Unable to proceed.",
                     )
                     + "\n"
                 )
@@ -1171,8 +1127,7 @@ class InstallWorkbenchWorker(QtCore.QThread):
             FreeCAD.Console.PrintWarning(
                 translate(
                     "AddonsInstaller",
-                    "You are installing a Python 2 workbench on "
-                    "a system running Python 3 - ",
+                    "You are installing a Python 2 workbench on a system running Python 3 - ",
                 )
                 + str(self.repo.name)
                 + "\n"
@@ -1184,8 +1139,7 @@ class InstallWorkbenchWorker(QtCore.QThread):
             repo.pull()  # Refuses to take a progress object?
             answer = translate(
                 "AddonsInstaller",
-                "Workbench successfully updated. "
-                "Please restart FreeCAD to apply the changes.",
+                "Workbench successfully updated. Please restart FreeCAD to apply the changes.",
             )
         except Exception as e:
             answer = (
@@ -1212,8 +1166,7 @@ class InstallWorkbenchWorker(QtCore.QThread):
             FreeCAD.Console.PrintWarning(
                 translate(
                     "AddonsInstaller",
-                    "You are installing a Python 2 workbench on "
-                    "a system running Python 3 - ",
+                    "You are installing a Python 2 workbench on a system running Python 3 - ",
                 )
                 + str(self.repo.name)
                 + "\n"
@@ -1239,8 +1192,7 @@ class InstallWorkbenchWorker(QtCore.QThread):
 
         answer = translate(
             "AddonsInstaller",
-            "Workbench successfully installed. Please restart "
-            "FreeCAD to apply the changes.",
+            "Workbench successfully installed. Please restart FreeCAD to apply the changes.",
         )
 
         if self.repo.repo_type == AddonManagerRepo.RepoType.WORKBENCH:
@@ -1265,8 +1217,7 @@ class InstallWorkbenchWorker(QtCore.QThread):
                         ).SetString("destination", clonedir)
                         answer += "\n\n" + translate(
                             "AddonsInstaller",
-                            "A macro has been installed and is available "
-                            "under Macro -> Macros menu",
+                            "A macro has been installed and is available under Macro -> Macros menu",
                         )
                         answer += ":\n<b>" + f + "</b>"
         self.update_metadata()

--- a/src/Mod/AddonManager/dependency_resolution_dialog.ui
+++ b/src/Mod/AddonManager/dependency_resolution_dialog.ui
@@ -73,7 +73,7 @@
       <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ignore</set>
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ignore|QDialogButtonBox::Yes</set>
      </property>
     </widget>
    </item>

--- a/src/Mod/AddonManager/dependency_resolution_dialog.ui
+++ b/src/Mod/AddonManager/dependency_resolution_dialog.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>455</width>
-    <height>200</height>
+    <height>260</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -20,7 +20,9 @@
    <item>
     <widget class="QLabel" name="label">
      <property name="text">
-      <string>This Addon has the following required and optional dependencies. You must install them before this Addon can be used.</string>
+      <string>This Addon has the following required and optional dependencies. You must install them before this Addon can be used.
+
+Do you want the Addon Manager to install them automatically? Choose &quot;Ignore&quot; to install the Addon without installing the dependencies.</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>


### PR DESCRIPTION
This PR implements FreeCAD and Python dependency installation when using the Addon Manager to install an Addon. 

To test: first, make sure you re-cache the Addon Manager's data. Next, you need to install a workbench that has dependencies! InventorLoader has quite a few ("xlutils", "xlwt", "olefile", and "xlrd"), and SteelColumn has one ("ezdxf"). InventorLoader is a good test case because it's easy to tell if your system found the installed dependencies: if it did not, InventorLoader tries to install them itself the next time you launch FreeCAD. If that happens, something when wrong with the Addon Manager, please report it below (you will want to turn on logging when you run FreeCAD, a fair bit of debugging information is currently being written at a log-level output).

## Details

For historical and compatibility reasons, three different metadata files are examined for dependency information:
* package.xml -- for FreeCAD workbench and addon dependencies
* metadata.txt -- for FreeCAD workbench and Python required and optional dependencies
* requirements.txt -- for Python required dependencies

These files are consolidated into a single dependency source (note that version information is stripped from requirements.txt, and no pip options or file include options are supported in that file). This information is cached for each Addon in the Addon Manager.

When a user requests installation of a package with dependencies, the Addon Manager resolves them as follows:
1) Dependencies on FreeCAD Workbenches are checked against the installed WB list, and if not satisfied the installation is terminated: this is an unrecoverable condition, a new copy of FreeCAD with the appropriate Workbenches is required.
2) Dependencies on other FreeCAD Addons are checked, and if found are added to a list of required dependencies.
3) Dependencies on Python packages are checked by attempting to import the required package, and catching the import error on failure and adding the failure to the list of required dependencies.
4) Optional Python dependencies are checked the same way as required, but added to a separate list.
5) If there are unmet dependencies they are presented to the user in three columns: one for FreeCAD addon dependencies (installed with the Addon Manager as a normal FreeCAD Addon), another for Python requirements (installed with pip into a FreeCAD-specific USER_APP_DATA_DIR/AdditionalPythonPackages directory), and finally a third column of optional Python packages, presented as a checkable list for the user to select from for installation.

Note that only packages listed in the new ALLOWED_PYTHON_PACKAGES.txt file are installed by the Addon Manager, as a malware-prevention strategy. Also, packages installed in AdditionalPythonPackages take lower precedence than system packages.