### PR TITLE
Draft: Fix flatten wire

### DIFF
--- a/src/Mod/Draft/draftviewproviders/view_bezcurve.py
+++ b/src/Mod/Draft/draftviewproviders/view_bezcurve.py
@@ -39,6 +39,9 @@ class ViewProviderBezCurve(ViewProviderWire):
     def __init__(self, vobj):
         super(ViewProviderBezCurve, self).__init__(vobj)
 
+    def setupContextMenu(self, vobj, menu):
+        return
+
 
 # Alias for compatibility with v0.18 and earlier
 _ViewProviderBezCurve = ViewProviderBezCurve

--- a/src/Mod/Draft/draftviewproviders/view_bspline.py
+++ b/src/Mod/Draft/draftviewproviders/view_bspline.py
@@ -39,6 +39,9 @@ class ViewProviderBSpline(ViewProviderWire):
     def __init__(self, vobj):
         super(ViewProviderBSpline, self).__init__(vobj)
 
+    def setupContextMenu(self, vobj, menu):
+        return
+
 
 # Alias for compatibility with v0.18 and earlier
 _ViewProviderBSpline = ViewProviderBSpline

--- a/src/Mod/Draft/draftviewproviders/view_fillet.py
+++ b/src/Mod/Draft/draftviewproviders/view_fillet.py
@@ -39,4 +39,8 @@ class ViewProviderFillet(ViewProviderWire):
     def __init__(self, vobj):
         super(ViewProviderFillet, self).__init__(vobj)
 
+    def setupContextMenu(self, vobj, menu):
+        return
+
+
 ## @}


### PR DESCRIPTION
The flatten command (context menu) did not work properly and did not respect the Draft working plane.

The context option has been removed for Draft_BSplines and Draft_BezCurves because properly flattening these objects (get a correct 2D projection, but also retain the original object type) is (probably?) not possible.

For Draft_Fillets, which are not parametric, the context option also does not make sense.

Forum topic:
https://forum.freecadweb.org/viewtopic.php?f=23&t=60279

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the issue ID number from our [Issues database](https://github.com/FreeCAD/FreeCAD/issues) in case a particular commit solves or is related to an existing issue. Ex: `Draft: fix typos - fixes #4805`

---
