### PR TITLE
Draft: Fix alignment of angular dimension arrows in svg.py

### DIFF
--- a/src/Mod/Draft/draftfunctions/svg.py
+++ b/src/Mod/Draft/draftfunctions/svg.py
@@ -544,25 +544,24 @@ def get_svg(obj,
                         p2 = get_proj(prx.p2, plane)
                         p3 = get_proj(prx.p3, plane)
                         arrowsize = obj.ViewObject.ArrowSize.Value/pointratio
-                        arrowlength = 4*obj.ViewObject.ArrowSize.Value
+                        halfarrowlength = 2 * arrowsize
+                        arrowangle = 2 * math.asin(halfarrowlength / prx.circle.Curve.Radius)
+                        if hasattr(obj.ViewObject, "FlipArrows") \
+                                and obj.ViewObject.FlipArrows:
+                            arrowangle = -arrowangle
 
                         _v1a = prx.circle.valueAt(prx.circle.FirstParameter
-                                                  + arrowlength)
+                                                  + arrowangle)
                         _v1b = prx.circle.valueAt(prx.circle.FirstParameter)
 
                         _v2a = prx.circle.valueAt(prx.circle.LastParameter
-                                                  - arrowlength)
+                                                  - arrowangle)
                         _v2b = prx.circle.valueAt(prx.circle.LastParameter)
 
                         u1 = get_proj(_v1a - _v1b, plane)
                         u2 = get_proj(_v2a - _v2b, plane)
                         angle1 = -DraftVecUtils.angle(u1)
                         angle2 = -DraftVecUtils.angle(u2)
-
-                        if hasattr(obj.ViewObject, "FlipArrows"):
-                            if obj.ViewObject.FlipArrows:
-                                angle1 = angle1 + math.pi
-                                angle2 = angle2 + math.pi
 
                         svg += get_arrow(obj,
                                          obj.ViewObject.ArrowType,
@@ -580,7 +579,7 @@ def get_svg(obj,
                         t = prx.circle.tangentAt(prx.circle.FirstParameter
                                                  + _diff/2.0)
                         t = get_proj(t, plane)
-                        tangle = DraftVecUtils.angle(t)
+                        tangle = -DraftVecUtils.angle(t)
                         if (tangle <= -math.pi/2) or (tangle > math.pi/2):
                             tangle = tangle + math.pi
 


### PR DESCRIPTION
This was missed in https://github.com/FreeCAD/FreeCAD/pull/7453.

Additionally: Changed the sign of `tangle`.

Two issues to look at later:
1. The value of `pointratio` seems to be wrong. The arrows appear bigger in a TechDraw_DraftView than in the 3D view.
2. The texts of angular dimensions are rotated to a 'readable' angle in a TechDraw_DraftView, this does not happen in the 3D view.

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the issue ID number from our [Issues database](https://github.com/FreeCAD/FreeCAD/issues) in case a particular commit solves or is related to an existing issue. Ex: `Draft: fix typos - fixes #4805`

---
