### PR TITLE
[Macros] change text of Addons... button to Download to help new people

### DIFF
--- a/src/Gui/DlgMacroExecute.ui
+++ b/src/Gui/DlgMacroExecute.ui
@@ -279,6 +279,9 @@
          <property name="enabled">
           <bool>false</bool>
          </property>
+         <property name="toolTip">
+          <string>Launch a guide on how to set up a macro in a custom global toolbar.</string>
+         </property>
          <property name="text">
           <string>Toolbar</string>
          </property>
@@ -302,8 +305,11 @@
          <property name="enabled">
           <bool>true</bool>
          </property>
+         <property name="toolTip">
+          <string>Open Addon Manager where macros created by the community and other addons can be downloaded.</string>
+         </property>
          <property name="text">
-          <string>Addons...</string>
+          <string>Download</string>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
It may not be immediately clear to some newbies that the Addons... button is used to download macros. Suggested among the flame war in https://forum.freecadweb.org/viewtopic.php?p=580097#p580083
also added a couple of tooltips, the rest of the buttons are self explanatory IMO so I didn't add tooltips.