### PR TITLE
Arch: Fix ArchWall onBeforeChange

### DIFF
--- a/src/Mod/Arch/ArchWall.py
+++ b/src/Mod/Arch/ArchWall.py
@@ -988,6 +988,8 @@ class _Wall(ArchComponent.Component):
         If "Length" has changed, record the old length so that .onChanged() can
         be sure that the base needs to be changed.
 
+        Also call ArchComponent.Component.onBeforeChange().
+
         Parameters
         ----------
         prop: string
@@ -996,6 +998,7 @@ class _Wall(ArchComponent.Component):
 
         if prop == "Length":
             self.oldLength = obj.Length.Value
+        ArchComponent.Component.onBeforeChange(self,obj,prop)
 
     def onChanged(self, obj, prop):
         """Method called when the object has a property changed.


### PR DESCRIPTION
The `onBeforeChange` method in the `ArchWall` class did not call `onBeforeChange` from its parent class. This blocked the 'MoveWithHost' behavior of windows placed in walls.

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

---
