### PR TITLE
Prepend CMAKE_INSTALL_PREFIX if CMAKE_INSTALL_LIBDIR is not absolute

### DIFF
--- a/src/Ext/freecad/CMakeLists.txt
+++ b/src/Ext/freecad/CMakeLists.txt
@@ -10,7 +10,8 @@ if (WIN32)
                        REALPATH BASE_DIR "${CMAKE_INSTALL_PREFIX}")
     set( ${CMAKE_INSTALL_BINDIR})
 else()
-    set(FREECAD_LIBRARY_INSTALL_DIR ${CMAKE_INSTALL_LIBDIR})
+    get_filename_component(FREECAD_LIBRARY_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}"
+                       REALPATH BASE_DIR "${CMAKE_INSTALL_PREFIX}")
 endif()
 
 configure_file(__init__.py.template ${NAMESPACE_INIT})


### PR DESCRIPTION
This solves an issue where `import freecad` does not work if you don't set CMAKE_INSTALL_LIBDIR to an absolute path during compilation.

This should simplify packaging a little, not sure if this is the correct way of doing this but it works for me. Can someone explain what is done in the windows portion of this?