### PR TITLE
Gui: do not detach parameter observer from PythonEditor

### DIFF
--- a/src/Gui/PythonEditor.cpp
+++ b/src/Gui/PythonEditor.cpp
@@ -87,7 +87,6 @@ PythonEditor::PythonEditor(QWidget* parent)
 /** Destroys the object and frees any allocated resources */
 PythonEditor::~PythonEditor()
 {
-    getWindowParameter()->Detach( this );
     delete d;
 }
 


### PR DESCRIPTION
 Parameter observing (including observer deletion) is 100% managed by TextEditor superclass

I caught it because closing FreeCAD with macro editor opened reports `Observer 0xYYYYYYY already detached`