### PR TITLE
[Sketcher] Some tools for more control over b-splines at creation (2/??)

### DIFF
--- a/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
+++ b/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
@@ -4608,7 +4608,7 @@ public:
                 return;
             }
         }
-        else if (Mode==STATUS_SEEK_ADDITIONAL_CONTROLPOINTS){
+        else if (Mode==STATUS_SEEK_ADDITIONAL_CONTROLPOINTS) {
 
             EditCurve[EditCurve.size()-1] = onSketchPos;
 
@@ -4695,8 +4695,6 @@ public:
 
                     return true;
                 }
-
-
             }
 
             // insert circle point for pole, defer internal alignment constraining.
@@ -4772,7 +4770,6 @@ public:
             int currentgeoid = getHighestCurveIndex();
 
             try {
-
                 //Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Add B-spline curve"));
 
                 /*Gui::cmdAppObjectArgs(sketchgui->getObject(), "addGeometry(Part.BSplineCurve"
@@ -4790,7 +4787,6 @@ public:
                                         SplineDegree,
                                         geometryCreationMode==Construction?"True":"False");
 
-
                 currentgeoid++;
 
                 // autoconstraints were added to the circles of the poles, which is ok because they must go to the
@@ -4799,7 +4795,6 @@ public:
                 // as the ones created by this tool are intended for the b-spline endpoints, and not for the poles,
                 // so here we retrieve any autoconstraint on those poles' center and mangle it to the endpoint.
                 if (ConstrMethod == 0) {
-
                     for(auto & constr : static_cast<Sketcher::SketchObject *>(sketchgui->getObject())->Constraints.getValues()) {
                         if(constr->First == FirstPoleGeoId && constr->FirstPos == Sketcher::PointPos::mid) {
                             constr->First = currentgeoid;
@@ -4848,21 +4843,7 @@ public:
 
             if(continuousMode){
                 // This code enables the continuous creation mode.
-                Mode = STATUS_SEEK_FIRST_CONTROLPOINT;
-                EditCurve.clear();
-                drawEdit(EditCurve);
-                EditCurve.resize(2);
-                applyCursor();
-
-                SplineDegree = 3;
-
-                sugConstr.clear();
-
-                std::vector<AutoConstraint> sugConstr1;
-                sugConstr.push_back(sugConstr1);
-
-                CurrentConstraint=0;
-                IsClosed=false;
+                resetHandlerState();
 
                 /* It is ok not to call to purgeHandler
                  * in continuous creation mode because the
@@ -4921,19 +4902,7 @@ public:
             }
             else {
                 // This code disregards existing data and enables the continuous creation mode.
-                Mode = STATUS_SEEK_FIRST_CONTROLPOINT;
-                EditCurve.clear();
-                drawEdit(EditCurve);
-                EditCurve.resize(2);
-                applyCursor();
-
-                sugConstr.clear();
-
-                std::vector<AutoConstraint> sugConstr1;
-                sugConstr.push_back(sugConstr1);
-
-                CurrentConstraint=0;
-                IsClosed=false;
+                resetHandlerState();
             }
         }
         else { // we have no data (CurrentConstraint == 0) so user when right-clicking really wants to exit
@@ -4942,6 +4911,25 @@ public:
     }
 
 private:
+    void resetHandlerState()
+    {
+        Mode = STATUS_SEEK_FIRST_CONTROLPOINT;
+        EditCurve.clear();
+        drawEdit(EditCurve);
+        EditCurve.resize(2);
+        applyCursor();
+
+        SplineDegree = 3;
+
+        sugConstr.clear();
+
+        std::vector<AutoConstraint> sugConstr1;
+        sugConstr.push_back(sugConstr1);
+
+        CurrentConstraint = 0;
+        IsClosed = false;
+    }
+
     virtual void activated() override
     {
         setCrosshairCursor("Sketcher_Pointer_Create_BSpline");


### PR DESCRIPTION
New tool(s):
- Press "D" to open a dialog to set the degree (already merged in #6463).
- Press "Backspace" to delete the last defined pole (this PR).