### PR TITLE
[Std_SendToPythonConsole] add doc, sub, and subs

### DIFF
--- a/src/Gui/CommandFeat.cpp
+++ b/src/Gui/CommandFeat.cpp
@@ -136,32 +136,60 @@ StdCmdSendToPythonConsole::StdCmdSendToPythonConsole()
 
 bool StdCmdSendToPythonConsole::isActive(void)
 {
-    return (Gui::Selection().size() == 1);
+    //active only if either 1 object is selected or multiple subobjects from the same object
+    return Gui::Selection().getSelectionEx().size() == 1;
 }
 
 void StdCmdSendToPythonConsole::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-
-    const std::vector<Gui::SelectionObject> &sels = Gui::Selection().getSelectionEx("*",App::DocumentObject::getClassTypeId(),true,true);
+    const std::vector<Gui::SelectionObject> &sels = Gui::Selection().getSelectionEx("*",App::DocumentObject::getClassTypeId(),true,false);
     if (sels.empty())
         return;
     const App::DocumentObject *obj = sels[0].getObject();
+    if (!obj)
+        return;
     QString docname = QString::fromLatin1(obj->getDocument()->getName());
     QString objname = QString::fromLatin1(obj->getNameInDocument());
     try {
-        QString cmd = QString::fromLatin1("obj = App.getDocument(\"%1\").getObject(\"%2\")").arg(docname,objname);
+        // clear variables from previous run, if any
+        QString cmd = QLatin1String("try:\n    del(doc,lnk,obj,shp,sub,subs)\nexcept Exception:\n    pass\n");
         Gui::Command::runCommand(Gui::Command::Gui,cmd.toLatin1());
-        if (sels[0].hasSubNames()) {
-            std::vector<std::string> subnames = sels[0].getSubNames();
-            if (obj->getPropertyByName("Shape")) {
-                QString subname = QString::fromLatin1(subnames[0].c_str());
-                cmd = QString::fromLatin1("shp = App.getDocument(\"%1\").getObject(\"%2\").Shape")
-                    .arg(docname, objname);
-                Gui::Command::runCommand(Gui::Command::Gui,cmd.toLatin1());
-                cmd = QString::fromLatin1("elt = App.getDocument(\"%1\").getObject(\"%2\").Shape.%4")
-                    .arg(docname,objname,subname);
-                Gui::Command::runCommand(Gui::Command::Gui,cmd.toLatin1());
+        cmd = QString::fromLatin1("doc = App.getDocument(\"%1\")").arg(docname);
+        Gui::Command::runCommand(Gui::Command::Gui,cmd.toLatin1());
+        //support links
+        if (obj->getTypeId().isDerivedFrom(App::Link::getClassTypeId())) {
+            cmd = QString::fromLatin1("lnk = doc.getObject(\"%1\")").arg(objname);
+            Gui::Command::runCommand(Gui::Command::Gui,cmd.toLatin1());
+            cmd = QString::fromLatin1("obj = lnk.getLinkedObject()");
+            Gui::Command::runCommand(Gui::Command::Gui,cmd.toLatin1());
+            const App::Link* link = static_cast<const App::Link*>(obj);
+            obj = link->getLinkedObject();
+        } else {
+            cmd = QString::fromLatin1("obj = doc.getObject(\"%1\")").arg(objname);
+            Gui::Command::runCommand(Gui::Command::Gui,cmd.toLatin1());
+        }
+        if (obj->getTypeId().isDerivedFrom(App::GeoFeature::getClassTypeId())) {
+            const App::GeoFeature* geoObj = static_cast<const App::GeoFeature*>(obj);
+            const App::PropertyGeometry* geo = geoObj->getPropertyOfGeometry();
+            if (geo){
+                cmd = QString::fromLatin1("shp = obj.") + QLatin1String(geo->getName()); //"Shape", "Mesh", "Points", etc.
+                Gui::Command::runCommand(Gui::Command::Gui, cmd.toLatin1());
+                if (sels[0].hasSubNames()) {
+                    std::vector<std::string> subnames = sels[0].getSubNames();
+                    QString subname = QString::fromLatin1(subnames[0].c_str());
+                    cmd = QString::fromLatin1("sub = obj.getSubObject(\"%1\")").arg(subname);
+                    Gui::Command::runCommand(Gui::Command::Gui,cmd.toLatin1());
+                    if (subnames.size() > 1) {
+                        std::ostringstream strm;
+                        strm << "subs = [";
+                        for (std::vector<std::string>::iterator it = subnames.begin(); it != subnames.end(); ++it) {
+                            strm << "obj.getSubObject(\"" << *it << "\"),";
+                        }
+                        strm << "]";
+                        Gui::Command::runCommand(Gui::Command::Gui, strm.str().c_str());
+                    }
+                }
             }
         }
         //show the python console if it's not already visible, and set the keyboard focus to it


### PR DESCRIPTION
doc = document containing selected object
obj = selected object
sub = selected subobject, e.g. face, edge (renamed from elt)
subs = list of selected subobjects

All previous definitions of these objects are deleted each time the command is run.

Edit: Updated to support App::Links.
lnk = App::Link object
obj = linked object
