### PR TITLE
check for nullptr in BrowserView::onLoadFinished() before calling MainWindow::showMessage() at the end of unit tests

### DIFF
--- a/src/Mod/Web/Gui/BrowserView.cpp
+++ b/src/Mod/Web/Gui/BrowserView.cpp
@@ -781,7 +781,10 @@ void BrowserView::onLoadFinished(bool ok)
     QProgressBar* bar = SequencerBar::instance()->getProgressBar();
     bar->setValue(100);
     bar->hide();
-    getMainWindow()->showMessage(QString());
+    Gui::MainWindow* win = Gui::getMainWindow();
+    if (win) {
+        win->showMessage(QString());
+    }
     isLoading = false;
 }
 


### PR DESCRIPTION

https://forum.freecadweb.org/viewtopic.php?f=10&t=66474&p=575132#p575132