### PR TITLE
Base: Fix Placement.rotate() to match documentation

### DIFF
--- a/src/Base/PlacementPy.xml
+++ b/src/Base/PlacementPy.xml
@@ -63,14 +63,19 @@ Alias to move(), to be compatible with TopoShape.translate().\n
 vector : Base.Vector\n    Vector by which to move the placement.</UserDocu>
 			</Documentation>
 		</Methode>
-        <Methode Name="rotate">
+        <Methode Name="rotate" Keyword="true">
         <Documentation>
-            <UserDocu>rotate(center, axis, angle) -> None\n
+            <UserDocu>rotate(center, axis, angle, comp) -> None\n
 Rotate the current placement around center and axis with the given angle.
-This method is compatible with TopoShape.rotate().\n
+This method is compatible with TopoShape.rotate() if the (optional) keyword
+argument comp is True (default=False).
+
 center : Base.Vector, sequence of float\n    Rotation center.
 axis : Base.Vector, sequence of float\n    Rotation axis.
-angle : float\n    Rotation angle in degrees.</UserDocu>
+angle : float\n    Rotation angle in degrees.
+comp : bool\n    optional keyword only argument, if True (default=False),
+behave like TopoShape.rotate() (i.e. the resulting placements are interchangeable).
+</UserDocu>
         </Documentation>
         </Methode>
                 <Methode Name="multiply" Const="true">


### PR DESCRIPTION
Documentation for Placement.rotate() claims this function would be
compatible to TopoShape.rotate() which isn't exactly correct as the
generated placements differ because of backwards multiplication.

This commit adds a "comp" (as in "compatible") keyword argument that -
when "True" (default is False) - produces a Placement that is interchangable with the one
that is generated from TopoShape.rotate().

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [x]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [ ]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the issue ID number from our [Issues database](https://github.com/FreeCAD/FreeCAD/issues) in case a particular commit solves or is related to an existing issue. Ex: `Draft: fix typos - fixes #4805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
