### PR TITLE
Arch: When inverting hinge position, keep opening direction

### DIFF
--- a/src/Mod/Arch/ArchWindow.py
+++ b/src/Mod/Arch/ArchWindow.py
@@ -1232,6 +1232,9 @@ class _ViewProviderWindow(ArchComponent.ViewProviderComponent):
 
         pairs = [["Edge6","Edge8"],["Edge5","Edge7"]]
         self.invertPairs(pairs)
+        # Also invert opening direction, so the door still opens towards
+        # the same side of the wall
+        self.invertOpening()
 
     def invertPairs(self,pairs):
 


### PR DESCRIPTION
Previously, just the hinge position was changed, with the rotation
direction kept unchanged, which would make the door open towards the
other side of the wall. This also inverts the rotation direction, so the
door still opens toward the same side of the wall, which is more
intuitively what you would expect.

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [ ]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [x]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  ~~Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the issue ID number from our [Issues database](https://github.com/FreeCAD/FreeCAD/issues) in case a particular commit solves or is related to an existing issue. Ex: `Draft: fix typos - fixes #4805`~~