### PR TITLE
[TD]remove problematic boost check for planarity

### DIFF
--- a/src/Mod/TechDraw/App/EdgeWalker.cpp
+++ b/src/Mod/TechDraw/App/EdgeWalker.cpp
@@ -163,41 +163,6 @@ bool EdgeWalker::prepare()
         }
     }
 
-    // Test for planarity
-    using vec_t = std::vector< graph_traits<TechDraw::graph>::edge_descriptor >;
-    std::vector<vec_t> embedding(num_vertices(m_g));
-    using kura_edges_t = std::vector< graph_traits<TechDraw::graph>::edge_descriptor >;
-    kura_edges_t kEdges;
-    kura_edges_t::iterator ki, ki_end;
-    graph_traits<TechDraw::graph>::edge_descriptor e1;
-
-#if 0 // Function declared in block and lacking of implementation
-    // Get the index associated with edge
-    graph_traits<TechDraw::graph>::edges_size_type
-        get(boost::edge_index_t,
-            const TechDraw::graph& m_g,
-            graph_traits<TechDraw::graph>::edge_descriptor edge);
-#endif
-
-    bool isPlanar = boyer_myrvold_planarity_test(boyer_myrvold_params::graph = m_g,
-                                 boyer_myrvold_params::embedding = &embedding[0],            // this is "an" embedding but not one for finding
-                                 boyer_myrvold_params::kuratowski_subgraph =                 // closed regions in an edge pile.
-                                       std::back_inserter(kEdges));
-    if (!isPlanar) {
-        //TODO: remove kura subgraph to make planar??
-        Base::Console().Message("EW::prepare - input is NOT planar\n");
-        ki_end = kEdges.end();
-        std::stringstream ss;
-        ss << "EW::prepare - obstructing edges: ";
-        for(ki = kEdges.begin(); ki != ki_end; ++ki) {
-            e1 = *ki;
-            ss << boost::get(edge_index, m_g, e1) << ", ";
-        }
-        ss << std::endl;
-        Base::Console().Message("%s\n", ss.str().c_str());
-        return false;
-    }
-
     m_eV.setGraph(m_g);
     planar_face_traversal(m_g, &planar_embedding[0], m_eV);
 


### PR DESCRIPTION
- boost check for planar graph was consuming memory until crashing.
- since all our edges have been projected onto a plane, we don't require this check

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [ ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
