### PR TITLE
[github ci] run build in parallel

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -297,7 +297,7 @@ jobs:
         run: |
           set +e
 
-          cmake --build build/ > ${{ env.logdir }}Build.log 2> ${{ env.logdir }}BuildErrors.log
+          cmake --build build/ -j$(nproc) > ${{ env.logdir }}Build.log 2> ${{ env.logdir }}BuildErrors.log
 
           exitCode=$?
 


### PR DESCRIPTION
the building section of the CI might be faster like this, a run of the CI in my fork repo (so no ccache available yet) took more than 3.5h: https://github.com/adrianinsaval/FreeCAD/actions/runs/3559298775/jobs/5978923132

from my experience a clean (parallel) build without cache should take about 2.5h on github's runners:
https://github.com/adrianinsaval/pacman-repo/actions/runs/2382265820

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [ ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
