### PR TITLE
Spreadsheet: Add Python API for getUsedCells

### DIFF
--- a/src/Mod/Spreadsheet/App/PropertySheet.cpp
+++ b/src/Mod/Spreadsheet/App/PropertySheet.cpp
@@ -151,6 +151,38 @@ bool PropertySheet::isValidAlias(const std::string &candidate)
         return false;
 }
 
+namespace
+{
+
+// A utility function that gets the range (the minimum and maximum row and column) out of a 
+// vector of cell addresses. Note that it's possible that neither cell in the tuple itself
+// has data in it, but operating on all cells in the inclusive range specified by the tuple
+// is guaranteed to include all cells in the passed-in vector, and no cells exist to the
+// left, right, above, or below the block specified.
+std::tuple<CellAddress, CellAddress> extractRange(const std::vector<CellAddress> &cells)
+{
+    CellAddress firstRowAndColumn;
+    CellAddress lastRowAndColumn;
+    for (const auto & cell : cells) {
+        int row = cell.row();
+        int column = cell.col();
+        if (row < firstRowAndColumn.row() || !firstRowAndColumn.isValid()) {
+            firstRowAndColumn.setRow(row);
+        }
+        if (column < firstRowAndColumn.col() || !firstRowAndColumn.isValid()) {
+            firstRowAndColumn.setCol(column);
+        }
+        if (row > lastRowAndColumn.row() || !lastRowAndColumn.isValid()) {
+            lastRowAndColumn.setRow(row);
+        }
+        if (column > lastRowAndColumn.col() || !lastRowAndColumn.isValid()) {
+            lastRowAndColumn.setCol(column);
+        }
+    }
+    return std::make_tuple(firstRowAndColumn, lastRowAndColumn);
+}
+}// namespace
+
 std::vector<CellAddress> PropertySheet::getUsedCells() const
 {
     std::vector<CellAddress> usedSet;
@@ -161,6 +193,12 @@ std::vector<CellAddress> PropertySheet::getUsedCells() const
     }
 
     return usedSet;
+}
+
+std::tuple<CellAddress, CellAddress> PropertySheet::getUsedRange() const
+{
+    auto usedCells = getUsedCells();
+    return extractRange(usedCells);
 }
 
 std::vector<CellAddress> PropertySheet::getNonEmptyCells() const
@@ -175,6 +213,12 @@ std::vector<CellAddress> PropertySheet::getNonEmptyCells() const
     }
 
     return usedSet;
+}
+
+std::tuple<CellAddress, CellAddress> PropertySheet::getNonEmptyRange() const
+{
+    auto nonEmptyCells = getNonEmptyCells();
+    return extractRange(nonEmptyCells);
 }
 
 void PropertySheet::setDirty(CellAddress address)

--- a/src/Mod/Spreadsheet/App/PropertySheet.h
+++ b/src/Mod/Spreadsheet/App/PropertySheet.h
@@ -115,7 +115,11 @@ public:
 
     std::vector<App::CellAddress> getUsedCells() const;
 
+    std::tuple<App::CellAddress, App::CellAddress> getUsedRange() const;
+
     std::vector<App::CellAddress> getNonEmptyCells() const;
+
+    std::tuple<App::CellAddress, App::CellAddress> getNonEmptyRange() const;
 
     Sheet * sheet() const { return owner; }
 

--- a/src/Mod/Spreadsheet/App/SheetPy.xml
+++ b/src/Mod/Spreadsheet/App/SheetPy.xml
@@ -180,5 +180,26 @@ following dependency order.
         </UserDocu>
       </Documentation>
     </Methode>
+	  
+    <Methode Name="getUsedCells">
+      <Documentation>
+        <UserDocu>
+getUsedCells()
+
+Get a list of the names of all cells that are marked as used. These cells may
+or may not have a non-empty string content.
+        </UserDocu>
+      </Documentation>
+    </Methode>
+	  
+    <Methode Name="getNonEmptyCells">
+      <Documentation>
+        <UserDocu>
+getNonEmptyCells()
+
+Get a list of the names of all cells with data in them.
+        </UserDocu>
+      </Documentation>
+    </Methode>
   </PythonExport>
 </GenerateModel>

--- a/src/Mod/Spreadsheet/App/SheetPy.xml
+++ b/src/Mod/Spreadsheet/App/SheetPy.xml
@@ -201,5 +201,32 @@ Get a list of the names of all cells with data in them.
         </UserDocu>
       </Documentation>
     </Methode>
+    
+    <Methode Name="getUsedRange">
+      <Documentation>
+        <UserDocu>
+getUsedRange()
+
+Get a the total range of the used cells in a sheet, as a pair of strings
+representing the lowest row and column that are used, and the highest row and
+column that are used (inclusive). Note that the actual first and last cell
+of the block are not necessarily used.
+        </UserDocu>
+      </Documentation>
+    </Methode>
+    
+    <Methode Name="getNonEmptyRange">
+      <Documentation>
+        <UserDocu>
+getNonEmptyRange()
+
+Get a the total range of the used cells in a sheet, as a pair of cell addresses
+representing the lowest row and column that contain data, and the highest row and
+column that contain data (inclusive). Note that the actual first and last cell
+of the block do not necessarily contain anything.
+        </UserDocu>
+      </Documentation>
+    </Methode>
+    
   </PythonExport>
 </GenerateModel>

--- a/src/Mod/Spreadsheet/App/SheetPyImp.cpp
+++ b/src/Mod/Spreadsheet/App/SheetPyImp.cpp
@@ -982,6 +982,9 @@ PyObject *SheetPy::recomputeCells(PyObject *args) {
 
 PyObject *SheetPy::getUsedCells(PyObject *args)
 {
+    if (!PyArg_ParseTuple(args, "")) {
+        return nullptr;
+    }
     auto usedCells = getSheetPtr()->getCells()->getUsedCells();
     Py::List pyCellList;
     for (const auto &cell : usedCells) { 
@@ -992,6 +995,9 @@ PyObject *SheetPy::getUsedCells(PyObject *args)
 
 PyObject *SheetPy::getUsedRange(PyObject *args)
 {
+    if (!PyArg_ParseTuple(args, "")) {
+        return nullptr;
+    }
     auto usedRange = getSheetPtr()->getCells()->getUsedRange();
     Py::Tuple pyTuple(2);
     pyTuple[0] = Py::String(std::get<0>(usedRange).toString());
@@ -1001,6 +1007,9 @@ PyObject *SheetPy::getUsedRange(PyObject *args)
 
 PyObject *SheetPy::getNonEmptyCells(PyObject *args)
 {
+    if (!PyArg_ParseTuple(args, "")) {
+        return nullptr;
+    }
     auto nonEmptyCells = getSheetPtr()->getCells()->getNonEmptyCells();
     Py::List pyCellList;
     for (const auto &cell : nonEmptyCells) { 
@@ -1011,6 +1020,9 @@ PyObject *SheetPy::getNonEmptyCells(PyObject *args)
 
 PyObject *SheetPy::getNonEmptyRange(PyObject *args)
 {
+    if (!PyArg_ParseTuple(args, "")) {
+        return nullptr;
+    }
     auto nonEmptyRange = getSheetPtr()->getCells()->getNonEmptyRange();
     Py::Tuple pyTuple(2);
     pyTuple[0] = Py::String(std::get<0>(nonEmptyRange).toString());

--- a/src/Mod/Spreadsheet/App/SheetPyImp.cpp
+++ b/src/Mod/Spreadsheet/App/SheetPyImp.cpp
@@ -990,14 +990,32 @@ PyObject *SheetPy::getUsedCells(PyObject *args)
     return Py::new_reference_to(pyCellList);
 }
 
+PyObject *SheetPy::getUsedRange(PyObject *args)
+{
+    auto usedRange = getSheetPtr()->getCells()->getUsedRange();
+    Py::Tuple pyTuple(2);
+    pyTuple[0] = Py::String(std::get<0>(usedRange).toString());
+    pyTuple[1] = Py::String(std::get<1>(usedRange).toString());
+    return Py::new_reference_to(pyTuple);
+}
+
 PyObject *SheetPy::getNonEmptyCells(PyObject *args)
 {
-    auto usedCells = getSheetPtr()->getCells()->getNonEmptyCells();
+    auto nonEmptyCells = getSheetPtr()->getCells()->getNonEmptyCells();
     Py::List pyCellList;
-    for (const auto &cell : usedCells) { 
+    for (const auto &cell : nonEmptyCells) { 
         pyCellList.append(Py::String(cell.toString())); 
     }
     return Py::new_reference_to(pyCellList);
+}
+
+PyObject *SheetPy::getNonEmptyRange(PyObject *args)
+{
+    auto nonEmptyRange = getSheetPtr()->getCells()->getNonEmptyRange();
+    Py::Tuple pyTuple(2);
+    pyTuple[0] = Py::String(std::get<0>(nonEmptyRange).toString());
+    pyTuple[1] = Py::String(std::get<1>(nonEmptyRange).toString());
+    return Py::new_reference_to(pyTuple);
 }
 
 

--- a/src/Mod/Spreadsheet/App/SheetPyImp.cpp
+++ b/src/Mod/Spreadsheet/App/SheetPyImp.cpp
@@ -980,6 +980,27 @@ PyObject *SheetPy::recomputeCells(PyObject *args) {
     }PY_CATCH;
 }
 
+PyObject *SheetPy::getUsedCells(PyObject *args)
+{
+    auto usedCells = getSheetPtr()->getCells()->getUsedCells();
+    Py::List pyCellList;
+    for (const auto &cell : usedCells) { 
+        pyCellList.append(Py::String(cell.toString()));
+    }
+    return Py::new_reference_to(pyCellList);
+}
+
+PyObject *SheetPy::getNonEmptyCells(PyObject *args)
+{
+    auto usedCells = getSheetPtr()->getCells()->getNonEmptyCells();
+    Py::List pyCellList;
+    for (const auto &cell : usedCells) { 
+        pyCellList.append(Py::String(cell.toString())); 
+    }
+    return Py::new_reference_to(pyCellList);
+}
+
+
 // +++ custom attributes implementer ++++++++++++++++++++++++++++++++++++++++
 
 PyObject *SheetPy::getCustomAttributes(const char*) const

--- a/src/Mod/Spreadsheet/TestSpreadsheet.py
+++ b/src/Mod/Spreadsheet/TestSpreadsheet.py
@@ -1345,6 +1345,40 @@ class SpreadsheetCases(unittest.TestCase):
         with self.assertRaises(AttributeError):
             self.assertEqual(ss1.B1, "fail")
 
+    def testGetUsedCells(self):
+        sheet = self.doc.addObject('Spreadsheet::Sheet','Spreadsheet')
+        test_cells = ['B13','C14','D15']
+        for i,cell in enumerate(test_cells):
+            sheet.set(cell,str(i))
+
+        used_cells = sheet.getUsedCells()
+        self.assertEqual(len(used_cells), len(test_cells))
+        for cell in test_cells:
+            self.assertTrue(cell in used_cells)
+
+        for cell in test_cells:
+            sheet.set(cell,"")
+            sheet.setAlignment(cell,"center")
+        non_empty_cells = sheet.getUsedCells()
+        self.assertEqual(len(non_empty_cells), len(test_cells)) # Alignment counts as "used"
+
+    def testGetNonEmptyCells(self):
+        sheet = self.doc.addObject('Spreadsheet::Sheet','Spreadsheet')
+        test_cells = ['B13','C14','D15']
+        for i,cell in enumerate(test_cells):
+            sheet.set(cell,str(i))
+
+        non_empty_cells = sheet.getNonEmptyCells()
+        self.assertEqual(len(non_empty_cells), len(test_cells))
+        for cell in test_cells:
+            self.assertTrue(cell in non_empty_cells)
+
+        for cell in test_cells:
+            sheet.set(cell,"")
+            sheet.setAlignment(cell,"center")
+        non_empty_cells = sheet.getNonEmptyCells()
+        self.assertEqual(len(non_empty_cells), 0) # Alignment does not count as "non-empty"
+
     def tearDown(self):
         #closing doc
         FreeCAD.closeDocument(self.doc.Name)

--- a/src/Mod/Spreadsheet/TestSpreadsheet.py
+++ b/src/Mod/Spreadsheet/TestSpreadsheet.py
@@ -1362,6 +1362,20 @@ class SpreadsheetCases(unittest.TestCase):
         non_empty_cells = sheet.getUsedCells()
         self.assertEqual(len(non_empty_cells), len(test_cells)) # Alignment counts as "used"
 
+    def testGetUsedRange(self):
+        sheet = self.doc.addObject('Spreadsheet::Sheet','Spreadsheet')
+        test_cells = ['C5','Z3','D10','E20']
+        for i,cell in enumerate(test_cells):
+            sheet.set(cell,str(i))
+        used_range = sheet.getUsedRange()
+        self.assertEquals(used_range,("C3","Z20"))
+        
+        for i,cell in enumerate(test_cells):
+            sheet.set(cell,"")
+            sheet.setAlignment(cell,"center")
+        used_range = sheet.getUsedRange()
+        self.assertEquals(used_range,("C3","Z20"))
+
     def testGetNonEmptyCells(self):
         sheet = self.doc.addObject('Spreadsheet::Sheet','Spreadsheet')
         test_cells = ['B13','C14','D15']
@@ -1378,6 +1392,23 @@ class SpreadsheetCases(unittest.TestCase):
             sheet.setAlignment(cell,"center")
         non_empty_cells = sheet.getNonEmptyCells()
         self.assertEqual(len(non_empty_cells), 0) # Alignment does not count as "non-empty"
+
+    def testGetNonEmptyRange(self):
+        sheet = self.doc.addObject('Spreadsheet::Sheet','Spreadsheet')
+        test_cells = ['C5','Z3','D10','E20']
+        for i,cell in enumerate(test_cells):
+            sheet.set(cell,str(i))
+        non_empty_range = sheet.getNonEmptyRange()
+        self.assertEquals(non_empty_range,("C3","Z20"))
+        
+        for i,cell in enumerate(test_cells):
+            sheet.set(cell,"")
+            sheet.setAlignment(cell,"center")
+        more_cells = ['D10','X5','E10','K15']
+        for i,cell in enumerate(more_cells):
+            sheet.set(cell,str(i))
+        non_empty_range = sheet.getNonEmptyRange()
+        self.assertEquals(non_empty_range,("D5","X15"))
 
     def tearDown(self):
         #closing doc


### PR DESCRIPTION
Also adds access to `getNonEmptyCells()`, and unit tests for both. In a second commit, two new C++ functions are introduced to get the range of non-empty and used cells, `getNonEmptyRange()` and `getUsedRange()`. These functions return a pair of cell addresses representing the bounding box of the data in the sheet. Python wrappers and unit tests are also provided.

Designed to fix #7587.