### PR TITLE
Draft: Point array: Take placement of point object into account and accept more point object types

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_pointarray.py
+++ b/src/Mod/Draft/draftguitools/gui_pointarray.py
@@ -25,16 +25,7 @@
 # ***************************************************************************
 """Provides GUI tools to create PointArray objects.
 
-The copies will be created where various points are located.
-
-The points need to be grouped under a compound before using this tool.
-To create this compound, select various points and then use the Draft Upgrade
-tool to create a `Block`, or use a `Part::Compound`.
-You can also create a Sketch, and place explicit points.
-
-Other geometrical objects may be contained inside the compounds but only
-the explicit point and vertex objects will be used when creating
-the point array.
+The copies will be created at the points of a point object.
 """
 ## @package gui_pointarray
 # \ingroup draftguitools
@@ -74,7 +65,7 @@ class PointArray(gui_base_original.Modifier):
 
         return {'Pixmap': 'Draft_PointArray',
                 'MenuText': QT_TRANSLATE_NOOP("Draft_PointArray", "Point array"),
-                'ToolTip': QT_TRANSLATE_NOOP("Draft_PointArray", "Creates copies of the selected object, and places the copies at the position of various points.\n\nThe points need to be grouped under a compound of points before using this tool.\nTo create this compound, select various points and then use the Part Compound tool,\nor use the Draft Upgrade tool to create a 'Block', or create a Sketch and add simple points to it.\n\nSelect the base object, and then select the compound or the sketch to create the point array.")}
+                'ToolTip': QT_TRANSLATE_NOOP("Draft_PointArray", "Creates copies of the selected base object at the points of a point object.\nFirst select the base object, and then select the point object.")}
 
     def Activated(self, name="Point array"):
         """Execute when the command is called."""


### PR DESCRIPTION
The Placement of some point objects was ignored. And the number of supported point object types was rather restrictive.

Forum topics:
https://forum.freecadweb.org/viewtopic.php?f=23&t=59359
https://forum.freecadweb.org/viewtopic.php?f=3&t=61144&p=524241#p524233
https://forum.freecadweb.org/viewtopic.php?f=23&t=71957

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the issue ID number from our [Issues database](https://github.com/FreeCAD/FreeCAD/issues) in case a particular commit solves or is related to an existing issue. Ex: `Draft: fix typos - fixes #4805`

---
