### PR TITLE
Arch: fix cutplane color

### DIFF
--- a/src/Mod/Arch/ArchCutPlane.py
+++ b/src/Mod/Arch/ArchCutPlane.py
@@ -20,7 +20,8 @@
 #*                                                                           *
 #*****************************************************************************
 
-import FreeCAD,ArchCommands
+import FreeCAD, Draft, ArchCommands
+
 if FreeCAD.GuiUp:
     import FreeCADGui
     from PySide import QtCore, QtGui
@@ -61,12 +62,11 @@ def cutComponentwithPlane(archObject, cutPlane, sideFace):
     if cutVolume:
         obj = FreeCAD.ActiveDocument.addObject("Part::Feature","CutVolume")
         obj.Shape = cutVolume
-        obj.ViewObject.ShapeColor = (1.00,0.00,0.00)
-        obj.ViewObject.Transparency = 75
         if "Additions" in archObject.Object.PropertiesList:
-            ArchCommands.removeComponents(obj,archObject.Object)
+            ArchCommands.removeComponents(obj, archObject.Object) # Also changes the obj colors.
             return None
         else:
+            Draft.format_object(obj, archObject.Object)
             cutObj = FreeCAD.ActiveDocument.addObject("Part::Cut","CutPlane")
             cutObj.Base = archObject.Object
             cutObj.Tool = obj

--- a/src/Mod/Arch/ArchCutPlane.py
+++ b/src/Mod/Arch/ArchCutPlane.py
@@ -21,7 +21,6 @@
 #*****************************************************************************
 
 import FreeCAD, Draft, ArchCommands
-
 if FreeCAD.GuiUp:
     import FreeCADGui
     from PySide import QtCore, QtGui


### PR DESCRIPTION
When using Arch_CutPlane on an object that is not a Component, the cut volume got a red shape color and a 75% transparency. The meant that the cut faces of the resulting object would also have these properties. To solve this `Draft.format_object()` is now applied to the cut volume.

Forum topic:
https://forum.freecadweb.org/viewtopic.php?f=3&t=72070

- [ ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

---
