### PR TITLE
[Python console] prevent crash

### DIFF
--- a/src/Gui/PythonConsole.cpp
+++ b/src/Gui/PythonConsole.cpp
@@ -190,7 +190,9 @@ PyObject* InteractiveInterpreter::compile(const char* source) const
     PyObject* eval = PyObject_CallObject(func,args);  // must decref later
 #endif
 
-    Py_DECREF(args);
+    if (args) {
+        Py_DECREF(args);
+    }
     Py_DECREF(func);
 
     if (eval){


### PR DESCRIPTION
Forum topic: https://forum.freecadweb.org/viewtopic.php?f=8&t=70732

Crash occurs when pasting the following into the python console:

```
if True:
    print('ß')
    print('ß')
```

There might be a better way to fix the issue, which seems almost certainly related to the use of non-ASCII characters.