### PR TITLE
Sketcher: Split more curves

### DIFF
--- a/src/App/Document.h
+++ b/src/App/Document.h
@@ -29,6 +29,7 @@
 
 #include <map>
 #include <vector>
+#include <QString>
 
 namespace Base {
     class Writer;
@@ -68,6 +69,13 @@ public:
         RestoreError = 10,
         LinkStampChanged = 11, // Indicates during restore time if any linked document's time stamp has changed
         IgnoreErrorOnRecompute = 12, // Don't report errors if the recompute failed
+    };
+
+    enum class NotificationType {
+        Information,
+        Warning,
+        Error,
+        Critical,
     };
 
     /** @name Properties */
@@ -172,6 +180,8 @@ public:
     boost::signals2::signal<void (const App::Document&, const std::vector<App::DocumentObject*>&)> signalSkipRecompute;
     boost::signals2::signal<void (const App::DocumentObject&)> signalFinishRestoreObject;
     boost::signals2::signal<void (const App::Document&,const App::Property&)> signalChangePropertyEditor;
+    // signal user message
+    boost::signals2::signal<void (const App::DocumentObject&, const QString &, NotificationType)> signalUserMessage;
     //@}
     boost::signals2::signal<void (std::string)> signalLinkXsetValue;
 

--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -198,6 +198,7 @@ struct ApplicationP
     /// Handles all commands
     CommandManager commandManager;
     ViewProviderMap viewproviderMap;
+    std::bitset<32> StatusBits;
 };
 
 static PyObject *
@@ -2287,6 +2288,16 @@ void Application::runApplication()
     }
 
     Base::Console().Log("Finish: Event loop left\n");
+}
+
+bool Application::testStatus(Status pos) const
+{
+    return d->StatusBits.test((size_t)pos);
+}
+
+void Application::setStatus(Status pos, bool on)
+{
+    d->StatusBits.set((size_t)pos, on);
 }
 
 void Application::setStyleSheet(const QString& qssFile, bool tiledBackground)

--- a/src/Gui/Application.h
+++ b/src/Gui/Application.h
@@ -54,6 +54,10 @@ class ViewProviderDocumentObject;
 class GuiExport Application
 {
 public:
+    enum Status {
+        UserInitiatedOpenDocument = 0
+    };
+
     /// construction
     explicit Application(bool GUIenabled);
     /// destruction
@@ -232,7 +236,12 @@ public:
     static void runApplication();
     void tryClose( QCloseEvent * e );
     //@}
-    
+
+    /// return the status bits
+    bool testStatus(Status pos) const;
+    /// set the status bits
+    void setStatus(Status pos, bool on);
+
     /** @name User edit mode */
     //@{
 protected:
@@ -320,7 +329,7 @@ public:
 
     static PyObject* sAddDocObserver           (PyObject *self,PyObject *args);
     static PyObject* sRemoveDocObserver        (PyObject *self,PyObject *args);
-    
+
     static PyObject* sListUserEditModes        (PyObject *self,PyObject *args);
     static PyObject* sGetUserEditMode          (PyObject *self,PyObject *args);
     static PyObject* sSetUserEditMode          (PyObject *self,PyObject *args);

--- a/src/Gui/CommandDoc.cpp
+++ b/src/Gui/CommandDoc.cpp
@@ -29,7 +29,7 @@
 # include <QDateTime>
 # include <QMessageBox>
 # include <QTextStream>
-# include <QTreeWidgetItem> 
+# include <QTreeWidgetItem>
 #endif
 
 #include <boost/regex.hpp>
@@ -150,7 +150,13 @@ void StdCmdOpen::activated(int iMsg)
     }
     else {
         for (SelectModule::Dict::iterator it = dict.begin(); it != dict.end(); ++it) {
+
+            // Set flag indicating that this load/restore has been initiated by the user (not by a macro)
+            getGuiApplication()->setStatus(Gui::Application::UserInitiatedOpenDocument, true);
+
             getGuiApplication()->open(it.key().toUtf8(), it.value().toLatin1());
+
+            getGuiApplication()->setStatus(Gui::Application::UserInitiatedOpenDocument, false);
 
             App::Document *doc = App::GetApplication().getActiveDocument();
 
@@ -276,7 +282,7 @@ StdCmdExport::StdCmdExport()
 
 /**
 Create a default filename from a user-specified format string
- 
+
 Format options are:
 %F - the basename of the .FCStd file (or the label, if it is not saved yet)
 %Lx - the label of the selected object(s), separated by character 'x'
@@ -311,7 +317,7 @@ QString createDefaultExportBasename()
     QString docFilename = QString::fromUtf8(App::GetApplication().getActiveDocument()->getFileName());
     QFileInfo fi(docFilename);
     QString fcstdBasename = fi.completeBaseName();
-    if (fcstdBasename.isEmpty()) 
+    if (fcstdBasename.isEmpty())
         fcstdBasename = QString::fromStdString(App::GetApplication().getActiveDocument()->Label.getStrValue());
 
     // %L - the label of the selected object(s)
@@ -352,7 +358,7 @@ QString createDefaultExportBasename()
                 auto formatChar = exportFormatString.at(i);
                 QChar separatorChar = QLatin1Char('-');
                 // If this format type requires an additional char, read that now (or default to
-                // '-' if the format string ends) 
+                // '-' if the format string ends)
                 if (formatChar == QLatin1Char('L') ||
                     formatChar == QLatin1Char('P')) {
                     if (i < exportFormatString.size() - 1) {
@@ -378,8 +384,8 @@ QString createDefaultExportBasename()
                     defaultFilename.append(localISO8601);
                 }
                 else {
-                    FC_WARN("When parsing default export filename format string, %" 
-                        << QString(formatChar).toStdString() 
+                    FC_WARN("When parsing default export filename format string, %"
+                        << QString(formatChar).toStdString()
                         << " is not a known format string.");
                 }
             }
@@ -419,7 +425,7 @@ void StdCmdExport::activated(int iMsg)
             filterList << QString::fromStdString(filter.first);
     }
     QString formatList = filterList.join(QLatin1String(";;"));
-    Base::Reference<ParameterGrp> hPath = 
+    Base::Reference<ParameterGrp> hPath =
         App::GetApplication().GetUserParameter().GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("General");
     QString selectedFilter = QString::fromStdString(hPath->GetASCII("FileExportFilter"));
     if (!lastExportFilterUsed.isEmpty())
@@ -486,7 +492,7 @@ void StdCmdExport::activated(int iMsg)
         // there is one.
         QFileInfo defaultExportFI(defaultFilename);
         QFileInfo thisExportFI(fileName);
-        if (filenameWasGenerated && 
+        if (filenameWasGenerated &&
             thisExportFI.completeBaseName() == defaultExportFI.completeBaseName())
             lastExportUsedGeneratedFilename = true;
         else

--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -28,6 +28,7 @@
 # include <QFileInfo>
 # include <QMessageBox>
 # include <QTextStream>
+# include <QTimer>
 # include <Inventor/actions/SoSearchAction.h>
 # include <Inventor/nodes/SoSeparator.h>
 #endif
@@ -69,6 +70,175 @@ using namespace Gui;
 namespace bp = boost::placeholders;
 
 namespace Gui {
+
+/** This class is an implementation only class to handle user notifications offered by App::Document.
+ *
+ * It provides a mechanism requiring confirmation for critical notifications only during User initiated restore/document loading ( it
+ * does not require confirmation for macro/Python initiated restore, not to interfere with automations).
+ *
+ * Additionally, it provides a mechanism to show autoclosing non-modal user notifications in a non-intrusive way.
+ **/
+class MessageManager {
+public:
+    MessageManager() = default;
+    ~MessageManager();
+
+    void setDocument(Gui::Document * pDocument);
+    void slotUserMessage(const App::DocumentObject&, const QString &, App::Document::NotificationType);
+
+
+private:
+    void reorderAutoClosingMessages();
+    QMessageBox* createNonModalMessage(const QString & msg, App::Document::NotificationType notificationtype);
+    void pushAutoClosingMessage(const QString & msg, App::Document::NotificationType notificationtype);
+    void pushAutoClosingMessageTooManyMessages();
+
+private:
+    using Connection = boost::signals2::connection;
+    Gui::Document * pDoc;
+    Connection connectUserMessage;
+    bool requireConfirmationCriticalMessageDuringRestoring = true;
+    std::vector<QMessageBox*> openAutoClosingMessages;
+    std::mutex mutexAutoClosingMessages;
+    const int autoClosingTimeout = 5000; // ms
+    const int autoClosingMessageStackingOffset = 10;
+    const unsigned int maxNumberOfOpenAutoClosingMessages = 3;
+    bool maxNumberOfOpenAutoClosingMessagesLimitReached = false;
+};
+
+MessageManager::~MessageManager(){
+    connectUserMessage.disconnect();
+}
+
+void MessageManager::setDocument(Gui::Document * pDocument)
+{
+
+    pDoc = pDocument;
+
+    connectUserMessage = pDoc->getDocument()->signalUserMessage.connect
+        (boost::bind(&Gui::MessageManager::slotUserMessage, this, bp::_1, bp::_2, bp::_3));
+
+}
+
+void MessageManager::slotUserMessage(const App::DocumentObject& obj, const QString & msg, App::Document::NotificationType notificationtype)
+{
+    (void) obj;
+
+    auto userInitiatedRestore = Application::Instance->testStatus(Gui::Application::UserInitiatedOpenDocument);
+
+    if(notificationtype == App::Document::NotificationType::Critical && userInitiatedRestore && requireConfirmationCriticalMessageDuringRestoring) {
+        auto confirmMsg = msg + QStringLiteral("\n\n") + QObject::tr("Do you want to skip confirmation of further critical message notifications while loading the file?");
+        auto button = QMessageBox::critical(pDoc->getActiveView(), QObject::tr("Critical Message"), confirmMsg, QMessageBox::Yes | QMessageBox::No, QMessageBox::No );
+
+        if(button == QMessageBox::Yes)
+            requireConfirmationCriticalMessageDuringRestoring = false;
+    }
+    else { // Non-critical errors and warnings - auto-closing non-blocking message box
+
+        auto messageNumber =  openAutoClosingMessages.size();
+
+        // Not opening more than the number of maximum autoclosing messages
+        // If maximum reached, the mechanism only resets after all present messages are auto-closed
+        if( messageNumber < maxNumberOfOpenAutoClosingMessages) {
+            if(messageNumber == 0 && maxNumberOfOpenAutoClosingMessagesLimitReached) {
+                maxNumberOfOpenAutoClosingMessagesLimitReached = false;
+            }
+
+            if(!maxNumberOfOpenAutoClosingMessagesLimitReached) {
+                pushAutoClosingMessage(msg, notificationtype);
+            }
+        }
+        else {
+            if(!maxNumberOfOpenAutoClosingMessagesLimitReached)
+                pushAutoClosingMessageTooManyMessages();
+
+            maxNumberOfOpenAutoClosingMessagesLimitReached = true;
+        }
+    }
+}
+
+void MessageManager::pushAutoClosingMessage(const QString & msg, App::Document::NotificationType notificationtype)
+{
+    std::lock_guard<std::mutex> g(mutexAutoClosingMessages); // guard to avoid creating new messages while closing old messages (via timer)
+
+    auto msgBox = createNonModalMessage(msg, notificationtype);
+
+    msgBox->show();
+
+    int numberOpenAutoClosingMessages = openAutoClosingMessages.size();
+
+    openAutoClosingMessages.push_back(msgBox);
+
+    reorderAutoClosingMessages();
+
+    QTimer::singleShot(autoClosingTimeout*numberOpenAutoClosingMessages, [msgBox, this](){
+        std::lock_guard<std::mutex> g(mutexAutoClosingMessages); // guard to avoid closing old messages while creating new ones
+        if(msgBox) {
+            msgBox->done(0);
+            openAutoClosingMessages.erase(
+                std::remove(openAutoClosingMessages.begin(), openAutoClosingMessages.end(), msgBox),
+                openAutoClosingMessages.end());
+
+            reorderAutoClosingMessages();
+        }
+    });
+}
+
+void MessageManager::pushAutoClosingMessageTooManyMessages()
+{
+    pushAutoClosingMessage(QObject::tr("Too many message notifications. Notification temporarily stopped. Look at the report view for more information."), App::Document::NotificationType::Warning);
+}
+
+
+QMessageBox* MessageManager::createNonModalMessage(const QString & msg, App::Document::NotificationType notificationtype)
+{
+        auto parent = pDoc->getActiveView();
+
+        QMessageBox* msgBox = new QMessageBox(parent);
+        msgBox->setAttribute(Qt::WA_DeleteOnClose); // msgbox deleted automatically upon closed
+        msgBox->setStandardButtons(QMessageBox::NoButton);
+        msgBox->setWindowFlag(Qt::FramelessWindowHint,true);
+        msgBox->setText(msg);
+
+        if(notificationtype == App::Document::NotificationType::Error) {
+            msgBox->setWindowTitle(QObject::tr("Error"));
+            msgBox->setIcon(QMessageBox::Critical);
+        }
+        else if(notificationtype == App::Document::NotificationType::Warning) {
+            msgBox->setWindowTitle(QObject::tr("Warning"));
+            msgBox->setIcon(QMessageBox::Warning);
+        }
+        else if(notificationtype == App::Document::NotificationType::Information) {
+            msgBox->setWindowTitle(QObject::tr("Information"));
+            msgBox->setIcon(QMessageBox::Information);
+        }
+        else if(notificationtype == App::Document::NotificationType::Critical) {
+            msgBox->setWindowTitle(QObject::tr("Critical"));
+            msgBox->setIcon(QMessageBox::Critical);
+        }
+
+        msgBox->setModal( false ); // if you want it non-modal
+
+        return msgBox;
+}
+
+void MessageManager::reorderAutoClosingMessages()
+{
+    auto parent = pDoc->getActiveView();
+
+    int numberOpenAutoClosingMessages = openAutoClosingMessages.size();
+
+    auto x = parent->width() / 2;
+    auto y = parent->height() / 7;
+
+    int posindex = numberOpenAutoClosingMessages - 1;
+    for (auto rit = openAutoClosingMessages.rbegin(); rit != openAutoClosingMessages.rend(); ++rit, posindex--) {
+        int xw = x - (*rit)->width() / 2 + autoClosingMessageStackingOffset*posindex;;
+        int yw = y + autoClosingMessageStackingOffset*posindex;
+        (*rit)->move(xw, yw);
+        (*rit)->raise();
+    }
+}
 
 // Pimpl class
 struct DocumentP
@@ -130,8 +300,9 @@ struct DocumentP
     using ConnectionBlock = boost::signals2::shared_connection_block;
     ConnectionBlock connectActObjectBlocker;
     ConnectionBlock connectChangeDocumentBlocker;
-};
 
+    MessageManager messageManager;
+};
 } // namespace Gui
 
 /* TRANSLATOR Gui::Document */
@@ -211,6 +382,8 @@ Document::Document(App::Document* pcDocument,Application * app)
         (boost::bind(&Gui::Document::slotTransactionAppend, this, bp::_1, bp::_2));
     d->connectTransactionRemove = pcDocument->signalTransactionRemove.connect
         (boost::bind(&Gui::Document::slotTransactionRemove, this, bp::_1, bp::_2));
+
+    d->messageManager.setDocument(this);
     // pointer to the python class
     // NOTE: As this Python object doesn't get returned to the interpreter we
     // mustn't increment it (Werner Jan-12-2006)
@@ -1074,7 +1247,7 @@ static bool checkCanonicalPath(const std::map<App::Document*, bool> &docs)
                     << QObject::tr("Path:") << ' ' << QString::fromUtf8(doc->FileName.getValue());
                     for (auto d : v.second) {
                         if (d == doc) continue;
-                        ts << "\n" 
+                        ts << "\n"
                         << QObject::tr("Document:") << ' ' << docName(d)
                         << "\n  "
                         << QObject::tr("Path:") << ' ' << QString::fromUtf8(d->FileName.getValue());
@@ -1689,7 +1862,6 @@ void Document::slotFinishImportObjects(const std::vector<App::DocumentObject*> &
     //     if(vpd) vpd->finishRestoring();
     // }
 }
-
 
 void Document::addRootObjectsToGroup(const std::vector<App::DocumentObject*>& obj, App::DocumentObjectGroup* grp)
 {

--- a/src/Mod/Part/App/Geometry.cpp
+++ b/src/Mod/Part/App/Geometry.cpp
@@ -1602,19 +1602,9 @@ void GeomBSplineCurve::Trim(double u, double v)
     };
 
     try {
-        if(!isPeriodic()) {
-            splitUnwrappedBSpline(u, v);
-        }
-        else { // periodic
-            if( v < u ) { // wraps over origin
-                v = v + 1.0; // v needs one extra lap (1.0)
-
-                splitUnwrappedBSpline(u, v);
-            }
-            else {
-                splitUnwrappedBSpline(u, v);
-            }
-        }
+        if (isPeriodic() && (v - u  <= Precision::PConfusion()))
+            v = v + myCurve->LastParameter() - myCurve->FirstParameter(); // v needs one extra lap
+        splitUnwrappedBSpline(u, v);
     }
     catch (Standard_Failure& e) {
         THROWM(Base::CADKernelError,e.GetMessageString())

--- a/src/Mod/Part/App/Geometry.cpp
+++ b/src/Mod/Part/App/Geometry.cpp
@@ -1602,7 +1602,7 @@ void GeomBSplineCurve::Trim(double u, double v)
     };
 
     try {
-        if (isPeriodic() && (v - u  <= Precision::PConfusion()))
+        if (isPeriodic() && (v < u))
             v = v + myCurve->LastParameter() - myCurve->FirstParameter(); // v needs one extra lap
         splitUnwrappedBSpline(u, v);
     }

--- a/src/Mod/Sketcher/App/Constraint.h
+++ b/src/Mod/Sketcher/App/Constraint.h
@@ -76,6 +76,7 @@ enum InternalAlignmentType {
     ParabolaFocus           = 8,
     BSplineControlPoint     = 9,
     BSplineKnotPoint        = 10,
+    ParabolaFocalAxis       = 11,
     NumInternalAlignmentType // must be the last item!
 };
 
@@ -144,7 +145,7 @@ private:
 
     constexpr static std::array<const char *,InternalAlignmentType::NumInternalAlignmentType> internalAlignmentType2str {
         {   "Undef", "EllipseMajorDiameter", "EllipseMinorDiameter", "EllipseFocus1", "EllipseFocus2", "HyperbolaMajor", "HyperbolaMinor",
-            "HyperbolaFocus", "ParabolaFocus", "BSplineControlPoint", "BSplineKnotPoint"}
+            "HyperbolaFocus", "ParabolaFocus", "BSplineControlPoint", "BSplineKnotPoint", "ParabolaFocalAxis"}
     };
 
 public:

--- a/src/Mod/Sketcher/App/Sketch.cpp
+++ b/src/Mod/Sketcher/App/Sketch.cpp
@@ -1898,6 +1898,9 @@ int Sketch::addConstraint(const Constraint *constraint)
             case BSplineKnotPoint:
                 rtn = addInternalAlignmentKnotPoint(constraint->First,constraint->Second, constraint->InternalAlignmentIndex);
                 break;
+            case ParabolaFocalAxis:
+                rtn = addInternalAlignmentParabolaFocalDistance(constraint->First,constraint->Second);
+                break;
             default:
                 break;
         }
@@ -3253,6 +3256,44 @@ int Sketch::addInternalAlignmentParabolaFocus(int geoId1, int geoId2)
         GCSsys.addConstraintInternalAlignmentParabolaFocus(a1, p1, tag);
         return ConstraintsCounter;
     }
+    return -1;
+}
+
+int Sketch::addInternalAlignmentParabolaFocalDistance(int geoId1, int geoId2)
+{
+    std::swap(geoId1, geoId2);
+
+    geoId1 = checkGeoId(geoId1);
+    geoId2 = checkGeoId(geoId2);
+
+    if (Geoms[geoId1].type != ArcOfParabola)
+        return -1;
+    if (Geoms[geoId2].type != Line)
+        return -1;
+
+    int pointId1 = getPointId(geoId2, PointPos::start);
+    int pointId2 = getPointId(geoId2, PointPos::end);
+
+    if (pointId1 >= 0 && pointId1 < int(Points.size()) &&
+        pointId2 >= 0 && pointId2 < int(Points.size())) {
+
+        GCS::Point &p1 = Points[pointId1];
+        GCS::Point &p2 = Points[pointId2];
+
+        GCS::ArcOfParabola &a1 = ArcsOfParabola[Geoms[geoId1].index];
+
+        auto & vertexpoint = a1.vertex;
+        auto & focuspoint = a1.focus1;
+
+        int tag = ++ConstraintsCounter;
+        GCSsys.addConstraintP2PCoincident(p1, vertexpoint, tag);
+
+        tag = ++ConstraintsCounter;
+        GCSsys.addConstraintP2PCoincident(p2, focuspoint, tag);
+
+        return ConstraintsCounter;
+    }
+
     return -1;
 }
 

--- a/src/Mod/Sketcher/App/Sketch.h
+++ b/src/Mod/Sketcher/App/Sketch.h
@@ -374,6 +374,7 @@ public:
     int addInternalAlignmentHyperbolaMinorDiameter(int geoId1, int geoId2);
     int addInternalAlignmentHyperbolaFocus(int geoId1, int geoId2);
     int addInternalAlignmentParabolaFocus(int geoId1, int geoId2);
+    int addInternalAlignmentParabolaFocalDistance(int geoId1, int geoId2);
     int addInternalAlignmentBSplineControlPoint(int geoId1, int geoId2, int poleindex);
     int addInternalAlignmentKnotPoint(int geoId1, int geoId2, int knotindex);
     //@}

--- a/src/Mod/Sketcher/App/SketchGeometryExtension.h
+++ b/src/Mod/Sketcher/App/SketchGeometryExtension.h
@@ -47,6 +47,7 @@ namespace Sketcher
             ParabolaFocus           = 8,
             BSplineControlPoint     = 9,
             BSplineKnotPoint        = 10,
+            ParabolaFocalAxis       = 11,
             NumInternalGeometryType        // Must be the last
         };
     }
@@ -104,7 +105,7 @@ public:
     int getGeometryLayerId() const override { return GeometryLayer;}
     void setGeometryLayerId(int geolayer) override { GeometryLayer = geolayer;}
 
-    constexpr static std::array<const char *,InternalType::NumInternalGeometryType> internaltype2str {{ "None", "EllipseMajorDiameter", "EllipseMinorDiameter","EllipseFocus1", "EllipseFocus2", "HyperbolaMajor", "HyperbolaMinor", "HyperbolaFocus", "ParabolaFocus", "BSplineControlPoint", "BSplineKnotPoint" }};
+    constexpr static std::array<const char *,InternalType::NumInternalGeometryType> internaltype2str {{ "None", "EllipseMajorDiameter", "EllipseMinorDiameter","EllipseFocus1", "EllipseFocus2", "HyperbolaMajor", "HyperbolaMinor", "HyperbolaFocus", "ParabolaFocus", "BSplineControlPoint", "BSplineKnotPoint", "ParabolaFocalAxis" }};
 
     constexpr static std::array<const char *,GeometryMode::NumGeometryMode> geometrymode2str {{ "Blocked", "Construction" }};
 

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -3053,6 +3053,28 @@ int SketchObject::split(int GeoId, const Base::Vector3d &point)
             ok = true;
         }
     }
+    else if (geo->getTypeId() == Part::GeomEllipse::getClassTypeId()) {
+        const Part::GeomEllipse *curve = static_cast<const Part::GeomEllipse *>(geo);
+
+        // find split point
+        curve->closestParameter(point, splitParam);
+        double period = curve->getLastParameter() - curve->getFirstParameter();
+        startParam = splitParam;
+        endParam = splitParam + period;
+
+        // create new arc
+        auto newArc = new Part::GeomArcOfEllipse(Handle(Geom_Ellipse)::DownCast(curve->handle()->Copy()));
+        newArc->setRange(startParam, endParam, false);
+        int newId = addGeometry(newArc);
+        if (newId >= 0) {
+            newIds.push_back(newId);
+            setConstruction(newId, GeometryFacade::getConstruction(geo));
+            exposeInternalGeometry(newId);
+
+            transferConstraints(GeoId, PointPos::mid, newId, PointPos::mid);
+            ok = true;
+        }
+    }
     else if (geo->getTypeId() == Part::GeomArcOfCircle::getClassTypeId()) {
         const Part::GeomArcOfCircle *arc = static_cast<const Part::GeomArcOfCircle *>(geo);
 

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -8135,8 +8135,6 @@ void SketchObject::migrateSketch()
         // There are parabolas and there isn't an IA axis. (1) there are no axis or (2) there is a legacy construction line
         if(focalaxisfound == constraints.end()) {
 
-            Base::Console().Warning("Migrating parabolas. Migrated files won't open in previous versions of FreeCAD!!\n");
-
             // maps parabola geoid to focusgeoid
             std::map<int,int> parabolageoid2focusgeoid;
 
@@ -8225,6 +8223,11 @@ void SketchObject::migrateSketch()
             }
 
             Constraints.setValues(std::move(newconstraints));
+
+            Base::Console().Warning("In Sketch %s, parabolas were migrated. Migrated files won't open in previous versions of FreeCAD!!\n",this->Label.getStrValue().c_str());
+
+            this->getDocument()->signalUserMessage(*this, QStringLiteral(QT_TRANSLATE_NOOP("CriticalMessages","Sketch:")) + QStringLiteral(" ") + QString::fromStdString(this->Label.getStrValue()) +
+                QStringLiteral(".\n\n") + QString::fromLatin1(QT_TRANSLATE_NOOP("CriticalMessages","Parabolas were migrated. Migrated files won't open in previous versions of FreeCAD!!")), App::Document::NotificationType::Critical);
         }
     }
 }

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -3117,8 +3117,8 @@ int SketchObject::split(int GeoId, const Base::Vector3d &point)
             }
         }
     }
-    else if (geo->getTypeId() == Part::GeomArcOfEllipse::getClassTypeId()) {
-        const Part::GeomArcOfEllipse *arc = static_cast<const Part::GeomArcOfEllipse *>(geo);
+    else if (geo->isDerivedFrom(Part::GeomArcOfConic::getClassTypeId())) {
+        const Part::GeomArcOfConic *arc = static_cast<const Part::GeomArcOfConic *>(geo);
 
         startPoint = arc->getStartPoint();
         endPoint = arc->getEndPoint();
@@ -3128,13 +3128,13 @@ int SketchObject::split(int GeoId, const Base::Vector3d &point)
         startParam = arc->getFirstParameter();
         endParam = arc->getLastParameter();
         // TODO: Using parameter difference as a poor substitute of length.
-        // Computing length of an arc of an ellipse would be expensive.
+        // Computing length of an arc of a generic conic would be expensive.
         if (endParam - splitParam > splitParam - startParam) {
             longestPart = 1;
         }
 
         // create new arcs
-        auto newArc = static_cast<Part::GeomArcOfEllipse *>(arc->clone());
+        auto newArc = static_cast<Part::GeomArcOfConic *>(arc->clone());
         int newId(GeoEnum::GeoUndef);
         newGeometries.push_back(newArc);
         newArc->setRange(startParam, splitParam, /*emulateCCW=*/true);
@@ -3145,7 +3145,7 @@ int SketchObject::split(int GeoId, const Base::Vector3d &point)
             exposeInternalGeometry(newId);
 
             // the "second" half
-            auto newArc2 = static_cast<Part::GeomArcOfEllipse *>(arc->clone());
+            auto newArc2 = static_cast<Part::GeomArcOfConic *>(arc->clone());
             int newId2(GeoEnum::GeoUndef);
             newArc2->setRange(splitParam, endParam, /*emulateCCW=*/true);
             newId2 = addGeometry(newArc2);

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -3025,6 +3025,11 @@ int SketchObject::split(int GeoId, const Base::Vector3d &point)
             endParam = curve->getLastParameter();
             // TODO: Using parameter difference as a poor substitute of length.
             // Computing length of an arc of a generic conic would be expensive.
+            if (endParam - splitParam < Precision::PConfusion() ||
+                splitParam - startParam < Precision::PConfusion()) {
+                THROWM(ValueError, "Split point is at one of the end points of the curve.");
+                return false;
+            }
             if (endParam - splitParam > splitParam - startParam) {
                 longestPart = 1;
             }

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -3028,7 +3028,6 @@ int SketchObject::split(int GeoId, const Base::Vector3d &point)
             if (endParam - splitParam < Precision::PConfusion() ||
                 splitParam - startParam < Precision::PConfusion()) {
                 THROWM(ValueError, "Split point is at one of the end points of the curve.");
-                return false;
             }
             if (endParam - splitParam > splitParam - startParam) {
                 longestPart = 1;

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -3116,14 +3116,88 @@ int SketchObject::split(int GeoId, const Base::Vector3d &point)
             }
         }
     }
+    else if (geo->getTypeId() == Part::GeomBSplineCurve::getClassTypeId()) {
+        const Part::GeomBSplineCurve *bsp = static_cast<const Part::GeomBSplineCurve *>(geo);
+
+        // find split point
+        double splitParam;
+        bsp->closestParameter(point, splitParam);
+
+        // what to do for periodic b-splines?
+        if (bsp->isPeriodic()) {
+            Part::GeomBSplineCurve* newBsp;
+            int newId(GeoEnum::GeoUndef);
+            newBsp = static_cast<Part::GeomBSplineCurve *>(bsp->clone());
+            newGeometries.push_back(newBsp);
+            newBsp->Trim(splitParam, splitParam);
+            newId = addGeometry(newBsp);
+            if (newId >= 0) {
+                newIds.push_back(newId);
+                setConstruction(newId, GeometryFacade::getConstruction(geo));
+                exposeInternalGeometry(newId);
+
+                // no constraints to transfer here, and we assume the split is to "break" the b-spline
+                ok = true;
+            }
+        }
+        else {
+            // create new b-splines
+            Part::GeomBSplineCurve* newBsp;
+            int newId(GeoEnum::GeoUndef);
+            newBsp = static_cast<Part::GeomBSplineCurve *>(bsp->clone());
+            newGeometries.push_back(newBsp);
+            newBsp->Trim(newBsp->getFirstParameter(), splitParam);
+            newId = addGeometry(newBsp);
+            if (newId >= 0) {
+                newIds.push_back(newId);
+                setConstruction(newId, GeometryFacade::getConstruction(geo));
+                exposeInternalGeometry(newId);
+
+                // the "second" half
+                newBsp = static_cast<Part::GeomBSplineCurve *>(bsp->clone());
+                newGeometries.push_back(newBsp);
+                newBsp->Trim(splitParam, newBsp->getLastParameter());
+                newId = addGeometry(newBsp);
+                if (newId >= 0) {
+                    newIds.push_back(newId);
+                    setConstruction(newId, GeometryFacade::getConstruction(geo));
+                    exposeInternalGeometry(newId);
+
+                    // apply appropriate constraints on the new points at split point
+                    Constraint* joint = new Constraint();
+                    joint->Type = Coincident;
+                    joint->First = newIds[0];
+                    joint->FirstPos = PointPos::end;
+                    joint->Second = newIds[1];
+                    joint->SecondPos = PointPos::start;
+                    newConstraints.push_back(joint);
+
+                    // transfer constraints from start and end of original spline
+                    transferConstraints(GeoId, PointPos::start, newIds[0], PointPos::start, true);
+                    transferConstraints(GeoId, PointPos::end, newIds[1], PointPos::end, true);
+                    ok = true;
+                }
+            }
+        }
+    }
 
     if (ok) {
         std::vector<int> oldConstraints;
         getConstraintIndices(GeoId, oldConstraints);
 
+        const auto& allConstraints = this->Constraints.getValues();
+
+        // keep constraints on internal geometries so they are deleted
+        // when the old curve is deleted
+        oldConstraints.erase(
+            std::remove_if(
+                oldConstraints.begin(), oldConstraints.end(),
+                [=](const auto& i){return allConstraints[i]->Type == InternalAlignment;}),
+            oldConstraints.end());
+
         for (unsigned int i = 0; i < oldConstraints.size(); ++i) {
 
-            Constraint *con = this->Constraints.getValues()[oldConstraints[i]];
+            Constraint *con = allConstraints[oldConstraints[i]];
             int conId = con->First;
             PointPos conPos = con->FirstPos;
             if (conId == GeoId) {

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -887,13 +887,21 @@ int SketchObject::addGeometry(const std::vector<Part::Geometry *> &geoList, bool
 
 int SketchObject::addGeometry(const Part::Geometry *geo, bool construction/*=false*/)
 {
+    // this copy has a new random tag (see copy() vs clone())
+    auto geoNew = std::unique_ptr<Part::Geometry>(geo->copy());
+
+    return addGeometry(std::move(geoNew),construction);
+}
+
+int SketchObject::addGeometry(std::unique_ptr<Part::Geometry> newgeo, bool construction/*=false*/)
+{
     Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
 
     const std::vector< Part::Geometry * > &vals = getInternalGeometry();
 
     std::vector< Part::Geometry * > newVals(vals);
 
-    Part::Geometry *geoNew = geo->copy();
+    auto *geoNew = newgeo.release();
 
     if( geoNew->getTypeId() == Part::GeomPoint::getClassTypeId()) {
         // creation mode for points is always construction not to

--- a/src/Mod/Sketcher/App/SketchObject.h
+++ b/src/Mod/Sketcher/App/SketchObject.h
@@ -94,12 +94,23 @@ public:
      */
     bool isSupportedGeometry(const Part::Geometry *geo) const;
     /*!
-     \brief Add geometry to a sketch
+     \brief Add geometry to a sketch - It adds a copy with a different uuid (internally uses copy() instead of clone())
      \param geo - geometry to add
      \param construction - true for construction lines
      \retval int - GeoId of added element
      */
     int addGeometry(const Part::Geometry *geo, bool construction=false);
+
+    /*!
+     \brief Add geometry to a sketch using up the provided newgeo. Caveat: It will use the provided newgeo with the uuid it has.
+     This is different from the addGeometry method with a naked pointer, where a different uuid is ensured. The caller is responsible
+     for provided a new or existing uuid, as necessary.
+     \param geo - geometry to add
+     \param construction - true for construction lines
+     \retval int - GeoId of added element
+     */
+    int addGeometry(std::unique_ptr<Part::Geometry> newgeo, bool construction=false);
+
     /*!
      \brief Add multiple geometry elements to a sketch
      \param geoList - geometry to add

--- a/src/Mod/Sketcher/App/SketchObjectPyImp.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectPyImp.cpp
@@ -1154,11 +1154,16 @@ PyObject* SketchObjectPy::split(PyObject *args)
         return nullptr;
 
     Base::Vector3d v1 = static_cast<Base::VectorPy*>(pcObj)->value();
-    if (this->getSketchObjectPtr()->split(GeoId,v1)) {
-        std::stringstream str;
-        str << "Not able to split curve with the given index: " << GeoId;
-        PyErr_SetString(PyExc_ValueError, str.str().c_str());
-        return nullptr;
+    try {
+        if (this->getSketchObjectPtr()->split(GeoId,v1)) {
+            std::stringstream str;
+            str << "Not able to split curve with the given index: " << GeoId;
+            PyErr_SetString(PyExc_ValueError, str.str().c_str());
+            return nullptr;
+        }
+    }
+    catch (const Base::ValueError & e) {
+        throw Py::ValueError(e.getMessage());
     }
 
     Py_Return;

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerSplitting.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerSplitting.h
@@ -52,8 +52,7 @@ public:
             const Part::Geometry *geom = Sketch->getGeometry(GeoId);
             if (geom->getTypeId() == Part::GeomLineSegment::getClassTypeId()
                 || geom->getTypeId() == Part::GeomCircle::getClassTypeId()
-                || geom->getTypeId() == Part::GeomArcOfCircle::getClassTypeId()
-                || geom->getTypeId() == Part::GeomArcOfEllipse::getClassTypeId()
+                || geom->isDerivedFrom(Part::GeomArcOfConic::getClassTypeId())
                 || geom->getTypeId() == Part::GeomBSplineCurve::getClassTypeId()) {
                 return true;
             }
@@ -90,8 +89,7 @@ public:
             const Part::Geometry *geom = sketchgui->getSketchObject()->getGeometry(GeoId);
             if (geom->getTypeId() == Part::GeomLineSegment::getClassTypeId()
                 || geom->getTypeId() == Part::GeomCircle::getClassTypeId()
-                || geom->getTypeId() == Part::GeomArcOfCircle::getClassTypeId()
-                || geom->getTypeId() == Part::GeomArcOfEllipse::getClassTypeId()
+                || geom->isDerivedFrom(Part::GeomArcOfConic::getClassTypeId())
                 || geom->getTypeId() == Part::GeomBSplineCurve::getClassTypeId()) {
                 try {
                     Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Split edge"));

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerSplitting.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerSplitting.h
@@ -52,6 +52,7 @@ public:
             const Part::Geometry *geom = Sketch->getGeometry(GeoId);
             if (geom->getTypeId() == Part::GeomLineSegment::getClassTypeId()
                 || geom->getTypeId() == Part::GeomCircle::getClassTypeId()
+                || geom->getTypeId() == Part::GeomEllipse::getClassTypeId()
                 || geom->isDerivedFrom(Part::GeomArcOfConic::getClassTypeId())
                 || geom->getTypeId() == Part::GeomBSplineCurve::getClassTypeId()) {
                 return true;
@@ -89,6 +90,7 @@ public:
             const Part::Geometry *geom = sketchgui->getSketchObject()->getGeometry(GeoId);
             if (geom->getTypeId() == Part::GeomLineSegment::getClassTypeId()
                 || geom->getTypeId() == Part::GeomCircle::getClassTypeId()
+                || geom->getTypeId() == Part::GeomEllipse::getClassTypeId()
                 || geom->isDerivedFrom(Part::GeomArcOfConic::getClassTypeId())
                 || geom->getTypeId() == Part::GeomBSplineCurve::getClassTypeId()) {
                 try {

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerSplitting.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerSplitting.h
@@ -53,6 +53,7 @@ public:
             if (geom->getTypeId() == Part::GeomLineSegment::getClassTypeId()
                 || geom->getTypeId() == Part::GeomCircle::getClassTypeId()
                 || geom->getTypeId() == Part::GeomArcOfCircle::getClassTypeId()
+                || geom->getTypeId() == Part::GeomArcOfEllipse::getClassTypeId()
                 || geom->getTypeId() == Part::GeomBSplineCurve::getClassTypeId()) {
                 return true;
             }
@@ -90,6 +91,7 @@ public:
             if (geom->getTypeId() == Part::GeomLineSegment::getClassTypeId()
                 || geom->getTypeId() == Part::GeomCircle::getClassTypeId()
                 || geom->getTypeId() == Part::GeomArcOfCircle::getClassTypeId()
+                || geom->getTypeId() == Part::GeomArcOfEllipse::getClassTypeId()
                 || geom->getTypeId() == Part::GeomBSplineCurve::getClassTypeId()) {
                 try {
                     Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Split edge"));

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerSplitting.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerSplitting.h
@@ -52,7 +52,8 @@ public:
             const Part::Geometry *geom = Sketch->getGeometry(GeoId);
             if (geom->getTypeId() == Part::GeomLineSegment::getClassTypeId()
                 || geom->getTypeId() == Part::GeomCircle::getClassTypeId()
-                || geom->getTypeId() == Part::GeomArcOfCircle::getClassTypeId()) {
+                || geom->getTypeId() == Part::GeomArcOfCircle::getClassTypeId()
+                || geom->getTypeId() == Part::GeomBSplineCurve::getClassTypeId()) {
                 return true;
             }
         }
@@ -88,7 +89,8 @@ public:
             const Part::Geometry *geom = sketchgui->getSketchObject()->getGeometry(GeoId);
             if (geom->getTypeId() == Part::GeomLineSegment::getClassTypeId()
                 || geom->getTypeId() == Part::GeomCircle::getClassTypeId()
-                || geom->getTypeId() == Part::GeomArcOfCircle::getClassTypeId()) {
+                || geom->getTypeId() == Part::GeomArcOfCircle::getClassTypeId()
+                || geom->getTypeId() == Part::GeomBSplineCurve::getClassTypeId()) {
                 try {
                     Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Split edge"));
                     Gui::cmdAppObjectArgs(sketchgui->getObject(), "split(%d,App.Vector(%f,%f,0))",

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerSplitting.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerSplitting.h
@@ -58,6 +58,15 @@ public:
                 return true;
             }
         }
+        else if (element.substr(0,6) == "Vertex") {
+            int VertId = std::atoi(element.substr(6,4000).c_str()) - 1;
+            int GeoId = Sketcher::GeoEnum::GeoUndef;
+            Sketcher::PointPos PosId = Sketcher::PointPos::none;
+            Sketcher::SketchObject *Sketch = static_cast<Sketcher::SketchObject*>(object);
+            Sketch->getGeoVertexIndex(VertId, GeoId, PosId);
+            if (isBsplineKnot(Sketch, GeoId))
+                return true;
+        }
         return  false;
     }
 };
@@ -85,25 +94,51 @@ public:
 
     bool releaseButton(Base::Vector2d onSketchPos) override
     {
-        int GeoId = getPreselectCurve();
-        if (GeoId >= 0) {
-            const Part::Geometry *geom = sketchgui->getSketchObject()->getGeometry(GeoId);
+        int GeoId = Sketcher::GeoEnum::GeoUndef;
+
+        int curveGeoId = getPreselectCurve();
+        if (curveGeoId >= 0) {
+            const Part::Geometry *geom = sketchgui->getSketchObject()->getGeometry(curveGeoId);
             if (geom->getTypeId() == Part::GeomLineSegment::getClassTypeId()
                 || geom->getTypeId() == Part::GeomCircle::getClassTypeId()
                 || geom->getTypeId() == Part::GeomEllipse::getClassTypeId()
                 || geom->isDerivedFrom(Part::GeomArcOfConic::getClassTypeId())
                 || geom->getTypeId() == Part::GeomBSplineCurve::getClassTypeId()) {
-                try {
-                    Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Split edge"));
-                    Gui::cmdAppObjectArgs(sketchgui->getObject(), "split(%d,App.Vector(%f,%f,0))",
-                              GeoId, onSketchPos.x, onSketchPos.y);
-                    Gui::Command::commitCommand();
-                    tryAutoRecompute(static_cast<Sketcher::SketchObject *>(sketchgui->getObject()));
-                }
-                catch (const Base::Exception& e) {
-                    Base::Console().Error("Failed to split edge: %s\n", e.what());
-                    Gui::Command::abortCommand();
-                }
+                GeoId = curveGeoId;
+            }
+        }
+        else {
+            // No curve of interest is pre-selected. Try pre-selected point.
+            int pointGeoId = getPreselectPoint();
+
+            if (pointGeoId >=0) {
+                // TODO: This has to be a knot. Find the spline.
+
+                const auto& constraints = getSketchObject()->Constraints.getValues();
+                const auto& conIt = std::find_if(
+                    constraints.begin(), constraints.end(),
+                    [pointGeoId](auto constr) {
+                        return (constr->Type == Sketcher::InternalAlignment &&
+                                constr->AlignmentType == Sketcher::BSplineKnotPoint &&
+                                constr->First == pointGeoId);
+                    });
+
+                if (conIt != constraints.end())
+                    GeoId = (*conIt)->Second;
+            }
+        }
+
+        if (GeoId >= 0) {
+            try {
+                Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Split edge"));
+                Gui::cmdAppObjectArgs(sketchgui->getObject(), "split(%d,App.Vector(%f,%f,0))",
+                                      GeoId, onSketchPos.x, onSketchPos.y);
+                Gui::Command::commitCommand();
+                tryAutoRecompute(static_cast<Sketcher::SketchObject *>(sketchgui->getObject()));
+            }
+            catch (const Base::Exception& e) {
+                Base::Console().Error("Failed to split edge: %s\n", e.what());
+                Gui::Command::abortCommand();
             }
         }
         else {

--- a/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
@@ -1307,9 +1307,9 @@ void EditModeConstraintCoinManager::updateConstraintColor(const std::vector<Sket
                     case EllipseMinorDiameter:
                     case HyperbolaMajor:
                     case HyperbolaMinor:
+                    case ParabolaFocalAxis:
                     {
                         selectline(constraint->First);
-
                     }
                     break;
                     case EllipseFocus1:

--- a/src/Mod/Web/Gui/BrowserView.cpp
+++ b/src/Mod/Web/Gui/BrowserView.cpp
@@ -595,7 +595,10 @@ void BrowserView::urlFilter(const QUrl & url)
                     }
                     // Gui::Command::doCommand(Gui::Command::Gui,"execfile('%s')",(const char*) fi.absoluteFilePath().	toLocal8Bit());
                     QString filename = Base::Tools::escapeEncodeFilename(fi.absoluteFilePath());
+                    // Set flag indicating that this load/restore has been initiated by the user (not by a macro)
+                    Gui::Application::Instance->setStatus(Gui::Application::UserInitiatedOpenDocument, true);
                     Gui::Command::doCommand(Gui::Command::Gui,"with open('%s') as file:\n\texec(file.read())",(const char*) filename.toUtf8());
+                    Gui::Application::Instance->setStatus(Gui::Application::UserInitiatedOpenDocument, false);
                 }
                 catch (const Base::Exception& e) {
                     QMessageBox::critical(this, tr("Error"), QString::fromUtf8(e.what()));


### PR DESCRIPTION
Supercedes PR #6494. I expect to make some major changes to the method for a bit more code-reuse, ~so it's best to keep that PR as is~. 

UPDATE [2 July 2022]: After the recent removal of `DrawSketchHandlers` from `CommandCreateGeo.cpp` into their own classes, I chose to drop #6494 and only rebase this one.

Solves #5835.

Known issues:
1. Splitting parabolas makes constraints malformed. See issue #6969.