### PR TITLE
[FEM] fix wrong error message about comments

### DIFF
--- a/src/Mod/Fem/femtools/tokrules.py
+++ b/src/Mod/Fem/femtools/tokrules.py
@@ -36,7 +36,6 @@ tokens = (
     'EQUALS',
     'LPAREN',
     'RPAREN',
-    'COMMENT',
     'POWER'
 )
 


### PR DESCRIPTION
- fixes an annoying warning (that is output as error) about unused COMMENT

To reproduce:
- open a result object of a FEM analysis
- in the appearing dialog do nothing else than to press the button "Calculate"
result:
```
23:03:10  WARNING: Token 'COMMENT' defined, but not used
23:03:10  WARNING: There is 1 unused token
```

The warning is output in red and has error level (FC's report panel shows up) and is therefore annoying.

The PR fixes this according to https://www.dabeaz.com/ply/ply.html#ply_nn8 and https://groups.google.com/g/ply-hack/c/g0aPM7pEFoo