### PR TITLE
Gui: Fix problem where Python output and errors are not redirected to report view until preferences window is opened

### DIFF
--- a/src/Gui/ReportView.cpp
+++ b/src/Gui/ReportView.cpp
@@ -349,14 +349,12 @@ public:
             Base::PyGILStateLocker lock;
             default_stdout = PySys_GetObject(const_cast<char*>("stdout"));
             replace_stdout = new OutputStdout();
-            redirected_stdout = false;
         }
 
         if (!default_stderr) {
             Base::PyGILStateLocker lock;
             default_stderr = PySys_GetObject(const_cast<char*>("stderr"));
             replace_stderr = new OutputStderr();
-            redirected_stderr = false;
         }
     }
     ~Data()
@@ -382,11 +380,11 @@ public:
     static PyObject* replace_stderr;
 };
 
-bool ReportOutput::Data::redirected_stdout = false;
+bool ReportOutput::Data::redirected_stdout = true;
 PyObject* ReportOutput::Data::default_stdout = 0;
 PyObject* ReportOutput::Data::replace_stdout = 0;
 
-bool ReportOutput::Data::redirected_stderr = false;
+bool ReportOutput::Data::redirected_stderr = true;
 PyObject* ReportOutput::Data::default_stderr = 0;
 PyObject* ReportOutput::Data::replace_stderr = 0;
 
@@ -427,6 +425,15 @@ ReportOutput::ReportOutput(QWidget* parent)
 
     // scroll to bottom at startup to make sure that last appended text is visible
     ensureCursorVisible();
+    
+    if (d->redirected_stdout){
+        d->redirected_stdout = false;
+        onToggleRedirectPythonStdout();
+    }
+    if (d->redirected_stderr){
+        d->redirected_stderr = false;
+        onToggleRedirectPythonStderr();
+    }
 }
 
 /**


### PR DESCRIPTION
I noticed that when FreeCAD is first started before preferences are initialised, the Report view settings to redirect Python output and redirect Python errors (which currently are intended to default to true) are not set until the preferences window is opened and OK is clicked.

Steps to reproduce:
1. mv ~/.config/FreeCAD ~/.config/FreeCAD.bak
2. Start FreeCAD
3. View | Panels | Report View
4. Right click in report view -> Options
5. Note that "Redirect Python output" and "Redirect Python errors" are un-checked
6. Edit | Preferences; click OK
7. Right click in report view | Options and note that "Redirect Python output" and "Redirect Python errors" are now checked

The same issue was discussed previously at https://forum.freecadweb.org/viewtopic.php?t=15060 and the issue was marked as resolved here: https://tracker.freecadweb.org/view.php?id=0002724 - but for some reason it still seems to be an issue.

This pull request fixes it for me although it may not be the most elegant way.

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [ ]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [x]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

---
