### PR TITLE
Partially revert #4118 and implement intended fix

### DIFF
--- a/src/Gui/Workbench.cpp
+++ b/src/Gui/Workbench.cpp
@@ -651,7 +651,7 @@ MenuItem* StdWorkbench::setupMenuBar() const
     *view << "Std_ViewCreate" << "Std_OrthographicCamera" << "Std_PerspectiveCamera" << "Std_MainFullscreen" << "Separator"
           << stdviews << "Std_FreezeViews" << "Std_DrawStyle" << "Std_SelBoundingBox"
           << "Separator" << view3d << zoom
-          << "Std_ViewDockUndockFullscreen" << "Std_AxisCross" << "Std_ToggleClipPlane" << "Part_SectionCut"
+          << "Std_ViewDockUndockFullscreen" << "Std_AxisCross" << "Std_ToggleClipPlane"
           << "Std_TextureMapping"
 #ifdef BUILD_VR
           << "Std_ViewVR"

--- a/src/Mod/Part/Gui/Workbench.cpp
+++ b/src/Mod/Part/Gui/Workbench.cpp
@@ -137,6 +137,7 @@ Gui::MenuItem* Workbench::setupMenuBar() const
           << "Part_Loft"
           << "Part_Sweep"
           << "Part_Section"
+          << "Part_SectionCut"
           << "Part_CrossSections"
           << "Part_Offset"
           << "Part_Offset2D"


### PR DESCRIPTION
`Part_SectionCut` was erroneously added to `src/Gui/Workbench.cpp` which led to a warning `Unknown command 'Part_SectionCut'` when starting up FreeCAD. This commit removes it and adds it to the appropriate place in `src/Mod/Part/Gui/Workbench.cpp`

Thread: https://forum.freecadweb.org/viewtopic.php?p=569276#p569276