### PR TITLE
Reduce debug log output

### DIFF
--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -818,7 +818,6 @@ void TreeWidget::_updateStatus(bool delay) {
     int timeout = TreeParams::Instance()->StatusTimeout();
     if (timeout < 0)
         timeout = 1;
-    FC_LOG("delay update status");
     statusTimer->start(timeout);
 }
 

--- a/src/Mod/Spreadsheet/App/Sheet.cpp
+++ b/src/Mod/Spreadsheet/App/Sheet.cpp
@@ -954,7 +954,7 @@ DocumentObjectExecReturn *Sheet::execute(void)
         FC_LOG("recomputing " << getFullName());
         for(auto &pos : make_order) {
             const auto &addr = VertexIndexList[pos];
-            FC_LOG(addr.toString());
+            FC_TRACE(addr.toString());
             recomputeCell(addr);
         }
     } catch (std::exception &) {


### PR DESCRIPTION
The relevant log outputs take significant amount of time when recomputing large spreadsheet in debug build. See [here](https://github.com/FreeCAD/FreeCAD/pull/6779#issuecomment-1106717916). 