### PR TITLE
[Bugfix]Gui: TinkerCAD mouse mode was always stopping RMB propagation

### DIFF
--- a/src/Gui/TinkerCADNavigationStyle.cpp
+++ b/src/Gui/TinkerCADNavigationStyle.cpp
@@ -114,7 +114,7 @@ SbBool TinkerCADNavigationStyle::processSoEvent(const SoEvent * const ev)
         const auto event = (const SoMouseButtonEvent *) ev;
         const int button = event->getButton();
         const SbBool press = event->getState() == SoButtonEvent::DOWN ? true : false;
-        SbBool canOpenPopupMenu = false;
+        SbBool shortRMBclick = false;
 
         switch (button) {
         case SoMouseButtonEvent::BUTTON1:
@@ -144,7 +144,7 @@ SbBool TinkerCADNavigationStyle::processSoEvent(const SoEvent * const ev)
                 float dci = float(QApplication::doubleClickInterval())/1000.0f;
                 // time between press and release event
                 if (tmp.getValue() < dci) {
-                    canOpenPopupMenu = true;
+                    shortRMBclick = true;
                 }
             }
 
@@ -156,14 +156,16 @@ SbBool TinkerCADNavigationStyle::processSoEvent(const SoEvent * const ev)
                 processed = true;
             }
             else if (!press && (curmode == NavigationStyle::DRAGGING)) {
-                if (!viewer->isEditing() && canOpenPopupMenu) {
-                    // If we are in drag mode but mouse hasn't been moved open the context-menu
-                    if (this->isPopupMenuEnabled()) {
-                        this->openPopupMenu(event->getPosition());
+                if (shortRMBclick) {
+                    newmode = NavigationStyle::IDLE;
+                    if (!viewer->isEditing()) {
+                        // If we are in drag mode but mouse hasn't been moved open the context-menu
+                        if (this->isPopupMenuEnabled()) {
+                            this->openPopupMenu(event->getPosition());
+                        }
+                        processed = true;
                     }
                 }
-                newmode = NavigationStyle::IDLE;
-                processed = true;
             }
             break;
         case SoMouseButtonEvent::BUTTON3:


### PR DESCRIPTION
https://forum.freecadweb.org/viewtopic.php?f=3&t=72174

Bugs comes from TinkerCAD mode using RMB dragging to rotate view.
So it has to itself handle when a user makes a short "single" click with RMB.
There was a problem with how conditions was nested, so actually it was always catching the mouse event -- stopping propagation -- even when the viewer was in Edit mode (which it shouldn't).
This for example prevents Sketcher tools to be exited with RMB.
The PR brings a correct behavior in case of short "single" RMB click : if viewer is not in Edit mode, the event is caught and processed ; if viewer is in Edit mode, the event is ignored and let free to propagate.