### PR TITLE
Addon Manager: Improve failed pip behavior

### DIFF
--- a/src/Mod/AddonManager/AddonManager.py
+++ b/src/Mod/AddonManager/AddonManager.py
@@ -65,7 +65,6 @@ from install_to_toolbar import (
     remove_custom_toolbar_button,
 )
 from manage_python_dependencies import (
-    CheckForPythonPackageUpdatesWorker,
     PythonPackageManager,
 )
 from addonmanager_devmode import DeveloperMode
@@ -915,23 +914,8 @@ class CommandAddonManager:
         self.dialog.buttonCheckForUpdates.setEnabled(True)
 
     def check_python_updates(self) -> None:
-        if hasattr(self, "check_for_python_package_updates_worker"):
-            thread = self.check_for_python_package_updates_worker
-            if thread:
-                if not thread.isFinished():
-                    self.do_next_startup_phase()
-                    return
-        self.check_for_python_package_updates_worker = (
-            CheckForPythonPackageUpdatesWorker()
-        )
-        self.check_for_python_package_updates_worker.python_package_updates_available.connect(
-            lambda: self.dialog.buttonUpdateDependencies.show()
-        )
-        self.check_for_python_package_updates_worker.finished.connect(
-            self.do_next_startup_phase
-        )
         self.update_allowed_packages_list()  # Not really the best place for it...
-        self.check_for_python_package_updates_worker.start()
+        self.do_next_startup_phase()
 
     def show_python_updates_dialog(self) -> None:
         if not hasattr(self, "manage_python_packages_dialog"):

--- a/src/Mod/AddonManager/manage_python_dependencies.py
+++ b/src/Mod/AddonManager/manage_python_dependencies.py
@@ -90,13 +90,16 @@ def call_pip(args) -> List[str]:
         call_args.extend(args)
         proc = None
         try:
+            no_window_flag = 0
+            if hasattr(subprocess,"CREATE_NO_WINDOW"):
+                no_window_flag = subprocess.CREATE_NO_WINDOW # Added in Python 3.7
             proc = subprocess.run(
                 call_args,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
-                shell=True,
                 check=True,
                 timeout=30,
+                creationflags=no_window_flag,
             )
             if proc.returncode != 0:
                 pip_failed = True

--- a/src/Mod/AddonManager/manage_python_dependencies.py
+++ b/src/Mod/AddonManager/manage_python_dependencies.py
@@ -37,6 +37,7 @@ import addonmanager_utilities as utils
 
 translate = FreeCAD.Qt.translate
 
+#pylint: disable=too-few-public-methods
 
 class PipFailed(Exception):
     """Exception thrown when pip times out or otherwise fails to return valid results"""
@@ -51,17 +52,17 @@ class CheckForPythonPackageUpdatesWorker(QtCore.QThread):
         QtCore.QThread.__init__(self)
 
     def run(self):
-        """Usually not called directly: instead, instantiate this class and call its start() function
-        in a parent thread. emits a python_package_updates_available signal if updates are available
-        for any of the installed Python packages."""
+        """Usually not called directly: instead, instantiate this class and call its start()
+        function in a parent thread. emits a python_package_updates_available signal if updates
+        are available for any of the installed Python packages."""
 
         if check_for_python_package_updates():
             self.python_package_updates_available.emit()
 
 
 def check_for_python_package_updates() -> bool:
-    """Returns True if any of the Python packages installed into the AdditionalPythonPackages directory
-    have updates available, or False if the are all up-to-date."""
+    """Returns True if any of the Python packages installed into the AdditionalPythonPackages
+    directory have updates available, or False if the are all up-to-date."""
 
     vendor_path = os.path.join(FreeCAD.getUserAppDataDir(), "AdditionalPythonPackages")
     package_counter = 0
@@ -79,8 +80,8 @@ def check_for_python_package_updates() -> bool:
 
 
 def call_pip(args) -> List[str]:
-    """Tries to locate the appropriate Python executable and run pip with version checking disabled. Fails
-    if Python can't be found or if pip is not installed."""
+    """Tries to locate the appropriate Python executable and run pip with version checking
+    disabled. Fails if Python can't be found or if pip is not installed."""
 
     python_exe = utils.get_python_exe()
     pip_failed = False
@@ -127,7 +128,8 @@ def call_pip(args) -> List[str]:
 
 class PythonPackageManager:
 
-    """A GUI-based pip interface allowing packages to be updated, either individually or all at once."""
+    """A GUI-based pip interface allowing packages to be updated, either individually or all at
+    once."""
 
     def __init__(self, addons):
         self.dlg = FreeCADGui.PySideUic.loadUi(
@@ -244,8 +246,8 @@ class PythonPackageManager:
     def _parse_pip_list_output(
         self, all_packages, outdated_packages
     ) -> Dict[str, Dict[str, str]]:
-        """Parses the output from pip into a dictionary with update information in it. The pip output should
-        be an array of lines of text."""
+        """Parses the output from pip into a dictionary with update information in it. The pip
+        output should be an array of lines of text."""
 
         # All Packages output looks like this:
         # Package    Version


### PR DESCRIPTION
For some users `pip` is timing out after 30 seconds, rather than returning a list of packages to update. It's not clear why this is happening yet, but in the meantime, try to improve the behavior of the code when it happens.