### PR TITLE
DRAFT: Make "draftify" type upgrades return the new object

### DIFF
--- a/src/Mod/Draft/draftfunctions/upgrade.py
+++ b/src/Mod/Draft/draftfunctions/upgrade.py
@@ -486,6 +486,7 @@ def upgrade(objects, delete=False, force=None):
                   and not objects[0].isDerivedFrom("Part::Part2DObjectPython")):
                 result = ext_draftify.draftify(objects[0])
                 if result:
+                    add_list.append(result)
                     _msg(translate("draft","Found 1 non-parametric objects: draftifying it"))
 
         # in the following cases there are no faces
@@ -533,6 +534,7 @@ def upgrade(objects, delete=False, force=None):
                 if edge_type in ("Line", "Circle"):
                     result = ext_draftify.draftify(objects[0])
                     if result:
+                        add_list.append(result)
                         _msg(translate("draft","Found 1 object: draftifying it"))
             # only points, no edges
             elif not edges and len(objects) > 1:


### PR DESCRIPTION
This PR changes the Draft upgrade function so that it returns the new object when it's a draftify.  (Like the wiki documentation says, and like the other types of upgrade do)