### PR TITLE
Sketcher task constraint :  fix some issues introduced by PR #7566

### DIFF
--- a/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
@@ -869,15 +869,16 @@ TaskSketcherConstraints::TaskSketcherConstraints(ViewProviderSketch *sketchView)
 
     multiFilterStatus = filterList->getMultiFilter();
 
-    slotConstraintsChanged();
-
-    specialFilterMode = SpecialFilterType::None;
-
     ui->listWidgetConstraints->setStyleSheet(QString::fromLatin1("margin-top: 0px"));
 
     Gui::Application* app = Gui::Application::Instance;
     changedSketchView = app->signalChangedObject.connect(boost::bind
     (&TaskSketcherConstraints::onChangedSketchView, this, bp::_1, bp::_2));
+
+    slotConstraintsChanged(); // Populate constraints list
+    // Initialize special filters
+    for (int i = filterList->normalFilterCount ; i < filterList->count() ; i++)
+        on_filterList_itemChanged(filterList->item(i));
 }
 
 TaskSketcherConstraints::~TaskSketcherConstraints()

--- a/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
@@ -1223,9 +1223,9 @@ void TaskSketcherConstraints::onSelectionChanged(const Gui::SelectionChanges& ms
 
     std::string temp;
     if (msg.Type == Gui::SelectionChanges::ClrSelection) {
-        ui->listWidgetConstraints->blockSignals(true);
+        auto tmpBlock = ui->listWidgetConstraints->blockSignals(true);
         ui->listWidgetConstraints->clearSelection();
-        ui->listWidgetConstraints->blockSignals(false);
+        ui->listWidgetConstraints->blockSignals(tmpBlock);
 
         if(specialFilterMode == SpecialFilterType::Selected) {
             updateSelectionFilter();
@@ -1259,9 +1259,9 @@ void TaskSketcherConstraints::onSelectionChanged(const Gui::SelectionChanges& ms
                             ConstraintItem* item = static_cast<ConstraintItem*>
                                 (ui->listWidgetConstraints->item(i));
                             if (item->ConstraintNbr == ConstrId) {
-                                ui->listWidgetConstraints->blockSignals(true);
+                                auto tmpBlock = ui->listWidgetConstraints->blockSignals(true);
                                 item->setSelected(select);
-                                ui->listWidgetConstraints->blockSignals(false);
+                                ui->listWidgetConstraints->blockSignals(tmpBlock);
                                 break;
                             }
                         }
@@ -1570,12 +1570,12 @@ void TaskSketcherConstraints::slotConstraintsChanged()
         ui->listWidgetConstraints->addItem(new ConstraintItem(sketch, sketchView, i));
 
     /* Update the states */
-    ui->listWidgetConstraints->blockSignals(true);
+    auto tmpBlock = ui->listWidgetConstraints->blockSignals(true);
     for (int i = 0; i <  ui->listWidgetConstraints->count(); ++i) {
         ConstraintItem * it = static_cast<ConstraintItem*>(ui->listWidgetConstraints->item(i));
         it->updateVirtualSpaceStatus();
     }
-    ui->listWidgetConstraints->blockSignals(false);
+    ui->listWidgetConstraints->blockSignals(tmpBlock);
 
     /* Update filtering */
     for(std::size_t i = 0; i < vals.size(); ++i) {
@@ -1589,10 +1589,10 @@ void TaskSketcherConstraints::slotConstraintsChanged()
         // case a name has changed because this function gets
         // called after changing the constraint list property
         QAbstractItemModel* model = ui->listWidgetConstraints->model();
-        bool block = model->blockSignals(true);
+        auto tmpBlock = model->blockSignals(true);
         it->setHidden(!visible);
         it->setData(Qt::EditRole, Base::Tools::fromStdString(constraint->Name));
-        model->blockSignals(block);
+        model->blockSignals(tmpBlock);
 
     }
 }
@@ -1610,7 +1610,7 @@ void TaskSketcherConstraints::on_filterList_itemChanged(QListWidgetItem* item)
 {
     int filterindex = filterList->row(item);
 
-    filterList->blockSignals(true);
+    auto tmpBlock = filterList->blockSignals(true);
 
     if (filterindex < filterList->normalFilterCount) {
 
@@ -1645,7 +1645,7 @@ void TaskSketcherConstraints::on_filterList_itemChanged(QListWidgetItem* item)
             specialFilterMode = SpecialFilterType::None;
     }
 
-    filterList->blockSignals(false);
+    filterList->blockSignals(tmpBlock);
 
     //Save the state of the filter.
     int filterState = 0;

--- a/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
@@ -781,6 +781,7 @@ TaskSketcherConstraints::TaskSketcherConstraints(ViewProviderSketch *sketchView)
         action4->setChecked(hGrp->GetBool("ExtendedConstraintInformation", false));
         action5->setChecked(hGrp->GetBool("HideInternalAlignment", false));
     }
+    hGrp->Attach(this);
 
     auto settingsBut = qAsConst(ui->settingsButton);
 
@@ -886,6 +887,7 @@ TaskSketcherConstraints::TaskSketcherConstraints(ViewProviderSketch *sketchView)
 TaskSketcherConstraints::~TaskSketcherConstraints()
 {
     connectionConstraintsChanged.disconnect();
+    App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher")->Detach(this);
 }
 
 void TaskSketcherConstraints::on_settings_extendedInformation_changed(bool value)
@@ -1293,6 +1295,29 @@ void TaskSketcherConstraints::onSelectionChanged(const Gui::SelectionChanges& ms
     }
     else if (msg.Type == Gui::SelectionChanges::SetSelection) {
         // do nothing here
+    }
+}
+
+void TaskSketcherConstraints::OnChange(Base::Subject<const char*> &rCaller,const char* rcReason)
+{
+    Q_UNUSED(rCaller);
+    int actNum = -1;
+    auto hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher");
+    if (strcmp(rcReason, "AutoRemoveRedundants") == 0) {
+        actNum = 1;
+    }
+    else if (strcmp(rcReason, "VisualisationTrackingFilter") == 0) {
+        actNum = 2;
+    }
+    else if (strcmp(rcReason, "ExtendedConstraintInformation") == 0) {
+        actNum = 3;
+    }
+    else if (strcmp(rcReason, "HideInternalAlignment") == 0) {
+        actNum = 4;
+    }
+    if (actNum >= 0) {
+        assert(actNum < static_cast<int>(ui->settingsButton->actions().size()));
+        qAsConst(ui->settingsButton)->actions()[actNum]->setChecked(hGrp->GetBool(rcReason, false));
     }
 }
 

--- a/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
@@ -759,11 +759,12 @@ TaskSketcherConstraints::TaskSketcherConstraints(ViewProviderSketch *sketchView)
 
     // Create local settings menu
     // FIXME there is probably a smarter way to handle this menu
-    QAction* action1 = new QAction(QString::fromLatin1("Auto constraints"), this);
-    QAction* action2 = new QAction(QString::fromLatin1("Auto remove redundants"), this);
-    QAction* action3 = new QAction(QString::fromLatin1("Show only filtered Constraints"), this);
-    QAction* action4 = new QAction(QString::fromLatin1("Extended information (in widget)"), this);
-    QAction* action5 = new QAction(QString::fromLatin1("Hide internal alignment (in widget)"), this);
+    // FIXME translations aren't updated automatically at language change
+    QAction* action1 = new QAction(tr("Auto constraints"), this);
+    QAction* action2 = new QAction(tr("Auto remove redundants"), this);
+    QAction* action3 = new QAction(tr("Show only filtered Constraints"), this);
+    QAction* action4 = new QAction(tr("Extended information (in widget)"), this);
+    QAction* action5 = new QAction(tr("Hide internal alignment (in widget)"), this);
 
     action1->setCheckable(true);
     action2->setCheckable(true);

--- a/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
@@ -897,7 +897,7 @@ void TaskSketcherConstraints::on_settings_extendedInformation_changed(bool value
     slotConstraintsChanged();
 }
 
-void TaskSketcherConstraints::on_settings_hideInternalAligment_changed(bool value) // FIXME doesn't work
+void TaskSketcherConstraints::on_settings_hideInternalAligment_changed(bool value)
 {
     // synchronise  parameter
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher");

--- a/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
@@ -651,13 +651,9 @@ ConstraintFilterList::ConstraintFilterList(QWidget* parent)
 
         it->setFlags(it->flags() | Qt::ItemIsUserCheckable);
         addItem(it);
-        if (row(it) < normalFilterCount) {
-            bool isChecked = static_cast<bool>(filterState & 1); //get the first bit of filterState
-            it->setCheckState(isChecked ? Qt::Checked : Qt::Unchecked);
-            filterState = filterState >> 1; //shift right to get rid of the used bit.
-        }
-        else //associated and selected should not be checked by default.
-            it->setCheckState(Qt::Unchecked);
+        bool isChecked = static_cast<bool>(filterState & 1); //get the first bit of filterState
+        it->setCheckState(isChecked ? Qt::Checked : Qt::Unchecked);
+        filterState = filterState >> 1; //shift right to get rid of the used bit.
     }
     languageChange();
 
@@ -1651,7 +1647,7 @@ void TaskSketcherConstraints::on_filterList_itemChanged(QListWidgetItem* item)
     filterList->blockSignals(false);
 
     //Save the state of the filter.
-    int filterState = INT_MIN; //INT_MIN = 000000000000000000000000000000 in binary.
+    int filterState = 0;
     for (int i = filterList->count() - 1; i >= 0; i--) {
         bool isChecked = filterList->item(i)->checkState() == Qt::Checked;
         filterState = filterState << 1; //we shift left first, else the list is shifted at the end.

--- a/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
@@ -1515,6 +1515,9 @@ bool TaskSketcherConstraints::isConstraintFiltered(QListWidgetItem * item)
             visible = (std::find(associatedConstraintsFilter.begin(), associatedConstraintsFilter.end(), it->ConstraintNbr) != associatedConstraintsFilter.end());
         }
     }
+    else if (constraint->Type == Sketcher::InternalAlignment) {
+        visible = !hideInternalAlignment;
+    }
 
     return !visible;
 }

--- a/src/Mod/Sketcher/Gui/TaskSketcherConstraints.h
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstraints.h
@@ -163,9 +163,6 @@ private:
     void updateSelectionFilter();
     void updateAssociatedConstraintsFilter();
     void updateList();
-    void createFilterButtonActions();
-    void createSettingButtonActions();
-    void connectSignals();
 
     void getSelectionGeoId(QString expr, int & geoid, Sketcher::PointPos & pos);
 
@@ -180,11 +177,11 @@ public Q_SLOTS:
     void on_listWidgetConstraints_emitHideSelection3DVisibility();
     void on_filterBox_stateChanged(int val);
     void on_showHideButton_clicked(bool);
-    void on_settings_restrictVisibility_changed();
-    void on_settings_extendedInformation_changed();
-    void on_settings_hideInternalAligment_changed();
-    void on_settings_autoConstraints_changed();
-    void on_settings_autoRemoveRedundant_changed();
+    void on_settings_restrictVisibility_changed(bool value = false);
+    void on_settings_extendedInformation_changed(bool value = false);
+    void on_settings_hideInternalAligment_changed(bool value = false);
+    void on_settings_autoConstraints_changed(bool value = false);
+    void on_settings_autoRemoveRedundant_changed(bool value = false);
     void on_filterList_itemChanged(QListWidgetItem* item);
 
 protected:

--- a/src/Mod/Sketcher/Gui/TaskSketcherConstraints.h
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstraints.h
@@ -24,6 +24,7 @@
 #ifndef GUI_TASKVIEW_TaskSketcherConstraints_H
 #define GUI_TASKVIEW_TaskSketcherConstraints_H
 
+#include <Base/Parameter.h>
 #include <Gui/TaskView/TaskView.h>
 #include <Gui/Selection.h>
 #include <boost_signals2.hpp>
@@ -131,7 +132,10 @@ private:
     };
 };
 
-class TaskSketcherConstraints : public Gui::TaskView::TaskBox, public Gui::SelectionObserver
+class TaskSketcherConstraints :
+    public Gui::TaskView::TaskBox,
+    public Gui::SelectionObserver,
+    public ParameterGrp::ObserverType
 {
     Q_OBJECT
 
@@ -152,6 +156,7 @@ public:
 
     /// Observer message from the Selection
     void onSelectionChanged(const Gui::SelectionChanges& msg) override;
+    void OnChange(Base::Subject<const char*> &rCaller,const char* rcReason) override;
 
     SpecialFilterType specialFilterMode;
 


### PR DESCRIPTION
This PR fixes most (if not all) the issues introduced by #7566 

@abdullahtahiriyo May you be kind to review ? These are quite massive changes at the end. Some changes are almost certainly suboptimal but may be reverted when we decide which parameters to keep as sketch-specific and which as global.
Also it would deserve to be refactored in a more elegant way, probably having the settings enclosed in a class inherited from QMenu. Again, I can probably tackle this when parameter owners are decided.

There are still things to see:
* Constraints hidden because "Show only filtered constraints" is set aren't correctly restored visible when same setting is disabled. Then they stay in virtual space even if filter is disabled completely
* Settings aren't translated directly when you change language. You have to exit+re-enter edit mode
Both looks minor to me (compared to other fixes) and I didn't check if they were introduced by #7566 or were already there before.

**The most important point now**  if you think, having seen this PR, that this isn't the proper way and it's better to cancel all changed and rethink it completely, then please reject this PR and revert PR #7566 -- we have to do it quickly enough so that there is no merge conflicts --.

@adrianinsaval May you be able to give it a functional testing ?