### PR TITLE
Remove redundant reference to C++14

### DIFF
--- a/cMake/FreeCAD_Helpers/CompilerChecksAndSetups.cmake
+++ b/cMake/FreeCAD_Helpers/CompilerChecksAndSetups.cmake
@@ -46,8 +46,6 @@ macro(CompilerChecksAndSetups)
         set(CMAKE_CXX_STANDARD 20)
     elseif(${BUILD_ENABLE_CXX_STD} MATCHES "C\\+\\+17")
         set(CMAKE_CXX_STANDARD 17)
-    elseif(${BUILD_ENABLE_CXX_STD} MATCHES "C\\+\\+14")
-        set(CMAKE_CXX_STANDARD 14)
     endif()
 
     # Log the compiler and version


### PR DESCRIPTION
C++14 has been previously deprecated for FreeCAD