### PR TITLE
Improve grid maxNumberOfLines warning message

### DIFF
--- a/src/Mod/Part/Gui/ViewProvider2DObject.cpp
+++ b/src/Mod/Part/Gui/ViewProvider2DObject.cpp
@@ -202,7 +202,7 @@ SoSeparator* ViewProvider2DObjectGrid::createGrid(void)
 
     if (lines > maxNumberOfLines.getValue()) {
         Base::Console().Warning("Grid Disabled: Requested number of lines %d is larger than the maximum configured of %d\n."
-                                "In order to increase the maximum adjust the property 'maxNumberOfLines'\n", lines, maxNumberOfLines.getValue());
+                                "Either increase the 'GridSize' property to a more reasonable value (recommended) or increase the 'maxNumberOfLines' property.\n", lines, maxNumberOfLines.getValue());
         parent->addChild(vts);
         parent->addChild(grid);
         return GridRoot;


### PR DESCRIPTION
It is better to advise to increase the grid spacing to a reasonable value since increasing the max lines usually results in a grid that is too fine to be of use unless you want to work zooming in **a lot** on a specific part of the sketch, I don't see this a common usecase since sketches are not meant to be finely adjusted by mouse but rather with constraints.
Here an example of how the grid might look when encountering this issue and following the advise to increase maximum lines:
![image](https://user-images.githubusercontent.com/36372335/180267497-7006eb4a-4081-4ec9-823b-ec550d1d7931.png)
vs the more sane approach of increasing grid spacing:
![image](https://user-images.githubusercontent.com/36372335/180267722-d34e4f81-df77-4829-95c2-9155bae6233b.png)
