### PR TITLE
[Readme] Update build status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [Git repository](https://github.com/FreeCAD/FreeCAD)
 
 
-[![Release](https://img.shields.io/github/release/freecad/freecad.svg)](https://github.com/freecad/freecad/releases/latest) [![Master][freecad-master-status]][travis-branches] [![Crowdin](https://d322cqt584bo4o.cloudfront.net/freecad/localized.svg)](https://crowdin.com/project/freecad) [![Gitter](https://img.shields.io/gitter/room/freecad/freecad.svg)](https://gitter.im/freecad/freecad?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/FreeCAD/FreeCAD.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/FreeCAD/FreeCAD/context:python) [![Language grade: C/C++](https://img.shields.io/lgtm/grade/cpp/g/FreeCAD/FreeCAD.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/FreeCAD/FreeCAD/context:cpp) [![Liberapay](https://img.shields.io/liberapay/receives/FreeCAD.svg?logo=liberapay)](https://liberapay.com/FreeCAD)
+[![Release](https://img.shields.io/github/release/freecad/freecad.svg)](https://github.com/freecad/freecad/releases/latest) [![Master][freecad-master-status]][gitlab-branch-master] [![Crowdin](https://d322cqt584bo4o.cloudfront.net/freecad/localized.svg)](https://crowdin.com/project/freecad) [![Gitter](https://img.shields.io/gitter/room/freecad/freecad.svg)](https://gitter.im/freecad/freecad?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/FreeCAD/FreeCAD.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/FreeCAD/FreeCAD/context:python) [![Language grade: C/C++](https://img.shields.io/lgtm/grade/cpp/g/FreeCAD/FreeCAD.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/FreeCAD/FreeCAD/context:cpp) [![Liberapay](https://img.shields.io/liberapay/receives/FreeCAD.svg?logo=liberapay)](https://liberapay.com/FreeCAD)
 
 ![screenshot](https://wiki.freecadweb.org/images/thumb/7/72/Freecad016_screenshot1.jpg/800px-Freecad016_screenshot1.jpg)
 
@@ -57,11 +57,12 @@ Build Status
 
 | Master | 0.19 | Translation |
 |:------:|:----:|:-----------:|
-|[![Master][freecad-master-status]][travis-branches]|[![0.19][freecad-0.19-status]][travis-branches]|[![Crowdin](https://d322cqt584bo4o.cloudfront.net/freecad/localized.svg)](https://crowdin.com/project/freecad)|
+|[![Master][freecad-master-status]][gitlab-branch-master]|[![0.19][freecad-0.19-status]][gitlab-branch-0.19]|[![Crowdin](https://d322cqt584bo4o.cloudfront.net/freecad/localized.svg)](https://crowdin.com/project/freecad)|
 
-[freecad-0.19-status]: https://travis-ci.org/FreeCAD/FreeCAD.svg?branch=releases/FreeCAD-0-19
-[freecad-master-status]: https://travis-ci.org/FreeCAD/FreeCAD.svg?branch=master
-[travis-branches]: https://travis-ci.org/FreeCAD/FreeCAD/branches
+[freecad-0.19-status]: https://gitlab.com/freecad/FreeCAD-CI/badges/releases/FreeCAD-0-19/pipeline.svg
+[freecad-master-status]: https://gitlab.com/freecad/FreeCAD-CI/badges/master/pipeline.svg
+[gitlab-branch-0.19]: https://gitlab.com/freecad/FreeCAD-CI/-/commits/releases/FreeCAD-0-19
+[gitlab-branch-master]: https://gitlab.com/freecad/FreeCAD-CI/-/commits/master
 [travis-builds]: https://travis-ci.org/FreeCAD/FreeCAD/builds
 
 Compiling


### PR DESCRIPTION
The old Travis-CI badges are about a year old. These changes replace the links with those for Gitlab-CI.

Adapted from instructions at https://docs.gitlab.com/ee/user/project/badges.html#use-custom-badge-images.

Not sure what tag to use. I can force push and re-title the commit if needed.