### PR TITLE
[FEM] Add reference highlighting for displacement constraints

### DIFF
--- a/src/Mod/Fem/Gui/CMakeLists.txt
+++ b/src/Mod/Fem/Gui/CMakeLists.txt
@@ -42,6 +42,7 @@ link_directories(${SMESH_LIB_PATH})
 set(FemGui_LIBS
     Fem
     FreeCADGui
+    PartGui
 )
 
 
@@ -220,6 +221,8 @@ SET(FemGui_SRCS_ViewProvider
     FemSelectionGate.h
     ViewProviderFemConstraint.cpp
     ViewProviderFemConstraint.h
+    ViewProviderFemConstraintOnBoundary.cpp
+    ViewProviderFemConstraintOnBoundary.h
     ViewProviderFemConstraintBearing.cpp
     ViewProviderFemConstraintBearing.h
     ViewProviderFemConstraintFixed.cpp

--- a/src/Mod/Fem/Gui/TaskFemConstraintOnBoundary.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintOnBoundary.cpp
@@ -59,10 +59,12 @@ using namespace Gui;
 TaskFemConstraintOnBoundary::TaskFemConstraintOnBoundary(ViewProviderFemConstraint *ConstraintView, QWidget *parent, const char* pixmapname)
     : TaskFemConstraint(ConstraintView, parent, pixmapname)
 {
+    ConstraintView->highlightReferences(true);
 }
 
 TaskFemConstraintOnBoundary::~TaskFemConstraintOnBoundary()
 {
+    ConstraintView->highlightReferences(false);
 }
 
 void TaskFemConstraintOnBoundary::_addToSelection(bool checked)
@@ -73,6 +75,7 @@ void TaskFemConstraintOnBoundary::_addToSelection(bool checked)
         if (selection.empty()) {
             this->clearButtons(refAdd);
             selChangeMode = refAdd;
+            ConstraintView->highlightReferences(true);
         } else {
             this->addToSelection();
             clearButtons(none);
@@ -90,6 +93,7 @@ void TaskFemConstraintOnBoundary::_removeFromSelection(bool checked)
         if (selection.empty()) {
             this->clearButtons(refRemove);
             selChangeMode = refRemove;
+            ConstraintView->highlightReferences(true);
         } else {
             this->removeFromSelection();
             clearButtons(none);
@@ -116,6 +120,7 @@ void TaskFemConstraintOnBoundary::onSelectionChanged(const Gui::SelectionChanges
         default:
             return;
         }
+        ConstraintView->highlightReferences(true);
     }
 }
 

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraint.h
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraint.h
@@ -68,6 +68,9 @@ public:
     std::vector<App::DocumentObject*> claimChildren(void)const;
     void setupContextMenu(QMenu*, QObject*, const char*);
 
+    /// Highlight the references that have been selected
+    virtual void highlightReferences(const bool /* on */) {}
+
     static std::string gethideMeshShowPartStr();
     static std::string gethideMeshShowPartStr(const std::string showConstr);
 

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintDisplacement.h
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintDisplacement.h
@@ -26,11 +26,11 @@
 #ifndef GUI_VIEWPROVIDERFEMCONSTRAINTDISPLACEMENT_H
 #define GUI_VIEWPROVIDERFEMCONSTRAINTDISPLACEMENT_H
 
-#include "ViewProviderFemConstraint.h"
+#include "ViewProviderFemConstraintOnBoundary.h"
 
 namespace FemGui {
 
-class FemGuiExport ViewProviderFemConstraintDisplacement : public FemGui::ViewProviderFemConstraint
+class FemGuiExport ViewProviderFemConstraintDisplacement : public FemGui::ViewProviderFemConstraintOnBoundary
 {
     PROPERTY_HEADER(FemGui::ViewProviderFemConstraintDisplacement);
 

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintFluidBoundary.h
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintFluidBoundary.h
@@ -25,12 +25,12 @@
 #ifndef GUI_VIEWPROVIDERFEMFLUIDBOUNDARY_H
 #define GUI_VIEWPROVIDERFEMFLUIDBOUNDARY_H
 
-#include "ViewProviderFemConstraint.h"
+#include "ViewProviderFemConstraintOnBoundary.h"
 
 namespace FemGui
 {
 
-class FemGuiExport ViewProviderFemConstraintFluidBoundary : public FemGui::ViewProviderFemConstraint
+class FemGuiExport ViewProviderFemConstraintFluidBoundary : public FemGui::ViewProviderFemConstraintOnBoundary
 {
     PROPERTY_HEADER(FemGui::ViewProviderFemConstraintFluidBoundary);
 

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintForce.h
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintForce.h
@@ -25,12 +25,12 @@
 #ifndef GUI_VIEWPROVIDERFEMCONSTRAINTFORCE_H
 #define GUI_VIEWPROVIDERFEMCONSTRAINTFORCE_H
 
-#include "ViewProviderFemConstraint.h"
+#include "ViewProviderFemConstraintOnBoundary.h"
 
 namespace FemGui
 {
 
-class FemGuiExport ViewProviderFemConstraintForce : public FemGui::ViewProviderFemConstraint
+class FemGuiExport ViewProviderFemConstraintForce : public FemGui::ViewProviderFemConstraintOnBoundary
 {
     PROPERTY_HEADER(FemGui::ViewProviderFemConstraintForce);
 

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintHeatflux.h
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintHeatflux.h
@@ -26,11 +26,11 @@
 #ifndef GUI_VIEWPROVIDERFEMCONSTRAINTHEATFLUX_H
 #define GUI_VIEWPROVIDERFEMCONSTRAINTHEATFLUX_H
 
-#include "ViewProviderFemConstraint.h"
+#include "ViewProviderFemConstraintOnBoundary.h"
 
 namespace FemGui {
 
-class FemGuiExport ViewProviderFemConstraintHeatflux : public FemGui::ViewProviderFemConstraint
+class FemGuiExport ViewProviderFemConstraintHeatflux : public FemGui::ViewProviderFemConstraintOnBoundary
 {
     PROPERTY_HEADER(FemGui::ViewProviderFemConstraintHeatflux);
 

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintOnBoundary.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintOnBoundary.cpp
@@ -1,0 +1,128 @@
+/***************************************************************************
+ *   Copyright (c) 2022 FreeCAD Developers                                 *
+ *   Author: Ajinkya Dahale <dahale.a.p@gmail.com>                         *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#include "PreCompiled.h"
+
+#ifndef _PreComp_
+# include <Standard_math.hxx>
+# include <Precision.hxx>
+#endif
+
+#include "Mod/Fem/App/FemConstraint.h"
+#include "TaskFemConstraintOnBoundary.h"
+#include "ViewProviderFemConstraintOnBoundary.h"
+#include <Base/Console.h>
+#include <Gui/Application.h>
+#include <Gui/Control.h>
+#include <Mod/Part/Gui/ViewProvider.h>
+#include <Mod/Part/Gui/ReferenceHighlighter.h>
+
+using namespace FemGui;
+
+PROPERTY_SOURCE(FemGui::ViewProviderFemConstraintOnBoundary, FemGui::ViewProviderFemConstraint)
+
+ViewProviderFemConstraintOnBoundary::ViewProviderFemConstraintOnBoundary()
+{
+}
+
+ViewProviderFemConstraintOnBoundary::~ViewProviderFemConstraintOnBoundary()
+{
+}
+
+void ViewProviderFemConstraintOnBoundary::highlightReferences(const bool on)
+{
+    Fem::Constraint* pcConstraint = static_cast<Fem::Constraint*>(this->getObject());
+    const auto& subSets = pcConstraint->References.getSubListValues();
+
+    for (auto& subSet : subSets) {
+        // if somehow the subnames are empty, we have nothing to do
+        if (subSet.second.empty())
+            continue;
+
+        Part::Feature* base = static_cast<Part::Feature*>(subSet.first);
+        PartGui::ViewProviderPart* vp = dynamic_cast<PartGui::ViewProviderPart*>(
+            Gui::Application::Instance->getViewProvider(base));
+        if (vp == nullptr) continue;
+
+        if (on) {
+            // identify the type of subelements
+            // TODO: Assumed here the subelements are of the same type.
+            // It is a requirement but we should keep safeguards.
+            if (subSet.second[0].find("Vertex") != std::string::npos) {
+                // make sure original colors are remembered
+                if (originalPointColors[base].empty())
+                    originalPointColors[base] = vp->PointColorArray.getValues();
+                std::vector<App::Color> colors = originalPointColors[base];
+
+                // go through the subelements with constraint and recolor them
+                // TODO: Replace `ShapeColor` with anything more appropriate
+                PartGui::ReferenceHighlighter highlighter(base->Shape.getValue(), colors.empty()?ShapeColor.getValue():colors[0]);
+                highlighter.getVertexColors(subSet.second, colors);
+                vp->PointColorArray.setValues(colors);
+            }
+            else if (subSet.second[0].find("Edge") != std::string::npos) {
+                // make sure original colors are remembered
+                if (originalLineColors[base].empty())
+                    originalLineColors[base] = vp->LineColorArray.getValues();
+                std::vector<App::Color> colors = originalLineColors[base];
+
+                // go through the subelements with constraint and recolor them
+                // TODO: Replace `ShapeColor` with anything more appropriate
+                PartGui::ReferenceHighlighter highlighter(base->Shape.getValue(), colors.empty()?ShapeColor.getValue():colors[0]);
+                highlighter.getEdgeColors(subSet.second, colors);
+                vp->LineColorArray.setValues(colors);
+            }
+            else if (subSet.second[0].find("Face") != std::string::npos) {
+                // make sure original colors are remembered
+                if (originalFaceColors[base].empty())
+                    originalFaceColors[base] = vp->DiffuseColor.getValues();
+                std::vector<App::Color> colors = originalFaceColors[base];
+
+                // go through the subelements with constraint and recolor them
+                // TODO: Replace `FaceColor` with anything more appropriate
+                PartGui::ReferenceHighlighter highlighter(base->Shape.getValue(), colors.empty()?FaceColor.getValue():colors[0]);
+                highlighter.getFaceColors(subSet.second, colors);
+                vp->DiffuseColor.setValues(colors);
+            }
+        }
+        else {
+            if (subSet.second[0].find("Vertex") != std::string::npos &&
+                !originalPointColors[base].empty()) {
+                vp->PointColorArray.setValues(originalPointColors[base]);
+                originalPointColors[base].clear();
+            }
+            else if (subSet.second[0].find("Edge") != std::string::npos &&
+                     !originalLineColors[base].empty()) {
+                vp->LineColorArray.setValues(originalLineColors[base]);
+                originalLineColors[base].clear();
+            }
+            else if (subSet.second[0].find("Face") != std::string::npos &&
+                     !originalFaceColors[base].empty()) {
+                vp->DiffuseColor.setValues(originalFaceColors[base]);
+                originalFaceColors[base].clear();
+            }
+        }
+    }
+}
+

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintOnBoundary.h
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintOnBoundary.h
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (c) 2013 Jan Rheinländer                                    *
- *                                   <jrheinlaender@users.sourceforge.net> *
+ *   Copyright (c) 2022 FreeCAD Developers                                 *
+ *   Author: Ajinkya Dahale <dahale.a.p@gmail.com>                         *
  *                                                                         *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *
@@ -21,31 +21,31 @@
  *                                                                         *
  ***************************************************************************/
 
+#ifndef GUI_VIEWPROVIDERFEMCONSTRAINTONBOUNDARY_H
+#define GUI_VIEWPROVIDERFEMCONSTRAINTONBOUNDARY_H
 
-#ifndef GUI_VIEWPROVIDERFEMCONSTRAINTFIXED_H
-#define GUI_VIEWPROVIDERFEMCONSTRAINTFIXED_H
+#include <Mod/Part/App/PartFeature.h>
 
-#include "ViewProviderFemConstraintOnBoundary.h"
+#include "ViewProviderFemConstraint.h"
 
-namespace FemGui
+namespace FemGui {
+
+class FemGuiExport ViewProviderFemConstraintOnBoundary : public FemGui::ViewProviderFemConstraint
 {
-
-class FemGuiExport ViewProviderFemConstraintFixed : public FemGui::ViewProviderFemConstraintOnBoundary
-{
-    PROPERTY_HEADER(FemGui::ViewProviderFemConstraintFixed);
+    PROPERTY_HEADER(FemGui::ViewProviderFemConstraintOnBoundary);
 
 public:
-    /// Constructor
-    ViewProviderFemConstraintFixed();
-    virtual ~ViewProviderFemConstraintFixed();
+    ViewProviderFemConstraintOnBoundary();
+    virtual ~ViewProviderFemConstraintOnBoundary();
 
-    virtual void updateData(const App::Property*);
+    void highlightReferences(const bool on) override;
 
-protected:
-    virtual bool setEdit(int ModNum);
+private:
+    std::map< Part::Feature*, std::vector<App::Color> > originalPointColors;
+    std::map< Part::Feature*, std::vector<App::Color> > originalLineColors;
+    std::map< Part::Feature*, std::vector<App::Color> > originalFaceColors;
 };
 
-} //namespace FemGui
+}
 
-
-#endif // GUI_VIEWPROVIDERFEMCONSTRAINTFIXED_H
+#endif // GUI_VIEWPROVIDERFEMCONSTRAINTONBOUNDARY_H

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintPressure.h
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintPressure.h
@@ -24,11 +24,11 @@
 #ifndef GUI_VIEWPROVIDERFEMCONSTRAINTPRESSURE_H
 #define GUI_VIEWPROVIDERFEMCONSTRAINTPRESSURE_H
 
-#include "ViewProviderFemConstraint.h"
+#include "ViewProviderFemConstraintOnBoundary.h"
 
 namespace FemGui {
 
-class FemGuiExport ViewProviderFemConstraintPressure : public FemGui::ViewProviderFemConstraint
+class FemGuiExport ViewProviderFemConstraintPressure : public FemGui::ViewProviderFemConstraintOnBoundary
 {
     PROPERTY_HEADER(FemGui::ViewProviderFemConstraintPressure);
 

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintSpring.h
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintSpring.h
@@ -24,11 +24,11 @@
 #ifndef GUI_VIEWPROVIDERFEMCONSTRAINTSPRING_H
 #define GUI_VIEWPROVIDERFEMCONSTRAINTSPRING_H
 
-#include "ViewProviderFemConstraint.h"
+#include "ViewProviderFemConstraintOnBoundary.h"
 
 namespace FemGui {
 
-class FemGuiExport ViewProviderFemConstraintSpring : public FemGui::ViewProviderFemConstraint
+class FemGuiExport ViewProviderFemConstraintSpring : public FemGui::ViewProviderFemConstraintOnBoundary
 {
     PROPERTY_HEADER(FemGui::ViewProviderFemConstraintSpring);
 

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintTemperature.h
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintTemperature.h
@@ -26,11 +26,11 @@
 #ifndef GUI_VIEWPROVIDERFEMCONSTRAINTTemperature_H
 #define GUI_VIEWPROVIDERFEMCONSTRAINTTemperature_H
 
-#include "ViewProviderFemConstraint.h"
+#include "ViewProviderFemConstraintOnBoundary.h"
 
 namespace FemGui {
 
-class FemGuiExport ViewProviderFemConstraintTemperature : public FemGui::ViewProviderFemConstraint
+class FemGuiExport ViewProviderFemConstraintTemperature : public FemGui::ViewProviderFemConstraintOnBoundary
 {
     PROPERTY_HEADER(FemGui::ViewProviderFemConstraintTemperature);
 


### PR DESCRIPTION
This PR when ready is intended to highlight the geometries on which a particular FEM constraint is applied, when in the constraint's taskview.

Forum post: https://forum.freecadweb.org/viewtopic.php?f=18&t=65412.