### PR TITLE
Addon Manager: Switch to using QWebEngineView for README

### DIFF
--- a/src/Mod/AddonManager/CMakeLists.txt
+++ b/src/Mod/AddonManager/CMakeLists.txt
@@ -20,6 +20,7 @@ SET(AddonManager_SRCS
     NetworkManager.py
     package_list.py
     package_details.py
+    loading.html
 )
 
 SOURCE_GROUP("" FILES ${AddonManager_SRCS})

--- a/src/Mod/AddonManager/loading.html
+++ b/src/Mod/AddonManager/loading.html
@@ -1,0 +1,93 @@
+<!--
+Adapted from:
+https://codepen.io/MattIn4D/pen/LiKFC
+
+Copyright © 2021 MattIn4D
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the “Software”), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+
+<html>
+<head>
+    <style>
+        /* Absolute Center Spinner */
+        .loading {
+            position: fixed;
+            z-index: 999;
+            height: 2em;
+            width: 2em;
+            overflow: visible;
+            margin: auto;
+            top: 0;
+            left: 0;
+            bottom: 0;
+            right: 0;
+        }
+
+        /* Transparent Overlay */
+        .loading:before {
+            content: '';
+            display: block;
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background-color: rgba(0,0,0,0.3);
+        }
+
+        /* :not(:required) hides these rules from IE9 and below */
+        .loading:not(:required) {
+            /* hide "loading..." text */
+            font: 0/0 a;
+            color: transparent;
+            text-shadow: none;
+            background-color: transparent;
+            border: 0;
+        }
+
+        .loading:not(:required):after {
+            content: '';
+            display: block;
+            font-size: 10px;
+            width: 1em;
+            height: 1em;
+            margin-top: -0.5em;
+            animation: spinner 5000ms infinite linear;
+            border-radius: 0.5em;
+            box-shadow: rgba(0, 0, 0, 0.75) 1.5em 0 0 0, rgba(0, 0, 0, 0.75) 1.1em 1.1em 0 0, rgba(0, 0, 0, 0.75) 0 1.5em 0 0, rgba(0, 0, 0, 0.75) -1.1em 1.1em 0 0, rgba(0, 0, 0, 0.75) -1.5em 0 0 0, rgba(0, 0, 0, 0.75) -1.1em -1.1em 0 0, rgba(0, 0, 0, 0.75) 0 -1.5em 0 0, rgba(0, 0, 0, 0.75) 1.1em -1.1em 0 0;
+        }
+
+        /* Animation */
+
+        @keyframes spinner {
+            0% {
+                transform: rotate(0deg);
+            }
+
+            100% {
+                transform: rotate(360deg);
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="loading">Loading...</div>
+</body>
+</html>

--- a/src/Mod/AddonManager/package_details.py
+++ b/src/Mod/AddonManager/package_details.py
@@ -24,20 +24,19 @@
 from PySide2.QtCore import *
 from PySide2.QtGui import *
 from PySide2.QtWidgets import *
+from PySide2.QtWebEngineWidgets import *
 
 import os
-import shutil
-from datetime import date, timedelta
 
 import FreeCAD
 
 import addonmanager_utilities as utils
-from addonmanager_workers import ShowWorker, GetMacroDetailsWorker
+from addonmanager_workers import GetMacroDetailsWorker, CheckSingleUpdateWorker
 from AddonManagerRepo import AddonManagerRepo
 
-import inspect
-
 translate = FreeCAD.Qt.translate
+
+show_javascript_console_output = False
 
 
 class PackageDetails(QWidget):
@@ -57,9 +56,10 @@ class PackageDetails(QWidget):
 
         self.worker = None
         self.repo = None
+        self.status_update_thread = None
 
         self.ui.buttonBack.clicked.connect(self.back.emit)
-        self.ui.buttonRefresh.clicked.connect(self.refresh)
+        self.ui.buttonBack.clicked.connect(self.clear_web_view)
         self.ui.buttonExecute.clicked.connect(lambda: self.execute.emit(self.repo))
         self.ui.buttonInstall.clicked.connect(lambda: self.install.emit(self.repo))
         self.ui.buttonUninstall.clicked.connect(lambda: self.uninstall.emit(self.repo))
@@ -67,34 +67,64 @@ class PackageDetails(QWidget):
         self.ui.buttonCheckForUpdate.clicked.connect(
             lambda: self.check_for_update.emit(self.repo)
         )
+        self.ui.webView.loadStarted.connect(self.load_started)
+        self.ui.webView.loadProgress.connect(self.load_progress)
+        self.ui.webView.loadFinished.connect(self.load_finished)
+
+        loading_html_file = os.path.join(os.path.dirname(__file__), "loading.html")
+        with open(loading_html_file, "r", errors="ignore") as f:
+            html = f.read()
+            self.ui.loadingLabel.setHtml(html)
+            self.ui.loadingLabel.show()
+            self.ui.webView.hide()
 
     def show_repo(self, repo: AddonManagerRepo, reload: bool = False) -> None:
 
-        self.repo = repo
+        # If this is the same repo we were already showing, we do not have to do the
+        # expensive refetch unless reload is true
+        if self.repo != repo or reload:
+            self.repo = repo
+            self.ui.loadingLabel.show()
+            self.ui.webView.hide()
+            self.ui.progressBar.show()
 
-        if self.worker is not None:
-            if not self.worker.isFinished():
-                self.worker.requestInterruption()
-                self.worker.wait()
+            if self.worker is not None:
+                if not self.worker.isFinished():
+                    self.worker.requestInterruption()
+                    self.worker.wait()
 
-        # Always load bare macros from scratch, we need to grab their code, which isn't cached
-        force_reload = reload
-        if repo.repo_type == AddonManagerRepo.RepoType.MACRO:
-            force_reload = True
+            if repo.repo_type == AddonManagerRepo.RepoType.MACRO:
+                self.show_macro(repo)
+                self.ui.buttonExecute.show()
+            elif repo.repo_type == AddonManagerRepo.RepoType.WORKBENCH:
+                self.show_workbench(repo)
+                self.ui.buttonExecute.hide()
+            elif repo.repo_type == AddonManagerRepo.RepoType.PACKAGE:
+                self.show_package(repo)
+                self.ui.buttonExecute.hide()
 
-        self.check_and_clean_cache(force_reload)
+        if self.status_update_thread is not None:
+            if not self.status_update_thread.isFinished():
+                self.status_update_thread.requestInterruption()
+                self.status_update_thread.wait()
 
-        if repo.repo_type == AddonManagerRepo.RepoType.MACRO:
-            self.show_macro(repo)
-            self.ui.buttonExecute.show()
-        elif repo.repo_type == AddonManagerRepo.RepoType.WORKBENCH:
-            self.show_workbench(repo)
-            self.ui.buttonExecute.hide()
-        elif repo.repo_type == AddonManagerRepo.RepoType.PACKAGE:
-            self.show_package(repo)
-            self.ui.buttonExecute.hide()
+        if repo.status() == AddonManagerRepo.UpdateStatus.UNCHECKED:
+            self.status_update_thread = QThread()
+            self.status_update_worker = CheckSingleUpdateWorker(repo, self)
+            self.status_update_worker.moveToThread(self.status_update_thread)
+            self.status_update_thread.finished.connect(
+                self.status_update_worker.deleteLater
+            )
+            self.check_for_update.connect(self.status_update_worker.do_work)
+            self.status_update_worker.update_status.connect(self.display_repo_status)
+            self.status_update_thread.start()
+            self.check_for_update.emit(self.repo)
 
-        if repo.update_status != AddonManagerRepo.UpdateStatus.NOT_INSTALLED:
+        self.display_repo_status(self.repo.update_status)
+
+    def display_repo_status(self, status):
+        repo = self.repo
+        if status != AddonManagerRepo.UpdateStatus.NOT_INSTALLED:
 
             version = repo.installed_version
             date = ""
@@ -125,7 +155,7 @@ class PackageDetails(QWidget):
                     translate("AddonsInstaller", "Installed") + ". "
                 )
 
-            if repo.update_status == AddonManagerRepo.UpdateStatus.UPDATE_AVAILABLE:
+            if status == AddonManagerRepo.UpdateStatus.UPDATE_AVAILABLE:
                 if repo.metadata:
                     installed_version_string += (
                         "<b>"
@@ -151,21 +181,19 @@ class PackageDetails(QWidget):
                         )
                         + ".</b>"
                     )
-            elif (
-                repo.update_status == AddonManagerRepo.UpdateStatus.NO_UPDATE_AVAILABLE
-            ):
+            elif status == AddonManagerRepo.UpdateStatus.NO_UPDATE_AVAILABLE:
                 installed_version_string += (
                     translate("AddonsInstaller", "This is the latest version available")
                     + "."
                 )
-            elif repo.update_status == AddonManagerRepo.UpdateStatus.PENDING_RESTART:
+            elif status == AddonManagerRepo.UpdateStatus.PENDING_RESTART:
                 installed_version_string += (
                     translate(
                         "AddonsInstaller", "Updated, please restart FreeCAD to use"
                     )
                     + "."
                 )
-            elif repo.update_status == AddonManagerRepo.UpdateStatus.UNCHECKED:
+            elif status == AddonManagerRepo.UpdateStatus.UNCHECKED:
 
                 pref = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Addons")
                 autocheck = pref.GetBool("AutoCheck", False)
@@ -181,7 +209,7 @@ class PackageDetails(QWidget):
 
             installed_version_string += "</h3>"
             self.ui.labelPackageDetails.setText(installed_version_string)
-            if repo.update_status == AddonManagerRepo.UpdateStatus.UPDATE_AVAILABLE:
+            if repo.status() == AddonManagerRepo.UpdateStatus.UPDATE_AVAILABLE:
                 self.ui.labelPackageDetails.setStyleSheet(
                     "color:" + utils.attention_color_string()
                 )
@@ -206,27 +234,27 @@ class PackageDetails(QWidget):
             self.ui.labelPackageDetails.hide()
             self.ui.labelInstallationLocation.hide()
 
-        if repo.update_status == AddonManagerRepo.UpdateStatus.NOT_INSTALLED:
+        if status == AddonManagerRepo.UpdateStatus.NOT_INSTALLED:
             self.ui.buttonInstall.show()
             self.ui.buttonUninstall.hide()
             self.ui.buttonUpdate.hide()
             self.ui.buttonCheckForUpdate.hide()
-        elif repo.update_status == AddonManagerRepo.UpdateStatus.NO_UPDATE_AVAILABLE:
+        elif status == AddonManagerRepo.UpdateStatus.NO_UPDATE_AVAILABLE:
             self.ui.buttonInstall.hide()
             self.ui.buttonUninstall.show()
             self.ui.buttonUpdate.hide()
             self.ui.buttonCheckForUpdate.hide()
-        elif repo.update_status == AddonManagerRepo.UpdateStatus.UPDATE_AVAILABLE:
+        elif status == AddonManagerRepo.UpdateStatus.UPDATE_AVAILABLE:
             self.ui.buttonInstall.hide()
             self.ui.buttonUninstall.show()
             self.ui.buttonUpdate.show()
             self.ui.buttonCheckForUpdate.hide()
-        elif repo.update_status == AddonManagerRepo.UpdateStatus.UNCHECKED:
+        elif status == AddonManagerRepo.UpdateStatus.UNCHECKED:
             self.ui.buttonInstall.hide()
             self.ui.buttonUninstall.show()
             self.ui.buttonUpdate.hide()
             self.ui.buttonCheckForUpdate.show()
-        elif repo.update_status == AddonManagerRepo.UpdateStatus.PENDING_RESTART:
+        elif status == AddonManagerRepo.UpdateStatus.PENDING_RESTART:
             self.ui.buttonInstall.hide()
             self.ui.buttonUninstall.show()
             self.ui.buttonUpdate.hide()
@@ -255,127 +283,155 @@ class PackageDetails(QWidget):
         else:
             self.ui.labelWarningInfo.hide()
 
-    @classmethod
-    def cache_path(self, repo: AddonManagerRepo) -> str:
-        cache_path = FreeCAD.getUserCachePath()
-        full_path = os.path.join(cache_path, "AddonManager", repo.name)
-        return full_path
-
-    def check_and_clean_cache(self, force: bool = False) -> None:
-        cache_path = PackageDetails.cache_path(self.repo)
-        readme_cache_file = os.path.join(cache_path, "README.html")
-        readme_images_path = os.path.join(cache_path, "Images")
-        download_interrupted_sentinel = os.path.join(
-            readme_images_path, "download_in_progress"
-        )
-        download_interrupted = os.path.isfile(download_interrupted_sentinel)
-        if os.path.isfile(readme_cache_file):
-            pref = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Addons")
-            days_between_updates = pref.GetInt("DaysBetweenUpdates", 2 ^ 32)
-            timestamp = os.path.getmtime(readme_cache_file)
-            last_cache_update = date.fromtimestamp(timestamp)
-            delta_update = timedelta(days=days_between_updates)
-            if (
-                date.today() >= last_cache_update + delta_update
-                or download_interrupted
-                or force
-            ):
-                if force:
-                    FreeCAD.Console.PrintLog(
-                        f"Forced README cache update for {self.repo.name}\n"
-                    )
-                elif download_interrupted:
-                    FreeCAD.Console.PrintLog(
-                        f"Restarting interrupted README download for {self.repo.name}\n"
-                    )
-                else:
-                    FreeCAD.Console.PrintLog(
-                        f"Cache expired, downloading README for {self.repo.name} again\n"
-                    )
-                os.remove(readme_cache_file)
-                if os.path.isdir(readme_images_path):
-                    shutil.rmtree(readme_images_path)
-
-    def refresh(self):
-        self.check_and_clean_cache(force=True)
-        self.show_repo(self.repo)
-
-    def show_cached_readme(self, repo: AddonManagerRepo) -> bool:
-        """Attempts to show a cached readme, returns true if there was a cache, or false if not"""
-
-        cache_path = PackageDetails.cache_path(repo)
-        readme_cache_file = os.path.join(cache_path, "README.html")
-        if os.path.isfile(readme_cache_file):
-            with open(readme_cache_file, "rb") as f:
-                data = f.read()
-                self.ui.textBrowserReadMe.setText(data.decode())
-                return True
-        return False
-
     def show_workbench(self, repo: AddonManagerRepo) -> None:
         """loads information of a given workbench"""
-
-        if not self.show_cached_readme(repo):
-            self.ui.textBrowserReadMe.setText(
-                translate(
-                    "AddonsInstaller", "Fetching README.md from package repository"
-                )
-            )
-            self.worker = ShowWorker(repo, PackageDetails.cache_path(repo))
-            self.worker.readme_updated.connect(
-                lambda desc: self.cache_readme(repo, desc)
-            )
-            self.worker.readme_updated.connect(
-                lambda desc: self.ui.textBrowserReadMe.setText(desc)
-            )
-            self.worker.update_status.connect(self.update_status.emit)
-            self.worker.update_status.connect(self.show)
-            self.worker.start()
+        url = utils.get_readme_html_url(repo)
+        self.ui.webView.load(QUrl(url))
+        self.ui.urlBar.setText(url)
 
     def show_package(self, repo: AddonManagerRepo) -> None:
         """Show the details for a package (a repo with a package.xml metadata file)"""
 
-        if not self.show_cached_readme(repo):
-            self.ui.textBrowserReadMe.setText(
-                translate(
-                    "AddonsInstaller", "Fetching README.md from package repository"
-                )
-            )
-            self.worker = ShowWorker(repo, PackageDetails.cache_path(repo))
-            self.worker.readme_updated.connect(
-                lambda desc: self.cache_readme(repo, desc)
-            )
-            self.worker.readme_updated.connect(
-                lambda desc: self.ui.textBrowserReadMe.setText(desc)
-            )
-            self.worker.update_status.connect(self.update_status.emit)
-            self.worker.update_status.connect(self.show)
-            self.worker.start()
+        readme_url = None
+        if repo.metadata:
+            urls = repo.metadata.Urls
+            for url in urls:
+                if url["type"] == "readme":
+                    readme_url = url["location"]
+                    break
+        if not readme_url:
+            readme_url = utils.get_readme_html_url(repo)
+        self.ui.webView.load(QUrl(readme_url))
+        self.ui.urlBar.setText(readme_url)
 
     def show_macro(self, repo: AddonManagerRepo) -> None:
         """loads information of a given macro"""
 
-        if not self.show_cached_readme(repo):
-            self.ui.textBrowserReadMe.setText(
-                translate(
-                    "AddonsInstaller", "Fetching README.md from package repository"
-                )
-            )
-            self.worker = GetMacroDetailsWorker(repo)
-            self.worker.readme_updated.connect(
-                lambda desc: self.cache_readme(repo, desc)
-            )
-            self.worker.readme_updated.connect(
-                lambda desc: self.ui.textBrowserReadMe.setText(desc)
-            )
-            self.worker.start()
+        self.ui.webView.load(QUrl(repo.macro.url))
+        self.ui.urlBar.setText(repo.macro.url)
 
-    def cache_readme(self, repo: AddonManagerRepo, readme: str) -> None:
-        cache_path = PackageDetails.cache_path(repo)
-        readme_cache_file = os.path.join(cache_path, "README.html")
-        os.makedirs(cache_path, exist_ok=True)
-        with open(readme_cache_file, "wb") as f:
-            f.write(readme.encode())
+        # We need to populate the macro information... may as well do it while the user reads the wiki page
+        self.worker = GetMacroDetailsWorker(repo)
+        self.worker.start()
+
+    def run_javascript(self):
+        """Modify the page for a README to optimize for viewing in a smaller window"""
+
+        s = """
+( function() {
+    const url = new URL (window.location);
+    const body = document.getElementsByTagName("body")[0];
+    if (url.hostname === "github.com") {
+        const articles = document.getElementsByTagName("article");
+        if (articles.length > 0) {
+            const article = articles[0];
+            body.appendChild (article);
+            body.style.padding = "1em";
+            let sibling = article.previousSibling;
+            while (sibling) {
+                sibling.remove();
+                sibling = article.previousSibling;
+            }
+        }
+    } else if (url.hostname === "gitlab.com" || 
+               url.hostname === "framagit.org" || 
+               url.hostname === "salsa.debian.org") {
+        // These all use the GitLab page display...
+        const articles = document.getElementsByTagName("article");
+        if (articles.length > 0) {
+            const article = articles[0];
+            body.appendChild (article);
+            body.style.padding = "1em";
+            let sibling = article.previousSibling;
+            while (sibling) {
+                sibling.remove();
+                sibling = article.previousSibling;
+            }
+        }
+    } else if (url.hostname === "wiki.freecad.org" || 
+               url.hostname === "wiki.freecadweb.org") {
+        const first_heading = document.getElementById('firstHeading');
+        const body_content = document.getElementById('bodyContent');
+        const new_node = document.createElement("div");
+        new_node.appendChild(first_heading);
+        new_node.appendChild(body_content);
+        body.appendChild(new_node);
+        let sibling = new_node.previousSibling;
+        while (sibling) {
+            sibling.remove();
+            sibling = new_node.previousSibling;
+        }
+    }
+}
+) ()
+"""
+        self.ui.webView.page().runJavaScript(s)
+
+    def clear_web_view(self):
+        self.ui.webView.setHtml("<html><body><h1>Loading...</h1></body></html>")
+
+    def load_started(self):
+        self.ui.progressBar.show()
+        self.ui.progressBar.setValue(0)
+
+    def load_progress(self, progress: int):
+        self.ui.progressBar.setValue(progress)
+
+    def load_finished(self, load_succeeded: bool):
+        self.ui.loadingLabel.hide()
+        self.ui.webView.show()
+        self.ui.progressBar.hide()
+        url = self.ui.webView.url()
+        if load_succeeded:
+            # It says it succeeded, but it might have only succeeded in loading a "Page not found" page!
+            title = self.ui.webView.title()
+            path_components = url.path().split("/")
+            expected_content = path_components[-1]
+            if url.host() == "github.com" and expected_content not in title:
+                self.show_error_for(url)
+            elif title == "":
+                self.show_error_for(url)
+            else:
+                self.run_javascript()
+        else:
+            self.show_error_for(url)
+
+    def show_error_for(self, url: QUrl) -> None:
+        m = translate(
+            "AddonsInstaller", "Could not load README data from URL {}"
+        ).format(url.toString())
+        html = f"<html><body><p>{m}</p></body></html>"
+        self.ui.webView.setHtml(html)
+
+
+class RestrictedWebPage(QWebEnginePage):
+    """A class that follows links to FreeCAD wiki pages, but opens all other clicked links in the system web browser"""
+
+    def __init__(self, parent):
+        super().__init__(parent)
+        self.settings().setAttribute(QWebEngineSettings.ErrorPageEnabled, False)
+
+    def acceptNavigationRequest(self, url, _type, isMainFrame):
+        if _type == QWebEnginePage.NavigationTypeLinkClicked:
+
+            # See if the link is to a FreeCAD Wiki page -- if so, follow it, otherwise ask the OS to open it
+            if url.host() == "wiki.freecad.org" or url.host() == "wiki.freecadweb.org":
+                return super().acceptNavigationRequest(url, _type, isMainFrame)
+            else:
+                QDesktopServices.openUrl(url)
+                return False
+        return super().acceptNavigationRequest(url, _type, isMainFrame)
+
+    def javaScriptConsoleMessage(self, level, message, lineNumber, sourceID):
+        global show_javascript_console_output
+        if show_javascript_console_output:
+            tag = translate("AddonsInstaller", "Page JavaScript reported")
+            if level == QWebEnginePage.InfoMessageLevel:
+                FreeCAD.Console.PrintMessage(f"{tag} {lineNumber}: {message}\n")
+            elif level == QWebEnginePage.WarningMessageLevel:
+                FreeCAD.Console.PrintWarning(f"{tag} {lineNumber}: {message}\n")
+            elif level == QWebEnginePage.ErrorMessageLevel:
+                FreeCAD.Console.PrintError(f"{tag} {lineNumber}: {message}\n")
 
 
 class Ui_PackageDetails(object):
@@ -391,14 +447,8 @@ class Ui_PackageDetails(object):
         self.buttonBack.setIcon(
             QIcon.fromTheme("back", QIcon(":/icons/button_left.svg"))
         )
-        self.buttonRefresh = QToolButton(PackageDetails)
-        self.buttonRefresh.setObjectName("buttonRefresh")
-        self.buttonRefresh.setIcon(
-            QIcon.fromTheme("refresh", QIcon(":/icons/view-refresh.svg"))
-        )
 
         self.layoutDetailsBackButton.addWidget(self.buttonBack)
-        self.layoutDetailsBackButton.addWidget(self.buttonRefresh)
 
         self.horizontalSpacer = QSpacerItem(
             40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum
@@ -449,12 +499,34 @@ class Ui_PackageDetails(object):
 
         self.verticalLayout_2.addWidget(self.labelWarningInfo)
 
-        self.textBrowserReadMe = QTextBrowser(PackageDetails)
-        self.textBrowserReadMe.setObjectName("textBrowserReadMe")
-        self.textBrowserReadMe.setOpenExternalLinks(True)
-        self.textBrowserReadMe.setOpenLinks(True)
+        sizePolicy1 = QSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+        sizePolicy1.setHorizontalStretch(0)
+        sizePolicy1.setVerticalStretch(0)
 
-        self.verticalLayout_2.addWidget(self.textBrowserReadMe)
+        self.webView = QWebEngineView(PackageDetails)
+        self.webView.setObjectName("webView")
+        self.webView.setSizePolicy(sizePolicy1)
+        self.webView.setPage(RestrictedWebPage(PackageDetails))
+
+        self.verticalLayout_2.addWidget(self.webView)
+
+        self.loadingLabel = QWebEngineView(PackageDetails)
+        self.loadingLabel.setObjectName("loadingLabel")
+        self.loadingLabel.setSizePolicy(sizePolicy1)
+
+        self.verticalLayout_2.addWidget(self.loadingLabel)
+
+        self.progressBar = QProgressBar(PackageDetails)
+        self.progressBar.setObjectName("progressBar")
+        self.progressBar.setTextVisible(False)
+
+        self.verticalLayout_2.addWidget(self.progressBar)
+
+        self.urlBar = QLineEdit(PackageDetails)
+        self.urlBar.setObjectName("urlBar")
+        self.urlBar.setReadOnly(True)
+
+        self.verticalLayout_2.addWidget(self.urlBar)
 
         self.retranslateUi(PackageDetails)
 
@@ -462,7 +534,7 @@ class Ui_PackageDetails(object):
 
     # setupUi
 
-    def retranslateUi(self, PackageDetails):
+    def retranslateUi(self, _):
         self.buttonBack.setText("")
         self.buttonInstall.setText(
             QCoreApplication.translate("AddonsInstaller", "Install", None)
@@ -482,13 +554,6 @@ class Ui_PackageDetails(object):
         self.buttonBack.setToolTip(
             QCoreApplication.translate(
                 "AddonsInstaller", "Return to package list", None
-            )
-        )
-        self.buttonRefresh.setToolTip(
-            QCoreApplication.translate(
-                "AddonsInstaller",
-                "Delete cached version of this README and re-download",
-                None,
             )
         )
 

--- a/src/Mod/AddonManager/package_list.py
+++ b/src/Mod/AddonManager/package_list.py
@@ -226,7 +226,7 @@ class PackageListItemModel(QAbstractListModel):
         row = index.row()
         self.write_lock.acquire()
         if role == PackageListItemModel.StatusUpdateRole:
-            self.repos[row].update_status = value
+            self.repos[row].set_status(value)
             self.dataChanged.emit(
                 self.index(row, 2),
                 self.index(row, 2),
@@ -408,13 +408,13 @@ class PackageListItemDelegate(QStyledItemDelegate):
         """Get a single-line string listing details about the installed version and date"""
 
         result = ""
-        if repo.update_status == AddonManagerRepo.UpdateStatus.UNCHECKED:
+        if repo.status() == AddonManagerRepo.UpdateStatus.UNCHECKED:
             result = translate("AddonsInstaller", "Installed")
-        elif repo.update_status == AddonManagerRepo.UpdateStatus.NO_UPDATE_AVAILABLE:
+        elif repo.status() == AddonManagerRepo.UpdateStatus.NO_UPDATE_AVAILABLE:
             result = translate("AddonsInstaller", "Up-to-date")
-        elif repo.update_status == AddonManagerRepo.UpdateStatus.UPDATE_AVAILABLE:
+        elif repo.status() == AddonManagerRepo.UpdateStatus.UPDATE_AVAILABLE:
             result = translate("AddonsInstaller", "Update available")
-        elif repo.update_status == AddonManagerRepo.UpdateStatus.PENDING_RESTART:
+        elif repo.status() == AddonManagerRepo.UpdateStatus.PENDING_RESTART:
             result = translate("AddonsInstaller", "Pending restart")
         return result
 
@@ -424,7 +424,7 @@ class PackageListItemDelegate(QStyledItemDelegate):
         result = ""
 
         installed_version_string = ""
-        if repo.update_status != AddonManagerRepo.UpdateStatus.NOT_INSTALLED:
+        if repo.status() != AddonManagerRepo.UpdateStatus.NOT_INSTALLED:
             if repo.installed_version:
                 installed_version_string = (
                     "\n" + translate("AddonsInstaller", "Installed version") + ": "
@@ -453,20 +453,20 @@ class PackageListItemDelegate(QStyledItemDelegate):
             )
             available_version_string += repo.metadata.Version
 
-        if repo.update_status == AddonManagerRepo.UpdateStatus.UNCHECKED:
+        if repo.status() == AddonManagerRepo.UpdateStatus.UNCHECKED:
             result = translate("AddonsInstaller", "Installed")
             result += installed_version_string
             result += installed_date_string
-        elif repo.update_status == AddonManagerRepo.UpdateStatus.NO_UPDATE_AVAILABLE:
+        elif repo.status() == AddonManagerRepo.UpdateStatus.NO_UPDATE_AVAILABLE:
             result = translate("AddonsInstaller", "Up-to-date")
             result += installed_version_string
             result += installed_date_string
-        elif repo.update_status == AddonManagerRepo.UpdateStatus.UPDATE_AVAILABLE:
+        elif repo.status() == AddonManagerRepo.UpdateStatus.UPDATE_AVAILABLE:
             result = translate("AddonsInstaller", "Update available")
             result += installed_version_string
             result += installed_date_string
             result += available_version_string
-        elif repo.update_status == AddonManagerRepo.UpdateStatus.PENDING_RESTART:
+        elif repo.status() == AddonManagerRepo.UpdateStatus.PENDING_RESTART:
             result = translate("AddonsInstaller", "Pending restart")
 
         return result
@@ -530,18 +530,18 @@ class PackageListFilter(QSortFilterProxyModel):
                 return False
 
         if self.status == StatusFilter.INSTALLED:
-            if data.update_status == AddonManagerRepo.UpdateStatus.NOT_INSTALLED:
+            if data.status() == AddonManagerRepo.UpdateStatus.NOT_INSTALLED:
                 return False
         elif self.status == StatusFilter.NOT_INSTALLED:
-            if data.update_status != AddonManagerRepo.UpdateStatus.NOT_INSTALLED:
+            if data.status() != AddonManagerRepo.UpdateStatus.NOT_INSTALLED:
                 return False
         elif self.status == StatusFilter.UPDATE_AVAILABLE:
-            if data.update_status != AddonManagerRepo.UpdateStatus.UPDATE_AVAILABLE:
+            if data.status() != AddonManagerRepo.UpdateStatus.UPDATE_AVAILABLE:
                 return False
 
         # If it's not installed, check to see if it's Py2 only
         if (
-            data.update_status == AddonManagerRepo.UpdateStatus.NOT_INSTALLED
+            data.status() == AddonManagerRepo.UpdateStatus.NOT_INSTALLED
             and self.hide_py2
             and data.python2
         ):
@@ -549,7 +549,7 @@ class PackageListFilter(QSortFilterProxyModel):
 
         # If it's not installed, check to see if it's marked obsolete
         if (
-            data.update_status == AddonManagerRepo.UpdateStatus.NOT_INSTALLED
+            data.status() == AddonManagerRepo.UpdateStatus.NOT_INSTALLED
             and self.hide_obsolete
             and data.obsolete
         ):


### PR DESCRIPTION
Take Two -- some different design decisions this time. The basic idea is to use QWebEngineView (which is basically a fork of Chromium) to display the README and Macro Wiki Page content, since that content is really web-based and makes sense in a web browser. However, it is not intended as a general purpose web browser: almost all links you click on will ask the system to open its default web browser, the same way the original version did. The only exception is FreeCAD wiki pages, which this web view will render.