### PR TITLE
[Path] Fix # 5956.  

### DIFF
--- a/src/Mod/Path/PathScripts/PathAreaOp.py
+++ b/src/Mod/Path/PathScripts/PathAreaOp.py
@@ -156,6 +156,7 @@ class ObjectOp(PathOp.ObjectOp):
         self.areaOpOnChanged(obj, prop)
 
     def opOnDocumentRestored(self, obj):
+        PathLog.track()
         for prop in ["AreaParams", "PathParams", "removalshape"]:
             if hasattr(obj, prop):
                 obj.setEditorMode(prop, 2)
@@ -419,6 +420,7 @@ class ObjectOp(PathOp.ObjectOp):
                 FreeCAD.Console.PrintError(
                     "Something unexpected happened. Check project and tool config."
                 )
+                raise e
             else:
                 if profileEdgesIsOpen:
                     ppCmds = pp

--- a/src/Mod/Path/PathScripts/PathPocketBase.py
+++ b/src/Mod/Path/PathScripts/PathPocketBase.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # ***************************************************************************
 # *   Copyright (c) 2017 sliptonic <shopinthewoods@gmail.com>               *
 # *   Copyright (c) 2020 russ4262 (Russell Johnson)                         *
@@ -106,6 +105,9 @@ class ObjectPocket(PathAreaOp.ObjectOp):
         Can safely be overwritten by subclass."""
         pass
 
+    def areaOpSetDefaultValues(self, obj, job):
+        obj.PocketLastStepOver = 0
+
     def pocketInvertExtraOffset(self):
         """pocketInvertExtraOffset() ... return True if ExtraOffset's direction is inward.
         Can safely be overwritten by subclass."""
@@ -175,6 +177,15 @@ class ObjectPocket(PathAreaOp.ObjectOp):
                 "App::Property", "Attempts to avoid unnecessary retractions."
             ),
         )
+        obj.addProperty(
+            "App::PropertyPercent",
+            "PocketLastStepOver",
+            "Pocket",
+            QT_TRANSLATE_NOOP(
+                "App::Property",
+                "Last Stepover Radius.  If 0, 50% of cutter is used. Tuning this can be used to improve stepover for some shapes",
+            ),
+        )
 
         for n in self.pocketPropertyEnumerations():
             setattr(obj, n[0], n[1])
@@ -191,6 +202,7 @@ class ObjectPocket(PathAreaOp.ObjectOp):
 
     def areaOpAreaParams(self, obj, isHole):
         """areaOpAreaParams(obj, isHole) ... return dictionary with pocket's area parameters"""
+        PathLog.track()
         params = {}
         params["Fill"] = 0
         params["Coplanar"] = 0
@@ -204,6 +216,7 @@ class ObjectPocket(PathAreaOp.ObjectOp):
             extraOffset = 0 - extraOffset
         params["PocketExtraOffset"] = extraOffset
         params["ToolRadius"] = self.radius
+        params["PocketLastStepover"] = obj.PocketLastStepOver
 
         Pattern = [
             "ZigZag",
@@ -221,6 +234,20 @@ class ObjectPocket(PathAreaOp.ObjectOp):
             params["FitArcs"] = False
 
         return params
+
+    def opOnDocumentRestored(self, obj):
+        if not hasattr(obj, "PocketLastStepover"):
+            obj.addProperty(
+                "App::PropertyPercent",
+                "PocketLastStepOver",
+                "Pocket",
+                QT_TRANSLATE_NOOP(
+                    "App::Property",
+                    "Last Stepover Radius.  If 0, 50% of cutter is used. Tuning this can be used to improve stepover for some shapes",
+                ),
+            )
+            obj.PocketLastStepOver = 0
+        PathLog.track()
 
     def areaOpPathParams(self, obj, isHole):
         """areaOpAreaParams(obj, isHole) ... return dictionary with pocket's path parameters"""


### PR DESCRIPTION
Expose PocketLastStepOver property
Property can be useful to fine tune the last stepover for some shapes.
If the default value (0) is used, current behavior is unchanged.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [ ]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [ ]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [ ]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [ ]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the issue ID number from our [Issues database](https://github.com/FreeCAD/FreeCAD/issues) in case a particular commit solves or is related to an existing issue. Ex: `Draft: fix typos - fixes #4805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
