### PR TITLE
FEM WB Elmer viscosity bug fix.

### DIFF
--- a/src/Mod/Fem/femsolver/elmer/writer.py
+++ b/src/Mod/Fem/femsolver/elmer/writer.py
@@ -694,6 +694,10 @@ class Writer(object):
             youngsModulus *= 1e3
         return youngsModulus
 
+    def _isMaterialFlow(self, body):
+        m = self._getBodyMaterial(body).Material
+        return "KinematicViscosity" in m
+
     def _handleFlow(self):
         activeIn = []
         for equation in self.solver.Group:
@@ -704,7 +708,8 @@ class Writer(object):
                     activeIn = self._getAllBodies()
                 solverSection = self._getFlowSolver(equation)
                 for body in activeIn:
-                    self._addSolver(body, solverSection)
+                    if self._isMaterialFlow(body):
+                        self._addSolver(body, solverSection)
         if activeIn:
             self._handleFlowConstants()
             self._handleFlowBndConditions()


### PR DESCRIPTION
FEM WB: error "Requested property: [Viscosity], not found" if used mixed solid and fluid simulation in Elmer is fixed.
When project uses thermal-flow simulation for solid and fluid together then Navier-Stokes equation is applied both for solid and fluid. But solid has not "Viscosity" property so Elmer prints warnings and calculation has very long time or may not converged.
This fix disables Stokes-Navier equation for Solid objects.

