### PR TITLE
Gui: ActionGroup also get its tooltip title updated

### DIFF
--- a/src/Gui/Action.cpp
+++ b/src/Gui/Action.cpp
@@ -544,7 +544,7 @@ void ActionGroup::setCheckedAction(int index)
     this->setIcon(act->icon());
 
     if (!this->_isMode) {
-        this->setToolTip(act->toolTip());
+        this->setToolTip(act->toolTip(), act->text());
     }
     this->setProperty("defaultAction", QVariant(index));
 }
@@ -572,7 +572,7 @@ void ActionGroup::onActivated (QAction* act)
 
     this->setIcon(act->icon());
     if (!this->_isMode) {
-        this->setToolTip(act->toolTip());
+        this->setToolTip(act->toolTip(), act->text());
     }
     this->setProperty("defaultAction", QVariant(index));
     command()->invoke(index, Command::TriggerChildAction);


### PR DESCRIPTION
Problem solved:
In grouped actions (in toolbar), when user drops down then selects another action than the first, the tooltip is only partially updated.
Tooltip message is, but tooltip title isn't.
This leads to misleading situations

Solution proposed:
With this PR, the tooltip title is updated with the selected action text bringing consistency.

- [ ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR
