### PR TITLE
Draft: Change Snap toolbar to standard toolbar

### DIFF
--- a/src/Mod/Arch/InitGui.py
+++ b/src/Mod/Arch/InitGui.py
@@ -153,6 +153,7 @@ class ArchWorkbench(FreeCADGui.Workbench):
         self.draft_modification_commands = it.get_draft_modification_commands()
         self.draft_utility_commands = it.get_draft_utility_commands_menu()
         self.draft_context_commands = it.get_draft_context_commands()
+        self.draft_snap_commands = it.get_draft_snap_commands()
 
         # Set up toolbars
         it.init_toolbar(self,
@@ -167,6 +168,9 @@ class ArchWorkbench(FreeCADGui.Workbench):
         it.init_toolbar(self,
                         QT_TRANSLATE_NOOP("Workbench", "Draft modification tools"),
                         self.draft_modification_commands)
+        it.init_toolbar(self,
+                        QT_TRANSLATE_NOOP("Workbench", "Draft snap"),
+                        self.draft_snap_commands)
 
         # Set up menus
         it.init_menu(self,

--- a/src/Mod/Draft/InitGui.py
+++ b/src/Mod/Draft/InitGui.py
@@ -112,6 +112,9 @@ class DraftWorkbench(FreeCADGui.Workbench):
         it.init_toolbar(self,
                         QT_TRANSLATE_NOOP("Workbench", "Draft utility tools"),
                         self.utility_commands_toolbar)
+        it.init_toolbar(self,
+                        QT_TRANSLATE_NOOP("Workbench", "Draft snap"),
+                        it.get_draft_snap_commands())
 
         # Set up menus
         it.init_menu(self,

--- a/src/Mod/Draft/draftguitools/gui_snaps.py
+++ b/src/Mod/Draft/draftguitools/gui_snaps.py
@@ -1,7 +1,8 @@
 # ***************************************************************************
-# *   (c) 2009, 2010 Yorik van Havre <yorik@uncreated.net>                  *
-# *   (c) 2009, 2010 Ken Cline <cline@frii.com>                             *
-# *   (c) 2020 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de>           *
+# *   Copyright (c) 2009, 2010 Yorik van Havre <yorik@uncreated.net>        *
+# *   Copyright (c) 2009, 2010 Ken Cline <cline@frii.com>                   *
+# *   Copyright (c) 2020 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de> *
+# *   Copyright (c) 2022 FreeCAD Project Association                        *
 # *                                                                         *
 # *   This file is part of the FreeCAD CAx development system.              *
 # *                                                                         *
@@ -29,570 +30,307 @@
 
 ## \addtogroup draftguitools
 # @{
-import PySide.QtGui as QtGui
+from PySide import QtGui
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCADGui as Gui
 import draftguitools.gui_base as gui_base
 
-from draftutils.messages import _msg, _log
+from draftutils.messages import _log
 from draftutils.translate import translate
 
 
-# UTILITIES -----------------------------------------------------------------
-
-
-def get_snap_statusbar_widget():
-    """Return snap statusbar button."""
-    mw = Gui.getMainWindow()
-    if mw:
-        sb = mw.statusBar()
-        if sb:
-            return sb.findChild(QtGui.QToolBar,"draft_snap_widget")
-    return None
-
-
-def sync_snap_toolbar_button(button, status):
-    """Set snap toolbar button to given state."""
-    snap_toolbar = Gui.Snapper.get_snap_toolbar()
-    if not snap_toolbar:
-        return
-
-    # Setting the snap lock button enables or disables all of the other snap actions:
-    if button == "Draft_Snap_Lock_Button":
-        snap_toolbar.actions()[0].setChecked(status) # Snap lock must be the first button
-        for action in snap_toolbar.actions()[1:]:
-            if action.objectName()[:10] == "Draft_Snap":
-                action.setEnabled(status)
-
-    # All other buttons only affect themselves
-    else:
-        for action in snap_toolbar.actions():
-            if action.objectName() == button:
-                action.setChecked(status)
-                if action.isChecked():
-                    action.setToolTip(action.toolTip().replace("OFF","ON"))
-                else:
-                    action.setToolTip(action.toolTip().replace("ON","OFF"))
-                return
-
-
-def sync_snap_statusbar_button(button, status):
-    """Set snap statusbar button to given state."""
-    ssw = get_snap_statusbar_widget()
-    if not ssw:
-        return
-    for child in ssw.children():
-        if child.objectName() == "Snap_Statusbutton":
-            ssb = child
-    actions = []
-    for a in ssb.menu().actions() + ssw.children()[-6:]:
-        actions.append(a)
-
-    if button == "Draft_Snap_Lock_Statusbutton":
-        ssb.setChecked(status)
-        for a in actions[1:]:
-            if a.objectName()[:10] == "Draft_Snap":
-                a.setEnabled(status)
-    else:
-        for a in actions:
-            if a.objectName() == button:
-                a.setChecked(status)
-                return
-
-
-# SNAP GUI TOOLS ------------------------------------------------------------
-
 class Draft_Snap_Base():
-    def __init__(self, name="None"):
-        self.command_name = name
+    """Base Class inherited by all Draft Snap commands."""
+
+    def __init__(self, command_name="None"):
+        self.command_name = command_name
+
+    def Activated(self, status=0):
+        # _log("GuiCommand: {}".format(self.command_name))
+        if hasattr(Gui, "Snapper"):
+            Gui.Snapper.toggle_snap(self.command_name[11:], bool(status))
 
     def IsActive(self):
-        return True
+        return hasattr(Gui, "Snapper") and Gui.Snapper.isEnabled("Lock")
 
-    def Activated(self):
-        _log("GuiCommand: {}".format(self.command_name))
-        #_msg("{}".format(16*"-"))
-        #_msg("GuiCommand: {}".format(self.command_name))
+    def isChecked(self):
+        """Return true if the given snap is active in Snapper."""
+        return hasattr(Gui, "Snapper") and self.command_name[11:] in Gui.Snapper.active_snaps
 
 
 class Draft_Snap_Lock(Draft_Snap_Base):
-    """GuiCommand for the Draft_Snap_Lock tool.
-
-    Activate or deactivate all snap methods at once.
-    """
+    """GuiCommand for the Draft_Snap_Lock tool."""
 
     def __init__(self):
-        super(Draft_Snap_Lock, self).__init__(name=translate("draft","Main toggle snap"))
+        super().__init__(command_name="Draft_Snap_Lock")
 
     def GetResources(self):
-        """Set icon, menu and tooltip."""
+        return {"Pixmap":    "Snap_Lock",
+                "Accel":     "Shift+S",
+                "MenuText":  QT_TRANSLATE_NOOP("Draft_Snap_Lock", "Snap Lock"),
+                "ToolTip":   QT_TRANSLATE_NOOP("Draft_Snap_Lock", "Enables or disables snapping globally."),
+                "CmdType":   "NoTransaction",
+                "Checkable": self.isChecked()}
 
-        return {'Pixmap': 'Snap_Lock',
-                'Accel': "Shift+S",
-                'MenuText': QT_TRANSLATE_NOOP("Draft_Snap_Lock", "Main snapping toggle On/Off"),
-                'ToolTip': QT_TRANSLATE_NOOP("Draft_Snap_Lock", "Activates or deactivates all snap methods at once.")}
-
-    def Activated(self):
-        """Execute when the command is called."""
-        super(Draft_Snap_Lock, self).Activated()
-
-        if hasattr(Gui, "Snapper"):
-            status = Gui.Snapper.toggle_snap('Lock')
-            # change interface consistently
-            sync_snap_toolbar_button("Draft_Snap_Lock"+"_Button", status)
-            sync_snap_statusbar_button("Draft_Snap_Lock"+"_Statusbutton", status)
+    def IsActive(self): return True
 
 
-Gui.addCommand('Draft_Snap_Lock', Draft_Snap_Lock())
+Gui.addCommand("Draft_Snap_Lock", Draft_Snap_Lock())
 
 
 class Draft_Snap_Midpoint(Draft_Snap_Base):
-    """GuiCommand for the Draft_Snap_Midpoint tool.
-
-    Set snapping to the midpoint of an edge.
-    """
+    """GuiCommand for the Draft_Snap_Midpoint tool."""
 
     def __init__(self):
-        super(Draft_Snap_Midpoint, self).__init__(name=translate("draft","Midpoint snap"))
+        super().__init__(command_name="Draft_Snap_Midpoint")
 
     def GetResources(self):
-        """Set icon, menu and tooltip."""
-
-        return {'Pixmap': 'Snap_Midpoint',
-                'MenuText': QT_TRANSLATE_NOOP("Draft_Snap_Midpoint", "Midpoint"),
-                'ToolTip': QT_TRANSLATE_NOOP("Draft_Snap_Midpoint", "Set snapping to the midpoint of an edge.")}
-
-    def Activated(self):
-        """Execute when the command is called."""
-        super(Draft_Snap_Midpoint, self).Activated()
-
-        if hasattr(Gui, "Snapper"):
-            status = Gui.Snapper.toggle_snap('Midpoint')
-            # change interface consistently
-            sync_snap_toolbar_button("Draft_Snap_Midpoint"+"_Button", status)
-            sync_snap_statusbar_button("Draft_Snap_Midpoint_Statusbutton", status)
+        return {"Pixmap":    "Snap_Midpoint",
+                "MenuText":  QT_TRANSLATE_NOOP("Draft_Snap_Midpoint", "Snap Midpoint"),
+                "ToolTip":   QT_TRANSLATE_NOOP("Draft_Snap_Midpoint", "Snaps to the midpoint of edges."),
+                "CmdType":   "NoTransaction",
+                "Checkable": self.isChecked()}
 
 
-Gui.addCommand('Draft_Snap_Midpoint', Draft_Snap_Midpoint())
+Gui.addCommand("Draft_Snap_Midpoint", Draft_Snap_Midpoint())
 
 
 class Draft_Snap_Perpendicular(Draft_Snap_Base):
-    """GuiCommand for the Draft_Snap_Perpendicular tool.
-
-    Set snapping to a direction that is perpendicular to an edge.
-    """
+    """GuiCommand for the Draft_Snap_Perpendicular tool."""
 
     def __init__(self):
-        super(Draft_Snap_Perpendicular, self).__init__(name=translate("draft","Perpendicular snap"))
+        super().__init__(command_name="Draft_Snap_Perpendicular")
 
     def GetResources(self):
-        """Set icon, menu and tooltip."""
-
-        return {'Pixmap': 'Snap_Perpendicular',
-                'MenuText': QT_TRANSLATE_NOOP("Draft_Snap_Perpendicular", "Perpendicular"),
-                'ToolTip': QT_TRANSLATE_NOOP("Draft_Snap_Perpendicular", "Set snapping to a direction that is perpendicular to an edge.")}
-
-    def Activated(self):
-        """Execute when the command is called."""
-        super(Draft_Snap_Perpendicular, self).Activated()
-
-        if hasattr(Gui, "Snapper"):
-            status = Gui.Snapper.toggle_snap('Perpendicular')
-            # change interface consistently
-            sync_snap_toolbar_button("Draft_Snap_Perpendicular"+"_Button", status)
-            sync_snap_statusbar_button("Draft_Snap_Perpendicular_Statusbutton", status)
+        return {"Pixmap":    "Snap_Perpendicular",
+                "MenuText":  QT_TRANSLATE_NOOP("Draft_Snap_Perpendicular", "Snap Perpendicular"),
+                "ToolTip":   QT_TRANSLATE_NOOP("Draft_Snap_Perpendicular", "Snaps to the perpendicular points on faces and edges."),
+                "CmdType":   "NoTransaction",
+                "Checkable": self.isChecked()}
 
 
-Gui.addCommand('Draft_Snap_Perpendicular', Draft_Snap_Perpendicular())
+Gui.addCommand("Draft_Snap_Perpendicular", Draft_Snap_Perpendicular())
 
 
 class Draft_Snap_Grid(Draft_Snap_Base):
-    """GuiCommand for the Draft_Snap_Grid tool.
-
-    Set snapping to the intersection of grid lines.
-    """
+    """GuiCommand for the Draft_Snap_Grid tool."""
 
     def __init__(self):
-        super(Draft_Snap_Grid, self).__init__(name=translate("draft","Grid snap"))
+        super().__init__(command_name="Draft_Snap_Grid")
 
     def GetResources(self):
-        """Set icon, menu and tooltip."""
-
-        return {'Pixmap': 'Snap_Grid',
-                'MenuText': QT_TRANSLATE_NOOP("Draft_Snap_Grid", "Grid"),
-                'ToolTip': QT_TRANSLATE_NOOP("Draft_Snap_Grid", "Set snapping to the intersection of grid lines.")}
-
-    def Activated(self):
-        """Execute when the command is called."""
-        super(Draft_Snap_Grid, self).Activated()
-
-        if hasattr(Gui, "Snapper"):
-            status = Gui.Snapper.toggle_snap('Grid')
-            # change interface consistently
-            sync_snap_toolbar_button("Draft_Snap_Grid"+"_Button", status)
-            sync_snap_statusbar_button("Draft_Snap_Grid_Statusbutton", status)
+        return {"Pixmap":    "Snap_Grid",
+                "MenuText":  QT_TRANSLATE_NOOP("Draft_Snap_Grid", "Snap Grid"),
+                "ToolTip":   QT_TRANSLATE_NOOP("Draft_Snap_Grid", "Snaps to the intersections of grid lines."),
+                "CmdType":   "NoTransaction",
+                "Checkable": self.isChecked()}
 
 
-Gui.addCommand('Draft_Snap_Grid', Draft_Snap_Grid())
+Gui.addCommand("Draft_Snap_Grid", Draft_Snap_Grid())
 
 
 class Draft_Snap_Intersection(Draft_Snap_Base):
-    """GuiCommand for the Draft_Snap_Intersection tool.
-
-    Set snapping to the intersection of edges.
-    """
+    """GuiCommand for the Draft_Snap_Intersection tool."""
 
     def __init__(self):
-        super(Draft_Snap_Intersection, self).__init__(name=translate("draft","Intersection snap"))
+        super().__init__(command_name="Draft_Snap_Intersection")
 
     def GetResources(self):
-        """Set icon, menu and tooltip."""
-
-        return {'Pixmap': 'Snap_Intersection',
-                'MenuText': QT_TRANSLATE_NOOP("Draft_Snap_Intersection","Intersection"),
-                'ToolTip': QT_TRANSLATE_NOOP("Draft_Snap_Intersection","Set snapping to the intersection of edges.")}
-
-    def Activated(self):
-        """Execute when the command is called."""
-        super(Draft_Snap_Intersection, self).Activated()
-
-        if hasattr(Gui, "Snapper"):
-            status = Gui.Snapper.toggle_snap('Intersection')
-            # change interface consistently
-            sync_snap_toolbar_button("Draft_Snap_Intersection"+"_Button", status)
-            sync_snap_statusbar_button("Draft_Snap_Intersection_Statusbutton", status)
+        return {"Pixmap":    "Snap_Intersection",
+                "MenuText":  QT_TRANSLATE_NOOP("Draft_Snap_Intersection", "Snap Intersection"),
+                "ToolTip":   QT_TRANSLATE_NOOP("Draft_Snap_Intersection", "Snaps to the intersection of two edges."),
+                "CmdType":   "NoTransaction",
+                "Checkable": self.isChecked()}
 
 
-Gui.addCommand('Draft_Snap_Intersection', Draft_Snap_Intersection())
+Gui.addCommand("Draft_Snap_Intersection", Draft_Snap_Intersection())
 
 
 class Draft_Snap_Parallel(Draft_Snap_Base):
-    """GuiCommand for the Draft_Snap_Parallel tool.
-
-    Set snapping to a direction that is parallel to an edge.
-    """
+    """GuiCommand for the Draft_Snap_Parallel tool."""
 
     def __init__(self):
-        super(Draft_Snap_Parallel, self).__init__(name=translate("draft","Parallel snap"))
+        super().__init__(command_name="Draft_Snap_Parallel")
 
     def GetResources(self):
-        """Set icon, menu and tooltip."""
-
-        return {'Pixmap': 'Snap_Parallel',
-                'MenuText': QT_TRANSLATE_NOOP("Draft_Snap_Parallel", "Parallel"),
-                'ToolTip': QT_TRANSLATE_NOOP("Draft_Snap_Parallel", "Set snapping to a direction that is parallel to an edge.")}
-
-    def Activated(self):
-        """Execute when the command is called."""
-        super(Draft_Snap_Parallel, self).Activated()
-
-        if hasattr(Gui, "Snapper"):
-            status = Gui.Snapper.toggle_snap('Parallel')
-            # change interface consistently
-            sync_snap_toolbar_button("Draft_Snap_Parallel"+"_Button", status)
-            sync_snap_statusbar_button("Draft_Snap_Parallel_Statusbutton", status)
+        return {"Pixmap":    "Snap_Parallel",
+                "MenuText":  QT_TRANSLATE_NOOP("Draft_Snap_Parallel", "Snap Parallel"),
+                "ToolTip":   QT_TRANSLATE_NOOP("Draft_Snap_Parallel", "Snaps to an imaginary line parallel to straight edges."),
+                "CmdType":   "NoTransaction",
+                "Checkable": self.isChecked()}
 
 
-Gui.addCommand('Draft_Snap_Parallel', Draft_Snap_Parallel())
+Gui.addCommand("Draft_Snap_Parallel", Draft_Snap_Parallel())
 
 
 class Draft_Snap_Endpoint(Draft_Snap_Base):
-    """GuiCommand for the Draft_Snap_Endpoint tool.
-
-    Set snapping to endpoints of an edge.
-    """
+    """GuiCommand for the Draft_Snap_Endpoint tool."""
 
     def __init__(self):
-        super(Draft_Snap_Endpoint, self).__init__(name=translate("draft","Endpoint snap"))
+        super().__init__(command_name="Draft_Snap_Endpoint")
 
     def GetResources(self):
-        """Set icon, menu and tooltip."""
-
-        return {'Pixmap': 'Snap_Endpoint',
-                'MenuText': QT_TRANSLATE_NOOP("Draft_Snap_Endpoint", "Endpoint"),
-                'ToolTip': QT_TRANSLATE_NOOP("Draft_Snap_Endpoint", "Set snapping to endpoints of an edge.")}
-
-    def Activated(self):
-        """Execute when the command is called."""
-        super(Draft_Snap_Endpoint, self).Activated()
-
-        if hasattr(Gui, "Snapper"):
-            status = Gui.Snapper.toggle_snap('Endpoint')
-            # change interface consistently
-            sync_snap_toolbar_button("Draft_Snap_Endpoint"+"_Button", status)
-            sync_snap_statusbar_button("Draft_Snap_Endpoint_Statusbutton", status)
+        return {"Pixmap":    "Snap_Endpoint",
+                "MenuText":  QT_TRANSLATE_NOOP("Draft_Snap_Endpoint", "Snap Endpoint"),
+                "ToolTip":   QT_TRANSLATE_NOOP("Draft_Snap_Endpoint", "Snaps to the endpoints of edges."),
+                "CmdType":   "NoTransaction",
+                "Checkable": self.isChecked()}
 
 
-Gui.addCommand('Draft_Snap_Endpoint', Draft_Snap_Endpoint())
+Gui.addCommand("Draft_Snap_Endpoint", Draft_Snap_Endpoint())
 
 
 class Draft_Snap_Angle(Draft_Snap_Base):
-    """GuiCommand for the Draft_Snap_Angle tool.
-
-    Set snapping to points in a circular arc located at multiples
-    of 30 and 45 degree angles.
-    """
+    """GuiCommand for the Draft_Snap_Angle tool."""
 
     def __init__(self):
-        super(Draft_Snap_Angle, self).__init__(name=translate("draft","Angle snap (30 and 45 degrees)"))
+        super().__init__(command_name="Draft_Snap_Angle")
 
     def GetResources(self):
-        """Set icon, menu and tooltip."""
-
-        return {'Pixmap': 'Snap_Angle',
-                'MenuText': QT_TRANSLATE_NOOP("Draft_Snap_Angle", "Angle"),
-                'ToolTip': QT_TRANSLATE_NOOP("Draft_Snap_Angle", "Set snapping to points in a circular arc located at multiples of 30 and 45 degree angles.")}
-
-    def Activated(self):
-        """Execute when the command is called."""
-        super(Draft_Snap_Angle, self).Activated()
-
-        if hasattr(Gui, "Snapper"):
-            status = Gui.Snapper.toggle_snap('Angle')
-            # change interface consistently
-            sync_snap_toolbar_button("Draft_Snap_Angle"+"_Button", status)
-            sync_snap_statusbar_button("Draft_Snap_Angle_Statusbutton", status)
+        return {"Pixmap":    "Snap_Angle",
+                "MenuText":  QT_TRANSLATE_NOOP("Draft_Snap_Angle", "Snap Angle"),
+                "ToolTip":   QT_TRANSLATE_NOOP("Draft_Snap_Angle", "Snaps to the special cardinal points on circular edges, at multiples of 30° and 45°."),
+                "CmdType":   "NoTransaction",
+                "Checkable": self.isChecked()}
 
 
-Gui.addCommand('Draft_Snap_Angle', Draft_Snap_Angle())
+Gui.addCommand("Draft_Snap_Angle", Draft_Snap_Angle())
 
 
 class Draft_Snap_Center(Draft_Snap_Base):
-    """GuiCommand for the Draft_Snap_Center tool.
-
-    Set snapping to the center of a circular arc.
-    """
+    """GuiCommand for the Draft_Snap_Center tool."""
 
     def __init__(self):
-        super(Draft_Snap_Center, self).__init__(name=translate("draft","Arc center snap"))
+        super().__init__(command_name="Draft_Snap_Center")
 
     def GetResources(self):
-        """Set icon, menu and tooltip."""
-
-        return {'Pixmap': 'Snap_Center',
-                'MenuText': QT_TRANSLATE_NOOP("Draft_Snap_Center", "Center"),
-                'ToolTip': QT_TRANSLATE_NOOP("Draft_Snap_Center", "Set snapping to the center of a circular arc.")}
-
-    def Activated(self):
-        """Execute when the command is called."""
-        super(Draft_Snap_Center, self).Activated()
-
-        if hasattr(Gui, "Snapper"):
-            status = Gui.Snapper.toggle_snap('Center')
-            # change interface consistently
-            sync_snap_toolbar_button("Draft_Snap_Center"+"_Button", status)
-            sync_snap_statusbar_button("Draft_Snap_Center_Statusbutton", status)
+        return {"Pixmap":    "Snap_Center",
+                "MenuText":  QT_TRANSLATE_NOOP("Draft_Snap_Center", "Snap Center"),
+                "ToolTip":   QT_TRANSLATE_NOOP("Draft_Snap_Center", "Snaps to the center point of faces and circular edges, and to the Placement point of Working Plane Proxies and Building Parts."),
+                "CmdType":   "NoTransaction",
+                "Checkable": self.isChecked()}
 
 
-Gui.addCommand('Draft_Snap_Center', Draft_Snap_Center())
+Gui.addCommand("Draft_Snap_Center", Draft_Snap_Center())
 
 
 class Draft_Snap_Extension(Draft_Snap_Base):
-    """GuiCommand for the Draft_Snap_Extension tool.
-
-    Set snapping to the extension of an edge.
-    """
+    """GuiCommand for the Draft_Snap_Extension tool."""
 
     def __init__(self):
-        super(Draft_Snap_Extension, self).__init__(name=translate("draft","Edge extension snap"))
+        super().__init__(command_name="Draft_Snap_Extension")
 
     def GetResources(self):
-        """Set icon, menu and tooltip."""
-
-        return {'Pixmap': 'Snap_Extension',
-                'MenuText': QT_TRANSLATE_NOOP("Draft_Snap_Extension", "Extension"),
-                'ToolTip': QT_TRANSLATE_NOOP("Draft_Snap_Extension", "Set snapping to the extension of an edge.")}
-
-    def Activated(self):
-        """Execute when the command is called."""
-        super(Draft_Snap_Extension, self).Activated()
-
-        if hasattr(Gui, "Snapper"):
-            status = Gui.Snapper.toggle_snap('Extension')
-            # change interface consistently
-            sync_snap_toolbar_button("Draft_Snap_Extension"+"_Button", status)
-            sync_snap_statusbar_button("Draft_Snap_Extension_Statusbutton", status)
+        return {"Pixmap":    "Snap_Extension",
+                "MenuText":  QT_TRANSLATE_NOOP("Draft_Snap_Extension", "Snap Extension"),
+                "ToolTip":   QT_TRANSLATE_NOOP("Draft_Snap_Extension", "Snaps to an imaginary line that extends beyond the endpoints of straight edges."),
+                "CmdType":   "NoTransaction",
+                "Checkable": self.isChecked()}
 
 
-Gui.addCommand('Draft_Snap_Extension', Draft_Snap_Extension())
+Gui.addCommand("Draft_Snap_Extension", Draft_Snap_Extension())
 
 
 class Draft_Snap_Near(Draft_Snap_Base):
-    """GuiCommand for the Draft_Snap_Near tool.
-
-    Set snapping to the nearest point of an edge.
-    """
+    """GuiCommand for the Draft_Snap_Near tool."""
 
     def __init__(self):
-        super(Draft_Snap_Near, self).__init__(name=translate("draft","Near snap"))
+        super().__init__(command_name="Draft_Snap_Near")
 
     def GetResources(self):
-        """Set icon, menu and tooltip."""
-
-        return {'Pixmap': 'Snap_Near',
-                'MenuText': QT_TRANSLATE_NOOP("Draft_Snap_Near", "Nearest"),
-                'ToolTip': QT_TRANSLATE_NOOP("Draft_Snap_Near", "Set snapping to the nearest point of an edge.")}
-
-    def Activated(self):
-        """Execute when the command is called."""
-        super(Draft_Snap_Near, self).Activated()
-
-        if hasattr(Gui, "Snapper"):
-            status = Gui.Snapper.toggle_snap('Near')
-            # change interface consistently
-            sync_snap_toolbar_button("Draft_Snap_Near"+"_Button", status)
-            sync_snap_statusbar_button("Draft_Snap_Near_Statusbutton", status)
+        return {"Pixmap":    "Snap_Near",
+                "MenuText":  QT_TRANSLATE_NOOP("Draft_Snap_Near", "Snap Near"),
+                "ToolTip":   QT_TRANSLATE_NOOP("Draft_Snap_Near", "Snaps to the nearest point on faces and edges."),
+                "CmdType":   "NoTransaction",
+                "Checkable": self.isChecked()}
 
 
-Gui.addCommand('Draft_Snap_Near', Draft_Snap_Near())
+Gui.addCommand("Draft_Snap_Near", Draft_Snap_Near())
 
 
 class Draft_Snap_Ortho(Draft_Snap_Base):
-    """GuiCommand for the Draft_Snap_Ortho tool.
-
-    Set snapping to a direction that is a multiple of 45 degrees
-    from a point.
-    """
+    """GuiCommand for the Draft_Snap_Ortho tool."""
 
     def __init__(self):
-        super(Draft_Snap_Ortho, self).__init__(name=translate("draft","Orthogonal snap"))
+        super().__init__(command_name="Draft_Snap_Ortho")
 
     def GetResources(self):
-        """Set icon, menu and tooltip."""
-
-        return {'Pixmap': 'Snap_Ortho',
-                'MenuText': QT_TRANSLATE_NOOP("Draft_Snap_Ortho", "Orthogonal"),
-                'ToolTip': QT_TRANSLATE_NOOP("Draft_Snap_Ortho", "Set snapping to a direction that is a multiple of 45 degrees from a point.")}
-
-    def Activated(self):
-        """Execute when the command is called."""
-        super(Draft_Snap_Ortho, self).Activated()
-
-        if hasattr(Gui, "Snapper"):
-            status = Gui.Snapper.toggle_snap('Ortho')
-            # change interface consistently
-            sync_snap_toolbar_button("Draft_Snap_Ortho"+"_Button", status)
-            sync_snap_statusbar_button("Draft_Snap_Ortho"+"_Statusbutton", status)
+        return {"Pixmap":    "Snap_Ortho",
+                "MenuText":  QT_TRANSLATE_NOOP("Draft_Snap_Ortho", "Snap Ortho"),
+                "ToolTip":   QT_TRANSLATE_NOOP("Draft_Snap_Ortho", "Snaps to imaginary lines that cross the previous point at multiples of 45°."),
+                "CmdType":   "NoTransaction",
+                "Checkable": self.isChecked()}
 
 
-Gui.addCommand('Draft_Snap_Ortho', Draft_Snap_Ortho())
+Gui.addCommand("Draft_Snap_Ortho", Draft_Snap_Ortho())
 
 
 class Draft_Snap_Special(Draft_Snap_Base):
-    """GuiCommand for the Draft_Snap_Special tool.
-
-    Set snapping to the special points defined inside an object.
-    """
+    """GuiCommand for the Draft_Snap_Special tool."""
 
     def __init__(self):
-        super(Draft_Snap_Special, self).__init__(name=translate("draft","Special point snap"))
+        super().__init__(command_name="Draft_Snap_Special")
 
     def GetResources(self):
-        """Set icon, menu and tooltip."""
-
-        return {'Pixmap': 'Snap_Special',
-                'MenuText': QT_TRANSLATE_NOOP("Draft_Snap_Special", "Special"),
-                'ToolTip': QT_TRANSLATE_NOOP("Draft_Snap_Special", "Set snapping to the special points defined inside an object.")}
-
-    def Activated(self):
-        """Execute when the command is called."""
-        super(Draft_Snap_Special, self).Activated()
-
-        if hasattr(Gui, "Snapper"):
-            status = Gui.Snapper.toggle_snap('Special')
-            # change interface consistently
-            sync_snap_toolbar_button("Draft_Snap_Special"+"_Button", status)
-            sync_snap_statusbar_button("Draft_Snap_Special_Statusbutton", status)
+        return {"Pixmap":    "Snap_Special",
+                "MenuText":  QT_TRANSLATE_NOOP("Draft_Snap_Special", "Snap Special"),
+                "ToolTip":   QT_TRANSLATE_NOOP("Draft_Snap_Special", "Snaps to special points defined by the object."),
+                "CmdType":   "NoTransaction",
+                "Checkable": self.isChecked()}
 
 
-Gui.addCommand('Draft_Snap_Special', Draft_Snap_Special())
+Gui.addCommand("Draft_Snap_Special", Draft_Snap_Special())
 
 
 class Draft_Snap_Dimensions(Draft_Snap_Base):
-    """GuiCommand for the Draft_Snap_Dimensions tool.
-
-    Show temporary linear dimensions when editing an object
-    and using other snapping methods.
-    """
+    """GuiCommand for the Draft_Snap_Dimensions tool."""
 
     def __init__(self):
-        super(Draft_Snap_Dimensions, self).__init__(name=translate("draft","Dimension display"))
+        super().__init__(command_name="Draft_Snap_Dimensions")
 
     def GetResources(self):
-        """Set icon, menu and tooltip."""
-
-        return {'Pixmap': 'Snap_Dimensions',
-                'MenuText': QT_TRANSLATE_NOOP("Draft_Snap_Dimensions", "Show dimensions"),
-                'ToolTip': QT_TRANSLATE_NOOP("Draft_Snap_Dimensions", "Show temporary linear dimensions when editing an object and using other snapping methods.")}
-
-    def Activated(self):
-        """Execute when the command is called."""
-        super(Draft_Snap_Dimensions, self).Activated()
-
-        if hasattr(Gui, "Snapper"):
-            status = Gui.Snapper.toggle_snap('Dimensions')
-            # change interface consistently
-            sync_snap_toolbar_button("Draft_Snap_Dimensions"+"_Button", status)
-            sync_snap_statusbar_button("Draft_Snap_Dimensions"+"_Statusbutton", status)
+        return {"Pixmap":    "Snap_Dimensions",
+                "MenuText":  QT_TRANSLATE_NOOP("Draft_Snap_Dimensions", "Snap Dimensions"),
+                "ToolTip":   QT_TRANSLATE_NOOP("Draft_Snap_Dimensions", "Shows temporary X and Y dimensions."),
+                "CmdType":   "NoTransaction",
+                "Checkable": self.isChecked()}
 
 
-Gui.addCommand('Draft_Snap_Dimensions', Draft_Snap_Dimensions())
+Gui.addCommand("Draft_Snap_Dimensions", Draft_Snap_Dimensions())
 
 
 class Draft_Snap_WorkingPlane(Draft_Snap_Base):
-    """GuiCommand for the Draft_Snap_WorkingPlane tool.
-
-    Restricts snapping to a point in the current working plane.
-    If you select a point outside the working plane, for example,
-    by using other snapping methods, it will snap to that point's
-    projection in the current working plane.
-    """
+    """GuiCommand for the Draft_Snap_WorkingPlane tool."""
 
     def __init__(self):
-        super(Draft_Snap_WorkingPlane, self).__init__(name=translate("draft","Working plane snap"))
+        super().__init__(command_name="Draft_Snap_WorkingPlane")
 
     def GetResources(self):
-        """Set icon, menu and tooltip."""
-
-        return {'Pixmap': 'Snap_WorkingPlane',
-                'MenuText': QT_TRANSLATE_NOOP("Draft_Snap_WorkingPlane","Working plane"),
-                'ToolTip': QT_TRANSLATE_NOOP("Draft_Snap_WorkingPlane","Restricts snapping to a point in the current working plane.\nIf you select a point outside the working plane, for example, by using other snapping methods,\nit will snap to that point's projection in the current working plane.")}
-
-    def Activated(self):
-        """Execute when the command is called."""
-        super(Draft_Snap_WorkingPlane, self).Activated()
-
-        if hasattr(Gui, "Snapper"):
-            status = Gui.Snapper.toggle_snap('WorkingPlane')
-            # change interface consistently
-            sync_snap_toolbar_button("Draft_Snap_WorkingPlane"+"_Button", status)
-            sync_snap_statusbar_button("Draft_Snap_WorkingPlane_Statusbutton", status)
+        return {"Pixmap":    "Snap_WorkingPlane",
+                "MenuText":  QT_TRANSLATE_NOOP("Draft_Snap_WorkingPlane", "Snap Working Plane"),
+                "ToolTip":   QT_TRANSLATE_NOOP("Draft_Snap_WorkingPlane", "Projects snap points onto the current working plane."),
+                "CmdType":   "NoTransaction",
+                "Checkable": self.isChecked()}
 
 
-Gui.addCommand('Draft_Snap_WorkingPlane', Draft_Snap_WorkingPlane())
+Gui.addCommand("Draft_Snap_WorkingPlane", Draft_Snap_WorkingPlane())
 
 
 class ShowSnapBar(Draft_Snap_Base):
-    """GuiCommand for the Draft_ShowSnapBar tool.
-
-    Show the snap toolbar if it is hidden.
-    """
+    """GuiCommand for the Draft_ShowSnapBar tool."""
 
     def __init__(self):
-        super(ShowSnapBar, self).__init__(name=translate("draft","Show snap toolbar"))
+        super().__init__(command_name="Draft_ShowSnapBar")
 
     def GetResources(self):
-        """Set icon, menu and tooltip."""
-
-        return {'Pixmap': 'Draft_Snap',
-                'MenuText': QT_TRANSLATE_NOOP("Draft_ShowSnapBar","Show snap toolbar"),
-                'ToolTip': QT_TRANSLATE_NOOP("Draft_ShowSnapBar","Show the snap toolbar if it is hidden.")}
+        return {"Pixmap":    "Draft_Snap",
+                "MenuText":  QT_TRANSLATE_NOOP("Draft_ShowSnapBar", "Show snap toolbar"),
+                "ToolTip":   QT_TRANSLATE_NOOP("Draft_ShowSnapBar", "Shows the snap toolbar if it is hidden."),
+                "CmdType":   "NoTransaction"}
 
     def Activated(self):
         """Execute when the command is called."""
-        super(ShowSnapBar, self).Activated()
-
         if hasattr(Gui, "Snapper"):
             Gui.Snapper.show()
 

--- a/src/Mod/Draft/draftutils/init_draft_statusbar.py
+++ b/src/Mod/Draft/draftutils/init_draft_statusbar.py
@@ -48,21 +48,21 @@ draft_scales_metrics =  ["1:1000", "1:500", "1:250", "1:200", "1:100",
                          "1:50", "1:25","1:20", "1:10", "1:5","1:2",
                          "1:1",
                          "2:1", "5:1", "10:1", "20:1",
-                         translate("draft", "custom"),
+                         translate("draft", "Custom"),
                         ]
 
 draft_scales_arch_imperial =  ["1/16in=1ft", "3/32in=1ft", "1/8in=1ft",
                                "3/16in=1ft", "1/4in=1ft","3/8in=1ft",
                                "1/2in=1ft", "3/4in=1ft", "1in=1ft",
                                "1.5in=1ft", "3in=1ft",
-                               translate("draft", "custom"),
+                               translate("draft", "Custom"),
                               ]
 
 draft_scales_eng_imperial =  ["1in=10ft", "1in=20ft", "1in=30ft",
                               "1in=40ft", "1in=50ft", "1in=60ft",
                               "1in=70ft", "1in=80ft", "1in=90ft",
                               "1in=100ft",
-                              translate("draft", "custom"),
+                              translate("draft", "Custom"),
                              ]
 
 def get_scales(unit_system = 0):
@@ -136,7 +136,7 @@ def label_to_scale(label):
                 return scale
             except Exception:
                 err = translate("draft",
-                                "Unable to convert input into a  scale factor")
+                                "Unable to convert input into a scale factor")
                 App.Console.PrintWarning(err)
                 return None
 
@@ -149,8 +149,10 @@ def _set_scale(action):
 
     mw = Gui.getMainWindow()
     sb = mw.statusBar()
-    scale_widget = sb.findChild(QtGui.QToolBar,"draft_status_scale_widget")
-    if action.text() == translate("draft", "custom"):
+
+    scale_widget = sb.findChild(QtGui.QToolBar,"draft_scale_widget")
+
+    if action.text() == translate("draft", "Custom"):
         title_text = translate("draft", "Set custom scale")
         dialog_text = translate("draft",
                                 "Set custom annotation scale in format x:x, x=x")
@@ -172,6 +174,7 @@ def _set_scale(action):
 #----------------------------------------------------------------------------
 # MAIN DRAFT STATUSBAR FUNCTIONS
 #----------------------------------------------------------------------------
+
 def init_draft_statusbar_scale():
     """
     this function initializes draft statusbar scale widget
@@ -182,7 +185,7 @@ def init_draft_statusbar_scale():
     sb = mw.statusBar()
 
     scale_widget = QtGui.QToolBar()
-    scale_widget.setObjectName("draft_status_scale_widget")
+    scale_widget.setObjectName("draft_scale_widget")
 
     # get scales list according to system units
     draft_scales = get_scales()
@@ -219,121 +222,64 @@ def init_draft_statusbar_snap():
     """
     this function initializes draft statusbar snap widget
     """
-    param = App.ParamGet("User parameter:BaseApp/Preferences/Mod/Draft")
+
+    def _spacer():
+        """
+        empty label instead of snap_widget.addSeparator()
+        """
+        label = QtGui.QLabel()
+        label.setFixedWidth(2)
+        return label
 
     mw = Gui.getMainWindow()
     sb = mw.statusBar()
 
-    # SNAP WIDGET - init ----------------------------------------------------
+    # check if the toolbar is available, without it the required actions
+    # may be missing:
+    if mw.findChild(QtGui.QToolBar, "Draft snap") is None:
+        return
 
+    # snap widget:
     snap_widget = QtGui.QToolBar()
     snap_widget.setObjectName("draft_snap_widget")
-    snap_widget.setIconSize(QtCore.QSize(16,16))
-
-    # GRID BUTTON - init
-    gridbutton = QtGui.QPushButton(snap_widget)
-    gridbutton.setIcon(QtGui.QIcon.fromTheme("Draft",
-                                             QtGui.QIcon(":/icons/"
-                                                         "Draft_Grid.svg")))
-    gridbutton.setToolTip(translate("Draft", "Toggles Grid On/Off"))
-    gridbutton.setObjectName("Grid_Statusbutton")
-    gridbutton.setWhatsThis("Draft_ToggleGrid")
-    gridbutton.setFlat(True)
-    QtCore.QObject.connect(gridbutton,QtCore.SIGNAL("clicked()"),
-                           lambda f=Gui.doCommand,
-                           arg='Gui.runCommand("Draft_ToggleGrid")':f(arg))
-    snap_widget.addWidget(gridbutton)
-
-    # SNAP BUTTON - init
-    snappref = param.GetString("snapModes","111111111101111")[0]
-    snapbutton = QtGui.QPushButton(snap_widget)
-    snapbutton.setIcon(QtGui.QIcon.fromTheme("Draft",
-                                             QtGui.QIcon(":/icons/"
-                                                         "Snap_Lock.svg")))
-    snapbutton.setObjectName("Snap_Statusbutton")
-    snapbutton.setWhatsThis("Draft_ToggleLockSnap")
-    snapbutton.setToolTip(translate("Draft", "Object snapping"))
-    snapbutton.setCheckable(True)
-    snapbutton.setChecked(bool(int(snappref)))
-    snapbutton.setFlat(True)
-
-    snaps_menu = QtGui.QMenu(snapbutton)
-    snaps_menu.setObjectName("draft_statusbar_snap_toolbar")
-
-    snap_gui_commands = get_draft_snap_commands()
-    if 'Draft_Snap_Ortho' in snap_gui_commands:
-        snap_gui_commands.remove('Draft_Snap_Ortho')
-    if 'Draft_Snap_WorkingPlane' in snap_gui_commands:
-        snap_gui_commands.remove('Draft_Snap_WorkingPlane')
-    if 'Draft_Snap_Dimensions' in snap_gui_commands:
-        snap_gui_commands.remove('Draft_Snap_Dimensions')
-    if 'Draft_ToggleGrid' in snap_gui_commands:
-        snap_gui_commands.remove('Draft_ToggleGrid')
-
-    Gui.Snapper.init_draft_snap_buttons(snap_gui_commands,snaps_menu, "_Statusbutton")
-    Gui.Snapper.restore_snap_buttons_state(snaps_menu, "_Statusbutton")
-
-    snapbutton.setMenu(snaps_menu)
-    snap_widget.addWidget(snapbutton)
-
-
-    # DIMENSION BUTTON - init
-    dimpref = param.GetString("snapModes","111111111101111")[13]
-    dimbutton = QtGui.QPushButton(snap_widget)
-    dimbutton.setIcon(QtGui.QIcon.fromTheme("Draft",
-                                            QtGui.QIcon(":/icons/"
-                                                        "Snap_Dimensions.svg")))
-    dimbutton.setToolTip(translate("Draft",
-                                   "Toggles Visual Aid Dimensions On/Off"))
-    dimbutton.setObjectName("Draft_Snap_Dimensions_Statusbutton")
-    dimbutton.setWhatsThis("Draft_ToggleDimensions")
-    dimbutton.setFlat(True)
-    dimbutton.setCheckable(True)
-    dimbutton.setChecked(bool(int(dimpref)))
-    QtCore.QObject.connect(dimbutton,QtCore.SIGNAL("clicked()"),
-                           lambda f=Gui.doCommand,
-                           arg='Gui.runCommand("Draft_Snap_Dimensions")':f(arg))
-    snap_widget.addWidget(dimbutton)
-
-    # ORTHO BUTTON - init
-    ortopref = param.GetString("snapModes","111111111101111")[10]
-    orthobutton = QtGui.QPushButton(snap_widget)
-    orthobutton.setIcon(QtGui.QIcon.fromTheme("Draft",
-                                              QtGui.QIcon(":/icons/"
-                                                          "Snap_Ortho.svg")))
-    orthobutton.setObjectName("Draft_Snap_Ortho"+"_Statusbutton")
-    orthobutton.setWhatsThis("Draft_ToggleOrtho")
-    orthobutton.setToolTip(translate("Draft", "Toggles Ortho On/Off"))
-    orthobutton.setFlat(True)
-    orthobutton.setCheckable(True)
-    orthobutton.setChecked(bool(int(ortopref)))
-    QtCore.QObject.connect(orthobutton,QtCore.SIGNAL("clicked()"),
-                           lambda f=Gui.doCommand,
-                           arg='Gui.runCommand("Draft_Snap_Ortho")':f(arg))
-    snap_widget.addWidget(orthobutton)
-
-    # WORKINGPLANE BUTTON - init
-    wppref = param.GetString("snapModes","111111111101111")[14]
-    wpbutton = QtGui.QPushButton(snap_widget)
-    wpbutton.setIcon(QtGui.QIcon.fromTheme("Draft",
-                                           QtGui.QIcon(":/icons/"
-                                                       "Snap_WorkingPlane.svg")))
-    wpbutton.setObjectName("Draft_Snap_WorkingPlane_Statusbutton")
-    wpbutton.setWhatsThis("Draft_ToggleWorkingPlaneSnap")
-    wpbutton.setToolTip(translate("Draft",
-                                  "Toggles Constrain to Working Plane On/Off"))
-    wpbutton.setFlat(True)
-    wpbutton.setCheckable(True)
-    wpbutton.setChecked(bool(int(wppref)))
-    QtCore.QObject.connect(wpbutton,QtCore.SIGNAL("clicked()"),
-                           lambda f=Gui.doCommand,
-                           arg='Gui.runCommand("Draft_Snap_WorkingPlane")':f(arg))
-    snap_widget.addWidget(wpbutton)
-
-    # add snap widget to the statusbar
-    sb.insertPermanentWidget(2, snap_widget)
     snap_widget.setOrientation(QtCore.Qt.Orientation.Horizontal)
-    snap_widget.show()
+    snap_widget.setIconSize(QtCore.QSize(16, 16))
+    sb.insertPermanentWidget(2, snap_widget)
+
+    # grid button:
+    snap_widget.addAction(Gui.Command.get("Draft_ToggleGrid").getAction()[0])
+
+    snap_widget.addWidget(_spacer())
+
+    # lock button:
+    snap_widget.addAction(Gui.Command.get("Draft_Snap_Lock").getAction()[0])
+    snap_action = snap_widget.children()[-1]
+    snap_action.setFixedWidth(40) # Widen the button.
+
+    snap_widget.addWidget(_spacer())
+
+    # dimension button:
+    snap_widget.addAction(Gui.Command.get("Draft_Snap_Dimensions").getAction()[0])
+
+    snap_widget.addWidget(_spacer())
+
+    # ortho button:
+    snap_widget.addAction(Gui.Command.get("Draft_Snap_Ortho").getAction()[0])
+
+    snap_widget.addWidget(_spacer())
+
+    # working plane button:
+    snap_widget.addAction(Gui.Command.get("Draft_Snap_WorkingPlane").getAction()[0])
+
+    # menu for lock button:
+    for cmd in get_draft_snap_commands():
+        if cmd not in ["Separator",
+                       "Draft_ToggleGrid",
+                       "Draft_Snap_Lock", # Is automatically added to the menu anyway.
+                       "Draft_Snap_Dimensions",
+                       "Draft_Snap_Ortho",
+                       "Draft_Snap_WorkingPlane"]:
+            snap_action.addAction(Gui.Command.get(cmd).getAction()[0])
 
 
 def show_draft_statusbar():
@@ -346,13 +292,11 @@ def show_draft_statusbar():
     sb = mw.statusBar()
 
     if params.GetBool("DisplayStatusbarScaleWidget", True):
-        scale_widget = sb.findChild(QtGui.QToolBar,
-                                    "draft_status_scale_widget")
+        scale_widget = sb.findChild(QtGui.QToolBar, "draft_scale_widget")
         if scale_widget:
             scale_widget.show()
         else:
-            scale_widget = mw.findChild(QtGui.QToolBar,
-                            "draft_status_scale_widget")
+            scale_widget = mw.findChild(QtGui.QToolBar, "draft_scale_widget")
             if scale_widget:
                 sb.insertPermanentWidget(3, scale_widget)
                 scale_widget.show()
@@ -361,12 +305,12 @@ def show_draft_statusbar():
                 t.singleShot(500, init_draft_statusbar_scale)
 
     if params.GetBool("DisplayStatusbarSnapWidget", True):
-        snap_widget = sb.findChild(QtGui.QToolBar,"draft_snap_widget")
+        snap_widget = sb.findChild(QtGui.QToolBar, "draft_snap_widget")
         if snap_widget:
             snap_widget.setOrientation(QtCore.Qt.Orientation.Horizontal)
             snap_widget.show()
         else:
-            snap_widget = mw.findChild(QtGui.QToolBar,"draft_snap_widget")
+            snap_widget = mw.findChild(QtGui.QToolBar, "draft_snap_widget")
             if snap_widget:
                 sb.insertPermanentWidget(2, snap_widget)
                 snap_widget.setOrientation(QtCore.Qt.Orientation.Horizontal)
@@ -384,27 +328,27 @@ def hide_draft_statusbar():
     sb = mw.statusBar()
 
     # hide scale widget
-    scale_widget = sb.findChild(QtGui.QToolBar,
-                                "draft_status_scale_widget")
-    if scale_widget:
-        scale_widget.hide()
-    else:
+    scale_widget = sb.findChild(QtGui.QToolBar, "draft_scale_widget")
+    if scale_widget is None:
         # when switching workbenches, the toolbar sometimes "jumps"
         # out of the status bar to any other dock area...
-        scale_widget = mw.findChild(QtGui.QToolBar,
-                                    "draft_status_scale_widget")
-        if scale_widget:
-            scale_widget.hide()
+        scale_widget = mw.findChild(QtGui.QToolBar, "draft_scale_widget")
+    if scale_widget:
+        scale_widget.hide()
+        # prevent the widget from showing up as a blank item in the toolbar
+        # area context menu after switching to a different workbench:
+        scale_widget.toggleViewAction().setVisible(False)
 
     # hide snap widget
     snap_widget = sb.findChild(QtGui.QToolBar,"draft_snap_widget")
-    if snap_widget:
-        snap_widget.hide()
-    else:
+    if snap_widget is None:
         # when switching workbenches, the toolbar sometimes "jumps"
         # out of the status bar to any other dock area...
         snap_widget = mw.findChild(QtGui.QToolBar,"draft_snap_widget")
-        if snap_widget:
-            snap_widget.hide()
+    if snap_widget:
+        snap_widget.hide()
+        # prevent the widget from showing up as a blank item in the toolbar
+        # area context menu after switching to a different workbench:
+        snap_widget.toggleViewAction().setVisible(False)
 
 ## @}

--- a/src/Mod/Draft/draftutils/init_tools.py
+++ b/src/Mod/Draft/draftutils/init_tools.py
@@ -141,47 +141,26 @@ def get_draft_utility_commands_toolbar():
 
 def get_draft_snap_commands():
     """Return the snapping commands list."""
-    return ['Draft_Snap_Lock',
-            'Draft_Snap_Endpoint',
-            'Draft_Snap_Midpoint',
-            'Draft_Snap_Center',
-            'Draft_Snap_Angle',
-            'Draft_Snap_Intersection',
-            'Draft_Snap_Perpendicular',
-            'Draft_Snap_Extension',
-            'Draft_Snap_Parallel',
-            'Draft_Snap_Special',
-            'Draft_Snap_Near',
-            'Draft_Snap_Ortho',
-            'Draft_Snap_Grid',
-            'Draft_Snap_WorkingPlane',
-            'Draft_Snap_Dimensions',
-            'Separator',
-            'Draft_ToggleGrid']
-
-
-def get_draft_snap_tooltips():
-    """Return a dictionary with tooltips for the snapping commands.
-
-    For the snapping commands in the default toolbar and in the statusbar the
-    tooltips from the `GetResources` functions in gui_snaps.py are not used.
-    """
-    return {'Draft_Snap_Lock'         : translate('draft', 'Snap Lock'),
-            'Draft_Snap_Endpoint'     : translate('draft', 'Snap Endpoint'),
-            'Draft_Snap_Midpoint'     : translate('draft', 'Snap Midpoint'),
-            'Draft_Snap_Center'       : translate('draft', 'Snap Center'),
-            'Draft_Snap_Angle'        : translate('draft', 'Snap Angle'),
-            'Draft_Snap_Intersection' : translate('draft', 'Snap Intersection'),
-            'Draft_Snap_Perpendicular': translate('draft', 'Snap Perpendicular'),
-            'Draft_Snap_Extension'    : translate('draft', 'Snap Extension'),
-            'Draft_Snap_Parallel'     : translate('draft', 'Snap Parallel'),
-            'Draft_Snap_Special'      : translate('draft', 'Snap Special'),
-            'Draft_Snap_Near'         : translate('draft', 'Snap Near'),
-            'Draft_Snap_Ortho'        : translate('draft', 'Snap Ortho'),
-            'Draft_Snap_Grid'         : translate('draft', 'Snap Grid'),
-            'Draft_Snap_WorkingPlane' : translate('draft', 'Snap WorkingPlane'),
-            'Draft_Snap_Dimensions'   : translate('draft', 'Snap Dimensions'),
-            'Draft_ToggleGrid'        : translate('draft', 'Toggle Draft Grid')}
+    return ["Draft_Snap_Lock",
+            "Draft_Snap_Endpoint",
+            "Draft_Snap_Midpoint",
+            "Draft_Snap_Center",
+            "Draft_Snap_Angle",
+            "Draft_Snap_Intersection",
+            "Draft_Snap_Perpendicular",
+            "Draft_Snap_Extension",
+            "Draft_Snap_Parallel",
+            "Draft_Snap_Special",
+            "Draft_Snap_Near",
+            "Draft_Snap_Ortho",
+            "Draft_Snap_Grid",
+            "Draft_Snap_WorkingPlane",
+            "Draft_Snap_Dimensions",
+            # "Separator", # Removed: if the Python generated BIM snap toolbar
+                           # is displayed in the Draft WB the separator appears
+                           # after the last button. Can be reinstated when the
+                           # BIM WB has a `normal` snap toolbar as well.
+            "Draft_ToggleGrid"]
 
 
 def get_draft_context_commands():

--- a/src/Mod/Tux/PersistentToolbarsGui.py
+++ b/src/Mod/Tux/PersistentToolbarsGui.py
@@ -29,23 +29,16 @@ timer = QtCore.QTimer()
 mw = Gui.getMainWindow()
 
 def pythonToolbars():
-    """Manage Python based toolbars in Arch and Draft workbench."""
+    """Manage Python based toolbar in BIM workbench."""
 
     active = Gui.activeWorkbench().__class__.__name__
 
-    if active == "DraftWorkbench" or active == "ArchWorkbench" or active == "BIMWorkbench":
-        if hasattr(Gui, "draftToolBar"):
-            try:
-                Gui.draftToolBar.Activated()
-            except Exception:
-                m = "Persistent toolbars: draftToolBar toolbar not managed.\n"
-                App.Console.PrintMessage(m)
-        if hasattr(Gui, "Snapper"):
-            try:
-                Gui.Snapper.show()
-            except Exception:
-                m = "Persistent toolbars: Snapper toolbar not managed.\n"
-                App.Console.PrintMessage(m)
+    if active == "BIMWorkbench" and hasattr(Gui, "Snapper"):
+        try:
+            Gui.Snapper.show()
+        except Exception:
+            m = "Persistent toolbars: Snapper toolbar not managed.\n"
+            App.Console.PrintMessage(m)
     else:
         pass
 


### PR DESCRIPTION
This PR changes the Draft snap toolbar to a standard toolbar.

Many thanks to @carlopav for all his work on the gui_snaps.py file. I have basically adopted his solution. See https://github.com/carlopav/FreeCAD/tree/Draft_SnapToolbarToStandard.

The code has been tested with the BIM Workbench, for which a standard toolbar cannot be introduced just yet as it still has to work with FC0.20. For the BIM Workbench the snap toolbar is built by reusing the GUI actions that are available because of its Snapping menu. Reusing the available actions is the key to keeping the buttons synchronized. This solution is also used for the updated statusbar snap widget.

The new version of the statusbar snap widget behaves slightly differently. If the Lock button is clicked (short click) snapping is enabled/disabled. A long click on the button will open the menu.

Additionally:
* Some unnecessary imports were removed from gui_snapper.py.
* Renamed the toolbar from "Draft Snap" to "Draft snap". One cap for consistency with other toolbar names.
* Updated PersistentToolbarsGui.py: there now is only one Python toolbar: the BIM Snap toolbar.
* Changed "custom" to "Custom" in the scale widget menu.

Forum topic:
https://forum.freecadweb.org/viewtopic.php?f=23&t=61715

- [ ]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [ ]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the issue ID number from our [Issues database](https://github.com/FreeCAD/FreeCAD/issues) in case a particular commit solves or is related to an existing issue. Ex: `Draft: fix typos - fixes #4805`

---
