### PR TITLE
Gui: fix use of deprecated Qt::TextColorRole

### DIFF
--- a/src/Gui/propertyeditor/PropertyItem.cpp
+++ b/src/Gui/propertyeditor/PropertyItem.cpp
@@ -573,10 +573,10 @@ QVariant PropertyItem::data(int column, int role) const
 {
     // property name
     if (column == 0) {
-        if (role == Qt::TextColorRole && linked)
+        if (role == Qt::ForegroundRole && linked)
             return QVariant::fromValue(QColor(0x20,0xaa,0x20));
 
-        if (role == Qt::BackgroundRole || role == Qt::TextColorRole) {
+        if (role == Qt::BackgroundRole || role == Qt::ForegroundRole) {
             if(PropertyView::showAll()
                 && propertyItems.size() == 1
                 && propertyItems.front()->testStatus(App::Property::PropDynamic)


### PR DESCRIPTION
`Qt::TextColorRole` (`enum ItemDataRole`) is deprecated as of Qt 5.13 and will be removed in Qt 6:

- https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/global/qnamespace.h?h=v5.13.0#n1511

It's replaced with `Qt::ForegroundRole` which is available since at least Qt 5.0 (FreeCAD 0.20 will require Qt 5.9 or later).

- https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/global/qnamespace.h?h=v5.9.0
- https://wiki.freecadweb.org/0.20_Development_Cycle

Compiles and runs OK (Apple M1).