### PR TITLE
Path: Path Array dressup compatibility

### DIFF
--- a/src/Mod/Path/PathScripts/PathArray.py
+++ b/src/Mod/Path/PathScripts/PathArray.py
@@ -25,6 +25,7 @@ import FreeCADGui
 import Path
 import PathScripts
 from PathScripts import PathLog
+from PathScripts.PathDressup import toolController
 from PySide import QtCore
 import math
 import random
@@ -280,7 +281,7 @@ class ObjectArray:
         if len(base) == 0:
             return
 
-        obj.ToolController = base[0].ToolController
+        obj.ToolController = toolController(base[0])
 
         # Do not generate paths and clear current Path data if operation not
         if not obj.Active:
@@ -381,9 +382,12 @@ class PathArray:
                 return
             if not b.Path:
                 return
-            if not b.ToolController:
+
+            b_tool_controller = toolController(b)
+            if not b_tool_controller:
                 return
-            if b.ToolController != base[0].ToolController:
+
+            if b_tool_controller != toolController(base[0]):
                 # this may be important if Job output is split by tool controller
                 PathLog.warning(
                     translate(
@@ -512,13 +516,8 @@ class CommandPathArray:
         }
 
     def IsActive(self):
-        if bool(FreeCADGui.Selection.getSelection()) is False:
-            return False
-        try:
-            obj = FreeCADGui.Selection.getSelectionEx()[0].Object
-            return isinstance(obj.Proxy, PathScripts.PathOp.ObjectOp)
-        except (IndexError, AttributeError):
-            return False
+        selections = [sel.isDerivedFrom("Path::Feature") for sel in FreeCADGui.Selection.getSelection()]
+        return selections and all(selections)
 
     def Activated(self):
 


### PR DESCRIPTION
This commit makes PathArray able to discover the original base feature ToolController recursively through (nested) dressups. I've hard capped the recursion depth limit to 10 to avoid possible issues with cyclic references (if such are possible?). 

I've tested this with a nested Tag Dressup -> Ramp Dressup -> Profile and it seems to work fine.

I'd appreciate further testing from other users. I've tested this (+ ran unit tests) with Linux weekly AppImage build 27078.

Wiki page will need to be updated once this goes live.

Some discussion on this limitation 
* https://forum.freecadweb.org/viewtopic.php?t=26120 (2018)
* https://forum.freecadweb.org/viewtopic.php?f=15&t=54766 (2021)

Wiki page (section Limitations)
* https://wiki.freecadweb.org/Path_Array