### PR TITLE
[FEM] fix problem of several visible pipelines

### DIFF
--- a/src/Mod/Fem/Gui/ViewProviderFemPostObject.h
+++ b/src/Mod/Fem/Gui/ViewProviderFemPostObject.h
@@ -122,6 +122,7 @@ protected:
     bool setupPipeline();
     void updateVtk();
     void setRangeOfColorBar(double min, double max);
+    void WriteColorData(bool ResetColorBarRange);
 
     SoCoordinate3*              m_coordinates;
     SoIndexedPointSet*          m_markers;
@@ -156,7 +157,6 @@ private:
     void update3D();
     void WritePointData(vtkPoints *points, vtkDataArray *normals,
                         vtkDataArray *tcoords);
-    void WriteColorData(bool ResetColorBarRange);
     void WriteTransparency();
 
     App::Enumeration m_coloringEnum, m_vectorEnum;


### PR DESCRIPTION
When there are several visible pipelines, they are not drawn over each other because this is technically not possible (see comment on the PR). Therefore it is for the user like a bug that he has e.g. 3 pipelines but always see the one listed first in the Tree View.

After some discussions it turned out that the best way is to show the selected pipeline and make all other invisible.

Working on real-life simulations showed that there is indeed no use case where one likes/needs to have painted 2 pipelines over each other and see both.