### PR TITLE
Draft: test_modification.py: modified test and added test

### DIFF
--- a/src/Mod/Draft/drafttests/test_modification.py
+++ b/src/Mod/Draft/drafttests/test_modification.py
@@ -171,6 +171,7 @@ class DraftModification(unittest.TestCase):
         _msg("  Offset")
         _msg("  vector={}".format(offset))
         obj = Draft.offset(rect, offset, copy=True)
+        App.ActiveDocument.recompute()
         obj_is_ok = (obj.Shape.CenterOfGravity == Vector(5, 2, 0)
                      and obj.Length == 12
                      and obj.Height == 6)

--- a/src/Mod/Draft/drafttests/test_modification.py
+++ b/src/Mod/Draft/drafttests/test_modification.py
@@ -112,13 +112,13 @@ class DraftModification(unittest.TestCase):
                         "'{}' failed".format(operation))
 
     def test_offset_open(self):
-        """Create a wire, then produce an offset copy."""
+        """Create an open wire, then produce an offset copy."""
         operation = "Draft Offset"
         _msg("  Test '{}'".format(operation))
         a = Vector(0, 2, 0)
         b = Vector(2, 4, 0)
         c = Vector(5, 2, 0)
-        _msg("  Wire")
+        _msg("  Open wire")
         _msg("  a={0}, b={1}".format(a, b))
         _msg("  c={0}".format(c))
         wire = Draft.make_wire([a, b, c])
@@ -130,22 +130,51 @@ class DraftModification(unittest.TestCase):
         obj = Draft.offset(wire, offset, copy=True)
         self.assertTrue(obj, "'{}' failed".format(operation))
 
-    def test_offset_closed(self):
-        """Create a rectangle, then produce an offset copy."""
+    def test_offset_closed_with_reversed_edge(self):
+        """Create a closed wire with a reversed edge, then produce an offset copy."""
+        # Regression test for:
+        # https://github.com/FreeCAD/FreeCAD/pull/5496
         operation = "Draft Offset"
         _msg("  Test '{}'".format(operation))
-        length = 4
-        width = 2
-        _msg("  Rectangle")
+        _msg("  Closed wire with reversed edge")
+        a = Vector(0, 0, 0)
+        b = Vector(10, 0, 0)
+        c = Vector(10, 4, 0)
+        d = Vector(0, 4, 0)
+        edges = [Part.makeLine(a, b),
+                 Part.makeLine(b, c),
+                 Part.makeLine(c, d),
+                 Part.makeLine(a, d)]
+        wire = Part.Wire(edges)
+        obj = App.ActiveDocument.addObject("Part::Feature")
+        obj.Shape = wire
+
+        offset = Vector(0, -1, 0)
+        new = Draft.offset(obj, offset, copy=True)
+        self.assertTrue(len(new.Points) == 4, "'{}' failed".format(operation))
+
+    def test_offset_rectangle_with_face(self):
+        """Create a rectangle with a face, then produce an offset copy."""
+        # Regression test for:
+        # https://github.com/FreeCAD/FreeCAD/pull/7670
+        operation = "Draft Offset"
+        _msg("  Test '{}'".format(operation))
+        length = 10
+        width = 4
+        _msg("  Rectangle with face")
         _msg("  length={0}, width={1}".format(length, width))
         rect = Draft.make_rectangle(length, width)
+        rect.MakeFace = True
         App.ActiveDocument.recompute()
 
-        offset = Vector(-1, -1, 0)
+        offset = Vector(0, -1, 0)
         _msg("  Offset")
         _msg("  vector={}".format(offset))
         obj = Draft.offset(rect, offset, copy=True)
-        self.assertTrue(obj, "'{}' failed".format(operation))
+        obj_is_ok = (obj.Shape.CenterOfGravity == Vector(5, 2, 0)
+                     and obj.Length == 12
+                     and obj.Height == 6)
+        self.assertTrue(obj_is_ok, "'{}' failed".format(operation))
 
     def test_trim(self):
         """Trim a line. NOT IMPLEMENTED."""


### PR DESCRIPTION
This PR  adds a test and modifies an existing test.

The old `test_offset_closed` function was renamed to `test_offset_rectangle_with_face`. 
It is now also a regression test for: https://github.com/FreeCAD/FreeCAD/pull/7670

The added `test_offset_closed_with_reversed_edge` function is a regression test for: https://github.com/FreeCAD/FreeCAD/pull/5496

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the issue ID number from our [Issues database](https://github.com/FreeCAD/FreeCAD/issues) in case a particular commit solves or is related to an existing issue. Ex: `Draft: fix typos - fixes #4805`

---
