### PR TITLE
Assembly: fix older assembly code typos

### DIFF
--- a/src/Mod/Assembly/App/PartRef.cpp
+++ b/src/Mod/Assembly/App/PartRef.cpp
@@ -102,7 +102,7 @@ bool PartRef::holdsObject(App::DocumentObject* obj) const {
 
 void PartRef::setCalculatedPlacement(std::shared_ptr< Part3D > part) {
 
-    //part is the same as m_part, so it doasn't matter which one we use
+    //part is the same as m_part, so it doesn't matter which one we use
     Base::Placement p = dcm::get<Base::Placement>(part);
     
     Product* ass = getParentAssembly();

--- a/src/Mod/Assembly/App/opendcm/core.hpp
+++ b/src/Mod/Assembly/App/opendcm/core.hpp
@@ -21,11 +21,11 @@
 #define DCM_CORE_H
 
 #ifdef _WIN32
-	//warning about to long decoraded names, won't affect the code correctness
+	//warning about excessively long decorated names, won't affect the code correctness
 	#pragma warning( disable : 4503 )
-	//warning about changed pod initalising behaviour (boost blank in variant)
+	//warning about changed pod initialising behaviour (boost blank in variant)
 	#pragma warning( disable : 4345 )
-	//warning about multiple assignemnt operators in Equation
+	//warning about multiple assignment operators in Equation
 	#pragma warning( disable : 4522 )
 
 	//disable boost concept checks, as some of them have alignment problems which bring msvc to an error

--- a/src/Mod/Assembly/App/opendcm/core/clustergraph.hpp
+++ b/src/Mod/Assembly/App/opendcm/core/clustergraph.hpp
@@ -87,8 +87,8 @@ typedef boost::adjacency_list_traits<boost::listS, boost::listS, boost::undirect
  * @brief A type to be used as identifier for vertices and edges
  *
  * Vertices and edges need to be identified in a stable(safe/load), unique(over multiple clusters) and
- * comparable manner. The bgl vertex and edge discriptors don't fulfill this need as they have a direct
- * relation to the graphs storage. Therefore they change value on moving entitiys to different clusters or
+ * comparable manner. The bgl vertex and edge descriptors don't fulfill this need as they have a direct
+ * relation to the graphs storage. Therefore they change value on moving entities to different clusters or
  * clone actions. This class is used to overcome this problem.
  **/
 typedef int universalID;
@@ -134,8 +134,8 @@ struct IDgen {
     /**
      * @brief Set the current value for incremental creation
      *
-     * ID's are created incrementaly and if a specific startingpoint is wished it can be set here by
-     * supplying the last created ID or the amount of totaly created ID's
+     * ID's are created incrementally and if a specific startingpoint is wished, it can be set here by
+     * supplying the last created ID or the amount of totally created ID's
      *
      * @param id The last created ID
      * @return void
@@ -187,8 +187,8 @@ typedef details::universalID 				GlobalVertex;
 /**
  * @brief Identifier for global edge
  *
- * To overcome the locality of the bgl edge discriptors a global alternative is introduced. This descriptor
- * is unique over clusters and stable on moves and clones. It holds it's source and target also as global
+ * To overcome the locality of the bgl edge descriptors a global alternative is introduced. This descriptor
+ * is unique over clusters and stable on moves and clones. It holds its source and target also as global
  * descriptors of type GlobalVertex and has a unique ID in form of a universalID assigned.
  **/
 struct 	GlobalEdge {
@@ -240,9 +240,9 @@ public:
      * @brief mpl::vector with all edge properties
      *
      * The edge properties supplied as template argument to the ClusterGraph are extended with graph
-     * specific properties, for example a edge_index_prop. These extra properties are intendet to be
-     * used with boost graph algorithms as property maps. They need to be in specefied by the ClusterGraph
-     * as they are used within it's implementation. If the graph specific properties are already a part
+     * specific properties, for example a edge_index_prop. These extra properties are intended to be
+     * used with boost graph algorithms as property maps. They need to be in specified by the ClusterGraph
+     * as they are used within its implementation. If the graph specific properties are already a part
      * of the given property sequence, nothing happens, they are not added twice.
      **/
     typedef typename details::ensure_properties<edge_prop, details::bgl_e_props>::type   edge_properties;
@@ -250,9 +250,9 @@ public:
      * @brief mpl::vector with all vertex properties
      *
      * The vertex properties supplied as template argument to the ClusterGraph are extended with graph
-     * specific properties as vertex_index_prop. These extra properties are intendet to be
-     * used with boost graph algorithms as property maps. They need to be in specefied by the ClusterGraph
-     * as they are used within it's implementation.If the graph specific properties are already a part
+     * specific properties as vertex_index_prop. These extra properties are intended to be
+     * used with boost graph algorithms as property maps. They need to be in specified by the ClusterGraph
+     * as they are used within its implementation.If the graph specific properties are already a part
      * of the given property sequence, nothing happens, they are not added twice.
      **/
     typedef typename details::ensure_properties<vertex_prop, details::bgl_v_props>::type vertex_properties;
@@ -260,8 +260,8 @@ public:
     /**
      * @brief The property bundle for GlobalEdges
      *
-     * A local edge in a cluster can hold multiple gloabal ones. Therefor we need an extra bundle for
-     * the GlobalEdges. This bundle holds the objects which are added to that global edge and it's identifier.
+     * A local edge in a cluster can hold multiple global ones. Therefor we need an extra bundle for
+     * the GlobalEdges. This bundle holds the objects which are added to that global edge and its identifier.
      * Note that global edges don't have properties, these are only for local ones.
      **/
     typedef fusion::vector< typename details::sps<objects>::type, GlobalEdge > edge_bundle_single;
@@ -274,7 +274,7 @@ public:
      **/
     typedef fusion::vector< typename details::pts<edge_properties>::type, std::vector< edge_bundle_single > > edge_bundle;
     /**
-     * @brief Iteator to access all edge_bundle_single stored in a edge_bundle
+     * @brief Iterator to access all edge_bundle_single stored in a edge_bundle
      **/
     typedef typename std::vector< edge_bundle_single >::iterator edge_single_iterator;
     /**
@@ -310,7 +310,7 @@ public:
         template<typename T>
         result_type operator()(T& bundle) const;
     };
-    
+
     struct global_vertex_extractor  {
         typedef GlobalVertex result_type;
         ClusterGraph& graph;
@@ -379,7 +379,7 @@ public:
      *
      * This constructor creates a new cluster, but uses the given cluster as parent. It will therefore
      * create a tree-like relationship. Be aware, that the new cluster is not added to the parents
-     * subcluster list, that has to be done manualy. The new cluster shares the parents ID generator.
+     * subcluster list, that has to be done manually. The new cluster shares the parents ID generator.
      *
      * @param g the parent cluster graph
      **/
@@ -391,12 +391,12 @@ public:
     ~ClusterGraph() {};
 
     /**
-     * @brief Copys the Clustergraph into a new one
+     * @brief Copies the Clustergraph into a new one
      *
-     * Copys this cluster and all subclusters into the give one, which is cleared bevore copying. Be
+     * Copies this cluster and all subclusters into the given one, which is cleared before copying. Be
      * aware that all objects and properties are only copied, and as some are shared pointers (namely
      * all objects) you may have to clone them. If needed this can be done with the supplied functor,
-     * which receives all copied objects to his function operator which returns the new object.
+     * which receives all copied objects to its function operator which returns the new object.
      * @param into The Graph that should be a copy of this
      * @param functor The function objects which gets the graph objects and returns the ones for the
      * copied graph
@@ -423,10 +423,10 @@ public:
     /**
      * @brief Set different behaviour for changed markers
      *
-     * Some methods of the ClusterGraph set it's changed_prop to true. Thats sensible, as they change
+     * Some methods of the ClusterGraph set its changed_prop to true. That's sensible, as they change
      * the graph. However, there are situations where you want to use the methods but don't want the change
      * marked. For example recreations while cloning. This method can be used to disable the changed setting.
-     * @param on Turn change markers on or of
+     * @param on Turn change markers on or off
      * @return void
      **/
     void setCopyMode(bool on);
@@ -461,9 +461,9 @@ public:
     /**
      * @brief Creates a new subcluster
      *
-     * As clusters can be stacked in a tree like manner, this function can be used to create new
+     * As clusters can be stacked in a tree-like manner, this function can be used to create new
      * children. It automatically adds it to the subcluster list and adds it to the graph. The new
-     * subcluster is fully defined by its object and the vertex descriptor which is it's position
+     * subcluster is fully defined by its object and the vertex descriptor which is its position
      * in the current cluster.
      *
      * @return :pair< std::shared_ptr< ClusterGraph >, LocalVertex > Subcluster and its descriptor
@@ -473,8 +473,8 @@ public:
     /**
      * @brief Returns the parent cluster
      *
-     * In the stacked cluster hirarchy most clusters have a parent which can be accessed with this function.
-     * However, the toplevel cluster dos nothave a parent and a empty shared_ptr is returned.
+     * In the stacked cluster hierarchy, most clusters have a parent which can be accessed with this function.
+     * However, the toplevel cluster doesn't have a parent and an empty shared_ptr is returned.
      *
      * @return :shared_ptr< ClusterGraph > the parent cluster or empty pointer
      **/
@@ -512,7 +512,7 @@ public:
      * @brief Iterators for all subclusters
      *
      * A pair with two \ref cluster_iterator is returned which point to the first cluster and
-     * to one after the last. #this allows full iteration over all subclusters
+     * to one after the last. This allows full iteration over all subclusters
      *
      * @return :pair< cluster_iterator, cluster_iterator >
      **/
@@ -546,7 +546,7 @@ public:
     bool isCluster(const dcm::LocalVertex v) const;
 
     /**
-     * @brief Get the cluster corresponding the discriptor
+     * @brief Get the cluster corresponding the descriptor
      *
      * A subcluster is added as normal vertex to the parent cluster. There is no way to access
      * the clusters object with global or local descriptors only. Therefore this
@@ -554,12 +554,12 @@ public:
      * a cluster an empty pointer is returned.
      *
      * @param v The vertex for which the cluster is wanted
-     * @return std::shared_ptr<ClusterGraph> the coresponding cluster orempty pointer
+     * @return std::shared_ptr<ClusterGraph> the corresponding cluster or empty pointer
      **/
     std::shared_ptr<ClusterGraph> getVertexCluster(LocalVertex v);
 
     /**
-     * @brief Get the vertex descrptor which descripes the clusters position in the graph
+     * @brief Get the vertex descriptor which describes the clusters position in the graph
      *
      * This function is the inverse to \ref getVertexCluster
      *
@@ -586,11 +586,11 @@ public:
     void clearClusters();
 
     /**
-     * @brief Remove a subcluster and applys the functor to all removed edges and vertices
+     * @brief Remove a subcluster and applies the functor to all removed edges and vertices
      *
-     * All downstream elements of the local vertex v will be removed after the functor is applied to there
+     * All downstream elements of the local vertex v will be removed after the functor is applied to their
      * edges and vertices. Note that the LocalVertex which represents the cluster to delete is not passed
-     * to the functor. When ever the cluster is changed it will be passed to the functor, so that it need
+     * to the functor. When ever the cluster is changed it will be passed to the functor, so that it needs
      * to have three overloads: operator()(GlobalEdge), operator()(GlobalVertex), operator()(ClusterGraph&)
      *
      * @param v Local vertex which is a cluster and which should be deleted
@@ -621,15 +621,15 @@ public:
      * @brief Add a vertex to the local cluster with given global identifier
      *
      * Sometimes it is needed to add a vertex with given global identifier. As the global vertex can not
-     * be changed after creation, this method can be used to specify the global vertex by which this 
-     * graph vertex can be identified. The given global vertex is not checked, you need to ensure that 
+     * be changed after creation, this method can be used to specify the global vertex by which this
+     * graph vertex can be identified. The given global vertex is not checked, you need to ensure that
      * it is a unique id or the already existing vertex is returned.
      * The ID generator is changed so that it creates only identifier bigger than v.
-     * 
+     *
      * @return fusion::vector<LocalVertex, GlobalVertex> the local and global vertex descriptor
      **/
     fusion::vector<LocalVertex, GlobalVertex> addVertex(GlobalVertex v);
-    
+
     /**
      * @brief Iterators of all global vertices in this cluster
      *
@@ -643,7 +643,7 @@ public:
     /**
      * @brief Returns the edge between the local vertices
      *
-     * This function is the same as boost::edge(source, target, Graph) and only added for convienience.
+     * This function is the same as boost::edge(source, target, Graph) and only added for convenience.
      *
      * @param source LocalEdge as edge source
      * @param target LocalEdge as edge target
@@ -657,25 +657,25 @@ public:
      *
      * Add an edge that connects the two vertices and in the local clustergraph and assign the GlobalEdge to it. The
      * LocalVertex parameters should not represent a cluster which would result in the functions failure. If there's
-     * already a local edge between the vertices a new global edge will be added and returned. Failure will be
-     * recocnisable by a false value in the returned type sequence.
+     * already a local edge between the vertices, a new global edge will be added and returned. Failure will be
+     * recognizable by a false value in the returned type sequence.
      *
      * @param source The first vertex the edge should connect
      * @param target The second vertex the edge should connect
-     * @return fusion::vector<LocalEdge, GlobalEdge, success> with the local and global descriptors of the edge and an bool
-     * value indicationg the successful creation.
+     * @return fusion::vector<LocalEdge, GlobalEdge, success> with the local and global descriptors of the edge and
+     * a bool value indicating the successful creation.
      **/
     fusion::vector<LocalEdge, GlobalEdge, bool> addEdge(LocalVertex source, LocalVertex target);
 
     /**
      * @brief Add a edge between two vertices, defined by global descriptors.
      *
-     * Adds an edge between vertices which are not nesseccarily in this local cluster and have therefore to be
+     * Adds an edge between vertices which are not necessarily in this local cluster and have therefore to be
      * identified with global descriptors. The only condition for source and target vertex is that both must be
-     * in the local cluster or any of its subclusters. If thats not the case, the function will fail. On success
+     * in the local cluster or any of its subclusters. If that's not the case, the function will fail. On success
      * a new GlobalEdge will be created, but not necessarily a local one. If the vertices are in different cluster
-     * which are already connected the global edge will be added to this connecting local edge. Thats the one returned
-     * in the seqence. Note that it's possible that the local edge belongs to another subcluster and therefore can't be
+     * which are already connected the global edge will be added to this connecting local edge. That's the one returned
+     * in the sequence. Note that it's possible that the local edge belongs to another subcluster and therefore can't be
      * used in the local cluster. This case is indicated by the scope return value.
      *
      * @param source The first vertex the edge should connect
@@ -717,8 +717,8 @@ public:
      * @brief Get the local edge which holds the specified global edge.
      *
      * Note that GlobalEdge must be in a local edge of this cluster, means the connected vertices must be in this
-     * or one of it's subclusters (but not the same). Also if the containing LocalEdge is not in this cluster, but in one of it's
-     * subclusters, the function fails and the returned edge is invalid.
+     * or one of its subclusters (but not the same). Also if the containing LocalEdge is not in this cluster, but in one
+     * of its subclusters, the function fails and the returned edge is invalid.
      *
      * @param e GlobalEdge for which the containing local one is wanted
      * @return std:pair< LocalEdge, bool > with the containing LocalEdge and a bool indicator if function was successful.
@@ -729,7 +729,7 @@ public:
      * @brief Get the local edge which holds the specified global one and the subcluster in which it is valid.
      *
      * The function only fails when the global edge is hold by a local one upstream in the cluster
-     * herarchy.
+     * hierarchy.
      *
      * @param e GlobalEdge for which the containing local one is wanted
      * @return fusion::vector<LocalEdge, ClusterGraph*, bool> with the containing LocalEdge, the cluster which holds it and a bool indicator if function was successful.
@@ -737,7 +737,7 @@ public:
     fusion::vector<LocalEdge, ClusterGraph*, bool> getLocalEdgeGraph(GlobalEdge e);
 
     /**
-     * @brief Get the GlobalVertex assiociated with this local one.
+     * @brief Get the GlobalVertex associated with this local one.
      *
      * @param v LocalVertex
      * @return GlobalVertex
@@ -745,21 +745,21 @@ public:
     GlobalVertex getGlobalVertex(LocalVertex v) const;
 
     /**
-     * @brief Get the LocalVertex which corresponds to the golab one
+     * @brief Get the LocalVertex which corresponds to the global one
      *
-     * The GlobalVertex has to be in this cluster or any of it's subclusters. If its in a subcluster, the returned
-     * LocalVertex will represent this cluster. If the GlobalVertex is not in this clusters scope the function fails.
+     * The GlobalVertex has to be in this cluster or any of its subclusters. If it's in a subcluster, the returned
+     * LocalVertex will represent this cluster. If the GlobalVertex isn't in this cluster's scope, the function fails.
      *
      * @param vertex GlobalVertex for which the local one shall be returned
-     * @return std::pair< LocalVertex, bool > The LocalVertex containing the global one and an success indicator
+     * @return std::pair< LocalVertex, bool > The LocalVertex containing the global one and a success indicator
      **/
     std::pair<LocalVertex, bool> getLocalVertex(GlobalVertex vertex);
 
     /**
      * @brief Get the local vertex which holds the specified global one and the subcluster in which it is valid.
      *
-     * The function only fails when the global vertex is hold by a local one upstream in the cluster
-     * herarchy.
+     * The function only fails when the global vertex is held by a local one upstream in the cluster
+     * hierarchy.
      *
      * @param v GlobalVertex for which the containing local one is wanted
      * @return fusion::vector<LocalVertex, ClusterGraph*, bool> with the containing LocalVertex, the cluster which holds it and a bool indicator if function was successful.
@@ -780,12 +780,12 @@ private:
 
 public:
     /**
-    * @brief Removes a vertex from the local cluster and applys functor to removed edges
+    * @brief Removes a vertex from the local cluster and applies functor to removed edges
     *
     * Removes the vertex from the local graph and invalidates the global vertex id. Also all edges connecting
     * to this vertex will be removed after the functor was applied to them. The functor needs to implement
     * operato()(GlobalEdge e). Remark that there is no checking done if the vertex is a cluster, so you
-    * need to make sure it's not, as removing a clustervertex will not delete the coresponding cluster.
+    * need to make sure it's not, as removing a clustervertex will not delete the corresponding cluster.
     *
     * @param id Local Vertex which should be removed from the graph
     * @param f functor whose operator(GlobalEdge) is called for every removed edge
@@ -796,11 +796,11 @@ public:
     void removeVertex(LocalVertex id) ;
 
     /**
-    * @brief Removes a vertex from the cluster or it's subclusters and applys functor to removed edges
+    * @brief Removes a vertex from the cluster or its subclusters and applies functor to removed edges
     *
     * Removes the vertex from the graph or subclusters and invalidates the global vertex id. Also all edges connecting
     * to this vertex will be removed (upstream and downstream) after the functor was applied to them. The functor
-    * needs to implement operato()(LocalEdge edge).
+    * needs to implement operator()(LocalEdge edge).
     *
     * @param id Global Vertex which should be removed from the graph
     * @param f functor whose operator(LocalEdge) is called on every removed edge
@@ -811,7 +811,7 @@ public:
     void removeVertex(GlobalVertex id);
 
     /**
-    * @brief Removes a global Edge from the cluster or it's subclusters
+    * @brief Removes a global Edge from the cluster or its subclusters
     *
     * Removes the edge from the graph or subclusters and invalidates the global edge id. If the local edge holds
     * only this global one it will be removed also.
@@ -828,7 +828,7 @@ public:
     * operator()(GlobalEdge). If no functor is needed just use boost::remove_edge.
     *
     * @param id Global Edge which should be removed from the graph
-    * @param f functor whoms operator(GlobalEdge) is called
+    * @param f functor whose operator(GlobalEdge) is called
     * @return bool indicates if the global id could be removed
     **/
     template<typename Functor>
@@ -844,8 +844,8 @@ public:
     * @brief Get the desired object at the specified vertex or edge
     *
     * This function allows to access the objects stored in the graph. If no object of the desired type
-    * was set before, a empty shared_ptr will be returned. Accessing the object at a local edge is a special
-    * case, as it can hold many global edges, each with it's own objetcs. Using a LocalEdge as key will
+    * was set before, an empty shared_ptr will be returned. Accessing the object at a local edge is a special
+    * case, as it can hold many global edges, each with its own objects. Using a LocalEdge as key will
     * always return the object for the first GlobalEdge.
     *
     * @tparam Obj the object type which shall be returned
@@ -860,7 +860,7 @@ public:
      *
      * Sets the given value at the given key. Note that every entity can hold only one object, so setting
      * a new value resets all other objects which were set before. Setting the object at a local edge is a special
-     * case, as it can hold many global edges, each with it's own objects. Using a LocalEdge as key will
+     * case, as it can hold many global edges, each with its own objects. Using a LocalEdge as key will
      * always set the object for the first GlobalEdge.
      *
      * @tparam Obj the object type which shall be set
@@ -875,22 +875,22 @@ public:
      * @brief Get iterator range for all GlobalEdge objects hold by this local edge
      *
      * LocalEdge's can hold multiple global ones and the iterators can be used to access a specific object type in
-     * all global edges hold by this local edge.
+     * all global edges held by this local edge.
      *
      * @tparam Obj the object type over which it shall be iterated
      * @param k the LocalEdge over which all Objects should be iterated.
-     * @return pair< begin, end > the iterator rang from begin (first element) to end (first undefined element)
+     * @return pair< begin, end > the iterator range from begin (first element) to end (first undefined element)
      **/
     template<typename Obj>
     std::pair< object_iterator<Obj>, object_iterator<Obj> > getObjects(LocalEdge k);
 
     /**
-     * @brief Applys the functor to each occurrence of an object
+     * @brief Applies the functor to each occurrence of an object
      *
-     * Each valid object of the given type is extractet and passed to the function object. Vertices
+     * Each valid object of the given type is extracted and passed to the function object. Vertices
      * and edges are searched for valid object pointers, it happens in this order. When a recursive
-     * search is specified, all subclusters are searched too, but the cluster is passt to the Functor
-     * first. So make sure a function overload for clusters exist in this case.
+     * search is specified, all subclusters are searched too, but the cluster is passed to the Functor
+     * first. So make sure a function overload for clusters exists in this case.
      *
      * @tparam Obj the object type for which the functor shall be used
      * @param f the functor to which all valid objects get passed to.
@@ -900,11 +900,11 @@ public:
     void for_each(Functor& f, bool recursive = false);
 
     /**
-     * @brief Applys the functor to each object
+     * @brief Applies the functor to each object
      *
-     * Each valid object of any type is extractet and passed to the function object. Vertices
+     * Each valid object of any type is extracted and passed to the function object. Vertices
      * and edges are searched for valid object pointers, it happens in this order. When a recursive
-     * search is specified, all subclusters are searched too, but the cluster is passt to the Functor
+     * search is specified, all subclusters are searched too, but the cluster is passed to the Functor
      * first. So make sure a function overload for clusters exist in this case.
      *
      * @param f the functor to which all valid objects get passed to.
@@ -921,7 +921,7 @@ public:
     * @brief Get the desired property at the specified vertex or edge
     *
     * This function allows to access the properties stored in the graph. If no property of the desired type
-    * was set before, a default construced will be returned. Accessing the property at a global edge will return
+    * was set before, a default construct will be returned. Accessing the property at a global edge will return
     * the property of the holding local edge.
     *
     * @tparam property the property type which shall be returned
@@ -936,7 +936,7 @@ public:
      *
      * Sets the given value at the given key. Note that every entity can hold one of each property, as opposed
      * to objects. Setting the property at a local edge is a special case, as it can hold many global edges,
-     * each with it's own propertys. Using a LocalEdge as key will always set the property for the first GlobalEdge.
+     * each with its own properties. Using a LocalEdge as key will always set the property for the first GlobalEdge.
      *
      * @tparam property the property type which shall be set
      * @param k local or global Vertex/Edge descriptor for which the property should be set
@@ -992,7 +992,7 @@ public:
      * @brief Move a vertex to a subcluster
      *
      * This function moves the LocalVertex to the subcluster and reconnects all other vertices and clusters. The
-     * moved vertex will hold it's global descriptor but get a new local one assigned (the one returned). The same
+     * moved vertex will hold its global descriptor but get a new local one assigned (the one returned). The same
      * stands for all edges which use the moved vertex: global descriptors stay the same, but they are moved to new
      * local edges. It's allowed to move cluster vertices with this function.
      * The specified cluster has of course to be a valid and direct subcluster, the move vertex also has to be in the
@@ -1009,8 +1009,8 @@ public:
     /**
      * @brief Move a vertex to the parent cluster.
      *
-     * This function moves a vertex one step up in the subcluster hierarchie and reconnects all other vertices and clusters.
-     * The moved vertex will hold it's global descriptor but get a new local one assigned (the one returned). The same
+     * This function moves a vertex one step up in the subcluster hierarchy and reconnects all other vertices and clusters.
+     * The moved vertex will hold its global descriptor but get a new local one assigned (the one returned). The same
      * stands for all edges which use the moved vertex: global descriptors stay the same, but they are moved to new
      * local edges. Note that this function is the inverse of moveToSubcluster, and doing Pseudocode:
      * moveToParent(moveToSubcluster(v)) does nothing (only the local descriptor of the moved vertex is
@@ -1028,7 +1028,7 @@ public:
 
     ClusterMap	  m_clusters;
     int test;
-    
+
 protected:
     boost::weak_ptr<ClusterGraph> m_parent;
     details::IDpointer 	  m_id;
@@ -1043,7 +1043,7 @@ protected:
      * */
     std::pair<LocalVertex, bool> getContainingVertex(GlobalVertex id, bool recursive = true);
 
-    /* Searches the local vertex holding the specified global one in this and all it's subclusters.
+    /* Searches the local vertex holding the specified global one in this and all its subclusters.
      * If found, the holding local vertex and the graph in which it is valid will be returned.
      * */
     fusion::vector<LocalVertex, std::shared_ptr<ClusterGraph>, bool> getContainingVertexGraph(GlobalVertex id);
@@ -1054,7 +1054,7 @@ protected:
      * */
     std::pair<LocalEdge, bool> getContainingEdge(GlobalEdge id);
 
-    /* Searches the local edge holding the specified global one in this and all it's subclusters.
+    /* Searches the local edge holding the specified global one in this and all its subclusters.
      * If found, the holding local edge and the graph in which it is valid will be returned.
      * */
     fusion::vector<LocalEdge, ClusterGraph*, bool> getContainingEdgeGraph(GlobalEdge id);

--- a/src/Mod/Assembly/App/opendcm/core/constraint.hpp
+++ b/src/Mod/Assembly/App/opendcm/core/constraint.hpp
@@ -190,7 +190,7 @@ public:
             template< typename T >
             typename boost::enable_if<typename has_option<T>::type, void>::type
             operator()(EquationSet<T>& val) const;
-            //if the equation has no otpion we do nothing!
+            //if the equation has no option we do nothing!
             template< typename T >
             typename boost::enable_if<mpl::not_<typename has_option<T>::type>, void>::type
             operator()(EquationSet<T>& val) const;

--- a/src/Mod/Assembly/App/opendcm/core/equations.hpp
+++ b/src/Mod/Assembly/App/opendcm/core/equations.hpp
@@ -192,7 +192,7 @@ struct Equation : public EQ {
     typename boost::enable_if< mpl::is_sequence<T>, typename pushed_seq<T, Derived>::type >::type operator &(T& val);
     */
 
-    //set default option values, neeeded for repedability and to prevent unexpected behaviour
+    //set default option values, needed for repeatability and to prevent unexpected behaviour
     virtual void setDefault() {};
 };
 

--- a/src/Mod/Assembly/App/opendcm/core/geometry.hpp
+++ b/src/Mod/Assembly/App/opendcm/core/geometry.hpp
@@ -330,7 +330,7 @@ public:
             return m_toplocal.template segment<Dim>(0);
     };
 
-    //use m_value or parametermap as new value, dependend on the solving mode
+    //use m_value or parametermap as new value, depending on the solving mode
     void finishCalculation();
 
     template<typename VectorType>

--- a/src/Mod/Assembly/App/opendcm/core/imp/clustergraph_imp.hpp
+++ b/src/Mod/Assembly/App/opendcm/core/imp/clustergraph_imp.hpp
@@ -274,8 +274,8 @@ void ClusterGraph<edge_prop, vertex_prop, cluster_prop, objects>::copyInto(std::
 
     //first copy all vertices and edges, but be aware that the objects in the new graph
     //are also copys only and point to the old graph. there is a bug in older boost version
-    //(<1.5 i believe) that breaks vertex_all propety map for bundled properties, so we
-    //have to create our own copie functors
+    //(<1.5 i believe) that breaks vertex_all property map for bundled properties, so we
+    //have to create our own copier functors
     into->clear();
     vertex_copier<Graph> vc(*this, *into);
     edge_copier<Graph> ec(*this, *into);
@@ -552,14 +552,14 @@ ClusterGraph<edge_prop, vertex_prop, cluster_prop, objects>::addEdge(LocalVertex
     bool done;
     boost::tie(e, done) = boost::edge(source, target, *this);
 
-    //if done=true the edge alredy existed
+    //if done=true the edge already existed
     if(!done)
         boost::tie(e, done) = boost::add_edge(source, target, *this);
 
     if(!done)
         return fusion::make_vector(LocalEdge(), GlobalEdge(), false);
 
-    //init the bundle corecctly for new edge
+    //init the bundle correctly for new edge
     GlobalEdge global = { fusion::at_c<0> ((*this) [source]), fusion::at_c<0> ((*this) [target]), m_id->generate() };
     edge_bundle_single s;
     fusion::at_c<1> (s) = global;
@@ -599,7 +599,7 @@ ClusterGraph<edge_prop, vertex_prop, cluster_prop, objects>::addEdge(GlobalVerte
     if(!d3)
         return fusion::make_vector(LocalEdge(), GlobalEdge(), false, false);
 
-    //init the bundle corectly for new edge
+    //init the bundle correctly for new edge
     GlobalEdge global = { source, target, m_id->generate() };
     edge_bundle_single s;
     fusion::at_c<1> (s) = global;
@@ -670,7 +670,7 @@ void ClusterGraph<edge_prop, vertex_prop, cluster_prop, objects>::downstreamRemo
 
     std::pair<LocalVertex, bool> res = getContainingVertex(v);
 
-    //we don't throw, as this function gets invoked recursivly and it may happen that the
+    //we don't throw, as this function gets invoked recursively and it may happen that the
     //vertex to remove is only in the top layers, not the button ones
     if(!res.second)
         return;
@@ -1188,7 +1188,7 @@ ClusterGraph<edge_prop, vertex_prop, cluster_prop, objects>::apply_to_bundle(Glo
     fusion::vector<LocalVertex, std::shared_ptr<ClusterGraph>, bool> res = getContainingVertexGraph(k);
 
     if(!fusion::at_c<2> (res)) {
-        //TODO: Throw (propeties return reference, but can't init a reference temporarily)
+        //TODO: Throw (properties return reference, but can't init a reference temporarily)
     }
 
     return fusion::at_c<1> (res)->template apply_to_bundle<functor> (k, f);

--- a/src/Mod/Assembly/App/opendcm/core/imp/equations_imp.hpp
+++ b/src/Mod/Assembly/App/opendcm/core/imp/equations_imp.hpp
@@ -77,7 +77,7 @@ constraint_sequence<seq>::operator &(T& val) {
     //insert this object at the end of the sequence
     *fusion::find<T>(vec) = val;
 
-    //and return our new extendet sequence
+    //and return our new extended sequence
     return vec;
 };
 
@@ -113,7 +113,7 @@ constraint_sequence<seq>::operator &(T& val) {
     fusion::nview<Sequence, position_vector> view(vec);
     fusion::copy(*this, view);
 
-    //and return our new extendet sequence
+    //and return our new extended sequence
     return vec;
 };
 */
@@ -137,7 +137,7 @@ Derived& Equation<Derived, Option, id, a>::assign(const Derived& eq) {
     option_copy<options> oc(values);
     fusion::for_each(eq.values, oc);
 
-    //the assigned eqution can be set back to default for convenience in further usage
+    //the assigned equation can be set back to default for convenience in further usage
     const_cast<Derived*>(&eq)->setDefault();
 
     return *static_cast<Derived*>(this);
@@ -177,7 +177,7 @@ Equation<Derived, Option, id, a>::operator &(T& val) {
     //insert this object into the sequence
     *fusion::find<Derived>(vec) = *static_cast<Derived*>(this);
 
-    //and return our new extendet sequence
+    //and return our new extended sequence
     return vec;
 };
 */

--- a/src/Mod/Assembly/App/opendcm/core/imp/geometry_imp.hpp
+++ b/src/Mod/Assembly/App/opendcm/core/imp/geometry_imp.hpp
@@ -114,7 +114,7 @@ void Geometry<Kernel, Dim, TagList>::init() {
 
 template< typename Kernel, int Dim, typename TagList>
 void Geometry<Kernel, Dim, TagList>::normalize() {
-    //directions are not nessessarily normalized, but we need to ensure this in cluster mode
+    //directions are not necessarily normalized, but we need to ensure this in cluster mode
     for(int i=m_translations; i!=m_rotations; i++)
         m_global.template segment<Dim>(i*Dim).normalize();
 };

--- a/src/Mod/Assembly/App/opendcm/core/multimap.hpp
+++ b/src/Mod/Assembly/App/opendcm/core/multimap.hpp
@@ -204,7 +204,7 @@ public:
 
 
     // constructor for datapointer which resembles the fixed size derived type
-    // this works only if this is the only maped data!
+    // this works only if this is the only mapped data!
     inline MultiMapBase(PointerType data)
         : default_value(0), m_rows(RowsAtCompileTime), m_cols(ColsAtCompileTime) {
 

--- a/src/Mod/Assembly/App/opendcm/core/object.hpp
+++ b/src/Mod/Assembly/App/opendcm/core/object.hpp
@@ -47,8 +47,8 @@ namespace mpl = boost::mpl;
 namespace fusion = boost::fusion;
 
 /* Preprocessor implementation of emit signal. As we need many overloads with different number of
- * templated parameters we use boost preprocessor to do the hard repetive work. The definition and
- * implementation are definded first as they need to be known before usage
+ * templated parameters we use boost preprocessor to do the hard repetitive work. The definition and
+ * implementation are defined first as they need to be known before usage
  * */
 #define EMIT_ARGUMENTS(z, n, data) \
     BOOST_PP_CAT(data, n)
@@ -71,7 +71,7 @@ namespace dcm {
  *
  **/
 
-//few standart signal names
+//few standard signal names
 struct remove {};
 
 typedef int Connection;
@@ -85,8 +85,8 @@ struct SignalOwner {
     * @brief Connects a slot to a specified signal.
     *
     * Slots are boost::functions which get called when the signal is emitted. Any valid boost::function
-    * which ressembles the signal tyes signature can be registert. It is important that the signal type
-    * was registerd to this object on creation by the appropriate template parameter.
+    * which ressembles the signal types signature can be registered. It is important that the signal type
+    * was registered to this object on creation by the appropriate template parameter.
     *
     * @tparam S the signal which should be intercepted
     * @param function boost::function which resembles the signal type's signature

--- a/src/Mod/Assembly/App/opendcm/core/property.hpp
+++ b/src/Mod/Assembly/App/opendcm/core/property.hpp
@@ -62,15 +62,15 @@ namespace dcm {
  * The connection of data type and identifier is achieved through the property structs, which all follow
  * the same concept: Identifier is the struct type, the stored data is exposed as 'type' typedef. The data
  * type can be every c++ type (including classes and structs) which is default constructable. They don't need
- * to be assignable or copyable by default, thats only nesseccary if you want to change the hole stored
+ * to be assignable or copyable by default, that's only necessary if you want to change the hole stored
  * object by assigning. If not, the data object can be uncopyable and it should be used by
- * retrieving it's reference with get-methods.
+ * retrieving its reference with get-methods.
  *
  * Propertys are further designed to fit in the concept of compile-time modularisation. To allow the extension
- * of all data-holding entities with new data types, propertys store their own purpose. Thats
+ * of all data-holding entities with new data types, propertys store their own purpose. That's
  * done by extending the property struct with a second typedef which is named kind and which specifies of which
  * kind the property is. That means, that this typedef defines when the property shall be used and for which
- * context it is designed for. Dependend on the propertys kind, it will be added to different places inside the dcm.
+ * context it is designed for. Depending on the propertys kind, it will be added to different places inside the dcm.
  * A property of kind @ref vertex_property will added to vertices, a property of kind @ref object_property to all
  * objects and so on.
  *
@@ -78,7 +78,7 @@ namespace dcm {
  * constructor. Therefore a interface for setting default values is added to the property. If you want
  * to assign a default value you just need to add a struct default_value which returns the wanted default
  * value with the operator(). If you don't want a default value, just don't add the struct. The implementation
- * assignes the default value to the property, therefore it should only be used with assignalble types.
+ * assigns the default value to the property, therefore it should only be used with assignable types.
  *
  *
  * A property implementation for storing integers at a graph edge with the identifier
@@ -104,16 +104,16 @@ namespace dcm {
  * @endcode
  *
  *
- * If you want to use properties in your class you should derive from PropertyOwner class, as it doas all the
- * hanling needed and gives you get and set functions which work with the designed identifiers.
+ * If you want to use properties in your class you should derive from PropertyOwner class, as it does all the
+ * handling needed and gives you get and set functions which work with the designed identifiers.
  *
  * @{ */
 
 /**
  * @brief Exception for property errors
  *
- * This exception is thrown when a property related error is detected, for example if a objects is ask for a
- * property which it does not own. This exceptions own the error-code range from 300-399.
+ * This exception is thrown when a property related error is detected, for example if an object is asked for a
+ * property which it does not own. These exceptions own the error-code range from 300-399.
  **/
 struct property_error : virtual boost::exception { };
 
@@ -131,7 +131,7 @@ struct vertex_property {};
  *
  * This is a identifier structure for edge properties. Every property with this struct as 'kind' type
  * will be added to all local edges of a cluster. It is accessible through local edge
- * descriptors, or global one by getting it's holding local edge first. Note that global edges don't
+ * descriptors, or global one by getting its holding local edge first. Note that global edges don't
  * have properties, as the properties are intended for use inside boost graph algorithms and therefore
  * only needed in local edges. @see property_map
  */
@@ -140,8 +140,8 @@ struct edge_property {};
 /**
  * @brief Identifier for cluster properties
  *
- * A ClusterGraph has it's own properties, and ever property with this identifier as 'kind' type will be
- * added to it. This is intended for internal dcm usage, its possible to give the abstract cluster a meaning
+ * A ClusterGraph has its own properties, and every property with this identifier as 'kind' type will be
+ * added to it. This is intended for internal dcm usage, it's possible to give the abstract cluster a meaning
  * by adding special properties to it. It can be accessed by special ClusterGraph functions designed for this
  * purpose.
  **/
@@ -150,8 +150,8 @@ struct cluster_property {};
 /**
  *@brief Identifier for general object properties
  *
- * Aproperty with this struct as 'kind' type will be added to all existing objects, no matter of individual
- * type. Use this only for general, sharable properties. To add a property to a single object, use it's
+ * A property with this struct as 'kind' type will be added to all existing objects, no matter of individual
+ * type. Use this only for general, sharable properties. To add a property to a single object, use its
  * type as 'kind'.
  **/
 struct object_property {};
@@ -159,7 +159,7 @@ struct object_property {};
 /**
  *@brief Identifier for system setting properties
  *
- * Aproperty with this struct as 'kind' type will be added to the system class. Use this for user settings,
+ * A property with this struct as 'kind' type will be added to the system class. Use this for user settings,
  * which are just properties which are accessed horugh "setting" functions.
  **/
 struct setting_property {};
@@ -200,7 +200,7 @@ struct edge_selector {
  * @brief Select property information trait depending on property type
  *
  * Allows generic access to property information like descriptor or property sequence by exposing
- * a specific selector type ( @ref vertex_selector or @ref edge_selector ) dependend on the supplied
+ * a specific selector type ( @ref vertex_selector or @ref edge_selector ) depending on the supplied
  * property.
  **/
 template< typename Kind, typename Graph>
@@ -286,7 +286,7 @@ struct ensure_properties {
 };
 
 /**
- * @brief Property vector to a fusion sequence of the propety storage types
+ * @brief Property vector to a fusion sequence of the property storage types
  *
  * Properties are passed around as mpl sequences, mostly vectors. To store actual values, they need to
  * be transformed into fusion sequences. However, only the storage type needs to be in the vector, not
@@ -372,7 +372,7 @@ public:
     typedef typename Property::type&  reference;
     typedef boost::lvalue_property_map_tag category;
 
-    //expose cutom types for easy access
+    //expose custom types for easy access
     typedef Property property;
     typedef typename dcm::details::property_selector<typename Property::kind, Graph>::sequence_type sequence;
     typedef typename dcm::details::property_selector<typename Property::kind, Graph>::property_distance distance;
@@ -458,7 +458,7 @@ PropertyOwner<PropertyList>::PropertyOwner() {
 };
 
 /**
- * @brief Convienience specialization to ease interaction with system class
+ * @brief Convenience specialization to ease interaction with system class
  *
  * Normally property lists are retrieved from the system class, however, there are no empty lists. If no
  * property is supplied for a PropertyOwner derived class, a mpl::void_ type will be retrieved. To
@@ -499,7 +499,7 @@ void PropertyOwner<PropertyList>::setProperty(typename Prop::type value) {
 
 
 
-//now create some standart properties
+//now create some standard properties
 //***********************************
 
 /**
@@ -513,7 +513,7 @@ struct empty_prop {
 /**
  * @brief Add a type to clusters
  *
- * Allows to specify special types to ClusterGraphs and make a it possibe to distuingish between
+ * Allows to specify special types to ClusterGraphs and make a it possible to distinguish between
  * different purposes. The cluster types need to be int.
  **/
 struct type_prop {
@@ -525,7 +525,7 @@ struct type_prop {
 /**
  * @brief Was the cluster changed?
  *
- * Adds a boolean to the cluster which indicates if the cluster was changedsince the last
+ * Adds a boolean to the cluster which indicates if the cluster was changed since the last
  * processing. It should be set to true if vertices and edges were added or removed, Subclusters
  * created or deleted and so on.
  **/

--- a/src/Mod/Assembly/App/opendcm/core/system.hpp
+++ b/src/Mod/Assembly/App/opendcm/core/system.hpp
@@ -199,7 +199,7 @@ public:
             mpl::vector2<changed_prop, type_prop>  >::type cluster_properties;
 	    
     //we hold our own PropertyOwner which we use for system settings. Don't inherit it as the user 
-    //should not access the settings via the proeprty getter and setter functions.
+    //should not access the settings via the property getter and setter functions.
     typedef PropertyOwner<typename details::properties_by_kind<properties, setting_property>::type> OptionOwner;
     std::shared_ptr<OptionOwner> m_options;
 

--- a/src/Mod/Assembly/App/opendcm/externalize.hpp
+++ b/src/Mod/Assembly/App/opendcm/externalize.hpp
@@ -21,7 +21,7 @@
 #define DCM_EXTERNALIZE_H
 
 #ifdef _WIN32
-	//warning about to long decoraded names, won't affect the code correctness
+	//warning about excessively long decorated names, won't affect the code correctness
 	#pragma warning( disable : 4503 )
 #endif
 

--- a/src/Mod/Assembly/App/opendcm/module3d.hpp
+++ b/src/Mod/Assembly/App/opendcm/module3d.hpp
@@ -23,7 +23,7 @@
 #define DCM_USE_MODULE3D
 
 #ifdef _WIN32
-	//warning about to long decoraded names, won't affect the code correctness
+	//warning about excessively long decorated names, won't affect the code correctness
 	#pragma warning( disable : 4503 )
 #endif
 

--- a/src/Mod/Assembly/App/opendcm/module3d/alignment.hpp
+++ b/src/Mod/Assembly/App/opendcm/module3d/alignment.hpp
@@ -27,8 +27,8 @@
 namespace dcm {
 
 namespace details {
-//we need a custom orientation type to allow coincidents with points. We can't use the ci_orietation
-//as some geometries are supporte by align but not by coincident
+//we need a custom orientation type to allow coincidents with points. We can't use the ci_orientation
+//as some geometries are supported by align but not by coincident
 struct al_orientation : public Equation<al_orientation, Direction, 6, rotation> {
 
     using Equation::operator=;
@@ -106,7 +106,7 @@ struct al_orientation::type< Kernel, tag::plane3D, tag::plane3D > : public ci_or
 
 template< typename Kernel >
 struct al_orientation::type< Kernel, tag::plane3D, tag::cylinder3D > : public dcm::Orientation::type< Kernel, tag::plane3D, tag::cylinder3D > {
-    //we missuse the scale method to change whatever direction was set to the only valid one: perpendicular
+    //we misuse the scale method to change whatever direction was set to the only valid one: perpendicular
     void setScale(typename Kernel::number_type scale) {
         fusion::at_key<Direction>(dcm::Orientation::type< Kernel, tag::line3D, tag::plane3D >::values).second = perpendicular;
     };

--- a/src/Mod/Assembly/App/opendcm/module3d/clustermath.hpp
+++ b/src/Mod/Assembly/App/opendcm/module3d/clustermath.hpp
@@ -27,8 +27,8 @@
 #include <opendcm/core/kernel.hpp>
 #include "defines.hpp"
 
-#define MAXFAKTOR 1.2   //the maximal distance allowd by a point normed to the cluster size
-#define MINFAKTOR 0.8   //the minimal distance allowd by a point normed to the cluster size
+#define MAXFAKTOR 1.2   //the maximal distance allowed by a point normed to the cluster size
+#define MINFAKTOR 0.8   //the minimal distance allowed by a point normed to the cluster size
 #define SKALEFAKTOR 1.  //the faktor by which the biggest size is multiplied to get the scale value
 #define NQFAKTOR 0.5    //the faktor by which the norm quaternion is multiplied with to get the RealScalar
 //norm quaternion to generate the unit quaternion

--- a/src/Mod/Assembly/App/opendcm/module3d/coincident.hpp
+++ b/src/Mod/Assembly/App/opendcm/module3d/coincident.hpp
@@ -139,7 +139,7 @@ struct ci_orientation::type< Kernel, tag::point3D, tag::cylinder3D > : public ci
 
 template< typename Kernel >
 struct ci_orientation::type< Kernel, tag::line3D, tag::line3D > : public dcm::Orientation::type< Kernel, tag::line3D, tag::line3D > {
-    //we missuse the scale method to prevent a unallowed direcion: perpendicular (ad distance is not defined for it)
+    //we misuse the scale method to prevent an unallowed direction: perpendicular (and distance is not defined for it)
     void setScale(typename Kernel::number_type scale) {
         if(fusion::at_key<Direction>(dcm::Orientation::type< Kernel, tag::line3D, tag::line3D >::values).second == perpendicular)
             fusion::at_key<Direction>(dcm::Orientation::type< Kernel, tag::line3D, tag::line3D >::values).second = parallel;
@@ -148,7 +148,7 @@ struct ci_orientation::type< Kernel, tag::line3D, tag::line3D > : public dcm::Or
 
 template< typename Kernel >
 struct ci_orientation::type< Kernel, tag::line3D, tag::plane3D > : public dcm::Orientation::type< Kernel, tag::line3D, tag::plane3D > {
-    //we missuse the scale method to change whatever direction was set to the only valid one: perpendicular
+    //we misuse the scale method to change whatever direction was set to the only valid one: perpendicular
     void setScale(typename Kernel::number_type scale) {
         fusion::at_key<Direction>(dcm::Orientation::type< Kernel, tag::line3D, tag::plane3D >::values).second = perpendicular;
     };
@@ -156,7 +156,7 @@ struct ci_orientation::type< Kernel, tag::line3D, tag::plane3D > : public dcm::O
 
 template< typename Kernel >
 struct ci_orientation::type< Kernel, tag::line3D, tag::cylinder3D > : public dcm::Orientation::type< Kernel, tag::line3D, tag::cylinder3D > {
-    //we missuse the scale method to prevent a unallowed direcion: perpendicular (ad distance is not defined for it)
+    //we misuse the scale method to prevent an unallowed direction: perpendicular (and distance is not defined for it)
     void setScale(typename Kernel::number_type scale) {
         if(fusion::at_key<Direction>(dcm::Orientation::type< Kernel, tag::line3D, tag::cylinder3D >::values).second == perpendicular)
             fusion::at_key<Direction>(dcm::Orientation::type< Kernel, tag::line3D, tag::cylinder3D >::values).second = parallel;
@@ -165,7 +165,7 @@ struct ci_orientation::type< Kernel, tag::line3D, tag::cylinder3D > : public dcm
 
 template< typename Kernel >
 struct ci_orientation::type< Kernel, tag::plane3D, tag::plane3D > : public dcm::Orientation::type< Kernel, tag::plane3D, tag::plane3D > {
-//we missuse the scale method to prevent a unallowed direcion: perpendicular (ad distance is not defined for it)
+//we misuse the scale method to prevent an unallowed direction: perpendicular (and distance is not defined for it)
     void setScale(typename Kernel::number_type scale) {
         if(fusion::at_key<Direction>(dcm::Orientation::type< Kernel, tag::plane3D, tag::plane3D >::values).second == perpendicular)
             fusion::at_key<Direction>(dcm::Orientation::type< Kernel, tag::plane3D, tag::plane3D >::values).second = parallel;
@@ -174,7 +174,7 @@ struct ci_orientation::type< Kernel, tag::plane3D, tag::plane3D > : public dcm::
 
 template< typename Kernel >
 struct ci_orientation::type< Kernel, tag::cylinder3D, tag::cylinder3D > : public dcm::Orientation::type< Kernel, tag::cylinder3D, tag::cylinder3D > {
-    //we missuse the scale method to prevent a unallowed direcion: perpendicular (ad distance is not defined for it)
+    //we misuse the scale method to prevent an unallowed direction: perpendicular (and distance is not defined for it)
     void setScale(typename Kernel::number_type scale) {
         if(fusion::at_key<Direction>(dcm::Orientation::type< Kernel, tag::cylinder3D, tag::cylinder3D >::values).second == perpendicular)
             fusion::at_key<Direction>(dcm::Orientation::type< Kernel, tag::cylinder3D, tag::cylinder3D >::values).second = parallel;
@@ -290,7 +290,7 @@ struct Coincidence : public dcm::constraint_sequence< fusion::vector2< details::
     };
 };
 
-//no standart equation, create our own object
+//no standard equation, create our own object
 static Coincidence coincidence;
 
 }//dcm

--- a/src/Mod/Assembly/App/opendcm/module3d/distance.hpp
+++ b/src/Mod/Assembly/App/opendcm/module3d/distance.hpp
@@ -468,7 +468,7 @@ struct Distance::type< Kernel, tag::line3D, tag::line3D > {
         Scalar diff = (-dline1.template head<3>().dot(nxn)+c.dot(nxn_diff))*nxn_n;
         diff -= c.dot(nxn)*nxn.dot(nxn_diff)/nxn_n;
 
-        //absoulute value requires different differentation for different results
+        //absolute value requires different differentation for different results
         if(cdn <= 0)
             diff *= -1;
 
@@ -494,7 +494,7 @@ struct Distance::type< Kernel, tag::line3D, tag::line3D > {
         Scalar diff = (dline2.template head<3>().dot(nxn)+c.dot(nxn_diff))*nxn_n;
         diff -= c.dot(nxn)*nxn.dot(nxn_diff)/nxn_n;
 
-        //absoulute value requires different differentation for different results
+        //absolute value requires different differentation for different results
         if(cdn <= 0)
             diff *= -1;
 

--- a/src/Mod/Assembly/App/opendcm/module3d/geometry.hpp
+++ b/src/Mod/Assembly/App/opendcm/module3d/geometry.hpp
@@ -145,7 +145,7 @@ struct dummy_accessor {
     void finalize(T& t) {};
 };
 
-//dummy geometry traits for boost blank, wil bever be used
+//dummy geometry traits for boost blank, will never be used
 template<>
 struct geometry_traits<boost::blank> {
     typedef tag::direction3D tag;

--- a/src/Mod/Assembly/App/opendcm/module3d/imp/clustermath_imp.hpp
+++ b/src/Mod/Assembly/App/opendcm/module3d/imp/clustermath_imp.hpp
@@ -331,7 +331,7 @@ ClusterMath<Sys>::map_downstream::map_downstream(details::ClusterMath<Sys>& cm, 
 
 template<typename Sys>
 void ClusterMath<Sys>::map_downstream::operator()(Geom g) {
-    //allow iteration over all maped geometries
+    //allow iteration over all mapped geometries
     m_clusterMath.addGeometry(g);
     //set the offsets so that geometry knows where it is in the parameter map
     g->m_offset = m_clusterMath.getParameterOffset(general);
@@ -346,7 +346,7 @@ template<typename Sys>
 void ClusterMath<Sys>::map_downstream::operator()(std::shared_ptr<Cluster> c) {
     //we transform the GLOBAL geometries to local ones in the subcluster! therefore
     //we are not interested in the successive transformations, we only transform the
-    //global geometries with the cluster transform we want them to be local in, and thats
+    //global geometries with the cluster transform we want them to be local in, and that's
     //the one supplied in the constructor
     //m_transform *= c->template getClusterProperty<math_prop>().getTransform().inverse();
 };
@@ -524,7 +524,7 @@ void ClusterMath<Sys>::applyClusterScale(Scalar scale, bool isFixed) {
 
 
     //when fixed, the geometries never get recalculated. therefore we have to do a calculate now
-    //to alow the adoption of the scale. and no shift should been set.
+    //to allow the adoption of the scale. and no shift should been set.
     if(isFixed) {
         m_transform*=typename Kernel::Transform3D::Scaling(1./(scale*SKALEFAKTOR));
         m_ssrTransform*=typename Kernel::Transform3D::Scaling(1./(scale*SKALEFAKTOR));
@@ -540,7 +540,7 @@ void ClusterMath<Sys>::applyClusterScale(Scalar scale, bool isFixed) {
         return;
     }
 
-    //if this is our scale then just applie the midpoint as shift
+    //if this is our scale then just apply the midpoint as shift
     if(Kernel::isSame(scale, m_scale, 1e-10)) {
 
     }
@@ -575,7 +575,7 @@ void ClusterMath<Sys>::applyClusterScale(Scalar scale, bool isFixed) {
 
         //TODO: it's possible that for this case we get too far away from the outer points.
         //	    The m_scale for "midpoint outside the bounding box" may be bigger than the
-        //      scale to applie, so it results in an error.
+        //      scale to apply, so it results in an error.
         //get the closest point
         typedef typename Vec::iterator iter;
         for(iter it = m_points.begin(); it != m_points.end(); it++) {
@@ -660,7 +660,7 @@ template<typename Sys>
 typename ClusterMath<Sys>::Scalar ClusterMath<Sys>::calcThreePoints(const typename ClusterMath<Sys>::Kernel::Vector3& p1,
         const typename ClusterMath<Sys>::Kernel::Vector3& p2, const typename ClusterMath<Sys>::Kernel::Vector3& p3) {
 
-    //Three points form a triangle with it's minimal scale at the center of it's outer circle.
+    //Three points form a triangle with its minimal scale at the center of its outer circle.
     //Arbitrary scale values can be achieved by moving perpendicular to the triangle plane.
     typename Kernel::Vector3 d = p2-p1;
     typename Kernel::Vector3 e = p3-p1;

--- a/src/Mod/Assembly/App/opendcm/module3d/imp/constraint3d_imp.hpp
+++ b/src/Mod/Assembly/App/opendcm/module3d/imp/constraint3d_imp.hpp
@@ -69,7 +69,7 @@ template<typename Sys>
 template<typename Derived>
 std::shared_ptr<Derived> Module3D<Typelist, ID>::type<Sys>::Constraint3D_base<Derived>::clone(Sys& newSys) {
 
-    //copy the standart stuff
+    //copy the standard stuff
     std::shared_ptr<Derived> np = std::shared_ptr<Derived>(new Derived(*static_cast<Derived*>(this)));
     np->m_system = &newSys;
     //copy the internals

--- a/src/Mod/Assembly/App/opendcm/module3d/imp/geometry3d_imp.hpp
+++ b/src/Mod/Assembly/App/opendcm/module3d/imp/geometry3d_imp.hpp
@@ -127,7 +127,7 @@ template<typename Sys>
 template<typename Derived>
 std::shared_ptr<Derived> Module3D<Typelist, ID>::type<Sys>::Geometry3D_base<Derived>::clone(Sys& newSys) {
 
-    //copy the standart stuff
+    //copy the standard stuff
     std::shared_ptr<Derived> np = std::shared_ptr<Derived>(new Derived(*static_cast<Derived*>(this)));
     np->m_system = &newSys;
     //it's possible that the variant contains pointers, so we need to clone them

--- a/src/Mod/Assembly/App/opendcm/module3d/imp/module_imp.hpp
+++ b/src/Mod/Assembly/App/opendcm/module3d/imp/module_imp.hpp
@@ -108,7 +108,7 @@ void Module3D<Typelist, ID>::type<Sys>::inheriter_base::removeGeometry3D(Geom g)
     if(c)
         c->template emitSignal<remove>(c);
 
-    //emit remove geometry signal bevore actually deleting it, in case anyone want to access the
+    //emit remove geometry signal before actually deleting it, in case anyone wants to access the
     //graph before
     g->template emitSignal<remove>(g);
 

--- a/src/Mod/Assembly/App/opendcm/module3d/imp/solver_imp.hpp
+++ b/src/Mod/Assembly/App/opendcm/module3d/imp/solver_imp.hpp
@@ -292,11 +292,11 @@ void SystemSolver<Sys>::solveCluster(std::shared_ptr<Cluster> cluster, Sys& sys)
                 int offset_rot = mes.setParameterMap(cm.getNormQuaternionMap(), rotation);
                 //set translation as map to the parameter vector
                 int offset = mes.setParameterMap(cm.getTranslationMap(), general);
-                //write initail values to the parameter maps
+                //write initial values to the parameter maps
                 //remember the parameter offset as all downstream geometry must use this offset
                 cm.setParameterOffset(offset_rot, rotation);
                 cm.setParameterOffset(offset, general);
-                //wirte initial values
+                //write initial values
                 cm.initMaps();
             }
             else
@@ -369,12 +369,12 @@ void SystemSolver<Sys>::solveCluster(std::shared_ptr<Cluster> cluster, Sys& sys)
 
             if(!has_cycle) {
 #ifdef USE_LOGGING
-		BOOST_LOG_SEV(log, solving)<< "non-cyclic system dedected: solve rotation only";
+		BOOST_LOG_SEV(log, solving)<< "non-cyclic system detected: solve rotation only";
 #endif
 		//cool, lets do uncylic. first all rotational constraints with rotational parameters
 		mes.setAccess(rotation);
 
-		//rotations need to be calculated in a scaled manner. thats because the normals used for
+		//rotations need to be calculated in a scaled manner. that's because the normals used for
 		//rotation calculation are always 1, no matter how big the part is. This can lead to problems
 		//when for example two rotated faces have a precision error on the parallel normals but a distance
 		//at the outer edges is far bigger than the precision as the distance from normal origin to outer edge

--- a/src/Mod/Assembly/App/opendcm/module3d/imp/state_imp.hpp
+++ b/src/Mod/Assembly/App/opendcm/module3d/imp/state_imp.hpp
@@ -56,7 +56,7 @@ struct geom_visitor : public boost::static_visitor<std::string> {
     template<typename T>
     std::string operator()(T& i) const {
 
-        //we use stings in case new geometry gets added and the weights shift, meaning: backwards
+        //we use strings in case new geometry gets added and the weights shift, meaning: backwards
         //compatible
         std::string type;
 

--- a/src/Mod/Assembly/App/opendcm/module3d/module.hpp
+++ b/src/Mod/Assembly/App/opendcm/module3d/module.hpp
@@ -279,13 +279,13 @@ struct Module3D {
             sys.m_sheduler.addProcessJob(new SystemSolver());
         };
         static void system_copy(const Sys& from, Sys& into) {
-            //nothing to to as all objects and properties are copyed with the clustergraph
+            //nothing to to as all objects and properties are copied with the clustergraph
         };
     };
 };
 
 namespace details {
-//allow direct access to the stored geometry in a Geometry3D, copyed from boost variant get
+//allow direct access to the stored geometry in a Geometry3D, copied from boost variant get
 template <typename T>
 struct get_visitor {
 private:

--- a/src/Mod/Assembly/App/opendcm/moduleShape3d/generator.hpp
+++ b/src/Mod/Assembly/App/opendcm/moduleShape3d/generator.hpp
@@ -179,7 +179,7 @@ struct segment3D {
                 std::shared_ptr<Constraint3D> c2 = base::m_system->createConstraint3D(g1,g3, details::fixed);
                 c1->disable(); //required by fixed constraint
                 base::append(c1);
-                c2->disable(); //requiered by fixed constraint
+                c2->disable(); //required by fixed constraint
                 base::append(c2);
             }
             else if(base::m_geometries->size() == 2) {
@@ -217,7 +217,7 @@ struct segment3D {
                     std::shared_ptr<Constraint3D> c2 = base::m_system->createConstraint3D(g1,g3, details::fixed);
                     c1->disable(); //required by fixed constraint
                     base::append(c1);
-                    c2->disable(); //requiered by fixed constraint
+                    c2->disable(); //required by fixed constraint
                     base::append(c2);
 
                 }

--- a/src/Mod/Assembly/App/opendcm/moduleShape3d/module.hpp
+++ b/src/Mod/Assembly/App/opendcm/moduleShape3d/module.hpp
@@ -442,7 +442,7 @@ struct ModuleShape3D {
 
         struct inheriter_id : public inheriter_base {
             //we don't have a createshape3d method with identifier, as identifiers can be used to
-            //specifie creation geometries or shapes. Therefore a call would always be ambigious.
+            //specifie creation geometries or shapes. Therefore a call would always be ambiguous.
 
             void removeShape3D(ID id);
             bool hasShape3D(ID id);
@@ -791,7 +791,7 @@ void ModuleShape3D<Typelist, ID>::type<Sys>::inheriter_base::removeShape3D(std::
     //recursion
     g->disconnectAll();
 
-    //remove all constraints is unnessecary as they get removed together with the geometries
+    //remove all constraints is unnecessary as they get removed together with the geometries
     //remove all geometries
     typedef typename Shape3D::geometry3d_iterator git;
 

--- a/src/Mod/Assembly/App/opendcm/moduleState/imp/property_parser_imp.hpp
+++ b/src/Mod/Assembly/App/opendcm/moduleState/imp/property_parser_imp.hpp
@@ -76,7 +76,7 @@ prop_par<Sys, PropertyList>::prop_par() : prop_par<Sys, PropertyList>::base_type
                    typename fusion::result_of::as_vector<parent_rules_sequence>::type,
                    mpl::int_<0> >(sub_rules, parent_rules);
 
-    //we need to specialy treat empty sequences
+    //we need to especially treat empty sequences
     initalizeLastRule(parent_rules, prop);
 };
 

--- a/src/Mod/Assembly/App/opendcm/moduleState/object_generator.hpp
+++ b/src/Mod/Assembly/App/opendcm/moduleState/object_generator.hpp
@@ -27,9 +27,9 @@ namespace details {
         static void getProperties(std::shared_ptr<Object> ptr, typename details::pts<typename Object::PropertySequence>::type& seq);
     };
 
-    //when objects should not be generated we need to get a empy rule, as obj_rule_init
-    //trys always to access the rules attribute and when the parser_generator trait is not
-    //specialitzed it's impossible to have the attribute type right in the unspecialized trait
+    //when objects should not be generated we need to get an empty rule, as obj_rule_init
+    //always tries to access the rules attribute and when the parser_generator trait is not
+    //specialized it's impossible to have the attribute type right in the unspecialized trait
     template<typename Sys, typename seq, typename state>
     struct obj_generator_fold : mpl::fold< seq, state,
             mpl::if_< parser_generate<mpl::_2, Sys>,
@@ -46,14 +46,15 @@ namespace details {
         //create a vector with the appropriate rules for all objects. Do this with the rule init struct, as it gives
         //automatic initialisation of the rules when the objects are created
         typedef typename obj_generator_fold<Sys, ObjectList,mpl::vector<> >::type init_rules_vector;
-        //push back a empty rule so that we know where to go when nothing is to do
+        //push back a empty rule so that we know where to go when there's nothing to do
         typedef typename mpl::push_back<init_rules_vector, empty_grammar >::type rules_vector;
 
         //create the fusion sequence of our rules
         typedef typename fusion::result_of::as_vector<rules_vector>::type rules_sequnce;
 
-        //this struct returns the right accessvalue for the sequences. If we access a value bigger than the property vector size
-        //we use the last rule, as we made sure this is an empty one
+        //this struct returns the right access value for the sequences. If we access
+        //a value bigger than the property vector size we use the last rule, as we
+        //made sure this is an empty one
         template<int I>
         struct index : public mpl::if_< mpl::less<mpl::int_<I>, mpl::size<ObjectList> >,
                 mpl::int_<I>, typename mpl::size<ObjectList>::prior >::type {};

--- a/src/Mod/Assembly/App/opendcm/moduleState/object_parser.hpp
+++ b/src/Mod/Assembly/App/opendcm/moduleState/object_parser.hpp
@@ -41,9 +41,9 @@ struct obj_parser : public qi::grammar<IIterator, qi::unused_type(typename detai
     static void setProperties(std::shared_ptr<Object> ptr, typename details::pts<typename Object::PropertySequence>::type& seq);
 };
 
-//when objects should not be generated we need to get a empy rule, as obj_rule_init
-//trys always to access the rules attribute and when the parser_generator trait is not
-//specialitzed it's impossible to have the attribute type right in the unspecialized trait
+//when objects should not be generated we need to get an empty rule, as obj_rule_init
+//always tries to access the rules attribute and when the parser_generator trait is not
+//specialized it's impossible to have the attribute type right in the unspecialized trait
 template<typename Sys, typename seq, typename state>
 struct obj_parser_fold : mpl::fold< seq, state,
         mpl::if_< parser_parse<mpl::_2, Sys>,

--- a/src/Mod/Assembly/App/opendcm/modulepart.hpp
+++ b/src/Mod/Assembly/App/opendcm/modulepart.hpp
@@ -23,7 +23,7 @@
 #define DCM_USE_MODULEPART
 
 #ifdef _WIN32
-	//warning about to long decoraded names, won't affect the code correctness
+	//warning about excessively long decorated names, won't affect the code correctness
 	#pragma warning( disable : 4503 )
 #endif
 

--- a/src/Mod/Assembly/App/opendcm/moduleshape3d.hpp
+++ b/src/Mod/Assembly/App/opendcm/moduleshape3d.hpp
@@ -23,7 +23,7 @@
 #define DCM_USE_MODULEHL3D
 
 #ifdef _WIN32
-	//warning about to long decoraded names, won't affect the code correctness
+	//warning about excessively long decorated names, won't affect the code correctness
 	#pragma warning( disable : 4503 )
 #endif
 

--- a/src/Mod/Assembly/App/opendcm/modulestate.hpp
+++ b/src/Mod/Assembly/App/opendcm/modulestate.hpp
@@ -23,7 +23,7 @@
 #define DCM_USE_MODULESTATE
 
 #ifdef _WIN32
-	//warning about to long decoraded names, won't affect the code correctness
+	//warning about excessively long decorated names, won't affect the code correctness
 	#pragma warning( disable : 4503 )
 #endif
 


### PR DESCRIPTION
Includes @ickby's 3rdparty opendcm code