### PR TITLE
[Bugfix] Sketcher: fix issue with angle-constrained arc in Clone command

### DIFF
--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -4302,13 +4302,15 @@ int SketchObject::addCopy(const std::vector<int> &geoIdList, const Base::Vector3
                                         constNew->Second = fit->second; // first is already (*it->First)
                                         newconstrVals.push_back(constNew);
                                     }
-                                    else if ((*it)->Type == Sketcher::Angle && clone){
-                                        // Angles on a single Element are mapped to parallel constraints in clone mode
-                                        Constraint *constNew = (*it)->copy();
-                                        constNew->Type = Sketcher::Parallel;
-                                        constNew->isDriving = true;
-                                        constNew->Second = fit->second; // first is already (*it->First)
-                                        newconstrVals.push_back(constNew);
+                                    else if ((*it)->Type == Sketcher::Angle && clone) {
+                                        if (getGeometry((*it)->First)->getTypeId() == Part::GeomLineSegment::getClassTypeId()) {
+                                            // Angles on a single Element are mapped to parallel constraints in clone mode
+                                            Constraint *constNew = (*it)->copy();
+                                            constNew->Type = Sketcher::Parallel;
+                                            constNew->isDriving = true;
+                                            constNew->Second = fit->second; // first is already (*it->First)
+                                            newconstrVals.push_back(constNew);
+                                        }
                                     }
                                     else {
                                         Constraint *constNew = (*it)->copy();

--- a/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp
+++ b/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp
@@ -1134,10 +1134,6 @@ public:
 
             EditCurve[1] = endpoint;
             drawEdit(EditCurve);
-            if (seekAutoConstraint(sugConstr1, endpoint, Base::Vector2d(0.0, 0.0), AutoConstraint::VERTEX)) {
-                renderSuggestConstraintsCursor(sugConstr1);
-                return;
-            }
         }
         applyCursor();
     }
@@ -1160,7 +1156,6 @@ public:
             unsetCursor();
             resetPositionText();
 
-            int currentgeoid = static_cast<Sketcher::SketchObject *>(sketchgui->getObject())->getHighestCurveIndex();
             Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Copy/clone/move geometry"));
 
             try{
@@ -1180,20 +1175,6 @@ public:
             catch (const Base::Exception& e) {
                 Base::Console().Error("%s\n", e.what());
                 Gui::Command::abortCommand();
-            }
-
-            if (Op != SketcherCopy::Move) {
-                // add auto constraints for the destination copy
-                if (!sugConstr1.empty()) {
-                    createAutoConstraints(sugConstr1, currentgeoid+nElements, OriginPos);
-                    sugConstr1.clear();
-                }
-            }
-            else {
-                if (!sugConstr1.empty()) {
-                    createAutoConstraints(sugConstr1, OriginGeoId, OriginPos);
-                    sugConstr1.clear();
-                }
             }
 
             tryAutoRecomputeIfNotSolve(static_cast<Sketcher::SketchObject *>(sketchgui->getObject()));


### PR DESCRIPTION
First commit fixes the problem coming when an arc of circle having its aperture constrained with an angle is cloned.
Described here : https://forum.freecadweb.org/viewtopic.php?f=3&t=73427

2nd commit disabled auto-constraining ability in Clone/Copy/Move commands as it is unusable but just create misleading behaviors.

- [ ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR