### PR TITLE
Preference Packs: Add revert to backup option

### DIFF
--- a/cMake/FindOCC.cmake
+++ b/cMake/FindOCC.cmake
@@ -1,0 +1,173 @@
+# Try to find OCE / OCC
+# Once done this will define
+#
+# OCC_FOUND          - system has OCC - OpenCASCADE
+# OCC_INCLUDE_DIR    - where the OCC include directory can be found
+# OCC_LIBRARY_DIR    - where the OCC library directory can be found
+# OCC_LIBRARIES      - Link this to use OCC
+# OCC_OCAF_LIBRARIES - Link this to use OCC OCAF framework
+
+# First try to find OpenCASCADE Community Edition
+if(NOT DEFINED OCE_DIR)
+  # Check for OSX needs to come first because UNIX evaluates to true on OSX
+  if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    if(DEFINED MACPORTS_PREFIX)
+      find_package(OCE QUIET HINTS ${MACPORTS_PREFIX}/Library/Frameworks)
+    elseif(DEFINED HOMEBREW_PREFIX)
+      find_package(OCE QUIET HINTS ${HOMEBREW_PREFIX}/Cellar/oce/*)
+    endif()
+  elseif(UNIX)
+    set(OCE_DIR "/usr/local/share/cmake/")
+  elseif(WIN32)
+    set(OCE_DIR "c:/OCE-0.4.0/share/cmake")
+  endif()
+endif()
+
+if(${FREECAD_USE_OCC_VARIANT} MATCHES "Community Edition")
+  find_package(OCE QUIET)
+endif()
+
+if(OCE_FOUND)
+  message(STATUS "-- OpenCASCADE Community Edition has been found.")
+  # Disable this define. For more details see bug #0001872
+  #add_definitions (-DHAVE_CONFIG_H)
+  set(OCC_INCLUDE_DIR ${OCE_INCLUDE_DIRS})
+  #set(OCC_LIBRARY_DIR ${OCE_LIBRARY_DIR})
+else(OCE_FOUND) #look for OpenCASCADE
+  # we first try to find opencascade directly:
+  if(NOT OCCT_CMAKE_FALLBACK)
+    find_package(OpenCASCADE CONFIG QUIET)
+    if(NOT (CMAKE_VERSION VERSION_LESS 3.6.0))
+        get_property(flags DIRECTORY PROPERTY COMPILE_DEFINITIONS)
+        # OCCT 7.5 adds this define that causes hundreds of compiler warnings with Qt5.x, so remove it again
+        list(FILTER flags EXCLUDE REGEX [[GL_GLEXT_LEGACY]])
+        set_property(DIRECTORY PROPERTY COMPILE_DEFINITIONS ${flags})
+    endif()
+  endif(NOT OCCT_CMAKE_FALLBACK)
+  if(OpenCASCADE_FOUND)
+    set(OCC_FOUND ${OpenCASCADE_FOUND})
+    set(OCC_INCLUDE_DIR ${OpenCASCADE_INCLUDE_DIR})
+    set(OCC_LIBRARY_DIR ${OpenCASCADE_LIBRARY_DIR})
+    set(OCC_LIBRARIES ${OpenCASCADE_LIBRARIES})
+    set(OCC_OCAF_LIBRARIES TKCAF TKXCAF)
+  else(OpenCASCADE_FOUND)
+    if(WIN32)
+      if(CYGWIN OR MINGW)
+      FIND_PATH(OCC_INCLUDE_DIR Standard_Version.hxx
+          /usr/include/opencascade
+          /usr/local/include/opencascade
+          /opt/opencascade/include
+          /opt/opencascade/inc
+        )
+        FIND_LIBRARY(OCC_LIBRARY TKernel
+          /usr/lib
+          /usr/local/lib
+          /opt/opencascade/lib
+        )
+      else(CYGWIN OR MINGW)
+      FIND_PATH(OCC_INCLUDE_DIR Standard_Version.hxx
+          "[HKEY_LOCAL_MACHINE\\SOFTWARE\\SIM\\OCC\\2;Installation Path]/include"
+        )
+        FIND_LIBRARY(OCC_LIBRARY TKernel
+          "[HKEY_LOCAL_MACHINE\\SOFTWARE\\SIM\\OCC\\2;Installation Path]/lib"
+        )
+      endif(CYGWIN OR MINGW)
+    else(WIN32)
+      FIND_PATH(OCC_INCLUDE_DIR Standard_Version.hxx
+        /usr/include/occt
+        /usr/include/opencascade
+        /usr/local/include/opencascade
+        /opt/opencascade/include
+        /opt/opencascade/inc
+      )
+      FIND_LIBRARY(OCC_LIBRARY TKernel
+        /usr/lib
+        /usr/local/lib
+        /opt/opencascade/lib
+      )
+    endif(WIN32)
+    if(OCC_LIBRARY)
+      GET_FILENAME_COMPONENT(OCC_LIBRARY_DIR ${OCC_LIBRARY} PATH)
+      IF(NOT OCC_INCLUDE_DIR)
+        FIND_PATH(OCC_INCLUDE_DIR Standard_Version.hxx
+          ${OCC_LIBRARY_DIR}/../inc
+        )
+      ENDIF()
+    endif(OCC_LIBRARY)
+  endif(OpenCASCADE_FOUND)
+endif(OCE_FOUND)
+
+if(OCC_INCLUDE_DIR)
+  file(STRINGS ${OCC_INCLUDE_DIR}/Standard_Version.hxx OCC_MAJOR
+    REGEX "#define OCC_VERSION_MAJOR.*"
+  )
+  string(REGEX MATCH "[0-9]+" OCC_MAJOR ${OCC_MAJOR})
+  file(STRINGS ${OCC_INCLUDE_DIR}/Standard_Version.hxx OCC_MINOR
+    REGEX "#define OCC_VERSION_MINOR.*"
+  )
+  string(REGEX MATCH "[0-9]+" OCC_MINOR ${OCC_MINOR})
+  file(STRINGS ${OCC_INCLUDE_DIR}/Standard_Version.hxx OCC_MAINT
+    REGEX "#define OCC_VERSION_MAINTENANCE.*"
+  )
+  string(REGEX MATCH "[0-9]+" OCC_MAINT ${OCC_MAINT})
+
+  set(OCC_VERSION_STRING "${OCC_MAJOR}.${OCC_MINOR}.${OCC_MAINT}")
+endif(OCC_INCLUDE_DIR)
+
+# handle the QUIETLY and REQUIRED arguments and set OCC_FOUND to TRUE if
+# all listed variables are TRUE
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(OCC REQUIRED_VARS OCC_INCLUDE_DIR VERSION_VAR OCC_VERSION_STRING)
+
+if(OCC_FOUND)
+  set(OCC_LIBRARIES
+    TKFillet
+    TKMesh
+    TKernel
+    TKG2d
+    TKG3d
+    TKMath
+    TKIGES
+    TKSTL
+    TKShHealing
+    TKXSBase
+    TKBool
+    TKBO
+    TKBRep
+    TKTopAlgo
+    TKGeomAlgo
+    TKGeomBase
+    TKOffset
+    TKPrim
+    TKSTEPBase
+    TKSTEPAttr
+    TKSTEP209
+    TKSTEP
+    TKHLR
+    TKFeat
+  )
+  set(OCC_OCAF_LIBRARIES
+    TKBin
+    TKBinL
+    TKCAF
+    TKXCAF
+    TKLCAF
+    TKVCAF
+    TKCDF
+    TKXDESTEP
+    TKXDEIGES
+    TKMeshVS
+    TKService
+    TKV3d
+  )
+  if(OCC_VERSION_STRING VERSION_LESS 6.7.3)
+    list(APPEND OCC_OCAF_LIBRARIES TKAdvTools)
+  elseif(NOT OCC_VERSION_STRING VERSION_LESS 7.5.0)
+    list(APPEND OCC_OCAF_LIBRARIES TKRWMesh)
+  endif(OCC_VERSION_STRING VERSION_LESS 6.7.3)
+  message(STATUS "-- Found OCE/OpenCASCADE version: ${OCC_VERSION_STRING}")
+  message(STATUS "-- OCE/OpenCASCADE include directory: ${OCC_INCLUDE_DIR}")
+  message(STATUS "-- OCE/OpenCASCADE shared libraries directory: ${OCC_LIBRARY_DIR}")
+else(OCC_FOUND)
+  #message(SEND_ERROR "Neither OpenCASCADE Community Edition nor OpenCasCade were found: will not build CAD modules!")
+endif(OCC_FOUND)

--- a/src/Gui/CMakeLists.txt
+++ b/src/Gui/CMakeLists.txt
@@ -328,6 +328,7 @@ SET(Gui_UIC_SRCS
     DlgProjectUtility.ui
     DlgPropertyLink.ui
     DlgReportView.ui
+    DlgRevertToBackupConfig.ui
     DlgSettings3DView.ui
     DlgSettingsCacheDirectory.ui
     DlgSettingsNavigation.ui
@@ -423,6 +424,7 @@ SET(Dialog_CPP_SRCS
     DlgProjectInformationImp.cpp
     DlgProjectUtility.cpp
     DlgPropertyLink.cpp
+    DlgRevertToBackupConfigImp.cpp
     DlgExpressionInput.cpp
     TaskDlgRelocation.cpp
     DlgCheckableMessageBox.cpp
@@ -462,6 +464,7 @@ SET(Dialog_HPP_SRCS
     DlgProjectInformationImp.h
     DlgProjectUtility.h
     DlgPropertyLink.h
+    DlgRevertToBackupConfigImp.h
     DlgCheckableMessageBox.h
     DlgExpressionInput.h
     TaskDlgRelocation.h
@@ -506,6 +509,7 @@ SET(Dialog_SRCS
     DlgProjectInformation.ui
     DlgProjectUtility.ui
     DlgPropertyLink.ui
+    DlgRevertToBackupConfig.ui
     DlgCheckableMessageBox.ui
     DlgTreeWidget.ui
     DlgExpressionInput.ui

--- a/src/Gui/DlgGeneral.ui
+++ b/src/Gui/DlgGeneral.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>425</width>
-    <height>598</height>
+    <width>660</width>
+    <height>930</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -239,6 +239,13 @@
                </property>
               </widget>
              </item>
+             <item>
+              <widget class="QPushButton" name="RevertToSavedConfig">
+               <property name="text">
+                <string>Revert...</string>
+               </property>
+              </widget>
+             </item>
             </layout>
            </item>
           </layout>
@@ -342,7 +349,7 @@
            <property name="bottomMargin">
             <number>0</number>
            </property>
-           <item row="0" column="0">
+           <item>
             <widget class="QCheckBox" name="tiledBackground">
              <property name="toolTip">
               <string>Background of the main window will consist of tiles of a special image.
@@ -353,7 +360,7 @@ See the FreeCAD Wiki for details about the image.</string>
              </property>
             </widget>
            </item>
-           <item row="0" column="1">
+           <item>
             <widget class="Gui::PrefCheckBox" name="EnableCursorBlinking">
              <property name="toolTip">
               <string>The text cursor will be blinking</string>

--- a/src/Gui/DlgGeneralImp.h
+++ b/src/Gui/DlgGeneralImp.h
@@ -34,6 +34,7 @@ namespace Dialog {
 class Ui_DlgGeneral;
 class DlgCreateNewPreferencePackImp;
 class DlgPreferencePackManagementImp;
+class DlgRevertToBackupConfigImp;
 
 /** This class implements the settings for the application.
  *  You can change window style, size of pixmaps, size of recent file list and so on
@@ -62,11 +63,13 @@ protected Q_SLOTS:
 private:
     void setRecentFileSize();
     void saveAsNewPreferencePack();
+    void revertToSavedConfig();
 
 private:
     std::unique_ptr<Ui_DlgGeneral> ui;
     std::unique_ptr<DlgCreateNewPreferencePackImp> newPreferencePackDialog;
     std::unique_ptr<DlgPreferencePackManagementImp> preferencePackManagementDialog;
+    std::unique_ptr<DlgRevertToBackupConfigImp> revertToBackupConfigDialog;
 };
 
 } // namespace Dialog

--- a/src/Gui/DlgRevertToBackupConfig.ui
+++ b/src/Gui/DlgRevertToBackupConfig.ui
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Gui::Dialog::DlgRevertToBackupConfig</class>
+ <widget class="QDialog" name="Gui::Dialog::DlgRevertToBackupConfig">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>610</width>
+    <height>471</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Revert to Backup Config</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="label">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>WARNING: this process will undo any preference changes made since the specified date, and will also reset your Recent files and Macros to their state on that date.</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Fixed</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>10</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>Available backup files:</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QListWidget" name="listWidget"/>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>Gui::Dialog::DlgRevertToBackupConfig</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>304</x>
+     <y>450</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>304</x>
+     <y>235</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>Gui::Dialog::DlgRevertToBackupConfig</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>304</x>
+     <y>450</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>304</x>
+     <y>235</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/Gui/DlgRevertToBackupConfigImp.cpp
+++ b/src/Gui/DlgRevertToBackupConfigImp.cpp
@@ -1,0 +1,117 @@
+/***************************************************************************
+ *   Copyright (c) 2022 Chris Hennes <chennes@pioneerlibrarysystem.org>    *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#include "PreCompiled.h"
+#ifndef _PreComp_
+# include <QMessageBox>
+# include <QPushButton>
+# include <QDateTime>
+#endif
+
+#include "DlgRevertToBackupConfigImp.h"
+#include "ui_DlgRevertToBackupConfig.h"
+
+#include <Gui/Application.h>
+#include <Gui/PreferencePackManager.h>
+
+#include <boost/filesystem.hpp>
+
+using namespace Gui;
+using namespace Gui::Dialog;
+namespace fs = boost::filesystem;
+
+/* TRANSLATOR Gui::Dialog::DlgRevertToBackupConfigImp */
+
+DlgRevertToBackupConfigImp::DlgRevertToBackupConfigImp(QWidget* parent)
+    : QDialog(parent)
+    , ui(new Ui_DlgRevertToBackupConfig)
+{
+    ui->setupUi(this);
+    connect(ui->listWidget, &QListWidget::itemSelectionChanged, this, &DlgRevertToBackupConfigImp::onItemSelectionChanged);
+}
+
+DlgRevertToBackupConfigImp::~DlgRevertToBackupConfigImp()
+{
+}
+
+void Gui::Dialog::DlgRevertToBackupConfigImp::onItemSelectionChanged()
+{
+    auto items = ui->listWidget->selectedItems();
+    if (items.count() == 1) 
+        ui->buttonBox->button(QDialogButtonBox::StandardButton::Ok)->setEnabled(true);
+    else
+        ui->buttonBox->button(QDialogButtonBox::StandardButton::Ok)->setEnabled(false);
+
+}
+
+/**
+ * Sets the strings of the subwidgets using the current language.
+ */
+void DlgRevertToBackupConfigImp::changeEvent(QEvent *e)
+{
+    if (e->type() == QEvent::LanguageChange) {
+        ui->retranslateUi(this);
+    }
+    else {
+        QWidget::changeEvent(e);
+    }
+}
+
+void DlgRevertToBackupConfigImp::showEvent(QShowEvent* event)
+{
+    ui->listWidget->clear();
+    const auto& backups = Application::Instance->prefPackManager()->configBackups();
+    for (const auto& backup : backups) {
+        auto filename = backup.filename().string();
+        auto modification_date = QDateTime::fromTime_t(fs::last_write_time(backup));
+        auto item = new QListWidgetItem(QLocale().toString(modification_date));
+        item->setData(Qt::UserRole, QString::fromStdString(backup.string()));
+        ui->listWidget->addItem(item);
+    }
+    ui->buttonBox->button(QDialogButtonBox::StandardButton::Ok)->setEnabled(false);
+    QDialog::showEvent(event);
+}
+
+void DlgRevertToBackupConfigImp::accept()
+{
+    auto items = ui->listWidget->selectedItems();
+    if (items.count() != 1) {
+        Base::Console().Error(tr("No selection in dialog, cannot load backup file").toStdString().c_str());
+        return;
+    }
+    auto item = items[0];
+    auto path = item->data(Qt::UserRole).toString().toStdString();
+    if (fs::exists(path)) {
+        ParameterManager newParameters;
+        newParameters.LoadDocument(path.c_str());
+        auto baseAppGroup = App::GetApplication().GetUserParameter().GetGroup("BaseApp");
+        newParameters.GetGroup("BaseApp")->copyTo(baseAppGroup);
+    }
+    else {
+        Base::Console().Error("Preference Pack Internal Error: Invalid backup file location");
+    }
+
+    QDialog::accept();
+}
+
+#include "moc_DlgRevertToBackupConfigImp.cpp"

--- a/src/Gui/DlgRevertToBackupConfigImp.h
+++ b/src/Gui/DlgRevertToBackupConfigImp.h
@@ -1,0 +1,60 @@
+/***************************************************************************
+ *   Copyright (c) 2022 Chris Hennes <chennes@pioneerlibrarysystem.org>    *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#ifndef GUI_DIALOG_DLG_REVERT_TO_BACKUP_CONFIG_IMP
+#define GUI_DIALOG_DLG_REVERT_TO_BACKUP_CONFIG_IMP
+
+#include <memory>
+#include <QDialog>
+
+namespace Gui {
+namespace Dialog {
+class Ui_DlgRevertToBackupConfig;
+
+/** The DlgRevertToBackupConfigImp class
+ * \author Chris Hennes
+ */
+class DlgRevertToBackupConfigImp : public QDialog
+{
+    Q_OBJECT
+
+public:
+    DlgRevertToBackupConfigImp( QWidget* parent = 0 );
+    ~DlgRevertToBackupConfigImp();
+
+public Q_SLOTS:
+    void accept() override;
+    void onItemSelectionChanged();
+
+protected:
+    void changeEvent(QEvent *e);
+    void showEvent(QShowEvent* event) override;
+
+private:
+    std::unique_ptr<Ui_DlgRevertToBackupConfig> ui;
+};
+
+} // namespace Dialog
+} // namespace Gui
+
+#endif //GUI_DIALOG_DLG_REVERT_TO_BACKUP_CONFIG_IMP

--- a/src/Gui/PreferencePackManager.cpp
+++ b/src/Gui/PreferencePackManager.cpp
@@ -130,8 +130,6 @@ void PreferencePack::applyConfigChanges() const
     }
 }
 
-
-
 PreferencePackManager::PreferencePackManager()
 {
     auto modPath = fs::path(App::Application::getUserAppDataDir()) / "Mod";
@@ -526,4 +524,16 @@ void Gui::PreferencePackManager::DeleteOldBackups() const
             }
         }
     }
+}
+
+std::vector<boost::filesystem::path> Gui::PreferencePackManager::configBackups() const
+{
+    std::vector<boost::filesystem::path> results;
+    auto backupDirectory = fs::path(App::Application::getUserAppDataDir()) / "SavedPreferencePacks" / "Backups";
+    if (fs::exists(backupDirectory) && fs::is_directory(backupDirectory)) {
+        for (const auto& backup : fs::directory_iterator(backupDirectory)) {
+            results.push_back(backup);
+        }
+    }
+    return results;
 }

--- a/src/Gui/PreferencePackManager.h
+++ b/src/Gui/PreferencePackManager.h
@@ -184,6 +184,11 @@ namespace Gui {
 
         std::vector<TemplateFile> templateFiles(bool rescan = false);
 
+        /**
+         * Get a list of all available config file backups. Backups are currently stored for one week.
+         */
+        std::vector<boost::filesystem::path> configBackups() const;
+
     private:
 
         void FindPreferencePacksInPackage(const boost::filesystem::path& mod);

--- a/tsupdate_stderr.log
+++ b/tsupdate_stderr.log
@@ -1,0 +1,5592 @@
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Gui/FreeCAD.pro.
+/home/chennes/FreeCAD-chennes/src/Gui/Selection.h:192: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/BlenderNavigationStyle.cpp:66: Class 'Gui::BlenderNavigationStyle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/CADNavigationStyle.cpp:66: Class 'Gui::CADNavigationStyle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:96: Qualifying with unknown namespace/class ::StdCmdOpen
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:111: Qualifying with unknown namespace/class ::StdCmdOpen
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:187: Qualifying with unknown namespace/class ::StdCmdImport
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:201: Qualifying with unknown namespace/class ::StdCmdImport
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:273: Qualifying with unknown namespace/class ::StdCmdExport
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:414: Qualifying with unknown namespace/class ::StdCmdExport
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:520: Qualifying with unknown namespace/class ::StdCmdMergeProjects
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:533: Qualifying with unknown namespace/class ::StdCmdMergeProjects
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:573: Qualifying with unknown namespace/class ::StdCmdDependencyGraph
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:605: Qualifying with unknown namespace/class ::StdCmdNew
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:636: Qualifying with unknown namespace/class ::StdCmdSave
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:676: Qualifying with unknown namespace/class ::StdCmdSaveAs
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:716: Qualifying with unknown namespace/class ::StdCmdSaveCopy
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:749: Qualifying with unknown namespace/class ::StdCmdSaveAll
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:777: Qualifying with unknown namespace/class ::StdCmdRevert
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:816: Qualifying with unknown namespace/class ::StdCmdProjectInfo
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:847: Qualifying with unknown namespace/class ::StdCmdProjectUtil
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:874: Qualifying with unknown namespace/class ::StdCmdPrint
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:887: Qualifying with unknown namespace/class ::StdCmdPrint
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:906: Qualifying with unknown namespace/class ::StdCmdPrintPreview
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:936: Qualifying with unknown namespace/class ::StdCmdPrintPdf
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:948: Qualifying with unknown namespace/class ::StdCmdPrintPdf
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:968: Qualifying with unknown namespace/class ::StdCmdQuit
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:994: Qualifying with unknown namespace/class ::StdCmdUndo
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1038: Qualifying with unknown namespace/class ::StdCmdRedo
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1081: Qualifying with unknown namespace/class ::StdCmdCut
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1109: Qualifying with unknown namespace/class ::StdCmdCopy
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1144: Qualifying with unknown namespace/class ::StdCmdPaste
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1183: Qualifying with unknown namespace/class ::StdCmdDuplicateSelection
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1217: Qualifying with unknown namespace/class ::StdCmdDuplicateSelection
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1271: Qualifying with unknown namespace/class ::StdCmdSelectAll
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1302: Qualifying with unknown namespace/class ::StdCmdDelete
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1449: Qualifying with unknown namespace/class ::StdCmdDelete
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1475: Qualifying with unknown namespace/class ::StdCmdRefresh
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1503: Qualifying with unknown namespace/class ::StdCmdRefresh
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1529: Qualifying with unknown namespace/class ::StdCmdTransform
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1555: Qualifying with unknown namespace/class ::StdCmdPlacement
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1589: Qualifying with unknown namespace/class ::StdCmdTransformManip
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1623: Qualifying with unknown namespace/class ::StdCmdAlignment
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1693: Qualifying with unknown namespace/class ::StdCmdEdit
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1737: Class 'StdCmdExpression' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/CommandFeat.cpp:54: Qualifying with unknown namespace/class ::StdCmdFeatRecompute
+/home/chennes/FreeCAD-chennes/src/Gui/CommandFeat.cpp:77: Qualifying with unknown namespace/class ::StdCmdRandomColor
+/home/chennes/FreeCAD-chennes/src/Gui/CommandFeat.cpp:129: Qualifying with unknown namespace/class ::StdCmdSendToPythonConsole
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:80: Class 'StdCmdLinkMakeGroup' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:211: Qualifying with unknown namespace/class ::StdCmdLinkMake
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:260: Qualifying with unknown namespace/class ::StdCmdLinkMake
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:274: Qualifying with unknown namespace/class ::StdCmdLinkMakeRelative
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:335: Qualifying with unknown namespace/class ::StdCmdLinkMakeRelative
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:494: Qualifying with unknown namespace/class ::StdCmdLinkReplace
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:518: Qualifying with unknown namespace/class ::StdCmdLinkUnlink
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:542: Qualifying with unknown namespace/class ::StdCmdLinkImport
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:592: Qualifying with unknown namespace/class ::StdCmdLinkImport
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:606: Qualifying with unknown namespace/class ::StdCmdLinkImportAll
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:631: Qualifying with unknown namespace/class ::StdCmdLinkImportAll
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:647: Qualifying with unknown namespace/class ::StdCmdLinkSelectLinked
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:774: Qualifying with unknown namespace/class ::StdCmdLinkSelectLinkedFinal
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:808: Qualifying with unknown namespace/class ::StdCmdLinkSelectAllLinks
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:847: Class 'StdCmdLinkSelectActions' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:873: Class 'StdCmdLinkActions' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/CommandMacro.cpp:48: Qualifying with unknown namespace/class ::StdCmdDlgMacroRecord
+/home/chennes/FreeCAD-chennes/src/Gui/CommandMacro.cpp:77: Qualifying with unknown namespace/class ::StdCmdMacroStopRecord
+/home/chennes/FreeCAD-chennes/src/Gui/CommandMacro.cpp:105: Qualifying with unknown namespace/class ::StdCmdDlgMacroExecute
+/home/chennes/FreeCAD-chennes/src/Gui/CommandMacro.cpp:134: Qualifying with unknown namespace/class ::StdCmdDlgMacroExecuteDirect
+/home/chennes/FreeCAD-chennes/src/Gui/CommandMacro.cpp:160: Qualifying with unknown namespace/class ::StdCmdMacroAttachDebugger
+/home/chennes/FreeCAD-chennes/src/Gui/CommandMacro.cpp:185: Qualifying with unknown namespace/class ::StdCmdMacroStartDebug
+/home/chennes/FreeCAD-chennes/src/Gui/CommandMacro.cpp:215: Qualifying with unknown namespace/class ::StdCmdMacroStopDebug
+/home/chennes/FreeCAD-chennes/src/Gui/CommandMacro.cpp:242: Qualifying with unknown namespace/class ::StdCmdMacroStepOver
+/home/chennes/FreeCAD-chennes/src/Gui/CommandMacro.cpp:269: Qualifying with unknown namespace/class ::StdCmdMacroStepInto
+/home/chennes/FreeCAD-chennes/src/Gui/CommandMacro.cpp:296: Qualifying with unknown namespace/class ::StdCmdToggleBreakpoint
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:80: Qualifying with unknown namespace/class ::StdCmdWorkbench
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:109: Qualifying with unknown namespace/class ::StdCmdWorkbench
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:145: Qualifying with unknown namespace/class ::StdCmdRecentFiles
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:186: Qualifying with unknown namespace/class ::StdCmdRecentMacros
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:226: Qualifying with unknown namespace/class ::StdCmdAbout
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:292: Qualifying with unknown namespace/class ::StdCmdAboutQt
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:314: Qualifying with unknown namespace/class ::StdCmdWhatsThis
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:338: Qualifying with unknown namespace/class ::StdCmdDlgParameter
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:363: Qualifying with unknown namespace/class ::StdCmdDlgPreferences
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:395: Qualifying with unknown namespace/class ::StdCmdDlgCustomize
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:422: Qualifying with unknown namespace/class ::StdCmdCommandLine
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:470: Qualifying with unknown namespace/class ::StdCmdOnlineHelp
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:495: Qualifying with unknown namespace/class ::StdCmdOnlineHelpWebsite
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:522: Qualifying with unknown namespace/class ::StdCmdFreeCADDonation
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:549: Qualifying with unknown namespace/class ::StdCmdFreeCADWebsite
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:577: Qualifying with unknown namespace/class ::StdCmdFreeCADUserHub
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:605: Qualifying with unknown namespace/class ::StdCmdFreeCADPowerUserHub
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:633: Qualifying with unknown namespace/class ::StdCmdFreeCADForum
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:661: Qualifying with unknown namespace/class ::StdCmdFreeCADFAQ
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:689: Qualifying with unknown namespace/class ::StdCmdPythonWebsite
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:713: Qualifying with unknown namespace/class ::StdCmdMeasurementSimple
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:727: Qualifying with unknown namespace/class ::StdCmdMeasurementSimple
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:770: Qualifying with unknown namespace/class ::StdCmdTextDocument
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:803: Qualifying with unknown namespace/class ::StdCmdUnitsCalculator
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:839: Class 'StdCmdUserEditMode' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStructure.cpp:52: Qualifying with unknown namespace/class ::StdCmdPart
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStructure.cpp:93: Qualifying with unknown namespace/class ::StdCmdGroup
+/home/chennes/FreeCAD-chennes/src/Gui/CommandTest.cpp:714: Qualifying with unknown namespace/class ::CmdTestConsoleOutput
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:108: Qualifying with unknown namespace/class ::StdOrthographicCamera
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:158: Qualifying with unknown namespace/class ::StdPerspectiveCamera
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:218: Qualifying with unknown namespace/class ::StdCmdViewSaveCamera
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:244: Qualifying with unknown namespace/class ::StdCmdViewRestoreCamera
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:303: Class 'StdCmdFreezeViews' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:561: Qualifying with unknown namespace/class ::StdCmdToggleClipPlane
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:643: Class 'StdCmdDrawStyle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:862: Qualifying with unknown namespace/class ::StdCmdToggleVisibility
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:892: Qualifying with unknown namespace/class ::StdCmdToggleSelectability
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:939: Qualifying with unknown namespace/class ::StdCmdShowSelection
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:967: Qualifying with unknown namespace/class ::StdCmdHideSelection
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:995: Qualifying with unknown namespace/class ::StdCmdSelectVisibleObjects
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1037: Qualifying with unknown namespace/class ::StdCmdToggleObjects
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1078: Qualifying with unknown namespace/class ::StdCmdShowObjects
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1115: Qualifying with unknown namespace/class ::StdCmdHideObjects
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1152: Qualifying with unknown namespace/class ::StdCmdSetAppearance
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1195: Qualifying with unknown namespace/class ::StdCmdViewHome
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1223: Qualifying with unknown namespace/class ::StdCmdViewBottom
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1247: Qualifying with unknown namespace/class ::StdCmdViewFront
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1271: Qualifying with unknown namespace/class ::StdCmdViewLeft
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1295: Qualifying with unknown namespace/class ::StdCmdViewRear
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1319: Qualifying with unknown namespace/class ::StdCmdViewRight
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1343: Qualifying with unknown namespace/class ::StdCmdViewTop
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1367: Qualifying with unknown namespace/class ::StdCmdViewIsometric
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1391: Qualifying with unknown namespace/class ::StdCmdViewDimetric
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1414: Qualifying with unknown namespace/class ::StdCmdViewTrimetric
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1437: Qualifying with unknown namespace/class ::StdCmdViewRotateLeft
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1462: Qualifying with unknown namespace/class ::StdCmdViewRotateRight
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1487: Qualifying with unknown namespace/class ::StdCmdViewFitAll
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1518: Qualifying with unknown namespace/class ::StdCmdViewFitSelection
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1549: Qualifying with unknown namespace/class ::StdViewDock
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1578: Qualifying with unknown namespace/class ::StdViewUndock
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1607: Qualifying with unknown namespace/class ::StdMainFullscreen
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1639: Qualifying with unknown namespace/class ::StdViewFullscreen
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1669: Qualifying with unknown namespace/class ::StdViewDockUndockFullscreen
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1782: Qualifying with unknown namespace/class ::StdCmdViewVR
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1812: Qualifying with unknown namespace/class ::StdViewScreenShot
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1845: Qualifying with unknown namespace/class ::StdViewScreenShot
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1983: Qualifying with unknown namespace/class ::StdCmdViewCreate
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2012: Qualifying with unknown namespace/class ::StdCmdToggleNavigation
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2062: Class 'StdCmdAxisCross' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2196: Qualifying with unknown namespace/class ::StdCmdViewExample1
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2224: Qualifying with unknown namespace/class ::StdCmdViewExample2
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2252: Qualifying with unknown namespace/class ::StdCmdViewExample3
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2281: Qualifying with unknown namespace/class ::StdCmdViewIvStereoOff
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2310: Qualifying with unknown namespace/class ::StdCmdViewIvStereoRedGreen
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2338: Qualifying with unknown namespace/class ::StdCmdViewIvStereoQuadBuff
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2366: Qualifying with unknown namespace/class ::StdCmdViewIvStereoInterleavedRows
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2394: Qualifying with unknown namespace/class ::StdCmdViewIvStereoInterleavedColumns
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2423: Qualifying with unknown namespace/class ::StdCmdViewIvIssueCamPos
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2473: Qualifying with unknown namespace/class ::StdViewZoomIn
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2506: Qualifying with unknown namespace/class ::StdViewZoomOut
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2666: Qualifying with unknown namespace/class ::StdViewBoxZoom
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2736: Qualifying with unknown namespace/class ::StdBoxSelection
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2999: Qualifying with unknown namespace/class ::StdBoxElementSelection
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3040: Qualifying with unknown namespace/class ::StdTreeSelection
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3065: Qualifying with unknown namespace/class ::StdCmdTreeCollapse
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3090: Qualifying with unknown namespace/class ::StdCmdTreeExpand
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3115: Qualifying with unknown namespace/class ::StdCmdTreeSelectAllInstances
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3165: Qualifying with unknown namespace/class ::StdCmdMeasureDistance
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3256: Qualifying with unknown namespace/class ::StdCmdSceneInspector
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3289: Qualifying with unknown namespace/class ::StdCmdTextureMapping
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3316: Qualifying with unknown namespace/class ::StdCmdDemoMode
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3344: Qualifying with unknown namespace/class ::CmdViewMeasureClearAll
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3374: Qualifying with unknown namespace/class ::CmdViewMeasureToggleAll
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3403: Qualifying with unknown namespace/class ::StdCmdSelBack
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3433: Qualifying with unknown namespace/class ::StdCmdSelForward
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3483: Qualifying with unknown namespace/class ::StdTreeSingleDocument
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3500: Qualifying with unknown namespace/class ::StdTreeMultiDocument
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3517: Qualifying with unknown namespace/class ::StdTreeCollapseDocument
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3556: Qualifying with unknown namespace/class ::StdTreeSyncView
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3574: Qualifying with unknown namespace/class ::StdTreeSyncSelection
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3592: Qualifying with unknown namespace/class ::StdTreeSyncPlacement
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3610: Qualifying with unknown namespace/class ::StdTreePreSelection
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3628: Qualifying with unknown namespace/class ::StdTreeRecordSelection
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3646: Qualifying with unknown namespace/class ::StdTreeDrag
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3678: Class 'StdCmdTreeViewActions' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3715: Qualifying with unknown namespace/class ::StdCmdSelBoundingBox
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:55: Qualifying with unknown namespace/class ::StdCmdArrangeIcons
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:82: Qualifying with unknown namespace/class ::StdCmdTileWindows
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:110: Qualifying with unknown namespace/class ::StdCmdCascadeWindows
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:138: Qualifying with unknown namespace/class ::StdCmdCloseActiveWindow
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:170: Qualifying with unknown namespace/class ::StdCmdCloseAllWindows
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:198: Qualifying with unknown namespace/class ::StdCmdActivateNextWindow
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:227: Qualifying with unknown namespace/class ::StdCmdActivatePrevWindow
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:256: Qualifying with unknown namespace/class ::StdCmdWindows
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:280: Qualifying with unknown namespace/class ::StdCmdUserInterface
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:302: Qualifying with unknown namespace/class ::StdCmdDockViewMenu
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:338: Qualifying with unknown namespace/class ::StdCmdToolBarMenu
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:392: Qualifying with unknown namespace/class ::StdCmdStatusBar
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:438: Qualifying with unknown namespace/class ::StdCmdWindowsMenu
+/home/chennes/FreeCAD-chennes/src/Gui/DocumentModel.cpp:203: Class 'Gui::DocumentModel' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:95: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:222: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:238: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:341: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:482: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:524: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:571: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:618: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:666: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:752: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:802: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:855: Class 'Gui::GestureNavigationStyle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/InventorNavigationStyle.cpp:68: Class 'Gui::InventorNavigationStyle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/ManualAlignment.cpp:437: Class 'Gui::AlignmentView' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/MayaGestureNavigationStyle.cpp:107: Class 'Gui::MayaGestureNavigationStyle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/NaviCube.cpp:1695: Qualifying with unknown namespace/class ::ViewIsometricCmd
+/home/chennes/FreeCAD-chennes/src/Gui/NaviCube.cpp:1715: Qualifying with unknown namespace/class ::ViewOrthographicCmd
+/home/chennes/FreeCAD-chennes/src/Gui/NaviCube.cpp:1736: Qualifying with unknown namespace/class ::ViewPerspectiveCmd
+/home/chennes/FreeCAD-chennes/src/Gui/NaviCube.cpp:1757: Qualifying with unknown namespace/class ::ViewZoomToFitCmd
+/home/chennes/FreeCAD-chennes/src/Gui/OnlineDocumentation.cpp:367: Class 'Gui::StdCmdPythonHelp' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/OpenCascadeNavigationStyle.cpp:66: Class 'Gui::OpenCascadeNavigationStyle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/OpenSCADNavigationStyle.cpp:66: Class 'Gui::OpenSCADNavigationStyle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/RevitNavigationStyle.cpp:66: Class 'Gui::RevitNavigationStyle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/TinkerCADNavigationStyle.cpp:66: Class 'Gui::TinkerCADNavigationStyle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/TouchpadNavigationStyle.cpp:66: Class 'Gui::TouchpadNavigationStyle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/WhatsThis.cpp:46: Class 'Gui::StdCmdDescription' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/Widgets.cpp:1450: Class 'PropertyListDialog' lacks Q_OBJECT macro
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/AddonManager/AddonManager.pro.
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Arch/Arch.pro.
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Assembly/Assembly.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:36: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:37: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:42: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:46: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:47: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:48: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:52: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:56: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:57: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:58: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:62: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:66: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:67: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:71: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/distance.hpp:32: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/distance.hpp:77: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/distance.hpp:193: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/distance.hpp:317: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/distance.hpp:382: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/distance.hpp:553: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/distance.hpp:573: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/distance.hpp:616: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/distance.hpp:637: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/distance.hpp:696: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/parallel.hpp:166: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/parallel.hpp:207: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/parallel.hpp:262: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/parallel.hpp:322: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/parallel.hpp:337: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/parallel.hpp:340: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/parallel.hpp:380: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/angle.hpp:80: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/angle.hpp:121: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/angle.hpp:124: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/angle.hpp:138: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/angle.hpp:141: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/angle.hpp:155: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/imp/constraint3d_holder_imp.hpp:51: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/imp/constraint3d_holder_imp.hpp:60: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/moduleShape3d/distance.hpp:32: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/Command.cpp:52: Qualifying with unknown namespace/class ::CmdAssemblyAddNewPart
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/Command.cpp:73: Qualifying with unknown namespace/class ::CmdAssemblyAddNewPart
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/Command.cpp:108: Qualifying with unknown namespace/class ::CmdAssemblyAddNewComponent
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/Command.cpp:129: Qualifying with unknown namespace/class ::CmdAssemblyAddNewComponent
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/Command.cpp:154: Qualifying with unknown namespace/class ::CmdAssemblyAddExistingComponent
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/Command.cpp:175: Qualifying with unknown namespace/class ::CmdAssemblyAddExistingComponent
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/Command.cpp:217: Qualifying with unknown namespace/class ::CmdAssemblyImport
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/CommandConstraints.cpp:118: Qualifying with unknown namespace/class ::CmdAssemblyConstraint
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/CommandConstraints.cpp:202: Qualifying with unknown namespace/class ::CmdAssemblyConstraintDistance
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/CommandConstraints.cpp:269: Qualifying with unknown namespace/class ::CmdAssemblyConstraintFix
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/CommandConstraints.cpp:334: Qualifying with unknown namespace/class ::CmdAssemblyConstraintAngle
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/CommandConstraints.cpp:403: Qualifying with unknown namespace/class ::CmdAssemblyConstraintOrientation
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/CommandConstraints.cpp:471: Qualifying with unknown namespace/class ::CmdAssemblyConstraintCoincidence
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/CommandConstraints.cpp:539: Qualifying with unknown namespace/class ::CmdAssemblyConstraintAlignment
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/Workbench.cpp:94: Class 'AssemblyGui::Workbench' lacks Q_OBJECT macro
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Draft/Draft.pro.
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Drawing/Drawing.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/TaskOrthoViews.h:162: Discarding unconsumed meta data
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:60: Qualifying with unknown namespace/class ::CmdDrawingOpen
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:72: Qualifying with unknown namespace/class ::CmdDrawingOpen
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:93: Qualifying with unknown namespace/class ::CmdDrawingNewPage
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:271: Qualifying with unknown namespace/class ::CmdDrawingNewA3Landscape
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:310: Qualifying with unknown namespace/class ::CmdDrawingNewView
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:323: Qualifying with unknown namespace/class ::CmdDrawingNewView
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:389: Qualifying with unknown namespace/class ::CmdDrawingOrthoViews
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:402: Qualifying with unknown namespace/class ::CmdDrawingOrthoViews
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:439: Qualifying with unknown namespace/class ::CmdDrawingOpenBrowserView
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:452: Qualifying with unknown namespace/class ::CmdDrawingOpenBrowserView
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:477: Qualifying with unknown namespace/class ::CmdDrawingAnnotation
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:492: Qualifying with unknown namespace/class ::CmdDrawingAnnotation
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:525: Qualifying with unknown namespace/class ::CmdDrawingClip
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:540: Qualifying with unknown namespace/class ::CmdDrawingClip
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:570: Qualifying with unknown namespace/class ::CmdDrawingSymbol
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:585: Qualifying with unknown namespace/class ::CmdDrawingSymbol
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:627: Qualifying with unknown namespace/class ::CmdDrawingExportPage
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:640: Qualifying with unknown namespace/class ::CmdDrawingExportPage
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:680: Qualifying with unknown namespace/class ::CmdDrawingProjectShape
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:716: Qualifying with unknown namespace/class ::CmdDrawingDraftView
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:747: Qualifying with unknown namespace/class ::CmdDrawingSpreadsheetView
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:760: Qualifying with unknown namespace/class ::CmdDrawingSpreadsheetView
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Fem/Fem.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:295: Qualifying with unknown namespace/class ::CmdFemConstraintBearing
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:336: Qualifying with unknown namespace/class ::CmdFemConstraintContact
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:381: Qualifying with unknown namespace/class ::CmdFemConstraintDisplacement
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:424: Qualifying with unknown namespace/class ::CmdFemConstraintFixed
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:466: Qualifying with unknown namespace/class ::CmdFemConstraintFluidBoundary
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:509: Qualifying with unknown namespace/class ::CmdFemConstraintForce
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:553: Qualifying with unknown namespace/class ::CmdFemConstraintGear
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:594: Qualifying with unknown namespace/class ::CmdFemConstraintHeatflux
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:639: Qualifying with unknown namespace/class ::CmdFemConstraintInitialTemperature
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:682: Qualifying with unknown namespace/class ::CmdFemConstraintPlaneRotation
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:724: Qualifying with unknown namespace/class ::CmdFemConstraintPressure
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:769: Qualifying with unknown namespace/class ::CmdFemConstraintSpring
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:814: Qualifying with unknown namespace/class ::CmdFemConstraintPulley
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:860: Qualifying with unknown namespace/class ::CmdFemConstraintTemperature
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:903: Qualifying with unknown namespace/class ::CmdFemConstraintTransform
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1039: Qualifying with unknown namespace/class ::CmdFemDefineNodesSet
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1095: Qualifying with unknown namespace/class ::CmdFemCreateNodesSet
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1251: Qualifying with unknown namespace/class ::CmdFemPostClipFilter
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1277: Qualifying with unknown namespace/class ::CmdFemPostCutFilter
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1303: Qualifying with unknown namespace/class ::CmdFemPostDataAlongLineFilter
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1329: Qualifying with unknown namespace/class ::CmdFemPostDataAtPointFilter
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1357: Qualifying with unknown namespace/class ::CmdFemPostLinearizedStressesFilter
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1414: Qualifying with unknown namespace/class ::CmdFemPostScalarClipFilter
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1440: Qualifying with unknown namespace/class ::CmdFemPostWarpVectorFilter
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1466: Qualifying with unknown namespace/class ::CmdFemPostFunctions
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1606: Qualifying with unknown namespace/class ::CmdFemPostApllyChanges
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1651: Qualifying with unknown namespace/class ::CmdFemPostPipelineFromResult
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/ViewProviderFemConstraintDisplacement.cpp:145: Unbalanced opening parenthesis in C++ code (or abuse of the C++ preprocessor)
+resulttools.py: Unbalanced parentheses in Python code
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Image/Image.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Image/Gui/Command.cpp:54: Qualifying with unknown namespace/class ::CmdImageOpen
+/home/chennes/FreeCAD-chennes/src/Mod/Image/Gui/Command.cpp:69: Qualifying with unknown namespace/class ::CmdImageOpen
+/home/chennes/FreeCAD-chennes/src/Mod/Image/Gui/Command.cpp:99: Qualifying with unknown namespace/class ::CmdCreateImagePlane
+/home/chennes/FreeCAD-chennes/src/Mod/Image/Gui/Command.cpp:113: Qualifying with unknown namespace/class ::CmdCreateImagePlane
+/home/chennes/FreeCAD-chennes/src/Mod/Image/Gui/Command.cpp:173: Qualifying with unknown namespace/class ::CmdImageScaling
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Mesh/Mesh.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:94: Qualifying with unknown namespace/class ::CmdMeshTransform
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:133: Qualifying with unknown namespace/class ::CmdMeshDemolding
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:172: Qualifying with unknown namespace/class ::CmdMeshToolMesh
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:227: Qualifying with unknown namespace/class ::CmdMeshUnion
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:298: Qualifying with unknown namespace/class ::CmdMeshDifference
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:369: Qualifying with unknown namespace/class ::CmdMeshIntersection
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:440: Qualifying with unknown namespace/class ::CmdMeshImport
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:452: Qualifying with unknown namespace/class ::CmdMeshImport
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:491: Qualifying with unknown namespace/class ::CmdMeshExport
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:510: Qualifying with unknown namespace/class ::CmdMeshExport
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:566: Qualifying with unknown namespace/class ::CmdMeshFromGeometry
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:576: Qualifying with unknown namespace/class ::CmdMeshFromGeometry
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:624: Qualifying with unknown namespace/class ::CmdMeshFromPartShape
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:650: Qualifying with unknown namespace/class ::CmdMeshVertexCurvature
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:693: Qualifying with unknown namespace/class ::CmdMeshVertexCurvatureInfo
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:739: Qualifying with unknown namespace/class ::CmdMeshPolySegm
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:795: Qualifying with unknown namespace/class ::CmdMeshPolySelect
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:848: Qualifying with unknown namespace/class ::CmdMeshAddFacet
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:895: Qualifying with unknown namespace/class ::CmdMeshPolyCut
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:956: Qualifying with unknown namespace/class ::CmdMeshPolyTrim
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1017: Qualifying with unknown namespace/class ::CmdMeshTrimByPlane
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1046: Qualifying with unknown namespace/class ::CmdMeshSectionByPlane
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1075: Qualifying with unknown namespace/class ::CmdMeshCrossSections
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1101: Qualifying with unknown namespace/class ::CmdMeshPolySplit
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1155: Qualifying with unknown namespace/class ::CmdMeshEvaluation
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1198: Qualifying with unknown namespace/class ::CmdMeshEvaluateFacet
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1241: Qualifying with unknown namespace/class ::CmdMeshRemoveComponents
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1286: Qualifying with unknown namespace/class ::CmdMeshRemeshGmsh
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1319: Qualifying with unknown namespace/class ::CmdMeshRemoveCompByHand
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1363: Qualifying with unknown namespace/class ::CmdMeshEvaluateSolid
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1378: Qualifying with unknown namespace/class ::CmdMeshEvaluateSolid
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1401: Qualifying with unknown namespace/class ::CmdMeshSmoothing
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1464: Qualifying with unknown namespace/class ::CmdMeshDecimating
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1495: Qualifying with unknown namespace/class ::CmdMeshHarmonizeNormals
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1529: Qualifying with unknown namespace/class ::CmdMeshFlipNormals
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1563: Qualifying with unknown namespace/class ::CmdMeshBoundingBox
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1586: Qualifying with unknown namespace/class ::CmdMeshBoundingBox
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1605: Qualifying with unknown namespace/class ::CmdMeshBuildRegularSolid
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1636: Qualifying with unknown namespace/class ::CmdMeshFillupHoles
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1648: Qualifying with unknown namespace/class ::CmdMeshFillupHoles
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1674: Qualifying with unknown namespace/class ::CmdMeshFillInteractiveHole
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1716: Qualifying with unknown namespace/class ::CmdMeshSegmentation
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1752: Qualifying with unknown namespace/class ::CmdMeshSegmentationBestFit
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1788: Qualifying with unknown namespace/class ::CmdMeshMerge
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1831: Qualifying with unknown namespace/class ::CmdMeshSplitComponents
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1877: Qualifying with unknown namespace/class ::CmdMeshScale
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1892: Qualifying with unknown namespace/class ::CmdMeshScale
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/MeshPart/MeshPart.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/MeshPart/Gui/Command.cpp:59: Qualifying with unknown namespace/class ::CmdMeshPartMesher
+/home/chennes/FreeCAD-chennes/src/Mod/MeshPart/Gui/Command.cpp:84: Qualifying with unknown namespace/class ::CmdMeshPartTrimByPlane
+/home/chennes/FreeCAD-chennes/src/Mod/MeshPart/Gui/Command.cpp:192: Qualifying with unknown namespace/class ::CmdMeshPartSection
+/home/chennes/FreeCAD-chennes/src/Mod/MeshPart/Gui/Command.cpp:276: Qualifying with unknown namespace/class ::CmdMeshPartCrossSections
+/home/chennes/FreeCAD-chennes/src/Mod/MeshPart/Gui/Command.cpp:312: Qualifying with unknown namespace/class ::CmdMeshPartCurveOnMesh
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/OpenSCAD/OpenSCAD.pro.
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/PartDesign/PartDesign.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/App/FeatureGroove.cpp:113: Class 'PartDesign::Groove' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/App/FeatureHole.cpp:1654: Class 'PartDesign::Hole' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/App/FeaturePocket.cpp:118: Class 'PartDesign::Pocket' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:167: Qualifying with unknown namespace/class ::CmdPartDesignPlane
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:195: Qualifying with unknown namespace/class ::CmdPartDesignLine
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:223: Qualifying with unknown namespace/class ::CmdPartDesignPoint
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:251: Qualifying with unknown namespace/class ::CmdPartDesignCS
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:283: Qualifying with unknown namespace/class ::CmdPartDesignShapeBinder
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:348: Qualifying with unknown namespace/class ::CmdPartDesignSubShapeBinder
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:412: Qualifying with unknown namespace/class ::CmdPartDesignSubShapeBinder
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:431: Qualifying with unknown namespace/class ::CmdPartDesignClone
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:489: Qualifying with unknown namespace/class ::CmdPartDesignNewSketch
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:594: Qualifying with unknown namespace/class ::CmdPartDesignNewSketch
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1309: Qualifying with unknown namespace/class ::CmdPartDesignPad
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1341: Qualifying with unknown namespace/class ::CmdPartDesignPocket
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1373: Qualifying with unknown namespace/class ::CmdPartDesignHole
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1419: Qualifying with unknown namespace/class ::CmdPartDesignRevolution
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1477: Qualifying with unknown namespace/class ::CmdPartDesignGroove
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1543: Qualifying with unknown namespace/class ::CmdPartDesignAdditivePipe
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1593: Qualifying with unknown namespace/class ::CmdPartDesignSubtractivePipe
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1643: Qualifying with unknown namespace/class ::CmdPartDesignAdditiveLoft
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1693: Qualifying with unknown namespace/class ::CmdPartDesignSubtractiveLoft
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1742: Qualifying with unknown namespace/class ::CmdPartDesignAdditiveHelix
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1812: Qualifying with unknown namespace/class ::CmdPartDesignSubtractiveHelix
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1991: Qualifying with unknown namespace/class ::CmdPartDesignFillet
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:2019: Qualifying with unknown namespace/class ::CmdPartDesignChamfer
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:2048: Qualifying with unknown namespace/class ::CmdPartDesignDraft
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:2105: Qualifying with unknown namespace/class ::CmdPartDesignThickness
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:2253: Qualifying with unknown namespace/class ::CmdPartDesignMirrored
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:2315: Qualifying with unknown namespace/class ::CmdPartDesignLinearPattern
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:2379: Qualifying with unknown namespace/class ::CmdPartDesignPolarPattern
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:2444: Qualifying with unknown namespace/class ::CmdPartDesignScaled
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:2493: Qualifying with unknown namespace/class ::CmdPartDesignMultiTransform
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:2616: Qualifying with unknown namespace/class ::CmdPartDesignBoolean
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandBody.cpp:89: Qualifying with unknown namespace/class ::CmdPartDesignBody
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandBody.cpp:119: Qualifying with unknown namespace/class ::CmdPartDesignBody
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandBody.cpp:312: Qualifying with unknown namespace/class ::CmdPartDesignMigrate
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandBody.cpp:343: Qualifying with unknown namespace/class ::CmdPartDesignMigrate
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandBody.cpp:527: Qualifying with unknown namespace/class ::CmdPartDesignMoveTip
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandBody.cpp:555: Qualifying with unknown namespace/class ::CmdPartDesignMoveTip
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandBody.cpp:606: Qualifying with unknown namespace/class ::CmdPartDesignDuplicateSelection
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandBody.cpp:662: Qualifying with unknown namespace/class ::CmdPartDesignMoveFeature
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandBody.cpp:680: Qualifying with unknown namespace/class ::CmdPartDesignMoveFeature
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandBody.cpp:824: Qualifying with unknown namespace/class ::CmdPartDesignMoveFeatureInTree
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandBody.cpp:851: Qualifying with unknown namespace/class ::CmdPartDesignMoveFeatureInTree
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandPrimitive.cpp:69: Qualifying with unknown namespace/class ::CmdPrimtiveCompAdditive
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandPrimitive.cpp:243: Qualifying with unknown namespace/class ::CmdPrimtiveCompSubtractive
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandPrimitive.cpp:269: Qualifying with unknown namespace/class ::CmdPrimtiveCompSubtractive
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/FeaturePickDialog.cpp:45: Qualifying with unknown namespace/class ::FeaturePickDialog
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/ReferenceSelection.cpp:271: Class 'PartDesignGui::NoDependentsSelection' lacks Q_OBJECT macro
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Part/Part.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:90: Qualifying with unknown namespace/class ::CmdPartPickCurveNet
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:136: Qualifying with unknown namespace/class ::CmdPartBox2
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:177: Qualifying with unknown namespace/class ::CmdPartBox3
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:218: Qualifying with unknown namespace/class ::CmdPartPrimitives
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:272: Qualifying with unknown namespace/class ::CmdPartCut
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:286: Qualifying with unknown namespace/class ::CmdPartCut
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:350: Qualifying with unknown namespace/class ::CmdPartCommon
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:381: Qualifying with unknown namespace/class ::CmdPartCommon
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:450: Qualifying with unknown namespace/class ::CmdPartFuse
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:481: Qualifying with unknown namespace/class ::CmdPartFuse
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:551: Qualifying with unknown namespace/class ::CmdPartCompJoinFeatures
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:657: Qualifying with unknown namespace/class ::CmdPartCompSplitFeatures
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:779: Qualifying with unknown namespace/class ::CmdPartCompCompoundTools
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:886: Qualifying with unknown namespace/class ::CmdPartCompound
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:900: Qualifying with unknown namespace/class ::CmdPartCompound
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:943: Qualifying with unknown namespace/class ::CmdPartSection
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:957: Qualifying with unknown namespace/class ::CmdPartSection
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:991: Qualifying with unknown namespace/class ::CmdPartImport
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1053: Qualifying with unknown namespace/class ::CmdPartExport
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1100: Qualifying with unknown namespace/class ::CmdPartImportCurveNet
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1113: Qualifying with unknown namespace/class ::CmdPartImportCurveNet
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1148: Qualifying with unknown namespace/class ::CmdPartMakeSolid
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1227: Qualifying with unknown namespace/class ::CmdPartReverseShape
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1290: Qualifying with unknown namespace/class ::CmdPartBoolean
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1321: Qualifying with unknown namespace/class ::CmdPartExtrude
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1349: Qualifying with unknown namespace/class ::CmdPartMakeFace
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1401: Qualifying with unknown namespace/class ::CmdPartRevolve
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1429: Qualifying with unknown namespace/class ::CmdPartFillet
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1457: Qualifying with unknown namespace/class ::CmdPartChamfer
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1485: Qualifying with unknown namespace/class ::CmdPartMirror
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1513: Qualifying with unknown namespace/class ::CmdPartCrossSections
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1553: Qualifying with unknown namespace/class ::CmdPartBuilder
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1582: Qualifying with unknown namespace/class ::CmdPartLoft
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1611: Qualifying with unknown namespace/class ::CmdPartSweep
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1640: Qualifying with unknown namespace/class ::CmdPartOffset
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1692: Qualifying with unknown namespace/class ::CmdPartOffset2D
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1743: Qualifying with unknown namespace/class ::CmdPartCompOffset
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1836: Qualifying with unknown namespace/class ::CmdPartThickness
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2011: Qualifying with unknown namespace/class ::CmdPartRuledSurface
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2097: Qualifying with unknown namespace/class ::CmdPartRuledSurface
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2127: Qualifying with unknown namespace/class ::CmdCheckGeometry
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2161: Qualifying with unknown namespace/class ::CmdColorPerFace
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2200: Qualifying with unknown namespace/class ::CmdMeasureLinear
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2231: Qualifying with unknown namespace/class ::CmdMeasureAngular
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2260: Qualifying with unknown namespace/class ::CmdMeasureRefresh
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2290: Qualifying with unknown namespace/class ::CmdMeasureClearAll
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2319: Qualifying with unknown namespace/class ::CmdMeasureToggleAll
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2356: Qualifying with unknown namespace/class ::CmdMeasureToggle3d
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2387: Qualifying with unknown namespace/class ::CmdMeasureToggleDelta
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2419: Qualifying with unknown namespace/class ::CmdBoxSelection
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2448: Qualifying with unknown namespace/class ::CmdPartProjectionOnSurface
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandParametric.cpp:66: Qualifying with unknown namespace/class ::CmdPartCylinder
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandParametric.cpp:108: Qualifying with unknown namespace/class ::CmdPartBox
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandParametric.cpp:150: Qualifying with unknown namespace/class ::CmdPartSphere
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandParametric.cpp:192: Qualifying with unknown namespace/class ::CmdPartCone
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandParametric.cpp:234: Qualifying with unknown namespace/class ::CmdPartTorus
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandSimple.cpp:58: Qualifying with unknown namespace/class ::CmdPartSimpleCylinder
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandSimple.cpp:108: Qualifying with unknown namespace/class ::CmdPartShapeFromMesh
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandSimple.cpp:137: Qualifying with unknown namespace/class ::CmdPartPointsFromMesh
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandSimple.cpp:187: Qualifying with unknown namespace/class ::CmdPartSimpleCopy
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandSimple.cpp:258: Qualifying with unknown namespace/class ::CmdPartTransformedCopy
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandSimple.cpp:286: Qualifying with unknown namespace/class ::CmdPartElementCopy
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandSimple.cpp:314: Qualifying with unknown namespace/class ::CmdPartRefineShape
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandSimple.cpp:374: Qualifying with unknown namespace/class ::CmdPartDefeaturing
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Path/Path.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Path/App/VoronoiPyImp.cpp:206: Parenthesis/brace mismatch between #if and #else branches; using #if branch
+/home/chennes/FreeCAD-chennes/src/Mod/Path/Gui/Command.cpp:55: Qualifying with unknown namespace/class ::CmdPathArea
+/home/chennes/FreeCAD-chennes/src/Mod/Path/Gui/Command.cpp:137: Qualifying with unknown namespace/class ::CmdPathAreaWorkplane
+/home/chennes/FreeCAD-chennes/src/Mod/Path/Gui/Command.cpp:227: Qualifying with unknown namespace/class ::CmdPathCompound
+/home/chennes/FreeCAD-chennes/src/Mod/Path/Gui/Command.cpp:279: Qualifying with unknown namespace/class ::CmdPathShape
+fanuc_post.py:107: Unterminated string
+rrf_post.py:214: Unterminated string
+linuxcnc_post.py:99: Unterminated string
+dynapath_post.py:143: Unterminated string
+jtech_post.py:104: Unterminated string
+marlin_post.py:209: Unterminated string
+centroid_post.py:116: Unterminated string
+fablin_post.py:88: Unterminated string
+mach3_mach4_post.py:98: Unterminated string
+grbl_post.py:80: Unterminated string
+uccnc_post.py:298: Unterminated string
+smoothie_post.py:108: Unterminated string
+opensbp_post.py:80: Unterminated string
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Points/Points.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Points/Gui/Command.cpp:68: Qualifying with unknown namespace/class ::CmdPointsImport
+/home/chennes/FreeCAD-chennes/src/Mod/Points/Gui/Command.cpp:82: Qualifying with unknown namespace/class ::CmdPointsImport
+/home/chennes/FreeCAD-chennes/src/Mod/Points/Gui/Command.cpp:113: Qualifying with unknown namespace/class ::CmdPointsExport
+/home/chennes/FreeCAD-chennes/src/Mod/Points/Gui/Command.cpp:130: Qualifying with unknown namespace/class ::CmdPointsExport
+/home/chennes/FreeCAD-chennes/src/Mod/Points/Gui/Command.cpp:153: Qualifying with unknown namespace/class ::CmdPointsTransform
+/home/chennes/FreeCAD-chennes/src/Mod/Points/Gui/Command.cpp:190: Qualifying with unknown namespace/class ::CmdPointsConvert
+/home/chennes/FreeCAD-chennes/src/Mod/Points/Gui/Command.cpp:209: Qualifying with unknown namespace/class ::CmdPointsConvert
+/home/chennes/FreeCAD-chennes/src/Mod/Points/Gui/Command.cpp:282: Qualifying with unknown namespace/class ::CmdPointsPolyCut
+/home/chennes/FreeCAD-chennes/src/Mod/Points/Gui/Command.cpp:327: Qualifying with unknown namespace/class ::CmdPointsMerge
+/home/chennes/FreeCAD-chennes/src/Mod/Points/Gui/Command.cpp:370: Qualifying with unknown namespace/class ::CmdPointsStructure
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Raytracing.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:84: Qualifying with unknown namespace/class ::CmdRaytracingWriteCamera
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:137: Qualifying with unknown namespace/class ::CmdRaytracingWriteCamera
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:177: Qualifying with unknown namespace/class ::CmdRaytracingWritePart
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:188: Qualifying with unknown namespace/class ::CmdRaytracingWritePart
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:223: Qualifying with unknown namespace/class ::CmdRaytracingWriteView
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:250: Qualifying with unknown namespace/class ::CmdRaytracingWriteView
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:320: Qualifying with unknown namespace/class ::CmdRaytracingNewPovrayProject
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:437: Qualifying with unknown namespace/class ::CmdRaytracingNewPartSegment
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:449: Qualifying with unknown namespace/class ::CmdRaytracingNewPartSegment
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:521: Qualifying with unknown namespace/class ::CmdRaytracingExportProject
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:536: Qualifying with unknown namespace/class ::CmdRaytracingExportProject
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:584: Qualifying with unknown namespace/class ::CmdRaytracingRender
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:600: Qualifying with unknown namespace/class ::CmdRaytracingRender
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:766: Qualifying with unknown namespace/class ::CmdRaytracingNewLuxProject
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:879: Qualifying with unknown namespace/class ::CmdRaytracingResetCamera
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:893: Qualifying with unknown namespace/class ::CmdRaytracingResetCamera
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/ReverseEngineering.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/Gui/Command.cpp:74: Qualifying with unknown namespace/class ::CmdApproxSurface
+/home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/Gui/Command.cpp:110: Qualifying with unknown namespace/class ::CmdApproxPlane
+/home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/Gui/Command.cpp:211: Qualifying with unknown namespace/class ::CmdApproxCylinder
+/home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/Gui/Command.cpp:277: Qualifying with unknown namespace/class ::CmdApproxSphere
+/home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/Gui/Command.cpp:324: Qualifying with unknown namespace/class ::CmdApproxPolynomial
+/home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/Gui/Command.cpp:379: Qualifying with unknown namespace/class ::CmdSegmentation
+/home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/Gui/Command.cpp:411: Qualifying with unknown namespace/class ::CmdSegmentationManual
+/home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/Gui/Command.cpp:440: Qualifying with unknown namespace/class ::CmdSegmentationFromComponents
+/home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/Gui/Command.cpp:490: Qualifying with unknown namespace/class ::CmdMeshBoundary
+/home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/Gui/Command.cpp:556: Qualifying with unknown namespace/class ::CmdPoissonReconstruction
+/home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/Gui/Command.cpp:590: Qualifying with unknown namespace/class ::CmdViewTriangulation
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Robot/Robot.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/Command.cpp:55: Qualifying with unknown namespace/class ::CmdRobotSetHomePos
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/Command.cpp:75: Qualifying with unknown namespace/class ::CmdRobotSetHomePos
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/Command.cpp:104: Qualifying with unknown namespace/class ::CmdRobotRestoreHomePos
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/Command.cpp:124: Qualifying with unknown namespace/class ::CmdRobotRestoreHomePos
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/Command.cpp:158: Qualifying with unknown namespace/class ::CmdRobotConstraintAxle
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/Command.cpp:199: Qualifying with unknown namespace/class ::CmdRobotSimulate
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/Command.cpp:224: Qualifying with unknown namespace/class ::CmdRobotSimulate
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandExport.cpp:50: Qualifying with unknown namespace/class ::CmdRobotExportKukaCompact
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandExport.cpp:65: Qualifying with unknown namespace/class ::CmdRobotExportKukaCompact
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandExport.cpp:112: Qualifying with unknown namespace/class ::CmdRobotExportKukaFull
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandExport.cpp:127: Qualifying with unknown namespace/class ::CmdRobotExportKukaFull
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandInsertRobot.cpp:51: Qualifying with unknown namespace/class ::CmdRobotInsertKukaIR500
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandInsertRobot.cpp:93: Qualifying with unknown namespace/class ::CmdRobotInsertKukaIR16
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandInsertRobot.cpp:134: Qualifying with unknown namespace/class ::CmdRobotInsertKukaIR210
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandInsertRobot.cpp:174: Qualifying with unknown namespace/class ::CmdRobotInsertKukaIR125
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandInsertRobot.cpp:215: Qualifying with unknown namespace/class ::CmdRobotAddToolShape
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandInsertRobot.cpp:234: Qualifying with unknown namespace/class ::CmdRobotAddToolShape
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:62: Qualifying with unknown namespace/class ::CmdRobotCreateTrajectory
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:95: Qualifying with unknown namespace/class ::CmdRobotInsertWaypoint
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:111: Qualifying with unknown namespace/class ::CmdRobotInsertWaypoint
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:152: Qualifying with unknown namespace/class ::CmdRobotInsertWaypointPreselect
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:167: Qualifying with unknown namespace/class ::CmdRobotInsertWaypointPreselect
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:216: Qualifying with unknown namespace/class ::CmdRobotSetDefaultOrientation
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:254: Qualifying with unknown namespace/class ::CmdRobotSetDefaultValues
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:268: Qualifying with unknown namespace/class ::CmdRobotSetDefaultValues
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:320: Qualifying with unknown namespace/class ::CmdRobotEdge2Trac
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:384: Qualifying with unknown namespace/class ::CmdRobotTrajectoryDressUp
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:412: Qualifying with unknown namespace/class ::CmdRobotTrajectoryDressUp
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:431: Qualifying with unknown namespace/class ::CmdRobotTrajectoryCompound
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Sketcher.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:143: Qualifying with unknown namespace/class ::CmdSketcherNewSketch
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:164: Qualifying with unknown namespace/class ::CmdSketcherNewSketch
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:266: Qualifying with unknown namespace/class ::CmdSketcherEditSketch
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:296: Qualifying with unknown namespace/class ::CmdSketcherLeaveSketch
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:340: Qualifying with unknown namespace/class ::CmdSketcherStopOperation
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:381: Qualifying with unknown namespace/class ::CmdSketcherReorientSketch
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:508: Qualifying with unknown namespace/class ::CmdSketcherMapSketch
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:562: Qualifying with unknown namespace/class ::CmdSketcherMapSketch
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:683: Qualifying with unknown namespace/class ::CmdSketcherViewSketch
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:723: Qualifying with unknown namespace/class ::CmdSketcherValidateSketch
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:761: Qualifying with unknown namespace/class ::CmdSketcherMirrorSketch
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:868: Qualifying with unknown namespace/class ::CmdSketcherMergeSketches
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:952: Qualifying with unknown namespace/class ::CmdSketcherViewSection
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandAlterGeometry.cpp:74: Qualifying with unknown namespace/class ::CmdSketcherToggleConstruction
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandAlterGeometry.cpp:123: Qualifying with unknown namespace/class ::CmdSketcherToggleConstruction
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:883: Class 'CmdSketcherConstrainHorizontal' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:1121: Class 'CmdSketcherConstrainVertical' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:1355: Class 'CmdSketcherConstrainLock' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:1581: Class 'CmdSketcherConstrainBlock' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:1896: Class 'CmdSketcherConstrainCoincident' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:2102: Class 'CmdSketcherConstrainDistance' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:2451: Class 'CmdSketcherConstrainPointOnObject' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:2699: Class 'CmdSketcherConstrainDistanceX' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:2953: Class 'CmdSketcherConstrainDistanceY' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:3199: Class 'CmdSketcherConstrainParallel' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:3349: Class 'CmdSketcherConstrainPerpendicular' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:3987: Class 'CmdSketcherConstrainTangent' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:4695: Class 'CmdSketcherConstrainRadius' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:4997: Class 'CmdSketcherConstrainDiameter' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:5273: Class 'CmdSketcherConstrainRadiam' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:5577: Qualifying with unknown namespace/class ::CmdSketcherCompConstrainRadDia
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:5721: Class 'CmdSketcherConstrainAngle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:6248: Class 'CmdSketcherConstrainEqual' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:6465: Class 'CmdSketcherConstrainSymmetric' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:6765: Qualifying with unknown namespace/class ::CmdSketcherConstrainSnellsLaw
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:6784: Qualifying with unknown namespace/class ::CmdSketcherConstrainSnellsLaw
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:6931: Qualifying with unknown namespace/class ::CmdSketcherConstrainInternalAlignment
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:6949: Qualifying with unknown namespace/class ::CmdSketcherConstrainInternalAlignment
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:7391: Qualifying with unknown namespace/class ::CmdSketcherToggleDrivingConstraint
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:7430: Qualifying with unknown namespace/class ::CmdSketcherToggleDrivingConstraint
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:7518: Qualifying with unknown namespace/class ::CmdSketcherToggleActiveConstraint
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:7543: Qualifying with unknown namespace/class ::CmdSketcherToggleActiveConstraint
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:344: Qualifying with unknown namespace/class ::CmdSketcherCreateLine
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:649: Qualifying with unknown namespace/class ::CmdSketcherCreateRectangle
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:690: Qualifying with unknown namespace/class ::CmdSketcherCreateRectangleCenter
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:1016: Qualifying with unknown namespace/class ::CmdSketcherCreateOblong
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:1059: Qualifying with unknown namespace/class ::CmdSketcherCompCreateRectangles
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:1815: Qualifying with unknown namespace/class ::CmdSketcherCreatePolyline
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:2059: Qualifying with unknown namespace/class ::CmdSketcherCreateArc
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:2329: Qualifying with unknown namespace/class ::CmdSketcherCreate3PointArc
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:2357: Qualifying with unknown namespace/class ::CmdSketcherCompCreateArc
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:2591: Qualifying with unknown namespace/class ::CmdSketcherCreateCircle
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:3387: Qualifying with unknown namespace/class ::CmdSketcherCreateEllipseByCenter
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:3418: Qualifying with unknown namespace/class ::CmdSketcherCreateEllipseBy3Points
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:3746: Qualifying with unknown namespace/class ::CmdSketcherCreateArcOfEllipse
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:4090: Qualifying with unknown namespace/class ::CmdSketcherCreateArcOfHyperbola
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:4389: Qualifying with unknown namespace/class ::CmdSketcherCreateArcOfParabola
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:4422: Qualifying with unknown namespace/class ::CmdSketcherCompCreateConic
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:4925: Qualifying with unknown namespace/class ::CmdSketcherCreateBSpline
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:4970: Qualifying with unknown namespace/class ::CmdSketcherCreatePeriodicBSpline
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:5002: Qualifying with unknown namespace/class ::CmdSketcherCompCreateBSpline
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:5285: Qualifying with unknown namespace/class ::CmdSketcherCreate3PointCircle
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:5313: Qualifying with unknown namespace/class ::CmdSketcherCompCreateCircle
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:5493: Qualifying with unknown namespace/class ::CmdSketcherCreatePoint
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:5523: Qualifying with unknown namespace/class ::CmdSketcherCreateText
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:5551: Qualifying with unknown namespace/class ::CmdSketcherCreateDraftLine
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:5831: Qualifying with unknown namespace/class ::CmdSketcherCreateFillet
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:5860: Qualifying with unknown namespace/class ::CmdSketcherCreatePointFillet
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:5891: Qualifying with unknown namespace/class ::CmdSketcherCompCreateFillets
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:6121: Qualifying with unknown namespace/class ::CmdSketcherTrimming
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:6435: Qualifying with unknown namespace/class ::CmdSketcherExtend
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:6554: Qualifying with unknown namespace/class ::CmdSketcherSplit
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:6593: Class 'SketcherGui::ExternalSelection' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:6739: Qualifying with unknown namespace/class ::CmdSketcherExternal
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:6785: Class 'SketcherGui::CarbonCopySelection' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:6917: Qualifying with unknown namespace/class ::CmdSketcherCarbonCopy
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:7228: Qualifying with unknown namespace/class ::CmdSketcherCreateSlot
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:7421: Qualifying with unknown namespace/class ::CmdSketcherCreateTriangle
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:7448: Qualifying with unknown namespace/class ::CmdSketcherCreateSquare
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:7475: Qualifying with unknown namespace/class ::CmdSketcherCreatePentagon
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:7503: Qualifying with unknown namespace/class ::CmdSketcherCreateHexagon
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:7530: Qualifying with unknown namespace/class ::CmdSketcherCreateHeptagon
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:7557: Qualifying with unknown namespace/class ::CmdSketcherCreateOctagon
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:7584: Qualifying with unknown namespace/class ::CmdSketcherCreateRegularPolygon
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:7615: Qualifying with unknown namespace/class ::CmdSketcherCompCreateRegularPolygon
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:100: Qualifying with unknown namespace/class ::CmdSketcherBSplineDegree
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:129: Qualifying with unknown namespace/class ::CmdSketcherBSplinePolygon
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:158: Qualifying with unknown namespace/class ::CmdSketcherBSplineComb
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:187: Qualifying with unknown namespace/class ::CmdSketcherBSplineKnotMultiplicity
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:216: Qualifying with unknown namespace/class ::CmdSketcherBSplinePoleWeight
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:245: Qualifying with unknown namespace/class ::CmdSketcherCompBSplineShowHideGeometryInformation
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:374: Qualifying with unknown namespace/class ::CmdSketcherConvertToNURB
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:420: Qualifying with unknown namespace/class ::CmdSketcherConvertToNURB
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:442: Qualifying with unknown namespace/class ::CmdSketcherIncreaseDegree
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:491: Qualifying with unknown namespace/class ::CmdSketcherIncreaseDegree
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:515: Qualifying with unknown namespace/class ::CmdSketcherDecreaseDegree
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:569: Qualifying with unknown namespace/class ::CmdSketcherDecreaseDegree
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:592: Qualifying with unknown namespace/class ::CmdSketcherIncreaseKnotMultiplicity
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:607: Qualifying with unknown namespace/class ::CmdSketcherIncreaseKnotMultiplicity
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:746: Qualifying with unknown namespace/class ::CmdSketcherDecreaseKnotMultiplicity
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:761: Qualifying with unknown namespace/class ::CmdSketcherDecreaseKnotMultiplicity
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:888: Qualifying with unknown namespace/class ::CmdSketcherCompModifyKnotMultiplicity
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:981: Qualifying with unknown namespace/class ::CmdSketcherInsertKnot
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:996: Qualifying with unknown namespace/class ::CmdSketcherInsertKnot
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:105: Qualifying with unknown namespace/class ::CmdSketcherCloseShape
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:129: Qualifying with unknown namespace/class ::CmdSketcherCloseShape
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:217: Qualifying with unknown namespace/class ::CmdSketcherConnect
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:240: Qualifying with unknown namespace/class ::CmdSketcherConnect
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:304: Qualifying with unknown namespace/class ::CmdSketcherSelectConstraints
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:327: Qualifying with unknown namespace/class ::CmdSketcherSelectConstraints
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:381: Qualifying with unknown namespace/class ::CmdSketcherSelectOrigin
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:427: Qualifying with unknown namespace/class ::CmdSketcherSelectVerticalAxis
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:471: Qualifying with unknown namespace/class ::CmdSketcherSelectHorizontalAxis
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:514: Qualifying with unknown namespace/class ::CmdSketcherSelectRedundantConstraints
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:571: Qualifying with unknown namespace/class ::CmdSketcherSelectMalformedConstraints
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:627: Qualifying with unknown namespace/class ::CmdSketcherSelectPartiallyRedundantConstraints
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:683: Qualifying with unknown namespace/class ::CmdSketcherSelectConflictingConstraints
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:738: Qualifying with unknown namespace/class ::CmdSketcherSelectElementsAssociatedWithConstraints
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:836: Qualifying with unknown namespace/class ::CmdSketcherSelectElementsAssociatedWithConstraints
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:859: Qualifying with unknown namespace/class ::CmdSketcherSelectElementsWithDoFs
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:950: Qualifying with unknown namespace/class ::CmdSketcherRestoreInternalAlignmentGeometry
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:974: Qualifying with unknown namespace/class ::CmdSketcherRestoreInternalAlignmentGeometry
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:1046: Qualifying with unknown namespace/class ::CmdSketcherSymmetry
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:1069: Qualifying with unknown namespace/class ::CmdSketcherSymmetry
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:1581: Class 'CmdSketcherCopy' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:1627: Class 'CmdSketcherClone' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:1670: Class 'CmdSketcherMove' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:1704: Qualifying with unknown namespace/class ::CmdSketcherCompCopy
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:1986: Qualifying with unknown namespace/class ::CmdSketcherRectangularArray
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:2005: Qualifying with unknown namespace/class ::CmdSketcherRectangularArray
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:2126: Qualifying with unknown namespace/class ::CmdSketcherDeleteAllGeometry
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:2140: Qualifying with unknown namespace/class ::CmdSketcherDeleteAllGeometry
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:2189: Qualifying with unknown namespace/class ::CmdSketcherDeleteAllConstraints
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:2202: Qualifying with unknown namespace/class ::CmdSketcherDeleteAllConstraints
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:2253: Qualifying with unknown namespace/class ::CmdSketcherRemoveAxesAlignment
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:2272: Qualifying with unknown namespace/class ::CmdSketcherRemoveAxesAlignment
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherVirtualSpace.cpp:93: Qualifying with unknown namespace/class ::CmdSketcherSwitchVirtualSpace
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherVirtualSpace.cpp:115: Qualifying with unknown namespace/class ::CmdSketcherSwitchVirtualSpace
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Spreadsheet.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/AppSpreadsheetGui.cpp:87: Class 'SpreadsheetGui::Module' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:70: Qualifying with unknown namespace/class ::CmdSpreadsheetMergeCells
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:123: Qualifying with unknown namespace/class ::CmdSpreadsheetSplitCell
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:179: Qualifying with unknown namespace/class ::CmdSpreadsheetImport
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:191: Qualifying with unknown namespace/class ::CmdSpreadsheetImport
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:229: Qualifying with unknown namespace/class ::CmdSpreadsheetExport
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:247: Qualifying with unknown namespace/class ::CmdSpreadsheetExport
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:290: Qualifying with unknown namespace/class ::CmdSpreadsheetAlignLeft
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:342: Qualifying with unknown namespace/class ::CmdSpreadsheetAlignCenter
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:394: Qualifying with unknown namespace/class ::CmdSpreadsheetAlignRight
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:446: Qualifying with unknown namespace/class ::CmdSpreadsheetAlignTop
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:498: Qualifying with unknown namespace/class ::CmdSpreadsheetAlignBottom
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:550: Qualifying with unknown namespace/class ::CmdSpreadsheetAlignVCenter
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:602: Qualifying with unknown namespace/class ::CmdSpreadsheetStyleBold
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:676: Qualifying with unknown namespace/class ::CmdSpreadsheetStyleItalic
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:750: Qualifying with unknown namespace/class ::CmdSpreadsheetStyleUnderline
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:823: Qualifying with unknown namespace/class ::CmdSpreadsheetSetAlias
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:887: Qualifying with unknown namespace/class ::CmdCreateSpreadsheet
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Start/Start.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Start/Gui/Command.cpp:45: Qualifying with unknown namespace/class ::CmdStartPage
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/TechDraw/TechDraw.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:117: Qualifying with unknown namespace/class ::CmdTechDrawPageDefault
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:181: Qualifying with unknown namespace/class ::CmdTechDrawPageTemplate
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:195: Qualifying with unknown namespace/class ::CmdTechDrawPageTemplate
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:261: Qualifying with unknown namespace/class ::CmdTechDrawRedrawPage
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:298: Qualifying with unknown namespace/class ::CmdTechDrawView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:379: Qualifying with unknown namespace/class ::CmdTechDrawView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:442: Qualifying with unknown namespace/class ::CmdTechDrawActiveView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:476: Qualifying with unknown namespace/class ::CmdTechDrawSectionView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:494: Qualifying with unknown namespace/class ::CmdTechDrawSectionView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:526: Qualifying with unknown namespace/class ::CmdTechDrawDetailView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:545: Qualifying with unknown namespace/class ::CmdTechDrawDetailView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:575: Qualifying with unknown namespace/class ::CmdTechDrawProjectionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:655: Qualifying with unknown namespace/class ::CmdTechDrawProjectionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:855: Qualifying with unknown namespace/class ::CmdTechDrawBalloon
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:920: Qualifying with unknown namespace/class ::CmdTechDrawClipGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:959: Qualifying with unknown namespace/class ::CmdTechDrawClipGroupAdd
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:972: Qualifying with unknown namespace/class ::CmdTechDrawClipGroupAdd
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1043: Qualifying with unknown namespace/class ::CmdTechDrawClipGroupRemove
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1057: Qualifying with unknown namespace/class ::CmdTechDrawClipGroupRemove
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1118: Qualifying with unknown namespace/class ::CmdTechDrawSymbol
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1137: Qualifying with unknown namespace/class ::CmdTechDrawSymbol
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1173: Qualifying with unknown namespace/class ::CmdTechDrawDraftView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1194: Qualifying with unknown namespace/class ::CmdTechDrawDraftView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1239: Qualifying with unknown namespace/class ::CmdTechDrawArchView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1268: Qualifying with unknown namespace/class ::CmdTechDrawArchView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1304: Qualifying with unknown namespace/class ::CmdTechDrawSpreadsheetView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1317: Qualifying with unknown namespace/class ::CmdTechDrawSpreadsheetView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1363: Qualifying with unknown namespace/class ::CmdTechDrawExportPageSVG
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1388: Qualifying with unknown namespace/class ::CmdTechDrawExportPageSVG
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1408: Qualifying with unknown namespace/class ::CmdTechDrawExportPageDXF
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1428: Qualifying with unknown namespace/class ::CmdTechDrawExportPageDXF
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:101: Qualifying with unknown namespace/class ::CmdTechDrawLeaderLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:115: Qualifying with unknown namespace/class ::CmdTechDrawLeaderLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:163: Qualifying with unknown namespace/class ::CmdTechDrawRichTextAnnotation
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:176: Qualifying with unknown namespace/class ::CmdTechDrawRichTextAnnotation
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:215: Qualifying with unknown namespace/class ::CmdTechDrawCosmeticVertexGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:228: Qualifying with unknown namespace/class ::CmdTechDrawCosmeticVertexGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:404: Qualifying with unknown namespace/class ::CmdTechDrawCosmeticVertex
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:417: Qualifying with unknown namespace/class ::CmdTechDrawCosmeticVertex
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:465: Qualifying with unknown namespace/class ::CmdTechDrawMidpoints
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:478: Qualifying with unknown namespace/class ::CmdTechDrawMidpoints
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:504: Qualifying with unknown namespace/class ::CmdTechDrawQuadrants
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:517: Qualifying with unknown namespace/class ::CmdTechDrawQuadrants
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:543: Qualifying with unknown namespace/class ::CmdTechDrawAnnotation
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:583: Qualifying with unknown namespace/class ::CmdTechDrawCenterLineGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:596: Qualifying with unknown namespace/class ::CmdTechDrawCenterLineGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:686: Qualifying with unknown namespace/class ::CmdTechDrawFaceCenterLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:700: Qualifying with unknown namespace/class ::CmdTechDrawFaceCenterLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:796: Qualifying with unknown namespace/class ::CmdTechDraw2LineCenterLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:810: Qualifying with unknown namespace/class ::CmdTechDraw2LineCenterLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:873: Qualifying with unknown namespace/class ::CmdTechDraw2PointCenterLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:887: Qualifying with unknown namespace/class ::CmdTechDraw2PointCenterLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:986: Qualifying with unknown namespace/class ::CmdTechDraw2PointCosmeticLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:1000: Qualifying with unknown namespace/class ::CmdTechDraw2PointCosmeticLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:1138: Qualifying with unknown namespace/class ::CmdTechDrawCosmeticEraser
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:1151: Qualifying with unknown namespace/class ::CmdTechDrawCosmeticEraser
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:1265: Qualifying with unknown namespace/class ::CmdTechDrawDecorateLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:1279: Qualifying with unknown namespace/class ::CmdTechDrawDecorateLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:1344: Qualifying with unknown namespace/class ::CmdTechDrawShowAll
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:1357: Qualifying with unknown namespace/class ::CmdTechDrawShowAll
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:1409: Qualifying with unknown namespace/class ::CmdTechDrawWeldSymbol
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:1423: Qualifying with unknown namespace/class ::CmdTechDrawWeldSymbol
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:123: Qualifying with unknown namespace/class ::CmdTechDrawDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:250: Qualifying with unknown namespace/class ::CmdTechDrawRadiusDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:294: Qualifying with unknown namespace/class ::CmdTechDrawRadiusDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:372: Qualifying with unknown namespace/class ::CmdTechDrawDiameterDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:416: Qualifying with unknown namespace/class ::CmdTechDrawDiameterDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:493: Qualifying with unknown namespace/class ::CmdTechDrawLengthDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:547: Qualifying with unknown namespace/class ::CmdTechDrawLengthDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:595: Qualifying with unknown namespace/class ::CmdTechDrawHorizontalDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:650: Qualifying with unknown namespace/class ::CmdTechDrawHorizontalDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:698: Qualifying with unknown namespace/class ::CmdTechDrawVerticalDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:753: Qualifying with unknown namespace/class ::CmdTechDrawVerticalDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:800: Qualifying with unknown namespace/class ::CmdTechDrawAngleDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:845: Qualifying with unknown namespace/class ::CmdTechDrawAngleDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:888: Qualifying with unknown namespace/class ::CmdTechDraw3PtAngleDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:934: Qualifying with unknown namespace/class ::CmdTechDraw3PtAngleDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:980: Qualifying with unknown namespace/class ::CmdTechDrawLinkDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:1019: Qualifying with unknown namespace/class ::CmdTechDrawLinkDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:1058: Qualifying with unknown namespace/class ::CmdTechDrawExtentGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:1071: Qualifying with unknown namespace/class ::CmdTechDrawExtentGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:1151: Qualifying with unknown namespace/class ::CmdTechDrawHorizontalExtentDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:1165: Qualifying with unknown namespace/class ::CmdTechDrawHorizontalExtentDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:1238: Qualifying with unknown namespace/class ::CmdTechDrawVerticalExtentDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:1252: Qualifying with unknown namespace/class ::CmdTechDrawVerticalExtentDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:1321: Qualifying with unknown namespace/class ::CmdTechDrawLandmarkDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:1339: Qualifying with unknown namespace/class ::CmdTechDrawLandmarkDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandDecorate.cpp:87: Qualifying with unknown namespace/class ::CmdTechDrawHatch
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandDecorate.cpp:122: Qualifying with unknown namespace/class ::CmdTechDrawHatch
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandDecorate.cpp:208: Qualifying with unknown namespace/class ::CmdTechDrawGeometricHatch
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandDecorate.cpp:277: Qualifying with unknown namespace/class ::CmdTechDrawImage
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandDecorate.cpp:296: Qualifying with unknown namespace/class ::CmdTechDrawImage
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandDecorate.cpp:328: Qualifying with unknown namespace/class ::CmdTechDrawToggleFrame
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandDecorate.cpp:352: Qualifying with unknown namespace/class ::CmdTechDrawToggleFrame
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:145: Qualifying with unknown namespace/class ::CmdTechDrawExtensionInsertDiameter
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:178: Qualifying with unknown namespace/class ::CmdTechDrawExtensionInsertSquare
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:211: Qualifying with unknown namespace/class ::CmdTechDrawExtensionInsertPrefixGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:225: Qualifying with unknown namespace/class ::CmdTechDrawExtensionInsertPrefixGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:338: Qualifying with unknown namespace/class ::CmdTechDrawExtensionIncreaseDecimal
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:371: Qualifying with unknown namespace/class ::CmdTechDrawExtensionDecreaseDecimal
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:404: Qualifying with unknown namespace/class ::CmdTechDrawExtensionIncreaseDecreaseGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:418: Qualifying with unknown namespace/class ::CmdTechDrawExtensionIncreaseDecreaseGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:529: Qualifying with unknown namespace/class ::CmdTechDrawExtensionPosHorizChainDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:588: Qualifying with unknown namespace/class ::CmdTechDrawExtensionPosVertChainDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:653: Qualifying with unknown namespace/class ::CmdTechDrawExtensionPosObliqueChainDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:688: Qualifying with unknown namespace/class ::CmdTechDrawExtensionPosChainDimensionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:703: Qualifying with unknown namespace/class ::CmdTechDrawExtensionPosChainDimensionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:835: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCascadeHorizDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:899: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCascadeVertDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:972: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCascadeObliqueDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1008: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCascadeDimensionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1024: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCascadeDimensionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1162: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateHorizChainDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1228: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateVertChainDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1318: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateObliqueChainDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1352: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateChainDimensionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1366: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateChainDimensionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1505: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateHorizCoordDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1578: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateVertCoordDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1676: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateObliqueCoordDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1712: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateCoordDimensionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1728: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateCoordDimensionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1871: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateHorizChamferDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1940: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateVertChamferDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1973: Qualifying with unknown namespace/class ::CmdTechDrawExtensionChamferDimensionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1987: Qualifying with unknown namespace/class ::CmdTechDrawExtensionChamferDimensionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:2073: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateLengthArc
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:169: Qualifying with unknown namespace/class ::CmdTechDrawExtensionHoleCircle
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:243: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCircleCenterLines
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:277: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCircleCenterLinesGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:290: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCircleCenterLinesGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:395: Qualifying with unknown namespace/class ::CmdTechDrawExtensionThreadHoleSide
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:446: Qualifying with unknown namespace/class ::CmdTechDrawExtensionThreadBoltSide
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:497: Qualifying with unknown namespace/class ::CmdTechDrawExtensionThreadHoleBottom
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:548: Qualifying with unknown namespace/class ::CmdTechDrawExtensionThreadBoltBottom
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:582: Qualifying with unknown namespace/class ::CmdTechDrawExtensionThreadsGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:597: Qualifying with unknown namespace/class ::CmdTechDrawExtensionThreadsGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:715: Qualifying with unknown namespace/class ::CmdTechDrawExtensionSelectLineAttributes
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:749: Qualifying with unknown namespace/class ::CmdTechDrawExtensionChangeLineAttributes
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:808: Qualifying with unknown namespace/class ::CmdTechDrawExtensionVertexAtIntersection
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:898: Qualifying with unknown namespace/class ::CmdTechDrawExtensionDrawCosmArc
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:959: Qualifying with unknown namespace/class ::CmdTechDrawExtensionDrawCosmCircle
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:995: Qualifying with unknown namespace/class ::CmdTechDrawExtensionDrawCirclesGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1011: Qualifying with unknown namespace/class ::CmdTechDrawExtensionDrawCirclesGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1144: Qualifying with unknown namespace/class ::CmdTechDrawExtensionLineParallel
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1178: Qualifying with unknown namespace/class ::CmdTechDrawExtensionLinePerpendicular
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1212: Qualifying with unknown namespace/class ::CmdTechDrawExtensionLinePPGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1227: Qualifying with unknown namespace/class ::CmdTechDrawExtensionLinePPGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1315: Qualifying with unknown namespace/class ::CmdTechDrawExtensionLockUnlockView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1359: Qualifying with unknown namespace/class ::CmdTechDrawExtensionPositionSectionView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1376: Qualifying with unknown namespace/class ::CmdTechDrawExtensionPositionSectionView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1492: Qualifying with unknown namespace/class ::CmdTechDrawExtensionExtendLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1527: Qualifying with unknown namespace/class ::CmdTechDrawExtensionShortenLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1562: Qualifying with unknown namespace/class ::CmdTechDrawExtendShortenLineGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1577: Qualifying with unknown namespace/class ::CmdTechDrawExtendShortenLineGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/QGEPath.cpp:156: Discarding unconsumed meta data
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/QGIEdge.cpp:129: Discarding unconsumed meta data
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/QGIViewAnnotation.cpp:208: Class 'TechDrawGui::QGIViewAnnotation' lacks Q_OBJECT macro
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Test/Test.pro.
+Segmentation fault (core dumped)
+Cannot open Gui/Resources/translations/Testpy.ts: No such file or directory
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Tux/Tux.pro.
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Web/Web.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Web/Gui/Command.cpp:50: Qualifying with unknown namespace/class ::CmdWebOpenWebsite
+/home/chennes/FreeCAD-chennes/src/Mod/Web/Gui/Command.cpp:76: Qualifying with unknown namespace/class ::CmdWebBrowserBack
+/home/chennes/FreeCAD-chennes/src/Mod/Web/Gui/Command.cpp:105: Qualifying with unknown namespace/class ::CmdWebBrowserNext
+/home/chennes/FreeCAD-chennes/src/Mod/Web/Gui/Command.cpp:134: Qualifying with unknown namespace/class ::CmdWebBrowserRefresh
+/home/chennes/FreeCAD-chennes/src/Mod/Web/Gui/Command.cpp:162: Qualifying with unknown namespace/class ::CmdWebBrowserStop
+/home/chennes/FreeCAD-chennes/src/Mod/Web/Gui/Command.cpp:192: Qualifying with unknown namespace/class ::CmdWebBrowserZoomIn
+/home/chennes/FreeCAD-chennes/src/Mod/Web/Gui/Command.cpp:221: Qualifying with unknown namespace/class ::CmdWebBrowserZoomOut
+/home/chennes/FreeCAD-chennes/src/Mod/Web/Gui/Command.cpp:250: Qualifying with unknown namespace/class ::CmdWebBrowserSetURL
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Gui/FreeCAD.pro.
+/home/chennes/FreeCAD-chennes/src/Gui/Selection.h:192: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/BlenderNavigationStyle.cpp:66: Class 'Gui::BlenderNavigationStyle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/CADNavigationStyle.cpp:66: Class 'Gui::CADNavigationStyle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:96: Qualifying with unknown namespace/class ::StdCmdOpen
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:111: Qualifying with unknown namespace/class ::StdCmdOpen
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:187: Qualifying with unknown namespace/class ::StdCmdImport
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:201: Qualifying with unknown namespace/class ::StdCmdImport
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:273: Qualifying with unknown namespace/class ::StdCmdExport
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:414: Qualifying with unknown namespace/class ::StdCmdExport
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:520: Qualifying with unknown namespace/class ::StdCmdMergeProjects
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:533: Qualifying with unknown namespace/class ::StdCmdMergeProjects
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:573: Qualifying with unknown namespace/class ::StdCmdDependencyGraph
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:605: Qualifying with unknown namespace/class ::StdCmdNew
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:636: Qualifying with unknown namespace/class ::StdCmdSave
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:676: Qualifying with unknown namespace/class ::StdCmdSaveAs
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:716: Qualifying with unknown namespace/class ::StdCmdSaveCopy
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:749: Qualifying with unknown namespace/class ::StdCmdSaveAll
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:777: Qualifying with unknown namespace/class ::StdCmdRevert
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:816: Qualifying with unknown namespace/class ::StdCmdProjectInfo
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:847: Qualifying with unknown namespace/class ::StdCmdProjectUtil
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:874: Qualifying with unknown namespace/class ::StdCmdPrint
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:887: Qualifying with unknown namespace/class ::StdCmdPrint
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:906: Qualifying with unknown namespace/class ::StdCmdPrintPreview
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:936: Qualifying with unknown namespace/class ::StdCmdPrintPdf
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:948: Qualifying with unknown namespace/class ::StdCmdPrintPdf
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:968: Qualifying with unknown namespace/class ::StdCmdQuit
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:994: Qualifying with unknown namespace/class ::StdCmdUndo
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1038: Qualifying with unknown namespace/class ::StdCmdRedo
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1081: Qualifying with unknown namespace/class ::StdCmdCut
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1109: Qualifying with unknown namespace/class ::StdCmdCopy
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1144: Qualifying with unknown namespace/class ::StdCmdPaste
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1183: Qualifying with unknown namespace/class ::StdCmdDuplicateSelection
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1217: Qualifying with unknown namespace/class ::StdCmdDuplicateSelection
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1271: Qualifying with unknown namespace/class ::StdCmdSelectAll
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1302: Qualifying with unknown namespace/class ::StdCmdDelete
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1449: Qualifying with unknown namespace/class ::StdCmdDelete
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1475: Qualifying with unknown namespace/class ::StdCmdRefresh
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1503: Qualifying with unknown namespace/class ::StdCmdRefresh
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1529: Qualifying with unknown namespace/class ::StdCmdTransform
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1555: Qualifying with unknown namespace/class ::StdCmdPlacement
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1589: Qualifying with unknown namespace/class ::StdCmdTransformManip
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1623: Qualifying with unknown namespace/class ::StdCmdAlignment
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1693: Qualifying with unknown namespace/class ::StdCmdEdit
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1737: Class 'StdCmdExpression' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/CommandFeat.cpp:54: Qualifying with unknown namespace/class ::StdCmdFeatRecompute
+/home/chennes/FreeCAD-chennes/src/Gui/CommandFeat.cpp:77: Qualifying with unknown namespace/class ::StdCmdRandomColor
+/home/chennes/FreeCAD-chennes/src/Gui/CommandFeat.cpp:129: Qualifying with unknown namespace/class ::StdCmdSendToPythonConsole
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:80: Class 'StdCmdLinkMakeGroup' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:211: Qualifying with unknown namespace/class ::StdCmdLinkMake
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:260: Qualifying with unknown namespace/class ::StdCmdLinkMake
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:274: Qualifying with unknown namespace/class ::StdCmdLinkMakeRelative
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:335: Qualifying with unknown namespace/class ::StdCmdLinkMakeRelative
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:494: Qualifying with unknown namespace/class ::StdCmdLinkReplace
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:518: Qualifying with unknown namespace/class ::StdCmdLinkUnlink
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:542: Qualifying with unknown namespace/class ::StdCmdLinkImport
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:592: Qualifying with unknown namespace/class ::StdCmdLinkImport
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:606: Qualifying with unknown namespace/class ::StdCmdLinkImportAll
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:631: Qualifying with unknown namespace/class ::StdCmdLinkImportAll
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:647: Qualifying with unknown namespace/class ::StdCmdLinkSelectLinked
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:774: Qualifying with unknown namespace/class ::StdCmdLinkSelectLinkedFinal
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:808: Qualifying with unknown namespace/class ::StdCmdLinkSelectAllLinks
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:847: Class 'StdCmdLinkSelectActions' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:873: Class 'StdCmdLinkActions' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/CommandMacro.cpp:48: Qualifying with unknown namespace/class ::StdCmdDlgMacroRecord
+/home/chennes/FreeCAD-chennes/src/Gui/CommandMacro.cpp:77: Qualifying with unknown namespace/class ::StdCmdMacroStopRecord
+/home/chennes/FreeCAD-chennes/src/Gui/CommandMacro.cpp:105: Qualifying with unknown namespace/class ::StdCmdDlgMacroExecute
+/home/chennes/FreeCAD-chennes/src/Gui/CommandMacro.cpp:134: Qualifying with unknown namespace/class ::StdCmdDlgMacroExecuteDirect
+/home/chennes/FreeCAD-chennes/src/Gui/CommandMacro.cpp:160: Qualifying with unknown namespace/class ::StdCmdMacroAttachDebugger
+/home/chennes/FreeCAD-chennes/src/Gui/CommandMacro.cpp:185: Qualifying with unknown namespace/class ::StdCmdMacroStartDebug
+/home/chennes/FreeCAD-chennes/src/Gui/CommandMacro.cpp:215: Qualifying with unknown namespace/class ::StdCmdMacroStopDebug
+/home/chennes/FreeCAD-chennes/src/Gui/CommandMacro.cpp:242: Qualifying with unknown namespace/class ::StdCmdMacroStepOver
+/home/chennes/FreeCAD-chennes/src/Gui/CommandMacro.cpp:269: Qualifying with unknown namespace/class ::StdCmdMacroStepInto
+/home/chennes/FreeCAD-chennes/src/Gui/CommandMacro.cpp:296: Qualifying with unknown namespace/class ::StdCmdToggleBreakpoint
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:80: Qualifying with unknown namespace/class ::StdCmdWorkbench
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:109: Qualifying with unknown namespace/class ::StdCmdWorkbench
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:145: Qualifying with unknown namespace/class ::StdCmdRecentFiles
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:186: Qualifying with unknown namespace/class ::StdCmdRecentMacros
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:226: Qualifying with unknown namespace/class ::StdCmdAbout
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:292: Qualifying with unknown namespace/class ::StdCmdAboutQt
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:314: Qualifying with unknown namespace/class ::StdCmdWhatsThis
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:338: Qualifying with unknown namespace/class ::StdCmdDlgParameter
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:363: Qualifying with unknown namespace/class ::StdCmdDlgPreferences
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:395: Qualifying with unknown namespace/class ::StdCmdDlgCustomize
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:422: Qualifying with unknown namespace/class ::StdCmdCommandLine
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:470: Qualifying with unknown namespace/class ::StdCmdOnlineHelp
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:495: Qualifying with unknown namespace/class ::StdCmdOnlineHelpWebsite
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:522: Qualifying with unknown namespace/class ::StdCmdFreeCADDonation
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:549: Qualifying with unknown namespace/class ::StdCmdFreeCADWebsite
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:577: Qualifying with unknown namespace/class ::StdCmdFreeCADUserHub
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:605: Qualifying with unknown namespace/class ::StdCmdFreeCADPowerUserHub
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:633: Qualifying with unknown namespace/class ::StdCmdFreeCADForum
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:661: Qualifying with unknown namespace/class ::StdCmdFreeCADFAQ
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:689: Qualifying with unknown namespace/class ::StdCmdPythonWebsite
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:713: Qualifying with unknown namespace/class ::StdCmdMeasurementSimple
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:727: Qualifying with unknown namespace/class ::StdCmdMeasurementSimple
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:770: Qualifying with unknown namespace/class ::StdCmdTextDocument
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:803: Qualifying with unknown namespace/class ::StdCmdUnitsCalculator
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:839: Class 'StdCmdUserEditMode' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStructure.cpp:52: Qualifying with unknown namespace/class ::StdCmdPart
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStructure.cpp:93: Qualifying with unknown namespace/class ::StdCmdGroup
+/home/chennes/FreeCAD-chennes/src/Gui/CommandTest.cpp:714: Qualifying with unknown namespace/class ::CmdTestConsoleOutput
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:108: Qualifying with unknown namespace/class ::StdOrthographicCamera
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:158: Qualifying with unknown namespace/class ::StdPerspectiveCamera
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:218: Qualifying with unknown namespace/class ::StdCmdViewSaveCamera
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:244: Qualifying with unknown namespace/class ::StdCmdViewRestoreCamera
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:303: Class 'StdCmdFreezeViews' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:561: Qualifying with unknown namespace/class ::StdCmdToggleClipPlane
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:643: Class 'StdCmdDrawStyle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:862: Qualifying with unknown namespace/class ::StdCmdToggleVisibility
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:892: Qualifying with unknown namespace/class ::StdCmdToggleSelectability
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:939: Qualifying with unknown namespace/class ::StdCmdShowSelection
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:967: Qualifying with unknown namespace/class ::StdCmdHideSelection
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:995: Qualifying with unknown namespace/class ::StdCmdSelectVisibleObjects
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1037: Qualifying with unknown namespace/class ::StdCmdToggleObjects
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1078: Qualifying with unknown namespace/class ::StdCmdShowObjects
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1115: Qualifying with unknown namespace/class ::StdCmdHideObjects
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1152: Qualifying with unknown namespace/class ::StdCmdSetAppearance
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1195: Qualifying with unknown namespace/class ::StdCmdViewHome
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1223: Qualifying with unknown namespace/class ::StdCmdViewBottom
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1247: Qualifying with unknown namespace/class ::StdCmdViewFront
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1271: Qualifying with unknown namespace/class ::StdCmdViewLeft
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1295: Qualifying with unknown namespace/class ::StdCmdViewRear
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1319: Qualifying with unknown namespace/class ::StdCmdViewRight
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1343: Qualifying with unknown namespace/class ::StdCmdViewTop
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1367: Qualifying with unknown namespace/class ::StdCmdViewIsometric
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1391: Qualifying with unknown namespace/class ::StdCmdViewDimetric
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1414: Qualifying with unknown namespace/class ::StdCmdViewTrimetric
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1437: Qualifying with unknown namespace/class ::StdCmdViewRotateLeft
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1462: Qualifying with unknown namespace/class ::StdCmdViewRotateRight
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1487: Qualifying with unknown namespace/class ::StdCmdViewFitAll
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1518: Qualifying with unknown namespace/class ::StdCmdViewFitSelection
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1549: Qualifying with unknown namespace/class ::StdViewDock
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1578: Qualifying with unknown namespace/class ::StdViewUndock
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1607: Qualifying with unknown namespace/class ::StdMainFullscreen
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1639: Qualifying with unknown namespace/class ::StdViewFullscreen
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1669: Qualifying with unknown namespace/class ::StdViewDockUndockFullscreen
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1782: Qualifying with unknown namespace/class ::StdCmdViewVR
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1812: Qualifying with unknown namespace/class ::StdViewScreenShot
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1845: Qualifying with unknown namespace/class ::StdViewScreenShot
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1983: Qualifying with unknown namespace/class ::StdCmdViewCreate
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2012: Qualifying with unknown namespace/class ::StdCmdToggleNavigation
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2062: Class 'StdCmdAxisCross' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2196: Qualifying with unknown namespace/class ::StdCmdViewExample1
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2224: Qualifying with unknown namespace/class ::StdCmdViewExample2
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2252: Qualifying with unknown namespace/class ::StdCmdViewExample3
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2281: Qualifying with unknown namespace/class ::StdCmdViewIvStereoOff
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2310: Qualifying with unknown namespace/class ::StdCmdViewIvStereoRedGreen
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2338: Qualifying with unknown namespace/class ::StdCmdViewIvStereoQuadBuff
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2366: Qualifying with unknown namespace/class ::StdCmdViewIvStereoInterleavedRows
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2394: Qualifying with unknown namespace/class ::StdCmdViewIvStereoInterleavedColumns
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2423: Qualifying with unknown namespace/class ::StdCmdViewIvIssueCamPos
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2473: Qualifying with unknown namespace/class ::StdViewZoomIn
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2506: Qualifying with unknown namespace/class ::StdViewZoomOut
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2666: Qualifying with unknown namespace/class ::StdViewBoxZoom
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2736: Qualifying with unknown namespace/class ::StdBoxSelection
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2999: Qualifying with unknown namespace/class ::StdBoxElementSelection
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3040: Qualifying with unknown namespace/class ::StdTreeSelection
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3065: Qualifying with unknown namespace/class ::StdCmdTreeCollapse
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3090: Qualifying with unknown namespace/class ::StdCmdTreeExpand
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3115: Qualifying with unknown namespace/class ::StdCmdTreeSelectAllInstances
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3165: Qualifying with unknown namespace/class ::StdCmdMeasureDistance
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3256: Qualifying with unknown namespace/class ::StdCmdSceneInspector
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3289: Qualifying with unknown namespace/class ::StdCmdTextureMapping
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3316: Qualifying with unknown namespace/class ::StdCmdDemoMode
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3344: Qualifying with unknown namespace/class ::CmdViewMeasureClearAll
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3374: Qualifying with unknown namespace/class ::CmdViewMeasureToggleAll
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3403: Qualifying with unknown namespace/class ::StdCmdSelBack
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3433: Qualifying with unknown namespace/class ::StdCmdSelForward
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3483: Qualifying with unknown namespace/class ::StdTreeSingleDocument
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3500: Qualifying with unknown namespace/class ::StdTreeMultiDocument
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3517: Qualifying with unknown namespace/class ::StdTreeCollapseDocument
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3556: Qualifying with unknown namespace/class ::StdTreeSyncView
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3574: Qualifying with unknown namespace/class ::StdTreeSyncSelection
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3592: Qualifying with unknown namespace/class ::StdTreeSyncPlacement
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3610: Qualifying with unknown namespace/class ::StdTreePreSelection
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3628: Qualifying with unknown namespace/class ::StdTreeRecordSelection
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3646: Qualifying with unknown namespace/class ::StdTreeDrag
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3678: Class 'StdCmdTreeViewActions' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3715: Qualifying with unknown namespace/class ::StdCmdSelBoundingBox
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:55: Qualifying with unknown namespace/class ::StdCmdArrangeIcons
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:82: Qualifying with unknown namespace/class ::StdCmdTileWindows
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:110: Qualifying with unknown namespace/class ::StdCmdCascadeWindows
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:138: Qualifying with unknown namespace/class ::StdCmdCloseActiveWindow
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:170: Qualifying with unknown namespace/class ::StdCmdCloseAllWindows
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:198: Qualifying with unknown namespace/class ::StdCmdActivateNextWindow
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:227: Qualifying with unknown namespace/class ::StdCmdActivatePrevWindow
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:256: Qualifying with unknown namespace/class ::StdCmdWindows
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:280: Qualifying with unknown namespace/class ::StdCmdUserInterface
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:302: Qualifying with unknown namespace/class ::StdCmdDockViewMenu
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:338: Qualifying with unknown namespace/class ::StdCmdToolBarMenu
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:392: Qualifying with unknown namespace/class ::StdCmdStatusBar
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:438: Qualifying with unknown namespace/class ::StdCmdWindowsMenu
+/home/chennes/FreeCAD-chennes/src/Gui/DocumentModel.cpp:203: Class 'Gui::DocumentModel' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:95: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:222: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:238: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:341: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:482: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:524: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:571: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:618: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:666: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:752: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:802: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:855: Class 'Gui::GestureNavigationStyle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/InventorNavigationStyle.cpp:68: Class 'Gui::InventorNavigationStyle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/ManualAlignment.cpp:437: Class 'Gui::AlignmentView' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/MayaGestureNavigationStyle.cpp:107: Class 'Gui::MayaGestureNavigationStyle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/NaviCube.cpp:1695: Qualifying with unknown namespace/class ::ViewIsometricCmd
+/home/chennes/FreeCAD-chennes/src/Gui/NaviCube.cpp:1715: Qualifying with unknown namespace/class ::ViewOrthographicCmd
+/home/chennes/FreeCAD-chennes/src/Gui/NaviCube.cpp:1736: Qualifying with unknown namespace/class ::ViewPerspectiveCmd
+/home/chennes/FreeCAD-chennes/src/Gui/NaviCube.cpp:1757: Qualifying with unknown namespace/class ::ViewZoomToFitCmd
+/home/chennes/FreeCAD-chennes/src/Gui/OnlineDocumentation.cpp:367: Class 'Gui::StdCmdPythonHelp' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/OpenCascadeNavigationStyle.cpp:66: Class 'Gui::OpenCascadeNavigationStyle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/OpenSCADNavigationStyle.cpp:66: Class 'Gui::OpenSCADNavigationStyle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/RevitNavigationStyle.cpp:66: Class 'Gui::RevitNavigationStyle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/TinkerCADNavigationStyle.cpp:66: Class 'Gui::TinkerCADNavigationStyle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/TouchpadNavigationStyle.cpp:66: Class 'Gui::TouchpadNavigationStyle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/WhatsThis.cpp:46: Class 'Gui::StdCmdDescription' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/Widgets.cpp:1450: Class 'PropertyListDialog' lacks Q_OBJECT macro
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/AddonManager/AddonManager.pro.
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Arch/Arch.pro.
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Assembly/Assembly.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:36: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:37: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:42: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:46: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:47: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:48: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:52: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:56: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:57: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:58: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:62: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:66: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:67: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:71: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/distance.hpp:32: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/distance.hpp:77: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/distance.hpp:193: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/distance.hpp:317: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/distance.hpp:382: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/distance.hpp:553: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/distance.hpp:573: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/distance.hpp:616: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/distance.hpp:637: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/distance.hpp:696: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/parallel.hpp:166: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/parallel.hpp:207: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/parallel.hpp:262: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/parallel.hpp:322: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/parallel.hpp:337: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/parallel.hpp:340: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/parallel.hpp:380: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/angle.hpp:80: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/angle.hpp:121: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/angle.hpp:124: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/angle.hpp:138: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/angle.hpp:141: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/angle.hpp:155: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/imp/constraint3d_holder_imp.hpp:51: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/imp/constraint3d_holder_imp.hpp:60: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/moduleShape3d/distance.hpp:32: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/Command.cpp:52: Qualifying with unknown namespace/class ::CmdAssemblyAddNewPart
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/Command.cpp:73: Qualifying with unknown namespace/class ::CmdAssemblyAddNewPart
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/Command.cpp:108: Qualifying with unknown namespace/class ::CmdAssemblyAddNewComponent
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/Command.cpp:129: Qualifying with unknown namespace/class ::CmdAssemblyAddNewComponent
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/Command.cpp:154: Qualifying with unknown namespace/class ::CmdAssemblyAddExistingComponent
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/Command.cpp:175: Qualifying with unknown namespace/class ::CmdAssemblyAddExistingComponent
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/Command.cpp:217: Qualifying with unknown namespace/class ::CmdAssemblyImport
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/CommandConstraints.cpp:118: Qualifying with unknown namespace/class ::CmdAssemblyConstraint
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/CommandConstraints.cpp:202: Qualifying with unknown namespace/class ::CmdAssemblyConstraintDistance
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/CommandConstraints.cpp:269: Qualifying with unknown namespace/class ::CmdAssemblyConstraintFix
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/CommandConstraints.cpp:334: Qualifying with unknown namespace/class ::CmdAssemblyConstraintAngle
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/CommandConstraints.cpp:403: Qualifying with unknown namespace/class ::CmdAssemblyConstraintOrientation
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/CommandConstraints.cpp:471: Qualifying with unknown namespace/class ::CmdAssemblyConstraintCoincidence
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/CommandConstraints.cpp:539: Qualifying with unknown namespace/class ::CmdAssemblyConstraintAlignment
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/Workbench.cpp:94: Class 'AssemblyGui::Workbench' lacks Q_OBJECT macro
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Draft/Draft.pro.
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Drawing/Drawing.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/TaskOrthoViews.h:162: Discarding unconsumed meta data
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:60: Qualifying with unknown namespace/class ::CmdDrawingOpen
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:72: Qualifying with unknown namespace/class ::CmdDrawingOpen
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:93: Qualifying with unknown namespace/class ::CmdDrawingNewPage
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:271: Qualifying with unknown namespace/class ::CmdDrawingNewA3Landscape
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:310: Qualifying with unknown namespace/class ::CmdDrawingNewView
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:323: Qualifying with unknown namespace/class ::CmdDrawingNewView
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:389: Qualifying with unknown namespace/class ::CmdDrawingOrthoViews
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:402: Qualifying with unknown namespace/class ::CmdDrawingOrthoViews
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:439: Qualifying with unknown namespace/class ::CmdDrawingOpenBrowserView
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:452: Qualifying with unknown namespace/class ::CmdDrawingOpenBrowserView
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:477: Qualifying with unknown namespace/class ::CmdDrawingAnnotation
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:492: Qualifying with unknown namespace/class ::CmdDrawingAnnotation
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:525: Qualifying with unknown namespace/class ::CmdDrawingClip
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:540: Qualifying with unknown namespace/class ::CmdDrawingClip
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:570: Qualifying with unknown namespace/class ::CmdDrawingSymbol
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:585: Qualifying with unknown namespace/class ::CmdDrawingSymbol
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:627: Qualifying with unknown namespace/class ::CmdDrawingExportPage
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:640: Qualifying with unknown namespace/class ::CmdDrawingExportPage
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:680: Qualifying with unknown namespace/class ::CmdDrawingProjectShape
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:716: Qualifying with unknown namespace/class ::CmdDrawingDraftView
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:747: Qualifying with unknown namespace/class ::CmdDrawingSpreadsheetView
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:760: Qualifying with unknown namespace/class ::CmdDrawingSpreadsheetView
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Fem/Fem.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:295: Qualifying with unknown namespace/class ::CmdFemConstraintBearing
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:336: Qualifying with unknown namespace/class ::CmdFemConstraintContact
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:381: Qualifying with unknown namespace/class ::CmdFemConstraintDisplacement
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:424: Qualifying with unknown namespace/class ::CmdFemConstraintFixed
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:466: Qualifying with unknown namespace/class ::CmdFemConstraintFluidBoundary
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:509: Qualifying with unknown namespace/class ::CmdFemConstraintForce
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:553: Qualifying with unknown namespace/class ::CmdFemConstraintGear
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:594: Qualifying with unknown namespace/class ::CmdFemConstraintHeatflux
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:639: Qualifying with unknown namespace/class ::CmdFemConstraintInitialTemperature
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:682: Qualifying with unknown namespace/class ::CmdFemConstraintPlaneRotation
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:724: Qualifying with unknown namespace/class ::CmdFemConstraintPressure
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:769: Qualifying with unknown namespace/class ::CmdFemConstraintSpring
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:814: Qualifying with unknown namespace/class ::CmdFemConstraintPulley
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:860: Qualifying with unknown namespace/class ::CmdFemConstraintTemperature
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:903: Qualifying with unknown namespace/class ::CmdFemConstraintTransform
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1039: Qualifying with unknown namespace/class ::CmdFemDefineNodesSet
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1095: Qualifying with unknown namespace/class ::CmdFemCreateNodesSet
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1251: Qualifying with unknown namespace/class ::CmdFemPostClipFilter
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1277: Qualifying with unknown namespace/class ::CmdFemPostCutFilter
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1303: Qualifying with unknown namespace/class ::CmdFemPostDataAlongLineFilter
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1329: Qualifying with unknown namespace/class ::CmdFemPostDataAtPointFilter
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1357: Qualifying with unknown namespace/class ::CmdFemPostLinearizedStressesFilter
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1414: Qualifying with unknown namespace/class ::CmdFemPostScalarClipFilter
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1440: Qualifying with unknown namespace/class ::CmdFemPostWarpVectorFilter
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1466: Qualifying with unknown namespace/class ::CmdFemPostFunctions
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1606: Qualifying with unknown namespace/class ::CmdFemPostApllyChanges
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1651: Qualifying with unknown namespace/class ::CmdFemPostPipelineFromResult
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/ViewProviderFemConstraintDisplacement.cpp:145: Unbalanced opening parenthesis in C++ code (or abuse of the C++ preprocessor)
+resulttools.py: Unbalanced parentheses in Python code
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Image/Image.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Image/Gui/Command.cpp:54: Qualifying with unknown namespace/class ::CmdImageOpen
+/home/chennes/FreeCAD-chennes/src/Mod/Image/Gui/Command.cpp:69: Qualifying with unknown namespace/class ::CmdImageOpen
+/home/chennes/FreeCAD-chennes/src/Mod/Image/Gui/Command.cpp:99: Qualifying with unknown namespace/class ::CmdCreateImagePlane
+/home/chennes/FreeCAD-chennes/src/Mod/Image/Gui/Command.cpp:113: Qualifying with unknown namespace/class ::CmdCreateImagePlane
+/home/chennes/FreeCAD-chennes/src/Mod/Image/Gui/Command.cpp:173: Qualifying with unknown namespace/class ::CmdImageScaling
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Mesh/Mesh.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:94: Qualifying with unknown namespace/class ::CmdMeshTransform
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:133: Qualifying with unknown namespace/class ::CmdMeshDemolding
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:172: Qualifying with unknown namespace/class ::CmdMeshToolMesh
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:227: Qualifying with unknown namespace/class ::CmdMeshUnion
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:298: Qualifying with unknown namespace/class ::CmdMeshDifference
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:369: Qualifying with unknown namespace/class ::CmdMeshIntersection
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:440: Qualifying with unknown namespace/class ::CmdMeshImport
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:452: Qualifying with unknown namespace/class ::CmdMeshImport
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:491: Qualifying with unknown namespace/class ::CmdMeshExport
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:510: Qualifying with unknown namespace/class ::CmdMeshExport
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:566: Qualifying with unknown namespace/class ::CmdMeshFromGeometry
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:576: Qualifying with unknown namespace/class ::CmdMeshFromGeometry
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:624: Qualifying with unknown namespace/class ::CmdMeshFromPartShape
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:650: Qualifying with unknown namespace/class ::CmdMeshVertexCurvature
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:693: Qualifying with unknown namespace/class ::CmdMeshVertexCurvatureInfo
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:739: Qualifying with unknown namespace/class ::CmdMeshPolySegm
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:795: Qualifying with unknown namespace/class ::CmdMeshPolySelect
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:848: Qualifying with unknown namespace/class ::CmdMeshAddFacet
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:895: Qualifying with unknown namespace/class ::CmdMeshPolyCut
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:956: Qualifying with unknown namespace/class ::CmdMeshPolyTrim
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1017: Qualifying with unknown namespace/class ::CmdMeshTrimByPlane
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1046: Qualifying with unknown namespace/class ::CmdMeshSectionByPlane
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1075: Qualifying with unknown namespace/class ::CmdMeshCrossSections
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1101: Qualifying with unknown namespace/class ::CmdMeshPolySplit
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1155: Qualifying with unknown namespace/class ::CmdMeshEvaluation
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1198: Qualifying with unknown namespace/class ::CmdMeshEvaluateFacet
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1241: Qualifying with unknown namespace/class ::CmdMeshRemoveComponents
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1286: Qualifying with unknown namespace/class ::CmdMeshRemeshGmsh
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1319: Qualifying with unknown namespace/class ::CmdMeshRemoveCompByHand
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1363: Qualifying with unknown namespace/class ::CmdMeshEvaluateSolid
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1378: Qualifying with unknown namespace/class ::CmdMeshEvaluateSolid
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1401: Qualifying with unknown namespace/class ::CmdMeshSmoothing
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1464: Qualifying with unknown namespace/class ::CmdMeshDecimating
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1495: Qualifying with unknown namespace/class ::CmdMeshHarmonizeNormals
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1529: Qualifying with unknown namespace/class ::CmdMeshFlipNormals
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1563: Qualifying with unknown namespace/class ::CmdMeshBoundingBox
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1586: Qualifying with unknown namespace/class ::CmdMeshBoundingBox
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1605: Qualifying with unknown namespace/class ::CmdMeshBuildRegularSolid
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1636: Qualifying with unknown namespace/class ::CmdMeshFillupHoles
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1648: Qualifying with unknown namespace/class ::CmdMeshFillupHoles
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1674: Qualifying with unknown namespace/class ::CmdMeshFillInteractiveHole
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1716: Qualifying with unknown namespace/class ::CmdMeshSegmentation
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1752: Qualifying with unknown namespace/class ::CmdMeshSegmentationBestFit
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1788: Qualifying with unknown namespace/class ::CmdMeshMerge
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1831: Qualifying with unknown namespace/class ::CmdMeshSplitComponents
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1877: Qualifying with unknown namespace/class ::CmdMeshScale
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1892: Qualifying with unknown namespace/class ::CmdMeshScale
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/MeshPart/MeshPart.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/MeshPart/Gui/Command.cpp:59: Qualifying with unknown namespace/class ::CmdMeshPartMesher
+/home/chennes/FreeCAD-chennes/src/Mod/MeshPart/Gui/Command.cpp:84: Qualifying with unknown namespace/class ::CmdMeshPartTrimByPlane
+/home/chennes/FreeCAD-chennes/src/Mod/MeshPart/Gui/Command.cpp:192: Qualifying with unknown namespace/class ::CmdMeshPartSection
+/home/chennes/FreeCAD-chennes/src/Mod/MeshPart/Gui/Command.cpp:276: Qualifying with unknown namespace/class ::CmdMeshPartCrossSections
+/home/chennes/FreeCAD-chennes/src/Mod/MeshPart/Gui/Command.cpp:312: Qualifying with unknown namespace/class ::CmdMeshPartCurveOnMesh
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/OpenSCAD/OpenSCAD.pro.
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/PartDesign/PartDesign.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/App/FeatureGroove.cpp:113: Class 'PartDesign::Groove' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/App/FeatureHole.cpp:1654: Class 'PartDesign::Hole' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/App/FeaturePocket.cpp:118: Class 'PartDesign::Pocket' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:167: Qualifying with unknown namespace/class ::CmdPartDesignPlane
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:195: Qualifying with unknown namespace/class ::CmdPartDesignLine
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:223: Qualifying with unknown namespace/class ::CmdPartDesignPoint
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:251: Qualifying with unknown namespace/class ::CmdPartDesignCS
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:283: Qualifying with unknown namespace/class ::CmdPartDesignShapeBinder
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:348: Qualifying with unknown namespace/class ::CmdPartDesignSubShapeBinder
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:412: Qualifying with unknown namespace/class ::CmdPartDesignSubShapeBinder
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:431: Qualifying with unknown namespace/class ::CmdPartDesignClone
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:489: Qualifying with unknown namespace/class ::CmdPartDesignNewSketch
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:594: Qualifying with unknown namespace/class ::CmdPartDesignNewSketch
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1309: Qualifying with unknown namespace/class ::CmdPartDesignPad
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1341: Qualifying with unknown namespace/class ::CmdPartDesignPocket
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1373: Qualifying with unknown namespace/class ::CmdPartDesignHole
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1419: Qualifying with unknown namespace/class ::CmdPartDesignRevolution
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1477: Qualifying with unknown namespace/class ::CmdPartDesignGroove
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1543: Qualifying with unknown namespace/class ::CmdPartDesignAdditivePipe
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1593: Qualifying with unknown namespace/class ::CmdPartDesignSubtractivePipe
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1643: Qualifying with unknown namespace/class ::CmdPartDesignAdditiveLoft
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1693: Qualifying with unknown namespace/class ::CmdPartDesignSubtractiveLoft
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1742: Qualifying with unknown namespace/class ::CmdPartDesignAdditiveHelix
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1812: Qualifying with unknown namespace/class ::CmdPartDesignSubtractiveHelix
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1991: Qualifying with unknown namespace/class ::CmdPartDesignFillet
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:2019: Qualifying with unknown namespace/class ::CmdPartDesignChamfer
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:2048: Qualifying with unknown namespace/class ::CmdPartDesignDraft
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:2105: Qualifying with unknown namespace/class ::CmdPartDesignThickness
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:2253: Qualifying with unknown namespace/class ::CmdPartDesignMirrored
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:2315: Qualifying with unknown namespace/class ::CmdPartDesignLinearPattern
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:2379: Qualifying with unknown namespace/class ::CmdPartDesignPolarPattern
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:2444: Qualifying with unknown namespace/class ::CmdPartDesignScaled
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:2493: Qualifying with unknown namespace/class ::CmdPartDesignMultiTransform
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:2616: Qualifying with unknown namespace/class ::CmdPartDesignBoolean
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandBody.cpp:89: Qualifying with unknown namespace/class ::CmdPartDesignBody
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandBody.cpp:119: Qualifying with unknown namespace/class ::CmdPartDesignBody
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandBody.cpp:312: Qualifying with unknown namespace/class ::CmdPartDesignMigrate
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandBody.cpp:343: Qualifying with unknown namespace/class ::CmdPartDesignMigrate
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandBody.cpp:527: Qualifying with unknown namespace/class ::CmdPartDesignMoveTip
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandBody.cpp:555: Qualifying with unknown namespace/class ::CmdPartDesignMoveTip
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandBody.cpp:606: Qualifying with unknown namespace/class ::CmdPartDesignDuplicateSelection
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandBody.cpp:662: Qualifying with unknown namespace/class ::CmdPartDesignMoveFeature
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandBody.cpp:680: Qualifying with unknown namespace/class ::CmdPartDesignMoveFeature
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandBody.cpp:824: Qualifying with unknown namespace/class ::CmdPartDesignMoveFeatureInTree
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandBody.cpp:851: Qualifying with unknown namespace/class ::CmdPartDesignMoveFeatureInTree
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandPrimitive.cpp:69: Qualifying with unknown namespace/class ::CmdPrimtiveCompAdditive
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandPrimitive.cpp:243: Qualifying with unknown namespace/class ::CmdPrimtiveCompSubtractive
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandPrimitive.cpp:269: Qualifying with unknown namespace/class ::CmdPrimtiveCompSubtractive
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/FeaturePickDialog.cpp:45: Qualifying with unknown namespace/class ::FeaturePickDialog
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/ReferenceSelection.cpp:271: Class 'PartDesignGui::NoDependentsSelection' lacks Q_OBJECT macro
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Part/Part.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:90: Qualifying with unknown namespace/class ::CmdPartPickCurveNet
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:136: Qualifying with unknown namespace/class ::CmdPartBox2
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:177: Qualifying with unknown namespace/class ::CmdPartBox3
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:218: Qualifying with unknown namespace/class ::CmdPartPrimitives
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:272: Qualifying with unknown namespace/class ::CmdPartCut
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:286: Qualifying with unknown namespace/class ::CmdPartCut
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:350: Qualifying with unknown namespace/class ::CmdPartCommon
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:381: Qualifying with unknown namespace/class ::CmdPartCommon
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:450: Qualifying with unknown namespace/class ::CmdPartFuse
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:481: Qualifying with unknown namespace/class ::CmdPartFuse
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:551: Qualifying with unknown namespace/class ::CmdPartCompJoinFeatures
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:657: Qualifying with unknown namespace/class ::CmdPartCompSplitFeatures
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:779: Qualifying with unknown namespace/class ::CmdPartCompCompoundTools
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:886: Qualifying with unknown namespace/class ::CmdPartCompound
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:900: Qualifying with unknown namespace/class ::CmdPartCompound
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:943: Qualifying with unknown namespace/class ::CmdPartSection
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:957: Qualifying with unknown namespace/class ::CmdPartSection
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:991: Qualifying with unknown namespace/class ::CmdPartImport
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1053: Qualifying with unknown namespace/class ::CmdPartExport
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1100: Qualifying with unknown namespace/class ::CmdPartImportCurveNet
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1113: Qualifying with unknown namespace/class ::CmdPartImportCurveNet
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1148: Qualifying with unknown namespace/class ::CmdPartMakeSolid
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1227: Qualifying with unknown namespace/class ::CmdPartReverseShape
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1290: Qualifying with unknown namespace/class ::CmdPartBoolean
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1321: Qualifying with unknown namespace/class ::CmdPartExtrude
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1349: Qualifying with unknown namespace/class ::CmdPartMakeFace
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1401: Qualifying with unknown namespace/class ::CmdPartRevolve
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1429: Qualifying with unknown namespace/class ::CmdPartFillet
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1457: Qualifying with unknown namespace/class ::CmdPartChamfer
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1485: Qualifying with unknown namespace/class ::CmdPartMirror
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1513: Qualifying with unknown namespace/class ::CmdPartCrossSections
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1553: Qualifying with unknown namespace/class ::CmdPartBuilder
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1582: Qualifying with unknown namespace/class ::CmdPartLoft
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1611: Qualifying with unknown namespace/class ::CmdPartSweep
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1640: Qualifying with unknown namespace/class ::CmdPartOffset
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1692: Qualifying with unknown namespace/class ::CmdPartOffset2D
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1743: Qualifying with unknown namespace/class ::CmdPartCompOffset
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1836: Qualifying with unknown namespace/class ::CmdPartThickness
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2011: Qualifying with unknown namespace/class ::CmdPartRuledSurface
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2097: Qualifying with unknown namespace/class ::CmdPartRuledSurface
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2127: Qualifying with unknown namespace/class ::CmdCheckGeometry
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2161: Qualifying with unknown namespace/class ::CmdColorPerFace
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2200: Qualifying with unknown namespace/class ::CmdMeasureLinear
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2231: Qualifying with unknown namespace/class ::CmdMeasureAngular
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2260: Qualifying with unknown namespace/class ::CmdMeasureRefresh
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2290: Qualifying with unknown namespace/class ::CmdMeasureClearAll
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2319: Qualifying with unknown namespace/class ::CmdMeasureToggleAll
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2356: Qualifying with unknown namespace/class ::CmdMeasureToggle3d
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2387: Qualifying with unknown namespace/class ::CmdMeasureToggleDelta
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2419: Qualifying with unknown namespace/class ::CmdBoxSelection
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2448: Qualifying with unknown namespace/class ::CmdPartProjectionOnSurface
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandParametric.cpp:66: Qualifying with unknown namespace/class ::CmdPartCylinder
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandParametric.cpp:108: Qualifying with unknown namespace/class ::CmdPartBox
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandParametric.cpp:150: Qualifying with unknown namespace/class ::CmdPartSphere
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandParametric.cpp:192: Qualifying with unknown namespace/class ::CmdPartCone
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandParametric.cpp:234: Qualifying with unknown namespace/class ::CmdPartTorus
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandSimple.cpp:58: Qualifying with unknown namespace/class ::CmdPartSimpleCylinder
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandSimple.cpp:108: Qualifying with unknown namespace/class ::CmdPartShapeFromMesh
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandSimple.cpp:137: Qualifying with unknown namespace/class ::CmdPartPointsFromMesh
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandSimple.cpp:187: Qualifying with unknown namespace/class ::CmdPartSimpleCopy
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandSimple.cpp:258: Qualifying with unknown namespace/class ::CmdPartTransformedCopy
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandSimple.cpp:286: Qualifying with unknown namespace/class ::CmdPartElementCopy
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandSimple.cpp:314: Qualifying with unknown namespace/class ::CmdPartRefineShape
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandSimple.cpp:374: Qualifying with unknown namespace/class ::CmdPartDefeaturing
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Path/Path.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Path/App/VoronoiPyImp.cpp:206: Parenthesis/brace mismatch between #if and #else branches; using #if branch
+/home/chennes/FreeCAD-chennes/src/Mod/Path/Gui/Command.cpp:55: Qualifying with unknown namespace/class ::CmdPathArea
+/home/chennes/FreeCAD-chennes/src/Mod/Path/Gui/Command.cpp:137: Qualifying with unknown namespace/class ::CmdPathAreaWorkplane
+/home/chennes/FreeCAD-chennes/src/Mod/Path/Gui/Command.cpp:227: Qualifying with unknown namespace/class ::CmdPathCompound
+/home/chennes/FreeCAD-chennes/src/Mod/Path/Gui/Command.cpp:279: Qualifying with unknown namespace/class ::CmdPathShape
+fanuc_post.py:107: Unterminated string
+rrf_post.py:214: Unterminated string
+linuxcnc_post.py:99: Unterminated string
+dynapath_post.py:143: Unterminated string
+jtech_post.py:104: Unterminated string
+marlin_post.py:209: Unterminated string
+centroid_post.py:116: Unterminated string
+fablin_post.py:88: Unterminated string
+mach3_mach4_post.py:98: Unterminated string
+grbl_post.py:80: Unterminated string
+uccnc_post.py:298: Unterminated string
+smoothie_post.py:108: Unterminated string
+opensbp_post.py:80: Unterminated string
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Points/Points.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Points/Gui/Command.cpp:68: Qualifying with unknown namespace/class ::CmdPointsImport
+/home/chennes/FreeCAD-chennes/src/Mod/Points/Gui/Command.cpp:82: Qualifying with unknown namespace/class ::CmdPointsImport
+/home/chennes/FreeCAD-chennes/src/Mod/Points/Gui/Command.cpp:113: Qualifying with unknown namespace/class ::CmdPointsExport
+/home/chennes/FreeCAD-chennes/src/Mod/Points/Gui/Command.cpp:130: Qualifying with unknown namespace/class ::CmdPointsExport
+/home/chennes/FreeCAD-chennes/src/Mod/Points/Gui/Command.cpp:153: Qualifying with unknown namespace/class ::CmdPointsTransform
+/home/chennes/FreeCAD-chennes/src/Mod/Points/Gui/Command.cpp:190: Qualifying with unknown namespace/class ::CmdPointsConvert
+/home/chennes/FreeCAD-chennes/src/Mod/Points/Gui/Command.cpp:209: Qualifying with unknown namespace/class ::CmdPointsConvert
+/home/chennes/FreeCAD-chennes/src/Mod/Points/Gui/Command.cpp:282: Qualifying with unknown namespace/class ::CmdPointsPolyCut
+/home/chennes/FreeCAD-chennes/src/Mod/Points/Gui/Command.cpp:327: Qualifying with unknown namespace/class ::CmdPointsMerge
+/home/chennes/FreeCAD-chennes/src/Mod/Points/Gui/Command.cpp:370: Qualifying with unknown namespace/class ::CmdPointsStructure
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Raytracing.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:84: Qualifying with unknown namespace/class ::CmdRaytracingWriteCamera
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:137: Qualifying with unknown namespace/class ::CmdRaytracingWriteCamera
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:177: Qualifying with unknown namespace/class ::CmdRaytracingWritePart
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:188: Qualifying with unknown namespace/class ::CmdRaytracingWritePart
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:223: Qualifying with unknown namespace/class ::CmdRaytracingWriteView
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:250: Qualifying with unknown namespace/class ::CmdRaytracingWriteView
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:320: Qualifying with unknown namespace/class ::CmdRaytracingNewPovrayProject
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:437: Qualifying with unknown namespace/class ::CmdRaytracingNewPartSegment
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:449: Qualifying with unknown namespace/class ::CmdRaytracingNewPartSegment
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:521: Qualifying with unknown namespace/class ::CmdRaytracingExportProject
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:536: Qualifying with unknown namespace/class ::CmdRaytracingExportProject
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:584: Qualifying with unknown namespace/class ::CmdRaytracingRender
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:600: Qualifying with unknown namespace/class ::CmdRaytracingRender
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:766: Qualifying with unknown namespace/class ::CmdRaytracingNewLuxProject
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:879: Qualifying with unknown namespace/class ::CmdRaytracingResetCamera
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:893: Qualifying with unknown namespace/class ::CmdRaytracingResetCamera
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/ReverseEngineering.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/Gui/Command.cpp:74: Qualifying with unknown namespace/class ::CmdApproxSurface
+/home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/Gui/Command.cpp:110: Qualifying with unknown namespace/class ::CmdApproxPlane
+/home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/Gui/Command.cpp:211: Qualifying with unknown namespace/class ::CmdApproxCylinder
+/home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/Gui/Command.cpp:277: Qualifying with unknown namespace/class ::CmdApproxSphere
+/home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/Gui/Command.cpp:324: Qualifying with unknown namespace/class ::CmdApproxPolynomial
+/home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/Gui/Command.cpp:379: Qualifying with unknown namespace/class ::CmdSegmentation
+/home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/Gui/Command.cpp:411: Qualifying with unknown namespace/class ::CmdSegmentationManual
+/home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/Gui/Command.cpp:440: Qualifying with unknown namespace/class ::CmdSegmentationFromComponents
+/home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/Gui/Command.cpp:490: Qualifying with unknown namespace/class ::CmdMeshBoundary
+/home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/Gui/Command.cpp:556: Qualifying with unknown namespace/class ::CmdPoissonReconstruction
+/home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/Gui/Command.cpp:590: Qualifying with unknown namespace/class ::CmdViewTriangulation
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Robot/Robot.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/Command.cpp:55: Qualifying with unknown namespace/class ::CmdRobotSetHomePos
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/Command.cpp:75: Qualifying with unknown namespace/class ::CmdRobotSetHomePos
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/Command.cpp:104: Qualifying with unknown namespace/class ::CmdRobotRestoreHomePos
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/Command.cpp:124: Qualifying with unknown namespace/class ::CmdRobotRestoreHomePos
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/Command.cpp:158: Qualifying with unknown namespace/class ::CmdRobotConstraintAxle
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/Command.cpp:199: Qualifying with unknown namespace/class ::CmdRobotSimulate
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/Command.cpp:224: Qualifying with unknown namespace/class ::CmdRobotSimulate
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandExport.cpp:50: Qualifying with unknown namespace/class ::CmdRobotExportKukaCompact
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandExport.cpp:65: Qualifying with unknown namespace/class ::CmdRobotExportKukaCompact
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandExport.cpp:112: Qualifying with unknown namespace/class ::CmdRobotExportKukaFull
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandExport.cpp:127: Qualifying with unknown namespace/class ::CmdRobotExportKukaFull
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandInsertRobot.cpp:51: Qualifying with unknown namespace/class ::CmdRobotInsertKukaIR500
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandInsertRobot.cpp:93: Qualifying with unknown namespace/class ::CmdRobotInsertKukaIR16
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandInsertRobot.cpp:134: Qualifying with unknown namespace/class ::CmdRobotInsertKukaIR210
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandInsertRobot.cpp:174: Qualifying with unknown namespace/class ::CmdRobotInsertKukaIR125
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandInsertRobot.cpp:215: Qualifying with unknown namespace/class ::CmdRobotAddToolShape
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandInsertRobot.cpp:234: Qualifying with unknown namespace/class ::CmdRobotAddToolShape
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:62: Qualifying with unknown namespace/class ::CmdRobotCreateTrajectory
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:95: Qualifying with unknown namespace/class ::CmdRobotInsertWaypoint
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:111: Qualifying with unknown namespace/class ::CmdRobotInsertWaypoint
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:152: Qualifying with unknown namespace/class ::CmdRobotInsertWaypointPreselect
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:167: Qualifying with unknown namespace/class ::CmdRobotInsertWaypointPreselect
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:216: Qualifying with unknown namespace/class ::CmdRobotSetDefaultOrientation
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:254: Qualifying with unknown namespace/class ::CmdRobotSetDefaultValues
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:268: Qualifying with unknown namespace/class ::CmdRobotSetDefaultValues
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:320: Qualifying with unknown namespace/class ::CmdRobotEdge2Trac
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:384: Qualifying with unknown namespace/class ::CmdRobotTrajectoryDressUp
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:412: Qualifying with unknown namespace/class ::CmdRobotTrajectoryDressUp
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:431: Qualifying with unknown namespace/class ::CmdRobotTrajectoryCompound
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Sketcher.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:143: Qualifying with unknown namespace/class ::CmdSketcherNewSketch
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:164: Qualifying with unknown namespace/class ::CmdSketcherNewSketch
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:266: Qualifying with unknown namespace/class ::CmdSketcherEditSketch
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:296: Qualifying with unknown namespace/class ::CmdSketcherLeaveSketch
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:340: Qualifying with unknown namespace/class ::CmdSketcherStopOperation
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:381: Qualifying with unknown namespace/class ::CmdSketcherReorientSketch
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:508: Qualifying with unknown namespace/class ::CmdSketcherMapSketch
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:562: Qualifying with unknown namespace/class ::CmdSketcherMapSketch
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:683: Qualifying with unknown namespace/class ::CmdSketcherViewSketch
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:723: Qualifying with unknown namespace/class ::CmdSketcherValidateSketch
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:761: Qualifying with unknown namespace/class ::CmdSketcherMirrorSketch
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:868: Qualifying with unknown namespace/class ::CmdSketcherMergeSketches
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:952: Qualifying with unknown namespace/class ::CmdSketcherViewSection
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandAlterGeometry.cpp:74: Qualifying with unknown namespace/class ::CmdSketcherToggleConstruction
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandAlterGeometry.cpp:123: Qualifying with unknown namespace/class ::CmdSketcherToggleConstruction
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:883: Class 'CmdSketcherConstrainHorizontal' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:1121: Class 'CmdSketcherConstrainVertical' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:1355: Class 'CmdSketcherConstrainLock' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:1581: Class 'CmdSketcherConstrainBlock' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:1896: Class 'CmdSketcherConstrainCoincident' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:2102: Class 'CmdSketcherConstrainDistance' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:2451: Class 'CmdSketcherConstrainPointOnObject' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:2699: Class 'CmdSketcherConstrainDistanceX' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:2953: Class 'CmdSketcherConstrainDistanceY' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:3199: Class 'CmdSketcherConstrainParallel' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:3349: Class 'CmdSketcherConstrainPerpendicular' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:3987: Class 'CmdSketcherConstrainTangent' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:4695: Class 'CmdSketcherConstrainRadius' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:4997: Class 'CmdSketcherConstrainDiameter' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:5273: Class 'CmdSketcherConstrainRadiam' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:5577: Qualifying with unknown namespace/class ::CmdSketcherCompConstrainRadDia
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:5721: Class 'CmdSketcherConstrainAngle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:6248: Class 'CmdSketcherConstrainEqual' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:6465: Class 'CmdSketcherConstrainSymmetric' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:6765: Qualifying with unknown namespace/class ::CmdSketcherConstrainSnellsLaw
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:6784: Qualifying with unknown namespace/class ::CmdSketcherConstrainSnellsLaw
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:6931: Qualifying with unknown namespace/class ::CmdSketcherConstrainInternalAlignment
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:6949: Qualifying with unknown namespace/class ::CmdSketcherConstrainInternalAlignment
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:7391: Qualifying with unknown namespace/class ::CmdSketcherToggleDrivingConstraint
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:7430: Qualifying with unknown namespace/class ::CmdSketcherToggleDrivingConstraint
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:7518: Qualifying with unknown namespace/class ::CmdSketcherToggleActiveConstraint
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:7543: Qualifying with unknown namespace/class ::CmdSketcherToggleActiveConstraint
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:344: Qualifying with unknown namespace/class ::CmdSketcherCreateLine
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:649: Qualifying with unknown namespace/class ::CmdSketcherCreateRectangle
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:690: Qualifying with unknown namespace/class ::CmdSketcherCreateRectangleCenter
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:1016: Qualifying with unknown namespace/class ::CmdSketcherCreateOblong
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:1059: Qualifying with unknown namespace/class ::CmdSketcherCompCreateRectangles
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:1815: Qualifying with unknown namespace/class ::CmdSketcherCreatePolyline
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:2059: Qualifying with unknown namespace/class ::CmdSketcherCreateArc
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:2329: Qualifying with unknown namespace/class ::CmdSketcherCreate3PointArc
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:2357: Qualifying with unknown namespace/class ::CmdSketcherCompCreateArc
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:2591: Qualifying with unknown namespace/class ::CmdSketcherCreateCircle
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:3387: Qualifying with unknown namespace/class ::CmdSketcherCreateEllipseByCenter
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:3418: Qualifying with unknown namespace/class ::CmdSketcherCreateEllipseBy3Points
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:3746: Qualifying with unknown namespace/class ::CmdSketcherCreateArcOfEllipse
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:4090: Qualifying with unknown namespace/class ::CmdSketcherCreateArcOfHyperbola
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:4389: Qualifying with unknown namespace/class ::CmdSketcherCreateArcOfParabola
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:4422: Qualifying with unknown namespace/class ::CmdSketcherCompCreateConic
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:4925: Qualifying with unknown namespace/class ::CmdSketcherCreateBSpline
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:4970: Qualifying with unknown namespace/class ::CmdSketcherCreatePeriodicBSpline
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:5002: Qualifying with unknown namespace/class ::CmdSketcherCompCreateBSpline
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:5285: Qualifying with unknown namespace/class ::CmdSketcherCreate3PointCircle
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:5313: Qualifying with unknown namespace/class ::CmdSketcherCompCreateCircle
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:5493: Qualifying with unknown namespace/class ::CmdSketcherCreatePoint
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:5523: Qualifying with unknown namespace/class ::CmdSketcherCreateText
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:5551: Qualifying with unknown namespace/class ::CmdSketcherCreateDraftLine
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:5831: Qualifying with unknown namespace/class ::CmdSketcherCreateFillet
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:5860: Qualifying with unknown namespace/class ::CmdSketcherCreatePointFillet
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:5891: Qualifying with unknown namespace/class ::CmdSketcherCompCreateFillets
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:6121: Qualifying with unknown namespace/class ::CmdSketcherTrimming
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:6435: Qualifying with unknown namespace/class ::CmdSketcherExtend
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:6554: Qualifying with unknown namespace/class ::CmdSketcherSplit
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:6593: Class 'SketcherGui::ExternalSelection' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:6739: Qualifying with unknown namespace/class ::CmdSketcherExternal
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:6785: Class 'SketcherGui::CarbonCopySelection' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:6917: Qualifying with unknown namespace/class ::CmdSketcherCarbonCopy
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:7228: Qualifying with unknown namespace/class ::CmdSketcherCreateSlot
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:7421: Qualifying with unknown namespace/class ::CmdSketcherCreateTriangle
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:7448: Qualifying with unknown namespace/class ::CmdSketcherCreateSquare
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:7475: Qualifying with unknown namespace/class ::CmdSketcherCreatePentagon
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:7503: Qualifying with unknown namespace/class ::CmdSketcherCreateHexagon
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:7530: Qualifying with unknown namespace/class ::CmdSketcherCreateHeptagon
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:7557: Qualifying with unknown namespace/class ::CmdSketcherCreateOctagon
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:7584: Qualifying with unknown namespace/class ::CmdSketcherCreateRegularPolygon
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:7615: Qualifying with unknown namespace/class ::CmdSketcherCompCreateRegularPolygon
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:100: Qualifying with unknown namespace/class ::CmdSketcherBSplineDegree
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:129: Qualifying with unknown namespace/class ::CmdSketcherBSplinePolygon
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:158: Qualifying with unknown namespace/class ::CmdSketcherBSplineComb
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:187: Qualifying with unknown namespace/class ::CmdSketcherBSplineKnotMultiplicity
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:216: Qualifying with unknown namespace/class ::CmdSketcherBSplinePoleWeight
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:245: Qualifying with unknown namespace/class ::CmdSketcherCompBSplineShowHideGeometryInformation
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:374: Qualifying with unknown namespace/class ::CmdSketcherConvertToNURB
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:420: Qualifying with unknown namespace/class ::CmdSketcherConvertToNURB
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:442: Qualifying with unknown namespace/class ::CmdSketcherIncreaseDegree
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:491: Qualifying with unknown namespace/class ::CmdSketcherIncreaseDegree
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:515: Qualifying with unknown namespace/class ::CmdSketcherDecreaseDegree
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:569: Qualifying with unknown namespace/class ::CmdSketcherDecreaseDegree
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:592: Qualifying with unknown namespace/class ::CmdSketcherIncreaseKnotMultiplicity
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:607: Qualifying with unknown namespace/class ::CmdSketcherIncreaseKnotMultiplicity
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:746: Qualifying with unknown namespace/class ::CmdSketcherDecreaseKnotMultiplicity
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:761: Qualifying with unknown namespace/class ::CmdSketcherDecreaseKnotMultiplicity
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:888: Qualifying with unknown namespace/class ::CmdSketcherCompModifyKnotMultiplicity
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:981: Qualifying with unknown namespace/class ::CmdSketcherInsertKnot
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:996: Qualifying with unknown namespace/class ::CmdSketcherInsertKnot
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:105: Qualifying with unknown namespace/class ::CmdSketcherCloseShape
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:129: Qualifying with unknown namespace/class ::CmdSketcherCloseShape
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:217: Qualifying with unknown namespace/class ::CmdSketcherConnect
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:240: Qualifying with unknown namespace/class ::CmdSketcherConnect
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:304: Qualifying with unknown namespace/class ::CmdSketcherSelectConstraints
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:327: Qualifying with unknown namespace/class ::CmdSketcherSelectConstraints
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:381: Qualifying with unknown namespace/class ::CmdSketcherSelectOrigin
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:427: Qualifying with unknown namespace/class ::CmdSketcherSelectVerticalAxis
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:471: Qualifying with unknown namespace/class ::CmdSketcherSelectHorizontalAxis
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:514: Qualifying with unknown namespace/class ::CmdSketcherSelectRedundantConstraints
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:571: Qualifying with unknown namespace/class ::CmdSketcherSelectMalformedConstraints
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:627: Qualifying with unknown namespace/class ::CmdSketcherSelectPartiallyRedundantConstraints
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:683: Qualifying with unknown namespace/class ::CmdSketcherSelectConflictingConstraints
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:738: Qualifying with unknown namespace/class ::CmdSketcherSelectElementsAssociatedWithConstraints
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:836: Qualifying with unknown namespace/class ::CmdSketcherSelectElementsAssociatedWithConstraints
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:859: Qualifying with unknown namespace/class ::CmdSketcherSelectElementsWithDoFs
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:950: Qualifying with unknown namespace/class ::CmdSketcherRestoreInternalAlignmentGeometry
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:974: Qualifying with unknown namespace/class ::CmdSketcherRestoreInternalAlignmentGeometry
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:1046: Qualifying with unknown namespace/class ::CmdSketcherSymmetry
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:1069: Qualifying with unknown namespace/class ::CmdSketcherSymmetry
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:1581: Class 'CmdSketcherCopy' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:1627: Class 'CmdSketcherClone' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:1670: Class 'CmdSketcherMove' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:1704: Qualifying with unknown namespace/class ::CmdSketcherCompCopy
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:1986: Qualifying with unknown namespace/class ::CmdSketcherRectangularArray
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:2005: Qualifying with unknown namespace/class ::CmdSketcherRectangularArray
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:2126: Qualifying with unknown namespace/class ::CmdSketcherDeleteAllGeometry
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:2140: Qualifying with unknown namespace/class ::CmdSketcherDeleteAllGeometry
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:2189: Qualifying with unknown namespace/class ::CmdSketcherDeleteAllConstraints
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:2202: Qualifying with unknown namespace/class ::CmdSketcherDeleteAllConstraints
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:2253: Qualifying with unknown namespace/class ::CmdSketcherRemoveAxesAlignment
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:2272: Qualifying with unknown namespace/class ::CmdSketcherRemoveAxesAlignment
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherVirtualSpace.cpp:93: Qualifying with unknown namespace/class ::CmdSketcherSwitchVirtualSpace
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherVirtualSpace.cpp:115: Qualifying with unknown namespace/class ::CmdSketcherSwitchVirtualSpace
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Spreadsheet.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/AppSpreadsheetGui.cpp:87: Class 'SpreadsheetGui::Module' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:70: Qualifying with unknown namespace/class ::CmdSpreadsheetMergeCells
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:123: Qualifying with unknown namespace/class ::CmdSpreadsheetSplitCell
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:179: Qualifying with unknown namespace/class ::CmdSpreadsheetImport
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:191: Qualifying with unknown namespace/class ::CmdSpreadsheetImport
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:229: Qualifying with unknown namespace/class ::CmdSpreadsheetExport
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:247: Qualifying with unknown namespace/class ::CmdSpreadsheetExport
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:290: Qualifying with unknown namespace/class ::CmdSpreadsheetAlignLeft
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:342: Qualifying with unknown namespace/class ::CmdSpreadsheetAlignCenter
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:394: Qualifying with unknown namespace/class ::CmdSpreadsheetAlignRight
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:446: Qualifying with unknown namespace/class ::CmdSpreadsheetAlignTop
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:498: Qualifying with unknown namespace/class ::CmdSpreadsheetAlignBottom
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:550: Qualifying with unknown namespace/class ::CmdSpreadsheetAlignVCenter
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:602: Qualifying with unknown namespace/class ::CmdSpreadsheetStyleBold
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:676: Qualifying with unknown namespace/class ::CmdSpreadsheetStyleItalic
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:750: Qualifying with unknown namespace/class ::CmdSpreadsheetStyleUnderline
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:823: Qualifying with unknown namespace/class ::CmdSpreadsheetSetAlias
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:887: Qualifying with unknown namespace/class ::CmdCreateSpreadsheet
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Start/Start.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Start/Gui/Command.cpp:45: Qualifying with unknown namespace/class ::CmdStartPage
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/TechDraw/TechDraw.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:117: Qualifying with unknown namespace/class ::CmdTechDrawPageDefault
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:181: Qualifying with unknown namespace/class ::CmdTechDrawPageTemplate
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:195: Qualifying with unknown namespace/class ::CmdTechDrawPageTemplate
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:261: Qualifying with unknown namespace/class ::CmdTechDrawRedrawPage
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:298: Qualifying with unknown namespace/class ::CmdTechDrawView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:379: Qualifying with unknown namespace/class ::CmdTechDrawView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:442: Qualifying with unknown namespace/class ::CmdTechDrawActiveView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:476: Qualifying with unknown namespace/class ::CmdTechDrawSectionView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:494: Qualifying with unknown namespace/class ::CmdTechDrawSectionView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:526: Qualifying with unknown namespace/class ::CmdTechDrawDetailView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:545: Qualifying with unknown namespace/class ::CmdTechDrawDetailView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:575: Qualifying with unknown namespace/class ::CmdTechDrawProjectionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:655: Qualifying with unknown namespace/class ::CmdTechDrawProjectionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:855: Qualifying with unknown namespace/class ::CmdTechDrawBalloon
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:920: Qualifying with unknown namespace/class ::CmdTechDrawClipGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:959: Qualifying with unknown namespace/class ::CmdTechDrawClipGroupAdd
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:972: Qualifying with unknown namespace/class ::CmdTechDrawClipGroupAdd
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1043: Qualifying with unknown namespace/class ::CmdTechDrawClipGroupRemove
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1057: Qualifying with unknown namespace/class ::CmdTechDrawClipGroupRemove
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1118: Qualifying with unknown namespace/class ::CmdTechDrawSymbol
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1137: Qualifying with unknown namespace/class ::CmdTechDrawSymbol
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1173: Qualifying with unknown namespace/class ::CmdTechDrawDraftView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1194: Qualifying with unknown namespace/class ::CmdTechDrawDraftView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1239: Qualifying with unknown namespace/class ::CmdTechDrawArchView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1268: Qualifying with unknown namespace/class ::CmdTechDrawArchView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1304: Qualifying with unknown namespace/class ::CmdTechDrawSpreadsheetView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1317: Qualifying with unknown namespace/class ::CmdTechDrawSpreadsheetView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1363: Qualifying with unknown namespace/class ::CmdTechDrawExportPageSVG
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1388: Qualifying with unknown namespace/class ::CmdTechDrawExportPageSVG
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1408: Qualifying with unknown namespace/class ::CmdTechDrawExportPageDXF
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1428: Qualifying with unknown namespace/class ::CmdTechDrawExportPageDXF
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:101: Qualifying with unknown namespace/class ::CmdTechDrawLeaderLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:115: Qualifying with unknown namespace/class ::CmdTechDrawLeaderLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:163: Qualifying with unknown namespace/class ::CmdTechDrawRichTextAnnotation
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:176: Qualifying with unknown namespace/class ::CmdTechDrawRichTextAnnotation
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:215: Qualifying with unknown namespace/class ::CmdTechDrawCosmeticVertexGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:228: Qualifying with unknown namespace/class ::CmdTechDrawCosmeticVertexGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:404: Qualifying with unknown namespace/class ::CmdTechDrawCosmeticVertex
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:417: Qualifying with unknown namespace/class ::CmdTechDrawCosmeticVertex
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:465: Qualifying with unknown namespace/class ::CmdTechDrawMidpoints
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:478: Qualifying with unknown namespace/class ::CmdTechDrawMidpoints
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:504: Qualifying with unknown namespace/class ::CmdTechDrawQuadrants
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:517: Qualifying with unknown namespace/class ::CmdTechDrawQuadrants
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:543: Qualifying with unknown namespace/class ::CmdTechDrawAnnotation
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:583: Qualifying with unknown namespace/class ::CmdTechDrawCenterLineGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:596: Qualifying with unknown namespace/class ::CmdTechDrawCenterLineGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:686: Qualifying with unknown namespace/class ::CmdTechDrawFaceCenterLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:700: Qualifying with unknown namespace/class ::CmdTechDrawFaceCenterLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:796: Qualifying with unknown namespace/class ::CmdTechDraw2LineCenterLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:810: Qualifying with unknown namespace/class ::CmdTechDraw2LineCenterLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:873: Qualifying with unknown namespace/class ::CmdTechDraw2PointCenterLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:887: Qualifying with unknown namespace/class ::CmdTechDraw2PointCenterLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:986: Qualifying with unknown namespace/class ::CmdTechDraw2PointCosmeticLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:1000: Qualifying with unknown namespace/class ::CmdTechDraw2PointCosmeticLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:1138: Qualifying with unknown namespace/class ::CmdTechDrawCosmeticEraser
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:1151: Qualifying with unknown namespace/class ::CmdTechDrawCosmeticEraser
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:1265: Qualifying with unknown namespace/class ::CmdTechDrawDecorateLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:1279: Qualifying with unknown namespace/class ::CmdTechDrawDecorateLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:1344: Qualifying with unknown namespace/class ::CmdTechDrawShowAll
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:1357: Qualifying with unknown namespace/class ::CmdTechDrawShowAll
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:1409: Qualifying with unknown namespace/class ::CmdTechDrawWeldSymbol
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:1423: Qualifying with unknown namespace/class ::CmdTechDrawWeldSymbol
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:123: Qualifying with unknown namespace/class ::CmdTechDrawDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:250: Qualifying with unknown namespace/class ::CmdTechDrawRadiusDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:294: Qualifying with unknown namespace/class ::CmdTechDrawRadiusDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:372: Qualifying with unknown namespace/class ::CmdTechDrawDiameterDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:416: Qualifying with unknown namespace/class ::CmdTechDrawDiameterDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:493: Qualifying with unknown namespace/class ::CmdTechDrawLengthDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:547: Qualifying with unknown namespace/class ::CmdTechDrawLengthDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:595: Qualifying with unknown namespace/class ::CmdTechDrawHorizontalDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:650: Qualifying with unknown namespace/class ::CmdTechDrawHorizontalDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:698: Qualifying with unknown namespace/class ::CmdTechDrawVerticalDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:753: Qualifying with unknown namespace/class ::CmdTechDrawVerticalDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:800: Qualifying with unknown namespace/class ::CmdTechDrawAngleDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:845: Qualifying with unknown namespace/class ::CmdTechDrawAngleDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:888: Qualifying with unknown namespace/class ::CmdTechDraw3PtAngleDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:934: Qualifying with unknown namespace/class ::CmdTechDraw3PtAngleDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:980: Qualifying with unknown namespace/class ::CmdTechDrawLinkDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:1019: Qualifying with unknown namespace/class ::CmdTechDrawLinkDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:1058: Qualifying with unknown namespace/class ::CmdTechDrawExtentGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:1071: Qualifying with unknown namespace/class ::CmdTechDrawExtentGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:1151: Qualifying with unknown namespace/class ::CmdTechDrawHorizontalExtentDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:1165: Qualifying with unknown namespace/class ::CmdTechDrawHorizontalExtentDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:1238: Qualifying with unknown namespace/class ::CmdTechDrawVerticalExtentDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:1252: Qualifying with unknown namespace/class ::CmdTechDrawVerticalExtentDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:1321: Qualifying with unknown namespace/class ::CmdTechDrawLandmarkDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:1339: Qualifying with unknown namespace/class ::CmdTechDrawLandmarkDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandDecorate.cpp:87: Qualifying with unknown namespace/class ::CmdTechDrawHatch
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandDecorate.cpp:122: Qualifying with unknown namespace/class ::CmdTechDrawHatch
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandDecorate.cpp:208: Qualifying with unknown namespace/class ::CmdTechDrawGeometricHatch
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandDecorate.cpp:277: Qualifying with unknown namespace/class ::CmdTechDrawImage
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandDecorate.cpp:296: Qualifying with unknown namespace/class ::CmdTechDrawImage
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandDecorate.cpp:328: Qualifying with unknown namespace/class ::CmdTechDrawToggleFrame
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandDecorate.cpp:352: Qualifying with unknown namespace/class ::CmdTechDrawToggleFrame
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:145: Qualifying with unknown namespace/class ::CmdTechDrawExtensionInsertDiameter
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:178: Qualifying with unknown namespace/class ::CmdTechDrawExtensionInsertSquare
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:211: Qualifying with unknown namespace/class ::CmdTechDrawExtensionInsertPrefixGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:225: Qualifying with unknown namespace/class ::CmdTechDrawExtensionInsertPrefixGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:338: Qualifying with unknown namespace/class ::CmdTechDrawExtensionIncreaseDecimal
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:371: Qualifying with unknown namespace/class ::CmdTechDrawExtensionDecreaseDecimal
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:404: Qualifying with unknown namespace/class ::CmdTechDrawExtensionIncreaseDecreaseGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:418: Qualifying with unknown namespace/class ::CmdTechDrawExtensionIncreaseDecreaseGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:529: Qualifying with unknown namespace/class ::CmdTechDrawExtensionPosHorizChainDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:588: Qualifying with unknown namespace/class ::CmdTechDrawExtensionPosVertChainDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:653: Qualifying with unknown namespace/class ::CmdTechDrawExtensionPosObliqueChainDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:688: Qualifying with unknown namespace/class ::CmdTechDrawExtensionPosChainDimensionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:703: Qualifying with unknown namespace/class ::CmdTechDrawExtensionPosChainDimensionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:835: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCascadeHorizDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:899: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCascadeVertDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:972: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCascadeObliqueDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1008: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCascadeDimensionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1024: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCascadeDimensionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1162: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateHorizChainDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1228: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateVertChainDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1318: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateObliqueChainDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1352: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateChainDimensionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1366: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateChainDimensionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1505: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateHorizCoordDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1578: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateVertCoordDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1676: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateObliqueCoordDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1712: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateCoordDimensionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1728: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateCoordDimensionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1871: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateHorizChamferDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1940: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateVertChamferDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1973: Qualifying with unknown namespace/class ::CmdTechDrawExtensionChamferDimensionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1987: Qualifying with unknown namespace/class ::CmdTechDrawExtensionChamferDimensionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:2073: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateLengthArc
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:169: Qualifying with unknown namespace/class ::CmdTechDrawExtensionHoleCircle
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:243: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCircleCenterLines
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:277: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCircleCenterLinesGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:290: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCircleCenterLinesGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:395: Qualifying with unknown namespace/class ::CmdTechDrawExtensionThreadHoleSide
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:446: Qualifying with unknown namespace/class ::CmdTechDrawExtensionThreadBoltSide
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:497: Qualifying with unknown namespace/class ::CmdTechDrawExtensionThreadHoleBottom
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:548: Qualifying with unknown namespace/class ::CmdTechDrawExtensionThreadBoltBottom
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:582: Qualifying with unknown namespace/class ::CmdTechDrawExtensionThreadsGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:597: Qualifying with unknown namespace/class ::CmdTechDrawExtensionThreadsGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:715: Qualifying with unknown namespace/class ::CmdTechDrawExtensionSelectLineAttributes
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:749: Qualifying with unknown namespace/class ::CmdTechDrawExtensionChangeLineAttributes
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:808: Qualifying with unknown namespace/class ::CmdTechDrawExtensionVertexAtIntersection
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:898: Qualifying with unknown namespace/class ::CmdTechDrawExtensionDrawCosmArc
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:959: Qualifying with unknown namespace/class ::CmdTechDrawExtensionDrawCosmCircle
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:995: Qualifying with unknown namespace/class ::CmdTechDrawExtensionDrawCirclesGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1011: Qualifying with unknown namespace/class ::CmdTechDrawExtensionDrawCirclesGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1144: Qualifying with unknown namespace/class ::CmdTechDrawExtensionLineParallel
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1178: Qualifying with unknown namespace/class ::CmdTechDrawExtensionLinePerpendicular
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1212: Qualifying with unknown namespace/class ::CmdTechDrawExtensionLinePPGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1227: Qualifying with unknown namespace/class ::CmdTechDrawExtensionLinePPGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1315: Qualifying with unknown namespace/class ::CmdTechDrawExtensionLockUnlockView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1359: Qualifying with unknown namespace/class ::CmdTechDrawExtensionPositionSectionView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1376: Qualifying with unknown namespace/class ::CmdTechDrawExtensionPositionSectionView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1492: Qualifying with unknown namespace/class ::CmdTechDrawExtensionExtendLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1527: Qualifying with unknown namespace/class ::CmdTechDrawExtensionShortenLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1562: Qualifying with unknown namespace/class ::CmdTechDrawExtendShortenLineGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1577: Qualifying with unknown namespace/class ::CmdTechDrawExtendShortenLineGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/QGEPath.cpp:156: Discarding unconsumed meta data
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/QGIEdge.cpp:129: Discarding unconsumed meta data
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/QGIViewAnnotation.cpp:208: Class 'TechDrawGui::QGIViewAnnotation' lacks Q_OBJECT macro
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Test/Test.pro.
+Segmentation fault (core dumped)
+Cannot open Gui/Resources/translations/Testpy.ts: No such file or directory
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Tux/Tux.pro.
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Web/Web.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Web/Gui/Command.cpp:50: Qualifying with unknown namespace/class ::CmdWebOpenWebsite
+/home/chennes/FreeCAD-chennes/src/Mod/Web/Gui/Command.cpp:76: Qualifying with unknown namespace/class ::CmdWebBrowserBack
+/home/chennes/FreeCAD-chennes/src/Mod/Web/Gui/Command.cpp:105: Qualifying with unknown namespace/class ::CmdWebBrowserNext
+/home/chennes/FreeCAD-chennes/src/Mod/Web/Gui/Command.cpp:134: Qualifying with unknown namespace/class ::CmdWebBrowserRefresh
+/home/chennes/FreeCAD-chennes/src/Mod/Web/Gui/Command.cpp:162: Qualifying with unknown namespace/class ::CmdWebBrowserStop
+/home/chennes/FreeCAD-chennes/src/Mod/Web/Gui/Command.cpp:192: Qualifying with unknown namespace/class ::CmdWebBrowserZoomIn
+/home/chennes/FreeCAD-chennes/src/Mod/Web/Gui/Command.cpp:221: Qualifying with unknown namespace/class ::CmdWebBrowserZoomOut
+/home/chennes/FreeCAD-chennes/src/Mod/Web/Gui/Command.cpp:250: Qualifying with unknown namespace/class ::CmdWebBrowserSetURL
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Gui/FreeCAD.pro.
+/home/chennes/FreeCAD-chennes/src/Gui/Selection.h:192: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/BlenderNavigationStyle.cpp:66: Class 'Gui::BlenderNavigationStyle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/CADNavigationStyle.cpp:66: Class 'Gui::CADNavigationStyle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:96: Qualifying with unknown namespace/class ::StdCmdOpen
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:111: Qualifying with unknown namespace/class ::StdCmdOpen
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:187: Qualifying with unknown namespace/class ::StdCmdImport
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:201: Qualifying with unknown namespace/class ::StdCmdImport
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:273: Qualifying with unknown namespace/class ::StdCmdExport
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:414: Qualifying with unknown namespace/class ::StdCmdExport
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:520: Qualifying with unknown namespace/class ::StdCmdMergeProjects
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:533: Qualifying with unknown namespace/class ::StdCmdMergeProjects
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:573: Qualifying with unknown namespace/class ::StdCmdDependencyGraph
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:605: Qualifying with unknown namespace/class ::StdCmdNew
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:636: Qualifying with unknown namespace/class ::StdCmdSave
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:676: Qualifying with unknown namespace/class ::StdCmdSaveAs
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:716: Qualifying with unknown namespace/class ::StdCmdSaveCopy
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:749: Qualifying with unknown namespace/class ::StdCmdSaveAll
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:777: Qualifying with unknown namespace/class ::StdCmdRevert
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:816: Qualifying with unknown namespace/class ::StdCmdProjectInfo
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:847: Qualifying with unknown namespace/class ::StdCmdProjectUtil
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:874: Qualifying with unknown namespace/class ::StdCmdPrint
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:887: Qualifying with unknown namespace/class ::StdCmdPrint
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:906: Qualifying with unknown namespace/class ::StdCmdPrintPreview
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:936: Qualifying with unknown namespace/class ::StdCmdPrintPdf
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:948: Qualifying with unknown namespace/class ::StdCmdPrintPdf
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:968: Qualifying with unknown namespace/class ::StdCmdQuit
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:994: Qualifying with unknown namespace/class ::StdCmdUndo
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1038: Qualifying with unknown namespace/class ::StdCmdRedo
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1081: Qualifying with unknown namespace/class ::StdCmdCut
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1109: Qualifying with unknown namespace/class ::StdCmdCopy
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1144: Qualifying with unknown namespace/class ::StdCmdPaste
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1183: Qualifying with unknown namespace/class ::StdCmdDuplicateSelection
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1217: Qualifying with unknown namespace/class ::StdCmdDuplicateSelection
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1271: Qualifying with unknown namespace/class ::StdCmdSelectAll
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1302: Qualifying with unknown namespace/class ::StdCmdDelete
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1449: Qualifying with unknown namespace/class ::StdCmdDelete
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1475: Qualifying with unknown namespace/class ::StdCmdRefresh
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1503: Qualifying with unknown namespace/class ::StdCmdRefresh
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1529: Qualifying with unknown namespace/class ::StdCmdTransform
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1555: Qualifying with unknown namespace/class ::StdCmdPlacement
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1589: Qualifying with unknown namespace/class ::StdCmdTransformManip
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1623: Qualifying with unknown namespace/class ::StdCmdAlignment
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1693: Qualifying with unknown namespace/class ::StdCmdEdit
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1737: Class 'StdCmdExpression' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/CommandFeat.cpp:54: Qualifying with unknown namespace/class ::StdCmdFeatRecompute
+/home/chennes/FreeCAD-chennes/src/Gui/CommandFeat.cpp:77: Qualifying with unknown namespace/class ::StdCmdRandomColor
+/home/chennes/FreeCAD-chennes/src/Gui/CommandFeat.cpp:129: Qualifying with unknown namespace/class ::StdCmdSendToPythonConsole
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:80: Class 'StdCmdLinkMakeGroup' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:211: Qualifying with unknown namespace/class ::StdCmdLinkMake
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:260: Qualifying with unknown namespace/class ::StdCmdLinkMake
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:274: Qualifying with unknown namespace/class ::StdCmdLinkMakeRelative
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:335: Qualifying with unknown namespace/class ::StdCmdLinkMakeRelative
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:494: Qualifying with unknown namespace/class ::StdCmdLinkReplace
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:518: Qualifying with unknown namespace/class ::StdCmdLinkUnlink
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:542: Qualifying with unknown namespace/class ::StdCmdLinkImport
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:592: Qualifying with unknown namespace/class ::StdCmdLinkImport
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:606: Qualifying with unknown namespace/class ::StdCmdLinkImportAll
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:631: Qualifying with unknown namespace/class ::StdCmdLinkImportAll
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:647: Qualifying with unknown namespace/class ::StdCmdLinkSelectLinked
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:774: Qualifying with unknown namespace/class ::StdCmdLinkSelectLinkedFinal
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:808: Qualifying with unknown namespace/class ::StdCmdLinkSelectAllLinks
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:847: Class 'StdCmdLinkSelectActions' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:873: Class 'StdCmdLinkActions' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/CommandMacro.cpp:48: Qualifying with unknown namespace/class ::StdCmdDlgMacroRecord
+/home/chennes/FreeCAD-chennes/src/Gui/CommandMacro.cpp:77: Qualifying with unknown namespace/class ::StdCmdMacroStopRecord
+/home/chennes/FreeCAD-chennes/src/Gui/CommandMacro.cpp:105: Qualifying with unknown namespace/class ::StdCmdDlgMacroExecute
+/home/chennes/FreeCAD-chennes/src/Gui/CommandMacro.cpp:134: Qualifying with unknown namespace/class ::StdCmdDlgMacroExecuteDirect
+/home/chennes/FreeCAD-chennes/src/Gui/CommandMacro.cpp:160: Qualifying with unknown namespace/class ::StdCmdMacroAttachDebugger
+/home/chennes/FreeCAD-chennes/src/Gui/CommandMacro.cpp:185: Qualifying with unknown namespace/class ::StdCmdMacroStartDebug
+/home/chennes/FreeCAD-chennes/src/Gui/CommandMacro.cpp:215: Qualifying with unknown namespace/class ::StdCmdMacroStopDebug
+/home/chennes/FreeCAD-chennes/src/Gui/CommandMacro.cpp:242: Qualifying with unknown namespace/class ::StdCmdMacroStepOver
+/home/chennes/FreeCAD-chennes/src/Gui/CommandMacro.cpp:269: Qualifying with unknown namespace/class ::StdCmdMacroStepInto
+/home/chennes/FreeCAD-chennes/src/Gui/CommandMacro.cpp:296: Qualifying with unknown namespace/class ::StdCmdToggleBreakpoint
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:80: Qualifying with unknown namespace/class ::StdCmdWorkbench
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:109: Qualifying with unknown namespace/class ::StdCmdWorkbench
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:145: Qualifying with unknown namespace/class ::StdCmdRecentFiles
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:186: Qualifying with unknown namespace/class ::StdCmdRecentMacros
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:226: Qualifying with unknown namespace/class ::StdCmdAbout
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:292: Qualifying with unknown namespace/class ::StdCmdAboutQt
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:314: Qualifying with unknown namespace/class ::StdCmdWhatsThis
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:338: Qualifying with unknown namespace/class ::StdCmdDlgParameter
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:363: Qualifying with unknown namespace/class ::StdCmdDlgPreferences
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:395: Qualifying with unknown namespace/class ::StdCmdDlgCustomize
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:422: Qualifying with unknown namespace/class ::StdCmdCommandLine
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:470: Qualifying with unknown namespace/class ::StdCmdOnlineHelp
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:495: Qualifying with unknown namespace/class ::StdCmdOnlineHelpWebsite
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:522: Qualifying with unknown namespace/class ::StdCmdFreeCADDonation
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:549: Qualifying with unknown namespace/class ::StdCmdFreeCADWebsite
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:577: Qualifying with unknown namespace/class ::StdCmdFreeCADUserHub
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:605: Qualifying with unknown namespace/class ::StdCmdFreeCADPowerUserHub
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:633: Qualifying with unknown namespace/class ::StdCmdFreeCADForum
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:661: Qualifying with unknown namespace/class ::StdCmdFreeCADFAQ
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:689: Qualifying with unknown namespace/class ::StdCmdPythonWebsite
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:713: Qualifying with unknown namespace/class ::StdCmdMeasurementSimple
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:727: Qualifying with unknown namespace/class ::StdCmdMeasurementSimple
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:770: Qualifying with unknown namespace/class ::StdCmdTextDocument
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:803: Qualifying with unknown namespace/class ::StdCmdUnitsCalculator
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:839: Class 'StdCmdUserEditMode' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStructure.cpp:52: Qualifying with unknown namespace/class ::StdCmdPart
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStructure.cpp:93: Qualifying with unknown namespace/class ::StdCmdGroup
+/home/chennes/FreeCAD-chennes/src/Gui/CommandTest.cpp:714: Qualifying with unknown namespace/class ::CmdTestConsoleOutput
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:108: Qualifying with unknown namespace/class ::StdOrthographicCamera
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:158: Qualifying with unknown namespace/class ::StdPerspectiveCamera
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:218: Qualifying with unknown namespace/class ::StdCmdViewSaveCamera
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:244: Qualifying with unknown namespace/class ::StdCmdViewRestoreCamera
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:303: Class 'StdCmdFreezeViews' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:561: Qualifying with unknown namespace/class ::StdCmdToggleClipPlane
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:643: Class 'StdCmdDrawStyle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:862: Qualifying with unknown namespace/class ::StdCmdToggleVisibility
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:892: Qualifying with unknown namespace/class ::StdCmdToggleSelectability
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:939: Qualifying with unknown namespace/class ::StdCmdShowSelection
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:967: Qualifying with unknown namespace/class ::StdCmdHideSelection
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:995: Qualifying with unknown namespace/class ::StdCmdSelectVisibleObjects
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1037: Qualifying with unknown namespace/class ::StdCmdToggleObjects
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1078: Qualifying with unknown namespace/class ::StdCmdShowObjects
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1115: Qualifying with unknown namespace/class ::StdCmdHideObjects
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1152: Qualifying with unknown namespace/class ::StdCmdSetAppearance
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1195: Qualifying with unknown namespace/class ::StdCmdViewHome
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1223: Qualifying with unknown namespace/class ::StdCmdViewBottom
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1247: Qualifying with unknown namespace/class ::StdCmdViewFront
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1271: Qualifying with unknown namespace/class ::StdCmdViewLeft
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1295: Qualifying with unknown namespace/class ::StdCmdViewRear
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1319: Qualifying with unknown namespace/class ::StdCmdViewRight
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1343: Qualifying with unknown namespace/class ::StdCmdViewTop
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1367: Qualifying with unknown namespace/class ::StdCmdViewIsometric
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1391: Qualifying with unknown namespace/class ::StdCmdViewDimetric
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1414: Qualifying with unknown namespace/class ::StdCmdViewTrimetric
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1437: Qualifying with unknown namespace/class ::StdCmdViewRotateLeft
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1462: Qualifying with unknown namespace/class ::StdCmdViewRotateRight
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1487: Qualifying with unknown namespace/class ::StdCmdViewFitAll
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1518: Qualifying with unknown namespace/class ::StdCmdViewFitSelection
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1549: Qualifying with unknown namespace/class ::StdViewDock
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1578: Qualifying with unknown namespace/class ::StdViewUndock
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1607: Qualifying with unknown namespace/class ::StdMainFullscreen
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1639: Qualifying with unknown namespace/class ::StdViewFullscreen
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1669: Qualifying with unknown namespace/class ::StdViewDockUndockFullscreen
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1782: Qualifying with unknown namespace/class ::StdCmdViewVR
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1812: Qualifying with unknown namespace/class ::StdViewScreenShot
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1845: Qualifying with unknown namespace/class ::StdViewScreenShot
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1983: Qualifying with unknown namespace/class ::StdCmdViewCreate
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2012: Qualifying with unknown namespace/class ::StdCmdToggleNavigation
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2062: Class 'StdCmdAxisCross' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2196: Qualifying with unknown namespace/class ::StdCmdViewExample1
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2224: Qualifying with unknown namespace/class ::StdCmdViewExample2
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2252: Qualifying with unknown namespace/class ::StdCmdViewExample3
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2281: Qualifying with unknown namespace/class ::StdCmdViewIvStereoOff
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2310: Qualifying with unknown namespace/class ::StdCmdViewIvStereoRedGreen
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2338: Qualifying with unknown namespace/class ::StdCmdViewIvStereoQuadBuff
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2366: Qualifying with unknown namespace/class ::StdCmdViewIvStereoInterleavedRows
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2394: Qualifying with unknown namespace/class ::StdCmdViewIvStereoInterleavedColumns
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2423: Qualifying with unknown namespace/class ::StdCmdViewIvIssueCamPos
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2473: Qualifying with unknown namespace/class ::StdViewZoomIn
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2506: Qualifying with unknown namespace/class ::StdViewZoomOut
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2666: Qualifying with unknown namespace/class ::StdViewBoxZoom
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2736: Qualifying with unknown namespace/class ::StdBoxSelection
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2999: Qualifying with unknown namespace/class ::StdBoxElementSelection
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3040: Qualifying with unknown namespace/class ::StdTreeSelection
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3065: Qualifying with unknown namespace/class ::StdCmdTreeCollapse
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3090: Qualifying with unknown namespace/class ::StdCmdTreeExpand
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3115: Qualifying with unknown namespace/class ::StdCmdTreeSelectAllInstances
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3165: Qualifying with unknown namespace/class ::StdCmdMeasureDistance
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3256: Qualifying with unknown namespace/class ::StdCmdSceneInspector
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3289: Qualifying with unknown namespace/class ::StdCmdTextureMapping
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3316: Qualifying with unknown namespace/class ::StdCmdDemoMode
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3344: Qualifying with unknown namespace/class ::CmdViewMeasureClearAll
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3374: Qualifying with unknown namespace/class ::CmdViewMeasureToggleAll
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3403: Qualifying with unknown namespace/class ::StdCmdSelBack
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3433: Qualifying with unknown namespace/class ::StdCmdSelForward
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3483: Qualifying with unknown namespace/class ::StdTreeSingleDocument
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3500: Qualifying with unknown namespace/class ::StdTreeMultiDocument
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3517: Qualifying with unknown namespace/class ::StdTreeCollapseDocument
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3556: Qualifying with unknown namespace/class ::StdTreeSyncView
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3574: Qualifying with unknown namespace/class ::StdTreeSyncSelection
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3592: Qualifying with unknown namespace/class ::StdTreeSyncPlacement
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3610: Qualifying with unknown namespace/class ::StdTreePreSelection
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3628: Qualifying with unknown namespace/class ::StdTreeRecordSelection
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3646: Qualifying with unknown namespace/class ::StdTreeDrag
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3678: Class 'StdCmdTreeViewActions' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3715: Qualifying with unknown namespace/class ::StdCmdSelBoundingBox
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:55: Qualifying with unknown namespace/class ::StdCmdArrangeIcons
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:82: Qualifying with unknown namespace/class ::StdCmdTileWindows
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:110: Qualifying with unknown namespace/class ::StdCmdCascadeWindows
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:138: Qualifying with unknown namespace/class ::StdCmdCloseActiveWindow
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:170: Qualifying with unknown namespace/class ::StdCmdCloseAllWindows
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:198: Qualifying with unknown namespace/class ::StdCmdActivateNextWindow
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:227: Qualifying with unknown namespace/class ::StdCmdActivatePrevWindow
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:256: Qualifying with unknown namespace/class ::StdCmdWindows
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:280: Qualifying with unknown namespace/class ::StdCmdUserInterface
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:302: Qualifying with unknown namespace/class ::StdCmdDockViewMenu
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:338: Qualifying with unknown namespace/class ::StdCmdToolBarMenu
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:392: Qualifying with unknown namespace/class ::StdCmdStatusBar
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:438: Qualifying with unknown namespace/class ::StdCmdWindowsMenu
+/home/chennes/FreeCAD-chennes/src/Gui/DocumentModel.cpp:203: Class 'Gui::DocumentModel' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:95: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:222: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:238: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:341: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:482: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:524: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:571: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:618: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:666: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:752: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:802: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:855: Class 'Gui::GestureNavigationStyle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/InventorNavigationStyle.cpp:68: Class 'Gui::InventorNavigationStyle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/ManualAlignment.cpp:437: Class 'Gui::AlignmentView' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/MayaGestureNavigationStyle.cpp:107: Class 'Gui::MayaGestureNavigationStyle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/NaviCube.cpp:1695: Qualifying with unknown namespace/class ::ViewIsometricCmd
+/home/chennes/FreeCAD-chennes/src/Gui/NaviCube.cpp:1715: Qualifying with unknown namespace/class ::ViewOrthographicCmd
+/home/chennes/FreeCAD-chennes/src/Gui/NaviCube.cpp:1736: Qualifying with unknown namespace/class ::ViewPerspectiveCmd
+/home/chennes/FreeCAD-chennes/src/Gui/NaviCube.cpp:1757: Qualifying with unknown namespace/class ::ViewZoomToFitCmd
+/home/chennes/FreeCAD-chennes/src/Gui/OnlineDocumentation.cpp:367: Class 'Gui::StdCmdPythonHelp' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/OpenCascadeNavigationStyle.cpp:66: Class 'Gui::OpenCascadeNavigationStyle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/OpenSCADNavigationStyle.cpp:66: Class 'Gui::OpenSCADNavigationStyle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/RevitNavigationStyle.cpp:66: Class 'Gui::RevitNavigationStyle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/TinkerCADNavigationStyle.cpp:66: Class 'Gui::TinkerCADNavigationStyle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/TouchpadNavigationStyle.cpp:66: Class 'Gui::TouchpadNavigationStyle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/WhatsThis.cpp:46: Class 'Gui::StdCmdDescription' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/Widgets.cpp:1450: Class 'PropertyListDialog' lacks Q_OBJECT macro
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/AddonManager/AddonManager.pro.
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Arch/Arch.pro.
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Assembly/Assembly.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:36: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:37: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:42: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:46: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:47: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:48: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:52: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:56: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:57: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:58: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:62: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:66: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:67: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:71: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/distance.hpp:32: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/distance.hpp:77: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/distance.hpp:193: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/distance.hpp:317: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/distance.hpp:382: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/distance.hpp:553: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/distance.hpp:573: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/distance.hpp:616: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/distance.hpp:637: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/distance.hpp:696: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/parallel.hpp:166: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/parallel.hpp:207: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/parallel.hpp:262: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/parallel.hpp:322: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/parallel.hpp:337: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/parallel.hpp:340: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/parallel.hpp:380: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/angle.hpp:80: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/angle.hpp:121: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/angle.hpp:124: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/angle.hpp:138: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/angle.hpp:141: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/angle.hpp:155: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/imp/constraint3d_holder_imp.hpp:51: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/imp/constraint3d_holder_imp.hpp:60: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/moduleShape3d/distance.hpp:32: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/Command.cpp:52: Qualifying with unknown namespace/class ::CmdAssemblyAddNewPart
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/Command.cpp:73: Qualifying with unknown namespace/class ::CmdAssemblyAddNewPart
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/Command.cpp:108: Qualifying with unknown namespace/class ::CmdAssemblyAddNewComponent
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/Command.cpp:129: Qualifying with unknown namespace/class ::CmdAssemblyAddNewComponent
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/Command.cpp:154: Qualifying with unknown namespace/class ::CmdAssemblyAddExistingComponent
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/Command.cpp:175: Qualifying with unknown namespace/class ::CmdAssemblyAddExistingComponent
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/Command.cpp:217: Qualifying with unknown namespace/class ::CmdAssemblyImport
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/CommandConstraints.cpp:118: Qualifying with unknown namespace/class ::CmdAssemblyConstraint
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/CommandConstraints.cpp:202: Qualifying with unknown namespace/class ::CmdAssemblyConstraintDistance
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/CommandConstraints.cpp:269: Qualifying with unknown namespace/class ::CmdAssemblyConstraintFix
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/CommandConstraints.cpp:334: Qualifying with unknown namespace/class ::CmdAssemblyConstraintAngle
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/CommandConstraints.cpp:403: Qualifying with unknown namespace/class ::CmdAssemblyConstraintOrientation
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/CommandConstraints.cpp:471: Qualifying with unknown namespace/class ::CmdAssemblyConstraintCoincidence
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/CommandConstraints.cpp:539: Qualifying with unknown namespace/class ::CmdAssemblyConstraintAlignment
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/Workbench.cpp:94: Class 'AssemblyGui::Workbench' lacks Q_OBJECT macro
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Draft/Draft.pro.
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Drawing/Drawing.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/TaskOrthoViews.h:162: Discarding unconsumed meta data
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:60: Qualifying with unknown namespace/class ::CmdDrawingOpen
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:72: Qualifying with unknown namespace/class ::CmdDrawingOpen
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:93: Qualifying with unknown namespace/class ::CmdDrawingNewPage
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:271: Qualifying with unknown namespace/class ::CmdDrawingNewA3Landscape
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:310: Qualifying with unknown namespace/class ::CmdDrawingNewView
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:323: Qualifying with unknown namespace/class ::CmdDrawingNewView
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:389: Qualifying with unknown namespace/class ::CmdDrawingOrthoViews
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:402: Qualifying with unknown namespace/class ::CmdDrawingOrthoViews
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:439: Qualifying with unknown namespace/class ::CmdDrawingOpenBrowserView
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:452: Qualifying with unknown namespace/class ::CmdDrawingOpenBrowserView
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:477: Qualifying with unknown namespace/class ::CmdDrawingAnnotation
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:492: Qualifying with unknown namespace/class ::CmdDrawingAnnotation
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:525: Qualifying with unknown namespace/class ::CmdDrawingClip
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:540: Qualifying with unknown namespace/class ::CmdDrawingClip
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:570: Qualifying with unknown namespace/class ::CmdDrawingSymbol
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:585: Qualifying with unknown namespace/class ::CmdDrawingSymbol
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:627: Qualifying with unknown namespace/class ::CmdDrawingExportPage
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:640: Qualifying with unknown namespace/class ::CmdDrawingExportPage
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:680: Qualifying with unknown namespace/class ::CmdDrawingProjectShape
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:716: Qualifying with unknown namespace/class ::CmdDrawingDraftView
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:747: Qualifying with unknown namespace/class ::CmdDrawingSpreadsheetView
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:760: Qualifying with unknown namespace/class ::CmdDrawingSpreadsheetView
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Fem/Fem.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:295: Qualifying with unknown namespace/class ::CmdFemConstraintBearing
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:336: Qualifying with unknown namespace/class ::CmdFemConstraintContact
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:381: Qualifying with unknown namespace/class ::CmdFemConstraintDisplacement
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:424: Qualifying with unknown namespace/class ::CmdFemConstraintFixed
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:466: Qualifying with unknown namespace/class ::CmdFemConstraintFluidBoundary
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:509: Qualifying with unknown namespace/class ::CmdFemConstraintForce
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:553: Qualifying with unknown namespace/class ::CmdFemConstraintGear
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:594: Qualifying with unknown namespace/class ::CmdFemConstraintHeatflux
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:639: Qualifying with unknown namespace/class ::CmdFemConstraintInitialTemperature
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:682: Qualifying with unknown namespace/class ::CmdFemConstraintPlaneRotation
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:724: Qualifying with unknown namespace/class ::CmdFemConstraintPressure
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:769: Qualifying with unknown namespace/class ::CmdFemConstraintSpring
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:814: Qualifying with unknown namespace/class ::CmdFemConstraintPulley
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:860: Qualifying with unknown namespace/class ::CmdFemConstraintTemperature
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:903: Qualifying with unknown namespace/class ::CmdFemConstraintTransform
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1039: Qualifying with unknown namespace/class ::CmdFemDefineNodesSet
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1095: Qualifying with unknown namespace/class ::CmdFemCreateNodesSet
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1251: Qualifying with unknown namespace/class ::CmdFemPostClipFilter
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1277: Qualifying with unknown namespace/class ::CmdFemPostCutFilter
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1303: Qualifying with unknown namespace/class ::CmdFemPostDataAlongLineFilter
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1329: Qualifying with unknown namespace/class ::CmdFemPostDataAtPointFilter
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1357: Qualifying with unknown namespace/class ::CmdFemPostLinearizedStressesFilter
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1414: Qualifying with unknown namespace/class ::CmdFemPostScalarClipFilter
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1440: Qualifying with unknown namespace/class ::CmdFemPostWarpVectorFilter
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1466: Qualifying with unknown namespace/class ::CmdFemPostFunctions
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1606: Qualifying with unknown namespace/class ::CmdFemPostApllyChanges
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1651: Qualifying with unknown namespace/class ::CmdFemPostPipelineFromResult
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/ViewProviderFemConstraintDisplacement.cpp:145: Unbalanced opening parenthesis in C++ code (or abuse of the C++ preprocessor)
+resulttools.py: Unbalanced parentheses in Python code
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Image/Image.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Image/Gui/Command.cpp:54: Qualifying with unknown namespace/class ::CmdImageOpen
+/home/chennes/FreeCAD-chennes/src/Mod/Image/Gui/Command.cpp:69: Qualifying with unknown namespace/class ::CmdImageOpen
+/home/chennes/FreeCAD-chennes/src/Mod/Image/Gui/Command.cpp:99: Qualifying with unknown namespace/class ::CmdCreateImagePlane
+/home/chennes/FreeCAD-chennes/src/Mod/Image/Gui/Command.cpp:113: Qualifying with unknown namespace/class ::CmdCreateImagePlane
+/home/chennes/FreeCAD-chennes/src/Mod/Image/Gui/Command.cpp:173: Qualifying with unknown namespace/class ::CmdImageScaling
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Mesh/Mesh.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:94: Qualifying with unknown namespace/class ::CmdMeshTransform
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:133: Qualifying with unknown namespace/class ::CmdMeshDemolding
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:172: Qualifying with unknown namespace/class ::CmdMeshToolMesh
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:227: Qualifying with unknown namespace/class ::CmdMeshUnion
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:298: Qualifying with unknown namespace/class ::CmdMeshDifference
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:369: Qualifying with unknown namespace/class ::CmdMeshIntersection
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:440: Qualifying with unknown namespace/class ::CmdMeshImport
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:452: Qualifying with unknown namespace/class ::CmdMeshImport
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:491: Qualifying with unknown namespace/class ::CmdMeshExport
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:510: Qualifying with unknown namespace/class ::CmdMeshExport
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:566: Qualifying with unknown namespace/class ::CmdMeshFromGeometry
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:576: Qualifying with unknown namespace/class ::CmdMeshFromGeometry
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:624: Qualifying with unknown namespace/class ::CmdMeshFromPartShape
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:650: Qualifying with unknown namespace/class ::CmdMeshVertexCurvature
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:693: Qualifying with unknown namespace/class ::CmdMeshVertexCurvatureInfo
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:739: Qualifying with unknown namespace/class ::CmdMeshPolySegm
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:795: Qualifying with unknown namespace/class ::CmdMeshPolySelect
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:848: Qualifying with unknown namespace/class ::CmdMeshAddFacet
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:895: Qualifying with unknown namespace/class ::CmdMeshPolyCut
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:956: Qualifying with unknown namespace/class ::CmdMeshPolyTrim
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1017: Qualifying with unknown namespace/class ::CmdMeshTrimByPlane
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1046: Qualifying with unknown namespace/class ::CmdMeshSectionByPlane
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1075: Qualifying with unknown namespace/class ::CmdMeshCrossSections
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1101: Qualifying with unknown namespace/class ::CmdMeshPolySplit
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1155: Qualifying with unknown namespace/class ::CmdMeshEvaluation
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1198: Qualifying with unknown namespace/class ::CmdMeshEvaluateFacet
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1241: Qualifying with unknown namespace/class ::CmdMeshRemoveComponents
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1286: Qualifying with unknown namespace/class ::CmdMeshRemeshGmsh
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1319: Qualifying with unknown namespace/class ::CmdMeshRemoveCompByHand
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1363: Qualifying with unknown namespace/class ::CmdMeshEvaluateSolid
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1378: Qualifying with unknown namespace/class ::CmdMeshEvaluateSolid
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1401: Qualifying with unknown namespace/class ::CmdMeshSmoothing
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1464: Qualifying with unknown namespace/class ::CmdMeshDecimating
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1495: Qualifying with unknown namespace/class ::CmdMeshHarmonizeNormals
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1529: Qualifying with unknown namespace/class ::CmdMeshFlipNormals
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1563: Qualifying with unknown namespace/class ::CmdMeshBoundingBox
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1586: Qualifying with unknown namespace/class ::CmdMeshBoundingBox
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1605: Qualifying with unknown namespace/class ::CmdMeshBuildRegularSolid
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1636: Qualifying with unknown namespace/class ::CmdMeshFillupHoles
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1648: Qualifying with unknown namespace/class ::CmdMeshFillupHoles
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1674: Qualifying with unknown namespace/class ::CmdMeshFillInteractiveHole
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1716: Qualifying with unknown namespace/class ::CmdMeshSegmentation
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1752: Qualifying with unknown namespace/class ::CmdMeshSegmentationBestFit
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1788: Qualifying with unknown namespace/class ::CmdMeshMerge
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1831: Qualifying with unknown namespace/class ::CmdMeshSplitComponents
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1877: Qualifying with unknown namespace/class ::CmdMeshScale
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1892: Qualifying with unknown namespace/class ::CmdMeshScale
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/MeshPart/MeshPart.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/MeshPart/Gui/Command.cpp:59: Qualifying with unknown namespace/class ::CmdMeshPartMesher
+/home/chennes/FreeCAD-chennes/src/Mod/MeshPart/Gui/Command.cpp:84: Qualifying with unknown namespace/class ::CmdMeshPartTrimByPlane
+/home/chennes/FreeCAD-chennes/src/Mod/MeshPart/Gui/Command.cpp:192: Qualifying with unknown namespace/class ::CmdMeshPartSection
+/home/chennes/FreeCAD-chennes/src/Mod/MeshPart/Gui/Command.cpp:276: Qualifying with unknown namespace/class ::CmdMeshPartCrossSections
+/home/chennes/FreeCAD-chennes/src/Mod/MeshPart/Gui/Command.cpp:312: Qualifying with unknown namespace/class ::CmdMeshPartCurveOnMesh
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/OpenSCAD/OpenSCAD.pro.
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/PartDesign/PartDesign.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/App/FeatureGroove.cpp:113: Class 'PartDesign::Groove' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/App/FeatureHole.cpp:1654: Class 'PartDesign::Hole' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/App/FeaturePocket.cpp:118: Class 'PartDesign::Pocket' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:167: Qualifying with unknown namespace/class ::CmdPartDesignPlane
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:195: Qualifying with unknown namespace/class ::CmdPartDesignLine
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:223: Qualifying with unknown namespace/class ::CmdPartDesignPoint
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:251: Qualifying with unknown namespace/class ::CmdPartDesignCS
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:283: Qualifying with unknown namespace/class ::CmdPartDesignShapeBinder
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:348: Qualifying with unknown namespace/class ::CmdPartDesignSubShapeBinder
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:412: Qualifying with unknown namespace/class ::CmdPartDesignSubShapeBinder
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:431: Qualifying with unknown namespace/class ::CmdPartDesignClone
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:489: Qualifying with unknown namespace/class ::CmdPartDesignNewSketch
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:594: Qualifying with unknown namespace/class ::CmdPartDesignNewSketch
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1309: Qualifying with unknown namespace/class ::CmdPartDesignPad
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1341: Qualifying with unknown namespace/class ::CmdPartDesignPocket
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1373: Qualifying with unknown namespace/class ::CmdPartDesignHole
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1419: Qualifying with unknown namespace/class ::CmdPartDesignRevolution
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1477: Qualifying with unknown namespace/class ::CmdPartDesignGroove
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1543: Qualifying with unknown namespace/class ::CmdPartDesignAdditivePipe
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1593: Qualifying with unknown namespace/class ::CmdPartDesignSubtractivePipe
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1643: Qualifying with unknown namespace/class ::CmdPartDesignAdditiveLoft
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1693: Qualifying with unknown namespace/class ::CmdPartDesignSubtractiveLoft
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1742: Qualifying with unknown namespace/class ::CmdPartDesignAdditiveHelix
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1812: Qualifying with unknown namespace/class ::CmdPartDesignSubtractiveHelix
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1991: Qualifying with unknown namespace/class ::CmdPartDesignFillet
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:2019: Qualifying with unknown namespace/class ::CmdPartDesignChamfer
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:2048: Qualifying with unknown namespace/class ::CmdPartDesignDraft
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:2105: Qualifying with unknown namespace/class ::CmdPartDesignThickness
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:2253: Qualifying with unknown namespace/class ::CmdPartDesignMirrored
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:2315: Qualifying with unknown namespace/class ::CmdPartDesignLinearPattern
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:2379: Qualifying with unknown namespace/class ::CmdPartDesignPolarPattern
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:2444: Qualifying with unknown namespace/class ::CmdPartDesignScaled
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:2493: Qualifying with unknown namespace/class ::CmdPartDesignMultiTransform
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:2616: Qualifying with unknown namespace/class ::CmdPartDesignBoolean
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandBody.cpp:89: Qualifying with unknown namespace/class ::CmdPartDesignBody
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandBody.cpp:119: Qualifying with unknown namespace/class ::CmdPartDesignBody
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandBody.cpp:312: Qualifying with unknown namespace/class ::CmdPartDesignMigrate
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandBody.cpp:343: Qualifying with unknown namespace/class ::CmdPartDesignMigrate
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandBody.cpp:527: Qualifying with unknown namespace/class ::CmdPartDesignMoveTip
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandBody.cpp:555: Qualifying with unknown namespace/class ::CmdPartDesignMoveTip
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandBody.cpp:606: Qualifying with unknown namespace/class ::CmdPartDesignDuplicateSelection
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandBody.cpp:662: Qualifying with unknown namespace/class ::CmdPartDesignMoveFeature
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandBody.cpp:680: Qualifying with unknown namespace/class ::CmdPartDesignMoveFeature
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandBody.cpp:824: Qualifying with unknown namespace/class ::CmdPartDesignMoveFeatureInTree
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandBody.cpp:851: Qualifying with unknown namespace/class ::CmdPartDesignMoveFeatureInTree
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandPrimitive.cpp:69: Qualifying with unknown namespace/class ::CmdPrimtiveCompAdditive
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandPrimitive.cpp:243: Qualifying with unknown namespace/class ::CmdPrimtiveCompSubtractive
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandPrimitive.cpp:269: Qualifying with unknown namespace/class ::CmdPrimtiveCompSubtractive
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/FeaturePickDialog.cpp:45: Qualifying with unknown namespace/class ::FeaturePickDialog
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/ReferenceSelection.cpp:271: Class 'PartDesignGui::NoDependentsSelection' lacks Q_OBJECT macro
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Part/Part.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:90: Qualifying with unknown namespace/class ::CmdPartPickCurveNet
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:136: Qualifying with unknown namespace/class ::CmdPartBox2
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:177: Qualifying with unknown namespace/class ::CmdPartBox3
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:218: Qualifying with unknown namespace/class ::CmdPartPrimitives
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:272: Qualifying with unknown namespace/class ::CmdPartCut
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:286: Qualifying with unknown namespace/class ::CmdPartCut
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:350: Qualifying with unknown namespace/class ::CmdPartCommon
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:381: Qualifying with unknown namespace/class ::CmdPartCommon
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:450: Qualifying with unknown namespace/class ::CmdPartFuse
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:481: Qualifying with unknown namespace/class ::CmdPartFuse
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:551: Qualifying with unknown namespace/class ::CmdPartCompJoinFeatures
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:657: Qualifying with unknown namespace/class ::CmdPartCompSplitFeatures
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:779: Qualifying with unknown namespace/class ::CmdPartCompCompoundTools
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:886: Qualifying with unknown namespace/class ::CmdPartCompound
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:900: Qualifying with unknown namespace/class ::CmdPartCompound
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:943: Qualifying with unknown namespace/class ::CmdPartSection
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:957: Qualifying with unknown namespace/class ::CmdPartSection
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:991: Qualifying with unknown namespace/class ::CmdPartImport
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1053: Qualifying with unknown namespace/class ::CmdPartExport
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1100: Qualifying with unknown namespace/class ::CmdPartImportCurveNet
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1113: Qualifying with unknown namespace/class ::CmdPartImportCurveNet
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1148: Qualifying with unknown namespace/class ::CmdPartMakeSolid
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1227: Qualifying with unknown namespace/class ::CmdPartReverseShape
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1290: Qualifying with unknown namespace/class ::CmdPartBoolean
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1321: Qualifying with unknown namespace/class ::CmdPartExtrude
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1349: Qualifying with unknown namespace/class ::CmdPartMakeFace
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1401: Qualifying with unknown namespace/class ::CmdPartRevolve
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1429: Qualifying with unknown namespace/class ::CmdPartFillet
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1457: Qualifying with unknown namespace/class ::CmdPartChamfer
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1485: Qualifying with unknown namespace/class ::CmdPartMirror
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1513: Qualifying with unknown namespace/class ::CmdPartCrossSections
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1553: Qualifying with unknown namespace/class ::CmdPartBuilder
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1582: Qualifying with unknown namespace/class ::CmdPartLoft
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1611: Qualifying with unknown namespace/class ::CmdPartSweep
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1640: Qualifying with unknown namespace/class ::CmdPartOffset
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1692: Qualifying with unknown namespace/class ::CmdPartOffset2D
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1743: Qualifying with unknown namespace/class ::CmdPartCompOffset
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1836: Qualifying with unknown namespace/class ::CmdPartThickness
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2011: Qualifying with unknown namespace/class ::CmdPartRuledSurface
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2097: Qualifying with unknown namespace/class ::CmdPartRuledSurface
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2127: Qualifying with unknown namespace/class ::CmdCheckGeometry
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2161: Qualifying with unknown namespace/class ::CmdColorPerFace
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2200: Qualifying with unknown namespace/class ::CmdMeasureLinear
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2231: Qualifying with unknown namespace/class ::CmdMeasureAngular
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2260: Qualifying with unknown namespace/class ::CmdMeasureRefresh
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2290: Qualifying with unknown namespace/class ::CmdMeasureClearAll
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2319: Qualifying with unknown namespace/class ::CmdMeasureToggleAll
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2356: Qualifying with unknown namespace/class ::CmdMeasureToggle3d
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2387: Qualifying with unknown namespace/class ::CmdMeasureToggleDelta
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2419: Qualifying with unknown namespace/class ::CmdBoxSelection
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2448: Qualifying with unknown namespace/class ::CmdPartProjectionOnSurface
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandParametric.cpp:66: Qualifying with unknown namespace/class ::CmdPartCylinder
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandParametric.cpp:108: Qualifying with unknown namespace/class ::CmdPartBox
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandParametric.cpp:150: Qualifying with unknown namespace/class ::CmdPartSphere
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandParametric.cpp:192: Qualifying with unknown namespace/class ::CmdPartCone
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandParametric.cpp:234: Qualifying with unknown namespace/class ::CmdPartTorus
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandSimple.cpp:58: Qualifying with unknown namespace/class ::CmdPartSimpleCylinder
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandSimple.cpp:108: Qualifying with unknown namespace/class ::CmdPartShapeFromMesh
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandSimple.cpp:137: Qualifying with unknown namespace/class ::CmdPartPointsFromMesh
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandSimple.cpp:187: Qualifying with unknown namespace/class ::CmdPartSimpleCopy
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandSimple.cpp:258: Qualifying with unknown namespace/class ::CmdPartTransformedCopy
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandSimple.cpp:286: Qualifying with unknown namespace/class ::CmdPartElementCopy
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandSimple.cpp:314: Qualifying with unknown namespace/class ::CmdPartRefineShape
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandSimple.cpp:374: Qualifying with unknown namespace/class ::CmdPartDefeaturing
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Path/Path.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Path/App/VoronoiPyImp.cpp:206: Parenthesis/brace mismatch between #if and #else branches; using #if branch
+/home/chennes/FreeCAD-chennes/src/Mod/Path/Gui/Command.cpp:55: Qualifying with unknown namespace/class ::CmdPathArea
+/home/chennes/FreeCAD-chennes/src/Mod/Path/Gui/Command.cpp:137: Qualifying with unknown namespace/class ::CmdPathAreaWorkplane
+/home/chennes/FreeCAD-chennes/src/Mod/Path/Gui/Command.cpp:227: Qualifying with unknown namespace/class ::CmdPathCompound
+/home/chennes/FreeCAD-chennes/src/Mod/Path/Gui/Command.cpp:279: Qualifying with unknown namespace/class ::CmdPathShape
+fanuc_post.py:107: Unterminated string
+rrf_post.py:214: Unterminated string
+linuxcnc_post.py:99: Unterminated string
+dynapath_post.py:143: Unterminated string
+jtech_post.py:104: Unterminated string
+marlin_post.py:209: Unterminated string
+centroid_post.py:116: Unterminated string
+fablin_post.py:88: Unterminated string
+mach3_mach4_post.py:98: Unterminated string
+grbl_post.py:80: Unterminated string
+uccnc_post.py:298: Unterminated string
+smoothie_post.py:108: Unterminated string
+opensbp_post.py:80: Unterminated string
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Points/Points.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Points/Gui/Command.cpp:68: Qualifying with unknown namespace/class ::CmdPointsImport
+/home/chennes/FreeCAD-chennes/src/Mod/Points/Gui/Command.cpp:82: Qualifying with unknown namespace/class ::CmdPointsImport
+/home/chennes/FreeCAD-chennes/src/Mod/Points/Gui/Command.cpp:113: Qualifying with unknown namespace/class ::CmdPointsExport
+/home/chennes/FreeCAD-chennes/src/Mod/Points/Gui/Command.cpp:130: Qualifying with unknown namespace/class ::CmdPointsExport
+/home/chennes/FreeCAD-chennes/src/Mod/Points/Gui/Command.cpp:153: Qualifying with unknown namespace/class ::CmdPointsTransform
+/home/chennes/FreeCAD-chennes/src/Mod/Points/Gui/Command.cpp:190: Qualifying with unknown namespace/class ::CmdPointsConvert
+/home/chennes/FreeCAD-chennes/src/Mod/Points/Gui/Command.cpp:209: Qualifying with unknown namespace/class ::CmdPointsConvert
+/home/chennes/FreeCAD-chennes/src/Mod/Points/Gui/Command.cpp:282: Qualifying with unknown namespace/class ::CmdPointsPolyCut
+/home/chennes/FreeCAD-chennes/src/Mod/Points/Gui/Command.cpp:327: Qualifying with unknown namespace/class ::CmdPointsMerge
+/home/chennes/FreeCAD-chennes/src/Mod/Points/Gui/Command.cpp:370: Qualifying with unknown namespace/class ::CmdPointsStructure
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Raytracing.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:84: Qualifying with unknown namespace/class ::CmdRaytracingWriteCamera
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:137: Qualifying with unknown namespace/class ::CmdRaytracingWriteCamera
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:177: Qualifying with unknown namespace/class ::CmdRaytracingWritePart
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:188: Qualifying with unknown namespace/class ::CmdRaytracingWritePart
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:223: Qualifying with unknown namespace/class ::CmdRaytracingWriteView
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:250: Qualifying with unknown namespace/class ::CmdRaytracingWriteView
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:320: Qualifying with unknown namespace/class ::CmdRaytracingNewPovrayProject
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:437: Qualifying with unknown namespace/class ::CmdRaytracingNewPartSegment
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:449: Qualifying with unknown namespace/class ::CmdRaytracingNewPartSegment
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:521: Qualifying with unknown namespace/class ::CmdRaytracingExportProject
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:536: Qualifying with unknown namespace/class ::CmdRaytracingExportProject
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:584: Qualifying with unknown namespace/class ::CmdRaytracingRender
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:600: Qualifying with unknown namespace/class ::CmdRaytracingRender
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:766: Qualifying with unknown namespace/class ::CmdRaytracingNewLuxProject
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:879: Qualifying with unknown namespace/class ::CmdRaytracingResetCamera
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:893: Qualifying with unknown namespace/class ::CmdRaytracingResetCamera
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/ReverseEngineering.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/Gui/Command.cpp:74: Qualifying with unknown namespace/class ::CmdApproxSurface
+/home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/Gui/Command.cpp:110: Qualifying with unknown namespace/class ::CmdApproxPlane
+/home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/Gui/Command.cpp:211: Qualifying with unknown namespace/class ::CmdApproxCylinder
+/home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/Gui/Command.cpp:277: Qualifying with unknown namespace/class ::CmdApproxSphere
+/home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/Gui/Command.cpp:324: Qualifying with unknown namespace/class ::CmdApproxPolynomial
+/home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/Gui/Command.cpp:379: Qualifying with unknown namespace/class ::CmdSegmentation
+/home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/Gui/Command.cpp:411: Qualifying with unknown namespace/class ::CmdSegmentationManual
+/home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/Gui/Command.cpp:440: Qualifying with unknown namespace/class ::CmdSegmentationFromComponents
+/home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/Gui/Command.cpp:490: Qualifying with unknown namespace/class ::CmdMeshBoundary
+/home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/Gui/Command.cpp:556: Qualifying with unknown namespace/class ::CmdPoissonReconstruction
+/home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/Gui/Command.cpp:590: Qualifying with unknown namespace/class ::CmdViewTriangulation
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Robot/Robot.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/Command.cpp:55: Qualifying with unknown namespace/class ::CmdRobotSetHomePos
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/Command.cpp:75: Qualifying with unknown namespace/class ::CmdRobotSetHomePos
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/Command.cpp:104: Qualifying with unknown namespace/class ::CmdRobotRestoreHomePos
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/Command.cpp:124: Qualifying with unknown namespace/class ::CmdRobotRestoreHomePos
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/Command.cpp:158: Qualifying with unknown namespace/class ::CmdRobotConstraintAxle
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/Command.cpp:199: Qualifying with unknown namespace/class ::CmdRobotSimulate
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/Command.cpp:224: Qualifying with unknown namespace/class ::CmdRobotSimulate
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandExport.cpp:50: Qualifying with unknown namespace/class ::CmdRobotExportKukaCompact
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandExport.cpp:65: Qualifying with unknown namespace/class ::CmdRobotExportKukaCompact
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandExport.cpp:112: Qualifying with unknown namespace/class ::CmdRobotExportKukaFull
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandExport.cpp:127: Qualifying with unknown namespace/class ::CmdRobotExportKukaFull
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandInsertRobot.cpp:51: Qualifying with unknown namespace/class ::CmdRobotInsertKukaIR500
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandInsertRobot.cpp:93: Qualifying with unknown namespace/class ::CmdRobotInsertKukaIR16
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandInsertRobot.cpp:134: Qualifying with unknown namespace/class ::CmdRobotInsertKukaIR210
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandInsertRobot.cpp:174: Qualifying with unknown namespace/class ::CmdRobotInsertKukaIR125
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandInsertRobot.cpp:215: Qualifying with unknown namespace/class ::CmdRobotAddToolShape
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandInsertRobot.cpp:234: Qualifying with unknown namespace/class ::CmdRobotAddToolShape
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:62: Qualifying with unknown namespace/class ::CmdRobotCreateTrajectory
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:95: Qualifying with unknown namespace/class ::CmdRobotInsertWaypoint
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:111: Qualifying with unknown namespace/class ::CmdRobotInsertWaypoint
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:152: Qualifying with unknown namespace/class ::CmdRobotInsertWaypointPreselect
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:167: Qualifying with unknown namespace/class ::CmdRobotInsertWaypointPreselect
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:216: Qualifying with unknown namespace/class ::CmdRobotSetDefaultOrientation
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:254: Qualifying with unknown namespace/class ::CmdRobotSetDefaultValues
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:268: Qualifying with unknown namespace/class ::CmdRobotSetDefaultValues
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:320: Qualifying with unknown namespace/class ::CmdRobotEdge2Trac
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:384: Qualifying with unknown namespace/class ::CmdRobotTrajectoryDressUp
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:412: Qualifying with unknown namespace/class ::CmdRobotTrajectoryDressUp
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:431: Qualifying with unknown namespace/class ::CmdRobotTrajectoryCompound
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Sketcher.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:143: Qualifying with unknown namespace/class ::CmdSketcherNewSketch
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:164: Qualifying with unknown namespace/class ::CmdSketcherNewSketch
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:266: Qualifying with unknown namespace/class ::CmdSketcherEditSketch
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:296: Qualifying with unknown namespace/class ::CmdSketcherLeaveSketch
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:340: Qualifying with unknown namespace/class ::CmdSketcherStopOperation
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:381: Qualifying with unknown namespace/class ::CmdSketcherReorientSketch
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:508: Qualifying with unknown namespace/class ::CmdSketcherMapSketch
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:562: Qualifying with unknown namespace/class ::CmdSketcherMapSketch
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:683: Qualifying with unknown namespace/class ::CmdSketcherViewSketch
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:723: Qualifying with unknown namespace/class ::CmdSketcherValidateSketch
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:761: Qualifying with unknown namespace/class ::CmdSketcherMirrorSketch
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:868: Qualifying with unknown namespace/class ::CmdSketcherMergeSketches
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:952: Qualifying with unknown namespace/class ::CmdSketcherViewSection
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandAlterGeometry.cpp:74: Qualifying with unknown namespace/class ::CmdSketcherToggleConstruction
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandAlterGeometry.cpp:123: Qualifying with unknown namespace/class ::CmdSketcherToggleConstruction
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:883: Class 'CmdSketcherConstrainHorizontal' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:1121: Class 'CmdSketcherConstrainVertical' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:1355: Class 'CmdSketcherConstrainLock' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:1581: Class 'CmdSketcherConstrainBlock' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:1896: Class 'CmdSketcherConstrainCoincident' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:2102: Class 'CmdSketcherConstrainDistance' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:2451: Class 'CmdSketcherConstrainPointOnObject' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:2699: Class 'CmdSketcherConstrainDistanceX' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:2953: Class 'CmdSketcherConstrainDistanceY' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:3199: Class 'CmdSketcherConstrainParallel' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:3349: Class 'CmdSketcherConstrainPerpendicular' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:3987: Class 'CmdSketcherConstrainTangent' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:4695: Class 'CmdSketcherConstrainRadius' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:4997: Class 'CmdSketcherConstrainDiameter' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:5273: Class 'CmdSketcherConstrainRadiam' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:5577: Qualifying with unknown namespace/class ::CmdSketcherCompConstrainRadDia
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:5721: Class 'CmdSketcherConstrainAngle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:6248: Class 'CmdSketcherConstrainEqual' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:6465: Class 'CmdSketcherConstrainSymmetric' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:6765: Qualifying with unknown namespace/class ::CmdSketcherConstrainSnellsLaw
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:6784: Qualifying with unknown namespace/class ::CmdSketcherConstrainSnellsLaw
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:6931: Qualifying with unknown namespace/class ::CmdSketcherConstrainInternalAlignment
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:6949: Qualifying with unknown namespace/class ::CmdSketcherConstrainInternalAlignment
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:7391: Qualifying with unknown namespace/class ::CmdSketcherToggleDrivingConstraint
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:7430: Qualifying with unknown namespace/class ::CmdSketcherToggleDrivingConstraint
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:7518: Qualifying with unknown namespace/class ::CmdSketcherToggleActiveConstraint
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:7543: Qualifying with unknown namespace/class ::CmdSketcherToggleActiveConstraint
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:344: Qualifying with unknown namespace/class ::CmdSketcherCreateLine
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:649: Qualifying with unknown namespace/class ::CmdSketcherCreateRectangle
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:690: Qualifying with unknown namespace/class ::CmdSketcherCreateRectangleCenter
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:1016: Qualifying with unknown namespace/class ::CmdSketcherCreateOblong
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:1059: Qualifying with unknown namespace/class ::CmdSketcherCompCreateRectangles
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:1815: Qualifying with unknown namespace/class ::CmdSketcherCreatePolyline
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:2059: Qualifying with unknown namespace/class ::CmdSketcherCreateArc
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:2329: Qualifying with unknown namespace/class ::CmdSketcherCreate3PointArc
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:2357: Qualifying with unknown namespace/class ::CmdSketcherCompCreateArc
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:2591: Qualifying with unknown namespace/class ::CmdSketcherCreateCircle
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:3387: Qualifying with unknown namespace/class ::CmdSketcherCreateEllipseByCenter
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:3418: Qualifying with unknown namespace/class ::CmdSketcherCreateEllipseBy3Points
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:3746: Qualifying with unknown namespace/class ::CmdSketcherCreateArcOfEllipse
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:4090: Qualifying with unknown namespace/class ::CmdSketcherCreateArcOfHyperbola
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:4389: Qualifying with unknown namespace/class ::CmdSketcherCreateArcOfParabola
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:4422: Qualifying with unknown namespace/class ::CmdSketcherCompCreateConic
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:4925: Qualifying with unknown namespace/class ::CmdSketcherCreateBSpline
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:4970: Qualifying with unknown namespace/class ::CmdSketcherCreatePeriodicBSpline
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:5002: Qualifying with unknown namespace/class ::CmdSketcherCompCreateBSpline
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:5285: Qualifying with unknown namespace/class ::CmdSketcherCreate3PointCircle
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:5313: Qualifying with unknown namespace/class ::CmdSketcherCompCreateCircle
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:5493: Qualifying with unknown namespace/class ::CmdSketcherCreatePoint
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:5523: Qualifying with unknown namespace/class ::CmdSketcherCreateText
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:5551: Qualifying with unknown namespace/class ::CmdSketcherCreateDraftLine
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:5831: Qualifying with unknown namespace/class ::CmdSketcherCreateFillet
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:5860: Qualifying with unknown namespace/class ::CmdSketcherCreatePointFillet
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:5891: Qualifying with unknown namespace/class ::CmdSketcherCompCreateFillets
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:6121: Qualifying with unknown namespace/class ::CmdSketcherTrimming
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:6435: Qualifying with unknown namespace/class ::CmdSketcherExtend
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:6554: Qualifying with unknown namespace/class ::CmdSketcherSplit
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:6593: Class 'SketcherGui::ExternalSelection' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:6739: Qualifying with unknown namespace/class ::CmdSketcherExternal
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:6785: Class 'SketcherGui::CarbonCopySelection' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:6917: Qualifying with unknown namespace/class ::CmdSketcherCarbonCopy
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:7228: Qualifying with unknown namespace/class ::CmdSketcherCreateSlot
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:7421: Qualifying with unknown namespace/class ::CmdSketcherCreateTriangle
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:7448: Qualifying with unknown namespace/class ::CmdSketcherCreateSquare
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:7475: Qualifying with unknown namespace/class ::CmdSketcherCreatePentagon
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:7503: Qualifying with unknown namespace/class ::CmdSketcherCreateHexagon
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:7530: Qualifying with unknown namespace/class ::CmdSketcherCreateHeptagon
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:7557: Qualifying with unknown namespace/class ::CmdSketcherCreateOctagon
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:7584: Qualifying with unknown namespace/class ::CmdSketcherCreateRegularPolygon
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:7615: Qualifying with unknown namespace/class ::CmdSketcherCompCreateRegularPolygon
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:100: Qualifying with unknown namespace/class ::CmdSketcherBSplineDegree
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:129: Qualifying with unknown namespace/class ::CmdSketcherBSplinePolygon
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:158: Qualifying with unknown namespace/class ::CmdSketcherBSplineComb
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:187: Qualifying with unknown namespace/class ::CmdSketcherBSplineKnotMultiplicity
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:216: Qualifying with unknown namespace/class ::CmdSketcherBSplinePoleWeight
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:245: Qualifying with unknown namespace/class ::CmdSketcherCompBSplineShowHideGeometryInformation
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:374: Qualifying with unknown namespace/class ::CmdSketcherConvertToNURB
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:420: Qualifying with unknown namespace/class ::CmdSketcherConvertToNURB
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:442: Qualifying with unknown namespace/class ::CmdSketcherIncreaseDegree
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:491: Qualifying with unknown namespace/class ::CmdSketcherIncreaseDegree
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:515: Qualifying with unknown namespace/class ::CmdSketcherDecreaseDegree
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:569: Qualifying with unknown namespace/class ::CmdSketcherDecreaseDegree
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:592: Qualifying with unknown namespace/class ::CmdSketcherIncreaseKnotMultiplicity
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:607: Qualifying with unknown namespace/class ::CmdSketcherIncreaseKnotMultiplicity
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:746: Qualifying with unknown namespace/class ::CmdSketcherDecreaseKnotMultiplicity
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:761: Qualifying with unknown namespace/class ::CmdSketcherDecreaseKnotMultiplicity
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:888: Qualifying with unknown namespace/class ::CmdSketcherCompModifyKnotMultiplicity
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:981: Qualifying with unknown namespace/class ::CmdSketcherInsertKnot
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:996: Qualifying with unknown namespace/class ::CmdSketcherInsertKnot
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:105: Qualifying with unknown namespace/class ::CmdSketcherCloseShape
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:129: Qualifying with unknown namespace/class ::CmdSketcherCloseShape
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:217: Qualifying with unknown namespace/class ::CmdSketcherConnect
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:240: Qualifying with unknown namespace/class ::CmdSketcherConnect
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:304: Qualifying with unknown namespace/class ::CmdSketcherSelectConstraints
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:327: Qualifying with unknown namespace/class ::CmdSketcherSelectConstraints
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:381: Qualifying with unknown namespace/class ::CmdSketcherSelectOrigin
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:427: Qualifying with unknown namespace/class ::CmdSketcherSelectVerticalAxis
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:471: Qualifying with unknown namespace/class ::CmdSketcherSelectHorizontalAxis
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:514: Qualifying with unknown namespace/class ::CmdSketcherSelectRedundantConstraints
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:571: Qualifying with unknown namespace/class ::CmdSketcherSelectMalformedConstraints
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:627: Qualifying with unknown namespace/class ::CmdSketcherSelectPartiallyRedundantConstraints
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:683: Qualifying with unknown namespace/class ::CmdSketcherSelectConflictingConstraints
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:738: Qualifying with unknown namespace/class ::CmdSketcherSelectElementsAssociatedWithConstraints
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:836: Qualifying with unknown namespace/class ::CmdSketcherSelectElementsAssociatedWithConstraints
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:859: Qualifying with unknown namespace/class ::CmdSketcherSelectElementsWithDoFs
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:950: Qualifying with unknown namespace/class ::CmdSketcherRestoreInternalAlignmentGeometry
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:974: Qualifying with unknown namespace/class ::CmdSketcherRestoreInternalAlignmentGeometry
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:1046: Qualifying with unknown namespace/class ::CmdSketcherSymmetry
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:1069: Qualifying with unknown namespace/class ::CmdSketcherSymmetry
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:1581: Class 'CmdSketcherCopy' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:1627: Class 'CmdSketcherClone' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:1670: Class 'CmdSketcherMove' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:1704: Qualifying with unknown namespace/class ::CmdSketcherCompCopy
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:1986: Qualifying with unknown namespace/class ::CmdSketcherRectangularArray
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:2005: Qualifying with unknown namespace/class ::CmdSketcherRectangularArray
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:2126: Qualifying with unknown namespace/class ::CmdSketcherDeleteAllGeometry
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:2140: Qualifying with unknown namespace/class ::CmdSketcherDeleteAllGeometry
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:2189: Qualifying with unknown namespace/class ::CmdSketcherDeleteAllConstraints
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:2202: Qualifying with unknown namespace/class ::CmdSketcherDeleteAllConstraints
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:2253: Qualifying with unknown namespace/class ::CmdSketcherRemoveAxesAlignment
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:2272: Qualifying with unknown namespace/class ::CmdSketcherRemoveAxesAlignment
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherVirtualSpace.cpp:93: Qualifying with unknown namespace/class ::CmdSketcherSwitchVirtualSpace
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherVirtualSpace.cpp:115: Qualifying with unknown namespace/class ::CmdSketcherSwitchVirtualSpace
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Spreadsheet.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/AppSpreadsheetGui.cpp:87: Class 'SpreadsheetGui::Module' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:70: Qualifying with unknown namespace/class ::CmdSpreadsheetMergeCells
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:123: Qualifying with unknown namespace/class ::CmdSpreadsheetSplitCell
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:179: Qualifying with unknown namespace/class ::CmdSpreadsheetImport
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:191: Qualifying with unknown namespace/class ::CmdSpreadsheetImport
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:229: Qualifying with unknown namespace/class ::CmdSpreadsheetExport
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:247: Qualifying with unknown namespace/class ::CmdSpreadsheetExport
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:290: Qualifying with unknown namespace/class ::CmdSpreadsheetAlignLeft
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:342: Qualifying with unknown namespace/class ::CmdSpreadsheetAlignCenter
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:394: Qualifying with unknown namespace/class ::CmdSpreadsheetAlignRight
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:446: Qualifying with unknown namespace/class ::CmdSpreadsheetAlignTop
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:498: Qualifying with unknown namespace/class ::CmdSpreadsheetAlignBottom
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:550: Qualifying with unknown namespace/class ::CmdSpreadsheetAlignVCenter
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:602: Qualifying with unknown namespace/class ::CmdSpreadsheetStyleBold
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:676: Qualifying with unknown namespace/class ::CmdSpreadsheetStyleItalic
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:750: Qualifying with unknown namespace/class ::CmdSpreadsheetStyleUnderline
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:823: Qualifying with unknown namespace/class ::CmdSpreadsheetSetAlias
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:887: Qualifying with unknown namespace/class ::CmdCreateSpreadsheet
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Start/Start.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Start/Gui/Command.cpp:45: Qualifying with unknown namespace/class ::CmdStartPage
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/TechDraw/TechDraw.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:117: Qualifying with unknown namespace/class ::CmdTechDrawPageDefault
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:181: Qualifying with unknown namespace/class ::CmdTechDrawPageTemplate
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:195: Qualifying with unknown namespace/class ::CmdTechDrawPageTemplate
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:261: Qualifying with unknown namespace/class ::CmdTechDrawRedrawPage
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:298: Qualifying with unknown namespace/class ::CmdTechDrawView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:379: Qualifying with unknown namespace/class ::CmdTechDrawView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:442: Qualifying with unknown namespace/class ::CmdTechDrawActiveView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:476: Qualifying with unknown namespace/class ::CmdTechDrawSectionView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:494: Qualifying with unknown namespace/class ::CmdTechDrawSectionView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:526: Qualifying with unknown namespace/class ::CmdTechDrawDetailView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:545: Qualifying with unknown namespace/class ::CmdTechDrawDetailView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:575: Qualifying with unknown namespace/class ::CmdTechDrawProjectionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:655: Qualifying with unknown namespace/class ::CmdTechDrawProjectionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:855: Qualifying with unknown namespace/class ::CmdTechDrawBalloon
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:920: Qualifying with unknown namespace/class ::CmdTechDrawClipGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:959: Qualifying with unknown namespace/class ::CmdTechDrawClipGroupAdd
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:972: Qualifying with unknown namespace/class ::CmdTechDrawClipGroupAdd
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1043: Qualifying with unknown namespace/class ::CmdTechDrawClipGroupRemove
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1057: Qualifying with unknown namespace/class ::CmdTechDrawClipGroupRemove
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1118: Qualifying with unknown namespace/class ::CmdTechDrawSymbol
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1137: Qualifying with unknown namespace/class ::CmdTechDrawSymbol
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1173: Qualifying with unknown namespace/class ::CmdTechDrawDraftView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1194: Qualifying with unknown namespace/class ::CmdTechDrawDraftView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1239: Qualifying with unknown namespace/class ::CmdTechDrawArchView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1268: Qualifying with unknown namespace/class ::CmdTechDrawArchView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1304: Qualifying with unknown namespace/class ::CmdTechDrawSpreadsheetView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1317: Qualifying with unknown namespace/class ::CmdTechDrawSpreadsheetView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1363: Qualifying with unknown namespace/class ::CmdTechDrawExportPageSVG
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1388: Qualifying with unknown namespace/class ::CmdTechDrawExportPageSVG
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1408: Qualifying with unknown namespace/class ::CmdTechDrawExportPageDXF
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1428: Qualifying with unknown namespace/class ::CmdTechDrawExportPageDXF
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:101: Qualifying with unknown namespace/class ::CmdTechDrawLeaderLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:115: Qualifying with unknown namespace/class ::CmdTechDrawLeaderLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:163: Qualifying with unknown namespace/class ::CmdTechDrawRichTextAnnotation
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:176: Qualifying with unknown namespace/class ::CmdTechDrawRichTextAnnotation
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:215: Qualifying with unknown namespace/class ::CmdTechDrawCosmeticVertexGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:228: Qualifying with unknown namespace/class ::CmdTechDrawCosmeticVertexGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:404: Qualifying with unknown namespace/class ::CmdTechDrawCosmeticVertex
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:417: Qualifying with unknown namespace/class ::CmdTechDrawCosmeticVertex
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:465: Qualifying with unknown namespace/class ::CmdTechDrawMidpoints
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:478: Qualifying with unknown namespace/class ::CmdTechDrawMidpoints
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:504: Qualifying with unknown namespace/class ::CmdTechDrawQuadrants
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:517: Qualifying with unknown namespace/class ::CmdTechDrawQuadrants
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:543: Qualifying with unknown namespace/class ::CmdTechDrawAnnotation
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:583: Qualifying with unknown namespace/class ::CmdTechDrawCenterLineGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:596: Qualifying with unknown namespace/class ::CmdTechDrawCenterLineGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:686: Qualifying with unknown namespace/class ::CmdTechDrawFaceCenterLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:700: Qualifying with unknown namespace/class ::CmdTechDrawFaceCenterLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:796: Qualifying with unknown namespace/class ::CmdTechDraw2LineCenterLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:810: Qualifying with unknown namespace/class ::CmdTechDraw2LineCenterLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:873: Qualifying with unknown namespace/class ::CmdTechDraw2PointCenterLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:887: Qualifying with unknown namespace/class ::CmdTechDraw2PointCenterLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:986: Qualifying with unknown namespace/class ::CmdTechDraw2PointCosmeticLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:1000: Qualifying with unknown namespace/class ::CmdTechDraw2PointCosmeticLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:1138: Qualifying with unknown namespace/class ::CmdTechDrawCosmeticEraser
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:1151: Qualifying with unknown namespace/class ::CmdTechDrawCosmeticEraser
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:1265: Qualifying with unknown namespace/class ::CmdTechDrawDecorateLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:1279: Qualifying with unknown namespace/class ::CmdTechDrawDecorateLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:1344: Qualifying with unknown namespace/class ::CmdTechDrawShowAll
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:1357: Qualifying with unknown namespace/class ::CmdTechDrawShowAll
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:1409: Qualifying with unknown namespace/class ::CmdTechDrawWeldSymbol
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:1423: Qualifying with unknown namespace/class ::CmdTechDrawWeldSymbol
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:123: Qualifying with unknown namespace/class ::CmdTechDrawDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:250: Qualifying with unknown namespace/class ::CmdTechDrawRadiusDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:294: Qualifying with unknown namespace/class ::CmdTechDrawRadiusDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:372: Qualifying with unknown namespace/class ::CmdTechDrawDiameterDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:416: Qualifying with unknown namespace/class ::CmdTechDrawDiameterDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:493: Qualifying with unknown namespace/class ::CmdTechDrawLengthDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:547: Qualifying with unknown namespace/class ::CmdTechDrawLengthDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:595: Qualifying with unknown namespace/class ::CmdTechDrawHorizontalDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:650: Qualifying with unknown namespace/class ::CmdTechDrawHorizontalDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:698: Qualifying with unknown namespace/class ::CmdTechDrawVerticalDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:753: Qualifying with unknown namespace/class ::CmdTechDrawVerticalDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:800: Qualifying with unknown namespace/class ::CmdTechDrawAngleDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:845: Qualifying with unknown namespace/class ::CmdTechDrawAngleDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:888: Qualifying with unknown namespace/class ::CmdTechDraw3PtAngleDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:934: Qualifying with unknown namespace/class ::CmdTechDraw3PtAngleDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:980: Qualifying with unknown namespace/class ::CmdTechDrawLinkDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:1019: Qualifying with unknown namespace/class ::CmdTechDrawLinkDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:1058: Qualifying with unknown namespace/class ::CmdTechDrawExtentGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:1071: Qualifying with unknown namespace/class ::CmdTechDrawExtentGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:1151: Qualifying with unknown namespace/class ::CmdTechDrawHorizontalExtentDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:1165: Qualifying with unknown namespace/class ::CmdTechDrawHorizontalExtentDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:1238: Qualifying with unknown namespace/class ::CmdTechDrawVerticalExtentDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:1252: Qualifying with unknown namespace/class ::CmdTechDrawVerticalExtentDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:1321: Qualifying with unknown namespace/class ::CmdTechDrawLandmarkDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:1339: Qualifying with unknown namespace/class ::CmdTechDrawLandmarkDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandDecorate.cpp:87: Qualifying with unknown namespace/class ::CmdTechDrawHatch
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandDecorate.cpp:122: Qualifying with unknown namespace/class ::CmdTechDrawHatch
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandDecorate.cpp:208: Qualifying with unknown namespace/class ::CmdTechDrawGeometricHatch
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandDecorate.cpp:277: Qualifying with unknown namespace/class ::CmdTechDrawImage
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandDecorate.cpp:296: Qualifying with unknown namespace/class ::CmdTechDrawImage
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandDecorate.cpp:328: Qualifying with unknown namespace/class ::CmdTechDrawToggleFrame
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandDecorate.cpp:352: Qualifying with unknown namespace/class ::CmdTechDrawToggleFrame
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:145: Qualifying with unknown namespace/class ::CmdTechDrawExtensionInsertDiameter
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:178: Qualifying with unknown namespace/class ::CmdTechDrawExtensionInsertSquare
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:211: Qualifying with unknown namespace/class ::CmdTechDrawExtensionInsertPrefixGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:225: Qualifying with unknown namespace/class ::CmdTechDrawExtensionInsertPrefixGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:338: Qualifying with unknown namespace/class ::CmdTechDrawExtensionIncreaseDecimal
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:371: Qualifying with unknown namespace/class ::CmdTechDrawExtensionDecreaseDecimal
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:404: Qualifying with unknown namespace/class ::CmdTechDrawExtensionIncreaseDecreaseGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:418: Qualifying with unknown namespace/class ::CmdTechDrawExtensionIncreaseDecreaseGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:529: Qualifying with unknown namespace/class ::CmdTechDrawExtensionPosHorizChainDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:588: Qualifying with unknown namespace/class ::CmdTechDrawExtensionPosVertChainDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:653: Qualifying with unknown namespace/class ::CmdTechDrawExtensionPosObliqueChainDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:688: Qualifying with unknown namespace/class ::CmdTechDrawExtensionPosChainDimensionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:703: Qualifying with unknown namespace/class ::CmdTechDrawExtensionPosChainDimensionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:835: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCascadeHorizDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:899: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCascadeVertDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:972: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCascadeObliqueDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1008: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCascadeDimensionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1024: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCascadeDimensionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1162: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateHorizChainDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1228: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateVertChainDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1318: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateObliqueChainDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1352: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateChainDimensionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1366: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateChainDimensionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1505: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateHorizCoordDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1578: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateVertCoordDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1676: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateObliqueCoordDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1712: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateCoordDimensionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1728: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateCoordDimensionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1871: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateHorizChamferDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1940: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateVertChamferDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1973: Qualifying with unknown namespace/class ::CmdTechDrawExtensionChamferDimensionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1987: Qualifying with unknown namespace/class ::CmdTechDrawExtensionChamferDimensionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:2073: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateLengthArc
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:169: Qualifying with unknown namespace/class ::CmdTechDrawExtensionHoleCircle
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:243: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCircleCenterLines
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:277: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCircleCenterLinesGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:290: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCircleCenterLinesGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:395: Qualifying with unknown namespace/class ::CmdTechDrawExtensionThreadHoleSide
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:446: Qualifying with unknown namespace/class ::CmdTechDrawExtensionThreadBoltSide
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:497: Qualifying with unknown namespace/class ::CmdTechDrawExtensionThreadHoleBottom
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:548: Qualifying with unknown namespace/class ::CmdTechDrawExtensionThreadBoltBottom
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:582: Qualifying with unknown namespace/class ::CmdTechDrawExtensionThreadsGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:597: Qualifying with unknown namespace/class ::CmdTechDrawExtensionThreadsGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:715: Qualifying with unknown namespace/class ::CmdTechDrawExtensionSelectLineAttributes
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:749: Qualifying with unknown namespace/class ::CmdTechDrawExtensionChangeLineAttributes
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:808: Qualifying with unknown namespace/class ::CmdTechDrawExtensionVertexAtIntersection
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:898: Qualifying with unknown namespace/class ::CmdTechDrawExtensionDrawCosmArc
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:959: Qualifying with unknown namespace/class ::CmdTechDrawExtensionDrawCosmCircle
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:995: Qualifying with unknown namespace/class ::CmdTechDrawExtensionDrawCirclesGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1011: Qualifying with unknown namespace/class ::CmdTechDrawExtensionDrawCirclesGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1144: Qualifying with unknown namespace/class ::CmdTechDrawExtensionLineParallel
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1178: Qualifying with unknown namespace/class ::CmdTechDrawExtensionLinePerpendicular
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1212: Qualifying with unknown namespace/class ::CmdTechDrawExtensionLinePPGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1227: Qualifying with unknown namespace/class ::CmdTechDrawExtensionLinePPGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1315: Qualifying with unknown namespace/class ::CmdTechDrawExtensionLockUnlockView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1359: Qualifying with unknown namespace/class ::CmdTechDrawExtensionPositionSectionView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1376: Qualifying with unknown namespace/class ::CmdTechDrawExtensionPositionSectionView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1492: Qualifying with unknown namespace/class ::CmdTechDrawExtensionExtendLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1527: Qualifying with unknown namespace/class ::CmdTechDrawExtensionShortenLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1562: Qualifying with unknown namespace/class ::CmdTechDrawExtendShortenLineGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1577: Qualifying with unknown namespace/class ::CmdTechDrawExtendShortenLineGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/QGEPath.cpp:156: Discarding unconsumed meta data
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/QGIEdge.cpp:129: Discarding unconsumed meta data
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/QGIViewAnnotation.cpp:208: Class 'TechDrawGui::QGIViewAnnotation' lacks Q_OBJECT macro
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Test/Test.pro.
+Segmentation fault (core dumped)
+Cannot open Gui/Resources/translations/Testpy.ts: No such file or directory
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Tux/Tux.pro.
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Web/Web.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Web/Gui/Command.cpp:50: Qualifying with unknown namespace/class ::CmdWebOpenWebsite
+/home/chennes/FreeCAD-chennes/src/Mod/Web/Gui/Command.cpp:76: Qualifying with unknown namespace/class ::CmdWebBrowserBack
+/home/chennes/FreeCAD-chennes/src/Mod/Web/Gui/Command.cpp:105: Qualifying with unknown namespace/class ::CmdWebBrowserNext
+/home/chennes/FreeCAD-chennes/src/Mod/Web/Gui/Command.cpp:134: Qualifying with unknown namespace/class ::CmdWebBrowserRefresh
+/home/chennes/FreeCAD-chennes/src/Mod/Web/Gui/Command.cpp:162: Qualifying with unknown namespace/class ::CmdWebBrowserStop
+/home/chennes/FreeCAD-chennes/src/Mod/Web/Gui/Command.cpp:192: Qualifying with unknown namespace/class ::CmdWebBrowserZoomIn
+/home/chennes/FreeCAD-chennes/src/Mod/Web/Gui/Command.cpp:221: Qualifying with unknown namespace/class ::CmdWebBrowserZoomOut
+/home/chennes/FreeCAD-chennes/src/Mod/Web/Gui/Command.cpp:250: Qualifying with unknown namespace/class ::CmdWebBrowserSetURL
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Gui/FreeCAD.pro.
+/home/chennes/FreeCAD-chennes/src/Gui/Selection.h:192: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/BlenderNavigationStyle.cpp:66: Class 'Gui::BlenderNavigationStyle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/CADNavigationStyle.cpp:66: Class 'Gui::CADNavigationStyle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:96: Qualifying with unknown namespace/class ::StdCmdOpen
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:111: Qualifying with unknown namespace/class ::StdCmdOpen
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:187: Qualifying with unknown namespace/class ::StdCmdImport
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:201: Qualifying with unknown namespace/class ::StdCmdImport
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:273: Qualifying with unknown namespace/class ::StdCmdExport
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:414: Qualifying with unknown namespace/class ::StdCmdExport
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:520: Qualifying with unknown namespace/class ::StdCmdMergeProjects
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:533: Qualifying with unknown namespace/class ::StdCmdMergeProjects
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:573: Qualifying with unknown namespace/class ::StdCmdDependencyGraph
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:605: Qualifying with unknown namespace/class ::StdCmdNew
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:636: Qualifying with unknown namespace/class ::StdCmdSave
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:676: Qualifying with unknown namespace/class ::StdCmdSaveAs
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:716: Qualifying with unknown namespace/class ::StdCmdSaveCopy
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:749: Qualifying with unknown namespace/class ::StdCmdSaveAll
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:777: Qualifying with unknown namespace/class ::StdCmdRevert
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:816: Qualifying with unknown namespace/class ::StdCmdProjectInfo
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:847: Qualifying with unknown namespace/class ::StdCmdProjectUtil
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:874: Qualifying with unknown namespace/class ::StdCmdPrint
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:887: Qualifying with unknown namespace/class ::StdCmdPrint
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:906: Qualifying with unknown namespace/class ::StdCmdPrintPreview
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:936: Qualifying with unknown namespace/class ::StdCmdPrintPdf
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:948: Qualifying with unknown namespace/class ::StdCmdPrintPdf
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:968: Qualifying with unknown namespace/class ::StdCmdQuit
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:994: Qualifying with unknown namespace/class ::StdCmdUndo
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1038: Qualifying with unknown namespace/class ::StdCmdRedo
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1081: Qualifying with unknown namespace/class ::StdCmdCut
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1109: Qualifying with unknown namespace/class ::StdCmdCopy
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1144: Qualifying with unknown namespace/class ::StdCmdPaste
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1183: Qualifying with unknown namespace/class ::StdCmdDuplicateSelection
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1217: Qualifying with unknown namespace/class ::StdCmdDuplicateSelection
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1271: Qualifying with unknown namespace/class ::StdCmdSelectAll
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1302: Qualifying with unknown namespace/class ::StdCmdDelete
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1449: Qualifying with unknown namespace/class ::StdCmdDelete
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1475: Qualifying with unknown namespace/class ::StdCmdRefresh
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1503: Qualifying with unknown namespace/class ::StdCmdRefresh
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1529: Qualifying with unknown namespace/class ::StdCmdTransform
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1555: Qualifying with unknown namespace/class ::StdCmdPlacement
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1589: Qualifying with unknown namespace/class ::StdCmdTransformManip
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1623: Qualifying with unknown namespace/class ::StdCmdAlignment
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1693: Qualifying with unknown namespace/class ::StdCmdEdit
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1737: Class 'StdCmdExpression' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/CommandFeat.cpp:54: Qualifying with unknown namespace/class ::StdCmdFeatRecompute
+/home/chennes/FreeCAD-chennes/src/Gui/CommandFeat.cpp:77: Qualifying with unknown namespace/class ::StdCmdRandomColor
+/home/chennes/FreeCAD-chennes/src/Gui/CommandFeat.cpp:129: Qualifying with unknown namespace/class ::StdCmdSendToPythonConsole
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:80: Class 'StdCmdLinkMakeGroup' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:211: Qualifying with unknown namespace/class ::StdCmdLinkMake
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:260: Qualifying with unknown namespace/class ::StdCmdLinkMake
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:274: Qualifying with unknown namespace/class ::StdCmdLinkMakeRelative
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:335: Qualifying with unknown namespace/class ::StdCmdLinkMakeRelative
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:494: Qualifying with unknown namespace/class ::StdCmdLinkReplace
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:518: Qualifying with unknown namespace/class ::StdCmdLinkUnlink
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:542: Qualifying with unknown namespace/class ::StdCmdLinkImport
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:592: Qualifying with unknown namespace/class ::StdCmdLinkImport
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:606: Qualifying with unknown namespace/class ::StdCmdLinkImportAll
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:631: Qualifying with unknown namespace/class ::StdCmdLinkImportAll
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:647: Qualifying with unknown namespace/class ::StdCmdLinkSelectLinked
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:774: Qualifying with unknown namespace/class ::StdCmdLinkSelectLinkedFinal
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:808: Qualifying with unknown namespace/class ::StdCmdLinkSelectAllLinks
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:847: Class 'StdCmdLinkSelectActions' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:873: Class 'StdCmdLinkActions' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/CommandMacro.cpp:48: Qualifying with unknown namespace/class ::StdCmdDlgMacroRecord
+/home/chennes/FreeCAD-chennes/src/Gui/CommandMacro.cpp:77: Qualifying with unknown namespace/class ::StdCmdMacroStopRecord
+/home/chennes/FreeCAD-chennes/src/Gui/CommandMacro.cpp:105: Qualifying with unknown namespace/class ::StdCmdDlgMacroExecute
+/home/chennes/FreeCAD-chennes/src/Gui/CommandMacro.cpp:134: Qualifying with unknown namespace/class ::StdCmdDlgMacroExecuteDirect
+/home/chennes/FreeCAD-chennes/src/Gui/CommandMacro.cpp:160: Qualifying with unknown namespace/class ::StdCmdMacroAttachDebugger
+/home/chennes/FreeCAD-chennes/src/Gui/CommandMacro.cpp:185: Qualifying with unknown namespace/class ::StdCmdMacroStartDebug
+/home/chennes/FreeCAD-chennes/src/Gui/CommandMacro.cpp:215: Qualifying with unknown namespace/class ::StdCmdMacroStopDebug
+/home/chennes/FreeCAD-chennes/src/Gui/CommandMacro.cpp:242: Qualifying with unknown namespace/class ::StdCmdMacroStepOver
+/home/chennes/FreeCAD-chennes/src/Gui/CommandMacro.cpp:269: Qualifying with unknown namespace/class ::StdCmdMacroStepInto
+/home/chennes/FreeCAD-chennes/src/Gui/CommandMacro.cpp:296: Qualifying with unknown namespace/class ::StdCmdToggleBreakpoint
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:80: Qualifying with unknown namespace/class ::StdCmdWorkbench
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:109: Qualifying with unknown namespace/class ::StdCmdWorkbench
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:145: Qualifying with unknown namespace/class ::StdCmdRecentFiles
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:186: Qualifying with unknown namespace/class ::StdCmdRecentMacros
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:226: Qualifying with unknown namespace/class ::StdCmdAbout
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:292: Qualifying with unknown namespace/class ::StdCmdAboutQt
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:314: Qualifying with unknown namespace/class ::StdCmdWhatsThis
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:338: Qualifying with unknown namespace/class ::StdCmdDlgParameter
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:363: Qualifying with unknown namespace/class ::StdCmdDlgPreferences
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:395: Qualifying with unknown namespace/class ::StdCmdDlgCustomize
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:422: Qualifying with unknown namespace/class ::StdCmdCommandLine
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:470: Qualifying with unknown namespace/class ::StdCmdOnlineHelp
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:495: Qualifying with unknown namespace/class ::StdCmdOnlineHelpWebsite
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:522: Qualifying with unknown namespace/class ::StdCmdFreeCADDonation
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:549: Qualifying with unknown namespace/class ::StdCmdFreeCADWebsite
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:577: Qualifying with unknown namespace/class ::StdCmdFreeCADUserHub
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:605: Qualifying with unknown namespace/class ::StdCmdFreeCADPowerUserHub
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:633: Qualifying with unknown namespace/class ::StdCmdFreeCADForum
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:661: Qualifying with unknown namespace/class ::StdCmdFreeCADFAQ
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:689: Qualifying with unknown namespace/class ::StdCmdPythonWebsite
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:713: Qualifying with unknown namespace/class ::StdCmdMeasurementSimple
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:727: Qualifying with unknown namespace/class ::StdCmdMeasurementSimple
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:770: Qualifying with unknown namespace/class ::StdCmdTextDocument
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:803: Qualifying with unknown namespace/class ::StdCmdUnitsCalculator
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:839: Class 'StdCmdUserEditMode' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStructure.cpp:52: Qualifying with unknown namespace/class ::StdCmdPart
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStructure.cpp:93: Qualifying with unknown namespace/class ::StdCmdGroup
+/home/chennes/FreeCAD-chennes/src/Gui/CommandTest.cpp:714: Qualifying with unknown namespace/class ::CmdTestConsoleOutput
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:108: Qualifying with unknown namespace/class ::StdOrthographicCamera
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:158: Qualifying with unknown namespace/class ::StdPerspectiveCamera
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:218: Qualifying with unknown namespace/class ::StdCmdViewSaveCamera
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:244: Qualifying with unknown namespace/class ::StdCmdViewRestoreCamera
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:303: Class 'StdCmdFreezeViews' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:561: Qualifying with unknown namespace/class ::StdCmdToggleClipPlane
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:643: Class 'StdCmdDrawStyle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:862: Qualifying with unknown namespace/class ::StdCmdToggleVisibility
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:892: Qualifying with unknown namespace/class ::StdCmdToggleSelectability
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:939: Qualifying with unknown namespace/class ::StdCmdShowSelection
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:967: Qualifying with unknown namespace/class ::StdCmdHideSelection
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:995: Qualifying with unknown namespace/class ::StdCmdSelectVisibleObjects
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1037: Qualifying with unknown namespace/class ::StdCmdToggleObjects
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1078: Qualifying with unknown namespace/class ::StdCmdShowObjects
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1115: Qualifying with unknown namespace/class ::StdCmdHideObjects
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1152: Qualifying with unknown namespace/class ::StdCmdSetAppearance
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1195: Qualifying with unknown namespace/class ::StdCmdViewHome
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1223: Qualifying with unknown namespace/class ::StdCmdViewBottom
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1247: Qualifying with unknown namespace/class ::StdCmdViewFront
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1271: Qualifying with unknown namespace/class ::StdCmdViewLeft
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1295: Qualifying with unknown namespace/class ::StdCmdViewRear
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1319: Qualifying with unknown namespace/class ::StdCmdViewRight
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1343: Qualifying with unknown namespace/class ::StdCmdViewTop
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1367: Qualifying with unknown namespace/class ::StdCmdViewIsometric
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1391: Qualifying with unknown namespace/class ::StdCmdViewDimetric
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1414: Qualifying with unknown namespace/class ::StdCmdViewTrimetric
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1437: Qualifying with unknown namespace/class ::StdCmdViewRotateLeft
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1462: Qualifying with unknown namespace/class ::StdCmdViewRotateRight
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1487: Qualifying with unknown namespace/class ::StdCmdViewFitAll
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1518: Qualifying with unknown namespace/class ::StdCmdViewFitSelection
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1549: Qualifying with unknown namespace/class ::StdViewDock
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1578: Qualifying with unknown namespace/class ::StdViewUndock
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1607: Qualifying with unknown namespace/class ::StdMainFullscreen
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1639: Qualifying with unknown namespace/class ::StdViewFullscreen
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1669: Qualifying with unknown namespace/class ::StdViewDockUndockFullscreen
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1782: Qualifying with unknown namespace/class ::StdCmdViewVR
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1812: Qualifying with unknown namespace/class ::StdViewScreenShot
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1845: Qualifying with unknown namespace/class ::StdViewScreenShot
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1983: Qualifying with unknown namespace/class ::StdCmdViewCreate
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2012: Qualifying with unknown namespace/class ::StdCmdToggleNavigation
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2062: Class 'StdCmdAxisCross' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2196: Qualifying with unknown namespace/class ::StdCmdViewExample1
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2224: Qualifying with unknown namespace/class ::StdCmdViewExample2
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2252: Qualifying with unknown namespace/class ::StdCmdViewExample3
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2281: Qualifying with unknown namespace/class ::StdCmdViewIvStereoOff
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2310: Qualifying with unknown namespace/class ::StdCmdViewIvStereoRedGreen
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2338: Qualifying with unknown namespace/class ::StdCmdViewIvStereoQuadBuff
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2366: Qualifying with unknown namespace/class ::StdCmdViewIvStereoInterleavedRows
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2394: Qualifying with unknown namespace/class ::StdCmdViewIvStereoInterleavedColumns
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2423: Qualifying with unknown namespace/class ::StdCmdViewIvIssueCamPos
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2473: Qualifying with unknown namespace/class ::StdViewZoomIn
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2506: Qualifying with unknown namespace/class ::StdViewZoomOut
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2666: Qualifying with unknown namespace/class ::StdViewBoxZoom
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2736: Qualifying with unknown namespace/class ::StdBoxSelection
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2999: Qualifying with unknown namespace/class ::StdBoxElementSelection
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3040: Qualifying with unknown namespace/class ::StdTreeSelection
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3065: Qualifying with unknown namespace/class ::StdCmdTreeCollapse
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3090: Qualifying with unknown namespace/class ::StdCmdTreeExpand
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3115: Qualifying with unknown namespace/class ::StdCmdTreeSelectAllInstances
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3165: Qualifying with unknown namespace/class ::StdCmdMeasureDistance
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3256: Qualifying with unknown namespace/class ::StdCmdSceneInspector
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3289: Qualifying with unknown namespace/class ::StdCmdTextureMapping
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3316: Qualifying with unknown namespace/class ::StdCmdDemoMode
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3344: Qualifying with unknown namespace/class ::CmdViewMeasureClearAll
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3374: Qualifying with unknown namespace/class ::CmdViewMeasureToggleAll
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3403: Qualifying with unknown namespace/class ::StdCmdSelBack
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3433: Qualifying with unknown namespace/class ::StdCmdSelForward
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3483: Qualifying with unknown namespace/class ::StdTreeSingleDocument
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3500: Qualifying with unknown namespace/class ::StdTreeMultiDocument
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3517: Qualifying with unknown namespace/class ::StdTreeCollapseDocument
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3556: Qualifying with unknown namespace/class ::StdTreeSyncView
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3574: Qualifying with unknown namespace/class ::StdTreeSyncSelection
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3592: Qualifying with unknown namespace/class ::StdTreeSyncPlacement
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3610: Qualifying with unknown namespace/class ::StdTreePreSelection
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3628: Qualifying with unknown namespace/class ::StdTreeRecordSelection
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3646: Qualifying with unknown namespace/class ::StdTreeDrag
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3678: Class 'StdCmdTreeViewActions' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3715: Qualifying with unknown namespace/class ::StdCmdSelBoundingBox
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:55: Qualifying with unknown namespace/class ::StdCmdArrangeIcons
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:82: Qualifying with unknown namespace/class ::StdCmdTileWindows
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:110: Qualifying with unknown namespace/class ::StdCmdCascadeWindows
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:138: Qualifying with unknown namespace/class ::StdCmdCloseActiveWindow
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:170: Qualifying with unknown namespace/class ::StdCmdCloseAllWindows
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:198: Qualifying with unknown namespace/class ::StdCmdActivateNextWindow
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:227: Qualifying with unknown namespace/class ::StdCmdActivatePrevWindow
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:256: Qualifying with unknown namespace/class ::StdCmdWindows
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:280: Qualifying with unknown namespace/class ::StdCmdUserInterface
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:302: Qualifying with unknown namespace/class ::StdCmdDockViewMenu
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:338: Qualifying with unknown namespace/class ::StdCmdToolBarMenu
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:392: Qualifying with unknown namespace/class ::StdCmdStatusBar
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:438: Qualifying with unknown namespace/class ::StdCmdWindowsMenu
+/home/chennes/FreeCAD-chennes/src/Gui/DocumentModel.cpp:203: Class 'Gui::DocumentModel' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:95: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:222: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:238: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:341: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:482: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:524: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:571: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:618: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:666: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:752: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:802: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:855: Class 'Gui::GestureNavigationStyle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/InventorNavigationStyle.cpp:68: Class 'Gui::InventorNavigationStyle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/ManualAlignment.cpp:437: Class 'Gui::AlignmentView' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/MayaGestureNavigationStyle.cpp:107: Class 'Gui::MayaGestureNavigationStyle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/NaviCube.cpp:1695: Qualifying with unknown namespace/class ::ViewIsometricCmd
+/home/chennes/FreeCAD-chennes/src/Gui/NaviCube.cpp:1715: Qualifying with unknown namespace/class ::ViewOrthographicCmd
+/home/chennes/FreeCAD-chennes/src/Gui/NaviCube.cpp:1736: Qualifying with unknown namespace/class ::ViewPerspectiveCmd
+/home/chennes/FreeCAD-chennes/src/Gui/NaviCube.cpp:1757: Qualifying with unknown namespace/class ::ViewZoomToFitCmd
+/home/chennes/FreeCAD-chennes/src/Gui/OnlineDocumentation.cpp:367: Class 'Gui::StdCmdPythonHelp' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/OpenCascadeNavigationStyle.cpp:66: Class 'Gui::OpenCascadeNavigationStyle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/OpenSCADNavigationStyle.cpp:66: Class 'Gui::OpenSCADNavigationStyle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/RevitNavigationStyle.cpp:66: Class 'Gui::RevitNavigationStyle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/TinkerCADNavigationStyle.cpp:66: Class 'Gui::TinkerCADNavigationStyle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/TouchpadNavigationStyle.cpp:66: Class 'Gui::TouchpadNavigationStyle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/WhatsThis.cpp:46: Class 'Gui::StdCmdDescription' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/Widgets.cpp:1450: Class 'PropertyListDialog' lacks Q_OBJECT macro
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/AddonManager/AddonManager.pro.
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Arch/Arch.pro.
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Assembly/Assembly.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:36: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:37: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:42: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:46: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:47: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:48: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:52: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:56: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:57: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:58: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:62: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:66: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:67: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:71: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/distance.hpp:32: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/distance.hpp:77: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/distance.hpp:193: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/distance.hpp:317: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/distance.hpp:382: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/distance.hpp:553: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/distance.hpp:573: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/distance.hpp:616: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/distance.hpp:637: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/distance.hpp:696: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/parallel.hpp:166: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/parallel.hpp:207: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/parallel.hpp:262: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/parallel.hpp:322: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/parallel.hpp:337: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/parallel.hpp:340: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/parallel.hpp:380: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/angle.hpp:80: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/angle.hpp:121: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/angle.hpp:124: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/angle.hpp:138: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/angle.hpp:141: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/angle.hpp:155: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/imp/constraint3d_holder_imp.hpp:51: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/imp/constraint3d_holder_imp.hpp:60: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/moduleShape3d/distance.hpp:32: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/Command.cpp:52: Qualifying with unknown namespace/class ::CmdAssemblyAddNewPart
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/Command.cpp:73: Qualifying with unknown namespace/class ::CmdAssemblyAddNewPart
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/Command.cpp:108: Qualifying with unknown namespace/class ::CmdAssemblyAddNewComponent
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/Command.cpp:129: Qualifying with unknown namespace/class ::CmdAssemblyAddNewComponent
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/Command.cpp:154: Qualifying with unknown namespace/class ::CmdAssemblyAddExistingComponent
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/Command.cpp:175: Qualifying with unknown namespace/class ::CmdAssemblyAddExistingComponent
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/Command.cpp:217: Qualifying with unknown namespace/class ::CmdAssemblyImport
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/CommandConstraints.cpp:118: Qualifying with unknown namespace/class ::CmdAssemblyConstraint
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/CommandConstraints.cpp:202: Qualifying with unknown namespace/class ::CmdAssemblyConstraintDistance
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/CommandConstraints.cpp:269: Qualifying with unknown namespace/class ::CmdAssemblyConstraintFix
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/CommandConstraints.cpp:334: Qualifying with unknown namespace/class ::CmdAssemblyConstraintAngle
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/CommandConstraints.cpp:403: Qualifying with unknown namespace/class ::CmdAssemblyConstraintOrientation
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/CommandConstraints.cpp:471: Qualifying with unknown namespace/class ::CmdAssemblyConstraintCoincidence
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/CommandConstraints.cpp:539: Qualifying with unknown namespace/class ::CmdAssemblyConstraintAlignment
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/Workbench.cpp:94: Class 'AssemblyGui::Workbench' lacks Q_OBJECT macro
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Draft/Draft.pro.
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Drawing/Drawing.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/TaskOrthoViews.h:162: Discarding unconsumed meta data
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:60: Qualifying with unknown namespace/class ::CmdDrawingOpen
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:72: Qualifying with unknown namespace/class ::CmdDrawingOpen
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:93: Qualifying with unknown namespace/class ::CmdDrawingNewPage
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:271: Qualifying with unknown namespace/class ::CmdDrawingNewA3Landscape
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:310: Qualifying with unknown namespace/class ::CmdDrawingNewView
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:323: Qualifying with unknown namespace/class ::CmdDrawingNewView
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:389: Qualifying with unknown namespace/class ::CmdDrawingOrthoViews
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:402: Qualifying with unknown namespace/class ::CmdDrawingOrthoViews
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:439: Qualifying with unknown namespace/class ::CmdDrawingOpenBrowserView
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:452: Qualifying with unknown namespace/class ::CmdDrawingOpenBrowserView
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:477: Qualifying with unknown namespace/class ::CmdDrawingAnnotation
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:492: Qualifying with unknown namespace/class ::CmdDrawingAnnotation
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:525: Qualifying with unknown namespace/class ::CmdDrawingClip
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:540: Qualifying with unknown namespace/class ::CmdDrawingClip
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:570: Qualifying with unknown namespace/class ::CmdDrawingSymbol
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:585: Qualifying with unknown namespace/class ::CmdDrawingSymbol
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:627: Qualifying with unknown namespace/class ::CmdDrawingExportPage
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:640: Qualifying with unknown namespace/class ::CmdDrawingExportPage
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:680: Qualifying with unknown namespace/class ::CmdDrawingProjectShape
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:716: Qualifying with unknown namespace/class ::CmdDrawingDraftView
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:747: Qualifying with unknown namespace/class ::CmdDrawingSpreadsheetView
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:760: Qualifying with unknown namespace/class ::CmdDrawingSpreadsheetView
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Fem/Fem.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:295: Qualifying with unknown namespace/class ::CmdFemConstraintBearing
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:336: Qualifying with unknown namespace/class ::CmdFemConstraintContact
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:381: Qualifying with unknown namespace/class ::CmdFemConstraintDisplacement
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:424: Qualifying with unknown namespace/class ::CmdFemConstraintFixed
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:466: Qualifying with unknown namespace/class ::CmdFemConstraintFluidBoundary
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:509: Qualifying with unknown namespace/class ::CmdFemConstraintForce
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:553: Qualifying with unknown namespace/class ::CmdFemConstraintGear
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:594: Qualifying with unknown namespace/class ::CmdFemConstraintHeatflux
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:639: Qualifying with unknown namespace/class ::CmdFemConstraintInitialTemperature
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:682: Qualifying with unknown namespace/class ::CmdFemConstraintPlaneRotation
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:724: Qualifying with unknown namespace/class ::CmdFemConstraintPressure
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:769: Qualifying with unknown namespace/class ::CmdFemConstraintSpring
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:814: Qualifying with unknown namespace/class ::CmdFemConstraintPulley
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:860: Qualifying with unknown namespace/class ::CmdFemConstraintTemperature
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:903: Qualifying with unknown namespace/class ::CmdFemConstraintTransform
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1039: Qualifying with unknown namespace/class ::CmdFemDefineNodesSet
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1095: Qualifying with unknown namespace/class ::CmdFemCreateNodesSet
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1251: Qualifying with unknown namespace/class ::CmdFemPostClipFilter
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1277: Qualifying with unknown namespace/class ::CmdFemPostCutFilter
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1303: Qualifying with unknown namespace/class ::CmdFemPostDataAlongLineFilter
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1329: Qualifying with unknown namespace/class ::CmdFemPostDataAtPointFilter
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1357: Qualifying with unknown namespace/class ::CmdFemPostLinearizedStressesFilter
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1414: Qualifying with unknown namespace/class ::CmdFemPostScalarClipFilter
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1440: Qualifying with unknown namespace/class ::CmdFemPostWarpVectorFilter
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1466: Qualifying with unknown namespace/class ::CmdFemPostFunctions
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1606: Qualifying with unknown namespace/class ::CmdFemPostApllyChanges
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1651: Qualifying with unknown namespace/class ::CmdFemPostPipelineFromResult
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/ViewProviderFemConstraintDisplacement.cpp:145: Unbalanced opening parenthesis in C++ code (or abuse of the C++ preprocessor)
+resulttools.py: Unbalanced parentheses in Python code
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Image/Image.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Image/Gui/Command.cpp:54: Qualifying with unknown namespace/class ::CmdImageOpen
+/home/chennes/FreeCAD-chennes/src/Mod/Image/Gui/Command.cpp:69: Qualifying with unknown namespace/class ::CmdImageOpen
+/home/chennes/FreeCAD-chennes/src/Mod/Image/Gui/Command.cpp:99: Qualifying with unknown namespace/class ::CmdCreateImagePlane
+/home/chennes/FreeCAD-chennes/src/Mod/Image/Gui/Command.cpp:113: Qualifying with unknown namespace/class ::CmdCreateImagePlane
+/home/chennes/FreeCAD-chennes/src/Mod/Image/Gui/Command.cpp:173: Qualifying with unknown namespace/class ::CmdImageScaling
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Mesh/Mesh.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:94: Qualifying with unknown namespace/class ::CmdMeshTransform
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:133: Qualifying with unknown namespace/class ::CmdMeshDemolding
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:172: Qualifying with unknown namespace/class ::CmdMeshToolMesh
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:227: Qualifying with unknown namespace/class ::CmdMeshUnion
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:298: Qualifying with unknown namespace/class ::CmdMeshDifference
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:369: Qualifying with unknown namespace/class ::CmdMeshIntersection
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:440: Qualifying with unknown namespace/class ::CmdMeshImport
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:452: Qualifying with unknown namespace/class ::CmdMeshImport
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:491: Qualifying with unknown namespace/class ::CmdMeshExport
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:510: Qualifying with unknown namespace/class ::CmdMeshExport
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:566: Qualifying with unknown namespace/class ::CmdMeshFromGeometry
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:576: Qualifying with unknown namespace/class ::CmdMeshFromGeometry
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:624: Qualifying with unknown namespace/class ::CmdMeshFromPartShape
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:650: Qualifying with unknown namespace/class ::CmdMeshVertexCurvature
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:693: Qualifying with unknown namespace/class ::CmdMeshVertexCurvatureInfo
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:739: Qualifying with unknown namespace/class ::CmdMeshPolySegm
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:795: Qualifying with unknown namespace/class ::CmdMeshPolySelect
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:848: Qualifying with unknown namespace/class ::CmdMeshAddFacet
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:895: Qualifying with unknown namespace/class ::CmdMeshPolyCut
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:956: Qualifying with unknown namespace/class ::CmdMeshPolyTrim
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1017: Qualifying with unknown namespace/class ::CmdMeshTrimByPlane
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1046: Qualifying with unknown namespace/class ::CmdMeshSectionByPlane
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1075: Qualifying with unknown namespace/class ::CmdMeshCrossSections
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1101: Qualifying with unknown namespace/class ::CmdMeshPolySplit
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1155: Qualifying with unknown namespace/class ::CmdMeshEvaluation
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1198: Qualifying with unknown namespace/class ::CmdMeshEvaluateFacet
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1241: Qualifying with unknown namespace/class ::CmdMeshRemoveComponents
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1286: Qualifying with unknown namespace/class ::CmdMeshRemeshGmsh
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1319: Qualifying with unknown namespace/class ::CmdMeshRemoveCompByHand
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1363: Qualifying with unknown namespace/class ::CmdMeshEvaluateSolid
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1378: Qualifying with unknown namespace/class ::CmdMeshEvaluateSolid
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1401: Qualifying with unknown namespace/class ::CmdMeshSmoothing
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1464: Qualifying with unknown namespace/class ::CmdMeshDecimating
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1495: Qualifying with unknown namespace/class ::CmdMeshHarmonizeNormals
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1529: Qualifying with unknown namespace/class ::CmdMeshFlipNormals
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1563: Qualifying with unknown namespace/class ::CmdMeshBoundingBox
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1586: Qualifying with unknown namespace/class ::CmdMeshBoundingBox
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1605: Qualifying with unknown namespace/class ::CmdMeshBuildRegularSolid
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1636: Qualifying with unknown namespace/class ::CmdMeshFillupHoles
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1648: Qualifying with unknown namespace/class ::CmdMeshFillupHoles
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1674: Qualifying with unknown namespace/class ::CmdMeshFillInteractiveHole
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1716: Qualifying with unknown namespace/class ::CmdMeshSegmentation
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1752: Qualifying with unknown namespace/class ::CmdMeshSegmentationBestFit
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1788: Qualifying with unknown namespace/class ::CmdMeshMerge
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1831: Qualifying with unknown namespace/class ::CmdMeshSplitComponents
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1877: Qualifying with unknown namespace/class ::CmdMeshScale
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1892: Qualifying with unknown namespace/class ::CmdMeshScale
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/MeshPart/MeshPart.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/MeshPart/Gui/Command.cpp:59: Qualifying with unknown namespace/class ::CmdMeshPartMesher
+/home/chennes/FreeCAD-chennes/src/Mod/MeshPart/Gui/Command.cpp:84: Qualifying with unknown namespace/class ::CmdMeshPartTrimByPlane
+/home/chennes/FreeCAD-chennes/src/Mod/MeshPart/Gui/Command.cpp:192: Qualifying with unknown namespace/class ::CmdMeshPartSection
+/home/chennes/FreeCAD-chennes/src/Mod/MeshPart/Gui/Command.cpp:276: Qualifying with unknown namespace/class ::CmdMeshPartCrossSections
+/home/chennes/FreeCAD-chennes/src/Mod/MeshPart/Gui/Command.cpp:312: Qualifying with unknown namespace/class ::CmdMeshPartCurveOnMesh
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/OpenSCAD/OpenSCAD.pro.
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/PartDesign/PartDesign.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/App/FeatureGroove.cpp:113: Class 'PartDesign::Groove' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/App/FeatureHole.cpp:1654: Class 'PartDesign::Hole' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/App/FeaturePocket.cpp:118: Class 'PartDesign::Pocket' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:167: Qualifying with unknown namespace/class ::CmdPartDesignPlane
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:195: Qualifying with unknown namespace/class ::CmdPartDesignLine
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:223: Qualifying with unknown namespace/class ::CmdPartDesignPoint
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:251: Qualifying with unknown namespace/class ::CmdPartDesignCS
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:283: Qualifying with unknown namespace/class ::CmdPartDesignShapeBinder
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:348: Qualifying with unknown namespace/class ::CmdPartDesignSubShapeBinder
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:412: Qualifying with unknown namespace/class ::CmdPartDesignSubShapeBinder
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:431: Qualifying with unknown namespace/class ::CmdPartDesignClone
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:489: Qualifying with unknown namespace/class ::CmdPartDesignNewSketch
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:594: Qualifying with unknown namespace/class ::CmdPartDesignNewSketch
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1309: Qualifying with unknown namespace/class ::CmdPartDesignPad
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1341: Qualifying with unknown namespace/class ::CmdPartDesignPocket
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1373: Qualifying with unknown namespace/class ::CmdPartDesignHole
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1419: Qualifying with unknown namespace/class ::CmdPartDesignRevolution
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1477: Qualifying with unknown namespace/class ::CmdPartDesignGroove
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1543: Qualifying with unknown namespace/class ::CmdPartDesignAdditivePipe
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1593: Qualifying with unknown namespace/class ::CmdPartDesignSubtractivePipe
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1643: Qualifying with unknown namespace/class ::CmdPartDesignAdditiveLoft
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1693: Qualifying with unknown namespace/class ::CmdPartDesignSubtractiveLoft
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1742: Qualifying with unknown namespace/class ::CmdPartDesignAdditiveHelix
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1812: Qualifying with unknown namespace/class ::CmdPartDesignSubtractiveHelix
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1991: Qualifying with unknown namespace/class ::CmdPartDesignFillet
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:2019: Qualifying with unknown namespace/class ::CmdPartDesignChamfer
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:2048: Qualifying with unknown namespace/class ::CmdPartDesignDraft
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:2105: Qualifying with unknown namespace/class ::CmdPartDesignThickness
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:2253: Qualifying with unknown namespace/class ::CmdPartDesignMirrored
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:2315: Qualifying with unknown namespace/class ::CmdPartDesignLinearPattern
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:2379: Qualifying with unknown namespace/class ::CmdPartDesignPolarPattern
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:2444: Qualifying with unknown namespace/class ::CmdPartDesignScaled
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:2493: Qualifying with unknown namespace/class ::CmdPartDesignMultiTransform
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:2616: Qualifying with unknown namespace/class ::CmdPartDesignBoolean
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandBody.cpp:89: Qualifying with unknown namespace/class ::CmdPartDesignBody
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandBody.cpp:119: Qualifying with unknown namespace/class ::CmdPartDesignBody
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandBody.cpp:312: Qualifying with unknown namespace/class ::CmdPartDesignMigrate
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandBody.cpp:343: Qualifying with unknown namespace/class ::CmdPartDesignMigrate
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandBody.cpp:527: Qualifying with unknown namespace/class ::CmdPartDesignMoveTip
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandBody.cpp:555: Qualifying with unknown namespace/class ::CmdPartDesignMoveTip
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandBody.cpp:606: Qualifying with unknown namespace/class ::CmdPartDesignDuplicateSelection
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandBody.cpp:662: Qualifying with unknown namespace/class ::CmdPartDesignMoveFeature
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandBody.cpp:680: Qualifying with unknown namespace/class ::CmdPartDesignMoveFeature
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandBody.cpp:824: Qualifying with unknown namespace/class ::CmdPartDesignMoveFeatureInTree
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandBody.cpp:851: Qualifying with unknown namespace/class ::CmdPartDesignMoveFeatureInTree
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandPrimitive.cpp:69: Qualifying with unknown namespace/class ::CmdPrimtiveCompAdditive
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandPrimitive.cpp:243: Qualifying with unknown namespace/class ::CmdPrimtiveCompSubtractive
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandPrimitive.cpp:269: Qualifying with unknown namespace/class ::CmdPrimtiveCompSubtractive
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/FeaturePickDialog.cpp:45: Qualifying with unknown namespace/class ::FeaturePickDialog
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/ReferenceSelection.cpp:271: Class 'PartDesignGui::NoDependentsSelection' lacks Q_OBJECT macro
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Part/Part.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:90: Qualifying with unknown namespace/class ::CmdPartPickCurveNet
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:136: Qualifying with unknown namespace/class ::CmdPartBox2
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:177: Qualifying with unknown namespace/class ::CmdPartBox3
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:218: Qualifying with unknown namespace/class ::CmdPartPrimitives
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:272: Qualifying with unknown namespace/class ::CmdPartCut
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:286: Qualifying with unknown namespace/class ::CmdPartCut
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:350: Qualifying with unknown namespace/class ::CmdPartCommon
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:381: Qualifying with unknown namespace/class ::CmdPartCommon
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:450: Qualifying with unknown namespace/class ::CmdPartFuse
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:481: Qualifying with unknown namespace/class ::CmdPartFuse
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:551: Qualifying with unknown namespace/class ::CmdPartCompJoinFeatures
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:657: Qualifying with unknown namespace/class ::CmdPartCompSplitFeatures
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:779: Qualifying with unknown namespace/class ::CmdPartCompCompoundTools
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:886: Qualifying with unknown namespace/class ::CmdPartCompound
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:900: Qualifying with unknown namespace/class ::CmdPartCompound
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:943: Qualifying with unknown namespace/class ::CmdPartSection
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:957: Qualifying with unknown namespace/class ::CmdPartSection
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:991: Qualifying with unknown namespace/class ::CmdPartImport
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1053: Qualifying with unknown namespace/class ::CmdPartExport
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1100: Qualifying with unknown namespace/class ::CmdPartImportCurveNet
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1113: Qualifying with unknown namespace/class ::CmdPartImportCurveNet
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1148: Qualifying with unknown namespace/class ::CmdPartMakeSolid
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1227: Qualifying with unknown namespace/class ::CmdPartReverseShape
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1290: Qualifying with unknown namespace/class ::CmdPartBoolean
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1321: Qualifying with unknown namespace/class ::CmdPartExtrude
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1349: Qualifying with unknown namespace/class ::CmdPartMakeFace
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1401: Qualifying with unknown namespace/class ::CmdPartRevolve
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1429: Qualifying with unknown namespace/class ::CmdPartFillet
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1457: Qualifying with unknown namespace/class ::CmdPartChamfer
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1485: Qualifying with unknown namespace/class ::CmdPartMirror
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1513: Qualifying with unknown namespace/class ::CmdPartCrossSections
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1553: Qualifying with unknown namespace/class ::CmdPartBuilder
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1582: Qualifying with unknown namespace/class ::CmdPartLoft
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1611: Qualifying with unknown namespace/class ::CmdPartSweep
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1640: Qualifying with unknown namespace/class ::CmdPartOffset
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1692: Qualifying with unknown namespace/class ::CmdPartOffset2D
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1743: Qualifying with unknown namespace/class ::CmdPartCompOffset
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1836: Qualifying with unknown namespace/class ::CmdPartThickness
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2011: Qualifying with unknown namespace/class ::CmdPartRuledSurface
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2097: Qualifying with unknown namespace/class ::CmdPartRuledSurface
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2127: Qualifying with unknown namespace/class ::CmdCheckGeometry
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2161: Qualifying with unknown namespace/class ::CmdColorPerFace
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2200: Qualifying with unknown namespace/class ::CmdMeasureLinear
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2231: Qualifying with unknown namespace/class ::CmdMeasureAngular
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2260: Qualifying with unknown namespace/class ::CmdMeasureRefresh
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2290: Qualifying with unknown namespace/class ::CmdMeasureClearAll
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2319: Qualifying with unknown namespace/class ::CmdMeasureToggleAll
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2356: Qualifying with unknown namespace/class ::CmdMeasureToggle3d
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2387: Qualifying with unknown namespace/class ::CmdMeasureToggleDelta
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2419: Qualifying with unknown namespace/class ::CmdBoxSelection
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2448: Qualifying with unknown namespace/class ::CmdPartProjectionOnSurface
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandParametric.cpp:66: Qualifying with unknown namespace/class ::CmdPartCylinder
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandParametric.cpp:108: Qualifying with unknown namespace/class ::CmdPartBox
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandParametric.cpp:150: Qualifying with unknown namespace/class ::CmdPartSphere
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandParametric.cpp:192: Qualifying with unknown namespace/class ::CmdPartCone
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandParametric.cpp:234: Qualifying with unknown namespace/class ::CmdPartTorus
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandSimple.cpp:58: Qualifying with unknown namespace/class ::CmdPartSimpleCylinder
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandSimple.cpp:108: Qualifying with unknown namespace/class ::CmdPartShapeFromMesh
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandSimple.cpp:137: Qualifying with unknown namespace/class ::CmdPartPointsFromMesh
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandSimple.cpp:187: Qualifying with unknown namespace/class ::CmdPartSimpleCopy
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandSimple.cpp:258: Qualifying with unknown namespace/class ::CmdPartTransformedCopy
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandSimple.cpp:286: Qualifying with unknown namespace/class ::CmdPartElementCopy
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandSimple.cpp:314: Qualifying with unknown namespace/class ::CmdPartRefineShape
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandSimple.cpp:374: Qualifying with unknown namespace/class ::CmdPartDefeaturing
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Path/Path.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Path/App/VoronoiPyImp.cpp:206: Parenthesis/brace mismatch between #if and #else branches; using #if branch
+/home/chennes/FreeCAD-chennes/src/Mod/Path/Gui/Command.cpp:55: Qualifying with unknown namespace/class ::CmdPathArea
+/home/chennes/FreeCAD-chennes/src/Mod/Path/Gui/Command.cpp:137: Qualifying with unknown namespace/class ::CmdPathAreaWorkplane
+/home/chennes/FreeCAD-chennes/src/Mod/Path/Gui/Command.cpp:227: Qualifying with unknown namespace/class ::CmdPathCompound
+/home/chennes/FreeCAD-chennes/src/Mod/Path/Gui/Command.cpp:279: Qualifying with unknown namespace/class ::CmdPathShape
+fanuc_post.py:107: Unterminated string
+rrf_post.py:214: Unterminated string
+linuxcnc_post.py:99: Unterminated string
+dynapath_post.py:143: Unterminated string
+jtech_post.py:104: Unterminated string
+marlin_post.py:209: Unterminated string
+centroid_post.py:116: Unterminated string
+fablin_post.py:88: Unterminated string
+mach3_mach4_post.py:98: Unterminated string
+grbl_post.py:80: Unterminated string
+uccnc_post.py:298: Unterminated string
+smoothie_post.py:108: Unterminated string
+opensbp_post.py:80: Unterminated string
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Points/Points.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Points/Gui/Command.cpp:68: Qualifying with unknown namespace/class ::CmdPointsImport
+/home/chennes/FreeCAD-chennes/src/Mod/Points/Gui/Command.cpp:82: Qualifying with unknown namespace/class ::CmdPointsImport
+/home/chennes/FreeCAD-chennes/src/Mod/Points/Gui/Command.cpp:113: Qualifying with unknown namespace/class ::CmdPointsExport
+/home/chennes/FreeCAD-chennes/src/Mod/Points/Gui/Command.cpp:130: Qualifying with unknown namespace/class ::CmdPointsExport
+/home/chennes/FreeCAD-chennes/src/Mod/Points/Gui/Command.cpp:153: Qualifying with unknown namespace/class ::CmdPointsTransform
+/home/chennes/FreeCAD-chennes/src/Mod/Points/Gui/Command.cpp:190: Qualifying with unknown namespace/class ::CmdPointsConvert
+/home/chennes/FreeCAD-chennes/src/Mod/Points/Gui/Command.cpp:209: Qualifying with unknown namespace/class ::CmdPointsConvert
+/home/chennes/FreeCAD-chennes/src/Mod/Points/Gui/Command.cpp:282: Qualifying with unknown namespace/class ::CmdPointsPolyCut
+/home/chennes/FreeCAD-chennes/src/Mod/Points/Gui/Command.cpp:327: Qualifying with unknown namespace/class ::CmdPointsMerge
+/home/chennes/FreeCAD-chennes/src/Mod/Points/Gui/Command.cpp:370: Qualifying with unknown namespace/class ::CmdPointsStructure
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Raytracing.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:84: Qualifying with unknown namespace/class ::CmdRaytracingWriteCamera
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:137: Qualifying with unknown namespace/class ::CmdRaytracingWriteCamera
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:177: Qualifying with unknown namespace/class ::CmdRaytracingWritePart
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:188: Qualifying with unknown namespace/class ::CmdRaytracingWritePart
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:223: Qualifying with unknown namespace/class ::CmdRaytracingWriteView
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:250: Qualifying with unknown namespace/class ::CmdRaytracingWriteView
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:320: Qualifying with unknown namespace/class ::CmdRaytracingNewPovrayProject
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:437: Qualifying with unknown namespace/class ::CmdRaytracingNewPartSegment
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:449: Qualifying with unknown namespace/class ::CmdRaytracingNewPartSegment
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:521: Qualifying with unknown namespace/class ::CmdRaytracingExportProject
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:536: Qualifying with unknown namespace/class ::CmdRaytracingExportProject
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:584: Qualifying with unknown namespace/class ::CmdRaytracingRender
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:600: Qualifying with unknown namespace/class ::CmdRaytracingRender
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:766: Qualifying with unknown namespace/class ::CmdRaytracingNewLuxProject
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:879: Qualifying with unknown namespace/class ::CmdRaytracingResetCamera
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:893: Qualifying with unknown namespace/class ::CmdRaytracingResetCamera
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/ReverseEngineering.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/Gui/Command.cpp:74: Qualifying with unknown namespace/class ::CmdApproxSurface
+/home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/Gui/Command.cpp:110: Qualifying with unknown namespace/class ::CmdApproxPlane
+/home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/Gui/Command.cpp:211: Qualifying with unknown namespace/class ::CmdApproxCylinder
+/home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/Gui/Command.cpp:277: Qualifying with unknown namespace/class ::CmdApproxSphere
+/home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/Gui/Command.cpp:324: Qualifying with unknown namespace/class ::CmdApproxPolynomial
+/home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/Gui/Command.cpp:379: Qualifying with unknown namespace/class ::CmdSegmentation
+/home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/Gui/Command.cpp:411: Qualifying with unknown namespace/class ::CmdSegmentationManual
+/home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/Gui/Command.cpp:440: Qualifying with unknown namespace/class ::CmdSegmentationFromComponents
+/home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/Gui/Command.cpp:490: Qualifying with unknown namespace/class ::CmdMeshBoundary
+/home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/Gui/Command.cpp:556: Qualifying with unknown namespace/class ::CmdPoissonReconstruction
+/home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/Gui/Command.cpp:590: Qualifying with unknown namespace/class ::CmdViewTriangulation
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Robot/Robot.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/Command.cpp:55: Qualifying with unknown namespace/class ::CmdRobotSetHomePos
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/Command.cpp:75: Qualifying with unknown namespace/class ::CmdRobotSetHomePos
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/Command.cpp:104: Qualifying with unknown namespace/class ::CmdRobotRestoreHomePos
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/Command.cpp:124: Qualifying with unknown namespace/class ::CmdRobotRestoreHomePos
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/Command.cpp:158: Qualifying with unknown namespace/class ::CmdRobotConstraintAxle
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/Command.cpp:199: Qualifying with unknown namespace/class ::CmdRobotSimulate
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/Command.cpp:224: Qualifying with unknown namespace/class ::CmdRobotSimulate
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandExport.cpp:50: Qualifying with unknown namespace/class ::CmdRobotExportKukaCompact
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandExport.cpp:65: Qualifying with unknown namespace/class ::CmdRobotExportKukaCompact
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandExport.cpp:112: Qualifying with unknown namespace/class ::CmdRobotExportKukaFull
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandExport.cpp:127: Qualifying with unknown namespace/class ::CmdRobotExportKukaFull
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandInsertRobot.cpp:51: Qualifying with unknown namespace/class ::CmdRobotInsertKukaIR500
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandInsertRobot.cpp:93: Qualifying with unknown namespace/class ::CmdRobotInsertKukaIR16
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandInsertRobot.cpp:134: Qualifying with unknown namespace/class ::CmdRobotInsertKukaIR210
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandInsertRobot.cpp:174: Qualifying with unknown namespace/class ::CmdRobotInsertKukaIR125
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandInsertRobot.cpp:215: Qualifying with unknown namespace/class ::CmdRobotAddToolShape
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandInsertRobot.cpp:234: Qualifying with unknown namespace/class ::CmdRobotAddToolShape
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:62: Qualifying with unknown namespace/class ::CmdRobotCreateTrajectory
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:95: Qualifying with unknown namespace/class ::CmdRobotInsertWaypoint
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:111: Qualifying with unknown namespace/class ::CmdRobotInsertWaypoint
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:152: Qualifying with unknown namespace/class ::CmdRobotInsertWaypointPreselect
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:167: Qualifying with unknown namespace/class ::CmdRobotInsertWaypointPreselect
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:216: Qualifying with unknown namespace/class ::CmdRobotSetDefaultOrientation
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:254: Qualifying with unknown namespace/class ::CmdRobotSetDefaultValues
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:268: Qualifying with unknown namespace/class ::CmdRobotSetDefaultValues
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:320: Qualifying with unknown namespace/class ::CmdRobotEdge2Trac
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:384: Qualifying with unknown namespace/class ::CmdRobotTrajectoryDressUp
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:412: Qualifying with unknown namespace/class ::CmdRobotTrajectoryDressUp
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:431: Qualifying with unknown namespace/class ::CmdRobotTrajectoryCompound
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Sketcher.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:143: Qualifying with unknown namespace/class ::CmdSketcherNewSketch
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:164: Qualifying with unknown namespace/class ::CmdSketcherNewSketch
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:266: Qualifying with unknown namespace/class ::CmdSketcherEditSketch
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:296: Qualifying with unknown namespace/class ::CmdSketcherLeaveSketch
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:340: Qualifying with unknown namespace/class ::CmdSketcherStopOperation
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:381: Qualifying with unknown namespace/class ::CmdSketcherReorientSketch
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:508: Qualifying with unknown namespace/class ::CmdSketcherMapSketch
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:562: Qualifying with unknown namespace/class ::CmdSketcherMapSketch
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:683: Qualifying with unknown namespace/class ::CmdSketcherViewSketch
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:723: Qualifying with unknown namespace/class ::CmdSketcherValidateSketch
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:761: Qualifying with unknown namespace/class ::CmdSketcherMirrorSketch
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:868: Qualifying with unknown namespace/class ::CmdSketcherMergeSketches
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:952: Qualifying with unknown namespace/class ::CmdSketcherViewSection
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandAlterGeometry.cpp:74: Qualifying with unknown namespace/class ::CmdSketcherToggleConstruction
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandAlterGeometry.cpp:123: Qualifying with unknown namespace/class ::CmdSketcherToggleConstruction
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:883: Class 'CmdSketcherConstrainHorizontal' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:1121: Class 'CmdSketcherConstrainVertical' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:1355: Class 'CmdSketcherConstrainLock' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:1581: Class 'CmdSketcherConstrainBlock' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:1896: Class 'CmdSketcherConstrainCoincident' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:2102: Class 'CmdSketcherConstrainDistance' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:2451: Class 'CmdSketcherConstrainPointOnObject' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:2699: Class 'CmdSketcherConstrainDistanceX' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:2953: Class 'CmdSketcherConstrainDistanceY' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:3199: Class 'CmdSketcherConstrainParallel' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:3349: Class 'CmdSketcherConstrainPerpendicular' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:3987: Class 'CmdSketcherConstrainTangent' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:4695: Class 'CmdSketcherConstrainRadius' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:4997: Class 'CmdSketcherConstrainDiameter' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:5273: Class 'CmdSketcherConstrainRadiam' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:5577: Qualifying with unknown namespace/class ::CmdSketcherCompConstrainRadDia
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:5721: Class 'CmdSketcherConstrainAngle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:6248: Class 'CmdSketcherConstrainEqual' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:6465: Class 'CmdSketcherConstrainSymmetric' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:6765: Qualifying with unknown namespace/class ::CmdSketcherConstrainSnellsLaw
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:6784: Qualifying with unknown namespace/class ::CmdSketcherConstrainSnellsLaw
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:6931: Qualifying with unknown namespace/class ::CmdSketcherConstrainInternalAlignment
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:6949: Qualifying with unknown namespace/class ::CmdSketcherConstrainInternalAlignment
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:7391: Qualifying with unknown namespace/class ::CmdSketcherToggleDrivingConstraint
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:7430: Qualifying with unknown namespace/class ::CmdSketcherToggleDrivingConstraint
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:7518: Qualifying with unknown namespace/class ::CmdSketcherToggleActiveConstraint
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:7543: Qualifying with unknown namespace/class ::CmdSketcherToggleActiveConstraint
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:344: Qualifying with unknown namespace/class ::CmdSketcherCreateLine
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:649: Qualifying with unknown namespace/class ::CmdSketcherCreateRectangle
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:690: Qualifying with unknown namespace/class ::CmdSketcherCreateRectangleCenter
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:1016: Qualifying with unknown namespace/class ::CmdSketcherCreateOblong
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:1059: Qualifying with unknown namespace/class ::CmdSketcherCompCreateRectangles
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:1815: Qualifying with unknown namespace/class ::CmdSketcherCreatePolyline
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:2059: Qualifying with unknown namespace/class ::CmdSketcherCreateArc
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:2329: Qualifying with unknown namespace/class ::CmdSketcherCreate3PointArc
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:2357: Qualifying with unknown namespace/class ::CmdSketcherCompCreateArc
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:2591: Qualifying with unknown namespace/class ::CmdSketcherCreateCircle
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:3387: Qualifying with unknown namespace/class ::CmdSketcherCreateEllipseByCenter
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:3418: Qualifying with unknown namespace/class ::CmdSketcherCreateEllipseBy3Points
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:3746: Qualifying with unknown namespace/class ::CmdSketcherCreateArcOfEllipse
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:4090: Qualifying with unknown namespace/class ::CmdSketcherCreateArcOfHyperbola
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:4389: Qualifying with unknown namespace/class ::CmdSketcherCreateArcOfParabola
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:4422: Qualifying with unknown namespace/class ::CmdSketcherCompCreateConic
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:4925: Qualifying with unknown namespace/class ::CmdSketcherCreateBSpline
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:4970: Qualifying with unknown namespace/class ::CmdSketcherCreatePeriodicBSpline
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:5002: Qualifying with unknown namespace/class ::CmdSketcherCompCreateBSpline
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:5285: Qualifying with unknown namespace/class ::CmdSketcherCreate3PointCircle
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:5313: Qualifying with unknown namespace/class ::CmdSketcherCompCreateCircle
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:5493: Qualifying with unknown namespace/class ::CmdSketcherCreatePoint
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:5523: Qualifying with unknown namespace/class ::CmdSketcherCreateText
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:5551: Qualifying with unknown namespace/class ::CmdSketcherCreateDraftLine
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:5831: Qualifying with unknown namespace/class ::CmdSketcherCreateFillet
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:5860: Qualifying with unknown namespace/class ::CmdSketcherCreatePointFillet
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:5891: Qualifying with unknown namespace/class ::CmdSketcherCompCreateFillets
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:6121: Qualifying with unknown namespace/class ::CmdSketcherTrimming
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:6435: Qualifying with unknown namespace/class ::CmdSketcherExtend
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:6554: Qualifying with unknown namespace/class ::CmdSketcherSplit
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:6593: Class 'SketcherGui::ExternalSelection' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:6739: Qualifying with unknown namespace/class ::CmdSketcherExternal
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:6785: Class 'SketcherGui::CarbonCopySelection' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:6917: Qualifying with unknown namespace/class ::CmdSketcherCarbonCopy
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:7228: Qualifying with unknown namespace/class ::CmdSketcherCreateSlot
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:7421: Qualifying with unknown namespace/class ::CmdSketcherCreateTriangle
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:7448: Qualifying with unknown namespace/class ::CmdSketcherCreateSquare
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:7475: Qualifying with unknown namespace/class ::CmdSketcherCreatePentagon
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:7503: Qualifying with unknown namespace/class ::CmdSketcherCreateHexagon
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:7530: Qualifying with unknown namespace/class ::CmdSketcherCreateHeptagon
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:7557: Qualifying with unknown namespace/class ::CmdSketcherCreateOctagon
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:7584: Qualifying with unknown namespace/class ::CmdSketcherCreateRegularPolygon
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:7615: Qualifying with unknown namespace/class ::CmdSketcherCompCreateRegularPolygon
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:100: Qualifying with unknown namespace/class ::CmdSketcherBSplineDegree
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:129: Qualifying with unknown namespace/class ::CmdSketcherBSplinePolygon
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:158: Qualifying with unknown namespace/class ::CmdSketcherBSplineComb
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:187: Qualifying with unknown namespace/class ::CmdSketcherBSplineKnotMultiplicity
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:216: Qualifying with unknown namespace/class ::CmdSketcherBSplinePoleWeight
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:245: Qualifying with unknown namespace/class ::CmdSketcherCompBSplineShowHideGeometryInformation
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:374: Qualifying with unknown namespace/class ::CmdSketcherConvertToNURB
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:420: Qualifying with unknown namespace/class ::CmdSketcherConvertToNURB
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:442: Qualifying with unknown namespace/class ::CmdSketcherIncreaseDegree
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:491: Qualifying with unknown namespace/class ::CmdSketcherIncreaseDegree
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:515: Qualifying with unknown namespace/class ::CmdSketcherDecreaseDegree
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:569: Qualifying with unknown namespace/class ::CmdSketcherDecreaseDegree
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:592: Qualifying with unknown namespace/class ::CmdSketcherIncreaseKnotMultiplicity
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:607: Qualifying with unknown namespace/class ::CmdSketcherIncreaseKnotMultiplicity
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:746: Qualifying with unknown namespace/class ::CmdSketcherDecreaseKnotMultiplicity
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:761: Qualifying with unknown namespace/class ::CmdSketcherDecreaseKnotMultiplicity
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:888: Qualifying with unknown namespace/class ::CmdSketcherCompModifyKnotMultiplicity
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:981: Qualifying with unknown namespace/class ::CmdSketcherInsertKnot
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:996: Qualifying with unknown namespace/class ::CmdSketcherInsertKnot
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:105: Qualifying with unknown namespace/class ::CmdSketcherCloseShape
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:129: Qualifying with unknown namespace/class ::CmdSketcherCloseShape
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:217: Qualifying with unknown namespace/class ::CmdSketcherConnect
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:240: Qualifying with unknown namespace/class ::CmdSketcherConnect
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:304: Qualifying with unknown namespace/class ::CmdSketcherSelectConstraints
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:327: Qualifying with unknown namespace/class ::CmdSketcherSelectConstraints
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:381: Qualifying with unknown namespace/class ::CmdSketcherSelectOrigin
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:427: Qualifying with unknown namespace/class ::CmdSketcherSelectVerticalAxis
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:471: Qualifying with unknown namespace/class ::CmdSketcherSelectHorizontalAxis
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:514: Qualifying with unknown namespace/class ::CmdSketcherSelectRedundantConstraints
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:571: Qualifying with unknown namespace/class ::CmdSketcherSelectMalformedConstraints
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:627: Qualifying with unknown namespace/class ::CmdSketcherSelectPartiallyRedundantConstraints
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:683: Qualifying with unknown namespace/class ::CmdSketcherSelectConflictingConstraints
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:738: Qualifying with unknown namespace/class ::CmdSketcherSelectElementsAssociatedWithConstraints
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:836: Qualifying with unknown namespace/class ::CmdSketcherSelectElementsAssociatedWithConstraints
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:859: Qualifying with unknown namespace/class ::CmdSketcherSelectElementsWithDoFs
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:950: Qualifying with unknown namespace/class ::CmdSketcherRestoreInternalAlignmentGeometry
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:974: Qualifying with unknown namespace/class ::CmdSketcherRestoreInternalAlignmentGeometry
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:1046: Qualifying with unknown namespace/class ::CmdSketcherSymmetry
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:1069: Qualifying with unknown namespace/class ::CmdSketcherSymmetry
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:1581: Class 'CmdSketcherCopy' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:1627: Class 'CmdSketcherClone' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:1670: Class 'CmdSketcherMove' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:1704: Qualifying with unknown namespace/class ::CmdSketcherCompCopy
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:1986: Qualifying with unknown namespace/class ::CmdSketcherRectangularArray
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:2005: Qualifying with unknown namespace/class ::CmdSketcherRectangularArray
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:2126: Qualifying with unknown namespace/class ::CmdSketcherDeleteAllGeometry
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:2140: Qualifying with unknown namespace/class ::CmdSketcherDeleteAllGeometry
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:2189: Qualifying with unknown namespace/class ::CmdSketcherDeleteAllConstraints
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:2202: Qualifying with unknown namespace/class ::CmdSketcherDeleteAllConstraints
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:2253: Qualifying with unknown namespace/class ::CmdSketcherRemoveAxesAlignment
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:2272: Qualifying with unknown namespace/class ::CmdSketcherRemoveAxesAlignment
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherVirtualSpace.cpp:93: Qualifying with unknown namespace/class ::CmdSketcherSwitchVirtualSpace
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherVirtualSpace.cpp:115: Qualifying with unknown namespace/class ::CmdSketcherSwitchVirtualSpace
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Spreadsheet.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/AppSpreadsheetGui.cpp:87: Class 'SpreadsheetGui::Module' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:70: Qualifying with unknown namespace/class ::CmdSpreadsheetMergeCells
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:123: Qualifying with unknown namespace/class ::CmdSpreadsheetSplitCell
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:179: Qualifying with unknown namespace/class ::CmdSpreadsheetImport
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:191: Qualifying with unknown namespace/class ::CmdSpreadsheetImport
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:229: Qualifying with unknown namespace/class ::CmdSpreadsheetExport
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:247: Qualifying with unknown namespace/class ::CmdSpreadsheetExport
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:290: Qualifying with unknown namespace/class ::CmdSpreadsheetAlignLeft
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:342: Qualifying with unknown namespace/class ::CmdSpreadsheetAlignCenter
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:394: Qualifying with unknown namespace/class ::CmdSpreadsheetAlignRight
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:446: Qualifying with unknown namespace/class ::CmdSpreadsheetAlignTop
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:498: Qualifying with unknown namespace/class ::CmdSpreadsheetAlignBottom
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:550: Qualifying with unknown namespace/class ::CmdSpreadsheetAlignVCenter
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:602: Qualifying with unknown namespace/class ::CmdSpreadsheetStyleBold
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:676: Qualifying with unknown namespace/class ::CmdSpreadsheetStyleItalic
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:750: Qualifying with unknown namespace/class ::CmdSpreadsheetStyleUnderline
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:823: Qualifying with unknown namespace/class ::CmdSpreadsheetSetAlias
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:887: Qualifying with unknown namespace/class ::CmdCreateSpreadsheet
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Start/Start.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Start/Gui/Command.cpp:45: Qualifying with unknown namespace/class ::CmdStartPage
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/TechDraw/TechDraw.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:117: Qualifying with unknown namespace/class ::CmdTechDrawPageDefault
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:181: Qualifying with unknown namespace/class ::CmdTechDrawPageTemplate
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:195: Qualifying with unknown namespace/class ::CmdTechDrawPageTemplate
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:261: Qualifying with unknown namespace/class ::CmdTechDrawRedrawPage
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:298: Qualifying with unknown namespace/class ::CmdTechDrawView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:379: Qualifying with unknown namespace/class ::CmdTechDrawView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:442: Qualifying with unknown namespace/class ::CmdTechDrawActiveView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:476: Qualifying with unknown namespace/class ::CmdTechDrawSectionView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:494: Qualifying with unknown namespace/class ::CmdTechDrawSectionView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:526: Qualifying with unknown namespace/class ::CmdTechDrawDetailView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:545: Qualifying with unknown namespace/class ::CmdTechDrawDetailView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:575: Qualifying with unknown namespace/class ::CmdTechDrawProjectionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:655: Qualifying with unknown namespace/class ::CmdTechDrawProjectionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:855: Qualifying with unknown namespace/class ::CmdTechDrawBalloon
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:920: Qualifying with unknown namespace/class ::CmdTechDrawClipGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:959: Qualifying with unknown namespace/class ::CmdTechDrawClipGroupAdd
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:972: Qualifying with unknown namespace/class ::CmdTechDrawClipGroupAdd
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1043: Qualifying with unknown namespace/class ::CmdTechDrawClipGroupRemove
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1057: Qualifying with unknown namespace/class ::CmdTechDrawClipGroupRemove
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1118: Qualifying with unknown namespace/class ::CmdTechDrawSymbol
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1137: Qualifying with unknown namespace/class ::CmdTechDrawSymbol
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1173: Qualifying with unknown namespace/class ::CmdTechDrawDraftView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1194: Qualifying with unknown namespace/class ::CmdTechDrawDraftView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1239: Qualifying with unknown namespace/class ::CmdTechDrawArchView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1268: Qualifying with unknown namespace/class ::CmdTechDrawArchView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1304: Qualifying with unknown namespace/class ::CmdTechDrawSpreadsheetView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1317: Qualifying with unknown namespace/class ::CmdTechDrawSpreadsheetView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1363: Qualifying with unknown namespace/class ::CmdTechDrawExportPageSVG
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1388: Qualifying with unknown namespace/class ::CmdTechDrawExportPageSVG
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1408: Qualifying with unknown namespace/class ::CmdTechDrawExportPageDXF
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1428: Qualifying with unknown namespace/class ::CmdTechDrawExportPageDXF
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:101: Qualifying with unknown namespace/class ::CmdTechDrawLeaderLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:115: Qualifying with unknown namespace/class ::CmdTechDrawLeaderLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:163: Qualifying with unknown namespace/class ::CmdTechDrawRichTextAnnotation
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:176: Qualifying with unknown namespace/class ::CmdTechDrawRichTextAnnotation
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:215: Qualifying with unknown namespace/class ::CmdTechDrawCosmeticVertexGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:228: Qualifying with unknown namespace/class ::CmdTechDrawCosmeticVertexGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:404: Qualifying with unknown namespace/class ::CmdTechDrawCosmeticVertex
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:417: Qualifying with unknown namespace/class ::CmdTechDrawCosmeticVertex
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:465: Qualifying with unknown namespace/class ::CmdTechDrawMidpoints
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:478: Qualifying with unknown namespace/class ::CmdTechDrawMidpoints
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:504: Qualifying with unknown namespace/class ::CmdTechDrawQuadrants
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:517: Qualifying with unknown namespace/class ::CmdTechDrawQuadrants
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:543: Qualifying with unknown namespace/class ::CmdTechDrawAnnotation
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:583: Qualifying with unknown namespace/class ::CmdTechDrawCenterLineGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:596: Qualifying with unknown namespace/class ::CmdTechDrawCenterLineGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:686: Qualifying with unknown namespace/class ::CmdTechDrawFaceCenterLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:700: Qualifying with unknown namespace/class ::CmdTechDrawFaceCenterLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:796: Qualifying with unknown namespace/class ::CmdTechDraw2LineCenterLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:810: Qualifying with unknown namespace/class ::CmdTechDraw2LineCenterLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:873: Qualifying with unknown namespace/class ::CmdTechDraw2PointCenterLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:887: Qualifying with unknown namespace/class ::CmdTechDraw2PointCenterLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:986: Qualifying with unknown namespace/class ::CmdTechDraw2PointCosmeticLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:1000: Qualifying with unknown namespace/class ::CmdTechDraw2PointCosmeticLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:1138: Qualifying with unknown namespace/class ::CmdTechDrawCosmeticEraser
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:1151: Qualifying with unknown namespace/class ::CmdTechDrawCosmeticEraser
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:1265: Qualifying with unknown namespace/class ::CmdTechDrawDecorateLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:1279: Qualifying with unknown namespace/class ::CmdTechDrawDecorateLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:1344: Qualifying with unknown namespace/class ::CmdTechDrawShowAll
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:1357: Qualifying with unknown namespace/class ::CmdTechDrawShowAll
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:1409: Qualifying with unknown namespace/class ::CmdTechDrawWeldSymbol
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:1423: Qualifying with unknown namespace/class ::CmdTechDrawWeldSymbol
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:123: Qualifying with unknown namespace/class ::CmdTechDrawDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:250: Qualifying with unknown namespace/class ::CmdTechDrawRadiusDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:294: Qualifying with unknown namespace/class ::CmdTechDrawRadiusDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:372: Qualifying with unknown namespace/class ::CmdTechDrawDiameterDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:416: Qualifying with unknown namespace/class ::CmdTechDrawDiameterDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:493: Qualifying with unknown namespace/class ::CmdTechDrawLengthDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:547: Qualifying with unknown namespace/class ::CmdTechDrawLengthDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:595: Qualifying with unknown namespace/class ::CmdTechDrawHorizontalDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:650: Qualifying with unknown namespace/class ::CmdTechDrawHorizontalDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:698: Qualifying with unknown namespace/class ::CmdTechDrawVerticalDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:753: Qualifying with unknown namespace/class ::CmdTechDrawVerticalDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:800: Qualifying with unknown namespace/class ::CmdTechDrawAngleDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:845: Qualifying with unknown namespace/class ::CmdTechDrawAngleDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:888: Qualifying with unknown namespace/class ::CmdTechDraw3PtAngleDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:934: Qualifying with unknown namespace/class ::CmdTechDraw3PtAngleDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:980: Qualifying with unknown namespace/class ::CmdTechDrawLinkDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:1019: Qualifying with unknown namespace/class ::CmdTechDrawLinkDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:1058: Qualifying with unknown namespace/class ::CmdTechDrawExtentGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:1071: Qualifying with unknown namespace/class ::CmdTechDrawExtentGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:1151: Qualifying with unknown namespace/class ::CmdTechDrawHorizontalExtentDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:1165: Qualifying with unknown namespace/class ::CmdTechDrawHorizontalExtentDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:1238: Qualifying with unknown namespace/class ::CmdTechDrawVerticalExtentDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:1252: Qualifying with unknown namespace/class ::CmdTechDrawVerticalExtentDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:1321: Qualifying with unknown namespace/class ::CmdTechDrawLandmarkDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:1339: Qualifying with unknown namespace/class ::CmdTechDrawLandmarkDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandDecorate.cpp:87: Qualifying with unknown namespace/class ::CmdTechDrawHatch
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandDecorate.cpp:122: Qualifying with unknown namespace/class ::CmdTechDrawHatch
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandDecorate.cpp:208: Qualifying with unknown namespace/class ::CmdTechDrawGeometricHatch
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandDecorate.cpp:277: Qualifying with unknown namespace/class ::CmdTechDrawImage
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandDecorate.cpp:296: Qualifying with unknown namespace/class ::CmdTechDrawImage
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandDecorate.cpp:328: Qualifying with unknown namespace/class ::CmdTechDrawToggleFrame
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandDecorate.cpp:352: Qualifying with unknown namespace/class ::CmdTechDrawToggleFrame
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:145: Qualifying with unknown namespace/class ::CmdTechDrawExtensionInsertDiameter
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:178: Qualifying with unknown namespace/class ::CmdTechDrawExtensionInsertSquare
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:211: Qualifying with unknown namespace/class ::CmdTechDrawExtensionInsertPrefixGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:225: Qualifying with unknown namespace/class ::CmdTechDrawExtensionInsertPrefixGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:338: Qualifying with unknown namespace/class ::CmdTechDrawExtensionIncreaseDecimal
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:371: Qualifying with unknown namespace/class ::CmdTechDrawExtensionDecreaseDecimal
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:404: Qualifying with unknown namespace/class ::CmdTechDrawExtensionIncreaseDecreaseGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:418: Qualifying with unknown namespace/class ::CmdTechDrawExtensionIncreaseDecreaseGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:529: Qualifying with unknown namespace/class ::CmdTechDrawExtensionPosHorizChainDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:588: Qualifying with unknown namespace/class ::CmdTechDrawExtensionPosVertChainDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:653: Qualifying with unknown namespace/class ::CmdTechDrawExtensionPosObliqueChainDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:688: Qualifying with unknown namespace/class ::CmdTechDrawExtensionPosChainDimensionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:703: Qualifying with unknown namespace/class ::CmdTechDrawExtensionPosChainDimensionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:835: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCascadeHorizDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:899: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCascadeVertDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:972: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCascadeObliqueDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1008: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCascadeDimensionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1024: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCascadeDimensionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1162: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateHorizChainDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1228: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateVertChainDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1318: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateObliqueChainDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1352: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateChainDimensionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1366: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateChainDimensionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1505: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateHorizCoordDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1578: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateVertCoordDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1676: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateObliqueCoordDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1712: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateCoordDimensionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1728: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateCoordDimensionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1871: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateHorizChamferDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1940: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateVertChamferDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1973: Qualifying with unknown namespace/class ::CmdTechDrawExtensionChamferDimensionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1987: Qualifying with unknown namespace/class ::CmdTechDrawExtensionChamferDimensionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:2073: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateLengthArc
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:169: Qualifying with unknown namespace/class ::CmdTechDrawExtensionHoleCircle
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:243: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCircleCenterLines
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:277: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCircleCenterLinesGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:290: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCircleCenterLinesGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:395: Qualifying with unknown namespace/class ::CmdTechDrawExtensionThreadHoleSide
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:446: Qualifying with unknown namespace/class ::CmdTechDrawExtensionThreadBoltSide
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:497: Qualifying with unknown namespace/class ::CmdTechDrawExtensionThreadHoleBottom
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:548: Qualifying with unknown namespace/class ::CmdTechDrawExtensionThreadBoltBottom
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:582: Qualifying with unknown namespace/class ::CmdTechDrawExtensionThreadsGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:597: Qualifying with unknown namespace/class ::CmdTechDrawExtensionThreadsGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:715: Qualifying with unknown namespace/class ::CmdTechDrawExtensionSelectLineAttributes
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:749: Qualifying with unknown namespace/class ::CmdTechDrawExtensionChangeLineAttributes
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:808: Qualifying with unknown namespace/class ::CmdTechDrawExtensionVertexAtIntersection
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:898: Qualifying with unknown namespace/class ::CmdTechDrawExtensionDrawCosmArc
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:959: Qualifying with unknown namespace/class ::CmdTechDrawExtensionDrawCosmCircle
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:995: Qualifying with unknown namespace/class ::CmdTechDrawExtensionDrawCirclesGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1011: Qualifying with unknown namespace/class ::CmdTechDrawExtensionDrawCirclesGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1144: Qualifying with unknown namespace/class ::CmdTechDrawExtensionLineParallel
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1178: Qualifying with unknown namespace/class ::CmdTechDrawExtensionLinePerpendicular
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1212: Qualifying with unknown namespace/class ::CmdTechDrawExtensionLinePPGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1227: Qualifying with unknown namespace/class ::CmdTechDrawExtensionLinePPGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1315: Qualifying with unknown namespace/class ::CmdTechDrawExtensionLockUnlockView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1359: Qualifying with unknown namespace/class ::CmdTechDrawExtensionPositionSectionView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1376: Qualifying with unknown namespace/class ::CmdTechDrawExtensionPositionSectionView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1492: Qualifying with unknown namespace/class ::CmdTechDrawExtensionExtendLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1527: Qualifying with unknown namespace/class ::CmdTechDrawExtensionShortenLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1562: Qualifying with unknown namespace/class ::CmdTechDrawExtendShortenLineGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1577: Qualifying with unknown namespace/class ::CmdTechDrawExtendShortenLineGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/QGEPath.cpp:156: Discarding unconsumed meta data
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/QGIEdge.cpp:129: Discarding unconsumed meta data
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/QGIViewAnnotation.cpp:208: Class 'TechDrawGui::QGIViewAnnotation' lacks Q_OBJECT macro
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Test/Test.pro.
+Segmentation fault (core dumped)
+Cannot open Gui/Resources/translations/Testpy.ts: No such file or directory
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Tux/Tux.pro.
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Web/Web.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Web/Gui/Command.cpp:50: Qualifying with unknown namespace/class ::CmdWebOpenWebsite
+/home/chennes/FreeCAD-chennes/src/Mod/Web/Gui/Command.cpp:76: Qualifying with unknown namespace/class ::CmdWebBrowserBack
+/home/chennes/FreeCAD-chennes/src/Mod/Web/Gui/Command.cpp:105: Qualifying with unknown namespace/class ::CmdWebBrowserNext
+/home/chennes/FreeCAD-chennes/src/Mod/Web/Gui/Command.cpp:134: Qualifying with unknown namespace/class ::CmdWebBrowserRefresh
+/home/chennes/FreeCAD-chennes/src/Mod/Web/Gui/Command.cpp:162: Qualifying with unknown namespace/class ::CmdWebBrowserStop
+/home/chennes/FreeCAD-chennes/src/Mod/Web/Gui/Command.cpp:192: Qualifying with unknown namespace/class ::CmdWebBrowserZoomIn
+/home/chennes/FreeCAD-chennes/src/Mod/Web/Gui/Command.cpp:221: Qualifying with unknown namespace/class ::CmdWebBrowserZoomOut
+/home/chennes/FreeCAD-chennes/src/Mod/Web/Gui/Command.cpp:250: Qualifying with unknown namespace/class ::CmdWebBrowserSetURL
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Gui/FreeCAD.pro.
+/home/chennes/FreeCAD-chennes/src/Gui/Selection.h:192: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/BlenderNavigationStyle.cpp:66: Class 'Gui::BlenderNavigationStyle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/CADNavigationStyle.cpp:66: Class 'Gui::CADNavigationStyle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:96: Qualifying with unknown namespace/class ::StdCmdOpen
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:111: Qualifying with unknown namespace/class ::StdCmdOpen
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:187: Qualifying with unknown namespace/class ::StdCmdImport
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:201: Qualifying with unknown namespace/class ::StdCmdImport
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:273: Qualifying with unknown namespace/class ::StdCmdExport
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:414: Qualifying with unknown namespace/class ::StdCmdExport
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:520: Qualifying with unknown namespace/class ::StdCmdMergeProjects
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:533: Qualifying with unknown namespace/class ::StdCmdMergeProjects
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:573: Qualifying with unknown namespace/class ::StdCmdDependencyGraph
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:605: Qualifying with unknown namespace/class ::StdCmdNew
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:636: Qualifying with unknown namespace/class ::StdCmdSave
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:676: Qualifying with unknown namespace/class ::StdCmdSaveAs
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:716: Qualifying with unknown namespace/class ::StdCmdSaveCopy
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:749: Qualifying with unknown namespace/class ::StdCmdSaveAll
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:777: Qualifying with unknown namespace/class ::StdCmdRevert
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:816: Qualifying with unknown namespace/class ::StdCmdProjectInfo
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:847: Qualifying with unknown namespace/class ::StdCmdProjectUtil
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:874: Qualifying with unknown namespace/class ::StdCmdPrint
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:887: Qualifying with unknown namespace/class ::StdCmdPrint
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:906: Qualifying with unknown namespace/class ::StdCmdPrintPreview
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:936: Qualifying with unknown namespace/class ::StdCmdPrintPdf
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:948: Qualifying with unknown namespace/class ::StdCmdPrintPdf
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:968: Qualifying with unknown namespace/class ::StdCmdQuit
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:994: Qualifying with unknown namespace/class ::StdCmdUndo
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1038: Qualifying with unknown namespace/class ::StdCmdRedo
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1081: Qualifying with unknown namespace/class ::StdCmdCut
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1109: Qualifying with unknown namespace/class ::StdCmdCopy
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1144: Qualifying with unknown namespace/class ::StdCmdPaste
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1183: Qualifying with unknown namespace/class ::StdCmdDuplicateSelection
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1217: Qualifying with unknown namespace/class ::StdCmdDuplicateSelection
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1271: Qualifying with unknown namespace/class ::StdCmdSelectAll
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1302: Qualifying with unknown namespace/class ::StdCmdDelete
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1449: Qualifying with unknown namespace/class ::StdCmdDelete
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1475: Qualifying with unknown namespace/class ::StdCmdRefresh
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1503: Qualifying with unknown namespace/class ::StdCmdRefresh
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1529: Qualifying with unknown namespace/class ::StdCmdTransform
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1555: Qualifying with unknown namespace/class ::StdCmdPlacement
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1589: Qualifying with unknown namespace/class ::StdCmdTransformManip
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1623: Qualifying with unknown namespace/class ::StdCmdAlignment
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1693: Qualifying with unknown namespace/class ::StdCmdEdit
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1737: Class 'StdCmdExpression' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/CommandFeat.cpp:54: Qualifying with unknown namespace/class ::StdCmdFeatRecompute
+/home/chennes/FreeCAD-chennes/src/Gui/CommandFeat.cpp:77: Qualifying with unknown namespace/class ::StdCmdRandomColor
+/home/chennes/FreeCAD-chennes/src/Gui/CommandFeat.cpp:129: Qualifying with unknown namespace/class ::StdCmdSendToPythonConsole
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:80: Class 'StdCmdLinkMakeGroup' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:211: Qualifying with unknown namespace/class ::StdCmdLinkMake
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:260: Qualifying with unknown namespace/class ::StdCmdLinkMake
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:274: Qualifying with unknown namespace/class ::StdCmdLinkMakeRelative
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:335: Qualifying with unknown namespace/class ::StdCmdLinkMakeRelative
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:494: Qualifying with unknown namespace/class ::StdCmdLinkReplace
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:518: Qualifying with unknown namespace/class ::StdCmdLinkUnlink
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:542: Qualifying with unknown namespace/class ::StdCmdLinkImport
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:592: Qualifying with unknown namespace/class ::StdCmdLinkImport
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:606: Qualifying with unknown namespace/class ::StdCmdLinkImportAll
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:631: Qualifying with unknown namespace/class ::StdCmdLinkImportAll
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:647: Qualifying with unknown namespace/class ::StdCmdLinkSelectLinked
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:774: Qualifying with unknown namespace/class ::StdCmdLinkSelectLinkedFinal
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:808: Qualifying with unknown namespace/class ::StdCmdLinkSelectAllLinks
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:847: Class 'StdCmdLinkSelectActions' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:873: Class 'StdCmdLinkActions' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/CommandMacro.cpp:48: Qualifying with unknown namespace/class ::StdCmdDlgMacroRecord
+/home/chennes/FreeCAD-chennes/src/Gui/CommandMacro.cpp:77: Qualifying with unknown namespace/class ::StdCmdMacroStopRecord
+/home/chennes/FreeCAD-chennes/src/Gui/CommandMacro.cpp:105: Qualifying with unknown namespace/class ::StdCmdDlgMacroExecute
+/home/chennes/FreeCAD-chennes/src/Gui/CommandMacro.cpp:134: Qualifying with unknown namespace/class ::StdCmdDlgMacroExecuteDirect
+/home/chennes/FreeCAD-chennes/src/Gui/CommandMacro.cpp:160: Qualifying with unknown namespace/class ::StdCmdMacroAttachDebugger
+/home/chennes/FreeCAD-chennes/src/Gui/CommandMacro.cpp:185: Qualifying with unknown namespace/class ::StdCmdMacroStartDebug
+/home/chennes/FreeCAD-chennes/src/Gui/CommandMacro.cpp:215: Qualifying with unknown namespace/class ::StdCmdMacroStopDebug
+/home/chennes/FreeCAD-chennes/src/Gui/CommandMacro.cpp:242: Qualifying with unknown namespace/class ::StdCmdMacroStepOver
+/home/chennes/FreeCAD-chennes/src/Gui/CommandMacro.cpp:269: Qualifying with unknown namespace/class ::StdCmdMacroStepInto
+/home/chennes/FreeCAD-chennes/src/Gui/CommandMacro.cpp:296: Qualifying with unknown namespace/class ::StdCmdToggleBreakpoint
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:80: Qualifying with unknown namespace/class ::StdCmdWorkbench
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:109: Qualifying with unknown namespace/class ::StdCmdWorkbench
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:145: Qualifying with unknown namespace/class ::StdCmdRecentFiles
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:186: Qualifying with unknown namespace/class ::StdCmdRecentMacros
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:226: Qualifying with unknown namespace/class ::StdCmdAbout
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:292: Qualifying with unknown namespace/class ::StdCmdAboutQt
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:314: Qualifying with unknown namespace/class ::StdCmdWhatsThis
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:338: Qualifying with unknown namespace/class ::StdCmdDlgParameter
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:363: Qualifying with unknown namespace/class ::StdCmdDlgPreferences
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:395: Qualifying with unknown namespace/class ::StdCmdDlgCustomize
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:422: Qualifying with unknown namespace/class ::StdCmdCommandLine
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:470: Qualifying with unknown namespace/class ::StdCmdOnlineHelp
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:495: Qualifying with unknown namespace/class ::StdCmdOnlineHelpWebsite
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:522: Qualifying with unknown namespace/class ::StdCmdFreeCADDonation
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:549: Qualifying with unknown namespace/class ::StdCmdFreeCADWebsite
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:577: Qualifying with unknown namespace/class ::StdCmdFreeCADUserHub
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:605: Qualifying with unknown namespace/class ::StdCmdFreeCADPowerUserHub
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:633: Qualifying with unknown namespace/class ::StdCmdFreeCADForum
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:661: Qualifying with unknown namespace/class ::StdCmdFreeCADFAQ
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:689: Qualifying with unknown namespace/class ::StdCmdPythonWebsite
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:713: Qualifying with unknown namespace/class ::StdCmdMeasurementSimple
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:727: Qualifying with unknown namespace/class ::StdCmdMeasurementSimple
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:770: Qualifying with unknown namespace/class ::StdCmdTextDocument
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:803: Qualifying with unknown namespace/class ::StdCmdUnitsCalculator
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:839: Class 'StdCmdUserEditMode' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStructure.cpp:52: Qualifying with unknown namespace/class ::StdCmdPart
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStructure.cpp:93: Qualifying with unknown namespace/class ::StdCmdGroup
+/home/chennes/FreeCAD-chennes/src/Gui/CommandTest.cpp:714: Qualifying with unknown namespace/class ::CmdTestConsoleOutput
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:108: Qualifying with unknown namespace/class ::StdOrthographicCamera
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:158: Qualifying with unknown namespace/class ::StdPerspectiveCamera
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:218: Qualifying with unknown namespace/class ::StdCmdViewSaveCamera
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:244: Qualifying with unknown namespace/class ::StdCmdViewRestoreCamera
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:303: Class 'StdCmdFreezeViews' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:561: Qualifying with unknown namespace/class ::StdCmdToggleClipPlane
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:643: Class 'StdCmdDrawStyle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:862: Qualifying with unknown namespace/class ::StdCmdToggleVisibility
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:892: Qualifying with unknown namespace/class ::StdCmdToggleSelectability
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:939: Qualifying with unknown namespace/class ::StdCmdShowSelection
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:967: Qualifying with unknown namespace/class ::StdCmdHideSelection
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:995: Qualifying with unknown namespace/class ::StdCmdSelectVisibleObjects
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1037: Qualifying with unknown namespace/class ::StdCmdToggleObjects
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1078: Qualifying with unknown namespace/class ::StdCmdShowObjects
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1115: Qualifying with unknown namespace/class ::StdCmdHideObjects
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1152: Qualifying with unknown namespace/class ::StdCmdSetAppearance
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1195: Qualifying with unknown namespace/class ::StdCmdViewHome
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1223: Qualifying with unknown namespace/class ::StdCmdViewBottom
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1247: Qualifying with unknown namespace/class ::StdCmdViewFront
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1271: Qualifying with unknown namespace/class ::StdCmdViewLeft
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1295: Qualifying with unknown namespace/class ::StdCmdViewRear
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1319: Qualifying with unknown namespace/class ::StdCmdViewRight
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1343: Qualifying with unknown namespace/class ::StdCmdViewTop
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1367: Qualifying with unknown namespace/class ::StdCmdViewIsometric
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1391: Qualifying with unknown namespace/class ::StdCmdViewDimetric
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1414: Qualifying with unknown namespace/class ::StdCmdViewTrimetric
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1437: Qualifying with unknown namespace/class ::StdCmdViewRotateLeft
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1462: Qualifying with unknown namespace/class ::StdCmdViewRotateRight
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1487: Qualifying with unknown namespace/class ::StdCmdViewFitAll
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1518: Qualifying with unknown namespace/class ::StdCmdViewFitSelection
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1549: Qualifying with unknown namespace/class ::StdViewDock
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1578: Qualifying with unknown namespace/class ::StdViewUndock
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1607: Qualifying with unknown namespace/class ::StdMainFullscreen
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1639: Qualifying with unknown namespace/class ::StdViewFullscreen
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1669: Qualifying with unknown namespace/class ::StdViewDockUndockFullscreen
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1782: Qualifying with unknown namespace/class ::StdCmdViewVR
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1812: Qualifying with unknown namespace/class ::StdViewScreenShot
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1845: Qualifying with unknown namespace/class ::StdViewScreenShot
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1983: Qualifying with unknown namespace/class ::StdCmdViewCreate
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2012: Qualifying with unknown namespace/class ::StdCmdToggleNavigation
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2062: Class 'StdCmdAxisCross' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2196: Qualifying with unknown namespace/class ::StdCmdViewExample1
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2224: Qualifying with unknown namespace/class ::StdCmdViewExample2
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2252: Qualifying with unknown namespace/class ::StdCmdViewExample3
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2281: Qualifying with unknown namespace/class ::StdCmdViewIvStereoOff
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2310: Qualifying with unknown namespace/class ::StdCmdViewIvStereoRedGreen
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2338: Qualifying with unknown namespace/class ::StdCmdViewIvStereoQuadBuff
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2366: Qualifying with unknown namespace/class ::StdCmdViewIvStereoInterleavedRows
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2394: Qualifying with unknown namespace/class ::StdCmdViewIvStereoInterleavedColumns
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2423: Qualifying with unknown namespace/class ::StdCmdViewIvIssueCamPos
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2473: Qualifying with unknown namespace/class ::StdViewZoomIn
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2506: Qualifying with unknown namespace/class ::StdViewZoomOut
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2666: Qualifying with unknown namespace/class ::StdViewBoxZoom
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2736: Qualifying with unknown namespace/class ::StdBoxSelection
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2999: Qualifying with unknown namespace/class ::StdBoxElementSelection
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3040: Qualifying with unknown namespace/class ::StdTreeSelection
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3065: Qualifying with unknown namespace/class ::StdCmdTreeCollapse
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3090: Qualifying with unknown namespace/class ::StdCmdTreeExpand
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3115: Qualifying with unknown namespace/class ::StdCmdTreeSelectAllInstances
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3165: Qualifying with unknown namespace/class ::StdCmdMeasureDistance
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3256: Qualifying with unknown namespace/class ::StdCmdSceneInspector
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3289: Qualifying with unknown namespace/class ::StdCmdTextureMapping
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3316: Qualifying with unknown namespace/class ::StdCmdDemoMode
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3344: Qualifying with unknown namespace/class ::CmdViewMeasureClearAll
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3374: Qualifying with unknown namespace/class ::CmdViewMeasureToggleAll
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3403: Qualifying with unknown namespace/class ::StdCmdSelBack
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3433: Qualifying with unknown namespace/class ::StdCmdSelForward
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3483: Qualifying with unknown namespace/class ::StdTreeSingleDocument
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3500: Qualifying with unknown namespace/class ::StdTreeMultiDocument
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3517: Qualifying with unknown namespace/class ::StdTreeCollapseDocument
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3556: Qualifying with unknown namespace/class ::StdTreeSyncView
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3574: Qualifying with unknown namespace/class ::StdTreeSyncSelection
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3592: Qualifying with unknown namespace/class ::StdTreeSyncPlacement
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3610: Qualifying with unknown namespace/class ::StdTreePreSelection
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3628: Qualifying with unknown namespace/class ::StdTreeRecordSelection
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3646: Qualifying with unknown namespace/class ::StdTreeDrag
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3678: Class 'StdCmdTreeViewActions' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3715: Qualifying with unknown namespace/class ::StdCmdSelBoundingBox
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:55: Qualifying with unknown namespace/class ::StdCmdArrangeIcons
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:82: Qualifying with unknown namespace/class ::StdCmdTileWindows
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:110: Qualifying with unknown namespace/class ::StdCmdCascadeWindows
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:138: Qualifying with unknown namespace/class ::StdCmdCloseActiveWindow
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:170: Qualifying with unknown namespace/class ::StdCmdCloseAllWindows
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:198: Qualifying with unknown namespace/class ::StdCmdActivateNextWindow
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:227: Qualifying with unknown namespace/class ::StdCmdActivatePrevWindow
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:256: Qualifying with unknown namespace/class ::StdCmdWindows
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:280: Qualifying with unknown namespace/class ::StdCmdUserInterface
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:302: Qualifying with unknown namespace/class ::StdCmdDockViewMenu
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:338: Qualifying with unknown namespace/class ::StdCmdToolBarMenu
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:392: Qualifying with unknown namespace/class ::StdCmdStatusBar
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:438: Qualifying with unknown namespace/class ::StdCmdWindowsMenu
+/home/chennes/FreeCAD-chennes/src/Gui/DocumentModel.cpp:203: Class 'Gui::DocumentModel' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:95: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:222: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:238: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:341: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:482: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:524: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:571: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:618: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:666: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:752: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:802: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:855: Class 'Gui::GestureNavigationStyle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/InventorNavigationStyle.cpp:68: Class 'Gui::InventorNavigationStyle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/ManualAlignment.cpp:437: Class 'Gui::AlignmentView' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/MayaGestureNavigationStyle.cpp:107: Class 'Gui::MayaGestureNavigationStyle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/NaviCube.cpp:1695: Qualifying with unknown namespace/class ::ViewIsometricCmd
+/home/chennes/FreeCAD-chennes/src/Gui/NaviCube.cpp:1715: Qualifying with unknown namespace/class ::ViewOrthographicCmd
+/home/chennes/FreeCAD-chennes/src/Gui/NaviCube.cpp:1736: Qualifying with unknown namespace/class ::ViewPerspectiveCmd
+/home/chennes/FreeCAD-chennes/src/Gui/NaviCube.cpp:1757: Qualifying with unknown namespace/class ::ViewZoomToFitCmd
+/home/chennes/FreeCAD-chennes/src/Gui/OnlineDocumentation.cpp:367: Class 'Gui::StdCmdPythonHelp' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/OpenCascadeNavigationStyle.cpp:66: Class 'Gui::OpenCascadeNavigationStyle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/OpenSCADNavigationStyle.cpp:66: Class 'Gui::OpenSCADNavigationStyle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/RevitNavigationStyle.cpp:66: Class 'Gui::RevitNavigationStyle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/TinkerCADNavigationStyle.cpp:66: Class 'Gui::TinkerCADNavigationStyle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/TouchpadNavigationStyle.cpp:66: Class 'Gui::TouchpadNavigationStyle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/WhatsThis.cpp:46: Class 'Gui::StdCmdDescription' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/Widgets.cpp:1450: Class 'PropertyListDialog' lacks Q_OBJECT macro
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/AddonManager/AddonManager.pro.
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Arch/Arch.pro.
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Assembly/Assembly.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:36: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:37: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:42: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:46: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:47: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:48: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:52: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:56: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:57: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:58: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:62: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:66: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:67: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:71: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/distance.hpp:32: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/distance.hpp:77: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/distance.hpp:193: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/distance.hpp:317: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/distance.hpp:382: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/distance.hpp:553: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/distance.hpp:573: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/distance.hpp:616: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/distance.hpp:637: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/distance.hpp:696: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/parallel.hpp:166: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/parallel.hpp:207: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/parallel.hpp:262: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/parallel.hpp:322: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/parallel.hpp:337: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/parallel.hpp:340: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/parallel.hpp:380: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/angle.hpp:80: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/angle.hpp:121: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/angle.hpp:124: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/angle.hpp:138: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/angle.hpp:141: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/angle.hpp:155: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/imp/constraint3d_holder_imp.hpp:51: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/imp/constraint3d_holder_imp.hpp:60: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/moduleShape3d/distance.hpp:32: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/Command.cpp:52: Qualifying with unknown namespace/class ::CmdAssemblyAddNewPart
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/Command.cpp:73: Qualifying with unknown namespace/class ::CmdAssemblyAddNewPart
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/Command.cpp:108: Qualifying with unknown namespace/class ::CmdAssemblyAddNewComponent
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/Command.cpp:129: Qualifying with unknown namespace/class ::CmdAssemblyAddNewComponent
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/Command.cpp:154: Qualifying with unknown namespace/class ::CmdAssemblyAddExistingComponent
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/Command.cpp:175: Qualifying with unknown namespace/class ::CmdAssemblyAddExistingComponent
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/Command.cpp:217: Qualifying with unknown namespace/class ::CmdAssemblyImport
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/CommandConstraints.cpp:118: Qualifying with unknown namespace/class ::CmdAssemblyConstraint
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/CommandConstraints.cpp:202: Qualifying with unknown namespace/class ::CmdAssemblyConstraintDistance
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/CommandConstraints.cpp:269: Qualifying with unknown namespace/class ::CmdAssemblyConstraintFix
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/CommandConstraints.cpp:334: Qualifying with unknown namespace/class ::CmdAssemblyConstraintAngle
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/CommandConstraints.cpp:403: Qualifying with unknown namespace/class ::CmdAssemblyConstraintOrientation
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/CommandConstraints.cpp:471: Qualifying with unknown namespace/class ::CmdAssemblyConstraintCoincidence
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/CommandConstraints.cpp:539: Qualifying with unknown namespace/class ::CmdAssemblyConstraintAlignment
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/Workbench.cpp:94: Class 'AssemblyGui::Workbench' lacks Q_OBJECT macro
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Draft/Draft.pro.
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Drawing/Drawing.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/TaskOrthoViews.h:162: Discarding unconsumed meta data
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:60: Qualifying with unknown namespace/class ::CmdDrawingOpen
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:72: Qualifying with unknown namespace/class ::CmdDrawingOpen
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:93: Qualifying with unknown namespace/class ::CmdDrawingNewPage
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:271: Qualifying with unknown namespace/class ::CmdDrawingNewA3Landscape
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:310: Qualifying with unknown namespace/class ::CmdDrawingNewView
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:323: Qualifying with unknown namespace/class ::CmdDrawingNewView
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:389: Qualifying with unknown namespace/class ::CmdDrawingOrthoViews
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:402: Qualifying with unknown namespace/class ::CmdDrawingOrthoViews
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:439: Qualifying with unknown namespace/class ::CmdDrawingOpenBrowserView
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:452: Qualifying with unknown namespace/class ::CmdDrawingOpenBrowserView
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:477: Qualifying with unknown namespace/class ::CmdDrawingAnnotation
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:492: Qualifying with unknown namespace/class ::CmdDrawingAnnotation
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:525: Qualifying with unknown namespace/class ::CmdDrawingClip
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:540: Qualifying with unknown namespace/class ::CmdDrawingClip
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:570: Qualifying with unknown namespace/class ::CmdDrawingSymbol
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:585: Qualifying with unknown namespace/class ::CmdDrawingSymbol
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:627: Qualifying with unknown namespace/class ::CmdDrawingExportPage
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:640: Qualifying with unknown namespace/class ::CmdDrawingExportPage
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:680: Qualifying with unknown namespace/class ::CmdDrawingProjectShape
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:716: Qualifying with unknown namespace/class ::CmdDrawingDraftView
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:747: Qualifying with unknown namespace/class ::CmdDrawingSpreadsheetView
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:760: Qualifying with unknown namespace/class ::CmdDrawingSpreadsheetView
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Fem/Fem.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:295: Qualifying with unknown namespace/class ::CmdFemConstraintBearing
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:336: Qualifying with unknown namespace/class ::CmdFemConstraintContact
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:381: Qualifying with unknown namespace/class ::CmdFemConstraintDisplacement
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:424: Qualifying with unknown namespace/class ::CmdFemConstraintFixed
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:466: Qualifying with unknown namespace/class ::CmdFemConstraintFluidBoundary
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:509: Qualifying with unknown namespace/class ::CmdFemConstraintForce
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:553: Qualifying with unknown namespace/class ::CmdFemConstraintGear
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:594: Qualifying with unknown namespace/class ::CmdFemConstraintHeatflux
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:639: Qualifying with unknown namespace/class ::CmdFemConstraintInitialTemperature
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:682: Qualifying with unknown namespace/class ::CmdFemConstraintPlaneRotation
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:724: Qualifying with unknown namespace/class ::CmdFemConstraintPressure
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:769: Qualifying with unknown namespace/class ::CmdFemConstraintSpring
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:814: Qualifying with unknown namespace/class ::CmdFemConstraintPulley
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:860: Qualifying with unknown namespace/class ::CmdFemConstraintTemperature
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:903: Qualifying with unknown namespace/class ::CmdFemConstraintTransform
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1039: Qualifying with unknown namespace/class ::CmdFemDefineNodesSet
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1095: Qualifying with unknown namespace/class ::CmdFemCreateNodesSet
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1251: Qualifying with unknown namespace/class ::CmdFemPostClipFilter
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1277: Qualifying with unknown namespace/class ::CmdFemPostCutFilter
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1303: Qualifying with unknown namespace/class ::CmdFemPostDataAlongLineFilter
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1329: Qualifying with unknown namespace/class ::CmdFemPostDataAtPointFilter
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1357: Qualifying with unknown namespace/class ::CmdFemPostLinearizedStressesFilter
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1414: Qualifying with unknown namespace/class ::CmdFemPostScalarClipFilter
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1440: Qualifying with unknown namespace/class ::CmdFemPostWarpVectorFilter
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1466: Qualifying with unknown namespace/class ::CmdFemPostFunctions
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1606: Qualifying with unknown namespace/class ::CmdFemPostApllyChanges
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1651: Qualifying with unknown namespace/class ::CmdFemPostPipelineFromResult
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/ViewProviderFemConstraintDisplacement.cpp:145: Unbalanced opening parenthesis in C++ code (or abuse of the C++ preprocessor)
+resulttools.py: Unbalanced parentheses in Python code
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Image/Image.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Image/Gui/Command.cpp:54: Qualifying with unknown namespace/class ::CmdImageOpen
+/home/chennes/FreeCAD-chennes/src/Mod/Image/Gui/Command.cpp:69: Qualifying with unknown namespace/class ::CmdImageOpen
+/home/chennes/FreeCAD-chennes/src/Mod/Image/Gui/Command.cpp:99: Qualifying with unknown namespace/class ::CmdCreateImagePlane
+/home/chennes/FreeCAD-chennes/src/Mod/Image/Gui/Command.cpp:113: Qualifying with unknown namespace/class ::CmdCreateImagePlane
+/home/chennes/FreeCAD-chennes/src/Mod/Image/Gui/Command.cpp:173: Qualifying with unknown namespace/class ::CmdImageScaling
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Mesh/Mesh.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:94: Qualifying with unknown namespace/class ::CmdMeshTransform
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:133: Qualifying with unknown namespace/class ::CmdMeshDemolding
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:172: Qualifying with unknown namespace/class ::CmdMeshToolMesh
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:227: Qualifying with unknown namespace/class ::CmdMeshUnion
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:298: Qualifying with unknown namespace/class ::CmdMeshDifference
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:369: Qualifying with unknown namespace/class ::CmdMeshIntersection
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:440: Qualifying with unknown namespace/class ::CmdMeshImport
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:452: Qualifying with unknown namespace/class ::CmdMeshImport
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:491: Qualifying with unknown namespace/class ::CmdMeshExport
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:510: Qualifying with unknown namespace/class ::CmdMeshExport
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:566: Qualifying with unknown namespace/class ::CmdMeshFromGeometry
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:576: Qualifying with unknown namespace/class ::CmdMeshFromGeometry
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:624: Qualifying with unknown namespace/class ::CmdMeshFromPartShape
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:650: Qualifying with unknown namespace/class ::CmdMeshVertexCurvature
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:693: Qualifying with unknown namespace/class ::CmdMeshVertexCurvatureInfo
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:739: Qualifying with unknown namespace/class ::CmdMeshPolySegm
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:795: Qualifying with unknown namespace/class ::CmdMeshPolySelect
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:848: Qualifying with unknown namespace/class ::CmdMeshAddFacet
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:895: Qualifying with unknown namespace/class ::CmdMeshPolyCut
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:956: Qualifying with unknown namespace/class ::CmdMeshPolyTrim
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1017: Qualifying with unknown namespace/class ::CmdMeshTrimByPlane
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1046: Qualifying with unknown namespace/class ::CmdMeshSectionByPlane
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1075: Qualifying with unknown namespace/class ::CmdMeshCrossSections
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1101: Qualifying with unknown namespace/class ::CmdMeshPolySplit
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1155: Qualifying with unknown namespace/class ::CmdMeshEvaluation
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1198: Qualifying with unknown namespace/class ::CmdMeshEvaluateFacet
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1241: Qualifying with unknown namespace/class ::CmdMeshRemoveComponents
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1286: Qualifying with unknown namespace/class ::CmdMeshRemeshGmsh
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1319: Qualifying with unknown namespace/class ::CmdMeshRemoveCompByHand
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1363: Qualifying with unknown namespace/class ::CmdMeshEvaluateSolid
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1378: Qualifying with unknown namespace/class ::CmdMeshEvaluateSolid
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1401: Qualifying with unknown namespace/class ::CmdMeshSmoothing
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1464: Qualifying with unknown namespace/class ::CmdMeshDecimating
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1495: Qualifying with unknown namespace/class ::CmdMeshHarmonizeNormals
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1529: Qualifying with unknown namespace/class ::CmdMeshFlipNormals
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1563: Qualifying with unknown namespace/class ::CmdMeshBoundingBox
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1586: Qualifying with unknown namespace/class ::CmdMeshBoundingBox
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1605: Qualifying with unknown namespace/class ::CmdMeshBuildRegularSolid
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1636: Qualifying with unknown namespace/class ::CmdMeshFillupHoles
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1648: Qualifying with unknown namespace/class ::CmdMeshFillupHoles
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1674: Qualifying with unknown namespace/class ::CmdMeshFillInteractiveHole
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1716: Qualifying with unknown namespace/class ::CmdMeshSegmentation
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1752: Qualifying with unknown namespace/class ::CmdMeshSegmentationBestFit
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1788: Qualifying with unknown namespace/class ::CmdMeshMerge
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1831: Qualifying with unknown namespace/class ::CmdMeshSplitComponents
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1877: Qualifying with unknown namespace/class ::CmdMeshScale
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1892: Qualifying with unknown namespace/class ::CmdMeshScale
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/MeshPart/MeshPart.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/MeshPart/Gui/Command.cpp:59: Qualifying with unknown namespace/class ::CmdMeshPartMesher
+/home/chennes/FreeCAD-chennes/src/Mod/MeshPart/Gui/Command.cpp:84: Qualifying with unknown namespace/class ::CmdMeshPartTrimByPlane
+/home/chennes/FreeCAD-chennes/src/Mod/MeshPart/Gui/Command.cpp:192: Qualifying with unknown namespace/class ::CmdMeshPartSection
+/home/chennes/FreeCAD-chennes/src/Mod/MeshPart/Gui/Command.cpp:276: Qualifying with unknown namespace/class ::CmdMeshPartCrossSections
+/home/chennes/FreeCAD-chennes/src/Mod/MeshPart/Gui/Command.cpp:312: Qualifying with unknown namespace/class ::CmdMeshPartCurveOnMesh
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/OpenSCAD/OpenSCAD.pro.
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/PartDesign/PartDesign.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/App/FeatureGroove.cpp:113: Class 'PartDesign::Groove' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/App/FeatureHole.cpp:1654: Class 'PartDesign::Hole' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/App/FeaturePocket.cpp:118: Class 'PartDesign::Pocket' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:167: Qualifying with unknown namespace/class ::CmdPartDesignPlane
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:195: Qualifying with unknown namespace/class ::CmdPartDesignLine
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:223: Qualifying with unknown namespace/class ::CmdPartDesignPoint
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:251: Qualifying with unknown namespace/class ::CmdPartDesignCS
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:283: Qualifying with unknown namespace/class ::CmdPartDesignShapeBinder
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:348: Qualifying with unknown namespace/class ::CmdPartDesignSubShapeBinder
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:412: Qualifying with unknown namespace/class ::CmdPartDesignSubShapeBinder
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:431: Qualifying with unknown namespace/class ::CmdPartDesignClone
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:489: Qualifying with unknown namespace/class ::CmdPartDesignNewSketch
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:594: Qualifying with unknown namespace/class ::CmdPartDesignNewSketch
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1309: Qualifying with unknown namespace/class ::CmdPartDesignPad
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1341: Qualifying with unknown namespace/class ::CmdPartDesignPocket
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1373: Qualifying with unknown namespace/class ::CmdPartDesignHole
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1419: Qualifying with unknown namespace/class ::CmdPartDesignRevolution
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1477: Qualifying with unknown namespace/class ::CmdPartDesignGroove
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1543: Qualifying with unknown namespace/class ::CmdPartDesignAdditivePipe
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1593: Qualifying with unknown namespace/class ::CmdPartDesignSubtractivePipe
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1643: Qualifying with unknown namespace/class ::CmdPartDesignAdditiveLoft
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1693: Qualifying with unknown namespace/class ::CmdPartDesignSubtractiveLoft
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1742: Qualifying with unknown namespace/class ::CmdPartDesignAdditiveHelix
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1812: Qualifying with unknown namespace/class ::CmdPartDesignSubtractiveHelix
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1991: Qualifying with unknown namespace/class ::CmdPartDesignFillet
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:2019: Qualifying with unknown namespace/class ::CmdPartDesignChamfer
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:2048: Qualifying with unknown namespace/class ::CmdPartDesignDraft
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:2105: Qualifying with unknown namespace/class ::CmdPartDesignThickness
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:2253: Qualifying with unknown namespace/class ::CmdPartDesignMirrored
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:2315: Qualifying with unknown namespace/class ::CmdPartDesignLinearPattern
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:2379: Qualifying with unknown namespace/class ::CmdPartDesignPolarPattern
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:2444: Qualifying with unknown namespace/class ::CmdPartDesignScaled
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:2493: Qualifying with unknown namespace/class ::CmdPartDesignMultiTransform
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:2616: Qualifying with unknown namespace/class ::CmdPartDesignBoolean
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandBody.cpp:89: Qualifying with unknown namespace/class ::CmdPartDesignBody
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandBody.cpp:119: Qualifying with unknown namespace/class ::CmdPartDesignBody
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandBody.cpp:312: Qualifying with unknown namespace/class ::CmdPartDesignMigrate
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandBody.cpp:343: Qualifying with unknown namespace/class ::CmdPartDesignMigrate
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandBody.cpp:527: Qualifying with unknown namespace/class ::CmdPartDesignMoveTip
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandBody.cpp:555: Qualifying with unknown namespace/class ::CmdPartDesignMoveTip
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandBody.cpp:606: Qualifying with unknown namespace/class ::CmdPartDesignDuplicateSelection
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandBody.cpp:662: Qualifying with unknown namespace/class ::CmdPartDesignMoveFeature
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandBody.cpp:680: Qualifying with unknown namespace/class ::CmdPartDesignMoveFeature
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandBody.cpp:824: Qualifying with unknown namespace/class ::CmdPartDesignMoveFeatureInTree
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandBody.cpp:851: Qualifying with unknown namespace/class ::CmdPartDesignMoveFeatureInTree
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandPrimitive.cpp:69: Qualifying with unknown namespace/class ::CmdPrimtiveCompAdditive
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandPrimitive.cpp:243: Qualifying with unknown namespace/class ::CmdPrimtiveCompSubtractive
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandPrimitive.cpp:269: Qualifying with unknown namespace/class ::CmdPrimtiveCompSubtractive
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/FeaturePickDialog.cpp:45: Qualifying with unknown namespace/class ::FeaturePickDialog
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/ReferenceSelection.cpp:271: Class 'PartDesignGui::NoDependentsSelection' lacks Q_OBJECT macro
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Part/Part.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:90: Qualifying with unknown namespace/class ::CmdPartPickCurveNet
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:136: Qualifying with unknown namespace/class ::CmdPartBox2
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:177: Qualifying with unknown namespace/class ::CmdPartBox3
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:218: Qualifying with unknown namespace/class ::CmdPartPrimitives
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:272: Qualifying with unknown namespace/class ::CmdPartCut
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:286: Qualifying with unknown namespace/class ::CmdPartCut
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:350: Qualifying with unknown namespace/class ::CmdPartCommon
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:381: Qualifying with unknown namespace/class ::CmdPartCommon
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:450: Qualifying with unknown namespace/class ::CmdPartFuse
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:481: Qualifying with unknown namespace/class ::CmdPartFuse
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:551: Qualifying with unknown namespace/class ::CmdPartCompJoinFeatures
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:657: Qualifying with unknown namespace/class ::CmdPartCompSplitFeatures
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:779: Qualifying with unknown namespace/class ::CmdPartCompCompoundTools
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:886: Qualifying with unknown namespace/class ::CmdPartCompound
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:900: Qualifying with unknown namespace/class ::CmdPartCompound
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:943: Qualifying with unknown namespace/class ::CmdPartSection
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:957: Qualifying with unknown namespace/class ::CmdPartSection
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:991: Qualifying with unknown namespace/class ::CmdPartImport
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1053: Qualifying with unknown namespace/class ::CmdPartExport
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1100: Qualifying with unknown namespace/class ::CmdPartImportCurveNet
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1113: Qualifying with unknown namespace/class ::CmdPartImportCurveNet
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1148: Qualifying with unknown namespace/class ::CmdPartMakeSolid
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1227: Qualifying with unknown namespace/class ::CmdPartReverseShape
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1290: Qualifying with unknown namespace/class ::CmdPartBoolean
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1321: Qualifying with unknown namespace/class ::CmdPartExtrude
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1349: Qualifying with unknown namespace/class ::CmdPartMakeFace
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1401: Qualifying with unknown namespace/class ::CmdPartRevolve
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1429: Qualifying with unknown namespace/class ::CmdPartFillet
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1457: Qualifying with unknown namespace/class ::CmdPartChamfer
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1485: Qualifying with unknown namespace/class ::CmdPartMirror
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1513: Qualifying with unknown namespace/class ::CmdPartCrossSections
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1553: Qualifying with unknown namespace/class ::CmdPartBuilder
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1582: Qualifying with unknown namespace/class ::CmdPartLoft
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1611: Qualifying with unknown namespace/class ::CmdPartSweep
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1640: Qualifying with unknown namespace/class ::CmdPartOffset
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1692: Qualifying with unknown namespace/class ::CmdPartOffset2D
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1743: Qualifying with unknown namespace/class ::CmdPartCompOffset
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1836: Qualifying with unknown namespace/class ::CmdPartThickness
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2011: Qualifying with unknown namespace/class ::CmdPartRuledSurface
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2097: Qualifying with unknown namespace/class ::CmdPartRuledSurface
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2127: Qualifying with unknown namespace/class ::CmdCheckGeometry
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2161: Qualifying with unknown namespace/class ::CmdColorPerFace
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2200: Qualifying with unknown namespace/class ::CmdMeasureLinear
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2231: Qualifying with unknown namespace/class ::CmdMeasureAngular
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2260: Qualifying with unknown namespace/class ::CmdMeasureRefresh
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2290: Qualifying with unknown namespace/class ::CmdMeasureClearAll
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2319: Qualifying with unknown namespace/class ::CmdMeasureToggleAll
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2356: Qualifying with unknown namespace/class ::CmdMeasureToggle3d
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2387: Qualifying with unknown namespace/class ::CmdMeasureToggleDelta
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2419: Qualifying with unknown namespace/class ::CmdBoxSelection
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2448: Qualifying with unknown namespace/class ::CmdPartProjectionOnSurface
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandParametric.cpp:66: Qualifying with unknown namespace/class ::CmdPartCylinder
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandParametric.cpp:108: Qualifying with unknown namespace/class ::CmdPartBox
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandParametric.cpp:150: Qualifying with unknown namespace/class ::CmdPartSphere
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandParametric.cpp:192: Qualifying with unknown namespace/class ::CmdPartCone
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandParametric.cpp:234: Qualifying with unknown namespace/class ::CmdPartTorus
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandSimple.cpp:58: Qualifying with unknown namespace/class ::CmdPartSimpleCylinder
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandSimple.cpp:108: Qualifying with unknown namespace/class ::CmdPartShapeFromMesh
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandSimple.cpp:137: Qualifying with unknown namespace/class ::CmdPartPointsFromMesh
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandSimple.cpp:187: Qualifying with unknown namespace/class ::CmdPartSimpleCopy
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandSimple.cpp:258: Qualifying with unknown namespace/class ::CmdPartTransformedCopy
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandSimple.cpp:286: Qualifying with unknown namespace/class ::CmdPartElementCopy
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandSimple.cpp:314: Qualifying with unknown namespace/class ::CmdPartRefineShape
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandSimple.cpp:374: Qualifying with unknown namespace/class ::CmdPartDefeaturing
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Path/Path.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Path/App/VoronoiPyImp.cpp:206: Parenthesis/brace mismatch between #if and #else branches; using #if branch
+/home/chennes/FreeCAD-chennes/src/Mod/Path/Gui/Command.cpp:55: Qualifying with unknown namespace/class ::CmdPathArea
+/home/chennes/FreeCAD-chennes/src/Mod/Path/Gui/Command.cpp:137: Qualifying with unknown namespace/class ::CmdPathAreaWorkplane
+/home/chennes/FreeCAD-chennes/src/Mod/Path/Gui/Command.cpp:227: Qualifying with unknown namespace/class ::CmdPathCompound
+/home/chennes/FreeCAD-chennes/src/Mod/Path/Gui/Command.cpp:279: Qualifying with unknown namespace/class ::CmdPathShape
+fanuc_post.py:107: Unterminated string
+rrf_post.py:214: Unterminated string
+linuxcnc_post.py:99: Unterminated string
+dynapath_post.py:143: Unterminated string
+jtech_post.py:104: Unterminated string
+marlin_post.py:209: Unterminated string
+centroid_post.py:116: Unterminated string
+fablin_post.py:88: Unterminated string
+mach3_mach4_post.py:98: Unterminated string
+grbl_post.py:80: Unterminated string
+uccnc_post.py:298: Unterminated string
+smoothie_post.py:108: Unterminated string
+opensbp_post.py:80: Unterminated string
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Points/Points.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Points/Gui/Command.cpp:68: Qualifying with unknown namespace/class ::CmdPointsImport
+/home/chennes/FreeCAD-chennes/src/Mod/Points/Gui/Command.cpp:82: Qualifying with unknown namespace/class ::CmdPointsImport
+/home/chennes/FreeCAD-chennes/src/Mod/Points/Gui/Command.cpp:113: Qualifying with unknown namespace/class ::CmdPointsExport
+/home/chennes/FreeCAD-chennes/src/Mod/Points/Gui/Command.cpp:130: Qualifying with unknown namespace/class ::CmdPointsExport
+/home/chennes/FreeCAD-chennes/src/Mod/Points/Gui/Command.cpp:153: Qualifying with unknown namespace/class ::CmdPointsTransform
+/home/chennes/FreeCAD-chennes/src/Mod/Points/Gui/Command.cpp:190: Qualifying with unknown namespace/class ::CmdPointsConvert
+/home/chennes/FreeCAD-chennes/src/Mod/Points/Gui/Command.cpp:209: Qualifying with unknown namespace/class ::CmdPointsConvert
+/home/chennes/FreeCAD-chennes/src/Mod/Points/Gui/Command.cpp:282: Qualifying with unknown namespace/class ::CmdPointsPolyCut
+/home/chennes/FreeCAD-chennes/src/Mod/Points/Gui/Command.cpp:327: Qualifying with unknown namespace/class ::CmdPointsMerge
+/home/chennes/FreeCAD-chennes/src/Mod/Points/Gui/Command.cpp:370: Qualifying with unknown namespace/class ::CmdPointsStructure
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Raytracing.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:84: Qualifying with unknown namespace/class ::CmdRaytracingWriteCamera
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:137: Qualifying with unknown namespace/class ::CmdRaytracingWriteCamera
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:177: Qualifying with unknown namespace/class ::CmdRaytracingWritePart
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:188: Qualifying with unknown namespace/class ::CmdRaytracingWritePart
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:223: Qualifying with unknown namespace/class ::CmdRaytracingWriteView
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:250: Qualifying with unknown namespace/class ::CmdRaytracingWriteView
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:320: Qualifying with unknown namespace/class ::CmdRaytracingNewPovrayProject
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:437: Qualifying with unknown namespace/class ::CmdRaytracingNewPartSegment
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:449: Qualifying with unknown namespace/class ::CmdRaytracingNewPartSegment
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:521: Qualifying with unknown namespace/class ::CmdRaytracingExportProject
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:536: Qualifying with unknown namespace/class ::CmdRaytracingExportProject
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:584: Qualifying with unknown namespace/class ::CmdRaytracingRender
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:600: Qualifying with unknown namespace/class ::CmdRaytracingRender
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:766: Qualifying with unknown namespace/class ::CmdRaytracingNewLuxProject
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:879: Qualifying with unknown namespace/class ::CmdRaytracingResetCamera
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:893: Qualifying with unknown namespace/class ::CmdRaytracingResetCamera
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/ReverseEngineering.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/Gui/Command.cpp:74: Qualifying with unknown namespace/class ::CmdApproxSurface
+/home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/Gui/Command.cpp:110: Qualifying with unknown namespace/class ::CmdApproxPlane
+/home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/Gui/Command.cpp:211: Qualifying with unknown namespace/class ::CmdApproxCylinder
+/home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/Gui/Command.cpp:277: Qualifying with unknown namespace/class ::CmdApproxSphere
+/home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/Gui/Command.cpp:324: Qualifying with unknown namespace/class ::CmdApproxPolynomial
+/home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/Gui/Command.cpp:379: Qualifying with unknown namespace/class ::CmdSegmentation
+/home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/Gui/Command.cpp:411: Qualifying with unknown namespace/class ::CmdSegmentationManual
+/home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/Gui/Command.cpp:440: Qualifying with unknown namespace/class ::CmdSegmentationFromComponents
+/home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/Gui/Command.cpp:490: Qualifying with unknown namespace/class ::CmdMeshBoundary
+/home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/Gui/Command.cpp:556: Qualifying with unknown namespace/class ::CmdPoissonReconstruction
+/home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/Gui/Command.cpp:590: Qualifying with unknown namespace/class ::CmdViewTriangulation
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Robot/Robot.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/Command.cpp:55: Qualifying with unknown namespace/class ::CmdRobotSetHomePos
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/Command.cpp:75: Qualifying with unknown namespace/class ::CmdRobotSetHomePos
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/Command.cpp:104: Qualifying with unknown namespace/class ::CmdRobotRestoreHomePos
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/Command.cpp:124: Qualifying with unknown namespace/class ::CmdRobotRestoreHomePos
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/Command.cpp:158: Qualifying with unknown namespace/class ::CmdRobotConstraintAxle
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/Command.cpp:199: Qualifying with unknown namespace/class ::CmdRobotSimulate
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/Command.cpp:224: Qualifying with unknown namespace/class ::CmdRobotSimulate
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandExport.cpp:50: Qualifying with unknown namespace/class ::CmdRobotExportKukaCompact
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandExport.cpp:65: Qualifying with unknown namespace/class ::CmdRobotExportKukaCompact
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandExport.cpp:112: Qualifying with unknown namespace/class ::CmdRobotExportKukaFull
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandExport.cpp:127: Qualifying with unknown namespace/class ::CmdRobotExportKukaFull
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandInsertRobot.cpp:51: Qualifying with unknown namespace/class ::CmdRobotInsertKukaIR500
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandInsertRobot.cpp:93: Qualifying with unknown namespace/class ::CmdRobotInsertKukaIR16
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandInsertRobot.cpp:134: Qualifying with unknown namespace/class ::CmdRobotInsertKukaIR210
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandInsertRobot.cpp:174: Qualifying with unknown namespace/class ::CmdRobotInsertKukaIR125
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandInsertRobot.cpp:215: Qualifying with unknown namespace/class ::CmdRobotAddToolShape
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandInsertRobot.cpp:234: Qualifying with unknown namespace/class ::CmdRobotAddToolShape
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:62: Qualifying with unknown namespace/class ::CmdRobotCreateTrajectory
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:95: Qualifying with unknown namespace/class ::CmdRobotInsertWaypoint
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:111: Qualifying with unknown namespace/class ::CmdRobotInsertWaypoint
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:152: Qualifying with unknown namespace/class ::CmdRobotInsertWaypointPreselect
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:167: Qualifying with unknown namespace/class ::CmdRobotInsertWaypointPreselect
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:216: Qualifying with unknown namespace/class ::CmdRobotSetDefaultOrientation
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:254: Qualifying with unknown namespace/class ::CmdRobotSetDefaultValues
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:268: Qualifying with unknown namespace/class ::CmdRobotSetDefaultValues
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:320: Qualifying with unknown namespace/class ::CmdRobotEdge2Trac
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:384: Qualifying with unknown namespace/class ::CmdRobotTrajectoryDressUp
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:412: Qualifying with unknown namespace/class ::CmdRobotTrajectoryDressUp
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:431: Qualifying with unknown namespace/class ::CmdRobotTrajectoryCompound
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Sketcher.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:143: Qualifying with unknown namespace/class ::CmdSketcherNewSketch
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:164: Qualifying with unknown namespace/class ::CmdSketcherNewSketch
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:266: Qualifying with unknown namespace/class ::CmdSketcherEditSketch
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:296: Qualifying with unknown namespace/class ::CmdSketcherLeaveSketch
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:340: Qualifying with unknown namespace/class ::CmdSketcherStopOperation
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:381: Qualifying with unknown namespace/class ::CmdSketcherReorientSketch
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:508: Qualifying with unknown namespace/class ::CmdSketcherMapSketch
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:562: Qualifying with unknown namespace/class ::CmdSketcherMapSketch
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:683: Qualifying with unknown namespace/class ::CmdSketcherViewSketch
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:723: Qualifying with unknown namespace/class ::CmdSketcherValidateSketch
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:761: Qualifying with unknown namespace/class ::CmdSketcherMirrorSketch
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:868: Qualifying with unknown namespace/class ::CmdSketcherMergeSketches
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:952: Qualifying with unknown namespace/class ::CmdSketcherViewSection
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandAlterGeometry.cpp:74: Qualifying with unknown namespace/class ::CmdSketcherToggleConstruction
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandAlterGeometry.cpp:123: Qualifying with unknown namespace/class ::CmdSketcherToggleConstruction
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:883: Class 'CmdSketcherConstrainHorizontal' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:1121: Class 'CmdSketcherConstrainVertical' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:1355: Class 'CmdSketcherConstrainLock' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:1581: Class 'CmdSketcherConstrainBlock' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:1896: Class 'CmdSketcherConstrainCoincident' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:2102: Class 'CmdSketcherConstrainDistance' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:2451: Class 'CmdSketcherConstrainPointOnObject' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:2699: Class 'CmdSketcherConstrainDistanceX' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:2953: Class 'CmdSketcherConstrainDistanceY' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:3199: Class 'CmdSketcherConstrainParallel' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:3349: Class 'CmdSketcherConstrainPerpendicular' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:3987: Class 'CmdSketcherConstrainTangent' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:4695: Class 'CmdSketcherConstrainRadius' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:4997: Class 'CmdSketcherConstrainDiameter' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:5273: Class 'CmdSketcherConstrainRadiam' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:5577: Qualifying with unknown namespace/class ::CmdSketcherCompConstrainRadDia
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:5721: Class 'CmdSketcherConstrainAngle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:6248: Class 'CmdSketcherConstrainEqual' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:6465: Class 'CmdSketcherConstrainSymmetric' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:6765: Qualifying with unknown namespace/class ::CmdSketcherConstrainSnellsLaw
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:6784: Qualifying with unknown namespace/class ::CmdSketcherConstrainSnellsLaw
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:6931: Qualifying with unknown namespace/class ::CmdSketcherConstrainInternalAlignment
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:6949: Qualifying with unknown namespace/class ::CmdSketcherConstrainInternalAlignment
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:7391: Qualifying with unknown namespace/class ::CmdSketcherToggleDrivingConstraint
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:7430: Qualifying with unknown namespace/class ::CmdSketcherToggleDrivingConstraint
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:7518: Qualifying with unknown namespace/class ::CmdSketcherToggleActiveConstraint
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:7543: Qualifying with unknown namespace/class ::CmdSketcherToggleActiveConstraint
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:344: Qualifying with unknown namespace/class ::CmdSketcherCreateLine
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:649: Qualifying with unknown namespace/class ::CmdSketcherCreateRectangle
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:690: Qualifying with unknown namespace/class ::CmdSketcherCreateRectangleCenter
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:1016: Qualifying with unknown namespace/class ::CmdSketcherCreateOblong
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:1059: Qualifying with unknown namespace/class ::CmdSketcherCompCreateRectangles
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:1815: Qualifying with unknown namespace/class ::CmdSketcherCreatePolyline
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:2059: Qualifying with unknown namespace/class ::CmdSketcherCreateArc
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:2329: Qualifying with unknown namespace/class ::CmdSketcherCreate3PointArc
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:2357: Qualifying with unknown namespace/class ::CmdSketcherCompCreateArc
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:2591: Qualifying with unknown namespace/class ::CmdSketcherCreateCircle
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:3387: Qualifying with unknown namespace/class ::CmdSketcherCreateEllipseByCenter
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:3418: Qualifying with unknown namespace/class ::CmdSketcherCreateEllipseBy3Points
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:3746: Qualifying with unknown namespace/class ::CmdSketcherCreateArcOfEllipse
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:4090: Qualifying with unknown namespace/class ::CmdSketcherCreateArcOfHyperbola
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:4389: Qualifying with unknown namespace/class ::CmdSketcherCreateArcOfParabola
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:4422: Qualifying with unknown namespace/class ::CmdSketcherCompCreateConic
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:4925: Qualifying with unknown namespace/class ::CmdSketcherCreateBSpline
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:4970: Qualifying with unknown namespace/class ::CmdSketcherCreatePeriodicBSpline
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:5002: Qualifying with unknown namespace/class ::CmdSketcherCompCreateBSpline
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:5285: Qualifying with unknown namespace/class ::CmdSketcherCreate3PointCircle
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:5313: Qualifying with unknown namespace/class ::CmdSketcherCompCreateCircle
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:5493: Qualifying with unknown namespace/class ::CmdSketcherCreatePoint
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:5523: Qualifying with unknown namespace/class ::CmdSketcherCreateText
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:5551: Qualifying with unknown namespace/class ::CmdSketcherCreateDraftLine
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:5831: Qualifying with unknown namespace/class ::CmdSketcherCreateFillet
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:5860: Qualifying with unknown namespace/class ::CmdSketcherCreatePointFillet
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:5891: Qualifying with unknown namespace/class ::CmdSketcherCompCreateFillets
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:6121: Qualifying with unknown namespace/class ::CmdSketcherTrimming
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:6435: Qualifying with unknown namespace/class ::CmdSketcherExtend
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:6554: Qualifying with unknown namespace/class ::CmdSketcherSplit
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:6593: Class 'SketcherGui::ExternalSelection' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:6739: Qualifying with unknown namespace/class ::CmdSketcherExternal
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:6785: Class 'SketcherGui::CarbonCopySelection' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:6917: Qualifying with unknown namespace/class ::CmdSketcherCarbonCopy
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:7228: Qualifying with unknown namespace/class ::CmdSketcherCreateSlot
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:7421: Qualifying with unknown namespace/class ::CmdSketcherCreateTriangle
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:7448: Qualifying with unknown namespace/class ::CmdSketcherCreateSquare
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:7475: Qualifying with unknown namespace/class ::CmdSketcherCreatePentagon
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:7503: Qualifying with unknown namespace/class ::CmdSketcherCreateHexagon
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:7530: Qualifying with unknown namespace/class ::CmdSketcherCreateHeptagon
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:7557: Qualifying with unknown namespace/class ::CmdSketcherCreateOctagon
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:7584: Qualifying with unknown namespace/class ::CmdSketcherCreateRegularPolygon
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:7615: Qualifying with unknown namespace/class ::CmdSketcherCompCreateRegularPolygon
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:100: Qualifying with unknown namespace/class ::CmdSketcherBSplineDegree
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:129: Qualifying with unknown namespace/class ::CmdSketcherBSplinePolygon
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:158: Qualifying with unknown namespace/class ::CmdSketcherBSplineComb
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:187: Qualifying with unknown namespace/class ::CmdSketcherBSplineKnotMultiplicity
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:216: Qualifying with unknown namespace/class ::CmdSketcherBSplinePoleWeight
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:245: Qualifying with unknown namespace/class ::CmdSketcherCompBSplineShowHideGeometryInformation
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:374: Qualifying with unknown namespace/class ::CmdSketcherConvertToNURB
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:420: Qualifying with unknown namespace/class ::CmdSketcherConvertToNURB
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:442: Qualifying with unknown namespace/class ::CmdSketcherIncreaseDegree
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:491: Qualifying with unknown namespace/class ::CmdSketcherIncreaseDegree
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:515: Qualifying with unknown namespace/class ::CmdSketcherDecreaseDegree
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:569: Qualifying with unknown namespace/class ::CmdSketcherDecreaseDegree
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:592: Qualifying with unknown namespace/class ::CmdSketcherIncreaseKnotMultiplicity
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:607: Qualifying with unknown namespace/class ::CmdSketcherIncreaseKnotMultiplicity
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:746: Qualifying with unknown namespace/class ::CmdSketcherDecreaseKnotMultiplicity
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:761: Qualifying with unknown namespace/class ::CmdSketcherDecreaseKnotMultiplicity
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:888: Qualifying with unknown namespace/class ::CmdSketcherCompModifyKnotMultiplicity
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:981: Qualifying with unknown namespace/class ::CmdSketcherInsertKnot
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:996: Qualifying with unknown namespace/class ::CmdSketcherInsertKnot
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:105: Qualifying with unknown namespace/class ::CmdSketcherCloseShape
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:129: Qualifying with unknown namespace/class ::CmdSketcherCloseShape
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:217: Qualifying with unknown namespace/class ::CmdSketcherConnect
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:240: Qualifying with unknown namespace/class ::CmdSketcherConnect
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:304: Qualifying with unknown namespace/class ::CmdSketcherSelectConstraints
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:327: Qualifying with unknown namespace/class ::CmdSketcherSelectConstraints
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:381: Qualifying with unknown namespace/class ::CmdSketcherSelectOrigin
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:427: Qualifying with unknown namespace/class ::CmdSketcherSelectVerticalAxis
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:471: Qualifying with unknown namespace/class ::CmdSketcherSelectHorizontalAxis
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:514: Qualifying with unknown namespace/class ::CmdSketcherSelectRedundantConstraints
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:571: Qualifying with unknown namespace/class ::CmdSketcherSelectMalformedConstraints
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:627: Qualifying with unknown namespace/class ::CmdSketcherSelectPartiallyRedundantConstraints
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:683: Qualifying with unknown namespace/class ::CmdSketcherSelectConflictingConstraints
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:738: Qualifying with unknown namespace/class ::CmdSketcherSelectElementsAssociatedWithConstraints
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:836: Qualifying with unknown namespace/class ::CmdSketcherSelectElementsAssociatedWithConstraints
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:859: Qualifying with unknown namespace/class ::CmdSketcherSelectElementsWithDoFs
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:950: Qualifying with unknown namespace/class ::CmdSketcherRestoreInternalAlignmentGeometry
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:974: Qualifying with unknown namespace/class ::CmdSketcherRestoreInternalAlignmentGeometry
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:1046: Qualifying with unknown namespace/class ::CmdSketcherSymmetry
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:1069: Qualifying with unknown namespace/class ::CmdSketcherSymmetry
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:1581: Class 'CmdSketcherCopy' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:1627: Class 'CmdSketcherClone' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:1670: Class 'CmdSketcherMove' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:1704: Qualifying with unknown namespace/class ::CmdSketcherCompCopy
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:1986: Qualifying with unknown namespace/class ::CmdSketcherRectangularArray
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:2005: Qualifying with unknown namespace/class ::CmdSketcherRectangularArray
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:2126: Qualifying with unknown namespace/class ::CmdSketcherDeleteAllGeometry
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:2140: Qualifying with unknown namespace/class ::CmdSketcherDeleteAllGeometry
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:2189: Qualifying with unknown namespace/class ::CmdSketcherDeleteAllConstraints
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:2202: Qualifying with unknown namespace/class ::CmdSketcherDeleteAllConstraints
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:2253: Qualifying with unknown namespace/class ::CmdSketcherRemoveAxesAlignment
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:2272: Qualifying with unknown namespace/class ::CmdSketcherRemoveAxesAlignment
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherVirtualSpace.cpp:93: Qualifying with unknown namespace/class ::CmdSketcherSwitchVirtualSpace
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherVirtualSpace.cpp:115: Qualifying with unknown namespace/class ::CmdSketcherSwitchVirtualSpace
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Spreadsheet.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/AppSpreadsheetGui.cpp:87: Class 'SpreadsheetGui::Module' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:70: Qualifying with unknown namespace/class ::CmdSpreadsheetMergeCells
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:123: Qualifying with unknown namespace/class ::CmdSpreadsheetSplitCell
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:179: Qualifying with unknown namespace/class ::CmdSpreadsheetImport
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:191: Qualifying with unknown namespace/class ::CmdSpreadsheetImport
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:229: Qualifying with unknown namespace/class ::CmdSpreadsheetExport
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:247: Qualifying with unknown namespace/class ::CmdSpreadsheetExport
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:290: Qualifying with unknown namespace/class ::CmdSpreadsheetAlignLeft
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:342: Qualifying with unknown namespace/class ::CmdSpreadsheetAlignCenter
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:394: Qualifying with unknown namespace/class ::CmdSpreadsheetAlignRight
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:446: Qualifying with unknown namespace/class ::CmdSpreadsheetAlignTop
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:498: Qualifying with unknown namespace/class ::CmdSpreadsheetAlignBottom
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:550: Qualifying with unknown namespace/class ::CmdSpreadsheetAlignVCenter
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:602: Qualifying with unknown namespace/class ::CmdSpreadsheetStyleBold
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:676: Qualifying with unknown namespace/class ::CmdSpreadsheetStyleItalic
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:750: Qualifying with unknown namespace/class ::CmdSpreadsheetStyleUnderline
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:823: Qualifying with unknown namespace/class ::CmdSpreadsheetSetAlias
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:887: Qualifying with unknown namespace/class ::CmdCreateSpreadsheet
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Start/Start.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Start/Gui/Command.cpp:45: Qualifying with unknown namespace/class ::CmdStartPage
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/TechDraw/TechDraw.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:117: Qualifying with unknown namespace/class ::CmdTechDrawPageDefault
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:181: Qualifying with unknown namespace/class ::CmdTechDrawPageTemplate
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:195: Qualifying with unknown namespace/class ::CmdTechDrawPageTemplate
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:261: Qualifying with unknown namespace/class ::CmdTechDrawRedrawPage
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:298: Qualifying with unknown namespace/class ::CmdTechDrawView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:379: Qualifying with unknown namespace/class ::CmdTechDrawView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:442: Qualifying with unknown namespace/class ::CmdTechDrawActiveView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:476: Qualifying with unknown namespace/class ::CmdTechDrawSectionView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:494: Qualifying with unknown namespace/class ::CmdTechDrawSectionView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:526: Qualifying with unknown namespace/class ::CmdTechDrawDetailView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:545: Qualifying with unknown namespace/class ::CmdTechDrawDetailView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:575: Qualifying with unknown namespace/class ::CmdTechDrawProjectionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:655: Qualifying with unknown namespace/class ::CmdTechDrawProjectionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:855: Qualifying with unknown namespace/class ::CmdTechDrawBalloon
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:920: Qualifying with unknown namespace/class ::CmdTechDrawClipGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:959: Qualifying with unknown namespace/class ::CmdTechDrawClipGroupAdd
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:972: Qualifying with unknown namespace/class ::CmdTechDrawClipGroupAdd
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1043: Qualifying with unknown namespace/class ::CmdTechDrawClipGroupRemove
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1057: Qualifying with unknown namespace/class ::CmdTechDrawClipGroupRemove
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1118: Qualifying with unknown namespace/class ::CmdTechDrawSymbol
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1137: Qualifying with unknown namespace/class ::CmdTechDrawSymbol
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1173: Qualifying with unknown namespace/class ::CmdTechDrawDraftView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1194: Qualifying with unknown namespace/class ::CmdTechDrawDraftView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1239: Qualifying with unknown namespace/class ::CmdTechDrawArchView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1268: Qualifying with unknown namespace/class ::CmdTechDrawArchView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1304: Qualifying with unknown namespace/class ::CmdTechDrawSpreadsheetView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1317: Qualifying with unknown namespace/class ::CmdTechDrawSpreadsheetView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1363: Qualifying with unknown namespace/class ::CmdTechDrawExportPageSVG
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1388: Qualifying with unknown namespace/class ::CmdTechDrawExportPageSVG
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1408: Qualifying with unknown namespace/class ::CmdTechDrawExportPageDXF
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1428: Qualifying with unknown namespace/class ::CmdTechDrawExportPageDXF
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:101: Qualifying with unknown namespace/class ::CmdTechDrawLeaderLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:115: Qualifying with unknown namespace/class ::CmdTechDrawLeaderLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:163: Qualifying with unknown namespace/class ::CmdTechDrawRichTextAnnotation
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:176: Qualifying with unknown namespace/class ::CmdTechDrawRichTextAnnotation
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:215: Qualifying with unknown namespace/class ::CmdTechDrawCosmeticVertexGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:228: Qualifying with unknown namespace/class ::CmdTechDrawCosmeticVertexGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:404: Qualifying with unknown namespace/class ::CmdTechDrawCosmeticVertex
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:417: Qualifying with unknown namespace/class ::CmdTechDrawCosmeticVertex
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:465: Qualifying with unknown namespace/class ::CmdTechDrawMidpoints
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:478: Qualifying with unknown namespace/class ::CmdTechDrawMidpoints
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:504: Qualifying with unknown namespace/class ::CmdTechDrawQuadrants
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:517: Qualifying with unknown namespace/class ::CmdTechDrawQuadrants
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:543: Qualifying with unknown namespace/class ::CmdTechDrawAnnotation
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:583: Qualifying with unknown namespace/class ::CmdTechDrawCenterLineGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:596: Qualifying with unknown namespace/class ::CmdTechDrawCenterLineGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:686: Qualifying with unknown namespace/class ::CmdTechDrawFaceCenterLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:700: Qualifying with unknown namespace/class ::CmdTechDrawFaceCenterLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:796: Qualifying with unknown namespace/class ::CmdTechDraw2LineCenterLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:810: Qualifying with unknown namespace/class ::CmdTechDraw2LineCenterLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:873: Qualifying with unknown namespace/class ::CmdTechDraw2PointCenterLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:887: Qualifying with unknown namespace/class ::CmdTechDraw2PointCenterLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:986: Qualifying with unknown namespace/class ::CmdTechDraw2PointCosmeticLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:1000: Qualifying with unknown namespace/class ::CmdTechDraw2PointCosmeticLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:1138: Qualifying with unknown namespace/class ::CmdTechDrawCosmeticEraser
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:1151: Qualifying with unknown namespace/class ::CmdTechDrawCosmeticEraser
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:1265: Qualifying with unknown namespace/class ::CmdTechDrawDecorateLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:1279: Qualifying with unknown namespace/class ::CmdTechDrawDecorateLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:1344: Qualifying with unknown namespace/class ::CmdTechDrawShowAll
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:1357: Qualifying with unknown namespace/class ::CmdTechDrawShowAll
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:1409: Qualifying with unknown namespace/class ::CmdTechDrawWeldSymbol
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:1423: Qualifying with unknown namespace/class ::CmdTechDrawWeldSymbol
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:123: Qualifying with unknown namespace/class ::CmdTechDrawDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:250: Qualifying with unknown namespace/class ::CmdTechDrawRadiusDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:294: Qualifying with unknown namespace/class ::CmdTechDrawRadiusDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:372: Qualifying with unknown namespace/class ::CmdTechDrawDiameterDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:416: Qualifying with unknown namespace/class ::CmdTechDrawDiameterDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:493: Qualifying with unknown namespace/class ::CmdTechDrawLengthDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:547: Qualifying with unknown namespace/class ::CmdTechDrawLengthDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:595: Qualifying with unknown namespace/class ::CmdTechDrawHorizontalDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:650: Qualifying with unknown namespace/class ::CmdTechDrawHorizontalDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:698: Qualifying with unknown namespace/class ::CmdTechDrawVerticalDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:753: Qualifying with unknown namespace/class ::CmdTechDrawVerticalDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:800: Qualifying with unknown namespace/class ::CmdTechDrawAngleDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:845: Qualifying with unknown namespace/class ::CmdTechDrawAngleDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:888: Qualifying with unknown namespace/class ::CmdTechDraw3PtAngleDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:934: Qualifying with unknown namespace/class ::CmdTechDraw3PtAngleDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:980: Qualifying with unknown namespace/class ::CmdTechDrawLinkDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:1019: Qualifying with unknown namespace/class ::CmdTechDrawLinkDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:1058: Qualifying with unknown namespace/class ::CmdTechDrawExtentGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:1071: Qualifying with unknown namespace/class ::CmdTechDrawExtentGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:1151: Qualifying with unknown namespace/class ::CmdTechDrawHorizontalExtentDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:1165: Qualifying with unknown namespace/class ::CmdTechDrawHorizontalExtentDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:1238: Qualifying with unknown namespace/class ::CmdTechDrawVerticalExtentDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:1252: Qualifying with unknown namespace/class ::CmdTechDrawVerticalExtentDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:1321: Qualifying with unknown namespace/class ::CmdTechDrawLandmarkDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:1339: Qualifying with unknown namespace/class ::CmdTechDrawLandmarkDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandDecorate.cpp:87: Qualifying with unknown namespace/class ::CmdTechDrawHatch
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandDecorate.cpp:122: Qualifying with unknown namespace/class ::CmdTechDrawHatch
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandDecorate.cpp:208: Qualifying with unknown namespace/class ::CmdTechDrawGeometricHatch
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandDecorate.cpp:277: Qualifying with unknown namespace/class ::CmdTechDrawImage
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandDecorate.cpp:296: Qualifying with unknown namespace/class ::CmdTechDrawImage
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandDecorate.cpp:328: Qualifying with unknown namespace/class ::CmdTechDrawToggleFrame
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandDecorate.cpp:352: Qualifying with unknown namespace/class ::CmdTechDrawToggleFrame
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:145: Qualifying with unknown namespace/class ::CmdTechDrawExtensionInsertDiameter
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:178: Qualifying with unknown namespace/class ::CmdTechDrawExtensionInsertSquare
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:211: Qualifying with unknown namespace/class ::CmdTechDrawExtensionInsertPrefixGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:225: Qualifying with unknown namespace/class ::CmdTechDrawExtensionInsertPrefixGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:338: Qualifying with unknown namespace/class ::CmdTechDrawExtensionIncreaseDecimal
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:371: Qualifying with unknown namespace/class ::CmdTechDrawExtensionDecreaseDecimal
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:404: Qualifying with unknown namespace/class ::CmdTechDrawExtensionIncreaseDecreaseGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:418: Qualifying with unknown namespace/class ::CmdTechDrawExtensionIncreaseDecreaseGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:529: Qualifying with unknown namespace/class ::CmdTechDrawExtensionPosHorizChainDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:588: Qualifying with unknown namespace/class ::CmdTechDrawExtensionPosVertChainDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:653: Qualifying with unknown namespace/class ::CmdTechDrawExtensionPosObliqueChainDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:688: Qualifying with unknown namespace/class ::CmdTechDrawExtensionPosChainDimensionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:703: Qualifying with unknown namespace/class ::CmdTechDrawExtensionPosChainDimensionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:835: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCascadeHorizDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:899: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCascadeVertDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:972: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCascadeObliqueDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1008: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCascadeDimensionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1024: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCascadeDimensionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1162: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateHorizChainDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1228: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateVertChainDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1318: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateObliqueChainDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1352: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateChainDimensionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1366: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateChainDimensionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1505: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateHorizCoordDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1578: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateVertCoordDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1676: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateObliqueCoordDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1712: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateCoordDimensionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1728: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateCoordDimensionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1871: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateHorizChamferDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1940: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateVertChamferDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1973: Qualifying with unknown namespace/class ::CmdTechDrawExtensionChamferDimensionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1987: Qualifying with unknown namespace/class ::CmdTechDrawExtensionChamferDimensionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:2073: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateLengthArc
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:169: Qualifying with unknown namespace/class ::CmdTechDrawExtensionHoleCircle
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:243: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCircleCenterLines
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:277: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCircleCenterLinesGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:290: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCircleCenterLinesGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:395: Qualifying with unknown namespace/class ::CmdTechDrawExtensionThreadHoleSide
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:446: Qualifying with unknown namespace/class ::CmdTechDrawExtensionThreadBoltSide
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:497: Qualifying with unknown namespace/class ::CmdTechDrawExtensionThreadHoleBottom
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:548: Qualifying with unknown namespace/class ::CmdTechDrawExtensionThreadBoltBottom
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:582: Qualifying with unknown namespace/class ::CmdTechDrawExtensionThreadsGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:597: Qualifying with unknown namespace/class ::CmdTechDrawExtensionThreadsGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:715: Qualifying with unknown namespace/class ::CmdTechDrawExtensionSelectLineAttributes
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:749: Qualifying with unknown namespace/class ::CmdTechDrawExtensionChangeLineAttributes
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:808: Qualifying with unknown namespace/class ::CmdTechDrawExtensionVertexAtIntersection
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:898: Qualifying with unknown namespace/class ::CmdTechDrawExtensionDrawCosmArc
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:959: Qualifying with unknown namespace/class ::CmdTechDrawExtensionDrawCosmCircle
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:995: Qualifying with unknown namespace/class ::CmdTechDrawExtensionDrawCirclesGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1011: Qualifying with unknown namespace/class ::CmdTechDrawExtensionDrawCirclesGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1144: Qualifying with unknown namespace/class ::CmdTechDrawExtensionLineParallel
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1178: Qualifying with unknown namespace/class ::CmdTechDrawExtensionLinePerpendicular
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1212: Qualifying with unknown namespace/class ::CmdTechDrawExtensionLinePPGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1227: Qualifying with unknown namespace/class ::CmdTechDrawExtensionLinePPGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1315: Qualifying with unknown namespace/class ::CmdTechDrawExtensionLockUnlockView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1359: Qualifying with unknown namespace/class ::CmdTechDrawExtensionPositionSectionView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1376: Qualifying with unknown namespace/class ::CmdTechDrawExtensionPositionSectionView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1492: Qualifying with unknown namespace/class ::CmdTechDrawExtensionExtendLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1527: Qualifying with unknown namespace/class ::CmdTechDrawExtensionShortenLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1562: Qualifying with unknown namespace/class ::CmdTechDrawExtendShortenLineGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1577: Qualifying with unknown namespace/class ::CmdTechDrawExtendShortenLineGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/QGEPath.cpp:156: Discarding unconsumed meta data
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/QGIEdge.cpp:129: Discarding unconsumed meta data
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/QGIViewAnnotation.cpp:208: Class 'TechDrawGui::QGIViewAnnotation' lacks Q_OBJECT macro
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Test/Test.pro.
+Segmentation fault (core dumped)
+Cannot open Gui/Resources/translations/Testpy.ts: No such file or directory
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Tux/Tux.pro.
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Web/Web.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Web/Gui/Command.cpp:50: Qualifying with unknown namespace/class ::CmdWebOpenWebsite
+/home/chennes/FreeCAD-chennes/src/Mod/Web/Gui/Command.cpp:76: Qualifying with unknown namespace/class ::CmdWebBrowserBack
+/home/chennes/FreeCAD-chennes/src/Mod/Web/Gui/Command.cpp:105: Qualifying with unknown namespace/class ::CmdWebBrowserNext
+/home/chennes/FreeCAD-chennes/src/Mod/Web/Gui/Command.cpp:134: Qualifying with unknown namespace/class ::CmdWebBrowserRefresh
+/home/chennes/FreeCAD-chennes/src/Mod/Web/Gui/Command.cpp:162: Qualifying with unknown namespace/class ::CmdWebBrowserStop
+/home/chennes/FreeCAD-chennes/src/Mod/Web/Gui/Command.cpp:192: Qualifying with unknown namespace/class ::CmdWebBrowserZoomIn
+/home/chennes/FreeCAD-chennes/src/Mod/Web/Gui/Command.cpp:221: Qualifying with unknown namespace/class ::CmdWebBrowserZoomOut
+/home/chennes/FreeCAD-chennes/src/Mod/Web/Gui/Command.cpp:250: Qualifying with unknown namespace/class ::CmdWebBrowserSetURL
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Gui/FreeCAD.pro.
+/home/chennes/FreeCAD-chennes/src/Gui/Selection.h:192: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/BlenderNavigationStyle.cpp:66: Class 'Gui::BlenderNavigationStyle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/CADNavigationStyle.cpp:66: Class 'Gui::CADNavigationStyle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:96: Qualifying with unknown namespace/class ::StdCmdOpen
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:111: Qualifying with unknown namespace/class ::StdCmdOpen
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:187: Qualifying with unknown namespace/class ::StdCmdImport
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:201: Qualifying with unknown namespace/class ::StdCmdImport
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:273: Qualifying with unknown namespace/class ::StdCmdExport
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:414: Qualifying with unknown namespace/class ::StdCmdExport
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:520: Qualifying with unknown namespace/class ::StdCmdMergeProjects
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:533: Qualifying with unknown namespace/class ::StdCmdMergeProjects
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:573: Qualifying with unknown namespace/class ::StdCmdDependencyGraph
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:605: Qualifying with unknown namespace/class ::StdCmdNew
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:636: Qualifying with unknown namespace/class ::StdCmdSave
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:676: Qualifying with unknown namespace/class ::StdCmdSaveAs
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:716: Qualifying with unknown namespace/class ::StdCmdSaveCopy
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:749: Qualifying with unknown namespace/class ::StdCmdSaveAll
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:777: Qualifying with unknown namespace/class ::StdCmdRevert
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:816: Qualifying with unknown namespace/class ::StdCmdProjectInfo
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:847: Qualifying with unknown namespace/class ::StdCmdProjectUtil
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:874: Qualifying with unknown namespace/class ::StdCmdPrint
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:887: Qualifying with unknown namespace/class ::StdCmdPrint
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:906: Qualifying with unknown namespace/class ::StdCmdPrintPreview
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:936: Qualifying with unknown namespace/class ::StdCmdPrintPdf
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:948: Qualifying with unknown namespace/class ::StdCmdPrintPdf
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:968: Qualifying with unknown namespace/class ::StdCmdQuit
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:994: Qualifying with unknown namespace/class ::StdCmdUndo
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1038: Qualifying with unknown namespace/class ::StdCmdRedo
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1081: Qualifying with unknown namespace/class ::StdCmdCut
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1109: Qualifying with unknown namespace/class ::StdCmdCopy
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1144: Qualifying with unknown namespace/class ::StdCmdPaste
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1183: Qualifying with unknown namespace/class ::StdCmdDuplicateSelection
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1217: Qualifying with unknown namespace/class ::StdCmdDuplicateSelection
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1271: Qualifying with unknown namespace/class ::StdCmdSelectAll
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1302: Qualifying with unknown namespace/class ::StdCmdDelete
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1449: Qualifying with unknown namespace/class ::StdCmdDelete
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1475: Qualifying with unknown namespace/class ::StdCmdRefresh
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1503: Qualifying with unknown namespace/class ::StdCmdRefresh
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1529: Qualifying with unknown namespace/class ::StdCmdTransform
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1555: Qualifying with unknown namespace/class ::StdCmdPlacement
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1589: Qualifying with unknown namespace/class ::StdCmdTransformManip
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1623: Qualifying with unknown namespace/class ::StdCmdAlignment
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1693: Qualifying with unknown namespace/class ::StdCmdEdit
+/home/chennes/FreeCAD-chennes/src/Gui/CommandDoc.cpp:1737: Class 'StdCmdExpression' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/CommandFeat.cpp:54: Qualifying with unknown namespace/class ::StdCmdFeatRecompute
+/home/chennes/FreeCAD-chennes/src/Gui/CommandFeat.cpp:77: Qualifying with unknown namespace/class ::StdCmdRandomColor
+/home/chennes/FreeCAD-chennes/src/Gui/CommandFeat.cpp:129: Qualifying with unknown namespace/class ::StdCmdSendToPythonConsole
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:80: Class 'StdCmdLinkMakeGroup' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:211: Qualifying with unknown namespace/class ::StdCmdLinkMake
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:260: Qualifying with unknown namespace/class ::StdCmdLinkMake
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:274: Qualifying with unknown namespace/class ::StdCmdLinkMakeRelative
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:335: Qualifying with unknown namespace/class ::StdCmdLinkMakeRelative
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:494: Qualifying with unknown namespace/class ::StdCmdLinkReplace
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:518: Qualifying with unknown namespace/class ::StdCmdLinkUnlink
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:542: Qualifying with unknown namespace/class ::StdCmdLinkImport
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:592: Qualifying with unknown namespace/class ::StdCmdLinkImport
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:606: Qualifying with unknown namespace/class ::StdCmdLinkImportAll
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:631: Qualifying with unknown namespace/class ::StdCmdLinkImportAll
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:647: Qualifying with unknown namespace/class ::StdCmdLinkSelectLinked
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:774: Qualifying with unknown namespace/class ::StdCmdLinkSelectLinkedFinal
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:808: Qualifying with unknown namespace/class ::StdCmdLinkSelectAllLinks
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:847: Class 'StdCmdLinkSelectActions' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/CommandLink.cpp:873: Class 'StdCmdLinkActions' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/CommandMacro.cpp:48: Qualifying with unknown namespace/class ::StdCmdDlgMacroRecord
+/home/chennes/FreeCAD-chennes/src/Gui/CommandMacro.cpp:77: Qualifying with unknown namespace/class ::StdCmdMacroStopRecord
+/home/chennes/FreeCAD-chennes/src/Gui/CommandMacro.cpp:105: Qualifying with unknown namespace/class ::StdCmdDlgMacroExecute
+/home/chennes/FreeCAD-chennes/src/Gui/CommandMacro.cpp:134: Qualifying with unknown namespace/class ::StdCmdDlgMacroExecuteDirect
+/home/chennes/FreeCAD-chennes/src/Gui/CommandMacro.cpp:160: Qualifying with unknown namespace/class ::StdCmdMacroAttachDebugger
+/home/chennes/FreeCAD-chennes/src/Gui/CommandMacro.cpp:185: Qualifying with unknown namespace/class ::StdCmdMacroStartDebug
+/home/chennes/FreeCAD-chennes/src/Gui/CommandMacro.cpp:215: Qualifying with unknown namespace/class ::StdCmdMacroStopDebug
+/home/chennes/FreeCAD-chennes/src/Gui/CommandMacro.cpp:242: Qualifying with unknown namespace/class ::StdCmdMacroStepOver
+/home/chennes/FreeCAD-chennes/src/Gui/CommandMacro.cpp:269: Qualifying with unknown namespace/class ::StdCmdMacroStepInto
+/home/chennes/FreeCAD-chennes/src/Gui/CommandMacro.cpp:296: Qualifying with unknown namespace/class ::StdCmdToggleBreakpoint
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:80: Qualifying with unknown namespace/class ::StdCmdWorkbench
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:109: Qualifying with unknown namespace/class ::StdCmdWorkbench
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:145: Qualifying with unknown namespace/class ::StdCmdRecentFiles
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:186: Qualifying with unknown namespace/class ::StdCmdRecentMacros
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:226: Qualifying with unknown namespace/class ::StdCmdAbout
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:292: Qualifying with unknown namespace/class ::StdCmdAboutQt
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:314: Qualifying with unknown namespace/class ::StdCmdWhatsThis
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:338: Qualifying with unknown namespace/class ::StdCmdDlgParameter
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:363: Qualifying with unknown namespace/class ::StdCmdDlgPreferences
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:395: Qualifying with unknown namespace/class ::StdCmdDlgCustomize
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:422: Qualifying with unknown namespace/class ::StdCmdCommandLine
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:470: Qualifying with unknown namespace/class ::StdCmdOnlineHelp
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:495: Qualifying with unknown namespace/class ::StdCmdOnlineHelpWebsite
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:522: Qualifying with unknown namespace/class ::StdCmdFreeCADDonation
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:549: Qualifying with unknown namespace/class ::StdCmdFreeCADWebsite
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:577: Qualifying with unknown namespace/class ::StdCmdFreeCADUserHub
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:605: Qualifying with unknown namespace/class ::StdCmdFreeCADPowerUserHub
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:633: Qualifying with unknown namespace/class ::StdCmdFreeCADForum
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:661: Qualifying with unknown namespace/class ::StdCmdFreeCADFAQ
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:689: Qualifying with unknown namespace/class ::StdCmdPythonWebsite
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:713: Qualifying with unknown namespace/class ::StdCmdMeasurementSimple
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:727: Qualifying with unknown namespace/class ::StdCmdMeasurementSimple
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:770: Qualifying with unknown namespace/class ::StdCmdTextDocument
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:803: Qualifying with unknown namespace/class ::StdCmdUnitsCalculator
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStd.cpp:839: Class 'StdCmdUserEditMode' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStructure.cpp:52: Qualifying with unknown namespace/class ::StdCmdPart
+/home/chennes/FreeCAD-chennes/src/Gui/CommandStructure.cpp:93: Qualifying with unknown namespace/class ::StdCmdGroup
+/home/chennes/FreeCAD-chennes/src/Gui/CommandTest.cpp:714: Qualifying with unknown namespace/class ::CmdTestConsoleOutput
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:108: Qualifying with unknown namespace/class ::StdOrthographicCamera
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:158: Qualifying with unknown namespace/class ::StdPerspectiveCamera
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:218: Qualifying with unknown namespace/class ::StdCmdViewSaveCamera
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:244: Qualifying with unknown namespace/class ::StdCmdViewRestoreCamera
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:303: Class 'StdCmdFreezeViews' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:561: Qualifying with unknown namespace/class ::StdCmdToggleClipPlane
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:643: Class 'StdCmdDrawStyle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:862: Qualifying with unknown namespace/class ::StdCmdToggleVisibility
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:892: Qualifying with unknown namespace/class ::StdCmdToggleSelectability
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:939: Qualifying with unknown namespace/class ::StdCmdShowSelection
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:967: Qualifying with unknown namespace/class ::StdCmdHideSelection
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:995: Qualifying with unknown namespace/class ::StdCmdSelectVisibleObjects
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1037: Qualifying with unknown namespace/class ::StdCmdToggleObjects
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1078: Qualifying with unknown namespace/class ::StdCmdShowObjects
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1115: Qualifying with unknown namespace/class ::StdCmdHideObjects
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1152: Qualifying with unknown namespace/class ::StdCmdSetAppearance
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1195: Qualifying with unknown namespace/class ::StdCmdViewHome
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1223: Qualifying with unknown namespace/class ::StdCmdViewBottom
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1247: Qualifying with unknown namespace/class ::StdCmdViewFront
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1271: Qualifying with unknown namespace/class ::StdCmdViewLeft
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1295: Qualifying with unknown namespace/class ::StdCmdViewRear
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1319: Qualifying with unknown namespace/class ::StdCmdViewRight
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1343: Qualifying with unknown namespace/class ::StdCmdViewTop
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1367: Qualifying with unknown namespace/class ::StdCmdViewIsometric
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1391: Qualifying with unknown namespace/class ::StdCmdViewDimetric
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1414: Qualifying with unknown namespace/class ::StdCmdViewTrimetric
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1437: Qualifying with unknown namespace/class ::StdCmdViewRotateLeft
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1462: Qualifying with unknown namespace/class ::StdCmdViewRotateRight
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1487: Qualifying with unknown namespace/class ::StdCmdViewFitAll
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1518: Qualifying with unknown namespace/class ::StdCmdViewFitSelection
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1549: Qualifying with unknown namespace/class ::StdViewDock
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1578: Qualifying with unknown namespace/class ::StdViewUndock
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1607: Qualifying with unknown namespace/class ::StdMainFullscreen
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1639: Qualifying with unknown namespace/class ::StdViewFullscreen
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1669: Qualifying with unknown namespace/class ::StdViewDockUndockFullscreen
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1782: Qualifying with unknown namespace/class ::StdCmdViewVR
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1812: Qualifying with unknown namespace/class ::StdViewScreenShot
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1845: Qualifying with unknown namespace/class ::StdViewScreenShot
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:1983: Qualifying with unknown namespace/class ::StdCmdViewCreate
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2012: Qualifying with unknown namespace/class ::StdCmdToggleNavigation
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2062: Class 'StdCmdAxisCross' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2196: Qualifying with unknown namespace/class ::StdCmdViewExample1
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2224: Qualifying with unknown namespace/class ::StdCmdViewExample2
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2252: Qualifying with unknown namespace/class ::StdCmdViewExample3
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2281: Qualifying with unknown namespace/class ::StdCmdViewIvStereoOff
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2310: Qualifying with unknown namespace/class ::StdCmdViewIvStereoRedGreen
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2338: Qualifying with unknown namespace/class ::StdCmdViewIvStereoQuadBuff
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2366: Qualifying with unknown namespace/class ::StdCmdViewIvStereoInterleavedRows
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2394: Qualifying with unknown namespace/class ::StdCmdViewIvStereoInterleavedColumns
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2423: Qualifying with unknown namespace/class ::StdCmdViewIvIssueCamPos
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2473: Qualifying with unknown namespace/class ::StdViewZoomIn
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2506: Qualifying with unknown namespace/class ::StdViewZoomOut
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2666: Qualifying with unknown namespace/class ::StdViewBoxZoom
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2736: Qualifying with unknown namespace/class ::StdBoxSelection
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:2999: Qualifying with unknown namespace/class ::StdBoxElementSelection
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3040: Qualifying with unknown namespace/class ::StdTreeSelection
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3065: Qualifying with unknown namespace/class ::StdCmdTreeCollapse
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3090: Qualifying with unknown namespace/class ::StdCmdTreeExpand
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3115: Qualifying with unknown namespace/class ::StdCmdTreeSelectAllInstances
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3165: Qualifying with unknown namespace/class ::StdCmdMeasureDistance
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3256: Qualifying with unknown namespace/class ::StdCmdSceneInspector
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3289: Qualifying with unknown namespace/class ::StdCmdTextureMapping
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3316: Qualifying with unknown namespace/class ::StdCmdDemoMode
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3344: Qualifying with unknown namespace/class ::CmdViewMeasureClearAll
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3374: Qualifying with unknown namespace/class ::CmdViewMeasureToggleAll
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3403: Qualifying with unknown namespace/class ::StdCmdSelBack
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3433: Qualifying with unknown namespace/class ::StdCmdSelForward
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3483: Qualifying with unknown namespace/class ::StdTreeSingleDocument
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3500: Qualifying with unknown namespace/class ::StdTreeMultiDocument
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3517: Qualifying with unknown namespace/class ::StdTreeCollapseDocument
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3556: Qualifying with unknown namespace/class ::StdTreeSyncView
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3574: Qualifying with unknown namespace/class ::StdTreeSyncSelection
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3592: Qualifying with unknown namespace/class ::StdTreeSyncPlacement
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3610: Qualifying with unknown namespace/class ::StdTreePreSelection
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3628: Qualifying with unknown namespace/class ::StdTreeRecordSelection
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3646: Qualifying with unknown namespace/class ::StdTreeDrag
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3678: Class 'StdCmdTreeViewActions' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/CommandView.cpp:3715: Qualifying with unknown namespace/class ::StdCmdSelBoundingBox
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:55: Qualifying with unknown namespace/class ::StdCmdArrangeIcons
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:82: Qualifying with unknown namespace/class ::StdCmdTileWindows
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:110: Qualifying with unknown namespace/class ::StdCmdCascadeWindows
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:138: Qualifying with unknown namespace/class ::StdCmdCloseActiveWindow
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:170: Qualifying with unknown namespace/class ::StdCmdCloseAllWindows
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:198: Qualifying with unknown namespace/class ::StdCmdActivateNextWindow
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:227: Qualifying with unknown namespace/class ::StdCmdActivatePrevWindow
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:256: Qualifying with unknown namespace/class ::StdCmdWindows
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:280: Qualifying with unknown namespace/class ::StdCmdUserInterface
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:302: Qualifying with unknown namespace/class ::StdCmdDockViewMenu
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:338: Qualifying with unknown namespace/class ::StdCmdToolBarMenu
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:392: Qualifying with unknown namespace/class ::StdCmdStatusBar
+/home/chennes/FreeCAD-chennes/src/Gui/CommandWindow.cpp:438: Qualifying with unknown namespace/class ::StdCmdWindowsMenu
+/home/chennes/FreeCAD-chennes/src/Gui/DocumentModel.cpp:203: Class 'Gui::DocumentModel' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:95: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:222: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:238: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:341: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:482: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:524: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:571: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:618: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:666: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:752: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:802: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Gui/GestureNavigationStyle.cpp:855: Class 'Gui::GestureNavigationStyle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/InventorNavigationStyle.cpp:68: Class 'Gui::InventorNavigationStyle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/ManualAlignment.cpp:437: Class 'Gui::AlignmentView' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/MayaGestureNavigationStyle.cpp:107: Class 'Gui::MayaGestureNavigationStyle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/NaviCube.cpp:1695: Qualifying with unknown namespace/class ::ViewIsometricCmd
+/home/chennes/FreeCAD-chennes/src/Gui/NaviCube.cpp:1715: Qualifying with unknown namespace/class ::ViewOrthographicCmd
+/home/chennes/FreeCAD-chennes/src/Gui/NaviCube.cpp:1736: Qualifying with unknown namespace/class ::ViewPerspectiveCmd
+/home/chennes/FreeCAD-chennes/src/Gui/NaviCube.cpp:1757: Qualifying with unknown namespace/class ::ViewZoomToFitCmd
+/home/chennes/FreeCAD-chennes/src/Gui/OnlineDocumentation.cpp:367: Class 'Gui::StdCmdPythonHelp' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/OpenCascadeNavigationStyle.cpp:66: Class 'Gui::OpenCascadeNavigationStyle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/OpenSCADNavigationStyle.cpp:66: Class 'Gui::OpenSCADNavigationStyle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/RevitNavigationStyle.cpp:66: Class 'Gui::RevitNavigationStyle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/TinkerCADNavigationStyle.cpp:66: Class 'Gui::TinkerCADNavigationStyle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/TouchpadNavigationStyle.cpp:66: Class 'Gui::TouchpadNavigationStyle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/WhatsThis.cpp:46: Class 'Gui::StdCmdDescription' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Gui/Widgets.cpp:1450: Class 'PropertyListDialog' lacks Q_OBJECT macro
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/AddonManager/AddonManager.pro.
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Arch/Arch.pro.
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Assembly/Assembly.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:36: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:37: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:42: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:46: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:47: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:48: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:52: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:56: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:57: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:58: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:62: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:66: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:67: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/externalize.hpp:71: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/distance.hpp:32: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/distance.hpp:77: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/distance.hpp:193: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/distance.hpp:317: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/distance.hpp:382: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/distance.hpp:553: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/distance.hpp:573: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/distance.hpp:616: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/distance.hpp:637: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/distance.hpp:696: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/parallel.hpp:166: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/parallel.hpp:207: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/parallel.hpp:262: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/parallel.hpp:322: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/parallel.hpp:337: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/parallel.hpp:340: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/parallel.hpp:380: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/angle.hpp:80: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/angle.hpp:121: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/angle.hpp:124: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/angle.hpp:138: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/angle.hpp:141: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/angle.hpp:155: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/imp/constraint3d_holder_imp.hpp:51: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/module3d/imp/constraint3d_holder_imp.hpp:60: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/App/opendcm/moduleShape3d/distance.hpp:32: Ignoring definition of undeclared qualified class
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/Command.cpp:52: Qualifying with unknown namespace/class ::CmdAssemblyAddNewPart
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/Command.cpp:73: Qualifying with unknown namespace/class ::CmdAssemblyAddNewPart
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/Command.cpp:108: Qualifying with unknown namespace/class ::CmdAssemblyAddNewComponent
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/Command.cpp:129: Qualifying with unknown namespace/class ::CmdAssemblyAddNewComponent
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/Command.cpp:154: Qualifying with unknown namespace/class ::CmdAssemblyAddExistingComponent
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/Command.cpp:175: Qualifying with unknown namespace/class ::CmdAssemblyAddExistingComponent
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/Command.cpp:217: Qualifying with unknown namespace/class ::CmdAssemblyImport
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/CommandConstraints.cpp:118: Qualifying with unknown namespace/class ::CmdAssemblyConstraint
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/CommandConstraints.cpp:202: Qualifying with unknown namespace/class ::CmdAssemblyConstraintDistance
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/CommandConstraints.cpp:269: Qualifying with unknown namespace/class ::CmdAssemblyConstraintFix
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/CommandConstraints.cpp:334: Qualifying with unknown namespace/class ::CmdAssemblyConstraintAngle
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/CommandConstraints.cpp:403: Qualifying with unknown namespace/class ::CmdAssemblyConstraintOrientation
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/CommandConstraints.cpp:471: Qualifying with unknown namespace/class ::CmdAssemblyConstraintCoincidence
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/CommandConstraints.cpp:539: Qualifying with unknown namespace/class ::CmdAssemblyConstraintAlignment
+/home/chennes/FreeCAD-chennes/src/Mod/Assembly/Gui/Workbench.cpp:94: Class 'AssemblyGui::Workbench' lacks Q_OBJECT macro
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Draft/Draft.pro.
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Drawing/Drawing.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/TaskOrthoViews.h:162: Discarding unconsumed meta data
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:60: Qualifying with unknown namespace/class ::CmdDrawingOpen
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:72: Qualifying with unknown namespace/class ::CmdDrawingOpen
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:93: Qualifying with unknown namespace/class ::CmdDrawingNewPage
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:271: Qualifying with unknown namespace/class ::CmdDrawingNewA3Landscape
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:310: Qualifying with unknown namespace/class ::CmdDrawingNewView
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:323: Qualifying with unknown namespace/class ::CmdDrawingNewView
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:389: Qualifying with unknown namespace/class ::CmdDrawingOrthoViews
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:402: Qualifying with unknown namespace/class ::CmdDrawingOrthoViews
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:439: Qualifying with unknown namespace/class ::CmdDrawingOpenBrowserView
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:452: Qualifying with unknown namespace/class ::CmdDrawingOpenBrowserView
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:477: Qualifying with unknown namespace/class ::CmdDrawingAnnotation
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:492: Qualifying with unknown namespace/class ::CmdDrawingAnnotation
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:525: Qualifying with unknown namespace/class ::CmdDrawingClip
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:540: Qualifying with unknown namespace/class ::CmdDrawingClip
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:570: Qualifying with unknown namespace/class ::CmdDrawingSymbol
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:585: Qualifying with unknown namespace/class ::CmdDrawingSymbol
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:627: Qualifying with unknown namespace/class ::CmdDrawingExportPage
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:640: Qualifying with unknown namespace/class ::CmdDrawingExportPage
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:680: Qualifying with unknown namespace/class ::CmdDrawingProjectShape
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:716: Qualifying with unknown namespace/class ::CmdDrawingDraftView
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:747: Qualifying with unknown namespace/class ::CmdDrawingSpreadsheetView
+/home/chennes/FreeCAD-chennes/src/Mod/Drawing/Gui/Command.cpp:760: Qualifying with unknown namespace/class ::CmdDrawingSpreadsheetView
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Fem/Fem.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:295: Qualifying with unknown namespace/class ::CmdFemConstraintBearing
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:336: Qualifying with unknown namespace/class ::CmdFemConstraintContact
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:381: Qualifying with unknown namespace/class ::CmdFemConstraintDisplacement
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:424: Qualifying with unknown namespace/class ::CmdFemConstraintFixed
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:466: Qualifying with unknown namespace/class ::CmdFemConstraintFluidBoundary
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:509: Qualifying with unknown namespace/class ::CmdFemConstraintForce
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:553: Qualifying with unknown namespace/class ::CmdFemConstraintGear
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:594: Qualifying with unknown namespace/class ::CmdFemConstraintHeatflux
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:639: Qualifying with unknown namespace/class ::CmdFemConstraintInitialTemperature
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:682: Qualifying with unknown namespace/class ::CmdFemConstraintPlaneRotation
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:724: Qualifying with unknown namespace/class ::CmdFemConstraintPressure
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:769: Qualifying with unknown namespace/class ::CmdFemConstraintSpring
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:814: Qualifying with unknown namespace/class ::CmdFemConstraintPulley
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:860: Qualifying with unknown namespace/class ::CmdFemConstraintTemperature
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:903: Qualifying with unknown namespace/class ::CmdFemConstraintTransform
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1039: Qualifying with unknown namespace/class ::CmdFemDefineNodesSet
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1095: Qualifying with unknown namespace/class ::CmdFemCreateNodesSet
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1251: Qualifying with unknown namespace/class ::CmdFemPostClipFilter
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1277: Qualifying with unknown namespace/class ::CmdFemPostCutFilter
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1303: Qualifying with unknown namespace/class ::CmdFemPostDataAlongLineFilter
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1329: Qualifying with unknown namespace/class ::CmdFemPostDataAtPointFilter
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1357: Qualifying with unknown namespace/class ::CmdFemPostLinearizedStressesFilter
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1414: Qualifying with unknown namespace/class ::CmdFemPostScalarClipFilter
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1440: Qualifying with unknown namespace/class ::CmdFemPostWarpVectorFilter
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1466: Qualifying with unknown namespace/class ::CmdFemPostFunctions
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1606: Qualifying with unknown namespace/class ::CmdFemPostApllyChanges
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/Command.cpp:1651: Qualifying with unknown namespace/class ::CmdFemPostPipelineFromResult
+/home/chennes/FreeCAD-chennes/src/Mod/Fem/Gui/ViewProviderFemConstraintDisplacement.cpp:145: Unbalanced opening parenthesis in C++ code (or abuse of the C++ preprocessor)
+resulttools.py: Unbalanced parentheses in Python code
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Image/Image.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Image/Gui/Command.cpp:54: Qualifying with unknown namespace/class ::CmdImageOpen
+/home/chennes/FreeCAD-chennes/src/Mod/Image/Gui/Command.cpp:69: Qualifying with unknown namespace/class ::CmdImageOpen
+/home/chennes/FreeCAD-chennes/src/Mod/Image/Gui/Command.cpp:99: Qualifying with unknown namespace/class ::CmdCreateImagePlane
+/home/chennes/FreeCAD-chennes/src/Mod/Image/Gui/Command.cpp:113: Qualifying with unknown namespace/class ::CmdCreateImagePlane
+/home/chennes/FreeCAD-chennes/src/Mod/Image/Gui/Command.cpp:173: Qualifying with unknown namespace/class ::CmdImageScaling
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Mesh/Mesh.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:94: Qualifying with unknown namespace/class ::CmdMeshTransform
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:133: Qualifying with unknown namespace/class ::CmdMeshDemolding
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:172: Qualifying with unknown namespace/class ::CmdMeshToolMesh
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:227: Qualifying with unknown namespace/class ::CmdMeshUnion
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:298: Qualifying with unknown namespace/class ::CmdMeshDifference
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:369: Qualifying with unknown namespace/class ::CmdMeshIntersection
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:440: Qualifying with unknown namespace/class ::CmdMeshImport
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:452: Qualifying with unknown namespace/class ::CmdMeshImport
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:491: Qualifying with unknown namespace/class ::CmdMeshExport
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:510: Qualifying with unknown namespace/class ::CmdMeshExport
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:566: Qualifying with unknown namespace/class ::CmdMeshFromGeometry
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:576: Qualifying with unknown namespace/class ::CmdMeshFromGeometry
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:624: Qualifying with unknown namespace/class ::CmdMeshFromPartShape
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:650: Qualifying with unknown namespace/class ::CmdMeshVertexCurvature
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:693: Qualifying with unknown namespace/class ::CmdMeshVertexCurvatureInfo
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:739: Qualifying with unknown namespace/class ::CmdMeshPolySegm
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:795: Qualifying with unknown namespace/class ::CmdMeshPolySelect
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:848: Qualifying with unknown namespace/class ::CmdMeshAddFacet
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:895: Qualifying with unknown namespace/class ::CmdMeshPolyCut
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:956: Qualifying with unknown namespace/class ::CmdMeshPolyTrim
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1017: Qualifying with unknown namespace/class ::CmdMeshTrimByPlane
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1046: Qualifying with unknown namespace/class ::CmdMeshSectionByPlane
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1075: Qualifying with unknown namespace/class ::CmdMeshCrossSections
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1101: Qualifying with unknown namespace/class ::CmdMeshPolySplit
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1155: Qualifying with unknown namespace/class ::CmdMeshEvaluation
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1198: Qualifying with unknown namespace/class ::CmdMeshEvaluateFacet
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1241: Qualifying with unknown namespace/class ::CmdMeshRemoveComponents
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1286: Qualifying with unknown namespace/class ::CmdMeshRemeshGmsh
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1319: Qualifying with unknown namespace/class ::CmdMeshRemoveCompByHand
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1363: Qualifying with unknown namespace/class ::CmdMeshEvaluateSolid
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1378: Qualifying with unknown namespace/class ::CmdMeshEvaluateSolid
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1401: Qualifying with unknown namespace/class ::CmdMeshSmoothing
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1464: Qualifying with unknown namespace/class ::CmdMeshDecimating
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1495: Qualifying with unknown namespace/class ::CmdMeshHarmonizeNormals
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1529: Qualifying with unknown namespace/class ::CmdMeshFlipNormals
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1563: Qualifying with unknown namespace/class ::CmdMeshBoundingBox
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1586: Qualifying with unknown namespace/class ::CmdMeshBoundingBox
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1605: Qualifying with unknown namespace/class ::CmdMeshBuildRegularSolid
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1636: Qualifying with unknown namespace/class ::CmdMeshFillupHoles
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1648: Qualifying with unknown namespace/class ::CmdMeshFillupHoles
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1674: Qualifying with unknown namespace/class ::CmdMeshFillInteractiveHole
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1716: Qualifying with unknown namespace/class ::CmdMeshSegmentation
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1752: Qualifying with unknown namespace/class ::CmdMeshSegmentationBestFit
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1788: Qualifying with unknown namespace/class ::CmdMeshMerge
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1831: Qualifying with unknown namespace/class ::CmdMeshSplitComponents
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1877: Qualifying with unknown namespace/class ::CmdMeshScale
+/home/chennes/FreeCAD-chennes/src/Mod/Mesh/Gui/Command.cpp:1892: Qualifying with unknown namespace/class ::CmdMeshScale
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/MeshPart/MeshPart.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/MeshPart/Gui/Command.cpp:59: Qualifying with unknown namespace/class ::CmdMeshPartMesher
+/home/chennes/FreeCAD-chennes/src/Mod/MeshPart/Gui/Command.cpp:84: Qualifying with unknown namespace/class ::CmdMeshPartTrimByPlane
+/home/chennes/FreeCAD-chennes/src/Mod/MeshPart/Gui/Command.cpp:192: Qualifying with unknown namespace/class ::CmdMeshPartSection
+/home/chennes/FreeCAD-chennes/src/Mod/MeshPart/Gui/Command.cpp:276: Qualifying with unknown namespace/class ::CmdMeshPartCrossSections
+/home/chennes/FreeCAD-chennes/src/Mod/MeshPart/Gui/Command.cpp:312: Qualifying with unknown namespace/class ::CmdMeshPartCurveOnMesh
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/OpenSCAD/OpenSCAD.pro.
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/PartDesign/PartDesign.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/App/FeatureGroove.cpp:113: Class 'PartDesign::Groove' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/App/FeatureHole.cpp:1654: Class 'PartDesign::Hole' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/App/FeaturePocket.cpp:118: Class 'PartDesign::Pocket' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:167: Qualifying with unknown namespace/class ::CmdPartDesignPlane
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:195: Qualifying with unknown namespace/class ::CmdPartDesignLine
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:223: Qualifying with unknown namespace/class ::CmdPartDesignPoint
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:251: Qualifying with unknown namespace/class ::CmdPartDesignCS
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:283: Qualifying with unknown namespace/class ::CmdPartDesignShapeBinder
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:348: Qualifying with unknown namespace/class ::CmdPartDesignSubShapeBinder
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:412: Qualifying with unknown namespace/class ::CmdPartDesignSubShapeBinder
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:431: Qualifying with unknown namespace/class ::CmdPartDesignClone
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:489: Qualifying with unknown namespace/class ::CmdPartDesignNewSketch
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:594: Qualifying with unknown namespace/class ::CmdPartDesignNewSketch
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1309: Qualifying with unknown namespace/class ::CmdPartDesignPad
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1341: Qualifying with unknown namespace/class ::CmdPartDesignPocket
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1373: Qualifying with unknown namespace/class ::CmdPartDesignHole
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1419: Qualifying with unknown namespace/class ::CmdPartDesignRevolution
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1477: Qualifying with unknown namespace/class ::CmdPartDesignGroove
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1543: Qualifying with unknown namespace/class ::CmdPartDesignAdditivePipe
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1593: Qualifying with unknown namespace/class ::CmdPartDesignSubtractivePipe
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1643: Qualifying with unknown namespace/class ::CmdPartDesignAdditiveLoft
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1693: Qualifying with unknown namespace/class ::CmdPartDesignSubtractiveLoft
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1742: Qualifying with unknown namespace/class ::CmdPartDesignAdditiveHelix
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1812: Qualifying with unknown namespace/class ::CmdPartDesignSubtractiveHelix
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:1991: Qualifying with unknown namespace/class ::CmdPartDesignFillet
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:2019: Qualifying with unknown namespace/class ::CmdPartDesignChamfer
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:2048: Qualifying with unknown namespace/class ::CmdPartDesignDraft
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:2105: Qualifying with unknown namespace/class ::CmdPartDesignThickness
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:2253: Qualifying with unknown namespace/class ::CmdPartDesignMirrored
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:2315: Qualifying with unknown namespace/class ::CmdPartDesignLinearPattern
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:2379: Qualifying with unknown namespace/class ::CmdPartDesignPolarPattern
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:2444: Qualifying with unknown namespace/class ::CmdPartDesignScaled
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:2493: Qualifying with unknown namespace/class ::CmdPartDesignMultiTransform
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/Command.cpp:2616: Qualifying with unknown namespace/class ::CmdPartDesignBoolean
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandBody.cpp:89: Qualifying with unknown namespace/class ::CmdPartDesignBody
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandBody.cpp:119: Qualifying with unknown namespace/class ::CmdPartDesignBody
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandBody.cpp:312: Qualifying with unknown namespace/class ::CmdPartDesignMigrate
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandBody.cpp:343: Qualifying with unknown namespace/class ::CmdPartDesignMigrate
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandBody.cpp:527: Qualifying with unknown namespace/class ::CmdPartDesignMoveTip
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandBody.cpp:555: Qualifying with unknown namespace/class ::CmdPartDesignMoveTip
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandBody.cpp:606: Qualifying with unknown namespace/class ::CmdPartDesignDuplicateSelection
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandBody.cpp:662: Qualifying with unknown namespace/class ::CmdPartDesignMoveFeature
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandBody.cpp:680: Qualifying with unknown namespace/class ::CmdPartDesignMoveFeature
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandBody.cpp:824: Qualifying with unknown namespace/class ::CmdPartDesignMoveFeatureInTree
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandBody.cpp:851: Qualifying with unknown namespace/class ::CmdPartDesignMoveFeatureInTree
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandPrimitive.cpp:69: Qualifying with unknown namespace/class ::CmdPrimtiveCompAdditive
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandPrimitive.cpp:243: Qualifying with unknown namespace/class ::CmdPrimtiveCompSubtractive
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/CommandPrimitive.cpp:269: Qualifying with unknown namespace/class ::CmdPrimtiveCompSubtractive
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/FeaturePickDialog.cpp:45: Qualifying with unknown namespace/class ::FeaturePickDialog
+/home/chennes/FreeCAD-chennes/src/Mod/PartDesign/Gui/ReferenceSelection.cpp:271: Class 'PartDesignGui::NoDependentsSelection' lacks Q_OBJECT macro
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Part/Part.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:90: Qualifying with unknown namespace/class ::CmdPartPickCurveNet
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:136: Qualifying with unknown namespace/class ::CmdPartBox2
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:177: Qualifying with unknown namespace/class ::CmdPartBox3
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:218: Qualifying with unknown namespace/class ::CmdPartPrimitives
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:272: Qualifying with unknown namespace/class ::CmdPartCut
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:286: Qualifying with unknown namespace/class ::CmdPartCut
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:350: Qualifying with unknown namespace/class ::CmdPartCommon
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:381: Qualifying with unknown namespace/class ::CmdPartCommon
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:450: Qualifying with unknown namespace/class ::CmdPartFuse
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:481: Qualifying with unknown namespace/class ::CmdPartFuse
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:551: Qualifying with unknown namespace/class ::CmdPartCompJoinFeatures
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:657: Qualifying with unknown namespace/class ::CmdPartCompSplitFeatures
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:779: Qualifying with unknown namespace/class ::CmdPartCompCompoundTools
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:886: Qualifying with unknown namespace/class ::CmdPartCompound
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:900: Qualifying with unknown namespace/class ::CmdPartCompound
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:943: Qualifying with unknown namespace/class ::CmdPartSection
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:957: Qualifying with unknown namespace/class ::CmdPartSection
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:991: Qualifying with unknown namespace/class ::CmdPartImport
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1053: Qualifying with unknown namespace/class ::CmdPartExport
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1100: Qualifying with unknown namespace/class ::CmdPartImportCurveNet
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1113: Qualifying with unknown namespace/class ::CmdPartImportCurveNet
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1148: Qualifying with unknown namespace/class ::CmdPartMakeSolid
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1227: Qualifying with unknown namespace/class ::CmdPartReverseShape
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1290: Qualifying with unknown namespace/class ::CmdPartBoolean
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1321: Qualifying with unknown namespace/class ::CmdPartExtrude
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1349: Qualifying with unknown namespace/class ::CmdPartMakeFace
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1401: Qualifying with unknown namespace/class ::CmdPartRevolve
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1429: Qualifying with unknown namespace/class ::CmdPartFillet
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1457: Qualifying with unknown namespace/class ::CmdPartChamfer
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1485: Qualifying with unknown namespace/class ::CmdPartMirror
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1513: Qualifying with unknown namespace/class ::CmdPartCrossSections
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1553: Qualifying with unknown namespace/class ::CmdPartBuilder
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1582: Qualifying with unknown namespace/class ::CmdPartLoft
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1611: Qualifying with unknown namespace/class ::CmdPartSweep
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1640: Qualifying with unknown namespace/class ::CmdPartOffset
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1692: Qualifying with unknown namespace/class ::CmdPartOffset2D
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1743: Qualifying with unknown namespace/class ::CmdPartCompOffset
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:1836: Qualifying with unknown namespace/class ::CmdPartThickness
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2011: Qualifying with unknown namespace/class ::CmdPartRuledSurface
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2097: Qualifying with unknown namespace/class ::CmdPartRuledSurface
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2127: Qualifying with unknown namespace/class ::CmdCheckGeometry
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2161: Qualifying with unknown namespace/class ::CmdColorPerFace
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2200: Qualifying with unknown namespace/class ::CmdMeasureLinear
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2231: Qualifying with unknown namespace/class ::CmdMeasureAngular
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2260: Qualifying with unknown namespace/class ::CmdMeasureRefresh
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2290: Qualifying with unknown namespace/class ::CmdMeasureClearAll
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2319: Qualifying with unknown namespace/class ::CmdMeasureToggleAll
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2356: Qualifying with unknown namespace/class ::CmdMeasureToggle3d
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2387: Qualifying with unknown namespace/class ::CmdMeasureToggleDelta
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2419: Qualifying with unknown namespace/class ::CmdBoxSelection
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/Command.cpp:2448: Qualifying with unknown namespace/class ::CmdPartProjectionOnSurface
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandParametric.cpp:66: Qualifying with unknown namespace/class ::CmdPartCylinder
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandParametric.cpp:108: Qualifying with unknown namespace/class ::CmdPartBox
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandParametric.cpp:150: Qualifying with unknown namespace/class ::CmdPartSphere
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandParametric.cpp:192: Qualifying with unknown namespace/class ::CmdPartCone
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandParametric.cpp:234: Qualifying with unknown namespace/class ::CmdPartTorus
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandSimple.cpp:58: Qualifying with unknown namespace/class ::CmdPartSimpleCylinder
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandSimple.cpp:108: Qualifying with unknown namespace/class ::CmdPartShapeFromMesh
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandSimple.cpp:137: Qualifying with unknown namespace/class ::CmdPartPointsFromMesh
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandSimple.cpp:187: Qualifying with unknown namespace/class ::CmdPartSimpleCopy
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandSimple.cpp:258: Qualifying with unknown namespace/class ::CmdPartTransformedCopy
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandSimple.cpp:286: Qualifying with unknown namespace/class ::CmdPartElementCopy
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandSimple.cpp:314: Qualifying with unknown namespace/class ::CmdPartRefineShape
+/home/chennes/FreeCAD-chennes/src/Mod/Part/Gui/CommandSimple.cpp:374: Qualifying with unknown namespace/class ::CmdPartDefeaturing
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Path/Path.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Path/App/VoronoiPyImp.cpp:206: Parenthesis/brace mismatch between #if and #else branches; using #if branch
+/home/chennes/FreeCAD-chennes/src/Mod/Path/Gui/Command.cpp:55: Qualifying with unknown namespace/class ::CmdPathArea
+/home/chennes/FreeCAD-chennes/src/Mod/Path/Gui/Command.cpp:137: Qualifying with unknown namespace/class ::CmdPathAreaWorkplane
+/home/chennes/FreeCAD-chennes/src/Mod/Path/Gui/Command.cpp:227: Qualifying with unknown namespace/class ::CmdPathCompound
+/home/chennes/FreeCAD-chennes/src/Mod/Path/Gui/Command.cpp:279: Qualifying with unknown namespace/class ::CmdPathShape
+fanuc_post.py:107: Unterminated string
+rrf_post.py:214: Unterminated string
+linuxcnc_post.py:99: Unterminated string
+dynapath_post.py:143: Unterminated string
+jtech_post.py:104: Unterminated string
+marlin_post.py:209: Unterminated string
+centroid_post.py:116: Unterminated string
+fablin_post.py:88: Unterminated string
+mach3_mach4_post.py:98: Unterminated string
+grbl_post.py:80: Unterminated string
+uccnc_post.py:298: Unterminated string
+smoothie_post.py:108: Unterminated string
+opensbp_post.py:80: Unterminated string
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Points/Points.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Points/Gui/Command.cpp:68: Qualifying with unknown namespace/class ::CmdPointsImport
+/home/chennes/FreeCAD-chennes/src/Mod/Points/Gui/Command.cpp:82: Qualifying with unknown namespace/class ::CmdPointsImport
+/home/chennes/FreeCAD-chennes/src/Mod/Points/Gui/Command.cpp:113: Qualifying with unknown namespace/class ::CmdPointsExport
+/home/chennes/FreeCAD-chennes/src/Mod/Points/Gui/Command.cpp:130: Qualifying with unknown namespace/class ::CmdPointsExport
+/home/chennes/FreeCAD-chennes/src/Mod/Points/Gui/Command.cpp:153: Qualifying with unknown namespace/class ::CmdPointsTransform
+/home/chennes/FreeCAD-chennes/src/Mod/Points/Gui/Command.cpp:190: Qualifying with unknown namespace/class ::CmdPointsConvert
+/home/chennes/FreeCAD-chennes/src/Mod/Points/Gui/Command.cpp:209: Qualifying with unknown namespace/class ::CmdPointsConvert
+/home/chennes/FreeCAD-chennes/src/Mod/Points/Gui/Command.cpp:282: Qualifying with unknown namespace/class ::CmdPointsPolyCut
+/home/chennes/FreeCAD-chennes/src/Mod/Points/Gui/Command.cpp:327: Qualifying with unknown namespace/class ::CmdPointsMerge
+/home/chennes/FreeCAD-chennes/src/Mod/Points/Gui/Command.cpp:370: Qualifying with unknown namespace/class ::CmdPointsStructure
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Raytracing.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:84: Qualifying with unknown namespace/class ::CmdRaytracingWriteCamera
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:137: Qualifying with unknown namespace/class ::CmdRaytracingWriteCamera
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:177: Qualifying with unknown namespace/class ::CmdRaytracingWritePart
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:188: Qualifying with unknown namespace/class ::CmdRaytracingWritePart
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:223: Qualifying with unknown namespace/class ::CmdRaytracingWriteView
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:250: Qualifying with unknown namespace/class ::CmdRaytracingWriteView
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:320: Qualifying with unknown namespace/class ::CmdRaytracingNewPovrayProject
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:437: Qualifying with unknown namespace/class ::CmdRaytracingNewPartSegment
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:449: Qualifying with unknown namespace/class ::CmdRaytracingNewPartSegment
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:521: Qualifying with unknown namespace/class ::CmdRaytracingExportProject
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:536: Qualifying with unknown namespace/class ::CmdRaytracingExportProject
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:584: Qualifying with unknown namespace/class ::CmdRaytracingRender
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:600: Qualifying with unknown namespace/class ::CmdRaytracingRender
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:766: Qualifying with unknown namespace/class ::CmdRaytracingNewLuxProject
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:879: Qualifying with unknown namespace/class ::CmdRaytracingResetCamera
+/home/chennes/FreeCAD-chennes/src/Mod/Raytracing/Gui/Command.cpp:893: Qualifying with unknown namespace/class ::CmdRaytracingResetCamera
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/ReverseEngineering.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/Gui/Command.cpp:74: Qualifying with unknown namespace/class ::CmdApproxSurface
+/home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/Gui/Command.cpp:110: Qualifying with unknown namespace/class ::CmdApproxPlane
+/home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/Gui/Command.cpp:211: Qualifying with unknown namespace/class ::CmdApproxCylinder
+/home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/Gui/Command.cpp:277: Qualifying with unknown namespace/class ::CmdApproxSphere
+/home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/Gui/Command.cpp:324: Qualifying with unknown namespace/class ::CmdApproxPolynomial
+/home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/Gui/Command.cpp:379: Qualifying with unknown namespace/class ::CmdSegmentation
+/home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/Gui/Command.cpp:411: Qualifying with unknown namespace/class ::CmdSegmentationManual
+/home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/Gui/Command.cpp:440: Qualifying with unknown namespace/class ::CmdSegmentationFromComponents
+/home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/Gui/Command.cpp:490: Qualifying with unknown namespace/class ::CmdMeshBoundary
+/home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/Gui/Command.cpp:556: Qualifying with unknown namespace/class ::CmdPoissonReconstruction
+/home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/Gui/Command.cpp:590: Qualifying with unknown namespace/class ::CmdViewTriangulation
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Robot/Robot.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/Command.cpp:55: Qualifying with unknown namespace/class ::CmdRobotSetHomePos
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/Command.cpp:75: Qualifying with unknown namespace/class ::CmdRobotSetHomePos
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/Command.cpp:104: Qualifying with unknown namespace/class ::CmdRobotRestoreHomePos
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/Command.cpp:124: Qualifying with unknown namespace/class ::CmdRobotRestoreHomePos
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/Command.cpp:158: Qualifying with unknown namespace/class ::CmdRobotConstraintAxle
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/Command.cpp:199: Qualifying with unknown namespace/class ::CmdRobotSimulate
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/Command.cpp:224: Qualifying with unknown namespace/class ::CmdRobotSimulate
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandExport.cpp:50: Qualifying with unknown namespace/class ::CmdRobotExportKukaCompact
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandExport.cpp:65: Qualifying with unknown namespace/class ::CmdRobotExportKukaCompact
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandExport.cpp:112: Qualifying with unknown namespace/class ::CmdRobotExportKukaFull
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandExport.cpp:127: Qualifying with unknown namespace/class ::CmdRobotExportKukaFull
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandInsertRobot.cpp:51: Qualifying with unknown namespace/class ::CmdRobotInsertKukaIR500
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandInsertRobot.cpp:93: Qualifying with unknown namespace/class ::CmdRobotInsertKukaIR16
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandInsertRobot.cpp:134: Qualifying with unknown namespace/class ::CmdRobotInsertKukaIR210
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandInsertRobot.cpp:174: Qualifying with unknown namespace/class ::CmdRobotInsertKukaIR125
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandInsertRobot.cpp:215: Qualifying with unknown namespace/class ::CmdRobotAddToolShape
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandInsertRobot.cpp:234: Qualifying with unknown namespace/class ::CmdRobotAddToolShape
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:62: Qualifying with unknown namespace/class ::CmdRobotCreateTrajectory
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:95: Qualifying with unknown namespace/class ::CmdRobotInsertWaypoint
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:111: Qualifying with unknown namespace/class ::CmdRobotInsertWaypoint
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:152: Qualifying with unknown namespace/class ::CmdRobotInsertWaypointPreselect
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:167: Qualifying with unknown namespace/class ::CmdRobotInsertWaypointPreselect
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:216: Qualifying with unknown namespace/class ::CmdRobotSetDefaultOrientation
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:254: Qualifying with unknown namespace/class ::CmdRobotSetDefaultValues
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:268: Qualifying with unknown namespace/class ::CmdRobotSetDefaultValues
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:320: Qualifying with unknown namespace/class ::CmdRobotEdge2Trac
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:384: Qualifying with unknown namespace/class ::CmdRobotTrajectoryDressUp
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:412: Qualifying with unknown namespace/class ::CmdRobotTrajectoryDressUp
+/home/chennes/FreeCAD-chennes/src/Mod/Robot/Gui/CommandTrajectory.cpp:431: Qualifying with unknown namespace/class ::CmdRobotTrajectoryCompound
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Sketcher.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:143: Qualifying with unknown namespace/class ::CmdSketcherNewSketch
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:164: Qualifying with unknown namespace/class ::CmdSketcherNewSketch
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:266: Qualifying with unknown namespace/class ::CmdSketcherEditSketch
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:296: Qualifying with unknown namespace/class ::CmdSketcherLeaveSketch
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:340: Qualifying with unknown namespace/class ::CmdSketcherStopOperation
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:381: Qualifying with unknown namespace/class ::CmdSketcherReorientSketch
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:508: Qualifying with unknown namespace/class ::CmdSketcherMapSketch
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:562: Qualifying with unknown namespace/class ::CmdSketcherMapSketch
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:683: Qualifying with unknown namespace/class ::CmdSketcherViewSketch
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:723: Qualifying with unknown namespace/class ::CmdSketcherValidateSketch
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:761: Qualifying with unknown namespace/class ::CmdSketcherMirrorSketch
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:868: Qualifying with unknown namespace/class ::CmdSketcherMergeSketches
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/Command.cpp:952: Qualifying with unknown namespace/class ::CmdSketcherViewSection
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandAlterGeometry.cpp:74: Qualifying with unknown namespace/class ::CmdSketcherToggleConstruction
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandAlterGeometry.cpp:123: Qualifying with unknown namespace/class ::CmdSketcherToggleConstruction
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:883: Class 'CmdSketcherConstrainHorizontal' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:1121: Class 'CmdSketcherConstrainVertical' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:1355: Class 'CmdSketcherConstrainLock' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:1581: Class 'CmdSketcherConstrainBlock' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:1896: Class 'CmdSketcherConstrainCoincident' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:2102: Class 'CmdSketcherConstrainDistance' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:2451: Class 'CmdSketcherConstrainPointOnObject' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:2699: Class 'CmdSketcherConstrainDistanceX' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:2953: Class 'CmdSketcherConstrainDistanceY' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:3199: Class 'CmdSketcherConstrainParallel' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:3349: Class 'CmdSketcherConstrainPerpendicular' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:3987: Class 'CmdSketcherConstrainTangent' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:4695: Class 'CmdSketcherConstrainRadius' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:4997: Class 'CmdSketcherConstrainDiameter' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:5273: Class 'CmdSketcherConstrainRadiam' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:5577: Qualifying with unknown namespace/class ::CmdSketcherCompConstrainRadDia
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:5721: Class 'CmdSketcherConstrainAngle' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:6248: Class 'CmdSketcherConstrainEqual' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:6465: Class 'CmdSketcherConstrainSymmetric' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:6765: Qualifying with unknown namespace/class ::CmdSketcherConstrainSnellsLaw
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:6784: Qualifying with unknown namespace/class ::CmdSketcherConstrainSnellsLaw
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:6931: Qualifying with unknown namespace/class ::CmdSketcherConstrainInternalAlignment
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:6949: Qualifying with unknown namespace/class ::CmdSketcherConstrainInternalAlignment
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:7391: Qualifying with unknown namespace/class ::CmdSketcherToggleDrivingConstraint
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:7430: Qualifying with unknown namespace/class ::CmdSketcherToggleDrivingConstraint
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:7518: Qualifying with unknown namespace/class ::CmdSketcherToggleActiveConstraint
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandConstraints.cpp:7543: Qualifying with unknown namespace/class ::CmdSketcherToggleActiveConstraint
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:344: Qualifying with unknown namespace/class ::CmdSketcherCreateLine
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:649: Qualifying with unknown namespace/class ::CmdSketcherCreateRectangle
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:690: Qualifying with unknown namespace/class ::CmdSketcherCreateRectangleCenter
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:1016: Qualifying with unknown namespace/class ::CmdSketcherCreateOblong
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:1059: Qualifying with unknown namespace/class ::CmdSketcherCompCreateRectangles
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:1815: Qualifying with unknown namespace/class ::CmdSketcherCreatePolyline
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:2059: Qualifying with unknown namespace/class ::CmdSketcherCreateArc
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:2329: Qualifying with unknown namespace/class ::CmdSketcherCreate3PointArc
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:2357: Qualifying with unknown namespace/class ::CmdSketcherCompCreateArc
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:2591: Qualifying with unknown namespace/class ::CmdSketcherCreateCircle
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:3387: Qualifying with unknown namespace/class ::CmdSketcherCreateEllipseByCenter
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:3418: Qualifying with unknown namespace/class ::CmdSketcherCreateEllipseBy3Points
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:3746: Qualifying with unknown namespace/class ::CmdSketcherCreateArcOfEllipse
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:4090: Qualifying with unknown namespace/class ::CmdSketcherCreateArcOfHyperbola
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:4389: Qualifying with unknown namespace/class ::CmdSketcherCreateArcOfParabola
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:4422: Qualifying with unknown namespace/class ::CmdSketcherCompCreateConic
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:4925: Qualifying with unknown namespace/class ::CmdSketcherCreateBSpline
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:4970: Qualifying with unknown namespace/class ::CmdSketcherCreatePeriodicBSpline
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:5002: Qualifying with unknown namespace/class ::CmdSketcherCompCreateBSpline
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:5285: Qualifying with unknown namespace/class ::CmdSketcherCreate3PointCircle
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:5313: Qualifying with unknown namespace/class ::CmdSketcherCompCreateCircle
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:5493: Qualifying with unknown namespace/class ::CmdSketcherCreatePoint
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:5523: Qualifying with unknown namespace/class ::CmdSketcherCreateText
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:5551: Qualifying with unknown namespace/class ::CmdSketcherCreateDraftLine
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:5831: Qualifying with unknown namespace/class ::CmdSketcherCreateFillet
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:5860: Qualifying with unknown namespace/class ::CmdSketcherCreatePointFillet
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:5891: Qualifying with unknown namespace/class ::CmdSketcherCompCreateFillets
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:6121: Qualifying with unknown namespace/class ::CmdSketcherTrimming
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:6435: Qualifying with unknown namespace/class ::CmdSketcherExtend
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:6554: Qualifying with unknown namespace/class ::CmdSketcherSplit
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:6593: Class 'SketcherGui::ExternalSelection' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:6739: Qualifying with unknown namespace/class ::CmdSketcherExternal
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:6785: Class 'SketcherGui::CarbonCopySelection' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:6917: Qualifying with unknown namespace/class ::CmdSketcherCarbonCopy
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:7228: Qualifying with unknown namespace/class ::CmdSketcherCreateSlot
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:7421: Qualifying with unknown namespace/class ::CmdSketcherCreateTriangle
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:7448: Qualifying with unknown namespace/class ::CmdSketcherCreateSquare
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:7475: Qualifying with unknown namespace/class ::CmdSketcherCreatePentagon
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:7503: Qualifying with unknown namespace/class ::CmdSketcherCreateHexagon
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:7530: Qualifying with unknown namespace/class ::CmdSketcherCreateHeptagon
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:7557: Qualifying with unknown namespace/class ::CmdSketcherCreateOctagon
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:7584: Qualifying with unknown namespace/class ::CmdSketcherCreateRegularPolygon
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp:7615: Qualifying with unknown namespace/class ::CmdSketcherCompCreateRegularPolygon
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:100: Qualifying with unknown namespace/class ::CmdSketcherBSplineDegree
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:129: Qualifying with unknown namespace/class ::CmdSketcherBSplinePolygon
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:158: Qualifying with unknown namespace/class ::CmdSketcherBSplineComb
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:187: Qualifying with unknown namespace/class ::CmdSketcherBSplineKnotMultiplicity
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:216: Qualifying with unknown namespace/class ::CmdSketcherBSplinePoleWeight
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:245: Qualifying with unknown namespace/class ::CmdSketcherCompBSplineShowHideGeometryInformation
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:374: Qualifying with unknown namespace/class ::CmdSketcherConvertToNURB
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:420: Qualifying with unknown namespace/class ::CmdSketcherConvertToNURB
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:442: Qualifying with unknown namespace/class ::CmdSketcherIncreaseDegree
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:491: Qualifying with unknown namespace/class ::CmdSketcherIncreaseDegree
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:515: Qualifying with unknown namespace/class ::CmdSketcherDecreaseDegree
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:569: Qualifying with unknown namespace/class ::CmdSketcherDecreaseDegree
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:592: Qualifying with unknown namespace/class ::CmdSketcherIncreaseKnotMultiplicity
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:607: Qualifying with unknown namespace/class ::CmdSketcherIncreaseKnotMultiplicity
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:746: Qualifying with unknown namespace/class ::CmdSketcherDecreaseKnotMultiplicity
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:761: Qualifying with unknown namespace/class ::CmdSketcherDecreaseKnotMultiplicity
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:888: Qualifying with unknown namespace/class ::CmdSketcherCompModifyKnotMultiplicity
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:981: Qualifying with unknown namespace/class ::CmdSketcherInsertKnot
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp:996: Qualifying with unknown namespace/class ::CmdSketcherInsertKnot
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:105: Qualifying with unknown namespace/class ::CmdSketcherCloseShape
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:129: Qualifying with unknown namespace/class ::CmdSketcherCloseShape
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:217: Qualifying with unknown namespace/class ::CmdSketcherConnect
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:240: Qualifying with unknown namespace/class ::CmdSketcherConnect
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:304: Qualifying with unknown namespace/class ::CmdSketcherSelectConstraints
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:327: Qualifying with unknown namespace/class ::CmdSketcherSelectConstraints
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:381: Qualifying with unknown namespace/class ::CmdSketcherSelectOrigin
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:427: Qualifying with unknown namespace/class ::CmdSketcherSelectVerticalAxis
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:471: Qualifying with unknown namespace/class ::CmdSketcherSelectHorizontalAxis
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:514: Qualifying with unknown namespace/class ::CmdSketcherSelectRedundantConstraints
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:571: Qualifying with unknown namespace/class ::CmdSketcherSelectMalformedConstraints
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:627: Qualifying with unknown namespace/class ::CmdSketcherSelectPartiallyRedundantConstraints
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:683: Qualifying with unknown namespace/class ::CmdSketcherSelectConflictingConstraints
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:738: Qualifying with unknown namespace/class ::CmdSketcherSelectElementsAssociatedWithConstraints
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:836: Qualifying with unknown namespace/class ::CmdSketcherSelectElementsAssociatedWithConstraints
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:859: Qualifying with unknown namespace/class ::CmdSketcherSelectElementsWithDoFs
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:950: Qualifying with unknown namespace/class ::CmdSketcherRestoreInternalAlignmentGeometry
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:974: Qualifying with unknown namespace/class ::CmdSketcherRestoreInternalAlignmentGeometry
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:1046: Qualifying with unknown namespace/class ::CmdSketcherSymmetry
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:1069: Qualifying with unknown namespace/class ::CmdSketcherSymmetry
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:1581: Class 'CmdSketcherCopy' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:1627: Class 'CmdSketcherClone' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:1670: Class 'CmdSketcherMove' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:1704: Qualifying with unknown namespace/class ::CmdSketcherCompCopy
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:1986: Qualifying with unknown namespace/class ::CmdSketcherRectangularArray
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:2005: Qualifying with unknown namespace/class ::CmdSketcherRectangularArray
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:2126: Qualifying with unknown namespace/class ::CmdSketcherDeleteAllGeometry
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:2140: Qualifying with unknown namespace/class ::CmdSketcherDeleteAllGeometry
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:2189: Qualifying with unknown namespace/class ::CmdSketcherDeleteAllConstraints
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:2202: Qualifying with unknown namespace/class ::CmdSketcherDeleteAllConstraints
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:2253: Qualifying with unknown namespace/class ::CmdSketcherRemoveAxesAlignment
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp:2272: Qualifying with unknown namespace/class ::CmdSketcherRemoveAxesAlignment
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherVirtualSpace.cpp:93: Qualifying with unknown namespace/class ::CmdSketcherSwitchVirtualSpace
+/home/chennes/FreeCAD-chennes/src/Mod/Sketcher/Gui/CommandSketcherVirtualSpace.cpp:115: Qualifying with unknown namespace/class ::CmdSketcherSwitchVirtualSpace
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Spreadsheet.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/AppSpreadsheetGui.cpp:87: Class 'SpreadsheetGui::Module' lacks Q_OBJECT macro
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:70: Qualifying with unknown namespace/class ::CmdSpreadsheetMergeCells
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:123: Qualifying with unknown namespace/class ::CmdSpreadsheetSplitCell
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:179: Qualifying with unknown namespace/class ::CmdSpreadsheetImport
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:191: Qualifying with unknown namespace/class ::CmdSpreadsheetImport
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:229: Qualifying with unknown namespace/class ::CmdSpreadsheetExport
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:247: Qualifying with unknown namespace/class ::CmdSpreadsheetExport
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:290: Qualifying with unknown namespace/class ::CmdSpreadsheetAlignLeft
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:342: Qualifying with unknown namespace/class ::CmdSpreadsheetAlignCenter
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:394: Qualifying with unknown namespace/class ::CmdSpreadsheetAlignRight
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:446: Qualifying with unknown namespace/class ::CmdSpreadsheetAlignTop
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:498: Qualifying with unknown namespace/class ::CmdSpreadsheetAlignBottom
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:550: Qualifying with unknown namespace/class ::CmdSpreadsheetAlignVCenter
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:602: Qualifying with unknown namespace/class ::CmdSpreadsheetStyleBold
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:676: Qualifying with unknown namespace/class ::CmdSpreadsheetStyleItalic
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:750: Qualifying with unknown namespace/class ::CmdSpreadsheetStyleUnderline
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:823: Qualifying with unknown namespace/class ::CmdSpreadsheetSetAlias
+/home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/Gui/Command.cpp:887: Qualifying with unknown namespace/class ::CmdCreateSpreadsheet
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Start/Start.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Start/Gui/Command.cpp:45: Qualifying with unknown namespace/class ::CmdStartPage
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/TechDraw/TechDraw.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:117: Qualifying with unknown namespace/class ::CmdTechDrawPageDefault
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:181: Qualifying with unknown namespace/class ::CmdTechDrawPageTemplate
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:195: Qualifying with unknown namespace/class ::CmdTechDrawPageTemplate
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:261: Qualifying with unknown namespace/class ::CmdTechDrawRedrawPage
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:298: Qualifying with unknown namespace/class ::CmdTechDrawView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:379: Qualifying with unknown namespace/class ::CmdTechDrawView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:442: Qualifying with unknown namespace/class ::CmdTechDrawActiveView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:476: Qualifying with unknown namespace/class ::CmdTechDrawSectionView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:494: Qualifying with unknown namespace/class ::CmdTechDrawSectionView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:526: Qualifying with unknown namespace/class ::CmdTechDrawDetailView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:545: Qualifying with unknown namespace/class ::CmdTechDrawDetailView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:575: Qualifying with unknown namespace/class ::CmdTechDrawProjectionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:655: Qualifying with unknown namespace/class ::CmdTechDrawProjectionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:855: Qualifying with unknown namespace/class ::CmdTechDrawBalloon
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:920: Qualifying with unknown namespace/class ::CmdTechDrawClipGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:959: Qualifying with unknown namespace/class ::CmdTechDrawClipGroupAdd
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:972: Qualifying with unknown namespace/class ::CmdTechDrawClipGroupAdd
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1043: Qualifying with unknown namespace/class ::CmdTechDrawClipGroupRemove
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1057: Qualifying with unknown namespace/class ::CmdTechDrawClipGroupRemove
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1118: Qualifying with unknown namespace/class ::CmdTechDrawSymbol
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1137: Qualifying with unknown namespace/class ::CmdTechDrawSymbol
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1173: Qualifying with unknown namespace/class ::CmdTechDrawDraftView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1194: Qualifying with unknown namespace/class ::CmdTechDrawDraftView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1239: Qualifying with unknown namespace/class ::CmdTechDrawArchView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1268: Qualifying with unknown namespace/class ::CmdTechDrawArchView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1304: Qualifying with unknown namespace/class ::CmdTechDrawSpreadsheetView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1317: Qualifying with unknown namespace/class ::CmdTechDrawSpreadsheetView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1363: Qualifying with unknown namespace/class ::CmdTechDrawExportPageSVG
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1388: Qualifying with unknown namespace/class ::CmdTechDrawExportPageSVG
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1408: Qualifying with unknown namespace/class ::CmdTechDrawExportPageDXF
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/Command.cpp:1428: Qualifying with unknown namespace/class ::CmdTechDrawExportPageDXF
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:101: Qualifying with unknown namespace/class ::CmdTechDrawLeaderLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:115: Qualifying with unknown namespace/class ::CmdTechDrawLeaderLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:163: Qualifying with unknown namespace/class ::CmdTechDrawRichTextAnnotation
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:176: Qualifying with unknown namespace/class ::CmdTechDrawRichTextAnnotation
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:215: Qualifying with unknown namespace/class ::CmdTechDrawCosmeticVertexGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:228: Qualifying with unknown namespace/class ::CmdTechDrawCosmeticVertexGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:404: Qualifying with unknown namespace/class ::CmdTechDrawCosmeticVertex
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:417: Qualifying with unknown namespace/class ::CmdTechDrawCosmeticVertex
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:465: Qualifying with unknown namespace/class ::CmdTechDrawMidpoints
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:478: Qualifying with unknown namespace/class ::CmdTechDrawMidpoints
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:504: Qualifying with unknown namespace/class ::CmdTechDrawQuadrants
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:517: Qualifying with unknown namespace/class ::CmdTechDrawQuadrants
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:543: Qualifying with unknown namespace/class ::CmdTechDrawAnnotation
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:583: Qualifying with unknown namespace/class ::CmdTechDrawCenterLineGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:596: Qualifying with unknown namespace/class ::CmdTechDrawCenterLineGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:686: Qualifying with unknown namespace/class ::CmdTechDrawFaceCenterLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:700: Qualifying with unknown namespace/class ::CmdTechDrawFaceCenterLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:796: Qualifying with unknown namespace/class ::CmdTechDraw2LineCenterLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:810: Qualifying with unknown namespace/class ::CmdTechDraw2LineCenterLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:873: Qualifying with unknown namespace/class ::CmdTechDraw2PointCenterLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:887: Qualifying with unknown namespace/class ::CmdTechDraw2PointCenterLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:986: Qualifying with unknown namespace/class ::CmdTechDraw2PointCosmeticLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:1000: Qualifying with unknown namespace/class ::CmdTechDraw2PointCosmeticLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:1138: Qualifying with unknown namespace/class ::CmdTechDrawCosmeticEraser
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:1151: Qualifying with unknown namespace/class ::CmdTechDrawCosmeticEraser
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:1265: Qualifying with unknown namespace/class ::CmdTechDrawDecorateLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:1279: Qualifying with unknown namespace/class ::CmdTechDrawDecorateLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:1344: Qualifying with unknown namespace/class ::CmdTechDrawShowAll
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:1357: Qualifying with unknown namespace/class ::CmdTechDrawShowAll
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:1409: Qualifying with unknown namespace/class ::CmdTechDrawWeldSymbol
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandAnnotate.cpp:1423: Qualifying with unknown namespace/class ::CmdTechDrawWeldSymbol
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:123: Qualifying with unknown namespace/class ::CmdTechDrawDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:250: Qualifying with unknown namespace/class ::CmdTechDrawRadiusDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:294: Qualifying with unknown namespace/class ::CmdTechDrawRadiusDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:372: Qualifying with unknown namespace/class ::CmdTechDrawDiameterDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:416: Qualifying with unknown namespace/class ::CmdTechDrawDiameterDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:493: Qualifying with unknown namespace/class ::CmdTechDrawLengthDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:547: Qualifying with unknown namespace/class ::CmdTechDrawLengthDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:595: Qualifying with unknown namespace/class ::CmdTechDrawHorizontalDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:650: Qualifying with unknown namespace/class ::CmdTechDrawHorizontalDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:698: Qualifying with unknown namespace/class ::CmdTechDrawVerticalDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:753: Qualifying with unknown namespace/class ::CmdTechDrawVerticalDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:800: Qualifying with unknown namespace/class ::CmdTechDrawAngleDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:845: Qualifying with unknown namespace/class ::CmdTechDrawAngleDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:888: Qualifying with unknown namespace/class ::CmdTechDraw3PtAngleDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:934: Qualifying with unknown namespace/class ::CmdTechDraw3PtAngleDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:980: Qualifying with unknown namespace/class ::CmdTechDrawLinkDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:1019: Qualifying with unknown namespace/class ::CmdTechDrawLinkDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:1058: Qualifying with unknown namespace/class ::CmdTechDrawExtentGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:1071: Qualifying with unknown namespace/class ::CmdTechDrawExtentGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:1151: Qualifying with unknown namespace/class ::CmdTechDrawHorizontalExtentDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:1165: Qualifying with unknown namespace/class ::CmdTechDrawHorizontalExtentDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:1238: Qualifying with unknown namespace/class ::CmdTechDrawVerticalExtentDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:1252: Qualifying with unknown namespace/class ::CmdTechDrawVerticalExtentDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:1321: Qualifying with unknown namespace/class ::CmdTechDrawLandmarkDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandCreateDims.cpp:1339: Qualifying with unknown namespace/class ::CmdTechDrawLandmarkDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandDecorate.cpp:87: Qualifying with unknown namespace/class ::CmdTechDrawHatch
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandDecorate.cpp:122: Qualifying with unknown namespace/class ::CmdTechDrawHatch
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandDecorate.cpp:208: Qualifying with unknown namespace/class ::CmdTechDrawGeometricHatch
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandDecorate.cpp:277: Qualifying with unknown namespace/class ::CmdTechDrawImage
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandDecorate.cpp:296: Qualifying with unknown namespace/class ::CmdTechDrawImage
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandDecorate.cpp:328: Qualifying with unknown namespace/class ::CmdTechDrawToggleFrame
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandDecorate.cpp:352: Qualifying with unknown namespace/class ::CmdTechDrawToggleFrame
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:145: Qualifying with unknown namespace/class ::CmdTechDrawExtensionInsertDiameter
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:178: Qualifying with unknown namespace/class ::CmdTechDrawExtensionInsertSquare
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:211: Qualifying with unknown namespace/class ::CmdTechDrawExtensionInsertPrefixGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:225: Qualifying with unknown namespace/class ::CmdTechDrawExtensionInsertPrefixGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:338: Qualifying with unknown namespace/class ::CmdTechDrawExtensionIncreaseDecimal
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:371: Qualifying with unknown namespace/class ::CmdTechDrawExtensionDecreaseDecimal
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:404: Qualifying with unknown namespace/class ::CmdTechDrawExtensionIncreaseDecreaseGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:418: Qualifying with unknown namespace/class ::CmdTechDrawExtensionIncreaseDecreaseGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:529: Qualifying with unknown namespace/class ::CmdTechDrawExtensionPosHorizChainDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:588: Qualifying with unknown namespace/class ::CmdTechDrawExtensionPosVertChainDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:653: Qualifying with unknown namespace/class ::CmdTechDrawExtensionPosObliqueChainDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:688: Qualifying with unknown namespace/class ::CmdTechDrawExtensionPosChainDimensionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:703: Qualifying with unknown namespace/class ::CmdTechDrawExtensionPosChainDimensionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:835: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCascadeHorizDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:899: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCascadeVertDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:972: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCascadeObliqueDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1008: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCascadeDimensionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1024: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCascadeDimensionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1162: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateHorizChainDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1228: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateVertChainDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1318: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateObliqueChainDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1352: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateChainDimensionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1366: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateChainDimensionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1505: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateHorizCoordDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1578: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateVertCoordDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1676: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateObliqueCoordDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1712: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateCoordDimensionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1728: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateCoordDimensionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1871: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateHorizChamferDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1940: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateVertChamferDimension
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1973: Qualifying with unknown namespace/class ::CmdTechDrawExtensionChamferDimensionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:1987: Qualifying with unknown namespace/class ::CmdTechDrawExtensionChamferDimensionGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp:2073: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCreateLengthArc
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:169: Qualifying with unknown namespace/class ::CmdTechDrawExtensionHoleCircle
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:243: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCircleCenterLines
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:277: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCircleCenterLinesGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:290: Qualifying with unknown namespace/class ::CmdTechDrawExtensionCircleCenterLinesGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:395: Qualifying with unknown namespace/class ::CmdTechDrawExtensionThreadHoleSide
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:446: Qualifying with unknown namespace/class ::CmdTechDrawExtensionThreadBoltSide
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:497: Qualifying with unknown namespace/class ::CmdTechDrawExtensionThreadHoleBottom
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:548: Qualifying with unknown namespace/class ::CmdTechDrawExtensionThreadBoltBottom
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:582: Qualifying with unknown namespace/class ::CmdTechDrawExtensionThreadsGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:597: Qualifying with unknown namespace/class ::CmdTechDrawExtensionThreadsGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:715: Qualifying with unknown namespace/class ::CmdTechDrawExtensionSelectLineAttributes
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:749: Qualifying with unknown namespace/class ::CmdTechDrawExtensionChangeLineAttributes
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:808: Qualifying with unknown namespace/class ::CmdTechDrawExtensionVertexAtIntersection
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:898: Qualifying with unknown namespace/class ::CmdTechDrawExtensionDrawCosmArc
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:959: Qualifying with unknown namespace/class ::CmdTechDrawExtensionDrawCosmCircle
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:995: Qualifying with unknown namespace/class ::CmdTechDrawExtensionDrawCirclesGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1011: Qualifying with unknown namespace/class ::CmdTechDrawExtensionDrawCirclesGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1144: Qualifying with unknown namespace/class ::CmdTechDrawExtensionLineParallel
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1178: Qualifying with unknown namespace/class ::CmdTechDrawExtensionLinePerpendicular
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1212: Qualifying with unknown namespace/class ::CmdTechDrawExtensionLinePPGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1227: Qualifying with unknown namespace/class ::CmdTechDrawExtensionLinePPGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1315: Qualifying with unknown namespace/class ::CmdTechDrawExtensionLockUnlockView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1359: Qualifying with unknown namespace/class ::CmdTechDrawExtensionPositionSectionView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1376: Qualifying with unknown namespace/class ::CmdTechDrawExtensionPositionSectionView
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1492: Qualifying with unknown namespace/class ::CmdTechDrawExtensionExtendLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1527: Qualifying with unknown namespace/class ::CmdTechDrawExtensionShortenLine
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1562: Qualifying with unknown namespace/class ::CmdTechDrawExtendShortenLineGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp:1577: Qualifying with unknown namespace/class ::CmdTechDrawExtendShortenLineGroup
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/QGEPath.cpp:156: Discarding unconsumed meta data
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/QGIEdge.cpp:129: Discarding unconsumed meta data
+/home/chennes/FreeCAD-chennes/src/Mod/TechDraw/Gui/QGIViewAnnotation.cpp:208: Class 'TechDrawGui::QGIViewAnnotation' lacks Q_OBJECT macro
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Test/Test.pro.
+Segmentation fault (core dumped)
+Cannot open Gui/Resources/translations/Testpy.ts: No such file or directory
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Tux/Tux.pro.
+lupdate warning: TS files from command line will override TRANSLATIONS in /home/chennes/FreeCAD-chennes/src/Mod/Web/Web.pro.
+/home/chennes/FreeCAD-chennes/src/Mod/Web/Gui/Command.cpp:50: Qualifying with unknown namespace/class ::CmdWebOpenWebsite
+/home/chennes/FreeCAD-chennes/src/Mod/Web/Gui/Command.cpp:76: Qualifying with unknown namespace/class ::CmdWebBrowserBack
+/home/chennes/FreeCAD-chennes/src/Mod/Web/Gui/Command.cpp:105: Qualifying with unknown namespace/class ::CmdWebBrowserNext
+/home/chennes/FreeCAD-chennes/src/Mod/Web/Gui/Command.cpp:134: Qualifying with unknown namespace/class ::CmdWebBrowserRefresh
+/home/chennes/FreeCAD-chennes/src/Mod/Web/Gui/Command.cpp:162: Qualifying with unknown namespace/class ::CmdWebBrowserStop
+/home/chennes/FreeCAD-chennes/src/Mod/Web/Gui/Command.cpp:192: Qualifying with unknown namespace/class ::CmdWebBrowserZoomIn
+/home/chennes/FreeCAD-chennes/src/Mod/Web/Gui/Command.cpp:221: Qualifying with unknown namespace/class ::CmdWebBrowserZoomOut
+/home/chennes/FreeCAD-chennes/src/Mod/Web/Gui/Command.cpp:250: Qualifying with unknown namespace/class ::CmdWebBrowserSetURL

--- a/tsupdate_stdout.log
+++ b/tsupdate_stdout.log
@@ -1,0 +1,630 @@
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Gui/.qmake.stash
+Updating 'Language/FreeCAD.ts'...
+    Found 2032 source text(s) (88 new and 1944 already existing)
+    Removed 186 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/AddonManager/.qmake.stash
+Updating 'Resources/translations/AddonManager.ts'...
+    Found 74 source text(s) (68 new and 6 already existing)
+    Removed 174 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Arch/.qmake.stash
+Updating 'Resources/translations/Arch.ts'...
+    Found 314 source text(s) (0 new and 314 already existing)
+    Removed 934 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Assembly/.qmake.stash
+Updating 'Gui/Resources/translations/Assembly.ts'...
+    Found 70 source text(s) (0 new and 70 already existing)
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Draft/.qmake.stash
+Updating 'Resources/translations/Draft.ts'...
+    Found 490 source text(s) (10 new and 480 already existing)
+    Removed 972 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Drawing/.qmake.stash
+Updating 'Gui/Resources/translations/Drawing.ts'...
+    Found 131 source text(s) (0 new and 131 already existing)
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Fem/.qmake.stash
+Updating 'Gui/Resources/translations/Fem.ts'...
+    Found 827 source text(s) (0 new and 827 already existing)
+    Removed 110 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Image/.qmake.stash
+Updating 'Gui/Resources/translations/Image.ts'...
+    Found 34 source text(s) (0 new and 34 already existing)
+    Removed 2 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Mesh/.qmake.stash
+Updating 'Gui/Resources/translations/Mesh.ts'...
+    Found 411 source text(s) (3 new and 408 already existing)
+    Removed 1 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/MeshPart/.qmake.stash
+Updating 'Gui/Resources/translations/MeshPart.ts'...
+    Found 102 source text(s) (1 new and 101 already existing)
+    Removed 4 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/OpenSCAD/.qmake.stash
+Updating 'Resources/translations/OpenSCAD.ts'...
+    Found 32 source text(s) (7 new and 25 already existing)
+    Removed 46 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/PartDesign/.qmake.stash
+Updating 'Gui/Resources/translations/PartDesign.ts'...
+    Found 820 source text(s) (60 new and 760 already existing)
+    Removed 55 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Part/.qmake.stash
+Updating 'Gui/Resources/translations/Part.ts'...
+    Found 1036 source text(s) (10 new and 1026 already existing)
+    Removed 29 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Path/.qmake.stash
+Updating 'Gui/Resources/translations/Path.ts'...
+    Found 793 source text(s) (39 new and 754 already existing)
+    Removed 861 obsolete entries
+ÿ
+ÿ
+ÿ
+ÿ
+ÿ
+ÿ
+ÿ
+ÿ
+ÿ
+ÿ
+ÿ
+ÿ
+ÿ
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Points/.qmake.stash
+Updating 'Gui/Resources/translations/Points.ts'...
+    Found 57 source text(s) (0 new and 57 already existing)
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Raytracing/.qmake.stash
+Updating 'Gui/Resources/translations/Raytracing.ts'...
+    Found 88 source text(s) (0 new and 88 already existing)
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/.qmake.stash
+Updating 'Gui/Resources/translations/ReverseEngineering.ts'...
+    Found 101 source text(s) (0 new and 101 already existing)
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Robot/.qmake.stash
+Updating 'Gui/Resources/translations/Robot.ts'...
+    Found 179 source text(s) (0 new and 179 already existing)
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Sketcher/.qmake.stash
+Updating 'Gui/Resources/translations/Sketcher.ts'...
+    Found 1010 source text(s) (117 new and 893 already existing)
+    Removed 59 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/.qmake.stash
+Updating 'Gui/Resources/translations/Spreadsheet.ts'...
+    Found 186 source text(s) (43 new and 143 already existing)
+    Removed 19 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Start/.qmake.stash
+Updating 'Gui/Resources/translations/Start.ts'...
+    Found 54 source text(s) (0 new and 54 already existing)
+    Removed 42 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/TechDraw/.qmake.stash
+Updating 'Gui/Resources/translations/TechDraw.ts'...
+    Found 1142 source text(s) (219 new and 923 already existing)
+    Removed 36 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Test/.qmake.stash
+Updating 'Gui/Resources/translations/Test.ts'...
+    Found 23 source text(s) (0 new and 23 already existing)
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Tux/.qmake.stash
+Updating 'Resources/translations/Tux.ts'...
+    Found 0 source text(s) (0 new and 0 already existing)
+    Removed 18 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Web/.qmake.stash
+Updating 'Gui/Resources/translations/Web.ts'...
+    Found 29 source text(s) (0 new and 29 already existing)
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Gui/.qmake.stash
+Updating 'Language/FreeCAD.ts'...
+    Found 2032 source text(s) (88 new and 1944 already existing)
+    Removed 186 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/AddonManager/.qmake.stash
+Updating 'Resources/translations/AddonManager.ts'...
+    Found 74 source text(s) (68 new and 6 already existing)
+    Removed 174 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Arch/.qmake.stash
+Updating 'Resources/translations/Arch.ts'...
+    Found 314 source text(s) (0 new and 314 already existing)
+    Removed 934 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Assembly/.qmake.stash
+Updating 'Gui/Resources/translations/Assembly.ts'...
+    Found 70 source text(s) (0 new and 70 already existing)
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Draft/.qmake.stash
+Updating 'Resources/translations/Draft.ts'...
+    Found 490 source text(s) (10 new and 480 already existing)
+    Removed 972 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Drawing/.qmake.stash
+Updating 'Gui/Resources/translations/Drawing.ts'...
+    Found 131 source text(s) (0 new and 131 already existing)
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Fem/.qmake.stash
+Updating 'Gui/Resources/translations/Fem.ts'...
+    Found 827 source text(s) (0 new and 827 already existing)
+    Removed 110 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Image/.qmake.stash
+Updating 'Gui/Resources/translations/Image.ts'...
+    Found 34 source text(s) (0 new and 34 already existing)
+    Removed 2 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Mesh/.qmake.stash
+Updating 'Gui/Resources/translations/Mesh.ts'...
+    Found 411 source text(s) (3 new and 408 already existing)
+    Removed 1 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/MeshPart/.qmake.stash
+Updating 'Gui/Resources/translations/MeshPart.ts'...
+    Found 102 source text(s) (1 new and 101 already existing)
+    Removed 4 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/OpenSCAD/.qmake.stash
+Updating 'Resources/translations/OpenSCAD.ts'...
+    Found 32 source text(s) (7 new and 25 already existing)
+    Removed 46 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/PartDesign/.qmake.stash
+Updating 'Gui/Resources/translations/PartDesign.ts'...
+    Found 820 source text(s) (60 new and 760 already existing)
+    Removed 55 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Part/.qmake.stash
+Updating 'Gui/Resources/translations/Part.ts'...
+    Found 1036 source text(s) (10 new and 1026 already existing)
+    Removed 29 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Path/.qmake.stash
+Updating 'Gui/Resources/translations/Path.ts'...
+    Found 793 source text(s) (39 new and 754 already existing)
+    Removed 861 obsolete entries
+ÿ
+ÿ
+ÿ
+ÿ
+ÿ
+ÿ
+ÿ
+ÿ
+ÿ
+ÿ
+ÿ
+ÿ
+ÿ
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Points/.qmake.stash
+Updating 'Gui/Resources/translations/Points.ts'...
+    Found 57 source text(s) (0 new and 57 already existing)
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Raytracing/.qmake.stash
+Updating 'Gui/Resources/translations/Raytracing.ts'...
+    Found 88 source text(s) (0 new and 88 already existing)
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/.qmake.stash
+Updating 'Gui/Resources/translations/ReverseEngineering.ts'...
+    Found 101 source text(s) (0 new and 101 already existing)
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Robot/.qmake.stash
+Updating 'Gui/Resources/translations/Robot.ts'...
+    Found 179 source text(s) (0 new and 179 already existing)
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Sketcher/.qmake.stash
+Updating 'Gui/Resources/translations/Sketcher.ts'...
+    Found 1010 source text(s) (117 new and 893 already existing)
+    Removed 59 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/.qmake.stash
+Updating 'Gui/Resources/translations/Spreadsheet.ts'...
+    Found 186 source text(s) (43 new and 143 already existing)
+    Removed 19 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Start/.qmake.stash
+Updating 'Gui/Resources/translations/Start.ts'...
+    Found 54 source text(s) (0 new and 54 already existing)
+    Removed 42 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/TechDraw/.qmake.stash
+Updating 'Gui/Resources/translations/TechDraw.ts'...
+    Found 1142 source text(s) (219 new and 923 already existing)
+    Removed 36 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Test/.qmake.stash
+Updating 'Gui/Resources/translations/Test.ts'...
+    Found 23 source text(s) (0 new and 23 already existing)
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Tux/.qmake.stash
+Updating 'Resources/translations/Tux.ts'...
+    Found 0 source text(s) (0 new and 0 already existing)
+    Removed 18 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Web/.qmake.stash
+Updating 'Gui/Resources/translations/Web.ts'...
+    Found 29 source text(s) (0 new and 29 already existing)
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Gui/.qmake.stash
+Updating 'Language/FreeCAD.ts'...
+    Found 2032 source text(s) (88 new and 1944 already existing)
+    Removed 186 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/AddonManager/.qmake.stash
+Updating 'Resources/translations/AddonManager.ts'...
+    Found 74 source text(s) (68 new and 6 already existing)
+    Removed 175 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Arch/.qmake.stash
+Updating 'Resources/translations/Arch.ts'...
+    Found 314 source text(s) (0 new and 314 already existing)
+    Removed 934 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Assembly/.qmake.stash
+Updating 'Gui/Resources/translations/Assembly.ts'...
+    Found 70 source text(s) (0 new and 70 already existing)
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Draft/.qmake.stash
+Updating 'Resources/translations/Draft.ts'...
+    Found 490 source text(s) (10 new and 480 already existing)
+    Removed 972 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Drawing/.qmake.stash
+Updating 'Gui/Resources/translations/Drawing.ts'...
+    Found 131 source text(s) (0 new and 131 already existing)
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Fem/.qmake.stash
+Updating 'Gui/Resources/translations/Fem.ts'...
+    Found 827 source text(s) (0 new and 827 already existing)
+    Removed 110 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Image/.qmake.stash
+Updating 'Gui/Resources/translations/Image.ts'...
+    Found 34 source text(s) (0 new and 34 already existing)
+    Removed 2 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Mesh/.qmake.stash
+Updating 'Gui/Resources/translations/Mesh.ts'...
+    Found 411 source text(s) (3 new and 408 already existing)
+    Removed 1 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/MeshPart/.qmake.stash
+Updating 'Gui/Resources/translations/MeshPart.ts'...
+    Found 102 source text(s) (1 new and 101 already existing)
+    Removed 4 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/OpenSCAD/.qmake.stash
+Updating 'Resources/translations/OpenSCAD.ts'...
+    Found 32 source text(s) (7 new and 25 already existing)
+    Removed 46 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/PartDesign/.qmake.stash
+Updating 'Gui/Resources/translations/PartDesign.ts'...
+    Found 820 source text(s) (60 new and 760 already existing)
+    Removed 55 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Part/.qmake.stash
+Updating 'Gui/Resources/translations/Part.ts'...
+    Found 1036 source text(s) (10 new and 1026 already existing)
+    Removed 29 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Path/.qmake.stash
+Updating 'Gui/Resources/translations/Path.ts'...
+    Found 793 source text(s) (39 new and 754 already existing)
+    Removed 861 obsolete entries
+ÿ
+ÿ
+ÿ
+ÿ
+ÿ
+ÿ
+ÿ
+ÿ
+ÿ
+ÿ
+ÿ
+ÿ
+ÿ
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Points/.qmake.stash
+Updating 'Gui/Resources/translations/Points.ts'...
+    Found 57 source text(s) (0 new and 57 already existing)
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Raytracing/.qmake.stash
+Updating 'Gui/Resources/translations/Raytracing.ts'...
+    Found 88 source text(s) (0 new and 88 already existing)
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/.qmake.stash
+Updating 'Gui/Resources/translations/ReverseEngineering.ts'...
+    Found 101 source text(s) (0 new and 101 already existing)
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Robot/.qmake.stash
+Updating 'Gui/Resources/translations/Robot.ts'...
+    Found 179 source text(s) (0 new and 179 already existing)
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Sketcher/.qmake.stash
+Updating 'Gui/Resources/translations/Sketcher.ts'...
+    Found 1010 source text(s) (117 new and 893 already existing)
+    Removed 59 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/.qmake.stash
+Updating 'Gui/Resources/translations/Spreadsheet.ts'...
+    Found 186 source text(s) (43 new and 143 already existing)
+    Removed 19 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Start/.qmake.stash
+Updating 'Gui/Resources/translations/Start.ts'...
+    Found 54 source text(s) (0 new and 54 already existing)
+    Removed 42 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/TechDraw/.qmake.stash
+Updating 'Gui/Resources/translations/TechDraw.ts'...
+    Found 1142 source text(s) (219 new and 923 already existing)
+    Removed 36 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Test/.qmake.stash
+Updating 'Gui/Resources/translations/Test.ts'...
+    Found 23 source text(s) (0 new and 23 already existing)
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Tux/.qmake.stash
+Updating 'Resources/translations/Tux.ts'...
+    Found 0 source text(s) (0 new and 0 already existing)
+    Removed 18 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Web/.qmake.stash
+Updating 'Gui/Resources/translations/Web.ts'...
+    Found 29 source text(s) (0 new and 29 already existing)
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Gui/.qmake.stash
+Updating 'Language/FreeCAD.ts'...
+    Found 2032 source text(s) (88 new and 1944 already existing)
+    Removed 186 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/AddonManager/.qmake.stash
+Updating 'Resources/translations/AddonManager.ts'...
+    Found 74 source text(s) (68 new and 6 already existing)
+    Removed 181 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Arch/.qmake.stash
+Updating 'Resources/translations/Arch.ts'...
+    Found 314 source text(s) (0 new and 314 already existing)
+    Removed 934 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Assembly/.qmake.stash
+Updating 'Gui/Resources/translations/Assembly.ts'...
+    Found 70 source text(s) (0 new and 70 already existing)
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Draft/.qmake.stash
+Updating 'Resources/translations/Draft.ts'...
+    Found 490 source text(s) (10 new and 480 already existing)
+    Removed 972 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Drawing/.qmake.stash
+Updating 'Gui/Resources/translations/Drawing.ts'...
+    Found 131 source text(s) (0 new and 131 already existing)
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Fem/.qmake.stash
+Updating 'Gui/Resources/translations/Fem.ts'...
+    Found 827 source text(s) (0 new and 827 already existing)
+    Removed 110 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Image/.qmake.stash
+Updating 'Gui/Resources/translations/Image.ts'...
+    Found 34 source text(s) (0 new and 34 already existing)
+    Removed 2 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Mesh/.qmake.stash
+Updating 'Gui/Resources/translations/Mesh.ts'...
+    Found 411 source text(s) (3 new and 408 already existing)
+    Removed 1 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/MeshPart/.qmake.stash
+Updating 'Gui/Resources/translations/MeshPart.ts'...
+    Found 102 source text(s) (1 new and 101 already existing)
+    Removed 4 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/OpenSCAD/.qmake.stash
+Updating 'Resources/translations/OpenSCAD.ts'...
+    Found 32 source text(s) (7 new and 25 already existing)
+    Removed 46 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/PartDesign/.qmake.stash
+Updating 'Gui/Resources/translations/PartDesign.ts'...
+    Found 820 source text(s) (60 new and 760 already existing)
+    Removed 55 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Part/.qmake.stash
+Updating 'Gui/Resources/translations/Part.ts'...
+    Found 1036 source text(s) (10 new and 1026 already existing)
+    Removed 29 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Path/.qmake.stash
+Updating 'Gui/Resources/translations/Path.ts'...
+    Found 793 source text(s) (39 new and 754 already existing)
+    Removed 861 obsolete entries
+ÿ
+ÿ
+ÿ
+ÿ
+ÿ
+ÿ
+ÿ
+ÿ
+ÿ
+ÿ
+ÿ
+ÿ
+ÿ
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Points/.qmake.stash
+Updating 'Gui/Resources/translations/Points.ts'...
+    Found 57 source text(s) (0 new and 57 already existing)
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Raytracing/.qmake.stash
+Updating 'Gui/Resources/translations/Raytracing.ts'...
+    Found 88 source text(s) (0 new and 88 already existing)
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/.qmake.stash
+Updating 'Gui/Resources/translations/ReverseEngineering.ts'...
+    Found 101 source text(s) (0 new and 101 already existing)
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Robot/.qmake.stash
+Updating 'Gui/Resources/translations/Robot.ts'...
+    Found 179 source text(s) (0 new and 179 already existing)
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Sketcher/.qmake.stash
+Updating 'Gui/Resources/translations/Sketcher.ts'...
+    Found 1010 source text(s) (117 new and 893 already existing)
+    Removed 59 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/.qmake.stash
+Updating 'Gui/Resources/translations/Spreadsheet.ts'...
+    Found 186 source text(s) (43 new and 143 already existing)
+    Removed 19 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Start/.qmake.stash
+Updating 'Gui/Resources/translations/Start.ts'...
+    Found 54 source text(s) (0 new and 54 already existing)
+    Removed 42 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/TechDraw/.qmake.stash
+Updating 'Gui/Resources/translations/TechDraw.ts'...
+    Found 1142 source text(s) (219 new and 923 already existing)
+    Removed 36 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Test/.qmake.stash
+Updating 'Gui/Resources/translations/Test.ts'...
+    Found 23 source text(s) (0 new and 23 already existing)
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Tux/.qmake.stash
+Updating 'Resources/translations/Tux.ts'...
+    Found 0 source text(s) (0 new and 0 already existing)
+    Removed 18 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Web/.qmake.stash
+Updating 'Gui/Resources/translations/Web.ts'...
+    Found 29 source text(s) (0 new and 29 already existing)
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Gui/.qmake.stash
+Updating 'Language/FreeCAD.ts'...
+    Found 2032 source text(s) (88 new and 1944 already existing)
+    Removed 186 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/AddonManager/.qmake.stash
+Updating 'Resources/translations/AddonManager.ts'...
+    Found 74 source text(s) (68 new and 6 already existing)
+    Removed 181 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Arch/.qmake.stash
+Updating 'Resources/translations/Arch.ts'...
+    Found 314 source text(s) (0 new and 314 already existing)
+    Removed 934 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Assembly/.qmake.stash
+Updating 'Gui/Resources/translations/Assembly.ts'...
+    Found 70 source text(s) (0 new and 70 already existing)
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Draft/.qmake.stash
+Updating 'Resources/translations/Draft.ts'...
+    Found 490 source text(s) (10 new and 480 already existing)
+    Removed 972 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Drawing/.qmake.stash
+Updating 'Gui/Resources/translations/Drawing.ts'...
+    Found 131 source text(s) (0 new and 131 already existing)
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Fem/.qmake.stash
+Updating 'Gui/Resources/translations/Fem.ts'...
+    Found 827 source text(s) (0 new and 827 already existing)
+    Removed 110 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Image/.qmake.stash
+Updating 'Gui/Resources/translations/Image.ts'...
+    Found 34 source text(s) (0 new and 34 already existing)
+    Removed 2 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Mesh/.qmake.stash
+Updating 'Gui/Resources/translations/Mesh.ts'...
+    Found 411 source text(s) (3 new and 408 already existing)
+    Removed 1 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/MeshPart/.qmake.stash
+Updating 'Gui/Resources/translations/MeshPart.ts'...
+    Found 102 source text(s) (1 new and 101 already existing)
+    Removed 4 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/OpenSCAD/.qmake.stash
+Updating 'Resources/translations/OpenSCAD.ts'...
+    Found 32 source text(s) (7 new and 25 already existing)
+    Removed 46 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/PartDesign/.qmake.stash
+Updating 'Gui/Resources/translations/PartDesign.ts'...
+    Found 820 source text(s) (60 new and 760 already existing)
+    Removed 55 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Part/.qmake.stash
+Updating 'Gui/Resources/translations/Part.ts'...
+    Found 1036 source text(s) (10 new and 1026 already existing)
+    Removed 29 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Path/.qmake.stash
+Updating 'Gui/Resources/translations/Path.ts'...
+    Found 793 source text(s) (39 new and 754 already existing)
+    Removed 861 obsolete entries
+ÿ
+ÿ
+ÿ
+ÿ
+ÿ
+ÿ
+ÿ
+ÿ
+ÿ
+ÿ
+ÿ
+ÿ
+ÿ
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Points/.qmake.stash
+Updating 'Gui/Resources/translations/Points.ts'...
+    Found 57 source text(s) (0 new and 57 already existing)
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Raytracing/.qmake.stash
+Updating 'Gui/Resources/translations/Raytracing.ts'...
+    Found 88 source text(s) (0 new and 88 already existing)
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/.qmake.stash
+Updating 'Gui/Resources/translations/ReverseEngineering.ts'...
+    Found 101 source text(s) (0 new and 101 already existing)
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Robot/.qmake.stash
+Updating 'Gui/Resources/translations/Robot.ts'...
+    Found 179 source text(s) (0 new and 179 already existing)
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Sketcher/.qmake.stash
+Updating 'Gui/Resources/translations/Sketcher.ts'...
+    Found 1010 source text(s) (117 new and 893 already existing)
+    Removed 59 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/.qmake.stash
+Updating 'Gui/Resources/translations/Spreadsheet.ts'...
+    Found 186 source text(s) (43 new and 143 already existing)
+    Removed 19 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Start/.qmake.stash
+Updating 'Gui/Resources/translations/Start.ts'...
+    Found 54 source text(s) (0 new and 54 already existing)
+    Removed 42 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/TechDraw/.qmake.stash
+Updating 'Gui/Resources/translations/TechDraw.ts'...
+    Found 1142 source text(s) (219 new and 923 already existing)
+    Removed 36 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Test/.qmake.stash
+Updating 'Gui/Resources/translations/Test.ts'...
+    Found 23 source text(s) (0 new and 23 already existing)
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Tux/.qmake.stash
+Updating 'Resources/translations/Tux.ts'...
+    Found 0 source text(s) (0 new and 0 already existing)
+    Removed 18 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Web/.qmake.stash
+Updating 'Gui/Resources/translations/Web.ts'...
+    Found 29 source text(s) (0 new and 29 already existing)
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Gui/.qmake.stash
+Updating 'Language/FreeCAD.ts'...
+    Found 2032 source text(s) (88 new and 1944 already existing)
+    Removed 186 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/AddonManager/.qmake.stash
+Updating 'Resources/translations/AddonManager.ts'...
+    Found 74 source text(s) (68 new and 6 already existing)
+    Removed 181 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Arch/.qmake.stash
+Updating 'Resources/translations/Arch.ts'...
+    Found 314 source text(s) (0 new and 314 already existing)
+    Removed 934 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Assembly/.qmake.stash
+Updating 'Gui/Resources/translations/Assembly.ts'...
+    Found 70 source text(s) (0 new and 70 already existing)
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Draft/.qmake.stash
+Updating 'Resources/translations/Draft.ts'...
+    Found 490 source text(s) (10 new and 480 already existing)
+    Removed 972 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Drawing/.qmake.stash
+Updating 'Gui/Resources/translations/Drawing.ts'...
+    Found 131 source text(s) (0 new and 131 already existing)
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Fem/.qmake.stash
+Updating 'Gui/Resources/translations/Fem.ts'...
+    Found 827 source text(s) (0 new and 827 already existing)
+    Removed 110 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Image/.qmake.stash
+Updating 'Gui/Resources/translations/Image.ts'...
+    Found 34 source text(s) (0 new and 34 already existing)
+    Removed 2 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Mesh/.qmake.stash
+Updating 'Gui/Resources/translations/Mesh.ts'...
+    Found 411 source text(s) (3 new and 408 already existing)
+    Removed 1 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/MeshPart/.qmake.stash
+Updating 'Gui/Resources/translations/MeshPart.ts'...
+    Found 102 source text(s) (1 new and 101 already existing)
+    Removed 4 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/OpenSCAD/.qmake.stash
+Updating 'Resources/translations/OpenSCAD.ts'...
+    Found 32 source text(s) (7 new and 25 already existing)
+    Removed 46 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/PartDesign/.qmake.stash
+Updating 'Gui/Resources/translations/PartDesign.ts'...
+    Found 820 source text(s) (60 new and 760 already existing)
+    Removed 55 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Part/.qmake.stash
+Updating 'Gui/Resources/translations/Part.ts'...
+    Found 1036 source text(s) (10 new and 1026 already existing)
+    Removed 29 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Path/.qmake.stash
+Updating 'Gui/Resources/translations/Path.ts'...
+    Found 793 source text(s) (39 new and 754 already existing)
+    Removed 861 obsolete entries
+ÿ
+ÿ
+ÿ
+ÿ
+ÿ
+ÿ
+ÿ
+ÿ
+ÿ
+ÿ
+ÿ
+ÿ
+ÿ
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Points/.qmake.stash
+Updating 'Gui/Resources/translations/Points.ts'...
+    Found 57 source text(s) (0 new and 57 already existing)
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Raytracing/.qmake.stash
+Updating 'Gui/Resources/translations/Raytracing.ts'...
+    Found 88 source text(s) (0 new and 88 already existing)
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/ReverseEngineering/.qmake.stash
+Updating 'Gui/Resources/translations/ReverseEngineering.ts'...
+    Found 101 source text(s) (0 new and 101 already existing)
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Robot/.qmake.stash
+Updating 'Gui/Resources/translations/Robot.ts'...
+    Found 179 source text(s) (0 new and 179 already existing)
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Sketcher/.qmake.stash
+Updating 'Gui/Resources/translations/Sketcher.ts'...
+    Found 1010 source text(s) (117 new and 893 already existing)
+    Removed 59 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Spreadsheet/.qmake.stash
+Updating 'Gui/Resources/translations/Spreadsheet.ts'...
+    Found 186 source text(s) (43 new and 143 already existing)
+    Removed 19 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Start/.qmake.stash
+Updating 'Gui/Resources/translations/Start.ts'...
+    Found 54 source text(s) (0 new and 54 already existing)
+    Removed 42 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/TechDraw/.qmake.stash
+Updating 'Gui/Resources/translations/TechDraw.ts'...
+    Found 1142 source text(s) (219 new and 923 already existing)
+    Removed 36 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Test/.qmake.stash
+Updating 'Gui/Resources/translations/Test.ts'...
+    Found 23 source text(s) (0 new and 23 already existing)
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Tux/.qmake.stash
+Updating 'Resources/translations/Tux.ts'...
+    Found 0 source text(s) (0 new and 0 already existing)
+    Removed 18 obsolete entries
+Info: creating stash file /home/chennes/FreeCAD-chennes/src/Mod/Web/.qmake.stash
+Updating 'Gui/Resources/translations/Web.ts'...
+    Found 29 source text(s) (0 new and 29 already existing)


### PR DESCRIPTION
Adds an option to the Preference Pack GUI to revert to a saved preference file.

When a preference pack is applied, FreeCAD automatically backs up the pre-pack config file. This PR adds a GUI to reverting to one of those saved backups. Right now this is a somewhat destructive process: the backup is a complete copy of the original config file, including things like "Recent Files". Reverting to the backup will thus reset your Recent Files list to whatever it was when the backup was taken.

In the future it would be best to make a more judicious backup, that only backs up the items that the preference pack affects. I submit this PR as an improvement over the current state of affairs, not as the end goal.

Testers: please make a manual backup of your user.cfg file prior to testing. To test, apply a preference pack (any one will do), then click the "Revert" button.