### PR TITLE
Sketcher: various fixes in constraint commands

### DIFF
--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -465,10 +465,10 @@ void SketcherGui::doEndpointTangency(Sketcher::SketchObject* Obj,
             std::swap(PosId1,PosId2);
         }
         // GeoId1 is the B-spline now
-        } // end of code supports simple B-spline endpoint tangency
+    } // end of code supports simple B-spline endpoint tangency
 
-        Gui::cmdAppObjectArgs(Obj, "addConstraint(Sketcher.Constraint('Tangent',%d,%d,%d,%d)) ",
-                GeoId1,static_cast<int>(PosId1),GeoId2,static_cast<int>(PosId2));
+    Gui::cmdAppObjectArgs(Obj, "addConstraint(Sketcher.Constraint('Tangent',%d,%d,%d,%d)) ",
+            GeoId1,static_cast<int>(PosId1),GeoId2,static_cast<int>(PosId2));
 }
 
 void SketcherGui::doEndpointToEdgeTangency( Sketcher::SketchObject* Obj, int GeoId1, PointPos PosId1, int GeoId2)

--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -2649,15 +2649,10 @@ void CmdSketcherConstrainPointOnObject::applyConstraint(std::vector<SelIdPair> &
         return;
     }
 
-    if(substituteConstraintCombinations(Obj, GeoIdVt, PosIdVt, GeoIdCrv)) {
-        commitCommand();
-        tryAutoRecompute(Obj);
-        return;
-    }
-
     if (allOK) {
-        Gui::cmdAppObjectArgs(sketchgui->getObject(), "addConstraint(Sketcher.Constraint('PointOnObject',%d,%d,%d)) ",
-             GeoIdVt, static_cast<int>(PosIdVt), GeoIdCrv);
+        if (!substituteConstraintCombinations(Obj, GeoIdVt, PosIdVt, GeoIdCrv))
+            Gui::cmdAppObjectArgs(  sketchgui->getObject(), "addConstraint(Sketcher.Constraint('PointOnObject',%d,%d,%d)) ",
+                                    GeoIdVt, static_cast<int>(PosIdVt), GeoIdCrv);
 
         commitCommand();
         tryAutoRecompute(Obj);


### PR DESCRIPTION
This PR has been extracted from #7478 

Commit 1 : in current state, even if condition aren't OK to apply 'point-on-object' (for example selected vertex belongs to selected curve) we try to substitute constraints (typically coincident + curve/curve tangency => smooth joint). This can lead to strange effect, like "command not working" but still "something else happens". Commit prevent trying constraint substitution if conditions aren't OK for the command to process

Commit 2 : fixes an indentation problem that makes code hard to understand properly

Commit 3 : improves command (undo transaction) management. In current code, constraint substitution in 'coincident' generates its own transaction. With commit it no more does and delegate the transaction management to the calling method, which is more optimal and also consistent with what happens in 'point-on-object' constraint. This change was also needed for the last commit of #7478 to work.

@donovaly here it is :)