### PR TITLE
[skip ci] codespell: correct ignore list entry

### DIFF
--- a/.github/codespellignore
+++ b/.github/codespellignore
@@ -33,7 +33,7 @@ hist
 indicies
 inout
 ist
-itSel
+itsel
 lod
 mantatory
 mata


### PR DESCRIPTION
All codespell ignore words should be lowercase.