### PR TITLE
PartDesign: Fillets / Chamfers add unit tests for UseAllEdges property

### DIFF
--- a/src/Mod/PartDesign/PartDesignTests/TestChamfer.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestChamfer.py
@@ -42,6 +42,22 @@ class TestChamfer(unittest.TestCase):
         self.Doc.recompute()
         self.MajorFaces = [face for face in self.Chamfer.Shape.Faces if face.Area > 1e-3]
         self.assertEqual(len(self.MajorFaces), 8)
+        #test UseAllEdges property
+        self.Chamfer.UseAllEdges = True
+        self.Chamfer.Base = (self.Box, ['']) # no subobjects, should still work
+        self.Doc.recompute()
+        self.MajorFaces = [face for face in self.Chamfer.Shape.Faces if face.Area > 1e-3]
+        self.assertEqual(len(self.MajorFaces), 8)
+        self.Chamfer.Base = (self.Box, ['Face50']) # non-existent face, test topo naming resilience
+        self.Doc.recompute()
+        self.MajorFaces = [face for face in self.Chamfer.Shape.Faces if face.Area > 1e-3]
+        self.assertEqual(len(self.MajorFaces), 8)
+        self.Chamfer.UseAllEdges = False
+        self.Chamfer.Base = (self.Box, ['Face1'])
+        self.Doc.recompute()
+        self.MajorFaces = [face for face in self.Chamfer.Shape.Faces if face.Area > 1e-3]
+        self.assertEqual(len(self.MajorFaces), 9)
+
 
     def tearDown(self):
         #closing doc

--- a/src/Mod/PartDesign/PartDesignTests/TestFillet.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestFillet.py
@@ -43,6 +43,18 @@ class TestFillet(unittest.TestCase):
         self.Body.addObject(self.Fillet)
         self.Doc.recompute()
         self.assertAlmostEqual(self.Fillet.Shape.Volume, 4/3 * pi * 5**3, places=3)
+        #test UseAllEdges property
+        self.Fillet.UseAllEdges = True
+        self.Fillet.Base = (self.Box, ['']) # no subobjects, should still work
+        self.Doc.recompute()
+        self.assertAlmostEqual(self.Fillet.Shape.Volume, 4/3 * pi * 5**3, places=3)
+        self.Fillet.Base = (self.Box, ['Face50']) # non-existent face, topo naming resilience
+        self.Doc.recompute()
+        self.assertAlmostEqual(self.Fillet.Shape.Volume, 4/3 * pi * 5**3, places=3)
+        self.Fillet.UseAllEdges = False
+        self.Fillet.Base = (self.Box, ['Face1'])
+        self.Doc.recompute()
+        self.assertNotAlmostEqual(self.Fillet.Shape.Volume, 4/3 * pi * 5**3, places=3)
 
     def tearDown(self):
         #closing doc


### PR DESCRIPTION
Test 1: set Base to no subobjects, with UseAllEdges = True, should be the same as if all faces were the Base subobjects.
Test 2: set Base to non-existent face (Face50) with UseAllEdges = True, tests for topological naming resilience
Test 3: set Base to only Face1 with UseAllEdges = False, should now be different from result of using all faces.