### PR TITLE
Draft: Fix Draft_Line Length is zero bug

### DIFF
--- a/src/Mod/Draft/draftobjects/wire.py
+++ b/src/Mod/Draft/draftobjects/wire.py
@@ -217,12 +217,14 @@ class Wire(DraftObject):
                     obj.Points = pts
 
         elif prop == "Length":
-            if obj.Shape and not obj.Shape.isNull():
-                if obj.Length.Value != obj.Shape.Length:
-                    if len(obj.Points) == 2:
-                        v = obj.Points[-1].sub(obj.Points[0])
-                        v = DraftVecUtils.scaleTo(v,obj.Length.Value)
-                        obj.Points = [obj.Points[0],obj.Points[0].add(v)]
+            if (len(obj.Points) == 2
+                    and obj.Length.Value > 1e-7
+                    and obj.Shape
+                    and (not obj.Shape.isNull())
+                    and obj.Length.Value != obj.Shape.Length):
+                v = obj.Points[-1].sub(obj.Points[0])
+                v = DraftVecUtils.scaleTo(v, obj.Length.Value)
+                obj.Points = [obj.Points[0], obj.Points[0].add(v)]
 
         elif prop == "Placement":
             pl = App.Placement(obj.Placement)


### PR DESCRIPTION
When changing the `Length` of a Draft_Line to f.e. 0.5 the input of the zero resulted in a zero length line.

Forum topic:
https://forum.freecadweb.org/viewtopic.php?f=3&t=66586

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the issue ID number from our [Issues database](https://github.com/FreeCAD/FreeCAD/issues) in case a particular commit solves or is related to an existing issue. Ex: `Draft: fix typos - fixes #4805`

---
