### PR TITLE
Draft: Fix handling of groups on move-copy and rotate-copy

### DIFF
--- a/src/Mod/Draft/draftfunctions/rotate.py
+++ b/src/Mod/Draft/draftfunctions/rotate.py
@@ -146,10 +146,10 @@ def rotate(objectslist, angle, center=App.Vector(0, 0, 0),
                 newobj = make_copy.make_copy(obj)
             else:
                 newobj = obj
-            shape = Part.Shape()
-            shape.Placement = newobj.Placement
-            shape.rotate(DraftVecUtils.tup(real_center), DraftVecUtils.tup(real_axis), angle)
-            newobj.Placement = shape.Placement
+            # Workaround for `faulty` implementation of Base.Placement.rotate(center, axis, angle).
+            # See: https://forum.freecadweb.org/viewtopic.php?p=613196#p613196
+            offset_rotation = App.Placement(App.Vector(0, 0, 0), App.Rotation(real_axis, angle), real_center)
+            newobj.Placement = offset_rotation * newobj.Placement
 
         elif hasattr(obj, "Shape"):
             if copy:
@@ -157,7 +157,7 @@ def rotate(objectslist, angle, center=App.Vector(0, 0, 0),
             else:
                 newobj = obj
             shape = newobj.Shape.copy()
-            shape.rotate(DraftVecUtils.tup(real_center), DraftVecUtils.tup(real_axis), angle)
+            shape.rotate(real_center, real_axis, angle)
             newobj.Shape = shape
 
         if newobj is not None:

--- a/src/Mod/Draft/draftutils/utils.py
+++ b/src/Mod/Draft/draftutils/utils.py
@@ -391,9 +391,9 @@ def get_real_name(name):
         The returned string cannot be empty; it will have
         at least one letter.
     """
-    for i in range(1, len(name)):
+    for i in range(1, len(name) + 1):
         if name[-i] not in '1234567890':
-            return name[:len(name) - (i-1)]
+            return name[:len(name) - (i - 1)]
     return name
 
 


### PR DESCRIPTION
Groups and layers were not handled properly by Draft_Move and Draft_Rotate if copy mode was ON.

I have started with `move.py` and have then adapted `rotate.py` accordingly.

To also handle nested groups it made more sense to fill the `newgroups` list in a separate, prior, loop.

Note that I have not changed the transformation algorithms although there are some strange inconsistencies. Notably in move.py there is the assumption that an object with a `Shape` also has a `Placement`, whereas in rotate.py `elif hasattr(obj,"Placement"):` is followed by `elif hasattr(obj,"Shape"):`.

Additionally:
* In move.py `elif utils.get_type(obj) == "Annotation":` did not work.
* In rotate.py `elif hasattr(obj,'Shape') and (utils.get_type(obj) not in ["WorkingPlaneProxy","BuildingPart"]):` was simplified to `elif hasattr(obj, "Shape"):`. WorkingPlaneProxy and BuildingPart objects have a `Placement` and are already handed by the previous `elif`.
* in utils.py the `get_real_name` function did not strip trailing digits from `"a123"`.

Forum topic: https://forum.freecadweb.org/viewtopic.php?f=23&t=70448

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the issue ID number from our [Issues database](https://github.com/FreeCAD/FreeCAD/issues) in case a particular commit solves or is related to an existing issue. Ex: `Draft: fix typos - fixes #4805`

---
