### PR TITLE
[TD] Explicitly call `std::signbit`

### DIFF
--- a/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp
+++ b/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp
@@ -876,7 +876,7 @@ void execCascadeHorizDimension(Gui::Command* cmd) {
     }
     float yMaster = validDimension[0]->Y.getValue();
     float dimDistance = activeDimAttributes.getCascadeSpacing();
-    if (signbit(yMaster))
+    if (std::signbit(yMaster))
         dimDistance = -dimDistance;
     for (auto dim : validDimension) {
         dim->Y.setValue(yMaster);
@@ -942,7 +942,7 @@ void execCascadeVertDimension(Gui::Command* cmd) {
     }
     float xMaster = validDimension[0]->X.getValue();
     float dimDistance = activeDimAttributes.getCascadeSpacing();
-    if (signbit(xMaster))
+    if (std::signbit(xMaster))
         dimDistance = -dimDistance;
     double fontSize = Preferences::dimFontSizeMM();
     for (auto dim : validDimension) {
@@ -1542,7 +1542,7 @@ void execCreateHorizCoordDimension(Gui::Command* cmd) {
         }
         float dimDistance = activeDimAttributes.getCascadeSpacing();
         float yMaster = allVertexes[0].point.y - dimDistance;
-        if (signbit(yMaster))
+        if (std::signbit(yMaster))
             dimDistance = -dimDistance;
         for (long unsigned int n = 0; n < allVertexes.size() - 1; n++) {
             TechDraw::DrawViewDimension* dim;
@@ -1613,7 +1613,7 @@ void execCreateVertCoordDimension(Gui::Command* cmd) {
         }
         float dimDistance = activeDimAttributes.getCascadeSpacing();
         float xMaster = allVertexes[0].point.x + dimDistance;
-        if (signbit(xMaster))
+        if (std::signbit(xMaster))
             dimDistance = -dimDistance;
         double fontSize = Preferences::dimFontSizeMM();
         for (long unsigned int n = 0; n < allVertexes.size() - 1; n++) {
@@ -1902,7 +1902,7 @@ void execCreateHorizChamferDimension(Gui::Command* cmd) {
         TechDraw::DrawViewDimension* dim;
         dim = _createLinDimension(cmd, objFeat, allVertexes[0].name, allVertexes[1].name, "DistanceX");
         float yMax = std::max(abs(allVertexes[0].point.y), abs(allVertexes[1].point.y)) + 7.0;
-        if (signbit(allVertexes[0].point.y))
+        if (std::signbit(allVertexes[0].point.y))
             yMax = -yMax;
         TechDraw::pointPair pp = dim->getLinearPoints();
         Base::Vector3d mid = (pp.first + pp.second) / 2.0;
@@ -1969,7 +1969,7 @@ void execCreateVertChamferDimension(Gui::Command* cmd) {
         TechDraw::DrawViewDimension* dim;
         dim = _createLinDimension(cmd, objFeat, allVertexes[0].name, allVertexes[1].name, "DistanceY");
         float xMax = std::max(abs(allVertexes[0].point.x), abs(allVertexes[1].point.x)) + 7.0;
-        if (signbit(allVertexes[0].point.x))
+        if (std::signbit(allVertexes[0].point.x))
             xMax = -xMax;
         TechDraw::pointPair pp = dim->getLinearPoints();
         Base::Vector3d mid = (pp.first + pp.second) / 2.0;


### PR DESCRIPTION
Snaps are failing because `signbit` isn't declared. Probably because of e29d1d03326035ffa32cffb9b2f8d2f67bf19d5a. One of the removed includes might have had a `using std` or such, which might also be present in some versions of the remaining includes (local, gitlab CI) but absent in others (snap CI).

Failed test details here: https://github.com/FreeCAD/FreeCAD-snap/actions/runs/3221426471/jobs/5269345313.