### PR TITLE
Fix for Python3.10

### DIFF
--- a/src/Gui/ApplicationPy.cpp
+++ b/src/Gui/ApplicationPy.cpp
@@ -1217,25 +1217,28 @@ PyObject* Application::sAddIconPath(PyObject * /*self*/, PyObject *args)
 PyObject* Application::sAddIcon(PyObject * /*self*/, PyObject *args)
 {
     const char *iconName;
-    const char *content;
-    Py_ssize_t size = 0;
+    Py_buffer content;
     const char *format = "XPM";
-    if (!PyArg_ParseTuple(args, "ss#|s", &iconName,&content,&size,&format))
+    if (!PyArg_ParseTuple(args, "ss*|s", &iconName, &content, &format))
         return nullptr;
 
     QPixmap icon;
     if (BitmapFactory().findPixmapInCache(iconName, icon)) {
         PyErr_SetString(PyExc_AssertionError, "Icon with this name already registered");
+        PyBuffer_Release(&content);
         return nullptr;
     }
 
-    QByteArray ary(content,size);
+    const char* contentStr = static_cast<const char*>(content.buf);
+    QByteArray ary(contentStr, content.len);
     icon.loadFromData(ary, format);
 
     if (icon.isNull()){
-        QString file = QString::fromUtf8(content);
+        QString file = QString::fromUtf8(contentStr, content.len);
         icon.load(file);
     }
+
+    PyBuffer_Release(&content);
 
     if (icon.isNull()) {
         PyErr_SetString(Base::BaseExceptionFreeCADError, "Invalid icon added to application");


### PR DESCRIPTION
Defines `PY_SSIZE_T_CLEAN` before <Python.h> include in Base/PyObjectBase.h.
This is required for modules calling `Gui.addIcon()` (e.g. Assembly3) that would otherwise fail to load.
The error reported as `Base.FreeCADError: PY_SSIZE_T_CLEAN macro must be defined for '#' formats`.

[Python 3.10 dropped support](https://bugs.python.org/issue40943) for calling PyArg_ParseTuple with ['#' formats](https://docs.python.org/3.10/c-api/arg.html?highlight=py_ssize_t_clean#strings-and-buffers)when `PY_SSIZE_T_CLEAN` is not defined. 

[`src/Gui/ApplicationPy.cpp:1223`](https://github.com/FreeCAD/FreeCAD/blob/cafb8601e003ca3def860142fad430c824b5a191/src/Gui/ApplicationPy.cpp#L1223) is the only location where `PyArg_ParseTuple` is called with "#" format.
(As reported by `rg "PyArg_Parse\w*\(.*?\".*#.*\""`)

This is PR adds `PY_SSIZE_T_CLEAN` defines before all <Python.h> includes, following the [current recommendations](https://docs.python.org/3.10/extending/embedding.html?highlight=py_ssize_t_clean#very-high-level-embedding) in the documentation. This will avoid potential issues when "#" format units are used in the future.

Alternatively, more minimalist changes are possible:
* Adding the define at the top of `src/Gui/ApplicationPy.cpp` only,
* Adding the define in `Base/Parameter.h`: In `src/Gui/ApplicationPy.cpp` unit, <Python.h> is included from `Base/Parameter.h`. This should cover more transitive include paths, while being far from exhaustive,
* Don't use '#' format unit at all (Inspect size from Py_buffer).

Please tell me if you prefer a different alternative.