### PR TITLE
Fix crash when setup Link CopyOnChange

### DIFF
--- a/src/App/Link.cpp
+++ b/src/App/Link.cpp
@@ -21,6 +21,7 @@
  ****************************************************************************/
 
 #include "PreCompiled.h"
+#include <boost/property_map/property_map.hpp>
 
 #include <boost/range.hpp>
 #include <boost/algorithm/string/predicate.hpp>
@@ -460,11 +461,17 @@ void LinkBaseExtension::setOnChangeCopyObject(
     if (external == exclude && !prop)
         return;
 
-    prop = static_cast<PropertyMap*>(
-            obj->addDynamicProperty("App::PropertyMap", "_CopyOnChangeControl"));
     if (!prop) {
-        FC_ERR("Failed to setup copy on change object " << obj->getFullName());
-        return;
+        try {
+            prop = static_cast<PropertyMap*>(
+                    obj->addDynamicProperty("App::PropertyMap", "_CopyOnChangeControl"));
+        } catch (Base::Exception &e) {
+            e.ReportException();
+        }
+        if (!prop) {
+            FC_ERR("Failed to setup copy on change object " << obj->getFullName());
+            return;
+        }
     }
 
     const char *key = flags.testFlag(OnChangeCopyOptions::ApplyAll) ? "*" : parent->getNameInDocument();

--- a/src/Gui/ViewProviderLink.cpp
+++ b/src/Gui/ViewProviderLink.cpp
@@ -2519,7 +2519,7 @@ void ViewProviderLink::setupContextMenu(QMenu* menu, QObject* receiver, const ch
                     auto sels = dlg.getSelections(DlgObjectSelection::SelectionOptions::InvertSort);
                     for (auto it=excludes.begin(); it!=excludes.end(); ++it) {
                         auto iter = std::lower_bound(sels.begin(), sels.end(), *it);
-                        if (iter == objs.end() || *iter != *it) {
+                        if (iter == sels.end() || *iter != *it) {
                             ext->setOnChangeCopyObject(*it, options);
                         } else
                             sels.erase(iter);


### PR DESCRIPTION
The crash happend when testing sample file in [this](https://forum.freecadweb.org/viewtopic.php?f=17&t=42183&e=1&view=unread#p592999) post.

Download file [try5_body.FCStd](https://forum.freecadweb.org/download/file.php?id=188410). Right click the Link, choose `Setup configurable object`. Select object `Parameters`. Crash.