### PR TITLE
Draft: Fix Angle Lock

### DIFF
--- a/src/Mod/Draft/DraftGui.py
+++ b/src/Mod/Draft/DraftGui.py
@@ -2161,7 +2161,8 @@ class DraftToolBar:
 
     def toggleAngle(self,b):
         self.alock = self.angleLock.isChecked()
-        if b:
+        self.update_cartesian_coords()
+        if self.alock:
             if not self.globalMode:
                 angle_vec = FreeCAD.DraftWorkingPlane.getGlobalRot(self.angle)
             else:


### PR DESCRIPTION
A previous PR of mine (https://github.com/FreeCAD/FreeCAD/pull/6544) introduced a problem. When the `toggleAngle` function is triggered `self.angle` can be `None` (f.e. if the cursor never entered the 3D view). The `FreeCAD.DraftWorkingPlane.getGlobalRot(self.angle)` code then fails. This is fixed by adding
```
        self.update_cartesian_coords()
```
to the function.

Additonally: replaced `if b:` with `if self.alock:` for clarity.

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the issue ID number from our [Issues database](https://github.com/FreeCAD/FreeCAD/issues) in case a particular commit solves or is related to an existing issue. Ex: `Draft: fix typos - fixes #4805`

---
