### PR TITLE
[Measurement]apply globalPlacement to geometry

### DIFF
--- a/src/Mod/Measure/App/Measurement.cpp
+++ b/src/Mod/Measure/App/Measurement.cpp
@@ -195,9 +195,14 @@ MeasureType Measurement::getType()
 TopoDS_Shape Measurement::getShape(App::DocumentObject *obj , const char *subName) const
 {
     try {
-        auto shape = Part::Feature::getShape(obj,subName,true);
+        Part::TopoShape partShape = Part::Feature::getTopoShape(obj);
+        App::GeoFeature* geoFeat = dynamic_cast<App::GeoFeature*>(obj);
+        if (geoFeat) {
+            partShape.setPlacement(geoFeat->globalPlacement());
+        }
+        TopoDS_Shape shape = partShape.getSubShape(subName);
         if(shape.IsNull())
-            throw Part::NullShapeException("null shape");
+            throw Part::NullShapeException("null shape in measurement");
         return shape;
     } catch (Standard_Failure& e) {
         throw Base::CADKernelError(e.GetMessageString());


### PR DESCRIPTION
Measurement does not take object placement into account.  This works fine as long as the measurement references are all in the same object.  To allow measurement between points on different objects, we need to apply placement before calculating the measurement value.

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [ ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
