### PR TITLE
TopoNaming: fix attacher

### DIFF
--- a/src/Mod/Part/App/Attacher.cpp
+++ b/src/Mod/Part/App/Attacher.cpp
@@ -971,10 +971,15 @@ Base::Placement AttachEngine::calculateAttachedPlacement(
         if(pla.getPosition().IsEqual(origPlacement.getPosition(),1e-7)
             && pla.getRotation().isSame(origPlacement.getRotation(),1e-12))
         {
-            if(subChanged) *subChanged = true;
-            subnames = std::move(subs);
-            for(auto &v : subChanges)
-                shadowSubs[v.first] = v.second.first;
+            // Only make changes if the caller supplies 'subChanged', because
+            // otherwise it means the caller just want to do an immutable test.
+            // See AttachExtension::isAttacherActive().
+            if(subChanged) {
+                *subChanged = true;
+                subnames = std::move(subs);
+                for(auto &v : subChanges)
+                    shadowSubs[v.first] = v.second.first;
+            }
             return pla;
         }
     }

--- a/src/Mod/Part/App/FeatureExtrusion.cpp
+++ b/src/Mod/Part/App/FeatureExtrusion.cpp
@@ -237,7 +237,7 @@ void Extrusion::extrudeShape(TopoShape &result, const TopoShape &source, const E
 {
     gp_Vec vec = gp_Vec(params.dir).Multiplied(params.lengthFwd + params.lengthRev);//total vector of extrusion
 
-#if 1
+#ifdef FC_NO_ELEMENT_MAP
     if (std::fabs(params.taperAngleFwd) >= Precision::Angular() ||
         std::fabs(params.taperAngleRev) >= Precision::Angular()) {
         //Tapered extrusion!
@@ -311,6 +311,9 @@ void Extrusion::extrudeShape(TopoShape &result, const TopoShape &source, const E
     }
 #else // FC_NO_ELEMENT_MAP
 
+    // #0000910: Circles Extrude Only Surfaces, thus use BRepBuilderAPI_Copy
+    TopoShape myShape(source.makECopy());
+
     if (std::fabs(params.taperAngleFwd) >= Precision::Angular() ||
         std::fabs(params.taperAngleRev) >= Precision::Angular()) {
         //Tapered extrusion!
@@ -328,9 +331,6 @@ void Extrusion::extrudeShape(TopoShape &result, const TopoShape &source, const E
         //Regular (non-tapered) extrusion!
         if (source.isNull())
             Standard_Failure::Raise("Cannot extrude empty shape");
-
-        // #0000910: Circles Extrude Only Surfaces, thus use BRepBuilderAPI_Copy
-        TopoShape myShape(source.makECopy());
 
         //apply reverse part of extrusion by shifting the source shape
         if (fabs(params.lengthRev) > Precision::Confusion()) {


### PR DESCRIPTION
Reported in https://forum.freecadweb.org/viewtopic.php?p=637174#p637035

The direct cause is that the topo naming generation in Part::FeatureExtrude is accidentally disabled, which is fixed in the first commit. The second commit improves attacher auto fix on name change.