### PR TITLE
[Units]Allow querying schema for unit of measure

### DIFF
--- a/src/Base/UnitsApi.cpp
+++ b/src/Base/UnitsApi.cpp
@@ -163,6 +163,11 @@ bool UnitsApi::isMultiUnitAngle()
     return UserPrefSystem->isMultiUnitAngle();
 }
 
+std::string UnitsApi::getBasicLengthUnit()
+{
+    return UserPrefSystem->getBasicLengthUnit();
+}
+
 // === static translation methods ==========================================
 
 QString UnitsApi::schemaTranslate(const Base::Quantity& quant, double &factor, QString &unitString)

--- a/src/Base/UnitsApi.h
+++ b/src/Base/UnitsApi.h
@@ -98,6 +98,9 @@ public:
     //return true if the current user schema uses multiple units for angles (ex. DMS)
     static bool isMultiUnitAngle();
 
+    //return the basic unit of measure for length in the current user schema.
+    static std::string getBasicLengthUnit();
+
     // Python interface
     static PyMethodDef    Methods[];
 

--- a/src/Base/UnitsSchema.h
+++ b/src/Base/UnitsSchema.h
@@ -71,6 +71,9 @@ public:
 
     //return true if this schema uses multiple units for angles (ex. DMS)
     virtual bool isMultiUnitAngle() const {return false;}
+
+    //return the basic length unit for this schema
+    virtual std::string getBasicLengthUnit() const { return std::string("mm"); }
 };
 
 

--- a/src/Base/UnitsSchemaCentimeters.h
+++ b/src/Base/UnitsSchemaCentimeters.h
@@ -37,6 +37,8 @@ class UnitsSchemaCentimeters: public UnitsSchema
 {
 public:
     QString schemaTranslate(const Base::Quantity& quant, double &factor, QString &unitString) override;
+
+    std::string getBasicLengthUnit() const override { return std::string("cm"); }
 };
 
 } // namespace Base

--- a/src/Base/UnitsSchemaImperial1.h
+++ b/src/Base/UnitsSchemaImperial1.h
@@ -41,6 +41,7 @@ public:
     //virtual void setSchemaUnits(void);
     //virtual void resetSchemaUnits(void);
     QString schemaTranslate(const Base::Quantity& quant, double &factor, QString &unitString) override;
+    std::string getBasicLengthUnit() const override { return std::string("in"); }
 };
 
 /** The schema class for the imperial unit system
@@ -53,6 +54,7 @@ public:
     //virtual void setSchemaUnits(void);
     //virtual void resetSchemaUnits(void);
     QString schemaTranslate(const Base::Quantity& quant, double &factor, QString &unitString) override;
+    std::string getBasicLengthUnit() const override { return std::string("in"); }
 };
 
 /** The schema class for the imperial unit system
@@ -65,6 +67,7 @@ public:
     //virtual void setSchemaUnits(void);
     //virtual void resetSchemaUnits(void);
     QString schemaTranslate(const Base::Quantity& quant, double &factor, QString &unitString) override;
+    std::string getBasicLengthUnit() const override { return std::string("ft"); }
 
     //return true if this schema uses multiple units for length (ex. Ft/In)
     bool isMultiUnitLength() const override {return true;}
@@ -81,6 +84,7 @@ public:
     //virtual void setSchemaUnits(void);
     //virtual void resetSchemaUnits(void);
     QString schemaTranslate(const Base::Quantity& quant, double &factor, QString &unitString) override;
+    std::string getBasicLengthUnit() const override { return std::string("ft"); }
 
     //return true if this schema uses multiple units for angles (ex. DMS)
     bool isMultiUnitAngle() const override {return true;}


### PR DESCRIPTION
TechDraw DrawViewDimension contains a routine which returns a unit of measure for each Unit Schema.  This routine contains a hard-coded list of schemata and a matching hard-coded list of length units, which is a maintenance issue. 

This PR adds a function to UnitsApi which returns the basic length unit of measure for the current user schema.  Most schemata return the default of "mm".  Exceptions override the default and return, for example, "in".



Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [ ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
