### PR TITLE
Arch: Arch_Window.py: do isdir and isfile check for librarypath

### DIFF
--- a/src/Mod/Arch/ArchWindow.py
+++ b/src/Mod/Arch/ArchWindow.py
@@ -383,15 +383,16 @@ class _CommandWindow:
         librarypath = librarypath.replace("\\", "/") + "/Architectural Parts"
         presetdir = FreeCAD.getUserAppDataDir().replace("\\", "/") + "/Arch"
         for path in [librarypath, presetdir]:
-            if os.path.exists(path):
+            if os.path.isdir(path):
                 for wtype in ["Windows", "Doors"]:
                     wdir = path + "/" + wtype
-                    if os.path.exists(wdir):
+                    if os.path.isdir(wdir):
                         for subtype in os.listdir(wdir):
                             subdir = wdir + "/" + subtype
-                            if os.path.exists(subdir):
+                            if os.path.isdir(subdir):
                                 for subfile in os.listdir(subdir):
-                                    if subfile.lower().endswith(".fcstd"):
+                                    if (os.path.isfile(subdir + "/" + subfile)
+                                            and subfile.lower().endswith(".fcstd")):
                                         self.librarypresets.append([wtype + " - " + subtype + " - " + subfile[:-6],
                                                                     subdir + "/" + subfile])
 


### PR DESCRIPTION
When analyzing the `librarypath` and the `presetdir` items from `os.listdir()` were not checked with `os.path.isdir()` and `os.path.isfile()`.

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the issue ID number from our [Issues database](https://github.com/FreeCAD/FreeCAD/issues) in case a particular commit solves or is related to an existing issue. Ex: `Draft: fix typos - fixes #4805`

---
