### PR TITLE
Draft: Fix handling of double quotes in shapestrings

### DIFF
--- a/src/Mod/Draft/drafttaskpanels/task_shapestring.py
+++ b/src/Mod/Draft/drafttaskpanels/task_shapestring.py
@@ -160,7 +160,8 @@ class ShapeStringTaskPanelCmd(ShapeStringTaskPanel):
     def createObject(self):
         """Create object in the current document."""
         dquote = '"'
-        String = dquote + self.form.leString.text() + dquote
+        String = self.form.leString.text()
+        String = dquote + String.replace(dquote, '\\"') + dquote
         FFile = dquote + str(self.fileSpec) + dquote
 
         Size = str(App.Units.Quantity(self.form.sbHeight.text()).Value)


### PR DESCRIPTION
Double quotes in the task panel input string need to be escaped.

Forum topic:
https://forum.freecadweb.org/viewtopic.php?f=23&t=72342

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the issue ID number from our [Issues database](https://github.com/FreeCAD/FreeCAD/issues) in case a particular commit solves or is related to an existing issue. Ex: `Draft: fix typos - fixes #4805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
