### PR TITLE
Fem: enable multi-threading for Gmsh

### DIFF
--- a/src/Mod/Fem/femmesh/gmshtools.py
+++ b/src/Mod/Fem/femmesh/gmshtools.py
@@ -733,6 +733,13 @@ class GmshTools():
         geo = open(self.temp_file_geo, "w")
         geo.write("// geo file for meshing with Gmsh meshing software created by FreeCAD\n")
         geo.write("\n")
+
+        cpu_count = os.cpu_count()
+        if cpu_count != None and cpu_count > 1:
+            geo.write("// enable multi-core processing\n")
+            geo.write(f"General.NumThreads = {cpu_count};\n")
+            geo.write("\n")
+
         geo.write("// open brep geometry\n")
         # explicit use double quotes in geo file
         geo.write('Merge "{}";\n'.format(self.temp_file_geometry))

--- a/src/Mod/Fem/femtest/app/support_utils.py
+++ b/src/Mod/Fem/femtest/app/support_utils.py
@@ -228,17 +228,21 @@ def compare_files(
     file1 = open(file_name1, "r")
     f1 = file1.readlines()
     file1.close()
+
+    # TODO: add support for variable values in the reference file
+    # instead of using this workaround
+
     # workaround to compare geos of elmer test and temporary file path
     # (not only names change, path changes with operating system)
     lf1 = [l for l in f1 if not (
-        l.startswith('Merge "') or l.startswith('Save "') or l.startswith("// ")
+        l.startswith('Merge "') or l.startswith('Save "') or l.startswith("// ") or l.startswith("General.NumThreads")
     )]
     lf1 = force_unix_line_ends(lf1)
     file2 = open(file_name2, "r")
     f2 = file2.readlines()
     file2.close()
     lf2 = [l for l in f2 if not (
-        l.startswith('Merge "') or l.startswith('Save "') or l.startswith("// ")
+        l.startswith('Merge "') or l.startswith('Save "') or l.startswith("// ") or l.startswith("General.NumThreads")
     )]
     lf2 = force_unix_line_ends(lf2)
     import difflib

--- a/src/Mod/Fem/femtest/data/elmer/group_mesh.geo
+++ b/src/Mod/Fem/femtest/data/elmer/group_mesh.geo
@@ -1,5 +1,8 @@
 // geo file for meshing with Gmsh meshing software created by FreeCAD
 
+// enable multi-core processing
+General.NumThreads = X;
+
 // open brep geometry
 Merge "/tmp/tmp0TVZbM.brep";
 


### PR DESCRIPTION
This patch will add the General.NumThreads = <cpu core count> setting to the shape2mesh.geo configuration file for gmsh. This will cause gmsh to run with multiple threads (it uses OMP internally). It does not affect gmsh binaries without OMP support.

Great speedups can are had, in a project I'm working on currently the meshing takes 2,5 minutes with a single thread, reduced to only 40 seconds when multi-threaded.