### PR TITLE
[TD] Fix incorrect using  of QT_TRANSLATE_NOOP in setText

### DIFF
--- a/src/Mod/TechDraw/Gui/TaskLeaderLine.cpp
+++ b/src/Mod/TechDraw/Gui/TaskLeaderLine.cpp
@@ -270,7 +270,7 @@ void TaskLeaderLine::setUiPrimary()
         ui->tbBaseView->setText(Base::Tools::fromStdString(baseName));
     }
 
-    ui->pbTracker->setText(QT_TRANSLATE_NOOP("Command", QString::fromUtf8("Pick points")));
+    ui->pbTracker->setText(tr("Pick points"));
     if (m_haveMdi) {
         ui->pbTracker->setEnabled(true);
         ui->pbCancelEdit->setEnabled(true);
@@ -319,7 +319,7 @@ void TaskLeaderLine::setUiEdit()
         ui->cboxEndSym->setCurrentIndex(m_lineFeat->EndSymbol.getValue());
         connect(ui->cboxEndSym, SIGNAL(currentIndexChanged(int)), this, SLOT(onEndSymbolChanged()));
 
-        ui->pbTracker->setText(QT_TRANSLATE_NOOP("Command", QString::fromUtf8("Edit points")));
+        ui->pbTracker->setText(tr("Edit points"));
         if (m_haveMdi) {
             ui->pbTracker->setEnabled(true);
             ui->pbCancelEdit->setEnabled(true);
@@ -515,7 +515,7 @@ void TaskLeaderLine::onTrackerClicked(bool b)
             m_tracker->terminateDrawing();
         }
         m_pbTrackerState = TRACKERPICK;
-        ui->pbTracker->setText(QT_TRANSLATE_NOOP("Command", QString::fromUtf8("Pick Points")));
+        ui->pbTracker->setText(tr("Pick Points"));
         ui->pbCancelEdit->setEnabled(false);
         enableTaskButtons(true);
 
@@ -527,7 +527,7 @@ void TaskLeaderLine::onTrackerClicked(bool b)
             m_qgLine->closeEdit();
         }
         m_pbTrackerState = TRACKERPICK;
-        ui->pbTracker->setText(QT_TRANSLATE_NOOP("Command", QString::fromUtf8("Edit Points")));
+        ui->pbTracker->setText(tr("Edit Points"));
         ui->pbCancelEdit->setEnabled(false);
         enableTaskButtons(true);
 
@@ -547,7 +547,7 @@ void TaskLeaderLine::onTrackerClicked(bool b)
         QString msg = tr("Pick a starting point for leader line");
         getMainWindow()->statusBar()->show();
         Gui::getMainWindow()->showMessage(msg,3000);
-        ui->pbTracker->setText(QT_TRANSLATE_NOOP("Command", QString::fromUtf8("Save Points")));
+        ui->pbTracker->setText(tr("Save Points"));
         ui->pbTracker->setEnabled(true);
         ui->pbCancelEdit->setEnabled(true);
         m_pbTrackerState = TRACKERSAVE;
@@ -574,7 +574,7 @@ void TaskLeaderLine::onTrackerClicked(bool b)
                 QString msg = tr("Click and drag markers to adjust leader line");
                 getMainWindow()->statusBar()->show();
                 Gui::getMainWindow()->showMessage(msg,3000);
-                ui->pbTracker->setText(QT_TRANSLATE_NOOP("Command", QString::fromUtf8("Save changes")));
+                ui->pbTracker->setText(tr("Save changes"));
                 ui->pbTracker->setEnabled(true);
                 ui->pbCancelEdit->setEnabled(true);
                 m_pbTrackerState = TRACKERSAVE;
@@ -591,7 +591,7 @@ void TaskLeaderLine::onTrackerClicked(bool b)
             QString msg = tr("Pick a starting point for leader line");
             getMainWindow()->statusBar()->show();
             Gui::getMainWindow()->showMessage(msg,3000);
-            ui->pbTracker->setText(QT_TRANSLATE_NOOP("Command", QString::fromUtf8("Save changes")));
+            ui->pbTracker->setText(tr("Save changes"));
             ui->pbTracker->setEnabled(true);
             ui->pbCancelEdit->setEnabled(true);
             m_pbTrackerState = TRACKERSAVE;
@@ -685,7 +685,7 @@ void TaskLeaderLine::onCancelEditClicked(bool b)
     }
 
     m_pbTrackerState = TRACKEREDIT;
-    ui->pbTracker->setText(QT_TRANSLATE_NOOP("Command", QString::fromUtf8("Edit points")));
+    ui->pbTracker->setText(tr("Edit points"));
     ui->pbCancelEdit->setEnabled(false);
     enableTaskButtons(true);
 
@@ -737,7 +737,7 @@ void TaskLeaderLine::onPointEditComplete(void)
     m_inProgressLock = false;
 
     m_pbTrackerState = TRACKEREDIT;
-    ui->pbTracker->setText(QT_TRANSLATE_NOOP("Command", QString::fromUtf8("Edit points")));
+    ui->pbTracker->setText(tr("Edit points"));
     ui->pbTracker->setEnabled(true);
     ui->pbCancelEdit->setEnabled(true);
     enableTaskButtons(true);
@@ -754,7 +754,7 @@ void TaskLeaderLine::abandonEditSession(void)
     Gui::getMainWindow()->showMessage(msg,4000);
 
     m_pbTrackerState = TRACKEREDIT;
-    ui->pbTracker->setText(QT_TRANSLATE_NOOP("Command", QString::fromUtf8("Edit points")));
+    ui->pbTracker->setText(tr("Edit points"));
     enableTaskButtons(true);
     ui->pbTracker->setEnabled(true);
     ui->pbCancelEdit->setEnabled(false);


### PR DESCRIPTION
Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [ ]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [ ]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [ ]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [ ]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the issue ID number from our [Issues database](https://github.com/FreeCAD/FreeCAD/issues) in case a particular commit solves or is related to an existing issue. Ex: `Draft: fix typos - fixes #4805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
