### PR TITLE
Path: Add Gcode for Spindle Stop (M5) before a Tool Change (M6)

### DIFF
--- a/src/Mod/Path/Generators/toolchange_generator.py
+++ b/src/Mod/Path/Generators/toolchange_generator.py
@@ -66,6 +66,7 @@ def generate(
     commands = []
 
     commands.append(Path.Command(f"({toollabel})"))
+    commands.append(Path.Command("M5"))
     commands.append(Path.Command("M6", {"T": int(toolnumber)}))
 
     if spindledirection is SpindleDirection.OFF:


### PR DESCRIPTION
Updates the Path Tool Controller to insert gcode for a M5 spindle stop before M6 tool change.  This helps to preserve fingers when performing manual tool changes.