### PR TITLE
Draft: Fix setEdit in view_text.py

### DIFF
--- a/src/Mod/Draft/draftviewproviders/view_text.py
+++ b/src/Mod/Draft/draftviewproviders/view_text.py
@@ -221,7 +221,9 @@ class ViewProviderText(ViewProviderDraftAnnotation):
     def setEdit(self,vobj,mode):
 
         import FreeCADGui
-        self.text = ''
+        if not hasattr(FreeCADGui, "draftToolBar"):
+            import Draft
+        self.text = ""
         FreeCADGui.draftToolBar.sourceCmd = self
         FreeCADGui.draftToolBar.taskUi()
         FreeCADGui.draftToolBar.textUi()

--- a/src/Mod/Draft/draftviewproviders/view_text.py
+++ b/src/Mod/Draft/draftviewproviders/view_text.py
@@ -222,7 +222,7 @@ class ViewProviderText(ViewProviderDraftAnnotation):
 
         import FreeCADGui
         if not hasattr(FreeCADGui, "draftToolBar"):
-            import Draft
+            import DraftGui
         self.text = ""
         FreeCADGui.draftToolBar.sourceCmd = self
         FreeCADGui.draftToolBar.taskUi()


### PR DESCRIPTION
The `setEdit` function should import the `Draft` module to make sure the `draftToolBar` is available. Without this there is an error if a text is double-clicked and the Draft Workbench has not yet been loaded.

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the issue ID number from our [Issues database](https://github.com/FreeCAD/FreeCAD/issues) in case a particular commit solves or is related to an existing issue. Ex: `Draft: fix typos - fixes #4805`

---
