### PR TITLE
Draft: Escape should not switch off continueMode

### DIFF
--- a/src/Mod/Draft/DraftGui.py
+++ b/src/Mod/Draft/DraftGui.py
@@ -1540,10 +1540,12 @@ class DraftToolBar:
                         translate("draft", "Please enter a font file."))
 
 
-    def finish(self):
+    def finish(self, cont=None):
         """finish button action"""
         if self.sourceCmd:
-            self.sourceCmd.finish(False)
+            if cont is None:
+                cont = self.continueMode
+            self.sourceCmd.finish(cont=cont)
         if self.cancel:
             self.cancel()
             self.cancel = None
@@ -1552,15 +1554,11 @@ class DraftToolBar:
 
     def escape(self):
         """escapes the current command"""
-        self.continueMode = False
-        if not self.taskmode:
-            # self.taskmode == 0  Draft toolbar is obsolete and has been disabled (February 2020)
-            self.continueCmd.setChecked(False)
-        self.finish()
+        self.finish(cont=False)
 
     def closeLine(self):
         """close button action"""
-        self.sourceCmd.finish(True)
+        self.sourceCmd.finish(cont=self.continueMode, closed=True)
         FreeCADGui.ActiveDocument.resetEdit()
 
     def wipeLine(self):
@@ -1624,7 +1622,6 @@ class DraftToolBar:
         elif txt.upper().startswith(inCommandShortcuts["Exit"][0]):
             if self.finishButton.isVisible():
                 self.finish()
-            spec = True
         elif txt.upper().startswith(inCommandShortcuts["Continue"][0]):
             if self.continueCmd.isVisible():
                 self.toggleContinue()

--- a/src/Mod/Draft/draftguitools/gui_arcs.py
+++ b/src/Mod/Draft/draftguitools/gui_arcs.py
@@ -87,20 +87,21 @@ class Arc(gui_base_original.Creator):
             self.call = self.view.addEventCallback("SoEvent", self.action)
             _msg(translate("draft", "Pick center point"))
 
-    def finish(self, closed=False, cont=False):
-        """Terminate the operation and close the arc if asked.
+    def finish(self, cont=False):
+        """Terminate the operation.
 
         Parameters
         ----------
-        closed: bool, optional
-            Close the line if `True`.
+        cont: bool or None, optional
+            Restart (continue) the command if `True`, or if `None` and
+            `ui.continueMode` is `True`.
         """
         super(Arc, self).finish()
         if self.ui:
             self.linetrack.finalize()
             self.arctrack.finalize()
             self.doc.recompute()
-        if self.ui and self.ui.continueMode:
+        if cont or (cont is None and self.ui and self.ui.continueMode):
             self.Activated()
 
     def updateAngle(self, angle):
@@ -392,7 +393,7 @@ class Arc(gui_base_original.Creator):
                 _err("Draft: error delaying commit")
 
         # Finalize full circle or cirular arc
-        self.finish(cont=True)
+        self.finish(cont=None)
 
     def numericInput(self, numx, numy, numz):
         """Validate the entry fields in the user interface.
@@ -565,9 +566,7 @@ class Arc_3Points(gui_base.GuiCommandSimplest):
                                         self.points[1],
                                         self.points[2]], primitive=False)
 
-            self.finish()
-            if Gui.Snapper.ui.continueMode:
-                self.Activated()
+            self.finish(cont=None)
 
     def drawArc(self, point, info):
         """Draw preview arc when we move the pointer in the 3D view.
@@ -589,9 +588,19 @@ class Arc_3Points(gui_base.GuiCommandSimplest):
                                           self.points[1],
                                           point)
 
-    def finish(self, close=False):
+    def finish(self, cont=False):
+        """Terminate the operation.
+
+        Parameters
+        ----------
+        cont: bool or None, optional
+            Restart (continue) the command if `True`, or if `None` and
+            `ui.continueMode` is `True`.
+        """
         self.tracker.finalize()
         self.doc.recompute()
+        if cont or (cont is None and Gui.Snapper.ui and Gui.Snapper.ui.continueMode):
+            self.Activated()
 
 
 Draft_Arc_3Points = Arc_3Points

--- a/src/Mod/Draft/draftguitools/gui_base_original.py
+++ b/src/Mod/Draft/draftguitools/gui_base_original.py
@@ -154,7 +154,7 @@ class DraftTool:
         _msg("{}".format(16*"-"))
         _msg("GuiCommand: {}".format(self.featureName))
 
-    def finish(self, close=False):
+    def finish(self, cont=False):
         """Finish the current command.
 
         These are general cleaning tasks that are performed

--- a/src/Mod/Draft/draftguitools/gui_beziers.py
+++ b/src/Mod/Draft/draftguitools/gui_beziers.py
@@ -102,7 +102,8 @@ class BezCurve(gui_lines.Line):
               and arg["State"] == "DOWN"
               and arg["Button"] == "BUTTON1"):  # left click
             if arg["Position"] == self.pos:
-                self.finish(False, cont=True)
+                self.finish(cont=None)
+                return
 
             if (not self.node) and (not self.support):  # first point
                 gui_tool_utils.getSupport(arg)
@@ -118,7 +119,7 @@ class BezCurve(gui_lines.Line):
                 # then create 2 handle points?
                 self.drawUpdate(self.point)
                 if not self.isWire and len(self.node) == 2:
-                    self.finish(False, cont=True)
+                    self.finish(cont=None, closed=False)
                 if len(self.node) > 2:
                     # does this make sense for a BCurve?
                     # DNC: allows to close the curve
@@ -127,7 +128,7 @@ class BezCurve(gui_lines.Line):
                     # old code has been to insensitive
                     if (self.point-self.node[0]).Length < utils.tolerance():
                         self.undolast()
-                        self.finish(True, cont=True)
+                        self.finish(cont=None, closed=True)
                         _msg(translate("draft",
                                        "Bézier curve has been closed"))
 
@@ -148,9 +149,7 @@ class BezCurve(gui_lines.Line):
             _msg(translate("draft", "Pick next point"))
         else:
             self.obj.Shape = self.updateShape(self.node)
-            _msg(translate("draft",
-                           "Pick next point, "
-                           "or finish (A) or close (O)"))
+            _msg(translate("draft", "Pick next point"))
 
     def updateShape(self, pts):
         """Create shape for display during creation process."""
@@ -174,13 +173,16 @@ class BezCurve(gui_lines.Line):
         w = Part.Wire(edges)
         return w
 
-    def finish(self, closed=False, cont=False):
+    def finish(self, cont=False, closed=False):
         """Terminate the operation and close the curve if asked.
 
         Parameters
         ----------
+        cont: bool or None, optional
+            Restart (continue) the command if `True`, or if `None` and
+            `ui.continueMode` is `True`.
         closed: bool, optional
-            Close the line if `True`.
+            Close the curve if `True`.
         """
         if self.ui:
             if hasattr(self, "bezcurvetrack"):
@@ -220,7 +222,7 @@ class BezCurve(gui_lines.Line):
         # another method that performs cleanup (superfinish)
         # that is not re-implemented by any of the child classes.
         gui_base_original.Creator.finish(self)
-        if self.ui and self.ui.continueMode:
+        if cont or (cont is None and self.ui and self.ui.continueMode):
             self.Activated()
 
 
@@ -309,7 +311,7 @@ class CubicBezCurve(gui_lines.Line):
                         # then create 2 handle points?
                         self.drawUpdate(self.point)
                         if not self.isWire and len(self.node) == 2:
-                            self.finish(False, cont=True)
+                            self.finish(cont=None, closed=False)
                         # does this make sense for a BCurve?
                         if len(self.node) > 2:
                             # add point to "clicked list"
@@ -327,7 +329,7 @@ class CubicBezCurve(gui_lines.Line):
                                 # close the curve with a smooth symmetric knot
                                 _sym = 2 * self.node[0] - self.node[1]
                                 self.node.append(_sym)
-                                self.finish(True, cont=True)
+                                self.finish(cont=None, closed=True)
                                 _msg(translate("draft",
                                                "Bézier curve has been closed"))
 
@@ -349,7 +351,7 @@ class CubicBezCurve(gui_lines.Line):
                         # then create 2 handle points?
                         self.drawUpdate(self.point)
                         if not self.isWire and len(self.node) == 2:
-                            self.finish(False, cont=True)
+                            self.finish(cont=None, closed=False)
                         # Does this make sense for a BCurve?
                         if len(self.node) > 2:
                             self.node[-3] = 2 * self.node[-2] - self.node[-1]
@@ -377,9 +379,7 @@ class CubicBezCurve(gui_lines.Line):
         elif (len(self.node) - 1) % self.degree == 1 and len(self.node) > 2:
             # is a knot
             self.obj.Shape = self.updateShape(self.node[:-1])
-            _msg(translate("draft",
-                           "Click and drag to define next knot, "
-                           "or finish (A) or close (O)"))
+            _msg(translate("draft", "Click and drag to define next knot"))
 
     def updateShape(self, pts):
         """Create shape for display during creation process."""
@@ -408,13 +408,16 @@ class CubicBezCurve(gui_lines.Line):
         w = Part.Wire(edges)
         return w
 
-    def finish(self, closed=False, cont=False):
+    def finish(self, cont=False, closed=False):
         """Terminate the operation and close the curve if asked.
 
         Parameters
         ----------
+        cont: bool or None, optional
+            Restart (continue) the command if `True`, or if `None` and
+            `ui.continueMode` is `True`.
         closed: bool, optional
-            Close the line if `True`.
+            Close the curve if `True`.
         """
         if self.ui:
             if hasattr(self, "bezcurvetrack"):
@@ -460,7 +463,7 @@ class CubicBezCurve(gui_lines.Line):
         # another method that performs cleanup (superfinish)
         # that is not re-implemented by any of the child classes.
         gui_base_original.Creator.finish(self)
-        if self.ui and self.ui.continueMode:
+        if cont or (cont is None and self.ui and self.ui.continueMode):
             self.Activated()
 
 

--- a/src/Mod/Draft/draftguitools/gui_circulararray.py
+++ b/src/Mod/Draft/draftguitools/gui_circulararray.py
@@ -132,7 +132,7 @@ class CircularArray(gui_base.GuiCommandBase):
                                           self.callback_click)
         if Gui.Control.activeDialog():
             Gui.Control.closeDialog()
-            super(CircularArray, self).finish()
+            self.finish()
 
 
 Gui.addCommand('Draft_CircularArray', CircularArray())

--- a/src/Mod/Draft/draftguitools/gui_clone.py
+++ b/src/Mod/Draft/draftguitools/gui_clone.py
@@ -110,9 +110,9 @@ class Clone(gui_base_original.Modifier):
                 Gui.Selection.addSelection(objects[-(1 + i)])
         self.finish()
 
-    def finish(self, close=False):
+    def finish(self):
         """Terminate the operation of the tool."""
-        super(Clone, self).finish(close=False)
+        super(Clone, self).finish()
         if self.moveAfterCloning:
             todo.ToDo.delay(Gui.runCommand, "Draft_Move")
 

--- a/src/Mod/Draft/draftguitools/gui_dimensions.py
+++ b/src/Mod/Draft/draftguitools/gui_dimensions.py
@@ -172,7 +172,7 @@ class Dimension(gui_base_original.Creator):
                 return False
         return True
 
-    def finish(self, closed=False):
+    def finish(self, cont=False):
         """Terminate the operation."""
         self.cont = None
         self.dir = None

--- a/src/Mod/Draft/draftguitools/gui_edit.py
+++ b/src/Mod/Draft/draftguitools/gui_edit.py
@@ -324,17 +324,14 @@ class Edit(gui_base_original.Modifier):
         App.ActiveDocument.recompute()
 
 
-    def finish(self, closed=False):
+    def finish(self, cont=False):
         """Terminate Edit Tool."""
         self.unregister_selection_callback()
         self.unregister_editing_callbacks()
         self.editing = None
         self.finalizeGhost()
         Gui.Snapper.setSelectMode(False)
-        if self.obj and closed:
-            if "Closed" in self.obj.PropertiesList:
-                if not self.obj.Closed:
-                    self.obj.Closed = True
+
         if self.ui:
             self.removeTrackers()
 
@@ -416,10 +413,6 @@ class Edit(gui_base_original.Modifier):
             # App.Console.PrintMessage("pressed key : "+str(key)+"\n")
             if key == 65307:  # ESC
                 self.finish()
-            if key == 97:  # "a"
-                self.finish()
-            if key == 111:  # "o"
-                self.finish(closed=True)
             if key == 101:  # "e"
                 self.display_tracker_menu(event)
             if key == 65535 and Gui.Selection.GetSelection() is None: # BUG: delete key activate Std::Delete command at the same time!

--- a/src/Mod/Draft/draftguitools/gui_fillets.py
+++ b/src/Mod/Draft/draftguitools/gui_fillets.py
@@ -58,7 +58,7 @@ class Fillet(gui_base_original.Creator):
         self.featureName = "Fillet"
 
     def GetResources(self):
-        """Set icon, menu and tooltip.""" 
+        """Set icon, menu and tooltip."""
         return {'Pixmap': 'Draft_Fillet',
                 'Accel':'F,I',
                 'MenuText': QT_TRANSLATE_NOOP("Draft_Fillet", "Fillet"),
@@ -188,7 +188,7 @@ class Fillet(gui_base_original.Creator):
         self.commit(translate("draft", "Create fillet"),
                     _cmd_list)
 
-    def finish(self, close=False):
+    def finish(self, cont=False):
         """Terminate the operation."""
         super(Fillet, self).finish()
         if self.ui:

--- a/src/Mod/Draft/draftguitools/gui_labels.py
+++ b/src/Mod/Draft/draftguitools/gui_labels.py
@@ -86,7 +86,7 @@ class Label(gui_base_original.Creator):
         self.labeltype = get_label_types()[i]
         utils.setParam("labeltype", self.labeltype)
 
-    def finish(self, closed=False, cont=False):
+    def finish(self, cont=False):
         """Finish the command."""
         if self.ghost:
             self.ghost.finalize()

--- a/src/Mod/Draft/draftguitools/gui_lines.py
+++ b/src/Mod/Draft/draftguitools/gui_lines.py
@@ -102,7 +102,8 @@ class Line(gui_base_original.Creator):
               and arg["State"] == "DOWN"
               and arg["Button"] == "BUTTON1"):
             if arg["Position"] == self.pos:
-                return self.finish(False, cont=True)
+                self.finish(cont=None)
+                return
             if (not self.node) and (not self.support):
                 gui_tool_utils.getSupport(arg)
                 (self.point,
@@ -113,21 +114,24 @@ class Line(gui_base_original.Creator):
                 self.node.append(self.point)
                 self.drawSegment(self.point)
                 if not self.isWire and len(self.node) == 2:
-                    self.finish(False, cont=True)
+                    self.finish(cont=None, closed=False)
                 if len(self.node) > 2:
                     # The wire is closed
                     if (self.point - self.node[0]).Length < utils.tolerance():
                         self.undolast()
                         if len(self.node) > 2:
-                            self.finish(True, cont=True)
+                            self.finish(cont=None, closed=True)
                         else:
-                            self.finish(False, cont=True)
+                            self.finish(cont=None, closed=False)
 
-    def finish(self, closed=False, cont=False):
+    def finish(self, cont=False, closed=False):
         """Terminate the operation and close the polyline if asked.
 
         Parameters
         ----------
+        cont: bool or None, optional
+            Restart (continue) the command if `True`, or if `None` and
+            `ui.continueMode` is `True`.
         closed: bool, optional
             Close the line if `True`.
         """
@@ -185,7 +189,7 @@ class Line(gui_base_original.Creator):
                 self.commit(translate("draft", "Create Wire"),
                             _cmd_list)
         super(Line, self).finish()
-        if self.ui and self.ui.continueMode:
+        if cont or (cont is None and self.ui and self.ui.continueMode):
             self.Activated()
 
     def removeTemporaryObject(self):
@@ -280,7 +284,7 @@ class Line(gui_base_original.Creator):
         self.node.append(self.point)
         self.drawSegment(self.point)
         if not self.isWire and len(self.node) == 2:
-            self.finish(False, cont=True)
+            self.finish(cont=None, closed=False)
         self.ui.setNextFocus()
 
 

--- a/src/Mod/Draft/draftguitools/gui_mirror.py
+++ b/src/Mod/Draft/draftguitools/gui_mirror.py
@@ -92,15 +92,11 @@ class Mirror(gui_base_original.Modifier):
         _msg(translate("draft", "Pick start point of mirror line"))
         self.ui.isCopy.hide()
 
-    def finish(self, closed=False, cont=False):
+    def finish(self, cont=False):
         """Terminate the operation of the tool."""
         if self.ghost:
             self.ghost.finalize()
         super(Mirror, self).finish()
-        if cont and self.ui:
-            if self.ui.continueMode:
-                Gui.Selection.clearSelection()
-                self.Activated()
 
     def mirror(self, p1, p2, copy=False):
         """Mirror the real shapes."""
@@ -187,7 +183,7 @@ class Mirror(gui_base_original.Modifier):
                         if gui_tool_utils.hasMod(arg, gui_tool_utils.MODALT):
                             self.extendedCopy = True
                         else:
-                            self.finish(cont=True)
+                            self.finish()
 
     def numericInput(self, numx, numy, numz):
         """Validate the entry fields in the user interface.

--- a/src/Mod/Draft/draftguitools/gui_move.py
+++ b/src/Mod/Draft/draftguitools/gui_move.py
@@ -102,13 +102,19 @@ class Move(gui_base_original.Modifier):
         self.call = self.view.addEventCallback("SoEvent", self.action)
         _msg(translate("draft", "Pick start point"))
 
-    def finish(self, closed=False, cont=False):
-        """Finish the move operation."""
+    def finish(self, cont=False):
+        """Terminate the operation.
+
+        Parameters
+        ----------
+        cont: bool or None, optional
+            Restart (continue) the command if `True`, or if `None` and
+            `ui.continueMode` is `True`.
+        """
         for ghost in self.ghosts:
             ghost.finalize()
-        if cont and self.ui:
-            if self.ui.continueMode:
-                todo.ToDo.delayAfter(self.Activated, [])
+        if cont or (cont is None and self.ui and self.ui.continueMode):
+            todo.ToDo.delayAfter(self.Activated, [])
         super(Move, self).finish()
 
     def action(self, arg):
@@ -170,7 +176,7 @@ class Move(gui_base_original.Modifier):
             if gui_tool_utils.hasMod(arg, gui_tool_utils.MODALT):
                 self.extendedCopy = True
             else:
-                self.finish(cont=True)
+                self.finish(cont=None)
 
     def set_ghosts(self):
         """Set the ghost to display."""

--- a/src/Mod/Draft/draftguitools/gui_offset.py
+++ b/src/Mod/Draft/draftguitools/gui_offset.py
@@ -264,7 +264,7 @@ class Offset(gui_base_original.Modifier):
                 else:
                     self.finish()
 
-    def finish(self, closed=False):
+    def finish(self, cont=False):
         """Finish the offset operation."""
         if self.running:
             if self.linetrack:

--- a/src/Mod/Draft/draftguitools/gui_orthoarray.py
+++ b/src/Mod/Draft/draftguitools/gui_orthoarray.py
@@ -119,7 +119,7 @@ class OrthoArray(gui_base.GuiCommandBase):
                                           self.callback_click)
         if Gui.Control.activeDialog():
             Gui.Control.closeDialog()
-            super(OrthoArray, self).finish()
+            self.finish()
 
 
 Gui.addCommand('Draft_OrthoArray', OrthoArray())

--- a/src/Mod/Draft/draftguitools/gui_points.py
+++ b/src/Mod/Draft/draftguitools/gui_points.py
@@ -148,19 +148,24 @@ class Point(gui_base_original.Creator):
                                        _cmd_list))
                 todo.ToDo.delayCommit(commitlist)
                 Gui.Snapper.off()
-            self.finish()
+            self.finish(cont=None)
 
     def finish(self, cont=False):
-        """Terminate the operation and restart if needed."""
+        """Terminate the operation.
+
+        Parameters
+        ----------
+        cont: bool or None, optional
+            Restart (continue) the command if `True`, or if `None` and
+            `ui.continueMode` is `True`.
+        """
         super(Point, self).finish()
         if self.callbackClick:
                 self.view.removeEventCallbackPivy(coin.SoMouseButtonEvent.getClassTypeId(), self.callbackClick)
         if self.callbackMove:
                 self.view.removeEventCallbackPivy(coin.SoLocation2Event.getClassTypeId(), self.callbackMove)
-
-        if self.ui:
-            if self.ui.continueMode:
-                self.Activated()
+        if cont or (cont is None and self.ui and self.ui.continueMode):
+            self.Activated()
 
 
 Gui.addCommand('Draft_Point', Point())

--- a/src/Mod/Draft/draftguitools/gui_polararray.py
+++ b/src/Mod/Draft/draftguitools/gui_polararray.py
@@ -132,7 +132,7 @@ class PolarArray(gui_base.GuiCommandBase):
                                           self.callback_click)
         if Gui.Control.activeDialog():
             Gui.Control.closeDialog()
-            super(PolarArray, self).finish()
+            self.finish()
 
 
 Gui.addCommand('Draft_PolarArray', PolarArray())

--- a/src/Mod/Draft/draftguitools/gui_polygons.py
+++ b/src/Mod/Draft/draftguitools/gui_polygons.py
@@ -77,14 +77,21 @@ class Polygon(gui_base_original.Creator):
             self.call = self.view.addEventCallback("SoEvent", self.action)
             _msg(translate("draft", "Pick center point"))
 
-    def finish(self, closed=False, cont=False):
-        """Terminate the operation."""
+    def finish(self, cont=False):
+        """Terminate the operation.
+
+        Parameters
+        ----------
+        cont: bool or None, optional
+            Restart (continue) the command if `True`, or if `None` and
+            `ui.continueMode` is `True`.
+        """
         super(Polygon, self).finish(self)
         if self.ui:
             self.arctrack.finalize()
             self.doc.recompute()
-            if self.ui.continueMode:
-                self.Activated()
+        if cont or (cont is None and self.ui and self.ui.continueMode):
+            self.Activated()
 
     def action(self, arg):
         """Handle the 3D scene events.
@@ -242,7 +249,7 @@ class Polygon(gui_base_original.Creator):
                          'FreeCAD.ActiveDocument.recompute()']
             self.commit(translate("draft", "Create Polygon"),
                         _cmd_list)
-        self.finish(cont=True)
+        self.finish(cont=None)
 
     def numericInput(self, numx, numy, numz):
         """Validate the entry fields in the user interface.

--- a/src/Mod/Draft/draftguitools/gui_rectangles.py
+++ b/src/Mod/Draft/draftguitools/gui_rectangles.py
@@ -68,10 +68,14 @@ class Rectangle(gui_base_original.Creator):
             self.rect = trackers.rectangleTracker()
             _msg(translate("draft", "Pick first point"))
 
-    def finish(self, closed=False, cont=False):
+    def finish(self, cont=False):
         """Terminate the operation.
 
-        The arguments of this function are not used and should be removed.
+        Parameters
+        ----------
+        cont: bool or None, optional
+            Restart (continue) the command if `True`, or if `None` and
+            `ui.continueMode` is `True`.
         """
         super(Rectangle, self).finish()
         if self.ui:
@@ -80,8 +84,8 @@ class Rectangle(gui_base_original.Creator):
                 del self.fillstate
             self.rect.off()
             self.rect.finalize()
-            if self.ui.continueMode:
-                self.Activated()
+        if cont or (cont is None and self.ui and self.ui.continueMode):
+            self.Activated()
 
     def createObject(self):
         """Create the final object in the current document."""
@@ -143,7 +147,7 @@ class Rectangle(gui_base_original.Creator):
                             _cmd_list)
         except Exception:
             _err("Draft: error delaying commit")
-        self.finish(cont=True)
+        self.finish(cont=None)
 
     def action(self, arg):
         """Handle the 3D scene events.
@@ -171,7 +175,8 @@ class Rectangle(gui_base_original.Creator):
               and arg["Button"] == "BUTTON1"):
 
             if arg["Position"] == self.pos:
-                self.finish()
+                self.finish(cont=None)
+                return
 
             if (not self.node) and (not self.support):
                 gui_tool_utils.getSupport(arg)
@@ -181,6 +186,7 @@ class Rectangle(gui_base_original.Creator):
                                                             noTracker=True)
             if self.point:
                 self.ui.redraw()
+                self.pos = arg["Position"]
                 self.appendPoint(self.point)
 
     def numericInput(self, numx, numy, numz):

--- a/src/Mod/Draft/draftguitools/gui_rotate.py
+++ b/src/Mod/Draft/draftguitools/gui_rotate.py
@@ -230,7 +230,7 @@ class Rotate(gui_base_original.Modifier):
         if gui_tool_utils.hasMod(arg, gui_tool_utils.MODALT):
             self.extendedCopy = True
         else:
-            self.finish(cont=True)
+            self.finish(cont=None)
 
     def set_ghosts(self):
         """Set the ghost to display."""
@@ -255,15 +255,21 @@ class Rotate(gui_base_original.Modifier):
                     ghosts.append(trackers.ghostTracker(subelement))
         return ghosts
 
-    def finish(self, closed=False, cont=False):
-        """Finish the rotate operation."""
+    def finish(self, cont=False):
+        """Terminate the operation.
+
+        Parameters
+        ----------
+        cont: bool or None, optional
+            Restart (continue) the command if `True`, or if `None` and
+            `ui.continueMode` is `True`.
+        """
         if self.arctrack:
             self.arctrack.finalize()
         for ghost in self.ghosts:
             ghost.finalize()
-        if cont and self.ui:
-            if self.ui.continueMode:
-                todo.ToDo.delayAfter(self.Activated, [])
+        if cont or (cont is None and self.ui and self.ui.continueMode):
+            todo.ToDo.delayAfter(self.Activated, [])
         super(Rotate, self).finish()
         if self.doc:
             self.doc.recompute()
@@ -419,7 +425,7 @@ class Rotate(gui_base_original.Modifier):
         else:
             self.angle = math.radians(rad)
             self.rotate(self.ui.isCopy.isChecked())
-            self.finish(cont=True)
+            self.finish(cont=None)
 
 
 Gui.addCommand('Draft_Rotate', Rotate())

--- a/src/Mod/Draft/draftguitools/gui_scale.py
+++ b/src/Mod/Draft/draftguitools/gui_scale.py
@@ -418,7 +418,7 @@ class Scale(gui_base_original.Modifier):
                     self.task.lock.setChecked(True)
                     self.task.setValue(d2/d1)
 
-    def finish(self, closed=False, cont=False):
+    def finish(self, cont=False):
         """Terminate the operation."""
         super(Scale, self).finish()
         for ghost in self.ghosts:

--- a/src/Mod/Draft/draftguitools/gui_selectplane.py
+++ b/src/Mod/Draft/draftguitools/gui_selectplane.py
@@ -150,7 +150,7 @@ class Draft_SelectPlane:
                 "Pick a face, 3 vertices or a WP Proxy to define the drawing plane"))
         self.call = self.view.addEventCallback("SoEvent", self.action)
 
-    def finish(self, close=False):
+    def finish(self):
         """Execute when the command is terminated."""
         # Store values
         self.param.SetBool("CenterPlaneOnView",

--- a/src/Mod/Draft/draftguitools/gui_shapestrings.py
+++ b/src/Mod/Draft/draftguitools/gui_shapestrings.py
@@ -85,7 +85,6 @@ class ShapeString(gui_base_original.Creator):
                 _msg(translate("draft", "Pick ShapeString location point"))
                 todo.ToDo.delay(Gui.Control.showDialog, self.task)
             else:
-                self.dialog = None
                 self.text = ''
                 self.ui.sourceCmd = self
                 self.ui.pointUi(title=translate("draft",self.featureName),
@@ -98,6 +97,8 @@ class ShapeString(gui_base_original.Creator):
                 _msg(translate("draft", "Pick ShapeString location point"))
                 Gui.draftToolBar.show()
 
+    # The createObject function is no longer used.
+    # See the function with the same name in task_shapestring.py.
     def createObject(self):
         """Create the actual object in the current document."""
         # print("debug: D_T ShapeString.createObject type(self.SString):"
@@ -209,14 +210,6 @@ class ShapeString(gui_base_original.Creator):
         self.FFile = FFile
         # last step in ShapeString parm capture, create object
         self.createObject()
-
-    def finish(self, finishbool=False):
-        """Terminate the operation."""
-        super(ShapeString, self).finish()
-        if self.ui:
-            # del self.dialog  # what does this do??
-            if self.ui.continueMode:
-                self.Activated()
 
 
 Gui.addCommand('Draft_ShapeString', ShapeString())

--- a/src/Mod/Draft/draftguitools/gui_stretch.py
+++ b/src/Mod/Draft/draftguitools/gui_stretch.py
@@ -254,7 +254,7 @@ class Stretch(gui_base_original.Modifier):
         point = App.Vector(numx, numy, numz)
         self.addPoint(point)
 
-    def finish(self, closed=False):
+    def finish(self, cont=False):
         """Terminate the operation of the command. and clean up."""
         if self.rectracker:
             self.rectracker.finalize()

--- a/src/Mod/Draft/draftguitools/gui_styles.py
+++ b/src/Mod/Draft/draftguitools/gui_styles.py
@@ -74,7 +74,7 @@ class ApplyStyle(gui_base_original.Modifier):
                         _cmd_list.append(_cmd)
                 self.commit(translate("draft", "Change Style"),
                             _cmd_list)
-            super(ApplyStyle, self).finish()
+            self.finish()
 
     def formatGroup(self, group):
         """Format a group instead of simple object."""

--- a/src/Mod/Draft/draftguitools/gui_texts.py
+++ b/src/Mod/Draft/draftguitools/gui_texts.py
@@ -64,7 +64,6 @@ class Text(gui_base_original.Creator):
         """Execute when the command is called."""
         super(Text, self).Activated(name="Text")
         if self.ui:
-            self.dialog = None
             self.text = ''
             self.ui.sourceCmd = self
             self.ui.pointUi(title=translate("draft", self.featureName), icon="Draft_Text")
@@ -77,13 +76,18 @@ class Text(gui_base_original.Creator):
             _msg(translate("draft", "Pick location point"))
             Gui.draftToolBar.show()
 
-    def finish(self, closed=False, cont=False):
-        """Terminate the operation."""
+    def finish(self, cont=False):
+        """Terminate the operation.
+
+        Parameters
+        ----------
+        cont: bool or None, optional
+            Restart (continue) the command if `True`, or if `None` and
+            `ui.continueMode` is `True`.
+        """
         super(Text, self).finish(self)
-        if self.ui:
-            del self.dialog
-            if self.ui.continueMode:
-                self.Activated()
+        if cont or (cont is None and self.ui and self.ui.continueMode):
+            self.Activated()
 
     def createObject(self):
         """Create the actual object in the current document."""
@@ -120,7 +124,7 @@ class Text(gui_base_original.Creator):
                      'FreeCAD.ActiveDocument.recompute()']
         self.commit(translate("draft", "Create Text"),
                     _cmd_list)
-        self.finish(cont=True)
+        self.finish(cont=None)
 
     def action(self, arg):
         """Handle the 3D scene events.

--- a/src/Mod/Draft/draftguitools/gui_trimex.py
+++ b/src/Mod/Draft/draftguitools/gui_trimex.py
@@ -547,7 +547,7 @@ class Trimex(gui_base_original.Modifier):
                     obj.FirstAngle = ang
         self.doc.recompute()
 
-    def finish(self, closed=False):
+    def finish(self, cont=False):
         """Terminate the operation of the Trimex tool."""
         super(Trimex, self).finish()
         self.force = None


### PR DESCRIPTION
Using Esc should not set continueMode to False.

To fix this the `finish()` functions were modified and made more consistent. If the function can be called from DraftGui.py it always has a `cont` argument. In some cases this is a dummy argument. The `closed` argument is only added when the object in question can in fact be closed.

Forum topic:
https://forum.freecadweb.org/viewtopic.php?f=23&t=59520

Additionally:
* DraftGui.py: Removed `spec = True` when inCommand "Exit" is used.
* gui_beziers.py, gui_ellipses.py, gui_lines.py and gui_rectangles.py: These contain a check `arg["Position"] == self.pos` which compares the current point with the previous point (coordinates in pixels). This check was not correctly implemented. Note that this check is completely absent from some of the other gui_*.py files. So perhaps it is superfluous.
* gui_beziers.py and gui_splines.py: Removed the "or finish (A) or close (O)" prompt. This information is already provided in the task panel and the "A" and "O" shortcuts are not fixed, but user preferences.
* gui_edit.py: Removed some unused 'closed' and 'finish' code.
* gui_shapestrings.py and gui_texts.py: Removed `self.dialog = None` as it is no longer used.

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the issue ID number from our [Issues database](https://github.com/FreeCAD/FreeCAD/issues) in case a particular commit solves or is related to an existing issue. Ex: `Draft: fix typos - fixes #4805`

---
