### PR TITLE
Addon Manager: Qt6 migration part 1, use PySide

### DIFF
--- a/src/Mod/AddonManager/AddonManager.py
+++ b/src/Mod/AddonManager/AddonManager.py
@@ -37,7 +37,7 @@ import re  # Needed for py 3.6 and earlier, can remove later, search for "re."
 from datetime import date, timedelta
 from typing import Dict, List
 
-from PySide2 import QtGui, QtCore, QtWidgets
+from PySide import QtGui, QtCore, QtWidgets
 import FreeCAD
 import FreeCADGui
 

--- a/src/Mod/AddonManager/AddonManagerOptions.py
+++ b/src/Mod/AddonManager/AddonManagerOptions.py
@@ -27,9 +27,9 @@ import os
 import FreeCAD
 import FreeCADGui
 
-from PySide2 import QtCore
-from PySide2.QtGui import QIcon
-from PySide2.QtWidgets import (
+from PySide import QtCore
+from PySide.QtGui import QIcon
+from PySide.QtWidgets import (
     QWidget,
     QCheckBox,
     QComboBox,

--- a/src/Mod/AddonManager/NetworkManager.py
+++ b/src/Mod/AddonManager/NetworkManager.py
@@ -74,10 +74,10 @@ except ImportError:
     # For standalone testing support working without the FreeCAD import
     HAVE_FREECAD = False
 
-from PySide2 import QtCore
+from PySide import QtCore
 
 if FreeCAD.GuiUp:
-    from PySide2 import QtWidgets
+    from PySide import QtWidgets
 
 
 # This is the global instance of the NetworkManager that outside code
@@ -86,20 +86,18 @@ AM_NETWORK_MANAGER = None
 
 HAVE_QTNETWORK = True
 try:
-    from PySide2 import QtNetwork
+    from PySide import QtNetwork
 except ImportError:
     if HAVE_FREECAD:
         FreeCAD.Console.PrintError(
             translate(
                 "AddonsInstaller",
-                "Could not import QtNetwork -- it does not appear to be installed on your system. Please install the package 'python3-pyside2.qtnetwork' on your system and if possible contact your FreeCAD package maintainer to alert them to the missing dependency. The Addon Manager will not be available.",
+                'Could not import QtNetwork -- it does not appear to be installed on your system. Your provider may have a package for this dependency (often called e.g. "python3-pyside2.qtnetwork", for example)',
             )
             + "\n"
         )
     else:
-        print(
-            "Could not import QtNetwork, unable to test this file. Try installing the python3-pyside2.qtnetwork package."
-        )
+        print("Could not import QtNetwork, unable to test this file.")
         sys.exit(1)
     HAVE_QTNETWORK = False
 

--- a/src/Mod/AddonManager/addonmanager_devmode.py
+++ b/src/Mod/AddonManager/addonmanager_devmode.py
@@ -29,18 +29,18 @@ import subprocess
 import FreeCAD
 import FreeCADGui
 
-from PySide2.QtWidgets import (
+from PySide.QtWidgets import (
     QFileDialog,
     QListWidgetItem,
     QDialog,
     QSizePolicy,
     QMessageBox,
 )
-from PySide2.QtGui import (
+from PySide.QtGui import (
     QIcon,
     QPixmap,
 )
-from PySide2.QtCore import Qt
+from PySide.QtCore import Qt
 from addonmanager_git import GitManager, NoGitFound
 
 from addonmanager_devmode_add_content import AddContent

--- a/src/Mod/AddonManager/addonmanager_devmode_add_content.py
+++ b/src/Mod/AddonManager/addonmanager_devmode_add_content.py
@@ -31,15 +31,15 @@ import FreeCADGui
 
 from Addon import INTERNAL_WORKBENCHES
 
-from PySide2.QtWidgets import (
+from PySide.QtWidgets import (
     QDialog,
     QLayout,
     QFileDialog,
     QTableWidgetItem,
     QSizePolicy,
 )
-from PySide2.QtGui import QIcon
-from PySide2.QtCore import Qt
+from PySide.QtGui import QIcon
+from PySide.QtCore import Qt
 
 from addonmanager_devmode_validators import (
     VersionValidator,

--- a/src/Mod/AddonManager/addonmanager_devmode_license_selector.py
+++ b/src/Mod/AddonManager/addonmanager_devmode_license_selector.py
@@ -29,22 +29,22 @@ from typing import Optional, Tuple
 import FreeCAD
 import FreeCADGui
 
-from PySide2.QtWidgets import QFileDialog, QDialog
-from PySide2.QtGui import QDesktopServices
-from PySide2.QtCore import QUrl, QFile, QIODevice
+from PySide.QtWidgets import QFileDialog, QDialog
+from PySide.QtGui import QDesktopServices
+from PySide.QtCore import QUrl, QFile, QIODevice
 
 try:
-    from PySide2.QtGui import (
+    from PySide.QtGui import (
         QRegularExpressionValidator,
     )
-    from PySide2.QtCore import QRegularExpression
+    from PySide.QtCore import QRegularExpression
     RegexWrapper = QRegularExpression
     RegexValidatorWrapper = QRegularExpressionValidator
 except ImportError:
-    from PySide2.QtGui import (
+    from PySide.QtGui import (
         QRegExpValidator,
     )
-    from PySide2.QtCore import QRegExp
+    from PySide.QtCore import QRegExp
     RegexWrapper = QRegExp
     RegexValidatorWrapper = QRegExpValidator
 

--- a/src/Mod/AddonManager/addonmanager_devmode_licenses_table.py
+++ b/src/Mod/AddonManager/addonmanager_devmode_licenses_table.py
@@ -24,8 +24,8 @@
 
 import os
 
-from PySide2.QtWidgets import QTableWidgetItem
-from PySide2.QtGui import QIcon
+from PySide.QtWidgets import QTableWidgetItem
+from PySide.QtGui import QIcon
 
 import FreeCAD
 import FreeCADGui

--- a/src/Mod/AddonManager/addonmanager_devmode_people_table.py
+++ b/src/Mod/AddonManager/addonmanager_devmode_people_table.py
@@ -24,9 +24,9 @@
 
 import os
 
-from PySide2.QtWidgets import QTableWidgetItem
-from PySide2.QtGui import QIcon
-from PySide2.QtCore import Qt
+from PySide.QtWidgets import QTableWidgetItem
+from PySide.QtGui import QIcon
+from PySide.QtCore import Qt
 
 import FreeCAD
 import FreeCADGui

--- a/src/Mod/AddonManager/addonmanager_devmode_person_editor.py
+++ b/src/Mod/AddonManager/addonmanager_devmode_person_editor.py
@@ -25,7 +25,7 @@
 import os
 from typing import Tuple  # Needed until Py 3.9, when tuple supports this directly
 
-from PySide2.QtWidgets import QDialog
+from PySide.QtWidgets import QDialog
 
 import FreeCAD
 import FreeCADGui

--- a/src/Mod/AddonManager/addonmanager_devmode_validators.py
+++ b/src/Mod/AddonManager/addonmanager_devmode_validators.py
@@ -24,24 +24,24 @@
 
 import keyword
 
-from PySide2.QtGui import (
+from PySide.QtGui import (
     QValidator,
 )
 
-# QRegularExpressionValidator was only added at the very end of the PySide2
+# QRegularExpressionValidator was only added at the very end of the PySide
 # development cycle, so make sure to support the older QRegExp version as well.
 try:
-    from PySide2.QtGui import (
+    from PySide.QtGui import (
         QRegularExpressionValidator,
     )
-    from PySide2.QtCore import QRegularExpression
+    from PySide.QtCore import QRegularExpression
     RegexWrapper = QRegularExpression
     RegexValidatorWrapper = QRegularExpressionValidator
 except ImportError:
-    from PySide2.QtGui import (
+    from PySide.QtGui import (
         QRegExpValidator,
     )
-    from PySide2.QtCore import QRegExp
+    from PySide.QtCore import QRegExp
     RegexWrapper = QRegExp
     RegexValidatorWrapper = QRegExpValidator
 

--- a/src/Mod/AddonManager/addonmanager_macro.py
+++ b/src/Mod/AddonManager/addonmanager_macro.py
@@ -33,7 +33,7 @@ from typing import Dict, Tuple, List, Union, Optional
 
 import FreeCAD
 import NetworkManager
-from PySide2 import QtCore
+from PySide import QtCore
 
 from addonmanager_utilities import remove_directory_if_empty, is_float
 

--- a/src/Mod/AddonManager/addonmanager_utilities.py
+++ b/src/Mod/AddonManager/addonmanager_utilities.py
@@ -32,7 +32,7 @@ from typing import Optional, Any
 
 from urllib.parse import urlparse
 
-from PySide2 import QtCore, QtWidgets
+from PySide import QtCore, QtWidgets
 
 import FreeCAD
 import FreeCADGui

--- a/src/Mod/AddonManager/addonmanager_workers_installation.py
+++ b/src/Mod/AddonManager/addonmanager_workers_installation.py
@@ -34,7 +34,7 @@ import zipfile
 from typing import Dict, List
 from enum import Enum, auto
 
-from PySide2 import QtCore
+from PySide import QtCore
 
 import FreeCAD
 import addonmanager_utilities as utils

--- a/src/Mod/AddonManager/addonmanager_workers_startup.py
+++ b/src/Mod/AddonManager/addonmanager_workers_startup.py
@@ -33,7 +33,7 @@ import threading
 import time
 from typing import List
 
-from PySide2 import QtCore
+from PySide import QtCore
 
 import FreeCAD
 import addonmanager_utilities as utils

--- a/src/Mod/AddonManager/addonmanager_workers_utility.py
+++ b/src/Mod/AddonManager/addonmanager_workers_utility.py
@@ -24,7 +24,7 @@
 from typing import Optional
 
 import FreeCAD
-from PySide2 import QtCore
+from PySide import QtCore
 import NetworkManager
 
 translate = FreeCAD.Qt.translate

--- a/src/Mod/AddonManager/change_branch.py
+++ b/src/Mod/AddonManager/change_branch.py
@@ -26,7 +26,7 @@ import os
 import FreeCAD
 import FreeCADGui
 
-from PySide2 import QtWidgets, QtCore
+from PySide import QtWidgets, QtCore
 
 translate = FreeCAD.Qt.translate
 

--- a/src/Mod/AddonManager/compact_view.py
+++ b/src/Mod/AddonManager/compact_view.py
@@ -8,9 +8,9 @@
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################
 
-from PySide2.QtCore import *
-from PySide2.QtGui import *
-from PySide2.QtWidgets import *
+from PySide.QtCore import *
+from PySide.QtGui import *
+from PySide.QtWidgets import *
 
 
 class Ui_CompactView(object):

--- a/src/Mod/AddonManager/expanded_view.py
+++ b/src/Mod/AddonManager/expanded_view.py
@@ -8,9 +8,9 @@
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################
 
-from PySide2.QtCore import *
-from PySide2.QtGui import *
-from PySide2.QtWidgets import *
+from PySide.QtCore import *
+from PySide.QtGui import *
+from PySide.QtWidgets import *
 
 
 class Ui_ExpandedView(object):

--- a/src/Mod/AddonManager/install_to_toolbar.py
+++ b/src/Mod/AddonManager/install_to_toolbar.py
@@ -25,7 +25,7 @@ import os
 
 import FreeCAD
 import FreeCADGui
-from PySide2 import QtCore, QtWidgets
+from PySide import QtCore, QtWidgets
 import Addon
 
 translate = FreeCAD.Qt.translate

--- a/src/Mod/AddonManager/manage_python_dependencies.py
+++ b/src/Mod/AddonManager/manage_python_dependencies.py
@@ -31,7 +31,7 @@ from functools import partial
 
 import FreeCAD
 import FreeCADGui
-from PySide2 import QtCore, QtGui, QtWidgets
+from PySide import QtCore, QtGui, QtWidgets
 
 import addonmanager_utilities as utils
 

--- a/src/Mod/AddonManager/package_details.py
+++ b/src/Mod/AddonManager/package_details.py
@@ -27,9 +27,9 @@
 import os
 from typing import Optional
 
-from PySide2.QtCore import *
-from PySide2.QtGui import *
-from PySide2.QtWidgets import *
+from PySide.QtCore import *
+from PySide.QtGui import *
+from PySide.QtWidgets import *
 
 import FreeCAD
 import FreeCADGui
@@ -55,14 +55,14 @@ translate = FreeCAD.Qt.translate
 show_javascript_console_output = False
 
 try:
-    from PySide2.QtWebEngineWidgets import *
+    from PySide.QtWebEngineWidgets import *
 
     HAS_QTWEBENGINE = True
 except ImportError:
     FreeCAD.Console.PrintWarning(
         translate(
             "AddonsInstaller",
-            "Addon Manager Warning: Could not import QtWebEngineWidgets, it seems to be missing from your system. Please use your system's package manager to install the python3-pyside2.qtwebengine* and python3-pyside2.qtwebchannel packages, and if possible alert your package creator to the missing dependency. Display of package README will be limited until this dependency is resolved.",
+            "Addon Manager Warning: Could not import QtWebEngineWidgets. Your system's package manager may provide a package for this dependency, search the package manager for possible resolutions. Display of package README will be limited until this dependency is resolved.",
         )
         + "\n"
     )

--- a/src/Mod/AddonManager/package_list.py
+++ b/src/Mod/AddonManager/package_list.py
@@ -29,9 +29,9 @@ import threading
 
 import FreeCAD
 
-from PySide2.QtCore import *
-from PySide2.QtGui import *
-from PySide2.QtWidgets import *
+from PySide.QtCore import *
+from PySide.QtGui import *
+from PySide.QtWidgets import *
 
 from Addon import Addon
 


### PR DESCRIPTION
Migrate the Addon Manager to the "PySide" wrapper, replacing all instances of "PySide2" with the generated files. When FreeCAD is compiled with `FREECAD_QT_VERSION=6`,  this wrapper automatically uses PySide6 instead of PySide2.