### PR TITLE
Part: Fix endless-loop in TopoShapePy::proximity function

### DIFF
--- a/src/Mod/Part/App/TopoShapePyImp.cpp
+++ b/src/Mod/Part/App/TopoShapePyImp.cpp
@@ -2494,54 +2494,12 @@ PyObject* TopoShapePy::proximity(PyObject *args)
     BRepExtrema_ShapeProximity proximity;
     proximity.LoadShape1 (s1);
     proximity.LoadShape2 (s2);
-    if (tol > 0.0)
+    if (tol > 0.0) {
         proximity.SetTolerance (tol);
+    }
+
     proximity.Perform();
     if (!proximity.IsDone()) {
-        // the proximity failed, maybe it's because the shapes are not yet mesh
-        TopLoc_Location aLoc;
-        TopExp_Explorer xp(s1, TopAbs_FACE);
-        while (xp.More()) {
-            const Handle(Poly_Triangulation)& aTriangulation =
-              BRep_Tool::Triangulation(TopoDS::Face(xp.Current()), aLoc);
-            if (aTriangulation.IsNull()) {
-                PyErr_SetString(PartExceptionOCCError, "BRepExtrema_ShapeProximity not done, call 'tessellate' beforehand");
-                return nullptr;
-            }
-        }
-
-        xp.Init(s2, TopAbs_FACE);
-        while (xp.More()) {
-            const Handle(Poly_Triangulation)& aTriangulation =
-              BRep_Tool::Triangulation(TopoDS::Face(xp.Current()), aLoc);
-            if (aTriangulation.IsNull()) {
-                PyErr_SetString(PartExceptionOCCError, "BRepExtrema_ShapeProximity not done, call 'tessellate' beforehand");
-                return nullptr;
-            }
-        }
-
-        // check also for free edges
-        xp.Init(s1, TopAbs_EDGE, TopAbs_FACE);
-        while (xp.More()) {
-            const Handle(Poly_Polygon3D)& aPoly3D =
-              BRep_Tool::Polygon3D(TopoDS::Edge(xp.Current()), aLoc);
-            if (aPoly3D.IsNull()) {
-                PyErr_SetString(PartExceptionOCCError, "BRepExtrema_ShapeProximity not done, call 'tessellate' beforehand");
-                return nullptr;
-            }
-        }
-
-        xp.Init(s2, TopAbs_EDGE, TopAbs_FACE);
-        while (xp.More()) {
-            const Handle(Poly_Polygon3D)& aPoly3D =
-              BRep_Tool::Polygon3D(TopoDS::Edge(xp.Current()), aLoc);
-            if (aPoly3D.IsNull()) {
-                PyErr_SetString(PartExceptionOCCError, "BRepExtrema_ShapeProximity not done, call 'tessellate' beforehand");
-                return nullptr;
-            }
-        }
-
-        // another problem must have occurred
         PyErr_SetString(PartExceptionOCCError, "BRepExtrema_ShapeProximity not done");
         return nullptr;
     }


### PR DESCRIPTION
Fix https://forum.freecadweb.org/viewtopic.php?f=22&t=73529
Even though the infinite loop is caused by not calling `TopExp_Explorer::Next()` in every while loop, these are unnecessary since an exception is raised anyway.


Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [ ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
