### PR TITLE
Fix typos [skip ci]

### DIFF
--- a/src/Mod/Path/PathScripts/PathProfileContour.py
+++ b/src/Mod/Path/PathScripts/PathProfileContour.py
@@ -32,7 +32,7 @@ __doc__ = "Implementation of the Contour operation (depreciated)."
 
 
 class ObjectContour(PathProfile.ObjectProfile):
-    '''Psuedo class for Profile operation,
+    '''Pseudo class for Profile operation,
     allowing for backward compatibility with pre-existing "Contour" operations.'''
     pass
 # Eclass

--- a/src/Mod/Path/PathScripts/PathProfileContourGui.py
+++ b/src/Mod/Path/PathScripts/PathProfileContourGui.py
@@ -34,7 +34,7 @@ __doc__ = "Contour operation page controller and command implementation (depreca
 
 
 class TaskPanelOpPage(PathProfileGui.TaskPanelOpPage):
-    """Psuedo page controller class for Profile operation,
+    """Pseudo page controller class for Profile operation,
     allowing for backward compatibility with pre-existing "Contour" operations."""
 
     pass

--- a/src/Mod/Path/PathScripts/PathProfileEdges.py
+++ b/src/Mod/Path/PathScripts/PathProfileEdges.py
@@ -33,7 +33,7 @@ __contributors__ = "russ4262 (Russell Johnson)"
 
 
 class ObjectProfile(PathProfile.ObjectProfile):
-    '''Psuedo class for Profile operation,
+    '''Pseudo class for Profile operation,
     allowing for backward compatibility with pre-existing "Profile Edges" operations.'''
     pass
 # Eclass

--- a/src/Mod/Path/PathScripts/PathProfileEdgesGui.py
+++ b/src/Mod/Path/PathScripts/PathProfileEdgesGui.py
@@ -36,7 +36,7 @@ __doc__ = (
 
 
 class TaskPanelOpPage(PathProfileGui.TaskPanelOpPage):
-    """Psuedo page controller class for Profile operation,
+    """Pseudo page controller class for Profile operation,
     allowing for backward compatibility with pre-existing "Profile Edges" operations."""
 
     pass

--- a/src/Mod/Path/PathScripts/PathProfileFaces.py
+++ b/src/Mod/Path/PathScripts/PathProfileFaces.py
@@ -34,7 +34,7 @@ __contributors__ = "Schildkroet"
 
 
 class ObjectProfile(PathProfile.ObjectProfile):
-    '''Psuedo class for Profile operation,
+    '''Pseudo class for Profile operation,
     allowing for backward compatibility with pre-existing "Profile Faces" operations.'''
     pass
 # Eclass

--- a/src/Mod/Path/PathScripts/PathProfileFacesGui.py
+++ b/src/Mod/Path/PathScripts/PathProfileFacesGui.py
@@ -36,7 +36,7 @@ __doc__ = (
 
 
 class TaskPanelOpPage(PathProfileGui.TaskPanelOpPage):
-    """Psuedo page controller class for Profile operation,
+    """Pseudo page controller class for Profile operation,
     allowing for backward compatibility with pre-existing "Profile Faces" operations."""
 
     pass

--- a/src/Mod/Robot/App/kdl_cp/solveri.hpp
+++ b/src/Mod/Robot/App/kdl_cp/solveri.hpp
@@ -85,7 +85,7 @@ class SolverI
 {
 public:
     enum {
-	/// Converged but degraded solution (e.g. WDLS with psuedo-inverse singular)
+	/// Converged but degraded solution (e.g. WDLS with pseudo-inverse singular)
         E_DEGRADED         = +1,
     //! No error
         E_NOERROR          =  0,


### PR DESCRIPTION
Found via `codespell -q 3 -L aci,ake,aline,alle,alledges,alocation,als,ang,anid,anormal,apoints,ba,beginn,behaviour,bloaded,bottome,byteorder,calculater,cancelled,cancelling,cas,cascade,centimetre,childrens,childs,colour,colours,commen,connexion,currenty,dof,doubleclick,dum,eiter,elemente,ende,feld,finde,findf,freez,hist,iff,indicies,initialisation,initialise,initialised,initialises,initialisiert,inout,ist,itsel,kilometre,lod,mantatory,methode,metres,millimetre,modell,nd,noe,normale,normaly,nto,numer,oce,oder,ontop,orgin,orginx,orginy,ot,pard,parm,parms,pres,programm,que,rady,recurrance,ro,rougly,seperator,serie,sinc,strack,substraction,te,technic,thist,thru,tread,uint,unter,vertexes,wallthickness,whitespaces -S ./.git,*.po,*.ts,./ChangeLog.txt,./src/3rdParty,./src/Mod/Assembly/App/opendcm,./src/CXX,./src/zipios++,./src/Base/swig*,./src/Mod/Robot/App/kdl_cp,./src/Mod/Import/App/SCL,./src/WindowsInstaller,./src/Doc/FreeCAD.uml,./src/Base/StackWalker.cpp,./build/doc/SourceDocu`