### PR TITLE
Move "Close" button to north in appearance and measure dialogs

### DIFF
--- a/src/Gui/DlgDisplayPropertiesImp.cpp
+++ b/src/Gui/DlgDisplayPropertiesImp.cpp
@@ -636,7 +636,7 @@ std::vector<Gui::ViewProvider*> DlgDisplayPropertiesImp::getSelection() const
 
 TaskDisplayProperties::TaskDisplayProperties()
 {
-    this->setButtonPosition(TaskDisplayProperties::South);
+    this->setButtonPosition(TaskDisplayProperties::North);
     widget = new DlgDisplayPropertiesImp(false);
     widget->showDefaultButtons(false);
     taskbox = new Gui::TaskView::TaskBox(QPixmap(), widget->windowTitle(),true, nullptr);

--- a/src/Mod/Part/Gui/TaskDimension.cpp
+++ b/src/Mod/Part/Gui/TaskDimension.cpp
@@ -668,7 +668,7 @@ void PartGui::TaskMeasureLinear::setUpGui()
   controlTaskBox->groupLayout()->addLayout(controlLayout);
   QObject::connect(control->resetButton, SIGNAL(clicked(bool)), this, SLOT(resetDialogSlot(bool)));
 
-  this->setButtonPosition(TaskDialog::South);
+  this->setButtonPosition(TaskDialog::North);
   Content.push_back(selectionTaskBox);
   Content.push_back(controlTaskBox);
 


### PR DESCRIPTION
for consistency with other task dialogs, requested in https://forum.freecadweb.org/viewtopic.php?p=623239 (#7516 )
I have not actually tested yet if this works