### PR TITLE
Draft: Housekeeping: call 'make' functions with new name

### DIFF
--- a/src/Mod/Draft/draftfunctions/offset.py
+++ b/src/Mod/Draft/draftfunctions/offset.py
@@ -34,12 +34,11 @@ import DraftVecUtils
 import draftutils.gui_utils as gui_utils
 import draftutils.utils as utils
 
-from draftmake.make_copy import make_copy
-from draftmake.make_rectangle import makeRectangle
-from draftmake.make_wire import makeWire
-from draftmake.make_polygon import makePolygon
-from draftmake.make_circle import makeCircle
-from draftmake.make_bspline import makeBSpline
+from draftmake.make_rectangle import make_rectangle
+from draftmake.make_wire import make_wire
+from draftmake.make_polygon import make_polygon
+from draftmake.make_circle import make_circle
+from draftmake.make_bspline import make_bspline
 
 
 def offset(obj, delta, copy=False, bind=False, sym=False, occ=False):
@@ -164,7 +163,7 @@ def offset(obj, delta, copy=False, bind=False, sym=False, occ=False):
         if sym: return None
         if utils.get_type(obj) == "Wire":
             if p:
-                newobj = makeWire(p)
+                newobj = make_wire(p)
                 newobj.Closed = obj.Closed
             elif newwire:
                 newobj = App.ActiveDocument.addObject("Part::Feature","Offset")
@@ -174,7 +173,7 @@ def offset(obj, delta, copy=False, bind=False, sym=False, occ=False):
         elif utils.get_type(obj) == "Rectangle":
             if p:
                 length,height,plac = getRect(p,obj)
-                newobj = makeRectangle(length,height,plac)
+                newobj = make_rectangle(length,height,plac)
             elif newwire:
                 newobj = App.ActiveDocument.addObject("Part::Feature","Offset")
                 newobj.Shape = newwire
@@ -182,24 +181,24 @@ def offset(obj, delta, copy=False, bind=False, sym=False, occ=False):
                 print("Draft.offset: Unable to duplicate this object")
         elif utils.get_type(obj) == "Circle":
             pl = obj.Placement
-            newobj = makeCircle(delta)
+            newobj = make_circle(delta)
             newobj.FirstAngle = obj.FirstAngle
             newobj.LastAngle = obj.LastAngle
             newobj.Placement = pl
         elif utils.get_type(obj) == "Polygon":
             pl = obj.Placement
-            newobj = makePolygon(obj.FacesNumber)
+            newobj = make_polygon(obj.FacesNumber)
             newobj.Radius = getRadius(obj,delta)
             newobj.DrawMode = obj.DrawMode
             newobj.Placement = pl
         elif utils.get_type(obj) == "BSpline":
-            newobj = makeBSpline(delta)
+            newobj = make_bspline(delta)
             newobj.Closed = obj.Closed
         else:
             # try to offset anyway
             try:
                 if p:
-                    newobj = makeWire(p)
+                    newobj = make_wire(p)
                     newobj.Closed = obj.Shape.isClosed()
             except Part.OCCError:
                 pass

--- a/src/Mod/Draft/draftguitools/gui_arcs.py
+++ b/src/Mod/Draft/draftguitools/gui_arcs.py
@@ -319,7 +319,7 @@ class Arc(gui_base_original.Creator):
                 else:
                     # Insert a Draft circle
                     _base = DraftVecUtils.toString(self.center)
-                    _cmd = 'Draft.makeCircle'
+                    _cmd = 'Draft.make_circle'
                     _cmd += '('
                     _cmd += 'radius=' + str(self.rad) + ', '
                     _cmd += 'placement=pl, '
@@ -371,7 +371,7 @@ class Arc(gui_base_original.Creator):
                 else:
                     # Insert a Draft circle
                     _base = DraftVecUtils.toString(self.center)
-                    _cmd = 'Draft.makeCircle'
+                    _cmd = 'Draft.make_circle'
                     _cmd += '('
                     _cmd += 'radius=' + str(self.rad) + ', '
                     _cmd += 'placement=pl, '

--- a/src/Mod/Draft/draftguitools/gui_beziers.py
+++ b/src/Mod/Draft/draftguitools/gui_beziers.py
@@ -197,7 +197,7 @@ class BezCurve(gui_lines.Line):
             try:
                 rot, sup, pts, fil = self.getStrings()
                 Gui.addModule("Draft")
-                _cmd = 'Draft.makeBezCurve'
+                _cmd = 'Draft.make_bezcurve'
                 _cmd += '('
                 _cmd += 'points, '
                 _cmd += 'closed=' + str(closed) + ', '
@@ -437,7 +437,7 @@ class CubicBezCurve(gui_lines.Line):
                 # to be committed through the `draftutils.todo.ToDo` class.
                 rot, sup, pts, fil = self.getStrings()
                 Gui.addModule("Draft")
-                _cmd = 'Draft.makeBezCurve'
+                _cmd = 'Draft.make_bezcurve'
                 _cmd += '('
                 _cmd += 'points, '
                 _cmd += 'closed=' + str(closed) + ', '

--- a/src/Mod/Draft/draftguitools/gui_splines.py
+++ b/src/Mod/Draft/draftguitools/gui_splines.py
@@ -169,7 +169,7 @@ class BSpline(gui_lines.Line):
                 rot, sup, pts, fil = self.getStrings()
                 Gui.addModule("Draft")
 
-                _cmd = 'Draft.makeBSpline'
+                _cmd = 'Draft.make_bspline'
                 _cmd += '('
                 _cmd += 'points, '
                 _cmd += 'closed=' + str(closed) + ', '

--- a/src/Mod/Draft/draftguitools/gui_wire2spline.py
+++ b/src/Mod/Draft/draftguitools/gui_wire2spline.py
@@ -27,7 +27,7 @@
 These tools work on polylines and B-splines which have multiple points.
 
 Essentially, the points of the original object are extracted
-and passed to the `makeWire` or `makeBSpline` functions,
+and passed to the `make_wire` or `make_bspline` functions,
 depending on the desired result.
 """
 ## @package gui_wire2spline
@@ -89,17 +89,17 @@ class WireToBSpline(gui_base_original.Modifier):
                         self.closed = self.obj.Closed
                         n = None
                         if utils.getType(self.obj) == 'Wire':
-                            n = Draft.makeBSpline(self.Points,
-                                                  closed=self.closed,
-                                                  placement=self.pl)
+                            n = Draft.make_bspline(self.Points,
+                                                   closed=self.closed,
+                                                   placement=self.pl)
                         elif utils.getType(self.obj) == 'BSpline':
                             self.bs2wire = True
-                            n = Draft.makeWire(self.Points,
-                                               closed=self.closed,
-                                               placement=self.pl,
-                                               face=None,
-                                               support=None,
-                                               bs2wire=self.bs2wire)
+                            n = Draft.make_wire(self.Points,
+                                                closed=self.closed,
+                                                placement=self.pl,
+                                                face=None,
+                                                support=None,
+                                                bs2wire=self.bs2wire)
                         if n:
                             Draft.formatObject(n, self.obj)
                             self.doc.recompute()

--- a/src/Mod/Draft/draftmake/make_arc_3points.py
+++ b/src/Mod/Draft/draftmake/make_arc_3points.py
@@ -178,10 +178,10 @@ def make_arc_3points(points, placement=None, face=False,
     _placement = App.Placement(center, rot)
     start = edge.FirstParameter
     end = math.degrees(edge.LastParameter)
-    obj = Draft.makeCircle(radius,
-                           placement=_placement, face=face,
-                           startangle=start, endangle=end,
-                           support=support)
+    obj = Draft.make_circle(radius,
+                            placement=_placement, face=face,
+                            startangle=start, endangle=end,
+                            support=support)
 
     if App.GuiUp:
         gui_utils.autogroup(obj)

--- a/src/Mod/Draft/draftmake/make_bspline.py
+++ b/src/Mod/Draft/draftmake/make_bspline.py
@@ -73,18 +73,18 @@ def make_bspline(pointslist, closed=False, placement=None, face=None, support=No
             nlist.append(v.Point)
         pointslist = nlist
     if len(pointslist) < 2:
-        _err = "Draft.makeBSpline: not enough points"
+        _err = "Draft.make_bspline: not enough points"
         App.Console.PrintError(translate("draft", _err)+"\n")
         return
     if (pointslist[0] == pointslist[-1]):
         if len(pointslist) > 2:
             closed = True
             pointslist.pop()
-            _err = "Draft.makeBSpline: Equal endpoints forced Closed"
+            _err = "Draft.make_bspline: Equal endpoints forced Closed"
             App.Console.PrintWarning(translate("Draft", _err) + _err + "\n")
         else:
             # len == 2 and first == last   GIGO
-            _err = "Draft.makeBSpline: Invalid pointslist"
+            _err = "Draft.make_bspline: Invalid pointslist"
             App.Console.PrintError(translate("Draft", _err)+"\n")
             return
     # should have sensible parms from here on

--- a/src/Mod/Draft/importDXF.py
+++ b/src/Mod/Draft/importDXF.py
@@ -871,7 +871,7 @@ def drawLine(line, forceShape=False):
         if not DraftVecUtils.equals(v1, v2):
             try:
                 if (dxfCreateDraft or dxfCreateSketch) and (not forceShape):
-                    return Draft.makeWire([v1, v2])
+                    return Draft.make_wire([v1, v2])
                 else:
                     return Part.LineSegment(v1, v2).toShape()
             except Part.OCCError:
@@ -989,7 +989,7 @@ def drawPolyline(polyline, forceShape=False, num=None):
                     else:
                         return Part.Face(w1)
                 elif (dxfCreateDraft or dxfCreateSketch) and (not curves) and (not forceShape):
-                    ob = Draft.makeWire(verts)
+                    ob = Draft.make_wire(verts)
                     ob.Closed = polyline.closed
                     ob.Placement = placementFromDXFOCS(polyline)
                     return ob
@@ -1047,9 +1047,9 @@ def drawArc(arc, forceShape=False):
     try:
         if (dxfCreateDraft or dxfCreateSketch) and (not forceShape):
             pl = placementFromDXFOCS(arc)
-            return Draft.makeCircle(circle.Radius, pl, face=False,
-                                    startangle=firstangle,
-                                    endangle=lastangle)
+            return Draft.make_circle(circle.Radius, pl, face=False,
+                                     startangle=firstangle,
+                                     endangle=lastangle)
         else:
             return circle.toShape(math.radians(firstangle),
                                   math.radians(lastangle))
@@ -1096,7 +1096,7 @@ def drawCircle(circle, forceShape=False):
     try:
         if (dxfCreateDraft or dxfCreateSketch) and (not forceShape):
             pl = placementFromDXFOCS(circle)
-            return Draft.makeCircle(circle.radius, pl)
+            return Draft.make_circle(circle.radius, pl)
         else:
             return curve.toShape()
     except Part.OCCError:
@@ -1155,7 +1155,7 @@ def drawEllipse(ellipse, forceShape=False):
                 shape.Placement = pl
                 return shape
             else:
-                return Draft.makeEllipse(majr, minr, pl)
+                return Draft.make_ellipse(majr, minr, pl)
         else:
             shape = el.toShape(start, end)
             shape.Placement = pl
@@ -1365,9 +1365,9 @@ def drawSplineIterpolation(verts, closed=False, forceShape=False,
     """
     if (dxfCreateDraft or dxfCreateSketch) and (not forceShape):
         if dxfDiscretizeCurves or alwaysDiscretize:
-            ob = Draft.makeWire(verts)
+            ob = Draft.make_wire(verts)
         else:
-            ob = Draft.makeBSpline(verts)
+            ob = Draft.make_bspline(verts)
         ob.Closed = closed
         return ob
     else:
@@ -1465,7 +1465,7 @@ def drawSpline(spline, forceShape=False):
     -------
     Part::Part2DObject or Part::TopoShape ('Edge', 'Face')
         The returned object is normally a `Draft BezCurve`
-        created with `Draft.makeBezCurve(controlpoints, Degree=degree)`,
+        created with `Draft.make_bezcurve(controlpoints, Degree=degree)`,
         if `forceShape` is `False` and there are no weights.
 
         Otherwise it tries to return a `Part.Shape` of type `'Wire'`,
@@ -1495,7 +1495,7 @@ def drawSpline(spline, forceShape=False):
 
     See also
     --------
-    drawBlock, Draft.makeBezCurve, Part.BezierCurve, drawSplineIterpolation,
+    drawBlock, Draft.make_bezcurve, Part.BezierCurve, drawSplineIterpolation,
     Part.BSplineCurve.buildFromPolesMultsKnots
 
     To do
@@ -1587,7 +1587,7 @@ def drawSpline(spline, forceShape=False):
             if not forceShape and weights is None:
                 points = controlpoints[:]
                 del points[degree+1::degree+1]
-                return Draft.makeBezCurve(points, Degree=degree)
+                return Draft.make_bezcurve(points, Degree=degree)
             else:
                 poles = controlpoints[:]
                 edges = []
@@ -1886,7 +1886,7 @@ def drawLayerBlock(objlist):
     obj = None
     if (dxfCreateDraft or dxfCreateSketch) and isObj:
         try:
-            obj = Draft.makeBlock(objlist)
+            obj = Draft.make_block(objlist)
         except Part.OCCError:
             pass
     else:
@@ -2016,7 +2016,7 @@ def addText(text, attrib=False):
 
     See also
     --------
-    locateLayer, drawBlock, Draft.makeText
+    locateLayer, drawBlock, Draft.make_text
 
     To do
     -----
@@ -2050,7 +2050,7 @@ def addText(text, attrib=False):
         #        val = val.encode("latin1")
         #    except Exception:
         #        pass
-        newob = Draft.makeText(val.split("\n"))
+        newob = Draft.make_text(val.split("\n"))
         if hasattr(lay, "addObject"):
             lay.addObject(newob)
         elif hasattr(lay, "Proxy") and hasattr(lay.Proxy, "addObject"):
@@ -2234,16 +2234,16 @@ def processdxf(document, filename, getShapes=False, reComputeFlag=True):
                     FreeCAD.ActiveDocument.recompute()
                     if dxfMakeBlocks or dxfJoin:
                         if sketch:
-                            shape = Draft.makeSketch(shape,
-                                                     autoconstraints=True,
-                                                     addTo=sketch)
+                            shape = Draft.make_sketch(shape,
+                                                      autoconstraints=True,
+                                                      addTo=sketch)
                         else:
-                            shape = Draft.makeSketch(shape,
-                                                     autoconstraints=True)
+                            shape = Draft.make_sketch(shape,
+                                                      autoconstraints=True)
                             sketch = shape
                     else:
-                        shape = Draft.makeSketch(shape,
-                                                 autoconstraints=True)
+                        shape = Draft.make_sketch(shape,
+                                                  autoconstraints=True)
                 elif dxfJoin or getShapes:
                     if isinstance(shape, Part.Shape):
                         shapes.append(shape)
@@ -2285,16 +2285,16 @@ def processdxf(document, filename, getShapes=False, reComputeFlag=True):
                     FreeCAD.ActiveDocument.recompute()
                     if dxfMakeBlocks or dxfJoin:
                         if sketch:
-                            shape = Draft.makeSketch(shape,
-                                                     autoconstraints=True,
-                                                     addTo=sketch)
+                            shape = Draft.make_sketch(shape,
+                                                      autoconstraints=True,
+                                                      addTo=sketch)
                         else:
-                            shape = Draft.makeSketch(shape,
-                                                     autoconstraints=True)
+                            shape = Draft.make_sketch(shape,
+                                                      autoconstraints=True)
                             sketch = shape
                     else:
-                        shape = Draft.makeSketch(shape,
-                                                 autoconstraints=True)
+                        shape = Draft.make_sketch(shape,
+                                                  autoconstraints=True)
                 elif dxfJoin or getShapes:
                     if isinstance(shape, Part.Shape):
                         shapes.append(shape)
@@ -2320,16 +2320,16 @@ def processdxf(document, filename, getShapes=False, reComputeFlag=True):
                     FreeCAD.ActiveDocument.recompute()
                     if dxfMakeBlocks or dxfJoin:
                         if sketch:
-                            shape = Draft.makeSketch(shape,
-                                                     autoconstraints=True,
-                                                     addTo=sketch)
+                            shape = Draft.make_sketch(shape,
+                                                      autoconstraints=True,
+                                                      addTo=sketch)
                         else:
-                            shape = Draft.makeSketch(shape,
-                                                     autoconstraints=True)
+                            shape = Draft.make_sketch(shape,
+                                                      autoconstraints=True)
                             sketch = shape
                     else:
-                        shape = Draft.makeSketch(shape,
-                                                 autoconstraints=True)
+                        shape = Draft.make_sketch(shape,
+                                                  autoconstraints=True)
                 elif dxfJoin or getShapes:
                     if isinstance(shape, Part.Shape):
                         shapes.append(shape)
@@ -2381,16 +2381,16 @@ def processdxf(document, filename, getShapes=False, reComputeFlag=True):
                     FreeCAD.ActiveDocument.recompute()
                     if dxfMakeBlocks or dxfJoin:
                         if sketch:
-                            shape = Draft.makeSketch(shape,
-                                                     autoconstraints=True,
-                                                     addTo=sketch)
+                            shape = Draft.make_sketch(shape,
+                                                      autoconstraints=True,
+                                                      addTo=sketch)
                         else:
-                            shape = Draft.makeSketch(shape,
-                                                     autoconstraints=True)
+                            shape = Draft.make_sketch(shape,
+                                                      autoconstraints=True)
                             sketch = shape
                     else:
-                        shape = Draft.makeSketch(shape,
-                                                 autoconstraints=True)
+                        shape = Draft.make_sketch(shape,
+                                                  autoconstraints=True)
                 elif dxfMakeBlocks:
                     addToBlock(shape, circle.layer)
                 elif getShapes:
@@ -2607,7 +2607,7 @@ def processdxf(document, filename, getShapes=False, reComputeFlag=True):
                     shape = Part.Vertex(x, y, z)
                     addToBlock(shape, lay)
                 else:
-                    newob = Draft.makePoint(x, y, z)
+                    newob = Draft.make_point(x, y, z)
                     lay = locateLayer(lay)
                     lay.addObject(newob)
                     if gui:
@@ -2623,7 +2623,7 @@ def processdxf(document, filename, getShapes=False, reComputeFlag=True):
         for leader in leaders:
             if dxfImportLayouts or (not rawValue(leader, 67)):
                 points = getMultiplePoints(leader)
-                newob = Draft.makeWire(points)
+                newob = Draft.make_wire(points)
                 lay = locateLayer(rawValue(leader, 8))
                 lay.addObject(newob)
                 if gui:
@@ -2654,7 +2654,7 @@ def processdxf(document, filename, getShapes=False, reComputeFlag=True):
                             if gui:
                                 formatObject(newob, hatch)
                     else:
-                        newob = Draft.makeWire(points)
+                        newob = Draft.make_wire(points)
                         locateLayer(lay).addObject(newob)
                         if gui:
                             formatObject(newob, hatch)


### PR DESCRIPTION
The `make` functions should be called with their new name, `make_`, in the Draft code.

Note that more PRs will follow.

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

---
