### PR TITLE
2 crash fixes when dealing with Surface properties

### DIFF
--- a/src/App/PropertyContainerPyImp.cpp
+++ b/src/App/PropertyContainerPyImp.cpp
@@ -459,7 +459,7 @@ PyObject* PropertyContainerPy::dumpPropertyContent(PyObject *args, PyObject *kwd
         prop->dumpToStream(stream, compression);
     }
     catch (...) {
-       PyErr_SetString(PyExc_IOError, "Unable parse content into binary representation");
+       PyErr_SetString(PyExc_IOError, "Unable to parse content into binary representation");
        return nullptr;
     }
 

--- a/src/Base/PersistencePyImp.cpp
+++ b/src/Base/PersistencePyImp.cpp
@@ -71,7 +71,7 @@ PyObject* PersistencePy::dumpContent(PyObject *args, PyObject *kwds)
         getPersistencePtr()->dumpToStream(stream, compression);
     }
     catch (...) {
-       PyErr_SetString(PyExc_IOError, "Unable parse content into binary representation");
+       PyErr_SetString(PyExc_IOError, "Unable to parse content into binary representation");
        return nullptr;
     }
 

--- a/src/Base/PersistencePyImp.cpp
+++ b/src/Base/PersistencePyImp.cpp
@@ -70,6 +70,10 @@ PyObject* PersistencePy::dumpContent(PyObject *args, PyObject *kwds)
     try {
         getPersistencePtr()->dumpToStream(stream, compression);
     }
+    catch(Base::NotImplementedError&) {
+        PyErr_SetString(PyExc_NotImplementedError, "Dumping content of this object type is not implemented");
+        return nullptr;
+    }
     catch (...) {
        PyErr_SetString(PyExc_IOError, "Unable to parse content into binary representation");
        return nullptr;

--- a/src/Mod/Part/App/Geometry.cpp
+++ b/src/Mod/Part/App/Geometry.cpp
@@ -4681,9 +4681,20 @@ Geometry *GeomPlane::copy(void) const
 }
 
 // Persistence implementer
-unsigned int GeomPlane::getMemSize (void) const               {assert(0); return 0;/* not implemented yet */}
-void         GeomPlane::Save       (Base::Writer &/*writer*/) const {assert(0);          /* not implemented yet */}
-void         GeomPlane::Restore    (Base::XMLReader &/*reader*/)    {assert(0);          /* not implemented yet */}
+unsigned int GeomPlane::getMemSize (void) const
+{
+    throw Base::NotImplementedError("GeomPlane::getMemSize");
+}
+
+void GeomPlane::Save(Base::Writer &/*writer*/) const
+{
+    throw Base::NotImplementedError("GeomPlane::Save");
+}
+
+void GeomPlane::Restore(Base::XMLReader &/*reader*/)
+{
+    throw Base::NotImplementedError("GeomPlane::Restore");
+}
 
 PyObject *GeomPlane::getPyObject(void)
 {

--- a/src/Mod/Part/App/TopoShapeFacePyImp.cpp
+++ b/src/Mod/Part/App/TopoShapeFacePyImp.cpp
@@ -878,6 +878,8 @@ PyObject* TopoShapeFacePy::cutHoles(PyObject *args)
 Py::Object TopoShapeFacePy::getSurface() const
 {
     const TopoDS_Face& f = TopoDS::Face(getTopoShapePtr()->getShape());
+    if (f.IsNull())
+        return Py::Object(Py_None);
     BRepAdaptor_Surface adapt(f);
     Base::PyObjectBase* surface = nullptr;
     switch(adapt.GetType())


### PR DESCRIPTION
This PR fixes 2 different crashes.

1st commit fixes crashes that happens with following Python code:
```
f = Part.Face()
f.Surface.
```
As soon as last dot is entered, a crash occurs

2nd commit fixes crash that happens eg. with following Python code:
```
l = Part.LineSegment(App.Vector(0,0,0),App.Vector(10,0,0)).toShape()
f = l.extrude(App.Vector(0,0,10))
f.Surface.dumpContent()
```

Other 2 commits are improvement only.