### PR TITLE
Path: Block operation recompute on task panel cancel [Bug]

### DIFF
--- a/src/Mod/Path/PathScripts/PathDressupAxisMap.py
+++ b/src/Mod/Path/PathScripts/PathDressupAxisMap.py
@@ -109,6 +109,10 @@ class ObjectDressup:
 
     def execute(self, obj):
 
+        if PathUtils.isDressupCancelled(obj):
+            PathLog.debug("Axis Map Dressup cancelled")
+            return
+
         inAxis = obj.AxisMap[0]
         outAxis = obj.AxisMap[3]
         d = 0.1
@@ -176,6 +180,8 @@ class TaskPanel:
 
     def reject(self):
         FreeCAD.ActiveDocument.abortTransaction()
+        # Set flag to cancel dressup execution
+        PathUtils.cancelExecution(self.obj.Name)
         FreeCADGui.Control.closeDialog()
         FreeCAD.ActiveDocument.recompute()
 

--- a/src/Mod/Path/PathScripts/PathDressupDogbone.py
+++ b/src/Mod/Path/PathScripts/PathDressupDogbone.py
@@ -887,6 +887,10 @@ class ObjectDressup(object):
         return commands, bones
 
     def execute(self, obj, forReal=True):
+        if PathUtils.isDressupCancelled(obj):
+            PathLog.debug("Dogbone Dressup cancelled")
+            return
+
         if not obj.Base:
             return
         if forReal and not obj.Base.isDerivedFrom("Path::Feature"):
@@ -1133,6 +1137,8 @@ class TaskPanel(object):
 
     def reject(self):
         FreeCAD.ActiveDocument.abortTransaction()
+        # Set flag to cancel dressup execution
+        PathUtils.cancelExecution(self.obj.Name)
         FreeCADGui.Control.closeDialog()
         FreeCAD.ActiveDocument.recompute()
         FreeCADGui.Selection.removeObserver(self.s)

--- a/src/Mod/Path/PathScripts/PathDressupDragknife.py
+++ b/src/Mod/Path/PathScripts/PathDressupDragknife.py
@@ -373,6 +373,10 @@ class ObjectDressup:
         return (results, replace)
 
     def execute(self, obj):
+        if PathUtils.isDressupCancelled(obj):
+            # PathLog.debug("Dragknife Dressup cancelled")  # PathLog module unavailable
+            return
+
         newpath = []
         global currLocation
 
@@ -512,6 +516,8 @@ class TaskPanel:
 
     def reject(self):
         FreeCAD.ActiveDocument.abortTransaction()
+        # Set flag to cancel dressup execution
+        PathUtils.cancelExecution(self.obj.Name)
         FreeCADGui.Control.closeDialog()
         FreeCAD.ActiveDocument.recompute()
 

--- a/src/Mod/Path/PathScripts/PathDressupHoldingTags.py
+++ b/src/Mod/Path/PathScripts/PathDressupHoldingTags.py
@@ -1230,6 +1230,10 @@ class ObjectTagDressup:
         return (tags, positions, disabled)
 
     def execute(self, obj):
+        if PathUtils.isDressupCancelled(obj):
+            PathLog.debug("Holding Tags Dressup cancelled")
+            return
+
         # import cProfile
         # pr = cProfile.Profile()
         # pr.enable()

--- a/src/Mod/Path/PathScripts/PathDressupLeadInOut.py
+++ b/src/Mod/Path/PathScripts/PathDressupLeadInOut.py
@@ -179,6 +179,10 @@ class ObjectDressup:
         obj.IncludeLayers = True
 
     def execute(self, obj):
+        if PathUtils.isDressupCancelled(obj):
+            PathLog.debug("LeadInOut Dressup cancelled")
+            return
+
         if not obj.Base:
             return
         if not obj.Base.isDerivedFrom("Path::Feature"):
@@ -633,6 +637,21 @@ class ObjectDressup:
 class TaskDressupLeadInOut(SimpleEditPanel):
     _transaction_name = "Edit LeadInOut Dress-up"
     _ui_file = ":/panels/DressUpLeadInOutEdit.ui"
+
+    def abort(self):
+        """abort() overwritten here to include task panel cancel action"""
+        FreeCAD.ActiveDocument.abortTransaction()
+        # Set flag to cancel dressup execution
+        PathUtils.cancelExecution(self.obj.Name)
+        self.cleanup(True)
+
+    def reject(self):
+        """reject() overwritten here to include task panel cancel action"""
+        FreeCAD.ActiveDocument.abortTransaction()
+        # Set flag to cancel dressup execution
+        PathUtils.cancelExecution(self.obj.Name)
+        FreeCADGui.Control.closeDialog()
+        FreeCAD.ActiveDocument.recompute()
 
     def setupUi(self):
         self.connectWidget("LeadIn", self.form.chkLeadIn)

--- a/src/Mod/Path/PathScripts/PathDressupPathBoundary.py
+++ b/src/Mod/Path/PathScripts/PathDressupPathBoundary.py
@@ -103,6 +103,10 @@ class DressupPathBoundary(object):
         return True
 
     def execute(self, obj):
+        if PathUtils.isDressupCancelled(obj):
+            PathLog.debug("Boundary Dressup cancelled")
+            return
+
         pb = PathBoundary(obj.Base, obj.Stock.Shape, obj.Inside)
         obj.Path = pb.execute()
 

--- a/src/Mod/Path/PathScripts/PathDressupPathBoundaryGui.py
+++ b/src/Mod/Path/PathScripts/PathDressupPathBoundaryGui.py
@@ -36,6 +36,7 @@ else:
 
 
 translate = FreeCAD.Qt.translate
+PathUtils = PathDressupPathBoundary.PathUtils
 
 
 class TaskPanel(object):
@@ -88,6 +89,8 @@ class TaskPanel(object):
 
     def reject(self):
         FreeCAD.ActiveDocument.abortTransaction()
+        # Set flag to cancel dressup execution
+        PathUtils.cancelExecution(self.obj.Name)
         self.cleanup(True)
 
     def accept(self):

--- a/src/Mod/Path/PathScripts/PathDressupTagGui.py
+++ b/src/Mod/Path/PathScripts/PathDressupTagGui.py
@@ -69,7 +69,7 @@ class PathDressupTagTaskPanel:
             self.jvoVisible = jvoVisibility
         self.pt = FreeCAD.Vector(0, 0, 0)
 
-        self.isDirty = True
+        self.isDirty = False  # True
         self.buttonBox = None
         self.tags = None
         self.Positions = None
@@ -95,10 +95,16 @@ class PathDressupTagTaskPanel:
 
     def abort(self):
         FreeCAD.ActiveDocument.abortTransaction()
+        if self.isDirty:
+            # Set flag to cancel dressup execution
+            PathUtils.cancelExecution(self.obj.Name)
         self.cleanup(False)
 
     def reject(self):
         FreeCAD.ActiveDocument.abortTransaction()
+        if self.isDirty:
+            # Set flag to cancel dressup execution
+            PathUtils.cancelExecution(self.obj.Name)
         self.cleanup(True)
 
     def accept(self):

--- a/src/Mod/Path/PathScripts/PathDressupZCorrect.py
+++ b/src/Mod/Path/PathScripts/PathDressupZCorrect.py
@@ -154,6 +154,10 @@ class ObjectDressup:
 
     def execute(self, obj):
 
+        if PathUtils.isDressupCancelled(obj):
+            PathLog.debug("Z Correct Dressup cancelled")
+            return
+
         sampleD = obj.SegInterpolate.Value
         curveD = obj.ArcInterpolate.Value
 
@@ -237,6 +241,8 @@ class TaskPanel:
 
     def reject(self):
         FreeCAD.ActiveDocument.abortTransaction()
+        # Set flag to cancel dressup execution
+        PathUtils.cancelExecution(self.obj.Name)
         FreeCADGui.Control.closeDialog()
         FreeCAD.ActiveDocument.recompute()
 

--- a/src/Mod/Path/PathScripts/PathJob.py
+++ b/src/Mod/Path/PathScripts/PathJob.py
@@ -105,6 +105,7 @@ Notification = NotificationClass()
 
 class ObjectJob:
     def __init__(self, obj, models, templateFile=None):
+        FreeCAD.pathCancelExecution = []
         self.obj = obj
         self.tooltip = None
         self.tooltipArgs = None
@@ -483,6 +484,7 @@ class ObjectJob:
                     ops.Label = label
 
     def onDocumentRestored(self, obj):
+        FreeCAD.pathCancelExecution = []
         self.setupBaseModel(obj)
         self.fixupOperations(obj)
         self.setupSetupSheet(obj)

--- a/src/Mod/Path/PathScripts/PathJobGui.py
+++ b/src/Mod/Path/PathScripts/PathJobGui.py
@@ -620,6 +620,7 @@ class TaskPanel:
             self.obj, self.form.jobBox.widget(1)
         )
         self.name = self.obj.Name
+        self.doNotRecomputeOps = False
 
         vUnit = FreeCAD.Units.Quantity(1, FreeCAD.Units.Velocity).getUserPreferred()[2]
         self.form.toolControllerList.horizontalHeaderItem(1).setText("#")
@@ -725,6 +726,9 @@ class TaskPanel:
 
     def cleanup(self, resetEdit):
         PathLog.track()
+        if self.doNotRecomputeOps:
+            self.doNotRecomputeOps = False
+            PathUtils.cancelAllOps(self.obj)
         FreeCADGui.Control.closeDialog()
         if resetEdit:
             FreeCADGui.ActiveDocument.resetEdit()
@@ -1024,6 +1028,8 @@ class TaskPanel:
                     name=tool.Label, tool=tool, toolNumber=toolNum
                 )
                 self.obj.Proxy.addToolController(tc)
+                # Cancel recompute for all ops, since new tool controller does not affect ops
+                # self.doNotRecomputeOps = True
 
             FreeCAD.ActiveDocument.recompute()
             self.updateToolController()

--- a/src/Mod/Path/PathScripts/PathOp.py
+++ b/src/Mod/Path/PathScripts/PathOp.py
@@ -767,6 +767,10 @@ class ObjectOp(object):
         """
         PathLog.track()
 
+        if PathUtils.isOperationCancelled(obj):
+            PathLog.debug("Operation cancelled")
+            return
+
         if not obj.Active:
             path = Path.Path("(inactive operation)")
             obj.Path = path

--- a/src/Mod/Path/PathScripts/PathOpGui.py
+++ b/src/Mod/Path/PathScripts/PathOpGui.py
@@ -1211,6 +1211,9 @@ class TaskPanel(object):
             except Exception as ee:
                 PathLog.debug("{}\n".format(ee))
             FreeCAD.ActiveDocument.commitTransaction()
+        else:
+            PathUtils.cancelExecution(self.obj.Name)
+
         self.cleanup(resetEdit)
         return True
 

--- a/src/Mod/Path/PathScripts/PathUtils.py
+++ b/src/Mod/Path/PathScripts/PathUtils.py
@@ -848,7 +848,7 @@ def RtoIJ(startpoint, command):
 # Helper functions to manage cancellation of `execute()` method in ops and dressups
 def cancelAllOps(job):
     """cancelAllOps()... Method to flag all operations, including their bases, as cancelled for execution."""
-    PathLog.debug("doNotRecomputeOps")
+    # PathLog.debug("cancelAllOps()")
     if not hasattr(FreeCAD, "pathCancelExecution"):
         FreeCAD.pathCancelExecution = []
     for op in job.Proxy.allOperations():
@@ -864,12 +864,11 @@ def isOperationCancelled(obj):
             # Reset cancel flag if direct child of Operations group
             idx = cancelList.index(obj.Name)
             cancelList.pop(idx)
-        PathLog.info(f"{obj.Name} cancelled")
+        PathLog.debug(f"{obj.Name} cancelled")
         return True
 
     # Reset cancel names
     FreeCAD.pathCancelExecution = []
-    # PathLog.debug(f"{obj.Name} not cancelled")
     return False
 
 
@@ -907,7 +906,6 @@ def isDressupCancelled(obj):
 
         if not clearObjName and not replaceBaseName:
             PathLog.error(f"{obj.Name} intermediate dressup error")
-            print(f"{cancelList}")
             return False
 
     # Update `pathCancelExecution` list items
@@ -926,10 +924,9 @@ def isDressupCancelled(obj):
             cancel = True
 
     if cancel:
-        PathLog.debug(f"   {obj.Name} cancelled")
+        PathLog.debug(f"{obj.Name} cancelled")
         return True
 
-    # PathLog.debug(f"   {obj.Name} not cancelled")
     FreeCAD.pathCancelExecution = []  # Reset cancel names
     return False
 

--- a/src/Mod/Path/PathTests/TestPathDressupDogbone.py
+++ b/src/Mod/Path/PathTests/TestPathDressupDogbone.py
@@ -41,6 +41,7 @@ class TestProfile:
 class TestFeature:
     def __init__(self):
         self.Path = Path.Path()
+        self.Name = "TestFeature"
 
     def addProperty(self, typ, nam, category, tip):
         setattr(self, nam, None)


### PR DESCRIPTION
This fix applies to standard operations and most dressups.  I think that the fix applied here must be applied to all other ViewProvider enabled actions if the cancel button is to block a recompute for those actions.  The implementation is fairly simple.  This implementation is triggers the cancel only on the GUI side.  There is not really an intended use for cancelling recomputes in scripting or command-line usage of FreeCAD.

This fix effectively flags the `execute()` method of the Proxy to return prematurely before updating any `obj` properties, leaving the source `obj` unchanged from its state prior to the aborted edit transaction started and ended in the task panel.

This is a long-standing bug or nuisance, especially with the often long-lasting 3D Surface computations.

Forum mention at:
* [3Dsurface still recomputes on Cancel.](https://forum.freecadweb.org/viewtopic.php?f=15&t=67326&sid=29b613681f528b052ca058c458ee3c7b)
* [Problem on millface and adaptive clearance. Stops responding](https://forum.freecadweb.org/viewtopic.php?f=15&t=64753)
* [Paths falsely marked as altered.](https://forum.freecadweb.org/viewtopic.php?f=15&t=63993)
* [Couple of potential bugs...](https://forum.freecadweb.org/viewtopic.php?f=15&t=24881&start=20)

Again, this PR does not fix the issue for all actions in Path workbench, just the standard operations based on PathOp & PathOpGui modules.  Dressups and other actions will have to be fixed individually.

Thanks to @J-Dunn, @mlampert, and many others for mentioning this bug on numerous occasions.  I think this PR will be the beginning of the end for recomputes on cancel in task panels!

Steps to reproduce bug:
* Create a big part, or small part if you have 3D Surface active.
* Create an operation (3D Surface or Adaptive work great for this) that takes a while (10 - 30 seconds) to compute, and save it.
* Double click on the operation in the object tree to edit using the task panel.
* Make changes if you like and apply them, but that might take some time (haha!).  ... Or do not for this example.
* Click the Cancel button.
* The operation will recompute upon exiting the task panel.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [x]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the issue ID number from our [Issues database](https://github.com/FreeCAD/FreeCAD/issues) in case a particular commit solves or is related to an existing issue. Ex: `Draft: fix typos - fixes #4805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
