### PR TITLE
Draft: Fix inconsistent properties of Draft annotations

### DIFF
--- a/src/Mod/Draft/Resources/ui/preferences-drafttexts.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-drafttexts.ui
@@ -141,12 +141,12 @@ such as "Arial:Bold"</string>
           </property>
           <item>
            <property name="text">
-            <string>text above (2D)</string>
+            <string>World</string>
            </property>
           </item>
           <item>
            <property name="text">
-            <string> text inside (3D)</string>
+            <string>Screen</string>
            </property>
           </item>
          </widget>

--- a/src/Mod/Draft/draftfunctions/svg.py
+++ b/src/Mod/Draft/draftfunctions/svg.py
@@ -227,7 +227,7 @@ def _svg_shape(svg, obj, plane,
 
 
 def _svg_dimension(obj, plane, scale, linewidth, fontsize,
-                   stroke, pointratio, techdraw, rotation):
+                   stroke, tstroke, pointratio, techdraw, rotation):
     """Return the SVG representation of a linear dimension."""
     if not App.GuiUp:
         _wrn("'{}': SVG can only be generated "
@@ -280,7 +280,7 @@ def _svg_dimension(obj, plane, scale, linewidth, fontsize,
     if not nolines:
         svg += '<path '
 
-    if vobj.DisplayMode == "2D":
+    if vobj.DisplayMode == "World":
         tangle = angle
         if tangle > math.pi/2:
             tangle = tangle-math.pi
@@ -361,7 +361,7 @@ def _svg_dimension(obj, plane, scale, linewidth, fontsize,
 
     # drawing text
     svg += svgtext.get_text(plane, techdraw,
-                            stroke, fontsize, vobj.FontName,
+                            tstroke, fontsize, vobj.FontName,
                             tangle, tbase, prx.string)
 
     return svg
@@ -505,7 +505,7 @@ def get_svg(obj,
 
     elif utils.get_type(obj) in ["Dimension", "LinearDimension"]:
         svg = _svg_dimension(obj, plane, scale, linewidth, fontsize,
-                             stroke, pointratio, techdraw, rotation)
+                             stroke, tstroke, pointratio, techdraw, rotation)
 
     elif utils.get_type(obj) == "AngularDimension":
         if not App.GuiUp:
@@ -518,7 +518,7 @@ def get_svg(obj,
 
                     # drawing arc
                     fill = "none"
-                    if obj.ViewObject.DisplayMode == "2D":
+                    if obj.ViewObject.DisplayMode == "World":
                         svg += get_path(obj, plane,
                                         fill, pathdata, stroke, linewidth,
                                         lstyle, fill_opacity=None,
@@ -573,7 +573,7 @@ def get_svg(obj,
                                          angle2)
 
                     # drawing text
-                    if obj.ViewObject.DisplayMode == "2D":
+                    if obj.ViewObject.DisplayMode == "World":
                         _diff = (prx.circle.LastParameter
                                  - prx.circle.FirstParameter)
                         t = prx.circle.tangentAt(prx.circle.FirstParameter
@@ -597,7 +597,7 @@ def get_svg(obj,
                         tbase = get_proj(prx.tbase, plane)
 
                     svg += svgtext.get_text(plane, techdraw,
-                                            stroke, fontsize,
+                                            tstroke, fontsize,
                                             obj.ViewObject.FontName,
                                             tangle, tbase, prx.string)
 
@@ -637,13 +637,13 @@ def get_svg(obj,
 
         # print text
         if App.GuiUp:
-            fontname = obj.ViewObject.TextFont
+            fontname = obj.ViewObject.FontName
             position = get_proj(obj.Placement.Base, plane)
             rotation = obj.Placement.Rotation
             justification = obj.ViewObject.Justification
             text = obj.Text
             svg += svgtext.get_text(plane, techdraw,
-                                    stroke, fontsize, fontname,
+                                    tstroke, fontsize, fontname,
                                     rotation, position, text,
                                     linespacing, justification)
 

--- a/src/Mod/Draft/draftmake/make_label.py
+++ b/src/Mod/Draft/draftmake/make_label.py
@@ -356,7 +356,7 @@ def make_label(target_point=App.Vector(0, 0, 0),
     if App.GuiUp:
         ViewProviderLabel(new_obj.ViewObject)
         h = utils.get_param("textheight", 0.20)
-        new_obj.ViewObject.TextSize = h
+        new_obj.ViewObject.FontSize = h
 
         gui_utils.format_object(new_obj)
         gui_utils.select(new_obj)

--- a/src/Mod/Draft/draftmake/make_text.py
+++ b/src/Mod/Draft/draftmake/make_text.py
@@ -124,10 +124,10 @@ def make_text(string, placement=None, screen=False):
 
         h = utils.get_param("textheight", 2)
 
-        new_obj.ViewObject.DisplayMode = "3D text"
+        new_obj.ViewObject.DisplayMode = "World"
         if screen:
             _msg("screen: {}".format(screen))
-            new_obj.ViewObject.DisplayMode = "2D text"
+            new_obj.ViewObject.DisplayMode = "Screen"
             h = h * 10
 
         new_obj.ViewObject.FontSize = h

--- a/src/Mod/Draft/draftobjects/draft_annotation.py
+++ b/src/Mod/Draft/draftobjects/draft_annotation.py
@@ -65,44 +65,27 @@ class DraftAnnotation(object):
         Check if new properties are present after the object is restored
         in order to migrate older objects.
         """
-        if hasattr(obj, "ViewObject") and obj.ViewObject:
-            vobj = obj.ViewObject
-            self.add_missing_properties_0v19(obj, vobj)
+        if not hasattr(obj, "ViewObject"):
+            return
+        vobj = obj.ViewObject
+        if not vobj:
+            return
+        if hasattr(vobj, "ScaleMultiplier") and hasattr(vobj, "AnnotationStyle"):
+            return
+
+        self.add_missing_properties_0v19(obj, vobj)
 
     def add_missing_properties_0v19(self, obj, vobj):
-        """Provide missing annotation properties, if they don't exist."""
-        vproperties = vobj.PropertiesList
-
-        if 'ScaleMultiplier' not in vproperties:
-            _tip = QT_TRANSLATE_NOOP("App::Property",
-                                     "General scaling factor that affects "
-                                     "the annotation consistently\n"
-                                     "because it scales the text, "
-                                     "and the line decorations, if any,\n"
-                                     "in the same proportion.")
-            vobj.addProperty("App::PropertyFloat",
-                             "ScaleMultiplier",
-                             "Annotation",
-                             _tip)
-            vobj.ScaleMultiplier = 1.00
-
-            _wrn("v0.19, " + obj.Label + ", " + translate("draft","added view property 'ScaleMultiplier'"))
-
-        if 'AnnotationStyle' not in vproperties:
-            _tip = QT_TRANSLATE_NOOP("App::Property","Annotation style to apply to this object.\nWhen using a saved style some of the view properties will become read-only;\nthey will only be editable by changing the style through the 'Annotation style editor' tool.")
-            vobj.addProperty("App::PropertyEnumeration",
-                             "AnnotationStyle",
-                             "Annotation",
-                             _tip)
-            styles = []
-            for key in obj.Document.Meta.keys():
-                if key.startswith("Draft_Style_"):
-                    styles.append(key[12:])
-
-            vobj.AnnotationStyle = [""] + styles
-
-            _info = "added view property 'AnnotationStyle'"
-            _wrn("v0.19, " + obj.Label + ", " + translate("draft","added view property 'ScaleMultiplier'"))
+        """Provide missing annotation properties."""
+        multiplier = None
+        if not hasattr(vobj, "ScaleMultiplier"):
+            multiplier = 1.00
+            _wrn("v0.19, " + obj.Label + ", " + translate("draft", "added view property 'ScaleMultiplier'"))
+        if not hasattr(vobj, "AnnotationStyle"):
+            _wrn("v0.19, " + obj.Label + ", " + translate("draft", "added view property 'AnnotationStyle'"))
+        vobj.Proxy.set_annotation_properties(vobj, vobj.PropertiesList)
+        if multiplier is not None:
+            vobj.ScaleMultiplier = multiplier
 
     def __getstate__(self):
         """Return a tuple of objects to save or None.

--- a/src/Mod/Draft/draftobjects/text.py
+++ b/src/Mod/Draft/draftobjects/text.py
@@ -39,7 +39,7 @@ class Text(DraftAnnotation):
     """The Draft Text object."""
 
     def __init__(self, obj):
-        super(Text, self).__init__(obj, "Text")
+        super().__init__(obj, "Text")
         self.set_properties(obj)
         obj.Proxy = self
 
@@ -68,13 +68,6 @@ class Text(DraftAnnotation):
                             "Base",
                             _tip)
             obj.Text = []
-
-    def onDocumentRestored(self, obj):
-        """Execute code when the document is restored.
-
-        It calls the parent class to add missing annotation properties.
-        """
-        super(Text, self).onDocumentRestored(obj)
 
 
 # Alias for compatibility with v0.18 and earlier

--- a/src/Mod/Draft/draftviewproviders/view_draft_annotation.py
+++ b/src/Mod/Draft/draftviewproviders/view_draft_annotation.py
@@ -1,6 +1,7 @@
 # ***************************************************************************
 # *   Copyright (c) 2020 Carlo Pavan <carlopav@gmail.com>                   *
 # *   Copyright (c) 2020 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de> *
+# *   Copyright (c) 2022 FreeCAD Project Association                        *
 # *                                                                         *
 # *   This file is part of the FreeCAD CAx development system.              *
 # *                                                                         *
@@ -72,6 +73,8 @@ class ViewProviderDraftAnnotation(object):
         """Set the properties only if they don't already exist."""
         properties = vobj.PropertiesList
         self.set_annotation_properties(vobj, properties)
+        self.set_text_properties(vobj, properties)
+        self.set_units_properties(vobj, properties)
         self.set_graphics_properties(vobj, properties)
 
     def set_annotation_properties(self, vobj, properties):
@@ -112,6 +115,37 @@ class ViewProviderDraftAnnotation(object):
 
             vobj.AnnotationStyle = [""] + styles
 
+    def set_text_properties(self, vobj, properties):
+        """Set text properties only if they don't already exist."""
+        if "FontName" not in properties:
+            _tip = QT_TRANSLATE_NOOP("App::Property",
+                                     "Font name")
+            vobj.addProperty("App::PropertyFont",
+                             "FontName",
+                             "Text",
+                             _tip)
+            vobj.FontName = utils.get_param("textfont", "sans")
+
+        if "FontSize" not in properties:
+            _tip = QT_TRANSLATE_NOOP("App::Property",
+                                     "Font size")
+            vobj.addProperty("App::PropertyLength",
+                             "FontSize",
+                             "Text",
+                             _tip)
+            vobj.FontSize = utils.get_param("textheight", 1)
+
+        if "TextColor" not in properties:
+            _tip = QT_TRANSLATE_NOOP("App::Property",
+                                     "Text color")
+            vobj.addProperty("App::PropertyColor",
+                             "TextColor",
+                             "Text",
+                             _tip)
+
+    def set_units_properties(self, vobj, properties):
+        return
+
     def set_graphics_properties(self, vobj, properties):
         """Set graphics properties only if they don't already exist."""
         if "LineWidth" not in properties:
@@ -146,8 +180,11 @@ class ViewProviderDraftAnnotation(object):
 
     def getDisplayModes(self, vobj):
         """Return the display modes that this viewprovider supports."""
-        modes = []
-        return modes
+        return ["World", "Screen"]
+
+    def getDefaultDisplayMode(self):
+        """Return the default display mode."""
+        return "World"
 
     def setDisplayMode(self, mode):
         """Return the saved display mode."""
@@ -159,7 +196,7 @@ class ViewProviderDraftAnnotation(object):
         meta = vobj.Object.Document.Meta
 
         if prop == "AnnotationStyle" and "AnnotationStyle" in properties:
-            if not vobj.AnnotationStyle or vobj.AnnotationStyle == " ":
+            if not vobj.AnnotationStyle or vobj.AnnotationStyle == "":
                 # unset style
                 _msg(16 * "-")
                 _msg("Unset style")
@@ -250,22 +287,5 @@ class ViewProviderDraftAnnotation(object):
     def getIcon(self):
         """Return the path to the icon used by the view provider."""
         return ":/icons/Draft_Text.svg"
-
-    def claimChildren(self):
-        """Return objects that will be placed under it in the tree view.
-
-        Editor: perhaps this is not useful???
-        """
-        objs = []
-        if hasattr(self.Object, "Base"):
-            objs.append(self.Object.Base)
-        if hasattr(self.Object, "Objects"):
-            objs.extend(self.Object.Objects)
-        if hasattr(self.Object, "Components"):
-            objs.extend(self.Object.Components)
-        if hasattr(self.Object, "Group"):
-            objs.extend(self.Object.Group)
-
-        return objs
 
 ## @}

--- a/src/Mod/Draft/draftviewproviders/view_text.py
+++ b/src/Mod/Draft/draftviewproviders/view_text.py
@@ -2,6 +2,7 @@
 # *   Copyright (c) 2009, 2010 Yorik van Havre <yorik@uncreated.net>        *
 # *   Copyright (c) 2009, 2010 Ken Cline <cline@frii.com>                   *
 # *   Copyright (c) 2020 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de> *
+# *   Copyright (c) 2022 FreeCAD Project Association                        *
 # *                                                                         *
 # *   This file is part of the FreeCAD CAx development system.              *
 # *                                                                         *
@@ -45,52 +46,18 @@ from draftviewproviders.view_draft_annotation \
 class ViewProviderText(ViewProviderDraftAnnotation):
     """Viewprovider for the Draft Text annotation."""
 
-    def __init__(self, vobj):
-        super(ViewProviderText, self).__init__(vobj)
-
-        self.set_properties(vobj)
-        self.Object = vobj.Object
-        vobj.Proxy = self
-
-    def set_properties(self, vobj):
-        """Set the properties only if they don't already exist."""
-        super(ViewProviderText, self).set_properties(vobj)
-        properties = vobj.PropertiesList
-
-        if "FontSize" not in properties:
-            _tip = QT_TRANSLATE_NOOP("App::Property",
-                                     "The size of the text")
-            vobj.addProperty("App::PropertyLength",
-                             "FontSize",
-                             "Text",
-                             _tip)
-            vobj.FontSize = utils.get_param("textheight", 1)
-
-        if "FontName" not in properties:
-            _tip = QT_TRANSLATE_NOOP("App::Property",
-                                     "The font of the text")
-            vobj.addProperty("App::PropertyFont",
-                             "FontName",
-                             "Text",
-                             _tip)
-            vobj.FontName = utils.get_param("textfont", "sans")
+    def set_text_properties(self, vobj, properties):
+        """Set text properties only if they don't already exist."""
+        super().set_text_properties(vobj, properties)
 
         if "Justification" not in properties:
             _tip = QT_TRANSLATE_NOOP("App::Property",
-                                     "The vertical alignment of the text")
+                                     "Horizontal alignment")
             vobj.addProperty("App::PropertyEnumeration",
                              "Justification",
                              "Text",
                              _tip)
             vobj.Justification = ["Left", "Center", "Right"]
-
-        if "TextColor" not in properties:
-            _tip = QT_TRANSLATE_NOOP("App::Property",
-                                     "Text color")
-            vobj.addProperty("App::PropertyColor",
-                             "TextColor",
-                             "Text",
-                             _tip)
 
         if "LineSpacing" not in properties:
             _tip = QT_TRANSLATE_NOOP("App::Property",
@@ -99,73 +66,63 @@ class ViewProviderText(ViewProviderDraftAnnotation):
                              "LineSpacing",
                              "Text",
                              _tip)
+            vobj.LineSpacing = 1.0
 
     def getIcon(self):
         """Return the path to the icon used by the view provider."""
         return ":/icons/Draft_Text.svg"
 
-    def claimChildren(self):
-        """Return objects that will be placed under it in the tree view."""
-        return []
-
     def attach(self, vobj):
         """Set up the scene sub-graph of the view provider."""
+        self.Object = vobj.Object
+
         # Main attributes of the Coin scenegraph
-        self.mattext = coin.SoMaterial()
         self.trans = coin.SoTransform()
+        self.mattext = coin.SoMaterial()
         self.font = coin.SoFont()
-        self.text2d = coin.SoText2()  # Faces the camera always
-        self.text3d = coin.SoAsciiText()  # Can be oriented in 3D space
+        self.text_wld = coin.SoAsciiText() # World orientation. Can be oriented in 3D space.
+        self.text_scr = coin.SoText2()     # Screen orientation. Always faces the camera.
 
         textdrawstyle = coin.SoDrawStyle()
         textdrawstyle.style = coin.SoDrawStyle.FILLED
 
         # The text string needs to be initialized to something,
         # otherwise it may crash
-        self.text2d.string = self.text3d.string = "Label"
-        self.text2d.justification = coin.SoText2.LEFT
-        self.text3d.justification = coin.SoAsciiText.LEFT
+        self.text_wld.string = self.text_scr.string = "Label"
+        self.text_wld.justification = coin.SoAsciiText.LEFT
+        self.text_scr.justification = coin.SoText2.LEFT
 
-        self.node2d = coin.SoGroup()
-        self.node2d.addChild(self.trans)
-        self.node2d.addChild(self.mattext)
-        self.node2d.addChild(textdrawstyle)
-        self.node2d.addChild(self.font)
-        self.node2d.addChild(self.text2d)
+        self.node_wld = coin.SoGroup()
+        self.node_wld.addChild(self.trans)
+        self.node_wld.addChild(self.mattext)
+        self.node_wld.addChild(textdrawstyle)
+        self.node_wld.addChild(self.font)
+        self.node_wld.addChild(self.text_wld)
 
-        self.node3d = coin.SoGroup()
-        self.node3d.addChild(self.trans)
-        self.node3d.addChild(self.mattext)
-        self.node3d.addChild(textdrawstyle)
-        self.node3d.addChild(self.font)
-        self.node3d.addChild(self.text3d)
+        self.node_scr = coin.SoGroup()
+        self.node_scr.addChild(self.trans)
+        self.node_scr.addChild(self.mattext)
+        self.node_scr.addChild(textdrawstyle)
+        self.node_scr.addChild(self.font)
+        self.node_scr.addChild(self.text_scr)
 
-        vobj.addDisplayMode(self.node2d, "2D text")
-        vobj.addDisplayMode(self.node3d, "3D text")
+        vobj.addDisplayMode(self.node_wld, "World")
+        vobj.addDisplayMode(self.node_scr, "Screen")
         self.onChanged(vobj, "TextColor")
         self.onChanged(vobj, "FontSize")
         self.onChanged(vobj, "FontName")
         self.onChanged(vobj, "Justification")
         self.onChanged(vobj, "LineSpacing")
         self.onChanged(vobj, "ScaleMultiplier")
-        self.Object = vobj.Object
-
-    def getDisplayModes(self, vobj):
-        """Return the display modes that this viewprovider supports."""
-        return ["2D text", "3D text"]
-
-    def setDisplayMode(self, mode):
-        """Return the saved display mode."""
-        return mode
 
     def updateData(self, obj, prop):
         """Execute when a property from the Proxy class is changed."""
         if prop == "Text" and obj.Text:
-            self.text2d.string.setValue("")
-            self.text3d.string.setValue("")
+            self.text_wld.string.setValue("")
+            self.text_scr.string.setValue("")
             _list = [l for l in obj.Text if l]
-            self.text2d.string.setValues(_list)
-            self.text3d.string.setValues(_list)
+            self.text_wld.string.setValues(_list)
+            self.text_scr.string.setValues(_list)
 
         elif prop == "Placement":
             self.trans.translation.setValue(obj.Placement.Base)
@@ -173,7 +130,7 @@ class ViewProviderText(ViewProviderDraftAnnotation):
 
     def onChanged(self, vobj, prop):
         """Execute when a view property is changed."""
-        super(ViewProviderText, self).onChanged(vobj, prop)
+        super().onChanged(vobj, prop)
 
         properties = vobj.PropertiesList
 
@@ -208,18 +165,18 @@ class ViewProviderText(ViewProviderDraftAnnotation):
             # However, in v0.19 this problem doesn't seem to exist any more
             # so we removed the try-except block.
             if vobj.Justification == "Left":
-                self.text2d.justification = coin.SoText2.LEFT
-                self.text3d.justification = coin.SoAsciiText.LEFT
+                self.text_wld.justification = coin.SoAsciiText.LEFT
+                self.text_scr.justification = coin.SoText2.LEFT
             elif vobj.Justification == "Right":
-                self.text2d.justification = coin.SoText2.RIGHT
-                self.text3d.justification = coin.SoAsciiText.RIGHT
+                self.text_wld.justification = coin.SoAsciiText.RIGHT
+                self.text_scr.justification = coin.SoText2.RIGHT
             else:
-                self.text2d.justification = coin.SoText2.CENTER
-                self.text3d.justification = coin.SoAsciiText.CENTER
+                self.text_wld.justification = coin.SoAsciiText.CENTER
+                self.text_scr.justification = coin.SoText2.CENTER
 
         elif prop == "LineSpacing" and "LineSpacing" in properties:
-            self.text2d.spacing = vobj.LineSpacing
-            self.text3d.spacing = vobj.LineSpacing
+            self.text_wld.spacing = vobj.LineSpacing
+            self.text_scr.spacing = vobj.LineSpacing
 
     def edit(self):
         if not hasattr(Gui, "draftToolBar"):


### PR DESCRIPTION
Fixes #7861.

This is a somewhat involved PR as it touches multiple files. Also while working I discovered some problems with how the viewprovider classes were organized. Code related to the setting of properties would be called up to 6 times when an object was created.

When dimension text was aligned with the screen it was handled differently (a factor 10 was applied to the FontSize) from Draft_Text and Draft_Label objects. I have removed that (and the related extra font node). There are still other things that seem inconsistent to me, but that may also be due to my lack of coin knowledge.

- [x]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
