### PR TITLE
std::unique_ptr is provided by the memory header

### DIFF
--- a/src/Mod/Part/App/BRepOffsetAPI_MakeFillingPyImp.cpp
+++ b/src/Mod/Part/App/BRepOffsetAPI_MakeFillingPyImp.cpp
@@ -35,6 +35,8 @@
 #include "TopoShapeEdgePy.h"
 #include "TopoShapeFacePy.h"
 #include <Base/VectorPy.h>
+// For std::unique_ptr
+#include <memory>
 
 using namespace Part;
 /*!

--- a/src/Mod/Part/App/ShapeUpgrade/UnifySameDomainPyImp.cpp
+++ b/src/Mod/Part/App/ShapeUpgrade/UnifySameDomainPyImp.cpp
@@ -29,6 +29,8 @@
 
 // Needed for OCCT 7.5.2
 #include <TopoDS_Edge.hxx>
+// Needed for std::unique_ptr
+#include <memory>
 
 #include "ShapeUpgrade/UnifySameDomainPy.h"
 #include "ShapeUpgrade/UnifySameDomainPy.cpp"


### PR DESCRIPTION
Required for newer GCC versions.