### PR TITLE
Gui: when customizing shortcuts, warn user if command isn't in use with a message box

### DIFF
--- a/src/Gui/DlgKeyboardImp.cpp
+++ b/src/Gui/DlgKeyboardImp.cpp
@@ -328,6 +328,11 @@ void DlgCustomKeyboardImp::on_editShortcut_textChanged(const QString& sc)
     Command* cmd = cCmdMgr.getCommandByName(name.constData());
     if (cmd && !cmd->getAction()) {
         Base::Console().Warning("Command %s not in use yet\n", cmd->getName());
+        QMessageBox::warning(this,
+                             tr("Command not in use yet"),
+                             tr("The command '%1' is loaded but not in use yet, so it can't be assigned a new shortcut.\n"
+                             "To enable assignment, please make '%2' the active workbench").arg(data.toString(),ui->categoryBox->currentText()),
+                             QMessageBox::Ok);
         ui->buttonAssign->setEnabled(false); // command not in use
         return;
     }


### PR DESCRIPTION
User was only warned in the report view which he/she may missed.
Use a warning message box.
Also provide advice about how to solve.

https://forum.freecadweb.org/viewtopic.php?f=8&t=39858

How it looks :
![image](https://user-images.githubusercontent.com/48731257/181224659-efb67e3c-ce76-4d0b-ba64-377e87965db4.png)
