### PR TITLE
Core: Add additional CMake code for building with Qt6

### DIFF
--- a/src/Tools/plugins/widget/CMakeLists.txt
+++ b/src/Tools/plugins/widget/CMakeLists.txt
@@ -9,14 +9,13 @@ if (NOT IS_SUB_PROJECT)
     set(CMAKE_INCLUDE_CURRENT_DIR ON)
     set(CMAKE_AUTOMOC ON)
 
-    find_package(Qt5Widgets REQUIRED)
-    find_package(Qt5Designer REQUIRED)
+    find_package(Qt${FREECAD_QT_MAJOR_VERSION} COMPONENTS Core Designer Widgets REQUIRED)
 endif()
 
 include_directories(
-    ${Qt5Core_INCLUDE_DIRS}
-    ${Qt5Widgets_INCLUDE_DIRS}
-    ${Qt5Designer_INCLUDE_DIRS}
+    ${Qt${FREECAD_QT_MAJOR_VERSION}Core_INCLUDE_DIRS}
+    ${Qt${FREECAD_QT_MAJOR_VERSION}Widgets_INCLUDE_DIRS}
+    ${Qt${FREECAD_QT_MAJOR_VERSION}Designer_INCLUDE_DIRS}
 )
 
 add_library(FreeCAD_widgets SHARED
@@ -27,8 +26,8 @@ add_library(FreeCAD_widgets SHARED
 )
 
 set(FreeCAD_widgets_LIBS
-    ${Qt5Widgets_LIBRARIES}
-    ${Qt5Designer_LIBRARIES}
+    ${Qt${FREECAD_QT_MAJOR_VERSION}Widgets_LIBRARIES}
+    ${Qt${FREECAD_QT_MAJOR_VERSION}Designer_LIBRARIES}
 )
 
 if(MSVC)
@@ -57,7 +56,7 @@ target_compile_options(FreeCAD_widgets PRIVATE ${COMPILE_OPTIONS})
 
 
 # Get the install location of a plugin to determine the path to designer plguins
-get_target_property(QMAKE_EXECUTABLE Qt5::qmake LOCATION)
+get_target_property(QMAKE_EXECUTABLE Qt${FREECAD_QT_MAJOR_VERSION}::qmake LOCATION)
 exec_program(${QMAKE_EXECUTABLE} ARGS "-query QT_INSTALL_PLUGINS" RETURN_VALUE return_code OUTPUT_VARIABLE DEFAULT_QT_PLUGINS_DIR )
 set(DESIGNER_PLUGIN_LOCATION ${DEFAULT_QT_PLUGINS_DIR}/designer CACHE PATH "Path where the plugin will be installed to")
 


### PR DESCRIPTION
We missed adding CMake code to also build the designer plugin against Qt6. See https://github.com/FreeCAD/FreeCAD/pull/7647#issuecomment-1297202448

This patch adds the code to enable this.

Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [ ]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the issue ID number from our [Issues database](https://github.com/FreeCAD/FreeCAD/issues) in case a particular commit solves or is related to an existing issue. Ex: `Draft: fix typos - fixes #4805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
