### PR TITLE
[Sketcher] Support for antialiasing in Sketcher

### DIFF
--- a/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
@@ -31,6 +31,7 @@
 # include <Inventor/nodes/SoCoordinate3.h>
 # include <Inventor/nodes/SoLineSet.h>
 # include <Inventor/nodes/SoFont.h>
+# include <Inventor/nodes/SoTransparencyType.h>
 
 # include <Inventor/nodes/SoMarkerSet.h>
 # include <Inventor/nodes/SoTranslation.h>
@@ -693,6 +694,10 @@ void EditModeCoinManager::createEditModeInventorNodes()
     editModeScenegraphNodes.EditRoot->setName("Sketch_EditRoot");
     ViewProviderSketchCoinAttorney::addNodeToRoot(viewProvider, editModeScenegraphNodes.EditRoot);
     editModeScenegraphNodes.EditRoot->renderCaching = SoSeparator::OFF ;
+
+    auto transparencytype = new SoTransparencyType;
+    transparencytype->value = SoTransparencyType::Type::SORTED_OBJECT_BLEND;
+    editModeScenegraphNodes.EditRoot->addChild(transparencytype);
 
     // Create Geometry Coin nodes ++++++++++++++++++++++++++++++++++++++
     pEditModeGeometryCoinManager->createEditModeInventorNodes();

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -2662,7 +2662,9 @@ void ViewProviderSketch::draw(bool temp /*=false*/, bool rebuildinformationoverl
 
     Gui::MDIView *mdi = this->getActiveView();
     if (mdi && mdi->isDerivedFrom(Gui::View3DInventor::getClassTypeId())) {
-        static_cast<Gui::View3DInventor *>(mdi)->getViewer()->redraw();
+        auto viewer = static_cast<Gui::View3DInventor *>(mdi)->getViewer();
+        viewer->getSoRenderManager()->setAntialiasing(true, 16);
+        viewer->redraw();
     }
 }
 


### PR DESCRIPTION
Exposing some antialiasing options from Coin3D.

Currently does not work as expected. With some higher number of passes, the lines seem a little thicker. Additionally, the constraint numbers are all displayed with black background. This suggests an issue with the alpha: anti-aliasing is happening, but Coin3D is drawing on the viewport without an alpha channel.

![without-antialiasing](https://user-images.githubusercontent.com/4316933/173397192-13507c76-e67e-4bf5-a8fa-e20bca061dd9.png)
Without anti-aliasing

![with-antialiasing-16](https://user-images.githubusercontent.com/4316933/173397270-1450b877-e329-4f59-b7b9-5466a6464f83.png)
With anti-aliasing (16 passes)

![with-antialiasing-128](https://user-images.githubusercontent.com/4316933/173398714-7e924ec4-b695-4152-869c-59de9330e32f.png)
With anti-aliasing (128 passes)