### PR TITLE
[Gui] attempt to improve NaviCube rendering

### DIFF
--- a/src/Gui/NaviCube.cpp
+++ b/src/Gui/NaviCube.cpp
@@ -422,7 +422,8 @@ GLuint NaviCubeImplementation::createCubeFaceTex(QtGLWidget* gl, float gap, cons
 	Q_UNUSED(gl);
 	QOpenGLTexture* texture = new QOpenGLTexture(image.mirrored());
 	m_glTextures.push_back(texture);
-	texture->setMinificationFilter(QOpenGLTexture::Nearest);
+	texture->generateMipMaps();
+	texture->setMinificationFilter(QOpenGLTexture::LinearMipMapLinear);
 	texture->setMagnificationFilter(QOpenGLTexture::Linear);
 	return texture->textureId();
 }
@@ -527,7 +528,8 @@ GLuint NaviCubeImplementation::createButtonTex(QtGLWidget* gl, int button) {
 	Q_UNUSED(gl);
 	QOpenGLTexture* texture = new QOpenGLTexture(image.mirrored());
 	m_glTextures.push_back(texture);
-	texture->setMinificationFilter(QOpenGLTexture::Nearest);
+	texture->generateMipMaps();
+	texture->setMinificationFilter(QOpenGLTexture::LinearMipMapLinear);
 	texture->setMagnificationFilter(QOpenGLTexture::Linear);
 	return texture->textureId();
 }
@@ -599,7 +601,8 @@ GLuint NaviCubeImplementation::createMenuTex(QtGLWidget* gl, bool forPicking) {
 	Q_UNUSED(gl);
 	QOpenGLTexture* texture = new QOpenGLTexture(image.mirrored());
 	m_glTextures.push_back(texture);
-	texture->setMinificationFilter(QOpenGLTexture::Linear);
+	texture->generateMipMaps();
+	texture->setMinificationFilter(QOpenGLTexture::LinearMipMapLinear);
 	texture->setMagnificationFilter(QOpenGLTexture::Linear);
 	return texture->textureId();
 }


### PR DESCRIPTION
When the NaviCube is relatively small, it looks clumsy on some screens. This PR tries to improve that.

Anybody, please test this PR and report back if this improves the rendering for you or not.

QOpenGLTexture::Nearest (master):
![NaviCube-master](https://user-images.githubusercontent.com/1828501/171968764-8551d37e-eff5-40af-9137-5ea1a2bf62f8.png)

QOpenGLTexture::Linear:
![NaviCube-linear](https://user-images.githubusercontent.com/1828501/171968778-3a320a72-26b1-44a9-82ab-97a887341d8d.png)

QOpenGLTexture::LinearMipMapLinear (this PR):
![NaviCube-MipMap](https://user-images.githubusercontent.com/1828501/171968783-33659743-2692-4652-8dc7-ce72d5758002.png)

The PR is the work of user asegura : https://forum.freecadweb.org/viewtopic.php?p=599543#p599543

