### PR TITLE
[Bugfix]Gui: allow set up expression even if property value is currently being edited

### DIFF
--- a/src/Gui/propertyeditor/PropertyEditor.cpp
+++ b/src/Gui/propertyeditor/PropertyEditor.cpp
@@ -748,6 +748,7 @@ void PropertyEditor::contextMenuEvent(QContextMenuEvent *) {
     case MA_Expression:
         if(contextIndex == currentIndex()) {
             Base::FlagToggler<> flag(binding);
+            closeEditor();
             openEditor(contextIndex);
         }
         break;


### PR DESCRIPTION
Fix a regression introduced by b42462ba14

It was no more possible to assign an expression using context menu in Property pane (eg. to a "Placement" property) if the value was currently being edited (left-click the value in the Property pane).
The "Expression..." context menu was still present but failed to open the expression dialog.