### PR TITLE
TechDraw: Improve and clean up code in some Python classes

### DIFF
--- a/src/Mod/TechDraw/App/DrawProjGroupItemPyImp.cpp
+++ b/src/Mod/TechDraw/App/DrawProjGroupItemPyImp.cpp
@@ -37,11 +37,14 @@ std::string DrawProjGroupItemPy::representation() const
 
 PyObject* DrawProjGroupItemPy::autoPosition(PyObject *args)
 {
-    (void) args;
+    if (!PyArg_ParseTuple(args, "")) {
+    return nullptr;
+    }
+
     DrawProjGroupItem* item = getDrawProjGroupItemPtr();
     item->autoPosition();
-    Py_INCREF(Py_None);
-    return Py_None;
+
+    Py_Return;
 }
 
 PyObject *DrawProjGroupItemPy::getCustomAttributes(const char* /*attr*/) const

--- a/src/Mod/TechDraw/App/DrawSVGTemplatePyImp.cpp
+++ b/src/Mod/TechDraw/App/DrawSVGTemplatePyImp.cpp
@@ -63,35 +63,26 @@ int DrawSVGTemplatePy::setCustomAttributes(const char* attr, PyObject* obj)
 
 PyObject* DrawSVGTemplatePy::getEditFieldContent(PyObject* args)
 {
-    PyObject* result = nullptr;
     char* fieldName;
     if (!PyArg_ParseTuple(args, "s", &fieldName)) {
-        Base::Console().Error("Error: DrawSVGTemplatePy::getEditFieldNames - Bad Arg\n");
         return nullptr;
     }
     std::string content = getDrawSVGTemplatePtr()->EditableTexts[fieldName];
     if (!content.empty()) {
-        result = PyUnicode_FromString(content.c_str());
+        return PyUnicode_FromString(content.c_str());
     }
-    return result;
+    Py_Return;
 }
 
 PyObject* DrawSVGTemplatePy::setEditFieldContent(PyObject* args)
 {
-    PyObject* result = Py_True;
     char* fieldName;
     char* newContent;
     if (!PyArg_ParseTuple(args, "ss", &fieldName, &newContent)) {
-        Base::Console().Error("Error: DrawSVGTemplatePy::getEditFieldNames - Bad Args\n");
-        result = Py_False;
-    } else {
-        try {
-            getDrawSVGTemplatePtr()->EditableTexts.setValue(fieldName, newContent);
-        }
-        catch (...) {
-            result = Py_False;
-        }
+        return nullptr;
     }
 
-    return result;
+    getDrawSVGTemplatePtr()->EditableTexts.setValue(fieldName, newContent);
+
+    Py_Return;
 }

--- a/src/Mod/TechDraw/App/DrawViewClipPyImp.cpp
+++ b/src/Mod/TechDraw/App/DrawViewClipPyImp.cpp
@@ -43,49 +43,31 @@ std::string DrawViewClipPy::representation() const
 
 PyObject* DrawViewClipPy::addView(PyObject* args)
 {
-    //this implements iRC = pyClip.addView(pyView)  -or-
-    //doCommand(Doc, "App.activeDocument().%s.addView(App.activeDocument().%s)", PageName.c_str(), FeatName.c_str());
     PyObject *pcDocObj;
-
-    if (!PyArg_ParseTuple(args, "O!", &(App::DocumentObjectPy::Type), &pcDocObj)) {
-        Base::Console().Error("Error: DrawViewClipPy::addView - Bad Arg - not DocumentObject\n");
+    if (!PyArg_ParseTuple(args, "O!", &(TechDraw::DrawViewPy::Type), &pcDocObj)) {
         return nullptr;
-        //TODO: sb PyErr??
-        //PyErr_SetString(PyExc_TypeError, "addView expects a DrawView");
-        //return -1;
     }
 
     DrawViewClip* clip = getDrawViewClipPtr();                         //get DrawViewClip for pyClip
-    //TODO: argument 1 arrives as "DocumentObjectPy", not "DrawViewPy"
-    //how to validate that obj is DrawView before use??
     DrawViewPy* pyView = static_cast<TechDraw::DrawViewPy*>(pcDocObj);
     DrawView* view = pyView->getDrawViewPtr();                 //get DrawView for pyView
-
     clip->addView(view);
+
     Py_Return;
 }
 
 PyObject* DrawViewClipPy::removeView(PyObject* args)
 {
-    //this implements iRC = pyClip.removeView(pyView)  -or-
-    //doCommand(Doc, "App.activeDocument().%s.removeView(App.activeDocument().%s)", PageName.c_str(), FeatName.c_str());
     PyObject *pcDocObj;
-
-    if (!PyArg_ParseTuple(args, "O!", &(App::DocumentObjectPy::Type), &pcDocObj)) {
-        Base::Console().Error("Error: DrawViewClipPy::removeView - Bad Arg - not DocumentObject\n");
+    if (!PyArg_ParseTuple(args, "O!", &(TechDraw::DrawViewPy::Type), &pcDocObj)) {
         return nullptr;
-        //TODO: sb PyErr??
-        //PyErr_SetString(PyExc_TypeError, "removeView expects a DrawView");
-        //return -1;
     }
 
     DrawViewClip* clip = getDrawViewClipPtr();                         //get DrawViewClip for pyClip
-    //TODO: argument 1 arrives as "DocumentObjectPy", not "DrawViewPy"
-    //how to validate that obj is DrawView before use??
     DrawViewPy* pyView = static_cast<TechDraw::DrawViewPy*>(pcDocObj);
     DrawView* view = pyView->getDrawViewPtr();                 //get DrawView for pyView
-
     clip->removeView(view);
+
     Py_Return;
 }
 
@@ -97,13 +79,10 @@ PyObject* DrawViewClipPy::getChildViewNames(PyObject* args)
 
     DrawViewClip* clip = getDrawViewClipPtr();
     std::vector<std::string> strings = clip->getChildViewNames();
-    int stringSize = strings.size();
+    Py::List result;
 
-    Py::List result(stringSize);
-
-    std::vector<std::string>::iterator it = strings.begin();
-    for( ; it != strings.end(); it++) {
-        result.append(Py::String(*it));
+    for (const auto& str: strings) {
+        result.append(Py::String(str));
     }
 
     return Py::new_reference_to(result);

--- a/src/Mod/TechDraw/App/DrawViewCollectionPyImp.cpp
+++ b/src/Mod/TechDraw/App/DrawViewCollectionPyImp.cpp
@@ -38,9 +38,7 @@ std::string DrawViewCollectionPy::representation(void) const
 PyObject* DrawViewCollectionPy::addView(PyObject* args)
 {
     PyObject *pcDocObj;
-
-    if (!PyArg_ParseTuple(args, "O!", &(App::DocumentObjectPy::Type), &pcDocObj)) {
-        PyErr_SetString(PyExc_TypeError, "DrawViewCollectionPy::addView - Bad Arg - not DocumentObject");
+    if (!PyArg_ParseTuple(args, "O!", &(TechDraw::DrawViewPy::Type), &pcDocObj)) {
         return nullptr;
     }
 
@@ -50,15 +48,13 @@ PyObject* DrawViewCollectionPy::addView(PyObject* args)
 
     int i = collect->addView(view);
 
-    return PyLong_FromLong((long) i);
+    return PyLong_FromLong(i);
 }
 
 PyObject* DrawViewCollectionPy::removeView(PyObject* args)
 {
     PyObject *pcDocObj;
-
-    if (!PyArg_ParseTuple(args, "O!", &(App::DocumentObjectPy::Type), &pcDocObj)) {
-        PyErr_SetString(PyExc_TypeError, "DrawViewCollectionPy::removeView - Bad Arg - not DocumentObject");
+    if (!PyArg_ParseTuple(args, "O!", &(TechDraw::DrawViewPy::Type), &pcDocObj)) {
         return nullptr;
     }
 
@@ -68,7 +64,7 @@ PyObject* DrawViewCollectionPy::removeView(PyObject* args)
 
     int i = collect->removeView(view);
 
-    return PyLong_FromLong((long) i);
+    return PyLong_FromLong(i);
 }
 
 

--- a/src/Mod/TechDraw/App/DrawViewDimensionPyImp.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDimensionPyImp.cpp
@@ -41,7 +41,10 @@ std::string DrawViewDimensionPy::representation() const
 
 PyObject* DrawViewDimensionPy::getRawValue(PyObject* args)
 {
-    (void) args;
+    if (!PyArg_ParseTuple(args, "")) {
+        return nullptr;
+    }
+
     DrawViewDimension* dvd = getDrawViewDimensionPtr();
     double val = dvd->getDimValue();
     PyObject* pyVal = PyFloat_FromDouble(val);
@@ -50,12 +53,10 @@ PyObject* DrawViewDimensionPy::getRawValue(PyObject* args)
 
 PyObject* DrawViewDimensionPy::getText(PyObject* args)
 {
-    (void) args;
-//    PyObject* asShape = Py_False;
-//    PyObject* pagePos = Py_False;
-//    if (!PyArg_ParseTuple(args, "|OO", &asShape, &pagePos)) {
-//        return 0;
-//    }
+    if (!PyArg_ParseTuple(args, "")) {
+        return nullptr;
+    }
+
     DrawViewDimension* dvd = getDrawViewDimensionPtr();
     std::string  textString = dvd->getFormattedDimensionValue();
 //TODO: check multiversion code!
@@ -65,7 +66,10 @@ PyObject* DrawViewDimensionPy::getText(PyObject* args)
 
 PyObject* DrawViewDimensionPy::getLinearPoints(PyObject* args)
 {
-    (void) args;
+    if (!PyArg_ParseTuple(args, "")) {
+        return nullptr;
+    }
+
     DrawViewDimension* dvd = getDrawViewDimensionPtr();
     pointPair pts = dvd->getLinearPoints();
     Py::List ret;
@@ -76,7 +80,10 @@ PyObject* DrawViewDimensionPy::getLinearPoints(PyObject* args)
 
 PyObject* DrawViewDimensionPy::getArcPoints(PyObject* args)
 {
-    (void) args;
+    if (!PyArg_ParseTuple(args, "")) {
+        return nullptr;
+    }
+
     DrawViewDimension* dvd = getDrawViewDimensionPtr();
     arcPoints pts = dvd->getArcPoints();
     Py::List ret;
@@ -91,7 +98,10 @@ PyObject* DrawViewDimensionPy::getArcPoints(PyObject* args)
 
 PyObject* DrawViewDimensionPy::getAnglePoints(PyObject* args)
 {
-    (void) args;
+    if (!PyArg_ParseTuple(args, "")) {
+        return nullptr;
+    }
+
     DrawViewDimension* dvd = getDrawViewDimensionPtr();
     anglePoints pts = dvd->getAnglePoints();
     Py::List ret;
@@ -103,7 +113,10 @@ PyObject* DrawViewDimensionPy::getAnglePoints(PyObject* args)
 
 PyObject* DrawViewDimensionPy::getArrowPositions(PyObject* args)
 {
-    (void) args;
+    if (!PyArg_ParseTuple(args, "")) {
+        return nullptr;
+    }
+
     DrawViewDimension* dvd = getDrawViewDimensionPtr();
     pointPair pts = dvd->getArrowPositions();
     Py::List ret;

--- a/src/Mod/TechDraw/App/DrawViewSymbolPyImp.cpp
+++ b/src/Mod/TechDraw/App/DrawViewSymbolPyImp.cpp
@@ -45,14 +45,10 @@ PyObject* DrawViewSymbolPy::dumpSymbol(PyObject *args)
 {
     const char* fileSpec;
     if (!PyArg_ParseTuple(args, "s", &fileSpec)) {
-       throw Py::TypeError("** dumpSymbol bad args.");
-    }
-    auto dvs = getDrawViewSymbolPtr();
-    std::string symbolRepr;
-    if (dvs) {
-        symbolRepr = dvs->Symbol.getValue();
+        return nullptr;
     }
 
+    std::string symbolRepr = getDrawViewSymbolPtr()->Symbol.getValue();
     Base::FileInfo fi(fileSpec);
     Base::ofstream outfile;
     outfile.open(fi);
@@ -63,8 +59,10 @@ PyObject* DrawViewSymbolPy::dumpSymbol(PyObject *args)
     } else {
         std::string error = std::string("Can't write ");
         error += fileSpec;
-        throw Py::RuntimeError(error);
+        PyErr_SetString(PyExc_RuntimeError, error.c_str());
+        return nullptr;
     }
+
     Py_Return;
 }
 

--- a/src/Mod/TechDraw/App/GeomFormatPyImp.cpp
+++ b/src/Mod/TechDraw/App/GeomFormatPyImp.cpp
@@ -63,7 +63,7 @@ PyObject* GeomFormatPy::clone(PyObject *args)
     if (type->tp_new)
         cpy = type->tp_new(type, this, nullptr);
     if (!cpy) {
-        PyErr_SetString(PyExc_TypeError, "failed to create clone of GeomFormat");
+        PyErr_SetString(PyExc_RuntimeError, "failed to create clone of GeomFormat");
         return nullptr;
     }
 
@@ -90,7 +90,7 @@ PyObject* GeomFormatPy::copy(PyObject *args)
     if (type->tp_new)
         cpy = type->tp_new(type, this, nullptr);
     if (!cpy) {
-        PyErr_SetString(PyExc_TypeError, "failed to create copy of GeomFormat");
+        PyErr_SetString(PyExc_RuntimeError, "failed to create copy of GeomFormat");
         return nullptr;
     }
 


### PR DESCRIPTION
* `DrawProjGroupItemPy::autoPosition`:
    Use `PyArg_ParseTuple` to check arguments.
* `DrawSVGTemplatePy::getEditFieldContent`:
    `nullptr` must be returned only if a exception is raised.
* `DrawSVGTemplatePy::setEditFieldContent`:
    Remove try-catch block and always return `None`.
* `DrawViewClipPy::addView`, `DrawViewClipPy::removeView`:
   Cast from `DocumentObjectPy` to `DrawViewPy` is undefined behaviour, so check `DrawViewPy` type in `PyArg_ParseTuple`.
* `DrawViewClipPy::getChildViewNames`:
    Fix initialization size in returned list.
* `DrawViewCollectionPy::addView`, `DrawViewCollectionPy::removeView`:
    Cast from `DocumentObjectPy` to `DrawViewPy` is undefined behaviour, so check `DrawViewPy` type in `PyArg_ParseTuple`.
* DrawViewDimensionPyImp.cpp:
    Use `PyArg_ParseTuple` to check arguments.



Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [ ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
