### PR TITLE
[FEM] fix linear filter plot

### DIFF
--- a/src/Mod/Fem/Gui/TaskPostBoxes.cpp
+++ b/src/Mod/Fem/Gui/TaskPostBoxes.cpp
@@ -735,14 +735,20 @@ std::string TaskPostDataAlongLine::Plot() {
     auto xlabel = tr("Length", "X-Axis plot label");
     std::ostringstream oss;
     oss << "import FreeCAD\n\
+from PySide import QtCore\n\
+from PySide.QtCore import Qt\n\
 import numpy as np\n\
 from matplotlib import pyplot as plt\n\
+plt.ioff()\n\
 plt.figure(1)\n\
 plt.plot(x, y)\n\
 plt.xlabel(\"" << xlabel.toStdString() << "\")\n\
 plt.ylabel(title)\n\
 plt.title(title)\n\
 plt.grid()\n\
+fig_manager = plt.get_current_fig_manager()\n\
+fig_manager.window.setParent(FreeCADGui.getMainWindow())\n\
+fig_manager.window.setWindowFlag(QtCore.Qt.Tool)\n\
 plt.show()\n";
     return oss.str();
 }

--- a/src/Mod/Fem/Gui/TaskPostBoxes.cpp
+++ b/src/Mod/Fem/Gui/TaskPostBoxes.cpp
@@ -736,7 +736,6 @@ std::string TaskPostDataAlongLine::Plot() {
     std::ostringstream oss;
     oss << "import FreeCAD\n\
 from PySide import QtCore\n\
-from PySide.QtCore import Qt\n\
 import numpy as np\n\
 from matplotlib import pyplot as plt\n\
 plt.ioff()\n\


### PR DESCRIPTION
the plot one can create from within the linear filter is at the moment detached from FreeCAD's main window.
This PR fixes it the same way as in https://github.com/FreeCAD/FreeCAD/commit/920e8e046