### PR TITLE
Gui: Add option to enable/disable text cursor blinking

### DIFF
--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -2099,6 +2099,10 @@ void Application::runApplication(void)
         mainApp.installEventFilter(filter);
     }
 
+    // set text cursor blinking state
+    int blinkTime = hGrp->GetBool("EnableCursorBlinking", true) ? -1 : 0;
+    qApp->setCursorFlashTime(blinkTime);
+
     {
         QWindow window;
         window.setSurfaceType(QWindow::OpenGLSurface);

--- a/src/Gui/DlgGeneral.ui
+++ b/src/Gui/DlgGeneral.ui
@@ -342,7 +342,7 @@
            <property name="bottomMargin">
             <number>0</number>
            </property>
-           <item>
+           <item row="0" column="0">
             <widget class="QCheckBox" name="tiledBackground">
              <property name="toolTip">
               <string>Background of the main window will consist of tiles of a special image.
@@ -350,6 +350,25 @@ See the FreeCAD Wiki for details about the image.</string>
              </property>
              <property name="text">
               <string>Enable tiled background</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="Gui::PrefCheckBox" name="EnableCursorBlinking">
+             <property name="toolTip">
+              <string>The text cursor will be blinking</string>
+             </property>
+             <property name="text">
+              <string>Enable cursor blinking</string>
+             </property>
+             <property name="checked">
+              <bool>true</bool>
+             </property>
+             <property name="prefEntry" stdset="0">
+              <cstring>EnableCursorBlinking</cstring>
+             </property>
+             <property name="prefPath" stdset="0">
+              <cstring>General</cstring>
              </property>
             </widget>
            </item>
@@ -625,6 +644,7 @@ horizontal space in Python console</string>
  <tabstops>
   <tabstop>Languages</tabstop>
   <tabstop>RecentFiles</tabstop>
+  <tabstop>EnableCursorBlinking</tabstop>
   <tabstop>SplashScreen</tabstop>
   <tabstop>PythonWordWrap</tabstop>
   <tabstop>PythonBlockCursor</tabstop>

--- a/src/Gui/DlgGeneralImp.cpp
+++ b/src/Gui/DlgGeneralImp.cpp
@@ -142,6 +142,7 @@ void DlgGeneralImp::saveSettings()
 
     ui->SubstituteDecimal->onSave();
     ui->RecentFiles->onSave();
+    ui->EnableCursorBlinking->onSave();
     ui->SplashScreen->onSave();
     ui->PythonWordWrap->onSave();
     ui->PythonBlockCursor->onSave();
@@ -173,6 +174,9 @@ void DlgGeneralImp::saveSettings()
     int pixel = size.toInt();
     hGrp->SetInt("ToolbarIconSize", pixel);
     getMainWindow()->setIconSize(QSize(pixel,pixel));
+
+    int blinkTime = hGrp->GetBool("EnableCursorBlinking", true) ? -1 : 0;
+    qApp->setCursorFlashTime(blinkTime);
 
     hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/DockWindows");
     bool treeView=false, propertyView=false, comboView=true;
@@ -208,6 +212,7 @@ void DlgGeneralImp::loadSettings()
 
     ui->SubstituteDecimal->onRestore();
     ui->RecentFiles->onRestore();
+    ui->EnableCursorBlinking->onRestore();
     ui->SplashScreen->onRestore();
     ui->PythonWordWrap->onRestore();
     ui->PythonBlockCursor->onRestore();


### PR DESCRIPTION
The hard coded  blinking time value `-1` is the [default value used by Qt](https://github.com/qt/qtbase/blob/dev/src/gui/kernel/qstylehints.cpp#L91)


Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [ ]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [ ]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [ ]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [ ]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
