### PR TITLE
Part: Link support -- replace TopoShape.getSubShape() with Part::Feat…

### DIFF
--- a/src/Mod/Part/App/FeatureExtrusion.cpp
+++ b/src/Mod/Part/App/FeatureExtrusion.cpp
@@ -100,7 +100,7 @@ bool Extrusion::fetchAxisLink(const App::PropertyLinkSub& axisLink, Base::Vector
 
     TopoDS_Shape axEdge;
     if (axisLink.getSubValues().size() > 0 && axisLink.getSubValues()[0].length() > 0) {
-        axEdge = Feature::getTopoShape(linked).getSubShape(axisLink.getSubValues()[0].c_str());
+        axEdge = Feature::getTopoShape(linked, axisLink.getSubValues()[0].c_str(), true /*need element*/).getShape();
     }
     else {
         axEdge = Feature::getShape(linked);

--- a/src/Mod/Part/App/FeatureRevolution.cpp
+++ b/src/Mod/Part/App/FeatureRevolution.cpp
@@ -94,7 +94,7 @@ bool Revolution::fetchAxisLink(const App::PropertyLinkSub &axisLink,
 
     TopoDS_Shape axEdge;
     if (axisLink.getSubValues().size() > 0  &&  axisLink.getSubValues()[0].length() > 0){
-        axEdge = Feature::getTopoShape(linked).getSubShape(axisLink.getSubValues()[0].c_str());
+        axEdge = Feature::getTopoShape(linked, axisLink.getSubValues()[0].c_str(), true /*need element*/).getShape();
     } else {
         axEdge = Feature::getShape(linked);
     }

--- a/src/Mod/Part/App/PartFeatures.cpp
+++ b/src/Mod/Part/App/PartFeatures.cpp
@@ -61,8 +61,6 @@ RuledSurface::RuledSurface()
     ADD_PROPERTY_TYPE(Curve2,(nullptr),"Ruled Surface",App::Prop_None,"Curve of ruled surface");
     ADD_PROPERTY_TYPE(Orientation,((long)0),"Ruled Surface",App::Prop_None,"Orientation of ruled surface");
     Orientation.setEnums(OrientationEnums);
-    ADD_PROPERTY_TYPE(ResetPlacement,(false),"Ruled Surface",App::Prop_None,
-                      "Whether to reset placement");
 }
 
 short RuledSurface::mustExecute() const
@@ -72,8 +70,6 @@ short RuledSurface::mustExecute() const
     if (Curve2.isTouched())
         return 1;
     if (Orientation.isTouched())
-        return 1;
-    if (ResetPlacement.isTouched())
         return 1;
     return 0;
 }
@@ -87,24 +83,23 @@ App::DocumentObjectExecReturn* RuledSurface::getShape(const App::PropertyLinkSub
                                                       TopoDS_Shape& shape) const
 {
     App::DocumentObject* obj = link.getValue();
-    const Part::TopoShape part = Part::Feature::getTopoShape(obj);
-    if (part.isNull()) {
+    if (!(obj && obj->getTypeId().isDerivedFrom(Part::Feature::getClassTypeId()))) {
         return new App::DocumentObjectExecReturn("No shape linked.");
     }
 
     // if no explicit sub-shape is selected use the whole part
     const std::vector<std::string>& element = link.getSubValues();
     if (element.empty()) {
-        shape = part.getShape();
+        shape = static_cast<Part::Feature*>(obj)->Shape.getValue();
         return nullptr;
     }
     else if (element.size() != 1) {
         return new App::DocumentObjectExecReturn("Not exactly one sub-shape linked.");
     }
 
+    const Part::TopoShape& part = static_cast<Part::Feature*>(obj)->Shape.getValue();
     if (!part.getShape().IsNull()) {
         if (!element[0].empty()) {
-            //shape = Part::Feature::getTopoShape(obj, element[0].c_str(), true /*need element*/).getShape();
             shape = part.getSubShape(element[0].c_str());
         }
         else {
@@ -242,22 +237,19 @@ App::DocumentObjectExecReturn *RuledSurface::execute(void)
         }
 
         // re-apply the placement in case we reset it
-        if (!Loc.IsIdentity())
+        if (!Loc.IsIdentity()) {
             ruledShape.Move(Loc);
+        }
 
         Loc = ruledShape.Location();
 
-        if (!Loc.IsIdentity() && ResetPlacement.getValue()) {
+        if (!Loc.IsIdentity()) {
             // reset the placement of the shape because the Placement
             // property will be changed
             ruledShape.Location(TopLoc_Location());
             Base::Matrix4D transform;
             TopoShape::convertToMatrix(Loc.Transformation(), transform);
             this->Placement.setValue(Base::Placement(transform));
-        } else {
-            if (!Loc.IsIdentity()){ //Reset Placement property = False
-                this->Placement.setValue(Base::Placement());
-            }
         }
 
         this->Shape.setValue(ruledShape);

--- a/src/Mod/Part/App/PartFeatures.h
+++ b/src/Mod/Part/App/PartFeatures.h
@@ -41,6 +41,7 @@ public:
     App::PropertyEnumeration Orientation;
     App::PropertyLinkSub Curve1;
     App::PropertyLinkSub Curve2;
+    App::PropertyBool ResetPlacement;
 
     /** @name methods override feature */
     //@{

--- a/src/Mod/Part/App/PartFeatures.h
+++ b/src/Mod/Part/App/PartFeatures.h
@@ -41,7 +41,6 @@ public:
     App::PropertyEnumeration Orientation;
     App::PropertyLinkSub Curve1;
     App::PropertyLinkSub Curve2;
-    App::PropertyBool ResetPlacement;
 
     /** @name methods override feature */
     //@{

--- a/src/Mod/Part/Gui/Command.cpp
+++ b/src/Mod/Part/Gui/Command.cpp
@@ -2108,11 +2108,11 @@ void CmdPartRuledSurface::activated(int iMsg)
             }
             if (ok && subnames1.size() <= 2) {
                 if (subnames1.size() >= 1) {
-                    curve1 = shape1.getSubShape(subnames1[0].c_str());
+                    curve1 = Part::Feature::getTopoShape(docobj1, subnames1[0].c_str(), true /*need element*/).getShape();
                     link1 = subnames1[0];
                 }
                 if (subnames1.size() == 2) {
-                    curve2 = shape1.getSubShape(subnames1[1].c_str());
+                    curve2 = Part::Feature::getTopoShape(docobj1, subnames1[1].c_str(), true /*need element*/).getShape();
                     link2 = subnames1[1];
                 }
                 if (subnames1.size() == 0) {
@@ -2132,7 +2132,7 @@ void CmdPartRuledSurface::activated(int iMsg)
                 ok = false;
             }
             if (ok && subnames2.size() == 1) {
-                curve2 = shape2.getSubShape(subnames2[0].c_str());
+                curve2 = Part::Feature::getTopoShape(docobj2, subnames2[0].c_str(), true /*need element*/).getShape();
                 link2 = subnames2[0];
             } else {
                 if (subnames2.size() == 0) {

--- a/src/Mod/Part/Gui/DlgExtrusion.cpp
+++ b/src/Mod/Part/Gui/DlgExtrusion.cpp
@@ -81,7 +81,7 @@ public:
             return false;
         }
         try {
-            TopoDS_Shape sub = part.getSubShape(sSubName);
+            TopoDS_Shape sub = Part::Feature::getTopoShape(pObj, sSubName, true /*need element*/).getShape();
             if (!sub.IsNull() && sub.ShapeType() == TopAbs_EDGE) {
                 const TopoDS_Edge& edge = TopoDS::Edge(sub);
                 BRepAdaptor_Curve adapt(edge);

--- a/src/Mod/Part/Gui/TaskSweep.cpp
+++ b/src/Mod/Part/Gui/TaskSweep.cpp
@@ -300,7 +300,7 @@ bool SweepWidget::accept()
         topoShape = Part::Feature::getTopoShape(docobj);
         if (!topoShape.isNull()) {
             for (std::vector<std::string>::const_iterator it = subnames.begin(); it != subnames.end(); ++it) {
-                subShapes.push_back(topoShape.getSubShape(subnames[0].c_str()));
+                subShapes.push_back(Part::Feature::getTopoShape(docobj, subnames[0].c_str(), true /*need element*/));
             }
             for (std::vector<Part::TopoShape>::iterator it = subShapes.begin(); it != subShapes.end(); ++it) {
                 TopoDS_Shape dsShape = (*it).getShape();


### PR DESCRIPTION
…ure::getTopoShape(obj, elementname, true).getShape() in order to support use of App::Link sublinks.

This change, as suggested by @realthunder, seems to correct the issue of sublinks not working.  But there are a couple of issues I discovered during testing.

1) Sweep will crash with a certain file.  I will upload the file to the forum and create a topic, and then link to it after I submit this PR.

2) Ruled surface gets moved to the wrong position.  This is due to a workaround, which might no longer be needed when using the getTopoShape().  To address this I have added a new boolean property to ruled surfaces called "ResetPlacement", defaulting to false.  If set true, you get the workaround, if false the workaround is not done.

