### PR TITLE
Sketcher: Split B-Splines

### DIFF
--- a/src/Mod/Part/App/Geometry.cpp
+++ b/src/Mod/Part/App/Geometry.cpp
@@ -1587,19 +1587,9 @@ void GeomBSplineCurve::Trim(double u, double v)
     };
 
     try {
-        if(!isPeriodic()) {
-            splitUnwrappedBSpline(u, v);
-        }
-        else { // periodic
-            if( v < u ) { // wraps over origin
-                v = v + 1.0; // v needs one extra lap (1.0)
-
-                splitUnwrappedBSpline(u, v);
-            }
-            else {
-                splitUnwrappedBSpline(u, v);
-            }
-        }
+        if (isPeriodic() && (v - u  <= Precision::PConfusion()))
+            v = v + myCurve->LastParameter() - myCurve->FirstParameter(); // v needs one extra lap
+        splitUnwrappedBSpline(u, v);
     }
     catch (Standard_Failure& e) {
         THROWM(Base::CADKernelError,e.GetMessageString())

--- a/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
+++ b/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
@@ -6595,7 +6595,8 @@ namespace SketcherGui {
                 const Part::Geometry *geom = Sketch->getGeometry(GeoId);
                 if (geom->getTypeId() == Part::GeomLineSegment::getClassTypeId()
                     || geom->getTypeId() == Part::GeomCircle::getClassTypeId()
-                    || geom->getTypeId() == Part::GeomArcOfCircle::getClassTypeId()) {
+                    || geom->getTypeId() == Part::GeomArcOfCircle::getClassTypeId()
+                    || geom->getTypeId() == Part::GeomBSplineCurve::getClassTypeId()) {
                     return true;
                 }
             }
@@ -6631,7 +6632,8 @@ public:
             const Part::Geometry *geom = sketchgui->getSketchObject()->getGeometry(GeoId);
             if (geom->getTypeId() == Part::GeomLineSegment::getClassTypeId()
                 || geom->getTypeId() == Part::GeomCircle::getClassTypeId()
-                || geom->getTypeId() == Part::GeomArcOfCircle::getClassTypeId()) {
+                || geom->getTypeId() == Part::GeomArcOfCircle::getClassTypeId()
+                || geom->getTypeId() == Part::GeomBSplineCurve::getClassTypeId()) {
                 try {
                     Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Split edge"));
                     Gui::cmdAppObjectArgs(sketchgui->getObject(), "split(%d,App.Vector(%f,%f,0))",


### PR DESCRIPTION
With these changes the split tool in sketcher also works on b-splines.

Some changes also had to be made in `Part::GeomBSplineCurve::Trim()` to split periodic b-splines.