### PR TITLE
Sketcher: Solver - Improvement of popularity contest and bug fix

### DIFF
--- a/src/Mod/Sketcher/App/Sketch.cpp
+++ b/src/Mod/Sketcher/App/Sketch.cpp
@@ -3283,6 +3283,8 @@ int Sketch::addInternalAlignmentKnotPoint(int geoId1, int geoId2, int knotindex)
 
         // no constraint is actually added, as knots are fixed geometry in this implementation
         // indexing is added here.
+        // However, we need to advance the tag, so that the index after a knot constraint is accurate
+        ConstraintsCounter++;
 
         b.knotpointGeoids[knotindex] = geoId2;
 

--- a/src/Mod/Sketcher/App/planegcs/Constraints.cpp
+++ b/src/Mod/Sketcher/App/planegcs/Constraints.cpp
@@ -37,7 +37,7 @@ namespace GCS
 ///////////////////////////////////////
 
 Constraint::Constraint()
-: origpvec(0), pvec(0), scale(1.), tag(0), pvecChangedFlag(true), driving(true)
+: origpvec(0), pvec(0), scale(1.), tag(0), pvecChangedFlag(true), driving(true), internalAlignment(Alignment::NoInternalAlignment)
 {
 }
 

--- a/src/Mod/Sketcher/App/planegcs/Constraints.h
+++ b/src/Mod/Sketcher/App/planegcs/Constraints.h
@@ -94,6 +94,13 @@ namespace GCS
 
     class Constraint
     {
+
+    public:
+        enum class Alignment  {
+            NoInternalAlignment,
+            InternalAlignment
+        };
+
     _PROTECTED_UNLESS_EXTRACT_MODE_:
         VEC_pD origpvec; // is used only as a reference for redirecting and reverting pvec
         VEC_pD pvec;
@@ -101,6 +108,8 @@ namespace GCS
         int tag;
         bool pvecChangedFlag;  //indicates that pvec has changed and saved pointers must be reconstructed (currently used only in AngleViaPoint)
         bool driving;
+        Alignment internalAlignment;
+
     public:
         Constraint();
         virtual ~Constraint(){}
@@ -114,6 +123,9 @@ namespace GCS
 
         void setDriving(bool isdriving) { driving = isdriving; }
         bool isDriving() const { return driving; }
+
+        void setInternalAlignment(Alignment isinternalalignment) { internalAlignment = isinternalalignment; }
+        Alignment isInternalAlignment() const { return internalAlignment; }
 
         virtual ConstraintType getTypeId();
         virtual void rescale(double coef=1.);

--- a/src/Mod/Sketcher/App/planegcs/GCS.h
+++ b/src/Mod/Sketcher/App/planegcs/GCS.h
@@ -230,7 +230,7 @@ namespace GCS
         void removeConstraint(Constraint *constr);
 
         // basic constraints
-        int addConstraintEqual(double *param1, double *param2, int tagId=0, bool driving = true);
+        int addConstraintEqual(double *param1, double *param2, int tagId=0, bool driving = true, Constraint::Alignment internalalignment = Constraint::Alignment::NoInternalAlignment);
         int addConstraintProportional(double *param1, double *param2, double ratio, int tagId, bool driving = true);
         int addConstraintDifference(double *param1, double *param2,
                                     double *difference, int tagId=0, bool driving = true);


### PR DESCRIPTION
================================================================

Master has a problem in that internal alignment constraints are suggested to the user for removal.

This is fundamentally wrong, as an internal alignment constraint are an inherent part of the geometry. They cannot be the ones suggested for removal.

The popularity contest algorithm is an heuristic algorithm that determines which redundant/conflicting constraints should be proposed for removal.

Basically, the algorithm works on groups of redundant/conflicting constraints detected via the QR decomposition. A constraint may belong to more than one group.

The algorithm runs some heuristics, each constraint scoring a value, the one constraint from each group scoring the highest is proposed (is more popular and wins the contest).

This PR documents the algorithm, and adds a further condition, that internal alignment constraints are never proposed.

As the solver works with solver constraints as opposed to the sketcher, which works with sketcher constraints, information about whether a solver constraint originated from a sketcher constraint that is internal alignment is necessary. So the solver constraint is extended to accomodate this piece of information.

As a bonus, it fixes a bug. Solver constraints carry information of the ID of the corresponding sketcher constraint in their tag. Knots are not currently implemented as constraints. However, the tag index was not being update. This caused the popularity contest to provide wrong suggestions despite good detection.
