### PR TITLE
PartDesign: improve offset handling of SubShapeBinder

### DIFF
--- a/src/Mod/PartDesign/App/ShapeBinder.cpp
+++ b/src/Mod/PartDesign/App/ShapeBinder.cpp
@@ -729,7 +729,20 @@ void SubShapeBinder::update(SubShapeBinder::UpdateOption options) {
             }
         }
 
-        if (!fused && result.hasSubShape(TopAbs_EDGE)
+        if (!fused && (MakeFace.getValue() || Offset.getValue() != 0.0)
+            && !result.hasSubShape(TopAbs_FACE)
+            && result.hasSubShape(TopAbs_EDGE))
+        {
+            result = result.makeWires();
+            if (MakeFace.getValue()) {
+                try {
+                    result = result.makeFace(nullptr);
+                }
+                catch (...) {}
+            }
+        }
+
+        if (!fused && result.hasSubShape(TopAbs_WIRE)
             && Offset.getValue() != 0.0) {
             try {
                 result = result.makeOffset2D(Offset.getValue(),
@@ -743,17 +756,6 @@ void SubShapeBinder::update(SubShapeBinder::UpdateOption options) {
                 msg << Label.getValue() << ": failed to make 2D offset" << std::endl;
                 Base::Console().Error(msg.str().c_str());
             }
-        }
-
-        if (!fused && MakeFace.getValue()
-            && !result.hasSubShape(TopAbs_FACE)
-            && result.hasSubShape(TopAbs_EDGE))
-        {
-            result = result.makeWires();
-            try {
-                result = result.makeFace(nullptr);
-            }
-            catch (...) {}
         }
 
         if (Refine.getValue())


### PR DESCRIPTION
https://forum.freecadweb.org/viewtopic.php?f=12&t=71615

Offset of SubShapeBinder wasn't working for closed or open wires.