### PR TITLE
Mod: Add C9 tool change command to opensbp path post processor

### DIFF
--- a/src/Mod/Path/PathScripts/post/opensbp_post.py
+++ b/src/Mod/Path/PathScripts/post/opensbp_post.py
@@ -299,6 +299,8 @@ def tool_change(command):
     txt += "\n"
     txt += "&Tool=" + str(int(command.Parameters["T"]))
     txt += "\n"
+    txt += "C9" # C9 is "tool change" command
+    txt += "\n"
     return txt
 
 


### PR DESCRIPTION
Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [X]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [ ]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [X]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [X]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the issue ID number from our [Issues database](https://github.com/FreeCAD/FreeCAD/issues) in case a particular commit solves or is related to an existing issue. Ex: `Draft: fix typos - fixes #4805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---

This PR modifies the `opensbp` (shopbot) post-processor. It adds the `C9` tool change command when there is a tool change. The `C9` command seems to be necessary for ATC-enabled shopbots and even for some manual-tool-change shopbots, as the spindle will not start without it. See [this forum thread](http://www.talkshopbot.com/forum/archive/index.php/t-21055.html).