### PR TITLE
Sketcher: remove unneeded flag

### DIFF
--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -3164,7 +3164,6 @@ void ViewProviderSketch::setEditViewer(Gui::View3DInventorViewer* viewer, int Mo
 void ViewProviderSketch::unsetEditViewer(Gui::View3DInventorViewer* viewer)
 {
     auto dataPtr = static_cast<VPRender*>(cameraSensor.getData());
-    dataPtr->attached = false;
     delete dataPtr;
     cameraSensor.setData(nullptr);
     cameraSensor.detach();
@@ -3178,7 +3177,7 @@ void ViewProviderSketch::unsetEditViewer(Gui::View3DInventorViewer* viewer)
 void ViewProviderSketch::camSensCB(void *data, SoSensor *)
 {
     VPRender *proxyVPrdr = static_cast<VPRender*>(data);
-    if (!proxyVPrdr || !proxyVPrdr->attached)
+    if (!proxyVPrdr)
         return;
 
     auto vp = proxyVPrdr->vp;

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.h
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.h
@@ -396,10 +396,6 @@ private:
     struct VPRender {
         ViewProviderSketch* vp;
         SoRenderManager* renderMgr;
-        // we have to manage an internal flag because as sensor events are queued in Coin,
-        // it may happen that the callback is called while the sensor is detached,
-        // leading to subsequent code trying to access deleted objects (passed as sensor data)
-        bool attached = true;
     };
 
 public:


### PR DESCRIPTION
@wwmayer I actually introduced this flag because I did something stupid when testing corner cases when I introduced the last changes.
Your commit ee0a0817f shed light on my mistake ... at the price of some inconvenience for you. Sorry for that.
Another lesson learned. :)