### PR TITLE
Sketcher: prevent crash when accessing null pointer

### DIFF
--- a/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
@@ -1198,6 +1198,7 @@ Base::Vector3d EditModeConstraintCoinManager::seekConstraintPosition(const Base:
 
     auto rp = ViewProviderSketchCoinAttorney::getRayPickAction(viewProvider);
 
+
     float scaled_step = step * ViewProviderSketchCoinAttorney::getScaleFactor(viewProvider);
 
     int multiplier = 0;
@@ -1207,7 +1208,9 @@ Base::Vector3d EditModeConstraintCoinManager::seekConstraintPosition(const Base:
         // Calculate new position of constraint
         relPos = norm * 0.5f + dir * multiplier;
         freePos = origPos + relPos * scaled_step;
-
+        if (!rp){    //prevent crash : https://forum.freecadweb.org/viewtopic.php?f=8&t=65305
+            return relPos * step;
+        }
         rp->setRadius(0.1f);
         rp->setPickAll(true);
         rp->setRay(SbVec3f(freePos.x, freePos.y, -1.f), SbVec3f(0, 0, 1) );


### PR DESCRIPTION
https://forum.freecadweb.org/viewtopic.php?f=8&t=65305

This prevents the crash, but there might be a better default return value than relPos * step.

File that causes crash:
[phone-tripod-central-leg.zip](https://github.com/FreeCAD/FreeCAD/files/7872183/phone-tripod-central-leg.zip)

Is there a way to support uploading .FCStd files here instead of zipping?

To reproduce crash: Double click Sketch used to create Pad.
