### PR TITLE
Gui: functions to store/recall temporary working view moved from hardcoded to commands

### DIFF
--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -3615,6 +3615,68 @@ Action * StdCmdSelBoundingBox::createAction()
 }
 
 //===========================================================================
+// Std_StoreWorkingView
+//===========================================================================
+DEF_STD_CMD_A(StdStoreWorkingView)
+
+StdStoreWorkingView::StdStoreWorkingView()
+  : Command("Std_StoreWorkingView")
+{
+    sGroup        = "Standard-View";
+    sMenuText     = QT_TR_NOOP("Store working view");
+    sToolTipText  = QT_TR_NOOP("Store a document-specific temporary working view");
+    sStatusTip    = QT_TR_NOOP("Store a document-specific temporary working view");
+    sWhatsThis    = "Std_StoreWorkingView";
+    sAccel        = "Shift+End";
+    eType         = NoTransaction;
+}
+
+void StdStoreWorkingView::activated(int iMsg)
+{
+    Q_UNUSED(iMsg);
+    if (auto view = dynamic_cast<Gui::View3DInventor*>(Gui::getMainWindow()->activeWindow())) {
+        view->getViewer()->saveHomePosition();
+    }
+}
+
+bool StdStoreWorkingView::isActive()
+{
+    return dynamic_cast<Gui::View3DInventor*>(Gui::getMainWindow()->activeWindow());
+}
+
+//===========================================================================
+// Std_RecallWorkingView
+//===========================================================================
+DEF_STD_CMD_A(StdRecallWorkingView)
+
+StdRecallWorkingView::StdRecallWorkingView()
+  : Command("Std_RecallWorkingView")
+{
+    sGroup        = "Standard-View";
+    sMenuText     = QT_TR_NOOP("Recall working view");
+    sToolTipText  = QT_TR_NOOP("Recall previously stored temporary working view");
+    sStatusTip    = QT_TR_NOOP("Recall previously stored temporary working view");
+    sWhatsThis    = "Std_RecallWorkingView";
+    sAccel        = "End";
+    eType         = NoTransaction;
+}
+
+void StdRecallWorkingView::activated(int iMsg)
+{
+    Q_UNUSED(iMsg);
+    if (auto view = dynamic_cast<Gui::View3DInventor*>(Gui::getMainWindow()->activeWindow())) {
+        if (view->getViewer()->hasHomePosition())
+            view->getViewer()->resetToHomePosition();
+    }
+}
+
+bool StdRecallWorkingView::isActive()
+{
+    auto view = dynamic_cast<Gui::View3DInventor*>(Gui::getMainWindow()->activeWindow());
+    return view && view->getViewer()->hasHomePosition();
+}
+
+//===========================================================================
 // Instantiation
 //===========================================================================
 
@@ -3641,6 +3703,8 @@ void CreateViewStdCommands()
     rcCmdMgr.addCommand(new StdCmdViewFitSelection());
     rcCmdMgr.addCommand(new StdCmdViewRotateLeft());
     rcCmdMgr.addCommand(new StdCmdViewRotateRight());
+    rcCmdMgr.addCommand(new StdStoreWorkingView());
+    rcCmdMgr.addCommand(new StdRecallWorkingView());
 
     rcCmdMgr.addCommand(new StdCmdViewExample1());
     rcCmdMgr.addCommand(new StdCmdViewExample2());

--- a/src/Gui/NavigationStyle.cpp
+++ b/src/Gui/NavigationStyle.cpp
@@ -1614,14 +1614,6 @@ SbBool NavigationStyle::processKeyboardEvent(const SoKeyboardEvent * const event
     case SoKeyboardEvent::RIGHT_ALT:
         this->altdown = press;
         break;
-    case SoKeyboardEvent::H:
-        processed = true;
-        viewer->saveHomePosition();
-        break;
-    case SoKeyboardEvent::R:
-        processed = true;
-        viewer->resetToHomePosition();
-        break;
     case SoKeyboardEvent::S:
     case SoKeyboardEvent::HOME:
     case SoKeyboardEvent::LEFT_ARROW:

--- a/src/Gui/Quarter/SoQTQuarterAdaptor.h
+++ b/src/Gui/Quarter/SoQTQuarterAdaptor.h
@@ -91,6 +91,7 @@ public:
 
     virtual void saveHomePosition();
     virtual void resetToHomePosition();
+    virtual bool hasHomePosition() const {return m_storedcamera;}
 
     virtual void setSceneGraph(SoNode* root) {
         QuarterWidget::setSceneGraph(root);

--- a/src/Gui/Workbench.cpp
+++ b/src/Gui/Workbench.cpp
@@ -654,7 +654,8 @@ MenuItem* StdWorkbench::setupMenuBar() const
               << "Separator" << "Std_ViewHome" << "Std_ViewFront" << "Std_ViewTop"
               << "Std_ViewRight" << "Separator" << "Std_ViewRear"
               << "Std_ViewBottom" << "Std_ViewLeft"
-              << "Separator" << "Std_ViewRotateLeft" << "Std_ViewRotateRight";
+              << "Separator" << "Std_ViewRotateLeft" << "Std_ViewRotateRight"
+              << "Separator" << "Std_StoreWorkingView" << "Std_RecallWorkingView";
 
     // stereo
     auto view3d = new MenuItem;


### PR DESCRIPTION
This PR moves 2 functions used to store/recall a document-specific temporary view in 3D viewport : 
- from hardcoded in the navigation style base class
- to 2 normal commands that user can use as needed (especially customize shortcuts)
The hardcoded behavior was creating some very weird effect to user in specific conditions (see forum link)

The commands are added at the end of the `standard view` submenu in the `view` menu.
Default shortcuts are `Shift+End` and `End` respectively for store and recall.

![image](https://user-images.githubusercontent.com/48731257/192138425-7bfdc157-c036-45ee-ae74-75c1f07806df.png)

https://forum.freecadweb.org/viewtopic.php?f=3&t=72082