### PR TITLE
[PD] change default FaceMaker to Bullseye

### DIFF
--- a/src/Mod/PartDesign/App/FeatureSketchBased.cpp
+++ b/src/Mod/PartDesign/App/FeatureSketchBased.cpp
@@ -72,18 +72,18 @@
 
 #endif
 
+#include <App/OriginFeature.h>
+#include <App/Document.h>
 #include <Base/Exception.h>
 #include <Base/Parameter.h>
 #include <Base/Reader.h>
 #include <Base/Console.h>
 #include <Base/Tools.h>
 #include <App/Application.h>
-#include <App/OriginFeature.h>
-#include <App/Document.h>
 #include <Mod/Part/App/FaceMakerCheese.h>
-#include "FeatureSketchBased.h"
-#include "DatumPlane.h"
 #include "DatumLine.h"
+#include "DatumPlane.h"
+#include "FeatureSketchBased.h"
 
 using namespace PartDesign;
 
@@ -218,7 +218,7 @@ TopoDS_Shape ProfileBased::getVerifiedFace(bool silent) const {
                     if (!shape.hasSubShape(TopAbs_WIRE))
                         shape = shape.makEWires();
                     if (shape.hasSubShape(TopAbs_WIRE))
-                        shape = shape.makEFace(0, "Part::FaceMakerCheese");
+                        shape = shape.makEFace(0, "Part::FaceMakerBullseye");
                     else
                         err = "Cannot make face from profile";
                 }


### PR DESCRIPTION
Part does already use this FaceMaker since it can also handle islands.

The PR therefore
- uniforms the behavior of PD and Part
- fixes #6366
- enables to use nested sketches for the various PD features like Revolve

Here is an example file what becomes now possible:
[revolveExample.zip](https://github.com/FreeCAD/FreeCAD/files/8076715/revolveExample.zip)
![FreeCAD_Ifx8RosEme](https://user-images.githubusercontent.com/1828501/154196716-f524d8fa-a729-4fe2-a53d-8a9890f81e6a.png)


