### PR TITLE
[TD]fix misleading error messages

### DIFF
--- a/src/Mod/TechDraw/App/Preferences.cpp
+++ b/src/Mod/TechDraw/App/Preferences.cpp
@@ -196,8 +196,8 @@ QString Preferences::defaultTemplate()
     QString templateFileName = QString::fromStdString(prefFileName);
     Base::FileInfo fi(prefFileName);
     if (!fi.isReadable()) {
-        templateFileName = QString::fromStdString(defaultFileName);
         Base::Console().Warning("Template File: %s is not readable\n", prefFileName.c_str());
+        templateFileName = QString::fromStdString(defaultFileName);
     }
     return templateFileName;
 }
@@ -212,8 +212,8 @@ QString Preferences::defaultTemplateDir()
     QString templateDir = QString::fromStdString(prefTemplateDir);
     Base::FileInfo fi(prefTemplateDir);
     if (!fi.isReadable()) {
-        templateDir = QString::fromStdString(defaultDir);
         Base::Console().Warning("Template Directory: %s is not readable\n", prefTemplateDir.c_str());
+        templateDir = QString::fromStdString(defaultDir);
    }
     return templateDir;
 }
@@ -228,8 +228,8 @@ std::string Preferences::lineGroupFile()
     std::string lgFileName = hGrp->GetASCII("LineGroupFile",defaultFileName.c_str());
     Base::FileInfo fi(lgFileName);
     if (!fi.isReadable()) {
-        lgFileName = defaultFileName;
         Base::Console().Warning("Line Group File: %s is not readable\n", lgFileName.c_str());
+        lgFileName = defaultFileName;
     }
     return lgFileName;
 }

--- a/src/Mod/TechDraw/Gui/PreferencesGui.cpp
+++ b/src/Mod/TechDraw/Gui/PreferencesGui.cpp
@@ -193,9 +193,8 @@ QString PreferencesGui::weldingDirectory()
     QString qSymbolDir = QString::fromUtf8(symbolDir.c_str());
     Base::FileInfo fi(symbolDir);
     if (!fi.isReadable()) {
-        qSymbolDir = QString::fromUtf8(defaultDir.c_str());
         Base::Console().Warning("Welding Directory: %s is not readable\n", symbolDir.c_str());
-
+        qSymbolDir = QString::fromUtf8(defaultDir.c_str());
     }
     return qSymbolDir;
 }


### PR DESCRIPTION
This PR addresses an issue where the wrong filename is reported as being unreadable in several error messages.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [ ]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [ ]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [ ]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [ ]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the issue ID number from our [Issues database](https://github.com/FreeCAD/FreeCAD/issues) in case a particular commit solves or is related to an existing issue. Ex: `Draft: fix typos - fixes #4805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
