### PR TITLE
Bug/engravingsketch

### DIFF
--- a/src/Mod/Path/PathCommands.py
+++ b/src/Mod/Path/PathCommands.py
@@ -108,8 +108,8 @@ class _CommandSelectLoop:
         if loopwire:
             FreeCADGui.Selection.clearSelection()
             elist = obj.Shape.Edges
-            for e in elist:
-                for i in loopwire.Edges:
+            for i in loopwire.Edges:
+                for e in elist:
                     if e.hashCode() == i.hashCode():
                         FreeCADGui.Selection.addSelection(
                             obj, "Edge" + str(elist.index(e) + 1)

--- a/src/Mod/Path/PathScripts/PathEngraveBase.py
+++ b/src/Mod/Path/PathScripts/PathEngraveBase.py
@@ -63,15 +63,23 @@ class ObjectOp(PathOp.ObjectOp):
         """buildpathocc(obj, wires, zValues, relZ=False) ... internal helper function to generate engraving commands."""
         PathLog.track(obj.Label, len(wires), zValues)
 
+        decomposewires = []
         for wire in wires:
-            offset = wire
+            decomposewires.extend(PathOpTools.makeWires(wire.Edges))
+
+        wires = decomposewires
+        for wire in wires:
+            # offset = wire
 
             # reorder the wire
             if hasattr(obj, "StartVertex"):
                 start_idx = obj.StartVertex
+            edges = wire.Edges
 
-            edges = copy.copy(PathOpTools.orientWire(offset, forward).Edges)
-            edges = Part.sortEdges(edges)[0]
+            # edges = copy.copy(PathOpTools.orientWire(offset, forward).Edges)
+            # PathLog.track("wire: {} offset: {}".format(len(wire.Edges), len(edges)))
+            # edges = Part.sortEdges(edges)[0]
+            # PathLog.track("edges: {}".format(len(edges)))
 
             last = None
 

--- a/src/Mod/Path/PathScripts/PathOpTools.py
+++ b/src/Mod/Path/PathScripts/PathOpTools.py
@@ -82,6 +82,13 @@ def debugEdge(label, e):
         )
 
 
+def makeWires(inEdges):
+    """makeWires ... function to make non-forking wires from a collection of edges"""
+    edgelists = Part.sortEdges(inEdges)
+    result = [Part.Wire(e) for e in edgelists]
+    return result
+
+
 def debugWire(label, w):
     """debugWire(label, w) ... prints python statements for all edges of w to be added to the object tree in a group."""
     if not PrintWireDebug:
@@ -160,7 +167,7 @@ def orientWire(w, forward=True):
     If forward = True (the default) the wire is oriented clockwise, looking down the negative Z axis.
     If forward = False the wire is oriented counter clockwise.
     If forward = None the orientation is determined by the order in which the edges appear in the wire."""
-    PathLog.debug("orienting forward: {}".format(forward))
+    PathLog.debug("orienting forward: {}: {} edges".format(forward, len(w.Edges)))
     wire = Part.Wire(_orientEdges(w.Edges))
     if forward is not None:
         if forward != _isWireClockwise(wire):


### PR DESCRIPTION
Recreating PR for two minor bugs
Fixes segment order in loopdetect
fixes engraving of forked wires

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [x]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [ ]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the issue ID number from our [Issues database](https://github.com/FreeCAD/FreeCAD/issues) in case a particular commit solves or is related to an existing issue. Ex: `Draft: fix typos - fixes #4805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
