### PR TITLE
Path: Fix roughly equal depth entries

### DIFF
--- a/src/Mod/Path/PathScripts/PathUtils.py
+++ b/src/Mod/Path/PathScripts/PathUtils.py
@@ -737,50 +737,59 @@ class depth_params(object):
         to be removed, so as to eliminate an effective step-down depth with the removal
         of repetitive roughly-equal values."""
 
-        if len(depths) == 2:
-            if PathGeom.isRoughly(depths[0], depths[1]):
-                return [depths[1]]
-            return depths
+        depthcopy = depths.copy()  #make a copy so we don't touch original
+        depthcopy.reverse()  # reverse it low to high
+        keep = [depthcopy[0]]  # initialize keep list with first element
+        for depth in depthcopy[1:]:  # iterate the list from second element on
+            if not PathGeom.isRoughly(depth, keep[-1]):  #Compare each to the last kept item
+                keep.append(depth)  # if different, add to keep
+        keep.reverse()  # reverse results back high to low
+        return keep
 
-        # print("raw depths: {}".format(depths))
+        # if len(depths) == 2:
+        #     if PathGeom.isRoughly(depths[0], depths[1]):
+        #         return [depths[1]]
+        #     return depths
 
-        uniqueDepths = depths
-        lastDepth = None
-        maxLoops = 0
-        while maxLoops < 10:
-            # print("\nStart scan... uniqueDepths: {}".format(uniqueDepths))
-            stop = True
-            keep = []
-            # Filter out unique values from consecutive pairs
-            for i in range(0, len(uniqueDepths) - 1):
-                dep1 = uniqueDepths[i]
-                dep2 = uniqueDepths[i + 1]
-                # print("comparing: {} and {}".format(dep1, dep2))
-                # print("lastDepth: {}".format(lastDepth))
+        # # print("raw depths: {}".format(depths))
 
-                if PathGeom.isRoughly(dep1, dep2):
-                    if PathGeom.isRoughly(lastDepth, dep2):
-                        keep.pop()
-                    keep.append(dep2)
-                    # Cycle again if a roughly-equal pair is found
-                    stop = False
-                else:
-                    if lastDepth is None:
-                        keep.append(dep1)
-                    else:
-                        if not PathGeom.isRoughly(lastDepth, dep1):
-                            keep.append(dep1)
-                    keep.append(dep2)
+        # uniqueDepths = depths
+        # lastDepth = None
+        # maxLoops = 0
+        # while maxLoops < 10:
+        #     # print("\nStart scan... uniqueDepths: {}".format(uniqueDepths))
+        #     stop = True
+        #     keep = []
+        #     # Filter out unique values from consecutive pairs
+        #     for i in range(0, len(uniqueDepths) - 1):
+        #         dep1 = uniqueDepths[i]
+        #         dep2 = uniqueDepths[i + 1]
+        #         # print("comparing: {} and {}".format(dep1, dep2))
+        #         # print("lastDepth: {}".format(lastDepth))
 
-                lastDepth = dep2
-            # Efor
-            uniqueDepths = keep
-            maxLoops += 1
-            if stop:
-                break
+        #         if PathGeom.isRoughly(dep1, dep2):
+        #             if PathGeom.isRoughly(lastDepth, dep2):
+        #                 keep.pop()
+        #             keep.append(dep2)
+        #             # Cycle again if a roughly-equal pair is found
+        #             stop = False
+        #         else:
+        #             if lastDepth is None:
+        #                 keep.append(dep1)
+        #             else:
+        #                 if not PathGeom.isRoughly(lastDepth, dep1):
+        #                     keep.append(dep1)
+        #             keep.append(dep2)
 
-        # print("uniqueDepths: {}".format(uniqueDepths))
-        return uniqueDepths
+        #         lastDepth = dep2
+        #     # Efor
+        #     uniqueDepths = keep
+        #     maxLoops += 1
+        #     if stop:
+        #         break
+
+        # # print("uniqueDepths: {}".format(uniqueDepths))
+        # return uniqueDepths
 
     def __equal_steps(self, start, stop, max_size):
         """returns a list of depths beginning with the bottom (included), ending

--- a/src/Mod/Path/PathScripts/PathUtils.py
+++ b/src/Mod/Path/PathScripts/PathUtils.py
@@ -609,11 +609,7 @@ class depth_params(object):
         self.__step_down = math.fabs(step_down)
         self.__z_finish_step = math.fabs(z_finish_step)
         self.__final_depth = final_depth
-        self.__user_depths = (
-            None
-            if user_depths is None
-            else self.__filter_roughly_equal_depths(user_depths)
-        )
+        self.__user_depths = user_depths
         self.data = self.__get_depths(equalstep=equalstep)
         self.index = 0
 
@@ -737,59 +733,13 @@ class depth_params(object):
         to be removed, so as to eliminate an effective step-down depth with the removal
         of repetitive roughly-equal values."""
 
-        depthcopy = depths.copy()  #make a copy so we don't touch original
-        depthcopy.reverse()  # reverse it low to high
-        keep = [depthcopy[0]]  # initialize keep list with first element
-        for depth in depthcopy[1:]:  # iterate the list from second element on
-            if not PathGeom.isRoughly(depth, keep[-1]):  #Compare each to the last kept item
-                keep.append(depth)  # if different, add to keep
+        depthcopy = sorted(depths)  # make a copy and sort low to high
+        keep = [depthcopy[0]]
+        for depth in depthcopy[1:]:
+            if not PathGeom.isRoughly(depth, keep[-1]):
+                keep.append(depth)
         keep.reverse()  # reverse results back high to low
         return keep
-
-        # if len(depths) == 2:
-        #     if PathGeom.isRoughly(depths[0], depths[1]):
-        #         return [depths[1]]
-        #     return depths
-
-        # # print("raw depths: {}".format(depths))
-
-        # uniqueDepths = depths
-        # lastDepth = None
-        # maxLoops = 0
-        # while maxLoops < 10:
-        #     # print("\nStart scan... uniqueDepths: {}".format(uniqueDepths))
-        #     stop = True
-        #     keep = []
-        #     # Filter out unique values from consecutive pairs
-        #     for i in range(0, len(uniqueDepths) - 1):
-        #         dep1 = uniqueDepths[i]
-        #         dep2 = uniqueDepths[i + 1]
-        #         # print("comparing: {} and {}".format(dep1, dep2))
-        #         # print("lastDepth: {}".format(lastDepth))
-
-        #         if PathGeom.isRoughly(dep1, dep2):
-        #             if PathGeom.isRoughly(lastDepth, dep2):
-        #                 keep.pop()
-        #             keep.append(dep2)
-        #             # Cycle again if a roughly-equal pair is found
-        #             stop = False
-        #         else:
-        #             if lastDepth is None:
-        #                 keep.append(dep1)
-        #             else:
-        #                 if not PathGeom.isRoughly(lastDepth, dep1):
-        #                     keep.append(dep1)
-        #             keep.append(dep2)
-
-        #         lastDepth = dep2
-        #     # Efor
-        #     uniqueDepths = keep
-        #     maxLoops += 1
-        #     if stop:
-        #         break
-
-        # # print("uniqueDepths: {}".format(uniqueDepths))
-        # return uniqueDepths
 
     def __equal_steps(self, start, stop, max_size):
         """returns a list of depths beginning with the bottom (included), ending

--- a/src/Mod/Path/PathTests/TestPathDepthParams.py
+++ b/src/Mod/Path/PathTests/TestPathDepthParams.py
@@ -43,7 +43,7 @@ class depthTestCases(unittest.TestCase):
         r = [i for i in d]
         self.assertListEqual(r, expected)
 
-    def test10(self):
+    def test001(self):
         """Stepping from zero to a negative depth"""
 
         args = {
@@ -62,7 +62,7 @@ class depthTestCases(unittest.TestCase):
         r = [i for i in d]
         self.assertListEqual(r, expected)
 
-    def test20(self):
+    def test002(self):
         """Start and end are equal or start lower than finish"""
 
         args = {
@@ -89,7 +89,7 @@ class depthTestCases(unittest.TestCase):
         r = [i for i in d]
         self.assertListEqual(r, expected)
 
-    def test30(self):
+    def test003(self):
         """User Parameters passed in"""
         args = {
             "clearance_height": 10,
@@ -107,7 +107,7 @@ class depthTestCases(unittest.TestCase):
         r = [i for i in d]
         self.assertListEqual(r, expected)
 
-    def test40(self):
+    def test004(self):
         """z_finish_step passed in."""
         args = {
             "clearance_height": 10,
@@ -125,7 +125,7 @@ class depthTestCases(unittest.TestCase):
         r = [i for i in d]
         self.assertListEqual(r, expected)
 
-    def test50(self):
+    def test005(self):
         """stepping down with equalstep=True"""
         args = {
             "clearance_height": 10,
@@ -144,7 +144,7 @@ class depthTestCases(unittest.TestCase):
         r = [i for i in d]
         self.assertListEqual(r, expected)
 
-    def test60(self):
+    def test006(self):
         """stepping down with equalstep=True and a finish depth"""
         args = {
             "clearance_height": 10,
@@ -162,7 +162,7 @@ class depthTestCases(unittest.TestCase):
         r = [i for i in d]
         self.assertListEqual(r, expected)
 
-    def test70(self):
+    def test007(self):
         """stepping down with stepdown greater than total depth"""
         args = {
             "clearance_height": 10,
@@ -180,7 +180,7 @@ class depthTestCases(unittest.TestCase):
         r = [i for i in d]
         self.assertListEqual(r, expected)
 
-    def test80(self):
+    def test008(self):
         """Test handling of negative step-down, negative finish step, and relative size of step/finish"""
 
         # negative steps should be converted to positive values
@@ -212,7 +212,7 @@ class depthTestCases(unittest.TestCase):
         }
         self.assertRaises(ValueError, PathUtils.depth_params, **args)
 
-    def test90(self):
+    def test009(self):
         """stepping down with single stepdown exactly equal to total depth"""
         args = {
             "clearance_height": 20.0,
@@ -232,7 +232,7 @@ class depthTestCases(unittest.TestCase):
             r, expected, "Expected {}, but result of {}".format(expected, r)
         )
 
-    def test100(self):
+    def test010(self):
         """stepping down with single stepdown roughly equal to total depth"""
         args = {
             "clearance_height": 20.0,
@@ -252,7 +252,7 @@ class depthTestCases(unittest.TestCase):
             r, expected, "Expected {}, but result of {}".format(expected, r)
         )
 
-    def test110(self):
+    def test011(self):
         """two custom user depths roughly equal to final depth"""
         args = {
             "clearance_height": 20.0,
@@ -272,7 +272,7 @@ class depthTestCases(unittest.TestCase):
             r, expected, "Expected {}, but result of {}".format(expected, r)
         )
 
-    def test120(self):
+    def test012(self):
         """four custom user depths with two roughly equal included"""
         args = {
             "clearance_height": 20.0,
@@ -292,7 +292,7 @@ class depthTestCases(unittest.TestCase):
             r, expected, "Expected {}, but result of {}".format(expected, r)
         )
 
-    def test130(self):
+    def test013(self):
         """five custom user depths with three roughly equal included"""
         args = {
             "clearance_height": 20.0,

--- a/src/Mod/Path/PathTests/TestPathDepthParams.py
+++ b/src/Mod/Path/PathTests/TestPathDepthParams.py
@@ -252,59 +252,15 @@ class depthTestCases(unittest.TestCase):
             r, expected, "Expected {}, but result of {}".format(expected, r)
         )
 
-    def test011(self):
-        """two custom user depths roughly equal to final depth"""
         args = {
             "clearance_height": 20.0,
             "safe_height": 15.0,
-            "start_depth": 9.0,
-            "step_down": 3.0,
+            "start_depth": 10.0,
+            "step_down": 9.9999999,
             "z_finish_step": 0.0,
             "final_depth": 0.0,
-            "user_depths": [0.00000001, 0.0],
+            "user_depths": None,
         }
-
-        expected = [0]
-
-        d = PathUtils.depth_params(**args)
-        r = [i for i in d]
-        self.assertListEqual(
-            r, expected, "Expected {}, but result of {}".format(expected, r)
-        )
-
-    def test012(self):
-        """four custom user depths with two roughly equal included"""
-        args = {
-            "clearance_height": 20.0,
-            "safe_height": 15.0,
-            "start_depth": 9.0,
-            "step_down": 3.0,
-            "z_finish_step": 0.0,
-            "final_depth": 0.0,
-            "user_depths": [6.0, 3.00000001, 3.0, 0.0],
-        }
-
-        expected = [6.0, 3.0, 0.0]
-
-        d = PathUtils.depth_params(**args)
-        r = [i for i in d]
-        self.assertListEqual(
-            r, expected, "Expected {}, but result of {}".format(expected, r)
-        )
-
-    def test013(self):
-        """five custom user depths with three roughly equal included"""
-        args = {
-            "clearance_height": 20.0,
-            "safe_height": 15.0,
-            "start_depth": 9.0,
-            "step_down": 3.0,
-            "z_finish_step": 0.0,
-            "final_depth": 0.0,
-            "user_depths": [6.0, 3.00000002, 3.00000001, 3.0, 0.0],
-        }
-
-        expected = [6.0, 3.0, 0.0]
 
         d = PathUtils.depth_params(**args)
         r = [i for i in d]

--- a/src/Mod/Path/PathTests/TestPathDepthParams.py
+++ b/src/Mod/Path/PathTests/TestPathDepthParams.py
@@ -211,3 +211,43 @@ class depthTestCases(unittest.TestCase):
             "user_depths": None,
         }
         self.assertRaises(ValueError, PathUtils.depth_params, **args)
+
+    def test90(self):
+        """stepping down with single stepdown exactly equal to total depth"""
+        args = {
+            "clearance_height": 20.0,
+            "safe_height": 15.0,
+            "start_depth": 10.0,
+            "step_down": 10.0,
+            "z_finish_step": 0.0,
+            "final_depth": 0.0,
+            "user_depths": None,
+        }
+
+        expected = [0]
+
+        d = PathUtils.depth_params(**args)
+        r = [i for i in d]
+        self.assertListEqual(
+            r, expected, "Expected {}, but result of {}".format(expected, r)
+        )
+
+    def test100(self):
+        """stepping down with single stepdown roughly equal to total depth"""
+        args = {
+            "clearance_height": 20.0,
+            "safe_height": 15.0,
+            "start_depth": 10.000000001,
+            "step_down": 10.0,
+            "z_finish_step": 0.0,
+            "final_depth": 0.0,
+            "user_depths": None,
+        }
+
+        expected = [0]
+
+        d = PathUtils.depth_params(**args)
+        r = [i for i in d]
+        self.assertListEqual(
+            r, expected, "Expected {}, but result of {}".format(expected, r)
+        )

--- a/src/Mod/Path/PathTests/TestPathDepthParams.py
+++ b/src/Mod/Path/PathTests/TestPathDepthParams.py
@@ -251,3 +251,63 @@ class depthTestCases(unittest.TestCase):
         self.assertListEqual(
             r, expected, "Expected {}, but result of {}".format(expected, r)
         )
+
+    def test110(self):
+        """two custom user depths roughly equal to final depth"""
+        args = {
+            "clearance_height": 20.0,
+            "safe_height": 15.0,
+            "start_depth": 9.0,
+            "step_down": 3.0,
+            "z_finish_step": 0.0,
+            "final_depth": 0.0,
+            "user_depths": [0.00000001, 0.0],
+        }
+
+        expected = [0]
+
+        d = PathUtils.depth_params(**args)
+        r = [i for i in d]
+        self.assertListEqual(
+            r, expected, "Expected {}, but result of {}".format(expected, r)
+        )
+
+    def test120(self):
+        """four custom user depths with two roughly equal included"""
+        args = {
+            "clearance_height": 20.0,
+            "safe_height": 15.0,
+            "start_depth": 9.0,
+            "step_down": 3.0,
+            "z_finish_step": 0.0,
+            "final_depth": 0.0,
+            "user_depths": [6.0, 3.00000001, 3.0, 0.0],
+        }
+
+        expected = [6.0, 3.0, 0.0]
+
+        d = PathUtils.depth_params(**args)
+        r = [i for i in d]
+        self.assertListEqual(
+            r, expected, "Expected {}, but result of {}".format(expected, r)
+        )
+
+    def test130(self):
+        """five custom user depths with three roughly equal included"""
+        args = {
+            "clearance_height": 20.0,
+            "safe_height": 15.0,
+            "start_depth": 9.0,
+            "step_down": 3.0,
+            "z_finish_step": 0.0,
+            "final_depth": 0.0,
+            "user_depths": [6.0, 3.00000002, 3.00000001, 3.0, 0.0],
+        }
+
+        expected = [6.0, 3.0, 0.0]
+
+        d = PathUtils.depth_params(**args)
+        r = [i for i in d]
+        self.assertListEqual(
+            r, expected, "Expected {}, but result of {}".format(expected, r)
+        )


### PR DESCRIPTION
Add code block to remove first of any two consecutive, roughly equal depth values (twin values).

Add two unit tests to support new code block and use cases.

This PR addresses an error in the `PathUtils.depth_params()` class that occurs when the total depth is roughly equal to a single stepdown.

Forum identification at [G-code generated twice. Why?](https://forum.freecadweb.org/viewtopic.php?f=15&t=67168&sid=818fe4ba0b7055ab736084b469599dd0).

Steps to reproduce:
* Create job with defaults.
* Create operation.
* Set Step Down value equal to total depth of cut (OpStartDepth - OpFinalDepth).
* Save operation.
* Inspect G-code for same operation, and note line count.  (This will produce one instance of the g-code.)
* Set Start Depth to say 0.00000001 mm more than existing entry (OpStartDepth + 0.00000001 mm).
* Save operation.
* Inspect G-code for same operation, and note increased line count.  (This will produce two stepdowns that are only about 0.00000001 mm  different - basically a copy of the single instance.)

Noting the difference in g-code line counts is easier with Adaptive because it throws in some comment lines as communication for the user.  However, this error exists with the other ops as well due to the use of the `PathUtils.depth_params()` class.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [x]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the issue ID number from our [Issues database](https://github.com/FreeCAD/FreeCAD/issues) in case a particular commit solves or is related to an existing issue. Ex: `Draft: fix typos - fixes #4805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
