### PR TITLE
Make image scaling command aware of user units

### DIFF
--- a/src/Gui/InputField.cpp
+++ b/src/Gui/InputField.cpp
@@ -642,6 +642,19 @@ void InputField::focusInEvent(QFocusEvent *event)
 
 void InputField::focusOutEvent(QFocusEvent *event)
 {
+    try {
+        if (Quantity::parse(this->text()).getUnit().isEmpty()) {
+            // if user didn't enter a unit, we virtually compensate
+            // the multiplication factor induced by user unit system
+            double factor;
+            QString unitStr;
+            actQuantity.getUserString(factor, unitStr);
+            actQuantity = actQuantity * factor;
+        }
+    }
+    catch (const Base::ParserError& e) {
+        // do nothing, let apply the last known good value
+    }
     this->setText(actQuantity.getUserString());
     QLineEdit::focusOutEvent(event);
 }

--- a/src/Mod/Image/ImageTools/_CommandImageScaling.py
+++ b/src/Mod/Image/ImageTools/_CommandImageScaling.py
@@ -108,9 +108,11 @@ def cmdCreateImageScaling(name, trackers):
             self.label.setObjectName(_fromUtf8("label"))
             self.horizontalLayout.addWidget(self.label)
 
-            self.lineEdit = QtGui.QLineEdit(Dialog)
-            self.lineEdit.setObjectName(_fromUtf8("lineEdit"))
-            self.horizontalLayout.addWidget(self.lineEdit)
+            self.quantity = FreeCADGui.UiLoader().createWidget("Gui::InputField")
+            self.quantity.setParent(Dialog)
+            self.quantity.setProperty('unit', 'mm')
+            self.quantity.setObjectName(_fromUtf8("QuantityField"))
+            self.horizontalLayout.addWidget(self.quantity)
 
             self.label1 = QtGui.QLabel(Dialog)
             self.label1.setObjectName(_fromUtf8("label1"))
@@ -136,23 +138,13 @@ def cmdCreateImageScaling(name, trackers):
     
         def retranslateUi(self, Dialog):
             Dialog.setWindowTitle(translate("Dialog", "Scale image plane", None))
-            self.label.setText(translate("Dialog", "Distance [mm]", None))
+            self.label.setText(translate("Dialog", "Distance", None))
             self.label1.setText(translate("Dialog", "Select first point", None))
             
         def accept(self):
             sel = FreeCADGui.Selection.getSelection()
             try:
-                try:
-                    q = FreeCAD.Units.parseQuantity(self.lineEdit.text())
-                    d = q.Value
-                    if q.Unit == FreeCAD.Units.Unit(): # plain number
-                        ok = True
-                    elif q.Unit == FreeCAD.Units.Length:
-                        ok = True
-                except Exception:
-                    ok = False
-                if not ok:
-                    raise ValueError
+                d = self.quantity.property('rawValue')
                 s=d/self.distance
                 sel[0].XSize.Value=sel[0].XSize.Value*s
                 sel[0].YSize.Value=sel[0].YSize.Value*s


### PR DESCRIPTION
This PR makes the "distance" in Image Scaling command aware of user unit, i.e. it will : 
* Propose a default value using and showing user base unit
* If a unitless value is entered, it will consider it is given as user base unit

To do so, the QLineEdit has been replaced by a InputField (so that user also benefit from the checker). This is 2nd commit.

However to do so, I had to make a general change in InputField class (this is 1st commit).
This commit will let a InputField consider a unitless value is given as user base unit, if and only if value has been entered by user in the GUI (programmatically set values are still considered in FC core base unit if unitless).
This change will not only affect Image Scaling command, but all InputField across FC (eg. grid size in the working plane panel), hence I'd like feedback about people implied in Draft dev before this is merged. @yorikvanhavre @Roy-043 