### PR TITLE
Addon Manager: Fix trailing whitespace

### DIFF
--- a/src/Mod/AddonManager/ALLOWED_PYTHON_PACKAGES.txt
+++ b/src/Mod/AddonManager/ALLOWED_PYTHON_PACKAGES.txt
@@ -1,5 +1,5 @@
 # This file lists the Python packages that the Addon Manager allows to be installed
-# automatically via pip. To request that a package be added to this list, submit a 
+# automatically via pip. To request that a package be added to this list, submit a
 # pull request to the FreeCAD git repository with the requested package added. Only
 # packages in this list will be processed from the metadata.txt and requirements.txt
 # files specified by an Addon. Note that this is NOT a requirements.txt-format file,

--- a/src/Mod/AddonManager/AddonManager.py
+++ b/src/Mod/AddonManager/AddonManager.py
@@ -190,7 +190,7 @@ class CommandAddonManager:
         firstRunDialog = FirstRunDialog()
         if not firstRunDialog.exec():
             return
-        
+
         self.connection_checker.start()
 
     def launch(self) -> None:

--- a/src/Mod/AddonManager/AddonManagerTest/app/test_addon.py
+++ b/src/Mod/AddonManager/AddonManagerTest/app/test_addon.py
@@ -147,7 +147,7 @@ class TestAddon(unittest.TestCase):
         self.assertTrue(addon_m.contains_macro())
         self.assertFalse(addon_m.contains_preference_pack())
 
-        # There is no equivalent for preference packs, they are always accompanied by a 
+        # There is no equivalent for preference packs, they are always accompanied by a
         # metadata file
 
     def test_create_from_macro(self):
@@ -175,7 +175,7 @@ class TestAddon(unittest.TestCase):
         self.assertTrue(addon.__dict__, second_addon.__dict__)
 
     def test_dependency_resolution(self):
-        
+
         addonA = Addon("AddonA","https://github.com/FreeCAD/FakeAddonA", Addon.Status.NOT_INSTALLED, "master")
         addonB = Addon("AddonB","https://github.com/FreeCAD/FakeAddonB", Addon.Status.NOT_INSTALLED, "master")
         addonC = Addon("AddonC","https://github.com/FreeCAD/FakeAddonC", Addon.Status.NOT_INSTALLED, "master")

--- a/src/Mod/AddonManager/AddonManagerTest/app/test_macro.py
+++ b/src/Mod/AddonManager/AddonManagerTest/app/test_macro.py
@@ -54,7 +54,7 @@ class TestMacro(unittest.TestCase):
         self.assertEqual(m.author, replacements["AUTHOR"])
         self.assertEqual(m.date, replacements["DATE"])
         self.assertEqual(m.icon, replacements["ICON"])
-    
+
     def test_other_files(self):
         replacements = {
             "FILES": "file_a,file_b,file_c",

--- a/src/Mod/AddonManager/AddonManagerTest/test_information.md
+++ b/src/Mod/AddonManager/AddonManagerTest/test_information.md
@@ -1,3 +1,3 @@
 ## Unit tests for the Addon Manager
 
-Data files are located in the data/ subdirectory.
+Data files are located in the `data/` subdirectory.

--- a/src/Mod/AddonManager/package_details.py
+++ b/src/Mod/AddonManager/package_details.py
@@ -555,8 +555,8 @@ class PackageDetails(QWidget):
                 sibling = article.previousSibling;
             }
         }
-    } else if (url.hostname === "gitlab.com" || 
-               url.hostname === "framagit.org" || 
+    } else if (url.hostname === "gitlab.com" ||
+               url.hostname === "framagit.org" ||
                url.hostname === "salsa.debian.org") {
         // These all use the GitLab page display...
         const articles = document.getElementsByTagName("article");
@@ -570,7 +570,7 @@ class PackageDetails(QWidget):
                 sibling = article.previousSibling;
             }
         }
-    } else if (url.hostname === "wiki.freecad.org" || 
+    } else if (url.hostname === "wiki.freecad.org" ||
                url.hostname === "wiki.freecadweb.org") {
         const first_heading = document.getElementById('firstHeading');
         const body_content = document.getElementById('bodyContent');


### PR DESCRIPTION
Pretty self-explanatory. I also tacked on a small markdown tweek [11088a6](https://github.com/FreeCAD/FreeCAD/pull/7905/commits/11088a62ac2c43e440ba8db52a5ff10fa7ee6584), if that's OK?