### PR TITLE
[PD] Use CompSolid in `FeatureTransformed`

### DIFF
--- a/src/Mod/PartDesign/App/FeatureTransformed.cpp
+++ b/src/Mod/PartDesign/App/FeatureTransformed.cpp
@@ -249,8 +249,8 @@ App::DocumentObjectExecReturn *Transformed::execute(void)
         TopoDS_Shape current = support;
 
         BRep_Builder builder;
-        TopoDS_Compound compShape;
-        builder.MakeCompound(compShape);
+        TopoDS_CompSolid compShape;
+        builder.MakeCompSolid(compShape);
         std::vector<TopoDS_Shape> shapes;
         bool overlapping = false;
 
@@ -323,6 +323,7 @@ App::DocumentObjectExecReturn *Transformed::execute(void)
     }
 
     this->Shape.setValue(getSolid(support));  // picking the first solid
+    // FIXME: For some reason `rejected.IsNull()` is false even with 1 solid
     rejected = getRemainingSolids(support);
 
     return App::DocumentObject::StdReturn;


### PR DESCRIPTION
Fixes #6641.

Possibly behavior of `fuse` is different with Compound and CompSolid.

Note that as mentioned in the comment, `rejected` stores a non-null shape (a
Compound). The shape still has no solids, faces or other elements.

Still an issue that if overlap is set to "overlap mode" instead of "detect", the issue stands.