### PR TITLE
Path: Fix Type=Polar regression in PathArray

### DIFF
--- a/src/Mod/Path/PathScripts/PathArray.py
+++ b/src/Mod/Path/PathScripts/PathArray.py
@@ -208,69 +208,6 @@ class ObjectArray:
 
         self.setEditorModes(obj)
 
-    def rotatePath(self, path, angle, centre):
-        """
-        Rotates Path around given centre vector
-        Only X and Y is considered
-        """
-        CmdMoveRapid = ["G0", "G00"]
-        CmdMoveStraight = ["G1", "G01"]
-        CmdMoveCW = ["G2", "G02"]
-        CmdMoveCCW = ["G3", "G03"]
-        CmdDrill = ["G81", "G82", "G83"]
-        CmdMoveArc = CmdMoveCW + CmdMoveCCW
-        CmdMove = CmdMoveStraight + CmdMoveArc
-
-        commands = []
-        ang = angle / 180 * math.pi
-        currX = 0
-        currY = 0
-        for cmd in path.Commands:
-            if (
-                (cmd.Name in CmdMoveRapid)
-                or (cmd.Name in CmdMove)
-                or (cmd.Name in CmdDrill)
-            ):
-                params = cmd.Parameters
-                x = params.get("X")
-                if x is None:
-                    x = currX
-                currX = x
-                y = params.get("Y")
-                if y is None:
-                    y = currY
-                currY = y
-
-                # "move" the centre to origin
-                x = x - centre.x
-                y = y - centre.y
-
-                # rotation around origin:
-                nx = x * math.cos(ang) - y * math.sin(ang)
-                ny = y * math.cos(ang) + x * math.sin(ang)
-
-                # "move" the centre back and update
-                params.update({"X": nx + centre.x, "Y": ny + centre.y})
-
-                # Arcs need to have the I and J params rotated as well
-                if cmd.Name in CmdMoveArc:
-                    i = params.get("I")
-                    if i is None:
-                        i = 0
-                    j = params.get("J")
-                    if j is None:
-                        j = 0
-
-                    ni = i * math.cos(ang) - j * math.sin(ang)
-                    nj = j * math.cos(ang) + i * math.sin(ang)
-                    params.update({"I": ni, "J": nj})
-
-                cmd.Parameters = params
-            commands.append(cmd)
-        newPath = Path.Path(commands)
-
-        return newPath
-
     def execute(self, obj):
         # backwards compatibility for PathArrays created before support for multiple bases
         if isinstance(obj.Base, list):
@@ -348,6 +285,69 @@ class PathArray:
                 self.baseList = baseList
             else:
                 self.baseList = [baseList]
+
+    def rotatePath(self, path, angle, centre):
+        """
+        Rotates Path around given centre vector
+        Only X and Y is considered
+        """
+        CmdMoveRapid = ["G0", "G00"]
+        CmdMoveStraight = ["G1", "G01"]
+        CmdMoveCW = ["G2", "G02"]
+        CmdMoveCCW = ["G3", "G03"]
+        CmdDrill = ["G81", "G82", "G83"]
+        CmdMoveArc = CmdMoveCW + CmdMoveCCW
+        CmdMove = CmdMoveStraight + CmdMoveArc
+
+        commands = []
+        ang = angle / 180 * math.pi
+        currX = 0
+        currY = 0
+        for cmd in path.Commands:
+            if (
+                (cmd.Name in CmdMoveRapid)
+                or (cmd.Name in CmdMove)
+                or (cmd.Name in CmdDrill)
+            ):
+                params = cmd.Parameters
+                x = params.get("X")
+                if x is None:
+                    x = currX
+                currX = x
+                y = params.get("Y")
+                if y is None:
+                    y = currY
+                currY = y
+
+                # "move" the centre to origin
+                x = x - centre.x
+                y = y - centre.y
+
+                # rotation around origin:
+                nx = x * math.cos(ang) - y * math.sin(ang)
+                ny = y * math.cos(ang) + x * math.sin(ang)
+
+                # "move" the centre back and update
+                params.update({"X": nx + centre.x, "Y": ny + centre.y})
+
+                # Arcs need to have the I and J params rotated as well
+                if cmd.Name in CmdMoveArc:
+                    i = params.get("I")
+                    if i is None:
+                        i = 0
+                    j = params.get("J")
+                    if j is None:
+                        j = 0
+
+                    ni = i * math.cos(ang) - j * math.sin(ang)
+                    nj = j * math.cos(ang) + i * math.sin(ang)
+                    params.update({"I": ni, "J": nj})
+
+                cmd.Parameters = params
+            commands.append(cmd)
+        newPath = Path.Path(commands)
+
+        return newPath
 
     # Private method
     def _calculateJitter(self, pos):
@@ -475,7 +475,7 @@ class PathArray:
                     ang = 360
                     if self.copies > 0:
                         ang = self.angle / self.copies * (1 + i)
-                    np = self.rotatePath(b.Path.Commands, ang, self.centre)
+                    np = self.rotatePath(b.Path, ang, self.centre)
                     output += np.toGCode()
 
         # return output


### PR DESCRIPTION
This regression was introduced in PR #4818 with the refactor.  The source of the regression is that the `rotatePath()` method was not included in the new `PathArray` class created in the refactor.
This commit relocates the missing method to the `PathArray` class where it belongs, and corrects the `path` argument where the method is called.

This PR is a great candidate for backporting to 0.20.x.
Error identified in forum at [bug of array of polar](https://forum.freecadweb.org/viewtopic.php?f=15&t=70032).

Source file in ZIP archive:
[PartDesignExample_PathArray_Fix.zip](https://github.com/FreeCAD/FreeCAD/files/9048540/PartDesignExample_PathArray_Fix.zip)
Change Type of Array object to Polar, and Copies to > 0, and Angle to other than 0.
Current master will throw error.  PR code will fix error, producing desired array.


Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the issue ID number from our [Issues database](https://github.com/FreeCAD/FreeCAD/issues) in case a particular commit solves or is related to an existing issue. Ex: `Draft: fix typos - fixes #4805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
