### PR TITLE
[CrashFix]Sketcher: prevent crash at FC closure when edit control panel is disabled

### DIFF
--- a/src/Mod/Sketcher/Gui/TaskDlgEditSketch.cpp
+++ b/src/Mod/Sketcher/Gui/TaskDlgEditSketch.cpp
@@ -81,6 +81,10 @@ TaskDlgEditSketch::~TaskDlgEditSketch()
     std::vector<QWidget*>::iterator it = std::find(Content.begin(), Content.end(), SolverAdvanced);
     if (it == Content.end())
         Content.push_back(SolverAdvanced);
+    // same thing for edit control panel
+    it = std::find(Content.begin(), Content.end(), General);
+    if (it == Content.end())
+        Content.push_back(General);
 }
 
 //==== calls from the TaskView ===============================================================


### PR DESCRIPTION
fixes #7931

Introduced by bf04c0e

@adrianinsaval may you please test it solves the issue for you ?
