### PR TITLE
#6871 - Certain PostProcessors spam errors and other output

### DIFF
--- a/src/Mod/Path/PathScripts/post/KineticNCBeamicon2_post.py
+++ b/src/Mod/Path/PathScripts/post/KineticNCBeamicon2_post.py
@@ -436,6 +436,3 @@ def parse(pathobj):
                 out = out.strip() + "\n"
 
         return out
-
-
-print(__name__ + " gcode postprocessor loaded.")

--- a/src/Mod/Path/PathScripts/post/centroid_post.py
+++ b/src/Mod/Path/PathScripts/post/centroid_post.py
@@ -359,6 +359,3 @@ def parse(pathobj):
                 out = out.strip() + "\n"
 
         return out
-
-
-print(__name__ + " gcode postprocessor loaded.")

--- a/src/Mod/Path/PathScripts/post/centroid_post.py
+++ b/src/Mod/Path/PathScripts/post/centroid_post.py
@@ -51,7 +51,6 @@ Arguments for centroid:
     --axis-precision=4               ... number of digits of precision for axis moves.  Default=4
     --inches                         ... Convert output for US imperial mode (G20)
 """
-now = datetime.datetime.now()
 
 # These globals set common customization preferences
 OUTPUT_COMMENTS = True
@@ -79,13 +78,19 @@ SPINDLE_DECIMALS = 0
 
 COMMENT = ";"
 
-HEADER = """
-;Exported by FreeCAD
+# gCode header with information about CAD-software, post-processor
+# and date/time
+if FreeCAD.ActiveDocument:
+    cam_file = FreeCAD.ActiveDocument.FileName
+else:
+    cam_file = "<None>"
+
+HEADER = """;Exported by FreeCAD
 ;Post Processor: {}
 ;CAM file: {}
 ;Output Time: {}
 """.format(
-    __name__, FreeCAD.ActiveDocument.FileName, str(now)
+    __name__, cam_file, str(datetime.datetime.now())
 )
 
 # Preamble text will appear at the beginning of the GCODE output file.

--- a/src/Mod/Path/PathScripts/post/dxf_post.py
+++ b/src/Mod/Path/PathScripts/post/dxf_post.py
@@ -143,5 +143,3 @@ def parse(pathobj):
 
     return objlist
 
-
-print(__name__ + " gcode postprocessor loaded.")

--- a/src/Mod/Path/PathScripts/post/nccad_post.py
+++ b/src/Mod/Path/PathScripts/post/nccad_post.py
@@ -21,7 +21,7 @@
 # *                                                                           *
 # ****************************************************************************/
 """Postprocessor to output real GCode for Max Computer GmbH nccad9."""
-import FreeCAD as App
+import FreeCAD
 from PathScripts import PostUtils
 import datetime
 
@@ -43,9 +43,7 @@ import nccad_post
 nccad_post.export([object], "/path/to/file.knc", "")
 """
 
-
 MACHINE_NAME = """Max Computer GmbH nccad9 MCS/KOSY"""
-
 
 # gCode for changing tools
 # M01 <String> ; Displays <String> and waits for user interaction
@@ -63,12 +61,17 @@ M10 O6.0 ; Stop spindle"""
 
 # gCode header with information about CAD-software, post-processor
 # and date/time
+if FreeCAD.ActiveDocument:
+    cam_file = FreeCAD.ActiveDocument.FileName
+else:
+    cam_file = "<None>"
+
 HEADER = """;Exported by FreeCAD
 ;Post Processor: {}
 ;CAM file: {}
 ;Output Time: {}
 """.format(
-    __name__, App.ActiveDocument.FileName, str(datetime.datetime.now())
+    __name__, FreeCAD.ActiveDocument.FileName, str(datetime.datetime.now())
 )
 
 
@@ -116,7 +119,7 @@ def export(objectslist, filename, argstring):
     gcode += POSTAMBLE + "\n"
 
     # Open editor window
-    if App.GuiUp:
+    if FreeCAD.GuiUp:
         dia = PostUtils.GCodeEditorDialog()
         dia.editor.setText(gcode)
         result = dia.exec_()

--- a/src/Mod/Path/PathScripts/post/uccnc_post.py
+++ b/src/Mod/Path/PathScripts/post/uccnc_post.py
@@ -694,6 +694,3 @@ def parse(pathobj):
                 out = out.strip() + "\n"
 
         return out
-
-
-print(__name__ + " for " + GCODE_PROCESSOR + " loaded.")


### PR DESCRIPTION
1. [from #6871] Set filename to "<None>" in Post-Processors that try to read the name of the ActiveDocument even if one isn't open.
2. Changed unnecessary renaming of 'FreeCAD' to 'App' during import.
3. [from #6871] Removed print-out of "Post-Processor loaded"-message from the few Post-Processor that have it.


------

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [ ]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [x]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the issue ID number from our [Issues database](https://github.com/FreeCAD/FreeCAD/issues) in case a particular commit solves or is related to an existing issue. Ex: `Draft: fix typos - fixes #4805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
