### PR TITLE
Draft: Avoid faulty Base.Placement.rotate() in draftobjects.array.py

### DIFF
--- a/src/Mod/Draft/draftobjects/array.py
+++ b/src/Mod/Draft/draftobjects/array.py
@@ -479,11 +479,8 @@ def polar_placements(base_placement,
     for i in range(number - 1):
         currangle = fraction + (i * fraction)
         npl = base_placement.copy()
-        # Workaround for `faulty` implementation of Base.Placement.rotate(center, axis, angle).
-        # See: https://forum.freecadweb.org/viewtopic.php?p=613196#p613196
-        offset_rotation = App.Placement(App.Vector(0, 0, 0), App.Rotation(axis, currangle), center)
-        npl = offset_rotation * npl
-
+        print("hier")
+        npl.rotate(center, axis, currangle, comp=True)
         if axisvector:
             if not DraftVecUtils.isNull(axisvector):
                 npl.translate(App.Vector(axisvector).multiply(i + 1))
@@ -519,10 +516,8 @@ def circ_placements(base_placement,
         for ycount in range(0, n):
             npl = base_placement.copy()
             npl.translate(trans)
-            # Workaround for `faulty` implementation of Base.Placement.rotate(center, axis, angle).
-            # See: https://forum.freecadweb.org/viewtopic.php?p=613196#p613196
-            offset_rotation = App.Placement(App.Vector(0, 0, 0), App.Rotation(axis, ycount * angle), center)
-            npl = offset_rotation * npl
+            print("hier")
+            npl.rotate(center, axis, ycount * angle, comp=True)
             placements.append(npl)
 
     return placements

--- a/src/Mod/Draft/draftobjects/array.py
+++ b/src/Mod/Draft/draftobjects/array.py
@@ -479,7 +479,6 @@ def polar_placements(base_placement,
     for i in range(number - 1):
         currangle = fraction + (i * fraction)
         npl = base_placement.copy()
-        print("hier")
         npl.rotate(center, axis, currangle, comp=True)
         if axisvector:
             if not DraftVecUtils.isNull(axisvector):
@@ -516,7 +515,6 @@ def circ_placements(base_placement,
         for ycount in range(0, n):
             npl = base_placement.copy()
             npl.translate(trans)
-            print("hier")
             npl.rotate(center, axis, ycount * angle, comp=True)
             placements.append(npl)
 


### PR DESCRIPTION
The implementation of `Base.Placement.rotate()` is 'faulty': it is not compatible with `TopoShape.rotate()`. To deal with this, unnecessarily complex code was created. Which did not always work for circular arrays.

The new code uses a workaround provided on the forum:
https://forum.freecadweb.org/viewtopic.php?p=613196#p613196

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the issue ID number from our [Issues database](https://github.com/FreeCAD/FreeCAD/issues) in case a particular commit solves or is related to an existing issue. Ex: `Draft: fix typos - fixes #4805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
