### PR TITLE
[PD] Check for reversal in `PartDesign::Feature::getSolid()`

### DIFF
--- a/src/Mod/PartDesign/App/Feature.cpp
+++ b/src/Mod/PartDesign/App/Feature.cpp
@@ -25,6 +25,7 @@
 #ifndef _PreComp_
 # include <BRep_Tool.hxx>
 # include <BRepBuilderAPI_MakeFace.hxx>
+# include <BRepGProp.hxx>
 # include <gp_Pln.hxx>
 # include <gp_Pnt.hxx>
 # include <Standard_Failure.hxx>
@@ -73,7 +74,15 @@ TopoDS_Shape Feature::getSolid(const TopoDS_Shape& shape)
     TopExp_Explorer xp;
     xp.Init(shape,TopAbs_SOLID);
     if (xp.More()) {
-        return xp.Current();
+        TopoDS_Shape solid = xp.Current();
+
+        // It can happen that a solid is flipped. Reverse if it happens.
+        GProp_GProps props;
+        BRepGProp::VolumeProperties(solid, props);
+        if (props.Mass() < 0)
+            solid.Reverse();
+
+        return solid;
     }
 
     return TopoDS_Shape();

--- a/src/Mod/PartDesign/App/Feature.cpp
+++ b/src/Mod/PartDesign/App/Feature.cpp
@@ -67,7 +67,7 @@ short Feature::mustExecute() const
     return Part::Feature::mustExecute();
 }
 
-TopoDS_Shape Feature::getSolid(const TopoDS_Shape& shape)
+TopoDS_Shape Feature::getSolid(const TopoDS_Shape& shape, bool correctInverted)
 {
     if (shape.IsNull())
         Standard_Failure::Raise("Shape is null");
@@ -76,11 +76,13 @@ TopoDS_Shape Feature::getSolid(const TopoDS_Shape& shape)
     if (xp.More()) {
         TopoDS_Shape solid = xp.Current();
 
-        // It can happen that a solid is flipped. Reverse if it happens.
-        GProp_GProps props;
-        BRepGProp::VolumeProperties(solid, props);
-        if (props.Mass() < 0)
-            solid.Reverse();
+        if (correctInverted) {
+            // It can happen that a solid is flipped. Reverse if it happens.
+            GProp_GProps props;
+            BRepGProp::VolumeProperties(solid, props);
+            if (props.Mass() < 0)
+                solid.Reverse();
+        }
 
         return solid;
     }

--- a/src/Mod/PartDesign/App/Feature.h
+++ b/src/Mod/PartDesign/App/Feature.h
@@ -62,7 +62,7 @@ public:
 
     /// Returns the body the feature is in, or none
     Body* getFeatureBody() const;
-    
+
     /**
      * Returns the BaseFeature property's object (if any)
      * @param silent if couldn't determine the base feature and silent == true,
@@ -85,12 +85,15 @@ protected:
 
     /**
      * Get a solid of the given shape. If no solid is found an exception is raised.
+     * @param shape The shape from which the solid is to be extracted.
+     * @param correctInverted If true, check if the resulting solid is inverted,
+     *                        and reverse it if it is. Default is true.
      */
-    static TopoDS_Shape getSolid(const TopoDS_Shape&);    
-    static int countSolids(const TopoDS_Shape&, TopAbs_ShapeEnum type = TopAbs_SOLID );    
+    static TopoDS_Shape getSolid(const TopoDS_Shape& shape, bool correctInverted = true);
+    static int countSolids(const TopoDS_Shape&, TopAbs_ShapeEnum type = TopAbs_SOLID);
 
     /// Grab any point from the given face
-    static const gp_Pnt getPointFromFace(const TopoDS_Face& f);    
+    static const gp_Pnt getPointFromFace(const TopoDS_Face& f);
     /// Make a shape from a base plane (convenience method)
     static gp_Pln makePlnFromPlane(const App::DocumentObject* obj);
     static TopoDS_Shape makeShapeFromPlane(const App::DocumentObject* obj);


### PR DESCRIPTION
Fixes FreeCAD#6584.

Under certain circumstances the created `TopoDS_Solid`s can be inverted. For issue FreeCAD#6584, this happened when creating PolarPattern.

This is meant to be an alternative to PR #6665 since that fix appears to have a significant performance cost. Only one of these PR's should need to be merged.