### PR TITLE
CI: allow manual launch of CI

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches: ['master', 'development/toponaming', 'releases/FreeCAD-0-20']
   pull_request:
+  workflow_dispatch:
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
This PR allows manual launch of CI workflow.
This allows any contributor working on its fork to manually launch the CI workflow at any time during development without need to do a PR.