### PR TITLE
Draft: Remove unnecessary DisplayStatusbar preference

### DIFF
--- a/src/Mod/Draft/Resources/ui/preferences-draftinterface.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-draftinterface.ui
@@ -924,20 +924,8 @@
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
-     <property name="toolTip">
-      <string>Enable draft statusbar customization</string>
-     </property>
      <property name="title">
       <string>Draft Statusbar</string>
-     </property>
-     <property name="checkable">
-      <bool>true</bool>
-     </property>
-     <property name="prefEntry" stdset="0">
-      <string notr="true">DisplayStatusbar</string>
-     </property>
-     <property name="prefPath" stdset="0">
-      <string notr="true">Mod/Draft</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>

--- a/src/Mod/Draft/draftutils/init_draft_statusbar.py
+++ b/src/Mod/Draft/draftutils/init_draft_statusbar.py
@@ -179,12 +179,7 @@ def init_draft_statusbar_scale():
     param = App.ParamGet("User parameter:BaseApp/Preferences/Mod/Draft")
 
     mw = Gui.getMainWindow()
-    if mw:
-        sb = mw.statusBar()
-        if sb is None:
-            return
-    else:
-        return
+    sb = mw.statusBar()
 
     scale_widget = QtGui.QToolBar()
     scale_widget.setObjectName("draft_status_scale_widget")
@@ -227,12 +222,7 @@ def init_draft_statusbar_snap():
     param = App.ParamGet("User parameter:BaseApp/Preferences/Mod/Draft")
 
     mw = Gui.getMainWindow()
-    if mw:
-        sb = mw.statusBar()
-        if sb is None:
-            return
-    else:
-        return
+    sb = mw.statusBar()
 
     # SNAP WIDGET - init ----------------------------------------------------
 
@@ -351,15 +341,11 @@ def show_draft_statusbar():
     shows draft statusbar if present or initializes it
     """
     params = App.ParamGet("User parameter:BaseApp/Preferences/Mod/Draft")
-    display_statusbar = params.GetBool("DisplayStatusbar", True)
-
-    if not display_statusbar:
-        return
 
     mw = Gui.getMainWindow()
-    if mw:
-        sb = mw.statusBar()
+    sb = mw.statusBar()
 
+    if params.GetBool("DisplayStatusbarScaleWidget", True):
         scale_widget = sb.findChild(QtGui.QToolBar,
                                     "draft_status_scale_widget")
         if scale_widget:
@@ -370,10 +356,11 @@ def show_draft_statusbar():
             if scale_widget:
                 sb.insertPermanentWidget(3, scale_widget)
                 scale_widget.show()
-            elif params.GetBool("DisplayStatusbarScaleWidget", True):
+            else:
                 t = QtCore.QTimer()
                 t.singleShot(500, init_draft_statusbar_scale)
 
+    if params.GetBool("DisplayStatusbarSnapWidget", True):
         snap_widget = sb.findChild(QtGui.QToolBar,"draft_snap_widget")
         if snap_widget:
             snap_widget.setOrientation(QtCore.Qt.Orientation.Horizontal)
@@ -384,7 +371,7 @@ def show_draft_statusbar():
                 sb.insertPermanentWidget(2, snap_widget)
                 snap_widget.setOrientation(QtCore.Qt.Orientation.Horizontal)
                 snap_widget.show()
-            elif params.GetBool("DisplayStatusbarSnapWidget", True):
+            else:
                 t = QtCore.QTimer()
                 t.singleShot(500, init_draft_statusbar_snap)
 
@@ -394,8 +381,6 @@ def hide_draft_statusbar():
     hides draft statusbar if present
     """
     mw = Gui.getMainWindow()
-    if not mw:
-        return
     sb = mw.statusBar()
 
     # hide scale widget


### PR DESCRIPTION
This PR removes the `DisplayStatusbar` preference. This preference was not implemented properly. The checkbox in the preferences did not work. And having a Boole preference to override two other Boole preferences is unnecessary IMO.

Forum topic:
https://forum.freecadweb.org/viewtopic.php?f=23&t=60400

Additionally:
* Minor code cleanup related to:
  * `mw = Gui.getMainWindow()` will never return `None`. If the Gui is up the MainWindow is available
  * `sb = mw.statusBar()` will never return `None`. It will create the statusbar if it is missing.
* Minor improvement of the `show_draft_statusbar` function. Changes to the `DisplayStatusbarScaleWidget` or the `DisplayStatusbarSnapWidget` preference now only require a workbench switch (f.e. Draft->Part->Draft) instead of a restart.

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the issue ID number from our [Issues database](https://github.com/FreeCAD/FreeCAD/issues) in case a particular commit solves or is related to an existing issue. Ex: `Draft: fix typos - fixes #4805`

---
