### PR TITLE
src: Add helper function to check Python types.

### DIFF
--- a/src/App/ApplicationPy.cpp
+++ b/src/App/ApplicationPy.cpp
@@ -845,21 +845,20 @@ PyObject *Application::sGetLinksTo(PyObject * /*self*/, PyObject *args)
         return nullptr;
 
     PY_TRY {
+        Base::PyTypeCheck(&pyobj, &DocumentObjectPy::Type, "Expect the first argument of type App.DocumentObject or None");
         DocumentObject *obj = nullptr;
-        if(pyobj!=Py_None) {
-            if(!PyObject_TypeCheck(pyobj,&DocumentObjectPy::Type)) {
-                PyErr_SetString(PyExc_TypeError, "Expect the first argument of type document object");
-                return nullptr;
-            }
+        if (pyobj)
             obj = static_cast<DocumentObjectPy*>(pyobj)->getDocumentObjectPtr();
-        }
+
         auto links = GetApplication().getLinksTo(obj,options,count);
         Py::Tuple ret(links.size());
         int i=0;
         for(auto o : links)
             ret.setItem(i++,Py::Object(o->getPyObject(),true));
+
         return Py::new_reference_to(ret);
-    }PY_CATCH;
+    }
+    PY_CATCH;
 }
 
 PyObject *Application::sGetDependentObjects(PyObject * /*self*/, PyObject *args)

--- a/src/App/DocumentObjectPyImp.cpp
+++ b/src/App/DocumentObjectPyImp.cpp
@@ -581,31 +581,30 @@ PyObject*  DocumentObjectPy::getLinkedObject(PyObject *args, PyObject *keywds)
                 &PyBool_Type,&recursive,&pyMat,&PyBool_Type,&transform,&depth))
         return nullptr;
 
-    Base::Matrix4D _mat;
-    Base::Matrix4D *mat = nullptr;
-    if(pyMat!=Py_None) {
-        if(!PyObject_TypeCheck(pyMat,&Base::MatrixPy::Type)) {
-            PyErr_SetString(PyExc_TypeError, "expect argument 'matrix' to be of type Base.Matrix");
-            return nullptr;
-        }
-        _mat = *static_cast<Base::MatrixPy*>(pyMat)->getMatrixPtr();
-        mat = &_mat;
-    }
-
     PY_TRY {
+        Base::PyTypeCheck(&pyMat, &Base::MatrixPy::Type, "expect argument 'matrix' to be of type Base.Matrix");
+        Base::Matrix4D _mat;
+        Base::Matrix4D *mat = nullptr;
+        if (pyMat) {
+            _mat = *static_cast<Base::MatrixPy*>(pyMat)->getMatrixPtr();
+            mat = &_mat;
+        }
+
         auto linked = getDocumentObjectPtr()->getLinkedObject(
                 Base::asBoolean(recursive), mat, Base::asBoolean(transform), depth);
-        if(!linked)
+        if (!linked)
             linked = getDocumentObjectPtr();
         auto pyObj = Py::Object(linked->getPyObject(),true);
-        if(mat) {
+        if (mat) {
             Py::Tuple ret(2);
             ret.setItem(0,pyObj);
             ret.setItem(1,Py::asObject(new Base::MatrixPy(*mat)));
             return Py::new_reference_to(ret);
         }
+
         return Py::new_reference_to(pyObj);
-    } PY_CATCH;
+    }
+    PY_CATCH;
 }
 
 PyObject*  DocumentObjectPy::isElementVisible(PyObject *args)

--- a/src/App/PropertyLinks.cpp
+++ b/src/App/PropertyLinks.cpp
@@ -460,17 +460,13 @@ PyObject *PropertyLink::getPyObject()
 
 void PropertyLink::setPyObject(PyObject *value)
 {
-    if (PyObject_TypeCheck(value, &(DocumentObjectPy::Type))) {
-        DocumentObjectPy  *pcObject = static_cast<DocumentObjectPy*>(value);
+    Base::PyTypeCheck(&value, &DocumentObjectPy::Type);
+    if (value) {
+        DocumentObjectPy *pcObject = static_cast<DocumentObjectPy*>(value);
         setValue(pcObject->getDocumentObjectPtr());
     }
-    else if (Py_None == value) {
-        setValue(nullptr);
-    }
     else {
-        std::string error = std::string("type must be 'DocumentObject' or 'NoneType', not ");
-        error += value->ob_type->tp_name;
-        throw Base::TypeError(error);
+        setValue(nullptr);
     }
 }
 
@@ -708,16 +704,9 @@ PyObject *PropertyLinkList::getPyObject()
 
 DocumentObject *PropertyLinkList::getPyValue(PyObject *item) const
 {
-    if (item == Py_None) {
-        return nullptr;
-    }
-    else if (PyObject_TypeCheck(item, &(DocumentObjectPy::Type))) {
-        return static_cast<DocumentObjectPy*>(item)->getDocumentObjectPtr();
-    }
+    Base::PyTypeCheck(&item, &DocumentObjectPy::Type);
 
-    std::string error = std::string("type must be 'DocumentObject', list of 'DocumentObject', or NoneType, not ");
-    error += item->ob_type->tp_name;
-    throw Base::TypeError(error);
+    return item ? static_cast<DocumentObjectPy*>(item)->getDocumentObjectPtr() : nullptr;
 }
 
 void PropertyLinkList::Save(Base::Writer &writer) const

--- a/src/Base/PyObjectBase.h
+++ b/src/Base/PyObjectBase.h
@@ -520,6 +520,36 @@ inline PyObject * PyAsUnicodeObject(const std::string &str)
     return PyAsUnicodeObject(str.c_str());
 }
 
+/** Helper functions to check if a python object is of a specific type or None,
+ *  otherwise raise an exception.
+ *  If the object is None, the pointer is set to nullptr.
+ */
+inline void PyTypeCheck(PyObject** ptr, PyTypeObject* type, const char* msg=nullptr)
+{
+    if (*ptr == Py_None) {
+        *ptr = nullptr;
+        return;
+    }
+    if (!PyObject_TypeCheck(*ptr, type)) {
+        if (!msg) {
+            std::stringstream str;
+            str << "Type must be " << type->tp_name << " or None, not " << (*ptr)->ob_type->tp_name;
+            throw Base::TypeError(str.str());
+        }
+        throw Base::TypeError(msg);
+    }
+}
+
+inline void PyTypeCheck(PyObject** ptr, int (*method)(PyObject*), const char* msg)
+{
+    if (*ptr == Py_None) {
+        *ptr = nullptr;
+        return;
+    }
+    if (!method(*ptr))
+        throw Base::TypeError(msg);
+}
+
 
 } // namespace Base
 

--- a/src/Gui/LinkViewPyImp.cpp
+++ b/src/Gui/LinkViewPyImp.cpp
@@ -308,23 +308,23 @@ PyObject* LinkViewPy::getDetailPath(PyObject* args)
     }PY_CATCH
 }
 
-PyObject* LinkViewPy::getBoundBox(PyObject* args) {
+PyObject* LinkViewPy::getBoundBox(PyObject* args)
+{
     PyObject *vobj = Py_None;
     if (!PyArg_ParseTuple(args, "O",&vobj))
         return nullptr;
-    ViewProviderDocumentObject *vpd = nullptr;
-    if(vobj!=Py_None) {
-        if(!PyObject_TypeCheck(vobj,&ViewProviderDocumentObjectPy::Type)) {
-            PyErr_SetString(PyExc_TypeError, "exepcting a type of ViewProviderDocumentObject");
-            return nullptr;
-        }
-        vpd = static_cast<ViewProviderDocumentObjectPy*>(vobj)->getViewProviderDocumentObjectPtr();
-    }
+
     PY_TRY {
+        Base::PyTypeCheck(&vobj, &ViewProviderDocumentObjectPy::Type);
+        ViewProviderDocumentObject *vpd = nullptr;
+        if (vobj)
+            vpd = static_cast<ViewProviderDocumentObjectPy*>(vobj)->getViewProviderDocumentObjectPtr();
+
         auto bbox = getLinkViewPtr()->getBoundBox(vpd);
         Py::Object ret(new Base::BoundBoxPy(new Base::BoundBox3d(bbox)));
         return Py::new_reference_to(ret);
-    }PY_CATCH
+    }
+    PY_CATCH
 }
 
 PyObject *LinkViewPy::getCustomAttributes(const char*) const

--- a/src/Gui/MDIViewPy.cpp
+++ b/src/Gui/MDIViewPy.cpp
@@ -238,17 +238,17 @@ Py::Object MDIViewPy::setActiveObject(const Py::Tuple& args)
     if (!PyArg_ParseTuple(args.ptr(), "s|Os", &name, &docObject, &subname))
         throw Py::Exception();
 
-    if (_view) {
-        if (docObject == Py_None) {
-            _view->setActiveObject(nullptr, name);
-        }
-        else {
-            if (!PyObject_TypeCheck(docObject, &App::DocumentObjectPy::Type))
-                throw Py::TypeError("Expect the second argument to be a document object or None");
-
-            App::DocumentObject* obj = static_cast<App::DocumentObjectPy*>(docObject)->getDocumentObjectPtr();
+    try {
+        Base::PyTypeCheck(&docObject, &App::DocumentObjectPy::Type,
+            "Expect the second argument to be a document object or None");
+        if (_view) {
+            App::DocumentObject* obj = docObject ?
+                static_cast<App::DocumentObjectPy*>(docObject)->getDocumentObjectPtr() : nullptr;
             _view->setActiveObject(obj, name, subname);
         }
+    }
+    catch (const Base::Exception& e) {
+        throw Py::Exception(e.getPyExceptionType(), e.what());
     }
 
     return Py::None();

--- a/src/Gui/Selection.cpp
+++ b/src/Gui/Selection.cpp
@@ -2523,17 +2523,10 @@ PyObject *SelectionSingleton::sSetVisible(PyObject * /*self*/, PyObject *args)
         return nullptr;
 
     PY_TRY {
-        VisibleState vis;
-        if(visible == Py_None) {
-            vis = VisToggle;
-        }
-        else if (PyBool_Check(visible)) {
-            vis = Base::asBoolean(visible) ? VisShow : VisHide;
-        }
-        else {
-            PyErr_SetString(PyExc_ValueError, "Argument is neither None nor Bool");
-            return nullptr;
-        }
+        VisibleState vis = VisToggle;
+        Base::PyTypeCheck(&visible, &PyBool_Type);
+        if (visible)
+            vis = PyObject_IsTrue(visible) ? VisShow : VisHide;
 
         Selection().setVisible(vis);
         Py_Return;

--- a/src/Gui/View3DPy.cpp
+++ b/src/Gui/View3DPy.cpp
@@ -2566,17 +2566,18 @@ Py::Object View3DInventorPy::setActiveObject(const Py::Tuple& args)
     if (!PyArg_ParseTuple(args.ptr(), "s|Os", &name, &docObject, &subname))
         throw Py::Exception();
 
-    if (docObject == Py_None) {
-        getView3DIventorPtr()->setActiveObject(nullptr, name);
-    }
-    else {
-        if (!PyObject_TypeCheck(docObject, &App::DocumentObjectPy::Type))
-            throw Py::TypeError("Expect the second argument to be a document object or None");
-        App::DocumentObject* obj = static_cast<App::DocumentObjectPy*>(docObject)->getDocumentObjectPtr();
+    try {
+        Base::PyTypeCheck(&docObject, &App::DocumentObjectPy::Type,
+            "Expect the second argument to be a document object or None");
+        App::DocumentObject* obj = docObject ?
+            static_cast<App::DocumentObjectPy*>(docObject)->getDocumentObjectPtr() : nullptr;
         getView3DIventorPtr()->setActiveObject(obj, name, subname);
-    }
 
-    return Py::None();
+        return Py::None();
+    }
+    catch (const Base::Exception& e) {
+        throw Py::Exception(e.getPyExceptionType(), e.what());
+    }
 }
 
 Py::Object View3DInventorPy::getActiveObject(const Py::Tuple& args)

--- a/src/Gui/ViewProviderPy.xml
+++ b/src/Gui/ViewProviderPy.xml
@@ -59,10 +59,10 @@ Check if the object is visible.</UserDocu>
         </Methode>
         <Methode Name="canDragObject">
             <Documentation>
-                <UserDocu>canDragObject(obj) -> bool\n
+                <UserDocu>canDragObject(obj=None) -> bool\n
 Check whether the child object can be removed by dragging.
 If 'obj' is not given, check without filter by any particular object.\n
-obj : App.DocumentObject\n    Object to be dragged. Optional.</UserDocu>
+obj : App.DocumentObject\n    Object to be dragged.</UserDocu>
             </Documentation>
         </Methode>
         <Methode Name="dragObject">
@@ -74,25 +74,25 @@ obj : App.DocumentObject\n    Object to be dragged.</UserDocu>
         </Methode>
         <Methode Name="canDropObject" Keyword="true">
             <Documentation>
-                <UserDocu>canDropObject(obj, owner, subname, elem) -> bool\n
+                <UserDocu>canDropObject(obj=None, owner=None, subname, elem=None) -> bool\n
 Check whether the child object can be added by dropping.
 If 'obj' is not given, check without filter by any particular object.\n
-obj : App.DocumentObject\n    Object to be dropped. Optional.
-owner : App.DocumentObject\n    Parent object of the dropping object. Optional.
+obj : App.DocumentObject\n    Object to be dropped.
+owner : App.DocumentObject\n    Parent object of the dropping object.
 subname : str\n    Subname reference to the dropping object. Optional.
 elem : sequence of str\n    Non-objects subelements selected when the object is
-    being dropped. Optional.</UserDocu>
+    being dropped.</UserDocu>
             </Documentation>
         </Methode>
         <Methode Name="dropObject" Keyword="true">
             <Documentation>
-                <UserDocu>dropObject(obj, owner, subname, elem) -> str\n
+                <UserDocu>dropObject(obj, owner=None, subname, elem=None) -> str\n
 Add a child object by dropping.\n
 obj : App.DocumentObject\n    Object to be dropped.
-owner : App.DocumentObject\n    Parent object of the dropping object. Optional.
+owner : App.DocumentObject\n    Parent object of the dropping object.
 subname : str\n    Subname reference to the dropping object. Optional.
 elem : sequence of str\n    Non-objects subelements selected when the object is
-    being dropped. Optional.</UserDocu>
+    being dropped.</UserDocu>
 </Documentation>
         </Methode>
         <Methode Name="canDragAndDropObject">

--- a/src/Gui/ViewProviderPyImp.cpp
+++ b/src/Gui/ViewProviderPyImp.cpp
@@ -161,11 +161,12 @@ PyObject*  ViewProviderPy::isVisible(PyObject *args)
 
 PyObject*  ViewProviderPy::canDragObject(PyObject *args)
 {
-    PyObject *obj = nullptr;
-    if (!PyArg_ParseTuple(args, "|O!", &App::DocumentObjectPy::Type, &obj))
+    PyObject *obj = Py_None;
+    if (!PyArg_ParseTuple(args, "|O", &obj))
         return nullptr;
 
     PY_TRY {
+        Base::PyTypeCheck(&obj, &App::DocumentObjectPy::Type);
         bool ret;
         if (!obj)
             ret = getViewProviderPtr()->canDragObjects();
@@ -180,17 +181,20 @@ PyObject*  ViewProviderPy::canDragObject(PyObject *args)
 
 PyObject*  ViewProviderPy::canDropObject(PyObject *args, PyObject *kw)
 {
-    PyObject *obj = nullptr;
-    PyObject *owner = nullptr;
-    PyObject *pyElements = nullptr;
+    PyObject *obj = Py_None;
+    PyObject *owner = Py_None;
+    PyObject *pyElements = Py_None;
     const char *subname = nullptr;
     static char* kwlist[] = {"obj","owner","subname","elem",nullptr};
-    if (!PyArg_ParseTupleAndKeywords(args, kw, "|O!O!sO", kwlist,
-            &App::DocumentObjectPy::Type,&obj, &App::DocumentObjectPy::Type, &owner,
-            &subname, &pyElements))
+    if (!PyArg_ParseTupleAndKeywords(args, kw, "|OOsO", kwlist,
+            &obj, &owner, &subname, &pyElements))
         return nullptr;
 
     PY_TRY {
+        Base::PyTypeCheck(&obj, &App::DocumentObjectPy::Type, "expecting 'obj' to be of type App.DocumentObject or None");
+        Base::PyTypeCheck(&owner, &App::DocumentObjectPy::Type, "expecting 'owner' to be of type App.DocumentObject or None");
+        Base::PyTypeCheck(&pyElements, PySequence_Check, "expecting 'elem' to be sequence or None");
+
         bool ret;
         App::DocumentObject* pcObject;
         App::DocumentObject* pcOwner = nullptr;
@@ -238,16 +242,18 @@ PyObject*  ViewProviderPy::canDragAndDropObject(PyObject *args)
 PyObject*  ViewProviderPy::dropObject(PyObject *args, PyObject *kw)
 {
     PyObject *obj;
-    PyObject *owner = nullptr;
-    PyObject *pyElements = nullptr;
+    PyObject *owner = Py_None;
+    PyObject *pyElements = Py_None;
     const char *subname = nullptr;
     static char* kwlist[] = {"obj","owner","subname","elem",nullptr};
-    if (!PyArg_ParseTupleAndKeywords(args, kw, "O!|O!sO", kwlist,
-            &App::DocumentObjectPy::Type,&obj, &App::DocumentObjectPy::Type, &owner,
-            &subname, &pyElements))
+    if (!PyArg_ParseTupleAndKeywords(args, kw, "O!|OsO", kwlist,
+            &App::DocumentObjectPy::Type, &obj, &owner, &subname, &pyElements))
         return nullptr;
 
     PY_TRY {
+        Base::PyTypeCheck(&owner, &App::DocumentObjectPy::Type, "expecting 'owner' to be of type App.DocumentObject or None");
+        Base::PyTypeCheck(&pyElements, PySequence_Check, "expecting 'elem' to be sequence or None");
+
         auto pcObject = static_cast<App::DocumentObjectPy*>(obj)->getDocumentObjectPtr();
         App::DocumentObject *pcOwner = nullptr;
         App::PropertyStringList elements;

--- a/src/Mod/Part/TestPartGui.py
+++ b/src/Mod/Part/TestPartGui.py
@@ -49,12 +49,12 @@ class PartGuiViewProviderTestCases(unittest.TestCase):
         # https://github.com/FreeCAD/FreeCAD/pull/6850
         box = self.Doc.addObject("Part::Box", "Box")
         with self.assertRaises(TypeError):
-            box.ViewObject.canDragObject(None)
+            box.ViewObject.canDragObject(0)
         with self.assertRaises(TypeError):
-            box.ViewObject.canDropObject(None)
+            box.ViewObject.canDropObject(0)
         box.ViewObject.canDropObject()
         with self.assertRaises(TypeError):
-            box.ViewObject.dropObject(box, None)
+            box.ViewObject.dropObject(box, 0)
 
     def tearDown(self):
         #closing doc

--- a/src/Mod/Spreadsheet/App/SheetPyImp.cpp
+++ b/src/Mod/Spreadsheet/App/SheetPyImp.cpp
@@ -494,13 +494,8 @@ PyObject* SheetPy::setAlias(PyObject *args)
 
     try {
         address = stringToAddress(strAddress);
-        if (PyUnicode_Check(value))
-            getSheetPtr()->setAlias(address, PyUnicode_AsUTF8(value));
-        else if (value == Py_None)
-            getSheetPtr()->setAlias(address, "");
-        else
-            throw Base::TypeError("String or None expected");
-
+        Base::PyTypeCheck(&value, &PyUnicode_Type, "String or None expected");
+        getSheetPtr()->setAlias(address, value ? PyUnicode_AsUTF8(value) : "");
         Py_Return;
     }
     catch (const Base::Exception & e) {
@@ -523,10 +518,8 @@ PyObject* SheetPy::getAlias(PyObject *args)
 
         if (cell && cell->getAlias(alias))
             return Py::new_reference_to( Py::String( alias ) );
-        else {
-            Py_INCREF(Py_None);
-            return Py_None;
-        }
+        else
+            Py_Return;
     }
     catch (const Base::Exception & e) {
         PyErr_SetString(PyExc_ValueError, e.what());
@@ -546,10 +539,8 @@ PyObject* SheetPy::getCellFromAlias(PyObject *args)
 
         if (!address.empty())
             return Py::new_reference_to( Py::String( address ) );
-        else {
-            Py_INCREF(Py_None);
-            return Py_None;
-        }
+        else
+            Py_Return;
     }
     catch (const Base::Exception & e) {
         PyErr_SetString(PyExc_ValueError, e.what());


### PR DESCRIPTION
Occasionally, a Python function argument may expect a specific type or `None`, by using the corresponding format unit in the parse function. The helper function `Base::PyTypeCheck` generates similar functionality to those format units, setting the `PyObject` pointer to `nullptr` in case the passed value is `None` and throwing an exception if the type is not correct.
In the ViewProvider Python implementation is restored the posibility to pass `None` to some arguments of the drag and drop functions to fix some regressions reported in the aseembly forum: https://forum.freecadweb.org/viewtopic.php?f=20&t=69777




Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [ ]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [ ]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [ ]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [ ]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the issue ID number from our [Issues database](https://github.com/FreeCAD/FreeCAD/issues) in case a particular commit solves or is related to an existing issue. Ex: `Draft: fix typos - fixes #4805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
