### PR TITLE
Notification Area - Non-Intrusive notifications

### DIFF
--- a/src/Base/Builder3D.cpp
+++ b/src/Base/Builder3D.cpp
@@ -987,7 +987,7 @@ void Builder3D::saveToLog()
 {
     ILogger* obs = Base::Console().Get("StatusBar");
     if (obs){
-        obs->SendLog(result.str().c_str(), Base::LogStyle::Log);
+        obs->SendLog("Builder3D",result.str().c_str(), Base::LogStyle::Log);
     }
 }
 

--- a/src/Base/Console.h
+++ b/src/Base/Console.h
@@ -489,7 +489,7 @@ public:
 
     /** Used to send a Log message at the given level.
      */
-    virtual void SendLog(const std::string& msg, LogStyle level) = 0;
+    virtual void SendLog(const std::string& notifiername, const std::string& msg, LogStyle level) = 0;
 
     virtual const char *Name(){return nullptr;}
     bool bErr,bMsg,bLog,bWrn;
@@ -515,24 +515,32 @@ public:
  */
 class BaseExport ConsoleSingleton
 {
-
 public:
     static const unsigned int BufferSize = 4024;
     // exported functions goes here +++++++++++++++++++++++++++++++++++++++
     /// Prints a Message
-    virtual void Message ( const char * pMsg, ... );
+    void Message ( const char * pMsg, ... );
     /// Prints a warning Message
-    virtual void Warning ( const char * pMsg, ... );
+    void Warning ( const char * pMsg, ... );
     /// Prints a error Message
-    virtual void Error   ( const char * pMsg, ... );
+    void Error   ( const char * pMsg, ... );
     /// Prints a log Message
-    virtual void Log     ( const char * pMsg, ... );
+    void Log     ( const char * pMsg, ... );
+    
+    /// Prints a Message with source indication
+    void MessageS ( const std::string &, const char * pMsg, ... );
+    /// Prints a warning Message with source indication
+    void WarningS ( const std::string &, const char * pMsg, ... );
+    /// Prints a error Message with source indication
+    void ErrorS   ( const std::string &, const char * pMsg, ... );
+    /// Prints a log Message with source indication
+    void LogS     ( const std::string &, const char * pMsg, ... );
 
     // observer processing
-    void NotifyMessage(const char *sMsg);
-    void NotifyWarning(const char *sMsg);
-    void NotifyError  (const char *sMsg);
-    void NotifyLog    (const char *sMsg);
+    void NotifyMessage(const char *sMsg, const std::string & notifiername = "");
+    void NotifyWarning(const char *sMsg, const std::string & notifiername = "");
+    void NotifyError  (const char *sMsg, const std::string & notifiername = "");
+    void NotifyLog    (const char *sMsg, const std::string & notifiername = "");
 
     /// Attaches an Observer to FCConsole
     void AttachObserver(ILogger *pcObserver);
@@ -603,6 +611,15 @@ protected:
     // Singleton!
     ConsoleSingleton();
     virtual ~ConsoleSingleton();
+    
+    /// Prints a Message with source indication
+    virtual void MessageV ( const std::string &, const char * pMsg, va_list args );
+    /// Prints a warning Message with source indication
+    virtual void WarningV ( const std::string &, const char * pMsg, va_list args );
+    /// Prints a error Message with source indication
+    virtual void ErrorV   ( const std::string &, const char * pMsg, va_list args );
+    /// Prints a log Message with source indication
+    virtual void LogV     ( const std::string &, const char * pMsg, va_list args );
 
 private:
     // singleton

--- a/src/Base/ConsoleObserver.cpp
+++ b/src/Base/ConsoleObserver.cpp
@@ -58,8 +58,10 @@ ConsoleObserverFile::~ConsoleObserverFile()
     cFileStream.close();
 }
 
-void ConsoleObserverFile::SendLog(const std::string& msg, LogStyle level)
+void ConsoleObserverFile::SendLog(const std::string& notifiername, const std::string& msg, LogStyle level)
 {
+    (void) notifiername;
+    
     std::string prefix;
     switch(level){
         case LogStyle::Warning:
@@ -94,8 +96,10 @@ ConsoleObserverStd::ConsoleObserverStd() :
 
 ConsoleObserverStd::~ConsoleObserverStd() = default;
 
-void ConsoleObserverStd::SendLog(const std::string& msg, LogStyle level)
+void ConsoleObserverStd::SendLog(const std::string& notifiername, const std::string& msg, LogStyle level)
 {
+    (void) notifiername;
+    
     switch(level){
         case LogStyle::Warning:
             this->Warning(msg.c_str());

--- a/src/Base/ConsoleObserver.h
+++ b/src/Base/ConsoleObserver.h
@@ -42,7 +42,7 @@ public:
     ConsoleObserverFile(const char *sFileName);
     ~ConsoleObserverFile() override;
 
-    void SendLog(const std::string& message, LogStyle level) override;
+    void SendLog(const std::string& notifiername, const std::string& message, LogStyle level) override;
     const char* Name() override {return "File";}
 
 protected:
@@ -57,7 +57,7 @@ class BaseExport ConsoleObserverStd: public ILogger
 public:
     ConsoleObserverStd();
     ~ConsoleObserverStd() override;
-    void SendLog(const std::string& message, LogStyle level) override;
+    void SendLog(const std::string& notifiername, const std::string& message, LogStyle level) override;
     const char* Name() override {return "Console";}
 protected:
     bool useColorStderr;

--- a/src/Gui/CMakeLists.txt
+++ b/src/Gui/CMakeLists.txt
@@ -1004,6 +1004,7 @@ SET(Widget_CPP_SRCS
     FileDialog.cpp
     MainWindow.cpp
     MainWindowPy.cpp
+    NotificationBox.cpp
     NotificationArea.cpp
     PrefWidgets.cpp
     InputField.cpp
@@ -1023,6 +1024,7 @@ SET(Widget_HPP_SRCS
     FileDialog.h
     MainWindow.h
     MainWindowPy.h
+    NotificationBox.h
     NotificationArea.h
     PrefWidgets.h
     InputField.h

--- a/src/Gui/CMakeLists.txt
+++ b/src/Gui/CMakeLists.txt
@@ -1004,6 +1004,7 @@ SET(Widget_CPP_SRCS
     FileDialog.cpp
     MainWindow.cpp
     MainWindowPy.cpp
+    NotificationArea.cpp
     PrefWidgets.cpp
     InputField.cpp
     ProgressBar.cpp
@@ -1022,6 +1023,7 @@ SET(Widget_HPP_SRCS
     FileDialog.h
     MainWindow.h
     MainWindowPy.h
+    NotificationArea.h
     PrefWidgets.h
     InputField.h
     ProgressBar.h

--- a/src/Gui/CommandTest.cpp
+++ b/src/Gui/CommandTest.cpp
@@ -728,8 +728,10 @@ public:
     TestConsoleObserver() : matchMsg(0), matchWrn(0), matchErr(0), matchLog(0)
     {
     }
-    void SendLog(const std::string& msg, Base::LogStyle level) override{
+    void SendLog(const std::string& notifiername, const std::string& msg, Base::LogStyle level) override{
 
+        (void) notifiername;
+        
         QMutexLocker ml(&mutex);
 
         switch(level){

--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -122,9 +122,18 @@ void MessageManager::slotUserMessage(const App::DocumentObject& obj, const QStri
 
         if(button == QMessageBox::Yes)
             requireConfirmationCriticalMessageDuringRestoring = false;
+
+        // The user has already acknowledged it, so record it as a Warning
+        showInNotificationArea(obj, msg, App::Document::NotificationType::Warning);
     }
     else { // Non-critical errors and warnings redirected to the notification area
-        showInNotificationArea(obj, msg, notificationtype);
+        if(notificationtype == App::Document::NotificationType::Critical) {
+            // The user has already acknowledged it, so record it as a Warning
+            showInNotificationArea(obj, msg, App::Document::NotificationType::Warning);
+        }
+        else {
+            showInNotificationArea(obj, msg, notificationtype);
+        }
     }
 }
 

--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -30,6 +30,7 @@
 # include <QMessageBox>
 # include <QTextStream>
 # include <QTimer>
+# include <QStatusBar>
 # include <Inventor/actions/SoSearchAction.h>
 # include <Inventor/nodes/SoSeparator.h>
 #endif
@@ -55,6 +56,7 @@
 #include "FileDialog.h"
 #include "MainWindow.h"
 #include "MDIView.h"
+#include "NotificationArea.h"
 #include "Selection.h"
 #include "Thumbnail.h"
 #include "Tree.h"
@@ -77,7 +79,7 @@ namespace Gui {
  * It provides a mechanism requiring confirmation for critical notifications only during User initiated restore/document loading ( it
  * does not require confirmation for macro/Python initiated restore, not to interfere with automations).
  *
- * Additionally, it provides a mechanism to show autoclosing non-modal user notifications in a non-intrusive way.
+ * Other notifications are provided to the Notification Area for non-intrusive notification.
  **/
 class MessageManager {
 public:
@@ -87,44 +89,31 @@ public:
     void setDocument(Gui::Document * pDocument);
     void slotUserMessage(const App::DocumentObject&, const QString &, App::Document::NotificationType);
 
-
 private:
-    void reorderAutoClosingMessages();
-    QMessageBox* createNonModalMessage(const QString & msg, App::Document::NotificationType notificationtype);
-    void pushAutoClosingMessage(const QString & msg, App::Document::NotificationType notificationtype);
-    void pushAutoClosingMessageTooManyMessages();
+    void showInNotificationArea(const App::DocumentObject& obj, const QString & msg, App::Document::NotificationType notificationtype);
 
 private:
     using Connection = boost::signals2::connection;
     Gui::Document * pDoc;
     Connection connectUserMessage;
     bool requireConfirmationCriticalMessageDuringRestoring = true;
-    std::vector<QMessageBox*> openAutoClosingMessages;
-    std::mutex mutexAutoClosingMessages;
-    const int autoClosingTimeout = 5000; // ms
-    const int autoClosingMessageStackingOffset = 10;
-    const unsigned int maxNumberOfOpenAutoClosingMessages = 3;
-    bool maxNumberOfOpenAutoClosingMessagesLimitReached = false;
 };
 
-MessageManager::~MessageManager(){
+MessageManager::~MessageManager()
+{
     connectUserMessage.disconnect();
 }
 
 void MessageManager::setDocument(Gui::Document * pDocument)
 {
-
     pDoc = pDocument;
 
     connectUserMessage = pDoc->getDocument()->signalUserMessage.connect
         (boost::bind(&Gui::MessageManager::slotUserMessage, this, bp::_1, bp::_2, bp::_3));
-
 }
 
 void MessageManager::slotUserMessage(const App::DocumentObject& obj, const QString & msg, App::Document::NotificationType notificationtype)
-{
-    (void) obj;
-
+{  
     auto userInitiatedRestore = Application::Instance->testStatus(Gui::Application::UserInitiatedOpenDocument);
 
     if(notificationtype == App::Document::NotificationType::Critical && userInitiatedRestore && requireConfirmationCriticalMessageDuringRestoring) {
@@ -134,112 +123,38 @@ void MessageManager::slotUserMessage(const App::DocumentObject& obj, const QStri
         if(button == QMessageBox::Yes)
             requireConfirmationCriticalMessageDuringRestoring = false;
     }
-    else { // Non-critical errors and warnings - auto-closing non-blocking message box
-
-        auto messageNumber =  openAutoClosingMessages.size();
-
-        // Not opening more than the number of maximum autoclosing messages
-        // If maximum reached, the mechanism only resets after all present messages are auto-closed
-        if( messageNumber < maxNumberOfOpenAutoClosingMessages) {
-            if(messageNumber == 0 && maxNumberOfOpenAutoClosingMessagesLimitReached) {
-                maxNumberOfOpenAutoClosingMessagesLimitReached = false;
-            }
-
-            if(!maxNumberOfOpenAutoClosingMessagesLimitReached) {
-                pushAutoClosingMessage(msg, notificationtype);
-            }
-        }
-        else {
-            if(!maxNumberOfOpenAutoClosingMessagesLimitReached)
-                pushAutoClosingMessageTooManyMessages();
-
-            maxNumberOfOpenAutoClosingMessagesLimitReached = true;
-        }
+    else { // Non-critical errors and warnings redirected to the notification area
+        showInNotificationArea(obj, msg, notificationtype);
     }
 }
 
-void MessageManager::pushAutoClosingMessage(const QString & msg, App::Document::NotificationType notificationtype)
+void MessageManager::showInNotificationArea(const App::DocumentObject& obj, const QString & msg, App::Document::NotificationType notificationtype)
 {
-    std::lock_guard<std::mutex> g(mutexAutoClosingMessages); // guard to avoid creating new messages while closing old messages (via timer)
-
-    auto msgBox = createNonModalMessage(msg, notificationtype);
-
-    msgBox->show();
-
-    int numberOpenAutoClosingMessages = openAutoClosingMessages.size();
-
-    openAutoClosingMessages.push_back(msgBox);
-
-    reorderAutoClosingMessages();
-
-    QTimer::singleShot(autoClosingTimeout*numberOpenAutoClosingMessages, [msgBox, this](){
-        std::lock_guard<std::mutex> g(mutexAutoClosingMessages); // guard to avoid closing old messages while creating new ones
-        if(msgBox) {
-            msgBox->done(0);
-            openAutoClosingMessages.erase(
-                std::remove(openAutoClosingMessages.begin(), openAutoClosingMessages.end(), msgBox),
-                openAutoClosingMessages.end());
-
-            reorderAutoClosingMessages();
-        }
-    });
-}
-
-void MessageManager::pushAutoClosingMessageTooManyMessages()
-{
-    pushAutoClosingMessage(QObject::tr("Too many message notifications. Notification temporarily stopped. Look at the report view for more information."), App::Document::NotificationType::Warning);
-}
-
-
-QMessageBox* MessageManager::createNonModalMessage(const QString & msg, App::Document::NotificationType notificationtype)
-{
-        auto parent = pDoc->getActiveView();
-
-        QMessageBox* msgBox = new QMessageBox(parent);
-        msgBox->setAttribute(Qt::WA_DeleteOnClose); // msgbox deleted automatically upon closed
-        msgBox->setStandardButtons(QMessageBox::NoButton);
-        msgBox->setWindowFlag(Qt::FramelessWindowHint,true);
-        msgBox->setText(msg);
-
-        if(notificationtype == App::Document::NotificationType::Error) {
-            msgBox->setWindowTitle(QObject::tr("Error"));
-            msgBox->setIcon(QMessageBox::Critical);
-        }
-        else if(notificationtype == App::Document::NotificationType::Warning) {
-            msgBox->setWindowTitle(QObject::tr("Warning"));
-            msgBox->setIcon(QMessageBox::Warning);
-        }
-        else if(notificationtype == App::Document::NotificationType::Information) {
-            msgBox->setWindowTitle(QObject::tr("Information"));
-            msgBox->setIcon(QMessageBox::Information);
-        }
-        else if(notificationtype == App::Document::NotificationType::Critical) {
-            msgBox->setWindowTitle(QObject::tr("Critical"));
-            msgBox->setIcon(QMessageBox::Critical);
-        }
-
-        msgBox->setModal( false ); // if you want it non-modal
-
-        return msgBox;
-}
-
-void MessageManager::reorderAutoClosingMessages()
-{
-    auto parent = pDoc->getActiveView();
-
-    int numberOpenAutoClosingMessages = openAutoClosingMessages.size();
-
-    auto x = parent->width() / 2;
-    auto y = parent->height() / 7;
-
-    int posindex = numberOpenAutoClosingMessages - 1;
-    for (auto rit = openAutoClosingMessages.rbegin(); rit != openAutoClosingMessages.rend(); ++rit, posindex--) {
-        int xw = x - (*rit)->width() / 2 + autoClosingMessageStackingOffset*posindex;;
-        int yw = y + autoClosingMessageStackingOffset*posindex;
-        (*rit)->move(xw, yw);
-        (*rit)->raise();
+    auto mw = getMainWindow();
+    auto statusbar = mw->statusBar();
+    
+    auto narea = statusbar->findChild<NotificationArea *>(QString::fromLatin1("notificationArea"));
+    
+    NotificationArea::NotificationType ntype;
+    
+    switch(notificationtype) {
+        case App::Document::NotificationType::Critical:
+            ntype = NotificationArea::NotificationType::Error;
+            break;
+        case App::Document::NotificationType::Error:
+            ntype = NotificationArea::NotificationType::Error;
+            break;
+        case App::Document::NotificationType::Warning:
+            ntype = NotificationArea::NotificationType::Warning;
+            break;
+        case App::Document::NotificationType::Information:
+            ntype = NotificationArea::NotificationType::Message;
+            break;
     }
+    
+    narea->pushNotification(ntype, QString::fromLatin1(obj.getFullName().c_str()), msg);
 }
+
 
 // Pimpl class
 struct DocumentP

--- a/src/Gui/GuiConsole.cpp
+++ b/src/Gui/GuiConsole.cpp
@@ -109,8 +109,10 @@ void GUIConsole::SendLog(const std::string& msg, Base::LogStyle level)
 // safely ignore GUIConsole::s_nMaxLines and  GUIConsole::s_nRefCount
 GUIConsole::GUIConsole () {}
 GUIConsole::~GUIConsole () {}
-void GUIConsole::SendLog(const std::string& msg, Base::LogStyle level)
+void GUIConsole::SendLog(const std::string& notifiername, const std::string& msg, Base::LogStyle level)
 {
+    (void) notifiername;
+    
     switch(level){
         case Base::LogStyle::Warning:
             std::cerr << "Warning: " << msg;

--- a/src/Gui/GuiConsole.h
+++ b/src/Gui/GuiConsole.h
@@ -47,7 +47,7 @@ public:
   GUIConsole();
   /// Destructor
   ~GUIConsole() override;
-  void SendLog(const std::string& msg, Base::LogStyle level) override;
+  void SendLog(const std::string& notifiername, const std::string& msg, Base::LogStyle level) override;
   const char* Name() override {return "GUIConsole";}
 
 protected:

--- a/src/Gui/Icons/InTray.svg
+++ b/src/Gui/Icons/InTray.svg
@@ -1,0 +1,577 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   inkscape:export-ydpi="90.000000"
+   inkscape:export-xdpi="90.000000"
+   inkscape:export-filename="/home/jimmac/Desktop/wi-fi.png"
+   width="64"
+   height="64"
+   id="svg11300"
+   sodipodi:version="0.32"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   sodipodi:docname="InTray.svg"
+   version="1.1"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs3">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3822">
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1"
+         offset="0"
+         id="stop3824" />
+      <stop
+         style="stop-color:#204a87;stop-opacity:1"
+         offset="1"
+         id="stop3826" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5060"
+       id="radialGradient5031"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-2.774389,0,0,1.969706,112.7623,-872.8854)"
+       cx="605.71429"
+       cy="486.64789"
+       fx="605.71429"
+       fy="486.64789"
+       r="117.14286" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5060">
+      <stop
+         style="stop-color:black;stop-opacity:1;"
+         offset="0"
+         id="stop5062" />
+      <stop
+         style="stop-color:black;stop-opacity:0;"
+         offset="1"
+         id="stop5064" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5060"
+       id="radialGradient5029"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.774389,0,0,1.969706,-1891.633,-872.8854)"
+       cx="605.71429"
+       cy="486.64789"
+       fx="605.71429"
+       fy="486.64789"
+       r="117.14286" />
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         style="stop-color:black;stop-opacity:0;"
+         offset="0"
+         id="stop5050" />
+      <stop
+         id="stop5056"
+         offset="0.5"
+         style="stop-color:black;stop-opacity:1;" />
+      <stop
+         style="stop-color:black;stop-opacity:0;"
+         offset="1"
+         id="stop5052" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5048"
+       id="linearGradient5027"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.774389,0,0,1.969706,-1892.179,-872.8854)"
+       x1="302.85715"
+       y1="366.64789"
+       x2="302.85715"
+       y2="609.50507" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3284">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3286" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3288" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3260">
+      <stop
+         style="stop-color:#204a87;stop-opacity:1;"
+         offset="0"
+         id="stop3262" />
+      <stop
+         style="stop-color:#204a87;stop-opacity:0;"
+         offset="1"
+         id="stop3264" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3239">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop3241" />
+      <stop
+         style="stop-color:#d3d7cf;stop-opacity:1"
+         offset="1"
+         id="stop3243" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11520">
+      <stop
+         id="stop11522"
+         offset="0.0000000"
+         style="stop-color:#ffffff;stop-opacity:1.0000000;" />
+      <stop
+         id="stop11524"
+         offset="1.0000000"
+         style="stop-color:#dcdcdc;stop-opacity:1.0000000;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11508"
+       inkscape:collect="always">
+      <stop
+         id="stop11510"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop11512"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11494"
+       inkscape:collect="always">
+      <stop
+         id="stop11496"
+         offset="0"
+         style="stop-color:#ef2929;stop-opacity:1;" />
+      <stop
+         id="stop11498"
+         offset="1"
+         style="stop-color:#ef2929;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11415">
+      <stop
+         id="stop11417"
+         offset="0.0000000"
+         style="stop-color:#204a87;stop-opacity:0.0000000;" />
+      <stop
+         style="stop-color:#204a87;stop-opacity:1.0000000;"
+         offset="0.50000000"
+         id="stop11423" />
+      <stop
+         id="stop11419"
+         offset="1"
+         style="stop-color:#204a87;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11399"
+       inkscape:collect="always">
+      <stop
+         id="stop11401"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop11403"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-60.28571,-0.285714)"
+       y2="34.462429"
+       x2="43.615788"
+       y1="3.774456"
+       x1="15.82836"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11425"
+       xlink:href="#linearGradient11415"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-60.57143,0)"
+       y2="39.033859"
+       x2="35.679932"
+       y1="9.3458843"
+       x1="9.6957054"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11427"
+       xlink:href="#linearGradient11415"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="33.462429"
+       x2="26.758644"
+       y1="19.774456"
+       x1="13.267134"
+       gradientTransform="translate(-60.85714,0.428571)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11439"
+       xlink:href="#linearGradient11415"
+       inkscape:collect="always" />
+    <radialGradient
+       r="8.5"
+       fy="39.142857"
+       fx="12.071428"
+       cy="39.142857"
+       cx="12.071428"
+       gradientTransform="matrix(1,0,0,0.487395,0,20.06483)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient11441"
+       xlink:href="#linearGradient11399"
+       inkscape:collect="always" />
+    <radialGradient
+       gradientTransform="matrix(1.243453,0,0,1.243453,-6.713754,-3.742847)"
+       gradientUnits="userSpaceOnUse"
+       r="3.8335035"
+       fy="15.048258"
+       fx="27.577173"
+       cy="15.048258"
+       cx="27.577173"
+       id="radialGradient11500"
+       xlink:href="#linearGradient11494"
+       inkscape:collect="always" />
+    <radialGradient
+       r="3.8335035"
+       fy="16.049133"
+       fx="27.577173"
+       cy="16.049133"
+       cx="27.577173"
+       gradientTransform="matrix(1.243453,0,0,1.243453,-6.713754,-3.742847)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient11504"
+       xlink:href="#linearGradient11494"
+       inkscape:collect="always" />
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.338462,0,29.48178)"
+       r="6.5659914"
+       fy="44.565483"
+       fx="30.203562"
+       cy="44.565483"
+       cx="30.203562"
+       id="radialGradient11514"
+       xlink:href="#linearGradient11508"
+       inkscape:collect="always" />
+    <radialGradient
+       gradientTransform="matrix(1.995058,0,0,1.995058,-24.32488,-35.70087)"
+       gradientUnits="userSpaceOnUse"
+       r="20.530962"
+       fy="35.87817"
+       fx="24.44569"
+       cy="35.87817"
+       cx="24.44569"
+       id="radialGradient11526"
+       xlink:href="#linearGradient11520"
+       inkscape:collect="always" />
+    <radialGradient
+       r="6.5659914"
+       fy="44.565483"
+       fx="30.203562"
+       cy="44.565483"
+       cx="30.203562"
+       gradientTransform="matrix(1,0,0,0.338462,0,29.48178)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient11532"
+       xlink:href="#linearGradient11508"
+       inkscape:collect="always" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11508"
+       id="radialGradient1348"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.338462,0,29.48178)"
+       cx="30.203562"
+       cy="44.565483"
+       fx="30.203562"
+       fy="44.565483"
+       r="6.5659914" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11520"
+       id="radialGradient1350"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.995058,0,0,1.995058,-24.32488,-35.70087)"
+       cx="24.44569"
+       cy="35.87817"
+       fx="24.44569"
+       fy="35.87817"
+       r="20.530962" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11494"
+       id="radialGradient1352"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.243453,0,0,1.243453,-6.713754,-3.742847)"
+       cx="27.577173"
+       cy="16.049133"
+       fx="27.577173"
+       fy="16.049133"
+       r="3.8335035" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11494"
+       id="radialGradient1354"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.243453,0,0,1.243453,-6.713754,-3.742847)"
+       cx="27.577173"
+       cy="15.048258"
+       fx="27.577173"
+       fy="15.048258"
+       r="3.8335035" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11508"
+       id="radialGradient1356"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.338462,0,29.48178)"
+       cx="30.203562"
+       cy="44.565483"
+       fx="30.203562"
+       fy="44.565483"
+       r="6.5659914" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11520"
+       id="radialGradient1366"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.049266,0,0,2.049266,-25.65002,-37.31089)"
+       cx="24.44569"
+       cy="35.87817"
+       fx="24.44569"
+       fy="35.87817"
+       r="20.530962" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3239"
+       id="linearGradient3249"
+       gradientUnits="userSpaceOnUse"
+       x1="15.663794"
+       y1="5.1465507"
+       x2="27.11207"
+       y2="42.353451"
+       gradientTransform="matrix(1.3975903,0,0,1.3975902,-1.8915666,-17.192769)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3260"
+       id="linearGradient3266"
+       x1="12.363961"
+       y1="11.394304"
+       x2="18.22703"
+       y2="17.58149"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3813389,0,0,1.3813389,-1.8428134,-16.461473)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3260"
+       id="linearGradient3270"
+       gradientUnits="userSpaceOnUse"
+       x1="12.363961"
+       y1="11.394304"
+       x2="18.22703"
+       y2="17.58149"
+       gradientTransform="matrix(-1.3813389,0,0,1.3813389,65.842795,-16.461473)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3260"
+       id="linearGradient3278"
+       gradientUnits="userSpaceOnUse"
+       x1="12.363961"
+       y1="11.394304"
+       x2="18.22703"
+       y2="17.58149"
+       gradientTransform="matrix(1.3813389,0,0,-1.3813389,-1.8428134,48.504624)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3260"
+       id="linearGradient3280"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.3813389,0,0,-1.3813389,65.842795,48.504624)"
+       x1="12.363961"
+       y1="11.394304"
+       x2="18.22703"
+       y2="17.58149" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3284"
+       id="radialGradient3290"
+       cx="25.455845"
+       cy="43.403805"
+       fx="25.455845"
+       fy="43.403805"
+       r="20.682873"
+       gradientTransform="matrix(1,0,0,0.205128,0,34.50046)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3822"
+       id="linearGradient3828"
+       x1="44"
+       y1="41"
+       x2="53"
+       y2="56"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3822-6-2"
+       id="linearGradient3834-3-0"
+       gradientUnits="userSpaceOnUse"
+       x1="48"
+       y1="54"
+       x2="46"
+       y2="42"
+       gradientTransform="rotate(180,34.5,29.5)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3822-6-2">
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1"
+         offset="0"
+         id="stop3824-7-3" />
+      <stop
+         style="stop-color:#204a87;stop-opacity:1"
+         offset="1"
+         id="stop3826-5-7" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     stroke="#ef2929"
+     fill="#204a87"
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="0.25490196"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11.313708"
+     inkscape:cx="29.654292"
+     inkscape:cy="26.5607"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:grid-bbox="true"
+     inkscape:document-units="px"
+     inkscape:showpageshadow="false"
+     inkscape:window-width="1920"
+     inkscape:window-height="986"
+     inkscape:window-x="0"
+     inkscape:window-y="32"
+     inkscape:snap-nodes="true"
+     inkscape:snap-bbox="true"
+     inkscape:window-maximized="1"
+     inkscape:pagecheckerboard="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3048"
+       empspacing="2"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata4">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>Jakub Steiner</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:source>http://jimmac.musichall.cz</dc:source>
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/by-sa/2.0/" />
+        <dc:title>View Fullscreen</dc:title>
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by-sa/2.0/">
+        <cc:permits
+           rdf:resource="http://web.resource.org/cc/Reproduction" />
+        <cc:permits
+           rdf:resource="http://web.resource.org/cc/Distribution" />
+        <cc:requires
+           rdf:resource="http://web.resource.org/cc/Notice" />
+        <cc:requires
+           rdf:resource="http://web.resource.org/cc/Attribution" />
+        <cc:permits
+           rdf:resource="http://web.resource.org/cc/DerivativeWorks" />
+        <cc:requires
+           rdf:resource="http://web.resource.org/cc/ShareAlike" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,16)">
+    <g
+       style="display:inline"
+       id="g5022"
+       transform="matrix(0.03152036,0,0,0.03344397,60.035325,37.041739)">
+      <rect
+         y="-150.69685"
+         x="-1559.2523"
+         height="478.35718"
+         width="1339.6335"
+         id="rect4173"
+         style="opacity:0.40206185;color:#000000;fill:url(#linearGradient5027);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+      <path
+         sodipodi:nodetypes="cccc"
+         id="path5058"
+         d="m -219.61876,-150.68038 c 0,0 0,478.33079 0,478.33079 142.874166,0.90045 345.40022,-107.16966 345.40014,-239.196175 0,-132.026537 -159.436816,-239.134595 -345.40014,-239.134615 z"
+         style="opacity:0.40206185;color:#000000;fill:url(#radialGradient5029);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+         inkscape:connector-curvature="0" />
+      <path
+         style="opacity:0.40206185;color:#000000;fill:url(#radialGradient5031);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+         d="m -1559.2523,-150.68038 c 0,0 0,478.33079 0,478.33079 -142.8742,0.90045 -345.4002,-107.16966 -345.4002,-239.196175 0,-132.026537 159.4368,-239.134595 345.4002,-239.134615 z"
+         id="path5018"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0" />
+    </g>
+    <rect
+       style="color:#000000;fill:url(#linearGradient3249);fill-opacity:1;fill-rule:evenodd;stroke:#888a85;stroke-width:1.99999975999999990;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible"
+       id="rect2354"
+       width="58"
+       height="57.999996"
+       x="3"
+       y="-12.999999"
+       rx="2.5900114"
+       ry="2.5900111" />
+    <path
+       sodipodi:type="inkscape:offset"
+       inkscape:radius="-1.0340382"
+       inkscape:original="M 5.5898438 -13 C 4.1549775 -13 3 -11.845022 3 -10.410156 L 3 42.410156 C 3 43.845022 4.1549775 45 5.5898438 45 L 58.410156 45 C 59.845023 45 61 43.845022 61 42.410156 L 61 -10.410156 C 61 -11.845022 59.845023 -13 58.410156 -13 L 5.5898438 -13 z "
+       xlink:href="#rect2354"
+       style="color:#000000;fill:none;stroke:#ffffff;stroke-width:2.07175946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible"
+       id="path3247"
+       inkscape:href="#rect2354"
+       d="m 5.59375,-11.96875 c -0.8780988,0 -1.5625,0.684401 -1.5625,1.5625 l 0,52.8125 c 0,0.878099 0.6844012,1.5625 1.5625,1.5625 l 52.8125,0 c 0.878098,0 1.5625,-0.684402 1.5625,-1.5625 l 0,-52.8125 c 0,-0.878098 -0.684402,-1.5625 -1.5625,-1.5625 l -52.8125,0 z"
+       transform="matrix(0.96536313,0,0,0.96536312,1.10838,0.55418996)" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path3050-5-8"
+       d="M 12,2 V 39 H 52 V 2 C 38.666667,2 25.333333,2 12,2 Z"
+       style="fill:url(#linearGradient3834-3-0);fill-opacity:1;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       sodipodi:nodetypes="cccccc"
+       inkscape:connector-curvature="0"
+       id="path3820-6-9"
+       d="M 50,5 32,20 14,5 14.15625,37 H 50 Z"
+       style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  </g>
+</svg>

--- a/src/Gui/Icons/Warning.svg
+++ b/src/Gui/Icons/Warning.svg
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="64px"
+   height="64px"
+   id="svg2735"
+   sodipodi:version="0.32"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   sodipodi:docname="Warning.svg"
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   version="1.1"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs2737">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3774">
+      <stop
+         style="stop-color:#c4a000;stop-opacity:1"
+         offset="0"
+         id="stop3776" />
+      <stop
+         style="stop-color:#edd400;stop-opacity:0;"
+         offset="1"
+         id="stop3778" />
+    </linearGradient>
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 32 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="64 : 32 : 1"
+       inkscape:persp3d-origin="32 : 21.333333 : 1"
+       id="perspective2743" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3774"
+       id="linearGradient3780"
+       x1="531.31073"
+       y1="35.292263"
+       x2="517.97607"
+       y2="-14.006179"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11"
+     inkscape:cx="27.590909"
+     inkscape:cy="34.318182"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:document-units="px"
+     inkscape:grid-bbox="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="986"
+     inkscape:window-x="0"
+     inkscape:window-y="32"
+     inkscape:window-maximized="1"
+     inkscape:pagecheckerboard="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2984"
+       empspacing="2"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata2740">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer">
+    <path
+       transform="matrix(1.0590534,0,0,1.0590534,-518.49688,29.778244)"
+       style="fill:#fce94f;fill-opacity:1;fill-rule:evenodd;stroke:#302b00;stroke-width:1.88847888;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       d="m 519.80087,-21.508116 27.38295,47.211972 -54.76589,0 z"
+       id="path2644"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+    <path
+       transform="matrix(0.89990936,0,0,0.93309237,-436.1315,31.069059)"
+       style="fill:url(#linearGradient3780);fill-opacity:1;fill-rule:evenodd;stroke:#fce94f;stroke-width:2.18257069999999986;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       d="m 520.1985,-21.508115 28.3867,47.15503 -56.77339,0 z"
+       id="path2644-3"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.959166px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 30,19 29,39.24 32,42 35,39.24 34,19 Z"
+       id="path67"
+       sodipodi:nodetypes="cccccc" />
+    <circle
+       style="fill:#000000;stroke:#000000;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path91"
+       cx="31.970903"
+       cy="48.55901"
+       r="2" />
+  </g>
+</svg>

--- a/src/Gui/Icons/resource.qrc
+++ b/src/Gui/Icons/resource.qrc
@@ -98,6 +98,7 @@
         <file>accessories-text-editor.svg</file>
         <file>accessories-calculator.svg</file>
         <file>internet-web-browser.svg</file>
+        <file>InTray.svg</file>
         <file>view-select.svg</file>
         <file>view-unselectable.svg</file>
         <file>view-refresh.svg</file>

--- a/src/Gui/Icons/resource.qrc
+++ b/src/Gui/Icons/resource.qrc
@@ -251,6 +251,7 @@
         <file>Std_UserEditModeTransform.svg</file>
         <file>Std_UserEditModeCutting.svg</file>
         <file>Std_UserEditModeColor.svg</file>
+        <file>Warning.svg</file>
     </qresource>
     <!-- Demonstrating support for an embedded icon theme -->
     <!-- See also http://permalink.gmane.org/gmane.comp.lib.qt.general/26374 -->

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -2123,8 +2123,10 @@ void StatusBarObserver::OnChange(Base::Subject<const char*> &rCaller, const char
     }
 }
 
-void StatusBarObserver::SendLog(const std::string& msg, Base::LogStyle level)
+void StatusBarObserver::SendLog(const std::string& notifiername, const std::string& msg, Base::LogStyle level)
 {
+    (void) notifiername;
+    
     int messageType = -1;
     switch(level){
         case Base::LogStyle::Warning:

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -80,6 +80,7 @@
 #include "DownloadManager.h"
 #include "FileDialog.h"
 #include "MenuManager.h"
+#include "NotificationArea.h"
 #include "ProgressBar.h"
 #include "PropertyView.h"
 #include "PythonConsole.h"
@@ -251,7 +252,6 @@ protected:
 
 } // namespace Gui
 
-
 /* TRANSLATOR Gui::MainWindow */
 
 MainWindow::MainWindow(QWidget * parent, Qt::WindowFlags f)
@@ -302,6 +302,11 @@ MainWindow::MainWindow(QWidget * parent, Qt::WindowFlags f)
     QProgressBar* progressBar = Gui::SequencerBar::instance()->getProgressBar(statusBar());
     statusBar()->addPermanentWidget(progressBar, 0);
     statusBar()->addPermanentWidget(d->sizeLabel, 0);
+    
+    NotificationArea* notificationArea = new NotificationArea(statusBar());
+    notificationArea->setObjectName(QString::fromLatin1("notificationArea"));
+    notificationArea->setIcon(QIcon(QString::fromLatin1(":/icons/InTray.svg")));
+    statusBar()->addPermanentWidget(notificationArea);
 
     // clears the action label
     d->actionTimer = new QTimer( this );

--- a/src/Gui/MainWindow.h
+++ b/src/Gui/MainWindow.h
@@ -375,7 +375,7 @@ public:
     /** Observes its parameter group. */
     void OnChange(Base::Subject<const char*> &rCaller, const char * sReason) override;
 
-    void SendLog(const std::string& msg, Base::LogStyle level) override;
+    void SendLog(const std::string& notifiername, const std::string& msg, Base::LogStyle level) override;
 
     /// name of the observer
     const char *Name() override {return "StatusBar";}

--- a/src/Gui/NotificationArea.cpp
+++ b/src/Gui/NotificationArea.cpp
@@ -1,0 +1,253 @@
+/***************************************************************************
+ *   Copyright (c) 2022 Abdullah Tahiri <abdullah.tahiri.yo@gmail.com      *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef _PreComp_
+# include <memory>
+# include <mutex>
+# include <QApplication>
+# include <QAction>
+# include <QActionEvent>
+# include <QEvent>
+# include <QHBoxLayout>
+# include <QMenu>
+# include <QStringList>
+# include <QTreeWidget>
+# include <QTimer>
+# include <QToolTip>
+# include <QWidgetAction>
+#endif
+
+#include <Base/Console.h>
+
+#include "BitmapFactory.h"
+
+#include "NotificationArea.h"
+
+using namespace Gui;
+
+namespace Gui {
+class NotificationItem : public QTreeWidgetItem
+{
+public:
+    NotificationItem(NotificationArea::NotificationType notificationtype, QString notifiername, QString message):
+        notificationType(notificationtype), notifierName(std::move(notifiername)), msg(std::move(message)){}
+
+    QVariant data(int column, int role) const override {
+        // property name
+        if( role == Qt::DisplayRole ) {
+            switch(column) {
+                case 1:
+                    return notifierName;
+                    break;
+                case 2:
+                    return msg;
+                    break;
+            }
+        }
+        else
+        if(column == 0 && role == Qt::DecorationRole) {
+            if(notificationType == NotificationArea::NotificationType::Error) {
+                return QVariant::fromValue(BitmapFactory().pixmapFromSvg(":/icons/edit_Cancel.svg",QSize(16, 16)));
+            }
+            else
+            if(notificationType == NotificationArea::NotificationType::Warning) {
+                return QVariant::fromValue(BitmapFactory().pixmapFromSvg(":/icons/Warning.svg",QSize(16, 16)));
+            }
+        }
+
+        return QVariant();
+    }
+
+    NotificationArea::NotificationType notificationType;
+    QString notifierName;
+    QString msg;
+};
+
+class NotificationAreaObserver: public Base::ILogger
+{
+public:
+    NotificationAreaObserver(NotificationArea * notificationarea);
+    ~NotificationAreaObserver() override;
+
+
+    void SendLog(const std::string& notifiername, const std::string& msg, Base::LogStyle level) override;
+
+    /// name of the observer
+    const char *Name() override {return "NotificationAreaObserver";}
+
+private:
+    NotificationArea * notificationArea;
+};
+
+struct NotificationAreaP
+{
+    int currentlyNotifyingIndex = 0;
+    std::mutex mutexNotification;
+    const unsigned int notificationExpirationTime = 5000;
+    QMenu * menu;
+    QTreeWidget * table;
+
+    std::unique_ptr<NotificationAreaObserver> observer;
+};
+
+} // namespace Gui
+
+NotificationAreaObserver::NotificationAreaObserver(NotificationArea * notificationarea): notificationArea(notificationarea)
+{
+    Base::Console().AttachObserver(this);
+}
+
+NotificationAreaObserver::~NotificationAreaObserver()
+{
+    Base::Console().DetachObserver(this);
+}
+
+void NotificationAreaObserver::SendLog(const std::string& notifiername, const std::string& msg, Base::LogStyle level)
+{
+    switch(level) {
+        case Base::LogStyle::Error:
+            notificationArea->pushNotification(NotificationArea::NotificationType::Error, QString::fromLatin1(notifiername.c_str()), QString::fromLatin1(msg.c_str()));
+            break;
+        case Base::LogStyle::Warning:
+            notificationArea->pushNotification(NotificationArea::NotificationType::Warning, QString::fromLatin1(notifiername.c_str()), QString::fromLatin1(msg.c_str()));
+            break;
+        case Base::LogStyle::Message:
+            notificationArea->pushNotification(NotificationArea::NotificationType::Message, QString::fromLatin1(notifiername.c_str()), QString::fromLatin1(msg.c_str()));
+            break;
+        default:
+            break;
+    }
+}
+
+class NotificationsAction : public QWidgetAction
+{
+public:
+    NotificationsAction(QWidget* parent) : QWidgetAction(parent), parentWidget(parent) {}
+
+    auto getTable(){return tableWidget;}
+protected:
+    QWidget* createWidget(QWidget* parent) override
+    {
+        QWidget* notificationsWidget = new QWidget(parent);
+
+        QHBoxLayout* layout = new QHBoxLayout(notificationsWidget);
+        notificationsWidget->setLayout(layout);
+
+        tableWidget = new QTreeWidget(parent);
+        tableWidget->setColumnCount(3);
+
+        QStringList headers;
+        headers << QObject::tr("Type") << QObject::tr("Notifier") << QObject::tr("Message");
+        tableWidget->setHeaderLabels(headers);
+
+        layout->addWidget(tableWidget);
+
+        //tableWidget->installEventFilter(this);
+
+        return notificationsWidget;
+    }
+
+private:
+    QTreeWidget * tableWidget;
+    QWidget * parentWidget;
+};
+
+NotificationArea::NotificationArea(QWidget *parent):QPushButton(parent)
+{
+    setFlat(true);
+
+    d = std::make_unique<NotificationAreaP>();
+
+    d->observer = std::make_unique<NotificationAreaObserver>(this);
+
+    d->menu = new QMenu(parent);
+    setMenu(d->menu);
+
+    auto na = new NotificationsAction(d->menu);
+
+    d->menu->addAction(na);
+
+    d->table = na->getTable();
+}
+
+void NotificationArea::pushNotification(NotificationType notificationtype, const QString & notifiername, const QString & message)
+{
+    auto * item = new NotificationItem(notificationtype, notifiername, message);
+
+    std::lock_guard<std::mutex> g(d->mutexNotification); // guard to avoid modifying the notification list and start index while creating the tooltip
+
+    d->table->insertTopLevelItem(0,item);
+    d->currentlyNotifyingIndex++;
+
+    showInNotificationArea();
+
+    QTimer::singleShot(d->notificationExpirationTime, [this](){
+        std::lock_guard<std::mutex> g(d->mutexNotification); // guard to avoid modifying the notification start index while creating the tooltip
+        d->currentlyNotifyingIndex--;
+    });
+
+}
+
+void NotificationArea::showInNotificationArea()
+{
+    QString msgw = QString::fromLatin1("<style>p { margin: 0 0 0 0 }</style><p style='white-space:nowrap'>              \
+    <table>                                                                                                             \
+     <tr>                                                                                                               \
+      <th><small>%1</small></th>                                                                                        \
+      <th><small>%2</small></th>                                                                                        \
+      <th><small>%3</small></th>                                                                                        \
+     </tr>")
+        .arg(QObject::tr("Type"))
+        .arg(QObject::tr("Notifier"))
+        .arg(QObject::tr("Message"));
+
+    for(int i = 0 ; i < d->currentlyNotifyingIndex; i++) {
+        NotificationItem* item = static_cast<NotificationItem*>(d->table->topLevelItem(i));
+
+        QString iconstr;
+        if(item->notificationType == NotificationArea::NotificationType::Error) {
+            iconstr = QStringLiteral(":/icons/edit_Cancel.svg");
+        }
+        else
+        if(item->notificationType == NotificationArea::NotificationType::Warning) {
+            iconstr = QStringLiteral(":/icons/Warning.svg");
+        }
+
+        msgw += QString::fromLatin1("                                                                                   \
+        <tr>                                                                                                            \
+        <td align='center'><img width=\"16\" height=\"16\" src='%1'></td>                                               \
+        <td align='center'>%2</td>                                                                                      \
+        <td align='center'>%3</td>                                                                                      \
+        </tr>")
+            .arg(iconstr)
+            .arg(item->notifierName)
+            .arg(item->msg);
+    }
+
+
+
+    msgw += QString::fromLatin1("</table></p>");
+
+
+    QToolTip::hideText(); // ensure the tooltip is not being shown
+    QToolTip::showText( this->mapToGlobal( QPoint( ) ), msgw);
+}

--- a/src/Gui/NotificationArea.cpp
+++ b/src/Gui/NotificationArea.cpp
@@ -1,5 +1,5 @@
 /***************************************************************************
- *   Copyright (c) 2022 Abdullah Tahiri <abdullah.tahiri.yo@gmail.com      *
+ *   Copyright (c) 2022 Abdullah Tahiri <abdullah.tahiri.yo@gmail.com>     *
  *                                                                         *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *
@@ -33,13 +33,13 @@
 # include <QStringList>
 # include <QTreeWidget>
 # include <QTimer>
-# include <QToolTip>
 # include <QWidgetAction>
 #endif
 
 #include <Base/Console.h>
 
 #include "BitmapFactory.h"
+#include "NotificationBox.h"
 
 #include "NotificationArea.h"
 
@@ -107,7 +107,7 @@ struct NotificationAreaP
     int currentlyNotifyingIndex = 0;
     unsigned int unread = 0;
     std::mutex mutexNotification;
-    const unsigned int notificationExpirationTime = 5000;
+    const unsigned int notificationExpirationTime = 10000;
     QMenu * menu;
     QTreeWidget * table;
 
@@ -230,14 +230,16 @@ void NotificationArea::pushNotification(NotificationType notificationtype, const
 
     QTimer::singleShot(d->notificationExpirationTime, [this](){
         std::lock_guard<std::mutex> g(d->mutexNotification); // guard to avoid modifying the notification start index while creating the tooltip
-        d->currentlyNotifyingIndex--;
+        if(d->currentlyNotifyingIndex > 0)
+            d->currentlyNotifyingIndex--;
     });
 
 }
 
 void NotificationArea::showInNotificationArea()
 {
-    QString msgw = QString::fromLatin1("<style>p { margin: 0 0 0 0 }</style><p style='white-space:nowrap'>              \
+    QString msgw = QString::fromLatin1("<style>p { margin: 0 0 0 0 } td { padding: 0 15px }</style>                     \
+    <p style='white-space:nowrap'>                                                                                      \
     <table>                                                                                                             \
      <tr>                                                                                                               \
       <th><small>%1</small></th>                                                                                        \
@@ -262,20 +264,17 @@ void NotificationArea::showInNotificationArea()
 
         msgw += QString::fromLatin1("                                                                                   \
         <tr>                                                                                                            \
-        <td align='center'><img width=\"16\" height=\"16\" src='%1'></td>                                               \
-        <td align='center'>%2</td>                                                                                      \
-        <td align='center'>%3</td>                                                                                      \
+        <td align='left'><img width=\"16\" height=\"16\" src='%1'></td>                                               \
+        <td align='left'>%2</td>                                                                                      \
+        <td align='left'>%3</td>                                                                                      \
         </tr>")
             .arg(iconstr)
             .arg(item->notifierName)
             .arg(item->msg);
     }
 
-
-
     msgw += QString::fromLatin1("</table></p>");
 
 
-    QToolTip::hideText(); // ensure the tooltip is not being shown
-    QToolTip::showText( this->mapToGlobal( QPoint( ) ), msgw);
+    NotificationBox::showText( this->mapToGlobal( QPoint( ) ), msgw, d->notificationExpirationTime);
 }

--- a/src/Gui/NotificationArea.h
+++ b/src/Gui/NotificationArea.h
@@ -1,0 +1,57 @@
+/***************************************************************************
+ *   Copyright (c) 2022 Abdullah Tahiri <abdullah.tahiri.yo@gmail.com      *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef GUI_NOTIFICATIONAREA_H
+#define GUI_NOTIFICATIONAREA_H
+
+#include <QPushButton>
+#include <QString>
+
+namespace Gui {
+
+struct NotificationAreaP;
+
+class NotificationArea : public QPushButton
+{
+public:
+    enum class NotificationType {
+        Error,
+        Warning,
+        Message,
+    };
+
+public:
+    NotificationArea(QWidget *parent = nullptr);
+
+    void pushNotification(NotificationType notificationtype, const QString & notifiername, const QString & message);
+
+private:
+    void showInNotificationArea();
+
+private:
+    std::unique_ptr<NotificationAreaP> d;
+};
+
+
+} // namespace Gui
+
+#endif // GUI_NOTIFICATIONAREA_H

--- a/src/Gui/NotificationArea.h
+++ b/src/Gui/NotificationArea.h
@@ -1,5 +1,5 @@
 /***************************************************************************
- *   Copyright (c) 2022 Abdullah Tahiri <abdullah.tahiri.yo@gmail.com      *
+ *   Copyright (c) 2022 Abdullah Tahiri <abdullah.tahiri.yo@gmail.com>     *
  *                                                                         *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *

--- a/src/Gui/NotificationBox.cpp
+++ b/src/Gui/NotificationBox.cpp
@@ -1,0 +1,325 @@
+/***************************************************************************
+ *   Copyright (c) 2023 Abdullah Tahiri <abdullah.tahiri.yo@gmail.com>     *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef _PreComp_
+# include <memory>
+# include <mutex>
+# include <QApplication>
+# include <QAction>
+# include <QActionEvent>
+# include <QDesktopWidget>
+# include <QEvent>
+# include <QHBoxLayout>
+# include <QHeaderView>
+# include <QLabel>
+# include <QMenu>
+# include <QPointer>
+# include <QScreen>
+# include <QStyleOption>
+# include <QStylePainter>
+# include <QStringList>
+# include <QTextDocument>
+# include <QTimer>
+#endif
+
+#include "NotificationBox.h"
+
+using namespace Gui;
+
+namespace Gui {
+
+class NotificationLabel : public QLabel
+{
+    Q_OBJECT
+public:
+    // Windows implementation uses QWidget w to pass the screen (see NotificationBox::showText).
+    // This screen is used as parent for QLabel.
+    // Linux implementation does not rely on a parent (w = nullptr).
+    NotificationLabel(const QString &text, const QPoint &pos, QWidget *w, int msecDisplayTime);
+    ~NotificationLabel();
+    static NotificationLabel *instance;
+    void adjustToollabelScreen(const QPoint &pos);
+    void updateSize(const QPoint &pos);
+    bool eventFilter(QObject *, QEvent *) override;
+    QBasicTimer hideTimer, expireTimer;
+    void reuseNotification(const QString &text, int msecDisplayTime, const QPoint &pos);
+    void hideNotification();
+    void hideNotificationImmediately();
+    void restartExpireTimer(int msecDisplayTime);
+    bool notificationLabelChanged(const QString &text);
+    void placeNotificationLabel(const QPoint &pos);
+protected:
+    void timerEvent(QTimerEvent *e) override;
+    void paintEvent(QPaintEvent *e) override;
+    void resizeEvent(QResizeEvent *e) override;
+};
+
+NotificationLabel *NotificationLabel::instance = nullptr;
+
+NotificationLabel::NotificationLabel(const QString &text, const QPoint &pos, QWidget *w, int msecDisplayTime)
+: QLabel(w, Qt::ToolTip | Qt::BypassGraphicsProxyWidget)
+{
+    delete instance;
+    instance = this;
+    setForegroundRole(QPalette::ToolTipText); // defaults to ToolTip QPalette
+    setBackgroundRole(QPalette::ToolTipBase); // defaults to ToolTip QPalette
+    setPalette(NotificationBox::palette());
+    ensurePolished();
+    setMargin(1 + style()->pixelMetric(QStyle::PM_ToolTipLabelFrameWidth, nullptr, this));
+    setFrameStyle(QFrame::NoFrame);
+    setAlignment(Qt::AlignLeft);
+    setIndent(1);
+    qApp->installEventFilter(this);
+    setWindowOpacity(style()->styleHint(QStyle::SH_ToolTipLabel_Opacity, nullptr, this) / 255.0);
+    setMouseTracking(false);
+    reuseNotification(text, msecDisplayTime, pos);
+}
+void NotificationLabel::restartExpireTimer(int msecDisplayTime)
+{
+    int time = 10000 + 40 * qMax(0, text().length()-100);
+    if (msecDisplayTime > 0) {
+        time = msecDisplayTime;
+    }
+    expireTimer.start(time, this);
+    hideTimer.stop();
+}
+void NotificationLabel::reuseNotification(const QString &text, int msecDisplayTime, const QPoint &pos)
+{
+    setText(text);
+    updateSize(pos);
+    restartExpireTimer(msecDisplayTime);
+}
+void NotificationLabel::updateSize(const QPoint &pos)
+{
+    // Ensure that we get correct sizeHints by placing this window on the right screen.
+    QFontMetrics fm(font());
+    QSize extra(1, 0);
+    // Make it look good with the default ToolTip font on Mac, which has a small descent.
+    if (fm.descent() == 2 && fm.ascent() >= 11) {
+        ++extra.rheight();
+    }
+
+    setWordWrap(Qt::mightBeRichText(text()));
+
+    QSize sh = sizeHint();
+
+    // ### When the above WinRT code is fixed, windowhandle should be used to find the screen.
+    QScreen *screen = QGuiApplication::screenAt(pos);
+    if (!screen) {
+        screen = QGuiApplication::primaryScreen();
+    }
+
+    if (screen) {
+        const qreal screenWidth = screen->geometry().width();
+        if (!wordWrap() && sh.width() > screenWidth) {
+            setWordWrap(true);
+            sh = sizeHint();
+        }
+    }
+
+    resize(sh + extra);
+}
+void NotificationLabel::paintEvent(QPaintEvent *ev)
+{
+    QStylePainter p(this);
+    QStyleOptionFrame opt;
+    opt.init(this);
+    p.drawPrimitive(QStyle::PE_PanelTipLabel, opt);
+    p.end();
+    QLabel::paintEvent(ev);
+}
+void NotificationLabel::resizeEvent(QResizeEvent *e)
+{
+    QStyleHintReturnMask frameMask;
+    QStyleOption option;
+
+    option.init(this);
+
+    if (style()->styleHint(QStyle::SH_ToolTip_Mask, &option, this, &frameMask)) {
+        setMask(frameMask.region);
+    }
+
+    QLabel::resizeEvent(e);
+}
+
+NotificationLabel::~NotificationLabel()
+{
+    instance = nullptr;
+}
+void NotificationLabel::hideNotification()
+{
+    if (!hideTimer.isActive()) {
+        hideTimer.start(300, this);
+    }
+}
+void NotificationLabel::hideNotificationImmediately()
+{
+    close(); // to trigger QEvent::Close which stops the animation
+    deleteLater();
+}
+
+void NotificationLabel::timerEvent(QTimerEvent *e)
+{
+    if (e->timerId() == hideTimer.timerId() ||
+        e->timerId() == expireTimer.timerId()) {
+
+        hideTimer.stop();
+        expireTimer.stop();
+        hideNotificationImmediately();
+    }
+}
+
+bool NotificationLabel::eventFilter(QObject *o, QEvent *e)
+{
+    Q_UNUSED(o)
+
+    switch (e->type()) {
+        case QEvent::MouseButtonPress:
+            hideNotification();
+            break;
+        default:
+            break;
+    }
+    return false;
+}
+
+void NotificationLabel::placeNotificationLabel(const QPoint &pos)
+{
+    QPoint p = pos;
+    const QScreen *screen = QGuiApplication::screenAt(pos);
+    // a QScreen's handle *should* never be null, so this is a bit paranoid
+    if (screen ? screen->handle() : nullptr) {
+        const QSize cursorSize = QSize(16, 16);
+
+        QPoint offset(2, cursorSize.height());
+        // assuming an arrow shape, we can just move to the side for very large cursors
+        if (cursorSize.height() > 2 * this->height())
+            offset = QPoint(cursorSize.width() / 2, 0);
+
+        p += offset;
+
+        QRect screenRect = screen->geometry();
+
+        if (p.x() + this->width() > screenRect.x() + screenRect.width())
+            p.rx() -= 4 + this->width();
+        if (p.y() + this->height() > screenRect.y() + screenRect.height())
+            p.ry() -= 24 + this->height();
+        if (p.y() < screenRect.y())
+            p.setY(screenRect.y());
+        if (p.x() + this->width() > screenRect.x() + screenRect.width())
+            p.setX(screenRect.x() + screenRect.width() - this->width());
+        if (p.x() < screenRect.x())
+            p.setX(screenRect.x());
+        if (p.y() + this->height() > screenRect.y() + screenRect.height())
+            p.setY(screenRect.y() + screenRect.height() - this->height());
+    }
+
+    this->move(p);
+}
+bool NotificationLabel::notificationLabelChanged(const QString &text)
+{
+    if (NotificationLabel::instance->text() != text) {
+        return true;
+    }
+
+    return false;
+}
+
+/***************************** NotificationBox **********************************/
+
+void NotificationBox::showText(const QPoint &pos, const QString &text, int msecDisplayTime)
+{
+    // a label does already exist
+    if (NotificationLabel::instance && NotificationLabel::instance->isVisible()){
+        if (text.isEmpty()){ // empty text means hide current label
+            NotificationLabel::instance->hideNotification();
+            return;
+        }
+        else {
+            // If the label has changed, reuse the one that is showing (removes flickering)
+            if (NotificationLabel::instance->notificationLabelChanged(text)){
+                NotificationLabel::instance->reuseNotification(text, msecDisplayTime, pos);
+                NotificationLabel::instance->placeNotificationLabel(pos);
+            }
+            return;
+        }
+    }
+
+    // no label can be reused, create new label:
+    if (!text.isEmpty()){
+        #ifdef Q_OS_WIN32
+        // On windows, we can't use the widget as parent otherwise the window will be
+        // raised when the toollabel will be shown
+        QT_WARNING_PUSH
+        QT_WARNING_DISABLE_DEPRECATED
+        new NotificationLabel(text, pos, QGuiApplication::screenAt(pos), msecDisplayTime); // NotificationLabel manages its own lifetime.
+        QT_WARNING_POP
+        #else
+        new NotificationLabel(text, pos, nullptr, msecDisplayTime); // sets NotificationLabel::instance to itself
+        #endif
+        NotificationLabel::instance->placeNotificationLabel(pos);
+        NotificationLabel::instance->setObjectName(QLatin1String("NotificationBox_label"));
+
+        NotificationLabel::instance->showNormal();
+    }
+}
+
+bool NotificationBox::isVisible()
+{
+    return (NotificationLabel::instance != nullptr && NotificationLabel::instance->isVisible());
+}
+
+QString NotificationBox::text()
+{
+    if (NotificationLabel::instance)
+        return NotificationLabel::instance->text();
+    return QString();
+}
+
+Q_GLOBAL_STATIC(QPalette, notificationbox_palette)
+
+QPalette NotificationBox::palette()
+{
+    return *notificationbox_palette();
+}
+
+QFont NotificationBox::font()
+{
+    return QApplication::font("NotificationLabel");
+}
+
+void NotificationBox::setPalette(const QPalette &palette)
+{
+    *notificationbox_palette() = palette;
+    if (NotificationLabel::instance)
+        NotificationLabel::instance->setPalette(palette);
+}
+
+void NotificationBox::setFont(const QFont &font)
+{
+    QApplication::setFont(font, "NotificationLabel");
+}
+
+} // namespace Gui
+
+#include "NotificationBox.moc"
+

--- a/src/Gui/NotificationBox.h
+++ b/src/Gui/NotificationBox.h
@@ -1,0 +1,56 @@
+/***************************************************************************
+ *   Copyright (c) 2023 Abdullah Tahiri <abdullah.tahiri.yo@gmail.com >    *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef GUI_NOTIFICATIONBOX_H
+#define GUI_NOTIFICATIONBOX_H
+
+
+
+namespace Gui {
+
+    /* This class provides a non-intrusive tip alike notification
+     * dialog, which unlike QToolTip, is kept shown during a time
+     * unless it is clicked.
+     *
+     * The time is calculated based on the length if not provided.
+     *
+     * This class interface and its implementation are based on QT's
+     * QToolTip.
+     */
+    class NotificationBox
+    {
+        NotificationBox() = delete;
+    public:
+        static void showText(const QPoint &pos, const QString &text, int msecShowTime = -1);
+        static inline void hideText() { showText(QPoint(), QString()); }
+        static bool isVisible();
+        static QString text();
+        static QPalette palette();
+        static void setPalette(const QPalette &);
+        static QFont font();
+        static void setFont(const QFont &);
+    };
+
+
+} // namespace Gui
+
+#endif // GUI_NOTIFICATIONBOX_H

--- a/src/Gui/ReportView.cpp
+++ b/src/Gui/ReportView.cpp
@@ -449,8 +449,10 @@ void ReportOutput::restoreFont()
     setFont(serifFont);
 }
 
-void ReportOutput::SendLog(const std::string& msg, Base::LogStyle level)
+void ReportOutput::SendLog(const std::string& notifiername, const std::string& msg, Base::LogStyle level)
 {
+    (void) notifiername;
+    
     ReportHighlighter::Paragraph style = ReportHighlighter::LogText;
     switch (level) {
         case Base::LogStyle::Warning:

--- a/src/Gui/ReportView.h
+++ b/src/Gui/ReportView.h
@@ -134,7 +134,7 @@ public:
     /** Observes its parameter group. */
     void OnChange(Base::Subject<const char*> &rCaller, const char * sReason) override;
 
-    void SendLog(const std::string& msg, Base::LogStyle level) override;
+    void SendLog(const std::string& notifiername, const std::string& msg, Base::LogStyle level) override;
 
     /// returns the name for observer handling
     const char* Name() override {return "ReportOutput";}

--- a/src/Gui/Splashscreen.cpp
+++ b/src/Gui/Splashscreen.cpp
@@ -123,8 +123,10 @@ public:
     {
         return "SplashObserver";
     }
-    void SendLog(const std::string& msg, Base::LogStyle level) override
+    void SendLog(const std::string& notifiername, const std::string& msg, Base::LogStyle level) override
     {
+        Q_UNUSED(notifiername)
+        
 #ifdef FC_DEBUG
         Log(msg.c_str());
         Q_UNUSED(level)

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -8316,8 +8316,6 @@ void SketchObject::migrateSketch()
 
             Constraints.setValues(std::move(newconstraints));
 
-            Base::Console().Warning("In Sketch %s, parabolas were migrated. Migrated files won't open in previous versions of FreeCAD!!\n",this->Label.getStrValue().c_str());
-
             this->getDocument()->signalUserMessage(*this, QString::fromLatin1(QT_TRANSLATE_NOOP("CriticalMessages","Parabolas were migrated. Migrated files won't open in previous versions of FreeCAD!!")), App::Document::NotificationType::Critical);
         }
     }

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -90,7 +90,6 @@ FC_LOG_LEVEL_INIT("Sketch",true,true)
 
 PROPERTY_SOURCE(Sketcher::SketchObject, Part::Part2DObject)
 
-
 SketchObject::SketchObject()
 {
     ADD_PROPERTY_TYPE(Geometry,        (nullptr)  ,"Sketch",(App::PropertyType)(App::Prop_None),"Sketch geometry");
@@ -301,11 +300,11 @@ int SketchObject::solve(bool updateGeoAfterSolving/*=true*/)
     }
 
     if(lastHasMalformedConstraints) {
-        Base::Console().Error("Sketch %s has malformed constraints!\n",this->getNameInDocument());
+        Base::Console().ErrorS(this->getFullName(),"The Sketch has malformed constraints!\n");
     }
 
     if(lastHasPartialRedundancies) {
-        Base::Console().Warning("Sketch %s has partially redundant constraints!\n",this->getNameInDocument());
+        Base::Console().WarningS(this->getFullName(),"The Sketch has partially redundant constraints!\n");
     }
 
     lastSolveTime=solvedSketch.getSolveTime();
@@ -8319,8 +8318,7 @@ void SketchObject::migrateSketch()
 
             Base::Console().Warning("In Sketch %s, parabolas were migrated. Migrated files won't open in previous versions of FreeCAD!!\n",this->Label.getStrValue().c_str());
 
-            this->getDocument()->signalUserMessage(*this, QStringLiteral(QT_TRANSLATE_NOOP("CriticalMessages","Sketch:")) + QStringLiteral(" ") + QString::fromStdString(this->Label.getStrValue()) +
-                QStringLiteral(".\n\n") + QString::fromLatin1(QT_TRANSLATE_NOOP("CriticalMessages","Parabolas were migrated. Migrated files won't open in previous versions of FreeCAD!!")), App::Document::NotificationType::Critical);
+            this->getDocument()->signalUserMessage(*this, QString::fromLatin1(QT_TRANSLATE_NOOP("CriticalMessages","Parabolas were migrated. Migrated files won't open in previous versions of FreeCAD!!")), App::Document::NotificationType::Critical);
         }
     }
 }

--- a/src/Mod/Test/Gui/AppTestGui.cpp
+++ b/src/Mod/Test/Gui/AppTestGui.cpp
@@ -40,7 +40,8 @@ public:
 
     void flush() {buffer.str("");buffer.clear();}
 
-    void SendLog(const std::string& msg, Base::LogStyle level) override{
+    void SendLog(const std::string& notifiername, const std::string& msg, Base::LogStyle level) override{
+        (void) notifiername;
         (void) msg;
         switch(level){
             case Base::LogStyle::Warning:


### PR DESCRIPTION
DRAFT PR! DO NOT MERGE! Not intended for code review!

The intention of this PR is to be a kind of proof of concept and provide a basis for discussion of whether we need something like this or not.

Problems:
1. Users have complained in the past that they are not notified of issues that may impact the ability to open with an older version of FreeCAD a file saved with a newer version of FreeCAD (Forward compability issues).
2. While running FreeCAD, many users prefer not to have the report window open (as it takes quite some space), but then they may miss notifications about errors and warnings that may be useful.
3. While running FreeCAD, many notifications of errors where the user can do nothing, but press ok, are modal (blocking) and interrupt the workflow.
4. In many errors/warnings it is not clear where the error originates. This is specially problematic when opening a file.

Solution:
(a) FreeCAD has a error/warning/message mechanism in place (Console based).
(b) FreeCAD has a user Message signaling mechanism which can be used to require confirmation from a user for (1).

The solution here seeks to implement a Notification Area in the statusbar at Application level, so that it can gather notifications from different documents [to solve (4)]. It extends (a) and (b), so that both can provide a "notifier" field. This notifier field can be the fullname of a Document or DocumentObject, or any string usable for identifying the notifier within the Application [to solve (4)]. Both (a) and (b) feed the Notification Area. The notification Area is a single button in the tool bar which makes accessible all notifications upon clicking on it [in order to address the space issue in (2)]. New notifications (error/warning/messages) are briefly shown, in a look similar to a tooltip, via a non-intrusive non-modal auto-closing widget over the Notification Area [addressing (2) and (3)]. The idea is to also integrate user messages into this system and do away with blocking modal dialogs (the Sketcher is full of them) [addressing (3)]. Well, "do away" may mean "provide the user with a preference to choose between non-intrusive non-blocking and intrusive blocking".

The solution described is an early basic implementation for discussion.

[NotificationArea.webm](https://user-images.githubusercontent.com/121720825/210188173-d328f9bb-e73c-425b-9f87-68424bd29ab2.webm)

Tooltip alike non-intrusive auto-closing notification:
![image](https://user-images.githubusercontent.com/121720825/210189232-2b3760a7-3833-49cb-acba-bd338eacbcbf.png)

Notifications widget:
![image](https://user-images.githubusercontent.com/121720825/210189200-312d5bd5-ef98-40db-8de5-6acd4d8517c8.png)

