### PR TITLE
[Path] Fix import error if camotics not installed.

### DIFF
--- a/src/Mod/Path/PathScripts/PathGuiInit.py
+++ b/src/Mod/Path/PathScripts/PathGuiInit.py
@@ -80,13 +80,14 @@ def Startup():
 
         # If camotics is installed and current enough, import the GUI
         try:
+            import camotics
             r = subprocess.run(
                 ["camotics", "--version"], capture_output=True, text=True
             ).stderr.strip()
             major, minor, patch = r.split(".")
             if int(major) >= 1 and int(minor) >= 2 and int(patch) >= 2:
                 from PathScripts import PathCamoticsGui
-        except FileNotFoundError:
+        except (FileNotFoundError, ModuleNotFoundError):
             pass
 
         Processed = True

--- a/src/Mod/Path/PathScripts/PathGuiInit.py
+++ b/src/Mod/Path/PathScripts/PathGuiInit.py
@@ -21,6 +21,7 @@
 # ***************************************************************************
 
 import PathScripts.PathLog as PathLog
+import subprocess
 
 LOGLEVEL = False
 
@@ -49,7 +50,6 @@ def Startup():
         from PathScripts import PathDressupPathBoundaryGui
         from PathScripts import PathDressupRampEntry
         from PathScripts import PathDressupTagGui
-        from PathScripts import PathDressupLeadInOut
         from PathScripts import PathDressupZCorrect
         from PathScripts import PathDrillingGui
         from PathScripts import PathEngraveGui
@@ -68,7 +68,6 @@ def Startup():
         from PathScripts import PathSetupSheetGui
         from PathScripts import PathSimpleCopy
         from PathScripts import PathSimulatorGui
-        from PathScripts import PathCamoticsGui
         from PathScripts import PathSlotGui
         from PathScripts import PathStop
         from PathScripts import PathThreadMillingGui
@@ -78,6 +77,17 @@ def Startup():
         from PathScripts import PathToolLibraryManager
         from PathScripts import PathUtilsGui
         from PathScripts import PathVcarveGui
+
+        # If camotics is installed and current enough, import the GUI
+        try:
+            r = subprocess.run(
+                ["camotics", "--version"], capture_output=True, text=True
+            ).stderr.strip()
+            major, minor, patch = r.split(".")
+            if int(major) >= 1 and int(minor) >= 2 and int(patch) >= 2:
+                from PathScripts import PathCamoticsGui
+        except FileNotFoundError:
+            pass
 
         Processed = True
     else:


### PR DESCRIPTION
The camotics python module is provided when the camotics application is installed.  This is not a dependency for FreeCAD, just another applicaiton that the user can install. If it's installed (and recent enough), Path can use it for simulation.
There was already a test in place when the Path workbench loaded which determined whether to enable the button.  But the camotics gui was being imported anyway and was, in turn, trying to import the python module.  this would throw an error.

Commit wraps the import in another test to avoid the error.

- [ ]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [ ]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [ ]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [ ]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the issue ID number from our [Issues database](https://github.com/FreeCAD/FreeCAD/issues) in case a particular commit solves or is related to an existing issue. Ex: `Draft: fix typos - fixes #4805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
