### PR TITLE
Draft: fix make_sketch bugs

### DIFF
--- a/src/Mod/Draft/draftgeoutils/general.py
+++ b/src/Mod/Draft/draftgeoutils/general.py
@@ -148,32 +148,30 @@ def isAligned(edge, axis="x"):
 
     The axis can be 'x', 'y' or 'z'.
     """
+    def is_same(a, b):
+      return round(a, precision()) == round(b, precision())
+
     if axis == "x":
         if isinstance(edge, Part.Edge):
             if len(edge.Vertexes) == 2:
-                if edge.Vertexes[0].X == edge.Vertexes[-1].X:
-                    return True
+                return is_same(edge.Vertexes[0].X, edge.Vertexes[-1].X)
         elif isinstance(edge, Part.LineSegment):
-            if edge.StartPoint.x == edge.EndPoint.x:
-                return True
+            return is_same(edge.StartPoint.x, edge.EndPoint.x)
 
     elif axis == "y":
         if isinstance(edge, Part.Edge):
             if len(edge.Vertexes) == 2:
-                if edge.Vertexes[0].Y == edge.Vertexes[-1].Y:
-                    return True
+                return is_same(edge.Vertexes[0].Y, edge.Vertexes[-1].Y)
         elif isinstance(edge, Part.LineSegment):
-            if edge.StartPoint.y == edge.EndPoint.y:
-                return True
+            return is_same(edge.StartPoint.y, edge.EndPoint.y)
 
     elif axis == "z":
         if isinstance(edge, Part.Edge):
             if len(edge.Vertexes) == 2:
-                if edge.Vertexes[0].Z == edge.Vertexes[-1].Z:
-                    return True
+                return is_same(edge.Vertexes[0].Z, edge.Vertexes[-1].Z)
         elif isinstance(edge, Part.LineSegment):
-            if edge.StartPoint.z == edge.EndPoint.z:
-                return True
+            return is_same(edge.StartPoint.z, edge.EndPoint.z)
+
     return False
 
 


### PR DESCRIPTION
This PR fixes 3 make_sketch bugs:

1. The last segment of an unrotated Rectangle was not constrained horizontally/vertically.
2. The `isAligned` function worked without a tolerance. This meant that none of the edges of a 90 degree rotated Rectangle was constrained horizontally/vertically.
3. Filleted Wires, Rectangles and Polygons where skipped. [Forum topic](https://forum.freecadweb.org/viewtopic.php?f=23&t=74194).

- [ ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

---
