### PR TITLE
[Bugfix]CI: disable line-ending conversion as it damages .FCStd files

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -221,6 +221,7 @@ jobs:
           echo "" >> ${{ env.logdir }}checkReport.md
 
       - name: Harmonize Line endings
+        if: false #disabled because it causes failure when applied on .FCStd files
         id: harmonize-line-endings
         shell: bash
         run: |


### PR DESCRIPTION
https://forum.freecadweb.org/viewtopic.php?f=10&t=72142

@wwmayer @chennes @donovaly May one merge quickly please ? This makes CI fails for no reason. Detailed explanations on forum thread. Thx