### PR TITLE
[PD] Helix: catch case of touching Helix

### DIFF
--- a/src/Mod/PartDesign/Gui/TaskHelixParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskHelixParameters.cpp
@@ -281,6 +281,9 @@ void TaskHelixParameters::updateStatus()
         else
             status = "";
     }
+    // if the helix touches itself along a single helical edge we get this error
+    else if (status.compare("NCollection_IndexedDataMap::FindFromKey") == 0)
+        status = "Error: helix touches itself";
     ui->labelMessage->setText(QString::fromUtf8(status.c_str()));
 }
 


### PR DESCRIPTION
when the helix touches itself along a single helical edge one gets a cryptic error.
This PR gives the user feedback what is going on.

To reproduce the issue, set in this file the pitch to 1.0 mm:
[HelixTouching-bug.zip](https://github.com/FreeCAD/FreeCAD/files/8328750/HelixTouching-bug.zip)
 