### PR TITLE
[Sketcher] Remove "incomplete" from insert knot command

### DIFF
--- a/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp
+++ b/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp
@@ -1054,7 +1054,7 @@ public:
     {
         Q_UNUSED(onSketchPos);
 
-        Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Insert knot (incomplete)"));
+        Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Insert knot"));
 
         bool applied = false;
         boost::uuids::uuid bsplinetag = Obj->getGeometry(GeoId)->getTag();


### PR DESCRIPTION
I had kept the qualifier there when developing the tool and forgot to remove it. At this time the tool is fairly well-developed.
