### PR TITLE
Draft: Fix path array float math issue

### DIFF
--- a/src/Mod/Draft/draftobjects/patharray.py
+++ b/src/Mod/Draft/draftobjects/patharray.py
@@ -452,14 +452,15 @@ def placements_on_path(shapeRotation, pathwire, count, xlate, align,
         for j in range(0, len(ends)):
             if travel <= ends[j]:
                 iend = j
+                remains = ends[iend] - travel
+                offset = path[iend].Length - remains
                 break
         else:
             # avoids problems with float math travel > ends[-1]
             iend = len(ends) - 1
+            offset = path[iend].Length
 
         # place shape at proper spot on proper edge
-        remains = ends[iend] - travel
-        offset = path[iend].Length - remains
         pt = path[iend].valueAt(get_parameter_from_v0(path[iend], offset))
         place = calculate_placement(shapeRotation,
                                     path[iend], offset,


### PR DESCRIPTION
The 'avoid problems with float math' solution in `placements_on_path()` did not work properly. The issue has come to light after #7506 which revised the calculation order of the placements.

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the issue ID number from our [Issues database](https://github.com/FreeCAD/FreeCAD/issues) in case a particular commit solves or is related to an existing issue. Ex: `Draft: fix typos - fixes #4805`

---
