### PR TITLE
Gui: add preference to enforce C locale usage

### DIFF
--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -2099,6 +2099,9 @@ void Application::runApplication(void)
         mainApp.installEventFilter(filter);
     }
 
+    if (hGrp->GetBool("UseCNumberFormat", false))
+        QLocale::setDefault(QLocale::c());
+
     // set text cursor blinking state
     int blinkTime = hGrp->GetBool("EnableCursorBlinking", true) ? -1 : 0;
     qApp->setCursorFlashTime(blinkTime);

--- a/src/Gui/DlgGeneral.ui
+++ b/src/Gui/DlgGeneral.ui
@@ -105,6 +105,23 @@
            </property>
           </widget>
          </item>
+         <item row="1" column="1">
+          <widget class="Gui::PrefCheckBox" name="UseCFormat">
+           <property name="toolTip">
+            <string>If enabled, FreeCAD with use C/POSIX number formatting
+C/POSIX locale is a cross-platform English-like format</string>
+           </property>
+           <property name="text">
+            <string>Use C/POSIX locale (needs restart)</string>
+           </property>
+           <property name="prefEntry" stdset="0">
+            <cstring>UseCNumberFormat</cstring>
+           </property>
+           <property name="prefPath" stdset="0">
+            <cstring>General</cstring>
+           </property>
+          </widget>
+         </item>
         </layout>
        </widget>
       </item>

--- a/src/Gui/DlgGeneralImp.cpp
+++ b/src/Gui/DlgGeneralImp.cpp
@@ -141,6 +141,7 @@ void DlgGeneralImp::saveSettings()
                           SetASCII("AutoloadModule", startWbName.toLatin1());
 
     ui->SubstituteDecimal->onSave();
+    ui->UseCFormat->onSave();
     ui->RecentFiles->onSave();
     ui->EnableCursorBlinking->onSave();
     ui->SplashScreen->onSave();
@@ -211,6 +212,7 @@ void DlgGeneralImp::loadSettings()
     ui->AutoloadModuleCombo->setCurrentIndex(ui->AutoloadModuleCombo->findData(startWbName));
 
     ui->SubstituteDecimal->onRestore();
+    ui->UseCFormat->onRestore();
     ui->RecentFiles->onRestore();
     ui->EnableCursorBlinking->onRestore();
     ui->SplashScreen->onRestore();


### PR DESCRIPTION
This PR brings a first level answer to #6330 by allowing user to enforce C/POSIX locale usage inside FreeCAD.
I think it covers the vast majority of issues regarding number (& date, ...) format incompatibility issues.