### PR TITLE
Gui: Remove unused error message

### DIFF
--- a/src/Gui/DocumentPyImp.cpp
+++ b/src/Gui/DocumentPyImp.cpp
@@ -105,42 +105,45 @@ PyObject* DocumentPy::setEdit(PyObject *args)
 {
     char *psFeatStr;
     int mod = 0;
-    char *subname = 0;
-    ViewProvider *vp = 0;
-    App::DocumentObject *obj = 0;
+    char *subname = nullptr;
+    ViewProvider *vp = nullptr;
+    App::DocumentObject *obj = nullptr;
 
     // by name
-    if (PyArg_ParseTuple(args, "s|is;Name of the object to edit has to be given!", &psFeatStr,&mod,&subname)) {
+    if (PyArg_ParseTuple(args, "s|is", &psFeatStr,&mod,&subname)) {
         obj = getDocumentPtr()->getDocument()->getObject(psFeatStr);
         if (!obj) {
             PyErr_Format(Base::BaseExceptionFreeCADError, "No such object found in document: '%s'", psFeatStr);
-            return 0;
+            return nullptr;
         }
     }
     else {
         PyErr_Clear();
         PyObject *pyObj;
         if (!PyArg_ParseTuple(args, "O|is", &pyObj,&mod,&subname))
-            return 0;
+            return nullptr;
 
-        if (PyObject_TypeCheck(pyObj,&App::DocumentObjectPy::Type))
+        if (PyObject_TypeCheck(pyObj,&App::DocumentObjectPy::Type)) {
             obj = static_cast<App::DocumentObjectPy*>(pyObj)->getDocumentObjectPtr();
-        else if (PyObject_TypeCheck(pyObj,&ViewProviderPy::Type))
+        }
+        else if (PyObject_TypeCheck(pyObj,&ViewProviderPy::Type)) {
             vp = static_cast<ViewProviderPy*>(pyObj)->getViewProviderPtr();
+        }
         else {
-            PyErr_SetString(PyExc_TypeError,"Expect the first argument to be string|DocObject|ViewObject");
-            return 0;
+            PyErr_SetString(PyExc_TypeError,"Expect the first argument to be string, DocumentObject or ViewObject");
+            return nullptr;
         }
     }
 
     if (!vp) {
         if (!obj || !obj->getNameInDocument() || !(vp=Application::Instance->getViewProvider(obj))) {
             PyErr_SetString(PyExc_ValueError,"Invalid document object");
-            return 0;
+            return nullptr;
         }
     }
 
     bool ok = getDocumentPtr()->setEdit(vp,mod,subname);
+
     return PyBool_FromLong(ok ? 1 : 0);
 }
 


### PR DESCRIPTION
The error message is cleared by PyErr_Clear.
Some curly braces are added to if-else blocks.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [ ]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [ ]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [ ]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [ ]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
