### PR TITLE
Sketcher: Gui: force-hide toolbars + Split sketcher toolbar

### DIFF
--- a/src/Gui/ToolBarManager.h
+++ b/src/Gui/ToolBarManager.h
@@ -35,8 +35,13 @@ namespace Gui {
 class GuiExport ToolBarItem
 {
 public:
+    enum class HideStyle {
+        VISIBLE,
+        FORCE_HIDE // Force a toolbar to be hidden. For when all elements are disabled at some point in a workbench.
+    };
+
     ToolBarItem();
-    ToolBarItem(ToolBarItem* item);
+    ToolBarItem(ToolBarItem* item, HideStyle forceHide = HideStyle::VISIBLE);
     ~ToolBarItem();
 
     void setCommand(const std::string&);
@@ -55,6 +60,8 @@ public:
     ToolBarItem& operator << (ToolBarItem* item);
     ToolBarItem& operator << (const std::string& command);
     QList<ToolBarItem*> getItems() const;
+
+    HideStyle forceHide;
 
 private:
     std::string _name;
@@ -81,6 +88,8 @@ public:
     void retranslate() const;
 
     void setMovable(bool movable) const;
+    void setToolbarVisibility(bool show, const QList<QString>& names);
+    void setToolbarVisibility(bool show, const QString& name);
 
 protected:
     void setup(ToolBarItem*, QToolBar*) const;

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -66,6 +66,7 @@
 #include <Gui/Utilities.h>
 #include <Gui/View3DInventor.h>
 #include <Gui/View3DInventorViewer.h>
+#include "Gui/ToolBarManager.h"
 
 #include <Mod/Part/App/Geometry.h>
 #include <Mod/Sketcher/App/GeoList.h>
@@ -82,6 +83,7 @@
 #include "TaskSketcherValidation.h"
 #include "Utils.h"
 #include "ViewProviderSketchGeometryExtension.h"
+
 
 
 FC_LOG_LEVEL_INIT("Sketch",true,true)
@@ -314,7 +316,6 @@ ViewProviderSketch::ViewProviderSketch()
     rubberband = std::make_unique<Gui::Rubberband>();
 
     cameraSensor.setFunction(&ViewProviderSketch::camSensCB);
-
 }
 
 ViewProviderSketch::~ViewProviderSketch()
@@ -2748,6 +2749,25 @@ void ViewProviderSketch::setupContextMenu(QMenu *menu, QObject *receiver, const 
     Gui::ViewProvider::setupContextMenu(menu, receiver, member);
 }
 
+namespace
+{
+    inline const QStringList editModeToolbarNames()
+    {
+        return QStringList{ QString::fromLatin1("Sketcher Edit Mode"),
+                            QString::fromLatin1("Sketcher geometries"),
+                            QString::fromLatin1("Sketcher constraints"),
+                            QString::fromLatin1("Sketcher tools"),
+                            QString::fromLatin1("Sketcher B-spline tools"),
+                            QString::fromLatin1("Sketcher virtual space") };
+    }
+
+    inline const QStringList nonEditModeToolbarNames()
+    {
+        return QStringList{ QString::fromLatin1("Structure"),
+                            QString::fromLatin1("Sketcher") };
+    }
+}
+
 bool ViewProviderSketch::setEdit(int ModNum)
 {
     // When double-clicking on the item for this sketch the
@@ -2890,6 +2910,14 @@ bool ViewProviderSketch::setEdit(int ModNum)
 
     Gui::getMainWindow()->installEventFilter(listener);
 
+    /*Modify toolbars dynamically.
+    First save state of toolbars in case user changed visibility of a toolbar but he's not changing the wb.
+    This happens in someone works directly from sketcher, changing from edit mode to not-edit-mode*/
+    Gui::ToolBarManager::getInstance()->saveState();
+
+    Gui::ToolBarManager::getInstance()->setToolbarVisibility(true, editModeToolbarNames());
+    Gui::ToolBarManager::getInstance()->setToolbarVisibility(false, nonEditModeToolbarNames());
+
     return true;
 }
 
@@ -3020,6 +3048,15 @@ void ViewProviderSketch::UpdateSolverInformation()
 void ViewProviderSketch::unsetEdit(int ModNum)
 {
     Q_UNUSED(ModNum);
+
+    /*Modify toolbars dynamically.
+    First save state of toolbars in case user changed visibility of a toolbar but he's not changing the wb.
+    This happens in someone works directly from sketcher, changing from edit mode to not-edit-mode*/
+    Gui::ToolBarManager::getInstance()->saveState();
+
+    Gui::ToolBarManager::getInstance()->setToolbarVisibility(false, editModeToolbarNames());
+    Gui::ToolBarManager::getInstance()->setToolbarVisibility(true, nonEditModeToolbarNames());
+
     TightGrid.setValue(true);
 
     if(listener) {

--- a/src/Mod/Sketcher/Gui/Workbench.cpp
+++ b/src/Mod/Sketcher/Gui/Workbench.cpp
@@ -114,27 +114,27 @@ Gui::ToolBarItem* Workbench::setupToolBars() const
     sketcher->setCommand("Sketcher");
     addSketcherWorkbenchSketchActions(*sketcher);
 
-    Gui::ToolBarItem* sketcherEditMode = new Gui::ToolBarItem(root);
-    sketcherEditMode->setCommand("Sketcher");
+    Gui::ToolBarItem* sketcherEditMode = new Gui::ToolBarItem(root, Gui::ToolBarItem::HideStyle::FORCE_HIDE);
+    sketcherEditMode->setCommand("Sketcher Edit Mode");
     addSketcherWorkbenchSketchEditModeActions(*sketcherEditMode);
 
-    Gui::ToolBarItem* geom = new Gui::ToolBarItem(root);
+    Gui::ToolBarItem* geom = new Gui::ToolBarItem(root, Gui::ToolBarItem::HideStyle::FORCE_HIDE);
     geom->setCommand("Sketcher geometries");
     addSketcherWorkbenchGeometries(*geom);
 
-    Gui::ToolBarItem* cons = new Gui::ToolBarItem(root);
+    Gui::ToolBarItem* cons = new Gui::ToolBarItem(root, Gui::ToolBarItem::HideStyle::FORCE_HIDE);
     cons->setCommand("Sketcher constraints");
     addSketcherWorkbenchConstraints(*cons);
 
-    Gui::ToolBarItem* consaccel = new Gui::ToolBarItem(root);
+    Gui::ToolBarItem* consaccel = new Gui::ToolBarItem(root, Gui::ToolBarItem::HideStyle::FORCE_HIDE);
     consaccel->setCommand("Sketcher tools");
     addSketcherWorkbenchTools(*consaccel);
 
-    Gui::ToolBarItem* bspline = new Gui::ToolBarItem(root);
+    Gui::ToolBarItem* bspline = new Gui::ToolBarItem(root, Gui::ToolBarItem::HideStyle::FORCE_HIDE);
     bspline->setCommand("Sketcher B-spline tools");
     addSketcherWorkbenchBSplines(*bspline);
 
-    Gui::ToolBarItem* virtualspace = new Gui::ToolBarItem(root);
+    Gui::ToolBarItem* virtualspace = new Gui::ToolBarItem(root, Gui::ToolBarItem::HideStyle::FORCE_HIDE);
     virtualspace->setCommand("Sketcher virtual space");
     addSketcherWorkbenchVirtualSpace(*virtualspace);
 

--- a/src/Mod/Sketcher/Gui/Workbench.cpp
+++ b/src/Mod/Sketcher/Gui/Workbench.cpp
@@ -96,6 +96,7 @@ Gui::MenuItem* Workbench::setupMenuBar() const
     root->insertItem(item, sketch);
     sketch->setCommand("S&ketch");
     addSketcherWorkbenchSketchActions(*sketch);
+    addSketcherWorkbenchSketchEditModeActions(*sketch);
     *sketch << geom
             << cons
             << consaccel
@@ -112,6 +113,10 @@ Gui::ToolBarItem* Workbench::setupToolBars() const
     Gui::ToolBarItem* sketcher = new Gui::ToolBarItem(root);
     sketcher->setCommand("Sketcher");
     addSketcherWorkbenchSketchActions(*sketcher);
+
+    Gui::ToolBarItem* sketcherEditMode = new Gui::ToolBarItem(root);
+    sketcherEditMode->setCommand("Sketcher");
+    addSketcherWorkbenchSketchEditModeActions(*sketcherEditMode);
 
     Gui::ToolBarItem* geom = new Gui::ToolBarItem(root);
     geom->setCommand("Sketcher geometries");
@@ -147,40 +152,48 @@ Gui::ToolBarItem* Workbench::setupCommandBars() const
 namespace SketcherGui {
 
 template <typename T>
-inline void SketcherAddWorkspaceSketchExtra(T& /*sketch*/) { }
+void SketcherAddWorkbenchSketchActions(T& sketch);
 
 template <>
-inline void SketcherAddWorkspaceSketchExtra<Gui::MenuItem>(Gui::MenuItem& sketch)
+inline void SketcherAddWorkbenchSketchActions(Gui::MenuItem& sketch)
 {
-    sketch  << "Sketcher_ReorientSketch"
+    sketch  << "Sketcher_NewSketch"
+            << "Sketcher_EditSketch"
+            << "Sketcher_MapSketch"
+            << "Sketcher_ReorientSketch"
             << "Sketcher_ValidateSketch"
             << "Sketcher_MergeSketches"
-            << "Sketcher_MirrorSketch"
-            << "Sketcher_StopOperation";
+            << "Sketcher_MirrorSketch";
 }
-
 template <>
-inline void SketcherAddWorkspaceSketchExtra<Gui::ToolBarItem>(Gui::ToolBarItem& sketch)
+inline void SketcherAddWorkbenchSketchActions(Gui::ToolBarItem& sketch)
 {
-    sketch  << "Sketcher_ReorientSketch"
+    sketch  << "Sketcher_NewSketch"
+            << "Sketcher_EditSketch"
+            << "Sketcher_MapSketch"
+            << "Sketcher_ReorientSketch"
             << "Sketcher_ValidateSketch"
             << "Sketcher_MergeSketches"
             << "Sketcher_MirrorSketch";
 }
 
 template <typename T>
-void SketcherAddWorkbenchSketchActions(T& sketch);
+void SketcherAddWorkbenchSketchEditModeActions(T& sketch);
 
-template <typename T>
-inline void SketcherAddWorkbenchSketchActions(T& sketch)
+template <>
+inline void SketcherAddWorkbenchSketchEditModeActions(Gui::MenuItem& sketch)
 {
-    sketch  << "Sketcher_NewSketch"
-            << "Sketcher_EditSketch"
-            << "Sketcher_LeaveSketch"
+    sketch  << "Sketcher_LeaveSketch"
             << "Sketcher_ViewSketch"
             << "Sketcher_ViewSection"
-            << "Sketcher_MapSketch";
-    SketcherAddWorkspaceSketchExtra(sketch);
+            << "Sketcher_StopOperation";
+}
+template <>
+inline void SketcherAddWorkbenchSketchEditModeActions(Gui::ToolBarItem& sketch)
+{
+    sketch  << "Sketcher_LeaveSketch"
+            << "Sketcher_ViewSketch"
+            << "Sketcher_ViewSection";
 }
 
 template <typename T>
@@ -444,6 +457,11 @@ void addSketcherWorkbenchSketchActions(Gui::MenuItem& sketch)
     SketcherAddWorkbenchSketchActions(sketch);
 }
 
+void addSketcherWorkbenchSketchEditModeActions(Gui::MenuItem& sketch)
+{
+    SketcherAddWorkbenchSketchEditModeActions(sketch);
+}
+
 void addSketcherWorkbenchGeometries(Gui::MenuItem& geom)
 {
     SketcherAddWorkbenchGeometries(geom);
@@ -472,6 +490,11 @@ void addSketcherWorkbenchVirtualSpace(Gui::MenuItem& virtualspace)
 void addSketcherWorkbenchSketchActions(Gui::ToolBarItem& sketch)
 {
     SketcherAddWorkbenchSketchActions(sketch);
+}
+
+void addSketcherWorkbenchSketchEditModeActions(Gui::ToolBarItem& sketch)
+{
+    SketcherAddWorkbenchSketchEditModeActions(sketch);
 }
 
 void addSketcherWorkbenchGeometries(Gui::ToolBarItem& geom)

--- a/src/Mod/Sketcher/Gui/Workbench.h
+++ b/src/Mod/Sketcher/Gui/Workbench.h
@@ -49,6 +49,7 @@ protected:
 };
 
 SketcherGuiExport void addSketcherWorkbenchSketchActions(Gui::MenuItem& sketch);
+SketcherGuiExport void addSketcherWorkbenchSketchEditModeActions(Gui::MenuItem& sketch);
 SketcherGuiExport void addSketcherWorkbenchGeometries(Gui::MenuItem& geom);
 SketcherGuiExport void addSketcherWorkbenchConstraints(Gui::MenuItem& cons);
 SketcherGuiExport void addSketcherWorkbenchTools(Gui::MenuItem& consaccel);
@@ -56,6 +57,7 @@ SketcherGuiExport void addSketcherWorkbenchBSplines(Gui::MenuItem& bspline);
 SketcherGuiExport void addSketcherWorkbenchVirtualSpace(Gui::MenuItem& virtualspace);
 
 SketcherGuiExport void addSketcherWorkbenchSketchActions(Gui::ToolBarItem& sketch);
+SketcherGuiExport void addSketcherWorkbenchSketchEditModeActions(Gui::ToolBarItem& sketch);
 SketcherGuiExport void addSketcherWorkbenchGeometries(Gui::ToolBarItem& geom);
 SketcherGuiExport void addSketcherWorkbenchConstraints(Gui::ToolBarItem& cons);
 SketcherGuiExport void addSketcherWorkbenchTools(Gui::ToolBarItem& consaccel);


### PR DESCRIPTION
The offered change is to :
Commit 1 - split the main sketcher toolbar in 2. One for tools that are only in edit mode. One for tools that are only in non-edit-mode.

![image](https://user-images.githubusercontent.com/19984177/198213097-0e620109-563a-46a3-99fc-bef74ab8f6c3.png)

Commit 2 - This adds the systemwide possibility to hide toolbars at anytime while in a workbench.
Show/hide automatically toolbars depending if we are in edit mode or not.
More specifically it hides : Sketcher-edit-mode, Geometry, constraint, tools, virtualSpace toolbars when in sketcher-not-edit-mode.
And it hides : Sketcher and Structure toolbar when in sketcher-edit-mode
Video presentation : https://youtu.be/5HF8f648JlU

[See discussion : https://forum.freecadweb.org/viewtopic.php?f=8&t=72946](https://forum.freecadweb.org/viewtopic.php?f=17&t=72978)

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [ ]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [ ]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [ ]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [ ]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the issue ID number from our [Issues database](https://github.com/FreeCAD/FreeCAD/issues) in case a particular commit solves or is related to an existing issue. Ex: `Draft: fix typos - fixes #4805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
