### PR TITLE
Fixed external SMESH cmake scripts - correct issue with bad FEM mesh generation with VTK9+

### DIFF
--- a/cMake/FindSMESH.cmake
+++ b/cMake/FindSMESH.cmake
@@ -5,28 +5,55 @@
 # SMESH_INCLUDE_DIR   - where the Salome SMESH include directory can be found
 # SMESH_LIBRARIES     - Link this to use Salome SMESH
 #
- 
 
+# SMESH needs VTK
+find_package(VTK REQUIRED)
+
+# If this definition is not set, linker errors will occur against SMESH on 64 bit machines.
+if(CMAKE_SIZEOF_VOID_P STREQUAL 8)
+	add_definitions(-DSALOME_USE_64BIT_IDS)
+endif(CMAKE_SIZEOF_VOID_P STREQUAL 8)
+ 
 IF (CMAKE_COMPILER_IS_GNUCC)
     FIND_PATH(SMESH_INCLUDE_DIR SMESH_Mesh.hxx
     # These are default search paths, why specify them?
-    # /usr/include
-    # /usr/local/include
-    PATH_SUFFIXES smesh
+    PATH_SUFFIXES smesh SMESH smesh/SMESH
     )
-    FIND_LIBRARY(SMESH_LIBRARY SMESH
-    #  /usr/lib
-    #  /usr/local/lib
-    )
+    FIND_LIBRARY(SMESH_LIBRARY SMESH)
 ELSE (CMAKE_COMPILER_IS_GNUCC)
     # Not yet implemented
 ENDIF (CMAKE_COMPILER_IS_GNUCC)
+
+IF(SMESH_INCLUDE_DIR)
+	SET(SMESH_INC_ROOT "${SMESH_INCLUDE_DIR}/..")
+	# Append extra include dirs
+	SET(SMESH_INCLUDE_DIR 
+	"${SMESH_INCLUDE_DIR};
+	${SMESH_INC_ROOT}/Controls;
+	${SMESH_INC_ROOT}/Driver;
+	${SMESH_INC_ROOT}/DriverDAT;
+	${SMESH_INC_ROOT}/DriverGMF;
+	${SMESH_INC_ROOT}/DriverSTL;
+	${SMESH_INC_ROOT}/DriverUNV;
+	${SMESH_INC_ROOT}/Geom;
+	${SMESH_INC_ROOT}/Kernel;
+	${SMESH_INC_ROOT}/MEFISTO2;
+	${SMESH_INC_ROOT}/MeshVSLink;
+	${SMESH_INC_ROOT}/Netgen;
+	${SMESH_INC_ROOT}/NETGENPlugin;
+	${SMESH_INC_ROOT}/SMDS;
+	${SMESH_INC_ROOT}/SMESHDS;
+	${SMESH_INC_ROOT}/SMESHUtils;
+	${SMESH_INC_ROOT}/StdMeshers;")
+ELSE(SMESH_INCLUDE_DIR)
+	message(FATAL_ERROR "SMESH include directories not found!")
+ENDIF(SMESH_INCLUDE_DIR)
 
 SET(SMESH_FOUND FALSE)
 IF(SMESH_LIBRARY)
   SET(SMESH_FOUND TRUE)
   GET_FILENAME_COMPONENT(SMESH_LIBRARY_DIR ${SMESH_LIBRARY} PATH)
-  set(SMESH_LIBRARIES
+  set(SMESH_LIBRARIES 
     ${SMESH_LIBRARY_DIR}/libDriver.so
     ${SMESH_LIBRARY_DIR}/libDriverDAT.so
     ${SMESH_LIBRARY_DIR}/libDriverSTL.so
@@ -36,5 +63,8 @@ IF(SMESH_LIBRARY)
     ${SMESH_LIBRARY_DIR}/libSMESHDS.so
     ${SMESH_LIBRARY_DIR}/libStdMeshers.so
   )
+  set(EXTERNAL_SMESH_LIBS ${SMESH_LIBRARIES})
+ELSE(SMESH_LIBRARY)
+	message(FATAL_ERROR "SMESH libraries NOT FOUND!")
 ENDIF(SMESH_LIBRARY)
 

--- a/cMake/FreeCAD_Helpers/SetupSalomeSMESH.cmake
+++ b/cMake/FreeCAD_Helpers/SetupSalomeSMESH.cmake
@@ -1,6 +1,10 @@
 macro(SetupSalomeSMESH)
 # -------------------------------- Salome SMESH --------------------------
 
+    # Allow using external SMESH
+    if (FREECAD_USE_EXTERNAL_SMESH)
+        find_package(SMESH REQUIRED)
+    endif(FREECAD_USE_EXTERNAL_SMESH)
     # Salome SMESH sources are under src/3rdParty now
     if(BUILD_SMESH)
         # set the internal smesh version:


### PR DESCRIPTION
Numerous reports (and personal past experiences on Windows + Linux) with corrupted/bad meshes being generated when FreeCAD is compiled with:

Internal SMESH
VTK >= 9
Either with GMSH or Netgen, the meshes come out looking like this:

![image](https://user-images.githubusercontent.com/19617165/182426620-7a17ad07-0b6f-4a79-9d08-a616879b568d.png)

(From: https://forum.freecadweb.org/viewtopic.php?style=10&p=609411)

I'm not sure what is incompatible in the internal SMESH module which causes, and why compiling against VTK 8.2 instead of VTK >= 9 fixes the issue, but many platforms now only have available VTK 9 by default. So when compiling FreeCAD from sources on these systems, mesh generation with the internal SMESH module does not work correctly.

I even saw this on the last LibPack I compiled for this project for Windows. I thought at the time the issue was with Netgen or GMSH, but it turns out this wasn't the case. It was the internal SMESH implementation.

The internal SMESH is based on SMESH 7, while the current external version is version 9. Compiling FreeCAD against VTK 9 with external SMESH fixes this mesh generation issue.

However, currently the FreeCAD CMake scripts do not properly link against or add the proper SMESH variables and configurations to the build process.

This commit fixes the CMake scripts to allow compiling against an external SMESH, and fixes the linker errors seen when attempting to link against external SMESH on 64-bit systems (this was due to `SALOME_USE_64BIT_IDS` not being defined, leading to FreeCAD expecting to link against SMESH functions with 32-bit arguments, while SMESH libraries exported functions with 64-bit arguments).

On my linux/Fedora machine, I was experiencing the same mesh generation issues with (both GMSH and Netgen) when compiling FreeCAD against VTK 9 with the internal SMESH enabled. Netgen would not even produce anything, it would just crash the module.

With external SMESH now properly working, the issue goes away and the FEM meshes are properly generated.

This is intended as a fix for VTK 9 compatibility, until the internal SMESH modules is updated to the latest SMESH sources.