### PR TITLE
Bump PACKAGE_VERSION_PATCH for next patch release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ project(FreeCAD)
 set(PACKAGE_VERSION_NAME "Vulcan")
 set(PACKAGE_VERSION_MAJOR "0")
 set(PACKAGE_VERSION_MINOR "20")
-set(PACKAGE_VERSION_PATCH "0")
+set(PACKAGE_VERSION_PATCH "1")
 set(PACKAGE_VERSION_SUFFIX "") # either "dev" for development snapshot or "" (empty string)
 set(FREECAD_VERSION_PATCH "1") # number of patch release (e.g. "4" for the 0.18.4 release)
 


### PR DESCRIPTION
This gets used here https://github.com/FreeCAD/FreeCAD/blob/5d49bf78de785a536f941f1a6d06d432582a95d3/src/XDGData/org.freecadweb.FreeCAD.appdata.xml.in#L61 and is the version picked up by flatpak so it should be updated too. Personally I don't understand why we have a PACKAGE_VERSION_PATCH and FREECAD_VERSION_PATCH as separate variables but I keep that way for now.