### PR TITLE
Arch: Fix ArchFrame

### DIFF
--- a/src/Mod/Arch/ArchFrame.py
+++ b/src/Mod/Arch/ArchFrame.py
@@ -152,9 +152,9 @@ class _Frame(ArchComponent.Component):
         else:
             if not obj.Profile:
                 return
-            if not obj.Profile.isDerivedFrom("Part::Part2DObject"):
-                return
             if not obj.Profile.Shape:
+                return
+            if obj.Profile.Shape.findPlane() is None:
                 return
             if not obj.Profile.Shape.Wires:
                 return
@@ -177,7 +177,6 @@ class _Frame(ArchComponent.Component):
                     baseprofile = Part.makeCompound(f)
             shapes = []
             normal = DraftGeomUtils.getNormal(obj.Base.Shape)
-            #for wire in obj.Base.Shape.Wires:
             edges = obj.Base.Shape.Edges
             if hasattr(obj,"Edges"):
                 if obj.Edges == "Vertical edges":
@@ -199,47 +198,44 @@ class _Frame(ArchComponent.Component):
                     z = edges[0].CenterOfMass.z
                     edges = [e for e in edges if abs(e.CenterOfMass.z-z) < 0.00001]
             for e in edges:
-                #e = wire.Edges[0]
                 bvec = DraftGeomUtils.vec(e)
                 bpoint = e.Vertexes[0].Point
                 profile = baseprofile.copy()
-                #basepoint = profile.Placement.Base
-                if hasattr(obj,"BasePoint"):
+                rot = None # New rotation.
+                # Supplying FreeCAD.Rotation() with two parallel vectors and
+                # a null vector may seem strange, but the function is perfectly
+                # able to handle this. Its algorithm will use default axes in
+                # such cases.
+                if obj.Align:
+                    if normal is None:
+                        rot = FreeCAD.Rotation(FreeCAD.Vector(), bvec, bvec, "ZYX")
+                    else:
+                        rot = FreeCAD.Rotation(FreeCAD.Vector(), normal, bvec, "ZYX")
+                    profile.Placement.Rotation = rot
+                if hasattr(obj, "BasePoint"):
                     edges = Part.__sortEdges__(profile.Edges)
-                    basepointliste = [profile.CenterOfMass]
+                    basepointliste = [profile.Placement.Base]
                     for edge in edges:
                         basepointliste.append(DraftGeomUtils.findMidpoint(edge))
                         basepointliste.append(edge.Vertexes[-1].Point)
                     try:
                         basepoint = basepointliste[obj.BasePoint]
                     except IndexError:
-                        FreeCAD.Console.PrintMessage(translate("Arch","Crossing point not found in profile.")+"\n")
+                        FreeCAD.Console.PrintMessage(translate("Arch", "Crossing point not found in profile.")+"\n")
                         basepoint = basepointliste[0]
-                else :
-                    basepoint = profile.CenterOfMass
-                profile.translate(bpoint.sub(basepoint))
-                if obj.Align:
-                    # Align profile's Z axis with the direction of the layout edge.
-                    axis = profile.Placement.Rotation.multVec(FreeCAD.Vector(0,0,1))
-                    angle = bvec.getAngle(axis)
-                    if round(angle,Draft.precision()) != 0:
-                        if round(angle,Draft.precision()) != round(math.pi,Draft.precision()):
-                            rotaxis = axis.cross(bvec)
-                            profile.rotate(DraftVecUtils.tup(bpoint), DraftVecUtils.tup(rotaxis), math.degrees(angle))
-                    # Align profile's Y axis with layouts normal vecror.
-                    axis = profile.Placement.Rotation.multVec(FreeCAD.Vector(0,1,0))
-                    angle = normal.getAngle(axis)
-                    if round(angle,Draft.precision()) != 0:
-                        if round(angle,Draft.precision()) != round(math.pi,Draft.precision()):
-                            rotaxis = axis.cross(normal)
-                            profile.rotate(DraftVecUtils.tup(bpoint), DraftVecUtils.tup(rotaxis), math.degrees(angle))
+                else:
+                    basepoint = profile.Placement.Base
+                delta = bpoint.sub(basepoint) # Translation vector.
+                if obj.Offset and (not DraftVecUtils.isNull(obj.Offset)):
+                    if rot is None:
+                        delta = delta + obj.Offset
+                    else:
+                        delta = delta + rot.multVec(obj.Offset)
+                profile.translate(delta)
                 if obj.Rotation:
-                    profile.rotate(DraftVecUtils.tup(bpoint), DraftVecUtils.tup(FreeCAD.Vector(bvec).normalize()), obj.Rotation)
-                #profile = wire.makePipeShell([profile],True,False,2) TODO buggy
+                    profile.rotate(bpoint, bvec, obj.Rotation)
+                # profile = wire.makePipeShell([profile], True, False, 2) TODO buggy
                 profile = profile.extrude(bvec)
-                if obj.Offset:
-                    if not DraftVecUtils.isNull(obj.Offset):
-                        profile.translate(obj.Offset)
                 shapes.append(profile)
             if shapes:
                 if hasattr(obj,"Fuse"):


### PR DESCRIPTION
A previous PR broke ArchFrame for non planar Base objects (single lines).

This PR fixes this and also simplifies the alignment algo by relying on the built-in capabilities of `FreeCAD.Rotation()`. The resulting alignments are more logical in general.

Additionally:
* The first Base Point now matches the `Placement.Base` of the profile. This makes more sense than using the `CenterOfMass` of its face.
* `Offset` is performed before `Rotation`. Again because this makes more sense.
* Replaced `obj.Profile.isDerivedFrom("Part::Part2DObject")` check with `obj.Profile.Shape.findPlane()` check. The latter is more reliable and flexible. A `Part::Part2DObject` does not have to be planar. And f.e. a Std_Part that contains a profile can now be used.

Forum topics:
https://forum.freecadweb.org/viewtopic.php?f=23&t=65266
https://forum.freecadweb.org/viewtopic.php?f=23&t=65342

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
