### PR TITLE
Draft: Fix orientWP method used by in Draft_Line command

### DIFF
--- a/src/Mod/Draft/WorkingPlane.py
+++ b/src/Mod/Draft/WorkingPlane.py
@@ -126,7 +126,9 @@ class Plane:
 
     def copy(self):
         """Return a new plane that is a copy of the present object."""
-        return plane(u=self.u, v=self.v, w=self.axis, pos=self.position)
+        p = plane(u=self.u, v=self.v, w=self.axis, pos=self.position)
+        p.weak = self.weak
+        return p
 
     def offsetToPoint(self, p, direction=None):
         """Return the signed distance from a point to the plane.
@@ -1277,6 +1279,34 @@ class Plane:
             norm = proj.cross(self.u)
             return DraftVecUtils.angle(self.u, proj, norm)
 
+    def getParameters(self):
+        """Return a dictionary with the data which define the plane:
+        `u`, `v`, `axis`, `weak`.
+
+        Returns
+        -------
+        dict
+            dictionary of the form:
+            {"position":position, "u":x, "v":v, "axis":axis, "weak":weak}
+        """
+        return {"position":self.position, "u":self.u, "v":self.v, "axis":self.axis, "weak":self.weak}
+
+    def setFromParameters(self, data):
+        """Set the plane according to data.
+
+        Parameters
+        ----------
+        data: dict
+            dictionary of the form:
+            {"position":position, "u":x, "v":v, "axis":axis, "weak":weak}
+       """
+        self.position = data["position"]
+        self.u = data["u"]
+        self.v = data["v"]
+        self.axis = data["axis"]
+        self.weak = data["weak"]
+
+        return None
 
 plane = Plane
 

--- a/src/Mod/Draft/draftguitools/gui_lines.py
+++ b/src/Mod/Draft/draftguitools/gui_lines.py
@@ -133,7 +133,7 @@ class Line(gui_base_original.Creator):
         """
         self.removeTemporaryObject()
         if self.oldWP:
-            App.DraftWorkingPlane = self.oldWP
+            App.DraftWorkingPlane.setFromParameters(self.oldWP)
             if hasattr(Gui, "Snapper"):
                 Gui.Snapper.setGrid()
                 Gui.Snapper.restack()
@@ -262,7 +262,7 @@ class Line(gui_base_original.Creator):
                 v = self.node[-2].sub(self.node[-1])
                 v = v.negative()
                 if not self.oldWP:
-                    self.oldWP = App.DraftWorkingPlane.copy()
+                    self.oldWP = App.DraftWorkingPlane.getParameters()
                 App.DraftWorkingPlane.alignToPointAndAxis(p, n, upvec=v)
                 if hasattr(Gui, "Snapper"):
                     Gui.Snapper.setGrid()

--- a/src/Mod/Draft/draftguitools/gui_trackers.py
+++ b/src/Mod/Draft/draftguitools/gui_trackers.py
@@ -1357,16 +1357,16 @@ class archDimTracker(Tracker):
         self.string = self.dimnode.string
         self.view = Draft.get3DView()
         self.camera = self.view.getCameraNode()
-        self.plane = FreeCAD.DraftWorkingPlane
         self.setMode(mode)
         self.setString()
         super().__init__(children=[self.transform, self.dimnode], name="archDimTracker")
 
     def setString(self, text=None):
         """Set the dim string to the given value or auto value."""
+        plane = FreeCAD.DraftWorkingPlane
         p1 = Vector(self.pnts.getValues()[0].getValue())
         p2 = Vector(self.pnts.getValues()[-1].getValue())
-        self.norm.setValue(self.plane.getNormal())
+        self.norm.setValue(plane.getNormal())
         # set the offset sign to prevent the dim line from intersecting the curve near the cursor
         sign_dx = math.copysign(1, (p2.sub(p1)).x)
         sign_dy = math.copysign(1, (p2.sub(p1)).y)
@@ -1381,7 +1381,7 @@ class archDimTracker(Tracker):
             self.Distance = (p2.sub(p1)).Length
 
         text = FreeCAD.Units.Quantity(self.Distance, FreeCAD.Units.Length).UserString
-        self.matrix.setValue(*self.plane.getPlacement().Matrix.transposed().A)
+        self.matrix.setValue(*plane.getPlacement().Matrix.transposed().A)
         self.string.setValue(text.encode('utf8'))
         # change the text position to external depending on the distance and scale values
         volume = self.camera.getViewVolume()
@@ -1404,10 +1404,11 @@ class archDimTracker(Tracker):
 
     def p1(self, point=None):
         """Set or get the first point of the dim."""
+        plane = FreeCAD.DraftWorkingPlane
         if point:
-            p1_proj = self.plane.projectPoint(point)
-            p1_proj_u = (p1_proj - self.plane.position).dot(self.plane.u.normalize())
-            p1_proj_v = (p1_proj - self.plane.position).dot(self.plane.v.normalize())
+            p1_proj = plane.projectPoint(point)
+            p1_proj_u = (p1_proj - plane.position).dot(plane.u.normalize())
+            p1_proj_v = (p1_proj - plane.position).dot(plane.v.normalize())
             self.pnts.set1Value(0, p1_proj_u, p1_proj_v, 0)
             self.setString()
         else:
@@ -1415,10 +1416,11 @@ class archDimTracker(Tracker):
 
     def p2(self, point=None):
         """Set or get the second point of the dim."""
+        plane = FreeCAD.DraftWorkingPlane
         if point:
-            p2_proj = self.plane.projectPoint(point)
-            p2_proj_u = (p2_proj - self.plane.position).dot(self.plane.u.normalize())
-            p2_proj_v = (p2_proj - self.plane.position).dot(self.plane.v.normalize())
+            p2_proj = plane.projectPoint(point)
+            p2_proj_u = (p2_proj - plane.position).dot(plane.u.normalize())
+            p2_proj_v = (p2_proj - plane.position).dot(plane.v.normalize())
             self.pnts.set1Value(1, p2_proj_u, p2_proj_v, 0)
             self.setString()
         else:


### PR DESCRIPTION
If the set WP button is used in the `Draft_Wire` command to reorient the work plane, closing the command does not restore the plane to the state before the button was pressed, instead it sets the plane aligned with the current view. This is because the plane is restored using the `Plane.copy` method, which ignores the attribute `weak` of the plane.
Also, after closing the command and restoring the plane, archDimTrackers stops working correctly because the instance generated by `Plane.copy` is different from the original instance used by the tracker.
Two new methods are added to the Plane class: `getParameters` to get the work plane data, and `setFromParameters` to modify the working plane without creating a new instance.



Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [ ]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [ ]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the issue ID number from our [Issues database](https://github.com/FreeCAD/FreeCAD/issues) in case a particular commit solves or is related to an existing issue. Ex: `Draft: fix typos - fixes #4805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
