### PR TITLE
[Sketch] set readable tooltip for DoF selection 

### DIFF
--- a/src/Mod/Sketcher/Gui/TaskSketcherMessages.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherMessages.cpp
@@ -111,26 +111,26 @@ void TaskSketcherMessages::slotSetUp(const QString& state, const QString& msg, c
 
 void TaskSketcherMessages::on_labelConstrainStatusLink_linkClicked(const QString &str)
 {
-    if( str == QString::fromLatin1("#conflicting"))
+    if (str == QString::fromLatin1("#conflicting"))
         Gui::Application::Instance->commandManager().runCommandByName("Sketcher_SelectConflictingConstraints");
     else
-    if( str == QString::fromLatin1("#redundant"))
+    if (str == QString::fromLatin1("#redundant"))
         Gui::Application::Instance->commandManager().runCommandByName("Sketcher_SelectRedundantConstraints");
     else
-    if( str == QString::fromLatin1("#dofs"))
+    if (str == QString::fromLatin1("Select geometrical elements where solver\n"
+                                    "detects unconstrained degrees of freedom"))
         Gui::Application::Instance->commandManager().runCommandByName("Sketcher_SelectElementsWithDoFs");
     else
-    if( str == QString::fromLatin1("#malformed"))
+    if (str == QString::fromLatin1("#malformed"))
         Gui::Application::Instance->commandManager().runCommandByName("Sketcher_SelectMalformedConstraints");
     else
-    if( str == QString::fromLatin1("#partiallyredundant"))
+    if (str == QString::fromLatin1("#partiallyredundant"))
         Gui::Application::Instance->commandManager().runCommandByName("Sketcher_SelectPartiallyRedundantConstraints");
-
 }
 
 void TaskSketcherMessages::on_autoUpdate_stateChanged(int state)
 {
-    if(state==Qt::Checked) {
+    if (state==Qt::Checked) {
         sketchView->getSketchObject()->noRecomputes=false;
         ui->autoUpdate->onSave();
     }

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -3009,8 +3009,9 @@ void ViewProviderSketch::UpdateSolverInformation()
     } else if (dofs > 0) {
         signalSetUp(QString::fromUtf8("under_constrained"),
             tr("Under constrained:"),
-            QString::fromUtf8("#dofs"),
-            tr("%n DoF(s)","",dofs));
+                    QString::fromUtf8("Select geometrical elements where solver\n"
+                                      "detects unconstrained degrees of freedom"),
+            tr("%n Degree(s) of freedom", "", dofs));
     }
     else {
         signalSetUp(QString::fromUtf8("fully_constrained"), tr("Fully constrained"), QString(), QString());


### PR DESCRIPTION
- since the removal of the DOF toolbar button we only have the link to select DOFs. this has however, only the meaningless tooltip "#dof" (we have many users who use English menus but are no native speakers because FC is not translated to their language. For them the term "#dof" is quite meaningless)
- also change the string "DoF" for the same reason

@chennes , @PaddleStroke 