### PR TITLE
[GUI] add missing apply to color gradients dialog

### DIFF
--- a/src/Gui/DlgSettingsColorGradientImp.cpp
+++ b/src/Gui/DlgSettingsColorGradientImp.cpp
@@ -23,6 +23,7 @@
 #include "PreCompiled.h"
 #ifndef _PreComp_
 # include <cmath>
+# include <QComboBox>
 # include <QDoubleValidator>
 # include <QFontMetrics>
 # include <QLocale>
@@ -54,7 +55,10 @@ DlgSettingsColorGradientImp::DlgSettingsColorGradientImp( QWidget* parent, Qt::W
     ui->floatLineEditMin->setValidator(fMinVal);
 
     QFontMetrics fm(ui->floatLineEditMax->font());
-    ui->floatLineEditMax->setMinimumWidth(QtTools::horizontalAdvance(fm, QString::fromLatin1("-1000.000000")));
+    ui->floatLineEditMax->setMinimumWidth(QtTools::horizontalAdvance(fm, QString::fromLatin1("-1000.0")));
+
+    connect(ui->comboBoxModel, qOverload<int>(&QComboBox::currentIndexChanged),
+        this, &DlgSettingsColorGradientImp::onModelChanged);
 }
 
 /**
@@ -169,6 +173,11 @@ void DlgSettingsColorGradientImp::accept()
     else {
         QDialog::accept();
     }
+}
+
+void DlgSettingsColorGradientImp::onModelChanged(int index)
+{
+    Q_EMIT ModelChange(index);
 }
 
 #include "moc_DlgSettingsColorGradientImp.cpp"

--- a/src/Gui/DlgSettingsColorGradientImp.h
+++ b/src/Gui/DlgSettingsColorGradientImp.h
@@ -77,6 +77,12 @@ public:
     int numberOfDecimals() const;
     //@}
 
+Q_SIGNALS:
+    void ModelChange(int index);
+
+protected Q_SLOTS:
+    void onModelChanged(int index);
+
 private:
     std::unique_ptr<Ui_DlgSettingsColorGradient> ui;
     QDoubleValidator* fMaxVal;

--- a/src/Gui/SoFCColorGradient.cpp
+++ b/src/Gui/SoFCColorGradient.cpp
@@ -299,6 +299,11 @@ bool SoFCColorGradient::isVisible (float fVal) const
     return true;
 }
 
+void SoFCColorGradient::onModelChanged(int index)
+{
+    _cColGrad.setColorModel(index);
+}
+
 bool SoFCColorGradient::customize()
 {
     QWidget* parent = Gui::getMainWindow()->activeWindow();
@@ -314,10 +319,11 @@ bool SoFCColorGradient::customize()
     float fMin, fMax;
     _cColGrad.getRange(fMin, fMax);
     dlg.setRange(fMin, fMax);
+    QObject::connect(dlg, SIGNAL(dlg.ModelChange(int index)), this, SLOT(onModelChanged(int index)));
 
     QPoint pos(QCursor::pos());
-    pos += QPoint((int)(-1.1*dlg.width()),(int)(-0.1*dlg.height()));
-    dlg.move( pos );
+    pos += QPoint((int)(-1.1 * dlg.width()), (int)(-0.1 * dlg.height()));
+    dlg.move(pos);
 
     if (dlg.exec() == QDialog::Accepted) {
         _cColGrad.setColorModel(dlg.colorModel());
@@ -336,3 +342,4 @@ bool SoFCColorGradient::customize()
 
     return false;
 }
+

--- a/src/Gui/SoFCColorGradient.h
+++ b/src/Gui/SoFCColorGradient.h
@@ -74,6 +74,9 @@ public:
   /** Returns the name of the color bar. */
   const char* getColorBarName() const { return "Color Gradient"; }
 
+protected Q_SLOTS:
+    void onModelChanged(int index);
+
 protected:
   /**
    * Sets the current viewer size this color gradient is embedded into, to recalculate its new position.


### PR DESCRIPTION
an attempt according to: https://forum.freecadweb.org/viewtopic.php?p=583897#p583897

@WandererFan , what do I do wrong? The compilation fails on this line

`QObject::connect(dlg, SIGNAL(dlg.ModelChange(int index)), this, SLOT(onModelChanged(int index)));`