### PR TITLE
[Bugfix]Sheet: fix issue with merged cells when removing rows, fixes #7575

### DIFF
--- a/src/Mod/Spreadsheet/App/PropertySheet.cpp
+++ b/src/Mod/Spreadsheet/App/PropertySheet.cpp
@@ -1068,8 +1068,8 @@ void PropertySheet::splitCell(CellAddress address)
     AtomicPropertyChange signaller(*this);
     cellAt(anchor)->getSpans(rows, cols);
 
-    for (int r = anchor.row(); r <= anchor.row() + rows; ++r)
-        for (int c = anchor.col(); c <= anchor.col() + cols; ++c) {
+    for (int r = anchor.row(); r < anchor.row() + rows; ++r)
+        for (int c = anchor.col(); c < anchor.col() + cols; ++c) {
             setDirty(CellAddress(r, c));
             mergedCells.erase(CellAddress(r, c));
         }


### PR DESCRIPTION
https://forum.freecadweb.org/viewtopic.php?f=3&t=72403

I managed to find a flaw in the code that is fixed by commit of this PR.

However, there still is an issue with border rendering when you have 2 subsequent rows with merged cells, with 2 spans from different width vertically overlapping.

To reproduce, you can take attached file and remove one of the toppest rows in the spreadsheet
[testsheet.zip](https://github.com/FreeCAD/FreeCAD/files/9744891/testsheet.zip)

I spent some time trying to analyze to no avail.
Could someone help there ? @wwmayer @chennes 
@realthunder Saw you recently played with border rendering. Maybe it gave you a good understanding. ;)
