### PR TITLE
Adjust Startpage version info to new format

### DIFF
--- a/src/Mod/Start/StartPage/StartPage.py
+++ b/src/Mod/Start/StartPage/StartPage.py
@@ -365,7 +365,7 @@ def handle():
     # get FreeCAD version
 
     v = FreeCAD.Version()
-    VERSIONSTRING = TranslationTexts.T_VERSION + " " + v[0] + "." + v[1] + " " + TranslationTexts.T_BUILD + " " + v[2]
+    VERSIONSTRING = TranslationTexts.T_VERSION + " " + v[0] + "." + v[1] + "." + v[2] +" " + TranslationTexts.T_BUILD + " " + v[3]
     HTML = HTML.replace("VERSIONSTRING",VERSIONSTRING)
 
     # translate texts


### PR DESCRIPTION
due to the changes from #7955

reported in https://forum.freecadweb.org/viewtopic.php?p=649107#p649107

should also be backported IMO, this is how it's currently shown in stable release
![image](https://user-images.githubusercontent.com/36372335/209415828-1bcc36c7-63d8-4332-8588-6bad9ba03944.png)
