### PR TITLE
[PD Pad/Pocket] Fix bug with midplane usage in TwoLengths mode

### DIFF
--- a/src/Mod/PartDesign/App/FeatureExtrude.cpp
+++ b/src/Mod/PartDesign/App/FeatureExtrude.cpp
@@ -144,12 +144,9 @@ void FeatureExtrude::generatePrism(TopoDS_Shape& prism,
 
 
         if (method == "TwoLengths") {
-            // midplane makes no sense here
             Ltotal += L2;
             if (reversed)
                 Loffset = -L;
-            else if (midplane)
-                Loffset = -0.5 * (L2 + L);
             else
                 Loffset = -L2;
         }
@@ -277,7 +274,7 @@ void FeatureExtrude::generateTaperedPrism(TopoDS_Shape& prism,
 void FeatureExtrude::updateProperties(const std::string &method)
 {
     // disable settings that are not valid on the current method
-    // disable everything unless we are sure we don't need it
+    // disable everything unless we are sure we need it
     bool isLengthEnabled = false;
     bool isLength2Enabled = false;
     bool isOffsetEnabled = false;

--- a/src/Mod/PartDesign/Gui/TaskPadParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPadParameters.cpp
@@ -111,9 +111,6 @@ void TaskPadParameters::onModeChanged(int index)
         break;
     case Modes::TwoDimensions:
         pcPad->Type.setValue("TwoLengths");
-        // symmetric is then not possible
-        if (ui->checkBoxMidplane->isChecked())
-            ui->checkBoxMidplane->setChecked(false);
         break;
     }
 

--- a/src/Mod/PartDesign/Gui/TaskPocketParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPocketParameters.cpp
@@ -122,9 +122,6 @@ void TaskPocketParameters::onModeChanged(int index)
         case Modes::TwoDimensions:
             oldLength = pcPocket->Length.getValue();
             pcPocket->Type.setValue("TwoLengths");
-            // symmetric is then not possible
-            if (ui->checkBoxMidplane->isChecked())
-                ui->checkBoxMidplane->setChecked(false);
             break;
     }
 


### PR DESCRIPTION
properly fix issue reported here: https://forum.freecadweb.org/viewtopic.php?f=3&t=70266

also reverted a previous commit that auto unchecked the midplane option in the task panel since it is now unnecessary with the fix and may result annoying if you want to go back to length mode expecting it to remain checked, also it is inconsistent since it only gets unchecked for two lengths but not the other modes were it is not a valid option either. IMO this was more a workaround than an actual fix for the bug as it could still be encountered through the property view or in old files.

This should be backported to 0.20 branch also