### PR TITLE
Gui: add decimal point converter to Translator

### DIFF
--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -2051,12 +2051,6 @@ void Application::runApplication()
         auto filter = new WheelEventFilter(&mainApp);
         mainApp.installEventFilter(filter);
     }
-    
-    //filter keyboard events to substitute decimal separator
-    if (hGrp->GetBool("SubstituteDecimalSeparator", false)) {
-        auto filter = new KeyboardFilter(&mainApp);
-        mainApp.installEventFilter(filter);
-    }
 
     // For values different to 1 and 2 use the OS locale settings
     auto localeFormat = hGrp->GetInt("UseLocaleFormatting", 0);

--- a/src/Gui/DlgGeneral.ui
+++ b/src/Gui/DlgGeneral.ui
@@ -103,22 +103,22 @@
           </widget>
          </item>
          <item row="1" column="2">
-          <widget class="Gui::PrefCheckBox" name="SubstituteDecimal">
-           <property name="toolTip">
-            <string>If enabled, numerical keypad decimal separator will be substituted with locale separator</string>
-           </property>
-           <property name="text">
-            <string>Substitute decimal separator (needs restart)</string>
-           </property>
-           <property name="prefEntry" stdset="0">
-            <cstring>SubstituteDecimalSeparator</cstring>
-           </property>
-           <property name="prefPath" stdset="0">
-            <cstring>General</cstring>
-           </property>
-          </widget>
-         </item>
-        </layout>
+           <widget class="Gui::PrefCheckBox" name="SubstituteDecimal">
+            <property name="toolTip">
+             <string>If enabled, numerical keypad decimal separator will be substituted with locale separator</string>
+            </property>
+            <property name="text">
+             <string>Substitute decimal separator (numpad)</string>
+            </property>
+            <property name="prefEntry" stdset="0">
+             <cstring>SubstituteDecimalSeparator</cstring>
+            </property>
+            <property name="prefPath" stdset="0">
+             <cstring>General</cstring>
+            </property>
+           </widget>
+          </item>
+         </layout>
        </widget>
       </item>
       <item>

--- a/src/Gui/DlgGeneralImp.cpp
+++ b/src/Gui/DlgGeneralImp.cpp
@@ -166,6 +166,10 @@ void DlgGeneralImp::setNumberLocale(bool force/* = false*/)
     localeIndex = localeFormat;
 }
 
+void DlgGeneralImp::setDecimalPointConversion(bool on) {
+    Translator::instance()->enableDecimalPointConversion(on);
+}
+
 void DlgGeneralImp::saveSettings()
 {
     int index = ui->AutoloadModuleCombo->currentIndex();
@@ -184,6 +188,7 @@ void DlgGeneralImp::saveSettings()
     bool force = setLanguage();
     // In case type is "Selected language", we need to force locale change
     setNumberLocale(force);
+    setDecimalPointConversion(ui->SubstituteDecimal->isChecked());
 
     ParameterGrp::handle hGrp = WindowParameter::getDefaultParameter()->GetGroup("General");
     QVariant size = ui->toolbarIconSize->itemData(ui->toolbarIconSize->currentIndex());

--- a/src/Gui/DlgGeneralImp.h
+++ b/src/Gui/DlgGeneralImp.h
@@ -67,6 +67,7 @@ private:
     void revertToSavedConfig();
     bool setLanguage(); //Returns true if language has been changed
     void setNumberLocale(bool force = false);
+    void setDecimalPointConversion(bool on);
 
 private:
     int localeIndex;

--- a/src/Gui/GuiApplication.cpp
+++ b/src/Gui/GuiApplication.cpp
@@ -31,7 +31,6 @@
 # include <QDataStream>
 # include <QFileInfo>
 # include <QFileOpenEvent>
-# include <QKeyEvent>
 # include <QSessionManager>
 # include <QTimer>
 #endif
@@ -321,30 +320,5 @@ bool WheelEventFilter::eventFilter(QObject* obj, QEvent* ev)
     }
     return false;
 }
-
-KeyboardFilter::KeyboardFilter(QObject* parent)
-  : QObject(parent)
-{
-}
-
-bool KeyboardFilter::eventFilter(QObject* obj, QEvent* ev)
-{
-    if (ev->type() == QEvent::KeyPress || ev->type() == QEvent::KeyRelease) {
-        auto kev = static_cast<QKeyEvent *>(ev);
-        Qt::KeyboardModifiers mod = kev->modifiers();
-        int key = kev->key();
-        if ((mod & Qt::KeypadModifier) && (key == Qt::Key_Period || key == Qt::Key_Comma))
-        {
-            QChar dp = QLocale().decimalPoint();
-            if (key != dp) {
-                QKeyEvent modifiedKeyEvent(kev->type(), dp.digitValue(), mod, QString(dp), kev->isAutoRepeat(), kev->count());
-                qApp->sendEvent(obj, &modifiedKeyEvent);
-                return true;
-            }
-        }
-    }
-    return false;
-}
-
 
 #include "moc_GuiApplication.cpp"

--- a/src/Gui/GuiApplication.h
+++ b/src/Gui/GuiApplication.h
@@ -92,15 +92,6 @@ public:
     bool eventFilter(QObject* obj, QEvent* ev) override;
 };
 
-class KeyboardFilter : public QObject
-{
-    Q_OBJECT
-
-public:
-    explicit KeyboardFilter(QObject* parent);
-    bool eventFilter(QObject* obj, QEvent* ev) override;
-};
-
 }
 
 #endif // GUI_APPLICATION_H

--- a/src/Gui/Language/Translator.cpp
+++ b/src/Gui/Language/Translator.cpp
@@ -367,13 +367,15 @@ bool Translator::eventFilter(QObject* obj, QEvent* ev)
         QKeyEvent *kev = static_cast<QKeyEvent *>(ev);
         Qt::KeyboardModifiers mod = kev->modifiers();
         int key = kev->key();
-        if ((mod & Qt::KeypadModifier) && (key == Qt::Key_Period || key == Qt::Key_Comma))
-        {
-            QChar dp = QLocale().decimalPoint();
-            if (key != dp) {
-                QKeyEvent modifiedKeyEvent(kev->type(), dp.digitValue(), mod, QString(dp), kev->isAutoRepeat(), kev->count());
-                qApp->sendEvent(obj, &modifiedKeyEvent);
-                return true;
+        if ((mod & Qt::KeypadModifier) && (key == Qt::Key_Period || key == Qt::Key_Comma)) {
+            if (ev->spontaneous()) {
+                QChar dp = QLocale().decimalPoint();
+                int dpcode = QKeySequence(dp)[0];
+                if (key != dp) {
+                    QKeyEvent modifiedKeyEvent(kev->type(), dpcode, mod, dp, kev->isAutoRepeat(), kev->count());
+                    qApp->sendEvent(obj, &modifiedKeyEvent);
+                    return true;
+                }
             }
         }
     }

--- a/src/Gui/Language/Translator.cpp
+++ b/src/Gui/Language/Translator.cpp
@@ -33,6 +33,7 @@
 #endif
 
 #include <App/Application.h>
+#include <Gui/TextEdit.h>
 #include "Translator.h"
 
 
@@ -376,6 +377,11 @@ bool Translator::eventFilter(QObject* obj, QEvent* ev)
                     qApp->sendEvent(obj, &modifiedKeyEvent);
                     return true;
                 }
+            }
+            if (dynamic_cast<Gui::TextEdit*>(obj) && key != Qt::Key_Period) {
+                QKeyEvent modifiedKeyEvent(kev->type(), Qt::Key_Period, mod, QChar::fromLatin1('.'), kev->isAutoRepeat(), kev->count());
+                qApp->sendEvent(obj, &modifiedKeyEvent);
+                return true;
             }
         }
     }

--- a/src/Gui/Language/Translator.h
+++ b/src/Gui/Language/Translator.h
@@ -74,6 +74,10 @@ public:
     TStringMap supportedLocales() const;
     /** Adds a path where localization files can be found */
     void addPath(const QString& path);
+    /** eventFilter used to convert decimal separator **/
+    bool eventFilter(QObject* obj, QEvent* ev);
+    /** Enables/disables decimal separator conversion **/
+    void enableDecimalPointConversion(bool on);
 
 private:
     Translator();
@@ -86,6 +90,7 @@ private:
 private:
     static Translator* _pcSingleton;
     TranslatorP* d;
+    bool decimalPointConversionEnabled;
 };
 
 } // namespace Gui

--- a/src/Gui/Language/Translator.h
+++ b/src/Gui/Language/Translator.h
@@ -90,7 +90,7 @@ private:
 private:
     static Translator* _pcSingleton;
     TranslatorP* d;
-    bool decimalPointConversionEnabled;
+    std::unique_ptr<Translator, std::function<void(Translator*)>> decimalPointConverter;
 };
 
 } // namespace Gui


### PR DESCRIPTION
This PR moves the decimal point converter (eventFitler) from GuiApplication to Translator.
This allows to have a hot enabling/disabling of the feature.
Also it harmonizes things as Translator now take cares of number format, which it is directly related.