### PR TITLE
[PATH] add OCC header/libdir to Path/libarea

### DIFF
--- a/src/Mod/Path/libarea/CMakeLists.txt
+++ b/src/Mod/Path/libarea/CMakeLists.txt
@@ -10,9 +10,12 @@ endif(MSVC)
 
 include_directories(
     ${PYTHON_INCLUDE_DIRS}
+    ${OCC_INCLUDE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_SOURCE_DIR}/src/Mod/Import/App/dxf
 )
+
+link_directories(${OCC_LIBRARY_DIR})
 
 
 if(NOT FREECAD_USE_PYBIND11)


### PR DESCRIPTION
This update adds the OpenCASCADE headers and lib path to `src/Mod/Path/libarea/CMakeLists.txt`, to fix a linker error.


configure finds OCC and the other modules have `OCC_INCLUDE_DIR` and `OCC_LIBRARY_DIR` but it appears to be omitted from the Path/libarea  

```
-- OCC:                 7.6.0 [TKFillet;TKMesh;TKernel;TKG2d;TKG3d;TKMath;TKIGES;TKSTL;TKShHealing;TKXSBase;TKBool;TKBO;TKBRep;TKTopAlgo;TKGeomAlgo;TKGeomBase;TKOffset;TKPrim;TKSTEPBase;TKSTEPAttr;TKSTEP209;TKSTEP;TKHLR;TKFeat] [/usr/local/lib] [/usr/local/include/OpenCASCADE]


-- Found OCC: /usr/local/include/OpenCASCADE (found version "7.6.0") 
-- -- Found OCE/OpenCASCADE version: 7.6.0
-- -- OCE/OpenCASCADE include directory: /usr/local/include/OpenCASCADE
-- -- OCE/OpenCASCADE shared libraries directory: /usr/local/lib



... build error:

--- Mod/Path/libarea-native.so ---
[ 81%] Linking CXX shared library ../../../../Mod/Path/libarea-native.so
cd /home/waitman/Projects/FreeCAD/build/src/Mod/Path/libarea && /usr/local/bin/cmake -E cmake_link_script CMakeFiles/area-native.dir/link.txt --verbose=1
/usr/bin/c++ -fPIC -Wall -Wextra -Wpedantic -Wno-write-strings  -Wno-undefined-var-template -fPIC -DNDEBUG  -Wl,-undefined,dynamic_lookup -shared -Wl,-soname,libarea-native.so -o ../../../../Mod/Path/libarea-native.so "CMakeFiles/area-native.dir/area-native_autogen/mocs_compilation.cpp.o" "CMakeFiles/area-native.dir/Arc.cpp.o" "CMakeFiles/area-native.dir/Area.cpp.o" "CMakeFiles/area-native.dir/AreaDxf.cpp.o" "CMakeFiles/area-native.dir/AreaOrderer.cpp.o" "CMakeFiles/area-native.dir/AreaPocket.cpp.o" "CMakeFiles/area-native.dir/Circle.cpp.o" "CMakeFiles/area-native.dir/Curve.cpp.o" "CMakeFiles/area-native.dir/kurve/Construction.cpp.o" "CMakeFiles/area-native.dir/kurve/Finite.cpp.o" "CMakeFiles/area-native.dir/kurve/kurve.cpp.o" "CMakeFiles/area-native.dir/kurve/Matrix.cpp.o" "CMakeFiles/area-native.dir/kurve/offset.cpp.o" "CMakeFiles/area-native.dir/AreaClipper.cpp.o" "CMakeFiles/area-native.dir/Adaptive.cpp.o" "CMakeFiles/area-native.dir/clipper.cpp.o"   -L/usr/local/mpi/openmpi/lib  -Wl,-rpath,/usr/local/mpi/openmpi/lib:/home/waitman/Projects/FreeCAD/build/Mod/Import:/home/waitman/Projects/FreeCAD/build/Mod/Part:/home/waitman/Projects/FreeCAD/build/lib:/usr/local/lib:/usr/local/lib/qt5: -lmpi_cxx -lmpi ../../../../Mod/Import/Import.so ../../../../Mod/Part/Part.so -lTKFillet -lTKMesh -lTKernel -lTKG2d -lTKG3d -lTKMath -lTKIGES -lTKSTL -lTKShHealing -lTKXSBase -lTKBool -lTKBO -lTKBRep -lTKTopAlgo -lTKGeomAlgo -lTKGeomBase -lTKOffTKPrim -lTKSTEPBase -lTKSTEPAttr -lTKSTEP209 -lTKSTEP -lTKHLR -lTKFeat ../../../../lib/libFreeCADApp.so ../../../../lib/libFreeCADBase.so -lmpi_cxx -lmpi /usr/local/lib/libxerces-c.so /usr/lib/libz.so /usr/local/lib/libpython3.9.so /usr/local/lib/libboost_filesystem.so /usr/local/lib/libboost_program_options.so /usr/local/lib/libboost_regex.so /usr/local/lib/libboost_system.so /usr/local/lib/libboost_thread.so -lpthread /usr/local/lib/libboost_date_time.so /usr/local/lib/libboost_chrono.so /usr/local/lib/libboost_atomic.so -lpthread /usr/local/lib/qt5/libQt5Xml.so.5.15.5 /usr/local/lib/qt5/libQt5Core.so.5.15.5 /usr/local/lib/libfreetype.so -lTKBin -lTKBinL -lTKCAF -lTKXCAF -lTKLCAF -lTKVCAF -lTKCDF -lTKXDESTEP -lTKXDEIGES -lTKMeshVS -lTKService -lTKV3d -lTKRWMesh 
ld: error: unable to find library -lTKFillet
ld: error: unable to find library -lTKMesh
ld: error: unable to find library -lTKernel
ld: error: unable to find library -lTKG2d
ld: error: unable to find library -lTKG3d
ld: error: unable to find library -lTKMath
ld: error: unable to find library -lTKIGES
ld: error: unable to find library -lTKSTL
ld: error: unable to find library -lTKShHealing
ld: error: unable to find library -lTKXSBase
ld: error: unable to find library -lTKBool
ld: error: unable to find library -lTKBO
ld: error: unable to find library -lTKBRep
ld: error: unable to find library -lTKTopAlgo
ld: error: unable to find library -lTKGeomAlgo
ld: error: unable to find library -lTKGeomBase
ld: error: unable to find library -lTKOffset
ld: error: unable to find library -lTKPrim
ld: error: unable to find library -lTKSTEPBase
ld: error: unable to find library -lTKSTEPAttr
ld: error: too many errors emitted, stopping now (use -error-limit=0 to see all errors)
c++: error: linker command failed with exit code 1 (use -v to see invocation)
*** [Mod/Path/libarea-native.so] Error code 1

make[2]: stopped in /usr/home/waitman/Projects/FreeCAD/build
--- src/Gui/CMakeFiles/FreeCADGui.dir/all ---
*** [src/Gui/CMakeFiles/FreeCADGui.dir/all] Error code 6
```


