### PR TITLE
Addon Manager: Add search and display of tags

### DIFF
--- a/src/App/MetadataPyImp.cpp
+++ b/src/App/MetadataPyImp.cpp
@@ -39,8 +39,11 @@ std::string MetadataPy::representation(void) const
     str << ptr->name();
     str << "), Description=(";
     str << ptr->description();
-    str << "), Maintainer=(";
-    str << ptr->maintainer().front().name << ")]";
+    if (!ptr->maintainer().empty()) {
+        str << "), Maintainer=(";
+        str << ptr->maintainer().front().name;
+    }
+    str << ")]";
 
     return str.str();
 }
@@ -258,7 +261,7 @@ Py::Object MetadataPy::getContent(void) const
     for (const auto& key : keys) {
         Py::List pyContentForKey;
         auto elements = content.equal_range(key);
-        for (auto element = elements.first; element != elements.second; ++element) {
+        for (auto & element = elements.first; element != elements.second; ++element) {
             auto contentMetadataItem = new MetadataPy(new Metadata(element->second));
             pyContentForKey.append(Py::asObject(contentMetadataItem));
         }

--- a/src/Mod/AddonManager/expanded_view.py
+++ b/src/Mod/AddonManager/expanded_view.py
@@ -17,8 +17,8 @@ class Ui_ExpandedView(object):
     def setupUi(self, ExpandedView):
         if not ExpandedView.objectName():
             ExpandedView.setObjectName(u"ExpandedView")
-        ExpandedView.resize(657, 64)
-        sizePolicy = QSizePolicy(QSizePolicy.MinimumExpanding, QSizePolicy.Minimum)
+        ExpandedView.resize(807, 141)
+        sizePolicy = QSizePolicy(QSizePolicy.MinimumExpanding, QSizePolicy.Preferred)
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
         sizePolicy.setHeightForWidth(ExpandedView.sizePolicy().hasHeightForWidth())
@@ -36,6 +36,8 @@ class Ui_ExpandedView(object):
         sizePolicy1.setHeightForWidth(self.labelIcon.sizePolicy().hasHeightForWidth())
         self.labelIcon.setSizePolicy(sizePolicy1)
         self.labelIcon.setMinimumSize(QSize(48, 48))
+        self.labelIcon.setMaximumSize(QSize(48, 48))
+        self.labelIcon.setBaseSize(QSize(48, 48))
 
         self.horizontalLayout_2.addWidget(self.labelIcon)
 
@@ -67,6 +69,11 @@ class Ui_ExpandedView(object):
         self.labelVersion.setSizePolicy(sizePolicy2)
 
         self.horizontalLayout.addWidget(self.labelVersion)
+
+        self.labelTags = QLabel(ExpandedView)
+        self.labelTags.setObjectName(u"labelTags")
+
+        self.horizontalLayout.addWidget(self.labelTags)
 
         self.horizontalSpacer_2 = QSpacerItem(
             40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum
@@ -127,6 +134,9 @@ class Ui_ExpandedView(object):
         )
         self.labelVersion.setText(
             QCoreApplication.translate("ExpandedView", u"Version", None)
+        )
+        self.labelTags.setText(
+            QCoreApplication.translate("ExpandedView", u"(tags)", None)
         )
         self.labelDescription.setText(
             QCoreApplication.translate("ExpandedView", u"Description", None)

--- a/src/Mod/AddonManager/expanded_view.ui
+++ b/src/Mod/AddonManager/expanded_view.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>657</width>
-    <height>64</height>
+    <width>807</width>
+    <height>141</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -112,6 +112,13 @@
          </property>
          <property name="text">
           <string>Version</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="labelTags">
+         <property name="text">
+          <string>(tags)</string>
          </property>
         </widget>
        </item>

--- a/src/Mod/AddonManager/package_list.py
+++ b/src/Mod/AddonManager/package_list.py
@@ -338,6 +338,7 @@ class PackageListItemDelegate(QStyledItemDelegate):
             self.widget.ui.labelIcon.setPixmap(repo.icon.pixmap(QSize(16, 16)))
 
         self.widget.ui.labelIcon.setText("")
+        self.widget.ui.labelTags.setText("")
         if repo.metadata:
             self.widget.ui.labelDescription.setText(repo.metadata.Description)
             self.widget.ui.labelVersion.setText(f"<i>v{repo.metadata.Version}</i>")
@@ -353,8 +354,16 @@ class PackageListItemDelegate(QStyledItemDelegate):
                     n = len(maintainers)
                     string = translate("AddonsInstaller", "Maintainers:", "", n)
                     for maintainer in maintainers:
-                        string += f"\n{maintainer['name']} <{maintainer['email']}>"
-                self.widget.ui.labelMaintainer.setText(string)
+                        maintainers_string += (
+                            f"\n{maintainer['name']} <{maintainer['email']}>"
+                        )
+                self.widget.ui.labelMaintainer.setText(maintainers_string)
+                if repo.tags:
+                    self.widget.ui.labelTags.setText(
+                        translate("AddonsInstaller", "Tags")
+                        + ": "
+                        + ", ".join(repo.tags)
+                    )
         elif repo.macro and repo.macro.parsed:
             self.widget.ui.labelDescription.setText(repo.macro.comment)
             self.widget.ui.labelVersion.setText(repo.macro.version)
@@ -562,6 +571,9 @@ class PackageListFilter(QSortFilterProxyModel):
                     and re.match(data.macro.comment).hasMatch()
                 ):
                     return True
+                for tag in data.tags:
+                    if re.match(tag).hasMatch():
+                        return True
                 return False
             else:
                 return False
@@ -573,6 +585,15 @@ class PackageListFilter(QSortFilterProxyModel):
                     return True
                 if re.indexIn(desc) != -1:
                     return True
+                if (
+                    data.macro
+                    and data.macro.comment
+                    and re.indexIn(data.macro.comment) != -1
+                ):
+                    return True
+                for tag in data.tags:
+                    if re.indexIn(tag) != -1:
+                        return True
                 return False
             else:
                 return False


### PR DESCRIPTION
Tags display in expanded view (right now just as a simple comma-separated list), but are searched regardless of whether they are displaying or not.