### PR TITLE
Fix #6532 file not saved if backups are disabled and FCBak ext is enabled

### DIFF
--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -2541,12 +2541,6 @@ private:
             }
         }
 
-        Base::FileInfo tmp(sourcename);
-        if (tmp.renameFile(targetname.c_str()) == false) {
-            throw Base::FileException(
-                "Save interrupted: Cannot rename temporary file to project file", tmp);
-        }
-
         if (numberOfFiles <= 0) {
             try {
                 fi.deleteFile();
@@ -2555,6 +2549,12 @@ private:
                 Base::Console().Warning("Cannot remove backup file: %s\n", fi.fileName().c_str());
                 backupManagementError = true;
            }
+        }
+
+        Base::FileInfo tmp(sourcename);
+        if (tmp.renameFile(targetname.c_str()) == false) {
+            throw Base::FileException(
+                "Save interrupted: Cannot rename temporary file to project file", tmp);
         }
 
         if (backupManagementError) {


### PR DESCRIPTION
There were two bugs in `applyTimeStamp`: a backup was created even if backups are disabled and then the saved file was immediately deleted if backups are disabled.

Please review carefully as I don't really understand any of what happens in this file but it did solve the mentioned bugs for me. The line change count is misleading as most of it are just adding indentation.

I have some doubts about `applyTimeStamp`: what's the point of having an `if (useFCBakExtension)` condition inside it when this backup policy is only set if that bool is true.
Why when failing to delete the original file the thrown error says it's the backup that can't be removed?
```
            try {
                fi.deleteFile();
            }
            catch (...) {
                Base::Console().Warning("Cannot remove backup file: %s\n", fi.fileName().c_str());
                backupManagementError = true;
            }
```
Plus, why do we even need to delete the original file in the first place.

And should `applyStandard` also have this try-catch block?