### PR TITLE
Draft: Fix Angle Lock for non-XY workingplane

### DIFF
--- a/src/Mod/Draft/DraftGui.py
+++ b/src/Mod/Draft/DraftGui.py
@@ -2153,12 +2153,20 @@ class DraftToolBar:
             return None
         self.update_cartesian_coords()
         if self.angleLock.isChecked():
-            FreeCADGui.Snapper.setAngle(self.angle)
+            if not self.globalMode:
+                angle_vec = FreeCAD.DraftWorkingPlane.getGlobalRot(self.angle)
+            else:
+                angle_vec = self.angle
+            FreeCADGui.Snapper.setAngle(angle_vec)
 
     def toggleAngle(self,b):
         self.alock = self.angleLock.isChecked()
         if b:
-            FreeCADGui.Snapper.setAngle(self.angle)
+            if not self.globalMode:
+                angle_vec = FreeCAD.DraftWorkingPlane.getGlobalRot(self.angle)
+            else:
+                angle_vec = self.angle
+            FreeCADGui.Snapper.setAngle(angle_vec)
         else:
             FreeCADGui.Snapper.setAngle()
             self.angle = None


### PR DESCRIPTION
Angle Lock would only work if the workingplane was plane-parallel to the XY plane of the global coordinate system. The `self.angle` value (BTW: it's a vector!) was not translated from the workingplane coordinate system to the global coordinate system.

Note that I do not check for the existence of the `DraftWorkingPlane`. It always seems to be available if the GUI is up. Even if the startup workbench is Part f.e.

Elsewhere in the code we see this:
https://github.com/FreeCAD/FreeCAD/blob/c5a0db5e4736a6cd43d239e15d5e0daf7006a642/src/Mod/Draft/DraftGui.py#L1478
But I do not think that is a correct way to check for the presence of  the `DraftWorkingPlane`. You would have to use `hasattr` instead.

Forum topic: https://forum.freecadweb.org/viewtopic.php?f=23&t=66963

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the issue ID number from our [Issues database](https://github.com/FreeCAD/FreeCAD/issues) in case a particular commit solves or is related to an existing issue. Ex: `Draft: fix typos - fixes #4805`

---
