### PR TITLE
Path: Correct beginning retraction to safe height in Boundary Dressup, issue #6279 [Bug]

### DIFF
--- a/src/Mod/Path/PathScripts/PathDressupPathBoundary.py
+++ b/src/Mod/Path/PathScripts/PathDressupPathBoundary.py
@@ -123,7 +123,7 @@ class PathBoundary:
         self.inside = inside
         self.safeHeight = None
         self.clearanceHeight = None
-        self.strG1ZsafeHeight = None
+        self.strG0ZsafeHeight = None
         self.strG0ZclearanceHeight = None
 
     def boundaryCommands(self, begin, end, verticalFeed):
@@ -132,7 +132,7 @@ class PathBoundary:
             return []
         cmds = []
         if begin.z < self.safeHeight:
-            cmds.append(self.strG1ZsafeHeight)
+            cmds.append(self.strG0ZsafeHeight)
         if begin.z < self.clearanceHeight:
             cmds.append(self.strG0ZclearanceHeight)
         if end:
@@ -161,8 +161,8 @@ class PathBoundary:
         self.clearanceHeight = float(
             PathUtil.opProperty(self.baseOp, "ClearanceHeight")
         )
-        self.strG1ZsafeHeight = Path.Command(
-            "G1", {"Z": self.safeHeight, "F": tc.VertFeed.Value}
+        self.strG0ZsafeHeight = Path.Command(  # was a Feed rate with G1
+            "G0", {"Z": self.safeHeight, "F": tc.VertRapid.Value}
         )
         self.strG0ZclearanceHeight = Path.Command("G0", {"Z": self.clearanceHeight})
 


### PR DESCRIPTION
This commit changes the feed rate of the beginning retraction from G1 at Feed to a G0 Rapid rate.  This initial command is causing a problem with the Tag Dressup due to the first move being a G1 to Safe Height.

This bug was discovered via Tag Dressup error in forum at [Boundary Dressup and Tag Dressup](https://forum.freecadweb.org/viewtopic.php?f=15&t=63433).

We should really consider adding a warning to the user in the Boundary Dressup that informs them their effective Z-boundary is higher than the base operation's Final Depth.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [x]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [x]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the issue ID number from our [Issues database](https://github.com/FreeCAD/FreeCAD/issues) in case a particular commit solves or is related to an existing issue. Ex: `Draft: fix typos - fixes #4805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
