### PR TITLE
[FEM] fix solver console bugs

### DIFF
--- a/src/Mod/Fem/femsolver/elmer/tasks.py
+++ b/src/Mod/Fem/femsolver/elmer/tasks.py
@@ -121,10 +121,18 @@ class Solve(run.Solve):
                 if os.path.isdir(solvpath):
                     os.environ["ELMER_HOME"] = solvpath
                     os.environ["LD_LIBRARY_PATH"] = "$LD_LIBRARY_PATH:{}/modules".format(solvpath)
-            self._process = subprocess.Popen(
+            # hide the popups on Windows
+            if system() == "Windows":
+                self._process = subprocess.Popen(
                 [binary], cwd=self.directory,
                 stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE)
+                stderr=subprocess.PIPE,
+                startupinfo=femutils.startProgramInfo("hide"))
+            else:
+                self._process = subprocess.Popen(
+                    [binary], cwd=self.directory,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE)
             self.signalAbort.add(self._process.terminate)
             output = self._observeSolver(self._process)
             self._process.communicate()

--- a/src/Mod/Fem/femsolver/elmer/writer.py
+++ b/src/Mod/Fem/femsolver/elmer/writer.py
@@ -33,6 +33,7 @@ import os
 import os.path
 import subprocess
 import tempfile
+from platform import system
 
 from FreeCAD import Console
 from FreeCAD import Units
@@ -216,7 +217,12 @@ class Writer(object):
                     unvPath,
                     "-scale", "0.001", "0.001", "0.001",
                     "-out", self.directory]
-            subprocess.call(args, stdout=subprocess.DEVNULL)
+            # hide the popups on Windows
+            if system() == "Windows":
+                subprocess.call(args, stdout=subprocess.DEVNULL,
+                    startupinfo=femutils.startProgramInfo("hide"))
+            else:
+                subprocess.call(args, stdout=subprocess.DEVNULL)
 
     def _writeStartinfo(self):
         path = os.path.join(self.directory, _STARTINFO_NAME)

--- a/src/Mod/Fem/femsolver/z88/tasks.py
+++ b/src/Mod/Fem/femsolver/z88/tasks.py
@@ -31,6 +31,7 @@ __url__ = "https://www.freecadweb.org"
 import os
 import os.path
 import subprocess
+from platform import system
 
 import FreeCAD
 
@@ -117,23 +118,28 @@ class Solve(run.Solve):
         # TODO: search out for "Vector GS" and "Vector KOI" and print values
         # may be compare with the used ones
         self.pushStatus("Executing solver in test mode...\n")
-        self._process = subprocess.Popen(
-            [binary, "-t", "-" + solver],
-            cwd=self.directory,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE)
-        self.signalAbort.add(self._process.terminate)
-        self._process.communicate()
-        self.signalAbort.remove(self._process.terminate)
+        Solve.runZ88(self, "-t", binary, solver, "hide")
 
         # run solver real mode
         self.pushStatus("Executing solver in real mode...\n")
-        binary = settings.get_binary("Z88")
-        self._process = subprocess.Popen(
-            [binary, "-c", "-" + solver],
-            cwd=self.directory,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE)
+        # starting normal because the user must see the z88 window
+        Solve.runZ88(self, "-c", binary, solver, "normal")
+
+    def runZ88(self, command, binary, solver, state):
+        # minimize or hide the popups on Windows
+        if system() == "Windows":
+            self._process = subprocess.Popen(
+                [binary, command, "-" + solver],
+                cwd=self.directory,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                startupinfo=femutils.startProgramInfo(state))
+        else:
+            self._process = subprocess.Popen(
+                [binary, command, "-" + solver],
+                 cwd=self.directory,
+                 stdout=subprocess.PIPE,
+                 stderr=subprocess.PIPE)
         self.signalAbort.add(self._process.terminate)
         self._process.communicate()
         self.signalAbort.remove(self._process.terminate)

--- a/src/Mod/Fem/femtools/femutils.py
+++ b/src/Mod/Fem/femtools/femutils.py
@@ -1,6 +1,7 @@
 # ***************************************************************************
 # *   Copyright (c) 2017 Markus Hovorka <m.hovorka@live.de>                 *
 # *   Copyright (c) 2018 Bernd Hahnebach <bernd@bimstatik.org>              *
+# *   Copyright (c) 2022 Uwe Stöhr <uwestoehr@lyx.org>                      *
 # *                                                                         *
 # *   This file is part of the FreeCAD CAx development system.              *
 # *                                                                         *
@@ -27,14 +28,14 @@ This module contains function for extracting relevant parts of geometry and
 a few unrelated function useful at various places in the Fem module.
 """
 
-
 __title__ = "FEM Utilities"
-__author__ = "Markus Hovorka, Bernd Hahnebach"
+__author__ = 'Markus Hovorka, Bernd Hahnebach, Uwe Stöhr'
 __url__ = "https://www.freecadweb.org"
-
 
 import os
 import sys
+import subprocess
+from platform import system
 
 import FreeCAD
 if FreeCAD.GuiUp:
@@ -387,3 +388,20 @@ def pydecode(bytestring):
         return bytestring
     else:
         return bytestring.decode("utf-8")
+
+
+def startProgramInfo(code):
+    """ starts a program under Windows minimized, hidden or normal """
+    if system() == "Windows":
+        info = subprocess.STARTUPINFO()
+        if code == "hide":
+            SW_HIDE = 0
+            info.wShowWindow = SW_HIDE
+        elif code == "minimize":
+            SW_MINIMIZE = 6
+            info.wShowWindow = SW_MINIMIZE
+        elif code == "normal":
+            SW_DEFAULT = 10
+            info.wShowWindow = SW_DEFAULT
+        info.dwFlags = subprocess.STARTF_USESHOWWINDOW
+        return info


### PR DESCRIPTION
- for Elmer and Z88 on Windows several window popup. This is maybe annoying and the user is wondering what is going on, but the main problem is that when you close them you break the solving process.
Therefore, on Windows only, hide the empty popup windows