### PR TITLE
Sketcher: SketchObject - Add ability to diagnose constraint redundancy before addition

### DIFF
--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -694,6 +694,24 @@ int SketchObject::setUpSketch()
         Constraints.touch();
 
     return lastDoF;
+}
+
+int SketchObject::diagnoseAdditionalConstraints(std::vector<Sketcher::Constraint *> additionalconstraints)
+{
+    auto objectconstraints = Constraints.getValues();
+
+    std::vector<Sketcher::Constraint *> allconstraints;
+    allconstraints.reserve(objectconstraints.size()+additionalconstraints.size());
+
+    std::copy(objectconstraints.begin(), objectconstraints.end(), back_inserter(allconstraints));
+    std::copy(additionalconstraints.begin(), additionalconstraints.end(), back_inserter(allconstraints));
+
+    lastDoF = solvedSketch.setUpSketch(getCompleteGeometry(), allconstraints,
+                                       getExternalGeometryCount());
+
+    retrieveSolverDiagnostics();
+
+    return lastDoF;
 
 }
 

--- a/src/Mod/Sketcher/App/SketchObject.h
+++ b/src/Mod/Sketcher/App/SketchObject.h
@@ -211,6 +211,9 @@ public:
      */
     int setUpSketch();
 
+    /** Performs a full analysis of the addition of additional constraints without adding them to the sketch object */
+    int diagnoseAdditionalConstraints(std::vector<Sketcher::Constraint *> additionalconstraints);
+
     /** solves the sketch and updates the geometry, but not all the dependent features (does not recompute)
         When a recompute is necessary, recompute triggers execute() which solves the sketch and updates all dependent features
         When a solve only is necessary (e.g. DoF changed), solve() solves the sketch and


### PR DESCRIPTION

This commit does not add visible functionality to FC. I provides the ability to obtain the solver state that an addition would cause without actually effecting any change to the properties of the sketchobject. It is intended to be used together with the new ability to get solver information per parameter (though it can also be used for other cases).

In particular:

It preserves the SketchObject properties. Therefore it does not trigger any property update, redraws, ...
