### PR TITLE
Arch: Housekeeping: import translate from correct file

### DIFF
--- a/src/Mod/Arch/ArchAxis.py
+++ b/src/Mod/Arch/ArchAxis.py
@@ -26,7 +26,7 @@ from FreeCAD import Vector
 if FreeCAD.GuiUp:
     import FreeCADGui, re
     from PySide import QtCore, QtGui
-    from DraftTools import translate
+    from draftutils.translate import translate
     from pivy import coin
     from PySide.QtCore import QT_TRANSLATE_NOOP
 

--- a/src/Mod/Arch/ArchAxisSystem.py
+++ b/src/Mod/Arch/ArchAxisSystem.py
@@ -23,7 +23,7 @@ import FreeCAD, DraftGeomUtils
 if FreeCAD.GuiUp:
     import FreeCADGui, Draft
     from PySide import QtCore, QtGui
-    from DraftTools import translate
+    from draftutils.translate import translate
     from pivy import coin
     from PySide.QtCore import QT_TRANSLATE_NOOP
 else:

--- a/src/Mod/Arch/ArchBuilding.py
+++ b/src/Mod/Arch/ArchBuilding.py
@@ -24,7 +24,7 @@ import FreeCAD,Draft,ArchCommands,ArchFloor
 if FreeCAD.GuiUp:
     import FreeCADGui
     from PySide import QtCore
-    from DraftTools import translate
+    from draftutils.translate import translate
     from PySide.QtCore import QT_TRANSLATE_NOOP
 else:
     # \cond

--- a/src/Mod/Arch/ArchBuildingPart.py
+++ b/src/Mod/Arch/ArchBuildingPart.py
@@ -30,7 +30,7 @@ import tempfile
 import os
 if FreeCAD.GuiUp:
     import FreeCADGui
-    from DraftTools import translate
+    from draftutils.translate import translate
     from PySide.QtCore import QT_TRANSLATE_NOOP
     import draftutils.units as units
 else:

--- a/src/Mod/Arch/ArchCurtainWall.py
+++ b/src/Mod/Arch/ArchCurtainWall.py
@@ -32,7 +32,7 @@ import DraftVecUtils
 
 if FreeCAD.GuiUp:
     import FreeCADGui
-    from DraftTools import translate
+    from draftutils.translate import translate
     from PySide.QtCore import QT_TRANSLATE_NOOP
 else:
     # \cond

--- a/src/Mod/Arch/ArchCutPlane.py
+++ b/src/Mod/Arch/ArchCutPlane.py
@@ -24,7 +24,7 @@ import FreeCAD,ArchCommands
 if FreeCAD.GuiUp:
     import FreeCADGui
     from PySide import QtCore, QtGui
-    from DraftTools import translate
+    from draftutils.translate import translate
 else:
     # \cond
     def translate(ctxt,txt):

--- a/src/Mod/Arch/ArchEquipment.py
+++ b/src/Mod/Arch/ArchEquipment.py
@@ -28,7 +28,7 @@ import FreeCAD,ArchComponent,DraftVecUtils
 if FreeCAD.GuiUp:
     import FreeCADGui
     from PySide import QtGui
-    from DraftTools import translate
+    from draftutils.translate import translate
     from PySide.QtCore import QT_TRANSLATE_NOOP
 else:
     # \cond

--- a/src/Mod/Arch/ArchFloor.py
+++ b/src/Mod/Arch/ArchFloor.py
@@ -31,7 +31,7 @@ IfcType.
 import FreeCAD,Draft,ArchCommands, DraftVecUtils, ArchIFC
 if FreeCAD.GuiUp:
     import FreeCADGui
-    from DraftTools import translate
+    from draftutils.translate import translate
     from PySide.QtCore import QT_TRANSLATE_NOOP
 else:
     # \cond

--- a/src/Mod/Arch/ArchFrame.py
+++ b/src/Mod/Arch/ArchFrame.py
@@ -22,7 +22,7 @@
 import FreeCAD,Draft,ArchComponent,DraftVecUtils
 if FreeCAD.GuiUp:
     import FreeCADGui
-    from DraftTools import translate
+    from draftutils.translate import translate
     from PySide.QtCore import QT_TRANSLATE_NOOP
 else:
     # \cond

--- a/src/Mod/Arch/ArchGrid.py
+++ b/src/Mod/Arch/ArchGrid.py
@@ -23,7 +23,7 @@ import FreeCAD, Part, math
 if FreeCAD.GuiUp:
     import FreeCADGui
     from PySide import QtCore, QtGui
-    from DraftTools import translate
+    from draftutils.translate import translate
     from PySide.QtCore import QT_TRANSLATE_NOOP
 else:
     # \cond

--- a/src/Mod/Arch/ArchMaterial.py
+++ b/src/Mod/Arch/ArchMaterial.py
@@ -24,7 +24,7 @@ if FreeCAD.GuiUp:
     import FreeCADGui, os
     import Arch_rc # Needed for access to icons # lgtm [py/unused_import]
     from PySide import QtCore, QtGui
-    from DraftTools import translate
+    from draftutils.translate import translate
     from PySide.QtCore import QT_TRANSLATE_NOOP
 else:
     # \cond

--- a/src/Mod/Arch/ArchPanel.py
+++ b/src/Mod/Arch/ArchPanel.py
@@ -24,7 +24,7 @@ from FreeCAD import Vector
 if FreeCAD.GuiUp:
     import FreeCADGui
     from PySide import QtCore, QtGui
-    from DraftTools import translate
+    from draftutils.translate import translate
     from PySide.QtCore import QT_TRANSLATE_NOOP
     import draftguitools.gui_trackers as DraftTrackers
 else:

--- a/src/Mod/Arch/ArchPipe.py
+++ b/src/Mod/Arch/ArchPipe.py
@@ -23,7 +23,7 @@
 import FreeCAD, ArchComponent
 if FreeCAD.GuiUp:
     import FreeCADGui, Arch_rc
-    from DraftTools import translate
+    from draftutils.translate import translate
     from PySide.QtCore import QT_TRANSLATE_NOOP
 else:
     # \cond

--- a/src/Mod/Arch/ArchPrecast.py
+++ b/src/Mod/Arch/ArchPrecast.py
@@ -29,7 +29,7 @@ Beams, pillars, slabs and panels"""
 import ArchCommands,ArchComponent,FreeCAD
 from FreeCAD import Vector
 if FreeCAD.GuiUp:
-    from DraftTools import translate
+    from draftutils.translate import translate
     from PySide.QtCore import QT_TRANSLATE_NOOP
 else:
     # \cond

--- a/src/Mod/Arch/ArchProfile.py
+++ b/src/Mod/Arch/ArchProfile.py
@@ -38,7 +38,7 @@ import csv
 if FreeCAD.GuiUp:
     import FreeCADGui
     from PySide import QtCore, QtGui
-    from DraftTools import translate
+    from draftutils.translate import translate
     from PySide.QtCore import QT_TRANSLATE_NOOP
 else:
     # \cond

--- a/src/Mod/Arch/ArchProject.py
+++ b/src/Mod/Arch/ArchProject.py
@@ -28,7 +28,7 @@ certain IFC relevant values.
 import FreeCAD,ArchIFC,ArchIFCView
 if FreeCAD.GuiUp:
     import FreeCADGui
-    from DraftTools import translate
+    from draftutils.translate import translate
     from PySide.QtCore import QT_TRANSLATE_NOOP
 else:
     def translate(ctxt,txt):

--- a/src/Mod/Arch/ArchRebar.py
+++ b/src/Mod/Arch/ArchRebar.py
@@ -23,7 +23,7 @@
 import FreeCAD,Draft,ArchComponent,DraftVecUtils,ArchCommands
 if FreeCAD.GuiUp:
     import FreeCADGui
-    from DraftTools import translate
+    from draftutils.translate import translate
     from PySide.QtCore import QT_TRANSLATE_NOOP
 else:
     # \cond

--- a/src/Mod/Arch/ArchReference.py
+++ b/src/Mod/Arch/ArchReference.py
@@ -32,7 +32,7 @@ import sys
 if FreeCAD.GuiUp:
     import FreeCADGui
     from PySide import QtCore, QtGui
-    from DraftTools import translate
+    from draftutils.translate import translate
     from PySide.QtCore import QT_TRANSLATE_NOOP
 else:
     # \cond

--- a/src/Mod/Arch/ArchRoof.py
+++ b/src/Mod/Arch/ArchRoof.py
@@ -32,7 +32,7 @@ from FreeCAD import Vector
 if FreeCAD.GuiUp:
     import FreeCADGui
     from PySide import QtCore, QtGui
-    from DraftTools import translate
+    from draftutils.translate import translate
     from PySide.QtCore import QT_TRANSLATE_NOOP
 else:
     # \cond

--- a/src/Mod/Arch/ArchSchedule.py
+++ b/src/Mod/Arch/ArchSchedule.py
@@ -26,7 +26,7 @@ import FreeCAD
 if FreeCAD.GuiUp:
     import FreeCADGui
     from PySide import QtCore, QtGui
-    from DraftTools import translate
+    from draftutils.translate import translate
     from PySide.QtCore import QT_TRANSLATE_NOOP
 else:
     # \cond

--- a/src/Mod/Arch/ArchSectionPlane.py
+++ b/src/Mod/Arch/ArchSectionPlane.py
@@ -34,7 +34,7 @@ from FreeCAD import Vector
 if FreeCAD.GuiUp:
     import FreeCADGui
     from PySide import QtCore, QtGui
-    from DraftTools import translate
+    from draftutils.translate import translate
     from pivy import coin
     from PySide.QtCore import QT_TRANSLATE_NOOP
 else:

--- a/src/Mod/Arch/ArchSite.py
+++ b/src/Mod/Arch/ArchSite.py
@@ -27,7 +27,7 @@ containers for Arch objects, and also define a terrain surface.
 import FreeCAD,Draft,ArchCommands,math,re,datetime,ArchIFC
 if FreeCAD.GuiUp:
     import FreeCADGui
-    from DraftTools import translate
+    from draftutils.translate import translate
     from PySide.QtCore import QT_TRANSLATE_NOOP
 else:
     # \cond

--- a/src/Mod/Arch/ArchSpace.py
+++ b/src/Mod/Arch/ArchSpace.py
@@ -149,7 +149,7 @@ import FreeCAD,ArchComponent,ArchCommands,Draft,sys
 if FreeCAD.GuiUp:
     import FreeCADGui
     from PySide import QtCore, QtGui
-    from DraftTools import translate
+    from draftutils.translate import translate
     from PySide.QtCore import QT_TRANSLATE_NOOP
 else:
     # \cond

--- a/src/Mod/Arch/ArchStairs.py
+++ b/src/Mod/Arch/ArchStairs.py
@@ -31,7 +31,7 @@ import Part, DraftGeomUtils
 from FreeCAD import Vector
 if FreeCAD.GuiUp:
     import FreeCADGui
-    from DraftTools import translate
+    from draftutils.translate import translate
     from PySide.QtCore import QT_TRANSLATE_NOOP
 else:
     # \cond

--- a/src/Mod/Arch/ArchStructure.py
+++ b/src/Mod/Arch/ArchStructure.py
@@ -27,7 +27,7 @@ import ArchProfile
 if FreeCAD.GuiUp:
     import FreeCADGui
     from PySide import QtCore, QtGui
-    from DraftTools import translate
+    from draftutils.translate import translate
     from PySide.QtCore import QT_TRANSLATE_NOOP
     import ArchPrecast
     import draftguitools.gui_trackers as DraftTrackers

--- a/src/Mod/Arch/ArchTruss.py
+++ b/src/Mod/Arch/ArchTruss.py
@@ -30,7 +30,7 @@ import ArchComponent
 
 if FreeCAD.GuiUp:
     import FreeCADGui
-    from DraftTools import translate
+    from draftutils.translate import translate
     from PySide.QtCore import QT_TRANSLATE_NOOP
 else:
     # \cond

--- a/src/Mod/Arch/ArchWall.py
+++ b/src/Mod/Arch/ArchWall.py
@@ -34,7 +34,7 @@ from FreeCAD import Vector
 if FreeCAD.GuiUp:
     import FreeCADGui
     from PySide import QtCore, QtGui
-    from DraftTools import translate
+    from draftutils.translate import translate
     from PySide.QtCore import QT_TRANSLATE_NOOP
     import draftguitools.gui_trackers as DraftTrackers
 else:

--- a/src/Mod/Arch/ArchWindow.py
+++ b/src/Mod/Arch/ArchWindow.py
@@ -30,7 +30,7 @@ from draftutils.messages import _wrn
 if FreeCAD.GuiUp:
     import FreeCADGui
     from PySide import QtCore, QtGui, QtSvg
-    from DraftTools import translate
+    from draftutils.translate import translate
     from PySide.QtCore import QT_TRANSLATE_NOOP
     import draftguitools.gui_trackers as DraftTrackers
 else:

--- a/src/Mod/Arch/importDAE.py
+++ b/src/Mod/Arch/importDAE.py
@@ -21,7 +21,7 @@
 
 import FreeCAD, Mesh, os, numpy, MeshPart, Arch, Draft
 if FreeCAD.GuiUp:
-    from DraftTools import translate
+    from draftutils.translate import translate
 else:
     # \cond
     def translate(context,text):

--- a/src/Mod/Arch/importGBXML.py
+++ b/src/Mod/Arch/importGBXML.py
@@ -26,7 +26,7 @@ __url__    = "https://www.freecadweb.org"
 import FreeCAD,Draft
 
 if FreeCAD.GuiUp:
-    from DraftTools import translate
+    from draftutils.translate import translate
 else:
     # \cond
     def translate(ctx,txt):

--- a/src/Mod/Arch/importIFClegacy.py
+++ b/src/Mod/Arch/importIFClegacy.py
@@ -27,7 +27,7 @@
 
 
 import FreeCAD, Arch, Draft, os, sys, time, Part, DraftVecUtils, uuid, math, re
-from DraftTools import translate
+from draftutils.translate import translate
 
 __title__="FreeCAD IFC importer"
 __author__ = "Yorik van Havre"

--- a/src/Mod/Arch/importJSON.py
+++ b/src/Mod/Arch/importJSON.py
@@ -27,7 +27,7 @@ import six
 
 if FreeCAD.GuiUp:
     import FreeCADGui
-    from DraftTools import translate
+    from draftutils.translate import translate
 
 else:
     FreeCADGui = None

--- a/src/Mod/Arch/importOBJ.py
+++ b/src/Mod/Arch/importOBJ.py
@@ -22,7 +22,7 @@
 import FreeCAD, DraftGeomUtils, Part, Draft, Arch, Mesh, MeshPart, os, sys, codecs, ntpath
 # import numpy as np
 if FreeCAD.GuiUp:
-    from DraftTools import translate
+    from draftutils.translate import translate
 else:
     # \cond
     def translate(context,text):

--- a/src/Mod/Arch/importWebGL.py
+++ b/src/Mod/Arch/importWebGL.py
@@ -42,7 +42,7 @@ import textwrap
 
 if FreeCAD.GuiUp:
     import FreeCADGui
-    from DraftTools import translate
+    from draftutils.translate import translate
 else:
     FreeCADGui = None
     def translate(ctxt, txt): return txt


### PR DESCRIPTION
For many Arch files the `translate` function was imported from `DraftTools`. But the function is not defined there (or used there).

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the issue ID number from our [Issues database](https://github.com/FreeCAD/FreeCAD/issues) in case a particular commit solves or is related to an existing issue. Ex: `Draft: fix typos - fixes #4805`

---