### PR TITLE
TechDraw: Use Draft.get_svg instead of Draft.getSVG

### DIFF
--- a/src/Mod/TechDraw/App/DrawViewDraft.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDraft.cpp
@@ -102,7 +102,7 @@ App::DocumentObjectExecReturn *DrawViewDraft::execute(void)
         std::string svgTail = getSVGTail();
         std::string FeatName = getNameInDocument();
         std::string SourceName = sourceObj->getNameInDocument();
-        // Draft.getSVG(obj,scale=1,linewidth=0.35,fontsize=12,fillstyle="shape color",direction=None,linestyle=None,color=None,linespacing=None,techdraw=False)
+        // Draft.get_svg(obj,scale=1,linewidth=0.35,fontsize=12,fillstyle="shape color",direction=None,linestyle=None,color=None,linespacing=None,techdraw=False)
 
         std::stringstream paramStr;
         App::Color col = Color.getValue();
@@ -122,7 +122,7 @@ App::DocumentObjectExecReturn *DrawViewDraft::execute(void)
 // (Arch section, etc)
 // like Draft.makeDrawingView, but we don't need to create the actual document objects in Draft, just the svg.
         Base::Interpreter().runString("import Draft");
-        Base::Interpreter().runStringArg("svgBody = Draft.getSVG(App.activeDocument().%s %s)",
+        Base::Interpreter().runStringArg("svgBody = Draft.get_svg(App.activeDocument().%s %s)",
                                          SourceName.c_str(),paramStr.str().c_str());
 //        Base::Interpreter().runString("print svgBody");
         Base::Interpreter().runStringArg("App.activeDocument().%s.Symbol = '%s' + svgBody + '%s'",


### PR DESCRIPTION
The `Draft.getSVG` has been renamed. Using it results in warnings in the Report view. The new function `Draft.get_svg` has the same signature.

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the issue ID number from our [Issues database](https://github.com/FreeCAD/FreeCAD/issues) in case a particular commit solves or is related to an existing issue. Ex: `Draft: fix typos - fixes #4805`

---
