### PR TITLE
[Part] Extrusion uses FaceMakerCheese

### DIFF
--- a/src/Mod/Part/App/FeatureExtrusion.cpp
+++ b/src/Mod/Part/App/FeatureExtrusion.cpp
@@ -558,9 +558,8 @@ void FaceMakerExtrusion::Build()
 
 }
 
-
 void Part::Extrusion::setupObject()
 {
     Part::Feature::setupObject();
-    this->FaceMakerClass.setValue("Part::FaceMakerBullseye"); //default for newly created features
+    this->FaceMakerClass.setValue("Part::FaceMakerCheese"); //default for newly created features
 }


### PR DESCRIPTION
this is already the case since 2016

(It is not clear why the Facemaker class is output to the feature properties at all since changing it has no effect.)