### PR TITLE
Crowdin: Add missing menu text for translation (fix for FreeCAD/FreeCAD-translations/issues/158)

### DIFF
--- a/src/Mod/Part/Gui/Workbench.cpp
+++ b/src/Mod/Part/Gui/Workbench.cpp
@@ -41,6 +41,7 @@ using namespace PartGui;
     qApp->translate("Workbench", "Split");
     qApp->translate("Workbench", "Compound");
     qApp->translate("Workbench", "Create a copy");
+    qApp->translate("Workbench", "Measure");
 #endif
 
 /// @namespace PartGui @class Workbench


### PR DESCRIPTION
will fix FreeCAD/FreeCAD-translations/issues/158