### PR TITLE
PartDesign: Taper angle in Pad

### DIFF
--- a/src/Mod/PartDesign/App/FeatureExtrude.h
+++ b/src/Mod/PartDesign/App/FeatureExtrude.h
@@ -46,6 +46,7 @@ public:
     App::PropertyBool        AlongSketchNormal;
     App::PropertyLength      Offset;
     App::PropertyLinkSub     ReferenceAxis;
+    App::PropertyAngle       TaperAngle;
 
     static App::PropertyQuantityConstraint::Constraints signedLengthConstraint;
 


### PR DESCRIPTION
Make Pad support tapered pads with the help of BRepOffsetAPI_DraftAngle

This works for pads that are created from line segments and arcs.
It does not work for profiles that contain bspline segments. It also cannot pad profiles with arcs in other
directions than the normal direction.

- The advantage is that the implementation is very simple.
- TNP friendly since the face numbering is not dependent on if taper angle is 0 or not 0.
- Produces simple faces (Planar faces and cones).
- Inner and outer wires are seamlessly supported and behaves consistently

This PR should be seen as a complement to #5357 and #5367.
In particular this PR does not contain any UI code. 

Forum discussion:
https://forum.freecadweb.org/viewtopic.php?f=10&t=65171

![image](https://user-images.githubusercontent.com/1278189/149406659-bd027288-65aa-42c9-b5fa-68fb8c7f5fbe.png)

Behavior is a bit different than the implementation in #5357. In this PR there is only one Taper angle and it will apply to both directions
![image](https://user-images.githubusercontent.com/1278189/149411757-3e20dbdd-da80-411c-ac6c-18c0e8238c9f.png)
