### PR TITLE
[Sketcher] Constraint tangent at B-spline knot

### DIFF
--- a/src/Mod/Sketcher/App/GeometryFacade.h
+++ b/src/Mod/Sketcher/App/GeometryFacade.h
@@ -166,6 +166,8 @@ public:
 
     bool isInternalAligned() const { return this->getInternalType() != InternalType::None; }
 
+    bool isInternalType(InternalType::InternalType type) const { return this->getInternalType() == type; }
+
     // Geometry Extension Information
     inline const std::string &getExtensionName () const {return SketchGeoExtension->getName();}
 

--- a/src/Mod/Sketcher/App/Sketch.cpp
+++ b/src/Mod/Sketcher/App/Sketch.cpp
@@ -111,6 +111,8 @@ void Sketch::clear()
     pDependencyGroups.clear();
     solverExtensions.clear();
 
+    internalAlignmentGeometryMap.clear();
+
     // deleting the geometry copied into this sketch
     for (std::vector<GeoDef>::iterator it = Geoms.begin(); it != Geoms.end(); ++it)
         if (it->geo) delete it->geo;
@@ -230,6 +232,8 @@ int Sketch::setUpSketch(const std::vector<Part::Geometry *> &GeoList,
     Base::Console().Log("\n");
 #endif //DEBUG_BLOCK_CONSTRAINT
 
+    buildInternalAlignmentGeometryMap(ConstraintList);
+
     addGeometry(intGeoList,onlyBlockedGeometry);
     int extStart=Geoms.size();
     addGeometry(extGeoList, true);
@@ -312,6 +316,15 @@ int Sketch::setUpSketch(const std::vector<Part::Geometry *> &GeoList,
     }
 
     return GCSsys.dofsNumber();
+}
+
+void Sketch::buildInternalAlignmentGeometryMap(const std::vector<Constraint *> &constraintList)
+{
+    for(auto* c : constraintList) {
+        if(c->Type==InternalAlignment){
+            internalAlignmentGeometryMap[c->First]=c->Second;
+        }
+    }
 }
 
 void Sketch::fixParametersAndDiagnose(std::vector<double *> &params_to_block)

--- a/src/Mod/Sketcher/App/Sketch.cpp
+++ b/src/Mod/Sketcher/App/Sketch.cpp
@@ -1737,7 +1737,9 @@ int Sketch::addConstraint(const Constraint *constraint)
 
                     auto linegeoid = checkGeoId(constraint->Second);
 
-                    rtn = addTangentLineAtBSplineKnotConstraint(linegeoid, bsplinegeoid, knotgeoId);
+                    if (Geoms[linegeoid].type == Line)
+                        rtn = addTangentLineAtBSplineKnotConstraint(
+                            linegeoid, bsplinegeoid, knotgeoId);
                 }
             }
         }

--- a/src/Mod/Sketcher/App/Sketch.cpp
+++ b/src/Mod/Sketcher/App/Sketch.cpp
@@ -1722,27 +1722,26 @@ int Sketch::addConstraint(const Constraint *constraint)
             //simple tangency
             rtn = addTangentConstraint(constraint->First,constraint->Second);
         }
-        else {
+        else if (constraint->FirstPos == PointPos::start &&
+                 constraint->SecondPos == PointPos::none &&
+                 constraint->Third == GeoEnum::GeoUndef) {
             // check for B-Spline Knot to curve tangency
-            if (constraint->FirstPos == PointPos::none &&
-                constraint->SecondPos == PointPos::none &&
-                constraint->ThirdPos == PointPos::start) {
-                auto knotgeoId = checkGeoId(constraint->Third);
-                if (Geoms[knotgeoId].type == Point) {
-                    auto *point = static_cast<const GeomPoint*>(Geoms[knotgeoId].geo);
+            auto knotgeoId = checkGeoId(constraint->First);
+            if (Geoms[knotgeoId].type == Point) {
+                auto *point = static_cast<const GeomPoint*>(Geoms[knotgeoId].geo);
 
-                    if (GeometryFacade::isInternalType(point,InternalType::BSplineKnotPoint)) {
-                        auto bsplinegeoid = internalAlignmentGeometryMap.at(constraint->Third);
+                if (GeometryFacade::isInternalType(point,InternalType::BSplineKnotPoint)) {
+                    auto bsplinegeoid = internalAlignmentGeometryMap.at(constraint->First);
 
-                        bsplinegeoid = checkGeoId(bsplinegeoid);
+                    bsplinegeoid = checkGeoId(bsplinegeoid);
 
-                        auto linegeoid = checkGeoId(constraint->Second);
+                    auto linegeoid = checkGeoId(constraint->Second);
 
-                        return addTangentLineAtBSplineKnotConstraint(linegeoid, bsplinegeoid, knotgeoId);
-                    }
+                    rtn = addTangentLineAtBSplineKnotConstraint(linegeoid, bsplinegeoid, knotgeoId);
                 }
             }
-
+        }
+        else {
             //any other point-wise tangency (endpoint-to-curve, endpoint-to-endpoint, tangent-via-point)
             c.value = new double(constraint->getValue());
             if(c.driving)

--- a/src/Mod/Sketcher/App/Sketch.h
+++ b/src/Mod/Sketcher/App/Sketch.h
@@ -282,6 +282,7 @@ public:
     int addPerpendicularConstraint(int geoId1, int geoId2);
     /// add a tangency constraint between two geometries
     int addTangentConstraint(int geoId1, int geoId2);
+    int addTangentLineAtBSplineKnotConstraint(int checkedlinegeoId, int checkedbsplinegeoId, int checkedknotgeoid);
     int addAngleAtPointConstraint(
             int geoId1, PointPos pos1,
             int geoId2, PointPos pos2,

--- a/src/Mod/Sketcher/App/Sketch.h
+++ b/src/Mod/Sketcher/App/Sketch.h
@@ -455,6 +455,9 @@ protected:
     // map of geoIds to corresponding solverextensions. This is useful when solved geometry is NOT to be assigned to the SketchObject
     std::vector<std::shared_ptr<SolverGeometryExtension>> solverExtensions;
 
+    // maps a geoid corresponding to an internalgeometry (focus,knot,pole) to the geometry it defines (ellipse, hyperbola, B-Spline)
+    std::map< int, int > internalAlignmentGeometryMap;
+
     std::vector < std::set < std::pair< int, Sketcher::PointPos>>> pDependencyGroups;
 
     // this map is intended to convert a parameter (double *) into a GeoId/PointPos and parameter number
@@ -519,6 +522,8 @@ private:
     void calculateDependentParametersElements();
 
     void clearTemporaryConstraints();
+
+    void buildInternalAlignmentGeometryMap(const std::vector<Constraint *> &constraintList);
 
     int internalSolve(std::string & solvername, int level = 0);
 

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -8492,7 +8492,7 @@ int SketchObject::port_reversedExternalArcs(bool justAnalyze)
 /// false - fail (this indicates an error, or that a constraint locking isn't supported).
 bool SketchObject::AutoLockTangencyAndPerpty(Constraint *cstr, bool bForce, bool bLock)
 {
-    try{
+    try {
         //assert ( cstr->Type == Tangent  ||  cstr->Type == Perpendicular);
         if(cstr->getValue() != 0.0 && ! bForce) /*tangency type already set. If not bForce - don't touch.*/
             return true;
@@ -8536,7 +8536,8 @@ bool SketchObject::AutoLockTangencyAndPerpty(Constraint *cstr, bool bForce, bool
                 cstr->setValue(angleDesire + angleOffset); //external tangency. The angle stored is offset by Pi/2 so that a value of 0.0 is invalid and treated as "undecided".
             }
         }
-    } catch (Base::Exception& e){
+    }
+    catch (Base::Exception& e){
         //failure to determine tangency type is not a big deal, so a warning.
         Base::Console().Warning("Error in AutoLockTangency. %s \n", e.what());
         return false;

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -8507,13 +8507,25 @@ bool SketchObject::AutoLockTangencyAndPerpty(Constraint *cstr, bool bForce, bool
             geoIdPt = cstr->Third;
             posPt = cstr->ThirdPos;
             if (geoIdPt == GeoEnum::GeoUndef){//not tangent-via-point, try endpoint-to-endpoint...
+
+                // First check if it is a tangency at knot constraint, if not continue with checking for endpoints.
+                // Endpoint constraints make use of the AngleViaPoint framework at solver level, so they need locking
+                // angle calculation, tangency at knot constraint does not.
+                auto geof = getGeometryFacade(cstr->First);
+                if(geof->isInternalType(InternalType::BSplineKnotPoint)) {
+                    // there is point that is a B-Spline knot in a two element constraint
+                    // this is not implement using AngleViaPoint (TangencyViaPoint)
+                    return false;
+                }
+
                 geoIdPt = cstr->First;
                 posPt = cstr->FirstPos;
             }
             if (posPt == PointPos::none){//not endpoint-to-curve and not endpoint-to-endpoint tangent (is simple tangency)
                 //no tangency lockdown is implemented for simple tangency. Do nothing.
                 return false;
-            } else {
+            }
+            else {
                 Base::Vector3d p = getPoint(geoIdPt, posPt);
 
                 //this piece of code is also present in Sketch.cpp, correct for offset

--- a/src/Mod/Sketcher/App/planegcs/Constraints.cpp
+++ b/src/Mod/Sketcher/App/planegcs/Constraints.cpp
@@ -283,12 +283,9 @@ ConstraintSlopeAtBSplineKnot::ConstraintSlopeAtBSplineKnot(BSpline& b, Line& l, 
     factors.resize(numpoles);
     slopefactors.resize(numpoles);
     for (size_t i = 0; i < numpoles + 1; ++i) {
-        // FIXME: `getLinCombFactor` seg-faults for the last knot so this safeguard exists
-        if (numpoles > 2) {
-            tempfactors[i] =
-                b.getLinCombFactor(*(b.knots[knotindex]), startpole + b.degree, startpole + i, b.degree - 1) /
-                (b.flattenedknots[startpole + b.degree + i] - b.flattenedknots[startpole + i]);
-        }
+        tempfactors[i] =
+            b.getLinCombFactor(*(b.knots[knotindex]), startpole + b.degree, startpole + i, b.degree - 1) /
+            (b.flattenedknots[startpole + b.degree + i] - b.flattenedknots[startpole + i]);
     }
     for (size_t i = 0; i < numpoles; ++i) {
         factors[i] =

--- a/src/Mod/Sketcher/App/planegcs/Constraints.h
+++ b/src/Mod/Sketcher/App/planegcs/Constraints.h
@@ -70,7 +70,8 @@ namespace GCS
         EqualFocalDistance = 24,
         EqualLineLength = 25,
         CenterOfGravity = 26,
-        WeightedLinearCombination = 27
+        WeightedLinearCombination = 27,
+        SlopeAtBSplineKnot = 28
     };
 
     enum InternalAlignmentType {
@@ -203,6 +204,31 @@ namespace GCS
         double grad(double *) override;
     private:
         std::vector<double> factors;
+        size_t numpoles;
+    };
+
+    // Slope at knot
+    class ConstraintSlopeAtBSplineKnot : public Constraint
+    {
+    private:
+        inline double* polexat(size_t i) { return pvec[i]; }
+        inline double* poleyat(size_t i) { return pvec[numpoles + i]; }
+        inline double* weightat(size_t i) { return pvec[2*numpoles + i]; }
+        inline double* linep1x() { return pvec[3*numpoles + 0]; }
+        inline double* linep1y() { return pvec[3*numpoles + 1]; }
+        inline double* linep2x() { return pvec[3*numpoles + 2]; }
+        inline double* linep2y() { return pvec[3*numpoles + 3]; }
+    public:
+        // TODO: Should be able to make the geometries passed const
+        // Constrains the slope at a (C1 continuous) knot of the b-spline
+        ConstraintSlopeAtBSplineKnot(BSpline& b, Line& l, size_t knotindex);
+        ConstraintType getTypeId() override;
+        void rescale(double coef=1.) override;
+        double error() override;
+        double grad(double *) override;
+    private:
+        std::vector<double> factors;
+        std::vector<double> slopefactors;
         size_t numpoles;
     };
 

--- a/src/Mod/Sketcher/App/planegcs/GCS.cpp
+++ b/src/Mod/Sketcher/App/planegcs/GCS.cpp
@@ -812,6 +812,14 @@ int System::addConstraintTangentCircumf(Point &p1, Point &p2, double *rad1, doub
     return addConstraint(constr);
 }
 
+int System::addConstraintTangentAtBSplineKnot(BSpline &b, Line &l, size_t knotindex, int tagId, bool driving)
+{
+    Constraint *constr = new ConstraintSlopeAtBSplineKnot(b, l, knotindex);
+    constr->setTag(tagId);
+    constr->setDriving(driving);
+    return addConstraint(constr);
+}
+
 // derived constraints
 
 int System::addConstraintP2PCoincident(Point &p1, Point &p2, int tagId, bool driving)

--- a/src/Mod/Sketcher/App/planegcs/GCS.cpp
+++ b/src/Mod/Sketcher/App/planegcs/GCS.cpp
@@ -812,7 +812,7 @@ int System::addConstraintTangentCircumf(Point &p1, Point &p2, double *rad1, doub
     return addConstraint(constr);
 }
 
-int System::addConstraintTangentAtBSplineKnot(BSpline &b, Line &l, size_t knotindex, int tagId, bool driving)
+int System::addConstraintTangentAtBSplineKnot(BSpline &b, Line &l, unsigned int knotindex, int tagId, bool driving)
 {
     Constraint *constr = new ConstraintSlopeAtBSplineKnot(b, l, knotindex);
     constr->setTag(tagId);

--- a/src/Mod/Sketcher/App/planegcs/GCS.h
+++ b/src/Mod/Sketcher/App/planegcs/GCS.h
@@ -257,6 +257,8 @@ namespace GCS
                                         int tagId=0, bool driving = true);
         int addConstraintTangentCircumf(Point &p1, Point &p2, double *rd1, double *rd2,
                                         bool internal=false, int tagId=0, bool driving = true);
+        int addConstraintTangentAtBSplineKnot(BSpline &b, Line &l, size_t knotindex,
+                                              int tagId=0, bool driving = true);
 
         // derived constraints
         int addConstraintP2PCoincident(Point &p1, Point &p2, int tagId=0, bool driving = true);

--- a/src/Mod/Sketcher/App/planegcs/GCS.h
+++ b/src/Mod/Sketcher/App/planegcs/GCS.h
@@ -257,7 +257,7 @@ namespace GCS
                                         int tagId=0, bool driving = true);
         int addConstraintTangentCircumf(Point &p1, Point &p2, double *rd1, double *rd2,
                                         bool internal=false, int tagId=0, bool driving = true);
-        int addConstraintTangentAtBSplineKnot(BSpline &b, Line &l, size_t knotindex,
+        int addConstraintTangentAtBSplineKnot(BSpline &b, Line &l, unsigned int knotindex,
                                               int tagId=0, bool driving = true);
 
         // derived constraints

--- a/src/Mod/Sketcher/App/planegcs/Geo.cpp
+++ b/src/Mod/Sketcher/App/planegcs/Geo.cpp
@@ -746,6 +746,20 @@ double BSpline::getLinCombFactor(double x, size_t k, size_t i, size_t p)
     return d[p];
 }
 
+double BSpline::splineValue(double x, size_t k, size_t p, VEC_D& d, const VEC_D& flatknots)
+{
+    for (size_t r = 1; r < p + 1; ++r) {
+        for (size_t j = p; j > r - 1; --j) {
+            double alpha =
+                (x - flatknots[j + k - p]) /
+                (flatknots[j + 1 + k - r] - flatknots[j + k - p]);
+            d[j] = (1.0 - alpha) * d[j-1] + alpha * d[j];
+        }
+    }
+
+    return d[p];
+}
+
 void BSpline::setupFlattenedKnots()
 {
     flattenedknots.clear();

--- a/src/Mod/Sketcher/App/planegcs/Geo.cpp
+++ b/src/Mod/Sketcher/App/planegcs/Geo.cpp
@@ -712,7 +712,7 @@ BSpline* BSpline::Copy()
     return crv;
 }
 
-double BSpline::getLinCombFactor(double x, size_t k, size_t i, size_t p)
+double BSpline::getLinCombFactor(double x, size_t k, size_t i, unsigned int p)
 {
     // Adapted to C++ from the python implementation in the Wikipedia page for de Boor algorithm
     // https://en.wikipedia.org/wiki/De_Boor%27s_algorithm.
@@ -734,7 +734,7 @@ double BSpline::getLinCombFactor(double x, size_t k, size_t i, size_t p)
         return 0.0;
     d[idxOfPole] = 1.0;
 
-    for (size_t r = 1; static_cast<int>(r) < p + 1; ++r) {
+    for (size_t r = 1; r < p + 1; ++r) {
         for (size_t j = p; j > r - 1; --j) {
             double alpha =
                 (x - flattenedknots[j + k - p]) /
@@ -746,7 +746,7 @@ double BSpline::getLinCombFactor(double x, size_t k, size_t i, size_t p)
     return d[p];
 }
 
-double BSpline::splineValue(double x, size_t k, size_t p, VEC_D& d, const VEC_D& flatknots)
+double BSpline::splineValue(double x, size_t k, unsigned int p, VEC_D& d, const VEC_D& flatknots)
 {
     for (size_t r = 1; r < p + 1; ++r) {
         for (size_t j = p; j > r - 1; --j) {

--- a/src/Mod/Sketcher/App/planegcs/Geo.cpp
+++ b/src/Mod/Sketcher/App/planegcs/Geo.cpp
@@ -712,7 +712,7 @@ BSpline* BSpline::Copy()
     return crv;
 }
 
-double BSpline::getLinCombFactor(double x, size_t k, size_t i)
+double BSpline::getLinCombFactor(double x, size_t k, size_t i, size_t p)
 {
     // Adapted to C++ from the python implementation in the Wikipedia page for de Boor algorithm
     // https://en.wikipedia.org/wiki/De_Boor%27s_algorithm.
@@ -727,23 +727,23 @@ double BSpline::getLinCombFactor(double x, size_t k, size_t i)
     if (flattenedknots.empty())
         setupFlattenedKnots();
 
-    std::vector d(degree + 1, 0.0);
+    std::vector d(p + 1, 0.0);
     // Ensure this is within range
-    int idxOfPole = static_cast<int>(i) + degree - static_cast<int>(k);
-    if (idxOfPole < 0 || idxOfPole > degree)
+    int idxOfPole = static_cast<int>(i) + p - static_cast<int>(k);
+    if (idxOfPole < 0 || idxOfPole > static_cast<int>(p))
         return 0.0;
     d[idxOfPole] = 1.0;
 
-    for (size_t r = 1; static_cast<int>(r) < degree + 1; ++r) {
-        for (size_t j = degree; j > r - 1; --j) {
+    for (size_t r = 1; static_cast<int>(r) < p + 1; ++r) {
+        for (size_t j = p; j > r - 1; --j) {
             double alpha =
-                (x - flattenedknots[j + k - degree]) /
-                (flattenedknots[j + 1 + k - r] - flattenedknots[j + k - degree]);
+                (x - flattenedknots[j + k - p]) /
+                (flattenedknots[j + 1 + k - r] - flattenedknots[j + k - p]);
             d[j] = (1.0 - alpha) * d[j-1] + alpha * d[j];
         }
     }
 
-    return d[degree];
+    return d[p];
 }
 
 void BSpline::setupFlattenedKnots()

--- a/src/Mod/Sketcher/App/planegcs/Geo.h
+++ b/src/Mod/Sketcher/App/planegcs/Geo.h
@@ -308,6 +308,13 @@ namespace GCS
         inline double getLinCombFactor(double x, size_t k, size_t i)
         { return getLinCombFactor(x, k, i, degree); }
         void setupFlattenedKnots();
+        /// finds spline(x) for the given parameter and knot/pole vector
+        /// x is the point at which combination is needed
+        /// k is the range in `flattenedknots` that contains x
+        /// p is the degree
+        /// d is the vector of (relevant) poles (this will be changed)
+        /// flatknots is the vector of knots
+        static double splineValue(double x, size_t k, size_t p, VEC_D& d, const VEC_D& flatknots);
     };
 
 } //namespace GCS

--- a/src/Mod/Sketcher/App/planegcs/Geo.h
+++ b/src/Mod/Sketcher/App/planegcs/Geo.h
@@ -300,10 +300,13 @@ namespace GCS
         void ReconstructOnNewPvec (VEC_pD &pvec, int &cnt) override;
         BSpline* Copy() override;
         /// finds the value B_i(x) such that spline(x) = sum(poles[i] * B_i(x))
-        /// i is index of control point
         /// x is the point at which combination is needed
         /// k is the range in `flattenedknots` that contains x
-        double getLinCombFactor(double x, size_t k, size_t i);
+        /// i is index of control point
+        /// p is the degree
+        double getLinCombFactor(double x, size_t k, size_t i, size_t p);
+        inline double getLinCombFactor(double x, size_t k, size_t i)
+        { return getLinCombFactor(x, k, i, degree); }
         void setupFlattenedKnots();
     };
 

--- a/src/Mod/Sketcher/App/planegcs/Geo.h
+++ b/src/Mod/Sketcher/App/planegcs/Geo.h
@@ -304,7 +304,7 @@ namespace GCS
         /// k is the range in `flattenedknots` that contains x
         /// i is index of control point
         /// p is the degree
-        double getLinCombFactor(double x, size_t k, size_t i, size_t p);
+        double getLinCombFactor(double x, size_t k, size_t i, unsigned int p);
         inline double getLinCombFactor(double x, size_t k, size_t i)
         { return getLinCombFactor(x, k, i, degree); }
         void setupFlattenedKnots();
@@ -314,7 +314,7 @@ namespace GCS
         /// p is the degree
         /// d is the vector of (relevant) poles (this will be changed)
         /// flatknots is the vector of knots
-        static double splineValue(double x, size_t k, size_t p, VEC_D& d, const VEC_D& flatknots);
+        static double splineValue(double x, size_t k, unsigned int p, VEC_D& d, const VEC_D& flatknots);
     };
 
 } //namespace GCS

--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -4226,7 +4226,15 @@ void CmdSketcherConstrainTangent::activated(int iMsg)
             }
 
             if (isSimpleVertex(Obj, GeoId1, PosId1)) {
-                if (!isBsplineKnot(Obj, GeoId1)) {
+                if (isBsplineKnot(Obj, GeoId1)) {
+                    const Part::Geometry *geom2 = Obj->getGeometry(GeoId2);
+                    if (!geom2 || geom2->getTypeId() !=Part::GeomLineSegment::getClassTypeId()) {
+                        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
+                                             QObject::tr("Tangent constraint at B-spline knot is only supported with lines!"));
+                        return;
+                    }
+                }
+                else {
                     QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
                                          QObject::tr("Cannot add a tangency constraint at an unconnected point!"));
                     return;

--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -4226,33 +4226,7 @@ void CmdSketcherConstrainTangent::activated(int iMsg)
             }
 
             if (isSimpleVertex(Obj, GeoId1, PosId1)) {
-                if (isBsplineKnot(Obj, GeoId1)) {
-                    // find the B-spline and treat as TangentViaPoint
-                    openCommand(QT_TRANSLATE_NOOP("Command", "Add tangent constraint"));
-                    const std::vector<Constraint *> &constraints = Obj->Constraints.getValues();
-                    for (const auto& constraint: constraints) {
-                        // TODO: wrap around with try-catch
-                        if (constraint->Type == Sketcher::ConstraintType::InternalAlignment &&
-                            constraint->First == GeoId1 &&
-                            constraint->AlignmentType == Sketcher::InternalAlignmentType::BSplineKnotPoint) {
-                            int GeoId3 = constraint->Second;
-                            // TODO: ensure C1 continuity at point
-                            if(! IsPointAlreadyOnCurve(GeoId2, GeoId1, PosId1, Obj)){
-                                Gui::cmdAppObjectArgs(selection[0].getObject(), "addConstraint(Sketcher.Constraint('PointOnObject',%d,%d,%d)) ",
-                                                      GeoId1,static_cast<int>(PosId1),GeoId2);
-                            }
-
-                            Gui::cmdAppObjectArgs(selection[0].getObject(), "addConstraint(Sketcher.Constraint('TangentViaPoint',%d,%d,%d,%d)) ",
-                                                  GeoId3,GeoId2,GeoId1,static_cast<int>(PosId1));
-                            commitCommand();
-                            tryAutoRecompute(Obj);
-
-                            getSelection().clearSelection();
-                            return;
-                        }
-                    }
-                }
-                else {
+                if (!isBsplineKnot(Obj, GeoId1)) {
                     QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
                                          QObject::tr("Cannot add a tangency constraint at an unconnected point!"));
                     return;

--- a/src/Mod/Sketcher/Gui/Utils.cpp
+++ b/src/Mod/Sketcher/Gui/Utils.cpp
@@ -226,8 +226,22 @@ bool SketcherGui::IsPointAlreadyOnCurve(int GeoIdCurve, int GeoIdPoint, Sketcher
     //Simple geometric test seems to be the best, because a point can be
     // constrained to a curve in a number of ways (e.g. it is an endpoint of an
     // arc, or is coincident to endpoint of an arc, or it is an endpoint of an
-    // ellipse's majopr diameter line). Testing all those possibilities is way
+    // ellipse's major diameter line). Testing all those possibilities is way
     // too much trouble, IMO(DeepSOIC).
+    // One exception: check for knots on their B-splines, at least until point on B-spline is implemented. (Ajinkya)
+    if (isBsplineKnot(Obj, GeoIdPoint)) {
+        const Part::Geometry *geoCurve = Obj->getGeometry(GeoIdCurve);
+        if (geoCurve->getTypeId() == Part::GeomBSplineCurve::getClassTypeId()) {
+            const std::vector<Constraint *> &constraints = Obj->Constraints.getValues();
+            for (const auto& constraint: constraints) {
+                if (constraint->Type == Sketcher::ConstraintType::InternalAlignment &&
+                    constraint->First == GeoIdPoint &&
+                    constraint->Second == GeoIdCurve)
+                    return true;
+            }
+        }
+    }
+
     Base::Vector3d p = Obj->getPoint(GeoIdPoint, PosIdPoint);
     return Obj->isPointOnCurve(GeoIdCurve, p.x, p.y);
 }


### PR DESCRIPTION
With these changes, a line segment can be made tangent to a B-spline at a given knot. It also contains commits from #7484 since we need to constraint knot on to the line segment.

This PR is part of [the B-spline constraint project](https://forum.freecadweb.org/viewtopic.php?f=9&t=71130).

See known issues [here](https://forum.freecadweb.org/viewtopic.php?f=9&t=71130&start=100#p632599).