### PR TITLE
Arch: Fix getCutVolume in ArchCommands.py

### DIFF
--- a/src/Mod/Arch/ArchCommands.py
+++ b/src/Mod/Arch/ArchCommands.py
@@ -427,7 +427,8 @@ def getCutVolume(cutplane,shapes,clip=False,depth=None):
         return None,None,None
     ce = p.CenterOfMass
     ax = p.normalAt(0,0)
-    u = p.Vertexes[1].Point.sub(p.Vertexes[0].Point).normalize()
+    prm_range = p.ParameterRange # (uMin, uMax, vMin, vMax)
+    u = p.valueAt(prm_range[0], 0).sub(p.valueAt(prm_range[1], 0)).normalize()
     v = u.cross(ax)
     if not bb.isCutPlane(ce,ax):
         #FreeCAD.Console.PrintMessage(translate("Arch","No objects are cut by the plane)+"\n")


### PR DESCRIPTION
Deriving the `u` vector from vertices does not work if the face is circular. Using points based on the parameter range instead.

Forum topic:
https://forum.freecadweb.org/viewtopic.php?f=23&t=70320

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the issue ID number from our [Issues database](https://github.com/FreeCAD/FreeCAD/issues) in case a particular commit solves or is related to an existing issue. Ex: `Draft: fix typos - fixes #4805`

---
