### PR TITLE
Draft: Fix EditMode for hatch, facebinder and shapestring

### DIFF
--- a/src/Mod/Draft/draftviewproviders/view_facebinder.py
+++ b/src/Mod/Draft/draftviewproviders/view_facebinder.py
@@ -32,13 +32,14 @@ import FreeCADGui as Gui
 from draftviewproviders.view_base import ViewProviderDraft
 
 class ViewProviderFacebinder(ViewProviderDraft):
-    def __init__(self,vobj):
+
+    def __init__(self, vobj):
         super(ViewProviderFacebinder, self).__init__(vobj)
 
     def getIcon(self):
         return ":/icons/Draft_Facebinder_Provider.svg"
 
-    def setEdit(self,vobj,mode):
+    def setEdit(self, vobj, mode):
         if mode != 0:
             return None
 
@@ -49,11 +50,10 @@ class ViewProviderFacebinder(ViewProviderDraft):
         Gui.Control.showDialog(taskd)
         return True
 
-    def unsetEdit(self,vobj,mode):
+    def unsetEdit(self, vobj, mode):
         if mode != 0:
             return None
 
-        Gui.Control.closeDialog()
         return True
 
 

--- a/src/Mod/Draft/draftviewproviders/view_facebinder.py
+++ b/src/Mod/Draft/draftviewproviders/view_facebinder.py
@@ -29,10 +29,7 @@
 # @{
 import FreeCADGui as Gui
 
-import DraftGui
-
 from draftviewproviders.view_base import ViewProviderDraft
-
 
 class ViewProviderFacebinder(ViewProviderDraft):
     def __init__(self,vobj):
@@ -42,6 +39,10 @@ class ViewProviderFacebinder(ViewProviderDraft):
         return ":/icons/Draft_Facebinder_Provider.svg"
 
     def setEdit(self,vobj,mode):
+        if mode != 0:
+            return None
+
+        import DraftGui # Moving this to the top of the file results in a circular import.
         taskd = DraftGui.FacebinderTaskPanel()
         taskd.obj = vobj.Object
         taskd.update()
@@ -49,8 +50,11 @@ class ViewProviderFacebinder(ViewProviderDraft):
         return True
 
     def unsetEdit(self,vobj,mode):
+        if mode != 0:
+            return None
+
         Gui.Control.closeDialog()
-        return False
+        return True
 
 
 # Alias for compatibility with v0.18 and earlier

--- a/src/Mod/Draft/draftviewproviders/view_hatch.py
+++ b/src/Mod/Draft/draftviewproviders/view_hatch.py
@@ -23,8 +23,6 @@
 
 """This module contains FreeCAD commands for the Draft workbench"""
 
-import os
-import FreeCAD
 from draftguitools.gui_hatch import Draft_Hatch_TaskPanel
 
 class ViewProviderDraftHatch:
@@ -47,6 +45,8 @@ class ViewProviderDraftHatch:
         return None
 
     def setEdit(self,vobj,mode):
+        if mode != 0:
+            return None
 
         import FreeCADGui
 
@@ -59,12 +59,10 @@ class ViewProviderDraftHatch:
         return True
 
     def unsetEdit(self,vobj,mode):
+        if mode != 0:
+            return None
 
         import FreeCADGui
 
         FreeCADGui.Control.closeDialog()
         return True
-
-    def doubleClicked(self,vobj):
-
-        self.setEdit(vobj,None)

--- a/src/Mod/Draft/draftviewproviders/view_shapestring.py
+++ b/src/Mod/Draft/draftviewproviders/view_shapestring.py
@@ -39,6 +39,8 @@ class ViewProviderShapeString(ViewProviderDraft):
         return ":/icons/Draft_ShapeString.svg"
 
     def setEdit(self, vobj, mode):
+        if mode != 0:
+            return None
 
         self.wb_before_edit = Gui.activeWorkbench()
         Gui.activateWorkbench("DraftWorkbench")
@@ -47,7 +49,9 @@ class ViewProviderShapeString(ViewProviderDraft):
 
         return True
 
-    def unsetEdit(self,vobj,mode):
+    def unsetEdit(self, vobj, mode):
+        if mode != 0:
+            return None
 
         self.task.finish()
         Gui.activateWorkbench(self.wb_before_edit.name())


### PR DESCRIPTION
EditMode was not handled properly for hatch, facebinder and shapestring objects.

Forum topic:
https://forum.freecadweb.org/viewtopic.php?f=8&t=70050

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the issue ID number from our [Issues database](https://github.com/FreeCAD/FreeCAD/issues) in case a particular commit solves or is related to an existing issue. Ex: `Draft: fix typos - fixes #4805`

---
