### PR TITLE
[TD] DrawViewPart: Fix Dimension attachment on Cosmetic CenterLines u…

### DIFF
--- a/src/Mod/TechDraw/App/DrawViewPart.h
+++ b/src/Mod/TechDraw/App/DrawViewPart.h
@@ -173,6 +173,7 @@ public:
     double getSizeAlongVector(Base::Vector3d alignmentVector);
 
     virtual void postHlrTasks(void);
+    virtual void postFaceExtractionTasks(void);
 
     bool isIso() const;
 


### PR DESCRIPTION
…pon document restore.  This PR fixes a bug in TechDraw, described [here in a Forum thread](https://forum.freecadweb.org/viewtopic.php?f=35&t=73326&sid=28b3c5461175f52fe5408f3e7b73dfa0)

The problem was that Dimensions attached to Cosmetic CenterLines were not restored properly during document restore, because the Dimension processing started before the multi-threaded Face detection algorithm had finished, and some types of CenterLines depended on the existence of these Faces.  This patch delays the Dimension processing until all geometry, including face-dependant CenterLines, actually exists.

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [x]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
