### PR TITLE
[PD] Pad/pocket: fix wrong error message

### DIFF
--- a/src/Mod/PartDesign/App/FeatureSketchBased.cpp
+++ b/src/Mod/PartDesign/App/FeatureSketchBased.cpp
@@ -20,7 +20,6 @@
  *                                                                         *
  ***************************************************************************/
 
-
 #include "PreCompiled.h"
 #ifndef _PreComp_
 # include <Bnd_Box.hxx>
@@ -462,7 +461,7 @@ void ProfileBased::getUpToFace(TopoDS_Face& upToFace,
 
         std::vector<Part::cutFaces> cfaces = Part::findAllFacesCutBy(support, sketchshape, dir);
         if (cfaces.empty())
-            throw Base::ValueError("SketchBased: Up to face: No faces found in this direction");
+            throw Base::ValueError("SketchBased: No faces found in this direction");
 
         // Find nearest/furthest face
         std::vector<Part::cutFaces>::const_iterator it, it_near, it_far;

--- a/src/Mod/PartDesign/Gui/TaskExtrudeParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskExtrudeParameters.cpp
@@ -20,21 +20,20 @@
  *                                                                         *
  ***************************************************************************/
 
-
 #include "PreCompiled.h"
-
 #ifndef _PreComp_
 # include <QSignalBlocker>
 #endif
 
-#include <Base/UnitsApi.h>
 #include <App/Document.h>
+#include <Base/UnitsApi.h>
 #include <Gui/Command.h>
 #include <Mod/PartDesign/App/FeatureExtrude.h>
 
 #include "ui_TaskPadPocketParameters.h"
 #include "TaskExtrudeParameters.h"
 #include "ReferenceSelection.h"
+
 
 using namespace PartDesignGui;
 using namespace Gui;

--- a/src/Mod/PartDesign/Gui/TaskPadParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPadParameters.cpp
@@ -20,16 +20,16 @@
  *                                                                         *
  ***************************************************************************/
 
-
 #include "PreCompiled.h"
-
 #ifndef _PreComp_
 # include <Precision.hxx>
 #endif
 
 #include <Mod/PartDesign/App/FeaturePad.h>
+
 #include "ui_TaskPadPocketParameters.h"
 #include "TaskPadParameters.h"
+
 
 using namespace PartDesignGui;
 using namespace Gui;
@@ -103,6 +103,8 @@ void TaskPadParameters::onModeChanged(int index)
         pcPad->Type.setValue("UpToFirst");
         break;
     case Modes::ToFace:
+        // Note: ui->checkBoxReversed is purposely enabled because the selected face
+        // could be a circular one around the sketch
         pcPad->Type.setValue("UpToFace");
         if (ui->lineFaceName->text().isEmpty()) {
             ui->buttonFace->setChecked(true);

--- a/src/Mod/PartDesign/Gui/TaskPocketParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPocketParameters.cpp
@@ -20,16 +20,16 @@
  *                                                                         *
  ***************************************************************************/
 
-
 #include "PreCompiled.h"
-
 #ifndef _PreComp_
 # include <Precision.hxx>
 #endif
 
 #include <Mod/PartDesign/App/FeaturePocket.h>
+
 #include "ui_TaskPadPocketParameters.h"
 #include "TaskPocketParameters.h"
+
 
 using namespace PartDesignGui;
 using namespace Gui;
@@ -108,8 +108,10 @@ void TaskPocketParameters::onModeChanged(int index)
             pcPocket->Type.setValue("UpToFirst");
             break;
         case Modes::ToFace:
-            // Because of the code at the beginning of Pocket::execute() which is used to detect
-            // broken legacy parts, we must set the length to zero here!
+            // Note: ui->checkBoxReversed is purposely enabled because the selected face
+            // could be a circular one around the sketch
+            // Also note: Because of the code at the beginning of Pocket::execute() which is used
+            // to detect broken legacy parts, we must set the length to zero here!
             oldLength = pcPocket->Length.getValue();
             pcPocket->Type.setValue("UpToFace");
             pcPocket->Length.setValue(0.0);


### PR DESCRIPTION
- the error can also occur when the mode it not UpToFace (ToFirst or ToLast)
- also add note when Reversed checkbox is enabled since this is no obvious (as discussed in the forum)
- also some whitespace unification and include sorting