### PR TITLE
Path: Extend Job integrity check to GUI side, issue #6207 [Bug]

### DIFF
--- a/src/Mod/Path/PathScripts/PathJob.py
+++ b/src/Mod/Path/PathScripts/PathJob.py
@@ -284,7 +284,7 @@ class ObjectJob:
         # ops = FreeCAD.ActiveDocument.addObject(
         #     "Path::FeatureCompoundPython", "Operations"
         # )
-        ops = FreeCAD.ActiveDocument.addObject("App::DocumentObjectGroup","Operations")
+        ops = FreeCAD.ActiveDocument.addObject("App::DocumentObjectGroup", "Operations")
         if ops.ViewObject:
             # ops.ViewObject.Proxy = 0
             ops.ViewObject.Visibility = True
@@ -295,14 +295,15 @@ class ObjectJob:
 
     def setupSetupSheet(self, obj):
         if not getattr(obj, "SetupSheet", None):
-            obj.addProperty(
-                "App::PropertyLink",
-                "SetupSheet",
-                "Base",
-                QT_TRANSLATE_NOOP(
-                    "App::Property", "SetupSheet holding the settings for this job"
-                ),
-            )
+            if not hasattr(obj, "SetupSheet"):
+                obj.addProperty(
+                    "App::PropertyLink",
+                    "SetupSheet",
+                    "Base",
+                    QT_TRANSLATE_NOOP(
+                        "App::Property", "SetupSheet holding the settings for this job"
+                    ),
+                )
             obj.SetupSheet = PathSetupSheet.Create()
             if obj.SetupSheet.ViewObject:
                 import PathScripts.PathIconViewProvider
@@ -659,7 +660,7 @@ class ObjectJob:
 
     def execute(self, obj):
         if getattr(obj, "Operations", None):
-            #obj.Path = obj.Operations.Path
+            # obj.Path = obj.Operations.Path
             self.getCycleTime()
 
     def getCycleTime(self):

--- a/src/Mod/Path/PathScripts/PathJobGui.py
+++ b/src/Mod/Path/PathScripts/PathJobGui.py
@@ -1572,15 +1572,37 @@ class TaskPanel:
 
     def _jobIntegrityCheck(self):
         """_jobIntegrityCheck() ... Check Job object for existence of Model and Tools
-        If either Model or Tools is empty, change GUI tab and open appropriate selection window."""
+        If either Model or Tools is empty, change GUI tab, issue appropriate warning,
+        and offer chance to add appropriate item."""
+
+        def _displayWarningWindow(msg):
+            """Display window with warning message and Add action button.
+            Return action state."""
+            txtHeader = translate("Path_Job", "Warning")
+            txtPleaseAddOne = translate("Path_Job", "Please add one.")
+            txtOk = translate("Path_Job", "Ok")
+            txtAdd = translate("Path_Job", "Add")
+
+            msgbox = QtGui.QMessageBox(
+                QtGui.QMessageBox.Warning, txtHeader, msg + " " + txtPleaseAddOne
+            )
+            msgbox.addButton(txtOk, QtGui.QMessageBox.AcceptRole)  # Add 'Ok' button
+            msgbox.addButton(txtAdd, QtGui.QMessageBox.ActionRole)  # Add 'Add' button
+            return msgbox.exec_()
+
+        # Check if at least on base model is present
         if len(self.obj.Model.Group) == 0:
-            PathLog.info(translate("Path_Job", "Please select a model for this job."))
             self.form.setCurrentIndex(0)  # Change tab to General tab
-            self.jobModelEdit()
+            no_model_txt = translate("Path_Job", "This job has no base model.")
+            if _displayWarningWindow(no_model_txt) == 1:
+                self.jobModelEdit()
+
+        # Check if at least one tool is present
         if len(self.obj.Tools.Group) == 0:
-            PathLog.info(translate("Path_Job", "Please add a tool to this job."))
             self.form.setCurrentIndex(3)  # Change tab to Tools tab
-            self.toolControllerAdd()
+            no_tool_txt = translate("Path_Job", "This job has no tool.")
+            if _displayWarningWindow(no_tool_txt) == 1:
+                self.toolControllerAdd()
 
     # SelectionObserver interface
     def addSelection(self, doc, obj, sub, pnt):

--- a/src/Mod/Path/PathScripts/PathJobGui.py
+++ b/src/Mod/Path/PathScripts/PathJobGui.py
@@ -694,7 +694,7 @@ class TaskPanel:
 
     def accept(self, resetEdit=True):
         PathLog.track()
-        self._jobIntegrityCheck()  # Check existance of Model and Tools
+        self._jobIntegrityCheck()  # Check existence of Model and Tools
         self.preCleanup()
         self.getFields()
         self.setupGlobal.accept()
@@ -1571,7 +1571,7 @@ class TaskPanel:
         FreeCADGui.Selection.addObserver(self)
 
     def _jobIntegrityCheck(self):
-        """_jobIntegrityCheck() ... Check Job object for existance of Model and Tools
+        """_jobIntegrityCheck() ... Check Job object for existence of Model and Tools
         If either Model or Tools is empty, change GUI tab and open appropriate selection window."""
         if len(self.obj.Model.Group) == 0:
             PathLog.info(translate("Path_Job", "Please select a model for this job."))

--- a/src/Mod/Path/PathScripts/PathJobGui.py
+++ b/src/Mod/Path/PathScripts/PathJobGui.py
@@ -694,6 +694,7 @@ class TaskPanel:
 
     def accept(self, resetEdit=True):
         PathLog.track()
+        self._jobIntegrityCheck()  # Check existance of Model and Tools
         self.preCleanup()
         self.getFields()
         self.setupGlobal.accept()
@@ -1568,6 +1569,18 @@ class TaskPanel:
 
     def open(self):
         FreeCADGui.Selection.addObserver(self)
+
+    def _jobIntegrityCheck(self):
+        """_jobIntegrityCheck() ... Check Job object for existance of Model and Tools
+        If either Model or Tools is empty, change GUI tab and open appropriate selection window."""
+        if len(self.obj.Model.Group) == 0:
+            PathLog.info(translate("Path_Job", "Please select a model for this job."))
+            self.form.setCurrentIndex(0)  # Change tab to General tab
+            self.jobModelEdit()
+        if len(self.obj.Tools.Group) == 0:
+            PathLog.info(translate("Path_Job", "Please add a tool to this job."))
+            self.form.setCurrentIndex(3)  # Change tab to Tools tab
+            self.toolControllerAdd()
 
     # SelectionObserver interface
     def addSelection(self, doc, obj, sub, pnt):


### PR DESCRIPTION
This commit adds a simple `_jobIntegrityCheck()` method to verify that a model and tool exists within the Job object, when interacting with the Task Panel.  If either is missing, the appropriate tab is activated in the task window, and the appropriate edit window is opened for the user, with messages printed in the report view window.

Add check for existence of `SetupSheet` property of empty Job object.

These changes improve upon fixes in PR #5008 and related bug fixes.

fixes #6207 

@sliptonic I would like feedback about my use of redirects to, and opening of, appropriate Model Selection or Tool Selection windows if no job model or tool exists for any job.  The premise is that a user has deleted all children of a Job object, leaving it empty in the object tree.  This PR allows recovery and rebuilding of the Job object's structure with no intention or attempt to rebuild deleted operations or tools.
I think I would rather simply present the user with a simple error message

Currently with this fix, when a model/tool is non-existent, then the task panel tab is switched to the General/Tools tab, and the Model Selection/Add Tool window is opened automatically.  Additionally, a related message is printed in the report view.  I think I prefer that only a popup window appear with the printed message to be acknowledged, along with changing to the appropriate General/Tools tab, but I do not know how to code such a simple popup message window to be acknowledged.  I need help with this change.

To test this, open a current file with a simple Job object with/out paths.  Expand all children in the Job.  Select all of the children of the Job (Operations, Model, SetupSheet, Tools) and their children.  Delete them, leaving only the Job object.

This PR should allow this to be completed without crashing FreeCAD.  You should then be able to double click on the empty Job object and the editing task panel should open.  The job's structure should be rebuilt. Click okay without changing any settings in the task panel.  The new `_jobIntegrityCheck()` method will activate and change tab to General and open the Model Selection window.  After selecting (or canceling) a model, the Tools tab will activate and a file explorer window will open encouraging the user to select a tool to add to the job.  Afterward the task panel will close, and the Job should be rebuilt with the selected model and tool (or without either if the user cancelled either model or tool selection).

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [x]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [x]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the issue ID number from our [Issues database](https://github.com/FreeCAD/FreeCAD/issues) in case a particular commit solves or is related to an existing issue. Ex: `Draft: fix typos - fixes #4805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
