### PR TITLE
[Path]  Warn user if enabling legacy tools

### DIFF
--- a/src/Mod/Path/PathScripts/PathJob.py
+++ b/src/Mod/Path/PathScripts/PathJob.py
@@ -32,6 +32,7 @@ import PathScripts.PathToolController as PathToolController
 import PathScripts.PathUtil as PathUtil
 import json
 import time
+import Path
 
 
 # lazily loaded modules
@@ -284,7 +285,7 @@ class ObjectJob:
         # ops = FreeCAD.ActiveDocument.addObject(
         #     "Path::FeatureCompoundPython", "Operations"
         # )
-        ops = FreeCAD.ActiveDocument.addObject("App::DocumentObjectGroup","Operations")
+        ops = FreeCAD.ActiveDocument.addObject("App::DocumentObjectGroup", "Operations")
         if ops.ViewObject:
             # ops.ViewObject.Proxy = 0
             ops.ViewObject.Visibility = True
@@ -544,6 +545,14 @@ class ObjectJob:
         for n in self.propertyEnumerations():
             setattr(obj, n[0], n[1])
 
+        if True in [isinstance(t.Tool, Path.Tool) for t in obj.Tools.Group]:
+            FreeCAD.Console.PrintWarning(
+                translate(
+                    "Path",
+                    "This job contains Legacy tools. Legacy tools are deprecated. They will be removed after version 0.20",
+                )
+            )
+
     def onChanged(self, obj, prop):
         if prop == "PostProcessor" and obj.PostProcessor:
             processor = PostProcessor.load(obj.PostProcessor)
@@ -659,7 +668,7 @@ class ObjectJob:
 
     def execute(self, obj):
         if getattr(obj, "Operations", None):
-            #obj.Path = obj.Operations.Path
+            # obj.Path = obj.Operations.Path
             self.getCycleTime()
 
     def getCycleTime(self):

--- a/src/Mod/Path/PathScripts/PathPreferences.py
+++ b/src/Mod/Path/PathScripts/PathPreferences.py
@@ -24,12 +24,15 @@ import FreeCAD
 import glob
 import os
 import PathScripts.PathLog as PathLog
+from PySide.QtGui import QMessageBox
 
 if False:
     PathLog.setLevel(PathLog.Level.DEBUG, PathLog.thisModule())
     PathLog.trackModule(PathLog.thisModule())
 else:
     PathLog.setLevel(PathLog.Level.INFO, PathLog.thisModule())
+
+translate = FreeCAD.Qt.translate
 
 DefaultFilePath = "DefaultFilePath"
 DefaultJobTemplate = "DefaultJobTemplate"
@@ -182,6 +185,16 @@ def toolsStoreAbsolutePaths():
 
 def setToolsSettings(legacy, relative):
     pref = preferences()
+    if legacy:
+        msgBox = QMessageBox()
+        msgBox.setIcon(QMessageBox.Warning)
+        msgBox.setText(
+            translate(
+                "Path",
+                "Legacy tools are deprecated. They will be removed after version 0.20",
+            )
+        )
+        msgBox.exec_()
     pref.SetBool(UseLegacyTools, legacy)
     pref.SetBool(UseAbsoluteToolPaths, relative)
     # pref.SetBool(OpenLastLibrary, lastlibrary)


### PR DESCRIPTION
Warn user if opening job that contains legacy tools or enabling legacy tools
Legacy tools are deprecated and will be removed after v 0.20


- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [x]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the issue ID number from our [Issues database](https://github.com/FreeCAD/FreeCAD/issues) in case a particular commit solves or is related to an existing issue. Ex: `Draft: fix typos - fixes #4805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
