### PR TITLE
Discussion: Refactor some legacy features in splashscreen

### DIFF
--- a/src/Gui/Splashscreen.h
+++ b/src/Gui/Splashscreen.h
@@ -44,11 +44,21 @@ public:
     explicit SplashScreen(  const QPixmap & pixmap = QPixmap ( ), Qt::WindowFlags f = Qt::WindowFlags() );
     ~SplashScreen() override;
 
+    void showMessage(const QString &message);
 protected:
     void drawContents ( QPainter * painter ) override;
 
 private:
-    SplashObserver* messages;
+    // these three functions can, and likely should, be put someplace else
+    // this is not stuff a splash screen should care about
+    static int alignStrToInt(std::string str);
+    static std::string fromConfig(const std::map<std::string, std::string>& config, std::string
+                                                                                      value);
+    static QColor colorFromString(const std::string str);
+
+    SplashObserver* splashObserver;
+    int alignment {Qt::AlignBottom | Qt::AlignLeft};
+    QColor textColor {Qt::black};
 };
 
 namespace Dialog {
@@ -66,7 +76,7 @@ public:
     static void setDefaultFactory(AboutDialogFactory *factory);
 
 private:
-    static AboutDialogFactory* factory;
+    static AboutDialogFactory* factory {};
 };
 
 class GuiExport LicenseView : public Gui::MDIView
@@ -84,6 +94,17 @@ public:
 
 private:
     QTextBrowser* browser;
+};
+
+class SummaryReport{
+public:
+    SummaryReport();
+    ~SummaryReport();
+    void addItem(const std::string item);
+    std::string asStdString();
+    std::string codeWrap(std::string wrappee);
+private:
+    std::vector<std::string> items {};
 };
 
 /** This widget provides the "About dialog" of an application.
@@ -113,7 +134,14 @@ protected Q_SLOTS:
 
 private:
     Ui_AboutApplication* ui;
-    class LibraryInfo;
+    QString libraryInfoAsHtml();
+    QTextBrowser *showCommon(const char *name,
+                             const char *tabName,
+                             const bool openExternalLinks = false,
+                             const bool openLinks = true);
+    std::string makeSummaryReport();
+
+    SummaryReport summaryReport {};
 };
 
 } // namespace Dialog


### PR DESCRIPTION
Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [ ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---

For discussion.

 I take Splashscreen file pair and describe some features I would describe as "legacy", and offer
 possible solutions. Untested. Achieved by many small refactorings.


 1. A block of code repeated 18 times (!), with varying data.

 2. Another block of code repeated multiple times almost identically.

 3a. makeSummaryReport() has many (and tangled) responsibilities.

 3b. makeSummaryReport() pulls information from all over the place.

 4. SplashObserver involved in text color and alignment.

 5. UPPER_CASE constexpr looks like a macro.

 6. Lots of type juggling esp std <==> Q <==> char.

 7. App::Application::Config() returns a variable which is operated on all over the place.


To address these (making minimum changes to overall functioning of code):

 1. Move the data part into an array (which could ultimately come from anywhere), and create a
    single function.

 2. Make one common function with paramters to handle minor variations.

 3a. Many refactorings to untangle responsibilities into sub-scopes, using closures . It became
     obvious that most of these responsibilities actually belonged elsewhere.
     The core purpose of the function was now exposed: Prepare a string. Only.

 3b. The dependencies should be moved out. Interim step create SummaryReport class.

 4. Move format stuff out of observer. It is an unwanted extra responsibility.

 5. Lodged issue on FC github, with view to PR (assuming no objection).

 6. Once responsibilities are in discrete scopes they often become much simpler and many type
    juggles superfluous because they were previously pandering to surrounding code. Often simple
    std types were much more readable and direct. As a result much code was suddenly more readable.

 7. Not tackled, but it seems obvious config should be a separate class or struct with associated
    operations included.


 Suggested reading: https://gist.github.com/wojteklu/73c6914cc446146b8b533c0988cf8d29


