### PR TITLE
Path: Only allow faces and meshes through surface op selection gate

### DIFF
--- a/src/Mod/Path/CMakeLists.txt
+++ b/src/Mod/Path/CMakeLists.txt
@@ -260,6 +260,7 @@ SET(PathTests_SRCS
     PathTests/TestPathPost.py
     PathTests/TestPathPreferences.py
     PathTests/TestPathPropertyBag.py
+    PathTests/TestPathSelection.py
     PathTests/TestPathSetupSheet.py
     PathTests/TestPathStock.py
     PathTests/TestPathToolChangeGenerator.py

--- a/src/Mod/Path/PathScripts/PathSelection.py
+++ b/src/Mod/Path/PathScripts/PathSelection.py
@@ -288,6 +288,19 @@ class ALLGate(PathBaseGate):
         return False
 
 
+class GateCombinator(PathBaseGate):
+    def __init__(self, *gates):
+        self.gates = gates
+
+    def allow(self, *args):
+        return any((gate.allow(*args) for gate in self.gates))
+
+
+class SURFACEGate(GateCombinator):
+    def __init__(self):
+        super().__init__(FACEGate(), MESHGate())
+
+
 def contourselect():
     FreeCADGui.Selection.addSelectionGate(CONTOURGate())
     if not PathPreferences.suppressSelectionModeWarning():
@@ -349,10 +362,7 @@ def slotselect():
 
 
 def surfaceselect():
-    gate = False
-    if MESHGate() or FACEGate():
-        gate = True
-    FreeCADGui.Selection.addSelectionGate(gate)
+    FreeCADGui.Selection.addSelectionGate(SURFACEGate())
     if not PathPreferences.suppressSelectionModeWarning():
         FreeCAD.Console.PrintWarning("Surfacing Select Mode\n")
 

--- a/src/Mod/Path/PathTests/TestPathSelection.py
+++ b/src/Mod/Path/PathTests/TestPathSelection.py
@@ -1,0 +1,191 @@
+# -*- coding: utf-8 -*-
+# ***************************************************************************
+# *   Copyright (c) 2022                                                    *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   This program is distributed in the hope that it will be useful,       *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with this program; if not, write to the Free Software   *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+
+import FreeCAD
+import MeshPart
+import Part
+import PathScripts.PathSetupSheet as PathSetupSheet
+import PathScripts.PathLog as PathLog
+import sys
+
+PathLog.setLevel(PathLog.Level.DEBUG, PathLog.thisModule())
+
+from PathTests.PathTestUtils import PathTestBase
+from PathScripts.PathSelection import GateCombinator, FACEGate, MESHGate, SURFACEGate
+
+if FreeCAD.GuiUp:
+    import FreeCADGui as Gui
+
+
+class AbcGate:
+    def allow(self, doc, obj, sub):
+        return doc == "A" and obj == "B" and sub == "C"
+
+
+class XyzGate:
+    def allow(self, doc, obj, sub):
+        return doc == "X" and obj == "Y" and sub == "Z"
+
+
+class TestGateCombinator(PathTestBase):
+    def test_00(self):
+        """Cannot select non match"""
+        self.assertFalse(GateCombinator(AbcGate(), XyzGate()).allow("L", "M", "N"))
+
+    def test_01(self):
+        """Can select if selection is allowed through first gate"""
+        self.assertTrue(GateCombinator(AbcGate(), XyzGate()).allow("A", "B", "C"))
+
+    def test_02(self):
+        """Can select if selection is allowed through second gate"""
+        self.assertTrue(GateCombinator(AbcGate(), XyzGate()).allow("X", "Y", "Z"))
+
+
+class TestSelectionGates(PathTestBase):
+    def setUp(self):
+        self.doc = FreeCAD.newDocument("TestPathSetupSheet")
+        self.box = self.doc.addObject("Part::Box", "Box")
+        self.box.Length = 10
+        self.box.Width = 10
+        self.box.Height = 10
+
+        wire = Part.show(
+            Part.makePolygon(
+                [
+                    FreeCAD.Vector(0, 0, 0),
+                    FreeCAD.Vector(0, 1, 0),
+                    FreeCAD.Vector(1, 1, 0),
+                    FreeCAD.Vector(1, 0, 0),
+                    FreeCAD.Vector(0, 0, 0),
+                ]
+            )
+        )
+        self.face = self.doc.addObject("Part::Face", "Face")
+        self.face.Sources = wire
+
+        sphere = self.doc.addObject("Part::Sphere", "Sphere")
+        cylinder = self.doc.addObject("Part::Cylinder", "Cylinder")
+        self.compound = self.doc.addObject("Part::Compound", "Compound")
+        self.compound.Links = [sphere, cylinder]
+
+        self.mesh = self.doc.addObject("Mesh::Feature", "Mesh")
+        self.mesh.Mesh = MeshPart.meshFromShape(
+            Shape=self.box.Shape,
+            LinearDeflection=0.1,
+            AngularDeflection=0.453786,
+            Relative=False,
+        )
+
+        self.doc.recompute()
+
+    def tearDown(self):
+        FreeCAD.closeDocument(self.doc.Name)
+
+    def assertCanSelectFace(self, gate):
+        self.assertTrue(gate.allow(self.doc, self.face, "Face1"))
+
+    def assertCannotSelectFace(self, gate):
+        self.assertFalse(gate.allow(self.doc, self.face, "Face1"))
+
+    def assertCanSelectFaceFromSolid(self, gate):
+        self.assertTrue(gate.allow(self.doc, self.box, "Face1"))
+
+    def assertCannotSelectFaceFromSolid(self, gate):
+        self.assertFalse(gate.allow(self.doc, self.box, "Face1"))
+
+    def assertCanSelectFaceFromCompound(self, gate):
+        self.assertTrue(gate.allow(self.doc, self.compound, "Face1"))
+
+    def assertCannotSelectFaceFromCompound(self, gate):
+        self.assertFalse(gate.allow(self.doc, self.compound, "Face1"))
+
+    def assertCanSelectMesh(self, gate):
+        self.assertTrue(gate.allow(self.doc, self.mesh, ""))
+
+    def assertCannotSelectMesh(self, gate):
+        self.assertFalse(gate.allow(self.doc, self.mesh, ""))
+
+    def assertCannotSelectEdge(self, gate):
+        self.assertFalse(gate.allow(self.doc, self.box, "Edge1"))
+
+    # FACEGate
+    def test00(self):
+        """Test FACEGate can select face"""
+        self.assertCanSelectFace(FACEGate())
+
+    def test01(self):
+        """Test FACEGate can select face from solid"""
+        self.assertCanSelectFaceFromSolid(FACEGate())
+
+    def test02(self):
+        """Test FACEGate can select face from compound"""
+        self.assertCanSelectFaceFromCompound(FACEGate())
+
+    def test03(self):
+        """Test FACEGate cannot select mesh"""
+        self.assertCannotSelectMesh(FACEGate())
+
+    def test04(self):
+        """Test FACEGate cannot select edge"""
+        self.assertCannotSelectEdge(FACEGate())
+
+    # MESHGate
+    def test10(self):
+        """Test MESHGate cannot select face"""
+        self.assertCannotSelectFace(MESHGate())
+
+    def test11(self):
+        """Test MESHGate cannot select face from solid"""
+        self.assertCannotSelectFaceFromSolid(MESHGate())
+
+    def test12(self):
+        """Test MESHGate cannot select face from compound"""
+        self.assertCannotSelectFaceFromCompound(MESHGate())
+
+    def test13(self):
+        """Test MESHGate can select mesh"""
+        self.assertCanSelectMesh(MESHGate())
+
+    def test14(self):
+        """Test MESHGate cannot select edge"""
+        self.assertCannotSelectEdge(MESHGate())
+
+    # SURFACEGate
+    def test20(self):
+        """Test SURFACEGate can select face"""
+        self.assertCanSelectFace(SURFACEGate())
+
+    def test21(self):
+        """Test SURFACEGate can select face from solid"""
+        self.assertCanSelectFaceFromSolid(SURFACEGate())
+
+    def test22(self):
+        """Test SURFACEGate can select face from compound"""
+        self.assertCanSelectFaceFromCompound(SURFACEGate())
+
+    def test23(self):
+        """Test SURFACEGate can select mesh"""
+        self.assertCanSelectMesh(SURFACEGate())
+
+    def test24(self):
+        """Test SURFACEGate cannot select edge"""
+        self.assertCannotSelectEdge(SURFACEGate())

--- a/src/Mod/Path/TestPathApp.py
+++ b/src/Mod/Path/TestPathApp.py
@@ -46,6 +46,7 @@ from PathTests.TestPathPost import TestOutputNameSubstitution
 from PathTests.TestPathPreferences import TestPathPreferences
 from PathTests.TestPathPropertyBag import TestPathPropertyBag
 from PathTests.TestPathRotationGenerator import TestPathRotationGenerator
+from PathTests.TestPathSelection import TestGateCombinator, TestSelectionGates
 from PathTests.TestPathSetupSheet import TestPathSetupSheet
 from PathTests.TestPathStock import TestPathStock
 from PathTests.TestPathThreadMilling import TestPathThreadMilling
@@ -76,6 +77,8 @@ False if TestBuildPostList.__name__ else True
 False if TestDressupDogbone.__name__ else True
 False if TestHoldingTags.__name__ else True
 False if TestOutputNameSubstitution.__name__ else True
+False if TestGateCombinator.__name__ else True
+False if TestSelectionGates.__name__ else True
 False if TestPathAdaptive.__name__ else True
 False if TestPathCore.__name__ else True
 False if TestPathDeburr.__name__ else True
@@ -114,3 +117,4 @@ False if TestRefactoredGrblPost.__name__ else True
 False if TestRefactoredLinuxCNCPost.__name__ else True
 False if TestRefactoredMach3Mach4Post.__name__ else True
 False if TestRefactoredTestPost.__name__ else True
+


### PR DESCRIPTION
Changes the surface selection gate to only allow faces and meshes instead. Previous behaviour was to not filter out any selections.
See discussion: https://forum.freecadweb.org/viewtopic.php?f=15&t=70288

Introduces a GateCombinator that takes N gate class instances. If any of the instances let the selection through, then the GateCombinator will let the selection through.

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- []  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the issue ID number from our [Issues database](https://github.com/FreeCAD/FreeCAD/issues) in case a particular commit solves or is related to an existing issue. Ex: `Draft: fix typos - fixes #4805`