### PR TITLE
Base: Experiment using constexpr to displace preprocessor (NOT FOR MERGE)

### DIFF
--- a/src/Base/ConsoleObserver.h
+++ b/src/Base/ConsoleObserver.h
@@ -27,8 +27,56 @@
 #include <Base/Console.h>
 #include <Base/Stream.h>
 
+namespace{
+
+enum class SysTypes
+{
+    Windows,
+    Linux,
+    MacOS,
+    BSD,
+    Other
+};
+
+#if defined(FC_OS_WIN32)
+constexpr auto sysType = sysTypes::Windows;
+#elif defined(FC_OS_LINUX)
+constexpr auto sysType = SysTypes::Linux;
+#elif defined(FC_OS_MACOSX)
+constexpr auto sysType = SysTypes::MacOS;
+#elif defined(FC_OS_BSD)
+constexpr auto sysType = SysTypes::BSD;
+#else
+constexpr auto sysType = SysTypes::Other;
+#endif
+
+#if defined(FC_OS_WIN32)
+constexpr auto fRed{FOREGROUND_RED};
+constexpr auto fGreen{FOREGROUND_GREEN};
+constexpr auto fBlue{FOREGROUND_BLUE};
+constexpr auto fIntensity{FOREGROUND_INTENSITY};
+auto setConsoleTextAttr = [](auto format) {
+    ::SetConsoleTextAttribute(::GetStdHandle(STD_ERROR_HANDLE), format);
+};
+#else
+constexpr auto fRed{0};
+constexpr auto fGreen{0};
+constexpr auto fBlue{0};
+constexpr auto fIntensity{0};
+auto setConsoleTextAttr = [](auto format) {};
+#endif
+
+constexpr bool isLinuxBased =
+    sysType == SysTypes::Linux
+     || sysType == SysTypes::MacOS
+     || sysType == SysTypes::BSD;
+
+}//namespace
 
 namespace Base {
+
+constexpr unsigned int bufferSize {80};
+
 
 //=========================================================================
 // some special observers


### PR DESCRIPTION
This is an experiment to see how constexpr might assist to push ugly preprocessor
stuff back from mainstream application code.

Created some constexpr's from existing defines.

Changed some repetitive code to data.

NB(AFAICT): Compile-time 'if constexpr' only works in templates, and not after being passed as parameter.

Code inside a if constexpr(){} is evaluated at compile-time and will or will not
be instantiated (compiled) by the compiler depending on evaluation of the condition.

Builds ok on mac, but untested.

All feedback most welcome !