### PR TITLE
Sketcher: SolverGeometryExtension and sketch parameter information improvements

### DIFF
--- a/src/Mod/Sketcher/App/Sketch.h
+++ b/src/Mod/Sketcher/App/Sketch.h
@@ -36,7 +36,8 @@
 
 namespace Sketcher
 {
-
+    // Forward declarations
+    class SolverGeometryExtension;
 
 class SketcherExport Sketch :public Base::Persistence
 {
@@ -116,6 +117,8 @@ public:
     inline const std::vector<int> &getMalformedConstraints(void) const { return MalformedConstraints; }
 public:
     std::set < std::pair< int, Sketcher::PointPos>> getDependencyGroup(int geoId, PointPos pos) const;
+
+    std::shared_ptr<SolverGeometryExtension> getSolverExtension(int geoId) const;
 
 
 public:
@@ -441,10 +444,13 @@ protected:
 
     std::vector<double *> pDependentParametersList;
 
+    // map of geoIds to corresponding solverextensions. This is useful when solved geometry is NOT to be assigned to the SketchObject
+    std::vector<std::shared_ptr<SolverGeometryExtension>> solverExtensions;
+
     std::vector < std::set < std::pair< int, Sketcher::PointPos>>> pDependencyGroups;
 
-    // this map is intended to convert a parameter (double *) into a GeoId/PointPos pair
-    std::map<double *, std::pair<int,Sketcher::PointPos>> param2geoelement;
+    // this map is intended to convert a parameter (double *) into a GeoId/PointPos and parameter number
+    std::map<double *, std::tuple<int, Sketcher::PointPos, int>> param2geoelement;
 
     // solving parameters
     std::vector<double*> Parameters;    // with memory allocation

--- a/src/Mod/Sketcher/App/SolverGeometryExtension.cpp
+++ b/src/Mod/Sketcher/App/SolverGeometryExtension.cpp
@@ -24,6 +24,8 @@
 
 #include <Base/Exception.h>
 
+#include <Mod/Part/App/Geometry.h>
+
 #include "SolverGeometryExtension.h"
 
 using namespace Sketcher;
@@ -33,7 +35,6 @@ using namespace Sketcher;
 TYPESYSTEM_SOURCE(Sketcher::SolverGeometryExtension,Part::GeometryExtension)
 
 SolverGeometryExtension::SolverGeometryExtension():
-    Edge(SolverGeometryExtension::Dependent),
     Start(SolverGeometryExtension::Dependent),
     Mid(SolverGeometryExtension::Dependent),
     End(SolverGeometryExtension::Dependent)
@@ -68,3 +69,101 @@ PyObject * SolverGeometryExtension::getPyObject(void)
     THROWM(Base::NotImplementedError, "SolverGeometryExtension does not have a Python counterpart");
 }
 
+SolverGeometryExtension::PointParameterStatus SolverGeometryExtension::getPoint(Sketcher::PointPos pos) const {
+    if(pos==Sketcher::PointPos::start)
+        return getStartPoint();
+    if(pos==Sketcher::PointPos::end)
+        return getEndPoint();
+    if(pos==Sketcher::PointPos::mid)
+        return getMidPoint();
+
+    THROWM(Base::ValueError, "SolverGeometryExtension - getPoint: Edge is not a point");
+}
+
+void SolverGeometryExtension::notifyAttachment(Part::Geometry * geo)
+{
+    // maps type to number of solver parameters taken by the edge
+    static std::map<Base::Type,int> edgeParamMap = {
+        {Part::GeomPoint::getClassTypeId(), 0},
+        {Part::GeomLineSegment::getClassTypeId(), 0},
+        {Part::GeomArcOfCircle::getClassTypeId(), 3},
+        {Part::GeomCircle::getClassTypeId(), 1},
+        {Part::GeomArcOfEllipse::getClassTypeId(), 5},
+        {Part::GeomEllipse::getClassTypeId(), 3},
+        {Part::GeomArcOfHyperbola::getClassTypeId(), 5},
+        {Part::GeomArcOfParabola::getClassTypeId(), 4},
+        {Part::GeomBSplineCurve::getClassTypeId(), 0} // is dynamic
+    };
+
+    GeometryType = geo->getTypeId();
+
+    auto result = edgeParamMap.find(GeometryType);
+
+    if( result == edgeParamMap.end() )
+        THROWM(Base::TypeError, "SolverGeometryExtension - notifyAttachment - Geometry not supported!!");
+
+    auto nedgeparams = (*result).second;
+
+    if(nedgeparams>0)
+        Edge.init(nedgeparams);
+}
+
+void SolverGeometryExtension::ensureType(const Base::Type & type)
+{
+    if(GeometryType != type)
+        THROWM(Base::TypeError, "SolverGeometryExtension - requested edge parameters do not match underlying type!");
+}
+
+SolverGeometryExtension::Point & SolverGeometryExtension::getPoint()
+{
+    ensureType(Part::GeomPoint::getClassTypeId());
+    return static_cast<Point &>(Edge);
+}
+
+SolverGeometryExtension::Line & SolverGeometryExtension::getLine()
+{
+    ensureType(Part::GeomLineSegment::getClassTypeId());
+    return static_cast<Line &>(Edge);
+}
+
+SolverGeometryExtension::Arc & SolverGeometryExtension::getArc()
+{
+    ensureType(Part::GeomArcOfCircle::getClassTypeId());
+    return static_cast<Arc &>(Edge);
+}
+
+SolverGeometryExtension::Circle & SolverGeometryExtension::getCircle()
+{
+    ensureType(Part::GeomCircle::getClassTypeId());
+    return static_cast<Circle &>(Edge);
+}
+
+SolverGeometryExtension::ArcOfEllipse & SolverGeometryExtension::getArcOfEllipse()
+{
+    ensureType(Part::GeomArcOfEllipse::getClassTypeId());
+    return static_cast<ArcOfEllipse &>(Edge);
+}
+
+SolverGeometryExtension::Ellipse & SolverGeometryExtension::getEllipse()
+{
+    ensureType(Part::GeomEllipse::getClassTypeId());
+    return static_cast<Ellipse &>(Edge);
+}
+
+SolverGeometryExtension::ArcOfHyperbola & SolverGeometryExtension::getArcOfHyperbola()
+{
+    ensureType(Part::GeomArcOfHyperbola::getClassTypeId());
+    return static_cast<ArcOfHyperbola &>(Edge);
+}
+
+SolverGeometryExtension::ArcOfParabola & SolverGeometryExtension::getArcOfParabola()
+{
+    ensureType(Part::GeomArcOfParabola::getClassTypeId());
+    return static_cast<ArcOfParabola &>(Edge);
+}
+
+SolverGeometryExtension::BSpline & SolverGeometryExtension::getBSpline()
+{
+    ensureType(Part::GeomBSplineCurve::getClassTypeId());
+    return static_cast<BSpline &>(Edge);
+}


### PR DESCRIPTION

This commit does not affect functionality of current FC. It is a first step to increase the amount of solver information available at sketcher level, so that it is known not only whether a geometry has a DoF unconstrained, but also exactly which DoF is the one that is unconstrained. This will help in avoiding to arrive to situations of redundant and conflicting constraints in future commits.

In particular:

* SolverGeometryExtension is extended to:
- Enable to determine whether the x or the y of a point is a dependent or independent parameter
- Extend SolverExtension to provide information on individual edge parameters
- Convenience access to DoF status

* Sketch (solver interface) is extended to store geometry parameter dependency state, for these reasons:

Geometry and Constraint solver information is generated when performing a full solve() [QR decomposition + minimization(e.g. DogLeg)].

Constraint information remains in the sketch object (not SketchObject, but sketch), which is then retrieved by SketchObject.

Geometry information is incorporated to the deep copy of Geometry that the sketch object comprises. However, this information is only
available outside the sketch object, if the Geometry property of SketchObject is assigned. This is always the situation after a successful
full solve. However, it is not the case in a successful temporary minimal diagnosis (here succesful relates to conflicting/redundant constraints and
convergence).

The lightweight solution is to keep a (shallow) copy of the SolverGeometryExtensions (shared pointer) to be retrieved by GeoId, which is what is provided.