### PR TITLE
Mesh: fix test code so it will compile when used

### DIFF
--- a/src/Mod/Mesh/App/MeshPyImp.cpp
+++ b/src/Mod/Mesh/App/MeshPyImp.cpp
@@ -1875,7 +1875,7 @@ PyObject* MeshPy::nearestFacetOnRay(PyObject *args)
             builder.addBoundingBox(Base::Vector3f(box.MinX,box.MinY, box.MinZ),
                                    Base::Vector3f(box.MaxX,box.MaxY, box.MaxZ));
             sprintf(szBuf, "(%lu,%lu,%lu)", uX, uY, uZ);
-            builder.addText(box.CalcCenter(), szBuf);
+            builder.addText(box.GetCenter(), szBuf);
         }
         builder.addSingleArrow(pnt-20.0f*dir, pnt+10.0f*dir);
         builder.close();


### PR DESCRIPTION
BoundBox3 class must have changed afterwards.  Now this test code inside #if 0 blocks does not build when enabled.