### PR TITLE
Tools: small bug in CreatePyModule.py

### DIFF
--- a/src/Tools/fcbt/CreatePyModule.py
+++ b/src/Tools/fcbt/CreatePyModule.py
@@ -32,7 +32,7 @@ import MakeAppTools
 import re
 
 FilFilter = ["^.*\\.o$",
-          "^.*\\Makefile$",
+          "^.*Makefile$",
           "^.*\\.la$",
           "^.*\\.lo$",
           "^.*\\.positions$",


### PR DESCRIPTION
'CreatesPyModule.py' generates an error when executed with the fcbt-Tool. With this fix the code is the same as in 'CreateModule.py' and works fine.