### PR TITLE
Draft: Fix several translation issues

### DIFF
--- a/src/Mod/Draft/DraftGui.py
+++ b/src/Mod/Draft/DraftGui.py
@@ -691,7 +691,7 @@ class DraftToolBar:
         self.autoGroupButton = self._pushbutton(
             "autoGroup", self.bottomtray,icon=":/icons/button_invalid.svg",
             hide=False, width=120)
-        self.autoGroupButton.setText("None")
+        self.autoGroupButton.setText(translate("draft", "None"))
         self.autoGroupButton.setFlat(True)
 
         QtCore.QObject.connect(self.wplabel,QtCore.SIGNAL("pressed()"),self.selectplane)
@@ -2044,7 +2044,7 @@ class DraftToolBar:
     def setAutoGroup(self,value=None):
         if value is None:
             self.autogroup = None
-            self.autoGroupButton.setText("None")
+            self.autoGroupButton.setText(translate("draft", "None"))
             self.autoGroupButton.setIcon(QtGui.QIcon.fromTheme('Draft_AutoGroup_off',
                                                                QtGui.QIcon(':/icons/button_invalid.svg')))
             self.autoGroupButton.setToolTip(translate("draft", "Autogroup off"))
@@ -2059,7 +2059,7 @@ class DraftToolBar:
                 self.autoGroupButton.setDown(False)
             else:
                 self.autogroup = None
-                self.autoGroupButton.setText("None")
+                self.autoGroupButton.setText(translate("draft", "None"))
                 self.autoGroupButton.setIcon(QtGui.QIcon.fromTheme('Draft_AutoGroup_off',
                                                                    QtGui.QIcon(':/icons/button_invalid.svg')))
                 self.autoGroupButton.setToolTip(translate("draft", "Autogroup off"))

--- a/src/Mod/Draft/draftguitools/gui_beziers.py
+++ b/src/Mod/Draft/draftguitools/gui_beziers.py
@@ -1,6 +1,4 @@
 # ***************************************************************************
-# *   (c) 2009 Yorik van Havre <yorik@uncreated.net>                        *
-# *   (c) 2010 Ken Cline <cline@frii.com>                                   *
 # *   (c) 2020 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de>           *
 # *                                                                         *
 # *   This file is part of the FreeCAD CAx development system.              *
@@ -22,474 +20,108 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides GUI tools to create BezCurve objects.
-
-In particular, a cubic Bézier curve is defined, as it is one of the most
-useful curves for many applications.
-
-See https://en.wikipedia.org/wiki/B%C3%A9zier_curve
-"""
-## @package gui_beziers
+"""Provides GUI tools to create orthogonal Array objects."""
+## @package gui_orthoarray
 # \ingroup draftguitools
-# \brief Provides GUI tools to create BezCurve objects.
+# \brief Provides GUI tools to create orthogonal Array objects.
 
 ## \addtogroup draftguitools
 # @{
+from pivy import coin
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
+import FreeCAD as App
 import FreeCADGui as Gui
-import draftutils.utils as utils
+import Draft
+import Draft_rc  # include resources, icons, ui files
 import draftutils.todo as todo
-import draftguitools.gui_base_original as gui_base_original
-import draftguitools.gui_tool_utils as gui_tool_utils
-import draftguitools.gui_lines as gui_lines
-import draftguitools.gui_trackers as trackers
 
-from draftutils.messages import _msg, _err
+from draftutils.messages import _msg, _log
 from draftutils.translate import translate
+from draftguitools import gui_base
+from drafttaskpanels import task_orthoarray
+
+# The module is used to prevent complaints from code checkers (flake8)
+bool(Draft_rc.__name__)
 
 
-class BezCurve(gui_lines.Line):
-    """Gui command for the Bézier Curve tool."""
+class OrthoArray(gui_base.GuiCommandBase):
+    """Gui command for the OrthoArray tool."""
 
     def __init__(self):
-        super(BezCurve, self).__init__(wiremode=True)
-        self.degree = None
+        super(OrthoArray, self).__init__()
+        self.command_name = "Orthogonal array"
+        # self.location = None
+        self.mouse_event = None
+        self.view = None
+        # self.callback_move = None
+        self.callback_click = None
+        self.ui = None
+        self.point = App.Vector()
 
     def GetResources(self):
         """Set icon, menu and tooltip."""
-
-        return {'Pixmap': 'Draft_BezCurve',
-                'Accel': 'B, Z',
-                'MenuText': QT_TRANSLATE_NOOP('Draft_BezCurve', 'Bézier curve'),
-                'ToolTip': QT_TRANSLATE_NOOP('Draft_BezCurve', 'Creates an N-degree Bézier curve. The more points you pick, the higher the degree.\nCTRL to snap, SHIFT to constrain.')}
+        return {"Pixmap": "Draft_Array",
+                "MenuText": QT_TRANSLATE_NOOP("Draft_OrthoArray", "Array"),
+                "ToolTip": QT_TRANSLATE_NOOP("Draft_OrthoArray", "Creates copies of the selected object, and places the copies in an orthogonal pattern,\nmeaning the copies follow the specified direction in the X, Y, Z axes.\n\nThe array can be turned into a polar or a circular array by changing its type.")}
 
     def Activated(self):
         """Execute when the command is called.
 
-        Activate the specific Bézier curve tracker.
+        We add callbacks that connect the 3D view with
+        the widgets of the task panel.
         """
-        super(BezCurve, self).Activated(name="BezCurve",
-                                        icon="Draft_BezCurve")
-        if self.doc:
-            self.bezcurvetrack = trackers.bezcurveTracker()
+        _log("GuiCommand: {}".format(self.command_name))
+        #_msg("{}".format(16*"-"))
+        #_msg("GuiCommand: {}".format(self.command_name))
 
-    def action(self, arg):
-        """Handle the 3D scene events.
+        # self.location = coin.SoLocation2Event.getClassTypeId()
+        self.mouse_event = coin.SoMouseButtonEvent.getClassTypeId()
+        self.view = Draft.get3DView()
+        # self.callback_move = \
+        #     self.view.addEventCallbackPivy(self.location, self.move)
+        self.callback_click = \
+            self.view.addEventCallbackPivy(self.mouse_event, self.click)
 
-        This is installed as an EventCallback in the Inventor view
-        by the `Activated` method of the parent class.
+        self.ui = task_orthoarray.TaskPanelOrthoArray()
+        # The calling class (this one) is saved in the object
+        # of the interface, to be able to call a function from within it.
+        self.ui.source_command = self
+        # Gui.Control.showDialog(self.ui)
+        todo.ToDo.delay(Gui.Control.showDialog, self.ui)
 
-        Parameters
-        ----------
-        arg: dict
-            Dictionary with strings that indicates the type of event received
-            from the 3D view.
+    def click(self, event_cb=None):
+        """Execute as a callback when the pointer clicks on the 3D view.
+
+        It should act as if the Enter key was pressed, or the OK button
+        was pressed in the task panel.
         """
-        if arg["Type"] == "SoKeyboardEvent":
-            if arg["Key"] == "ESCAPE":
-                self.finish()
-        elif arg["Type"] == "SoLocation2Event":  # mouse movement detection
-            (self.point,
-             ctrlPoint, info) = gui_tool_utils.getPoint(self, arg,
-                                                        noTracker=True)
+        if event_cb:
+            event = event_cb.getEvent()
+            if (event.getState() != coin.SoMouseButtonEvent.DOWN
+                    or event.getButton() != coin.SoMouseButtonEvent.BUTTON1):
+                return
+        if self.ui and self.point:
+            # The accept function of the interface
+            # should call the completed function
+            # of the calling class (this one).
+            self.ui.accept()
 
-            # existing points + this pointer position
-            self.bezcurvetrack.update(self.node + [self.point],
-                                      degree=self.degree)
-            gui_tool_utils.redraw3DView()
-        elif (arg["Type"] == "SoMouseButtonEvent"
-              and arg["State"] == "DOWN"
-              and arg["Button"] == "BUTTON1"):  # left click
-            if arg["Position"] == self.pos:
-                self.finish(False, cont=True)
+    def completed(self):
+        """Execute when the command is terminated.
 
-            if (not self.node) and (not self.support):  # first point
-                gui_tool_utils.getSupport(arg)
-                (self.point,
-                 ctrlPoint, info) = gui_tool_utils.getPoint(self, arg,
-                                                            noTracker=True)
-            if self.point:
-                self.ui.redraw()
-                self.pos = arg["Position"]
-                self.node.append(self.point)  # add point to "clicked list"
-                # sb add a control point,
-                # if mod(len(cpoints), 2) == 0
-                # then create 2 handle points?
-                self.drawUpdate(self.point)
-                if not self.isWire and len(self.node) == 2:
-                    self.finish(False, cont=True)
-                if len(self.node) > 2:
-                    # does this make sense for a BCurve?
-                    # DNC: allows to close the curve
-                    # by placing ends close to each other
-                    # with tol = Draft tolerance
-                    # old code has been to insensitive
-                    if (self.point-self.node[0]).Length < utils.tolerance():
-                        self.undolast()
-                        self.finish(True, cont=True)
-                        _msg(translate("draft",
-                                       "Bézier curve has been closed"))
-
-    def undolast(self):
-        """Undo last line segment."""
-        if len(self.node) > 1:
-            self.node.pop()
-            self.bezcurvetrack.update(self.node, degree=self.degree)
-            self.obj.Shape = self.updateShape(self.node)
-            _msg(translate("draft", "Last point has been removed"))
-
-    def drawUpdate(self, point):
-        """Draw and update to the curve."""
-        if len(self.node) == 1:
-            self.bezcurvetrack.on()
-            if self.planetrack:
-                self.planetrack.set(self.node[0])
-            _msg(translate("draft", "Pick next point"))
-        else:
-            self.obj.Shape = self.updateShape(self.node)
-            _msg(translate("draft",
-                           "Pick next point, "
-                           "or finish (A) or close (O)"))
-
-    def updateShape(self, pts):
-        """Create shape for display during creation process."""
-        import Part
-        edges = []
-        if len(pts) >= 2:  # allow lower degree segment
-            poles = pts[1:]
-        else:
-            poles = []
-        if self.degree:
-            segpoleslst = [poles[x:x+self.degree] for x in range(0, len(poles), (self.degree or 1))]
-        else:
-            segpoleslst = [pts]
-        startpoint = pts[0]
-        for segpoles in segpoleslst:
-            c = Part.BezierCurve()  # last segment may have lower degree
-            c.increase(len(segpoles))
-            c.setPoles([startpoint] + segpoles)
-            edges.append(Part.Edge(c))
-            startpoint = segpoles[-1]
-        w = Part.Wire(edges)
-        return w
-
-    def finish(self, closed=False, cont=False):
-        """Terminate the operation and close the curve if asked.
-
-        Parameters
-        ----------
-        closed: bool, optional
-            Close the line if `True`.
+        We should remove the callbacks that were added to the 3D view
+        and then close the task panel.
         """
-        if self.ui:
-            if hasattr(self, "bezcurvetrack"):
-                self.bezcurvetrack.finalize()
-        if not utils.getParam("UiMode", 1):
+        # self.view.removeEventCallbackPivy(self.location,
+        #                                   self.callback_move)
+        self.view.removeEventCallbackPivy(self.mouse_event,
+                                          self.callback_click)
+        if Gui.Control.activeDialog():
             Gui.Control.closeDialog()
-        if self.obj:
-            # remove temporary object, if any
-            old = self.obj.Name
-            todo.ToDo.delay(self.doc.removeObject, old)
-        if len(self.node) > 1:
-            # The command to run is built as a series of text strings
-            # to be committed through the `draftutils.todo.ToDo` class.
-            try:
-                rot, sup, pts, fil = self.getStrings()
-                Gui.addModule("Draft")
-                _cmd = 'Draft.makeBezCurve'
-                _cmd += '('
-                _cmd += 'points, '
-                _cmd += 'closed=' + str(closed) + ', '
-                _cmd += 'support=' + sup + ', '
-                _cmd += 'degree=' + str(self.degree)
-                _cmd += ')'
-                _cmd_list = ['points = ' + pts,
-                             'bez = ' + _cmd,
-                             'Draft.autogroup(bez)',
-                             'FreeCAD.ActiveDocument.recompute()']
-                self.commit(translate("draft", "Create BezCurve"),
-                            _cmd_list)
-            except Exception:
-                _err("Draft: error delaying commit")
-
-        # `Creator` is the grandfather class, the parent of `Line`;
-        # we need to call it to perform final cleanup tasks.
-        #
-        # Calling it directly like this is a bit messy; maybe we need
-        # another method that performs cleanup (superfinish)
-        # that is not re-implemented by any of the child classes.
-        gui_base_original.Creator.finish(self)
-        if self.ui and self.ui.continueMode:
-            self.Activated()
+            super(OrthoArray, self).finish()
 
 
-Gui.addCommand('Draft_BezCurve', BezCurve())
-
-
-class CubicBezCurve(gui_lines.Line):
-    """Gui command for the 3rd degree Bézier Curve tool."""
-
-    def __init__(self):
-        super(CubicBezCurve, self).__init__(wiremode=True)
-        self.degree = 3
-
-    def GetResources(self):
-        """Set icon, menu and tooltip."""
-
-        return {'Pixmap': 'Draft_CubicBezCurve',
-                # 'Accel': 'B, Z',
-                'MenuText': QT_TRANSLATE_NOOP('Draft_CubicBezCurve', 'Cubic Bézier curve'),
-                'ToolTip': QT_TRANSLATE_NOOP('Draft_CubicBezCurve', 'Creates a Bézier curve made of 2nd degree (quadratic) and 3rd degree (cubic) segments. Click and drag to define each segment.\nAfter the curve is created you can go back to edit each control point and set the properties of each knot.\nCTRL to snap, SHIFT to constrain.')}
-
-    def Activated(self):
-        """Execute when the command is called.
-
-        Activate the specific BezCurve tracker.
-        """
-        super(CubicBezCurve, self).Activated(name="CubicBezCurve",
-                                             icon="Draft_CubicBezCurve")
-        if self.doc:
-            self.bezcurvetrack = trackers.bezcurveTracker()
-
-    def action(self, arg):
-        """Handle the 3D scene events.
-
-        This is installed as an EventCallback in the Inventor view
-        by the `Activated` method of the parent class.
-
-        Parameters
-        ----------
-        arg: dict
-            Dictionary with strings that indicates the type of event received
-            from the 3D view.
-        """
-        if arg["Type"] == "SoKeyboardEvent":
-            if arg["Key"] == "ESCAPE":
-                self.finish()
-        elif arg["Type"] == "SoLocation2Event":  # mouse movement detection
-            (self.point,
-             ctrlPoint, info) = gui_tool_utils.getPoint(self, arg,
-                                                        noTracker=True)
-            if (len(self.node) - 1) % self.degree == 0 and len(self.node) > 2:
-                prevctrl = 2 * self.node[-1] - self.point
-                # Existing points + this pointer position
-                self.bezcurvetrack.update(self.node[0:-2]
-                                          + [prevctrl]
-                                          + [self.node[-1]]
-                                          + [self.point], degree=self.degree)
-            else:
-                # Existing points + this pointer position
-                self.bezcurvetrack.update(self.node
-                                          + [self.point], degree=self.degree)
-            gui_tool_utils.redraw3DView()
-        elif arg["Type"] == "SoMouseButtonEvent":
-            # Press and hold the button
-            if arg["State"] == "DOWN" and arg["Button"] == "BUTTON1":
-                if arg["Position"] == self.pos:
-                    if len(self.node) > 2:
-                        self.node = self.node[0:-2]
-                    else:
-                        self.node = []
-                    return
-                else:
-                    if (not self.node) and (not self.support):  # first point
-                        gui_tool_utils.getSupport(arg)
-                        (self.point,
-                         ctrlPoint,
-                         info) = gui_tool_utils.getPoint(self, arg,
-                                                         noTracker=True)
-                    if self.point:
-                        self.ui.redraw()
-                        self.pos = arg["Position"]
-                        # add point to "clicked list"
-                        self.node.append(self.point)
-                        # sb add a control point,
-                        # if mod(len(cpoints), 2) == 0
-                        # then create 2 handle points?
-                        self.drawUpdate(self.point)
-                        if not self.isWire and len(self.node) == 2:
-                            self.finish(False, cont=True)
-                        # does this make sense for a BCurve?
-                        if len(self.node) > 2:
-                            # add point to "clicked list"
-                            self.node.append(self.point)
-                            self.drawUpdate(self.point)
-                            # DNC: allows to close the curve
-                            # by placing ends close to each other
-                            # with tol = Draft tolerance
-                            # old code has been to insensitive
-                            _diff = (self.point - self.node[0]).Length
-                            if (_diff < utils.tolerance()
-                                    and len(self.node) >= 4):
-                                # self.undolast()
-                                self.node = self.node[0:-2]
-                                # close the curve with a smooth symmetric knot
-                                _sym = 2 * self.node[0] - self.node[1]
-                                self.node.append(_sym)
-                                self.finish(True, cont=True)
-                                _msg(translate("draft",
-                                               "Bézier curve has been closed"))
-
-            # Release the held button
-            if arg["State"] == "UP" and arg["Button"] == "BUTTON1":
-                if arg["Position"] == self.pos:
-                    self.node = self.node[0:-2]
-                    return
-                else:
-                    if (not self.node) and (not self.support):  # first point
-                        return
-                    if self.point:
-                        self.ui.redraw()
-                        self.pos = arg["Position"]
-                        # add point to "clicked list"
-                        self.node.append(self.point)
-                        # sb add a control point,
-                        # if mod(len(cpoints),2) == 0
-                        # then create 2 handle points?
-                        self.drawUpdate(self.point)
-                        if not self.isWire and len(self.node) == 2:
-                            self.finish(False, cont=True)
-                        # Does this make sense for a BCurve?
-                        if len(self.node) > 2:
-                            self.node[-3] = 2 * self.node[-2] - self.node[-1]
-                            self.drawUpdate(self.point)
-                            # DNC: allows to close the curve
-                            # by placing ends close to each other
-                            # with tol = Draft tolerance
-                            # old code has been to insensitive
-
-    def undolast(self):
-        """Undo last line segment."""
-        if len(self.node) > 1:
-            self.node.pop()
-            self.bezcurvetrack.update(self.node, degree=self.degree)
-            self.obj.Shape = self.updateShape(self.node)
-            _msg(translate("draft", "Last point has been removed"))
-
-    def drawUpdate(self, point):
-        """Create shape for display during creation process."""
-        if len(self.node) == 1:
-            self.bezcurvetrack.on()
-            if self.planetrack:
-                self.planetrack.set(self.node[0])
-            _msg(translate("draft", "Click and drag to define next knot"))
-        elif (len(self.node) - 1) % self.degree == 1 and len(self.node) > 2:
-            # is a knot
-            self.obj.Shape = self.updateShape(self.node[:-1])
-            _msg(translate("draft",
-                           "Click and drag to define next knot, "
-                           "or finish (A) or close (O)"))
-
-    def updateShape(self, pts):
-        """Create shape for display during creation process."""
-        import Part
-        # Not quite right. draws 1 big bez. sb segmented
-        edges = []
-
-        if len(pts) >= 2:  # allow lower degree segment
-            poles = pts[1:]
-        else:
-            poles = []
-
-        if self.degree:
-            segpoleslst = [poles[x:x+self.degree] for x in range(0, len(poles), (self.degree or 1))]
-        else:
-            segpoleslst = [pts]
-
-        startpoint = pts[0]
-
-        for segpoles in segpoleslst:
-            c = Part.BezierCurve()  # last segment may have lower degree
-            c.increase(len(segpoles))
-            c.setPoles([startpoint] + segpoles)
-            edges.append(Part.Edge(c))
-            startpoint = segpoles[-1]
-        w = Part.Wire(edges)
-        return w
-
-    def finish(self, closed=False, cont=False):
-        """Terminate the operation and close the curve if asked.
-
-        Parameters
-        ----------
-        closed: bool, optional
-            Close the line if `True`.
-        """
-        if self.ui:
-            if hasattr(self, "bezcurvetrack"):
-                self.bezcurvetrack.finalize()
-        if not utils.getParam("UiMode", 1):
-            Gui.Control.closeDialog()
-        if self.obj:
-            # remove temporary object, if any
-            old = self.obj.Name
-            todo.ToDo.delay(self.doc.removeObject, old)
-        if closed is False:
-            cleannd = (len(self.node) - 1) % self.degree
-            if cleannd == 0:
-                self.node = self.node[0:-3]
-            if cleannd > 0:
-                self.node = self.node[0:-cleannd]
-        if len(self.node) > 1:
-            try:
-                # The command to run is built as a series of text strings
-                # to be committed through the `draftutils.todo.ToDo` class.
-                rot, sup, pts, fil = self.getStrings()
-                Gui.addModule("Draft")
-                _cmd = 'Draft.makeBezCurve'
-                _cmd += '('
-                _cmd += 'points, '
-                _cmd += 'closed=' + str(closed) + ', '
-                _cmd += 'support=' + sup + ', '
-                _cmd += 'degree=' + str(self.degree)
-                _cmd += ')'
-                _cmd_list = ['points = ' + pts,
-                             'bez = ' + _cmd,
-                             'Draft.autogroup(bez)',
-                             'FreeCAD.ActiveDocument.recompute()']
-                self.commit(translate("draft", "Create BezCurve"),
-                            _cmd_list)
-            except Exception:
-                _err("Draft: error delaying commit")
-
-        # `Creator` is the grandfather class, the parent of `Line`;
-        # we need to call it to perform final cleanup tasks.
-        #
-        # Calling it directly like this is a bit messy; maybe we need
-        # another method that performs cleanup (superfinish)
-        # that is not re-implemented by any of the child classes.
-        gui_base_original.Creator.finish(self)
-        if self.ui and self.ui.continueMode:
-            self.Activated()
-
-
-Gui.addCommand('Draft_CubicBezCurve', CubicBezCurve())
-
-
-class BezierGroup:
-    """Gui Command group for the Bézier curve tools."""
-
-    def GetResources(self):
-        """Set icon, menu and tooltip."""
-        return {'MenuText': QT_TRANSLATE_NOOP('Draft_BezierTools', 'Bézier tools'),
-                'ToolTip': QT_TRANSLATE_NOOP('Draft_BezierTools', 'Create various types of Bézier curves.')}
-
-    def GetCommands(self):
-        """Return a tuple of commands in the group."""
-        return ('Draft_CubicBezCurve', 'Draft_BezCurve')
-
-    def IsActive(self):
-        """Return True when this command should be available.
-
-        It is `True` when there is a document.
-        """
-        if Gui.ActiveDocument:
-            return True
-        else:
-            return False
-
-
-Gui.addCommand('Draft_BezierTools', BezierGroup())
+Gui.addCommand('Draft_OrthoArray', OrthoArray())
 
 ## @}

--- a/src/Mod/Draft/draftguitools/gui_beziers.py
+++ b/src/Mod/Draft/draftguitools/gui_beziers.py
@@ -1,4 +1,6 @@
 # ***************************************************************************
+# *   (c) 2009 Yorik van Havre <yorik@uncreated.net>                        *
+# *   (c) 2010 Ken Cline <cline@frii.com>                                   *
 # *   (c) 2020 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de>           *
 # *                                                                         *
 # *   This file is part of the FreeCAD CAx development system.              *
@@ -20,108 +22,474 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides GUI tools to create orthogonal Array objects."""
-## @package gui_orthoarray
+"""Provides GUI tools to create BezCurve objects.
+
+In particular, a cubic Bézier curve is defined, as it is one of the most
+useful curves for many applications.
+
+See https://en.wikipedia.org/wiki/B%C3%A9zier_curve
+"""
+## @package gui_beziers
 # \ingroup draftguitools
-# \brief Provides GUI tools to create orthogonal Array objects.
+# \brief Provides GUI tools to create BezCurve objects.
 
 ## \addtogroup draftguitools
 # @{
-from pivy import coin
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
-import FreeCAD as App
 import FreeCADGui as Gui
-import Draft
-import Draft_rc  # include resources, icons, ui files
+import draftutils.utils as utils
 import draftutils.todo as todo
+import draftguitools.gui_base_original as gui_base_original
+import draftguitools.gui_tool_utils as gui_tool_utils
+import draftguitools.gui_lines as gui_lines
+import draftguitools.gui_trackers as trackers
 
-from draftutils.messages import _msg, _log
+from draftutils.messages import _msg, _err
 from draftutils.translate import translate
-from draftguitools import gui_base
-from drafttaskpanels import task_orthoarray
-
-# The module is used to prevent complaints from code checkers (flake8)
-bool(Draft_rc.__name__)
 
 
-class OrthoArray(gui_base.GuiCommandBase):
-    """Gui command for the OrthoArray tool."""
+class BezCurve(gui_lines.Line):
+    """Gui command for the Bézier Curve tool."""
 
     def __init__(self):
-        super(OrthoArray, self).__init__()
-        self.command_name = "Orthogonal array"
-        # self.location = None
-        self.mouse_event = None
-        self.view = None
-        # self.callback_move = None
-        self.callback_click = None
-        self.ui = None
-        self.point = App.Vector()
+        super(BezCurve, self).__init__(wiremode=True)
+        self.degree = None
 
     def GetResources(self):
         """Set icon, menu and tooltip."""
-        return {"Pixmap": "Draft_Array",
-                "MenuText": QT_TRANSLATE_NOOP("Draft_OrthoArray", "Array"),
-                "ToolTip": QT_TRANSLATE_NOOP("Draft_OrthoArray", "Creates copies of the selected object, and places the copies in an orthogonal pattern,\nmeaning the copies follow the specified direction in the X, Y, Z axes.\n\nThe array can be turned into a polar or a circular array by changing its type.")}
+
+        return {"Pixmap": "Draft_BezCurve",
+                "Accel": "B, Z",
+                "MenuText": QT_TRANSLATE_NOOP("Draft_BezCurve", "Bézier curve"),
+                "ToolTip": QT_TRANSLATE_NOOP("Draft_BezCurve", "Creates an N-degree Bézier curve. The more points you pick, the higher the degree.\nCTRL to snap, SHIFT to constrain.")}
 
     def Activated(self):
         """Execute when the command is called.
 
-        We add callbacks that connect the 3D view with
-        the widgets of the task panel.
+        Activate the specific Bézier curve tracker.
         """
-        _log("GuiCommand: {}".format(self.command_name))
-        #_msg("{}".format(16*"-"))
-        #_msg("GuiCommand: {}".format(self.command_name))
+        super(BezCurve, self).Activated(name="BezCurve",
+                                        icon="Draft_BezCurve")
+        if self.doc:
+            self.bezcurvetrack = trackers.bezcurveTracker()
 
-        # self.location = coin.SoLocation2Event.getClassTypeId()
-        self.mouse_event = coin.SoMouseButtonEvent.getClassTypeId()
-        self.view = Draft.get3DView()
-        # self.callback_move = \
-        #     self.view.addEventCallbackPivy(self.location, self.move)
-        self.callback_click = \
-            self.view.addEventCallbackPivy(self.mouse_event, self.click)
+    def action(self, arg):
+        """Handle the 3D scene events.
 
-        self.ui = task_orthoarray.TaskPanelOrthoArray()
-        # The calling class (this one) is saved in the object
-        # of the interface, to be able to call a function from within it.
-        self.ui.source_command = self
-        # Gui.Control.showDialog(self.ui)
-        todo.ToDo.delay(Gui.Control.showDialog, self.ui)
+        This is installed as an EventCallback in the Inventor view
+        by the `Activated` method of the parent class.
 
-    def click(self, event_cb=None):
-        """Execute as a callback when the pointer clicks on the 3D view.
-
-        It should act as if the Enter key was pressed, or the OK button
-        was pressed in the task panel.
+        Parameters
+        ----------
+        arg: dict
+            Dictionary with strings that indicates the type of event received
+            from the 3D view.
         """
-        if event_cb:
-            event = event_cb.getEvent()
-            if (event.getState() != coin.SoMouseButtonEvent.DOWN
-                    or event.getButton() != coin.SoMouseButtonEvent.BUTTON1):
-                return
-        if self.ui and self.point:
-            # The accept function of the interface
-            # should call the completed function
-            # of the calling class (this one).
-            self.ui.accept()
+        if arg["Type"] == "SoKeyboardEvent":
+            if arg["Key"] == "ESCAPE":
+                self.finish()
+        elif arg["Type"] == "SoLocation2Event":  # mouse movement detection
+            (self.point,
+             ctrlPoint, info) = gui_tool_utils.getPoint(self, arg,
+                                                        noTracker=True)
 
-    def completed(self):
-        """Execute when the command is terminated.
+            # existing points + this pointer position
+            self.bezcurvetrack.update(self.node + [self.point],
+                                      degree=self.degree)
+            gui_tool_utils.redraw3DView()
+        elif (arg["Type"] == "SoMouseButtonEvent"
+              and arg["State"] == "DOWN"
+              and arg["Button"] == "BUTTON1"):  # left click
+            if arg["Position"] == self.pos:
+                self.finish(False, cont=True)
 
-        We should remove the callbacks that were added to the 3D view
-        and then close the task panel.
+            if (not self.node) and (not self.support):  # first point
+                gui_tool_utils.getSupport(arg)
+                (self.point,
+                 ctrlPoint, info) = gui_tool_utils.getPoint(self, arg,
+                                                            noTracker=True)
+            if self.point:
+                self.ui.redraw()
+                self.pos = arg["Position"]
+                self.node.append(self.point)  # add point to "clicked list"
+                # sb add a control point,
+                # if mod(len(cpoints), 2) == 0
+                # then create 2 handle points?
+                self.drawUpdate(self.point)
+                if not self.isWire and len(self.node) == 2:
+                    self.finish(False, cont=True)
+                if len(self.node) > 2:
+                    # does this make sense for a BCurve?
+                    # DNC: allows to close the curve
+                    # by placing ends close to each other
+                    # with tol = Draft tolerance
+                    # old code has been to insensitive
+                    if (self.point-self.node[0]).Length < utils.tolerance():
+                        self.undolast()
+                        self.finish(True, cont=True)
+                        _msg(translate("draft",
+                                       "Bézier curve has been closed"))
+
+    def undolast(self):
+        """Undo last line segment."""
+        if len(self.node) > 1:
+            self.node.pop()
+            self.bezcurvetrack.update(self.node, degree=self.degree)
+            self.obj.Shape = self.updateShape(self.node)
+            _msg(translate("draft", "Last point has been removed"))
+
+    def drawUpdate(self, point):
+        """Draw and update to the curve."""
+        if len(self.node) == 1:
+            self.bezcurvetrack.on()
+            if self.planetrack:
+                self.planetrack.set(self.node[0])
+            _msg(translate("draft", "Pick next point"))
+        else:
+            self.obj.Shape = self.updateShape(self.node)
+            _msg(translate("draft",
+                           "Pick next point, "
+                           "or finish (A) or close (O)"))
+
+    def updateShape(self, pts):
+        """Create shape for display during creation process."""
+        import Part
+        edges = []
+        if len(pts) >= 2:  # allow lower degree segment
+            poles = pts[1:]
+        else:
+            poles = []
+        if self.degree:
+            segpoleslst = [poles[x:x+self.degree] for x in range(0, len(poles), (self.degree or 1))]
+        else:
+            segpoleslst = [pts]
+        startpoint = pts[0]
+        for segpoles in segpoleslst:
+            c = Part.BezierCurve()  # last segment may have lower degree
+            c.increase(len(segpoles))
+            c.setPoles([startpoint] + segpoles)
+            edges.append(Part.Edge(c))
+            startpoint = segpoles[-1]
+        w = Part.Wire(edges)
+        return w
+
+    def finish(self, closed=False, cont=False):
+        """Terminate the operation and close the curve if asked.
+
+        Parameters
+        ----------
+        closed: bool, optional
+            Close the line if `True`.
         """
-        # self.view.removeEventCallbackPivy(self.location,
-        #                                   self.callback_move)
-        self.view.removeEventCallbackPivy(self.mouse_event,
-                                          self.callback_click)
-        if Gui.Control.activeDialog():
+        if self.ui:
+            if hasattr(self, "bezcurvetrack"):
+                self.bezcurvetrack.finalize()
+        if not utils.getParam("UiMode", 1):
             Gui.Control.closeDialog()
-            super(OrthoArray, self).finish()
+        if self.obj:
+            # remove temporary object, if any
+            old = self.obj.Name
+            todo.ToDo.delay(self.doc.removeObject, old)
+        if len(self.node) > 1:
+            # The command to run is built as a series of text strings
+            # to be committed through the `draftutils.todo.ToDo` class.
+            try:
+                rot, sup, pts, fil = self.getStrings()
+                Gui.addModule("Draft")
+                _cmd = 'Draft.makeBezCurve'
+                _cmd += '('
+                _cmd += 'points, '
+                _cmd += 'closed=' + str(closed) + ', '
+                _cmd += 'support=' + sup + ', '
+                _cmd += 'degree=' + str(self.degree)
+                _cmd += ')'
+                _cmd_list = ['points = ' + pts,
+                             'bez = ' + _cmd,
+                             'Draft.autogroup(bez)',
+                             'FreeCAD.ActiveDocument.recompute()']
+                self.commit(translate("draft", "Create BezCurve"),
+                            _cmd_list)
+            except Exception:
+                _err("Draft: error delaying commit")
+
+        # `Creator` is the grandfather class, the parent of `Line`;
+        # we need to call it to perform final cleanup tasks.
+        #
+        # Calling it directly like this is a bit messy; maybe we need
+        # another method that performs cleanup (superfinish)
+        # that is not re-implemented by any of the child classes.
+        gui_base_original.Creator.finish(self)
+        if self.ui and self.ui.continueMode:
+            self.Activated()
 
 
-Gui.addCommand('Draft_OrthoArray', OrthoArray())
+Gui.addCommand('Draft_BezCurve', BezCurve())
+
+
+class CubicBezCurve(gui_lines.Line):
+    """Gui command for the 3rd degree Bézier Curve tool."""
+
+    def __init__(self):
+        super(CubicBezCurve, self).__init__(wiremode=True)
+        self.degree = 3
+
+    def GetResources(self):
+        """Set icon, menu and tooltip."""
+
+        return {"Pixmap": "Draft_CubicBezCurve",
+                # "Accel": "B, Z",
+                "MenuText": QT_TRANSLATE_NOOP("Draft_CubicBezCurve", "Cubic Bézier curve"),
+                "ToolTip": QT_TRANSLATE_NOOP("Draft_CubicBezCurve", "Creates a Bézier curve made of 2nd degree (quadratic) and 3rd degree (cubic) segments. Click and drag to define each segment.\nAfter the curve is created you can go back to edit each control point and set the properties of each knot.\nCTRL to snap, SHIFT to constrain.")}
+
+    def Activated(self):
+        """Execute when the command is called.
+
+        Activate the specific BezCurve tracker.
+        """
+        super(CubicBezCurve, self).Activated(name="CubicBezCurve",
+                                             icon="Draft_CubicBezCurve")
+        if self.doc:
+            self.bezcurvetrack = trackers.bezcurveTracker()
+
+    def action(self, arg):
+        """Handle the 3D scene events.
+
+        This is installed as an EventCallback in the Inventor view
+        by the `Activated` method of the parent class.
+
+        Parameters
+        ----------
+        arg: dict
+            Dictionary with strings that indicates the type of event received
+            from the 3D view.
+        """
+        if arg["Type"] == "SoKeyboardEvent":
+            if arg["Key"] == "ESCAPE":
+                self.finish()
+        elif arg["Type"] == "SoLocation2Event":  # mouse movement detection
+            (self.point,
+             ctrlPoint, info) = gui_tool_utils.getPoint(self, arg,
+                                                        noTracker=True)
+            if (len(self.node) - 1) % self.degree == 0 and len(self.node) > 2:
+                prevctrl = 2 * self.node[-1] - self.point
+                # Existing points + this pointer position
+                self.bezcurvetrack.update(self.node[0:-2]
+                                          + [prevctrl]
+                                          + [self.node[-1]]
+                                          + [self.point], degree=self.degree)
+            else:
+                # Existing points + this pointer position
+                self.bezcurvetrack.update(self.node
+                                          + [self.point], degree=self.degree)
+            gui_tool_utils.redraw3DView()
+        elif arg["Type"] == "SoMouseButtonEvent":
+            # Press and hold the button
+            if arg["State"] == "DOWN" and arg["Button"] == "BUTTON1":
+                if arg["Position"] == self.pos:
+                    if len(self.node) > 2:
+                        self.node = self.node[0:-2]
+                    else:
+                        self.node = []
+                    return
+                else:
+                    if (not self.node) and (not self.support):  # first point
+                        gui_tool_utils.getSupport(arg)
+                        (self.point,
+                         ctrlPoint,
+                         info) = gui_tool_utils.getPoint(self, arg,
+                                                         noTracker=True)
+                    if self.point:
+                        self.ui.redraw()
+                        self.pos = arg["Position"]
+                        # add point to "clicked list"
+                        self.node.append(self.point)
+                        # sb add a control point,
+                        # if mod(len(cpoints), 2) == 0
+                        # then create 2 handle points?
+                        self.drawUpdate(self.point)
+                        if not self.isWire and len(self.node) == 2:
+                            self.finish(False, cont=True)
+                        # does this make sense for a BCurve?
+                        if len(self.node) > 2:
+                            # add point to "clicked list"
+                            self.node.append(self.point)
+                            self.drawUpdate(self.point)
+                            # DNC: allows to close the curve
+                            # by placing ends close to each other
+                            # with tol = Draft tolerance
+                            # old code has been to insensitive
+                            _diff = (self.point - self.node[0]).Length
+                            if (_diff < utils.tolerance()
+                                    and len(self.node) >= 4):
+                                # self.undolast()
+                                self.node = self.node[0:-2]
+                                # close the curve with a smooth symmetric knot
+                                _sym = 2 * self.node[0] - self.node[1]
+                                self.node.append(_sym)
+                                self.finish(True, cont=True)
+                                _msg(translate("draft",
+                                               "Bézier curve has been closed"))
+
+            # Release the held button
+            if arg["State"] == "UP" and arg["Button"] == "BUTTON1":
+                if arg["Position"] == self.pos:
+                    self.node = self.node[0:-2]
+                    return
+                else:
+                    if (not self.node) and (not self.support):  # first point
+                        return
+                    if self.point:
+                        self.ui.redraw()
+                        self.pos = arg["Position"]
+                        # add point to "clicked list"
+                        self.node.append(self.point)
+                        # sb add a control point,
+                        # if mod(len(cpoints),2) == 0
+                        # then create 2 handle points?
+                        self.drawUpdate(self.point)
+                        if not self.isWire and len(self.node) == 2:
+                            self.finish(False, cont=True)
+                        # Does this make sense for a BCurve?
+                        if len(self.node) > 2:
+                            self.node[-3] = 2 * self.node[-2] - self.node[-1]
+                            self.drawUpdate(self.point)
+                            # DNC: allows to close the curve
+                            # by placing ends close to each other
+                            # with tol = Draft tolerance
+                            # old code has been to insensitive
+
+    def undolast(self):
+        """Undo last line segment."""
+        if len(self.node) > 1:
+            self.node.pop()
+            self.bezcurvetrack.update(self.node, degree=self.degree)
+            self.obj.Shape = self.updateShape(self.node)
+            _msg(translate("draft", "Last point has been removed"))
+
+    def drawUpdate(self, point):
+        """Create shape for display during creation process."""
+        if len(self.node) == 1:
+            self.bezcurvetrack.on()
+            if self.planetrack:
+                self.planetrack.set(self.node[0])
+            _msg(translate("draft", "Click and drag to define next knot"))
+        elif (len(self.node) - 1) % self.degree == 1 and len(self.node) > 2:
+            # is a knot
+            self.obj.Shape = self.updateShape(self.node[:-1])
+            _msg(translate("draft",
+                           "Click and drag to define next knot, "
+                           "or finish (A) or close (O)"))
+
+    def updateShape(self, pts):
+        """Create shape for display during creation process."""
+        import Part
+        # Not quite right. draws 1 big bez. sb segmented
+        edges = []
+
+        if len(pts) >= 2:  # allow lower degree segment
+            poles = pts[1:]
+        else:
+            poles = []
+
+        if self.degree:
+            segpoleslst = [poles[x:x+self.degree] for x in range(0, len(poles), (self.degree or 1))]
+        else:
+            segpoleslst = [pts]
+
+        startpoint = pts[0]
+
+        for segpoles in segpoleslst:
+            c = Part.BezierCurve()  # last segment may have lower degree
+            c.increase(len(segpoles))
+            c.setPoles([startpoint] + segpoles)
+            edges.append(Part.Edge(c))
+            startpoint = segpoles[-1]
+        w = Part.Wire(edges)
+        return w
+
+    def finish(self, closed=False, cont=False):
+        """Terminate the operation and close the curve if asked.
+
+        Parameters
+        ----------
+        closed: bool, optional
+            Close the line if `True`.
+        """
+        if self.ui:
+            if hasattr(self, "bezcurvetrack"):
+                self.bezcurvetrack.finalize()
+        if not utils.getParam("UiMode", 1):
+            Gui.Control.closeDialog()
+        if self.obj:
+            # remove temporary object, if any
+            old = self.obj.Name
+            todo.ToDo.delay(self.doc.removeObject, old)
+        if closed is False:
+            cleannd = (len(self.node) - 1) % self.degree
+            if cleannd == 0:
+                self.node = self.node[0:-3]
+            if cleannd > 0:
+                self.node = self.node[0:-cleannd]
+        if len(self.node) > 1:
+            try:
+                # The command to run is built as a series of text strings
+                # to be committed through the `draftutils.todo.ToDo` class.
+                rot, sup, pts, fil = self.getStrings()
+                Gui.addModule("Draft")
+                _cmd = 'Draft.makeBezCurve'
+                _cmd += '('
+                _cmd += 'points, '
+                _cmd += 'closed=' + str(closed) + ', '
+                _cmd += 'support=' + sup + ', '
+                _cmd += 'degree=' + str(self.degree)
+                _cmd += ')'
+                _cmd_list = ['points = ' + pts,
+                             'bez = ' + _cmd,
+                             'Draft.autogroup(bez)',
+                             'FreeCAD.ActiveDocument.recompute()']
+                self.commit(translate("draft", "Create BezCurve"),
+                            _cmd_list)
+            except Exception:
+                _err("Draft: error delaying commit")
+
+        # `Creator` is the grandfather class, the parent of `Line`;
+        # we need to call it to perform final cleanup tasks.
+        #
+        # Calling it directly like this is a bit messy; maybe we need
+        # another method that performs cleanup (superfinish)
+        # that is not re-implemented by any of the child classes.
+        gui_base_original.Creator.finish(self)
+        if self.ui and self.ui.continueMode:
+            self.Activated()
+
+
+Gui.addCommand('Draft_CubicBezCurve', CubicBezCurve())
+
+
+class BezierGroup:
+    """Gui Command group for the Bézier curve tools."""
+
+    def GetResources(self):
+        """Set icon, menu and tooltip."""
+        return {"MenuText": QT_TRANSLATE_NOOP("Draft_BezierTools", "Bézier tools"),
+                "ToolTip": QT_TRANSLATE_NOOP("Draft_BezierTools", "Create various types of Bézier curves.")}
+
+    def GetCommands(self):
+        """Return a tuple of commands in the group."""
+        return ('Draft_CubicBezCurve', 'Draft_BezCurve')
+
+    def IsActive(self):
+        """Return True when this command should be available.
+
+        It is `True` when there is a document.
+        """
+        if Gui.ActiveDocument:
+            return True
+        else:
+            return False
+
+
+Gui.addCommand('Draft_BezierTools', BezierGroup())
 
 ## @}

--- a/src/Mod/Draft/draftguitools/gui_beziers.py
+++ b/src/Mod/Draft/draftguitools/gui_beziers.py
@@ -24,7 +24,7 @@
 # ***************************************************************************
 """Provides GUI tools to create BezCurve objects.
 
-In particular, a cubic Bezier curve is defined, as it is one of the most
+In particular, a cubic Bézier curve is defined, as it is one of the most
 useful curves for many applications.
 
 See https://en.wikipedia.org/wiki/B%C3%A9zier_curve
@@ -50,7 +50,7 @@ from draftutils.translate import translate
 
 
 class BezCurve(gui_lines.Line):
-    """Gui command for the Bezier Curve tool."""
+    """Gui command for the Bézier Curve tool."""
 
     def __init__(self):
         super(BezCurve, self).__init__(wiremode=True)
@@ -60,14 +60,14 @@ class BezCurve(gui_lines.Line):
         """Set icon, menu and tooltip."""
 
         return {'Pixmap': 'Draft_BezCurve',
-                'Accel': "B, Z",
-                'MenuText': QT_TRANSLATE_NOOP("Draft_BezCurve", "Bezier curve"),
-                'ToolTip': QT_TRANSLATE_NOOP("Draft_BezCurve", "Creates an N-degree Bezier curve. The more points you pick, the higher the degree.\nCTRL to snap, SHIFT to constrain.")}
+                'Accel': 'B, Z',
+                'MenuText': QT_TRANSLATE_NOOP('Draft_BezCurve', 'Bézier curve'),
+                'ToolTip': QT_TRANSLATE_NOOP('Draft_BezCurve', 'Creates an N-degree Bézier curve. The more points you pick, the higher the degree.\nCTRL to snap, SHIFT to constrain.')}
 
     def Activated(self):
         """Execute when the command is called.
 
-        Activate the specific bezier curve tracker.
+        Activate the specific Bézier curve tracker.
         """
         super(BezCurve, self).Activated(name="BezCurve",
                                         icon="Draft_BezCurve")
@@ -129,7 +129,7 @@ class BezCurve(gui_lines.Line):
                         self.undolast()
                         self.finish(True, cont=True)
                         _msg(translate("draft",
-                                       "Bezier curve has been closed"))
+                                       "Bézier curve has been closed"))
 
     def undolast(self):
         """Undo last line segment."""
@@ -228,7 +228,7 @@ Gui.addCommand('Draft_BezCurve', BezCurve())
 
 
 class CubicBezCurve(gui_lines.Line):
-    """Gui command for the 3rd degree Bezier Curve tool."""
+    """Gui command for the 3rd degree Bézier Curve tool."""
 
     def __init__(self):
         super(CubicBezCurve, self).__init__(wiremode=True)
@@ -238,9 +238,9 @@ class CubicBezCurve(gui_lines.Line):
         """Set icon, menu and tooltip."""
 
         return {'Pixmap': 'Draft_CubicBezCurve',
-                # 'Accel': "B, Z",
-                'MenuText': QT_TRANSLATE_NOOP("Draft_CubicBezCurve", "Cubic bezier curve"),
-                'ToolTip': QT_TRANSLATE_NOOP("Draft_CubicBezCurve", "Creates a Bezier curve made of 2nd degree (quadratic) and 3rd degree (cubic) segments. Click and drag to define each segment.\nAfter the curve is created you can go back to edit each control point and set the properties of each knot.\nCTRL to snap, SHIFT to constrain.")}
+                # 'Accel': 'B, Z',
+                'MenuText': QT_TRANSLATE_NOOP('Draft_CubicBezCurve', 'Cubic Bézier curve'),
+                'ToolTip': QT_TRANSLATE_NOOP('Draft_CubicBezCurve', 'Creates a Bézier curve made of 2nd degree (quadratic) and 3rd degree (cubic) segments. Click and drag to define each segment.\nAfter the curve is created you can go back to edit each control point and set the properties of each knot.\nCTRL to snap, SHIFT to constrain.')}
 
     def Activated(self):
         """Execute when the command is called.
@@ -329,7 +329,7 @@ class CubicBezCurve(gui_lines.Line):
                                 self.node.append(_sym)
                                 self.finish(True, cont=True)
                                 _msg(translate("draft",
-                                               "Bezier curve has been closed"))
+                                               "Bézier curve has been closed"))
 
             # Release the held button
             if arg["State"] == "UP" and arg["Button"] == "BUTTON1":
@@ -468,12 +468,12 @@ Gui.addCommand('Draft_CubicBezCurve', CubicBezCurve())
 
 
 class BezierGroup:
-    """Gui Command group for the Bezier curve tools."""
+    """Gui Command group for the Bézier curve tools."""
 
     def GetResources(self):
         """Set icon, menu and tooltip."""
-        return {'MenuText': QT_TRANSLATE_NOOP("Draft_BezierTools", "Bezier tools"),
-                'ToolTip': QT_TRANSLATE_NOOP("Draft_BezierTools", "Create various types of Bezier curves.")}
+        return {'MenuText': QT_TRANSLATE_NOOP('Draft_BezierTools', 'Bézier tools'),
+                'ToolTip': QT_TRANSLATE_NOOP('Draft_BezierTools', 'Create various types of Bézier curves.')}
 
     def GetCommands(self):
         """Return a tuple of commands in the group."""

--- a/src/Mod/Draft/draftguitools/gui_groups.py
+++ b/src/Mod/Draft/draftguitools/gui_groups.py
@@ -235,7 +235,7 @@ class SetAutoGroup(gui_base.GuiCommandSimplest):
 
         # Otherwise it builds a list of layers, with names and icons,
         # including the options "None" and "Add new layer".
-        self.groups = ["None"]
+        self.groups = [translate("draft", "None")]
         gn = [o.Name for o in self.doc.Objects if utils.get_type(o) == "Layer"]
         if params.GetBool("AutogroupAddGroups", False):
             gn.extend(groups.get_group_names())
@@ -389,11 +389,10 @@ class Ui_AddNamedGroup():
 
 
     def accept(self):
-        group = App.activeDocument().addObject("App::DocumentObjectGroup",translate("Gui::Dialog::DlgAddProperty","Group"))
+        group = App.activeDocument().addObject("App::DocumentObjectGroup",translate("draft", "Group"))
         group.Label=self.name.text()
         moveToGroup(group)
         Gui.Control.closeDialog()
-
 
 
 ## @}

--- a/src/Mod/Draft/draftguitools/gui_orthoarray.py
+++ b/src/Mod/Draft/draftguitools/gui_orthoarray.py
@@ -61,9 +61,9 @@ class OrthoArray(gui_base.GuiCommandBase):
 
     def GetResources(self):
         """Set icon, menu and tooltip."""
-        return {'Pixmap': 'Draft_Array',
-                'MenuText': QT_TRANSLATE_NOOP('Draft_OrthoArray', 'Array'),
-                'ToolTip': QT_TRANSLATE_NOOP('Draft_OrthoArray', 'Creates copies of the selected object, and places the copies in an orthogonal pattern,\nmeaning the copies follow the specified direction in the X, Y, Z axes.\n\nThe array can be turned into a polar or a circular array by changing its type.')}
+        return {"Pixmap": "Draft_Array",
+                "MenuText": QT_TRANSLATE_NOOP("Draft_OrthoArray", "Array"),
+                "ToolTip": QT_TRANSLATE_NOOP("Draft_OrthoArray", "Creates copies of the selected object, and places the copies in an orthogonal pattern,\nmeaning the copies follow the specified direction in the X, Y, Z axes.\n\nThe array can be turned into a polar or a circular array by changing its type.")}
 
     def Activated(self):
         """Execute when the command is called.

--- a/src/Mod/Draft/draftguitools/gui_orthoarray.py
+++ b/src/Mod/Draft/draftguitools/gui_orthoarray.py
@@ -62,8 +62,8 @@ class OrthoArray(gui_base.GuiCommandBase):
     def GetResources(self):
         """Set icon, menu and tooltip."""
         return {'Pixmap': 'Draft_Array',
-               'MenuText': QT_TRANSLATE_NOOP("Draft_Array", "Array"),
-               'ToolTip': QT_TRANSLATE_NOOP("Draft_Array", "Creates copies of the selected object, and places the copies in an orthogonal pattern,\nmeaning the copies follow the specified direction in the X, Y, Z axes.\n\nThe array can be turned into a polar or a circular array by changing its type.")}
+                'MenuText': QT_TRANSLATE_NOOP('Draft_OrthoArray', 'Array'),
+                'ToolTip': QT_TRANSLATE_NOOP('Draft_OrthoArray', 'Creates copies of the selected object, and places the copies in an orthogonal pattern,\nmeaning the copies follow the specified direction in the X, Y, Z axes.\n\nThe array can be turned into a polar or a circular array by changing its type.')}
 
     def Activated(self):
         """Execute when the command is called.

--- a/src/Mod/Draft/draftutils/init_tools.py
+++ b/src/Mod/Draft/draftutils/init_tools.py
@@ -55,7 +55,7 @@ def get_draft_drawing_commands():
             "Draft_Rectangle",
             "Draft_Polygon",
             "Draft_BSpline",
-            ([QT_TRANSLATE_NOOP("Workbench", "Bezier tools")],
+            ([QT_TRANSLATE_NOOP("Workbench", "Bézier tools")],
                 list(bez_group.GetCommands(bez_group))),
             ("Draft_BezierTools", ),
             "Draft_Point",

--- a/src/Mod/Draft/draftutils/translate.py
+++ b/src/Mod/Draft/draftutils/translate.py
@@ -205,48 +205,4 @@ def translate(context, text, utf8_decode=False):
 QT_TRANSLATE_NOOP = QtCore.QT_TRANSLATE_NOOP
 
 
-def _tr(text):
-    """Translate with the context set to Draft. Our own function.
-
-    It uses our own `translate` defined function which internally still
-    uses `QtCore.QCoreApplication.translate`.
-
-    This is normally used inside a function that prints text.
-
-    >>> print(tr("Some text that will be translated"))
-
-    Parameters
-    ----------
-    text : str
-        Any text string.
-
-    Returns
-    -------
-    str
-        Returns the translated string at runtime.
-    """
-    return translate("Draft", text)
-
-
-def _qtr(text):
-    """Translate with the context set to Draft. QtCore function.
-
-    It uses `QtCore.QT_TRANSLATE_NOOP` function to perform translation.
-
-    This is normally used inside a function that prints text.
-
-    >>> print(qtr("Some text that will be translated"))
-
-    Parameters
-    ----------
-    text : str
-        Any text string.
-
-    Returns
-    -------
-    str
-        Returns the translated string at runtime.
-    """
-    return QT_TRANSLATE_NOOP("Draft", text)
-
 ## @}

--- a/src/Mod/Draft/draftviewproviders/view_base.py
+++ b/src/Mod/Draft/draftviewproviders/view_base.py
@@ -99,21 +99,21 @@ class ViewProviderDraft(object):
     def _set_properties(self, vobj):
         """Set the properties of objects if they don't exist."""
         if not hasattr(vobj, "Pattern"):
-            _tip = "Defines a hatch pattern."
             vobj.addProperty("App::PropertyEnumeration",
                              "Pattern",
                              "Draft",
-                             QT_TRANSLATE_NOOP("App::Property", _tip))
+                             QT_TRANSLATE_NOOP("App::Property",
+                                               "Defines an SVG pattern."))
             patterns = list(utils.svg_patterns().keys())
             patterns.sort()
             vobj.Pattern = ["None"] + patterns
 
         if not hasattr(vobj, "PatternSize"):
-            _tip = "Defines the size of the hatch pattern."
             vobj.addProperty("App::PropertyFloat",
                              "PatternSize",
                              "Draft",
-                             QT_TRANSLATE_NOOP("App::Property", _tip))
+                             QT_TRANSLATE_NOOP("App::Property",
+                                               "Defines the size of the SVG pattern."))
             vobj.PatternSize = utils.get_param("HatchPatternSize", 1)
 
     def __getstate__(self):
@@ -398,8 +398,8 @@ class ViewProviderDraft(object):
             Gui.runCommand("Draft_Edit")
             return True
         else:
-            _wrn = "Please load the Draft Workbench to enable editing this object"
-            App.Console.PrintWarning(QT_TRANSLATE_NOOP("Draft", _wrn))
+            App.Console.PrintWarning(QT_TRANSLATE_NOOP("draft",
+                                                       "Please load the Draft Workbench to enable editing this object"))
             return False
 
     def unsetEdit(self, vobj, mode=0):


### PR DESCRIPTION
PR to fix several translation issues. See forum topic.

Forum topic:
https://forum.freecadweb.org/viewtopic.php?f=23&t=65346

Additionally:
* Removed the faulty `_tr` and `_qtr` functions from `translate.py`. They are no longer used by the Draft or Arch WB.
* In `view_base.py`: Fixed wrong use of variables in `QT_TRANSLATE_NOOP` calls and changed the tooltips from 'hatch' pattern to 'SVG' pattern.

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

---
