### PR TITLE
[Sketcher] Allow driving constraint on construction geometry

### DIFF
--- a/src/Mod/Sketcher/App/SketchObject.h
+++ b/src/Mod/Sketcher/App/SketchObject.h
@@ -229,7 +229,7 @@ public:
     /// get the driving status of this constraint
     int getDriving(int ConstrId, bool &isdriving);
     /// toggle the driving status of this constraint
-    int toggleDriving(int ConstrId);
+    int toggleDriving(int ConstrId) {return setDriving(ConstrId, !Constraints.getValues()[ConstrId]->isDriving);}
 
     /// set the driving status of this constraint and solve
     int setActive(int ConstrId, bool isactive);


### PR DESCRIPTION
Fixes issue #7442.

There appears to be no reason to not allow construction points to be constrained. I may be wrong here though.