### PR TITLE
Arch: Fix wall baseface generation for overlapping and self-intersecting traces

### DIFF
--- a/src/Mod/Arch/ArchWall.py
+++ b/src/Mod/Arch/ArchWall.py
@@ -1351,7 +1351,7 @@ class _Wall(ArchComponent.Component):
 
                             if not DraftVecUtils.isNull(dvec):
                                 dvec.normalize()
-                            sh = None
+                            face = None
 
                             curAligns = aligns[0]
                             off = obj.Offset.Value
@@ -1399,7 +1399,7 @@ class _Wall(ArchComponent.Component):
                                                                normal=normal,
                                                                basewireOffset=off)
 
-                                sh = DraftGeomUtils.bind(w1,w2)
+                                face = DraftGeomUtils.bind(w1, w2, per_segment=True)
 
                             elif curAligns == "Right":
                                 dvec = dvec.negative()
@@ -1440,7 +1440,7 @@ class _Wall(ArchComponent.Component):
                                                                normal=normal,
                                                                basewireOffset=off)
 
-                                sh = DraftGeomUtils.bind(w1,w2)
+                                face = DraftGeomUtils.bind(w1, w2, per_segment=True)
 
                             #elif obj.Align == "Center":
                             elif curAligns == "Center":
@@ -1473,18 +1473,16 @@ class _Wall(ArchComponent.Component):
                                                                    alignList=aligns,
                                                                    normal=normal,
                                                                    basewireOffset=off)
-                                sh = DraftGeomUtils.bind(w1,w2)
+                                face = DraftGeomUtils.bind(w1, w2, per_segment=True)
 
                             del widths[0:edgeNum]
                             del aligns[0:edgeNum]
-                            if sh:
+                            if face:
 
                                 if layers and (layers[i] < 0):
                                     # layers with negative values are not drawn
                                     continue
 
-                                sh.fix(0.1,0,1) # fixes self-intersecting wires
-                                f = Part.Face(sh)
                                 if baseface:
 
                                     # To allow exportIFC.py to work properly on
@@ -1505,14 +1503,14 @@ class _Wall(ArchComponent.Component):
                                     # - 1st finding : if a rectangle + 1 line, can't removesSplitter properly...
                                     # - 2nd finding : if 2 faces do not touch, can't form a shell; then, subsequently for remaining faces even though touch each faces, can't form a shell
 
-                                    baseface.append(f)
+                                    baseface.append(face)
                                     # The above make Refine methods below (in else) useless, regardless removeSpitters yet to be improved for cases do not work well
-                                    '''  Whether layers or not, all baseface.append(f) '''
+                                    '''  Whether layers or not, all baseface.append(face) '''
 
                                 else:
-                                    baseface = [f]
+                                    baseface = [face]
 
-                                    '''  Whether layers or not, all baseface = [f] '''
+                                    '''  Whether layers or not, all baseface = [face] '''
 
                         if baseface:
                             base,placement = self.rebase(baseface)


### PR DESCRIPTION
To fix the issue a new argument, `per_segment`, was introduced for the `bind` function in `faces.py`. Additionally the call to `face.fix()` was moved to that function.

Fixes #7370

Forum topics:
https://forum.freecadweb.org/viewtopic.php?f=23&t=67107&start=30
https://forum.freecadweb.org/viewtopic.php?f=23&t=71107

- [ ]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [x]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the issue ID number from our [Issues database](https://github.com/FreeCAD/FreeCAD/issues) in case a particular commit solves or is related to an existing issue. Ex: `Draft: fix typos - fixes #4805`

---
