### PR TITLE
XDGData: Fixes wrong xml element in mimetype file

### DIFF
--- a/src/XDGData/org.freecadweb.FreeCAD.xml
+++ b/src/XDGData/org.freecadweb.FreeCAD.xml
@@ -4,6 +4,6 @@
     <!-- <sub-class-of type="application/zip"/> -->
     <comment>FreeCAD document files</comment>
     <glob pattern="*.fcstd"/>
-    <icon name="org.freecadweb.FreeCAD"/>
+    <generic-icon name="org.freecadweb.FreeCAD"/>
   </mime-type>
 </mime-info>

--- a/src/XDGData/org.freecadweb.FreeCAD.xml
+++ b/src/XDGData/org.freecadweb.FreeCAD.xml
@@ -4,6 +4,6 @@
     <!-- <sub-class-of type="application/zip"/> -->
     <comment>FreeCAD document files</comment>
     <glob pattern="*.fcstd"/>
-    <generic-icon name="org.freecadweb.FreeCAD"/>
+    <generic-icon name="application-x-extension-fcstd"/>
   </mime-type>
 </mime-info>


### PR DESCRIPTION
When the thumbnailer is not installed, the icon for files with mimetype of application/x-extension-fcstd should show, but it doesn't.
This is because the icon key in the mimetype file for .FCStd is wrong. It's `icon` when it should be `generic-icon`. This PR fixes that.

P.S. If you have the FreeCAD logo on your .FCStd file, not a white page with the corner folded and the FreeCAD logo on it - this is different. In this case you are seeing what the thumbnailer shows if you have it enabled but have chosen to not include a preview of the file in the thumbnail.
 
- [X]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [ ]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [X]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [X]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [X]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the issue ID number from our [Issues database](https://github.com/FreeCAD/FreeCAD/issues) in case a particular commit solves or is related to an existing issue. Ex: `Draft: fix typos - fixes #4805`
