### PR TITLE
[TD]Fix ExtendShorten handling of Center Lines

### DIFF
--- a/src/Mod/TechDraw/App/Cosmetic.cpp
+++ b/src/Mod/TechDraw/App/Cosmetic.cpp
@@ -779,16 +779,16 @@ TechDraw::BaseGeomPtr CenterLine::scaledGeometry(TechDraw::DrawViewPart* partFea
 {
 //    Base::Console().Message("CL::scaledGeometry() - m_type: %d\n", m_type);
     double scale = partFeat->getScale();
-    if (m_faces.empty() &&
-        m_edges.empty() &&
-        m_verts.empty() ) {
-        Base::Console().Message("CL::scaledGeometry - no geometry to scale!\n");
-        return nullptr;
-    }
-    
     std::pair<Base::Vector3d, Base::Vector3d> ends;
     try {
-        if (m_type == CLTYPE::FACE) {
+        if (m_faces.empty() &&
+            m_edges.empty() &&
+            m_verts.empty() ) {
+//            Base::Console().Message("CL::scaledGeometry - no geometry to scale!\n");
+            //CenterLine was created by points without a geometry reference,
+            ends = calcEndPointsNoRef(m_start, m_end, scale, m_extendBy,
+                                      m_hShift,m_vShift, m_rotate);
+        } else if (m_type == CLTYPE::FACE) {
             ends = calcEndPoints(partFeat,
                                  m_faces,
                                  m_mode, m_extendBy,
@@ -871,6 +871,60 @@ void CenterLine::dump(const char* title)
 {
     Base::Console().Message("CL::dump - %s \n",title);
     Base::Console().Message("CL::dump - %s \n",toString().c_str());
+}
+
+//end points for centerline with no geometry reference
+std::pair<Base::Vector3d, Base::Vector3d> CenterLine::calcEndPointsNoRef(
+                                                      Base::Vector3d start,
+                                                      Base::Vector3d end,
+                                                      double scale,
+                                                      double ext,
+                                                      double hShift, double vShift,
+                                                      double rotate)
+{
+//    Base::Console().Message("CL::calcEndPointsNoRef()\n");
+    std::pair<Base::Vector3d, Base::Vector3d> result;
+    Base::Vector3d p1 = start;
+    Base::Vector3d p2 = end;
+    Base::Vector3d mid = (p1 + p2) / 2.0;
+
+    //extend
+    Base::Vector3d clDir = p2 - p1;
+    clDir.Normalize();
+    p1 = p1 - (clDir * ext);
+    p2 = p2 + (clDir * ext);
+
+    //rotate
+    if (!DrawUtil::fpCompare(rotate, 0.0)) {
+        //rotate p1, p2 about mid point
+        double revRotate = -rotate;
+        double cosTheta = cos(revRotate * M_PI / 180.0);
+        double sinTheta = sin(revRotate * M_PI / 180.0);
+        Base::Vector3d toOrg = p1 - mid;
+        double xRot = toOrg.x * cosTheta - toOrg.y * sinTheta;
+        double yRot = toOrg.y * cosTheta + toOrg.x * sinTheta;
+        p1 = Base::Vector3d(xRot, yRot, 0.0) + mid;
+        toOrg = p2 - mid;
+        xRot = toOrg.x * cosTheta - toOrg.y * sinTheta;
+        yRot = toOrg.y * cosTheta + toOrg.x * sinTheta;
+        p2 = Base::Vector3d(xRot, yRot, 0.0) + mid;
+    }
+
+    //shift
+    if (!DrawUtil::fpCompare(hShift, 0.0)) {
+        double hss = hShift * scale;
+        p1.x = p1.x + hss;
+        p2.x = p2.x + hss;
+    }
+    if (!DrawUtil::fpCompare(vShift, 0.0)) {
+        double vss = vShift * scale;
+        p1.y = p1.y + vss;
+        p2.y = p2.y + vss;
+    }
+
+    result.first = p1 / scale;
+    result.second = p2 / scale;
+    return result;
 }
 
 //end points for face centerline

--- a/src/Mod/TechDraw/App/Cosmetic.h
+++ b/src/Mod/TechDraw/App/Cosmetic.h
@@ -210,6 +210,14 @@ public:
                                          int mode = 0,
                                          bool flip = false);
     TechDraw::BaseGeomPtr scaledGeometry(TechDraw::DrawViewPart* partFeat);
+
+    static std::pair<Base::Vector3d, Base::Vector3d> calcEndPointsNoRef(
+                                                          Base::Vector3d start,
+                                                          Base::Vector3d end,
+                                                          double scale,
+                                                          double ext,
+                                                          double hShift, double vShift,
+                                                          double rotate);
     static std::pair<Base::Vector3d, Base::Vector3d> calcEndPoints(
                                           TechDraw::DrawViewPart* partFeat,
                                           std::vector<std::string> faceNames,

--- a/src/Mod/TechDraw/App/CosmeticExtension.cpp
+++ b/src/Mod/TechDraw/App/CosmeticExtension.cpp
@@ -281,7 +281,8 @@ std::string CosmeticExtension::addCenterLine(Base::Vector3d start,
                                                Base::Vector3d end)
 {
 //    Base::Console().Message("CEx::addCenterLine(%s)\n",
- //                           DrawUtil::formatVector(pos).c_str());
+//                            DrawUtil::formatVector(start).c_str(),
+//                            DrawUtil::formatVector(end).c_str());
     std::vector<CenterLine*> cLines = CenterLines.getValues();
     TechDraw::CenterLine* cl = new TechDraw::CenterLine(start, end);
     cLines.push_back(cl);

--- a/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp
+++ b/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp
@@ -88,6 +88,7 @@ namespace TechDrawGui {
     void _setLineAttributes(TechDraw::CosmeticEdge* cosEdge);
     void _setLineAttributes(TechDraw::CenterLine* cosEdge);
     void _setLineAttributes(TechDraw::CosmeticEdge* cosEdge, int style, float weight, App::Color color);
+    void _setLineAttributes(TechDraw::CenterLine* cosEdge, int style, float weight, App::Color color);
     float _getAngle(Base::Vector3d center, Base::Vector3d point);
     std::vector<Base::Vector3d> _getVertexPoints(std::vector<std::string> SubNames, TechDraw::DrawViewPart* objFeat);
     bool _checkSel(Gui::Command* cmd,
@@ -1509,6 +1510,7 @@ void execExtendShortenLine(Gui::Command* cmd, bool extend) {
                     TechDraw::GenericPtr genLine = std::static_pointer_cast<TechDraw::Generic>(baseGeo);
                     Base::Vector3d P0 = genLine->points.at(0);
                     Base::Vector3d P1 = genLine->points.at(1);
+                    bool isCenterLine = false;
                     if (baseGeo->cosmetic) {
                         std::string uniTag = baseGeo->getCosmeticTag();
                         int oldStyle = 1;
@@ -1524,6 +1526,7 @@ void execExtendShortenLine(Gui::Command* cmd, bool extend) {
                             objFeat->removeCosmeticEdge(toDelete);
                         }
                         else if (baseGeo->source() == 2) {
+                            isCenterLine = true;
                             auto centerEdge = objFeat->getCenterLine(uniTag);
                             oldStyle = centerEdge->m_format.m_style;
                             oldWeight = centerEdge->m_format.m_weight;
@@ -1544,10 +1547,16 @@ void execExtendShortenLine(Gui::Command* cmd, bool extend) {
                         }
                         startPt.y = -startPt.y;
                         endPt.y = -endPt.y;
-                        std::string lineTag = objFeat->addCosmeticEdge(startPt / scale, endPt / scale);
-                        TechDraw::CosmeticEdge* lineEdge = objFeat->getCosmeticEdge(lineTag);
-                        _setLineAttributes(lineEdge, oldStyle, oldWeight, oldColor);
-                        cmd->getSelection().clearSelection();
+                        if (isCenterLine) {
+                            std::string lineTag = objFeat->addCenterLine(startPt / scale, endPt / scale);
+                            TechDraw::CenterLine* lineEdge = objFeat->getCenterLine(lineTag);
+                            _setLineAttributes(lineEdge, oldStyle, oldWeight, oldColor);
+                        } else {
+                            std::string lineTag = objFeat->addCosmeticEdge(startPt / scale, endPt / scale);
+                            TechDraw::CosmeticEdge* lineEdge = objFeat->getCosmeticEdge(lineTag);
+                            _setLineAttributes(lineEdge, oldStyle, oldWeight, oldColor);
+                        }
+//                        cmd->getSelection().clearSelection();
                         objFeat->refreshCEGeoms();
                         objFeat->refreshCLGeoms();
                         objFeat->requestPaint();
@@ -2036,6 +2045,13 @@ namespace TechDrawGui {
 
     void _setLineAttributes(TechDraw::CosmeticEdge* cosEdge, int style, float weight, App::Color color) {
         // set line attributes of a cosmetic edge
+        cosEdge->m_format.m_style = style;
+        cosEdge->m_format.m_weight = weight;
+        cosEdge->m_format.m_color = color;
+    }
+
+    void _setLineAttributes(TechDraw::CenterLine* cosEdge, int style, float weight, App::Color color) {
+        // set line attributes of a centerline
         cosEdge->m_format.m_style = style;
         cosEdge->m_format.m_weight = weight;
         cosEdge->m_format.m_color = color;

--- a/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp
+++ b/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp
@@ -1511,6 +1511,7 @@ void execExtendShortenLine(Gui::Command* cmd, bool extend) {
                     Base::Vector3d P0 = genLine->points.at(0);
                     Base::Vector3d P1 = genLine->points.at(1);
                     bool isCenterLine = false;
+                    TechDraw::CenterLine* centerEdge = nullptr;
                     if (baseGeo->cosmetic) {
                         std::string uniTag = baseGeo->getCosmeticTag();
                         int oldStyle = 1;
@@ -1527,11 +1528,7 @@ void execExtendShortenLine(Gui::Command* cmd, bool extend) {
                         }
                         else if (baseGeo->source() == 2) {
                             isCenterLine = true;
-                            auto centerEdge = objFeat->getCenterLine(uniTag);
-                            oldStyle = centerEdge->m_format.m_style;
-                            oldWeight = centerEdge->m_format.m_weight;
-                            oldColor = centerEdge->m_format.m_color;
-                            objFeat->removeCenterLine(toDelete);
+                            centerEdge = objFeat->getCenterLine(uniTag);
                         }
                         double scale = objFeat->getScale();
                         Base::Vector3d direction = (P1 - P0).Normalize();
@@ -1548,17 +1545,14 @@ void execExtendShortenLine(Gui::Command* cmd, bool extend) {
                         startPt.y = -startPt.y;
                         endPt.y = -endPt.y;
                         if (isCenterLine) {
-                            std::string lineTag = objFeat->addCenterLine(startPt / scale, endPt / scale);
-                            TechDraw::CenterLine* lineEdge = objFeat->getCenterLine(lineTag);
-                            _setLineAttributes(lineEdge, oldStyle, oldWeight, oldColor);
+                            centerEdge->m_extendBy += activeDimAttributes.getLineStretch();
+                            objFeat->refreshCLGeoms();
                         } else {
                             std::string lineTag = objFeat->addCosmeticEdge(startPt / scale, endPt / scale);
                             TechDraw::CosmeticEdge* lineEdge = objFeat->getCosmeticEdge(lineTag);
                             _setLineAttributes(lineEdge, oldStyle, oldWeight, oldColor);
+                            objFeat->refreshCEGeoms();
                         }
-//                        cmd->getSelection().clearSelection();
-                        objFeat->refreshCEGeoms();
-                        objFeat->refreshCLGeoms();
                         objFeat->requestPaint();
                     }
                 }


### PR DESCRIPTION
This PR corrects a situation where the ExtendShorten command inadvertently converted center lines into cosmetic edges.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [ ]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [ ]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [ ]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [ ]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the issue ID number from our [Issues database](https://github.com/FreeCAD/FreeCAD/issues) in case a particular commit solves or is related to an existing issue. Ex: `Draft: fix typos - fixes #4805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
