### PR TITLE
[Gui] preferences: clarify Part/PD page

### DIFF
--- a/src/Gui/DlgPreferencesImp.cpp
+++ b/src/Gui/DlgPreferencesImp.cpp
@@ -123,8 +123,15 @@ QTabWidget* DlgPreferencesImp::createTabForGroup(const std::string &groupName)
     QListWidgetItem* item = new QListWidgetItem(ui->listBox);
     item->setData(GroupNameRole, QVariant(groupNameQString));
     item->setText(QObject::tr(groupNameQString.toLatin1()));
-    item->setToolTip(QObject::tr(groupNameQString.toLatin1()));
+    // for Part/PD we need another tooltip since this group is for 2 WBs
+    if (groupName.compare("Part/Part Design") == 0)
+        item->setToolTip(QObject::tr(QString::fromStdString("Part and Part Design workbench").toLatin1()));
+    else
+        item->setToolTip(QObject::tr(groupNameQString.toLatin1()));
     std::string fileName = groupName;
+    // for Part/PD the filename cannot be groupName since this group is for 2 WBs
+    if (groupName.compare("Part/Part Design") == 0)
+        fileName = "Part design";
     for (auto &ch : fileName) {
         if (ch == ' ')
             ch = '_';

--- a/src/Mod/Part/Gui/AppPartGui.cpp
+++ b/src/Mod/Part/Gui/AppPartGui.cpp
@@ -206,13 +206,12 @@ PyMOD_INIT_FUNC(PartGui)
         err.ReportException();
     }
 
-
     // register preferences pages
-    (void)new Gui::PrefPageProducer<PartGui::DlgSettingsGeneral>      ( QT_TRANSLATE_NOOP("QObject","Part design") );
-    (void)new Gui::PrefPageProducer<PartGui::DlgSettings3DViewPart>   ( QT_TRANSLATE_NOOP("QObject","Part design") );
-    (void)new Gui::PrefPageProducer<PartGui::DlgSettingsObjectColor>  ( QT_TRANSLATE_NOOP("QObject","Part design") );
-    (void)new Gui::PrefPageProducer<PartGui::DlgImportExportIges>     ( QT_TRANSLATE_NOOP("QObject","Import-Export") );
-    (void)new Gui::PrefPageProducer<PartGui::DlgImportExportStep>     ( QT_TRANSLATE_NOOP("QObject","Import-Export") );
+    (void)new Gui::PrefPageProducer<PartGui::DlgSettingsGeneral>(QT_TRANSLATE_NOOP("QObject", "Part/Part Design"));
+    (void)new Gui::PrefPageProducer<PartGui::DlgSettings3DViewPart>(QT_TRANSLATE_NOOP("QObject", "Part/Part Design"));
+    (void)new Gui::PrefPageProducer<PartGui::DlgSettingsObjectColor>(QT_TRANSLATE_NOOP("QObject", "Part/Part Design"));
+    (void)new Gui::PrefPageProducer<PartGui::DlgImportExportIges>(QT_TRANSLATE_NOOP("QObject", "Import-Export"));
+    (void)new Gui::PrefPageProducer<PartGui::DlgImportExportStep>(QT_TRANSLATE_NOOP("QObject", "Import-Export"));
     Gui::ViewProviderBuilder::add(
         Part::PropertyPartShape::getClassTypeId(),
         PartGui::ViewProviderPart::getClassTypeId());


### PR DESCRIPTION
- users are confused that we have a preferences page named "Part design" that also defines things for the Part WB. The Wiki is clear that the preferences page is for both, Part and PD, however the UI is not.
This PR makes this clear.

Even experienced users stumble over this, see for example: https://github.com/FreeCAD/FreeCAD/pull/7148#issuecomment-1179571003

With the PR it should be clear.