### PR TITLE
Display Midplane checkbox with Pocket/ThroughAll

### DIFF
--- a/src/Mod/PartDesign/Gui/TaskExtrudeParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskExtrudeParameters.cpp
@@ -415,6 +415,7 @@ void TaskExtrudeParameters::setCheckboxes(Modes mode, Type type)
         isOffsetEditVisible = true;
         isOffsetEditEnabled = false; // offset may have some meaning for through all but it doesn't work
         isMidplaneEnabled = true;
+        isMidplaneVisible = true;
         isReversedEnabled = !ui->checkBoxMidplane->isChecked();
     }
     else if (mode == Modes::ToLast && type == Type::Pad) {


### PR DESCRIPTION
Was enabled but not visible.
Hopefully last time I fix it. :)