### PR TITLE
L10N: Don't translate "..." string

### DIFF
--- a/src/Gui/DemoMode.ui
+++ b/src/Gui/DemoMode.ui
@@ -47,7 +47,7 @@
          <item row="0" column="0">
           <widget class="QLabel" name="label_3">
            <property name="text">
-            <string>-90°</string>
+            <string notr="true">-90°</string>
            </property>
           </widget>
          </item>
@@ -67,7 +67,7 @@
          <item row="0" column="2">
           <widget class="QLabel" name="label_4">
            <property name="text">
-            <string>90°</string>
+            <string notr="true">90°</string>
            </property>
           </widget>
          </item>

--- a/src/Gui/DlgActions.ui
+++ b/src/Gui/DlgActions.ui
@@ -147,7 +147,7 @@
          </size>
         </property>
         <property name="text">
-         <string>...</string>
+         <string notr="true">...</string>
         </property>
        </widget>
       </item>

--- a/src/Gui/DlgLocationAngle.ui
+++ b/src/Gui/DlgLocationAngle.ui
@@ -94,42 +94,42 @@
      </property>
      <item>
       <property name="text">
-       <string>1 °</string>
+       <string notr="true">1 °</string>
       </property>
      </item>
      <item>
       <property name="text">
-       <string>2 °</string>
+       <string notr="true">2 °</string>
       </property>
      </item>
      <item>
       <property name="text">
-       <string>5 °</string>
+       <string notr="true">5 °</string>
       </property>
      </item>
      <item>
       <property name="text">
-       <string>10 °</string>
+       <string notr="true">10 °</string>
       </property>
      </item>
      <item>
       <property name="text">
-       <string>20 °</string>
+       <string notr="true">20 °</string>
       </property>
      </item>
      <item>
       <property name="text">
-       <string>45 °</string>
+       <string notr="true">45 °</string>
       </property>
      </item>
      <item>
       <property name="text">
-       <string>90 °</string>
+       <string notr="true">90 °</string>
       </property>
      </item>
      <item>
       <property name="text">
-       <string>180 °</string>
+       <string notr="true">180 °</string>
       </property>
      </item>
     </widget>

--- a/src/Gui/DlgMacroRecord.ui
+++ b/src/Gui/DlgMacroRecord.ui
@@ -96,7 +96,7 @@
          </size>
         </property>
         <property name="text">
-         <string>...</string>
+         <string notr="true">...</string>
         </property>
        </widget>
       </item>

--- a/src/Gui/DlgMaterialProperties.ui
+++ b/src/Gui/DlgMaterialProperties.ui
@@ -140,7 +140,7 @@
         <item>
          <widget class="QSpinBox" name="shininess">
           <property name="suffix">
-           <string>%</string>
+           <string notr="true">%</string>
           </property>
           <property name="singleStep">
            <number>5</number>

--- a/src/Gui/DlgRunExternal.ui
+++ b/src/Gui/DlgRunExternal.ui
@@ -84,7 +84,7 @@
         <item>
          <widget class="QPushButton" name="chooseProgram">
           <property name="text">
-           <string>...</string>
+           <string notr="true">...</string>
           </property>
          </widget>
         </item>

--- a/src/Gui/DlgSettings3DView.ui
+++ b/src/Gui/DlgSettings3DView.ui
@@ -83,7 +83,7 @@ in the corner -- in % of height/width of viewport</string>
            <number>10</number>
           </property>
           <property name="suffix">
-           <string>%</string>
+           <string notr="true">%</string>
           </property>
           <property name="prefEntry" stdset="0">
            <cstring>CornerCoordSystemSize</cstring>

--- a/src/Gui/DlgSettingsUnits.ui
+++ b/src/Gui/DlgSettingsUnits.ui
@@ -78,37 +78,37 @@
           </property>
           <item>
            <property name="text">
-            <string>1/2"</string>
+            <string notr="true">1/2"</string>
            </property>
           </item>
           <item>
            <property name="text">
-            <string>1/4"</string>
+            <string notr="true">1/4"</string>
            </property>
           </item>
           <item>
            <property name="text">
-            <string>1/8"</string>
+            <string notr="true">1/8"</string>
            </property>
           </item>
           <item>
            <property name="text">
-            <string>1/16"</string>
+            <string notr="true">1/16"</string>
            </property>
           </item>
           <item>
            <property name="text">
-            <string>1/32"</string>
+            <string notr="true">1/32"</string>
            </property>
           </item>
           <item>
            <property name="text">
-            <string>1/64"</string>
+            <string notr="true">1/64"</string>
            </property>
           </item>
           <item>
            <property name="text">
-            <string>1/128"</string>
+            <string notr="true">1/128"</string>
            </property>
           </item>
          </widget>

--- a/src/Gui/TaskView/TaskSelectLinkProperty.ui
+++ b/src/Gui/TaskView/TaskSelectLinkProperty.ui
@@ -19,21 +19,21 @@
      <item>
       <widget class="QToolButton" name="Remove">
        <property name="text">
-        <string>...</string>
+        <string notr="true">...</string>
        </property>
       </widget>
      </item>
      <item>
       <widget class="QToolButton" name="Add">
        <property name="text">
-        <string>...</string>
+        <string notr="true">...</string>
        </property>
       </widget>
      </item>
      <item>
       <widget class="QToolButton" name="Invert">
        <property name="text">
-        <string>...</string>
+        <string notr="true">...</string>
        </property>
       </widget>
      </item>
@@ -53,7 +53,7 @@
      <item>
       <widget class="QToolButton" name="Help">
        <property name="text">
-        <string>...</string>
+        <string notr="true">...</string>
        </property>
       </widget>
      </item>

--- a/src/Gui/VectorListEditor.ui
+++ b/src/Gui/VectorListEditor.ui
@@ -120,7 +120,7 @@
      <item>
       <widget class="QToolButton" name="toolButtonMouse">
        <property name="text">
-        <string>...</string>
+        <string notr="true">...</string>
        </property>
        <property name="icon">
         <iconset resource="Icons/resource.qrc">
@@ -131,7 +131,7 @@
      <item>
       <widget class="QToolButton" name="toolButtonAdd">
        <property name="text">
-        <string>...</string>
+        <string notr="true">...</string>
        </property>
        <property name="icon">
         <iconset resource="Icons/resource.qrc">
@@ -142,7 +142,7 @@
      <item>
       <widget class="QToolButton" name="toolButtonRemove">
        <property name="text">
-        <string>...</string>
+        <string notr="true">...</string>
        </property>
        <property name="icon">
         <iconset resource="Icons/resource.qrc">
@@ -153,7 +153,7 @@
      <item>
       <widget class="QToolButton" name="toolButtonAccept">
        <property name="text">
-        <string>...</string>
+        <string notr="true">...</string>
        </property>
        <property name="icon">
         <iconset resource="Icons/resource.qrc">

--- a/src/Mod/AddonManager/AddonManagerOptions.ui
+++ b/src/Mod/AddonManager/AddonManagerOptions.ui
@@ -185,14 +185,14 @@ installed addons will be checked for available updates
      <item>
       <widget class="QToolButton" name="addCustomRepositoryButton">
        <property name="text">
-        <string>...</string>
+        <string notr="true">...</string>
        </property>
       </widget>
      </item>
      <item>
       <widget class="QToolButton" name="removeCustomRepositoryButton">
        <property name="text">
-        <string>...</string>
+        <string notr="true">...</string>
        </property>
       </widget>
      </item>

--- a/src/Mod/AddonManager/developer_mode.ui
+++ b/src/Mod/AddonManager/developer_mode.ui
@@ -298,14 +298,14 @@
         <item>
          <widget class="QToolButton" name="addContentItemToolButton">
           <property name="text">
-           <string>...</string>
+           <string notr="true">...</string>
           </property>
          </widget>
         </item>
         <item>
          <widget class="QToolButton" name="removeContentItemToolButton">
           <property name="text">
-           <string>...</string>
+           <string notr="true">...</string>
           </property>
          </widget>
         </item>

--- a/src/Mod/AddonManager/developer_mode_advanced_freecad_versions.ui
+++ b/src/Mod/AddonManager/developer_mode_advanced_freecad_versions.ui
@@ -68,14 +68,14 @@
      <item>
       <widget class="QToolButton" name="addEntryToolButton">
        <property name="text">
-        <string>...</string>
+        <string notr="true">...</string>
        </property>
       </widget>
      </item>
      <item>
       <widget class="QToolButton" name="removeEntryToolButton">
        <property name="text">
-        <string>...</string>
+        <string notr="true">...</string>
        </property>
       </widget>
      </item>

--- a/src/Mod/AddonManager/developer_mode_dependencies.ui
+++ b/src/Mod/AddonManager/developer_mode_dependencies.ui
@@ -69,14 +69,14 @@
      <item>
       <widget class="QToolButton" name="addDependencyToolButton">
        <property name="text">
-        <string>...</string>
+        <string notr="true">...</string>
        </property>
       </widget>
      </item>
      <item>
       <widget class="QToolButton" name="removeDependencyToolButton">
        <property name="text">
-        <string>...</string>
+        <string notr="true">...</string>
        </property>
       </widget>
      </item>

--- a/src/Mod/AddonManager/developer_mode_licenses_table.ui
+++ b/src/Mod/AddonManager/developer_mode_licenses_table.ui
@@ -94,7 +94,7 @@
         <item>
          <widget class="QToolButton" name="addButton">
           <property name="text">
-           <string>...</string>
+           <string notr="true">...</string>
           </property>
           <property name="autoRaise">
            <bool>true</bool>
@@ -104,7 +104,7 @@
         <item>
          <widget class="QToolButton" name="removeButton">
           <property name="text">
-           <string>...</string>
+           <string notr="true">...</string>
           </property>
           <property name="autoRaise">
            <bool>true</bool>

--- a/src/Mod/AddonManager/developer_mode_people_table.ui
+++ b/src/Mod/AddonManager/developer_mode_people_table.ui
@@ -87,7 +87,7 @@
         <item>
          <widget class="QToolButton" name="addButton">
           <property name="text">
-           <string>...</string>
+           <string notr="true">...</string>
           </property>
           <property name="autoRaise">
            <bool>true</bool>
@@ -97,7 +97,7 @@
         <item>
          <widget class="QToolButton" name="removeButton">
           <property name="text">
-           <string>...</string>
+           <string notr="true">...</string>
           </property>
           <property name="autoRaise">
            <bool>true</bool>

--- a/src/Mod/AddonManager/package_details.ui
+++ b/src/Mod/AddonManager/package_details.ui
@@ -26,7 +26,7 @@
      <item>
       <widget class="QToolButton" name="buttonRefresh">
        <property name="text">
-        <string>...</string>
+        <string notr="true">...</string>
        </property>
       </widget>
      </item>

--- a/src/Mod/Arch/Resources/ui/ArchNest.ui
+++ b/src/Mod/Arch/Resources/ui/ArchNest.ui
@@ -132,7 +132,7 @@
          <string>A comma-separated list of angles to try and rotate the shapes</string>
         </property>
         <property name="text">
-         <string>0,90,180,270</string>
+         <string notr="true">0,90,180,270</string>
         </property>
        </widget>
       </item>

--- a/src/Mod/Arch/Resources/ui/preferences-arch.ui
+++ b/src/Mod/Arch/Resources/ui/preferences-arch.ui
@@ -586,7 +586,7 @@
 to projections of hidden objects.</string>
           </property>
           <property name="text">
-           <string>30, 10</string>
+           <string notr="true">30, 10</string>
           </property>
           <property name="alignment">
            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>

--- a/src/Mod/Draft/Resources/ui/TaskPanel_SetStyle.ui
+++ b/src/Mod/Draft/Resources/ui/TaskPanel_SetStyle.ui
@@ -183,7 +183,7 @@
          <string>The transparency of faces</string>
         </property>
         <property name="suffix">
-         <string> %</string>
+         <string notr="true"> %</string>
         </property>
         <property name="maximum">
          <number>100</number>

--- a/src/Mod/Draft/Resources/ui/dialogHatch.ui
+++ b/src/Mod/Draft/Resources/ui/dialogHatch.ui
@@ -68,7 +68,7 @@
    <item row="3" column="1">
     <widget class="QDoubleSpinBox" name="Rotation">
      <property name="suffix">
-      <string>°</string>
+      <string notr="true">°</string>
      </property>
      <property name="maximum">
       <double>359.990000000000009</double>

--- a/src/Mod/Draft/Resources/ui/preferences-draftinterface.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-draftinterface.ui
@@ -605,7 +605,7 @@
            </size>
           </property>
           <property name="text">
-           <string>`</string>
+           <string notr="true">`</string>
           </property>
           <property name="maxLength">
            <number>1</number>
@@ -693,7 +693,7 @@
            </size>
           </property>
           <property name="text">
-           <string>/</string>
+           <string notr="true">/</string>
           </property>
           <property name="maxLength">
            <number>1</number>
@@ -781,7 +781,7 @@
            </size>
           </property>
           <property name="text">
-           <string>[</string>
+           <string notr="true">[</string>
           </property>
           <property name="maxLength">
            <number>1</number>
@@ -825,7 +825,7 @@
            </size>
           </property>
           <property name="text">
-           <string>]</string>
+           <string notr="true">]</string>
           </property>
           <property name="maxLength">
            <number>1</number>

--- a/src/Mod/Draft/Resources/ui/preferences-draftvisual.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-draftvisual.ui
@@ -395,7 +395,7 @@
            <string>An SVG linestyle definition</string>
           </property>
           <property name="text">
-           <string>0.09,0.05</string>
+           <string notr="true">0.09,0.05</string>
           </property>
           <property name="alignment">
            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -438,7 +438,7 @@
            <string>An SVG linestyle definition</string>
           </property>
           <property name="text">
-           <string>0.09,0.05,0.02,0.05</string>
+           <string notr="true">0.09,0.05,0.02,0.05</string>
           </property>
           <property name="alignment">
            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -481,7 +481,7 @@
            <string>An SVG linestyle definition</string>
           </property>
           <property name="text">
-           <string>0.02,0.02</string>
+           <string notr="true">0.02,0.02</string>
           </property>
           <property name="alignment">
            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>

--- a/src/Mod/Fem/Gui/Resources/ui/ElementFluid1D.ui
+++ b/src/Mod/Fem/Gui/Resources/ui/ElementFluid1D.ui
@@ -618,27 +618,27 @@
               <widget class="QTableWidget" name="tw_pump_characteristics">
                <row>
                 <property name="text">
-                 <string>1</string>
+                 <string notr="true">1</string>
                 </property>
                </row>
                <row>
                 <property name="text">
-                 <string>2</string>
+                 <string notr="true">2</string>
                 </property>
                </row>
                <row>
                 <property name="text">
-                 <string>3</string>
+                 <string notr="true">3</string>
                 </property>
                </row>
                <row>
                 <property name="text">
-                 <string>4</string>
+                 <string notr="true">4</string>
                 </property>
                </row>
                <row>
                 <property name="text">
-                 <string>5</string>
+                 <string notr="true">5</string>
                 </property>
                </row>
                <column>

--- a/src/Mod/Fem/Gui/Resources/ui/SolverCalculix.ui
+++ b/src/Mod/Fem/Gui/Resources/ui/SolverCalculix.ui
@@ -42,7 +42,7 @@
          <bool>true</bool>
         </property>
         <property name="text">
-         <string>...</string>
+         <string notr="true">...</string>
         </property>
        </widget>
       </item>

--- a/src/Mod/Fem/Gui/TaskFemConstraintSpring.ui
+++ b/src/Mod/Fem/Gui/TaskFemConstraintSpring.ui
@@ -85,7 +85,7 @@
      <item row="0" column="1">
       <widget class="Gui::InputField" name="if_norm">
        <property name="text">
-        <string>0 </string>
+        <string notr="true">0 </string>
        </property>
        <property name="unit" stdset="0">
         <string notr="true"/>

--- a/src/Mod/Fem/Gui/TaskPanelConstraintTemperature.ui
+++ b/src/Mod/Fem/Gui/TaskPanelConstraintTemperature.ui
@@ -49,7 +49,7 @@
     </rect>
    </property>
    <property name="text">
-    <string>25</string>
+    <string notr="true">25</string>
    </property>
    <property name="alignment">
     <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>

--- a/src/Mod/Fem/Gui/TaskPanelInitialTemperature.ui
+++ b/src/Mod/Fem/Gui/TaskPanelInitialTemperature.ui
@@ -53,7 +53,7 @@
     </rect>
    </property>
    <property name="text">
-    <string>25</string>
+    <string notr="true">25</string>
    </property>
    <property name="alignment">
     <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>

--- a/src/Mod/Fem/Gui/TaskPostScalarClip.ui
+++ b/src/Mod/Fem/Gui/TaskPostScalarClip.ui
@@ -141,7 +141,7 @@
         </sizepolicy>
        </property>
        <property name="text">
-        <string>-100000</string>
+        <string notr="true">-100000</string>
        </property>
       </widget>
      </item>
@@ -185,7 +185,7 @@
         <enum>Qt::LeftToRight</enum>
        </property>
        <property name="text">
-        <string>0</string>
+        <string notr="true">0</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>

--- a/src/Mod/Mesh/Gui/DlgSettingsMeshView.ui
+++ b/src/Mod/Mesh/Gui/DlgSettingsMeshView.ui
@@ -120,7 +120,7 @@
         <item row="0" column="4">
          <widget class="Gui::PrefSpinBox" name="spinMeshTransparency">
           <property name="suffix">
-           <string>%</string>
+           <string notr="true">%</string>
           </property>
           <property name="maximum">
            <number>100</number>
@@ -189,7 +189,7 @@
         <item row="1" column="4">
          <widget class="Gui::PrefSpinBox" name="spinLineTransparency">
           <property name="suffix">
-           <string>%</string>
+           <string notr="true">%</string>
           </property>
           <property name="maximum">
            <number>100</number>
@@ -372,7 +372,7 @@ to a smoother appearance.
  If face angle &lt; crease angle, smooth shading is used</string>
         </property>
         <property name="suffix">
-         <string> °</string>
+         <string notr="true"> °</string>
         </property>
         <property name="maximum">
          <double>180.000000000000000</double>

--- a/src/Mod/OpenSCAD/Resources/ui/openscadprefs-base.ui
+++ b/src/Mod/OpenSCAD/Resources/ui/openscadprefs-base.ui
@@ -296,7 +296,7 @@
            <string>Minimum angle for a fragment</string>
           </property>
           <property name="suffix">
-           <string>°</string>
+           <string notr="true">°</string>
           </property>
           <property name="minimum">
            <double>0.010000000000000</double>

--- a/src/Mod/Part/Gui/DlgPartImportIges.ui
+++ b/src/Mod/Part/Gui/DlgPartImportIges.ui
@@ -51,7 +51,7 @@
          </size>
         </property>
         <property name="text">
-         <string>...</string>
+         <string notr="true">...</string>
         </property>
        </widget>
       </item>

--- a/src/Mod/Part/Gui/DlgPartImportStep.ui
+++ b/src/Mod/Part/Gui/DlgPartImportStep.ui
@@ -51,7 +51,7 @@
          </size>
         </property>
         <property name="text">
-         <string>...</string>
+         <string notr="true">...</string>
         </property>
        </widget>
       </item>

--- a/src/Mod/Part/Gui/DlgSettings3DViewPart.ui
+++ b/src/Mod/Part/Gui/DlgSettings3DViewPart.ui
@@ -56,7 +56,7 @@
         <item row="0" column="1">
          <widget class="Gui::PrefDoubleSpinBox" name="maxDeviation">
           <property name="suffix">
-           <string> %</string>
+           <string notr="true"> %</string>
           </property>
           <property name="decimals">
            <number>4</number>
@@ -91,7 +91,7 @@
         <item row="1" column="1">
          <widget class="Gui::PrefDoubleSpinBox" name="maxAngularDeflection">
           <property name="suffix">
-           <string> °</string>
+           <string notr="true"> °</string>
           </property>
           <property name="decimals">
            <number>2</number>

--- a/src/Mod/Part/Gui/DlgSettingsObjectColor.ui
+++ b/src/Mod/Part/Gui/DlgSettingsObjectColor.ui
@@ -90,7 +90,7 @@
            <string>The default transparency for new shapes</string>
           </property>
           <property name="suffix">
-           <string>%</string>
+           <string notr="true">%</string>
           </property>
           <property name="maximum">
            <number>100</number>

--- a/src/Mod/Part/Gui/SectionCutting.ui
+++ b/src/Mod/Part/Gui/SectionCutting.ui
@@ -339,7 +339,7 @@ Works only if all objects have the same values.</string>
          <bool>false</bool>
         </property>
         <property name="toolTip">
-         <string>0 %</string>
+         <string notr="true">0 %</string>
         </property>
         <property name="maximum">
          <number>100</number>

--- a/src/Mod/Path/Gui/Resources/panels/PageDepthsEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PageDepthsEdit.ui
@@ -59,7 +59,7 @@
       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Transfer the Z value of the selected feature as the Start Depth for the operation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="text">
-      <string>...</string>
+      <string notr="true">...</string>
      </property>
      <property name="icon">
       <iconset>
@@ -105,7 +105,7 @@
       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Transfer the Z value of the selected feature as the Final Depth for the operation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="text">
-      <string>...</string>
+      <string notr="true">...</string>
      </property>
      <property name="icon">
       <iconset>

--- a/src/Mod/Path/Gui/Resources/panels/PageDiametersEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PageDiametersEdit.ui
@@ -43,7 +43,7 @@
       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Transfer the Z value of the selected feature as the Start Depth for the operation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="text">
-      <string>...</string>
+      <string notr="true">...</string>
      </property>
      <property name="icon">
       <iconset resource="../../../../../Gui/Icons/resource.qrc">
@@ -80,7 +80,7 @@
       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Transfer the Z value of the selected feature as the Final Depth for the operation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="text">
-      <string>...</string>
+      <string notr="true">...</string>
      </property>
      <property name="icon">
       <iconset resource="../../../../../Gui/Icons/resource.qrc">

--- a/src/Mod/Path/Gui/Resources/panels/PageOpProbeEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PageOpProbeEdit.ui
@@ -152,7 +152,7 @@
       <item row="0" column="2">
        <widget class="QToolButton" name="SetOutputFileName">
         <property name="text">
-         <string>...</string>
+         <string notr="true">...</string>
         </property>
        </widget>
       </item>

--- a/src/Mod/Path/Gui/Resources/panels/PathEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PathEdit.ui
@@ -145,7 +145,7 @@
     <item row="0" column="2">
      <widget class="QToolButton" name="postProcessorSetOutputFile">
       <property name="text">
-       <string>...</string>
+       <string notr="true">...</string>
       </property>
      </widget>
     </item>
@@ -1403,7 +1403,7 @@
          <item>
           <widget class="QToolButton" name="operationUp">
            <property name="text">
-            <string>...</string>
+            <string notr="true">...</string>
            </property>
            <property name="icon">
             <iconset resource="../../../../../Gui/Icons/resource.qrc">
@@ -1414,7 +1414,7 @@
          <item>
           <widget class="QToolButton" name="operationDown">
            <property name="text">
-            <string>...</string>
+            <string notr="true">...</string>
            </property>
            <property name="icon">
             <iconset resource="../../../../../Gui/Icons/resource.qrc">

--- a/src/Mod/Path/Gui/Resources/panels/TaskPathSimulator.ui
+++ b/src/Mod/Path/Gui/Resources/panels/TaskPathSimulator.ui
@@ -258,7 +258,7 @@
         </size>
        </property>
        <property name="text">
-        <string>%</string>
+        <string notr="true">%</string>
        </property>
       </widget>
      </item>

--- a/src/Mod/Path/Gui/Resources/panels/ToolBitEditor.ui
+++ b/src/Mod/Path/Gui/Resources/panels/ToolBitEditor.ui
@@ -135,10 +135,10 @@
           <item row="0" column="1">
            <widget class="Gui::InputField" name="toolCuttingEdgeAngle">
             <property name="text">
-             <string>0 °</string>
+             <string notr="true">0 °</string>
             </property>
             <property name="unit" stdset="0">
-             <string>°</string>
+             <string notr="true">°</string>
             </property>
            </widget>
           </item>

--- a/src/Mod/Path/Gui/Resources/panels/ToolBitEditor.ui
+++ b/src/Mod/Path/Gui/Resources/panels/ToolBitEditor.ui
@@ -106,7 +106,7 @@
                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Change file defining type and shape of Tool Bit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                </property>
                <property name="text">
-                <string>...</string>
+                <string notr="true">...</string>
                </property>
               </widget>
              </item>

--- a/src/Mod/Path/Gui/Resources/panels/ToolEditor.ui
+++ b/src/Mod/Path/Gui/Resources/panels/ToolEditor.ui
@@ -71,7 +71,7 @@
       <item row="3" column="1">
        <widget class="Gui::InputField" name="toolLengthOffset">
         <property name="text">
-         <string>0.00</string>
+         <string notr="true">0.00</string>
         </property>
         <property name="unit" stdset="0">
          <string>mm</string>
@@ -128,7 +128,7 @@
       <item row="1" column="1">
        <widget class="Gui::InputField" name="toolDiameter">
         <property name="text">
-         <string>0.00</string>
+         <string notr="true">0.00</string>
         </property>
         <property name="unit" stdset="0">
          <string>mm</string>
@@ -138,7 +138,7 @@
       <item row="3" column="1">
        <widget class="Gui::InputField" name="toolFlatRadius">
         <property name="text">
-         <string>0.00</string>
+         <string notr="true">0.00</string>
         </property>
         <property name="unit" stdset="0">
          <string>mm</string>
@@ -148,7 +148,7 @@
       <item row="4" column="1">
        <widget class="Gui::InputField" name="toolCornerRadius">
         <property name="text">
-         <string>0.00</string>
+         <string notr="true">0.00</string>
         </property>
         <property name="unit" stdset="0">
          <string>mm</string>
@@ -158,17 +158,17 @@
       <item row="5" column="1">
        <widget class="Gui::InputField" name="toolCuttingEdgeAngle">
         <property name="text">
-         <string>180°</string>
+         <string notr="true">180°</string>
         </property>
         <property name="unit" stdset="0">
-         <string>°</string>
+         <string notr="true">°</string>
         </property>
        </widget>
       </item>
       <item row="6" column="1">
        <widget class="Gui::InputField" name="toolCuttingEdgeHeight">
         <property name="text">
-         <string>0.00</string>
+         <string notr="true">0.00</string>
         </property>
         <property name="unit" stdset="0">
          <string>mm</string>
@@ -200,7 +200,7 @@
          <item row="1" column="1">
           <widget class="Gui::InputField" name="value_D">
            <property name="text">
-            <string>0.00</string>
+            <string notr="true">0.00</string>
            </property>
            <property name="unit" stdset="0">
             <string>mm</string>
@@ -217,7 +217,7 @@
          <item row="2" column="1">
           <widget class="Gui::InputField" name="value_d">
            <property name="text">
-            <string>0.00</string>
+            <string notr="true">0.00</string>
            </property>
            <property name="unit" stdset="0">
             <string>mm</string>
@@ -234,7 +234,7 @@
          <item row="3" column="1">
           <widget class="Gui::InputField" name="value_H">
            <property name="text">
-            <string>0.00</string>
+            <string notr="true">0.00</string>
            </property>
            <property name="unit" stdset="0">
             <string>mm</string>
@@ -244,17 +244,17 @@
          <item row="4" column="0">
           <widget class="QLabel" name="label_a">
            <property name="text">
-            <string>α = </string>
+            <string notr="true">α = </string>
            </property>
           </widget>
          </item>
          <item row="4" column="1">
           <widget class="Gui::InputField" name="value_a">
            <property name="text">
-            <string>180°</string>
+            <string notr="true">180°</string>
            </property>
            <property name="unit" stdset="0">
-            <string>°</string>
+            <string notr="true">°</string>
            </property>
           </widget>
          </item>
@@ -274,7 +274,7 @@
             <bool>false</bool>
            </property>
            <property name="text">
-            <string>0.00</string>
+            <string notr="true">0.00</string>
            </property>
            <property name="unit" stdset="0">
             <string>mm</string>

--- a/src/Mod/Path/Gui/Resources/panels/ZCorrectEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/ZCorrectEdit.ui
@@ -61,7 +61,7 @@
           <item row="0" column="2">
            <widget class="QToolButton" name="SetProbePointFileName">
             <property name="text">
-             <string>...</string>
+             <string notr="true">...</string>
             </property>
            </widget>
           </item>

--- a/src/Mod/Path/Gui/Resources/preferences/PathJob.ui
+++ b/src/Mod/Path/Gui/Resources/preferences/PathJob.ui
@@ -55,7 +55,7 @@
           <item row="0" column="3">
            <widget class="QToolButton" name="tbDefaultFilePath">
             <property name="text">
-             <string>...</string>
+             <string notr="true">...</string>
             </property>
            </widget>
           </item>
@@ -76,7 +76,7 @@
           <item row="1" column="3">
            <widget class="QToolButton" name="tbDefaultJobTemplate">
             <property name="text">
-             <string>...</string>
+             <string notr="true">...</string>
             </property>
            </widget>
           </item>
@@ -186,7 +186,7 @@
             <item>
              <widget class="QToolButton" name="tbOutputFile">
               <property name="text">
-               <string>...</string>
+               <string notr="true">...</string>
               </property>
              </widget>
             </item>

--- a/src/Mod/Points/Gui/DlgPointsRead.ui
+++ b/src/Mod/Points/Gui/DlgPointsRead.ui
@@ -154,12 +154,12 @@
           </property>
           <item>
            <property name="text">
-            <string>,</string>
+            <string notr="true">,</string>
            </property>
           </item>
           <item>
            <property name="text">
-            <string>;</string>
+            <string notr="true">;</string>
            </property>
           </item>
           <item>
@@ -345,7 +345,7 @@
         <item>
          <widget class="QLineEdit" name="lineEditPreviewLines">
           <property name="text">
-           <string>100</string>
+           <string notr="true">100</string>
           </property>
          </widget>
         </item>

--- a/src/Mod/Robot/Gui/TaskRobot6Axis.ui
+++ b/src/Mod/Robot/Gui/TaskRobot6Axis.ui
@@ -342,7 +342,7 @@
         </size>
        </property>
        <property name="text">
-        <string>...</string>
+        <string notr="true">...</string>
        </property>
       </widget>
      </item>

--- a/src/Mod/Robot/Gui/TaskTrajectory.ui
+++ b/src/Mod/Robot/Gui/TaskTrajectory.ui
@@ -117,7 +117,7 @@
         </font>
        </property>
        <property name="text">
-        <string>||</string>
+        <string notr="true">||</string>
        </property>
       </widget>
      </item>
@@ -234,7 +234,7 @@
      <item>
       <widget class="QSpinBox" name="Override">
        <property name="suffix">
-        <string>%</string>
+        <string notr="true">%</string>
        </property>
        <property name="maximum">
         <number>100</number>

--- a/src/Mod/Robot/Gui/TaskTrajectoryDressUpParameter.ui
+++ b/src/Mod/Robot/Gui/TaskTrajectoryDressUpParameter.ui
@@ -133,7 +133,7 @@
      <item>
       <widget class="QLineEdit" name="lineEditPlacement">
        <property name="text">
-        <string>(0,0,0),(0,0,0)</string>
+        <string notr="true">(0,0,0),(0,0,0)</string>
        </property>
        <property name="readOnly">
         <bool>true</bool>

--- a/src/Mod/Robot/Gui/TaskTrajectoryDressUpParameter.ui
+++ b/src/Mod/Robot/Gui/TaskTrajectoryDressUpParameter.ui
@@ -146,7 +146,7 @@
         <bool>false</bool>
        </property>
        <property name="text">
-        <string>...</string>
+        <string notr="true">...</string>
        </property>
       </widget>
      </item>

--- a/src/Mod/Robot/Gui/TrajectorySimulate.ui
+++ b/src/Mod/Robot/Gui/TrajectorySimulate.ui
@@ -117,7 +117,7 @@
         </font>
        </property>
        <property name="text">
-        <string>||</string>
+        <string notr="true">||</string>
        </property>
       </widget>
      </item>
@@ -234,7 +234,7 @@
      <item>
       <widget class="QSpinBox" name="Override">
        <property name="suffix">
-        <string>%</string>
+        <string notr="true">%</string>
        </property>
        <property name="maximum">
         <number>100</number>

--- a/src/Mod/Sketcher/Gui/TaskSketcherConstraints.ui
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstraints.ui
@@ -43,7 +43,7 @@
         <string notr="true">padding-right: 0px; margin-right: 0px</string>
        </property>
        <property name="text">
-        <string></string>
+        <string notr="true"></string>
        </property>
       </widget>
      </item>

--- a/src/Mod/Sketcher/Gui/TaskSketcherElements.ui
+++ b/src/Mod/Sketcher/Gui/TaskSketcherElements.ui
@@ -43,7 +43,7 @@
         <string notr="true">padding-right: 0px; margin-right: 0px</string>
        </property>
        <property name="text">
-        <string></string>
+        <string notr="true"></string>
        </property>
       </widget>
      </item>

--- a/src/Mod/Spreadsheet/Gui/DlgSettings.ui
+++ b/src/Mod/Spreadsheet/Gui/DlgSettings.ui
@@ -76,12 +76,12 @@
         </item>
         <item>
          <property name="text">
-          <string>;</string>
+          <string notr="true">;</string>
          </property>
         </item>
         <item>
          <property name="text">
-          <string>,</string>
+          <string notr="true">,</string>
          </property>
         </item>
        </widget>
@@ -108,7 +108,7 @@
          <string/>
         </property>
         <property name="text">
-         <string>"</string>
+         <string notr="true">"</string>
         </property>
         <property name="prefEntry" stdset="0">
          <cstring>ImportExportQuoteCharacter</cstring>
@@ -137,7 +137,7 @@
          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Escape character, typically the backslash (\), used to indicate special unprintable characters, e.g. \t = tab. Must be a single character.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
         <property name="text">
-         <string>\</string>
+         <string notr="true">\</string>
         </property>
         <property name="prefEntry" stdset="0">
          <cstring>ImportExportEscapeCharacter</cstring>

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawDimensions.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawDimensions.ui
@@ -407,7 +407,7 @@ Multiplier of 'Font Size'</string>
            <string>Character used to indicate diameter dimensions</string>
           </property>
           <property name="text">
-           <string>⌀</string>
+           <string notr="true">⌀</string>
           </property>
           <property name="alignment">
            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>

--- a/src/Mod/TechDraw/Gui/TaskMoveView.ui
+++ b/src/Mod/TechDraw/Gui/TaskMoveView.ui
@@ -33,7 +33,7 @@
      <item row="0" column="2">
       <widget class="QPushButton" name="pbView">
        <property name="text">
-        <string>...</string>
+        <string notr="true">...</string>
        </property>
       </widget>
      </item>
@@ -54,7 +54,7 @@
      <item row="1" column="2">
       <widget class="QPushButton" name="pbFromPage">
        <property name="text">
-        <string>...</string>
+        <string notr="true">...</string>
        </property>
       </widget>
      </item>
@@ -75,7 +75,7 @@
      <item row="2" column="2">
       <widget class="QPushButton" name="pbToPage">
        <property name="text">
-        <string>...</string>
+        <string notr="true">...</string>
        </property>
       </widget>
      </item>

--- a/src/Mod/TechDraw/Gui/TaskProjGroup.ui
+++ b/src/Mod/TechDraw/Gui/TaskProjGroup.ui
@@ -133,7 +133,7 @@
      <item>
       <widget class="QLabel" name="label_4">
        <property name="text">
-        <string>:</string>
+        <string notr="true">:</string>
        </property>
       </widget>
      </item>

--- a/src/Mod/TechDraw/Gui/TaskRestoreLines.ui
+++ b/src/Mod/TechDraw/Gui/TaskRestoreLines.ui
@@ -26,7 +26,7 @@
      <item row="0" column="1">
       <widget class="QLabel" name="l_All">
        <property name="text">
-        <string>0</string>
+        <string notr="true">0</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignCenter</set>
@@ -43,7 +43,7 @@
      <item row="1" column="1">
       <widget class="QLabel" name="l_Geometry">
        <property name="text">
-        <string>0</string>
+        <string notr="true">0</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignCenter</set>
@@ -60,7 +60,7 @@
      <item row="2" column="1">
       <widget class="QLabel" name="l_Cosmetic">
        <property name="text">
-        <string>0</string>
+        <string notr="true">0</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignCenter</set>
@@ -77,7 +77,7 @@
      <item row="3" column="1">
       <widget class="QLabel" name="l_Center">
        <property name="text">
-        <string>0</string>
+        <string notr="true">0</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignCenter</set>

--- a/src/Mod/TechDraw/Gui/TaskSurfaceFinishSymbols.ui
+++ b/src/Mod/TechDraw/Gui/TaskSurfaceFinishSymbols.ui
@@ -105,7 +105,7 @@
         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Rotation angle&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
        </property>
        <property name="text">
-        <string>0</string>
+        <string notr="true">0</string>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
Follow-up to db18325a39  
As chennes wrote, there is no context where translators do anything with this because it gets translated literally. This removes all instances of `...`strings from translation. 