### PR TITLE
CI: Switch to QtWebEngine instead of QtWebKit

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -139,7 +139,7 @@ jobs:
                             pyqt5-dev-tools                             \
                             libqt5opengl5-dev                           \
                             libqt5svg5-dev                              \
-                            libqt5webkit5-dev                           \
+                            qtwebengine5-dev                            \
                             libqt5x11extras5-dev                        \
                             libqt5xmlpatterns5-dev                      \
                             qtbase5-dev                                 \


### PR DESCRIPTION
QtWebKit is obsolete and will soon be removed from FreeCAD -- it is replaced by QtWebEngine (e.g. Chromium).