### PR TITLE
Arch: Invert opening symbol Simple door

### DIFF
--- a/src/Mod/Arch/ArchWindowPresets.py
+++ b/src/Mod/Arch/ArchWindowPresets.py
@@ -450,7 +450,7 @@ def makeWindowPreset(windowtype,width,height,h1,h2,h3,w1,w2,o1,o2,placement=None
         elif windowtype == "Simple door":
 
             wp = doorFrame(s,width,height,h1,w1,o1)
-            wp.extend(["Door","Solid panel","Wire1,Edge8,Mode2",str(w2),str(o2)+"+V"])
+            wp.extend(["Door","Solid panel","Wire1,Edge8,Mode1",str(w2),str(o2)+"+V"])
 
         elif windowtype == "Glass door":
 


### PR DESCRIPTION
The opening symbol of the "Simple door" preset was incorrect. See image.

![opening_symbol_simple_door_should_be_inverted](https://user-images.githubusercontent.com/70520633/177284303-4bfc1020-3985-49f6-a1dd-3ac738d25226.png)

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the issue ID number from our [Issues database](https://github.com/FreeCAD/FreeCAD/issues) in case a particular commit solves or is related to an existing issue. Ex: `Draft: fix typos - fixes #4805`

---
