### PR TITLE
LGTM: Remove unnecessary deletion of local variables

### DIFF
--- a/src/Mod/Draft/importDXF.py
+++ b/src/Mod/Draft/importDXF.py
@@ -2721,7 +2721,6 @@ def processdxf(document, filename, getShapes=False, reComputeFlag=True):
     if badobjects:
         print("dxf: ", len(badobjects), " objects were not imported")
     del doc
-    del blockshapes
 
 
 def warn(dxfobject, num=None):

--- a/src/Mod/Draft/importOCA.py
+++ b/src/Mod/Draft/importOCA.py
@@ -332,8 +332,6 @@ def parse(filename, doc):
                      float(c[2])/255,
                      float(c[3])/255)
 
-    del color
-
 
 def decodeName(name):
     """Decode encoded name.


### PR DESCRIPTION
"Passing a local variable to a del statement results in that variable being removed from the local namespace. When exiting a function all local variables are deleted, so it is unnecessary to explicitly delete variables in such cases."

ref: https://lgtm.com/rules/1506104658325/  
https://lgtm.com/projects/g/FreeCAD/FreeCAD?mode=tree&ruleFocus=1506104658325

Note: I have not tested these code changes. Please review closely.