### PR TITLE
Gui: Add button to set point color in Appearance task dialog

### DIFF
--- a/src/Gui/DlgDisplayProperties.ui
+++ b/src/Gui/DlgDisplayProperties.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>290</width>
-    <height>487</height>
+    <height>680</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -20,7 +20,16 @@
       <string>Viewing mode</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_3">
-      <property name="margin">
+      <property name="leftMargin">
+       <number>11</number>
+      </property>
+      <property name="topMargin">
+       <number>11</number>
+      </property>
+      <property name="rightMargin">
+       <number>11</number>
+      </property>
+      <property name="bottomMargin">
        <number>11</number>
       </property>
       <item row="0" column="0">
@@ -28,7 +37,16 @@
         <property name="spacing">
          <number>6</number>
         </property>
-        <property name="margin">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
          <number>0</number>
         </property>
         <item>
@@ -48,7 +66,16 @@
         <property name="spacing">
          <number>6</number>
         </property>
-        <property name="margin">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
          <number>0</number>
         </property>
         <item>
@@ -84,7 +111,16 @@
         <property name="spacing">
          <number>6</number>
         </property>
-        <property name="margin">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
          <number>0</number>
         </property>
         <item>
@@ -151,7 +187,17 @@
         <item row="2" column="1">
          <widget class="Gui::ColorButton" name="buttonLineColor"/>
         </item>
-       </layout>
+        <item row="3" column="0">
+         <widget class="QLabel" name="label_5">
+          <property name="text">
+           <string>Point color:</string>
+          </property>
+         </widget>
+        </item>
+       <item row="3" column="1">
+         <widget class="Gui::ColorButton" name="buttonPointColor"/>
+        </item>
+        </layout>
       </item>
      </layout>
     </widget>
@@ -162,7 +208,16 @@
       <string>Display</string>
      </property>
      <layout class="QGridLayout">
-      <property name="margin">
+      <property name="leftMargin">
+       <number>9</number>
+      </property>
+      <property name="topMargin">
+       <number>9</number>
+      </property>
+      <property name="rightMargin">
+       <number>9</number>
+      </property>
+      <property name="bottomMargin">
        <number>9</number>
       </property>
       <property name="spacing">
@@ -173,7 +228,16 @@
         <property name="spacing">
          <number>6</number>
         </property>
-        <property name="margin">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
          <number>0</number>
         </property>
         <item>
@@ -191,7 +255,7 @@
           <property name="sizeType">
            <enum>QSizePolicy::Expanding</enum>
           </property>
-          <property name="sizeHint" stdset="0">
+          <property name="sizeHint">
            <size>
             <width>71</width>
             <height>20</height>
@@ -219,7 +283,16 @@
         <property name="spacing">
          <number>6</number>
         </property>
-        <property name="margin">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
          <number>0</number>
         </property>
         <item>
@@ -237,7 +310,7 @@
           <property name="sizeType">
            <enum>QSizePolicy::Expanding</enum>
           </property>
-          <property name="sizeHint" stdset="0">
+          <property name="sizeHint">
            <size>
             <width>71</width>
             <height>20</height>
@@ -272,7 +345,16 @@
         <property name="spacing">
          <number>6</number>
         </property>
-        <property name="margin">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
          <number>0</number>
         </property>
         <item>
@@ -303,7 +385,7 @@
         </item>
        </layout>
       </item>
-     <item row="4" column="0">
+      <item row="4" column="0">
        <widget class="QLabel" name="label">
         <property name="text">
          <string>Line transparency:</string>
@@ -315,7 +397,16 @@
         <property name="spacing">
          <number>6</number>
         </property>
-        <property name="margin">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
          <number>0</number>
         </property>
         <item>
@@ -340,7 +431,7 @@
         </item>
        </layout>
       </item>
-      </layout>
+     </layout>
     </widget>
    </item>
    <item row="3" column="0">

--- a/src/Gui/DlgDisplayPropertiesImp.cpp
+++ b/src/Gui/DlgDisplayPropertiesImp.cpp
@@ -75,6 +75,7 @@ DlgDisplayPropertiesImp::DlgDisplayPropertiesImp(bool floating, QWidget* parent,
     d->ui.textLabel1_3->hide();
     d->ui.changePlot->hide();
     d->ui.buttonLineColor->setModal(false);
+    d->ui.buttonPointColor->setModal(false);
     d->ui.buttonColor->setModal(false);
     d->floating = floating;
 
@@ -85,6 +86,7 @@ DlgDisplayPropertiesImp::DlgDisplayPropertiesImp(bool floating, QWidget* parent,
     setColorPlot(views);
     setShapeColor(views);
     setLineColor(views);
+    setPointColor(views);
     setPointSize(views);
     setLineWidth(views);
     setTransparency(views);
@@ -144,6 +146,7 @@ void DlgDisplayPropertiesImp::OnChange(Gui::SelectionSingleton::SubjectType &rCa
         setColorPlot(views);
         setShapeColor(views);
         setLineColor(views);
+        setPointColor(views);
         setPointSize(views);
         setLineWidth(views);
         setTransparency(views);
@@ -172,17 +175,24 @@ void DlgDisplayPropertiesImp::slotChangedObject(const Gui::ViewProvider& obj,
             App::Color value = static_cast<const App::PropertyColor&>(prop).getValue();
             if (prop_name == "ShapeColor") {
                 bool blocked = d->ui.buttonColor->blockSignals(true);
-                d->ui.buttonColor->setColor(QColor((int)(255.0f*value.r),
-                                                   (int)(255.0f*value.g),
-                                                   (int)(255.0f*value.b)));
+                d->ui.buttonColor->setColor(QColor((int)(255.0f * value.r),
+                                                   (int)(255.0f * value.g),
+                                                   (int)(255.0f * value.b)));
                 d->ui.buttonColor->blockSignals(blocked);
             }
             else if (prop_name == "LineColor") {
                 bool blocked = d->ui.buttonLineColor->blockSignals(true);
-                d->ui.buttonLineColor->setColor(QColor((int)(255.0f*value.r),
-                                                       (int)(255.0f*value.g),
-                                                       (int)(255.0f*value.b)));
+                d->ui.buttonLineColor->setColor(QColor((int)(255.0f * value.r),
+                                                       (int)(255.0f * value.g),
+                                                       (int)(255.0f * value.b)));
                 d->ui.buttonLineColor->blockSignals(blocked);
+            }
+            else if (prop_name == "PointColor") {
+                bool blocked = d->ui.buttonPointColor->blockSignals(true);
+                d->ui.buttonPointColor->setColor(QColor((int)(255.0f * value.r),
+                                                       (int)(255.0f * value.g),
+                                                       (int)(255.0f * value.b)));
+                d->ui.buttonPointColor->blockSignals(blocked);
             }
         }
         else if (prop.getTypeId().isDerivedFrom(App::PropertyInteger::getClassTypeId())) {
@@ -311,7 +321,7 @@ void DlgDisplayPropertiesImp::on_buttonColor_changed()
 {
     std::vector<Gui::ViewProvider*> Provider = getSelection();
     QColor s = d->ui.buttonColor->color();
-    App::Color c(s.red()/255.0,s.green()/255.0,s.blue()/255.0);
+    App::Color c(s.red() / 255.0, s.green() / 255.0, s.blue() / 255.0);
     for (auto It= Provider.begin();It!=Provider.end();++It) {
         App::Property* prop = (*It)->getPropertyByName("ShapeColor");
         if (prop && prop->getTypeId() == App::PropertyColor::getClassTypeId()) {
@@ -370,12 +380,26 @@ void DlgDisplayPropertiesImp::on_buttonLineColor_changed()
 {
     std::vector<Gui::ViewProvider*> Provider = getSelection();
     QColor s = d->ui.buttonLineColor->color();
-    App::Color c(s.red()/255.0,s.green()/255.0,s.blue()/255.0);
+    App::Color c(s.red() / 255.0, s.green() / 255.0, s.blue() / 255.0);
     for (const auto & It : Provider) {
         App::Property* prop = It->getPropertyByName("LineColor");
         if (prop && prop->getTypeId() == App::PropertyColor::getClassTypeId()) {
-            auto ShapeColor = static_cast<App::PropertyColor*>(prop);
-            ShapeColor->setValue(c);
+            auto LineColor = static_cast<App::PropertyColor*>(prop);
+            LineColor->setValue(c);
+        }
+    }
+}
+
+void DlgDisplayPropertiesImp::on_buttonPointColor_changed()
+{
+    std::vector<Gui::ViewProvider*> Provider = getSelection();
+    QColor s = d->ui.buttonPointColor->color();
+    App::Color c(s.red() / 255.0, s.green() / 255.0, s.blue() / 255.0);
+    for (const auto & It : Provider) {
+        App::Property* prop = It->getPropertyByName("PointColor");
+        if (prop && prop->getTypeId() == App::PropertyColor::getClassTypeId()) {
+            auto PointColor = static_cast<App::PropertyColor*>(prop);
+            PointColor->setValue(c);
         }
     }
 }
@@ -506,7 +530,7 @@ void DlgDisplayPropertiesImp::setShapeColor(const std::vector<Gui::ViewProvider*
         if (prop && prop->getTypeId() == App::PropertyColor::getClassTypeId()) {
             App::Color c = static_cast<App::PropertyColor*>(prop)->getValue();
             QColor shape;
-            shape.setRgb((int)(c.r*255.0f), (int)(c.g*255.0f),(int)(c.b*255.0f));
+            shape.setRgb((int)(c.r * 255.0f), (int)(c.g * 255.0f), (int)(c.b * 255.0f));
             bool blocked = d->ui.buttonColor->blockSignals(true);
             d->ui.buttonColor->setColor(shape);
             d->ui.buttonColor->blockSignals(blocked);
@@ -520,22 +544,42 @@ void DlgDisplayPropertiesImp::setShapeColor(const std::vector<Gui::ViewProvider*
 
 void DlgDisplayPropertiesImp::setLineColor(const std::vector<Gui::ViewProvider*>& views)
 {
-    bool shapeColor = false;
+    bool lineColor = false;
     for (const auto & view : views) {
         App::Property* prop = view->getPropertyByName("LineColor");
         if (prop && prop->getTypeId() == App::PropertyColor::getClassTypeId()) {
             App::Color c = static_cast<App::PropertyColor*>(prop)->getValue();
-            QColor shape;
-            shape.setRgb((int)(c.r*255.0f), (int)(c.g*255.0f),(int)(c.b*255.0f));
+            QColor line;
+            line.setRgb((int)(c.r * 255.0f), (int)(c.g * 255.0f), (int)(c.b * 255.0f));
             bool blocked = d->ui.buttonLineColor->blockSignals(true);
-            d->ui.buttonLineColor->setColor(shape);
+            d->ui.buttonLineColor->setColor(line);
             d->ui.buttonLineColor->blockSignals(blocked);
-            shapeColor = true;
+            lineColor = true;
             break;
         }
     }
 
-    d->ui.buttonLineColor->setEnabled(shapeColor);
+    d->ui.buttonLineColor->setEnabled(lineColor);
+}
+
+void DlgDisplayPropertiesImp::setPointColor(const std::vector<Gui::ViewProvider*>& views)
+{
+    bool pointColor = false;
+    for (const auto & view : views) {
+        App::Property* prop = view->getPropertyByName("PointColor");
+        if (prop && prop->getTypeId() == App::PropertyColor::getClassTypeId()) {
+            App::Color c = static_cast<App::PropertyColor*>(prop)->getValue();
+            QColor point;
+            point.setRgb((int)(c.r * 255.0f), (int)(c.g * 255.0f), (int)(c.b * 255.0f));
+            bool blocked = d->ui.buttonPointColor->blockSignals(true);
+            d->ui.buttonPointColor->setColor(point);
+            d->ui.buttonPointColor->blockSignals(blocked);
+            pointColor = true;
+            break;
+        }
+    }
+
+    d->ui.buttonPointColor->setEnabled(pointColor);
 }
 
 void DlgDisplayPropertiesImp::setPointSize(const std::vector<Gui::ViewProvider*>& views)

--- a/src/Gui/DlgDisplayPropertiesImp.h
+++ b/src/Gui/DlgDisplayPropertiesImp.h
@@ -72,6 +72,7 @@ private Q_SLOTS:
     void on_spinTransparency_valueChanged(int);
     void on_spinPointSize_valueChanged(int);
     void on_buttonLineColor_changed();
+    void on_buttonPointColor_changed();
     void on_spinLineWidth_valueChanged(int);
     void on_spinLineTransparency_valueChanged(int);
     void on_buttonUserDefinedMaterial_clicked();
@@ -88,6 +89,7 @@ private:
     void fillupMaterials();
     void setShapeColor(const std::vector<ViewProvider*>&);
     void setLineColor(const std::vector<ViewProvider*>&);
+    void setPointColor(const std::vector<ViewProvider*>&);
     void setPointSize(const std::vector<ViewProvider*>&);
     void setLineWidth(const std::vector<ViewProvider*>&);
     void setTransparency(const std::vector<ViewProvider*>&);


### PR DESCRIPTION
I missed having this button several times when editing the appearance of subhsapebinders and sketches, you can easily set the line color but then then the points stand out a lot and to change the point color you have to go to Property view > View tab > Point Color, making the appearance dialog useless.
![image](https://user-images.githubusercontent.com/36372335/200089159-8dc43473-3538-49fd-a98c-c2c03d54131b.png)
