### PR TITLE
[Bugfix]Sketcher: prevent dangling state of Shift key if key released out of Quarter

### DIFF
--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -511,12 +511,6 @@ bool ViewProviderSketch::keyPressed(bool pressed, int key)
             return false;
         }
         break;
-    case SoKeyboardEvent::LEFT_SHIFT:
-        if (Mode < STATUS_SKETCH_UseHandler) {
-            editCoinManager->setConstraintSelectability(!pressed);
-            return true;
-        }
-        [[fallthrough]];
     default:
         {
             if (isInEditMode() && sketchHandler)
@@ -1080,6 +1074,16 @@ bool ViewProviderSketch::mouseMove(const SbVec2s &cursorPos, Gui::View3DInventor
 {
     // maximum radius for mouse moves when selecting a geometry before switching to drag mode
     const int dragIgnoredDistance = 3;
+
+    static bool selectableConstraints = true;
+
+    if (Mode < STATUS_SKETCH_UseHandler) {
+        bool tmpSelCons = QApplication::keyboardModifiers() & Qt::ShiftModifier;
+        if (tmpSelCons != !selectableConstraints) {
+            selectableConstraints = !tmpSelCons;
+            editCoinManager->setConstraintSelectability(selectableConstraints);
+        }
+    }
 
     if (!isInEditMode())
         return false;


### PR DESCRIPTION
https://forum.freecadweb.org/viewtopic.php?f=3&t=71536

This bug appears because "Shift" in use in a "hold-to-act" way to disable constraints selectability when pressed.
With current implementation using viewprovider callback, if Shift is pressed with focus on Quarter widget, then focus is set to another widget, then only Shift is released (out of Quarter widget focus), the release event isn't catched by Quarter widget and so isn't forwarded to viewprovider.
When mouse back in the focus of the Quarter widget, the view provider still acts as if Shift key was presses. This basically lasts till the user does a Shift press+release cycle (with focus on Quarter widget).

The new implementation moves the Shift state detection to the `mouseMove` viewprovider function and read the state directly from `QApplication` so it totally immune to which widget currently has focus.