### PR TITLE
[Stylesheets] Remove whitespace and add "checked" icon style

### DIFF
--- a/src/Gui/Stylesheets/Behave-dark.qss
+++ b/src/Gui/Stylesheets/Behave-dark.qss
@@ -181,12 +181,20 @@ QMenu::right-arrow:selected {
 }
 
 QMenu::item {
-    padding: 2px 16px 2px 26px; /* make room for icon at left */
+    padding: 2px 4px; /* make room for icon at left */
     border: 1px solid transparent; /* reserve space for selection border */
 }
 
 QMenu::icon {
-    margin-left: 2px;
+    margin-left: 1px;
+    margin-right: 1px;
+}
+
+QMenu::icon:checked { /* appearance of a 'checked' icon */
+    background: #61D29D;
+    border: 2px #61D29D;
+    position: absolute;
+    border-radius: 2px;
 }
 
 QMenu::separator {

--- a/src/Gui/Stylesheets/Dark-blue.qss
+++ b/src/Gui/Stylesheets/Dark-blue.qss
@@ -148,12 +148,20 @@ QMenu::right-arrow:selected {
 }
 
 QMenu::item {
-    padding: 2px 16px 2px 26px; /* make room for icon at left */
+    padding: 2px 4px; /* make room for icon at left */
     border: 1px solid transparent; /* reserve space for selection border */
 }
 
 QMenu::icon {
-    margin-left: 2px;
+    margin-left: 1px;
+    margin-right: 1px;
+}
+
+QMenu::icon:checked { /* appearance of a 'checked' icon */
+    background: #5e90fa;
+    border: 2px #5e90fa;
+    position: absolute;
+    border-radius: 2px;
 }
 
 QMenu::separator {

--- a/src/Gui/Stylesheets/Dark-contrast.qss
+++ b/src/Gui/Stylesheets/Dark-contrast.qss
@@ -148,12 +148,20 @@ QMenu::right-arrow:selected {
 }
 
 QMenu::item {
-    padding: 2px 16px 2px 26px; /* make room for icon at left */
+    padding: 2px 4px; /* make room for icon at left */
     border: 1px solid transparent; /* reserve space for selection border */
 }
 
 QMenu::icon {
-    margin-left: 2px;
+    margin-left: 1px;
+    margin-right: 1px;
+}
+
+QMenu::icon:checked { /* appearance of a 'checked' icon */
+    background: #2053c0;
+    border: 2px #2053c0;
+    position: absolute;
+    border-radius: 2px;
 }
 
 QMenu::separator {

--- a/src/Gui/Stylesheets/Dark-green.qss
+++ b/src/Gui/Stylesheets/Dark-green.qss
@@ -148,12 +148,20 @@ QMenu::right-arrow:selected {
 }
 
 QMenu::item {
-    padding: 2px 16px 2px 26px; /* make room for icon at left */
+    padding: 2px 4px; /* make room for icon at left */
     border: 1px solid transparent; /* reserve space for selection border */
 }
 
 QMenu::icon {
-    margin-left: 2px;
+    margin-left: 1px;
+    margin-right: 1px;
+}
+
+QMenu::icon:checked { /* appearance of a 'checked' icon */
+    background: #94b30f;
+    border: 2px #94b30f;
+    position: absolute;
+    border-radius: 2px;
 }
 
 QMenu::separator {

--- a/src/Gui/Stylesheets/Dark-orange.qss
+++ b/src/Gui/Stylesheets/Dark-orange.qss
@@ -148,12 +148,20 @@ QMenu::right-arrow:selected {
 }
 
 QMenu::item {
-    padding: 2px 16px 2px 26px; /* make room for icon at left */
+    padding: 2px 4px; /* make room for icon at left */
     border: 1px solid transparent; /* reserve space for selection border */
 }
 
 QMenu::icon {
-    margin-left: 2px;
+    margin-left: 1px;
+    margin-right: 1px;
+}
+
+QMenu::icon:checked { /* appearance of a 'checked' icon */
+    background: #daa116;
+    border: 2px #daa116;
+    position: absolute;
+    border-radius: 2px;
 }
 
 QMenu::separator {

--- a/src/Gui/Stylesheets/Darker-blue.qss
+++ b/src/Gui/Stylesheets/Darker-blue.qss
@@ -148,12 +148,20 @@ QMenu::right-arrow:selected {
 }
 
 QMenu::item {
-    padding: 2px 16px 2px 26px; /* make room for icon at left */
+    padding: 2px 4px; /* make room for icon at left */
     border: 1px solid transparent; /* reserve space for selection border */
 }
 
 QMenu::icon {
-    margin-left: 2px;
+    margin-left: 1px;
+    margin-right: 1px;
+}
+
+QMenu::icon:checked { /* appearance of a 'checked' icon */
+    background: #2053c0;
+    border: 2px #2053c0;
+    position: absolute;
+    border-radius: 2px;
 }
 
 QMenu::separator {

--- a/src/Gui/Stylesheets/Darker-green.qss
+++ b/src/Gui/Stylesheets/Darker-green.qss
@@ -148,12 +148,20 @@ QMenu::right-arrow:selected {
 }
 
 QMenu::item {
-    padding: 2px 16px 2px 26px; /* make room for icon at left */
+    padding: 2px 4px; /* make room for icon at left */
     border: 1px solid transparent; /* reserve space for selection border */
 }
 
 QMenu::icon {
-    margin-left: 2px;
+    margin-left: 1px;
+    margin-right: 1px;
+}
+
+QMenu::icon:checked { /* appearance of a 'checked' icon */
+    background: #74831d;
+    border: 2px #74831d;
+    position: absolute;
+    border-radius: 2px;
 }
 
 QMenu::separator {

--- a/src/Gui/Stylesheets/Darker-orange.qss
+++ b/src/Gui/Stylesheets/Darker-orange.qss
@@ -148,12 +148,20 @@ QMenu::right-arrow:selected {
 }
 
 QMenu::item {
-    padding: 2px 16px 2px 26px; /* make room for icon at left */
+    padding: 2px 4px; /* make room for icon at left */
     border: 1px solid transparent; /* reserve space for selection border */
 }
 
 QMenu::icon {
-    margin-left: 2px;
+    margin-left: 1px;
+    margin-right: 1px;
+}
+
+QMenu::icon:checked { /* appearance of a 'checked' icon */
+    background: #b28416;
+    border: 2px #b28416;
+    position: absolute;
+    border-radius: 2px;
 }
 
 QMenu::separator {

--- a/src/Gui/Stylesheets/Light-blue.qss
+++ b/src/Gui/Stylesheets/Light-blue.qss
@@ -148,12 +148,20 @@ QMenu::right-arrow:selected {
 }
 
 QMenu::item {
-    padding: 2px 16px 2px 26px; /* make room for icon at left */
+    padding: 2px 4px; /* make room for icon at left */
     border: 1px solid transparent; /* reserve space for selection border */
 }
 
 QMenu::icon {
-    margin-left: 2px;
+    margin-left: 1px;
+    margin-right: 1px;
+}
+
+QMenu::icon:checked { /* appearance of a 'checked' icon */
+    background: #5e90fa;
+    border: 2px #5e90fa;
+    position: absolute;
+    border-radius: 2px;
 }
 
 QMenu::separator {

--- a/src/Gui/Stylesheets/Light-green.qss
+++ b/src/Gui/Stylesheets/Light-green.qss
@@ -148,12 +148,20 @@ QMenu::right-arrow:selected {
 }
 
 QMenu::item {
-    padding: 2px 16px 2px 26px; /* make room for icon at left */
+    padding: 2px 4px; /* make room for icon at left */
     border: 1px solid transparent; /* reserve space for selection border */
 }
 
 QMenu::icon {
-    margin-left: 2px;
+    margin-left: 1px;
+    margin-right: 1px;
+}
+
+QMenu::icon:checked { /* appearance of a 'checked' icon */
+    background: #94b30f;
+    border: 2px #94b30f;
+    position: absolute;
+    border-radius: 2px;
 }
 
 QMenu::separator {

--- a/src/Gui/Stylesheets/Light-orange.qss
+++ b/src/Gui/Stylesheets/Light-orange.qss
@@ -148,12 +148,20 @@ QMenu::right-arrow:selected {
 }
 
 QMenu::item {
-    padding: 2px 16px 2px 26px; /* make room for icon at left */
+    padding: 2px 4px; /* make room for icon at left */
     border: 1px solid transparent; /* reserve space for selection border */
 }
 
 QMenu::icon {
-    margin-left: 2px;
+    margin-left: 1px;
+    margin-right: 1px;
+}
+
+QMenu::icon:checked { /* appearance of a 'checked' icon */
+    background: #daa116;
+    border: 2px #daa116;
+    position: absolute;
+    border-radius: 2px;
 }
 
 QMenu::separator {

--- a/src/Gui/Stylesheets/ProDark.qss
+++ b/src/Gui/Stylesheets/ProDark.qss
@@ -191,12 +191,20 @@ QMenu::right-arrow:selected {
 }
 
 QMenu::item {
-    padding: 2px 16px 2px 26px; /* make room for icon at left */
+    padding: 2px 4px; /* make room for icon at left */
     border: 1px solid transparent; /* reserve space for selection border */
 }
 
 QMenu::icon {
-    margin-left: 2px;
+    margin-left: 1px;
+    margin-right: 1px;
+}
+
+QMenu::icon:checked { /* appearance of a 'checked' icon */
+    background: #557BB6;
+    border: 2px #557BB6;
+    position: absolute;
+    border-radius: 2px;
 }
 
 QMenu::separator {


### PR DESCRIPTION
- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [x]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [x]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the issue ID number from our [Issues database](https://github.com/FreeCAD/FreeCAD/issues) in case a particular commit solves or is related to an existing issue. Ex: `Draft: fix typos - fixes #4805`

---

> Please see also related PR: https://github.com/dracula/freecad/pull/6
> Further discussion in another issue: https://github.com/dracula/freecad/issues/4

All stylesheets included in the FreeCAD source have superfluous whitespace in dropdowns, but lack any highlighting for "checked" icons such as Orthographic vs Perspective view.

This PR adds solution proposed by [MisterMakerNL](https://github.com/MisterMakerNL) to all included stylesheets.

For every stylesheet, the `QMenu::item:pressed` color was chosen for the new checked highlight. Only Behave required a different color as its `pressed` color was difficult to see around the icon.


Example for one sheet:

Before:
![image](https://user-images.githubusercontent.com/39636046/179073561-68d207c3-693b-400d-a827-15fcfa2d7a87.png)

After:
![image](https://user-images.githubusercontent.com/39636046/179039143-bae79cad-d63a-4816-8764-0c589db3424e.png)

CC @luzpaz 