### PR TITLE
[BUGFIX] Gui: fix mouse Gesture navigation mode

### DIFF
--- a/src/Gui/GestureNavigationStyle.cpp
+++ b/src/Gui/GestureNavigationStyle.cpp
@@ -893,9 +893,9 @@ SbBool GestureNavigationStyle::processSoEvent(const SoEvent* const ev)
             return true;
     }
 
-    if (   (!smev.isRelease(1) && this->button1down)
-        || (!smev.isRelease(2) && this->button2down)
-        || (!smev.isRelease(3) && this->button3down)) {
+    if (   (smev.isRelease(1) && !this->button1down)
+        || (smev.isRelease(2) && !this->button2down)
+        || (smev.isRelease(3) && !this->button3down)) {
         //a button release event cane, but we didn't see the corresponding down
         //event. Discard it. This discarding is relied upon in some hacks to
         //overcome buggy synthetic mouse input coming from Qt when doing


### PR DESCRIPTION
 Regression introduced by commit c23a30b

Diff of commit that introduced regression : https://github.com/FreeCAD/FreeCAD/commit/c23a30b91628c8f940f0262492b68bde34a3eb98#diff-76b2d842b8ac050b741529e577356508cb9f8a4af6bb423fa8edc57e9e24fc28

Forum report : https://forum.freecadweb.org/viewtopic.php?f=12&t=69653 (basically Gesture navigation mode is broken)