### PR TITLE
Path: showed stock size

### DIFF
--- a/src/Mod/Path/PathScripts/PathStock.py
+++ b/src/Mod/Path/PathScripts/PathStock.py
@@ -173,7 +173,7 @@ class StockFromBase(Stock):
             "App::PropertyString",
             "Length",
             "Stock",
-            QT_TRANSLATE_NOOP("App::Property", "Stock lenght"),
+            QT_TRANSLATE_NOOP("App::Property", "Stock length"),
         )
         obj.setEditorMode("Length", 1)  # read-only
         obj.addProperty(

--- a/src/Mod/Path/PathScripts/PathStock.py
+++ b/src/Mod/Path/PathScripts/PathStock.py
@@ -169,6 +169,27 @@ class StockFromBase(Stock):
             "Component",
             QT_TRANSLATE_NOOP("App::Property", "A material for this object"),
         )
+        obj.addProperty(
+            "App::PropertyString",
+            "Length",
+            "Stock",
+            QT_TRANSLATE_NOOP("App::Property", "Stock lenght"),
+        )
+        obj.setEditorMode("Length", 1)  # read-only
+        obj.addProperty(
+            "App::PropertyString",
+            "Width",
+            "Stock",
+            QT_TRANSLATE_NOOP("App::Property", "Stock width"),
+        )
+        obj.setEditorMode("Width", 1)  # read-only
+        obj.addProperty(
+            "App::PropertyString",
+            "Height",
+            "Stock",
+            QT_TRANSLATE_NOOP("App::Property", "Stock height"),
+        )
+        obj.setEditorMode("Height", 1)  # read-only
 
         obj.Base = base
         obj.ExtXneg = 1.0
@@ -222,6 +243,10 @@ class StockFromBase(Stock):
             shape = Part.makeBox(self.length, self.width, self.height, self.origin)
             shape.Placement = obj.Placement
             obj.Shape = shape
+            obj.Length=FreeCAD.Units.Quantity(self.length, FreeCAD.Units.Length).UserString
+            obj.Width=FreeCAD.Units.Quantity(self.width, FreeCAD.Units.Length).UserString
+            obj.Height=FreeCAD.Units.Quantity(self.height, FreeCAD.Units.Length).UserString
+
 
     def onChanged(self, obj, prop):
         if (


### PR DESCRIPTION
When a path stock is "extend model's bound box" the stock size is showed.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [ ]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [ ]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [ ]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [ ]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the issue ID number from our [Issues database](https://github.com/FreeCAD/FreeCAD/issues) in case a particular commit solves or is related to an existing issue. Ex: `Draft: fix typos - fixes #4805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
