### PR TITLE
App and Addon Manager: Add min python version tag

### DIFF
--- a/src/App/Metadata.cpp
+++ b/src/App/Metadata.cpp
@@ -228,7 +228,11 @@ Meta::Version Metadata::freecadmin() const
 
 Meta::Version Metadata::freecadmax() const
 {
-    return _freecadmax;
+    return _freecadmax; }
+
+Meta::Version Metadata::pythonmin() const 
+{ 
+    return _pythonmin; 
 }
 
 std::multimap<std::string, Metadata> Metadata::content() const
@@ -341,6 +345,11 @@ void Metadata::addContentItem(const std::string& tag, const Metadata& item)
 void Metadata::setFreeCADMin(const Meta::Version& version)
 {
     _freecadmin = version;
+}
+
+void Metadata::setPythonMin(const Meta::Version &version) 
+{ 
+    _pythonmin = version;
 }
 
 void Metadata::setFreeCADMax(const Meta::Version& version)
@@ -687,8 +696,11 @@ void Metadata::appendToElement(DOMElement* root) const
     if (_freecadmin != Meta::Version())
         appendSimpleXMLNode(root, "freecadmin", _freecadmin.str());
 
-    if (_freecadmax != Meta::Version())
-        appendSimpleXMLNode(root, "freecadmax", _freecadmin.str());
+    if (_freecadmax != Meta::Version()) 
+        appendSimpleXMLNode(root, "freecadmax", _freecadmax.str());
+
+    if (_pythonmin != Meta::Version()) 
+        appendSimpleXMLNode(root, "pythonmin", _pythonmin.str());
 
     for (const auto& url : _url) {
         auto element = appendSimpleXMLNode(root, "url", url.location);
@@ -784,6 +796,8 @@ void Metadata::parseVersion1(const DOMNode* startNode)
             _freecadmin = Meta::Version(StrXUTF8(element->getTextContent()).str);
         else if (tagString == "freecadmax")
             _freecadmax = Meta::Version(StrXUTF8(element->getTextContent()).str);
+        else if (tagString == "pythonmin")
+            _pythonmin = Meta::Version(StrXUTF8(element->getTextContent()).str);
         else if (tagString == "url")
             _url.emplace_back(element);
         else if (tagString == "author")

--- a/src/App/Metadata.h
+++ b/src/App/Metadata.h
@@ -36,119 +36,130 @@
 #include <xercesc/parsers/XercesDOMParser.hpp>
 
 
-namespace App {
+namespace App
+{
 
-    namespace Meta {
+namespace Meta
+{
 
-        /**
+/**
          * \struct Contact
          * \brief A person or company representing a point of contact for the package (either author or maintainer).
          */
-        struct AppExport Contact {
-            Contact() = default;
-            Contact(const std::string& name, const std::string& email);
-            explicit Contact(const XERCES_CPP_NAMESPACE::DOMElement* e);
-            std::string name; //< Contact name - required
-            std::string email; //< Contact email - may be optional
-            bool operator==(const Contact &rhs) const;
-        };
+struct AppExport Contact {
+    Contact() = default;
+    Contact(const std::string &name, const std::string &email);
+    explicit Contact(const XERCES_CPP_NAMESPACE::DOMElement *e);
+    std::string name; //< Contact name - required
+    std::string email;//< Contact email - may be optional
+    bool operator==(const Contact &rhs) const;
+};
 
-        /**
+/**
          * \struct License
          * \brief A license that covers some or all of this package.
          *
          * Many licenses also require the inclusion of the complete license text, specified in this struct
          * using the "file" member.
          */
-        struct AppExport License {
-            License() = default;
-            License(const std::string& name, boost::filesystem::path file);
-            explicit License(const XERCES_CPP_NAMESPACE::DOMElement* e);
-            std::string name; //< Short name of license, e.g. "LGPL2", "MIT", "Mozilla Public License", etc.
-            boost::filesystem::path file; //< Optional path to the license file, relative to the XML file's location
-            bool operator==(const License &rhs) const;
-        };
+struct AppExport License {
+    License() = default;
+    License(const std::string &name, boost::filesystem::path file);
+    explicit License(const XERCES_CPP_NAMESPACE::DOMElement *e);
+    std::string name;//< Short name of license, e.g. "LGPL2", "MIT", "Mozilla Public License", etc.
+    boost::filesystem::path
+        file;//< Optional path to the license file, relative to the XML file's location
+    bool operator==(const License &rhs) const;
+};
 
-        enum class UrlType {
-            website,
-            repository,
-            bugtracker,
-            readme,
-            documentation,
-            discussion
-        };
+enum class UrlType
+{
+    website,
+    repository,
+    bugtracker,
+    readme,
+    documentation,
+    discussion
+};
 
-        /**
+/**
          * \struct Url
          * \brief A URL, including type information (e.g. website, repository, or bugtracker, in package.xml)
          */
-        struct AppExport Url {
-            Url();
-            Url(const std::string& location, UrlType type);
-            explicit Url(const XERCES_CPP_NAMESPACE::DOMElement* e);
-            std::string location; //< The actual URL, including protocol
-            UrlType type; //< What kind of URL this is
-            std::string branch; //< If it's a repository, which branch to use
-            bool operator==(const Url &rhs) const;
-        };
+struct AppExport Url {
+    Url();
+    Url(const std::string &location, UrlType type);
+    explicit Url(const XERCES_CPP_NAMESPACE::DOMElement *e);
+    std::string location;//< The actual URL, including protocol
+    UrlType type;        //< What kind of URL this is
+    std::string branch;  //< If it's a repository, which branch to use
+    bool operator==(const Url &rhs) const;
+};
 
-        /**
+/**
          * \struct Version
          * A semantic version structure providing comparison operators and conversion to and from std::string
          */
-        struct AppExport Version {
-            Version();
-            explicit Version(int major, int minor = 0, int patch = 0, const std::string& suffix = std::string());
-            explicit Version(const std::string& semanticString);
+struct AppExport Version {
+    Version();
+    explicit Version(int major, int minor = 0, int patch = 0,
+                     const std::string &suffix = std::string());
+    explicit Version(const std::string &semanticString);
 
-            int major;
-            int minor;
-            int patch;
-            std::string suffix;
+    int major;
+    int minor;
+    int patch;
+    std::string suffix;
 
-            std::string str() const;
+    std::string str() const;
 
-            bool operator<(const Version&) const;
-            bool operator>(const Version&) const;
-            bool operator<=(const Version&) const;
-            bool operator>=(const Version&) const;
-            bool operator==(const Version&) const;
-            bool operator!=(const Version&) const;
-        };
+    bool operator<(const Version &) const;
+    bool operator>(const Version &) const;
+    bool operator<=(const Version &) const;
+    bool operator>=(const Version &) const;
+    bool operator==(const Version &) const;
+    bool operator!=(const Version &) const;
+};
 
-        /**
+/**
          * \enum DependencyType
          * The type of dependency.
          */
-        enum class DependencyType
-        {
-            automatic,
-            internal,
-            addon,
-            python
-        };
+enum class DependencyType
+{
+    automatic,
+    internal,
+    addon,
+    python
+};
 
-        /**
+/**
          * \struct Dependency
          * \brief Another package that this package depends on, conflicts with, or replaces
          */
-        struct AppExport Dependency {
-            Dependency();
-            explicit Dependency(const std::string &pkg);
-            explicit Dependency(const XERCES_CPP_NAMESPACE::DOMElement* e);
-            std::string package; //< Required: must exactly match the contents of the "name" element in the referenced package's package.xml file.
-            std::string version_lt; //< Optional: The dependency to the package is restricted to versions less than the stated version number.
-            std::string version_lte; //< Optional: The dependency to the package is restricted to versions less or equal than the stated version number.
-            std::string version_eq; //< Optional: The dependency to the package is restricted to a version equal than the stated version number.
-            std::string version_gte; //< Optional: The dependency to the package is restricted to versions greater or equal than the stated version number.
-            std::string version_gt; //< Optional: The dependency to the package is restricted to versions greater than the stated version number.
-            std::string condition; //< Optional: Conditional expression as documented in REP149.
-            bool optional;//< Optional: Whether this dependency is considered "optional"
-            DependencyType dependencyType; //< Optional: defaults to "automatic"
-            bool operator==(const Dependency &rhs) const;
-        };
+struct AppExport Dependency {
+    Dependency();
+    explicit Dependency(const std::string &pkg);
+    explicit Dependency(const XERCES_CPP_NAMESPACE::DOMElement *e);
+    std::string
+        package;//< Required: must exactly match the contents of the "name" element in the referenced package's package.xml file.
+    std::string
+        version_lt;//< Optional: The dependency to the package is restricted to versions less than the stated version number.
+    std::string
+        version_lte;//< Optional: The dependency to the package is restricted to versions less or equal than the stated version number.
+    std::string
+        version_eq;//< Optional: The dependency to the package is restricted to a version equal than the stated version number.
+    std::string
+        version_gte;//< Optional: The dependency to the package is restricted to versions greater or equal than the stated version number.
+    std::string
+        version_gt;//< Optional: The dependency to the package is restricted to versions greater than the stated version number.
+    std::string condition;        //< Optional: Conditional expression as documented in REP149.
+    bool optional;                //< Optional: Whether this dependency is considered "optional"
+    DependencyType dependencyType;//< Optional: defaults to "automatic"
+    bool operator==(const Dependency &rhs) const;
+};
 
-        /**
+/**
          * \struct GenericMetadata
          * A structure to hold unrecognized single-level metadata.
          *
@@ -156,17 +167,17 @@ namespace App {
          * does not recognize, and that tag has no children, it is parsed into this data structure
          * for convenient access by client code.
          */
-        struct AppExport GenericMetadata {
-            GenericMetadata() = default;
-            explicit GenericMetadata(const XERCES_CPP_NAMESPACE::DOMElement* e);
-            explicit GenericMetadata(const std::string &contents);
-            std::string contents; //< The contents of the tag
-            std::map<std::string, std::string> attributes; //< The XML attributes of the tag
-        };
+struct AppExport GenericMetadata {
+    GenericMetadata() = default;
+    explicit GenericMetadata(const XERCES_CPP_NAMESPACE::DOMElement *e);
+    explicit GenericMetadata(const std::string &contents);
+    std::string contents;                         //< The contents of the tag
+    std::map<std::string, std::string> attributes;//< The XML attributes of the tag
+};
 
-    }
+}// namespace Meta
 
-    /**
+/**
      * \class Metadata
      * \brief Reads data from a metadata file.
      *
@@ -174,55 +185,66 @@ namespace App {
      * use. Full format documentation is available at the FreeCAD Wiki:
      * https://wiki.freecadweb.org/Package_Metadata
      */
-    class AppExport Metadata {
-    public:
+class AppExport Metadata
+{
+public:
+    Metadata();
 
-        Metadata();
-
-        /**
+    /**
          * Read the data from a file on disk
          *
          * This constructor takes a path to an XML file and loads the XML from that file as
          * metadata.
          */
-        explicit Metadata(const boost::filesystem::path& metadataFile);
+    explicit Metadata(const boost::filesystem::path &metadataFile);
 
-        /**
+    /**
          * Construct a Metadata object from a DOM node.
          *
          * This node may have any tag name: it is only accessed via its children, which are
          * expected to follow the standard Metadata format for the contents of the <package> element.
          */
-        Metadata(const XERCES_CPP_NAMESPACE::DOMNode* domNode, int format);
+    Metadata(const XERCES_CPP_NAMESPACE::DOMNode *domNode, int format);
 
-        ~Metadata();
+    ~Metadata();
 
 
-        //////////////////////////////////////////////////////////////
-        // Recognized Metadata
-        //////////////////////////////////////////////////////////////
+    //////////////////////////////////////////////////////////////
+    // Recognized Metadata
+    //////////////////////////////////////////////////////////////
 
-        std::string name() const; //< A short name for this package, often used as a menu entry.
-        Meta::Version version() const; //< Version string in symantic triplet format, e.g. "1.2.3".
-        std::string date() const; //< Date string -- currently arbitrary (when C++20 is well-supported we can revisit)
-        std::string description() const; //< Text-only description of the package. No markup.
-        std::vector<Meta::Contact> maintainer() const; //< Must be at least one, and must specify an email address.
-        std::vector<Meta::License> license() const; //< Must be at least one, and most licenses require including a license file.
-        std::vector<Meta::Url> url() const; //< Any number of URLs may be specified, but at least one repository URL must be included at the package level.
-        std::vector<Meta::Contact> author() const; //< Any number of authors may be specified, and email addresses are optional.
-        std::vector<Meta::Dependency> depend() const; //< Zero or more packages this package requires prior to use.
-        std::vector<Meta::Dependency> conflict() const; //< Zero of more packages this package conflicts with.
-        std::vector<Meta::Dependency> replace() const; //< Zero or more packages this package is intended to replace.
-        std::vector<std::string> tag() const; //< Zero or more text tags related to this package.
-        boost::filesystem::path icon() const; //< Path to an icon file.
-        std::string classname() const; //< Recognized for convenience -- generally only used by Workbenches.
-        boost::filesystem::path subdirectory() const; //< Optional, override the default subdirectory name for this item.
-        std::vector<boost::filesystem::path> file() const; //< Arbitrary files associated with this package or content item.
-        Meta::Version freecadmin() const; //< The minimum FreeCAD version.
-        Meta::Version freecadmax() const; //< The maximum FreeCAD version.
-        Meta::Version pythonmin() const; //< The minimum Python version.
+    std::string name() const;     //< A short name for this package, often used as a menu entry.
+    Meta::Version version() const;//< Version string in symantic triplet format, e.g. "1.2.3".
+    std::string date()
+        const;//< Date string -- currently arbitrary (when C++20 is well-supported we can revisit)
+    std::string description() const;//< Text-only description of the package. No markup.
+    std::vector<Meta::Contact>
+    maintainer() const;//< Must be at least one, and must specify an email address.
+    std::vector<Meta::License>
+    license() const;//< Must be at least one, and most licenses require including a license file.
+    std::vector<Meta::Url> url()
+        const;//< Any number of URLs may be specified, but at least one repository URL must be included at the package level.
+    std::vector<Meta::Contact>
+    author() const;//< Any number of authors may be specified, and email addresses are optional.
+    std::vector<Meta::Dependency>
+    depend() const;//< Zero or more packages this package requires prior to use.
+    std::vector<Meta::Dependency>
+    conflict() const;//< Zero of more packages this package conflicts with.
+    std::vector<Meta::Dependency>
+    replace() const;//< Zero or more packages this package is intended to replace.
+    std::vector<std::string> tag() const;//< Zero or more text tags related to this package.
+    boost::filesystem::path icon() const;//< Path to an icon file.
+    std::string
+    classname() const;//< Recognized for convenience -- generally only used by Workbenches.
+    boost::filesystem::path
+    subdirectory() const;//< Optional, override the default subdirectory name for this item.
+    std::vector<boost::filesystem::path>
+    file() const;//< Arbitrary files associated with this package or content item.
+    Meta::Version freecadmin() const;//< The minimum FreeCAD version.
+    Meta::Version freecadmax() const;//< The maximum FreeCAD version.
+    Meta::Version pythonmin() const; //< The minimum Python version.
 
-        /**
+    /**
          * Access the metadata for the content elements of this package
          *
          * In addition to the overall package metadata, this class reads in metadata contained in a
@@ -238,9 +260,9 @@ namespace App {
          *   </theme>
          * </content>
          */
-        std::multimap<std::string, Metadata> content() const;
+    std::multimap<std::string, Metadata> content() const;
 
-        /**
+    /**
          * Convenience accessor for unrecognized simple metadata.
          *
          * If the XML parser encounters tags that it does not recognize, and those tags have
@@ -248,113 +270,111 @@ namespace App {
          * operator[], which returns a (potentially empty) vector containing all instances of the
          * given tag. It cannot be used to *create* a new tag, however. See addGenericMetadata().
          */
-        std::vector<Meta::GenericMetadata> operator[] (const std::string& tag) const;
+    std::vector<Meta::GenericMetadata> operator[](const std::string &tag) const;
 
-        /**
+    /**
          * Directly access the DOM tree to support unrecognized multi-level metadata
          */
-        XERCES_CPP_NAMESPACE::DOMElement* dom() const;
+    XERCES_CPP_NAMESPACE::DOMElement *dom() const;
 
 
-        // Setters
-        void setName(const std::string& name);
-        void setVersion(const Meta::Version& version);
-        void setDate(const std::string &date);
-        void setDescription(const std::string& description);
-        void addMaintainer(const Meta::Contact &maintainer);
-        void addLicense(const Meta::License &license);
-        void addUrl(const Meta::Url &url);
-        void addAuthor(const Meta::Contact &author);
-        void addDepend(const Meta::Dependency &dep);
-        void addConflict(const Meta::Dependency &dep);
-        void addReplace(const Meta::Dependency &dep);
-        void addTag(const std::string &tag);
-        void setIcon(const boost::filesystem::path& path);
-        void setClassname(const std::string& name);
-        void setSubdirectory(const boost::filesystem::path& path);
-        void addFile(const boost::filesystem::path &path);
-        void addContentItem(const std::string &tag, const Metadata &item);
-        void setFreeCADMin(const Meta::Version& version);
-        void setFreeCADMax(const Meta::Version &version);
-        void setPythonMin(const Meta::Version &version);
-        void addGenericMetadata(const std::string &tag, const Meta::GenericMetadata &genericMetadata);
+    // Setters
+    void setName(const std::string &name);
+    void setVersion(const Meta::Version &version);
+    void setDate(const std::string &date);
+    void setDescription(const std::string &description);
+    void addMaintainer(const Meta::Contact &maintainer);
+    void addLicense(const Meta::License &license);
+    void addUrl(const Meta::Url &url);
+    void addAuthor(const Meta::Contact &author);
+    void addDepend(const Meta::Dependency &dep);
+    void addConflict(const Meta::Dependency &dep);
+    void addReplace(const Meta::Dependency &dep);
+    void addTag(const std::string &tag);
+    void setIcon(const boost::filesystem::path &path);
+    void setClassname(const std::string &name);
+    void setSubdirectory(const boost::filesystem::path &path);
+    void addFile(const boost::filesystem::path &path);
+    void addContentItem(const std::string &tag, const Metadata &item);
+    void setFreeCADMin(const Meta::Version &version);
+    void setFreeCADMax(const Meta::Version &version);
+    void setPythonMin(const Meta::Version &version);
+    void addGenericMetadata(const std::string &tag, const Meta::GenericMetadata &genericMetadata);
 
-        // Deleters
-        void removeContentItem(const std::string &tag, const std::string &itemName);
-        void removeMaintainer(const Meta::Contact &maintainer);
-        void removeLicense(const Meta::License &license);
-        void removeUrl(const Meta::Url &url);
-        void removeAuthor(const Meta::Contact &author);
-        void removeDepend(const Meta::Dependency &dep);
-        void removeConflict(const Meta::Dependency &dep);
-        void removeReplace(const Meta::Dependency &dep);
-        void removeTag(const std::string &tag);
-        void removeFile(const boost::filesystem::path &path);
+    // Deleters
+    void removeContentItem(const std::string &tag, const std::string &itemName);
+    void removeMaintainer(const Meta::Contact &maintainer);
+    void removeLicense(const Meta::License &license);
+    void removeUrl(const Meta::Url &url);
+    void removeAuthor(const Meta::Contact &author);
+    void removeDepend(const Meta::Dependency &dep);
+    void removeConflict(const Meta::Dependency &dep);
+    void removeReplace(const Meta::Dependency &dep);
+    void removeTag(const std::string &tag);
+    void removeFile(const boost::filesystem::path &path);
 
-        // Utility functions to clear lists
-        void clearContent();
-        void clearMaintainer();
-        void clearLicense();
-        void clearUrl();
-        void clearAuthor();
-        void clearDepend();
-        void clearConflict();
-        void clearReplace();
-        void clearTag();
-        void clearFile();
+    // Utility functions to clear lists
+    void clearContent();
+    void clearMaintainer();
+    void clearLicense();
+    void clearUrl();
+    void clearAuthor();
+    void clearDepend();
+    void clearConflict();
+    void clearReplace();
+    void clearTag();
+    void clearFile();
 
-        /**
+    /**
          * Write the metadata to an XML file
          */
-        void write(const boost::filesystem::path& file) const;
+    void write(const boost::filesystem::path &file) const;
 
-        /**
+    /**
          * Determine whether this package satisfies the given dependency
          */
-        bool satisfies(const Meta::Dependency&);
+    bool satisfies(const Meta::Dependency &);
 
-        /**
+    /**
          * Determine whether the current metadata specifies support for the currently-running version of FreeCAD.
          * Does not interrogate content items, which must be querried individually.
          */
-        bool supportsCurrentFreeCAD() const;
+    bool supportsCurrentFreeCAD() const;
 
-    private:
+private:
+    std::string _name;
+    Meta::Version _version;
+    std::string _date;
+    std::string _description;
+    std::vector<Meta::Contact> _maintainer;
+    std::vector<Meta::License> _license;
+    std::vector<Meta::Url> _url;
+    std::vector<Meta::Contact> _author;
+    std::vector<Meta::Dependency> _depend;
+    std::vector<Meta::Dependency> _conflict;
+    std::vector<Meta::Dependency> _replace;
+    std::vector<std::string> _tag;
+    boost::filesystem::path _icon;
+    std::string _classname;
+    boost::filesystem::path _subdirectory;
+    std::vector<boost::filesystem::path> _file;
+    Meta::Version _freecadmin;
+    Meta::Version _freecadmax;
+    Meta::Version _pythonmin;
 
-        std::string _name;
-        Meta::Version _version;
-        std::string _date;
-        std::string _description;
-        std::vector<Meta::Contact> _maintainer;
-        std::vector<Meta::License> _license;
-        std::vector<Meta::Url> _url;
-        std::vector<Meta::Contact> _author;
-        std::vector<Meta::Dependency> _depend;
-        std::vector<Meta::Dependency> _conflict;
-        std::vector<Meta::Dependency> _replace;
-        std::vector<std::string> _tag;
-        boost::filesystem::path _icon;
-        std::string _classname;
-        boost::filesystem::path _subdirectory;
-        std::vector<boost::filesystem::path> _file;
-        Meta::Version _freecadmin;
-        Meta::Version _freecadmax;
-        Meta::Version _pythonmin;
+    std::multimap<std::string, Metadata> _content;
 
-        std::multimap<std::string, Metadata> _content;
+    std::multimap<std::string, Meta::GenericMetadata> _genericMetadata;
 
-        std::multimap<std::string, Meta::GenericMetadata> _genericMetadata;
+    XERCES_CPP_NAMESPACE::DOMElement *_dom;
+    std::shared_ptr<XERCES_CPP_NAMESPACE::XercesDOMParser> _parser;
 
-        XERCES_CPP_NAMESPACE::DOMElement* _dom;
-        std::shared_ptr<XERCES_CPP_NAMESPACE::XercesDOMParser> _parser;
+    void parseVersion1(const XERCES_CPP_NAMESPACE::DOMNode *startNode);
+    void parseContentNodeVersion1(const XERCES_CPP_NAMESPACE::DOMElement *contentNode);
 
-        void parseVersion1(const XERCES_CPP_NAMESPACE::DOMNode* startNode);
-        void parseContentNodeVersion1(const XERCES_CPP_NAMESPACE::DOMElement* contentNode);
+    void appendToElement(XERCES_CPP_NAMESPACE::DOMElement *root) const;
+};
 
-        void appendToElement(XERCES_CPP_NAMESPACE::DOMElement* root) const;
-
-    };
-
-}
+}// namespace App
 
 #endif

--- a/src/App/Metadata.h
+++ b/src/App/Metadata.h
@@ -220,6 +220,7 @@ namespace App {
         std::vector<boost::filesystem::path> file() const; //< Arbitrary files associated with this package or content item.
         Meta::Version freecadmin() const; //< The minimum FreeCAD version.
         Meta::Version freecadmax() const; //< The maximum FreeCAD version.
+        Meta::Version pythonmin() const; //< The minimum Python version.
 
         /**
          * Access the metadata for the content elements of this package
@@ -274,7 +275,8 @@ namespace App {
         void addFile(const boost::filesystem::path &path);
         void addContentItem(const std::string &tag, const Metadata &item);
         void setFreeCADMin(const Meta::Version& version);
-        void setFreeCADMax(const Meta::Version& version);
+        void setFreeCADMax(const Meta::Version &version);
+        void setPythonMin(const Meta::Version &version);
         void addGenericMetadata(const std::string &tag, const Meta::GenericMetadata &genericMetadata);
 
         // Deleters
@@ -337,6 +339,7 @@ namespace App {
         std::vector<boost::filesystem::path> _file;
         Meta::Version _freecadmin;
         Meta::Version _freecadmax;
+        Meta::Version _pythonmin;
 
         std::multimap<std::string, Metadata> _content;
 

--- a/src/App/MetadataPy.xml
+++ b/src/App/MetadataPy.xml
@@ -184,6 +184,14 @@ If unset it will be 0.0.0.</UserDocu>
             <Parameter Name="FreeCADMax" Type="Object" />
         </Attribute>
 
+        <Attribute Name="PythonMin">
+            <Documentation>
+                <UserDocu>String representing the minimum version of Python needed for this item.
+If unset it will be 0.0.0.</UserDocu>
+            </Documentation>
+            <Parameter Name="PythonMin" Type="Object" />
+        </Attribute>
+
         <Methode Name="getLastSupportedFreeCADVersion">
             <Documentation>
                 <UserDocu>getLastSupportedFreeCADVersion() -> str or None\n

--- a/src/App/MetadataPyImp.cpp
+++ b/src/App/MetadataPyImp.cpp
@@ -864,6 +864,21 @@ void MetadataPy::setFreeCADMax(Py::Object args)
         getMetadataPtr()->setFreeCADMax(App::Meta::Version());
 }
 
+Py::Object MetadataPy::getPythonMin() const
+{
+    return Py::String(getMetadataPtr()->pythonmin().str());
+}
+
+void MetadataPy::setPythonMin(Py::Object args)
+{
+    char *version = nullptr;
+    PyObject *p = args.ptr();
+    if (!PyArg_Parse(p, "z", &version)) throw Py::Exception();
+    if (version) getMetadataPtr()->setPythonMin(App::Meta::Version(version));
+    else
+        getMetadataPtr()->setPythonMin(App::Meta::Version());
+}
+
 PyObject *MetadataPy::getFirstSupportedFreeCADVersion(PyObject *p)
 {
     if (!PyArg_ParseTuple(p, ""))

--- a/src/Mod/AddonManager/addonmanager_devmode_add_content.py
+++ b/src/Mod/AddonManager/addonmanager_devmode_add_content.py
@@ -20,7 +20,7 @@
 # *                                                                         *
 # ***************************************************************************
 
-""" Contains a class for adding a single content item, as well as auxilliary classes for
+""" Contains a class for adding a single content item, as well as auxiliary classes for
 its dependent dialog boxes. """
 
 import os
@@ -547,7 +547,7 @@ class EditDependency:
         if dep_type and dep_name:
             index = self.dialog.typeComboBox.findData(dep_type)
             if index == -1:
-                raise RuntimeError(f"Invaid dependency type {dep_type}")
+                raise RuntimeError(f"Invalid dependency type {dep_type}")
             self.dialog.typeComboBox.setCurrentIndex(index)
             index = self.dialog.dependencyComboBox.findData(dep_name)
             if index == -1:

--- a/src/Mod/AddonManager/addonmanager_macro.py
+++ b/src/Mod/AddonManager/addonmanager_macro.py
@@ -345,7 +345,7 @@ class Macro:
 
     def clean_icon(self):
         """Downloads the macro's icon from whatever source is specified and stores a local
-        copy, potentially updating the interal icon location to that local storage."""
+        copy, potentially updating the internal icon location to that local storage."""
         if self.icon.startswith("http://") or self.icon.startswith("https://"):
             FreeCAD.Console.PrintLog(
                 f"Attempting to fetch macro icon from {self.icon}\n"

--- a/src/Mod/AddonManager/addonmanager_utilities.py
+++ b/src/Mod/AddonManager/addonmanager_utilities.py
@@ -339,6 +339,7 @@ def get_python_exe() -> str:
     if not python_exe or not os.path.exists(python_exe):
         return ""
 
+    python_exe = python_exe.replace("/",os.path.sep)
     prefs.SetString("PythonExecutableForPip", python_exe)
     return python_exe
 

--- a/src/Mod/AddonManager/addonmanager_workers_installation.py
+++ b/src/Mod/AddonManager/addonmanager_workers_installation.py
@@ -377,7 +377,7 @@ class DependencyInstallationWorker(QtCore.QThread):
     def __init__(
         self,
         addons: List[Addon],
-        python_required: List[str],
+        python_requires: List[str],
         python_optional: List[str],
         location: os.PathLike = None,
     ):
@@ -387,7 +387,7 @@ class DependencyInstallationWorker(QtCore.QThread):
         for testing purposes and shouldn't be set by normal code in most circumstances."""
         QtCore.QThread.__init__(self)
         self.addons = addons
-        self.python_required = python_required
+        self.python_requires = python_requires
         self.python_optional = python_optional
         self.location = location
 
@@ -395,7 +395,7 @@ class DependencyInstallationWorker(QtCore.QThread):
         """Normally not called directly: create the object and call start() to launch it
         in its own thread. Installs dependencies for the Addon."""
         self._install_required_addons()
-        if self.python_required or self.python_optional:
+        if self.python_requires or self.python_optional:
             self._install_python_packages()
         self.success.emit()
 
@@ -464,7 +464,7 @@ class DependencyInstallationWorker(QtCore.QThread):
         """Install the required Python package dependencies. If any fail a failure signal is
         emitted and the function exits without proceeding with any additional installs."""
         python_exe = utils.get_python_exe()
-        for pymod in self.python_required:
+        for pymod in self.python_requires:
             if QtCore.QThread.currentThread().isInterruptionRequested():
                 return
             proc = subprocess.run(

--- a/src/Mod/AddonManager/addonmanager_workers_startup.py
+++ b/src/Mod/AddonManager/addonmanager_workers_startup.py
@@ -331,7 +331,9 @@ class CreateAddonListWorker(QtCore.QThread):
                 + "\n"
             )
             try:
-                os.chdir(os.path.join(macro_cache_location,"..")) # Make sure we are not IN this directory
+                os.chdir(
+                    os.path.join(macro_cache_location, "..")
+                )  # Make sure we are not IN this directory
                 shutil.rmtree(macro_cache_location, onerror=self._remove_readonly)
                 self.git_manager.clone(
                     "https://github.com/FreeCAD/FreeCAD-macros.git",
@@ -449,10 +451,11 @@ class LoadPackagesFromCacheWorker(QtCore.QThread):
                             repo.updated_timestamp = os.path.getmtime(
                                 repo_metadata_cache_path
                             )
-                        except Exception:
+                        except Exception as e:
                             FreeCAD.Console.PrintLog(
                                 f"Failed loading {repo_metadata_cache_path}\n"
                             )
+                            FreeCAD.Console.PrintLog(str(e) + "\n")
                     self.addon_repo.emit(repo)
 
 

--- a/src/Mod/AddonManager/developer_mode.ui
+++ b/src/Mod/AddonManager/developer_mode.ui
@@ -54,95 +54,6 @@
       <string>Metadata</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
-      <item row="12" column="0">
-       <widget class="QLabel" name="labelIcon">
-        <property name="text">
-         <string>Icon</string>
-        </property>
-       </widget>
-      </item>
-      <item row="7" column="0">
-       <widget class="QLabel" name="labelReadmeURL">
-        <property name="text">
-         <string>README URL</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QLineEdit" name="displayNameLineEdit">
-        <property name="toolTip">
-         <string>Displayed in the Addon Manager's list of Addons. Should not include the word &quot;FreeCAD&quot;, and must be a valid directory name on all support operating systems.</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QPlainTextEdit" name="descriptionTextEdit">
-        <property name="toolTip">
-         <string>Explanation of what this Addon provides. Displayed in the Addon Manager. It is not necessary for this to state that this is a FreeCAD Addon.</string>
-        </property>
-        <property name="tabChangesFocus">
-         <bool>true</bool>
-        </property>
-        <property name="placeholderText">
-         <string>TIP: Since this is displayed within FreeCAD, in the Addon Manager, it is not necessary to take up space saying things like &quot;This is a FreeCAD Addon...&quot; -- just say what it does.</string>
-        </property>
-       </widget>
-      </item>
-      <item row="7" column="1">
-       <widget class="QLineEdit" name="readmeURLLineEdit">
-        <property name="placeholderText">
-         <string>(Recommended)</string>
-        </property>
-       </widget>
-      </item>
-      <item row="8" column="1">
-       <widget class="QLineEdit" name="websiteURLLineEdit">
-        <property name="placeholderText">
-         <string>(Optional)</string>
-        </property>
-       </widget>
-      </item>
-      <item row="9" column="1">
-       <widget class="QLineEdit" name="bugtrackerURLLineEdit">
-        <property name="placeholderText">
-         <string>(Optional)</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0" colspan="2">
-       <layout class="QHBoxLayout" name="peopleAndLicenseshorizontalLayout"/>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="labelDisplayName">
-        <property name="toolTip">
-         <string>Displayed in the Addon Manager's list of Addons. Should not include the word &quot;FreeCAD&quot;, and must be a valid directory name on all support operating systems.</string>
-        </property>
-        <property name="text">
-         <string>Addon Name</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="labelVersion">
-        <property name="text">
-         <string>Version</string>
-        </property>
-       </widget>
-      </item>
-      <item row="10" column="0">
-       <widget class="QLabel" name="labelDocumentationURL">
-        <property name="text">
-         <string>Documentation URL</string>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="0">
-       <widget class="QLabel" name="labelRepoURL">
-        <property name="text">
-         <string>Repository URL</string>
-        </property>
-       </widget>
-      </item>
       <item row="6" column="1">
        <layout class="QHBoxLayout" name="horizontalLayout_6">
         <item>
@@ -160,13 +71,6 @@
         </item>
        </layout>
       </item>
-      <item row="11" column="0">
-       <widget class="QLabel" name="labelDiscssionURL">
-        <property name="text">
-         <string>Discussion URL</string>
-        </property>
-       </widget>
-      </item>
       <item row="1" column="0">
        <widget class="QLabel" name="labelDescription">
         <property name="toolTip">
@@ -180,17 +84,17 @@
         </property>
        </widget>
       </item>
-      <item row="10" column="1">
-       <widget class="QLineEdit" name="documentationURLLineEdit">
-        <property name="placeholderText">
-         <string>(Optional)</string>
+      <item row="11" column="0">
+       <widget class="QLabel" name="labelDiscssionURL">
+        <property name="text">
+         <string>Discussion URL</string>
         </property>
        </widget>
       </item>
-      <item row="8" column="0">
-       <widget class="QLabel" name="labelWebsiteURL">
+      <item row="13" column="0">
+       <widget class="QLabel" name="labelIcon">
         <property name="text">
-         <string>Website URL</string>
+         <string>Icon</string>
         </property>
        </widget>
       </item>
@@ -219,7 +123,65 @@
         </item>
        </layout>
       </item>
-      <item row="12" column="1">
+      <item row="3" column="0" colspan="2">
+       <layout class="QHBoxLayout" name="peopleAndLicenseshorizontalLayout"/>
+      </item>
+      <item row="11" column="1">
+       <widget class="QLineEdit" name="discussionURLLineEdit">
+        <property name="placeholderText">
+         <string>(Optional)</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLineEdit" name="displayNameLineEdit">
+        <property name="toolTip">
+         <string>Displayed in the Addon Manager's list of Addons. Should not include the word &quot;FreeCAD&quot;, and must be a valid directory name on all support operating systems.</string>
+        </property>
+       </widget>
+      </item>
+      <item row="10" column="1">
+       <widget class="QLineEdit" name="documentationURLLineEdit">
+        <property name="placeholderText">
+         <string>(Optional)</string>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="0">
+       <widget class="QLabel" name="labelReadmeURL">
+        <property name="text">
+         <string>README URL</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QPlainTextEdit" name="descriptionTextEdit">
+        <property name="toolTip">
+         <string>Explanation of what this Addon provides. Displayed in the Addon Manager. It is not necessary for this to state that this is a FreeCAD Addon.</string>
+        </property>
+        <property name="tabChangesFocus">
+         <bool>true</bool>
+        </property>
+        <property name="placeholderText">
+         <string>TIP: Since this is displayed within FreeCAD, in the Addon Manager, it is not necessary to take up space saying things like &quot;This is a FreeCAD Addon...&quot; -- just say what it does.</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="0">
+       <widget class="QLabel" name="labelRepoURL">
+        <property name="text">
+         <string>Repository URL</string>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="1">
+       <widget class="QLineEdit" name="websiteURLLineEdit">
+        <property name="placeholderText">
+         <string>(Optional)</string>
+        </property>
+       </widget>
+      </item>
+      <item row="13" column="1">
        <layout class="QHBoxLayout" name="iconHorizontalLayout">
         <item>
          <widget class="QLabel" name="iconDisplayLabel"/>
@@ -236,12 +198,75 @@
         </item>
        </layout>
       </item>
-      <item row="11" column="1">
-       <widget class="QLineEdit" name="discussionURLLineEdit">
+      <item row="8" column="0">
+       <widget class="QLabel" name="labelWebsiteURL">
+        <property name="text">
+         <string>Website URL</string>
+        </property>
+       </widget>
+      </item>
+      <item row="10" column="0">
+       <widget class="QLabel" name="labelDocumentationURL">
+        <property name="text">
+         <string>Documentation URL</string>
+        </property>
+       </widget>
+      </item>
+      <item row="9" column="1">
+       <widget class="QLineEdit" name="bugtrackerURLLineEdit">
         <property name="placeholderText">
          <string>(Optional)</string>
         </property>
        </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="labelDisplayName">
+        <property name="toolTip">
+         <string>Displayed in the Addon Manager's list of Addons. Should not include the word &quot;FreeCAD&quot;, and must be a valid directory name on all support operating systems.</string>
+        </property>
+        <property name="text">
+         <string>Addon Name</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="labelVersion">
+        <property name="text">
+         <string>Version</string>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="1">
+       <widget class="QLineEdit" name="readmeURLLineEdit">
+        <property name="placeholderText">
+         <string>(Recommended)</string>
+        </property>
+       </widget>
+      </item>
+      <item row="12" column="0">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Minimum Python</string>
+        </property>
+       </widget>
+      </item>
+      <item row="12" column="1">
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="QLineEdit" name="minPythonLineEdit">
+          <property name="placeholderText">
+           <string>(Optional, only 3.x version supported)</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="detectMinPythonButton">
+          <property name="text">
+           <string>Detect...</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
      </layout>
     </widget>


### PR DESCRIPTION
Add support for a `<pythonmin>` tag in the package.xml metadata file, and add auto detection of the required Python version to Addon Manager Developer Mode.