### PR TITLE
Part: 2doffset fix crash by checking for null shape before adding wit…

### DIFF
--- a/src/Mod/Part/App/TopoShape.cpp
+++ b/src/Mod/Part/App/TopoShape.cpp
@@ -3130,7 +3130,9 @@ TopoDS_Shape TopoShape::makeOffset2D(double offset, short joinType, bool fill, b
         BRep_Builder builder;
         builder.MakeCompound(result);
         for(TopoDS_Shape &sh : shapesToReturn) {
-            builder.Add(result, sh);
+            if (!sh.IsNull()) {
+                builder.Add(result, sh);
+            }
         }
         return TopoDS_Shape(std::move(result));
     }


### PR DESCRIPTION
…h builder.Add()

This was part of another PR to add 2d offsetting to green subshapebinders, but is being separated.

https://github.com/FreeCAD/FreeCAD/pull/6338/commits/c4d41712503035b3a981a71e8d9ed418e6e0a1b8


