### PR TITLE
Use Std_New for startup document creation

### DIFF
--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -1308,9 +1308,7 @@ void MainWindow::delayedStartup()
     ParameterGrp::handle hGrp = WindowParameter::getDefaultParameter()->GetGroup("Document");
     if (hGrp->GetBool("CreateNewDoc", false)) {
         if (App::GetApplication().getDocuments().empty()){
-            App::GetApplication().newDocument();
-            Gui::Command::doCommand(Gui::Command::Gui,
-                "Gui.activeDocument().activeView().viewDefaultOrientation()");
+            Application::Instance->commandManager().runCommandByName("Std_New");
         }
     }
 


### PR DESCRIPTION
This makes them use a translated string for the new document name
https://forum.freecadweb.org/viewtopic.php?f=10&t=69859&p=606617
@Kuzma30 