### PR TITLE
[GUI] Add missing include

### DIFF
--- a/src/Gui/Language/Translator.h
+++ b/src/Gui/Language/Translator.h
@@ -26,6 +26,7 @@
 #include <QObject>
 #include <list>
 #include <map>
+#include <memory>
 #include <string>
 #include <FCGlobal.h>
 


### PR DESCRIPTION
This `memory` header is needed for `unique_ptr`, at least on Manjaro/Arch Linux with GCC.
