### PR TITLE
[App] DocumentObject.cpp: Add more information to the error message ...

### DIFF
--- a/src/App/DocumentObject.cpp
+++ b/src/App/DocumentObject.cpp
@@ -100,6 +100,8 @@ App::DocumentObjectExecReturn *DocumentObject::recompute(void)
     //check if the links are valid before making the recompute
     if(!GeoFeatureGroupExtension::areLinksValid(this)) {
 #if 1
+        // Get objects that have invalid link scope, and print their names.
+        // Truncate the invalid object list name strings for readibility, if they happen to be very long.
         std::vector<App::DocumentObject*> invalid_linkobjs;
         std::string objnames = "", scopenames = "";
         GeoFeatureGroupExtension::getInvalidLinkObjects(this, invalid_linkobjs);
@@ -107,8 +109,16 @@ App::DocumentObjectExecReturn *DocumentObject::recompute(void)
             objnames += obj->getNameInDocument();
             objnames += " ";
             for (auto& scope : obj->getParents()) {
+                if (scopenames.length() > 80) {
+                    scopenames += "... ";
+                    break;
+                }
                 scopenames += scope.first->getNameInDocument();
                 scopenames += " ";
+            }
+            if (objnames.length() > 80) {
+                objnames += "... ";
+                break;
             }
         }
         if (objnames.empty()) {

--- a/src/App/DocumentObject.cpp
+++ b/src/App/DocumentObject.cpp
@@ -100,7 +100,28 @@ App::DocumentObjectExecReturn *DocumentObject::recompute(void)
     //check if the links are valid before making the recompute
     if(!GeoFeatureGroupExtension::areLinksValid(this)) {
 #if 1
-        Base::Console().Warning("%s / %s: Links go out of the allowed scope\n", getTypeId().getName(), getNameInDocument());
+        std::vector<App::DocumentObject*> invalid_linkobjs;
+        std::string objnames = "", scopenames = "";
+        GeoFeatureGroupExtension::getInvalidLinkObjects(this, invalid_linkobjs);
+        for (auto& obj : invalid_linkobjs) {
+            objnames += obj->getNameInDocument();
+            objnames += " ";
+            for (auto& scope : obj->getParents()) {
+                scopenames += scope.first->getNameInDocument();
+                scopenames += " ";
+            }
+        }
+        if (objnames.empty()) {
+            objnames = "N/A";
+        } else {
+            objnames.pop_back();
+        }
+        if (scopenames.empty()) {
+            scopenames = "N/A";
+        } else {
+            scopenames.pop_back();
+        }
+        Base::Console().Warning("%s: Link(s) to object(s) '%s' go out of the allowed scope '%s'. Instead, the linked object(s) reside within '%s'.\n", getTypeId().getName(), objnames.c_str(), getNameInDocument(), scopenames.c_str());
 #else
         return new App::DocumentObjectExecReturn("Links go out of the allowed scope", this);
 #endif


### PR DESCRIPTION
... printed to the console when links go out of allowed scope, namely linked object name(s), allowed scope name, invalid scope name(s).  The need for such extra information in the error message is discussed in [a Forum thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=65148).

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [x]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [x]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
