### PR TITLE
[PD] Fix button behavior in Pad up-to-face

### DIFF
--- a/src/Mod/PartDesign/Gui/TaskExtrudeParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskExtrudeParameters.cpp
@@ -220,7 +220,7 @@ void TaskExtrudeParameters::connectSlots()
         this, &TaskExtrudeParameters::onReversedChanged);
     connect(ui->changeMode, qOverload<int>(&QComboBox::currentIndexChanged),
         this, &TaskExtrudeParameters::onModeChanged);
-    connect(ui->buttonFace, &QPushButton::clicked,
+    connect(ui->buttonFace, &QPushButton::toggled,
         this, &TaskExtrudeParameters::onButtonFace);
     connect(ui->lineFaceName, &QLineEdit::textEdited,
         this, &TaskExtrudeParameters::onFaceName);
@@ -255,7 +255,7 @@ void TaskExtrudeParameters::onSelectionChanged(const Gui::SelectionChanges& msg)
                 ui->lineFaceName->setProperty("FeatureName", QByteArray(msg.pObjectName));
                 ui->lineFaceName->setProperty("FaceName", QByteArray(msg.pSubName));
                 // Turn off reference selection mode
-                onButtonFace(false);
+                ui->buttonFace->setChecked(false);
             }
             else {
                 clearFaceName();
@@ -468,7 +468,7 @@ void TaskExtrudeParameters::setCheckboxes(Modes mode, Type type)
         QMetaObject::invokeMethod(ui->lineFaceName, "setFocus", Qt::QueuedConnection);
         // Go into reference selection mode if no face has been selected yet
         if (ui->lineFaceName->property("FeatureName").isNull())
-            onButtonFace(true);
+            ui->buttonFace->setChecked(true);
     }
     else if (mode == Modes::TwoDimensions) {
         isLengthEditVisible = true;
@@ -507,7 +507,7 @@ void TaskExtrudeParameters::setCheckboxes(Modes mode, Type type)
     ui->buttonFace->setEnabled(isFaceEditEnabled);
     ui->lineFaceName->setEnabled(isFaceEditEnabled);
     if (!isFaceEditEnabled) {
-        onButtonFace(false);
+        ui->buttonFace->setChecked(false);
     }
 }
 
@@ -681,16 +681,13 @@ void TaskExtrudeParameters::getReferenceAxis(App::DocumentObject*& obj, std::vec
     }
 }
 
-void TaskExtrudeParameters::onButtonFace(const bool pressed)
+void TaskExtrudeParameters::onButtonFace(const bool checked)
 {
     // to distinguish that this is the direction selection
     selectionFace = true;
 
     // only faces are allowed
-    TaskSketchBasedParameters::onSelectReference(pressed ? AllowSelection::FACE : AllowSelection::NONE);
-
-    // Update button if onButtonFace() is called explicitly
-    ui->buttonFace->setChecked(pressed);
+    TaskSketchBasedParameters::onSelectReference(checked ? AllowSelection::FACE : AllowSelection::NONE);
 }
 
 void TaskExtrudeParameters::onFaceName(const QString& text)

--- a/src/Mod/PartDesign/Gui/TaskExtrudeParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskExtrudeParameters.h
@@ -90,7 +90,7 @@ protected Q_SLOTS:
     void onZDirectionEditChanged(double);
     void onMidplaneChanged(bool);
     void onReversedChanged(bool);
-    void onButtonFace(const bool pressed = true);
+    void onButtonFace(const bool checked = true);
     void onFaceName(const QString& text);
     virtual void onModeChanged(int);
 

--- a/src/Mod/PartDesign/Gui/TaskPadPocketParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskPadPocketParameters.ui
@@ -336,9 +336,12 @@ measured along the specified direction</string>
    <item>
     <layout class="QGridLayout" name="gridLayout_5">
      <item row="0" column="0">
-      <widget class="QPushButton" name="buttonFace">
+      <widget class="QToolButton" name="buttonFace">
        <property name="text">
         <string>Face</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
The previous behavior was somewhat erratic when trying to change the end face.

File used for testing attached (needs to be extracted first).
[base-model.zip](https://github.com/FreeCAD/FreeCAD/files/9118068/base-model.zip)
