### PR TITLE
Addon Manager: Add try/except to integer conversion

### DIFF
--- a/src/Mod/AddonManager/NetworkManager.py
+++ b/src/Mod/AddonManager/NetworkManager.py
@@ -212,7 +212,17 @@ if HAVE_QTNETWORK:
                     )  # This may still be QNetworkProxy.NoProxy
             elif userProxyCheck:
                 host, _, port_string = proxy_string.rpartition(":")
-                port = 0 if not port_string else int(port_string)
+                try:
+                    port = 0 if not port_string else int(port_string)
+                except ValueError:
+                    FreeCAD.Console.PrintError(
+                        translate(
+                            "AddonsInstaller",
+                            "Failed to convert the specified proxy port '{}' to a port number",
+                        ).format(port_string)
+                        + "\n"
+                    )
+                    port = 0
                 # For now assume an HttpProxy, but eventually this should be a parameter
                 proxy = QtNetwork.QNetworkProxy(
                     QtNetwork.QNetworkProxy.HttpProxy, host, port


### PR DESCRIPTION
As reported by a user on Facebook: if the proxy is an invalid string, it's possible to have the integer port conversion fail. Protect it with a try/except block and act as though no port was set, displaying an error message to the console.

Fixes #7736 .