### PR TITLE
[App] Application.cpp: increase thread safety

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -2912,7 +2912,7 @@ QString getUserHome()
     QString path;
 #if defined(FC_OS_LINUX) || defined(FC_OS_CYGWIN) || defined(FC_OS_BSD) || defined(FC_OS_MACOSX)
     // Default paths for the user specific stuff
-    struct passwd *pwd = getpwuid(getuid());
+    struct passwd *pwd = getpwuid_r(getuid());
     if (!pwd)
         throw Base::RuntimeError("Getting HOME path from system failed!");
     path = QString::fromUtf8(pwd->pw_dir);


### PR DESCRIPTION
- the CI reported "Consider using getpwuid_r(...) instead of getpwuid(...) for improved thread safety.  [runtime/threadsafe_fn] [2]"

I have only Windows thus cannot say if this change compiles for all platforms.

Original CI report: the last one here: https://github.com/FreeCAD/FreeCAD/pull/7493/commits/bfca5ec5