### PR TITLE
Gui: Stop Revit rotation and zoom on scroll release

### DIFF
--- a/src/Gui/RevitNavigationStyle.cpp
+++ b/src/Gui/RevitNavigationStyle.cpp
@@ -256,8 +256,6 @@ SbBool RevitNavigationStyle::processSoEvent(const SoEvent * const ev)
             newmode = NavigationStyle::SELECTION;
         break;
     case BUTTON1DOWN|BUTTON2DOWN:
-        newmode = NavigationStyle::PANNING;
-        break;
     case BUTTON3DOWN:
         newmode = NavigationStyle::PANNING;
         break;
@@ -273,6 +271,13 @@ SbBool RevitNavigationStyle::processSoEvent(const SoEvent * const ev)
         break;
 
     default:
+        // Reset mode to SELECTION when button 3 is released
+        // This stops the DRAGGING when button 3 is released but SHIFT is still pressed
+        // This stops the ZOOMING when button 3 is released but CTRL is still pressed
+        if ((curmode == NavigationStyle::DRAGGING || curmode == NavigationStyle::ZOOMING)
+            && !this->button3down) {
+            newmode = NavigationStyle::SELECTION;
+        }
         break;
     }
 


### PR DESCRIPTION
This fixes point 3 of the suggested changes from issue #5942, in short:
- Stops the rotation when scroll is released but SHIFT is still pressed
- Stops zooming when scroll is released but CTRL is still pressed

Issue #5942 also suggests some other things for the Revit navigation style. However, they deviate from the actual Revit navigation (tested in Revit 2023) so the other suggestions are not included.

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
