### PR TITLE
[TD]Fix group item moving when locked

### DIFF
--- a/src/Mod/TechDraw/App/DrawProjGroup.cpp
+++ b/src/Mod/TechDraw/App/DrawProjGroup.cpp
@@ -651,6 +651,8 @@ gp_Dir DrawProjGroup::vec2dir(Base::Vector3d v)
 //this can be improved.  this implementation positions views too far apart.
 Base::Vector3d DrawProjGroup::getXYPosition(const char *viewTypeCStr)
 {
+//    Base::Console().Message("DPG::getXYPosition(%s)\n",Label.getValue());
+
     Base::Vector3d result(0.0,0.0,0.0);
     //Front view position is always (0,0)
     if (strcmp(viewTypeCStr, "Front") == 0 ) {  // Front!
@@ -663,6 +665,12 @@ Base::Vector3d DrawProjGroup::getXYPosition(const char *viewTypeCStr)
 
         //TODO: bounding boxes do not take view orientation into account
         //      i.e. X&Y widths might be swapped on page
+
+    if (viewPtrs[viewIndex]->LockPosition.getValue()) {
+        result.x = viewPtrs[viewIndex]->X.getValue();
+        result.y = viewPtrs[viewIndex]->Y.getValue();
+        return result;
+    }
 
     if (AutoDistribute.getValue()) {
         std::vector<Base::Vector3d> position(idxCount);

--- a/src/Mod/TechDraw/App/DrawProjGroupItem.cpp
+++ b/src/Mod/TechDraw/App/DrawProjGroupItem.cpp
@@ -155,17 +155,18 @@ App::DocumentObjectExecReturn *DrawProjGroupItem::execute(void)
 void DrawProjGroupItem::autoPosition()
 {
 //    Base::Console().Message("DPGI::autoPosition(%s)\n",Label.getValue());
+    if (LockPosition.getValue()) {
+        return;
+    }
     auto pgroup = getPGroup();
     Base::Vector3d newPos;
     if (pgroup != nullptr) {
         if (pgroup->AutoDistribute.getValue()) {
-            if (!LockPosition.getValue()) {
-                newPos = pgroup->getXYPosition(Type.getValueAsString());
-                X.setValue(newPos.x);
-                Y.setValue(newPos.y);
-                requestPaint();
-                purgeTouched();               //prevents "still touched after recompute" message
-            }
+            newPos = pgroup->getXYPosition(Type.getValueAsString());
+            X.setValue(newPos.x);
+            Y.setValue(newPos.y);
+            requestPaint();
+            purgeTouched();               //prevents "still touched after recompute" message
         }
     }
 }

--- a/src/Mod/TechDraw/Gui/QGIView.cpp
+++ b/src/Mod/TechDraw/Gui/QGIView.cpp
@@ -424,19 +424,9 @@ void QGIView::draw()
     if (getViewObject() != nullptr) {
         x = Rez::guiX(getViewObject()->X.getValue());
         y = Rez::guiX(getViewObject()->Y.getValue());
-        if (getFrameState()) {
-            //+/- space for label if DPGI
-            TechDraw::DrawProjGroupItem* dpgi = dynamic_cast<TechDraw::DrawProjGroupItem*>(getViewObject());
-            if (dpgi != nullptr) {
-                double vertLabelSpace = Rez::guiX(Preferences::labelFontSizeMM());
-                if (y > 0) {
-                    y += vertLabelSpace;
-                } else if (y < 0) {
-                    y -= vertLabelSpace;
-                }
-            }
+        if (!getViewObject()->LockPosition.getValue()) {
+            setPosition(x, y);
         }
-        setPosition(x, y);
     }
     if (isVisible()) {
         drawBorder();
@@ -453,7 +443,6 @@ void QGIView::drawCaption()
     QRectF displayArea = customChildrenBoundingRect();
     m_caption->setDefaultTextColor(m_colCurrent);
     m_font.setFamily(getPrefFont());
-//    m_font.setPixelSize(calculateFontPixelSize(getPrefFontSize()));
     m_font.setPixelSize(PreferencesGui::labelFontSizePX());
     m_caption->setFont(m_font);
     QString captionStr = QString::fromUtf8(getViewObject()->Caption.getValue());
@@ -466,7 +455,6 @@ void QGIView::drawCaption()
     if (getFrameState() || vp->KeepLabel.getValue()) {            //place below label if label visible
         m_caption->setY(displayArea.bottom() + labelHeight);
     } else {
-//        m_caption->setY(displayArea.bottom() + labelCaptionFudge * getPrefFontSize());
         m_caption->setY(displayArea.bottom() + labelCaptionFudge * Preferences::labelFontSizeMM());
     }
     m_caption->show();
@@ -496,7 +484,6 @@ void QGIView::drawBorder()
 
     m_label->setDefaultTextColor(m_colCurrent);
     m_font.setFamily(getPrefFont());
-//    m_font.setPixelSize(calculateFontPixelSize(getPrefFontSize()));
     m_font.setPixelSize(PreferencesGui::labelFontSizePX());
 
     m_label->setFont(m_font);

--- a/src/Mod/TechDraw/Gui/TaskLeaderLine.cpp
+++ b/src/Mod/TechDraw/Gui/TaskLeaderLine.cpp
@@ -270,7 +270,7 @@ void TaskLeaderLine::setUiPrimary()
         ui->tbBaseView->setText(Base::Tools::fromStdString(baseName));
     }
 
-    ui->pbTracker->setText(QString::fromUtf8("Pick points"));
+    ui->pbTracker->setText(QT_TRANSLATE_NOOP("Command", QString::fromUtf8("Pick points")));
     if (m_haveMdi) {
         ui->pbTracker->setEnabled(true);
         ui->pbCancelEdit->setEnabled(true);
@@ -319,7 +319,7 @@ void TaskLeaderLine::setUiEdit()
         ui->cboxEndSym->setCurrentIndex(m_lineFeat->EndSymbol.getValue());
         connect(ui->cboxEndSym, SIGNAL(currentIndexChanged(int)), this, SLOT(onEndSymbolChanged()));
 
-        ui->pbTracker->setText(QString::fromUtf8("Edit points"));
+        ui->pbTracker->setText(QT_TRANSLATE_NOOP("Command", QString::fromUtf8("Edit points")));
         if (m_haveMdi) {
             ui->pbTracker->setEnabled(true);
             ui->pbCancelEdit->setEnabled(true);
@@ -515,7 +515,7 @@ void TaskLeaderLine::onTrackerClicked(bool b)
             m_tracker->terminateDrawing();
         }
         m_pbTrackerState = TRACKERPICK;
-        ui->pbTracker->setText(QString::fromUtf8("Pick Points"));
+        ui->pbTracker->setText(QT_TRANSLATE_NOOP("Command", QString::fromUtf8("Pick Points")));
         ui->pbCancelEdit->setEnabled(false);
         enableTaskButtons(true);
 
@@ -527,7 +527,7 @@ void TaskLeaderLine::onTrackerClicked(bool b)
             m_qgLine->closeEdit();
         }
         m_pbTrackerState = TRACKERPICK;
-        ui->pbTracker->setText(QString::fromUtf8("Edit Points"));
+        ui->pbTracker->setText(QT_TRANSLATE_NOOP("Command", QString::fromUtf8("Edit Points")));
         ui->pbCancelEdit->setEnabled(false);
         enableTaskButtons(true);
 
@@ -547,7 +547,7 @@ void TaskLeaderLine::onTrackerClicked(bool b)
         QString msg = tr("Pick a starting point for leader line");
         getMainWindow()->statusBar()->show();
         Gui::getMainWindow()->showMessage(msg,3000);
-        ui->pbTracker->setText(QString::fromUtf8("Save Points"));
+        ui->pbTracker->setText(QT_TRANSLATE_NOOP("Command", QString::fromUtf8("Save Points")));
         ui->pbTracker->setEnabled(true);
         ui->pbCancelEdit->setEnabled(true);
         m_pbTrackerState = TRACKERSAVE;
@@ -574,7 +574,7 @@ void TaskLeaderLine::onTrackerClicked(bool b)
                 QString msg = tr("Click and drag markers to adjust leader line");
                 getMainWindow()->statusBar()->show();
                 Gui::getMainWindow()->showMessage(msg,3000);
-                ui->pbTracker->setText(QString::fromUtf8("Save changes"));
+                ui->pbTracker->setText(QT_TRANSLATE_NOOP("Command", QString::fromUtf8("Save changes")));
                 ui->pbTracker->setEnabled(true);
                 ui->pbCancelEdit->setEnabled(true);
                 m_pbTrackerState = TRACKERSAVE;
@@ -591,7 +591,7 @@ void TaskLeaderLine::onTrackerClicked(bool b)
             QString msg = tr("Pick a starting point for leader line");
             getMainWindow()->statusBar()->show();
             Gui::getMainWindow()->showMessage(msg,3000);
-            ui->pbTracker->setText(QString::fromUtf8("Save changes"));
+            ui->pbTracker->setText(QT_TRANSLATE_NOOP("Command", QString::fromUtf8("Save changes")));
             ui->pbTracker->setEnabled(true);
             ui->pbCancelEdit->setEnabled(true);
             m_pbTrackerState = TRACKERSAVE;
@@ -685,7 +685,7 @@ void TaskLeaderLine::onCancelEditClicked(bool b)
     }
 
     m_pbTrackerState = TRACKEREDIT;
-    ui->pbTracker->setText(QString::fromUtf8("Edit points"));
+    ui->pbTracker->setText(QT_TRANSLATE_NOOP("Command", QString::fromUtf8("Edit points")));
     ui->pbCancelEdit->setEnabled(false);
     enableTaskButtons(true);
 
@@ -737,7 +737,7 @@ void TaskLeaderLine::onPointEditComplete(void)
     m_inProgressLock = false;
 
     m_pbTrackerState = TRACKEREDIT;
-    ui->pbTracker->setText(QString::fromUtf8("Edit points"));
+    ui->pbTracker->setText(QT_TRANSLATE_NOOP("Command", QString::fromUtf8("Edit points")));
     ui->pbTracker->setEnabled(true);
     ui->pbCancelEdit->setEnabled(true);
     enableTaskButtons(true);
@@ -754,7 +754,7 @@ void TaskLeaderLine::abandonEditSession(void)
     Gui::getMainWindow()->showMessage(msg,4000);
 
     m_pbTrackerState = TRACKEREDIT;
-    ui->pbTracker->setText(QString::fromUtf8("Edit points"));
+    ui->pbTracker->setText(QT_TRANSLATE_NOOP("Command", QString::fromUtf8("Edit points")));
     enableTaskButtons(true);
     ui->pbTracker->setEnabled(true);
     ui->pbCancelEdit->setEnabled(false);


### PR DESCRIPTION
This PR fixes a situation where DrawProjGroupItems do not respect the LockPosition property.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [ ]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [ ]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [ ]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [ ]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the issue ID number from our [Issues database](https://github.com/FreeCAD/FreeCAD/issues) in case a particular commit solves or is related to an existing issue. Ex: `Draft: fix typos - fixes #4805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
