### PR TITLE
Draft: fix task panel related issues

### DIFF
--- a/src/Mod/Draft/DraftGui.py
+++ b/src/Mod/Draft/DraftGui.py
@@ -615,7 +615,10 @@ class DraftToolBar:
         QtCore.QObject.connect(self.undoButton,QtCore.SIGNAL("pressed()"),self.undoSegment)
         QtCore.QObject.connect(self.selectButton,QtCore.SIGNAL("pressed()"),self.selectEdge)
         QtCore.QObject.connect(self.continueCmd,QtCore.SIGNAL("stateChanged(int)"),self.setContinue)
+
         QtCore.QObject.connect(self.isCopy,QtCore.SIGNAL("stateChanged(int)"),self.setCopymode)
+        QtCore.QObject.connect(self.isSubelementMode, QtCore.SIGNAL("stateChanged(int)"), self.setSubelementMode)
+
         QtCore.QObject.connect(self.isRelative,QtCore.SIGNAL("stateChanged(int)"),self.setRelative)
         QtCore.QObject.connect(self.isGlobal,QtCore.SIGNAL("stateChanged(int)"),self.setGlobal)
         QtCore.QObject.connect(self.hasFill,QtCore.SIGNAL("stateChanged(int)"),self.setFill)
@@ -981,7 +984,8 @@ class DraftToolBar:
 
     def rotateSetCenterUi(self):
         self.pointUi(translate("draft", "Rotate"),icon="Draft_Rotate")
-        self.continueCmd.show()
+        self.modUi()
+        self.isRelative.hide()
 
     def pointUi(self, title=translate("draft","Point"), cancel=None, extra=None,
                 getcoords=None, rel=False, icon="Draft_Draft"):
@@ -1305,6 +1309,9 @@ class DraftToolBar:
         if self.sourceCmd:
             if self.sourceCmd.featureName == "Offset":
                 p.SetBool("OffsetCopyMode",bool(val))
+
+    def setSubelementMode(self):
+        self.sourceCmd.set_ghosts()
 
     def relocate(self):
         """relocates the right-aligned buttons depending on the toolbar size"""

--- a/src/Mod/Draft/draftfunctions/scale.py
+++ b/src/Mod/Draft/draftfunctions/scale.py
@@ -39,9 +39,9 @@ import draftmake.make_line as make_line
 def scale(objectslist, scale=App.Vector(1,1,1),
           center=App.Vector(0,0,0), copy=False):
     """scale(objects, scale, [center], copy)
-    
-    Scales the objects contained in objects (that can be a list of objects or 
-    an object) of the given  around given center. 
+
+    Scales the objects contained in objects (that can be a list of objects or
+    an object) of the given  around given center.
 
     Parameters
     ----------
@@ -55,7 +55,7 @@ def scale(objectslist, scale=App.Vector(1,1,1),
 
     copy : bool
         If copy is True, the actual objects are not scaled, but copies
-        are created instead. 
+        are created instead.
 
     Return
     ----------
@@ -124,8 +124,8 @@ def scale(objectslist, scale=App.Vector(1,1,1),
                 obj.YSize = obj.YSize * scale.y
         if obj.ViewObject and hasattr(obj.ViewObject,"FontSize"):
             obj.ViewObject.FontSize = obj.ViewObject.FontSize * scale.y
-                
-                
+
+
         if copy:
             gui_utils.format_object(newobj,obj)
         newobjlist.append(newobj)
@@ -148,7 +148,7 @@ def scale_vertex(obj, vertex_index, scale, center):
     """
     points = obj.Points
     points[vertex_index] = obj.Placement.inverse().multVec(
-        scaleVectorFromCenter(
+        scale_vector_from_center(
             obj.Placement.multVec(points[vertex_index]),
             scale, center))
     obj.Points = points
@@ -173,11 +173,11 @@ def scale_edge(obj, edge_index, scale, center):
     Needed for SubObjects modifiers.
     Implemented by Dion Moult during 0.19 dev cycle (works only with Draft Wire).
     """
-    scaleVertex(obj, edge_index, scale, center)
-    if utils.isClosedEdge(edge_index, obj):
-        scaleVertex(obj, 0, scale, center)
+    scale_vertex(obj, edge_index, scale, center)
+    if utils.is_closed_edge(edge_index, obj):
+        scale_vertex(obj, 0, scale, center)
     else:
-        scaleVertex(obj, edge_index+1, scale, center)
+        scale_vertex(obj, edge_index+1, scale, center)
 
 
 scaleEdge = scale_edge
@@ -188,15 +188,15 @@ def copy_scaled_edge(obj, edge_index, scale, center):
     Needed for SubObjects modifiers.
     Implemented by Dion Moult during 0.19 dev cycle (works only with Draft Wire).
     """
-    vertex1 = scaleVectorFromCenter(
+    vertex1 = scale_vector_from_center(
         obj.Placement.multVec(obj.Points[edge_index]),
         scale, center)
-    if utils.isClosedEdge(edge_index, obj):
-        vertex2 = scaleVectorFromCenter(
+    if utils.is_closed_edge(edge_index, obj):
+        vertex2 = scale_vector_from_center(
             obj.Placement.multVec(obj.Points[0]),
             scale, center)
     else:
-        vertex2 = scaleVectorFromCenter(
+        vertex2 = scale_vector_from_center(
             obj.Placement.multVec(obj.Points[edge_index+1]),
             scale, center)
     return make_line.make_line(vertex1, vertex2)
@@ -212,7 +212,7 @@ def copy_scaled_edges(arguments):
     """
     copied_edges = []
     for argument in arguments:
-        copied_edges.append(copyScaledEdge(argument[0], argument[1],
+        copied_edges.append(copy_scaled_edge(argument[0], argument[1],
             argument[2], argument[3]))
     join.join_wires(copied_edges)
 

--- a/src/Mod/Draft/draftguitools/gui_mirror.py
+++ b/src/Mod/Draft/draftguitools/gui_mirror.py
@@ -84,7 +84,6 @@ class Mirror(gui_base_original.Modifier):
 
         self.sel = Gui.Selection.getSelection()
         self.ui.pointUi(title=translate("draft", self.featureName), icon="Draft_Mirror")
-        self.ui.modUi()
         self.ui.xValue.setFocus()
         self.ui.xValue.selectAll()
         # self.ghost = trackers.ghostTracker(self.sel)

--- a/src/Mod/Draft/draftguitools/gui_move.py
+++ b/src/Mod/Draft/draftguitools/gui_move.py
@@ -174,19 +174,23 @@ class Move(gui_base_original.Modifier):
 
     def set_ghosts(self):
         """Set the ghost to display."""
+        for ghost in self.ghosts:
+            ghost.remove()
         if self.ui.isSubelementMode.isChecked():
-            return self.set_subelement_ghosts()
-        self.ghosts = [trackers.ghostTracker(self.selected_objects)]
+            self.ghosts = self.get_subelement_ghosts()
+        else:
+            self.ghosts = [trackers.ghostTracker(self.selected_objects)]
 
-    def set_subelement_ghosts(self):
-        """Set ghost for the subelements."""
+    def get_subelement_ghosts(self):
+        """Get ghost for the subelements (vertices, edges)."""
         import Part
 
+        ghosts = []
         for object in self.selected_subelements:
             for subelement in object.SubObjects:
-                if (isinstance(subelement, Part.Vertex)
-                        or isinstance(subelement, Part.Edge)):
-                    self.ghosts.append(trackers.ghostTracker(subelement))
+                if isinstance(subelement, (Part.Vertex, Part.Edge)):
+                    ghosts.append(trackers.ghostTracker(subelement))
+        return ghosts
 
     def move(self, is_copy=False):
         """Perform the move of the subelements or the entire object."""

--- a/src/Mod/Draft/draftguitools/gui_rotate.py
+++ b/src/Mod/Draft/draftguitools/gui_rotate.py
@@ -94,7 +94,6 @@ class Rotate(gui_base_original.Modifier):
         self.step = 0
         self.center = None
         self.ui.rotateSetCenterUi()
-        self.ui.modUi()
         self.arctrack = trackers.arcTracker()
         self.call = self.view.addEventCallback("SoEvent", self.action)
         _msg(translate("draft", "Pick rotation center"))
@@ -235,19 +234,26 @@ class Rotate(gui_base_original.Modifier):
 
     def set_ghosts(self):
         """Set the ghost to display."""
+        for ghost in self.ghosts:
+            ghost.remove()
         if self.ui.isSubelementMode.isChecked():
-            return self.set_subelement_ghosts()
-        self.ghosts = [trackers.ghostTracker(self.selected_objects)]
+            self.ghosts = self.get_subelement_ghosts()
+        else:
+            self.ghosts = [trackers.ghostTracker(self.selected_objects)]
+        if self.center:
+            for ghost in self.ghosts:
+                ghost.center(self.center)
 
-    def set_subelement_ghosts(self):
-        """Set ghost for the subelements (vertices, edges)."""
+    def get_subelement_ghosts(self):
+        """Get ghost for the subelements (vertices, edges)."""
         import Part
 
-        for obj in self.selected_subelements:
-            for subelement in obj.SubObjects:
-                if (isinstance(subelement, Part.Vertex)
-                        or isinstance(subelement, Part.Edge)):
-                    self.ghosts.append(trackers.ghostTracker(subelement))
+        ghosts = []
+        for object in self.selected_subelements:
+            for subelement in object.SubObjects:
+                if isinstance(subelement, (Part.Vertex, Part.Edge)):
+                    ghosts.append(trackers.ghostTracker(subelement))
+        return ghosts
 
     def finish(self, closed=False, cont=False):
         """Finish the rotate operation."""

--- a/src/Mod/Draft/draftguitools/gui_scale.py
+++ b/src/Mod/Draft/draftguitools/gui_scale.py
@@ -99,7 +99,7 @@ class Scale(gui_base_original.Modifier):
         self.selected_subelements = Gui.Selection.getSelectionEx()
         self.refs = []
         self.ui.pointUi(title=translate("draft",self.featureName), icon="Draft_Scale")
-        self.ui.modUi()
+        self.ui.isRelative.hide()
         self.ui.xValue.setFocus()
         self.ui.xValue.selectAll()
         self.pickmode = False
@@ -108,19 +108,24 @@ class Scale(gui_base_original.Modifier):
         _msg(translate("draft", "Pick base point"))
 
     def set_ghosts(self):
-        """Set the previews of the objects to scale."""
-        if self.ui.isSubelementMode.isChecked():
-            return self.set_subelement_ghosts()
-        self.ghosts = [trackers.ghostTracker(self.selected_objects)]
+        """Set the ghost to display."""
+        for ghost in self.ghosts:
+            ghost.remove()
+        if self.task and self.task.isSubelementMode.isChecked():
+            self.ghosts = self.get_subelement_ghosts()
+        else:
+            self.ghosts = [trackers.ghostTracker(self.selected_objects)]
 
-    def set_subelement_ghosts(self):
-        """Set the previews of the subelements from an object to scale."""
+    def get_subelement_ghosts(self):
+        """Get ghost for the subelements (vertices, edges)."""
         import Part
 
+        ghosts = []
         for object in self.selected_subelements:
             for subelement in object.SubObjects:
                 if isinstance(subelement, (Part.Vertex, Part.Edge)):
-                    self.ghosts.append(trackers.ghostTracker(subelement))
+                    ghosts.append(trackers.ghostTracker(subelement))
+        return ghosts
 
     def pickRef(self):
         """Pick a point of reference."""

--- a/src/Mod/Draft/draftguitools/gui_stretch.py
+++ b/src/Mod/Draft/draftguitools/gui_stretch.py
@@ -118,7 +118,6 @@ class Stretch(gui_base_original.Modifier):
             self.step = 1
             self.refpoint = None
             self.ui.pointUi(title=translate("draft", self.featureName), icon="Draft_Stretch")
-            self.ui.extUi()
             self.call = self.view.addEventCallback("SoEvent", self.action)
             self.rectracker = trackers.rectangleTracker(dotted=True,
                                                         scolor=(0.0, 0.0, 1.0),

--- a/src/Mod/Draft/draftguitools/gui_trackers.py
+++ b/src/Mod/Draft/draftguitools/gui_trackers.py
@@ -81,7 +81,9 @@ class Tracker:
         ToDo.delay(self._insertSwitch, self.switch)
 
     def finalize(self):
-        """Finish the command by removing the switch."""
+        """Finish the command by removing the switch.
+        Also called by ghostTracker.remove.
+        """
         ToDo.delay(self._removeSwitch, self.switch)
         self.switch = None
 
@@ -694,14 +696,10 @@ class ghostTracker(Tracker):
         super().__init__(dotted, scolor, swidth,
                          children=self.children, name="ghostTracker")
 
-    def update(self, obj):
-        """Recreate the ghost from a new object."""
-        obj.ViewObject.show()
-        self.finalize()
-        sep = self.getNode(obj)
-        super().__init__(children=[sep])
-        self.on()
-        obj.ViewObject.hide()
+    def remove(self):
+        """Remove the ghost when switching to and from subelement mode."""
+        if self.switch:
+            self.finalize()
 
     def move(self, delta):
         """Move the ghost to a given position.
@@ -1151,7 +1149,7 @@ class gridTracker(Tracker):
                 loc = FreeCAD.Vector(-bound+self.space/2,-bound+self.space/2,0)
                 hpts = BimProject.getHuman(loc)
                 pts.extend([tuple(p) for p in hpts])
-                pidx.append(len(hpts))                
+                pidx.append(len(hpts))
             except Exception:
                 # BIM not installed
                 return


### PR DESCRIPTION
This PR fixes several task panel related issues for the following Draft modifier commands: Draft_Move, Draft_Rotate, Draft_Scale, Draft_Mirror and Draft_Stretch.

For the Draft_Scale command I have opted for the most practical solution:
* Except for the Global toggle, all toggles were removed from the 1st task panel.
* There is no longer a Continue toggle. It seems unlikely that Draft_Scale will ever be used in Continue mode. This mode is actually also unlikely for the other modifier commands.

When changing to and from Subelement mode the ghosts are now updated. But there is still a lot of work that has to be done in relation to this mode. It now only work for Draft_Wires and Draft_Lines. And f.e. a Draft_Wire that is filleted will already cause problems.

Forum topic:
https://forum.freecadweb.org/viewtopic.php?f=23&t=58234

Additionally:
Removed the  `update` function from `gui_trackers.py`. It was not used anywhere.
Updated the names of functions to the new naming scheme in `scale.py`.

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

---
