### PR TITLE
[TD]handle ScaleType for old documents + Section dialog ScaleType

### DIFF
--- a/src/Mod/TechDraw/App/DrawProjGroupItem.cpp
+++ b/src/Mod/TechDraw/App/DrawProjGroupItem.cpp
@@ -170,6 +170,7 @@ void DrawProjGroupItem::autoPosition()
 void DrawProjGroupItem::onDocumentRestored()
 {
 //    Base::Console().Message("DPGI::onDocumentRestored() - %s\n", getNameInDocument());
+    DrawView::onDocumentRestored();
     App::DocumentObjectExecReturn* rc = DrawProjGroupItem::execute();
     if (rc) {
         delete rc;

--- a/src/Mod/TechDraw/App/DrawView.cpp
+++ b/src/Mod/TechDraw/App/DrawView.cpp
@@ -239,8 +239,33 @@ void DrawView::onDocumentRestored()
 {
     handleXYLock();
     setScaleAttribute();
+    validateScale();
     DrawView::execute();
 }
+
+//in versions before 0.20 Scale and ScaleType were mishandled.
+//In order to not introduce unintended drawing changes in later
+//versions, ScaleType Page must be modified if view Scale does
+//not match Page Scale
+void DrawView::validateScale()
+{
+    if (ScaleType.isValue("Custom")) {
+        //nothing to do here
+        return;
+    }
+    DrawPage* page = findParentPage();
+    if (page) {
+        if (ScaleType.isValue("Page")) {
+            double pageScale = page->Scale.getValue();
+            double myScale = Scale.getValue();
+            if (!DrawUtil::fpCompare(pageScale, myScale)) {
+                ScaleType.setValue("Custom");
+                ScaleType.purgeTouched();
+            }
+        }
+    }
+}
+
 /**
  * @brief DrawView::countParentPages
  * Fixes a crash in TechDraw when user creates duplicate page without dependencies

--- a/src/Mod/TechDraw/App/DrawView.h
+++ b/src/Mod/TechDraw/App/DrawView.h
@@ -109,6 +109,7 @@ public:
 
 protected:
     virtual void onChanged(const App::Property* prop) override;
+    virtual void validateScale();
     std::string pageFeatName;
     bool autoPos;
     bool mouseMove;

--- a/src/Mod/TechDraw/Gui/TaskSectionView.h
+++ b/src/Mod/TechDraw/Gui/TaskSectionView.h
@@ -60,6 +60,8 @@ protected Q_SLOTS:
     void onXChanged();
     void onYChanged();
     void onZChanged();
+    void scaleTypeChanged(int index);
+
 
 protected:
     void changeEvent(QEvent *e);
@@ -98,6 +100,7 @@ private:
     Base::Vector3d m_saveDirection;
     Base::Vector3d m_saveOrigin;
     double m_saveScale;
+    int m_saveScaleType;
 
     std::string m_dirName;
     std::string m_sectionName;

--- a/src/Mod/TechDraw/Gui/TaskSectionView.ui
+++ b/src/Mod/TechDraw/Gui/TaskSectionView.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>370</width>
-    <height>326</height>
+    <height>368</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -22,10 +22,10 @@
   <layout class="QVBoxLayout" name="verticalLayout_3">
    <item>
     <layout class="QGridLayout" name="gridLayout_4">
-     <item row="0" column="0">
-      <widget class="QLabel" name="label_7">
+     <item row="3" column="0">
+      <widget class="QLabel" name="label">
        <property name="text">
-        <string>BaseView</string>
+        <string>Scale</string>
        </property>
       </widget>
      </item>
@@ -41,6 +41,26 @@
         </size>
        </property>
       </spacer>
+     </item>
+     <item row="1" column="2">
+      <widget class="QLineEdit" name="leSymbol">
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>22</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string>Identifier for this section</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="QLabel" name="label_7">
+       <property name="text">
+        <string>BaseView</string>
+       </property>
+      </widget>
      </item>
      <item row="0" column="2">
       <widget class="QLineEdit" name="leBaseView">
@@ -62,27 +82,7 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="2">
-      <widget class="QLineEdit" name="leSymbol">
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>22</height>
-        </size>
-       </property>
-       <property name="toolTip">
-        <string>Identifier for this section</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="label">
-       <property name="text">
-        <string>Scale</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="2">
+     <item row="3" column="2">
       <widget class="Gui::QuantitySpinBox" name="sbScale">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -119,6 +119,41 @@
        </property>
        <property name="decimals" stdset="0">
         <number>4</number>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="2">
+      <widget class="QComboBox" name="cmbScaleType">
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>22</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string>Scale Page/Auto/Custom</string>
+       </property>
+       <item>
+        <property name="text">
+         <string>Page</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Automatic</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Custom</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="label_3">
+       <property name="text">
+        <string>Scale Type</string>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
This PR has two parts.  The first corrects the handling of Scale/1ScaleType in old (pre v020) documents.  The second adds ScaleType to the Section dialog.