### PR TITLE
Gui: fix some weird behavior of number format option

### DIFF
--- a/src/Gui/Language/Translator.cpp
+++ b/src/Gui/Language/Translator.cpp
@@ -258,6 +258,10 @@ bool Translator::setLocale(const std::string& language) const
     if (!bcp47.empty())
         loc  = QLocale(QString::fromStdString(bcp47));
     QLocale::setDefault(loc);
+    // Need to manually send the event so locale change is fully took into account on widgets
+    auto ev = QEvent(QEvent::LocaleChange);
+    qApp->sendEvent(qApp, &ev);
+
 #ifdef FC_DEBUG
     Base::Console().Log("Locale changed to %s => %s\n", qPrintable(loc.bcp47Name()), qPrintable(loc.name()));
 #endif


### PR DESCRIPTION
Fixes problems seen on #6364 implementation

I should say that I didn't perfectly understand what was failing, but it seems that when using `QLocale::setDefault` after application has been started, the `LocaleChange` event isn't well propagated or handled.
Sending it manually afterwards solves the issue.