### PR TITLE
AddonManager: remove superfluous 'pass' per LGTM

### DIFF
--- a/src/Mod/AddonManager/addonmanager_workers.py
+++ b/src/Mod/AddonManager/addonmanager_workers.py
@@ -338,7 +338,6 @@ class LoadPackagesFromCacheWorker(QtCore.QThread):
                             FreeCAD.Console.PrintLog(
                                 f"Failed loading {repo_metadata_cache_path}\n"
                             )
-                            pass
                     self.addon_repo.emit(repo)
 
 


### PR DESCRIPTION
ref: https://lgtm.com/rules/910088/
