### PR TITLE
[FEM] Expand Add/Remove buttons in constraint tasks

### DIFF
--- a/src/Mod/Fem/Gui/TaskFemConstraintContact.ui
+++ b/src/Mod/Fem/Gui/TaskFemConstraintContact.ui
@@ -25,6 +25,12 @@
     <layout class="QHBoxLayout" name="hLayout1_2">
      <item>
       <widget class="QToolButton" name="btnAddMaster">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="text">
         <string>Add</string>
        </property>
@@ -35,6 +41,12 @@
      </item>
      <item>
       <widget class="QToolButton" name="btnRemoveMaster">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="text">
         <string>Remove</string>
        </property>
@@ -72,6 +84,12 @@
     <layout class="QHBoxLayout" name="hLayout1_3">
      <item>
       <widget class="QToolButton" name="btnAddSlave">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="text">
         <string>Add</string>
        </property>
@@ -82,6 +100,12 @@
      </item>
      <item>
       <widget class="QToolButton" name="btnRemoveSlave">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="text">
         <string>Remove</string>
        </property>

--- a/src/Mod/Fem/Gui/TaskFemConstraintDisplacement.ui
+++ b/src/Mod/Fem/Gui/TaskFemConstraintDisplacement.ui
@@ -46,6 +46,12 @@
     <layout class="QHBoxLayout" name="hLayout1">
      <item>
       <widget class="QToolButton" name="btnAdd">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="text">
         <string>Add</string>
        </property>
@@ -56,6 +62,12 @@
      </item>
      <item>
       <widget class="QToolButton" name="btnRemove">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="text">
         <string>Remove</string>
        </property>

--- a/src/Mod/Fem/Gui/TaskFemConstraintFixed.ui
+++ b/src/Mod/Fem/Gui/TaskFemConstraintFixed.ui
@@ -25,6 +25,12 @@
     <layout class="QHBoxLayout" name="hLayout1">
      <item>
       <widget class="QToolButton" name="btnAdd">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="text">
         <string>Add</string>
        </property>
@@ -35,6 +41,12 @@
      </item>
      <item>
       <widget class="QToolButton" name="btnRemove">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="text">
         <string>Remove</string>
        </property>

--- a/src/Mod/Fem/Gui/TaskFemConstraintFluidBoundary.ui
+++ b/src/Mod/Fem/Gui/TaskFemConstraintFluidBoundary.ui
@@ -75,6 +75,12 @@
     <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item>
       <widget class="QToolButton" name="btnAdd">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="text">
         <string>Add</string>
        </property>
@@ -85,6 +91,12 @@
      </item>
      <item>
       <widget class="QToolButton" name="btnRemove">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="text">
         <string>Remove</string>
        </property>

--- a/src/Mod/Fem/Gui/TaskFemConstraintForce.ui
+++ b/src/Mod/Fem/Gui/TaskFemConstraintForce.ui
@@ -37,6 +37,12 @@
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
       <widget class="QToolButton" name="btnAdd">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="text">
         <string>Add</string>
        </property>
@@ -47,6 +53,12 @@
      </item>
      <item>
       <widget class="QToolButton" name="btnRemove">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="text">
         <string>Remove</string>
        </property>

--- a/src/Mod/Fem/Gui/TaskFemConstraintHeatflux.ui
+++ b/src/Mod/Fem/Gui/TaskFemConstraintHeatflux.ui
@@ -25,6 +25,12 @@
     <layout class="QHBoxLayout" name="hLayout1">
      <item>
       <widget class="QToolButton" name="btnAdd">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="text">
         <string>Add</string>
        </property>
@@ -35,6 +41,12 @@
      </item>
      <item>
       <widget class="QToolButton" name="btnRemove">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="text">
         <string>Remove</string>
        </property>

--- a/src/Mod/Fem/Gui/TaskFemConstraintPlaneRotation.ui
+++ b/src/Mod/Fem/Gui/TaskFemConstraintPlaneRotation.ui
@@ -25,6 +25,12 @@
     <layout class="QHBoxLayout" name="hLayout1">
      <item>
       <widget class="QToolButton" name="btnAdd">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="text">
         <string>Add</string>
        </property>
@@ -35,6 +41,12 @@
      </item>
      <item>
       <widget class="QToolButton" name="btnRemove">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="text">
         <string>Remove</string>
        </property>

--- a/src/Mod/Fem/Gui/TaskFemConstraintPressure.ui
+++ b/src/Mod/Fem/Gui/TaskFemConstraintPressure.ui
@@ -25,6 +25,12 @@
     <layout class="QHBoxLayout" name="hLayout1">
      <item>
       <widget class="QToolButton" name="btnAdd">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="text">
         <string>Add</string>
        </property>
@@ -35,6 +41,12 @@
      </item>
      <item>
       <widget class="QToolButton" name="btnRemove">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="text">
         <string>Remove</string>
        </property>

--- a/src/Mod/Fem/Gui/TaskFemConstraintSpring.ui
+++ b/src/Mod/Fem/Gui/TaskFemConstraintSpring.ui
@@ -25,6 +25,12 @@
     <layout class="QHBoxLayout" name="hLayout1">
      <item>
       <widget class="QToolButton" name="btnAdd">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="text">
         <string>Add</string>
        </property>
@@ -35,6 +41,12 @@
      </item>
      <item>
       <widget class="QToolButton" name="btnRemove">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="text">
         <string>Remove</string>
        </property>

--- a/src/Mod/Fem/Gui/TaskFemConstraintTransform.ui
+++ b/src/Mod/Fem/Gui/TaskFemConstraintTransform.ui
@@ -49,6 +49,18 @@
     <layout class="QHBoxLayout" name="hLayout1">
      <item>
       <widget class="QToolButton" name="btnAdd">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="text">
         <string>Add</string>
        </property>
@@ -59,6 +71,18 @@
      </item>
      <item>
       <widget class="QToolButton" name="btnRemove">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="text">
         <string>Remove</string>
        </property>


### PR DESCRIPTION
Minor UI improvement. The behavior had changed when the buttons were changed
from `QPushButton` to `QToolButton`.

Before this PR:
![Screenshot from 2022-04-29 18-15-20](https://user-images.githubusercontent.com/4316933/165947989-2b132a5a-7170-4ba6-937d-568dc13ff78c.png)

With this PR:
![Screenshot from 2022-04-29 18-14-01](https://user-images.githubusercontent.com/4316933/165948134-12409cf0-3bd9-48fb-ab79-c98b18eb53a6.png)
