### PR TITLE
[PATH]  Fixes #5904

### DIFF
--- a/src/Mod/Path/Gui/Resources/panels/PathEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PathEdit.ui
@@ -31,8 +31,8 @@
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>561</width>
-         <height>675</height>
+         <width>139</width>
+         <height>357</height>
         </rect>
        </property>
        <attribute name="label">
@@ -409,7 +409,7 @@
     <item>
      <widget class="QToolBox" name="toolBox_2">
       <property name="currentIndex">
-       <number>1</number>
+       <number>0</number>
       </property>
       <widget class="QWidget" name="page_3">
        <property name="geometry">
@@ -1170,8 +1170,8 @@
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>561</width>
-         <height>675</height>
+         <width>300</width>
+         <height>145</height>
         </rect>
        </property>
        <attribute name="label">

--- a/src/Mod/Path/PathScripts/PathJobDlg.py
+++ b/src/Mod/Path/PathScripts/PathJobDlg.py
@@ -348,11 +348,14 @@ class JobTemplateExport:
                     job.Stock.Height,
                 )
             elif stockType == PathStock.StockType.CreateCylinder:
-                seHint = translate("Path_Job", "Cylinder: %.2f x %.2f") % (
+                seHint = translate("Path_Job:", "Cylinder: %.2f x %.2f") % (
                     job.Stock.Radius,
                     job.Stock.Height,
                 )
-            else:
+            elif stockType == PathStock.StockType.Unknown:
+                seHint = "-"
+
+            else:  # Existing Solid
                 seHint = "-"
                 PathLog.error(translate("Path_Job", "Unsupported stock type"))
             self.dialog.stockExtentHint.setText(seHint)


### PR DESCRIPTION
This issue was actually resolve by PR #4140.  I don't know why it was left open.  This PR removes an unnecessary error associated with path stock and also reverts an incorrectly saved tab on the job edit.

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [x]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [ ]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
