### PR TITLE
Addon Manager: Fix bad formatting in error handler

### DIFF
--- a/src/Mod/AddonManager/addonmanager_macro.py
+++ b/src/Mod/AddonManager/addonmanager_macro.py
@@ -324,7 +324,7 @@ class Macro:
                 FreeCAD.Console.PrintWarning(
                     translate(
                         "AddonsInstaller",
-                        "Unable to open macro code URL {rawcodeurl}",
+                        "Unable to open macro code URL {}",
                     ).format(self.raw_code_url)
                     + "\n"
                 )


### PR DESCRIPTION
Missed a change in the error handling code when adding translation strings to error messages.