### PR TITLE
Sketcher: Element widget: remove the checkbox enabling the filter

### DIFF
--- a/src/Mod/Sketcher/Gui/TaskSketcherElements.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherElements.cpp
@@ -592,10 +592,6 @@ void TaskSketcherElements::connectSignals()
         this, &TaskSketcherElements::onListMultiFilterItemChanged
     );
     QObject::connect(
-        ui->filterBox, &QCheckBox::stateChanged,
-        this, &TaskSketcherElements::onFilterBoxStateChanged
-    );
-    QObject::connect(
         ui->settingsButton, &QToolButton::clicked,
         ui->settingsButton, &QToolButton::showMenu
     );
@@ -620,13 +616,6 @@ void TaskSketcherElements::createFilterButtonActions()
     filterList = new ElementFilterList(this);
     action->setDefaultWidget(filterList);
     qAsConst(ui->filterButton)->addAction(action);
-}
-
-void TaskSketcherElements::onFilterBoxStateChanged(int val)
-{
-    Q_UNUSED(val);
-    ui->filterButton->setEnabled(ui->filterBox->checkState() == Qt::Checked);
-    slotElementsChanged();
 }
 
 enum class GeoFilterType { NormalGeos,
@@ -683,8 +672,6 @@ void TaskSketcherElements::onListMultiFilterItemChanged(QListWidgetItem* item)
 void TaskSketcherElements::setItemVisibility(QListWidgetItem* it)
 {
     ElementItem* item = static_cast<ElementItem*>(it);
-
-    if (ui->filterBox->checkState() == Qt::Unchecked) { item->setHidden(false); return; }
 
     using GeometryState = ElementItem::GeometryState;
 

--- a/src/Mod/Sketcher/Gui/TaskSketcherElements.h
+++ b/src/Mod/Sketcher/Gui/TaskSketcherElements.h
@@ -235,7 +235,6 @@ public Q_SLOTS:
     void onListWidgetElementsItemEntered(QListWidgetItem *item);
     void onListWidgetElementsMouseMoveOnItem(QListWidgetItem* item);
     void onSettingsExtendedInformationChanged();
-    void onFilterBoxStateChanged(int val);
     void onListMultiFilterItemChanged(QListWidgetItem* item);
 
 protected:

--- a/src/Mod/Sketcher/Gui/TaskSketcherElements.ui
+++ b/src/Mod/Sketcher/Gui/TaskSketcherElements.ui
@@ -29,28 +29,6 @@
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout1">
      <item>
-      <widget class="QCheckBox" name="filterBox">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="toolTip">
-        <string>Check to toggle filters</string>
-       </property>
-       <property name="styleSheet">
-        <string notr="true">padding-right: 0px; margin-right: 0px</string>
-       </property>
-       <property name="text">
-        <string></string>
-       </property>
-       <property name="checked">
-        <bool>false</bool>
-       </property>
-      </widget>
-     </item>
-	 <item>
       <widget class="QToolButton" name="filterButton">
        <property name="sizePolicy">
         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
@@ -63,9 +41,6 @@
        </property>
        <property name="styleSheet">
         <string notr="true">padding-left: 0px; margin-left: 0px</string>
-       </property>
-       <property name="enabled">
-        <bool>false</bool>
        </property>
        <property name="text">
         <string>Filters</string>


### PR DESCRIPTION
Uwe pointed out that this is not useful now that we are using QActionWidget while reviewing Constraint widget PR.

So this PR removes it in the Element widget as it's the same.

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [ ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
