### PR TITLE
[Gui] QSint: fix QGroupBox visibility

### DIFF
--- a/src/Gui/QSint/actionpanel/actionpanelscheme.cpp
+++ b/src/Gui/QSint/actionpanel/actionpanelscheme.cpp
@@ -89,6 +89,22 @@ const char* ActionPanelDefaultStyle =
         "background-color: #ddeeff;"
         "color: #006600;"
     "}"
+
+    // set a QGroupBox  to avoid that the OS styles it, see
+    // https://github.com/FreeCAD/FreeCAD/issues/6102
+    // the px values are taken from Behave-dark.qss, except the padding
+    "QSint--ActionGroup QFrame[class='content'] QGroupBox {"
+    "border: 1px solid #bbbbbb;"
+    "border-radius: 3px;"
+    "margin-top: 10px;"
+    "padding: 2px;"
+    "}"
+    // since we set a custom frame we also need to set the title
+    "QSint--ActionGroup QFrame[class='content'] QGroupBox::title {"
+    "padding-left: 3px;"
+    "top: -6px;"
+    "left: 12px;"
+    "}"
 ;
 
 


### PR DESCRIPTION
- fixes #6102
- the point is that we don't set any style for the group boxes, therefore the windows style steps as nothing was set yet. Its default style is the color #dddddd which is hardly visible on our blue default style.
as solution set an explicit color and use the grooved style.

This is the result:
![FreeCAD_YDnzT5OQyi](https://user-images.githubusercontent.com/1828501/182032553-f551f05c-e4c2-4d4b-b034-6d2dc1c4bd38.png)

