### PR TITLE
Fix various typos

### DIFF
--- a/src/Mod/Draft/importDXF.py
+++ b/src/Mod/Draft/importDXF.py
@@ -3009,7 +3009,7 @@ def getSplineSegs(edge):
         It returns the point in `edge.FirstParameter`,
         all the intermediate points, and the point in `edge.LastParameter`.
 
-        If the `segmentlenth` variable is zero in the parameters database,
+        If the `segmentlength` variable is zero in the parameters database,
         then it only returns the first and the last point of the `edge`.
     """
     params = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Draft")

--- a/src/Mod/Path/PathScripts/PathDressupAxisMap.py
+++ b/src/Mod/Path/PathScripts/PathDressupAxisMap.py
@@ -79,7 +79,7 @@ class ObjectDressup:
         return None
 
     def _linear2angular(self, radius, length):
-        """returns an angular distance in degrees to achieve a linear move of a given lenth"""
+        """returns an angular distance in degrees to achieve a linear move of a given length"""
         circum = 2 * math.pi * float(radius)
         return 360 * (float(length) / circum)
 

--- a/src/Mod/Path/PathScripts/PathHelix.py
+++ b/src/Mod/Path/PathScripts/PathHelix.py
@@ -198,7 +198,7 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
             endPoint = FreeCAD.Vector(hole["x"], hole["y"], obj.FinalDepth.Value)
             args["edge"] = Part.makeLine(startPoint, endPoint)
 
-            # move to starting postion
+            # move to starting position
             self.commandlist.append(
                 Path.Command("G0", {"Z": obj.ClearanceHeight.Value})
             )


### PR DESCRIPTION
Found via `codespell -q 3 -L aci,ake,aline,alle,alledges,alocation,als,ang,anid,anormal,apoints,ba,beginn,behaviour,bloaded,bottome,byteorder,calculater,cancelled,cancelling,cas,cascade,centimetre,childrens,childs,colour,colours,commen,connexion,currenty,dof,doubleclick,dum,eiter,elemente,ende,feld,finde,findf,freez,hist,iff,indicies,initialisation,initialise,initialised,initialises,initialisiert,inout,ist,itsel,kilometre,lod,mantatory,methode,metres,millimetre,modell,nd,noe,normale,normaly,nto,numer,oce,oder,ontop,orgin,orginx,orginy,ot,pard,parm,parms,pres,programm,que,rady,recurrance,ro,rougly,seperator,serie,sinc,strack,substraction,te,technic,thist,thru,tread,uint,unter,vertexes,wallthickness,whitespaces -S ./.git,*.po,*.ts,./ChangeLog.txt,./src/3rdParty,./src/Mod/Assembly/App/opendcm,./src/CXX,./src/zipios++,./src/Base/swig*,./src/Mod/Robot/App/kdl_cp,./src/Mod/Import/App/SCL,./src/WindowsInstaller,./src/Doc/FreeCAD.uml,./build/doc/SourceDocu`