### PR TITLE
PartDesign::SubShapeBinder add 2D offsetting

### DIFF
--- a/src/Mod/PartDesign/App/ShapeBinder.h
+++ b/src/Mod/PartDesign/App/ShapeBinder.h
@@ -99,6 +99,11 @@ public:
     App::PropertyInteger _Version;
     App::PropertyEnumeration BindCopyOnChange;
     App::PropertyBool Refine;
+    App::PropertyFloat Offset;
+    App::PropertyEnumeration OffsetJoinType;
+    App::PropertyBool OffsetFill;
+    App::PropertyBool OffsetOpenResult;
+    App::PropertyBool OffsetIntersection;
 
     enum UpdateOption {
         UpdateNone = 0,


### PR DESCRIPTION
Adds 2D offsetting of wires, edges, and face types.

Adds new "Offsetting" group to the green Part Design SubShapeBinders.  In this group:

Offset (float) the amount of 2D offset (in mm).  If Offset = 0.0, then no offsetting is done.  Can be positive or negative (for offsetting inwards).
OffsetJoinType (enumeration).  Values are "Arcs", "Tangent", "Intersection".
OffsetFill (boolean).  If True a face is made between the original wire and the offset.  (see image below)
OffsetOpenResult (boolean).  If False when offsetting an open wire a closed wire is produced.  If True, the open result is allowed.
OffsetIntersection (boolean).  Affects the way inner wires are offset relative to parent wire, inwards or outwards.


![Snip macro screenshot-623c80](https://user-images.githubusercontent.com/39143564/153505917-d720af7d-c97a-42dd-a7c0-1d08ce19c8c9.png)

