### PR TITLE
[TD]fix check of wrong variable

### DIFF
--- a/src/Mod/TechDraw/Gui/DrawGuiUtil.cpp
+++ b/src/Mod/TechDraw/Gui/DrawGuiUtil.cpp
@@ -141,8 +141,7 @@ TechDraw::DrawPage* DrawGuiUtil::findPage(Gui::Command* cmd,
             QMessageBox::warning(Gui::getMainWindow(), QObject::tr("No page found"),
                                  QObject::tr("No Drawing Pages in document."));
             return nullptr;
-        }
-        if (docPages.size() > 1) {
+        } else if (docPages.size() > 1) {
             //multiple pages in document, use active page if there is one
             Gui::MainWindow* w = Gui::getMainWindow();
             Gui::MDIView* mv = w->activeWindow();
@@ -150,10 +149,9 @@ TechDraw::DrawPage* DrawGuiUtil::findPage(Gui::Command* cmd,
             if (mvp) {
                 QGSPage* qp = mvp->getViewProviderPage()->getQGSPage();
                 return qp->getDrawPage();
-            }
-            else {
+            } else {
                 // none of pages in document is active, ask for help
-                for (auto obj : selPages) {
+                for (auto obj : docPages) {
                     std::string name = obj->getNameInDocument();
                     names.push_back(name);
                     std::string label = obj->Label.getValue();
@@ -165,13 +163,13 @@ TechDraw::DrawPage* DrawGuiUtil::findPage(Gui::Command* cmd,
                     App::Document* doc = cmd->getDocument();
                     return static_cast<TechDraw::DrawPage*>(doc->getObject(selName.c_str()));
                 }
+                return nullptr;
             }
         } else {
             //only 1 page in document - use it
             return static_cast<TechDraw::DrawPage*>(docPages.front());
         }
-    }
-    else if (selPages.size() > 1) {
+    } else if (selPages.size() > 1) {
         //multiple pages in selection
         for (auto obj : selPages) {
             std::string name = obj->getNameInDocument();


### PR DESCRIPTION
- replace check of pages in selection with check of pages in document
- fix mixed {} conventions
- fix fail to exit on user cancel

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [ ]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [ ]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [ ]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [ ]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the issue ID number from our [Issues database](https://github.com/FreeCAD/FreeCAD/issues) in case a particular commit solves or is related to an existing issue. Ex: `Draft: fix typos - fixes #4805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
