### PR TITLE
Draft: Fix rectangle with face offset bug

### DIFF
--- a/src/Mod/Draft/draftfunctions/offset.py
+++ b/src/Mod/Draft/draftfunctions/offset.py
@@ -72,9 +72,12 @@ def offset(obj, delta, copy=False, bind=False, sym=False, occ=False):
     newwire = None
     delete = None
 
-    if utils.get_type(obj).startswith("Part::") or utils.get_type(obj).startswith("Sketcher::"):
-        copy = True
+    if (copy is False
+            and (utils.get_type(obj).startswith("Sketcher::")
+                or utils.get_type(obj).startswith("Part::")
+                or utils.get_type(obj).startswith("PartDesign::"))): # For PartDesign_SubShapeBinders which can reference sketches.
         print("the offset tool is currently unable to offset a non-Draft object directly - Creating a copy")
+        copy = True
 
     def getRect(p,obj):
         """returns length,height,placement"""
@@ -199,7 +202,7 @@ def offset(obj, delta, copy=False, bind=False, sym=False, occ=False):
             try:
                 if p:
                     newobj = make_wire(p)
-                    newobj.Closed = obj.Shape.isClosed()
+                    newobj.Closed = DraftGeomUtils.isReallyClosed(obj.Shape)
             except Part.OCCError:
                 pass
             if (not newobj) and newwire:

--- a/src/Mod/Draft/draftgeoutils/offsets.py
+++ b/src/Mod/Draft/draftgeoutils/offsets.py
@@ -33,6 +33,7 @@ import DraftVecUtils
 
 from draftgeoutils.general import geomType, vec
 from draftgeoutils.geometry import get_normal
+from draftgeoutils.wires import isReallyClosed
 from draftgeoutils.intersections import wiresIntersect, connect
 
 # Delay import of module until first use because it is heavy
@@ -237,7 +238,7 @@ def offsetWire(wire, dvec, bind=False, occ=False,
         if norm is None:
             norm = App.Vector(0, 0, 1)
 
-    closed = wire.isClosed()
+    closed = isReallyClosed(wire)
     nedges = []
     if occ:
         length = abs(dvec.Length)

--- a/src/Mod/Draft/draftgeoutils/wires.py
+++ b/src/Mod/Draft/draftgeoutils/wires.py
@@ -272,14 +272,30 @@ def isReallyClosed(wire):
     # If more than 1 edge, further test below
     e1 = wire.Edges[0]
     e2 = wire.Edges[length-1]
-    if DraftVecUtils.equals(e1.Vertexes[0].Point, e2.Vertexes[0].Point):
-        return True
+
     if DraftVecUtils.equals(e1.Vertexes[0].Point, e2.Vertexes[1].Point):
-        return True
+        if length == 2:
+            return DraftVecUtils.equals(e1.Vertexes[1].Point, e2.Vertexes[0].Point)
+        else:
+            return True
+
     if DraftVecUtils.equals(e1.Vertexes[1].Point, e2.Vertexes[0].Point):
-        return True
+        if length == 2:
+            return DraftVecUtils.equals(e1.Vertexes[0].Point, e2.Vertexes[1].Point)
+        else:
+            return True
+
+    if DraftVecUtils.equals(e1.Vertexes[0].Point, e2.Vertexes[0].Point):
+        if length == 2:
+            return DraftVecUtils.equals(e1.Vertexes[1].Point, e2.Vertexes[1].Point)
+        else:
+            return True
+
     if DraftVecUtils.equals(e1.Vertexes[1].Point, e2.Vertexes[1].Point):
-        return True
+        if length == 2:
+            return DraftVecUtils.equals(e1.Vertexes[0].Point, e2.Vertexes[0].Point)
+        else:
+            return True
 
     return False
 

--- a/src/Mod/Draft/draftgeoutils/wires.py
+++ b/src/Mod/Draft/draftgeoutils/wires.py
@@ -270,9 +270,15 @@ def isReallyClosed(wire):
             return False
 
     # If more than 1 edge, further test below
-    v1 = wire.Edges[0].Vertexes[0].Point   # v1 = wire.Vertexes[0].Point
-    v2 = wire.Edges[length-1].Vertexes[1].Point  # v2 = wire.Vertexes[-1].Point
-    if DraftVecUtils.equals(v1, v2):
+    e1 = wire.Edges[0]
+    e2 = wire.Edges[length-1]
+    if DraftVecUtils.equals(e1.Vertexes[0].Point, e2.Vertexes[0].Point):
+        return True
+    if DraftVecUtils.equals(e1.Vertexes[0].Point, e2.Vertexes[1].Point):
+        return True
+    if DraftVecUtils.equals(e1.Vertexes[1].Point, e2.Vertexes[0].Point):
+        return True
+    if DraftVecUtils.equals(e1.Vertexes[1].Point, e2.Vertexes[1].Point):
         return True
 
     return False


### PR DESCRIPTION
Fix for a bug that was introduced with #5496 (my bad). The wire argument can be a face in offsets.py and `isClosed()` always(?) returns `False` for faces. Which led to a problem when offsetting Draft_Rectangles with faces.

I have now fixed `isReallyClosed()`, which is used in several other places anyway.

Forum topic:
https://forum.freecadweb.org/viewtopic.php?p=636954#p636954

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the issue ID number from our [Issues database](https://github.com/FreeCAD/FreeCAD/issues) in case a particular commit solves or is related to an existing issue. Ex: `Draft: fix typos - fixes #4805`

---
