### PR TITLE
[Gui] remove Python.h from PreCompiled.h

### DIFF
--- a/src/Gui/PreCompiled.h
+++ b/src/Gui/PreCompiled.h
@@ -94,9 +94,6 @@
 #include <boost/program_options.hpp>
 #include <boost/utility.hpp>
 
-// Python
-#include <Python.h>
-
 // Xerces
 #include <xercesc/util/TranscodingException.hpp>
 #include <xercesc/util/XMLString.hpp>


### PR DESCRIPTION
tested with PCH and it seems it is really not necessary. python.h is only used n one header in [Gui] and not relevant for PCH