### PR TITLE
[Sketcher] Fixing some issues with "Convert to NURBS"

### DIFF
--- a/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp
+++ b/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp
@@ -444,19 +444,25 @@ void CmdSketcherConvertToNURBS::activated(int iMsg)
 
     openCommand(QT_TRANSLATE_NOOP("Command", "Convert to NURBS"));
 
-    for (size_t i=0; i < SubNames.size(); i++) {
+    std::vector<int> GeoIdList;
+
+    for (auto subName : SubNames) {
         // only handle edges
-        if (SubNames[i].size() > 4 && SubNames[i].substr(0,4) == "Edge") {
-            int GeoId = std::atoi(SubNames[i].substr(4,4000).c_str()) - 1;
-            Gui::cmdAppObjectArgs(selection[0].getObject(), "convertToNURBS(%d) ", GeoId);
-            nurbsized = true;
-        }
-        else if (SubNames[i].size() > 12 && SubNames[i].substr(0,12) == "ExternalEdge") {
-            int GeoId = - (std::atoi(SubNames[i].substr(12,4000).c_str()) + 2);
-            Gui::cmdAppObjectArgs(selection[0].getObject(), "convertToNURBS(%d) ", GeoId);
-            nurbsized = true;
-        }
+        int GeoId;
+        if (subName.size() > 4 && subName.substr(0,4) == "Edge")
+            GeoId = std::atoi(subName.substr(4,4000).c_str()) - 1;
+        else if (subName.size() > 12 && subName.substr(0,12) == "ExternalEdge")
+            GeoId = - (std::atoi(subName.substr(12,4000).c_str()) + 2);
+        else
+            continue;
+        Gui::cmdAppObjectArgs(selection[0].getObject(), "convertToNURBS(%d) ", GeoId);
+        GeoIdList.push_back(GeoId);
+        nurbsized = true;
     }
+
+    // for creating the poles and knots
+    for (const auto& GeoId : GeoIdList)
+        Gui::cmdAppObjectArgs(selection[0].getObject(), "exposeInternalGeometry(%d)", GeoId);
 
     if (!nurbsized) {
         abortCommand();

--- a/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp
+++ b/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp
@@ -407,23 +407,23 @@ bool CmdSketcherCompBSplineShowHideGeometryInformation::isActive(void)
 }
 
 // Convert to NURBS
-DEF_STD_CMD_A(CmdSketcherConvertToNURB)
+DEF_STD_CMD_A(CmdSketcherConvertToNURBS)
 
-CmdSketcherConvertToNURB::CmdSketcherConvertToNURB()
-    : Command("Sketcher_BSplineConvertToNURB")
+CmdSketcherConvertToNURBS::CmdSketcherConvertToNURBS()
+    : Command("Sketcher_BSplineConvertToNURBS")
 {
     sAppModule      = "Sketcher";
     sGroup          = "Sketcher";
     sMenuText       = QT_TR_NOOP("Convert geometry to B-spline");
     sToolTipText    = QT_TR_NOOP("Converts the selected geometry to a B-spline");
-    sWhatsThis      = "Sketcher_BSplineConvertToNURB";
+    sWhatsThis      = "Sketcher_BSplineConvertToNURBS";
     sStatusTip      = sToolTipText;
     sPixmap         = "Sketcher_BSplineApproximate";
     sAccel          = "";
     eType           = ForEdit;
 }
 
-void CmdSketcherConvertToNURB::activated(int iMsg)
+void CmdSketcherConvertToNURBS::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
 
@@ -469,7 +469,7 @@ void CmdSketcherConvertToNURB::activated(int iMsg)
     tryAutoRecomputeIfNotSolve(Obj);
 }
 
-bool CmdSketcherConvertToNURB::isActive(void)
+bool CmdSketcherConvertToNURBS::isActive(void)
 {
     return isSketcherBSplineActive(getActiveGuiDocument(), true);
 }
@@ -1220,7 +1220,7 @@ void CreateSketcherCommandsBSpline(void)
     rcCmdMgr.addCommand(new CmdSketcherBSplineKnotMultiplicity());
     rcCmdMgr.addCommand(new CmdSketcherBSplinePoleWeight());
     rcCmdMgr.addCommand(new CmdSketcherCompBSplineShowHideGeometryInformation());
-    rcCmdMgr.addCommand(new CmdSketcherConvertToNURB());
+    rcCmdMgr.addCommand(new CmdSketcherConvertToNURBS());
     rcCmdMgr.addCommand(new CmdSketcherIncreaseDegree());
     rcCmdMgr.addCommand(new CmdSketcherDecreaseDegree());
     rcCmdMgr.addCommand(new CmdSketcherIncreaseKnotMultiplicity());

--- a/src/Mod/Sketcher/Gui/Resources/translations/Sketcher.ts
+++ b/src/Mod/Sketcher/Gui/Resources/translations/Sketcher.ts
@@ -688,7 +688,7 @@ with respect to a line or a third point</source>
     </message>
 </context>
 <context>
-    <name>CmdSketcherConvertToNURB</name>
+    <name>CmdSketcherConvertToNURBS</name>
     <message>
         <location filename="../../CommandSketcherBSpline.cpp" line="385"/>
         <source>Convert geometry to B-spline</source>

--- a/src/Mod/Sketcher/Gui/Workbench.cpp
+++ b/src/Mod/Sketcher/Gui/Workbench.cpp
@@ -408,7 +408,7 @@ inline void SketcherAddWorkbenchBSplines<Gui::MenuItem>(Gui::MenuItem& bspline)
             << "Sketcher_BSplineComb"
             << "Sketcher_BSplineKnotMultiplicity"
             << "Sketcher_BSplinePoleWeight"
-            << "Sketcher_BSplineConvertToNURB"
+            << "Sketcher_BSplineConvertToNURBS"
             << "Sketcher_BSplineIncreaseDegree"
             << "Sketcher_BSplineDecreaseDegree"
             << "Sketcher_BSplineIncreaseKnotMultiplicity"
@@ -420,7 +420,7 @@ template <>
 inline void SketcherAddWorkbenchBSplines<Gui::ToolBarItem>(Gui::ToolBarItem& bspline)
 {
     bspline << "Sketcher_CompBSplineShowHideGeometryInformation"
-            << "Sketcher_BSplineConvertToNURB"
+            << "Sketcher_BSplineConvertToNURBS"
             << "Sketcher_BSplineIncreaseDegree"
             << "Sketcher_BSplineDecreaseDegree"
             << "Sketcher_CompModifyKnotMultiplicity"


### PR DESCRIPTION
Fixes include:
1. Rename `CmdSketcherConvertToNURB` to `CmdSketcherConvertToNURBS`.
2. TODO: Make sure internal geometries (knots, poles) are created in the tool.