### PR TITLE
[TD]fix unit display to standards

### DIFF
--- a/src/Mod/TechDraw/App/DrawViewDimension.h
+++ b/src/Mod/TechDraw/App/DrawViewDimension.h
@@ -145,7 +145,9 @@ public:
     virtual std::string getFormattedToleranceValue(int partial);
     virtual std::pair<std::string, std::string> getFormattedToleranceValues(int partial = 0);
     virtual std::string getFormattedDimensionValue(int partial = 0);
-    virtual std::string formatValue(qreal value, QString qFormatSpec, int partial = 0);
+    virtual std::string formatValue(qreal value, QString qFormatSpec, int partial = 0, bool isDim = true);
+
+    virtual bool haveTolerance(void);
 
     virtual double getDimValue();
     QStringList getPrefixSuffixSpec(QString fSpec);

--- a/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
@@ -359,7 +359,7 @@ void QGIDatumLabel::setToleranceString()
     std::pair<std::string, std::string> labelTexts, unitTexts;
 
     if (dim->ArbitraryTolerances.getValue()) {
-        labelTexts = dim->getFormattedToleranceValues(1); //just the number pref/spec/suf
+        labelTexts = dim->getFormattedToleranceValues(1);  //copy tolerance spec
         unitTexts.first = "";
         unitTexts.second = "";
     } else {
@@ -368,13 +368,13 @@ void QGIDatumLabel::setToleranceString()
             unitTexts.first = "";
             unitTexts.second = "";
         } else {
-            labelTexts = dim->getFormattedToleranceValues(1); //just the number pref/spec/suf
+            labelTexts = dim->getFormattedToleranceValues(1); // prefix value [unit] postfix
             unitTexts  = dim->getFormattedToleranceValues(2); //just the unit
         }
     }
 
-    m_tolTextUnder->setPlainText(QString::fromUtf8(labelTexts.first.c_str()) + QString::fromUtf8(unitTexts.first.c_str()));
-    m_tolTextOver->setPlainText(QString::fromUtf8(labelTexts.second.c_str()) + QString::fromUtf8(unitTexts.second.c_str()));
+    m_tolTextUnder->setPlainText(QString::fromUtf8(labelTexts.first.c_str()));
+    m_tolTextOver->setPlainText(QString::fromUtf8(labelTexts.second.c_str()));
 
     return;
 } 
@@ -580,10 +580,6 @@ void QGIViewDimension::setNormalColorAll()
     aHead2->setFillColor(qc);
 }
 
-
-//special handling to prevent unwanted repositioning
-//clicking on the dimension, but outside the label, should do nothing to position
-//label will get clicks before QGIVDim
 void QGIViewDimension::mouseReleaseEvent(QGraphicsSceneMouseEvent * event)
 {
 //    Base::Console().Message("QGIVDim::mouseReleaseEvent() - %s\n",getViewName());
@@ -633,27 +629,11 @@ void QGIViewDimension::updateDim()
         return;
     }
  
-    QString labelText;
-    QString unitText;
-    if ( (dim->Arbitrary.getValue() && !dim->EqualTolerance.getValue())
-        || (dim->Arbitrary.getValue() && dim->TheoreticalExact.getValue()) ) {
-        labelText = QString::fromUtf8(dim->getFormattedDimensionValue(1).c_str()); //just the number pref/spec/suf
-    } else {
-        if (dim->isMultiValueSchema()) {
-            labelText = QString::fromUtf8(dim->getFormattedDimensionValue(0).c_str()); //don't format multis
-        } else {
-            labelText = QString::fromUtf8(dim->getFormattedDimensionValue(1).c_str()); //just the number pref/spec/suf
-            if (dim->EqualTolerance.getValue()) {
-                if (dim->ArbitraryTolerances.getValue()) {
-                    unitText = QString();
-                } else {
-                    unitText = QString::fromUtf8(dim->getFormattedToleranceValue(2).c_str()); //just the unit
-                }
-            } else {
-                unitText = QString::fromUtf8(dim->getFormattedDimensionValue(2).c_str()); //just the unit
-            }
-        }
+    QString labelText= QString::fromUtf8(dim->getFormattedDimensionValue(1).c_str()); // pre value [unit] post
+    if (dim->isMultiValueSchema()) {
+        labelText = QString::fromUtf8(dim->getFormattedDimensionValue(0).c_str()); //don't format multis
     }
+
     QFont font = datumLabel->getFont();
     font.setFamily(QString::fromUtf8(vp->Font.getValue()));
     font.setPixelSize(calculateFontPixelSize(vp->Fontsize.getValue()));
@@ -662,7 +642,6 @@ void QGIViewDimension::updateDim()
     prepareGeometryChange();
     datumLabel->setDimString(labelText);
     datumLabel->setToleranceString();
-    datumLabel->setUnitString(unitText);
     datumLabel->setPosFromCenter(datumLabel->X(),datumLabel->Y());
 
     datumLabel->setFramed(dim->TheoreticalExact.getValue());


### PR DESCRIPTION
This PR corrects the display and positioning of units in dimension text.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [ ]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [ ]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [ ]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [ ]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the issue ID number from our [Issues database](https://github.com/FreeCAD/FreeCAD/issues) in case a particular commit solves or is related to an existing issue. Ex: `Draft: fix typos - fixes #4805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
