### PR TITLE
Addon Manager: Confirm delete

### DIFF
--- a/src/Mod/AddonManager/AddonManager.py
+++ b/src/Mod/AddonManager/AddonManager.py
@@ -1443,6 +1443,17 @@ class CommandAddonManager:
     def remove(self, repo: AddonManagerRepo) -> None:
         """uninstalls a macro or workbench"""
 
+        confirm = QtWidgets.QMessageBox.question(
+            self.dialog,
+            translate("AddonsInstaller", "Confirm remove"),
+            translate(
+                "AddonsInstaller", "Are you sure you want to uninstall this Addon?"
+            ),
+            QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.Cancel,
+        )
+        if confirm == QtWidgets.QMessageBox.Cancel:
+            return
+
         if (
             repo.repo_type == AddonManagerRepo.RepoType.WORKBENCH
             or repo.repo_type == AddonManagerRepo.RepoType.PACKAGE


### PR DESCRIPTION
Add a confirmation dialog before removing an addon (accidentally uninstalling Part Library would be very unfortunate, for example!).