### PR TITLE
LGTM: omit src/Tools/wiki2qhelp.py from analysis

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -12,6 +12,7 @@ path_classifiers:
   - "src/CXX/"
   template:
   - "src/Tools/examplePy2wiki.py"
+  - "src/Tools/wiki2qhelp.py"
   - "src/Mode/TemplatePyMod/"
   unmaintained:
   - "src/Mod/Robot/"


### PR DESCRIPTION
Per https://lgtm.com/projects/g/FreeCAD/FreeCAD  
[skip ci]