### PR TITLE
Sketcher: Element widget: Improve filter widget.

### DIFF
--- a/src/Mod/Sketcher/Gui/TaskSketcherElements.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherElements.cpp
@@ -492,31 +492,38 @@ ElementItem* ElementItemDelegate::getElementtItem(const QModelIndex& index) cons
 /* Filter element list widget ------------------------------------------------------ */
 ElementFilterList::ElementFilterList(QWidget* parent) : QListWidget(parent)
 {
-    addItem(new QListWidgetItem(QApplication::translate("ElementFilterList", "Normal"), this));
-    addItem(new QListWidgetItem(QApplication::translate("ElementFilterList", "Construction"), this));
-    addItem(new QListWidgetItem(QApplication::translate("ElementFilterList", "Internal"), this));
-    addItem(new QListWidgetItem(QApplication::translate("ElementFilterList", "External"), this));
-    addItem(new QListWidgetItem(QApplication::translate("ElementFilterList", "All types"), this));
-    addItem(new QListWidgetItem(QApplication::translate("ElementFilterList", " - Point"), this));
-    addItem(new QListWidgetItem(QApplication::translate("ElementFilterList", " - Line"), this));
-    addItem(new QListWidgetItem(QApplication::translate("ElementFilterList", " - Circle"), this));
-    addItem(new QListWidgetItem(QApplication::translate("ElementFilterList", " - Ellipse"), this));
-    addItem(new QListWidgetItem(QApplication::translate("ElementFilterList", " - Arc"), this));
-    addItem(new QListWidgetItem(QApplication::translate("ElementFilterList", " - Arc of ellipse"), this));
-    addItem(new QListWidgetItem(QApplication::translate("ElementFilterList", " - Arc of hyperbola"), this));
-    addItem(new QListWidgetItem(QApplication::translate("ElementFilterList", " - Arc of parabola"), this));
-    addItem(new QListWidgetItem(QApplication::translate("ElementFilterList", " - B-Spline"), this));
-
-    for (int i = 0; i < count(); i++) {
-        QListWidgetItem* it = item(i);
-
+    for (auto const &filterItem:filterItems) {
+        Q_UNUSED(filterItem);
+        auto it = new QListWidgetItem();
         it->setFlags(it->flags() | Qt::ItemIsUserCheckable);
         it->setCheckState(Qt::Checked);
+        addItem(it);
     }
+    languageChange();
 }
 
 ElementFilterList::~ElementFilterList()
 {
+}
+
+void ElementFilterList::changeEvent(QEvent* e)
+{
+    if (e->type() == QEvent::LanguageChange) {
+        languageChange();
+    }
+    QWidget::changeEvent(e);
+}
+
+void ElementFilterList::languageChange()
+{
+    assert(static_cast<int>(filterItems.size()) == count());
+    int i=0;
+    for (auto const &filterItem:filterItems) {
+        auto text = QStringLiteral("  ").repeated(filterItem.second-1) +
+            (filterItem.second > 0 ? QStringLiteral("- ") : QStringLiteral()) +
+            tr(filterItem.first);
+        item(i++)->setText(text);
+    }
 }
 
 

--- a/src/Mod/Sketcher/Gui/TaskSketcherElements.h
+++ b/src/Mod/Sketcher/Gui/TaskSketcherElements.h
@@ -185,6 +185,29 @@ public:
     explicit ElementFilterList(QWidget* parent = nullptr);
     ~ElementFilterList() override;
 
+protected:
+    void changeEvent(QEvent* e) override;
+    virtual void languageChange();
+
+private:
+    using filterItemRepr =  std::pair<const char *, const int>; // {filter item text, filter item level}
+    inline static const std::vector<filterItemRepr> filterItems = {
+        {QT_TR_NOOP("Normal"),0},
+        {QT_TR_NOOP("Construction"),0},
+        {QT_TR_NOOP("Internal"),0},
+        {QT_TR_NOOP("External"),0},
+        {QT_TR_NOOP("All types"),0},
+        {QT_TR_NOOP("Point"),1},
+        {QT_TR_NOOP("Line"),1},
+        {QT_TR_NOOP("Circle"),1},
+        {QT_TR_NOOP("Ellipse"),1},
+        {QT_TR_NOOP("Arc of circle"),1},
+        {QT_TR_NOOP("Arc of ellipse"),1},
+        {QT_TR_NOOP("Arc of hyperbola"),1},
+        {QT_TR_NOOP("Arc of parabola"),1},
+        {QT_TR_NOOP("B-Spline"),1}
+    };
+
 };
 
 class TaskSketcherElements : public Gui::TaskView::TaskBox, public Gui::SelectionObserver

--- a/src/Mod/Sketcher/Gui/TaskSketcherElements.h
+++ b/src/Mod/Sketcher/Gui/TaskSketcherElements.h
@@ -69,7 +69,7 @@ class ElementItem : public QListWidgetItem
         , StartingVertex(startingVertex)
         , MidVertex(midVertex)
         , EndVertex(endVertex)
-        , GeometryType(geometryType)
+        , GeometryType(std::move(geometryType))
         , State(state)
         , isLineSelected(false)
         , isStartingPointSelected(false)
@@ -177,6 +177,16 @@ Q_SIGNALS:
     void onItemHovered(QListWidgetItem *);
 };
 
+class ElementFilterList : public QListWidget
+{
+    Q_OBJECT
+
+public:
+    explicit ElementFilterList(QWidget* parent = nullptr);
+    ~ElementFilterList() override;
+
+};
+
 class TaskSketcherElements : public Gui::TaskView::TaskBox, public Gui::SelectionObserver
 {
     Q_OBJECT
@@ -188,13 +198,12 @@ public:
     /// Observer message from the Selection
     void onSelectionChanged(const Gui::SelectionChanges& msg) override;
 
-    bool eventFilter(QObject* obj, QEvent* event) override;
-
 private:
     void slotElementsChanged();
     void updateVisibility();
     void setItemVisibility(QListWidgetItem* item);
     void clearWidget();
+    void createFilterButtonActions();
     void createSettingsButtonActions();
     void connectSignals();
 
@@ -203,8 +212,6 @@ public Q_SLOTS:
     void onListWidgetElementsItemEntered(QListWidgetItem *item);
     void onListWidgetElementsMouseMoveOnItem(QListWidgetItem* item);
     void onSettingsExtendedInformationChanged();
-    void onSettingsAutoCollapseFilterChanged();
-    void onSettingsButtonClicked(bool);
     void onFilterBoxStateChanged(int val);
     void onListMultiFilterItemChanged(QListWidgetItem* item);
 
@@ -224,8 +231,9 @@ private:
     int previouslyHoveredItemIndex;
     SubElementType previouslyHoveredType;
 
+    ElementFilterList* filterList;
+
     bool isNamingBoxChecked;
-    bool collapseFilter;
 };
 
 } //namespace SketcherGui

--- a/src/Mod/Sketcher/Gui/TaskSketcherElements.ui
+++ b/src/Mod/Sketcher/Gui/TaskSketcherElements.ui
@@ -30,17 +30,48 @@
     <layout class="QHBoxLayout" name="horizontalLayout1">
      <item>
       <widget class="QCheckBox" name="filterBox">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="toolTip">
-        <string>Check to activate filters</string>
+        <string>Check to toggle filters</string>
        </property>
        <property name="styleSheet">
-        <string notr="true">padding-bottom: 0px; margin-bottom: 0px</string>
+        <string notr="true">padding-right: 0px; margin-right: 0px</string>
+       </property>
+       <property name="text">
+        <string></string>
+       </property>
+       <property name="checked">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+	 <item>
+      <widget class="QToolButton" name="filterButton">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string>Click to show filters</string>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">padding-left: 0px; margin-left: 0px</string>
+       </property>
+       <property name="enabled">
+        <bool>false</bool>
        </property>
        <property name="text">
         <string>Filters</string>
        </property>
-       <property name="checked">
-        <bool>false</bool>
+       <property name="popupMode">
+        <enum>QToolButton::MenuButtonPopup</enum>
        </property>
       </widget>
      </item>
@@ -68,98 +99,6 @@
       </widget>
      </item>
     </layout>
-   </item>
-   <item>
-    <widget class="QListWidget" name="listMultiFilter">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="styleSheet">
-      <string notr="true">padding-top: 0px; margin-top: 0px</string>
-     </property>
-     <property name="sizeAdjustPolicy">
-      <enum>QAbstractScrollArea::AdjustToContents</enum>
-     </property>
-     <property name="selectionMode">
-      <enum>QAbstractItemView::NoSelection</enum>
-     </property>
-     <property name="modelColumn">
-      <number>0</number>
-     </property>
-     <item>
-      <property name="text">
-       <string>Normal</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Construction</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Internal</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>External</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>All types</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string> - Point</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string> - Line</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string> - Circle</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string> - Ellipse </string>
-      </property>
-     </item>
-      <item>
-      <property name="text">
-       <string> - Arc</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string> - Arc of ellipse</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string> - Arc of hyperbola</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string> - Arc of parabola</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string> - B-Spline</string>
-      </property>
-     </item>
-    </widget>
    </item>
    <item>
     <widget class="ElementView" name="listWidgetElements">


### PR DESCRIPTION
Improve the recently reworked Element widget.
It put the filter widget in a qactionmenu. Which looks much better, avoid resizing the task box.
This is following the good suggestion of @adrianinsaval 

This is matching the filter of currently opened 'Constraint widget rework' PR.
![image](https://user-images.githubusercontent.com/19984177/202410302-5d4ad88f-afe9-4edb-ab48-8f5c89cbff30.png)

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [ ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
