### PR TITLE
Sketcher: Add Rendering Order widget to 'Element Widget' Settings button.

### DIFF
--- a/src/Mod/Sketcher/Gui/CMakeLists.txt
+++ b/src/Mod/Sketcher/Gui/CMakeLists.txt
@@ -155,6 +155,8 @@ SET(SketcherGui_SRCS
     ViewProviderPython.h
     ViewProviderSketchGeometryExtension.h
     ViewProviderSketchGeometryExtension.cpp
+    RenderingOrderWidget.h
+    RenderingOrderWidget.cpp
 )
 
 if(FREECAD_USE_PCH)

--- a/src/Mod/Sketcher/Gui/RenderingOrderWidget.cpp
+++ b/src/Mod/Sketcher/Gui/RenderingOrderWidget.cpp
@@ -28,7 +28,7 @@
 # include <QApplication>
 #endif
 
-# include <QEvent>
+#include <QEvent>
 #include <QString>
 
 #include <Gui/Application.h>
@@ -42,12 +42,11 @@ using namespace SketcherGui;
 RenderingOrderWidget::RenderingOrderWidget(QWidget *parent, ViewProviderSketch* sketchView)
   : QWidget(parent)
     , sketchView(sketchView)
+    , label(new QLabel(this))
+    , list(new QListWidget(this))
 {
-    label = new QLabel(this);
-    label->setText(QApplication::translate("RenderingOrderWidget", "Rendering order (global):"));
+    languageChanged();
 
-    list = new QListWidget(this);
-    list->setToolTip(QApplication::translate("RenderingOrderWidget", "To change, drag and drop a geometry type to top or bottom"));
     list->setDragEnabled(true);
     list->setDragDropMode(QAbstractItemView::InternalMove);
     list->setSortingEnabled(false);
@@ -131,8 +130,13 @@ void RenderingOrderWidget::changeEvent(QEvent *e)
 {
     QWidget::changeEvent(e);
     if (e->type() == QEvent::LanguageChange) {
-        label->setText(QApplication::translate("RenderingOrderWidget", "Rendering order (global):"));
-        list->setToolTip(QApplication::translate("RenderingOrderWidget", "To change, drag and drop a geometry type to top or bottom"));
+        languageChanged();
         loadSettings();
     }
+}
+
+void RenderingOrderWidget::languageChanged() {
+    label->setText(tr("Rendering order (global):"));
+    list->setToolTip(tr("To change, drag and drop a geometry type to top or bottom"));
+
 }

--- a/src/Mod/Sketcher/Gui/RenderingOrderWidget.cpp
+++ b/src/Mod/Sketcher/Gui/RenderingOrderWidget.cpp
@@ -1,0 +1,138 @@
+/***************************************************************************
+ *   Copyright (c) 2022 Pierre Boyer <pierrelouis.boyer google mail>       *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#include "PreCompiled.h"
+
+#ifndef _PreComp_
+# include <QVBoxLayout>
+# include <QApplication>
+#endif
+
+# include <QEvent>
+#include <QString>
+
+#include <Gui/Application.h>
+#include <Base/Tools.h>
+
+#include "ViewProviderSketch.h"
+#include "RenderingOrderWidget.h"
+
+using namespace SketcherGui;
+
+RenderingOrderWidget::RenderingOrderWidget(QWidget *parent, ViewProviderSketch* sketchView)
+  : QWidget(parent)
+    , sketchView(sketchView)
+{
+    label = new QLabel(this);
+    label->setText(QApplication::translate("RenderingOrderWidget", "Rendering order (global):"));
+
+    list = new QListWidget(this);
+    list->setToolTip(QApplication::translate("RenderingOrderWidget", "To change, drag and drop a geometry type to top or bottom"));
+    list->setDragEnabled(true);
+    list->setDragDropMode(QAbstractItemView::InternalMove);
+    list->setSortingEnabled(false);
+    list->setResizeMode(QListView::Fixed);
+    list->setSizeAdjustPolicy(QAbstractScrollArea::AdjustToContents);
+    list->setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
+    list->installEventFilter(this);
+    loadSettings();
+    list->setMaximumHeight(list->sizeHintForRow(0) * list->count() + 10);
+    auto* layout = new QVBoxLayout(this);
+    layout->addWidget(label);
+    layout->addWidget(list);
+    if (sketchView) {
+        layout->setMargin(0);
+        layout->setSpacing(0);
+        list->setStyleSheet(QString::fromUtf8("margin: 2px"));
+    }
+
+    label->setMinimumHeight(list->sizeHintForRow(0));
+}
+
+RenderingOrderWidget::~RenderingOrderWidget()
+{
+}
+
+bool RenderingOrderWidget::eventFilter(QObject *object, QEvent *event)
+{
+    if (object == list && event->type() == QEvent::ChildRemoved) {
+        if (sketchView) {
+            saveSettings(); //we don't save settings if we are in preference panel, as it's saved when clicking save button.
+            sketchView->updateColor();
+        }
+    }
+
+    return false;
+}
+
+void RenderingOrderWidget::saveSettings()
+{
+    int topid = list->item(0)->data(Qt::UserRole).toInt();
+    int midid = list->item(1)->data(Qt::UserRole).toInt();
+    int lowid = list->item(2)->data(Qt::UserRole).toInt();
+
+    ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher/General");
+    hGrp->SetInt("TopRenderGeometryId", topid);
+    hGrp->SetInt("MidRenderGeometryId", midid);
+    hGrp->SetInt("LowRenderGeometryId", lowid);
+}
+
+void RenderingOrderWidget::loadSettings()
+{
+    ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher/General");
+
+    // 1->Normal Geometry, 2->Construction, 3->External
+    int topid = hGrp->GetInt("TopRenderGeometryId", 1);
+    int midid = hGrp->GetInt("MidRenderGeometryId", 2);
+    int lowid = hGrp->GetInt("LowRenderGeometryId", 3);
+
+    {
+        QSignalBlocker block(this);
+        list->clear();
+
+        QListWidgetItem* newItem = new QListWidgetItem;
+        newItem->setData(Qt::UserRole, QVariant(topid));
+        newItem->setText(topid == 1 ? tr("Normal Geometry") : topid == 2 ? tr("Construction Geometry") : tr("External Geometry"));
+        list->insertItem(0, newItem);
+
+        newItem = new QListWidgetItem;
+        newItem->setData(Qt::UserRole, QVariant(midid));
+        newItem->setText(midid == 1 ? tr("Normal Geometry") : midid == 2 ? tr("Construction Geometry") : tr("External Geometry"));
+        list->insertItem(1, newItem);
+
+        newItem = new QListWidgetItem;
+        newItem->setData(Qt::UserRole, QVariant(lowid));
+        newItem->setText(lowid == 1 ? tr("Normal Geometry") : lowid == 2 ? tr("Construction Geometry") : tr("External Geometry"));
+        list->insertItem(2, newItem);
+    }
+}
+
+void RenderingOrderWidget::changeEvent(QEvent *e)
+{
+    QWidget::changeEvent(e);
+    if (e->type() == QEvent::LanguageChange) {
+        label->setText(QApplication::translate("RenderingOrderWidget", "Rendering order (global):"));
+        list->setToolTip(QApplication::translate("RenderingOrderWidget", "To change, drag and drop a geometry type to top or bottom"));
+        loadSettings();
+    }
+}

--- a/src/Mod/Sketcher/Gui/RenderingOrderWidget.h
+++ b/src/Mod/Sketcher/Gui/RenderingOrderWidget.h
@@ -44,6 +44,7 @@ public:
 
     void saveSettings();
     void loadSettings();
+    void languageChanged();
 
 protected:
     void changeEvent(QEvent *e) override;

--- a/src/Mod/Sketcher/Gui/RenderingOrderWidget.h
+++ b/src/Mod/Sketcher/Gui/RenderingOrderWidget.h
@@ -1,0 +1,59 @@
+/***************************************************************************
+ *   Copyright (c) 2022 Pierre Boyer <pierrelouis.boyer google mail>       *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#ifndef GUI_TASKVIEW_RenderingOrderWidget_H
+#define GUI_TASKVIEW_RenderingOrderWidget_H
+
+#include <QWidget>
+#include <QListWidget>
+#include <QLabel>
+
+namespace SketcherGui {
+
+class ViewProviderSketch;
+
+class RenderingOrderWidget : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit RenderingOrderWidget(QWidget *parent = nullptr, ViewProviderSketch* sketchView = nullptr);
+    ~RenderingOrderWidget() override;
+    
+    bool eventFilter(QObject *object, QEvent *event) override;
+
+    void saveSettings();
+    void loadSettings();
+
+protected:
+    void changeEvent(QEvent *e) override;
+    
+private:
+    ViewProviderSketch* sketchView;
+    QLabel* label;
+    QListWidget* list;
+};
+
+} //namespace SketcherGui
+
+#endif // GUI_TASKVIEW_RenderingOrderWidget_H

--- a/src/Mod/Sketcher/Gui/TaskSketcherElements.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherElements.cpp
@@ -1221,9 +1221,14 @@ void TaskSketcherElements::createSettingsButtonActions()
         action->setChecked(hGrp->GetBool("ExtendedNaming", false));
     }
 
-    ui->settingsButton->addAction(action);
+    qAsConst(ui->settingsButton)->addAction(action);
 
     isNamingBoxChecked = hGrp->GetBool("ExtendedNaming", false);
+
+    auto* action2 = new QWidgetAction(this);
+    renderingOrder = new RenderingOrderWidget(this, sketchView);
+    action2->setDefaultWidget(renderingOrder);
+    qAsConst(ui->settingsButton)->addAction(action2);
 }
 
 void TaskSketcherElements::onSettingsExtendedInformationChanged()

--- a/src/Mod/Sketcher/Gui/TaskSketcherElements.h
+++ b/src/Mod/Sketcher/Gui/TaskSketcherElements.h
@@ -31,6 +31,8 @@
 #include <QIcon>
 #include <QStyledItemDelegate>
 
+#include "RenderingOrderWidget.h"
+
 namespace App {
 class Property;
 }
@@ -255,6 +257,7 @@ private:
     SubElementType previouslyHoveredType;
 
     ElementFilterList* filterList;
+    RenderingOrderWidget* renderingOrder;
 
     bool isNamingBoxChecked;
 };


### PR DESCRIPTION
It adds rendering order from Edit Controls to Element widget setting button. As shown in below picture.

![image](https://user-images.githubusercontent.com/19984177/203117801-c8e9ef0c-7c88-4a7e-be50-c04481cb2233.png)


The discussion about Sketcher Edit control task bar :
https://forum.freecadweb.org/viewtopic.php?f=8&t=73113

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [ ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
