### PR TITLE
Path: Fix `self.removalshapes` declaration [Bug]

### DIFF
--- a/src/Mod/Path/PathScripts/PathMillFace.py
+++ b/src/Mod/Path/PathScripts/PathMillFace.py
@@ -151,13 +151,13 @@ class ObjectFace(PathPocketBase.ObjectPocket):
     def areaOpShapes(self, obj):
         """areaOpShapes(obj) ... return top face"""
         # Facing is done either against base objects
+        self.removalshapes = []
         holeShape = None
 
         PathLog.debug("depthparams: {}".format([i for i in self.depthparams]))
 
         if obj.Base:
             PathLog.debug("obj.Base: {}".format(obj.Base))
-            self.removalshapes = []
             faces = []
             holes = []
             holeEnvs = []


### PR DESCRIPTION
Prior to this fix, the `self.removalshapes` variable is not declared if `obj.Base` does not exist, or is empty.  This moves the declaration up in scope to the method level.

fixes #6577 

Reproduce error by:
* Create new Job, accepting defaults.
* Click MillFace icon in toolbar to initiate a new MillFace op, without selecting anything in the viewport.  This will be interpreted as milling the entire model.
* Error will be thrown.

No related forum thread.  Just found the bug working another issue here on GitHub related to FreeCAD Path workbench.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the issue ID number from our [Issues database](https://github.com/FreeCAD/FreeCAD/issues) in case a particular commit solves or is related to an existing issue. Ex: `Draft: fix typos - fixes #4805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
