### PR TITLE
Fix various typos

### DIFF
--- a/src/App/DocumentObject.cpp
+++ b/src/App/DocumentObject.cpp
@@ -101,7 +101,7 @@ App::DocumentObjectExecReturn *DocumentObject::recompute(void)
     if(!GeoFeatureGroupExtension::areLinksValid(this)) {
 #if 1
         // Get objects that have invalid link scope, and print their names.
-        // Truncate the invalid object list name strings for readibility, if they happen to be very long.
+        // Truncate the invalid object list name strings for readability, if they happen to be very long.
         std::vector<App::DocumentObject*> invalid_linkobjs;
         std::string objnames = "", scopenames = "";
         GeoFeatureGroupExtension::getInvalidLinkObjects(this, invalid_linkobjs);

--- a/src/Mod/Part/App/FeatureExtrusion.cpp
+++ b/src/Mod/Part/App/FeatureExtrusion.cpp
@@ -222,7 +222,7 @@ Base::Vector3d Extrusion::calculateShapeNormal(const App::PropertyLink& shapeLin
     GeomAdaptor_Surface surf(planeFinder.Surface());
     gp_Dir normal = surf.Plane().Axis().Direction();
 
-    //now se know the plane. But if there are faces, the
+    //now we know the plane. But if there are faces, the
     //plane normal direction is not dependent on face orientation (because findPlane only uses edges).
     //let's fix that.
     TopExp_Explorer ex(sh, TopAbs_FACE);

--- a/src/Mod/TechDraw/TechDrawTools/TDToolsUtil.py
+++ b/src/Mod/TechDraw/TechDrawTools/TDToolsUtil.py
@@ -18,7 +18,7 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides utility funtions for TD Tools."""
+"""Provides utility functions for TD Tools."""
 
 import FreeCAD as App
 


### PR DESCRIPTION
Found via `codespell -q 3 -L aci,ake,aline,alle,alledges,alocation,als,ang,anid,anormal,apoints,ba,beginn,behaviour,bloaded,bottome,byteorder,calculater,cancelled,cancelling,cas,cascade,centimetre,childrens,childs,colour,colours,commen,connexion,currenty,dof,doubleclick,dum,eiter,elemente,ende,feld,finde,findf,freez,hist,iff,indicies,initialisation,initialise,initialised,initialises,initialisiert,inout,ist,itsel,kilometre,lod,mantatory,methode,metres,millimetre,modell,nd,noe,normale,normaly,nto,numer,oce,oder,ontop,orgin,orginx,orginy,ot,pard,parm,parms,pres,programm,que,rady,recurrance,ro,rougly,seperator,serie,sinc,strack,substraction,te,technic,thist,thru,tread,uint,unter,vertexes,wallthickness,whitespaces -S ./.git,*.po,*.ts,./ChangeLog.txt,./src/3rdParty,./src/Mod/Assembly/App/opendcm,./src/CXX,./src/zipios++,./src/Base/swig*,./src/Mod/Robot/App/kdl_cp,./src/Mod/Import/App/SCL,./src/WindowsInstaller,./src/Doc/FreeCAD.uml,./build/doc/SourceDocu`