### PR TITLE
Draft: remove unnecessary deletion of local variable in importDXF.py

### DIFF
--- a/src/Mod/Draft/importDXF.py
+++ b/src/Mod/Draft/importDXF.py
@@ -2717,7 +2717,6 @@ def processdxf(document, filename, getShapes=False, reComputeFlag=True):
     FCC.PrintMessage("successfully imported " + filename + "\n")
     if badobjects:
         print("dxf: ", len(badobjects), " objects were not imported")
-    del doc
 
 
 def warn(dxfobject, num=None):


### PR DESCRIPTION
Passing a local variable to a `del` statement results in that variable being removed from the local namespace. When exiting a function all local variables are deleted, so it is unnecessary to explicitly delete variables in such cases.

ref: https://lgtm.com/rules/1506104658325/