### PR TITLE
Improve text color management in Report view + Python console + Macro editor

### DIFF
--- a/src/Gui/DlgEditorImp.cpp
+++ b/src/Gui/DlgEditorImp.cpp
@@ -68,7 +68,7 @@ DlgSettingsEditorImp::DlgSettingsEditorImp( QWidget* parent )
 
     d = new DlgSettingsEditorP();
     QColor col;
-    col = Qt::black;
+    col = qApp->palette().windowText().color();
     unsigned int lText = (col.red() << 24) | (col.green() << 16) | (col.blue() << 8);
     d->colormap.push_back(QPair<QString, unsigned int>
         (QString::fromLatin1(QT_TR_NOOP("Text")), lText));

--- a/src/Gui/DlgReportViewImp.cpp
+++ b/src/Gui/DlgReportViewImp.cpp
@@ -42,6 +42,7 @@ DlgReportViewImp::DlgReportViewImp( QWidget* parent )
   , ui(new Ui_DlgReportView)
 {
     ui->setupUi(this);
+    ui->colorText->setColor(qApp->palette().windowText().color());
 }
 
 /**

--- a/src/Gui/PythonConsole.cpp
+++ b/src/Gui/PythonConsole.cpp
@@ -100,7 +100,7 @@ struct PythonConsoleP
         callTipsList = nullptr;
         interactive = false;
         historyFile = QString::fromUtf8((App::Application::getUserAppDataDir() + "PythonHistory.log").c_str());
-        colormap[QLatin1String("Text")] = Qt::black;
+        colormap[QLatin1String("Text")] = qApp->palette().windowText().color();
         colormap[QLatin1String("Bookmark")] = Qt::cyan;
         colormap[QLatin1String("Breakpoint")] = Qt::red;
         colormap[QLatin1String("Keyword")] = Qt::blue;
@@ -932,7 +932,7 @@ void PythonConsole::changeEvent(QEvent *e)
         }
     }
     else if (e->type() == QEvent::StyleChange) {
-        QPalette pal = palette();
+        QPalette pal = qApp->palette();
         QColor color = pal.windowText().color();
         unsigned int text = (color.red() << 24) | (color.green() << 16) | (color.blue() << 8);
         auto value = static_cast<unsigned long>(text);

--- a/src/Gui/ReportView.cpp
+++ b/src/Gui/ReportView.cpp
@@ -526,7 +526,7 @@ bool ReportOutput::event(QEvent* event)
 void ReportOutput::changeEvent(QEvent *ev)
 {
     if (ev->type() == QEvent::StyleChange) {
-        QPalette pal = palette();
+        QPalette pal = qApp->palette();
         QColor color = pal.windowText().color();
         unsigned int text = (color.red() << 24) | (color.green() << 16) | (color.blue() << 8);
         auto value = static_cast<unsigned long>(text);

--- a/src/Gui/SyntaxHighlighter.cpp
+++ b/src/Gui/SyntaxHighlighter.cpp
@@ -22,6 +22,9 @@
 
 #include "PreCompiled.h"
 
+#include <QApplication>
+#include <QPalette>
+
 #include "SyntaxHighlighter.h"
 
 
@@ -33,11 +36,16 @@ class SyntaxHighlighterP
 public:
     SyntaxHighlighterP()
     {
-        cNormalText.setRgb(0, 0, 0); cComment.setRgb(0, 170, 0);
-        cBlockcomment.setRgb(160, 160, 164); cLiteral.setRgb(255, 0, 0);
-        cNumber.setRgb(0, 0, 255); cOperator.setRgb(160, 160, 164);
-        cKeyword.setRgb(0, 0, 255); cClassName.setRgb(255, 170, 0);
-        cDefineName.setRgb(255, 170, 0); cOutput.setRgb(170, 170, 127);
+        cNormalText = qApp->palette().windowText().color();
+        cComment.setRgb(0, 170, 0);
+        cBlockcomment.setRgb(160, 160, 164);
+        cLiteral.setRgb(255, 0, 0);
+        cNumber.setRgb(0, 0, 255);
+        cOperator.setRgb(160, 160, 164);
+        cKeyword.setRgb(0, 0, 255);
+        cClassName.setRgb(255, 170, 0);
+        cDefineName.setRgb(255, 170, 0);
+        cOutput.setRgb(170, 170, 127);
         cError.setRgb(255, 0, 0);
     }
 

--- a/src/Gui/TextEdit.cpp
+++ b/src/Gui/TextEdit.cpp
@@ -23,6 +23,7 @@
 #include "PreCompiled.h"
 
 #ifndef _PreComp_
+# include <QApplication>
 # include <QKeyEvent>
 # include <QPainter>
 # include <QShortcut>
@@ -195,7 +196,7 @@ struct TextEditorP
     QMap<QString, QColor> colormap; // Color map
     TextEditorP()
     {
-        colormap[QLatin1String("Text")] = Qt::black;
+        colormap[QLatin1String("Text")] = qApp->palette().windowText().color();
         colormap[QLatin1String("Bookmark")] = Qt::cyan;
         colormap[QLatin1String("Breakpoint")] = Qt::red;
         colormap[QLatin1String("Keyword")] = Qt::blue;


### PR DESCRIPTION
Both problems solved here come when you apply an OS native dark theme -- keeping default FC theme --.
In this case you are provided with a dark background for widgets, but it's not ideally managed in FC.

1st commit solves a problem that when you have a blank config, the color of the normal messages color in the Report view is chosen by Qt. With a dark OS theme, this text turns to white -- good --. The problem is that when opening the Preferences editor, the default value is always initialized to black, so if you save your preferences (for any reason), you will now get black text over dark background, which is unreadable. With this commit, the default value in the Preferences editor is initialized with the current text color used in the FC app.

2nd commit solves another similar problem existing in Python console & Macro editor. In these 2 widgets, the default color for code instructions is always black, making it unreadable on dark themes. With this commit, the color defaults to the one currently used in the FC app for normal texts.