### PR TITLE
AddonManager: fix typos

### DIFF
--- a/src/Mod/AddonManager/AddonManagerTest/app/test_addon.py
+++ b/src/Mod/AddonManager/AddonManagerTest/app/test_addon.py
@@ -215,6 +215,6 @@ class TestAddon(unittest.TestCase):
         addon.load_metadata_file(os.path.join(self.test_dir, "test_version_detection.xml"))
 
         self.assertEqual(len(addon.tags),1, "Wrong number of tags found: version requirements should have restricted to only one")
-        self.assertFalse("TagA" in addon.tags, "Found 'TagA' in tags, it should have been exluded by version requirement")
+        self.assertFalse("TagA" in addon.tags, "Found 'TagA' in tags, it should have been excluded by version requirement")
         self.assertTrue("TagB" in addon.tags, "Failed to find 'TagB' in tags, it should have been included")
-        self.assertFalse("TagC" in addon.tags, "Found 'TagA' in tags, it should have been exluded by version requirement")
+        self.assertFalse("TagC" in addon.tags, "Found 'TagA' in tags, it should have been excluded by version requirement")


### PR DESCRIPTION
Fixed via `codespell -q 3 -L aci,ake,aline,alle,alledges,alocation,als,ang,anid,anormal,apoints,ba,beginn,behaviour,bloaded,bottome,byteorder,calculater,cancelled,cancelling,cas,cascade,centimetre,childrens,childs,colour,colours,commen,connexion,currenty,dof,doubleclick,dum,eiter,elemente,ende,feld,finde,findf,freez,hist,iff,indicies,initialisation,initialise,initialised,initialises,initialisiert,inout,ist,itsel,kilometre,lod,mantatory,methode,metres,millimetre,modell,nd,noe,normale,normaly,nto,numer,oce,oder,ontop,orgin,orginx,orginy,ot,pard,parm,parms,pres,programm,que,rady,recurrance,ro,rougly,seperator,serie,sinc,strack,substraction,te,technic,thist,thru,tread,uint,unter,vertexes,wallthickness,whitespaces -S ./.git,*.po,*.ts,./ChangeLog.txt,./src/3rdParty,./src/Mod/Assembly/App/opendcm,./src/CXX,./src/zipios++,./src/Base/swig*,./src/Mod/Robot/App/kdl_cp,./src/Mod/Import/App/SCL,./src/WindowsInstaller,./src/Doc/FreeCAD.uml,./src/Base/StackWalker.cpp,./build/doc/SourceDocu`