### PR TITLE
PD: Fix w[z] plot in ShaftWizard

### DIFF
--- a/src/Mod/PartDesign/WizardShaft/SegmentFunction.py
+++ b/src/Mod/PartDesign/WizardShaft/SegmentFunction.py
@@ -375,21 +375,19 @@ class TranslationFunction:
         yresult = []
         # Coverity has reported a problem that I_i, C_i0 or C_i1:
         # Bad use of null-like value (CIDs are 192609, 192611, 192616)
-        # Since this code doesn't seem to be used anywhere the problematic
-        # part will be commented out
-        #for xval in sorted(xvals):
-        #    if xval in divs:
-        #        i = self.intfunc.index(xval)
-        #        (begin,  length) = self.intfunc.interval(xval)
-        #        I_i = self.intfunc.value(xval)
-        #        C_i0 = self.boundaries[2 * i]
-        #        C_i1 = self.boundaries[2 * i + 1]
-        #        FreeCAD.Console.PrintMessage("Interval %u: %f to %f, I_i: %f, C_i0: %f, C_i1: %f\n" % (i,  begin, length,  I_i,  C_i0,  C_i1))
-        #
-        #    xresult.append(xval)
-        #    # w(xval) = (transfunc(xval) + C_i0 * xval + C_i1) / (E * I_i)
-        #    value = (self.transfunc.value(xval)  + C_i0 * xval + C_i1) / (E * I_i)
-        #    yresult.append(value)
+        for xval in sorted(xvals):
+            if xval in divs:
+                i = self.intfunc.index(xval)
+                (begin,  length) = self.intfunc.interval(xval)
+                I_i = self.intfunc.value(xval)
+                C_i0 = self.boundaries[2 * i]
+                C_i1 = self.boundaries[2 * i + 1]
+                FreeCAD.Console.PrintMessage("Interval %u: %f to %f, I_i: %f, C_i0: %f, C_i1: %f\n" % (i,  begin, length,  I_i,  C_i0,  C_i1))
+        
+            xresult.append(xval)
+            # w(xval) = (transfunc(xval) + C_i0 * xval + C_i1) / (E * I_i)
+            value = (self.transfunc.value(xval)  + C_i0 * xval + C_i1) / (E * I_i)
+            yresult.append(value)
             
         return (xresult, yresult)
 


### PR DESCRIPTION
This PR uncomments a chunk of code that appears to have been erroneously removed based on static analysis. That code was responsible for calculating the data used to plot the translation data, and removing it broke that plot function.