### PR TITLE
[BugFix] Draft: ensure Working Panel toolbar is deactivated on FC closing

### DIFF
--- a/src/Mod/Draft/InitGui.py
+++ b/src/Mod/Draft/InitGui.py
@@ -137,6 +137,8 @@ class DraftWorkbench(FreeCADGui.Workbench):
                 FreeCADGui.addPreferencePage(":/ui/preferences-drafttexts.ui", QT_TRANSLATE_NOOP("Draft", "Draft"))
                 FreeCADGui.draftToolBar.loadedPreferences = True
 
+        FreeCADGui.getMainWindow().mainWindowClosed.connect(self.Deactivated)
+
         FreeCAD.Console.PrintLog('Loading Draft workbench, done.\n')
 
     def Activated(self):


### PR DESCRIPTION
Related to : https://forum.freecadweb.org/viewtopic.php?f=3&t=31720

Ensures that Working Panel toolbar is deactivated before toolbars are saved by connecting to appropriate signal the `Deactivated` function.

Before PR : 
* Start FC (ensure Draft WB isn't your default WB)
* Switch to Draft WB => Working Plane toolbar is activated
* Close FC
* Start FC again => :-1: Working Plane toolbar is present ! Only way to remove is activate then deactivate Draft WB

After PR : 
* Start FC (ensure Draft WB isn't your default WB)
* Switch to Draft WB => Working Plane toolbar is activated
* Close FC
* Start FC again => :+1: Working Plane toolbar is absent