### PR TITLE
Bump minimum cmake version to 3.16.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-# March 2021, the oldest we have to support : Ununtu 18.04 LTS
-cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+# Dec 2022 Bumped min (ubuntu 20.04: 3.16.3-1ubuntu1.20.04.1)
+cmake_minimum_required(VERSION 3.16.3 FATAL_ERROR)
 
 # policy CMP0072 was introduced with CMake 3.11
 # relates to FindOpenGL module


### PR DESCRIPTION
Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [x]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---

Ubuntu 18.04 LTS ends early '23.
Logically master branch should now be targeting 20.04 which has 3.16.3-1ubuntu1.20.04.1.

This change also makes available a bunch of cmake enhancements.