### PR TITLE
Draft: Fix WorkingPlane setup in automatic mode - fixes #6060

### DIFF
--- a/src/Mod/Draft/WorkingPlane.py
+++ b/src/Mod/Draft/WorkingPlane.py
@@ -787,9 +787,9 @@ class Plane:
                     vdir = view.getViewDirection()
                     # The angle is between 0 and 180 degrees.
                     angle = vdir.getAngle(self.axis)
-                    if (angle > 0.001) and (angle < 3.14159):
-                        # don't change the plane if it is already
-                        # perpendicular to the current view
+                    # don't change the plane if the axis is already
+                    # antiparallel to the current view
+                    if abs(math.pi - angle) > Part.Precision.angular():
                         self.alignToPointAndAxis(Vector(0, 0, 0),
                                                  vdir.negative(), 0, upvec)
                 except Exception:


### PR DESCRIPTION
The reported bug actually occurs whenever time the working plane is in automatic mode and the view flips to the opposite direction (ex. from left to right, from top to bottom), because the z-axis of the working plane it doesn't change.
This is incosistent because if, for example, in the transition from top view to bottom view the plane axis is set to another direction (say, perpendicular to left view), in the last step of the transition the plane is aligned according the bottom view.
With this changes the working plane remains unchanged only if the view is currently antiparallel to z-axis of the plane.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [x]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the issue ID number from our [Issues database](https://github.com/FreeCAD/FreeCAD/issues) in case a particular commit solves or is related to an existing issue. Ex: `Draft: fix typos - fixes #4805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
