### PR TITLE
PartDesign: Add format parameter for Wedge X-min under Task tab

### DIFF
--- a/src/Mod/PartDesign/Gui/TaskPrimitiveParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPrimitiveParameters.cpp
@@ -817,7 +817,7 @@ bool TaskBoxPrimitives::setPrimitive(App::DocumentObject *obj)
                     "%1.X2max=%10\n"
                     "%1.Z2max=%11\n")
                     .arg(name,
-                         Base::UnitsApi::toNumber(ui->wedgeXmin->value()),
+                         Base::UnitsApi::toNumber(ui->wedgeXmin->value(), format),
                          Base::UnitsApi::toNumber(ui->wedgeYmin->value(), format),
                          Base::UnitsApi::toNumber(ui->wedgeZmin->value(), format),
                          Base::UnitsApi::toNumber(ui->wedgeX2min->value(), format),


### PR DESCRIPTION
Currently, the X-min property of wedges are rounded to the nearest integer after pressing _OK_ under the _Tasks_ tab instead of the nearest hundredth like the other wedge properties. This small pull request adds the format parameter used with the other properties so X-min is handled the same as the other wedge properties. This fix does not affect the property table under the _Model_ tab since it has the correct behavior.

- [X]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [ ]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [X]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [X]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [X]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the issue ID number from our [Issues database](https://github.com/FreeCAD/FreeCAD/issues) in case a particular commit solves or is related to an existing issue. Ex: `Draft: fix typos - fixes #4805`