### PR TITLE
Base: Remove extraneous bracket from kinematic viscosity units

### DIFF
--- a/src/Base/UnitsSchemaMKS.cpp
+++ b/src/Base/UnitsSchemaMKS.cpp
@@ -456,7 +456,7 @@ QString UnitsSchemaMKS::schemaTranslate(const Quantity &quant, double &factor, Q
         factor = 0.001;
     }
     else if (unit == Unit::KinematicViscosity) {
-        unitString = QString::fromLatin1("m^2/s)");
+        unitString = QString::fromLatin1("m^2/s");
         factor = 1e6;
     }
     else {


### PR DESCRIPTION
In the MKS schema, this removes a typo which adds an extraneous bracket to the end of the string representation of kinematic viscosity: "m^2/s)"

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [ ]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [x]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the issue ID number from our [Issues database](https://github.com/FreeCAD/FreeCAD/issues) in case a particular commit solves or is related to an existing issue. Ex: `Draft: fix typos - fixes #4805`

