### PR TITLE
[PartDesign] fix Pad UpToFace for custom direction

### DIFF
--- a/src/Mod/PartDesign/App/FeatureSketchBased.cpp
+++ b/src/Mod/PartDesign/App/FeatureSketchBased.cpp
@@ -522,20 +522,13 @@ void ProfileBased::getUpToFace(TopoDS_Face& upToFace,
         }
     }
 
-    // Check that the upToFace does not intersect the sketch face and
-    // is not parallel to the extrusion direction (for simplicity, supportface is used instead of sketchshape)
-    BRepAdaptor_Surface adapt1(TopoDS::Face(supportface));
+    // Check that the upToFace is not parallel to the extrusion direction
     BRepAdaptor_Surface adapt2(TopoDS::Face(upToFace));
 
     if (adapt2.GetType() == GeomAbs_Plane) {
-        if (adapt1.Plane().Axis().IsNormal(adapt2.Plane().Axis(), Precision::Confusion()))
+        if (dir.IsNormal(adapt2.Plane().Axis().Direction(), Precision::Confusion()))
             throw Base::ValueError("SketchBased: Up to face: Must not be parallel to extrusion direction!");
     }
-
-    // We must measure from sketchshape, not supportface, here
-    BRepExtrema_DistShapeShape distSS(sketchshape, upToFace);
-    if (distSS.Value() < Precision::Confusion())
-        throw Base::ValueError("SketchBased: Up to face: Must not intersect sketch!");
 }
 
 void ProfileBased::addOffsetToFace(TopoDS_Face& upToFace, const gp_Dir& dir, double offset)


### PR DESCRIPTION
Use the custom direction to check the (up to) face parallelism. Remove the sketch/face intersection check which fail in custom dir case.

See https://forum.freecadweb.org/viewtopic.php?f=8&t=73674

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [x]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
