### PR TITLE
[Gui][Mod]: uniform spin button step size to 5%

### DIFF
--- a/src/Gui/DlgMaterialProperties.ui
+++ b/src/Gui/DlgMaterialProperties.ui
@@ -26,7 +26,16 @@
       <string>Material</string>
      </property>
      <layout class="QGridLayout">
-      <property name="margin">
+      <property name="leftMargin">
+       <number>9</number>
+      </property>
+      <property name="topMargin">
+       <number>9</number>
+      </property>
+      <property name="rightMargin">
+       <number>9</number>
+      </property>
+      <property name="bottomMargin">
        <number>9</number>
       </property>
       <property name="spacing">
@@ -46,7 +55,7 @@
         </property>
        </widget>
       </item>
-     <item row="1" column="0">
+      <item row="1" column="0">
        <widget class="QLabel" name="textLabel1">
         <property name="text">
          <string>Diffuse color:</string>
@@ -93,7 +102,16 @@
         <property name="spacing">
          <number>6</number>
         </property>
-        <property name="margin">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
          <number>0</number>
         </property>
         <item>
@@ -124,11 +142,14 @@
           <property name="suffix">
            <string>%</string>
           </property>
+          <property name="singleStep">
+           <number>5</number>
+          </property>
          </widget>
         </item>
        </layout>
       </item>
-      </layout>
+     </layout>
     </widget>
    </item>
    <item row="1" column="0">

--- a/src/Gui/ViewProviderGeometryObject.cpp
+++ b/src/Gui/ViewProviderGeometryObject.cpp
@@ -53,7 +53,7 @@ using namespace Gui;
 
 PROPERTY_SOURCE(Gui::ViewProviderGeometryObject, Gui::ViewProviderDragger)
 
-const App::PropertyIntegerConstraint::Constraints intPercent = {0, 100, 1};
+const App::PropertyIntegerConstraint::Constraints intPercent = {0, 100, 5};
 
 ViewProviderGeometryObject::ViewProviderGeometryObject()
     : pcBoundSwitch(nullptr)
@@ -65,9 +65,9 @@ ViewProviderGeometryObject::ViewProviderGeometryObject()
 
     if (randomColor){
         auto fMax = (float)RAND_MAX;
-        r = (float)rand()/fMax;
-        g = (float)rand()/fMax;
-        b = (float)rand()/fMax;
+        r = (float)rand() / fMax;
+        g = (float)rand() / fMax;
+        b = (float)rand() / fMax;
     }
     else {
         unsigned long shcol = hGrp->GetUnsigned("DefaultShapeColor", 3435973887UL); // light gray (204,204,204)

--- a/src/Mod/Mesh/Gui/DlgSettingsMeshView.ui
+++ b/src/Mod/Mesh/Gui/DlgSettingsMeshView.ui
@@ -14,7 +14,16 @@
    <string>Mesh view</string>
   </property>
   <layout class="QGridLayout">
-   <property name="margin">
+   <property name="leftMargin">
+    <number>9</number>
+   </property>
+   <property name="topMargin">
+    <number>9</number>
+   </property>
+   <property name="rightMargin">
+    <number>9</number>
+   </property>
+   <property name="bottomMargin">
     <number>9</number>
    </property>
    <property name="spacing">
@@ -26,7 +35,16 @@
       <string>Default appearance for new meshes</string>
      </property>
      <layout class="QGridLayout">
-      <property name="margin">
+      <property name="leftMargin">
+       <number>9</number>
+      </property>
+      <property name="topMargin">
+       <number>9</number>
+      </property>
+      <property name="rightMargin">
+       <number>9</number>
+      </property>
+      <property name="bottomMargin">
        <number>9</number>
       </property>
       <property name="spacing">
@@ -34,7 +52,16 @@
       </property>
       <item row="0" column="0">
        <layout class="QGridLayout">
-        <property name="margin">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
          <number>0</number>
         </property>
         <property name="spacing">
@@ -83,7 +110,7 @@
           </property>
          </spacer>
         </item>
-       <item row="0" column="3">
+        <item row="0" column="3">
          <widget class="QLabel" name="labelMeshTransparency">
           <property name="text">
            <string>Mesh transparency</string>
@@ -97,6 +124,9 @@
           </property>
           <property name="maximum">
            <number>100</number>
+          </property>
+          <property name="singleStep">
+           <number>5</number>
           </property>
           <property name="prefEntry" stdset="0">
            <cstring>MeshTransparency</cstring>
@@ -164,6 +194,9 @@
           <property name="maximum">
            <number>100</number>
           </property>
+          <property name="singleStep">
+           <number>5</number>
+          </property>
           <property name="prefEntry" stdset="0">
            <cstring>LineTransparency</cstring>
           </property>
@@ -216,7 +249,7 @@
          <widget class="Gui::PrefCheckBox" name="checkboxRendering">
           <property name="toolTip">
            <string>The bottom side of surface will be rendered the same way than top side.
-If not checked, it depends on the option "Enable backlight color"
+If not checked, it depends on the option &quot;Enable backlight color&quot;
 (preferences section Display -&gt; 3D View). Either the backlight color
 will be used or black.</string>
           </property>
@@ -253,7 +286,7 @@ will be used or black.</string>
           </property>
          </widget>
         </item>
-        </layout>
+       </layout>
       </item>
       <item row="0" column="1">
        <spacer>
@@ -280,7 +313,16 @@ will be used or black.</string>
       <string>Smoothing</string>
      </property>
      <layout class="QGridLayout">
-      <property name="margin">
+      <property name="leftMargin">
+       <number>9</number>
+      </property>
+      <property name="topMargin">
+       <number>9</number>
+      </property>
+      <property name="rightMargin">
+       <number>9</number>
+      </property>
+      <property name="bottomMargin">
        <number>9</number>
       </property>
       <property name="spacing">
@@ -311,7 +353,7 @@ to a smoother appearance.
       <item row="1" column="0">
        <widget class="QLabel" name="labelAngle">
         <property name="toolTip">
-         <string>&lt;html&gt;&lt;head&gt;&lt;meta name="qrichtext" content="1" /&gt;&lt;/head&gt;&lt;body style=" white-space: pre-wrap; font-family:MS Shell Dlg 2; font-size:7.8pt; font-weight:400; font-style:normal; text-decoration:none;"&gt;&lt;p style=" margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:8pt;"&gt;This is the smallest angle between two faces where normals get calculated to do flat shading.&lt;/p&gt;&lt;p style=" margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:8pt;"&gt;If the angle between the normals of two neighbouring faces is less than the crease angle, the faces will be smoothshaded around their common edge.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         <string>&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;/head&gt;&lt;body style=&quot; white-space: pre-wrap; font-family:MS Shell Dlg 2; font-size:7.8pt; font-weight:400; font-style:normal; text-decoration:none;&quot;&gt;&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:8pt;&quot;&gt;This is the smallest angle between two faces where normals get calculated to do flat shading.&lt;/p&gt;&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:8pt;&quot;&gt;If the angle between the normals of two neighbouring faces is less than the crease angle, the faces will be smoothshaded around their common edge.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
         <property name="text">
          <string>Crease angle</string>
@@ -359,7 +401,7 @@ to a smoother appearance.
       <item row="2" column="0" colspan="3">
        <widget class="QLabel" name="labelHint">
         <property name="text">
-         <string>&lt;html&gt;&lt;head&gt;&lt;meta name="qrichtext" content="1" /&gt;&lt;/head&gt;&lt;body style=" white-space: pre-wrap; font-family:MS Shell Dlg 2; font-size:7.8pt; font-weight:400; font-style:normal; text-decoration:none;"&gt;&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:8pt;"&gt;&lt;span style=" font-weight:600;"&gt;Hint&lt;/span&gt;&lt;/p&gt;&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:8pt;"&gt;Defining the normals per vertex is also called &lt;span style=" font-style:italic;"&gt;Phong shading&lt;/span&gt;&lt;/p&gt;&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:8pt; font-style:italic;"&gt;&lt;span style=" font-style:normal;"&gt;while defining the normals per face is called &lt;/span&gt;Flat shading&lt;span style=" font-style:normal;"&gt;.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         <string>&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;/head&gt;&lt;body style=&quot; white-space: pre-wrap; font-family:MS Shell Dlg 2; font-size:7.8pt; font-weight:400; font-style:normal; text-decoration:none;&quot;&gt;&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:8pt;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Hint&lt;/span&gt;&lt;/p&gt;&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:8pt;&quot;&gt;Defining the normals per vertex is also called &lt;span style=&quot; font-style:italic;&quot;&gt;Phong shading&lt;/span&gt;&lt;/p&gt;&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:8pt; font-style:italic;&quot;&gt;&lt;span style=&quot; font-style:normal;&quot;&gt;while defining the normals per face is called &lt;/span&gt;Flat shading&lt;span style=&quot; font-style:normal;&quot;&gt;.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
        </widget>
       </item>

--- a/src/Mod/Mesh/Gui/ViewProvider.cpp
+++ b/src/Mod/Mesh/Gui/ViewProvider.cpp
@@ -234,7 +234,7 @@ QIcon ViewProviderExport::getIcon() const
 
 App::PropertyFloatConstraint::Constraints ViewProviderMesh::floatRange = {1.0f, 64.0f, 1.0f};
 App::PropertyFloatConstraint::Constraints ViewProviderMesh::angleRange = {0.0f, 180.0f, 1.0f};
-App::PropertyIntegerConstraint::Constraints ViewProviderMesh::intPercent = {0, 100, 1};
+App::PropertyIntegerConstraint::Constraints ViewProviderMesh::intPercent = {0, 100, 5};
 const char* ViewProviderMesh::LightingEnums[]= {"One side", "Two side", nullptr};
 
 PROPERTY_SOURCE(MeshGui::ViewProviderMesh, Gui::ViewProviderGeometryObject)

--- a/src/Mod/Part/Gui/DlgSettingsObjectColor.ui
+++ b/src/Mod/Part/Gui/DlgSettingsObjectColor.ui
@@ -96,7 +96,7 @@
            <number>100</number>
           </property>
           <property name="singleStep">
-           <number>10</number>
+           <number>5</number>
           </property>
           <property name="prefEntry" stdset="0">
            <cstring>DefaultShapeTransparency</cstring>


### PR DESCRIPTION
- as discussed here: https://github.com/FreeCAD/FreeCAD/pull/7103 we have different transparency spin button step sizes. This PR uniforms them all to 5%.
- (the other changes were automatically made by Qt Designer)