### PR TITLE
Gui: Add default JPEG save quality

### DIFF
--- a/src/Gui/SoFCOffscreenRenderer.cpp
+++ b/src/Gui/SoFCOffscreenRenderer.cpp
@@ -121,7 +121,7 @@ void SoFCOffscreenRenderer::writeToImageFile(const char* filename, const char* c
         QByteArray ba;
         QBuffer buffer(&ba);
         buffer.open(QIODevice::WriteOnly);
-        image.save(&buffer, "JPG", quality = 100);
+        image.save(&buffer, "JPG", 90);
         writeJPEGComment(com, ba);
 
         QFile file(QString::fromUtf8(filename));

--- a/src/Gui/SoFCOffscreenRenderer.cpp
+++ b/src/Gui/SoFCOffscreenRenderer.cpp
@@ -121,7 +121,7 @@ void SoFCOffscreenRenderer::writeToImageFile(const char* filename, const char* c
         QByteArray ba;
         QBuffer buffer(&ba);
         buffer.open(QIODevice::WriteOnly);
-        image.save(&buffer, "JPG");
+        image.save(&buffer, "JPG", quality = 100);
         writeJPEGComment(com, ba);
 
         QFile file(QString::fromUtf8(filename));


### PR DESCRIPTION
Set jpg screenshot capture to 100% quality vs qimage defaulting to -1
[Save Picture/Export PDF quality issues](https://forum.freecadweb.org/viewtopic.php?f=10&t=72707)

- [x] Your pull request is confined strictly to a single module.
- [x] In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x] Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master git pull --rebase upstream master
Working in github only. Do I need to do this?
- [x] All FreeCAD unit tests are confirmed to pass by running ./bin/FreeCAD --run-test 0
Working in github only. I honestly don't know how to do this -_-
- [x] All commit messages are [well-written](https://chris.beams.io/posts/git-commit/)
- [x] Your pull request is well written and has a good description, and its title starts with the module name
- [x] Commit messages include issue #<id> or fixes #<id> where <id> is the issue ID number from our [Issues database](https://github.com/FreeCAD/FreeCAD/issues) in case a particular commit solves or is related to an existing issue.