### PR TITLE
Avoid writing temporary cache files from ply.yacc

### DIFF
--- a/src/Mod/Fem/femtools/tokrules.py
+++ b/src/Mod/Fem/femtools/tokrules.py
@@ -153,4 +153,4 @@ def p_error(p):
 
 
 import ply.yacc as yacc
-yacc.yacc()
+yacc.yacc(debug=False, write_tables=False)

--- a/src/Mod/OpenSCAD/importCSG.py
+++ b/src/Mod/OpenSCAD/importCSG.py
@@ -35,7 +35,6 @@ printverbose = False
 import FreeCAD
 import io
 import os
-import tempfile
 
 import ply.lex as lex
 import ply.yacc as yacc
@@ -178,9 +177,9 @@ def processcsg(filename):
 
     # Build the parser
     if printverbose: print('Load Parser')
-    # No debug out otherwise Linux has protection exception
-    temp = tempfile.gettempdir()
-    parser = yacc.yacc(debug=False,outputdir=temp)
+    # Disable generation of debug ('parser.out') and table cache ('parsetab.py'),
+    # as it requires a writable location
+    parser = yacc.yacc(debug=False, write_tables=False)
     if printverbose: print('Parser Loaded')
     # Give the lexer some input
     #f=open('test.scad', 'r')


### PR DESCRIPTION
Writing the parsetab.py cache file provides no measurable benefit, but causes several problems, so turn it off.

Also omit the generation of any debug output files.

Fixes #6315. 

- [ ]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [x]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [x]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the issue ID number from our [Issues database](https://github.com/FreeCAD/FreeCAD/issues) in case a particular commit solves or is related to an existing issue. Ex: `Draft: fix typos - fixes #4805`

---
