### PR TITLE
TechDraw: Ext. Tools: Improve menu texts and tooltips

### DIFF
--- a/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp
+++ b/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp
@@ -1507,6 +1507,7 @@ CmdTechDrawExtensionCreateHorizCoordDimension::CmdTechDrawExtensionCreateHorizCo
     sToolTipText    = QT_TR_NOOP("Create multiple evenly spaced horizontal dimensions starting from the same baseline:<br>\
 - Specify the cascade spacing (optional)<br>\
 - Select three or more vertexes<br>\
+- The selection order of the first two vertexes determines the position of the baseline<br>\
 - Click this tool");
     sWhatsThis      = "TechDraw_ExtensionCreateHorizCoordDimension";
     sStatusTip      = sMenuText;
@@ -1579,6 +1580,7 @@ CmdTechDrawExtensionCreateVertCoordDimension::CmdTechDrawExtensionCreateVertCoor
     sToolTipText    = QT_TR_NOOP("Create multiple evenly spaced vertical dimensions starting from the same baseline:<br>\
 - Specify the cascade spacing (optional)<br>\
 - Select three or more vertexes<br>\
+- The selection order of the first two vertexes determines the position of the baseline<br>\
 - Click this tool");
     sWhatsThis      = "TechDraw_ExtensionCreateVertCoordDimension";
     sStatusTip      = sMenuText;
@@ -1676,7 +1678,8 @@ CmdTechDrawExtensionCreateObliqueCoordDimension::CmdTechDrawExtensionCreateObliq
     sToolTipText    = QT_TR_NOOP("Create multiple evenly spaced oblique dimensions starting from the same baseline:<br>\
 - Specify the cascade spacing (optional)<br>\
 - Select three or more vertexes<br>\
-- The first two vertexes define the direction<br>\
+- The selection order of the first two vertexes determines the position of the baseline<br>\
+- The first two vertexes also define the direction<br>\
 - Click this tool");
     sWhatsThis      = "TechDraw_ExtensionCreateObliqueCoordDimension";
     sStatusTip      = sMenuText;
@@ -1711,6 +1714,7 @@ CmdTechDrawExtensionCreateCoordDimensionGroup::CmdTechDrawExtensionCreateCoordDi
     sToolTipText    = QT_TR_NOOP("Create multiple evenly spaced horizontal dimensions starting from the same baseline:<br>\
 - Specify the cascade spacing (optional)<br>\
 - Select three or more vertexes<br>\
+- The selection order of the first two vertexes determines the position of the baseline<br>\
 - Click this tool");
     sWhatsThis      = "TechDraw_ExtensionCreateCoordDimensionGroup";
     sStatusTip      = sMenuText;
@@ -1787,6 +1791,7 @@ void CmdTechDrawExtensionCreateCoordDimensionGroup::languageChange()
 "Create multiple evenly spaced horizontal dimensions starting from the same baseline:<br>\
 - Specify the cascade spacing (optional)<br>\
 - Select three or more vertexes<br>\
+- The selection order of the first two vertexes determines the position of the baseline<br>\
 - Click this tool"));
     arc1->setStatusTip(arc1->text());
     QAction* arc2 = a[1];
@@ -1795,6 +1800,7 @@ void CmdTechDrawExtensionCreateCoordDimensionGroup::languageChange()
 "Create multiple evenly spaced vertical dimensions starting from the same baseline:<br>\
 - Specify the cascade spacing (optional)<br>\
 - Select three or more vertexes<br>\
+- The selection order of the first two vertexes determines the position of the baseline<br>\
 - Click this tool"));
     arc2->setStatusTip(arc2->text());
     QAction* arc3 = a[2];
@@ -1803,7 +1809,8 @@ void CmdTechDrawExtensionCreateCoordDimensionGroup::languageChange()
 "Create multiple evenly spaced oblique dimensions starting from the same baseline:<br>\
 - Specify the cascade spacing (optional)<br>\
 - Select three or more vertexes<br>\
-- The first two vertexes define the direction<br>\
+- The selection order of the first two vertexes determines the position of the baseline<br>\
+- The first two vertexes also define the direction<br>\
 - Click this tool"));
     arc3->setStatusTip(arc3->text());
 }

--- a/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp
+++ b/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp
@@ -121,8 +121,8 @@ namespace TechDrawGui {
 void execInsertPrefixChar(Gui::Command* cmd, std::string prefixChar) {
     // insert a prefix character into the format specifier
     std::vector<Gui::SelectionObject> selection;
-    if (_checkSelection(cmd, selection, "TechDraw Insert Prefix Character")) {
-        Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Insert Prefix Character"));
+    if (_checkSelection(cmd, selection, "TechDraw Insert Prefix")) {
+        Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Insert Prefix"));
         for (auto selected : selection) {
             auto object = selected.getObject();
             if (object->isDerivedFrom(TechDraw::DrawViewDimension::getClassTypeId())) {
@@ -141,15 +141,15 @@ DEF_STD_CMD_A(CmdTechDrawExtensionInsertDiameter)
 CmdTechDrawExtensionInsertDiameter::CmdTechDrawExtensionInsertDiameter()
     : Command("TechDraw_ExtensionInsertDiameter")
 {
-    sAppModule = "TechDraw";
-    sGroup = QT_TR_NOOP("TechDraw");
-    sMenuText = QT_TR_NOOP("Insert '⌀' sign");
-    sToolTipText = QT_TR_NOOP("Insert '⌀' sign in a measure\n\
-    - select many measures\n\
-    - click this button");
-    sWhatsThis = "TechDraw_ExtensionInsertDiameter";
-    sStatusTip = sToolTipText;
-    sPixmap = "TechDraw_ExtensionInsertDiameter";
+    sAppModule      = "TechDraw";
+    sGroup          = QT_TR_NOOP("TechDraw");
+    sMenuText       = QT_TR_NOOP("Insert '⌀' Prefix");
+    sToolTipText    = QT_TR_NOOP("Insert a '⌀' symbol at the beginning of the dimension text:<br>\
+- Select one or more dimensions<br>\
+- Click this tool");
+    sWhatsThis      = "TechDraw_ExtensionInsertDiameter";
+    sStatusTip      = sMenuText;
+    sPixmap         = "TechDraw_ExtensionInsertDiameter";
 }
 
 void CmdTechDrawExtensionInsertDiameter::activated(int iMsg)
@@ -174,15 +174,15 @@ DEF_STD_CMD_A(CmdTechDrawExtensionInsertSquare)
 CmdTechDrawExtensionInsertSquare::CmdTechDrawExtensionInsertSquare()
     : Command("TechDraw_ExtensionInsertSquare")
 {
-    sAppModule = "TechDraw";
-    sGroup = QT_TR_NOOP("TechDraw");
-    sMenuText = QT_TR_NOOP("Insert '〼' sign");
-    sToolTipText = QT_TR_NOOP("Insert '〼' sign in a measure\n\
-    - select many measures\n\
-    - click this button");
-    sWhatsThis = "TechDraw_ExtensionInsertSquare";
-    sStatusTip = sToolTipText;
-    sPixmap = "TechDraw_ExtensionInsertSquare";
+    sAppModule      = "TechDraw";
+    sGroup          = QT_TR_NOOP("TechDraw");
+    sMenuText       = QT_TR_NOOP("Insert '〼' Prefix");
+    sToolTipText    = QT_TR_NOOP("Insert a '〼' symbol at the beginning of the dimension text:<br>\
+- Select one or more dimensions<br>\
+- Click this tool");
+    sWhatsThis      = "TechDraw_ExtensionInsertSquare";
+    sStatusTip      = sMenuText;
+    sPixmap         = "TechDraw_ExtensionInsertSquare";
 }
 
 void CmdTechDrawExtensionInsertSquare::activated(int iMsg)
@@ -207,14 +207,14 @@ DEF_STD_CMD_ACL(CmdTechDrawExtensionInsertPrefixGroup)
 CmdTechDrawExtensionInsertPrefixGroup::CmdTechDrawExtensionInsertPrefixGroup()
     : Command("TechDraw_ExtensionInsertPrefixGroup")
 {
-    sAppModule = "TechDraw";
-    sGroup = QT_TR_NOOP("TechDraw");
-    sMenuText = QT_TR_NOOP("Insert a '⌀' sign in a measure");
-    sToolTipText = QT_TR_NOOP("Insert a '⌀' sign in a measure:\n\
-    - select many measures\n\
-    - click this button");
-    sWhatsThis = "TechDraw_ExtensionInsertPrefixGroup";
-    sStatusTip = sToolTipText;
+    sAppModule      = "TechDraw";
+    sGroup          = QT_TR_NOOP("TechDraw");
+    sMenuText       = QT_TR_NOOP("Insert '⌀' Prefix");
+    sToolTipText    = QT_TR_NOOP("Insert a '⌀' symbol at the beginning of the dimension text:<br>\
+- Select one or more dimensions<br>\
+- Click this tool");
+    sWhatsThis      = "TechDraw_ExtensionInsertPrefixGroup";
+    sStatusTip      = sMenuText;
 }
 
 void CmdTechDrawExtensionInsertPrefixGroup::activated(int iMsg)
@@ -276,17 +276,19 @@ void CmdTechDrawExtensionInsertPrefixGroup::languageChange()
     QList<QAction*> a = pcAction->actions();
 
     QAction* arc1 = a[0];
-    arc1->setText(QApplication::translate("TechDraw_Extension", "Insert '⌀' sign in a measure"));
-    arc1->setToolTip(QApplication::translate("TechDraw_Extension", "Insert a '⌀' sign in a measure:\n\
-    - select many measures\n\
-    - click this button"));
-    arc1->setStatusTip(arc1->toolTip());
+    arc1->setText(QApplication::translate("CmdTechDrawExtensionInsertDiameter", "Insert '⌀' Prefix"));
+    arc1->setToolTip(QApplication::translate("CmdTechDrawExtensionInsertDiameter",
+"Insert a '⌀' symbol at the beginning of the dimension text:<br>\
+- Select one or more dimensions<br>\
+- Click this tool"));
+    arc1->setStatusTip(arc1->text());
     QAction* arc2 = a[1];
-    arc2->setText(QApplication::translate("TechDraw_Extension", "Insert a '〼' sign in a measure"));
-    arc2->setToolTip(QApplication::translate("TechDraw_Extension", "Insert a '〼' sign in a measure:\n\
-    - select many measures\n\
-    - click this button"));
-    arc2->setStatusTip(arc2->toolTip());
+    arc2->setText(QApplication::translate("CmdTechDrawExtensionInsertSquare", "Insert '〼' Prefix"));
+    arc2->setToolTip(QApplication::translate("CmdTechDrawExtensionInsertSquare",
+"Insert a '〼' symbol at the beginning of the dimension text:<br>\
+- Select one or more dimensions<br>\
+- Click this tool"));
+    arc2->setStatusTip(arc2->text());
 }
 
 bool CmdTechDrawExtensionInsertPrefixGroup::isActive(void)
@@ -335,11 +337,11 @@ CmdTechDrawExtensionIncreaseDecimal::CmdTechDrawExtensionIncreaseDecimal()
     sAppModule      = "TechDraw";
     sGroup          = QT_TR_NOOP("TechDraw");
     sMenuText       = QT_TR_NOOP("Increase Decimal Places");
-    sToolTipText    = QT_TR_NOOP("Increase Decimal Places of a Measure\n\
-    - select many measures\n\
-    - click this button");
+    sToolTipText    = QT_TR_NOOP("Increase the number of decimal places of the dimension text:<br>\
+- Select one or more dimensions<br>\
+- Click this tool");
     sWhatsThis      = "TechDraw_ExtensionIncreaseDecimal";
-    sStatusTip      = sToolTipText;
+    sStatusTip      = sMenuText;
     sPixmap         = "TechDraw_ExtensionIncreaseDecimal";
 }
 
@@ -368,11 +370,11 @@ CmdTechDrawExtensionDecreaseDecimal::CmdTechDrawExtensionDecreaseDecimal()
     sAppModule      = "TechDraw";
     sGroup          = QT_TR_NOOP("TechDraw");
     sMenuText       = QT_TR_NOOP("Decrease Decimal Places");
-    sToolTipText    = QT_TR_NOOP("Decrease Decimal Places of a Measure\n\
-    - select many measures\n\
-    - click this button");
+    sToolTipText    = QT_TR_NOOP("Decrease the number of decimal places of the dimension text:<br>\
+- Select one or more dimensions<br>\
+- Click this tool");
     sWhatsThis      = "TechDraw_ExtensionDecreaseDecimal";
-    sStatusTip      = sToolTipText;
+    sStatusTip      = sMenuText;
     sPixmap         = "TechDraw_ExtensionDecreaseDecimal";
 }
 
@@ -401,11 +403,11 @@ CmdTechDrawExtensionIncreaseDecreaseGroup::CmdTechDrawExtensionIncreaseDecreaseG
     sAppModule      = "TechDraw";
     sGroup          = QT_TR_NOOP("TechDraw");
     sMenuText       = QT_TR_NOOP("Increase Decimal Places");
-    sToolTipText    = QT_TR_NOOP("Increase Decimal Places of a Measure\n\
-    - select many measures\n\
-    - click this button");
+    sToolTipText    = QT_TR_NOOP("Increase the number of decimal places of the dimension text:<br>\
+- Select one or more dimensions<br>\
+- Click this tool");
     sWhatsThis      = "TechDraw_ExtensionIncreaseDecreaseGroup";
-    sStatusTip      = sToolTipText;
+    sStatusTip      = sMenuText;
 }
 
 void CmdTechDrawExtensionIncreaseDecreaseGroup::activated(int iMsg)
@@ -467,17 +469,19 @@ void CmdTechDrawExtensionIncreaseDecreaseGroup::languageChange()
     QList<QAction*> a = pcAction->actions();
 
     QAction* arc1 = a[0];
-    arc1->setText(QApplication::translate("TechDraw_Extension", "Increase Decimal Places"));
-    arc1->setToolTip(QApplication::translate("TechDraw_Extension", "Increase Decimal Places of a Measure\n\
-    - select many measures\n\
-    - click this button"));
-    arc1->setStatusTip(arc1->toolTip());
+    arc1->setText(QApplication::translate("CmdTechDrawExtensionIncreaseDecimal", "Increase Decimal Places"));
+    arc1->setToolTip(QApplication::translate("CmdTechDrawExtensionIncreaseDecimal",
+"Increase the number of decimal places of the dimension text:<br>\
+- Select one or more dimensions<br>\
+- Click this tool"));
+    arc1->setStatusTip(arc1->text());
     QAction* arc2 = a[1];
-    arc2->setText(QApplication::translate("TechDraw_Extension", "Decrease Decimal Places"));
-    arc2->setToolTip(QApplication::translate("TechDraw_Extension", "Decrease Decimal Places of a Measure\n\
-    - select many measures\n\
-    - click this button"));
-    arc2->setStatusTip(arc2->toolTip());
+    arc2->setText(QApplication::translate("CmdTechDrawExtensionDecreaseDecimal", "Decrease Decimal Places"));
+    arc2->setToolTip(QApplication::translate("CmdTechDrawExtensionDecreaseDecimal",
+"Decrease the number of decimal places of the dimension text:<br>\
+- Select one or more dimensions<br>\
+- Click this tool"));
+    arc2->setStatusTip(arc2->text());
 }
 
 bool CmdTechDrawExtensionIncreaseDecreaseGroup::isActive(void)
@@ -523,12 +527,13 @@ CmdTechDrawExtensionPosHorizChainDimension::CmdTechDrawExtensionPosHorizChainDim
 {
     sAppModule      = "TechDraw";
     sGroup          = QT_TR_NOOP("TechDraw");
-    sMenuText       = QT_TR_NOOP("Position Horizontal Chain Dimension");
-    sToolTipText    = QT_TR_NOOP("Arranges the selected horizontal dimensions on the same line:\n\
-    - select two or more measures\n\
-    - click this button");
+    sMenuText       = QT_TR_NOOP("Position Horizontal Chain Dimensions");
+    sToolTipText    = QT_TR_NOOP("Align horizontal dimensions to create a chain dimension:<br>\
+- Select two or more horizontal dimensions<br>\
+- The first dimension defines the position<br>\
+- Click this tool");
     sWhatsThis      = "TechDraw_ExtensionPosHorizChainDimension";
-    sStatusTip      = sToolTipText;
+    sStatusTip      = sMenuText;
     sPixmap         = "TechDraw_ExtensionPosHorizChainDimension";
 }
 
@@ -581,12 +586,13 @@ CmdTechDrawExtensionPosVertChainDimension::CmdTechDrawExtensionPosVertChainDimen
 {
     sAppModule      = "TechDraw";
     sGroup          = QT_TR_NOOP("TechDraw");
-    sMenuText       = QT_TR_NOOP("Position Vertical Chain Dimension");
-    sToolTipText    = QT_TR_NOOP("Arranges the selected vertical dimensions on the same line:\n\
-    - select two or more measures\n\
-    - click this button");
+    sMenuText       = QT_TR_NOOP("Position Vertical Chain Dimensions");
+    sToolTipText    = QT_TR_NOOP("Align vertical dimensions to create a chain dimension:<br>\
+- Select two or more vertical dimensions<br>\
+- The first dimension defines the position<br>\
+- Click this tool");
     sWhatsThis      = "TechDraw_ExtensionPosVertChainDimension";
-    sStatusTip      = sToolTipText;
+    sStatusTip      = sMenuText;
     sPixmap         = "TechDraw_ExtensionPosVertChainDimension";
 }
 
@@ -645,12 +651,13 @@ CmdTechDrawExtensionPosObliqueChainDimension::CmdTechDrawExtensionPosObliqueChai
 {
     sAppModule      = "TechDraw";
     sGroup          = QT_TR_NOOP("TechDraw");
-    sMenuText       = QT_TR_NOOP("Position Oblique Chain Dimension");
-    sToolTipText    = QT_TR_NOOP("Arranges the selected oblique dimensions on the same line:\n\
-    - select two or more measures\n\
-    - click this button");
+    sMenuText       = QT_TR_NOOP("Position Oblique Chain Dimensions");
+    sToolTipText    = QT_TR_NOOP("Align oblique dimensions to create a chain dimension:<br>\
+- Select two or more parallel oblique dimensions<br>\
+- The first dimension defines the position<br>\
+- Click this tool");
     sWhatsThis      = "TechDraw_ExtensionPosObliqueChainDimension";
-    sStatusTip      = sToolTipText;
+    sStatusTip      = sMenuText;
     sPixmap         = "TechDraw_ExtensionPosObliqueChainDimension";
 }
 
@@ -679,12 +686,13 @@ CmdTechDrawExtensionPosChainDimensionGroup::CmdTechDrawExtensionPosChainDimensio
 {
     sAppModule      = "TechDraw";
     sGroup          = QT_TR_NOOP("TechDraw");
-    sMenuText       = QT_TR_NOOP("Position Horizontal Chain Dimension");
-    sToolTipText    = QT_TR_NOOP("Arranges the selected horizontal dimensions on the same line:\n\
-    - select two or more measures\n\
-    - click this button");
+    sMenuText       = QT_TR_NOOP("Position Horizontal Chain Dimensions");
+    sToolTipText    = QT_TR_NOOP("Align horizontal dimensions to create a chain dimension:<br>\
+- Select two or more horizontal dimensions<br>\
+- The first dimension defines the position<br>\
+- Click this tool");
     sWhatsThis      = "TechDraw_ExtensionPosChainDimensionGroup";
-    sStatusTip      = sToolTipText;
+    sStatusTip      = sMenuText;
 }
 
 void CmdTechDrawExtensionPosChainDimensionGroup::activated(int iMsg)
@@ -753,26 +761,29 @@ void CmdTechDrawExtensionPosChainDimensionGroup::languageChange()
     QList<QAction*> a = pcAction->actions();
 
     QAction* arc1 = a[0];
-    arc1->setText(QApplication::translate("TechDraw_Extension", "Position Horizontal Chain Dimensions"));
-    arc1->setToolTip(QApplication::translate("TechDraw_Extension",
-        "Arranges the selected horizontal dimensions on the same line:\n\
-    - select two or more measures\n\
-    - click this button"));
-    arc1->setStatusTip(arc1->toolTip());
+    arc1->setText(QApplication::translate("CmdTechDrawExtensionPosHorizChainDimension", "Position Horizontal Chain Dimensions"));
+    arc1->setToolTip(QApplication::translate("CmdTechDrawExtensionPosHorizChainDimension",
+"Align horizontal dimensions to create a chain dimension:<br>\
+- Select two or more horizontal dimensions<br>\
+- The first dimension defines the position<br>\
+- Click this tool"));
+    arc1->setStatusTip(arc1->text());
     QAction* arc2 = a[1];
-    arc2->setText(QApplication::translate("TechDraw_Extension", "Position Vertical Chain Dimensions"));
-    arc2->setToolTip(QApplication::translate("TechDraw_Extension",
-        "Arranges the selected vertical dimensions on the same line:\n\
-    - select two or more measures\n\
-    - click this button"));
-    arc2->setStatusTip(arc2->toolTip());
+    arc2->setText(QApplication::translate("CmdTechDrawExtensionPosVertChainDimension", "Position Vertical Chain Dimensions"));
+    arc2->setToolTip(QApplication::translate("CmdTechDrawExtensionPosVertChainDimension",
+"Align vertical dimensions to create a chain dimension:<br>\
+- Select two or more vertical dimensions<br>\
+- The first dimension defines the position<br>\
+- Click this tool"));
+    arc2->setStatusTip(arc2->text());
     QAction* arc3 = a[2];
-    arc3->setText(QApplication::translate("TechDraw_Extension", "Position Oblique Chain Dimensions"));
-    arc3->setToolTip(QApplication::translate("TechDraw_Extension",
-        "Arranges the selected oblique dimensions on the same line:\n\
-    - select two or more measures\n\
-    - click this button"));
-    arc3->setStatusTip(arc3->toolTip());
+    arc3->setText(QApplication::translate("CmdTechDrawExtensionPosObliqueChainDimension", "Position Oblique Chain Dimensions"));
+    arc3->setToolTip(QApplication::translate("CmdTechDrawExtensionPosObliqueChainDimension",
+"Align oblique dimensions to create a chain dimension:<br>\
+- Select two or more parallel oblique dimensions<br>\
+- The first dimension defines the position<br>\
+- Click this tool"));
+    arc3->setStatusTip(arc3->text());
 }
 
 bool CmdTechDrawExtensionPosChainDimensionGroup::isActive(void)
@@ -823,11 +834,13 @@ CmdTechDrawExtensionCascadeHorizDimension::CmdTechDrawExtensionCascadeHorizDimen
     sAppModule      = "TechDraw";
     sGroup          = QT_TR_NOOP("TechDraw");
     sMenuText       = QT_TR_NOOP("Cascade Horizontal Dimensions");
-    sToolTipText    = QT_TR_NOOP("Spaces (vertically), the selected horizontal dimensions:\n\
-    - select two or more horizontal dimensions\n\
-    - click this button");
+    sToolTipText    = QT_TR_NOOP("Evenly space horizontal dimensions:<br>\
+- Specify the cascade spacing (optional)<br>\
+- Select two or more horizontal dimensions<br>\
+- The first dimension defines the position<br>\
+- Click this tool");
     sWhatsThis      = "TechDraw_ExtensionCascadeHorizDimension";
-    sStatusTip      = sToolTipText;
+    sStatusTip      = sMenuText;
     sPixmap         = "TechDraw_ExtensionCascadeHorizDimension";
 }
 
@@ -849,7 +862,7 @@ bool CmdTechDrawExtensionCascadeHorizDimension::isActive(void)
 //===========================================================================
 
 void execCascadeVertDimension(Gui::Command* cmd) {
-    // cascade horizontal dimensions
+    // cascade vertical dimensions
     std::vector<Gui::SelectionObject> selection;
     if (_checkSelection(cmd, selection, "TechDraw CascadeVertDimension")) {
         Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Cascade Vert Dim"));
@@ -885,11 +898,13 @@ CmdTechDrawExtensionCascadeVertDimension::CmdTechDrawExtensionCascadeVertDimensi
     sAppModule      = "TechDraw";
     sGroup          = QT_TR_NOOP("TechDraw");
     sMenuText       = QT_TR_NOOP("Cascade Vertical Dimensions");
-    sToolTipText    = QT_TR_NOOP("Spaces (horizontally), the selected vertical dimensions:\n\
-    - select two or more vertical dimensions\n\
-    - click this button");
+    sToolTipText    = QT_TR_NOOP("Evenly space vertical dimensions:<br>\
+- Specify the cascade spacing (optional)<br>\
+- Select two or more vertical dimensions<br>\
+- The first dimension defines the position<br>\
+- Click this tool");
     sWhatsThis      = "TechDraw_ExtensionCascadeVertDimension";
-    sStatusTip      = sToolTipText;
+    sStatusTip      = sMenuText;
     sPixmap         = "TechDraw_ExtensionCascadeVertDimension";
 }
 
@@ -956,12 +971,13 @@ CmdTechDrawExtensionCascadeObliqueDimension::CmdTechDrawExtensionCascadeObliqueD
     sAppModule      = "TechDraw";
     sGroup          = QT_TR_NOOP("TechDraw");
     sMenuText       = QT_TR_NOOP("Cascade Oblique Dimensions");
-    sToolTipText    = QT_TR_NOOP("Cascade oblique dimensions\n\
-    - select some parallel oblique measures\n\
-    - the first selected measure defines the position\n\
-    - click this button");
+    sToolTipText    = QT_TR_NOOP("Evenly space oblique dimensions:<br>\
+- Specify the cascade spacing (optional)<br>\
+- Select two or more parallel oblique dimensions<br>\
+- The first dimension defines the position<br>\
+- Click this tool");
     sWhatsThis      = "TechDraw_ExtensionCascadeObliqueDimension";
-    sStatusTip      = sToolTipText;
+    sStatusTip      = sMenuText;
     sPixmap         = "TechDraw_ExtensionCascadeObliqueDimension";
 }
 
@@ -991,11 +1007,13 @@ CmdTechDrawExtensionCascadeDimensionGroup::CmdTechDrawExtensionCascadeDimensionG
     sAppModule      = "TechDraw";
     sGroup          = QT_TR_NOOP("TechDraw");
     sMenuText       = QT_TR_NOOP("Cascade Horizontal Dimensions");
-    sToolTipText    = QT_TR_NOOP("Cascade Horizontal Dimensions\n\
-    - select many horizontal dimensions\n\
-    - click this button");
+    sToolTipText    = QT_TR_NOOP("Evenly space horizontal dimensions:<br>\
+- Specify the cascade spacing (optional)<br>\
+- Select two or more horizontal dimensions<br>\
+- The first dimension defines the position<br>\
+- Click this tool");
     sWhatsThis      = "TechDraw_ExtensionCascadeDimensionGroup";
-    sStatusTip      = sToolTipText;
+    sStatusTip      = sMenuText;
 }
 
 void CmdTechDrawExtensionCascadeDimensionGroup::activated(int iMsg)
@@ -1064,27 +1082,32 @@ void CmdTechDrawExtensionCascadeDimensionGroup::languageChange()
     QList<QAction*> a = pcAction->actions();
 
     QAction* arc1 = a[0];
-    arc1->setText(QApplication::translate("TechDraw_Extension", "Cascade Horizontal Dimensions"));
-    arc1->setToolTip(QApplication::translate("TechDraw_Extension",
-        "Spaces (vertically), the selected horizontal dimensions:\n\
-    - select two or more horizontal dimensions\n\
-    - click this button"));
-    arc1->setStatusTip(arc1->toolTip());
+    arc1->setText(QApplication::translate("CmdTechDrawExtensionCascadeHorizDimension", "Cascade Horizontal Dimensions"));
+    arc1->setToolTip(QApplication::translate("CmdTechDrawExtensionCascadeHorizDimension",
+"Evenly space horizontal dimensions:<br>\
+- Specify the cascade spacing (optional)<br>\
+- Select two or more horizontal dimensions<br>\
+- The first dimension defines the position<br>\
+- Click this tool"));
+    arc1->setStatusTip(arc1->text());
     QAction* arc2 = a[1];
-    arc2->setText(QApplication::translate("TechDraw_Extension", "Cascade Vertical Dimensions"));
-    arc2->setToolTip(QApplication::translate("TechDraw_Extension",
-        "Spaces (horizontally), the selected vertical dimensions:\n\
-    - select two or more vertical dimensions\n\
-    - click this button"));
-    arc2->setStatusTip(arc2->toolTip());
+    arc2->setText(QApplication::translate("CmdTechDrawExtensionCascadeVertDimension", "Cascade Vertical Dimensions"));
+    arc2->setToolTip(QApplication::translate("CmdTechDrawExtensionCascadeVertDimension",
+"Evenly space vertical dimensions:<br>\
+- Specify the cascade spacing (optional)<br>\
+- Select two or more vertical dimensions<br>\
+- The first dimension defines the position<br>\
+- Click this tool"));
+    arc2->setStatusTip(arc2->text());
     QAction* arc3 = a[2];
-    arc3->setText(QApplication::translate("TechDraw_Extension", "Cascade Oblique Dimensions"));
-    arc3->setToolTip(QApplication::translate("TechDraw_Extension",
-        "Cascade oblique dimensions\n\
-    - select some parallel oblique measures\n\
-    - the first selected measure defines the position\n\
-    - click this button"));
-    arc3->setStatusTip(arc3->toolTip());
+    arc3->setText(QApplication::translate("CmdTechDrawExtensionCascadeObliqueDimension", "Cascade Oblique Dimensions"));
+    arc3->setToolTip(QApplication::translate("CmdTechDrawExtensionCascadeObliqueDimension",
+"Evenly space oblique dimensions:<br>\
+- Specify the cascade spacing (optional)<br>\
+- Select two or more parallel oblique dimensions<br>\
+- The first dimension defines the position<br>\
+- Click this tool"));
+    arc3->setStatusTip(arc3->text());
 }
 
 bool CmdTechDrawExtensionCascadeDimensionGroup::isActive(void)
@@ -1137,12 +1160,12 @@ CmdTechDrawExtensionCreateHorizChainDimension::CmdTechDrawExtensionCreateHorizCh
 {
     sAppModule      = "TechDraw";
     sGroup          = QT_TR_NOOP("TechDraw");
-    sMenuText       = QT_TR_NOOP("Create Horizontal Chain Dimension");
-    sToolTipText    = QT_TR_NOOP("Create a horizontal chain dimension\n\
-    - Select three or more vertexes\n\
-    - click this button");
+    sMenuText       = QT_TR_NOOP("Create Horizontal Chain Dimensions");
+    sToolTipText    = QT_TR_NOOP("Create a sequence of aligned horizontal dimensions:<br>\
+- Select three or more vertexes<br>\
+- Click this tool");
     sWhatsThis      = "TechDraw_ExtensionCreateHorizChainDimension";
-    sStatusTip      = sToolTipText;
+    sStatusTip      = sMenuText;
     sPixmap         = "TechDraw_ExtensionCreateHorizChainDimension";
 }
 
@@ -1203,12 +1226,12 @@ CmdTechDrawExtensionCreateVertChainDimension::CmdTechDrawExtensionCreateVertChai
 {
     sAppModule      = "TechDraw";
     sGroup          = QT_TR_NOOP("TechDraw");
-    sMenuText       = QT_TR_NOOP("Create Vertical Chain Dimension");
-    sToolTipText    = QT_TR_NOOP("Create vertical chain dimension\n\
-    - Select three or more vertexes\n\
-    - click this button");
+    sMenuText       = QT_TR_NOOP("Create Vertical Chain Dimensions");
+    sToolTipText    = QT_TR_NOOP("Create a sequence of aligned vertical dimensions:<br>\
+- Select three or more vertexes<br>\
+- Click this tool");
     sWhatsThis      = "TechDraw_ExtensionCreateVertChainDimension";
-    sStatusTip      = sToolTipText;
+    sStatusTip      = sMenuText;
     sPixmap         = "TechDraw_ExtensionCreateVertChainDimension";
 }
 
@@ -1293,13 +1316,13 @@ CmdTechDrawExtensionCreateObliqueChainDimension::CmdTechDrawExtensionCreateObliq
 {
     sAppModule      = "TechDraw";
     sGroup          = QT_TR_NOOP("TechDraw");
-    sMenuText       = QT_TR_NOOP("Create Oblique Chain Dimension");
-    sToolTipText    = QT_TR_NOOP("Create an oblique dimension chain\n\
-    - select three or more  vertexes\n\
-    - the first two define the direction\n\
-    - click this button");
+    sMenuText       = QT_TR_NOOP("Create Oblique Chain Dimensions");
+    sToolTipText    = QT_TR_NOOP("Create a sequence of aligned oblique dimensions:<br>\
+- Select three or more vertexes<br>\
+- The first two vertexes define the direction<br>\
+- Click this tool");
     sWhatsThis      = "TechDraw_ExtensionCreateObliqueChainDimension";
-    sStatusTip      = sToolTipText;
+    sStatusTip      = sMenuText;
     sPixmap         = "TechDraw_ExtensionCreateObliqueChainDimension";
 }
 
@@ -1327,12 +1350,12 @@ CmdTechDrawExtensionCreateChainDimensionGroup::CmdTechDrawExtensionCreateChainDi
 {
     sAppModule      = "TechDraw";
     sGroup          = QT_TR_NOOP("TechDraw");
-    sMenuText       = QT_TR_NOOP("Create Chain Dimensions");
-    sToolTipText    = QT_TR_NOOP("Create a horizontal chain dimension\n\
-    - Select three or more vertexes\n\
-    - click this button");
+    sMenuText       = QT_TR_NOOP("Create Horizontal Chain Dimensions");
+    sToolTipText    = QT_TR_NOOP("Create a sequence of aligned horizontal dimensions:<br>\
+- Select three or more vertexes<br>\
+- Click this tool");
     sWhatsThis      = "TechDraw_ExtensionCreateChainDimensionGroup";
-    sStatusTip      = sToolTipText;
+    sStatusTip      = sMenuText;
 }
 
 void CmdTechDrawExtensionCreateChainDimensionGroup::activated(int iMsg)
@@ -1401,27 +1424,27 @@ void CmdTechDrawExtensionCreateChainDimensionGroup::languageChange()
     QList<QAction*> a = pcAction->actions();
 
     QAction* arc1 = a[0];
-    arc1->setText(QApplication::translate("TechDraw_Extension", "Create Horizontal Chain Dimensions"));
-    arc1->setToolTip(QApplication::translate("TechDraw_Extension",
-        "Create a horizontal chain dimension\n\
-    - Select three or more vertexes\n\
-    - click this button"));
-    arc1->setStatusTip(arc1->toolTip());
+    arc1->setText(QApplication::translate("CmdTechDrawExtensionCreateHorizChainDimension", "Create Horizontal Chain Dimensions"));
+    arc1->setToolTip(QApplication::translate("CmdTechDrawExtensionCreateHorizChainDimension",
+"Create a sequence of aligned horizontal dimensions:<br>\
+- Select three or more vertexes<br>\
+- Click this tool"));
+    arc1->setStatusTip(arc1->text());
     QAction* arc2 = a[1];
-    arc2->setText(QApplication::translate("TechDraw_Extension", "Create Vertical Chain Dimensions"));
-    arc2->setToolTip(QApplication::translate("TechDraw_Extension",
-        "Create vertical chain dimension\n\
-    - Select three or more vertexes\n\
-    - click this button"));
-    arc2->setStatusTip(arc2->toolTip());
+    arc2->setText(QApplication::translate("CmdTechDrawExtensionCreateVertChainDimension", "Create Vertical Chain Dimensions"));
+    arc2->setToolTip(QApplication::translate("CmdTechDrawExtensionCreateVertChainDimension",
+"Create a sequence of aligned vertical dimensions:<br>\
+- Select three or more vertexes<br>\
+- Click this tool"));
+    arc2->setStatusTip(arc2->text());
     QAction* arc3 = a[2];
-    arc3->setText(QApplication::translate("TechDraw_Extension", "Create Oblique Chain Dimensions"));
-    arc3->setToolTip(QApplication::translate("TechDraw_Extension",
-        "Create an oblique dimension chain\n\
-    - select three or more  vertexes\n\
-    - the first two define the direction\n\
-    - click this button"));
-    arc3->setStatusTip(arc3->toolTip());
+    arc3->setText(QApplication::translate("CmdTechDrawExtensionCreateObliqueChainDimension", "Create Oblique Chain Dimensions"));
+    arc3->setToolTip(QApplication::translate("CmdTechDrawExtensionCreateObliqueChainDimension",
+"Create a sequence of aligned oblique dimensions:<br>\
+- Select three or more vertexes<br>\
+- The first two vertexes define the direction<br>\
+- Click this tool"));
+    arc3->setStatusTip(arc3->text());
 }
 
 bool CmdTechDrawExtensionCreateChainDimensionGroup::isActive(void)
@@ -1480,12 +1503,13 @@ CmdTechDrawExtensionCreateHorizCoordDimension::CmdTechDrawExtensionCreateHorizCo
 {
     sAppModule      = "TechDraw";
     sGroup          = QT_TR_NOOP("TechDraw");
-    sMenuText       = QT_TR_NOOP("Create Horizontal Coordinate Dimension");
-    sToolTipText    = QT_TR_NOOP("Create horizontal coordinate dimensions\n\
-    - select three or more vertexes\n\
-    - click this button");
+    sMenuText       = QT_TR_NOOP("Create Horizontal Coordinate Dimensions");
+    sToolTipText    = QT_TR_NOOP("Create multiple evenly spaced horizontal dimensions starting from the same baseline:<br>\
+- Specify the cascade spacing (optional)<br>\
+- Select three or more vertexes<br>\
+- Click this tool");
     sWhatsThis      = "TechDraw_ExtensionCreateHorizCoordDimension";
-    sStatusTip      = sToolTipText;
+    sStatusTip      = sMenuText;
     sPixmap         = "TechDraw_ExtensionCreateHorizCoordDimension";
 }
 
@@ -1551,12 +1575,13 @@ CmdTechDrawExtensionCreateVertCoordDimension::CmdTechDrawExtensionCreateVertCoor
 {
     sAppModule      = "TechDraw";
     sGroup          = QT_TR_NOOP("TechDraw");
-    sMenuText       = QT_TR_NOOP("Create Vertical Coordinate Dimension");
-    sToolTipText    = QT_TR_NOOP("Create vertical coordinate dimensions\n\
-    - select three or more vertexes\n\
-    - click this button");
+    sMenuText       = QT_TR_NOOP("Create Vertical Coordinate Dimensions");
+    sToolTipText    = QT_TR_NOOP("Create multiple evenly spaced vertical dimensions starting from the same baseline:<br>\
+- Specify the cascade spacing (optional)<br>\
+- Select three or more vertexes<br>\
+- Click this tool");
     sWhatsThis      = "TechDraw_ExtensionCreateVertCoordDimension";
-    sStatusTip      = sToolTipText;
+    sStatusTip      = sMenuText;
     sPixmap         = "TechDraw_ExtensionCreateVertCoordDimension";
 }
 
@@ -1647,13 +1672,14 @@ CmdTechDrawExtensionCreateObliqueCoordDimension::CmdTechDrawExtensionCreateObliq
 {
     sAppModule      = "TechDraw";
     sGroup          = QT_TR_NOOP("TechDraw");
-    sMenuText       = QT_TR_NOOP("Create Oblique Coordinate Dimension");
-    sToolTipText    = QT_TR_NOOP("Create an oblique coordinate dimension\n\
-    - select three or more  vertexes\n\
-    - the first two define the direction\n\
-    - click this button");
+    sMenuText       = QT_TR_NOOP("Create Oblique Coordinate Dimensions");
+    sToolTipText    = QT_TR_NOOP("Create multiple evenly spaced oblique dimensions starting from the same baseline:<br>\
+- Specify the cascade spacing (optional)<br>\
+- Select three or more vertexes<br>\
+- The first two vertexes define the direction<br>\
+- Click this tool");
     sWhatsThis      = "TechDraw_ExtensionCreateObliqueCoordDimension";
-    sStatusTip      = sToolTipText;
+    sStatusTip      = sMenuText;
     sPixmap         = "TechDraw_ExtensionCreateObliqueCoordDimension";
 }
 
@@ -1681,12 +1707,13 @@ CmdTechDrawExtensionCreateCoordDimensionGroup::CmdTechDrawExtensionCreateCoordDi
 {
     sAppModule      = "TechDraw";
     sGroup          = QT_TR_NOOP("TechDraw");
-    sMenuText       = QT_TR_NOOP("Create Coordinate Dimensions");
-    sToolTipText    = QT_TR_NOOP("Create horizontal coordinate dimensions\n\
-    - select three or more vertexes\n\
-    - click this button");
+    sMenuText       = QT_TR_NOOP("Create Horizontal Coordinate Dimensions");
+    sToolTipText    = QT_TR_NOOP("Create multiple evenly spaced horizontal dimensions starting from the same baseline:<br>\
+- Specify the cascade spacing (optional)<br>\
+- Select three or more vertexes<br>\
+- Click this tool");
     sWhatsThis      = "TechDraw_ExtensionCreateCoordDimensionGroup";
-    sStatusTip      = sToolTipText;
+    sStatusTip      = sMenuText;
 }
 
 void CmdTechDrawExtensionCreateCoordDimensionGroup::activated(int iMsg)
@@ -1755,27 +1782,30 @@ void CmdTechDrawExtensionCreateCoordDimensionGroup::languageChange()
     QList<QAction*> a = pcAction->actions();
 
     QAction* arc1 = a[0];
-    arc1->setText(QApplication::translate("TechDraw_Extension", "Create Horizontal Coordinate Dimensions"));
-    arc1->setToolTip(QApplication::translate("TechDraw_Extension",
-        "Create horizontal coordinate dimensions\n\
-    - select three or more vertexes\n\
-    - click this button"));
-    arc1->setStatusTip(arc1->toolTip());
+    arc1->setText(QApplication::translate("CmdTechDrawExtensionCreateHorizCoordDimension", "Create Horizontal Coordinate Dimensions"));
+    arc1->setToolTip(QApplication::translate("CmdTechDrawExtensionCreateHorizCoordDimension",
+"Create multiple evenly spaced horizontal dimensions starting from the same baseline:<br>\
+- Specify the cascade spacing (optional)<br>\
+- Select three or more vertexes<br>\
+- Click this tool"));
+    arc1->setStatusTip(arc1->text());
     QAction* arc2 = a[1];
-    arc2->setText(QApplication::translate("TechDraw_Extension", "Create Vertical Coordinate Dimensions"));
-    arc2->setToolTip(QApplication::translate("TechDraw_Extension",
-        "Create vertical coordinate dimensions\n\
-    - select three or more vertexes\n\
-    - click this button"));
-    arc2->setStatusTip(arc2->toolTip());
+    arc2->setText(QApplication::translate("CmdTechDrawExtensionCreateVertCoordDimension", "Create Vertical Coordinate Dimensions"));
+    arc2->setToolTip(QApplication::translate("CmdTechDrawExtensionCreateVertCoordDimension",
+"Create multiple evenly spaced vertical dimensions starting from the same baseline:<br>\
+- Specify the cascade spacing (optional)<br>\
+- Select three or more vertexes<br>\
+- Click this tool"));
+    arc2->setStatusTip(arc2->text());
     QAction* arc3 = a[2];
-    arc3->setText(QApplication::translate("TechDraw_Extension", "Create Oblique Coordinate Dimensions"));
-    arc3->setToolTip(QApplication::translate("TechDraw_Extension",
-        "Create an oblique coordinate dimension\n\
-    - select three or more  vertexes\n\
-    - the first two define the direction\n\
-    - click this button"));
-    arc3->setStatusTip(arc3->toolTip());
+    arc3->setText(QApplication::translate("CmdTechDrawExtensionCreateObliqueCoordDimension", "Create Oblique Coordinate Dimensions"));
+    arc3->setToolTip(QApplication::translate("CmdTechDrawExtensionCreateObliqueCoordDimension",
+"Create multiple evenly spaced oblique dimensions starting from the same baseline:<br>\
+- Specify the cascade spacing (optional)<br>\
+- Select three or more vertexes<br>\
+- The first two vertexes define the direction<br>\
+- Click this tool"));
+    arc3->setStatusTip(arc3->text());
 }
 
 bool CmdTechDrawExtensionCreateCoordDimensionGroup::isActive(void)
@@ -1795,7 +1825,7 @@ void execCreateHorizChamferDimension(Gui::Command* cmd) {
     TechDraw::DrawViewPart* objFeat;
     if (!_checkSelAndObj(cmd, selection, objFeat, "TechDraw Create Horizontal Chamfer Dimension"))
         return;
-    Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Horiz Chamfer Dim"));
+    Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Create Horiz Chamfer Dim"));
     const std::vector<std::string> subNames = selection[0].getSubNames();
     std::vector<dimVertex> allVertexes;
     allVertexes = _getVertexInfo(objFeat, subNames);
@@ -1833,11 +1863,11 @@ CmdTechDrawExtensionCreateHorizChamferDimension::CmdTechDrawExtensionCreateHoriz
     sAppModule      = "TechDraw";
     sGroup          = QT_TR_NOOP("TechDraw");
     sMenuText       = QT_TR_NOOP("Create Horizontal Chamfer Dimension");
-    sToolTipText    = QT_TR_NOOP("Create Horizontal Chamfer Dimension\n\
-    - select two vertexes\n\
-    - click this button");
+    sToolTipText    = QT_TR_NOOP("Create a horizontal size and angle dimension for a chamfer:<br>\
+- Select two vertexes<br>\
+- Click this tool");
     sWhatsThis      = "TechDraw_ExtensionCreateHorizChamferDimension";
-    sStatusTip      = sToolTipText;
+    sStatusTip      = sMenuText;
     sPixmap         = "TechDraw_ExtensionCreateHorizChamferDimension";
 }
 
@@ -1864,7 +1894,7 @@ void execCreateVertChamferDimension(Gui::Command* cmd) {
     TechDraw::DrawViewPart* objFeat;
     if (!_checkSelAndObj(cmd, selection, objFeat, "TechDraw Create Vertical Chamfer Dimension"))
         return;
-    Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Vert Chamfer Dim"));
+    Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Create Vert Chamfer Dim"));
     const std::vector<std::string> subNames = selection[0].getSubNames();
     std::vector<dimVertex> allVertexes;
     allVertexes = _getVertexInfo(objFeat, subNames);
@@ -1902,11 +1932,11 @@ CmdTechDrawExtensionCreateVertChamferDimension::CmdTechDrawExtensionCreateVertCh
     sAppModule      = "TechDraw";
     sGroup          = QT_TR_NOOP("TechDraw");
     sMenuText       = QT_TR_NOOP("Create Vertical Chamfer Dimension");
-    sToolTipText    = QT_TR_NOOP("Create Vertical Chamfer Dimension\n\
-    - select two vertexes\n\
-    - click this button");
+    sToolTipText    = QT_TR_NOOP("Create a vertical size and angle dimension for a chamfer:<br>\
+- Select two vertexes<br>\
+- Click this tool");
     sWhatsThis      = "TechDraw_ExtensionCreateVertChamferDimension";
-    sStatusTip      = sToolTipText;
+    sStatusTip      = sMenuText;
     sPixmap         = "TechDraw_ExtensionCreateVertChamferDimension";
 }
 
@@ -1935,11 +1965,11 @@ CmdTechDrawExtensionChamferDimensionGroup::CmdTechDrawExtensionChamferDimensionG
     sAppModule      = "TechDraw";
     sGroup          = QT_TR_NOOP("TechDraw");
     sMenuText       = QT_TR_NOOP("Create Horizontal Chamfer Dimension");
-    sToolTipText    = QT_TR_NOOP("Create Horizontal Chamfer Dimension\n\
-    - select two vertexes\n\
-    - click this button");
+    sToolTipText    = QT_TR_NOOP("Create a horizontal size and angle dimension for a chamfer:<br>\
+- Select two vertexes<br>\
+- Click this tool");
     sWhatsThis      = "TechDraw_ExtensionChamferDimensionGroup";
-    sStatusTip      = sToolTipText;
+    sStatusTip      = sMenuText;
 }
 
 void CmdTechDrawExtensionChamferDimensionGroup::activated(int iMsg)
@@ -2001,17 +2031,19 @@ void CmdTechDrawExtensionChamferDimensionGroup::languageChange()
     QList<QAction*> a = pcAction->actions();
 
     QAction* arc1 = a[0];
-    arc1->setText(QApplication::translate("TechDraw_Extension", "Create Horizontal Chamfer Dimension"));
-    arc1->setToolTip(QApplication::translate("TechDraw_Extension", "Create Horizontal Chamfer Dimension\n\
-    - select two vertexes\n\
-    - click this button"));
-    arc1->setStatusTip(arc1->toolTip());
+    arc1->setText(QApplication::translate("CmdTechDrawExtensionCreateHorizChamferDimension", "Create Horizontal Chamfer Dimension"));
+    arc1->setToolTip(QApplication::translate("CmdTechDrawExtensionCreateHorizChamferDimension",
+"Create a horizontal size and angle dimension for a chamfer:<br>\
+- Select two vertexes<br>\
+- Click this tool"));
+    arc1->setStatusTip(arc1->text());
     QAction* arc2 = a[1];
-    arc2->setText(QApplication::translate("TechDraw_Extension", "Create Vertical Chamfer Dimension"));
-    arc2->setToolTip(QApplication::translate("TechDraw_Extension", "Create Vertical Chamfer Dimension\n\
-    - select two vertexes\n\
-    - click this button"));
-    arc2->setStatusTip(arc2->toolTip());
+    arc2->setText(QApplication::translate("CmdTechDrawExtensionCreateVertChamferDimension", "Create Vertical Chamfer Dimension"));
+    arc2->setToolTip(QApplication::translate("CmdTechDrawExtensionCreateVertChamferDimension",
+"Create a vertical size and angle dimension for a chamfer:<br>\
+- Select two vertexes<br>\
+- Click this tool"));
+    arc2->setStatusTip(arc2->text());
 }
 
 bool CmdTechDrawExtensionChamferDimensionGroup::isActive(void)
@@ -2032,23 +2064,23 @@ CmdTechDrawExtensionCreateLengthArc::CmdTechDrawExtensionCreateLengthArc()
 {
     sAppModule      = "TechDraw";
     sGroup          = QT_TR_NOOP("TechDraw");
-    sMenuText       = QT_TR_NOOP("Create Development/length arc");
-    sToolTipText    = QT_TR_NOOP("Create Development/length arc\n\
-    - select one arc\n\
-    - click this button");
+    sMenuText       = QT_TR_NOOP("Create Arc Length Dimension");
+    sToolTipText    = QT_TR_NOOP("Create an arc length dimension:<br>\
+- Select a single arc<br>\
+- Click this tool");
     sWhatsThis      = "TechDraw_ExtensionCreateLengthArc";
-    sStatusTip      = sToolTipText;
+    sStatusTip      = sMenuText;
     sPixmap         = "TechDraw_ExtensionCreateLengthArc";
 }
 
 void CmdTechDrawExtensionCreateLengthArc::activated(int iMsg) {
-    // create a development/length arc dimension
+    // create arc length dimension
     Q_UNUSED(iMsg);
     std::vector<Gui::SelectionObject> selection;
     TechDraw::DrawViewPart* objFeat;
-    if (!_checkSelAndObj(this, selection, objFeat, "TechDraw Create Development/length arc"))
+    if (!_checkSelAndObj(this, selection, objFeat, "TechDraw Create Arc Length Dimension"))
         return;
-    Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Create Length Arc"));
+    Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Create Arc Length Dim"));
     const std::vector<std::string> subNames = selection[0].getSubNames();
     int geoId = TechDraw::DrawUtil::getIndexFromName(subNames[0]);
     TechDraw::BaseGeomPtr geom = objFeat->getGeomByIndex(geoId);

--- a/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp
+++ b/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp
@@ -713,10 +713,10 @@ CmdTechDrawExtensionSelectLineAttributes::CmdTechDrawExtensionSelectLineAttribut
 {
     sAppModule      = "TechDraw";
     sGroup          = QT_TR_NOOP("TechDraw");
-    sMenuText       = QT_TR_NOOP("Select Line Attributes and Cascade Spacing");
-    sToolTipText    = QT_TR_NOOP("Select the attributes for new cosmetic lines and centerlines, and specify the cascade spacing:<br>\
+    sMenuText       = QT_TR_NOOP("Select Line Attributes, Cascade Spacing and Delta Distance");
+    sToolTipText    = QT_TR_NOOP("Select the attributes for new cosmetic lines and centerlines, and specify the cascade spacing and delta distance:<br>\
 - Click this tool<br>\
-- Specify the attributes and spacing in the dialog box<br>\
+- Specify the attributes, spacing and distance in the dialog box<br>\
 - Press OK");
     sWhatsThis      = "TechDraw_ExtensionSelectLineAttributes";
     sStatusTip      = sMenuText;

--- a/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp
+++ b/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp
@@ -128,10 +128,10 @@ namespace TechDrawGui {
         if (Circles.size() <= 2) {
             QMessageBox::warning(Gui::getMainWindow(),
                 QObject::tr("TechDraw Hole Circle"),
-                QObject::tr("Less then three circles selected"));
+                QObject::tr("Fewer than three circles selected"));
             return;
         }
-        Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Draw bolt circle centerlines"));
+        Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Bolt Circle Centerlines"));
         double scale = objFeat->getScale();
         Base::Vector3d bigCenter = _circleCenter(Circles[0]->center,
             Circles[1]->center,
@@ -167,13 +167,13 @@ CmdTechDrawExtensionHoleCircle::CmdTechDrawExtensionHoleCircle()
 {
     sAppModule      = "TechDraw";
     sGroup          = QT_TR_NOOP("TechDraw");
-    sMenuText       = QT_TR_NOOP("Draw bolt circle centerlines");
-    sToolTipText    = QT_TR_NOOP("Draw the centerlines of a bolt circle\n\
-    - pick favoured line attributes\n\
-    - select at least three circles of a bolt circle\n\
-    - click this button");
+    sMenuText       = QT_TR_NOOP("Add Bolt Circle Centerlines");
+    sToolTipText    = QT_TR_NOOP("Add centerlines to a circular pattern of circles:<br>\
+- Specify the line attributes (optional)<br>\
+- Select three or more circles forming a circular pattern<br>\
+- Click this tool");
     sWhatsThis      = "TechDraw_ExtensionHoleCircle";
-    sStatusTip      = sToolTipText;
+    sStatusTip      = sMenuText;
     sPixmap         = "TechDraw_ExtensionHoleCircle";
 }
 
@@ -181,7 +181,7 @@ void CmdTechDrawExtensionHoleCircle::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
     execHoleCircle(this);
-    //Base::Console().Message("HoleCircle gestartet\n");
+    //Base::Console().Message("HoleCircle started\n");
 }
 
 bool CmdTechDrawExtensionHoleCircle::isActive(void)
@@ -196,12 +196,12 @@ bool CmdTechDrawExtensionHoleCircle::isActive(void)
 //===========================================================================
 
 void execCircleCenterLines(Gui::Command* cmd) {
-    // create centerline cross at circles
+    // create circle centerlines
     std::vector<Gui::SelectionObject> selection;
     TechDraw::DrawViewPart* objFeat;
     if (!_checkSel(cmd, selection, objFeat, "TechDraw Circle Centerlines"))
         return;
-    Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Draw Circle Centerlines"));
+    Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Circle Centerlines"));
     double scale = objFeat->getScale();
     const std::vector<std::string> SubNames = selection[0].getSubNames();
     for (std::string Name : SubNames) {
@@ -241,13 +241,13 @@ CmdTechDrawExtensionCircleCenterLines::CmdTechDrawExtensionCircleCenterLines()
 {
     sAppModule      = "TechDraw";
     sGroup          = QT_TR_NOOP("TechDraw");
-    sMenuText       = QT_TR_NOOP("Draw circle center lines");
-    sToolTipText    = QT_TR_NOOP("Draw circle center line cross at circles\n\
-    - pick favoured line attributes\n\
-    - select many circles or arcs\n\
-    - click this button");
+    sMenuText       = QT_TR_NOOP("Add Circle Centerlines");
+    sToolTipText    = QT_TR_NOOP("Add centerlines to circles and arcs:<br>\
+- Specify the line attributes (optional)<br>\
+- Select one or more circles or arcs<br>\
+- Click this tool");
     sWhatsThis      = "TechDraw_ExtensionCircleCenterLines";
-    sStatusTip      = sToolTipText;
+    sStatusTip      = sMenuText;
     sPixmap         = "TechDraw_ExtensionCircleCenterLines";
 }
 
@@ -275,14 +275,13 @@ CmdTechDrawExtensionCircleCenterLinesGroup::CmdTechDrawExtensionCircleCenterLine
 {
     sAppModule      = "TechDraw";
     sGroup          = QT_TR_NOOP("TechDraw");
-    sMenuText       = QT_TR_NOOP("Insert Circle Center Line");
-    sToolTipText    = QT_TR_NOOP("Draw circle center line cross at circles\n\
-    - pick favoured line attributes\n\
-    - select many circles or arcs\n\
-    - click this button");
+    sMenuText       = QT_TR_NOOP("Add Circle Centerlines");
+    sToolTipText    = QT_TR_NOOP("Add centerlines to circles and arcs:<br>\
+- Specify the line attributes (optional)<br>\
+- Select one or more circles or arcs<br>\
+- Click this tool");
     sWhatsThis      = "TechDraw_ExtensionCircleCenterLinesGroup";
-    sStatusTip      = sToolTipText;
-
+    sStatusTip      = sMenuText;
 }
 
 void CmdTechDrawExtensionCircleCenterLinesGroup::activated(int iMsg) {
@@ -296,10 +295,10 @@ void CmdTechDrawExtensionCircleCenterLinesGroup::activated(int iMsg) {
     Gui::ActionGroup* pcAction = qobject_cast<Gui::ActionGroup*>(_pcAction);
     pcAction->setIcon(pcAction->actions().at(iMsg)->icon());
     switch (iMsg) {
-    case 0:                 //circle center lines
+    case 0:                 //circle centerlines
         execCircleCenterLines(this);
         break;
-    case 1:                 //bolt circle center lines
+    case 1:                 //bolt circle centerlines
         execHoleCircle(this);
         break;
     default:
@@ -342,21 +341,21 @@ void CmdTechDrawExtensionCircleCenterLinesGroup::languageChange()
     QList<QAction*> a = pcAction->actions();
 
     QAction* arc1 = a[0];
-    arc1->setText(QApplication::translate("TechDraw_Extension", "Add Centerlines to Circles"));
-    arc1->setToolTip(QApplication::translate("TechDraw_Extension",
-        "Draw circle center line cross at circles\n\
-    - pick favoured line attributes\n\
-    - select many circles or arcs\n\
-    - click this button"));
-    arc1->setStatusTip(arc1->toolTip());
+    arc1->setText(QApplication::translate("CmdTechDrawExtensionCircleCenterLines", "Add Circle Centerlines"));
+    arc1->setToolTip(QApplication::translate("CmdTechDrawExtensionCircleCenterLines",
+"Add centerlines to circles and arcs:<br>\
+- Specify the line attributes (optional)<br>\
+- Select one or more circles or arcs<br>\
+- Click this tool"));
+    arc1->setStatusTip(arc1->text());
     QAction* arc2 = a[1];
-    arc2->setText(QApplication::translate("TechDraw_Extension", "Add Centerlines to Boltcircle"));
-    arc2->setToolTip(QApplication::translate("TechDraw_Extension",
-        "Draw the centerlines of a bolt circle\n\
-    - pick favoured line attributes\n\
-    - select at least three circles of a bolt circle\n\
-    - click this buttone"));
-    arc2->setStatusTip(arc2->toolTip());
+    arc2->setText(QApplication::translate("CmdTechDrawExtensionHoleCircle", "Add Bolt Circle Centerlines"));
+    arc2->setToolTip(QApplication::translate("CmdTechDrawExtensionHoleCircle",
+"Add centerlines to a circular pattern of circles:<br>\
+- Specify the line attributes (optional)<br>\
+- Select three or more circles forming a circular pattern<br>\
+- Click this tool"));
+    arc2->setStatusTip(arc2->text());
 }
 
 bool CmdTechDrawExtensionCircleCenterLinesGroup::isActive(void)
@@ -371,12 +370,12 @@ bool CmdTechDrawExtensionCircleCenterLinesGroup::isActive(void)
 //===========================================================================
 
 void execThreadHoleSide(Gui::Command* cmd) {
-    // create symbolic thread in a hole seen from side
+    // add cosmetic thread to side view of hole
     std::vector<Gui::SelectionObject> selection;
     TechDraw::DrawViewPart* objFeat;
     if (!_checkSel(cmd, selection, objFeat, "TechDraw Thread Hole Side"))
         return;
-    Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Thread Hole Side"));
+    Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Cosmetic Thread Hole Side"));
     const std::vector<std::string> SubNames = selection[0].getSubNames();
     if (SubNames.size() >= 2) {
         _createThreadLines(SubNames, objFeat, 1.176f);
@@ -394,13 +393,13 @@ CmdTechDrawExtensionThreadHoleSide::CmdTechDrawExtensionThreadHoleSide()
 {
     sAppModule      = "TechDraw";
     sGroup          = QT_TR_NOOP("TechDraw");
-    sMenuText       = QT_TR_NOOP("Cosmetic thread hole side view");
-    sToolTipText    = QT_TR_NOOP("Draw cosmetic thread hole side view\n\
-    - pick favoured line attributes\n\
-    - select two parallel lines\n\
-    - click this button");
+    sMenuText       = QT_TR_NOOP("Add Cosmetic Thread Hole Side View");
+    sToolTipText    = QT_TR_NOOP("Add a cosmetic thread to the side view of a hole:<br>\
+- Specify the line attributes (optional)<br>\
+- Select two parallel lines<br>\
+- Click this tool");
     sWhatsThis      = "TechDraw_ExtensionThreadHoleSide";
-    sStatusTip      = sToolTipText;
+    sStatusTip      = sMenuText;
     sPixmap         = "TechDraw_ExtensionThreadHoleSide";
 }
 
@@ -422,12 +421,12 @@ bool CmdTechDrawExtensionThreadHoleSide::isActive(void)
 //===========================================================================
 
 void execThreadBoltSide(Gui::Command* cmd) {
-    // create symbolic thread at a bolt seen from side
+    // add cosmetic thread to side view of bolt
     std::vector<Gui::SelectionObject> selection;
     TechDraw::DrawViewPart* objFeat;
     if (!_checkSel(cmd, selection, objFeat, "TechDraw Thread Bolt Side"))
         return;
-    Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Thread Bolt Side"));
+    Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Cosmetic Thread Bolt Side"));
     const std::vector<std::string> SubNames = selection[0].getSubNames();
     if (SubNames.size() >= 2) {
         _createThreadLines(SubNames, objFeat, 0.85f);
@@ -445,13 +444,13 @@ CmdTechDrawExtensionThreadBoltSide::CmdTechDrawExtensionThreadBoltSide()
 {
     sAppModule      = "TechDraw";
     sGroup          = QT_TR_NOOP("TechDraw");
-    sMenuText       = QT_TR_NOOP("Cosmetic thread bolt side view");
-    sToolTipText    = QT_TR_NOOP("Thread Screw/pin/shaft side view/section\n\
-    - pick favoured line attributes\n\
-    - select two parallel lines\n\
-    - click this button");
+    sMenuText       = QT_TR_NOOP("Add Cosmetic Thread Bolt Side View");
+    sToolTipText    = QT_TR_NOOP("Add a cosmetic thread to the side view of a bolt/screw/rod:<br>\
+- Specify the line attributes (optional)<br>\
+- Select two parallel lines<br>\
+- Click this tool");
     sWhatsThis      = "TechDraw_ExtensionThreadBoltSide";
-    sStatusTip      = sToolTipText;
+    sStatusTip      = sMenuText;
     sPixmap         = "TechDraw_ExtensionThreadBoltSide";
 }
 
@@ -473,12 +472,12 @@ bool CmdTechDrawExtensionThreadBoltSide::isActive(void)
 //===========================================================================
 
 void execThreadHoleBottom(Gui::Command* cmd) {
-    // create symbolic thread in a hole seen from bottom
+    // add cosmetic thread to bottom view of hole
     std::vector<Gui::SelectionObject> selection;
     TechDraw::DrawViewPart* objFeat;
     if (!_checkSel(cmd, selection, objFeat, "TechDraw Thread Hole Bottom"))
         return;
-    Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Thread Hole Bottom"));
+    Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Cosmetic Thread Hole Bottom"));
     const std::vector<std::string> SubNames = selection[0].getSubNames();
     for (std::string Name : SubNames) {
         _createThreadCircle(Name, objFeat, 1.177f);
@@ -496,13 +495,13 @@ CmdTechDrawExtensionThreadHoleBottom::CmdTechDrawExtensionThreadHoleBottom()
 {
     sAppModule      = "TechDraw";
     sGroup          = QT_TR_NOOP("TechDraw");
-    sMenuText       = QT_TR_NOOP("Cosmetic hole thread ground view");
-    sToolTipText    = QT_TR_NOOP("Draw cosmetic hole threads ground view\n\
-    - pick favoured line attributes\n\
-    - select many circles\n\
-    - click this button");
+    sMenuText       = QT_TR_NOOP("Add Cosmetic Thread Hole Bottom View");
+    sToolTipText    = QT_TR_NOOP("Add a cosmetic thread to the top or bottom view of holes:<br>\
+- Specify the line attributes (optional)<br>\
+- Select one or more circles<br>\
+- Click this tool");
     sWhatsThis      = "TechDraw_ExtensionThreadHoleBottom";
-    sStatusTip      = sToolTipText;
+    sStatusTip      = sMenuText;
     sPixmap         = "TechDraw_ExtensionThreadHoleBottom";
 }
 
@@ -524,12 +523,12 @@ bool CmdTechDrawExtensionThreadHoleBottom::isActive(void)
 //===========================================================================
 
 void execThreadBoltBottom(Gui::Command* cmd) {
-    // create symbolic thread at a bolt seen from bottom
+    // add cosmetic thread to bottom view of bolt
     std::vector<Gui::SelectionObject> selection;
     TechDraw::DrawViewPart* objFeat;
     if (!_checkSel(cmd, selection, objFeat, "TechDraw Thread Bolt Bottom"))
         return;
-    Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Thread Bolt Bottom"));
+    Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Cosmetic Thread Bolt Bottom"));
     const std::vector<std::string> SubNames = selection[0].getSubNames();
     for (std::string Name : SubNames) {
         _createThreadCircle(Name, objFeat, 0.85f);
@@ -547,13 +546,13 @@ CmdTechDrawExtensionThreadBoltBottom::CmdTechDrawExtensionThreadBoltBottom()
 {
     sAppModule      = "TechDraw";
     sGroup          = QT_TR_NOOP("TechDraw");
-    sMenuText       = QT_TR_NOOP("Screw/pin/shaft thread in plan");
-    sToolTipText    = QT_TR_NOOP("Draw the technical symbol of the thread in the screw/pin/shaft plant\n\
-    - pick favoured line attributes\n\
-    - select many circles\n\
-    - click this button");
+    sMenuText       = QT_TR_NOOP("Add Cosmetic Thread Bolt Bottom View");
+    sToolTipText    = QT_TR_NOOP("Add a cosmetic thread to the top or bottom view of bolts/screws/rods:<br>\
+- Specify the line attributes (optional)<br>\
+- Select one or more circles<br>\
+- Click this tool");
     sWhatsThis      = "TechDraw_ExtensionThreadBoltBottom";
-    sStatusTip      = sToolTipText;
+    sStatusTip      = sMenuText;
     sPixmap         = "TechDraw_ExtensionThreadBoltBottom";
 }
 
@@ -581,13 +580,13 @@ CmdTechDrawExtensionThreadsGroup::CmdTechDrawExtensionThreadsGroup()
 {
     sAppModule      = "TechDraw";
     sGroup          = QT_TR_NOOP("TechDraw");
-    sMenuText       = QT_TR_NOOP("Cosmetic thread hole side view");
-    sToolTipText    = QT_TR_NOOP("Draw cosmetic thread hole side view\n\
-    - pick favoured line attributes\n\
-    - select two parallel lines\n\
-    - click this button");
+    sMenuText       = QT_TR_NOOP("Add Cosmetic Thread Hole Side View");
+    sToolTipText    = QT_TR_NOOP("Add a cosmetic thread to the side view of a hole:<br>\
+- Specify the line attributes (optional)<br>\
+- Select two parallel lines<br>\
+- Click this tool");
     sWhatsThis      = "TechDraw_ExtensionThreadsGroup";
-    sStatusTip      = sToolTipText;
+    sStatusTip      = sMenuText;
 }
 
 void CmdTechDrawExtensionThreadsGroup::activated(int iMsg)
@@ -663,37 +662,37 @@ void CmdTechDrawExtensionThreadsGroup::languageChange()
     QList<QAction*> a = pcAction->actions();
 
     QAction* arc1 = a[0];
-    arc1->setText(QApplication::translate("TechDraw_Extension", "Create Thread Hole Side View"));
-    arc1->setToolTip(QApplication::translate("TechDraw_Extension",
-        "Draw cosmetic thread hole side view\n\
-    - pick favoured line attributes\n\
-    - select two parallel lines\n\
-    - click this button"));
-    arc1->setStatusTip(arc1->toolTip());
+    arc1->setText(QApplication::translate("CmdTechDrawExtensionThreadHoleSide", "Add Cosmetic Thread Hole Side View"));
+    arc1->setToolTip(QApplication::translate("CmdTechDrawExtensionThreadHoleSide",
+"Add a cosmetic thread to the side view of a hole:<br>\
+- Specify the line attributes (optional)<br>\
+- Select two parallel lines<br>\
+- Click this tool"));
+    arc1->setStatusTip(arc1->text());
     QAction* arc2 = a[1];
-    arc2->setText(QApplication::translate("TechDraw_Extension", "Create Thread Hole Bottom View"));
-    arc2->setToolTip(QApplication::translate("TechDraw_Extension",
-        "Draw cosmetic hole threads ground view\n\
-    - pick favoured line attributes\n\
-    - select many circles\n\
-    - click this button"));
-    arc2->setStatusTip(arc2->toolTip());
+    arc2->setText(QApplication::translate("CmdTechDrawExtensionThreadHoleBottom", "Add Cosmetic Thread Hole Bottom View"));
+    arc2->setToolTip(QApplication::translate("CmdTechDrawExtensionThreadHoleBottom",
+"Add a cosmetic thread to the top or bottom view of holes:<br>\
+- Specify the line attributes (optional)<br>\
+- Select one or more circles<br>\
+- Click this tool"));
+    arc2->setStatusTip(arc2->text());
     QAction* arc3 = a[2];
-    arc3->setText(QApplication::translate("TechDraw_Extension", "Create Thread Bolt Side View"));
-    arc3->setToolTip(QApplication::translate("TechDraw_Extension",
-        "Thread Screw/pin/shaft side view/section\n\
-    - pick favoured line attributes\n\
-    - select two parallel lines\n\
-    - click this button"));
-    arc3->setStatusTip(arc3->toolTip());
+    arc3->setText(QApplication::translate("CmdTechDrawExtensionThreadBoltSide", "Add Cosmetic Thread Bolt Side View"));
+    arc3->setToolTip(QApplication::translate("CmdTechDrawExtensionThreadBoltSide",
+"Add a cosmetic thread to the side view of a bolt/screw/rod:<br>\
+- Specify the line attributes (optional)<br>\
+- Select two parallel lines<br>\
+- Click this tool"));
+    arc3->setStatusTip(arc3->text());
     QAction* arc4 = a[3];
-    arc4->setText(QApplication::translate("TechDraw_Extension", "Create Thread Bolt Bottom View"));
-    arc4->setToolTip(QApplication::translate("TechDraw_Extension",
-        "Draw the technical symbol of the thread in the screw/pin/shaft plant\n\
-    - pick favoured line attributes\n\
-    - select many circles\n\
-    - click this button"));
-    arc4->setStatusTip(arc4->toolTip());
+    arc4->setText(QApplication::translate("CmdTechDrawExtensionThreadBoltBottom", "Add Cosmetic Thread Bolt Bottom View"));
+    arc4->setToolTip(QApplication::translate("CmdTechDrawExtensionThreadBoltBottom",
+"Add a cosmetic thread to the top or bottom view of bolts/screws/rods:<br>\
+- Specify the line attributes (optional)<br>\
+- Select one or more circles<br>\
+- Click this tool"));
+    arc4->setStatusTip(arc4->text());
 }
 
 bool CmdTechDrawExtensionThreadsGroup::isActive(void)
@@ -714,12 +713,13 @@ CmdTechDrawExtensionSelectLineAttributes::CmdTechDrawExtensionSelectLineAttribut
 {
     sAppModule      = "TechDraw";
     sGroup          = QT_TR_NOOP("TechDraw");
-    sMenuText       = QT_TR_NOOP("Select line attributes");
-    sToolTipText    = QT_TR_NOOP("Select the line attributes\n\
-    - click this button\n\
-    - select line attributes in opened window");
+    sMenuText       = QT_TR_NOOP("Select Line Attributes and Cascade Spacing");
+    sToolTipText    = QT_TR_NOOP("Select the attributes for new cosmetic lines and centerlines, and specify the cascade spacing:<br>\
+- Click this tool<br>\
+- Specify the attributes and spacing in the dialog box<br>\
+- Press OK");
     sWhatsThis      = "TechDraw_ExtensionSelectLineAttributes";
-    sStatusTip      = sToolTipText;
+    sStatusTip      = sMenuText;
     sPixmap         = "TechDraw_ExtensionSelectLineAttributes";
 }
 
@@ -747,13 +747,13 @@ CmdTechDrawExtensionChangeLineAttributes::CmdTechDrawExtensionChangeLineAttribut
 {
     sAppModule      = "TechDraw";
     sGroup          = QT_TR_NOOP("TechDraw");
-    sMenuText       = QT_TR_NOOP("Change the line attributes");
-    sToolTipText    = QT_TR_NOOP("Change the attributes of selected lines\n\
-    - pick favoured line attributes\n\
-    - select many cosmetic or center lines\n\
-    - click this button");
+    sMenuText       = QT_TR_NOOP("Change Line Attributes");
+    sToolTipText    = QT_TR_NOOP("Change the attributes of cosmetic lines and centerlines:<br>\
+- Specify the line attributes (optional)<br>\
+- Select one or more lines<br>\
+- Click this tool");
     sWhatsThis      = "TechDraw_ExtensionChangeLineAttributes";
-    sStatusTip      = sToolTipText;
+    sStatusTip      = sMenuText;
     sPixmap         = "TechDraw_ExtensionChangeLineAttributes";
 }
 
@@ -806,12 +806,12 @@ CmdTechDrawExtensionVertexAtIntersection::CmdTechDrawExtensionVertexAtIntersecti
 {
     sAppModule      = "TechDraw";
     sGroup          = QT_TR_NOOP("TechDraw");
-    sMenuText       = QT_TR_NOOP("Create Vertex(es) at Intersection");
-    sToolTipText    = QT_TR_NOOP("Create the vertexes at intersection of lines\n\
-    - select two lines/circles/arcs\n\
-    - click this button");
+    sMenuText       = QT_TR_NOOP("Add Cosmetic Intersection Vertex(es)");
+    sToolTipText    = QT_TR_NOOP("Add cosmetic vertex(es) at the intersection(s) of selected edges:<br>\
+- Select two edges (lines, circles and/or arcs)<br>\
+- Click this tool");
     sWhatsThis      = "TechDraw_ExtensionVertexAtIntersection";
-    sStatusTip      = sToolTipText;
+    sStatusTip      = sMenuText;
     sPixmap         = "TechDraw_ExtensionVertexAtIntersection";
 }
 
@@ -821,9 +821,9 @@ void CmdTechDrawExtensionVertexAtIntersection::activated(int iMsg)
     //Base::Console().Message("VertexAtIntersection started\n");
     std::vector<Gui::SelectionObject> selection;
     TechDraw::DrawViewPart* objFeat;
-    if (!_checkSel(this, selection, objFeat, "TechDraw Create Vertex at Intersection"))
+    if (!_checkSel(this, selection, objFeat, "TechDraw Cosmetic Intersection Vertex(es)"))
         return;
-    Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Create Vertex at Intersection"));
+    Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Cosmetic Intersection Vertex(es)"));
     const std::vector<std::string> SubNames = selection[0].getSubNames();
     std::vector<Base::Vector3d> interPoints;
     if (SubNames.size() >= 2) {
@@ -867,9 +867,9 @@ void execDrawCosmArc(Gui::Command* cmd) {
     //draw a cosmetic arc of circle
     std::vector<Gui::SelectionObject> selection;
     TechDraw::DrawViewPart* objFeat;
-    if (!_checkSel(cmd, selection, objFeat, "TechDraw Draw Cosmetic Arc of Circle"))
+    if (!_checkSel(cmd, selection, objFeat, "TechDraw Cosmetic Arc"))
         return;
-    Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Draw Cosmetic Arc"));
+    Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Cosmetic Arc"));
     const std::vector<std::string> SubNames = selection[0].getSubNames();
     std::vector<Base::Vector3d> vertexPoints;
     vertexPoints = _getVertexPoints(SubNames, objFeat);
@@ -896,21 +896,22 @@ CmdTechDrawExtensionDrawCosmArc::CmdTechDrawExtensionDrawCosmArc()
 {
     sAppModule      = "TechDraw";
     sGroup          = QT_TR_NOOP("TechDraw");
-    sMenuText       = QT_TR_NOOP("Draw an cosmetic arc (center and two vertexes)");
-    sToolTipText    = QT_TR_NOOP("Draw an arc rotating math. positive\n\
-    - select three vertexes:\n\
-    - center, start, end\n\
-    - start defines the radius\n\
-    - click this button");
+    sMenuText       = QT_TR_NOOP("Add Cosmetic Arc");
+    sToolTipText    = QT_TR_NOOP("Add a cosmetic counter clockwise arc based on three vertexes:<br>\
+- Specify the line attributes (optional)<br>\
+- Select vertex 1 (center point)<br>\
+- Select vertex 2 (radius and start angle)<br>\
+- Select vertex 3 (end angle)<br>\
+- Click this tool");
     sWhatsThis      = "TechDraw_ExtensionDrawCosmArc";
-    sStatusTip      = sToolTipText;
+    sStatusTip      = sMenuText;
     sPixmap         = "TechDraw_ExtensionDrawCosmArc";
 }
 
 void CmdTechDrawExtensionDrawCosmArc::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-    //Base::Console().Message("Cosmetic Arc gestartet\n");
+    //Base::Console().Message("Cosmetic Arc started\n");
     execDrawCosmArc(this);
 }
 
@@ -929,9 +930,9 @@ void execDrawCosmCircle(Gui::Command* cmd) {
     //draw a cosmetic circle
     std::vector<Gui::SelectionObject> selection;
     TechDraw::DrawViewPart* objFeat;
-    if (!_checkSel(cmd, selection, objFeat, "TechDraw Draw Cosmetic Circle"))
+    if (!_checkSel(cmd, selection, objFeat, "TechDraw Cosmetic Circle"))
         return;
-    Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Draw Cosmetic Circle"));
+    Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Cosmetic Circle"));
     const std::vector<std::string> SubNames = selection[0].getSubNames();
     std::vector<Base::Vector3d> vertexPoints;
     vertexPoints = _getVertexPoints(SubNames, objFeat);
@@ -956,20 +957,21 @@ CmdTechDrawExtensionDrawCosmCircle::CmdTechDrawExtensionDrawCosmCircle()
 {
     sAppModule      = "TechDraw";
     sGroup          = QT_TR_NOOP("TechDraw");
-    sMenuText       = QT_TR_NOOP("Draw an cosmetic circumference (center and 1 vertex)");
-    sToolTipText    = QT_TR_NOOP("Draw a cosmetic circumference using two vertices\n\
-    - choose the line attributes\n\
-    - select the first vertex (center) -> in sequence the second (radius)\n\
-    - click this button");
+    sMenuText       = QT_TR_NOOP("Add Cosmetic Circle");
+    sToolTipText    = QT_TR_NOOP("Add a cosmetic circle based on two vertexes:<br>\
+- Specify the line attributes (optional)<br>\
+- Select vertex 1 (center point)<br>\
+- Select vertex 2 (radius)<br>\
+- Click this tool";
     sWhatsThis      = "TechDraw_ExtensionDrawCosmCircle";
-    sStatusTip      = sToolTipText;
+    sStatusTip      = sMenuText;
     sPixmap         = "TechDraw_ExtensionDrawCosmCircle";
 }
 
 void CmdTechDrawExtensionDrawCosmCircle::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-    //Base::Console().Message("Cosmetic Circle gestartet\n");
+    //Base::Console().Message("Cosmetic Circle started\n");
     execDrawCosmCircle(this);
 }
 
@@ -991,13 +993,14 @@ CmdTechDrawExtensionDrawCirclesGroup::CmdTechDrawExtensionDrawCirclesGroup()
 {
     sAppModule      = "TechDraw";
     sGroup          = QT_TR_NOOP("TechDraw");
-    sMenuText       = QT_TR_NOOP("Draw an cosmetic circumference (center and 1 vertex)");
-    sToolTipText    = QT_TR_NOOP("Draw a cosmetic circumference using two vertices\n\
-    - choose the line attributes\n\
-    - select the first vertex (center) -> in sequence the second (radius)\n\
-    - click this button");
+    sMenuText       = QT_TR_NOOP("Add Cosmetic Circle");
+    sToolTipText    = QT_TR_NOOP("Add a cosmetic circle based on two vertexes:<br>\
+- Specify the line attributes (optional)<br>\
+- Select vertex 1 (center point)<br>\
+- Select vertex 2 (radius)<br>\
+- Click this tool");
     sWhatsThis      = "TechDraw_ExtensionDrawCirclesGroup";
-    sStatusTip      = sToolTipText;
+    sStatusTip      = sMenuText;
 }
 
 void CmdTechDrawExtensionDrawCirclesGroup::activated(int iMsg)
@@ -1059,22 +1062,24 @@ void CmdTechDrawExtensionDrawCirclesGroup::languageChange()
     QList<QAction*> a = pcAction->actions();
 
     QAction* arc1 = a[0];
-    arc1->setText(QApplication::translate("TechDraw_Extension", "Draw Cosmetic Circle"));
-    arc1->setToolTip(QApplication::translate("TechDraw_Extension",
-        "Draw a cosmetic circumference using two vertices\n\
-    - choose the line attributes\n\
-    - select the first vertex (center) -> in sequence the second (radius)\n\
-    - click this button"));
-    arc1->setStatusTip(arc1->toolTip());
+    arc1->setText(QApplication::translate("CmdTechDrawExtensionDrawCosmCircle", "Add Cosmetic Circle"));
+    arc1->setToolTip(QApplication::translate("CmdTechDrawExtensionDrawCosmCircle",
+"Add a cosmetic circle based on two vertexes:<br>\
+- Specify the line attributes (optional)<br>\
+- Select vertex 1 (center point)<br>\
+- Select vertex 2 (radius)<br>\
+- Click this tool"));
+    arc1->setStatusTip(arc1->text());
     QAction* arc2 = a[1];
-    arc2->setText(QApplication::translate("TechDraw_Extension", "Draw Cosmetic Arc"));
-    arc2->setToolTip(QApplication::translate("TechDraw_Extension",
-        "Draw an arc rotating math. positive\n\
-    - select three vertexes:\n\
-    - center, start, end\n\
-    - start defines the radius\n\
-    - click this buttonc"));
-    arc2->setStatusTip(arc2->toolTip());
+    arc2->setText(QApplication::translate("CmdTechDrawExtensionDrawCosmArc", "Add Cosmetic Arc"));
+    arc2->setToolTip(QApplication::translate("CmdTechDrawExtensionDrawCosmArc",
+"Add a cosmetic counter clockwise arc based on three vertexes:<br>\
+- Specify the line attributes (optional)<br>\
+- Select vertex 1 (center point)<br>\
+- Select vertex 2 (radius and start angle)<br>\
+- Select vertex 3 (end angle)<br>\
+- Click this tool"));
+    arc2->setStatusTip(arc2->text());
 }
 
 bool CmdTechDrawExtensionDrawCirclesGroup::isActive(void)
@@ -1092,9 +1097,9 @@ void execLineParallelPerpendicular(Gui::Command* cmd, bool isParallel) {
     // create a line parallel or perpendicular to another line
     std::vector<Gui::SelectionObject> selection;
     TechDraw::DrawViewPart* objFeat;
-    if (!_checkSel(cmd, selection, objFeat, "TechDraw Create Line Parallel/Perpendicular"))
+    if (!_checkSel(cmd, selection, objFeat, "TechDraw Cosmetic Line Parallel/Perpendicular"))
         return;
-    Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Create Line Parallel/Perpendicular"));
+    Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Cosmetic Line Parallel/Perpendicular"));
     const std::vector<std::string> SubNames = selection[0].getSubNames();
     if (SubNames.size() >= 2) {
         std::string GeoType1 = TechDraw::DrawUtil::getGeomTypeFromName(SubNames[0]);
@@ -1137,14 +1142,13 @@ CmdTechDrawExtensionLineParallel::CmdTechDrawExtensionLineParallel()
 {
     sAppModule      = "TechDraw";
     sGroup          = QT_TR_NOOP("TechDraw");
-    sMenuText       = QT_TR_NOOP("Create a line parallel to another line");
-    sToolTipText    = QT_TR_NOOP("Create a line parallel to another line through a vertex\n\
-    - choose the line attributes\n\
-    - select one line\n\
-    - select one vertex\n\
-    - click this button");
+    sMenuText       = QT_TR_NOOP("Add Cosmetic Parallel Line");
+    sToolTipText    = QT_TR_NOOP("Add a cosmetic line parallel to another line through a vertex:<br>\
+- Select a line<br>\
+- Select a vertex<br>\
+- Click this tool");
     sWhatsThis      = "TechDraw_ExtensionLineParallel";
-    sStatusTip      = sToolTipText;
+    sStatusTip      = sMenuText;
     sPixmap         = "TechDraw_ExtensionLineParallel";
 }
 
@@ -1172,14 +1176,13 @@ CmdTechDrawExtensionLinePerpendicular::CmdTechDrawExtensionLinePerpendicular()
 {
     sAppModule      = "TechDraw";
     sGroup          = QT_TR_NOOP("TechDraw");
-    sMenuText       = QT_TR_NOOP("Create a line perpendicular to another line");
-    sToolTipText    = QT_TR_NOOP("Create a line perpendicular to another line through a vertex\n\
-    - choose the line attributes\n\
-    - select one line\n\
-    - select one vertex\n\
-    - click this button");
+    sMenuText       = QT_TR_NOOP("Add Cosmetic Perpendicular Line");
+    sToolTipText    = QT_TR_NOOP("Add a cosmetic line perpendicular to another line through a vertex:<br>\
+- Select a line<br>\
+- Select a vertex<br>\
+- Click this tool");
     sWhatsThis      = "TechDraw_ExtensionLinePerpendicular";
-    sStatusTip      = sToolTipText;
+    sStatusTip      = sMenuText;
     sPixmap         = "TechDraw_ExtensionLinePerpendicular";
 }
 
@@ -1207,14 +1210,13 @@ CmdTechDrawExtensionLinePPGroup::CmdTechDrawExtensionLinePPGroup()
 {
     sAppModule      = "TechDraw";
     sGroup          = QT_TR_NOOP("TechDraw");
-    sMenuText       = QT_TR_NOOP("Create a line parallel to another line");
-    sToolTipText    = QT_TR_NOOP("Create a line parallel to another line through a vertex\n\
-    - choose the line attributes\n\
-    - select one line\n\
-    - select one vertex\n\
-    - click this button");
+    sMenuText       = QT_TR_NOOP("Add Cosmetic Parallel Line");
+    sToolTipText    = QT_TR_NOOP("Add a cosmetic line parallel to another line through a vertex:<br>\
+- Select a line<br>\
+- Select a vertex<br>\
+- Click this tool");
     sWhatsThis      = "TechDraw_ExtensionLinePPGroup";
-    sStatusTip      = sToolTipText;
+    sStatusTip      = sMenuText;
 }
 
 void CmdTechDrawExtensionLinePPGroup::activated(int iMsg)
@@ -1276,23 +1278,21 @@ void CmdTechDrawExtensionLinePPGroup::languageChange()
     QList<QAction*> a = pcAction->actions();
 
     QAction* arc1 = a[0];
-    arc1->setText(QApplication::translate("TechDraw_Extension", "Create parallel Line"));
-    arc1->setToolTip(QApplication::translate("TechDraw_Extension",
-        "Create a line parallel to another line through a vertex\n\
-    - choose the line attributes\n\
-    - select one line\n\
-    - select one vertex\n\
-    - click this button"));
-    arc1->setStatusTip(arc1->toolTip());
+    arc1->setText(QApplication::translate("CmdTechDrawExtensionLineParallel", "Add Cosmetic Parallel Line"));
+    arc1->setToolTip(QApplication::translate("CmdTechDrawExtensionLineParallel",
+"Add a cosmetic line parallel to another line through a vertex:<br>\
+- Select a line<br>\
+- Select a vertex<br>\
+- Click this tool"));
+    arc1->setStatusTip(arc1->text());
     QAction* arc2 = a[1];
-    arc2->setText(QApplication::translate("TechDraw_Extension", "Create perpendicular Line"));
-    arc2->setToolTip(QApplication::translate("TechDraw_Extension",
-        "Create a line perpendicular to another line through a vertex\n\
-    - choose the line attributes\n\
-    - select one line\n\
-    - select one vertex\n\
-    - click this button"));
-    arc2->setStatusTip(arc2->toolTip());
+    arc2->setText(QApplication::translate("CmdTechDrawExtensionLinePerpendicular", "Add Cosmetic Perpendicular Line"));
+    arc2->setToolTip(QApplication::translate("CmdTechDrawExtensionLinePerpendicular",
+"Add a cosmetic line perpendicular to another line through a vertex:<br>\
+- Select a line<br>\
+- Select a vertex<br>\
+- Click this tool"));
+    arc2->setStatusTip(arc2->text());
 }
 
 bool CmdTechDrawExtensionLinePPGroup::isActive(void)
@@ -1313,12 +1313,12 @@ CmdTechDrawExtensionLockUnlockView::CmdTechDrawExtensionLockUnlockView()
 {
     sAppModule      = "TechDraw";
     sGroup          = QT_TR_NOOP("TechDraw");
-    sMenuText       = QT_TR_NOOP("Lock/Unlock a View");
-    sToolTipText    = QT_TR_NOOP("Lock/Unlock a View\n\
-    - select a view\n\
-    - click this button");
+    sMenuText       = QT_TR_NOOP("Lock/Unlock View");
+    sToolTipText    = QT_TR_NOOP("Lock or unlock the position of a view:<br>\
+- Select a single view<br>\
+- Click this tool");
     sWhatsThis      = "TechDraw_ExtensionLockUnlockView";
-    sStatusTip      = sToolTipText;
+    sStatusTip      = sMenuText;
     sPixmap         = "TechDraw_ExtensionLockUnlockView";
 }
 
@@ -1357,12 +1357,12 @@ CmdTechDrawExtensionPositionSectionView::CmdTechDrawExtensionPositionSectionView
 {
     sAppModule      = "TechDraw";
     sGroup          = QT_TR_NOOP("TechDraw");
-    sMenuText       = QT_TR_NOOP("Orthogonal projection group: section view positioning");
-    sToolTipText    = QT_TR_NOOP("Position a section view at same x or y as its base view\n\
-    - select a section view\n\
-    - click this button");
+    sMenuText       = QT_TR_NOOP("Position Section View");
+    sToolTipText    = QT_TR_NOOP("Orthogonally align a section view with its source view:<br>\
+- Select a single section view<br>\
+- Click this tool");
     sWhatsThis      = "TechDraw_ExtensionPositionSectionView";
-    sStatusTip      = sToolTipText;
+    sStatusTip      = sMenuText;
     sPixmap         = "TechDraw_ExtensionPositionSectionView";
 }
 
@@ -1373,7 +1373,7 @@ void CmdTechDrawExtensionPositionSectionView::activated(int iMsg) {
     auto selection = getSelection().getSelectionEx();
     if (selection.empty()) {
         QMessageBox::warning(Gui::getMainWindow(),
-            QObject::tr("TechDraw Lock/Unlock View"),
+            QObject::tr("TechDraw Position Section View"),
             QObject::tr("Selection is empty"));
         return;
     }
@@ -1415,12 +1415,12 @@ bool CmdTechDrawExtensionPositionSectionView::isActive(void)
 //===========================================================================
 
 void execExtendShortenLine(Gui::Command* cmd, bool extend) {
-    // extend or shorten a cosmetic or a center line
+    // extend or shorten a cosmetic line or a centerline
     std::vector<Gui::SelectionObject> selection;
     TechDraw::DrawViewPart* objFeat;
-    if (!_checkSel(cmd, selection, objFeat, "TechDraw Extend/shorten a Line"))
+    if (!_checkSel(cmd, selection, objFeat, "TechDraw Extend/Shorten Line"))
         return;
-    Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Extend/shorten a Line"));
+    Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Extend/Shorten Line"));
     const std::vector<std::string> subNames = selection[0].getSubNames();
     if (!subNames.empty()) {
         std::string name = subNames[0];
@@ -1490,12 +1490,12 @@ CmdTechDrawExtensionExtendLine::CmdTechDrawExtensionExtendLine()
 {
     sAppModule      = "TechDraw";
     sGroup          = QT_TR_NOOP("TechDraw");
-    sMenuText       = QT_TR_NOOP("Extend a Line");
-    sToolTipText    = QT_TR_NOOP("Extend a line at both ends\n\
-    - select one cosmetic or centerline\n\
-    - click this button");
+    sMenuText       = QT_TR_NOOP("Extend Line");
+    sToolTipText    = QT_TR_NOOP("Extend a cosmetic line or centerline at both ends:<br>\
+- Select a single line<br>\
+- Click this tool");
     sWhatsThis      = "TechDraw_ExtensionExtendLine";
-    sStatusTip      = sToolTipText;
+    sStatusTip      = sMenuText;
     sPixmap         = "TechDraw_ExtensionExtendLine";
 }
 
@@ -1524,12 +1524,12 @@ CmdTechDrawExtensionShortenLine::CmdTechDrawExtensionShortenLine()
 {
     sAppModule      = "TechDraw";
     sGroup          = QT_TR_NOOP("TechDraw");
-    sMenuText       = QT_TR_NOOP("Shorten a Line");
-    sToolTipText    = QT_TR_NOOP("Shorten a line at both ends\n\
-    - select one cosmetic or centerline\n\
-    - click this button");
+    sMenuText       = QT_TR_NOOP("Shorten Line");
+    sToolTipText    = QT_TR_NOOP("Shorten a cosmetic line or centerline at both ends:<br>\
+- Select a single line<br>\
+- Click this tool");
     sWhatsThis      = "TechDraw_ExtensionShortenLine";
-    sStatusTip      = sToolTipText;
+    sStatusTip      = sMenuText;
     sPixmap         = "TechDraw_ExtensionShortenLine";
 }
 
@@ -1558,12 +1558,12 @@ CmdTechDrawExtendShortenLineGroup::CmdTechDrawExtendShortenLineGroup()
 {
     sAppModule      = "TechDraw";
     sGroup          = QT_TR_NOOP("TechDraw");
-    sMenuText       = QT_TR_NOOP("Extend a Line");
-    sToolTipText    = QT_TR_NOOP("Extend a line at both ends\n\
-    - select one cosmetic or centerline\n\
-    - click this button");
+    sMenuText       = QT_TR_NOOP("Extend Line");
+    sToolTipText    = QT_TR_NOOP("Extend a cosmetic line or centerline at both ends:<br>\
+- Select a single line<br>\
+- Click this tool");
     sWhatsThis      = "TechDraw_ExtensionExtendShortenLineGroup";
-    sStatusTip      = sToolTipText;
+    sStatusTip      = sMenuText;
 }
 
 void CmdTechDrawExtendShortenLineGroup::activated(int iMsg)
@@ -1625,19 +1625,19 @@ void CmdTechDrawExtendShortenLineGroup::languageChange()
     QList<QAction*> a = pcAction->actions();
 
     QAction* arc1 = a[0];
-    arc1->setText(QApplication::translate("TechDraw_Extension", "Extend a Line"));
-    arc1->setToolTip(QApplication::translate("TechDraw_Extension",
-        "Extend a line at both ends\n\
-    - select one cosmetic or centerline\n\
-    - click this button"));
-    arc1->setStatusTip(arc1->toolTip());
+    arc1->setText(QApplication::translate("CmdTechDrawExtensionExtendLine", "Extend Line"));
+    arc1->setToolTip(QApplication::translate("CmdTechDrawExtensionExtendLine",
+"Extend a cosmetic line or centerline at both ends:<br>\
+- Select a single line<br>\
+- Click this tool"));
+    arc1->setStatusTip(arc1->text());
     QAction* arc2 = a[1];
-    arc2->setText(QApplication::translate("TechDraw_Extension", "Shorten a Line"));
-    arc2->setToolTip(QApplication::translate("TechDraw_Extension",
-        "Shorten a line at both ends\n\
-    - select one cosmetic or centerline\n\
-    - click this button"));
-    arc2->setStatusTip(arc2->toolTip());
+    arc2->setText(QApplication::translate("CmdTechDrawExtensionShortenLine", "Shorten Line"));
+    arc2->setToolTip(QApplication::translate("CmdTechDrawExtensionShortenLine",
+"Shorten a cosmetic line or centerline at both ends:<br>\
+- Select a single line<br>\
+- Click this tool"));
+    arc2->setStatusTip(arc2->text());
 }
 
 bool CmdTechDrawExtendShortenLineGroup::isActive(void)

--- a/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp
+++ b/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp
@@ -1492,6 +1492,7 @@ CmdTechDrawExtensionExtendLine::CmdTechDrawExtensionExtendLine()
     sGroup          = QT_TR_NOOP("TechDraw");
     sMenuText       = QT_TR_NOOP("Extend Line");
     sToolTipText    = QT_TR_NOOP("Extend a cosmetic line or centerline at both ends:<br>\
+- Specify the delta distance (optional)<br>\
 - Select a single line<br>\
 - Click this tool");
     sWhatsThis      = "TechDraw_ExtensionExtendLine";
@@ -1526,6 +1527,7 @@ CmdTechDrawExtensionShortenLine::CmdTechDrawExtensionShortenLine()
     sGroup          = QT_TR_NOOP("TechDraw");
     sMenuText       = QT_TR_NOOP("Shorten Line");
     sToolTipText    = QT_TR_NOOP("Shorten a cosmetic line or centerline at both ends:<br>\
+- Specify the delta distance (optional)<br>\
 - Select a single line<br>\
 - Click this tool");
     sWhatsThis      = "TechDraw_ExtensionShortenLine";
@@ -1560,6 +1562,7 @@ CmdTechDrawExtendShortenLineGroup::CmdTechDrawExtendShortenLineGroup()
     sGroup          = QT_TR_NOOP("TechDraw");
     sMenuText       = QT_TR_NOOP("Extend Line");
     sToolTipText    = QT_TR_NOOP("Extend a cosmetic line or centerline at both ends:<br>\
+- Specify the delta distance (optional)<br>\
 - Select a single line<br>\
 - Click this tool");
     sWhatsThis      = "TechDraw_ExtensionExtendShortenLineGroup";
@@ -1628,6 +1631,7 @@ void CmdTechDrawExtendShortenLineGroup::languageChange()
     arc1->setText(QApplication::translate("CmdTechDrawExtensionExtendLine", "Extend Line"));
     arc1->setToolTip(QApplication::translate("CmdTechDrawExtensionExtendLine",
 "Extend a cosmetic line or centerline at both ends:<br>\
+- Specify the delta distance (optional)<br>\
 - Select a single line<br>\
 - Click this tool"));
     arc1->setStatusTip(arc1->text());
@@ -1635,6 +1639,7 @@ void CmdTechDrawExtendShortenLineGroup::languageChange()
     arc2->setText(QApplication::translate("CmdTechDrawExtensionShortenLine", "Shorten Line"));
     arc2->setToolTip(QApplication::translate("CmdTechDrawExtensionShortenLine",
 "Shorten a cosmetic line or centerline at both ends:<br>\
+- Specify the delta distance (optional)<br>\
 - Select a single line<br>\
 - Click this tool"));
     arc2->setStatusTip(arc2->text());

--- a/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp
+++ b/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp
@@ -962,7 +962,7 @@ CmdTechDrawExtensionDrawCosmCircle::CmdTechDrawExtensionDrawCosmCircle()
 - Specify the line attributes (optional)<br>\
 - Select vertex 1 (center point)<br>\
 - Select vertex 2 (radius)<br>\
-- Click this tool";
+- Click this tool");
     sWhatsThis      = "TechDraw_ExtensionDrawCosmCircle";
     sStatusTip      = sMenuText;
     sPixmap         = "TechDraw_ExtensionDrawCosmCircle";

--- a/src/Mod/TechDraw/Gui/Workbench.cpp
+++ b/src/Mod/TechDraw/Gui/Workbench.cpp
@@ -363,6 +363,8 @@ Gui::ToolBarItem* Workbench::setupCommandBars() const
     *views << "TechDraw_DetailView";
     *views << "TechDraw_DraftView";
     *views << "TechDraw_SpreadsheetView";
+    *views << "TechDraw_MoveView";
+    *views << "TechDraw_CopyView";
 
     Gui::ToolBarItem *clips = new Gui::ToolBarItem(root);
     clips->setCommand("TechDraw Clips");

--- a/src/Mod/TechDraw/Gui/Workbench.cpp
+++ b/src/Mod/TechDraw/Gui/Workbench.cpp
@@ -232,7 +232,6 @@ Gui::ToolBarItem* Workbench::setupToolBars() const
     *views << "TechDraw_MoveView";
     *views << "TechDraw_CopyView";
 
-
     Gui::ToolBarItem *clips = new Gui::ToolBarItem(root);
     clips->setCommand("TechDraw Clips");
     *clips << "TechDraw_ClipGroup";
@@ -259,12 +258,12 @@ Gui::ToolBarItem* Workbench::setupToolBars() const
     Gui::ToolBarItem *extattribs = new Gui::ToolBarItem(root);
     extattribs->setCommand("TechDraw Attributes");
     *extattribs << "TechDraw_ExtensionSelectLineAttributes";
+    *extattribs << "TechDraw_ExtensionChangeLineAttributes";
     *extattribs << "TechDraw_ExtensionExtendShortenLineGroup";
 //    *extattribs << "TechDraw_ExtensionExtendLine";
 //    *extattribs << "TechDraw_ExtensionShortenLine";
     *extattribs << "TechDraw_ExtensionLockUnlockView";
     *extattribs << "TechDraw_ExtensionPositionSectionView";
-    *extattribs << "TechDraw_ExtensionChangeLineAttributes";
     *extattribs << "TechDraw_ExtensionPosChainDimensionGroup";
 //    *extattribs << "TechDraw_ExtensionPosHorizChainDimension";
 //    *extattribs << "TechDraw_ExtensionPosVertChainDimension";
@@ -279,6 +278,11 @@ Gui::ToolBarItem* Workbench::setupToolBars() const
     *extcenter << "TechDraw_ExtensionCircleCenterLinesGroup";
 //    *extcenter << "TechDraw_ExtensionCircleCenterLines";
 //    *extcenter << "TechDraw_ExtensionHoleCircle";
+    *extcenter << "TechDraw_ExtensionThreadsGroup";
+//    *extcenter << "TechDraw_ExtensionThreadHoleSide";
+//    *extcenter << "TechDraw_ExtensionThreadHoleBottom";
+//    *extcenter << "TechDraw_ExtensionThreadBoltSide";
+//    *extcenter << "TechDraw_ExtensionThreadBoltBottom";
     *extcenter << "TechDraw_ExtensionVertexAtIntersection";
     *extcenter << "TechDraw_ExtensionDrawCirclesGroup";
 //    *extcenter << "TechDraw_ExtensionDrawCosmCircle";
@@ -286,17 +290,9 @@ Gui::ToolBarItem* Workbench::setupToolBars() const
     *extcenter << "TechDraw_ExtensionLinePPGroup";
 //    *extcenter << "TechDraw_ExtensionLineParallel";
 //    *extcenter << "TechDraw_ExtensionLinePerpendicular";
-    *extcenter << "TechDraw_ExtensionThreadsGroup";
-//    *extcenter << "TechDraw_ExtensionThreadHoleSide";
-//    *extcenter << "TechDraw_ExtensionThreadHoleBottom";
-//    *extcenter << "TechDraw_ExtensionThreadBoltSide";
-//    *extcenter << "TechDraw_ExtensionThreadBoltBottom";
 
     Gui::ToolBarItem *extdimensions = new Gui::ToolBarItem(root);
     extdimensions->setCommand("TechDraw Extend Dimensions");
-    *extdimensions << "TechDraw_ExtensionInsertPrefixGroup";
-//    *extdimensions << "TechDraw_ExtensionInsertDiameter";
-//    *extdimensions << "TechDraw_ExtensionInsertSquare";
     *extdimensions << "TechDraw_ExtensionCreateChainDimensionGroup";
 //    *extdimensions << "TechDraw_ExtensionCreateHorizChainDimension";
 //    *extdimensions << "TechDraw_ExtensionCreateVertChainDimension";
@@ -309,6 +305,9 @@ Gui::ToolBarItem* Workbench::setupToolBars() const
 //    *extdimensions << "TechDraw_ExtensionCreateHorizChamferDimension";
 //    *extdimensions << "TechDraw_ExtensionCreateVertChamferDimension";
     *extdimensions << "TechDraw_ExtensionCreateLengthArc";
+    *extdimensions << "TechDraw_ExtensionInsertPrefixGroup";
+//    *extdimensions << "TechDraw_ExtensionInsertDiameter";
+//    *extdimensions << "TechDraw_ExtensionInsertSquare";
     *extdimensions << "TechDraw_ExtensionIncreaseDecreaseGroup";
 //    *extdimensions << "TechDraw_ExtensionIncreaseDecimal";
 //    *extdimensions << "TechDraw_ExtensionDecreaseDecimal";

--- a/src/Mod/TechDraw/Gui/Workbench.cpp
+++ b/src/Mod/TechDraw/Gui/Workbench.cpp
@@ -40,7 +40,7 @@ using namespace TechDrawGui;
     qApp->translate("Workbench", "Extensions: Dimensions");
     qApp->translate("Workbench", "Annotations");
     qApp->translate("Workbench", "Add Lines");
-    qApp->translate("Workbench", "Add Vertices");    
+    qApp->translate("Workbench", "Add Vertices");
     qApp->translate("Workbench", "TechDraw");
     // Translations for View > Toolbars
     qApp->translate("Workbench", "TechDraw Pages");
@@ -112,8 +112,8 @@ Gui::MenuItem* Workbench::setupMenuBar() const
     *toolcenter << "TechDraw_ExtensionHoleCircle";
     *toolcenter << "Separator";
     *toolcenter << "TechDraw_ExtensionThreadHoleSide";
-    *toolcenter << "TechDraw_ExtensionThreadBoltSide";
     *toolcenter << "TechDraw_ExtensionThreadHoleBottom";
+    *toolcenter << "TechDraw_ExtensionThreadBoltSide";
     *toolcenter << "TechDraw_ExtensionThreadBoltBottom";
     *toolcenter << "Separator";
     *toolcenter << "TechDraw_ExtensionVertexAtIntersection";
@@ -363,9 +363,6 @@ Gui::ToolBarItem* Workbench::setupCommandBars() const
     *views << "TechDraw_DetailView";
     *views << "TechDraw_DraftView";
     *views << "TechDraw_SpreadsheetView";
-    *views << "TechDraw_MoveView";
-    *views << "TechDraw_CopyView";
-
 
     Gui::ToolBarItem *clips = new Gui::ToolBarItem(root);
     clips->setCommand("TechDraw Clips");
@@ -393,12 +390,12 @@ Gui::ToolBarItem* Workbench::setupCommandBars() const
     Gui::ToolBarItem *extattribs = new Gui::ToolBarItem(root);
     extattribs->setCommand("TechDraw Attributes");
     *extattribs << "TechDraw_ExtensionSelectLineAttributes";
+    *extattribs << "TechDraw_ExtensionChangeLineAttributes";
     *extattribs << "TechDraw_ExtensionExtendShortenLineGroup";
 //    *extattribs << "TechDraw_ExtensionExtendLine";
 //    *extattribs << "TechDraw_ExtensionShortenLine";
     *extattribs << "TechDraw_ExtensionLockUnlockView";
     *extattribs << "TechDraw_ExtensionPositionSectionView";
-    *extattribs << "TechDraw_ExtensionChangeLineAttributes";
     *extattribs << "TechDraw_ExtensionPosChainDimensionGroup";
 //    *extattribs << "TechDraw_ExtensionPosHorizChainDimension";
 //    *extattribs << "TechDraw_ExtensionPosVertChainDimension";
@@ -413,6 +410,11 @@ Gui::ToolBarItem* Workbench::setupCommandBars() const
     *extcenter << "TechDraw_ExtensionCircleCenterLinesGroup";
 //    *extcenter << "TechDraw_ExtensionCircleCenterLines";
 //    *extcenter << "TechDraw_ExtensionHoleCircle";
+    *extcenter << "TechDraw_ExtensionThreadsGroup";
+//    *extcenter << "TechDraw_ExtensionThreadHoleSide";
+//    *extcenter << "TechDraw_ExtensionThreadHoleBottom";
+//    *extcenter << "TechDraw_ExtensionThreadBoltSide";
+//    *extcenter << "TechDraw_ExtensionThreadBoltBottom";
     *extcenter << "TechDraw_ExtensionVertexAtIntersection";
     *extcenter << "TechDraw_ExtensionDrawCirclesGroup";
 //    *extcenter << "TechDraw_ExtensionDrawCosmCircle";
@@ -420,17 +422,9 @@ Gui::ToolBarItem* Workbench::setupCommandBars() const
     *extcenter << "TechDraw_ExtensionLinePPGroup";
 //    *extcenter << "TechDraw_ExtensionLineParallel";
 //    *extcenter << "TechDraw_ExtensionLinePerpendicular";
-    *extcenter << "TechDraw_ExtensionThreadsGroup";
-//    *extcenter << "TechDraw_ExtensionThreadHoleSide";
-//    *extcenter << "TechDraw_ExtensionThreadHoleBottom";
-//    *extcenter << "TechDraw_ExtensionThreadBoltSide";
-//    *extcenter << "TechDraw_ExtensionThreadBoltBottom";
 
     Gui::ToolBarItem *extdimensions = new Gui::ToolBarItem(root);
     extdimensions->setCommand("TechDraw Extend Dimensions");
-    *extdimensions << "TechDraw_ExtensionInsertPrefixGroup";
-//    *extdimensions << "TechDraw_ExtensionInsertDiameter";
-//    *extdimensions << "TechDraw_ExtensionInsertSquare";
     *extdimensions << "TechDraw_ExtensionCreateChainDimensionGroup";
 //    *extdimensions << "TechDraw_ExtensionCreateHorizChainDimension";
 //    *extdimensions << "TechDraw_ExtensionCreateVertChainDimension";
@@ -443,6 +437,9 @@ Gui::ToolBarItem* Workbench::setupCommandBars() const
 //    *extdimensions << "TechDraw_ExtensionCreateHorizChamferDimension";
 //    *extdimensions << "TechDraw_ExtensionCreateVertChamferDimension";
     *extdimensions << "TechDraw_ExtensionCreateLengthArc";
+    *extdimensions << "TechDraw_ExtensionInsertPrefixGroup";
+//    *extdimensions << "TechDraw_ExtensionInsertDiameter";
+//    *extdimensions << "TechDraw_ExtensionInsertSquare";
     *extdimensions << "TechDraw_ExtensionIncreaseDecreaseGroup";
 //    *extdimensions << "TechDraw_ExtensionIncreaseDecimal";
 //    *extdimensions << "TechDraw_ExtensionDecreaseDecimal";


### PR DESCRIPTION
PR to make the GUI texts of the extension tools more consistent.

* Title case for all menu texts. This is consistent with most TechDraw menus.
* Linebreaks in tooltips should be `<br>`.
* Displaying the text of multiline tooltips in the statusbar does not work. So the menu text is now used for the statusbar text.

Additionally:
The order of the tools in the menu did not match the order in the toolbar. This was corrected.

Forum topic:
https://forum.freecadweb.org/viewtopic.php?f=35&t=65436

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

---
