### PR TITLE
Arch: Fix ArchCutPlane translation issue

### DIFF
--- a/src/Mod/Arch/ArchCutPlane.py
+++ b/src/Mod/Arch/ArchCutPlane.py
@@ -76,9 +76,9 @@ def cutComponentwithPlane(archObject, cutPlane, sideFace):
 class _CommandCutLine:
     "the Arch CutPlane command definition"
     def GetResources(self):
-        return {'Pixmap': 'Arch_CutLine',
-                'MenuText': QtCore.QT_TRANSLATE_NOOP('Arch_CutLine', 'Cut with line'),
-                'ToolTip': QtCore.QT_TRANSLATE_NOOP('Arch_CutLine', 'Cut an object with a line')}
+        return {"Pixmap": "Arch_CutLine",
+                "MenuText": QtCore.QT_TRANSLATE_NOOP("Arch_CutLine", "Cut with line"),
+                "ToolTip": QtCore.QT_TRANSLATE_NOOP("Arch_CutLine", "Cut an object with a line")}
 
     def IsActive(self):
         return len(FreeCADGui.Selection.getSelection()) > 1

--- a/src/Mod/Arch/ArchCutPlane.py
+++ b/src/Mod/Arch/ArchCutPlane.py
@@ -76,9 +76,9 @@ def cutComponentwithPlane(archObject, cutPlane, sideFace):
 class _CommandCutLine:
     "the Arch CutPlane command definition"
     def GetResources(self):
-       return {'Pixmap'  : 'Arch_CutLine',
-                'MenuText': QtCore.QT_TRANSLATE_NOOP("Arch_CutPlane","Cut with a line"),
-                'ToolTip': QtCore.QT_TRANSLATE_NOOP("Arch_CutPlane","Cut an object with a line with normal workplane")}
+        return {'Pixmap': 'Arch_CutLine',
+                'MenuText': QtCore.QT_TRANSLATE_NOOP('Arch_CutLine', 'Cut with line'),
+                'ToolTip': QtCore.QT_TRANSLATE_NOOP('Arch_CutLine', 'Cut an object with a line')}
 
     def IsActive(self):
         return len(FreeCADGui.Selection.getSelection()) > 1


### PR DESCRIPTION
Fixed wrong context for the Arch_CutLine command.

Additionally:
tweaked the menu text and the tooltip of the command.

Forum topic:
https://forum.freecadweb.org/viewtopic.php?f=23&t=65346

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

---
