### PR TITLE
PATH: Bugfix/vcarve c++ exception

### DIFF
--- a/src/Mod/Path/App/AppPath.cpp
+++ b/src/Mod/Path/App/AppPath.cpp
@@ -77,7 +77,7 @@ PyMOD_INIT_FUNC(Path)
     Base::Interpreter().addType(&Path::ToolPy           ::Type, pathModule, "Tool");
     Base::Interpreter().addType(&Path::TooltablePy      ::Type, pathModule, "Tooltable");
     Base::Interpreter().addType(&Path::AreaPy           ::Type, pathModule, "Area");
-    Base::Interpreter().addType(&Path::VoronoiPy        ::Type, pathModule, "Voronoi");
+    Base::Interpreter().addType(&Path::VoronoiPy        ::Type, pathModule, "VoronoiDiagram");
     Base::Interpreter().addType(&Path::VoronoiCellPy    ::Type, pathModule, "VoronoiCell");
     Base::Interpreter().addType(&Path::VoronoiEdgePy    ::Type, pathModule, "VoronoiEdge");
     Base::Interpreter().addType(&Path::VoronoiVertexPy  ::Type, pathModule, "VoronoiVertex");

--- a/src/Mod/Path/App/AppPath.cpp
+++ b/src/Mod/Path/App/AppPath.cpp
@@ -53,7 +53,7 @@
 
 
 namespace Path {
-extern PyObject* initModule();
+  extern PyObject* initModule();
 }
 
 /* Python entry */
@@ -71,16 +71,20 @@ PyMOD_INIT_FUNC(Path)
     PyObject* pathModule = Path::initModule();
     Base::Console().Log("Loading Path module... done\n");
 
+    Py::Object module(pathModule);
+
     // Add Types to module
     Base::Interpreter().addType(&Path::CommandPy        ::Type, pathModule, "Command");
     Base::Interpreter().addType(&Path::PathPy           ::Type, pathModule, "Path");
     Base::Interpreter().addType(&Path::ToolPy           ::Type, pathModule, "Tool");
     Base::Interpreter().addType(&Path::TooltablePy      ::Type, pathModule, "Tooltable");
     Base::Interpreter().addType(&Path::AreaPy           ::Type, pathModule, "Area");
-    Base::Interpreter().addType(&Path::VoronoiPy        ::Type, pathModule, "VoronoiDiagram");
-    Base::Interpreter().addType(&Path::VoronoiCellPy    ::Type, pathModule, "VoronoiCell");
-    Base::Interpreter().addType(&Path::VoronoiEdgePy    ::Type, pathModule, "VoronoiEdge");
-    Base::Interpreter().addType(&Path::VoronoiVertexPy  ::Type, pathModule, "VoronoiVertex");
+
+    PyObject* voronoiModule(module.getAttr("Voronoi").ptr());
+    Base::Interpreter().addType(&Path::VoronoiPy        ::Type, voronoiModule, "Diagram");
+    Base::Interpreter().addType(&Path::VoronoiCellPy    ::Type, voronoiModule, "Cell");
+    Base::Interpreter().addType(&Path::VoronoiEdgePy    ::Type, voronoiModule, "Edge");
+    Base::Interpreter().addType(&Path::VoronoiVertexPy  ::Type, voronoiModule, "Vertex");
 
     // NOTE: To finish the initialization of our own type objects we must
     // call PyType_Ready, otherwise we run into a segmentation fault, later on.

--- a/src/Mod/Path/App/AppPathPy.cpp
+++ b/src/Mod/Path/App/AppPathPy.cpp
@@ -90,344 +90,356 @@
     } throw Py::Exception();
 
 namespace Path {
-class Module : public Py::ExtensionModule<Module>
-{
+  class VoronoiModule : public Py::ExtensionModule<VoronoiModule>
+  {
+  public:
+      VoronoiModule() : Py::ExtensionModule<VoronoiModule>("Voronoi")
+      {
+          initialize("Working with Voronoi diagrams and data structures");
+      }
+      virtual ~VoronoiModule() {}
+  };
 
-public:
+  class Module : public Py::ExtensionModule<Module>
+  {
+      VoronoiModule voronoi;
+  public:
 
-    Module() : Py::ExtensionModule<Module>("Path")
-    {
-        add_varargs_method("write",&Module::write,
-            "write(object,filename): Exports a given path object to a GCode file"
-        );
-        add_varargs_method("read",&Module::read,
-            "read(filename,[document]): Imports a GCode file into the given document"
-        );
-        add_varargs_method("show",&Module::show,
-            "show(path,[string]): Add the path to the active document or create one if no document exists"
-        );
-        add_varargs_method("fromShape",&Module::fromShape,
-            "fromShape(Shape): Returns a Path object from a Part Shape (deprecated - use fromShapes() instead)"
-        );
-        add_keyword_method("fromShapes",&Module::fromShapes,
-            "fromShapes(shapes, start=Vector(), return_end=False" PARAM_PY_ARGS_DOC(ARG,AREA_PARAMS_PATH) ")\n"
-            "\nReturns a Path object from a list of shapes\n"
-            "\n* shapes: input list of shapes.\n"
-            "\n* start (Vector()): feed start position, and also serves as a hint of path entry.\n"
-            "\n* return_end (False): if True, returns tuple (path, endPosition).\n"
-            PARAM_PY_DOC(ARG, AREA_PARAMS_PATH)
-        );
-        add_keyword_method("sortWires",&Module::sortWires,
-            "sortWires(shapes, start=Vector(), "
-            PARAM_PY_ARGS_DOC(ARG,AREA_PARAMS_ARC_PLANE)
-            PARAM_PY_ARGS_DOC(ARG,AREA_PARAMS_SORT) ")\n"
-            "\nReturns (wires,end), where 'wires' is sorted across Z value and with optimized travel distance,\n"
-            "and 'end' is the ending position of the whole wires. If arc_plane==1, it returns (wires,end,arc_plane),\n"
-            "where arc_plane is the found plane if any, or unchanged.\n"
-            "\n* shapes: input shape list\n"
-            "\n* start (Vector()): optional start position.\n"
-            PARAM_PY_DOC(ARG, AREA_PARAMS_ARC_PLANE)
-            PARAM_PY_DOC(ARG, AREA_PARAMS_SORT)
-        );
-        initialize("This module is the Path module."); // register with Python
-    }
+      Module() : Py::ExtensionModule<Module>("Path")
+      {
+          add_varargs_method("write",&Module::write,
+              "write(object,filename): Exports a given path object to a GCode file"
+          );
+          add_varargs_method("read",&Module::read,
+              "read(filename,[document]): Imports a GCode file into the given document"
+          );
+          add_varargs_method("show",&Module::show,
+              "show(path,[string]): Add the path to the active document or create one if no document exists"
+          );
+          add_varargs_method("fromShape",&Module::fromShape,
+              "fromShape(Shape): Returns a Path object from a Part Shape (deprecated - use fromShapes() instead)"
+          );
+          add_keyword_method("fromShapes",&Module::fromShapes,
+              "fromShapes(shapes, start=Vector(), return_end=False" PARAM_PY_ARGS_DOC(ARG,AREA_PARAMS_PATH) ")\n"
+              "\nReturns a Path object from a list of shapes\n"
+              "\n* shapes: input list of shapes.\n"
+              "\n* start (Vector()): feed start position, and also serves as a hint of path entry.\n"
+              "\n* return_end (False): if True, returns tuple (path, endPosition).\n"
+              PARAM_PY_DOC(ARG, AREA_PARAMS_PATH)
+          );
+          add_keyword_method("sortWires",&Module::sortWires,
+              "sortWires(shapes, start=Vector(), "
+              PARAM_PY_ARGS_DOC(ARG,AREA_PARAMS_ARC_PLANE)
+              PARAM_PY_ARGS_DOC(ARG,AREA_PARAMS_SORT) ")\n"
+              "\nReturns (wires,end), where 'wires' is sorted across Z value and with optimized travel distance,\n"
+              "and 'end' is the ending position of the whole wires. If arc_plane==1, it returns (wires,end,arc_plane),\n"
+              "where arc_plane is the found plane if any, or unchanged.\n"
+              "\n* shapes: input shape list\n"
+              "\n* start (Vector()): optional start position.\n"
+              PARAM_PY_DOC(ARG, AREA_PARAMS_ARC_PLANE)
+              PARAM_PY_DOC(ARG, AREA_PARAMS_SORT)
+          );
+          initialize("This module is the Path module."); // register with Python
 
-    virtual ~Module() {}
+          PyModule_AddObject(m_module, "Voronoi", voronoi.module().ptr());
+      }
 
-private:
+      virtual ~Module() {}
 
-    Py::Object write(const Py::Tuple& args)
-    {
-        char* Name;
-        PyObject* pObj;
-        if (!PyArg_ParseTuple(args.ptr(), "Oet",&pObj,"utf-8",&Name))
-            throw Py::Exception();
-        std::string EncodedName = std::string(Name);
-        PyMem_Free(Name);
-        Base::FileInfo file(EncodedName.c_str());
+  private:
 
-        if (PyObject_TypeCheck(pObj, &(App::DocumentObjectPy::Type))) {
-            App::DocumentObject* obj = static_cast<App::DocumentObjectPy*>(pObj)->getDocumentObjectPtr();
-            if (obj->getTypeId().isDerivedFrom(Base::Type::fromName("Path::Feature"))) {
-                const Toolpath& path = static_cast<Path::Feature*>(obj)->Path.getValue();
-                std::string gcode = path.toGCode();
-                std::ofstream ofile(EncodedName.c_str());
-                ofile << gcode;
-                ofile.close();
-            }
-            else {
-                throw Py::RuntimeError("The given file is not a path");
-            }
-        }
+      Py::Object write(const Py::Tuple& args)
+      {
+          char* Name;
+          PyObject* pObj;
+          if (!PyArg_ParseTuple(args.ptr(), "Oet",&pObj,"utf-8",&Name))
+              throw Py::Exception();
+          std::string EncodedName = std::string(Name);
+          PyMem_Free(Name);
+          Base::FileInfo file(EncodedName.c_str());
 
-        return Py::None();
-    }
+          if (PyObject_TypeCheck(pObj, &(App::DocumentObjectPy::Type))) {
+              App::DocumentObject* obj = static_cast<App::DocumentObjectPy*>(pObj)->getDocumentObjectPtr();
+              if (obj->getTypeId().isDerivedFrom(Base::Type::fromName("Path::Feature"))) {
+                  const Toolpath& path = static_cast<Path::Feature*>(obj)->Path.getValue();
+                  std::string gcode = path.toGCode();
+                  std::ofstream ofile(EncodedName.c_str());
+                  ofile << gcode;
+                  ofile.close();
+              }
+              else {
+                  throw Py::RuntimeError("The given file is not a path");
+              }
+          }
 
-
-    Py::Object read(const Py::Tuple& args)
-    {
-        char* Name;
-        const char* DocName=nullptr;
-        if (!PyArg_ParseTuple(args.ptr(), "et|s","utf-8",&Name,&DocName))
-            throw Py::Exception();
-        std::string EncodedName = std::string(Name);
-        PyMem_Free(Name);
-
-        Base::FileInfo file(EncodedName.c_str());
-        if (!file.exists())
-            throw Py::RuntimeError("File doesn't exist");
-
-        App::Document *pcDoc;
-        if (DocName)
-            pcDoc = App::GetApplication().getDocument(DocName);
-        else
-            pcDoc = App::GetApplication().getActiveDocument();
-        if (!pcDoc)
-            pcDoc = App::GetApplication().newDocument(DocName);
-
-        try {
-            // read the gcode file
-            std::ifstream filestr(file.filePath().c_str());
-            std::stringstream buffer;
-            buffer << filestr.rdbuf();
-            std::string gcode = buffer.str();
-            Toolpath path;
-            path.setFromGCode(gcode);
-            Path::Feature *object = static_cast<Path::Feature *>(pcDoc->addObject("Path::Feature",file.fileNamePure().c_str()));
-            object->Path.setValue(path);
-            pcDoc->recompute();
-        }
-        catch (const Base::Exception& e) {
-            throw Py::RuntimeError(e.what());
-        }
-
-        return Py::None();
-    }
+          return Py::None();
+      }
 
 
-    Py::Object show(const Py::Tuple& args)
-    {
-        PyObject *pcObj;
-        char *name = "Path";
-        if (!PyArg_ParseTuple(args.ptr(), "O!|s", &(PathPy::Type), &pcObj, &name))
-            throw Py::Exception();
+      Py::Object read(const Py::Tuple& args)
+      {
+          char* Name;
+          const char* DocName=nullptr;
+          if (!PyArg_ParseTuple(args.ptr(), "et|s","utf-8",&Name,&DocName))
+              throw Py::Exception();
+          std::string EncodedName = std::string(Name);
+          PyMem_Free(Name);
 
-        try {
-            App::Document *pcDoc = App::GetApplication().getActiveDocument();
-            if (!pcDoc)
-                pcDoc = App::GetApplication().newDocument();
-            PathPy* pPath = static_cast<PathPy*>(pcObj);
-            Path::Feature *pcFeature = static_cast<Path::Feature*>(pcDoc->addObject("Path::Feature", name));
-            Path::Toolpath* pa = pPath->getToolpathPtr();
-            if (!pa) {
-                throw Py::Exception(PyExc_ReferenceError, "object doesn't reference a valid path");
-            }
+          Base::FileInfo file(EncodedName.c_str());
+          if (!file.exists())
+              throw Py::RuntimeError("File doesn't exist");
 
-            // copy the data
-            pcFeature->Path.setValue(*pa);
-        }
-        catch (const Base::Exception& e) {
-            throw Py::RuntimeError(e.what());
-        }
+          App::Document *pcDoc;
+          if (DocName)
+              pcDoc = App::GetApplication().getDocument(DocName);
+          else
+              pcDoc = App::GetApplication().getActiveDocument();
+          if (!pcDoc)
+              pcDoc = App::GetApplication().newDocument(DocName);
 
-        return Py::None();
-    }
+          try {
+              // read the gcode file
+              std::ifstream filestr(file.filePath().c_str());
+              std::stringstream buffer;
+              buffer << filestr.rdbuf();
+              std::string gcode = buffer.str();
+              Toolpath path;
+              path.setFromGCode(gcode);
+              Path::Feature *object = static_cast<Path::Feature *>(pcDoc->addObject("Path::Feature",file.fileNamePure().c_str()));
+              object->Path.setValue(path);
+              pcDoc->recompute();
+          }
+          catch (const Base::Exception& e) {
+              throw Py::RuntimeError(e.what());
+          }
+
+          return Py::None();
+      }
 
 
-    Py::Object fromShape(const Py::Tuple& args)
-    {
-        PyObject *pcObj;
-        if (!PyArg_ParseTuple(args.ptr(), "O", &pcObj))
-            throw Py::Exception();
-        TopoDS_Shape shape;
-        try {
-            if (PyObject_TypeCheck(pcObj, &(Part::TopoShapePy::Type))) {
-                shape = static_cast<Part::TopoShapePy*>(pcObj)->getTopoShapePtr()->getShape();
-            } else {
-                throw Py::TypeError("the given object is not a shape");
-            }
-            if (!shape.IsNull()) {
-                if (shape.ShapeType() == TopAbs_WIRE) {
-                    Path::Toolpath result;
-                    bool first = true;
-                    Base::Placement last;
+      Py::Object show(const Py::Tuple& args)
+      {
+          PyObject *pcObj;
+          char *name = "Path";
+          if (!PyArg_ParseTuple(args.ptr(), "O!|s", &(PathPy::Type), &pcObj, &name))
+              throw Py::Exception();
 
-                    TopExp_Explorer ExpEdges (shape,TopAbs_EDGE);
-                    while (ExpEdges.More()) {
-                        const TopoDS_Edge& edge = TopoDS::Edge(ExpEdges.Current());
-                        TopExp_Explorer ExpVerts(edge,TopAbs_VERTEX);
-                        bool vfirst = true;
-                        while (ExpVerts.More()) {
-                            const TopoDS_Vertex& vert = TopoDS::Vertex(ExpVerts.Current());
-                            gp_Pnt pnt = BRep_Tool::Pnt(vert);
-                            Base::Placement tpl;
-                            tpl.setPosition(Base::Vector3d(pnt.X(),pnt.Y(),pnt.Z()));
-                            if (first) {
-                                // add first point as a G0 move
-                                Path::Command cmd;
-                                std::ostringstream ctxt;
-                                ctxt << "G0 X" << tpl.getPosition().x << " Y" << tpl.getPosition().y << " Z" << tpl.getPosition().z;
-                                cmd.setFromGCode(ctxt.str());
-                                result.addCommand(cmd);
-                                first = false;
-                                vfirst = false;
-                            } else {
-                                if (vfirst)
-                                    vfirst = false;
-                                else {
-                                    Path::Command cmd;
-                                    cmd.setFromPlacement(tpl);
+          try {
+              App::Document *pcDoc = App::GetApplication().getActiveDocument();
+              if (!pcDoc)
+                  pcDoc = App::GetApplication().newDocument();
+              PathPy* pPath = static_cast<PathPy*>(pcObj);
+              Path::Feature *pcFeature = static_cast<Path::Feature*>(pcDoc->addObject("Path::Feature", name));
+              Path::Toolpath* pa = pPath->getToolpathPtr();
+              if (!pa) {
+                  throw Py::Exception(PyExc_ReferenceError, "object doesn't reference a valid path");
+              }
 
-                                    // write arc data if needed
-                                    BRepAdaptor_Curve adapt(edge);
-                                    if (adapt.GetType() == GeomAbs_Circle) {
-                                        gp_Circ circ = adapt.Circle();
-                                        gp_Pnt c = circ.Location();
-                                        bool clockwise = false;
-                                        gp_Dir n = circ.Axis().Direction();
-                                        if (n.Z() < 0)
-                                            clockwise = true;
-                                        Base::Vector3d center = Base::Vector3d(c.X(),c.Y(),c.Z());
-                                        // center coords must be relative to last point
-                                        center -= last.getPosition();
-                                        cmd.setCenter(center,clockwise);
-                                    }
-                                    result.addCommand(cmd);
-                                }
-                            }
-                            ExpVerts.Next();
-                            last = tpl;
-                        }
-                        ExpEdges.Next();
-                    }
-                    return Py::asObject(new PathPy(new Path::Toolpath(result)));
-                } else {
-                    throw Py::TypeError("the given shape must be a wire");
-                }
-            } else {
-                throw Py::TypeError("the given shape is empty");
-            }
-        }
-        catch (const Base::Exception& e) {
-            throw Py::RuntimeError(e.what());
-        }
-    }
+              // copy the data
+              pcFeature->Path.setValue(*pa);
+          }
+          catch (const Base::Exception& e) {
+              throw Py::RuntimeError(e.what());
+          }
 
-    Py::Object fromShapes(const Py::Tuple& args, const Py::Dict &kwds)
-    {
-        PARAM_PY_DECLARE_INIT(PARAM_FARG,AREA_PARAMS_PATH)
-        PyObject *pShapes=nullptr;
-        PyObject *start=nullptr;
-        PyObject *return_end=Py_False;
-        static char* kwd_list[] = {"shapes", "start", "return_end",
-                PARAM_FIELD_STRINGS(ARG,AREA_PARAMS_PATH), nullptr};
-        if (!PyArg_ParseTupleAndKeywords(args.ptr(), kwds.ptr(),
-                "O|O!O!" PARAM_PY_KWDS(AREA_PARAMS_PATH),
-                kwd_list, &pShapes, &(Base::VectorPy::Type), &start, &PyBool_Type, &return_end,
-                PARAM_REF(PARAM_FARG,AREA_PARAMS_PATH)))
-            throw Py::Exception();
+          return Py::None();
+      }
 
-        std::list<TopoDS_Shape> shapes;
-        if (PyObject_TypeCheck(pShapes, &(Part::TopoShapePy::Type)))
-            shapes.push_back(static_cast<Part::TopoShapePy*>(pShapes)->getTopoShapePtr()->getShape());
-        else if (PyObject_TypeCheck(pShapes, &(PyList_Type)) ||
-                PyObject_TypeCheck(pShapes, &(PyTuple_Type)))
-        {
-            Py::Sequence shapeSeq(pShapes);
-            for (Py::Sequence::iterator it = shapeSeq.begin(); it != shapeSeq.end(); ++it) {
-                PyObject* item = (*it).ptr();
-                if(!PyObject_TypeCheck(item, &(Part::TopoShapePy::Type))) {
-                    PyErr_SetString(PyExc_TypeError, "non-shape object in sequence");
-                    throw Py::Exception();
-                }
-                shapes.push_back(static_cast<Part::TopoShapePy*>(item)->getTopoShapePtr()->getShape());
-            }
-        }
 
-        gp_Pnt pstart;
-        if(start) {
-            Base::Vector3d vec = static_cast<Base::VectorPy*>(start)->value();
-            pstart.SetCoord(vec.x, vec.y, vec.z);
-        }
+      Py::Object fromShape(const Py::Tuple& args)
+      {
+          PyObject *pcObj;
+          if (!PyArg_ParseTuple(args.ptr(), "O", &pcObj))
+              throw Py::Exception();
+          TopoDS_Shape shape;
+          try {
+              if (PyObject_TypeCheck(pcObj, &(Part::TopoShapePy::Type))) {
+                  shape = static_cast<Part::TopoShapePy*>(pcObj)->getTopoShapePtr()->getShape();
+              } else {
+                  throw Py::TypeError("the given object is not a shape");
+              }
+              if (!shape.IsNull()) {
+                  if (shape.ShapeType() == TopAbs_WIRE) {
+                      Path::Toolpath result;
+                      bool first = true;
+                      Base::Placement last;
 
-        try {
-            gp_Pnt pend;
-            std::unique_ptr<Toolpath> path(new Toolpath);
-            Area::toPath(*path,shapes,start?&pstart:nullptr, &pend,
-                    PARAM_PY_FIELDS(PARAM_FARG,AREA_PARAMS_PATH));
-            if (!Base::asBoolean(return_end))
-                return Py::asObject(new PathPy(path.release()));
-            Py::Tuple tuple(2);
-            tuple.setItem(0, Py::asObject(new PathPy(path.release())));
-            tuple.setItem(1, Py::asObject(new Base::VectorPy(Base::Vector3d(pend.X(),pend.Y(),pend.Z()))));
-            return tuple;
-        } PATH_CATCH
-    }
+                      TopExp_Explorer ExpEdges (shape,TopAbs_EDGE);
+                      while (ExpEdges.More()) {
+                          const TopoDS_Edge& edge = TopoDS::Edge(ExpEdges.Current());
+                          TopExp_Explorer ExpVerts(edge,TopAbs_VERTEX);
+                          bool vfirst = true;
+                          while (ExpVerts.More()) {
+                              const TopoDS_Vertex& vert = TopoDS::Vertex(ExpVerts.Current());
+                              gp_Pnt pnt = BRep_Tool::Pnt(vert);
+                              Base::Placement tpl;
+                              tpl.setPosition(Base::Vector3d(pnt.X(),pnt.Y(),pnt.Z()));
+                              if (first) {
+                                  // add first point as a G0 move
+                                  Path::Command cmd;
+                                  std::ostringstream ctxt;
+                                  ctxt << "G0 X" << tpl.getPosition().x << " Y" << tpl.getPosition().y << " Z" << tpl.getPosition().z;
+                                  cmd.setFromGCode(ctxt.str());
+                                  result.addCommand(cmd);
+                                  first = false;
+                                  vfirst = false;
+                              } else {
+                                  if (vfirst)
+                                      vfirst = false;
+                                  else {
+                                      Path::Command cmd;
+                                      cmd.setFromPlacement(tpl);
 
-    Py::Object sortWires(const Py::Tuple& args, const Py::Dict &kwds)
-    {
-        PARAM_PY_DECLARE_INIT(PARAM_FARG,AREA_PARAMS_ARC_PLANE)
-        PARAM_PY_DECLARE_INIT(PARAM_FARG,AREA_PARAMS_SORT)
-        PyObject *pShapes=nullptr;
-        PyObject *start=nullptr;
-        static char* kwd_list[] = {"shapes", "start",
-                PARAM_FIELD_STRINGS(ARG,AREA_PARAMS_ARC_PLANE),
-                PARAM_FIELD_STRINGS(ARG,AREA_PARAMS_SORT), nullptr};
-        if (!PyArg_ParseTupleAndKeywords(args.ptr(), kwds.ptr(),
-                "O|O!"
-                PARAM_PY_KWDS(AREA_PARAMS_ARC_PLANE)
-                PARAM_PY_KWDS(AREA_PARAMS_SORT),
-                kwd_list, &pShapes, &(Base::VectorPy::Type), &start,
-                PARAM_REF(PARAM_FARG,AREA_PARAMS_ARC_PLANE),
-                PARAM_REF(PARAM_FARG,AREA_PARAMS_SORT)))
-            throw Py::Exception();
+                                      // write arc data if needed
+                                      BRepAdaptor_Curve adapt(edge);
+                                      if (adapt.GetType() == GeomAbs_Circle) {
+                                          gp_Circ circ = adapt.Circle();
+                                          gp_Pnt c = circ.Location();
+                                          bool clockwise = false;
+                                          gp_Dir n = circ.Axis().Direction();
+                                          if (n.Z() < 0)
+                                              clockwise = true;
+                                          Base::Vector3d center = Base::Vector3d(c.X(),c.Y(),c.Z());
+                                          // center coords must be relative to last point
+                                          center -= last.getPosition();
+                                          cmd.setCenter(center,clockwise);
+                                      }
+                                      result.addCommand(cmd);
+                                  }
+                              }
+                              ExpVerts.Next();
+                              last = tpl;
+                          }
+                          ExpEdges.Next();
+                      }
+                      return Py::asObject(new PathPy(new Path::Toolpath(result)));
+                  } else {
+                      throw Py::TypeError("the given shape must be a wire");
+                  }
+              } else {
+                  throw Py::TypeError("the given shape is empty");
+              }
+          }
+          catch (const Base::Exception& e) {
+              throw Py::RuntimeError(e.what());
+          }
+      }
 
-        std::list<TopoDS_Shape> shapes;
-        if (PyObject_TypeCheck(pShapes, &(Part::TopoShapePy::Type))) {
-            shapes.push_back(static_cast<Part::TopoShapePy*>(pShapes)->getTopoShapePtr()->getShape());
-        }
-        else if (PyObject_TypeCheck(pShapes, &(PyList_Type)) ||
-                PyObject_TypeCheck(pShapes, &(PyTuple_Type))) {
-            Py::Sequence shapeSeq(pShapes);
-            for (Py::Sequence::iterator it = shapeSeq.begin(); it != shapeSeq.end(); ++it) {
-                PyObject* item = (*it).ptr();
-                if(!PyObject_TypeCheck(item, &(Part::TopoShapePy::Type))) {
-                    PyErr_SetString(PyExc_TypeError, "non-shape object in sequence");
-                    throw Py::Exception();
-                }
-                shapes.push_back(static_cast<Part::TopoShapePy*>(item)->getTopoShapePtr()->getShape());
-            }
-        }
+      Py::Object fromShapes(const Py::Tuple& args, const Py::Dict &kwds)
+      {
+          PARAM_PY_DECLARE_INIT(PARAM_FARG,AREA_PARAMS_PATH)
+          PyObject *pShapes=nullptr;
+          PyObject *start=nullptr;
+          PyObject *return_end=Py_False;
+          static char* kwd_list[] = {"shapes", "start", "return_end",
+                  PARAM_FIELD_STRINGS(ARG,AREA_PARAMS_PATH), nullptr};
+          if (!PyArg_ParseTupleAndKeywords(args.ptr(), kwds.ptr(),
+                  "O|O!O!" PARAM_PY_KWDS(AREA_PARAMS_PATH),
+                  kwd_list, &pShapes, &(Base::VectorPy::Type), &start, &PyBool_Type, &return_end,
+                  PARAM_REF(PARAM_FARG,AREA_PARAMS_PATH)))
+              throw Py::Exception();
 
-        gp_Pnt pstart,pend;
-        if(start) {
-            Base::Vector3d vec = static_cast<Base::VectorPy*>(start)->value();
-            pstart.SetCoord(vec.x, vec.y, vec.z);
-        }
+          std::list<TopoDS_Shape> shapes;
+          if (PyObject_TypeCheck(pShapes, &(Part::TopoShapePy::Type)))
+              shapes.push_back(static_cast<Part::TopoShapePy*>(pShapes)->getTopoShapePtr()->getShape());
+          else if (PyObject_TypeCheck(pShapes, &(PyList_Type)) ||
+                  PyObject_TypeCheck(pShapes, &(PyTuple_Type)))
+          {
+              Py::Sequence shapeSeq(pShapes);
+              for (Py::Sequence::iterator it = shapeSeq.begin(); it != shapeSeq.end(); ++it) {
+                  PyObject* item = (*it).ptr();
+                  if(!PyObject_TypeCheck(item, &(Part::TopoShapePy::Type))) {
+                      PyErr_SetString(PyExc_TypeError, "non-shape object in sequence");
+                      throw Py::Exception();
+                  }
+                  shapes.push_back(static_cast<Part::TopoShapePy*>(item)->getTopoShapePtr()->getShape());
+              }
+          }
 
-        try {
-            bool need_arc_plane = arc_plane==Area::ArcPlaneAuto;
-            std::list<TopoDS_Shape> wires = Area::sortWires(shapes, start != nullptr, &pstart,
-                    &pend, nullptr, &arc_plane, PARAM_PY_FIELDS(PARAM_FARG,AREA_PARAMS_SORT));
-            Py::List list;
-            for(auto &wire : wires) {
-                list.append(Part::shape2pyshape(TopoDS::Wire(wire)));
-            }
+          gp_Pnt pstart;
+          if(start) {
+              Base::Vector3d vec = static_cast<Base::VectorPy*>(start)->value();
+              pstart.SetCoord(vec.x, vec.y, vec.z);
+          }
 
-            Py::Tuple ret(need_arc_plane ? 3 : 2);
-            ret.setItem(0, list);
-            ret.setItem(1, Py::asObject(new Base::VectorPy(Base::Vector3d(pend.X(),pend.Y(),pend.Z()))));
-            if (need_arc_plane)
-                ret.setItem(2, Py::Long(arc_plane));
+          try {
+              gp_Pnt pend;
+              std::unique_ptr<Toolpath> path(new Toolpath);
+              Area::toPath(*path,shapes,start?&pstart:nullptr, &pend,
+                      PARAM_PY_FIELDS(PARAM_FARG,AREA_PARAMS_PATH));
+              if (!Base::asBoolean(return_end))
+                  return Py::asObject(new PathPy(path.release()));
+              Py::Tuple tuple(2);
+              tuple.setItem(0, Py::asObject(new PathPy(path.release())));
+              tuple.setItem(1, Py::asObject(new Base::VectorPy(Base::Vector3d(pend.X(),pend.Y(),pend.Z()))));
+              return tuple;
+          } PATH_CATCH
+      }
 
-            return ret;
-        } PATH_CATCH
-    }
-};
+      Py::Object sortWires(const Py::Tuple& args, const Py::Dict &kwds)
+      {
+          PARAM_PY_DECLARE_INIT(PARAM_FARG,AREA_PARAMS_ARC_PLANE)
+          PARAM_PY_DECLARE_INIT(PARAM_FARG,AREA_PARAMS_SORT)
+          PyObject *pShapes=nullptr;
+          PyObject *start=nullptr;
+          static char* kwd_list[] = {"shapes", "start",
+                  PARAM_FIELD_STRINGS(ARG,AREA_PARAMS_ARC_PLANE),
+                  PARAM_FIELD_STRINGS(ARG,AREA_PARAMS_SORT), nullptr};
+          if (!PyArg_ParseTupleAndKeywords(args.ptr(), kwds.ptr(),
+                  "O|O!"
+                  PARAM_PY_KWDS(AREA_PARAMS_ARC_PLANE)
+                  PARAM_PY_KWDS(AREA_PARAMS_SORT),
+                  kwd_list, &pShapes, &(Base::VectorPy::Type), &start,
+                  PARAM_REF(PARAM_FARG,AREA_PARAMS_ARC_PLANE),
+                  PARAM_REF(PARAM_FARG,AREA_PARAMS_SORT)))
+              throw Py::Exception();
 
-PyObject* initModule()
-{
-    return Base::Interpreter().addModule(new Module);
-}
+          std::list<TopoDS_Shape> shapes;
+          if (PyObject_TypeCheck(pShapes, &(Part::TopoShapePy::Type))) {
+              shapes.push_back(static_cast<Part::TopoShapePy*>(pShapes)->getTopoShapePtr()->getShape());
+          }
+          else if (PyObject_TypeCheck(pShapes, &(PyList_Type)) ||
+                  PyObject_TypeCheck(pShapes, &(PyTuple_Type))) {
+              Py::Sequence shapeSeq(pShapes);
+              for (Py::Sequence::iterator it = shapeSeq.begin(); it != shapeSeq.end(); ++it) {
+                  PyObject* item = (*it).ptr();
+                  if(!PyObject_TypeCheck(item, &(Part::TopoShapePy::Type))) {
+                      PyErr_SetString(PyExc_TypeError, "non-shape object in sequence");
+                      throw Py::Exception();
+                  }
+                  shapes.push_back(static_cast<Part::TopoShapePy*>(item)->getTopoShapePtr()->getShape());
+              }
+          }
+
+          gp_Pnt pstart,pend;
+          if(start) {
+              Base::Vector3d vec = static_cast<Base::VectorPy*>(start)->value();
+              pstart.SetCoord(vec.x, vec.y, vec.z);
+          }
+
+          try {
+              bool need_arc_plane = arc_plane==Area::ArcPlaneAuto;
+              std::list<TopoDS_Shape> wires = Area::sortWires(shapes, start != nullptr, &pstart,
+                      &pend, nullptr, &arc_plane, PARAM_PY_FIELDS(PARAM_FARG,AREA_PARAMS_SORT));
+              Py::List list;
+              for(auto &wire : wires) {
+                  list.append(Part::shape2pyshape(TopoDS::Wire(wire)));
+              }
+
+              Py::Tuple ret(need_arc_plane ? 3 : 2);
+              ret.setItem(0, list);
+              ret.setItem(1, Py::asObject(new Base::VectorPy(Base::Vector3d(pend.X(),pend.Y(),pend.Z()))));
+              if (need_arc_plane)
+                  ret.setItem(2, Py::Long(arc_plane));
+
+              return ret;
+          } PATH_CATCH
+      }
+  };
+
+  PyObject* initModule()
+  {
+      return Base::Interpreter().addModule(new Module);
+  }
 
 } // namespace Path

--- a/src/Mod/Path/App/VoronoiCellPy.xml
+++ b/src/Mod/Path/App/VoronoiCellPy.xml
@@ -3,6 +3,7 @@
     <PythonExport 
         Father="BaseClassPy" 
         Name="VoronoiCellPy" 
+        PythonName="Path.Voronoi.Cell"
         Twin="VoronoiCell" 
         TwinPointer="VoronoiCell" 
         Include="Mod/Path/App/VoronoiCell.h" 

--- a/src/Mod/Path/App/VoronoiCellPy.xml
+++ b/src/Mod/Path/App/VoronoiCellPy.xml
@@ -36,9 +36,15 @@
         </Attribute>
         <Attribute Name="SourceCategory" ReadOnly="true">
             <Documentation>
-                <UserDocu>Returns the index of the cell's source</UserDocu>
+                <UserDocu>Returns the cell's category as an integer</UserDocu>
             </Documentation>
             <Parameter Name="SourceCategory" Type="Int"/>
+        </Attribute>
+        <Attribute Name="SourceCategoryName" ReadOnly="true">
+            <Documentation>
+                <UserDocu>Returns the cell's category as a string</UserDocu>
+            </Documentation>
+            <Parameter Name="SourceCategory" Type="String"/>
         </Attribute>
         <Attribute Name="IncidentEdge" ReadOnly="true">
             <Documentation>

--- a/src/Mod/Path/App/VoronoiCellPyImp.cpp
+++ b/src/Mod/Path/App/VoronoiCellPyImp.cpp
@@ -137,6 +137,21 @@ Py::Int VoronoiCellPy::getSourceCategory(void) const
   return Py::Int(c->ptr->source_category());
 }
 
+Py::String VoronoiCellPy::getSourceCategoryName(void) const
+{
+  VoronoiCell *c = getVoronoiCellFromPy(this);
+  switch (c->ptr->source_category()) {
+    case boost::polygon::SOURCE_CATEGORY_SINGLE_POINT:        return Py::String("SINGLE_POINT");
+    case boost::polygon::SOURCE_CATEGORY_SEGMENT_START_POINT: return Py::String("SEGMENT_START_POINT");
+    case boost::polygon::SOURCE_CATEGORY_SEGMENT_END_POINT:   return Py::String("SEGMENT_END_POINT");
+    case boost::polygon::SOURCE_CATEGORY_INITIAL_SEGMENT:     return Py::String("INITIAL_SEGMENT");
+    case boost::polygon::SOURCE_CATEGORY_REVERSE_SEGMENT:     return Py::String("REVERSE_SEGMENT");
+    case boost::polygon::SOURCE_CATEGORY_GEOMETRY_SHIFT:      return Py::String("GEOMETRY_SHIFT");
+    case boost::polygon::SOURCE_CATEGORY_BITMASK:             return Py::String("BITMASK");
+  }
+  return Py::String("");
+}
+
 Py::Object VoronoiCellPy::getIncidentEdge(void) const
 {
   VoronoiCell *c = getVoronoiCellFromPy(this);

--- a/src/Mod/Path/App/VoronoiEdgePy.xml
+++ b/src/Mod/Path/App/VoronoiEdgePy.xml
@@ -3,6 +3,7 @@
     <PythonExport 
         Father="BaseClassPy" 
         Name="VoronoiEdgePy" 
+        PythonName="Path.Voronoi.Edge"
         Twin="VoronoiEdge" 
         TwinPointer="VoronoiEdge" 
         Include="Mod/Path/App/VoronoiEdge.h" 

--- a/src/Mod/Path/App/VoronoiEdgePy.xml
+++ b/src/Mod/Path/App/VoronoiEdgePy.xml
@@ -100,6 +100,11 @@
                 <UserDocu>Returns true if edge goes through endpoint of the segment site</UserDocu>
             </Documentation>
         </Methode>
+        <Methode Name="isBorderline" Const="true">
+            <Documentation>
+                <UserDocu>Returns true if the point is on the segment</UserDocu>
+            </Documentation>
+        </Methode>
         <Methode Name="toShape" Const="true">
             <Documentation>
                 <UserDocu>Returns a shape for the edge</UserDocu>

--- a/src/Mod/Path/App/VoronoiPy.xml
+++ b/src/Mod/Path/App/VoronoiPy.xml
@@ -3,6 +3,7 @@
     <PythonExport 
         Father="BaseClassPy" 
         Name="VoronoiPy" 
+        PythonName="VoronoiDiagram"
         Twin="Voronoi" 
         TwinPointer="Voronoi" 
         Include="Mod/Path/App/Voronoi.h" 

--- a/src/Mod/Path/App/VoronoiPy.xml
+++ b/src/Mod/Path/App/VoronoiPy.xml
@@ -3,7 +3,7 @@
     <PythonExport 
         Father="BaseClassPy" 
         Name="VoronoiPy" 
-        PythonName="VoronoiDiagram"
+        PythonName="Path.Voronoi.Diagram"
         Twin="Voronoi" 
         TwinPointer="Voronoi" 
         Include="Mod/Path/App/Voronoi.h" 

--- a/src/Mod/Path/App/VoronoiPyImp.cpp
+++ b/src/Mod/Path/App/VoronoiPyImp.cpp
@@ -45,7 +45,7 @@ std::string VoronoiPy::representation(void) const
 {
   std::stringstream ss;
   ss.precision(5);
-  ss << "Voronoi("
+  ss << "VoronoiDiagram("
     << "{" << getVoronoiPtr()->numSegments() << ", " << getVoronoiPtr()->numPoints() << "}"
     << " -> "
     << "{" << getVoronoiPtr()->numCells() << ", " << getVoronoiPtr()->numEdges() << ", " << getVoronoiPtr()->numVertices() << "}"

--- a/src/Mod/Path/App/VoronoiVertexPy.xml
+++ b/src/Mod/Path/App/VoronoiVertexPy.xml
@@ -3,6 +3,7 @@
     <PythonExport 
         Father="BaseClassPy" 
         Name="VoronoiVertexPy" 
+        PythonName="Path.Voronoi.Vertex"
         Twin="VoronoiVertex" 
         TwinPointer="VoronoiVertex" 
         Include="Mod/Path/App/VoronoiVertex.h" 

--- a/src/Mod/Path/PathScripts/PathVcarve.py
+++ b/src/Mod/Path/PathScripts/PathVcarve.py
@@ -292,7 +292,7 @@ class ObjectVcarve(PathEngraveBase.ObjectOp):
 
         voronoiWires = []
         for f in faces:
-            vd = Path.Voronoi()
+            vd = Path.VoronoiDiagram()
             insert_many_wires(vd, f.Wires)
 
             vd.construct()
@@ -354,7 +354,7 @@ class ObjectVcarve(PathEngraveBase.ObjectOp):
             )
             return
 
-        try:
+        if True:
             faces = []
 
             for base in obj.BaseShapes:
@@ -383,10 +383,10 @@ class ObjectVcarve(PathEngraveBase.ObjectOp):
                     )
                 )
 
-        except Exception as e:
-            PathLog.error(
-                "Error processing Base object. Engraving operation will produce no output."
-            )
+        #except Exception as e:
+        #    PathLog.error(
+        #        "Error processing Base object. Engraving operation will produce no output."
+        #    )
 
     def opUpdateDepths(self, obj, ignoreErrors=False):
         """updateDepths(obj) ... engraving is always done at the top most z-value"""

--- a/src/Mod/Path/PathScripts/PathVcarve.py
+++ b/src/Mod/Path/PathScripts/PathVcarve.py
@@ -197,7 +197,7 @@ class ObjectVcarve(PathEngraveBase.ObjectOp):
     """Proxy class for Vcarve operation."""
 
     def opFeatures(self, obj):
-        """opFeatures(obj) ... return all standard features and edges based geomtries"""
+        """opFeatures(obj) ... return all standard features and edges based geometries"""
         return (
             PathOp.FeatureTool
             | PathOp.FeatureHeights
@@ -354,7 +354,7 @@ class ObjectVcarve(PathEngraveBase.ObjectOp):
             )
             return
 
-        if True:
+        try:
             faces = []
 
             for base in obj.BaseShapes:
@@ -383,10 +383,10 @@ class ObjectVcarve(PathEngraveBase.ObjectOp):
                     )
                 )
 
-        #except Exception as e:
-        #    PathLog.error(
-        #        "Error processing Base object. Engraving operation will produce no output."
-        #    )
+        except Exception as e:
+            PathLog.error(
+                "Error processing Base object. Engraving operation will produce no output."
+            )
 
     def opUpdateDepths(self, obj, ignoreErrors=False):
         """updateDepths(obj) ... engraving is always done at the top most z-value"""

--- a/src/Mod/Path/PathScripts/PathVcarve.py
+++ b/src/Mod/Path/PathScripts/PathVcarve.py
@@ -43,6 +43,7 @@ EXTERIOR1 = 2
 EXTERIOR2 = 3
 COLINEAR = 4
 TWIN = 5
+BORDERLINE = 6
 
 if False:
     PathLog.setLevel(PathLog.Level.DEBUG, PathLog.thisModule())
@@ -297,7 +298,13 @@ class ObjectVcarve(PathEngraveBase.ObjectOp):
             vd.construct()
 
             for e in vd.Edges:
-                e.Color = PRIMARY if e.isPrimary() else SECONDARY
+                if e.isPrimary():
+                    if e.isBorderline():
+                        e.Color = BORDERLINE
+                    else:
+                        e.Color = PRIMARY
+                else:
+                    e.Color = SECONDARY
             vd.colorExterior(EXTERIOR1)
             vd.colorExterior(
                 EXTERIOR2,

--- a/src/Mod/Path/PathScripts/PathVcarve.py
+++ b/src/Mod/Path/PathScripts/PathVcarve.py
@@ -292,7 +292,7 @@ class ObjectVcarve(PathEngraveBase.ObjectOp):
 
         voronoiWires = []
         for f in faces:
-            vd = Path.VoronoiDiagram()
+            vd = Path.Voronoi.Diagram()
             insert_many_wires(vd, f.Wires)
 
             vd.construct()

--- a/src/Mod/Path/PathTests/TestPathVoronoi.py
+++ b/src/Mod/Path/PathTests/TestPathVoronoi.py
@@ -49,7 +49,7 @@ def initVD():
         ptv = [FreeCAD.Vector(p[0], p[1]) for p in pts]
         ptv.append(ptv[0])
 
-        vd = Path.VoronoiDiagram()
+        vd = Path.Voronoi.Diagram()
         for i in range(len(pts)):
             vd.addSegment(ptv[i], ptv[i + 1])
 

--- a/src/Mod/Path/PathTests/TestPathVoronoi.py
+++ b/src/Mod/Path/PathTests/TestPathVoronoi.py
@@ -49,7 +49,7 @@ def initVD():
         ptv = [FreeCAD.Vector(p[0], p[1]) for p in pts]
         ptv.append(ptv[0])
 
-        vd = Path.Voronoi()
+        vd = Path.VoronoiDiagram()
         for i in range(len(pts)):
             vd.addSegment(ptv[i], ptv[i + 1])
 


### PR DESCRIPTION
This fixes the behaviour noted in https://forum.freecadweb.org/viewtopic.php?f=15&t=70208.
boost::polygon::voronoi generates some edges that don't make a lot of sense to process - I called them "borderline", for lack of a better name.

Also, "Voronoi" is now a module underneath "Path" and the object names are simplified accordingly ("Path.VoronoiEdge" -> "Path.Voronoi.Edge", ....)