### PR TITLE
Draft: Housekeeping: call 'make' functions with new name (3)

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_draft2sketch.py
+++ b/src/Mod/Draft/draftguitools/gui_draft2sketch.py
@@ -89,7 +89,7 @@ class Draft2Sketch(gui_base_original.Modifier):
         if not sel:
             return
         elif allDraft:
-            _cmd = "Draft.makeSketch"
+            _cmd = "Draft.make_sketch"
             _cmd += "("
             _cmd += "FreeCADGui.Selection.getSelection(), "
             _cmd += "autoconstraints=True"
@@ -123,7 +123,7 @@ class Draft2Sketch(gui_base_original.Modifier):
                 _cmd_df += "delete=False"
                 _cmd_df += ")"
 
-                _cmd_sk = "Draft.makeSketch"
+                _cmd_sk = "Draft.make_sketch"
                 _cmd_sk += "("
                 _cmd_sk += "FreeCAD.ActiveDocument." + obj.Name + ", "
                 _cmd_sk += "autoconstraints=True"

--- a/src/Mod/Draft/draftguitools/gui_lines.py
+++ b/src/Mod/Draft/draftguitools/gui_lines.py
@@ -171,7 +171,7 @@ class Line(gui_base_original.Creator):
                 rot, sup, pts, fil = self.getStrings()
 
                 _base = DraftVecUtils.toString(self.node[0])
-                _cmd = 'Draft.makeWire'
+                _cmd = 'Draft.make_wire'
                 _cmd += '('
                 _cmd += 'points, '
                 _cmd += 'placement=pl, '
@@ -347,7 +347,7 @@ class Wire(Line):
                     Gui.addModule("Draft")
                     # The command to run is built as a series of text strings
                     # to be committed through the `draftutils.todo.ToDo` class
-                    _cmd_list = ['wire = Draft.makeWire([' + pts + '])']
+                    _cmd_list = ['wire = Draft.make_wire([' + pts + '])']
                     _cmd_list.extend(rems)
                     _cmd_list.append('Draft.autogroup(wire)')
                     _cmd_list.append('FreeCAD.ActiveDocument.recompute()')

--- a/src/Mod/Draft/draftguitools/gui_planeproxy.py
+++ b/src/Mod/Draft/draftguitools/gui_planeproxy.py
@@ -63,7 +63,7 @@ class Draft_WorkingPlaneProxy:
         if hasattr(App, "DraftWorkingPlane"):
             App.ActiveDocument.openTransaction("Create WP proxy")
             Gui.addModule("Draft")
-            _cmd = "Draft.makeWorkingPlaneProxy("
+            _cmd = "Draft.make_workingplaneproxy("
             _cmd += "FreeCAD.DraftWorkingPlane.getPlacement()"
             _cmd += ")"
             Gui.doCommand(_cmd)

--- a/src/Mod/Draft/draftguitools/gui_points.py
+++ b/src/Mod/Draft/draftguitools/gui_points.py
@@ -135,7 +135,7 @@ class Point(gui_base_original.Creator):
                                        _cmd_list))
                 else:
                     # Insert a Draft point
-                    _cmd = 'Draft.makePoint'
+                    _cmd = 'Draft.make_point'
                     _cmd += '('
                     _cmd += str(self.stack[0][0]) + ', '
                     _cmd += str(self.stack[0][1]) + ', '

--- a/src/Mod/Draft/draftguitools/gui_polygons.py
+++ b/src/Mod/Draft/draftguitools/gui_polygons.py
@@ -225,7 +225,7 @@ class Polygon(gui_base_original.Creator):
                         _cmd_list)
         else:
             # Insert a Draft polygon
-            _cmd = 'Draft.makePolygon'
+            _cmd = 'Draft.make_polygon'
             _cmd += '('
             _cmd += str(self.ui.numFaces.value()) + ', '
             _cmd += 'radius=' + str(self.rad) + ', '

--- a/src/Mod/Draft/draftguitools/gui_shape2dview.py
+++ b/src/Mod/Draft/draftguitools/gui_shape2dview.py
@@ -87,7 +87,7 @@ class Shape2DView(gui_base_original.Modifier):
         commitlist = []
         Gui.addModule("Draft")
         if len(objs) == 1 and faces:
-            _cmd = "Draft.makeShape2DView"
+            _cmd = "Draft.make_shape2dview"
             _cmd += "("
             _cmd += "FreeCAD.ActiveDocument." + objs[0].Name + ", "
             _cmd += DraftVecUtils.toString(vec) + ", "
@@ -97,7 +97,7 @@ class Shape2DView(gui_base_original.Modifier):
         else:
             n = 0
             for o in objs:
-                _cmd = "Draft.makeShape2DView"
+                _cmd = "Draft.make_shape2dview"
                 _cmd += "("
                 _cmd += "FreeCAD.ActiveDocument." + o.Name + ", "
                 _cmd += DraftVecUtils.toString(vec)

--- a/src/Mod/Draft/draftguitools/gui_shapestrings.py
+++ b/src/Mod/Draft/draftguitools/gui_shapestrings.py
@@ -122,7 +122,7 @@ class ShapeString(gui_base_original.Creator):
         try:
             qr, sup, points, fil = self.getStrings()
             Gui.addModule("Draft")
-            _cmd = 'Draft.makeShapeString'
+            _cmd = 'Draft.make_shapestring'
             _cmd += '('
             _cmd += 'String=' + String + ', '
             _cmd += 'FontFile=' + FFile + ', '

--- a/src/Mod/Draft/draftmake/make_point.py
+++ b/src/Mod/Draft/draftmake/make_point.py
@@ -37,9 +37,9 @@ if App.GuiUp:
     from draftviewproviders.view_point import ViewProviderPoint
 
 
-def make_point(X=0, Y=0, Z=0, color=None, name = "Point", point_size= 5):
-    """ makePoint(x,y,z ,[color(r,g,b),point_size]) or
-        makePoint(Vector,color(r,g,b),point_size]) -
+def make_point(X=0, Y=0, Z=0, color=None, name="Point", point_size=5):
+    """ make_point(x, y, z, [color(r, g, b), point_size]) or
+        make_point(Vector, color(r, g, b), point_size])
 
     Creates a Draft Point in the current document.
 

--- a/src/Mod/Draft/draftmake/make_rectangle.py
+++ b/src/Mod/Draft/draftmake/make_rectangle.py
@@ -38,7 +38,7 @@ if App.GuiUp:
 
 
 def make_rectangle(length, height=0, placement=None, face=None, support=None):
-    """makeRectangle(length, width, [placement], [face])
+    """make_rectangle(length, width, [placement], [face])
 
     Creates a Rectangle object with length in X direction and height in Y
     direction.
@@ -49,13 +49,13 @@ def make_rectangle(length, height=0, placement=None, face=None, support=None):
 
     placement : Base.Placement
         If a placement is given, it is used.
-    
+
     face : Bool
-        If face is False, the rectangle is shown as a wireframe, 
+        If face is False, the rectangle is shown as a wireframe,
         otherwise as a face.
-        
+
     Rectangles can also be constructed by giving them a list of four vertices
-    as first argument: makeRectangle(list_of_vertices,face=...)
+    as first argument: make_rectangle(list_of_vertices, face=...)
     but you are responsible to check yourself that these 4 vertices are ordered
     and actually form a rectangle, otherwise the result might be wrong. Placement
     is ignored when constructing a rectangle this way (face argument is kept).
@@ -70,9 +70,9 @@ def make_rectangle(length, height=0, placement=None, face=None, support=None):
         xv = verts[1].sub(verts[0])
         yv = verts[3].sub(verts[0])
         zv = xv.cross(yv)
-        rr = App.Rotation(xv,yv,zv,"XYZ")
-        rp = App.Placement(verts[0],rr)
-        return makeRectangle(xv.Length,yv.Length,rp,face,support)
+        rr = App.Rotation(xv, yv, zv, "XYZ")
+        rp = App.Placement(verts[0], rr)
+        return make_rectangle(xv.Length, yv.Length, rp, face, support)
 
     if placement:
         utils.type_check([(placement,App.Placement)], "make_rectangle")

--- a/src/Mod/Draft/draftmake/make_shape2dview.py
+++ b/src/Mod/Draft/draftmake/make_shape2dview.py
@@ -37,7 +37,7 @@ if App.GuiUp:
 
 
 def make_shape2dview(baseobj,projectionVector=None,facenumbers=[]):
-    """makeShape2DView(object, [projectionVector], [facenumbers])
+    """make_shape2dview(object, [projectionVector], [facenumbers])
     
     Add a 2D shape to the document, which is a 2D projection of the given object. 
     

--- a/src/Mod/Draft/draftmake/make_sketch.py
+++ b/src/Mod/Draft/draftmake/make_sketch.py
@@ -40,8 +40,8 @@ from draftutils.translate import translate
 
 def make_sketch(objects_list, autoconstraints=False, addTo=None,
                 delete=False, name="Sketch", radiusPrecision=-1, tol=1e-3):
-    """makeSketch(objects_list,[autoconstraints],[addTo],[delete],
-                  [name],[radiusPrecision],[tol])
+    """make_sketch(objects_list, [autoconstraints], [addTo], [delete],
+                   [name], [radiusPrecision], [tol])
 
     Makes a Sketch objects_list with the given Draft objects.
 

--- a/src/Mod/Draft/draftmake/make_wire.py
+++ b/src/Mod/Draft/draftmake/make_wire.py
@@ -38,7 +38,7 @@ if App.GuiUp:
 
 
 def make_wire(pointslist, closed=False, placement=None, face=None, support=None, bs2wire=False):
-    """makeWire(pointslist,[closed],[placement])
+    """make_wire(pointslist, [closed], [placement])
     
     Creates a Wire object from the given list of vectors.  If face is
     true (and wire is closed), the wire will appear filled. Instead of

--- a/src/Mod/Draft/drafttaskpanels/task_shapestring.py
+++ b/src/Mod/Draft/drafttaskpanels/task_shapestring.py
@@ -137,12 +137,12 @@ class ShapeStringTaskPanel:
             qr, sup, points, fil = self.sourceCmd.getStrings()
             Gui.addModule("Draft")
             self.sourceCmd.commit(translate("draft", "Create ShapeString"),
-                                  ['ss=Draft.makeShapeString(String='+String+',FontFile='+FFile+',Size='+Size+',Tracking='+Tracking+')',
+                                  ['ss=Draft.make_shapestring(String=' + String + ', FontFile=' + FFile + ', Size=' + Size + ', Tracking=' + Tracking + ')',
                                    'plm=FreeCAD.Placement()',
-                                   'plm.Base='+DraftVecUtils.toString(ssBase),
-                                   'plm.Rotation.Q='+qr,
+                                   'plm.Base=' + DraftVecUtils.toString(ssBase),
+                                   'plm.Rotation.Q=' + qr,
                                    'ss.Placement=plm',
-                                   'ss.Support='+sup,
+                                   'ss.Support=' + sup,
                                    'Draft.autogroup(ss)'])
         except Exception:
             _err("Draft_ShapeString: error delaying commit\n")

--- a/src/Mod/Draft/importAirfoilDAT.py
+++ b/src/Mod/Draft/importAirfoilDAT.py
@@ -207,7 +207,7 @@ def process(filename):
 
     # do we use the parametric Draft Wire?
     if useDraftWire:
-        obj = Draft.makeWire(coords, True)
+        obj = Draft.make_wire(coords, True)
         # obj.label = airfoilname
     else:
         # alternate solution, uses common Part Faces


### PR DESCRIPTION
This PR is a continuation of https://github.com/FreeCAD/FreeCAD/pull/6337

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the issue ID number from our [Issues database](https://github.com/FreeCAD/FreeCAD/issues) in case a particular commit solves or is related to an existing issue. Ex: `Draft: fix typos - fixes #4805`

---
