### PR TITLE
Mod: Replaced python2 usage of next()

### DIFF
--- a/src/Mod/Arch/importIFCmulticore.py
+++ b/src/Mod/Arch/importIFCmulticore.py
@@ -106,17 +106,13 @@ def insert(filename,docname=None,preferences=None):
     count = 0
 
     # process objects
-    while True:
-        item = iterator.get()
-        if item:
-            brep = item.geometry.brep_data
-            ifcproduct = ifcfile.by_id(item.guid)
-            obj = createProduct(ifcproduct,brep)
-            progressbar.next(True)
-            writeProgress(count,productscount,starttime)
-            count += 1
-        if not iterator.next():
-            break
+    for item in iterator:
+        brep = item.geometry.brep_data
+        ifcproduct = ifcfile.by_id(item.guid)
+        obj = createProduct(ifcproduct,brep)
+        progressbar.next(True)
+        writeProgress(count,productscount,starttime)
+        count += 1
 
     # process 2D annotations
     annotations = ifcfile.by_type("IfcAnnotation")

--- a/src/Mod/Fem/femsolver/elmer/sifio.py
+++ b/src/Mod/Fem/femsolver/elmer/sifio.py
@@ -334,7 +334,7 @@ class _Writer(object):
 
     def _getOnlyElement(self, collection):
         it = iter(collection)
-        return it.next()
+        return next(it)
 
     def _isCollection(self, data):
         return (


### PR DESCRIPTION
iterator.next() is deprecated in python3.
next(iterator) is the direct replacement.
A for() loop made more sense for import IFCmulticore.py where we were looping through the whole list anyway

---
