### PR TITLE
[For testing] Sketcher: optionally merge 'coincident' within 'point-on-object' constraint

### DIFF
--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -465,10 +465,10 @@ void SketcherGui::doEndpointTangency(Sketcher::SketchObject* Obj,
             std::swap(PosId1,PosId2);
         }
         // GeoId1 is the B-spline now
-        } // end of code supports simple B-spline endpoint tangency
+    } // end of code supports simple B-spline endpoint tangency
 
-        Gui::cmdAppObjectArgs(Obj, "addConstraint(Sketcher.Constraint('Tangent',%d,%d,%d,%d)) ",
-                GeoId1,static_cast<int>(PosId1),GeoId2,static_cast<int>(PosId2));
+    Gui::cmdAppObjectArgs(Obj, "addConstraint(Sketcher.Constraint('Tangent',%d,%d,%d,%d)) ",
+            GeoId1,static_cast<int>(PosId1),GeoId2,static_cast<int>(PosId2));
 }
 
 void SketcherGui::doEndpointToEdgeTangency( Sketcher::SketchObject* Obj, int GeoId1, PointPos PosId1, int GeoId2)

--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -2649,15 +2649,10 @@ void CmdSketcherConstrainPointOnObject::applyConstraint(std::vector<SelIdPair> &
         return;
     }
 
-    if(substituteConstraintCombinations(Obj, GeoIdVt, PosIdVt, GeoIdCrv)) {
-        commitCommand();
-        tryAutoRecompute(Obj);
-        return;
-    }
-
     if (allOK) {
-        Gui::cmdAppObjectArgs(sketchgui->getObject(), "addConstraint(Sketcher.Constraint('PointOnObject',%d,%d,%d)) ",
-             GeoIdVt, static_cast<int>(PosIdVt), GeoIdCrv);
+        if (!substituteConstraintCombinations(Obj, GeoIdVt, PosIdVt, GeoIdCrv))
+            Gui::cmdAppObjectArgs(  sketchgui->getObject(), "addConstraint(Sketcher.Constraint('PointOnObject',%d,%d,%d)) ",
+                                    GeoIdVt, static_cast<int>(PosIdVt), GeoIdCrv);
 
         commitCommand();
         tryAutoRecompute(Obj);

--- a/src/Mod/Sketcher/Gui/Workbench.cpp
+++ b/src/Mod/Sketcher/Gui/Workbench.cpp
@@ -27,6 +27,7 @@
 # include <qobject.h>
 #endif
 
+#include <App/Application.h>
 #include "Workbench.h"
 #include <Gui/MenuManager.h>
 #include <Gui/ToolBarManager.h>
@@ -298,8 +299,11 @@ inline void SketcherAddWorkbenchConstraints(T& cons);
 template <>
 inline void SketcherAddWorkbenchConstraints<Gui::MenuItem>(Gui::MenuItem& cons)
 {
-    cons    << "Sketcher_ConstrainCoincident"
-            << "Sketcher_ConstrainPointOnObject"
+    if (!App::GetApplication().GetParameterGroupByPath(   "User parameter:BaseApp/Preferences/Mod/Sketcher/General")->
+                                                                GetBool("MergePointOnObjectWithCoincident", false))
+        cons    << "Sketcher_ConstrainCoincident";
+
+    cons    << "Sketcher_ConstrainPointOnObject"
             << "Sketcher_ConstrainVertical"
             << "Sketcher_ConstrainHorizontal"
             << "Sketcher_ConstrainParallel"
@@ -314,7 +318,6 @@ inline void SketcherAddWorkbenchConstraints<Gui::MenuItem>(Gui::MenuItem& cons)
             << "Sketcher_ConstrainDistanceY"
             << "Sketcher_ConstrainDistance"
             << "Sketcher_ConstrainRadius"
-            << "Sketcher_ConstrainDiameter"
             << "Sketcher_ConstrainRadiam"
             << "Sketcher_ConstrainAngle"
             << "Sketcher_ConstrainSnellsLaw"
@@ -327,8 +330,11 @@ inline void SketcherAddWorkbenchConstraints<Gui::MenuItem>(Gui::MenuItem& cons)
 template <>
 inline void SketcherAddWorkbenchConstraints<Gui::ToolBarItem>(Gui::ToolBarItem& cons)
 {
-    cons    << "Sketcher_ConstrainCoincident"
-            << "Sketcher_ConstrainPointOnObject"
+    if (!App::GetApplication().GetParameterGroupByPath(   "User parameter:BaseApp/Preferences/Mod/Sketcher/General")->
+                                                                GetBool("MergePointOnObjectWithCoincident", false))
+        cons    << "Sketcher_ConstrainCoincident";
+
+    cons    << "Sketcher_ConstrainPointOnObject"
             << "Sketcher_ConstrainVertical"
             << "Sketcher_ConstrainHorizontal"
             << "Sketcher_ConstrainParallel"


### PR DESCRIPTION
The merge is activated with `User parameter:BaseApp/Preferences/Mod/Sketcher/General/MergePointOnObjectWithCoincident` boolean switch

The PR is essentially done to have a test between 2 flavors (merged or not) and decide what is to be kept.

The "feature" is only the last commit. 3 first commits are independent fixes and improvements.