### PR TITLE
Draft: DisplayStatusbarScaleWidget should be checked in preferences-draftinterface.ui

### DIFF
--- a/src/Mod/Draft/Resources/ui/preferences-draftinterface.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-draftinterface.ui
@@ -972,6 +972,9 @@
           <property name="text">
            <string>Annotation scale widget</string>
           </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
           <property name="prefEntry" stdset="0">
            <cstring>DisplayStatusbarScaleWidget</cstring>
           </property>


### PR DESCRIPTION
The DisplayStatusbarScaleWidget checkbox should be checked in preferences-draftinterface.ui

The default elsewhere is True:
https://github.com/FreeCAD/FreeCAD/blob/05c250d7b5c7d67d4fd59a8b9a4160e00fc10521/src/Mod/Draft/draftutils/init_draft_statusbar.py#L341

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the issue ID number from our [Issues database](https://github.com/FreeCAD/FreeCAD/issues) in case a particular commit solves or is related to an existing issue. Ex: `Draft: fix typos - fixes #4805`

---
