### PR TITLE
[FEM] Refactor `TaskFemConstraintOnBoundary`

### DIFF
--- a/src/Mod/Fem/Gui/TaskFemConstraintDisplacement.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintDisplacement.cpp
@@ -154,10 +154,8 @@ TaskFemConstraintDisplacement::TaskFemConstraintDisplacement(ViewProviderFemCons
     connect(ui->rotzfree, SIGNAL(stateChanged(int)), this, SLOT(rotfreez(int)));
 
     //Selection buttons
-    connect(ui->btnAdd, SIGNAL(toggled(bool)),
-            this, SLOT(_addToSelection(bool)));
-    connect(ui->btnRemove, SIGNAL(toggled(bool)),
-            this, SLOT(_removeFromSelection(bool)));
+    buttonGroup->addButton(ui->btnAdd, (int)SelectionChangeModes::refAdd);
+    buttonGroup->addButton(ui->btnRemove, (int)SelectionChangeModes::refRemove);
 
     updateUI();
 }

--- a/src/Mod/Fem/Gui/TaskFemConstraintFixed.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintFixed.cpp
@@ -80,10 +80,8 @@ TaskFemConstraintFixed::TaskFemConstraintFixed(ViewProviderFemConstraintFixed* C
     }
 
     //Selection buttons
-    connect(ui->btnAdd, SIGNAL(toggled(bool)),
-            this, SLOT(_addToSelection(bool)));
-    connect(ui->btnRemove, SIGNAL(toggled(bool)),
-            this, SLOT(_removeFromSelection(bool)));
+    buttonGroup->addButton(ui->btnAdd, (int)SelectionChangeModes::refAdd);
+    buttonGroup->addButton(ui->btnRemove, (int)SelectionChangeModes::refRemove);
 
     updateUI();
 }

--- a/src/Mod/Fem/Gui/TaskFemConstraintFluidBoundary.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintFluidBoundary.cpp
@@ -165,10 +165,8 @@ TaskFemConstraintFluidBoundary::TaskFemConstraintFluidBoundary(ViewProviderFemCo
     ui->checkReverse->blockSignals(true);
 
     //Selection buttons
-    connect(ui->btnAdd, SIGNAL(toggled(bool)),
-            this, SLOT(_addToSelection(bool)));
-    connect(ui->btnRemove, SIGNAL(toggled(bool)),
-            this, SLOT(_removeFromSelection(bool)));
+    buttonGroup->addButton(ui->btnAdd, (int)SelectionChangeModes::refAdd);
+    buttonGroup->addButton(ui->btnRemove, (int)SelectionChangeModes::refRemove);
 
     // Get the feature data
     Fem::ConstraintFluidBoundary* pcConstraint = static_cast<Fem::ConstraintFluidBoundary*>(ConstraintView->getObject());

--- a/src/Mod/Fem/Gui/TaskFemConstraintForce.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintForce.cpp
@@ -106,10 +106,8 @@ TaskFemConstraintForce::TaskFemConstraintForce(ViewProviderFemConstraintForce* C
     ui->checkReverse->blockSignals(false);
 
     //Selection buttons
-    connect(ui->btnAdd, SIGNAL(toggled(bool)),
-            this, SLOT(_addToSelection(bool)));
-    connect(ui->btnRemove, SIGNAL(toggled(bool)),
-            this, SLOT(_removeFromSelection(bool)));
+    buttonGroup->addButton(ui->btnAdd, (int)SelectionChangeModes::refAdd);
+    buttonGroup->addButton(ui->btnRemove, (int)SelectionChangeModes::refRemove);
 
     updateUI();
 }

--- a/src/Mod/Fem/Gui/TaskFemConstraintHeatflux.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintHeatflux.cpp
@@ -117,10 +117,8 @@ TaskFemConstraintHeatflux::TaskFemConstraintHeatflux(ViewProviderFemConstraintHe
     }
 
     //Selection buttons
-    connect(ui->btnAdd, SIGNAL(toggled(bool)),
-            this, SLOT(_addToSelection(bool)));
-    connect(ui->btnRemove, SIGNAL(toggled(bool)),
-            this, SLOT(_removeFromSelection(bool)));
+    buttonGroup->addButton(ui->btnAdd, (int)SelectionChangeModes::refAdd);
+    buttonGroup->addButton(ui->btnRemove, (int)SelectionChangeModes::refRemove);
 
     ui->if_ambienttemp->blockSignals(false);
     //ui->if_facetemp->blockSignals(false);

--- a/src/Mod/Fem/Gui/TaskFemConstraintOnBoundary.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintOnBoundary.cpp
@@ -45,41 +45,33 @@ TaskFemConstraintOnBoundary::~TaskFemConstraintOnBoundary()
 
 void TaskFemConstraintOnBoundary::_addToSelection(bool checked)
 {
+    Gui::Selection().clearSelection();
+
     if (checked)
     {
-        const auto& selection = Gui::Selection().getSelectionEx(); //gets vector of selected objects of active document
-        if (selection.empty()) {
-            this->clearButtons(SelectionChangeModes::refAdd);
-            selChangeMode = SelectionChangeModes::refAdd;
-            ConstraintView->highlightReferences(true);
-        }
-        else {
-            this->addToSelection();
-            clearButtons(SelectionChangeModes::none);
-        }
+        this->clearButtons(SelectionChangeModes::refAdd);
+        selChangeMode = SelectionChangeModes::refAdd;
+        ConstraintView->highlightReferences(true);
     }
     else {
-        exitSelectionChangeMode();
+        if (selChangeMode == SelectionChangeModes::refAdd)
+            selChangeMode = SelectionChangeModes::none;
     }
 }
 
 void TaskFemConstraintOnBoundary::_removeFromSelection(bool checked)
 {
+    Gui::Selection().clearSelection();
+
     if (checked)
     {
-        const auto& selection = Gui::Selection().getSelectionEx(); //gets vector of selected objects of active document
-        if (selection.empty()) {
-            this->clearButtons(SelectionChangeModes::refRemove);
-            selChangeMode = SelectionChangeModes::refRemove;
-            ConstraintView->highlightReferences(true);
-        }
-        else {
-            this->removeFromSelection();
-            clearButtons(SelectionChangeModes::none);
-        }
+        this->clearButtons(SelectionChangeModes::refRemove);
+        selChangeMode = SelectionChangeModes::refRemove;
+        ConstraintView->highlightReferences(true);
     }
     else {
-        exitSelectionChangeMode();
+        if (selChangeMode == SelectionChangeModes::refRemove)
+            selChangeMode = SelectionChangeModes::none;
     }
 }
 
@@ -102,12 +94,6 @@ void TaskFemConstraintOnBoundary::onSelectionChanged(const Gui::SelectionChanges
         }
         ConstraintView->highlightReferences(true);
     }
-}
-
-void TaskFemConstraintOnBoundary::exitSelectionChangeMode()
-{
-    selChangeMode = SelectionChangeModes::none;
-    Gui::Selection().clearSelection();
 }
 
 #include "moc_TaskFemConstraintOnBoundary.cpp"

--- a/src/Mod/Fem/Gui/TaskFemConstraintOnBoundary.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintOnBoundary.cpp
@@ -35,6 +35,12 @@ TaskFemConstraintOnBoundary::TaskFemConstraintOnBoundary(ViewProviderFemConstrai
     , selChangeMode(SelectionChangeModes::none)
 {
     ConstraintView->highlightReferences(true);
+
+    buttonGroup = new ButtonGroup(this);
+    buttonGroup->setExclusive(true);
+
+    connect(buttonGroup, qOverload<QAbstractButton *, bool>(&QButtonGroup::buttonToggled),
+            this, &TaskFemConstraintOnBoundary::onButtonToggled);
 }
 
 TaskFemConstraintOnBoundary::~TaskFemConstraintOnBoundary()
@@ -42,35 +48,19 @@ TaskFemConstraintOnBoundary::~TaskFemConstraintOnBoundary()
     if (!ConstraintView.expired())
         ConstraintView->highlightReferences(false);
 }
-
-void TaskFemConstraintOnBoundary::_addToSelection(bool checked)
+void TaskFemConstraintOnBoundary::onButtonToggled(QAbstractButton *button, bool checked)
 {
+    auto mode = static_cast<SelectionChangeModes>(buttonGroup->id(button));
+
     Gui::Selection().clearSelection();
 
     if (checked)
     {
-        this->clearButtons(SelectionChangeModes::refAdd);
-        selChangeMode = SelectionChangeModes::refAdd;
+        selChangeMode = mode;
         ConstraintView->highlightReferences(true);
     }
     else {
-        if (selChangeMode == SelectionChangeModes::refAdd)
-            selChangeMode = SelectionChangeModes::none;
-    }
-}
-
-void TaskFemConstraintOnBoundary::_removeFromSelection(bool checked)
-{
-    Gui::Selection().clearSelection();
-
-    if (checked)
-    {
-        this->clearButtons(SelectionChangeModes::refRemove);
-        selChangeMode = SelectionChangeModes::refRemove;
-        ConstraintView->highlightReferences(true);
-    }
-    else {
-        if (selChangeMode == SelectionChangeModes::refRemove)
+        if (selChangeMode == mode)
             selChangeMode = SelectionChangeModes::none;
     }
 }

--- a/src/Mod/Fem/Gui/TaskFemConstraintOnBoundary.h
+++ b/src/Mod/Fem/Gui/TaskFemConstraintOnBoundary.h
@@ -63,7 +63,6 @@ protected:
     enum class SelectionChangeModes {none, refAdd, refRemove};
     virtual void onSelectionChanged(const Gui::SelectionChanges&) override;
     virtual void clearButtons(const SelectionChangeModes notThis) = 0;
-    void exitSelectionChangeMode();
 
 protected:
     enum SelectionChangeModes selChangeMode;

--- a/src/Mod/Fem/Gui/TaskFemConstraintOnBoundary.h
+++ b/src/Mod/Fem/Gui/TaskFemConstraintOnBoundary.h
@@ -28,6 +28,7 @@
 #include <Gui/TaskView/TaskView.h>
 #include <Gui/Selection.h>
 #include <Gui/TaskView/TaskDialog.h>
+#include <Gui/Widgets.h>
 #include <Base/Quantity.h>
 
 #include "TaskFemConstraint.h"
@@ -54,9 +55,8 @@ public:
     ~TaskFemConstraintOnBoundary();
 
 protected Q_SLOTS:
-    void _addToSelection(bool checked);
+    void onButtonToggled(QAbstractButton *button, bool checked);
     virtual void addToSelection() = 0;
-    void _removeFromSelection(bool checked);
     virtual void removeFromSelection() = 0;
 
 protected:
@@ -66,6 +66,7 @@ protected:
 
 protected:
     enum SelectionChangeModes selChangeMode;
+    Gui::ButtonGroup *buttonGroup;
 };
 
 } // namespace FemGui

--- a/src/Mod/Fem/Gui/TaskFemConstraintPressure.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintPressure.cpp
@@ -89,10 +89,8 @@ TaskFemConstraintPressure::TaskFemConstraintPressure(ViewProviderFemConstraintPr
     }
 
     //Selection buttons
-    connect(ui->btnAdd, SIGNAL(toggled(bool)),
-            this, SLOT(_addToSelection(bool)));
-    connect(ui->btnRemove, SIGNAL(toggled(bool)),
-            this, SLOT(_removeFromSelection(bool)));
+    buttonGroup->addButton(ui->btnAdd, (int)SelectionChangeModes::refAdd);
+    buttonGroup->addButton(ui->btnRemove, (int)SelectionChangeModes::refRemove);
 
     updateUI();
 }

--- a/src/Mod/Fem/Gui/TaskFemConstraintSpring.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintSpring.cpp
@@ -92,10 +92,8 @@ TaskFemConstraintSpring::TaskFemConstraintSpring(ViewProviderFemConstraintSpring
     }
 
     //Selection buttons
-    connect(ui->btnAdd, SIGNAL(toggled(bool)),
-            this, SLOT(_addToSelection(bool)));
-    connect(ui->btnRemove, SIGNAL(toggled(bool)),
-            this, SLOT(_removeFromSelection(bool)));
+    buttonGroup->addButton(ui->btnAdd, (int)SelectionChangeModes::refAdd);
+    buttonGroup->addButton(ui->btnRemove, (int)SelectionChangeModes::refRemove);
 
     updateUI();
 }

--- a/src/Mod/Fem/Gui/TaskFemConstraintTemperature.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintTemperature.cpp
@@ -106,10 +106,8 @@ TaskFemConstraintTemperature::TaskFemConstraintTemperature(ViewProviderFemConstr
     }
 
     //Selection buttons
-    connect(ui->btnAdd, SIGNAL(toggled(bool)),
-            this, SLOT(_addToSelection(bool)));
-    connect(ui->btnRemove, SIGNAL(toggled(bool)),
-            this, SLOT(_removeFromSelection(bool)));
+    buttonGroup->addButton(ui->btnAdd, (int)SelectionChangeModes::refAdd);
+    buttonGroup->addButton(ui->btnRemove, (int)SelectionChangeModes::refRemove);
 
     updateUI();
 }


### PR DESCRIPTION
Now the behavior is (slightly more) consistent with behavior of PD fillets, for example.
See https://forum.freecadweb.org/viewtopic.php?f=18&t=67135#p580192. In the
future it may be possible to reuse some code from there.

What isn't yet implemented:
- If opening a constraint with selection, the constraint is not applied to that selection already. I expect this will need to be done for each of the subclasses. Or possibly it can be done in the superclass itself with some NVI?
- The last element can be deleted. We may want to keep this behavior in case the user wants to select, say, edges when some faces are already selected.