### PR TITLE
Draft: fix 2 gui_groups.py translation issues

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_groups.py
+++ b/src/Mod/Draft/draftguitools/gui_groups.py
@@ -62,16 +62,16 @@ class AddToGroup(gui_base.GuiCommandNeedsSelection):
     """
 
     def __init__(self):
-        super(AddToGroup, self).__init__(name=translate("draft","Add to group"))
-        self.ungroup = QT_TRANSLATE_NOOP("Draft_AddToGroup","Ungroup")
+        super(AddToGroup, self).__init__(name=translate("draft", "Add to group"))
+        self.ungroup = translate("draft", "Ungroup")
         #add new group string option
         self.addNewGroupStr = "+ " + translate("draft", "Add new group")
 
     def GetResources(self):
         """Set icon, menu and tooltip."""
         return {'Pixmap': 'Draft_AddToGroup',
-                'MenuText': QT_TRANSLATE_NOOP("Draft_AddToGroup","Move to group")+"...",
-                'ToolTip': QT_TRANSLATE_NOOP("Draft_AddToGroup","Moves the selected objects to an existing group, or removes them from any group.\nCreate a group first to use this tool.")}
+                'MenuText': QT_TRANSLATE_NOOP("Draft_AddToGroup", "Move to group..."),
+                'ToolTip': QT_TRANSLATE_NOOP("Draft_AddToGroup", "Moves the selected objects to an existing group, or removes them from any group.\nCreate a group first to use this tool.")}
 
     def Activated(self):
         """Execute when the command is called."""


### PR DESCRIPTION
This PR fixes two remaining translation issues. Apparently `QT_TRANSLATE_NOOP` has some restrictions.

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [ ]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the issue ID number from our [Issues database](https://github.com/FreeCAD/FreeCAD/issues) in case a particular commit solves or is related to an existing issue. Ex: `Draft: fix typos - fixes #4805`

---
