### PR TITLE
Draft: Fix color handling in make_point.py

### DIFF
--- a/src/Mod/Draft/draftmake/make_point.py
+++ b/src/Mod/Draft/draftmake/make_point.py
@@ -45,7 +45,7 @@ def make_point(X=0, Y=0, Z=0, color=None, name="Point", point_size=5):
 
     Parameters
     ----------
-    X : 
+    X :
         float -> X coordinate of the point
         Base.Vector -> Ignore Y and Z coordinates and create the point
             from the vector.
@@ -59,9 +59,9 @@ def make_point(X=0, Y=0, Z=0, color=None, name="Point", point_size=5):
     color : (R, G, B)
         Point color as RGB
         example to create a colored point:
-        make_point(0,0,0,(1,0,0)) # color = red
+        make_point(0, 0, 0, (1, 0, 0)) # color = red
         example to change the color, make sure values are floats:
-        p1.ViewObject.PointColor =(0.0,0.0,1.0)
+        p1.ViewObject.PointColor = (0.0, 0.0, 1.0)
     """
     if not App.ActiveDocument:
         App.Console.PrintError("No active document. Aborting\n")
@@ -76,18 +76,13 @@ def make_point(X=0, Y=0, Z=0, color=None, name="Point", point_size=5):
 
     Point(obj, X, Y, Z)
 
-    # TODO: Check if this is a repetition:
-    obj.X = X
-    obj.Y = Y
-    obj.Z = Z
-
     if App.GuiUp:
         ViewProviderPoint(obj.ViewObject)
-        if hasattr(Gui,"draftToolBar") and (not color):
-            color = Gui.draftToolBar.getDefaultColor('line')
-        obj.ViewObject.PointColor = (float(color[0]), float(color[1]), float(color[2]))
+        if hasattr(Gui,"draftToolBar") and color is None:
+            color = Gui.draftToolBar.getDefaultColor("line")
+        if color is not None:
+            obj.ViewObject.PointColor = (float(color[0]), float(color[1]), float(color[2]))
         obj.ViewObject.PointSize = point_size
-        obj.ViewObject.Visibility = True
         gui_utils.select(obj)
 
     return obj


### PR DESCRIPTION
The code relied on the `import DraftGui` statement at the top of the file in the previous version of view_facebinder.py. See https://github.com/FreeCAD/FreeCAD/pull/7174.

In the new situation `draftToolBar` can be missing and `color` can stay `None`.

Additionally:
* The section marked as `# TODO: Check if this is a repetition:` was indeed a repetition and was removed.
* There is no need for `obj.ViewObject.Visibility = True`.

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the issue ID number from our [Issues database](https://github.com/FreeCAD/FreeCAD/issues) in case a particular commit solves or is related to an existing issue. Ex: `Draft: fix typos - fixes #4805`

---
