### PR TITLE
Draft: Fix near snap (issue #6613)

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_snapper.py
+++ b/src/Mod/Draft/draftguitools/gui_snapper.py
@@ -275,9 +275,7 @@ class Snapper:
             self.radiusTracker.off()
 
         # Activate snap
-        oldActive = False
         if Draft.getParam("alwaysSnap", True):
-            oldActive = active
             active = True
         if not self.active:
             active = False
@@ -320,8 +318,7 @@ class Snapper:
             self.snapInfo = objectsUnderCursor[self.snapObjectIndex]
 
         if self.snapInfo and "Component" in self.snapInfo:
-            osnap = self.snapToObject(lastpoint, active, constrain,
-                                     eline, point, oldActive)
+            osnap = self.snapToObject(lastpoint, active, constrain, eline, point)
             if osnap:
                 return osnap
 
@@ -352,8 +349,7 @@ class Snapper:
         self.snapObjectIndex = self.snapObjectIndex + 1
 
 
-    def snapToObject(self, lastpoint, active, constrain,
-                     eline, point, oldActive):
+    def snapToObject(self, lastpoint, active, constrain, eline, point):
         """Snap to an object."""
 
         parent = self.snapInfo.get('ParentObject', None)
@@ -499,13 +495,6 @@ class Snapper:
                     winner = snap
 
         if winner:
-            # see if we are out of the max radius, if any
-            if self.radius:
-                dv = point.sub(winner[2])
-                if (dv.Length > self.radius):
-                    if (not oldActive) and self.isEnabled("Near"):
-                        winner = self.snapToVertex(self.snapInfo)
-
             # setting the cursors
             if self.tracker and not self.selectMode:
                 self.tracker.setCoords(winner[2])


### PR DESCRIPTION
This PR fixes the inaccuracy of [Draft Snap Near](https://wiki.freecadweb.org/Draft_Snap_Near).

Forum topic:
https://forum.freecadweb.org/viewtopic.php?f=23&t=67289

Issue:
https://github.com/FreeCAD/FreeCAD/issues/6613

Additionally:
* Snap Perpendicular now also works for faces.
* Snap Perpendicular can now find multiple points. For example two points on a circular edge.
* For clarity the `snapToFace` function was renamed to `snapToCenterFace`.
* To snap to a vertex (f.e. a [Draft Point](https://wiki.freecadweb.org/Draft_Point)) Snap Endpoint must now be used. This makes more sense IMO and is also consistent with snapping to points in a point cloud.

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [x]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the issue ID number from our [Issues database](https://github.com/FreeCAD/FreeCAD/issues) in case a particular commit solves or is related to an existing issue. Ex: `Draft: fix typos - fixes #4805`

---
