### PR TITLE
Draft: Make Std_TransformManip work for Draft_Point

### DIFF
--- a/src/Mod/Draft/draftobjects/point.py
+++ b/src/Mod/Draft/draftobjects/point.py
@@ -60,9 +60,15 @@ class Point(DraftObject):
         import Part
         shape = Part.Vertex(App.Vector(0, 0, 0))
         obj.Shape = shape
-        obj.Placement.Base = App.Vector(obj.X.Value,
-                                        obj.Y.Value,
-                                        obj.Z.Value)
+        obj.Placement.Base = App.Vector(obj.X, obj.Y, obj.Z)
+
+    def onChanged(self, obj, prop):
+        if prop == "Placement" \
+                and obj.Placement.Base != App.Vector(obj.X, obj.Y, obj.Z):
+            base = obj.Placement.Base
+            obj.X = base.x
+            obj.Y = base.y
+            obj.Z = base.z
 
 
 # Alias for compatibility with v0.18 and earlier

--- a/src/Mod/Draft/draftobjects/point.py
+++ b/src/Mod/Draft/draftobjects/point.py
@@ -60,7 +60,8 @@ class Point(DraftObject):
         import Part
         shape = Part.Vertex(App.Vector(0, 0, 0))
         obj.Shape = shape
-        obj.Placement.Base = App.Vector(obj.X, obj.Y, obj.Z)
+        if obj.Placement.Base != App.Vector(obj.X, obj.Y, obj.Z):
+            obj.Placement.Base = App.Vector(obj.X, obj.Y, obj.Z)
 
     def onChanged(self, obj, prop):
         if prop == "Placement" \


### PR DESCRIPTION
Using the manipulator did not work for a Draft Point as its Placement got reset based on its X, Y and Z properties.

Reported here:
https://github.com/FreeCAD/FreeCAD/pull/4896#issuecomment-1280043096

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the issue ID number from our [Issues database](https://github.com/FreeCAD/FreeCAD/issues) in case a particular commit solves or is related to an existing issue. Ex: `Draft: fix typos - fixes #4805`

---
