### PR TITLE
Split "File" toolbar and add "Clipboard" toolbar

### DIFF
--- a/src/Gui/ToolBarManager.cpp
+++ b/src/Gui/ToolBarManager.cpp
@@ -37,11 +37,11 @@
 
 using namespace Gui;
 
-ToolBarItem::ToolBarItem() : forceHide(HideStyle::VISIBLE)
+ToolBarItem::ToolBarItem() : visibility(HideStyle::VISIBLE)
 {
 }
 
-ToolBarItem::ToolBarItem(ToolBarItem* item, HideStyle forcehide) : forceHide(forcehide)
+ToolBarItem::ToolBarItem(ToolBarItem* item, HideStyle visibility) : visibility(visibility)
 {
     if ( item )
         item->appendItem(this);
@@ -226,9 +226,9 @@ void ToolBarManager::setup(ToolBarItem* toolBarItems)
             toolbars.removeAt(index);
         }
 
-        bool visible = hPref->GetBool(toolbarName.c_str(), true) && (*it)->forceHide == ToolBarItem::HideStyle::VISIBLE;
+        bool visible = hPref->GetBool(toolbarName.c_str(), true) && (*it)->visibility == ToolBarItem::HideStyle::VISIBLE;
         toolbar->setVisible(visible);
-        toolbar->toggleViewAction()->setVisible((*it)->forceHide == ToolBarItem::HideStyle::VISIBLE);
+        toolbar->toggleViewAction()->setVisible((*it)->visibility != ToolBarItem::HideStyle::FORCE_HIDE);
 
         // setup the toolbar
         setup(*it, toolbar);
@@ -326,7 +326,7 @@ void ToolBarManager::saveState() const
         QToolBar* toolbar = findToolBar(toolbars, *it);
         if (toolbar) {
             if (!toolbar->toggleViewAction()->isVisible())
-                continue; //if toggleViewAction is not visible it means that the toolbar is forceHide. In which case we do not save settings.
+                continue; //if toggleViewAction is not visible it means that the toolbar is FORCE_HIDE. In which case we do not save settings.
             QByteArray toolbarName = toolbar->objectName().toUtf8();
             hPref->SetBool(toolbarName.constData(), toolbar->isVisible());
         }

--- a/src/Gui/ToolBarManager.h
+++ b/src/Gui/ToolBarManager.h
@@ -38,11 +38,12 @@ class GuiExport ToolBarItem
 public:
     enum class HideStyle {
         VISIBLE,
+        HIDDEN, // toolbar hidden by default
         FORCE_HIDE // Force a toolbar to be hidden. For when all elements are disabled at some point in a workbench.
     };
 
     ToolBarItem();
-    explicit ToolBarItem(ToolBarItem* item, HideStyle forceHide = HideStyle::VISIBLE);
+    explicit ToolBarItem(ToolBarItem* item, HideStyle visibility = HideStyle::VISIBLE);
     ~ToolBarItem();
 
     void setCommand(const std::string&);
@@ -62,7 +63,7 @@ public:
     ToolBarItem& operator << (const std::string& command);
     QList<ToolBarItem*> getItems() const;
 
-    HideStyle forceHide;
+    HideStyle visibility;
 
 private:
     std::string _name;

--- a/src/Gui/Workbench.cpp
+++ b/src/Gui/Workbench.cpp
@@ -759,10 +759,19 @@ ToolBarItem* StdWorkbench::setupToolBars() const
     // File
     auto file = new ToolBarItem( root );
     file->setCommand("File");
-    *file << "Std_New" << "Std_Open" << "Std_Save" << "Separator"
-          << "Std_Undo" << "Std_Redo" << "Separator"
-          << "Std_Refresh" << "Separator" << "Std_WhatsThis";
+    *file << "Std_New" << "Std_Open" << "Std_Save";
 
+    // Edit
+    auto edit = new ToolBarItem( root );
+    edit->setCommand("Edit");
+    *edit << "Std_Undo" << "Std_Redo"
+          << "Separator" << "Std_Refresh";
+    
+    // Clipboard
+    auto clipboard = new ToolBarItem( root , ToolBarItem::HideStyle::HIDDEN );
+    clipboard->setCommand("Clipboard");
+    *clipboard << "Std_Cut" << "Std_Copy" << "Std_Paste";
+    
     // Workbench switcher
     if (WorkbenchSwitcher::isToolbar(WorkbenchSwitcher::getValue())) {
         auto wb = new ToolBarItem(root);
@@ -790,6 +799,11 @@ ToolBarItem* StdWorkbench::setupToolBars() const
     structure->setCommand("Structure");
     *structure << "Std_Part" << "Std_Group" << "Std_LinkMake" << "Std_LinkActions";
 
+    // Help
+    auto help = new ToolBarItem( root );
+    help->setCommand("Help");
+    *help << "Std_WhatsThis";
+    
     return root;
 }
 


### PR DESCRIPTION
following forum discussions about toolbars, some users would like to have cut/copy/paste in the toolbar, by making it a separate toolbar it is easier to hide for those that don't want it. Same situation with the `what's this?` command, by making it a separate toolbar it is easily hidden by those not using it.
https://forum.freecadweb.org/viewtopic.php?f=8&t=71924&start=10
https://forum.freecadweb.org/viewtopic.php?p=626197#p626197
The undo/redo/refresh commands where moved into a separate `Edit` toolbar to be a little more consistent with the menus and to some extent with other software that have this separated, this also makes it easier to customize the location of toolbars, for example I would prefer to have the `Structure` toolbar between `File` and `Edit`. If this is undesired I will revert this portion of the changes.
