### PR TITLE
[Path] fix default unit string for mm/min

### DIFF
--- a/src/Mod/Path/PathScripts/post/marlin_post.py
+++ b/src/Mod/Path/PathScripts/post/marlin_post.py
@@ -60,7 +60,7 @@ MOTION_MODE = "G90"  # G90 only, for absolute moves
 WORK_PLANE = "G17"  # G17 only, XY plane, for vertical milling
 UNITS = "G21"  # G21 only, for metric
 UNIT_FORMAT = "mm"
-UNIT_FEED_FORMAT = "mm/s"
+UNIT_FEED_FORMAT = "mm/min"
 
 # *****************************************************************************
 # * Initial configuration, changeable via command line arguments              *


### PR DESCRIPTION
The marlin post is outputting mm/s gcode.  Gcode is always mm/min.   Changing the default.

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [x]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [ ]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
