### PR TITLE
Draft: improve context menus

### DIFF
--- a/src/Mod/Draft/draftviewproviders/view_bezcurve.py
+++ b/src/Mod/Draft/draftviewproviders/view_bezcurve.py
@@ -39,9 +39,6 @@ class ViewProviderBezCurve(ViewProviderWire):
     def __init__(self, vobj):
         super(ViewProviderBezCurve, self).__init__(vobj)
 
-    def setupContextMenu(self, vobj, menu):
-        return
-
 
 # Alias for compatibility with v0.18 and earlier
 _ViewProviderBezCurve = ViewProviderBezCurve

--- a/src/Mod/Draft/draftviewproviders/view_bspline.py
+++ b/src/Mod/Draft/draftviewproviders/view_bspline.py
@@ -39,9 +39,6 @@ class ViewProviderBSpline(ViewProviderWire):
     def __init__(self, vobj):
         super(ViewProviderBSpline, self).__init__(vobj)
 
-    def setupContextMenu(self, vobj, menu):
-        return
-
 
 # Alias for compatibility with v0.18 and earlier
 _ViewProviderBSpline = ViewProviderBSpline

--- a/src/Mod/Draft/draftviewproviders/view_dimension.py
+++ b/src/Mod/Draft/draftviewproviders/view_dimension.py
@@ -300,10 +300,6 @@ class ViewProviderDimensionBase(ViewProviderDraftAnnotation):
         """Execute when a view property is changed."""
         super(ViewProviderDimensionBase, self).onChanged(vobj, prop)
 
-    def doubleClicked(self, vobj):
-        """Execute when double clicking the icon in the tree view."""
-        self.setEdit(vobj)
-
     def getDisplayModes(self, vobj):
         """Return the display modes that this viewprovider supports."""
         return ["2D", "3D"]

--- a/src/Mod/Draft/draftviewproviders/view_fillet.py
+++ b/src/Mod/Draft/draftviewproviders/view_fillet.py
@@ -39,8 +39,5 @@ class ViewProviderFillet(ViewProviderWire):
     def __init__(self, vobj):
         super(ViewProviderFillet, self).__init__(vobj)
 
-    def setupContextMenu(self, vobj, menu):
-        return
-
 
 ## @}

--- a/src/Mod/Draft/draftviewproviders/view_hatch.py
+++ b/src/Mod/Draft/draftviewproviders/view_hatch.py
@@ -49,6 +49,11 @@ class ViewProviderDraftHatch:
 
         return None
 
+    def attach(self, vobj):
+
+        self.Object = vobj.Object
+        return
+
     def setEdit(self, vobj, mode):
         # EditMode 1 and 2 are handled by the Part::FeaturePython code.
         # EditMode 3 (Color) does not make sense for hatches (which do not
@@ -74,16 +79,26 @@ class ViewProviderDraftHatch:
         return True
 
     def setupContextMenu(self, vobj, menu):
-        action1 = QtGui.QAction(Gui.getIcon("Std_TransformManip.svg"),
-                                translate("Command", "Transform"), # Context `Command` instead of `draft`.
-                                menu)
-        QtCore.QObject.connect(action1,
+        action_edit = QtGui.QAction(translate("draft", "Edit"),
+                                    menu)
+        QtCore.QObject.connect(action_edit,
+                               QtCore.SIGNAL("triggered()"),
+                               self.edit)
+        menu.addAction(action_edit)
+
+        action_transform = QtGui.QAction(Gui.getIcon("Std_TransformManip.svg"),
+                                         translate("Command", "Transform"), # Context `Command` instead of `draft`.
+                                         menu)
+        QtCore.QObject.connect(action_transform,
                                QtCore.SIGNAL("triggered()"),
                                self.transform)
-        menu.addAction(action1)
+        menu.addAction(action_transform)
 
         return True # Removes `Transform` and `Set colors` from the default
-                    # Part::FeaturePython context menu.
+                    # Part::FeaturePython context menu. See view_base.py.
+
+    def edit(self):
+        Gui.ActiveDocument.setEdit(self.Object, 0)
 
     def transform(self):
-        Gui.runCommand("Std_TransformManip", 0)
+        Gui.ActiveDocument.setEdit(self.Object, 1)

--- a/src/Mod/Draft/draftviewproviders/view_label.py
+++ b/src/Mod/Draft/draftviewproviders/view_label.py
@@ -284,6 +284,7 @@ class ViewProviderLabel(ViewProviderDraftAnnotation):
         self.onChanged(vobj, "LineWidth")
         self.onChanged(vobj, "ArrowSize")
         self.onChanged(vobj, "Line")
+        self.Object = vobj.Object
 
     def getDisplayModes(self, vobj):
         """Return the display modes that this viewprovider supports."""

--- a/src/Mod/Draft/draftviewproviders/view_layer.py
+++ b/src/Mod/Draft/draftviewproviders/view_layer.py
@@ -458,31 +458,31 @@ class ViewProviderLayer:
 
     def setupContextMenu(self, vobj, menu):
         """Set up actions to perform in the context menu."""
-        action1 = QtGui.QAction(QtGui.QIcon(":/icons/button_right.svg"),
-                                translate("draft", "Activate this layer"),
-                                menu)
-        action1.triggered.connect(self.activate)
-        menu.addAction(action1)
+        action_activate = QtGui.QAction(QtGui.QIcon(":/icons/button_right.svg"),
+                                        translate("draft", "Activate this layer"),
+                                        menu)
+        action_activate.triggered.connect(self.activate)
+        menu.addAction(action_activate)
 
-        action2 = QtGui.QAction(QtGui.QIcon(":/icons/Draft_SelectGroup.svg"),
-                                translate("draft", "Select layer contents"),
-                                menu)
-        action2.triggered.connect(self.select_contents)
-        menu.addAction(action2)
+        action_select = QtGui.QAction(QtGui.QIcon(":/icons/Draft_SelectGroup.svg"),
+                                      translate("draft", "Select layer contents"),
+                                      menu)
+        action_select.triggered.connect(self.select_contents)
+        menu.addAction(action_select)
 
     def activate(self):
         """Activate the selected layer, it becomes the Autogroup."""
-        if hasattr(self, "Object"):
-            Gui.Selection.clearSelection()
-            Gui.Selection.addSelection(self.Object)
-            Gui.runCommand("Draft_AutoGroup")
+        Gui.Selection.clearSelection()
+        Gui.Selection.addSelection(self.Object)
+        if not "Draft_AutoGroup" in Gui.listCommands():
+            Gui.activateWorkbench("DraftWorkbench")
+        Gui.runCommand("Draft_AutoGroup")
 
     def select_contents(self):
         """Select the contents of the layer."""
-        if hasattr(self, "Object"):
-            Gui.Selection.clearSelection()
-            for layer_obj in self.Object.Group:
-                Gui.Selection.addSelection(layer_obj)
+        Gui.Selection.clearSelection()
+        for layer_obj in self.Object.Group:
+            Gui.Selection.addSelection(layer_obj)
 
 
 class ViewProviderLayerContainer:
@@ -502,22 +502,20 @@ class ViewProviderLayerContainer:
 
     def setupContextMenu(self, vobj, menu):
         """Set up actions to perform in the context menu."""
-        action1 = QtGui.QAction(QtGui.QIcon(":/icons/Draft_Layer.svg"),
-                                translate("draft", "Merge layer duplicates"),
-                                menu)
-        action1.triggered.connect(self.merge_by_name)
-        menu.addAction(action1)
-        action2 = QtGui.QAction(QtGui.QIcon(":/icons/Draft_NewLayer.svg"),
-                                translate("draft", "Add new layer"),
-                                menu)
-        action2.triggered.connect(self.add_layer)
-        menu.addAction(action2)
+        action_merge = QtGui.QAction(QtGui.QIcon(":/icons/Draft_Layer.svg"),
+                                     translate("draft", "Merge layer duplicates"),
+                                     menu)
+        action_merge.triggered.connect(self.merge_by_name)
+        menu.addAction(action_merge)
+
+        action_add = QtGui.QAction(QtGui.QIcon(":/icons/Draft_NewLayer.svg"),
+                                   translate("draft", "Add new layer"),
+                                   menu)
+        action_add.triggered.connect(self.add_layer)
+        menu.addAction(action_add)
 
     def merge_by_name(self):
         """Merge the layers that have the same base label."""
-        if not hasattr(self, "Object") or not hasattr(self.Object, "Group"):
-            return
-
         doc = App.ActiveDocument
         doc.openTransaction(translate("draft", "Merge layer duplicates"))
 

--- a/src/Mod/Draft/draftviewproviders/view_shapestring.py
+++ b/src/Mod/Draft/draftviewproviders/view_shapestring.py
@@ -42,11 +42,11 @@ class ViewProviderShapeString(ViewProviderDraft):
         if mode != 0:
             return None
 
-        self.wb_before_edit = Gui.activeWorkbench()
-        Gui.activateWorkbench("DraftWorkbench")
+        if not "Draft_Edit" in Gui.listCommands(): # Using Draft_Edit to detect if the Draft, Arch or BIM WB has been loaded.
+            self.wb_before_edit = Gui.activeWorkbench()
+            Gui.activateWorkbench("DraftWorkbench")
         self.task = ShapeStringTaskPanelEdit(vobj)
         Gui.Control.showDialog(self.task)
-
         return True
 
     def unsetEdit(self, vobj, mode):
@@ -54,6 +54,7 @@ class ViewProviderShapeString(ViewProviderDraft):
             return None
 
         self.task.finish()
-        Gui.activateWorkbench(self.wb_before_edit.name())
-
+        if hasattr(self, "wb_before_edit"):
+            Gui.activateWorkbench(self.wb_before_edit.name())
+            delattr(self, "wb_before_edit")
         return True

--- a/src/Mod/Draft/draftviewproviders/view_text.py
+++ b/src/Mod/Draft/draftviewproviders/view_text.py
@@ -30,10 +30,13 @@
 ## \addtogroup draftviewproviders
 # @{
 import pivy.coin as coin
-import sys
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
+import FreeCAD as App
+import FreeCADGui as Gui
+
 import draftutils.utils as utils
+from draftutils.translate import translate
 
 from draftviewproviders.view_draft_annotation \
     import ViewProviderDraftAnnotation
@@ -218,32 +221,18 @@ class ViewProviderText(ViewProviderDraftAnnotation):
             self.text2d.spacing = vobj.LineSpacing
             self.text3d.spacing = vobj.LineSpacing
 
-    def setEdit(self,vobj,mode):
-
-        import FreeCADGui
-        if not hasattr(FreeCADGui, "draftToolBar"):
+    def edit(self):
+        if not hasattr(Gui, "draftToolBar"):
             import DraftGui
         self.text = ""
-        FreeCADGui.draftToolBar.sourceCmd = self
-        FreeCADGui.draftToolBar.taskUi()
-        FreeCADGui.draftToolBar.textUi()
-        FreeCADGui.draftToolBar.textValue.setPlainText("\n".join(vobj.Object.Text))
-        FreeCADGui.draftToolBar.textValue.setFocus()
-
-    def unsetEdit(self,vobj=None,mode=0):
-
-        import FreeCADGui
-        FreeCADGui.Control.closeDialog()
-        return True
-
-    def doubleClicked(self,vobj):
-
-        self.setEdit(vobj,None)
+        Gui.draftToolBar.sourceCmd = self
+        Gui.draftToolBar.taskUi(title=translate("draft", "Text"), icon="Draft_Text")
+        Gui.draftToolBar.textUi()
+        Gui.draftToolBar.continueCmd.hide()
+        Gui.draftToolBar.textValue.setPlainText("\n".join(self.Object.Text))
+        Gui.draftToolBar.textValue.setFocus()
 
     def createObject(self):
-
-        import FreeCAD
-        import FreeCADGui
         if hasattr(self,"Object"):
             txt = self.text
             if not txt:
@@ -255,15 +244,13 @@ class ViewProviderText(ViewProviderDraftAnnotation):
             t_list = ['"' + l + '"' for l in txt]
             list_as_text = ", ".join(t_list)
             string = '[' + list_as_text + ']'
-            FreeCADGui.doCommand("FreeCAD.ActiveDocument."+self.Object.Name+".Text = "+string)
-            FreeCAD.ActiveDocument.recompute()
+            Gui.doCommand("FreeCAD.ActiveDocument." + self.Object.Name + ".Text = " + string)
+            App.ActiveDocument.recompute()
             self.finish()
 
-    def finish(self,args=None):
-
-        import FreeCADGui
-        FreeCADGui.draftToolBar.sourceCmd = None
-        FreeCADGui.draftToolBar.offUi()
+    def finish(self, cont=False):
+        Gui.draftToolBar.sourceCmd = None
+        Gui.draftToolBar.offUi()
 
 
 # Alias for compatibility with v0.18 and earlier

--- a/src/Mod/Draft/draftviewproviders/view_wire.py
+++ b/src/Mod/Draft/draftviewproviders/view_wire.py
@@ -148,15 +148,6 @@ class ViewProviderWire(ViewProviderDraft):
             return [self.Object.Base,self.Object.Tool]
         return []
 
-    def setupContextMenu(self, vobj, menu):
-        action1 = QtGui.QAction(QtGui.QIcon(":/icons/Draft_Edit.svg"),
-                                translate("draft", "Flatten"),
-                                menu)
-        QtCore.QObject.connect(action1,
-                               QtCore.SIGNAL("triggered()"),
-                               self.flatten)
-        menu.addAction(action1)
-
     def flatten(self): # Only to be used for Draft_Wires.
         if not hasattr(self, "Object"):
             return


### PR DESCRIPTION
This PR tries to improve the context menus of Draft objects.

Main changes:
1. Added an `Edit` option (for objects that can be edited). Similar to Part objects.
2. Objects without a face or that can only have a single face, no longer have a `Set colors...` option. This was previously only implemented for Hatches.
3. The Draft workbench is automatically loaded if required. This was previously only implemented for Shapestrings.
4. For most objects Edit modes 0 and 3 are handled. Edit mode 3 defaults to 0.

The automatic workbench loading may require some form of user confirmation ("Do you really want to..."). But let's first wait and see if users comment.

Some of the viewproviders files (view_bezcurve.py f.e.) have now become empty wrappers, but it is better to keep them for future use.

There is still some housekeeping left IMO, but that can be done later.

- [ ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

---
