### PR TITLE
Revert/extensions waterline

### DIFF
--- a/src/Mod/Path/Gui/Resources/panels/PageOpPocketExtEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PageOpPocketExtEdit.ui
@@ -17,39 +17,19 @@
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item>
-      <widget class="QPushButton" name="enableExtensions">
+      <widget class="QCheckBox" name="enableExtensions">
        <property name="text">
-        <string>Click to disable Extensions</string>
+        <string>Enable Extensions</string>
        </property>
        <property name="checkable">
         <bool>true</bool>
        </property>
        <property name="checked">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="includeEdges">
-       <property name="text">
-        <string>Ignore Edges and Wires</string>
-       </property>
-       <property name="checkable">
-        <bool>true</bool>
-       </property>
-       <property name="checked">
-        <bool>true</bool>
+        <bool>false</bool>
        </property>
       </widget>
      </item>
     </layout>
-   </item>
-   <item>
-    <widget class="QLabel" name="enableExtensionsWarning">
-     <property name="text">
-      <string>---</string>
-     </property>
-    </widget>
    </item>
    <item>
     <widget class="QWidget" name="extensionEdit" native="true">

--- a/src/Mod/Path/PathScripts/PathFeatureExtensions.py
+++ b/src/Mod/Path/PathScripts/PathFeatureExtensions.py
@@ -281,26 +281,7 @@ class Extension(object):
         and sub element provided at class instantiation, as a closed wire.  If no closed wire
         is possible, a `None` value is returned."""
 
-        if self.sub[:6] == "Avoid_":
-            feature = self.obj.Shape.getElement(self.feature)
-            self.extFaces = [Part.Face(feature.Wires[0])]
-            return feature.Wires[0]
-        if self.sub[:7] == "Extend_":
-            rtn = self._getOutlineWire()
-            if rtn:
-                return rtn
-            else:
-                PathLog.debug("no Outline Wire")
-                return None
-        if self.sub[:10] == "Waterline_":
-            rtn = self._getWaterlineWire()
-            if rtn:
-                return rtn
-            else:
-                PathLog.debug("no Waterline Wire")
-                return None
-        else:
-            return self._getRegularWire()
+        return self._getRegularWire()
 
     def _getRegularWire(self):
         """_getRegularWire()... Private method to retrieve the extension area, pertaining to the feature
@@ -402,88 +383,6 @@ class Extension(object):
 
         PathLog.debug("Extending multi-edge open wire")
         return extendWire(feature, sub, length)
-
-    def _getOutlineWire(self):
-        """_getOutlineWire()... Private method to retrieve an extended outline extension area,
-        pertaining to the feature and sub element provided at class instantiation, as a closed wire.
-        If no closed wire is possible, a `None` value is returned."""
-        PathLog.track()
-
-        baseShape = self.obj.Shape
-        face = baseShape.getElement(self.feature)
-        useOutline = False
-        msg = translate("PathAdaptive", "Extend Outline error")
-
-        if hasattr(self.op, "UseOutline"):
-            useOutline = self.op.UseOutline
-
-        if useOutline:
-            outFace = Part.Face(face.Wires[0])
-            rawFace = getExtendOutlineFace(baseShape, outFace, self.length)
-
-            if rawFace:
-                extFace = rawFace.cut(outFace)
-            else:
-                PathLog.error(msg + " 1")
-                extFace = outFace
-        else:
-            rawFace = getExtendOutlineFace(baseShape, face, self.length)
-
-            if rawFace:
-                extFace = rawFace.cut(face)
-            else:
-                PathLog.error(msg + " 2")
-                extFace = face
-
-        # Debug
-        # Part.show(extFace)
-        # FreeCAD.ActiveDocument.ActiveObject.Label = "outline_wire"
-
-        if len(extFace.Wires) > 0:
-            self.extFaces = [f for f in extFace.Faces]
-            return extFace.Wires[0]
-
-        return None
-
-    def _getWaterlineWire(self):
-        """_getWaterlineWire()... Private method to retrieve a waterline extension area,
-        pertaining to the feature and sub element provided at class instantiation, as a closed wire.
-        Only waterline faces touching source face are returned as part of the waterline extension area.
-        If no closed wire is possible, a `None` value is returned."""
-        PathLog.track()
-
-        msg = translate("PathFeatureExtensions", "Waterline error")
-        useOutline = False
-        if hasattr(self.op, "UseOutline"):
-            useOutline = self.op.UseOutline
-
-        baseShape = self.obj.Shape
-        if useOutline:
-            face = Part.Face(baseShape.getElement(self.feature).Wire1)
-        else:
-            face = baseShape.getElement(self.feature)
-
-        rawFace = getWaterlineFace(baseShape, face)
-
-        if not rawFace:
-            PathLog.error(msg + " 1")
-            return None
-
-        if rawFace:
-            extFace = rawFace.cut(face)
-        else:
-            PathLog.error(msg + " 2")
-            extFace = face
-
-        # Debug
-        # Part.show(extFace)
-        # FreeCAD.ActiveDocument.ActiveObject.Label = "waterline_face"
-
-        if len(extFace.Wires) > 0:
-            self.extFaces = [f for f in extFace.Faces]
-            return extFace.Wires[0]
-
-        return None
 
     def _makeCircularExtFace(self, edge, extWire):
         """_makeCircularExtensionFace(edge, extWire)...


### PR DESCRIPTION
Removal of waterline, outline, and avoid extensions to fix loading speed for ops using extensions feature.

Forum reference at [Toolpath computation takes forever](https://forum.freecadweb.org/viewtopic.php?f=15&t=66287#p571460) and [Operation Poket](https://forum.freecadweb.org/viewtopic.php?f=15&t=66236#p571103).

This PR also:
1.) converts the enable extensions button to a checkbox per thread comments
2.) turns off extensions by default per thread comments


Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [ ]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [ ]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [ ]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [ ]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the issue ID number from our [Issues database](https://github.com/FreeCAD/FreeCAD/issues) in case a particular commit solves or is related to an existing issue. Ex: `Draft: fix typos - fixes #4805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
