### PR TITLE
FEM: [Crowdin] fix typo in ElectrostaticPotential.ui tooltip

### DIFF
--- a/src/Mod/Fem/Gui/Resources/ui/ElectrostaticPotential.ui
+++ b/src/Mod/Fem/Gui/Resources/ui/ElectrostaticPotential.ui
@@ -156,7 +156,7 @@
         </size>
        </property>
        <property name="toolTip">
-        <string>Counter of the body (or face) with a capcitance</string>
+        <string>Counter of the body (or face) with a capacitance</string>
        </property>
        <property name="minimum">
         <number>1</number>


### PR DESCRIPTION
Fixes https://github.com/FreeCAD/FreeCAD-translations/issues/143  
[skip ci]