### PR TITLE
Gui: Increase default for prefCountBackupFiles to 5 (UX improvement)

### DIFF
--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -2678,7 +2678,7 @@ bool Document::saveToFile(const char* filename) const
     if (policy) {
         // if saving the project data succeeded rename to the actual file name
         int count_bak = App::GetApplication().GetParameterGroupByPath
-            ("User parameter:BaseApp/Preferences/Document")->GetInt("CountBackupFiles",1);
+            ("User parameter:BaseApp/Preferences/Document")->GetInt("CountBackupFiles",5);
         bool backup = App::GetApplication().GetParameterGroupByPath
             ("User parameter:BaseApp/Preferences/Document")->GetBool("CreateBackupFiles",true);
         if (!backup) {

--- a/src/Gui/DlgSettingsDocument.ui
+++ b/src/Gui/DlgSettingsDocument.ui
@@ -478,6 +478,9 @@ Common sizes are 128, 256 and 512</string>
           <property name="minimum">
            <number>1</number>
           </property>
+          <property name="value">
+           <number>5</number>
+          </property>
           <property name="prefEntry" stdset="0">
            <cstring>CountBackupFiles</cstring>
           </property>


### PR DESCRIPTION
Increasing the default preference for the amount of backup files from 1 to 5. 

Closes #6045 ~0004313 (https://tracker.freecadweb.org/view.php?id=4313)~ 
Forum thread: https://forum.freecadweb.org/viewtopic.php?f=3&t=45232