### PR TITLE
Fix Arch Panel Trapezoidal Wave Width 

### DIFF
--- a/src/Mod/Arch/ArchPanel.py
+++ b/src/Mod/Arch/ArchPanel.py
@@ -654,7 +654,7 @@ class _Panel(ArchComponent.Component):
                     upsegment = Part.makePolygon([p1,p2,p3,p4,p5])
                     if not downsegment:
                         a = ((p1.sub(p2)).getAngle(p3.sub(p2)))/2
-                        tx = obj.Thickness.Value*math.tan(a)
+                        tx = obj.Thickness.Value/math.tan(a)
                         d1 = Vector(tx,0,-obj.Thickness.Value)
                         d2 = Vector(-tx,0,-obj.Thickness.Value)
                         p6 = p1.add(d1)


### PR DESCRIPTION
[Arch] Fixes Panel Width of Trapezoidal Wave. 

When adding Trapezoidal waves in an Arch Panel, the width of the wave was not the same as the one defined on the properties throughout the entire panel, there are zones that are created wider. 

This Bug was discussed in :
https://forum.freecadweb.org/viewtopic.php?f=23&t=67234&p=581570#p581570
---
