### PR TITLE
TD: fix memory leaks with raw pointers of GeometryObject

### DIFF
--- a/src/Mod/TechDraw/App/AppTechDrawPy.cpp
+++ b/src/Mod/TechDraw/App/AppTechDrawPy.cpp
@@ -411,7 +411,7 @@ private:
             if (PyObject_TypeCheck(viewObj, &(TechDraw::DrawViewPartPy::Type))) {
                 obj = static_cast<App::DocumentObjectPy*>(viewObj)->getDocumentObjectPtr();
                 dvp = static_cast<TechDraw::DrawViewPart*>(obj);
-                TechDraw::GeometryObject* gObj = dvp->getGeometryObject();
+                TechDraw::GeometryObjectPtr gObj = dvp->getGeometryObject();
                 TopoDS_Shape shape = TechDraw::mirrorShape(gObj->getVisHard());
                 ss << dxfOut.exportEdges(shape);
                 shape = TechDraw::mirrorShape(gObj->getVisOutline());
@@ -469,7 +469,7 @@ private:
             if (PyObject_TypeCheck(viewObj, &(TechDraw::DrawViewPartPy::Type))) {
                 obj = static_cast<App::DocumentObjectPy*>(viewObj)->getDocumentObjectPtr();
                 dvp = static_cast<TechDraw::DrawViewPart*>(obj);
-                TechDraw::GeometryObject* gObj = dvp->getGeometryObject();
+                TechDraw::GeometryObjectPtr gObj = dvp->getGeometryObject();
                 //visible group begin "<g ... >"
                 ss << grpHead1;
 //                double thick = dvp->LineWidth.getValue();
@@ -533,7 +533,7 @@ private:
     {
         if(!dvp->hasGeometry())
             return;
-        TechDraw::GeometryObject* gObj = dvp->getGeometryObject();
+        TechDraw::GeometryObjectPtr gObj = dvp->getGeometryObject();
         TopoDS_Shape shape = TechDraw::mirrorShape(gObj->getVisHard());
         double offX = 0.0;
         double offY = 0.0;

--- a/src/Mod/TechDraw/App/DrawProjectSplit.cpp
+++ b/src/Mod/TechDraw/App/DrawProjectSplit.cpp
@@ -85,7 +85,7 @@ std::vector<TopoDS_Edge> DrawProjectSplit::getEdgesForWalker(TopoDS_Shape shape,
     scaledShape = TechDraw::scaleShape(copyShape,
                                        scale);
     gp_Ax2 viewAxis = TechDraw::legacyViewAxis1(Base::Vector3d(0.0, 0.0, 0.0), direction, false);
-    TechDraw::GeometryObject* go = buildGeometryObject(scaledShape, viewAxis);
+    TechDraw::GeometryObjectPtr go = buildGeometryObject(scaledShape, viewAxis);
     const std::vector<TechDraw::BaseGeomPtr>& goEdges = go->getVisibleFaceEdges(false, false);
     for (auto& e: goEdges){
         edgesIn.push_back(e->occEdge);
@@ -100,15 +100,14 @@ std::vector<TopoDS_Edge> DrawProjectSplit::getEdgesForWalker(TopoDS_Shape shape,
         }
     }
 
-    delete go;
     return nonZero;
 }
 
 //project the shape using viewAxis (coordinate system) and return a geometry object
-TechDraw::GeometryObject* DrawProjectSplit::buildGeometryObject(TopoDS_Shape shape,
+TechDraw::GeometryObjectPtr DrawProjectSplit::buildGeometryObject(TopoDS_Shape shape,
                                                                         const gp_Ax2& viewAxis)
 {
-    TechDraw::GeometryObject* geometryObject = new TechDraw::GeometryObject("DrawProjectSplit", nullptr);
+    TechDraw::GeometryObjectPtr geometryObject(std::make_shared<TechDraw::GeometryObject>("DrawProjectSplit", nullptr));
 
     if (geometryObject->usePolygonHLR()){
         geometryObject->projectShapeWithPolygonAlgo(shape, viewAxis);

--- a/src/Mod/TechDraw/App/DrawProjectSplit.h
+++ b/src/Mod/TechDraw/App/DrawProjectSplit.h
@@ -40,6 +40,7 @@ class gp_Ax2;
 namespace TechDraw
 {
 class GeometryObject;
+using GeometryObjectPtr = std::shared_ptr<GeometryObject>;
 class Vertex;
 class BaseGeom;
 }
@@ -98,7 +99,7 @@ public:
 
 public:
     static std::vector<TopoDS_Edge> getEdgesForWalker(TopoDS_Shape shape, double scale, Base::Vector3d direction);
-    static TechDraw::GeometryObject*  buildGeometryObject(TopoDS_Shape shape, const gp_Ax2& viewAxis);
+    static TechDraw::GeometryObjectPtr  buildGeometryObject(TopoDS_Shape shape, const gp_Ax2& viewAxis);
 
     static bool isOnEdge(TopoDS_Edge e, TopoDS_Vertex v, double& param, bool allowEnds = false);
     static std::vector<TopoDS_Edge> splitEdges(std::vector<TopoDS_Edge> orig, std::vector<splitPoint> splits);

--- a/src/Mod/TechDraw/App/DrawViewPart.h
+++ b/src/Mod/TechDraw/App/DrawViewPart.h
@@ -54,6 +54,7 @@ class Part;
 namespace TechDraw
 {
 class GeometryObject;
+using GeometryObjectPtr = std::shared_ptr<GeometryObject>;
 class Vertex;
 class BaseGeom;
 class Face;
@@ -124,7 +125,7 @@ public:
     const std::vector<TechDraw::FacePtr> getFaceGeometry() const;
 
     bool hasGeometry() const;
-    TechDraw::GeometryObject* getGeometryObject() const { return geometryObject; }
+    TechDraw::GeometryObjectPtr getGeometryObject() const { return geometryObject; }
 
     TechDraw::BaseGeomPtr getGeomByIndex(int idx) const;               //get existing geom for edge idx in projection
     TechDraw::VertexPtr getProjVertexByIndex(int idx) const;           //get existing geom for vertex idx in projection
@@ -221,15 +222,15 @@ public Q_SLOTS:
 protected:
     bool checkXDirection() const;
 
-    TechDraw::GeometryObject* geometryObject;
-    TechDraw::GeometryObject* m_tempGeometryObject;  //holds the new GO until hlr is completed
+    TechDraw::GeometryObjectPtr geometryObject;
+    TechDraw::GeometryObjectPtr m_tempGeometryObject;  //holds the new GO until hlr is completed
     Base::BoundBox3d bbox;
 
     void onChanged(const App::Property* prop) override;
     void unsetupObject() override;
 
-    virtual TechDraw::GeometryObject*  buildGeometryObject(TopoDS_Shape& shape, const gp_Ax2& viewAxis);
-    virtual TechDraw::GeometryObject*  makeGeometryForShape(TopoDS_Shape& shape);   //const??
+    virtual TechDraw::GeometryObjectPtr  buildGeometryObject(TopoDS_Shape& shape, const gp_Ax2& viewAxis);
+    virtual TechDraw::GeometryObjectPtr  makeGeometryForShape(TopoDS_Shape& shape);   //const??
     void partExec(TopoDS_Shape& shape);
     virtual void addShapes2d(void);
 

--- a/src/Mod/TechDraw/App/GeometryObject.h
+++ b/src/Mod/TechDraw/App/GeometryObject.h
@@ -25,6 +25,7 @@
 
 #include <Mod/TechDraw/TechDrawGlobal.h>
 
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -221,6 +222,8 @@ protected:
     double m_focus;
     bool m_usePolygonHLR;
 };
+
+using GeometryObjectPtr = std::shared_ptr<GeometryObject>;
 
 } //namespace TechDraw
 


### PR DESCRIPTION
@WandererFan 
Replacing the use of raw pointers of GeometryObject with shared pointers fixes the observed memory leaks when running the unit tests of TechDraw

[Forum thread](https://forum.freecadweb.org/viewtopic.php?p=640322#p640322)

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [ ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
