### PR TITLE
Github: rename Workbench tags so they present alphabetically in GH UI

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -2,38 +2,62 @@
 # source:
 # - any: ['src/**/*', '!src/docs/*']
 
-
-🛤️ Path:
-- 'src/Mod/Path/**/*'
-
-🏛 Arch:
-- 'src/Mod/Arch/**/*'
-
-🚜 PartDesign:
-- 'src/Mod/PartDesign/**/*'
-
-✏️ Sketcher:
-- 'src/Mod/Sketcher/**/*'
-
-📐 Draft:
-- 'src/Mod/Draft/**/*'
-
-🧪 FEM:
-- 'src/Mod/Fem/**/*'
-
-⚙ TechDraw:
-- 'src/Mod/TechDraw/**/*'
-
-🧱 Part:  
-- 'src/Mod/Part/**/*'
-
-🥅 Mesh:
-- 'src/Mod/Mesh/**/*'
-
-Spreadsheet:
-- 'src/Mod/Spreadsheet/**/*'
-
 Core:
 - 'src/App/**/*'
 - 'src/Base/**/*'
 - 'src/Gui/**/*'
+
+:octocat: :
+- '.github/**/*'
+
+Addon Manager:
+- 'src/Mod/AddonManager/**/*'
+
+WB Arch:
+- 'src/Mod/Arch/**/*'
+
+WB Draft:
+- 'src/Mod/Draft/**/*'
+
+WB FEM:
+- 'src/Mod/Fem/**/*'
+
+WB Mesh:
+- 'src/Mod/Mesh/**/*'
+
+WB MeshPart:
+- 'src/Mod/MeshPart/**/*'
+
+WB OpenSCAD:
+- 'src/Mod/OpenSCAD/**/*'
+
+WB Part:  
+- 'src/Mod/Part/**/*'
+
+WB PartDesign:
+- 'src/Mod/PartDesign/**/*'
+
+WB Path:
+- 'src/Mod/Path/**/*'
+
+WB Points:
+- 'src/Mod/Points/**/*'
+
+WB ReverseEngineering:
+- 'src/Mod/ReverseEngineering/**/*'
+
+WB Sketcher:
+- 'src/Mod/Sketcher/**/*'
+
+WB Spreadsheet:
+- 'src/Mod/Spreadsheet/**/*'
+
+WB Surface:
+- 'src/Mod/Surface/**/*/'
+
+WB TechDraw:
+- 'src/Mod/TechDraw/**/*'
+
+WB Test:
+- 'src/Mod/Test/**/*'
+


### PR DESCRIPTION
When choosing a specific workbench tag in the GH the current dropdown entries are scattered. By prepending `WB` to them and sorting them alphabetically will make it cleaner to select them. Due to this, the tags have been renamed.

This PR follows up the change of the tags to the GH auto-labeler action. Some extra tags were added as well like :octocat: for GH files and `Addon Manager` etc...