### PR TITLE
[FEM] add missing parser handling of '^' character

### DIFF
--- a/src/Mod/Fem/femtools/tokrules.py
+++ b/src/Mod/Fem/femtools/tokrules.py
@@ -37,6 +37,7 @@ tokens = (
     'LPAREN',
     'RPAREN',
     'COMMENT',
+    'POWER',
 )
 
 # Tokens
@@ -48,6 +49,7 @@ t_DIVIDE = r'/'
 t_EQUALS = r'='
 t_LPAREN = r'\('
 t_RPAREN = r'\)'
+t_POWER = r'\^'
 t_NAME = r'[a-zA-Z_][a-zA-Z0-9_]*'
 
 
@@ -92,6 +94,7 @@ precedence = (
     ('left', 'PLUS', 'MINUS'),
     ('left', 'TIMES', 'DIVIDE'),
     ('right', 'UMINUS'),
+    ('left', 'POWER'),
 )
 
 # dictionary of names (for storing variables)
@@ -112,11 +115,13 @@ def p_expression_binop(p):
     '''expression : expression PLUS expression
                   | expression MINUS expression
                   | expression TIMES expression
-                  | expression DIVIDE expression'''
+                  | expression DIVIDE expression
+                  | expression POWER expression'''
     if p[2] == '+'  : p[0] = p[1] + p[3]
     elif p[2] == '-': p[0] = p[1] - p[3]
     elif p[2] == '*': p[0] = p[1] * p[3]
     elif p[2] == '/': p[0] = p[1] / p[3]
+    elif p[2] == '^': p[0] = p[1] ** p[3]
 
 
 def p_expression_uminus(p):

--- a/src/Mod/Fem/femtools/tokrules.py
+++ b/src/Mod/Fem/femtools/tokrules.py
@@ -37,7 +37,7 @@ tokens = (
     'LPAREN',
     'RPAREN',
     'COMMENT',
-    'POWER',
+    'POWER'
 )
 
 # Tokens
@@ -93,8 +93,8 @@ lex.lex()
 precedence = (
     ('left', 'PLUS', 'MINUS'),
     ('left', 'TIMES', 'DIVIDE'),
-    ('right', 'UMINUS'),
     ('left', 'POWER'),
+    ('right', 'UMINUS')
 )
 
 # dictionary of names (for storing variables)


### PR DESCRIPTION
- it is common to use equations like "x^2" but one currently get only an error
- this PR fixes this by adding parsing support for the '^' character as power function

This way is it now also possible to calculate a root by e.g. "x^(0.5).