### PR TITLE
Arch: ArchSectionPlane always showed plan symbols of windows

### DIFF
--- a/src/Mod/Arch/ArchSectionPlane.py
+++ b/src/Mod/Arch/ArchSectionPlane.py
@@ -583,20 +583,15 @@ def getSVG(source,
     if windows:
         sh = []
         for w in windows:
-            wlo = w.getLinkedObject()  # To support Link of Windows(Doors)
-            if not hasattr(wlo.Proxy,"sshapes"):
-                wlo.Proxy.execute(wlo)
-            if hasattr(wlo.Proxy,"sshapes"):
-                if wlo.Proxy.sshapes and (w.Name in cutwindows):
-                    c = Part.makeCompound(wlo.Proxy.sshapes)
-                    c.Placement = w.Placement
-                    sh.append(c)
-            # buggy for now...
-            #if hasattr(w.Proxy,"vshapes"):
-            #    if w.Proxy.vshapes:
-            #        c = Part.makeCompound(w.Proxy.vshapes)
-            #        c.Placement = w.Placement
-            #        sh.append(c)
+            if w.Name in cutwindows:
+                wlo = w.getLinkedObject()  # To support Link of Windows(Doors)
+                if hasattr(wlo, "SymbolPlan") and wlo.SymbolPlan:
+                    if not hasattr(wlo.Proxy, "sshapes"):
+                        wlo.Proxy.execute(wlo)
+                    if hasattr(wlo.Proxy, "sshapes") and wlo.Proxy.sshapes:
+                        c = Part.makeCompound(wlo.Proxy.sshapes)
+                        c.Placement = w.Placement
+                        sh.append(c)
         if sh:
             if not techdraw:
                 svg += '<g transform="scale(1,-1)">'


### PR DESCRIPTION
The code for ArchSectionPlane did not check the SymbolPlan property of windows and doors. This this meant that plan symbols always were included.

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the issue ID number from our [Issues database](https://github.com/FreeCAD/FreeCAD/issues) in case a particular commit solves or is related to an existing issue. Ex: `Draft: fix typos - fixes #4805`

---
