### PR TITLE
Arch: improve context menus

### DIFF
--- a/src/Mod/Arch/ArchAxis.py
+++ b/src/Mod/Arch/ArchAxis.py
@@ -271,7 +271,7 @@ class _ViewProviderAxis:
         return []
 
     def attach(self, vobj):
-
+        self.Object = vobj.Object
         self.bubbles = None
         self.bubbletexts = []
         self.bubbledata = []
@@ -610,7 +610,9 @@ class _ViewProviderAxis:
 
         return self.bubbledata
 
-    def setEdit(self,vobj,mode=0):
+    def setEdit(self, vobj, mode):
+        if mode == 1 or mode == 2:
+            return None
 
         taskd = _AxisTaskPanel()
         taskd.obj = vobj.Object
@@ -618,14 +620,40 @@ class _ViewProviderAxis:
         FreeCADGui.Control.showDialog(taskd)
         return True
 
-    def unsetEdit(self,vobj,mode):
+    def unsetEdit(self, vobj, mode):
+        if mode == 1 or mode == 2:
+            return None
 
         FreeCADGui.Control.closeDialog()
-        return
+        return True
 
-    def doubleClicked(self,vobj):
+    def setupContextMenu(self, vobj, menu):
+        actionEdit = QtGui.QAction(translate("Arch", "Edit"),
+                                   menu)
+        QtCore.QObject.connect(actionEdit,
+                               QtCore.SIGNAL("triggered()"),
+                               self.edit)
+        menu.addAction(actionEdit)
 
-        self.setEdit(vobj)
+        # The default Part::FeaturePython context menu contains a `Set colors`
+        # option. This option makes no sense for Axis objects. We therefore
+        # override this menu and have to add our own `Transform` item.
+        # To override the default menu this function must return `True`.
+        action_transform = QtGui.QAction(FreeCADGui.getIcon("Std_TransformManip.svg"),
+                                         translate("Command", "Transform"), # Context `Command` instead of `Arch`.
+                                         menu)
+        QtCore.QObject.connect(action_transform,
+                               QtCore.SIGNAL("triggered()"),
+                               self.transform)
+        menu.addAction(action_transform)
+
+        return True
+
+    def edit(self):
+        FreeCADGui.ActiveDocument.setEdit(self.Object, 0)
+
+    def transform(self):
+        FreeCADGui.ActiveDocument.setEdit(self.Object, 1)
 
     def __getstate__(self):
 

--- a/src/Mod/Arch/ArchAxisSystem.py
+++ b/src/Mod/Arch/ArchAxisSystem.py
@@ -202,7 +202,7 @@ class _ViewProviderAxisSystem:
         return []
 
     def attach(self, vobj):
-
+        self.Object = vobj.Object
         self.axes = vobj.Object.Axes
         vobj.addDisplayMode(coin.SoSeparator(),"Default")
 
@@ -228,20 +228,34 @@ class _ViewProviderAxisSystem:
             for o in vobj.Object.Axes:
                 o.ViewObject.Visibility = vobj.Visibility
 
-    def setEdit(self,vobj,mode=0):
+    def setEdit(self, vobj, mode):
+        if mode != 0:
+            return None
 
         taskd = AxisSystemTaskPanel(vobj.Object)
         FreeCADGui.Control.showDialog(taskd)
         return True
 
-    def unsetEdit(self,vobj,mode):
+    def unsetEdit(self, vobj, mode):
+        if mode != 0:
+            return None
 
         FreeCADGui.Control.closeDialog()
-        return
+        return True
 
-    def doubleClicked(self,vobj):
+    def doubleClicked(self, vobj):
+        self.edit()
 
-        self.setEdit(vobj)
+    def setupContextMenu(self, vobj, menu):
+        actionEdit = QtGui.QAction(translate("Arch", "Edit"),
+                                   menu)
+        QtCore.QObject.connect(actionEdit,
+                               QtCore.SIGNAL("triggered()"),
+                               self.edit)
+        menu.addAction(actionEdit)
+
+    def edit(self):
+        FreeCADGui.ActiveDocument.setEdit(self.Object, 0)
 
     def __getstate__(self):
 

--- a/src/Mod/Arch/ArchBuildingPart.py
+++ b/src/Mod/Arch/ArchBuildingPart.py
@@ -880,44 +880,89 @@ class ViewProviderBuildingPart:
                 o.ViewObject.Lighting = "Two side"
         return True
 
-    def doubleClicked(self,vobj):
+    def setEdit(self, vobj, mode):
+        # For some reason mode is always 0.
+        # Using FreeCADGui.getUserEditMode() as a workaound.
+        if FreeCADGui.getUserEditMode() in ("Transform", "Cutting"):
+            return None
 
-        self.activate(vobj)
-        if (not hasattr(vobj,"DoubleClickActivates")) or vobj.DoubleClickActivates:
-            FreeCADGui.Selection.clearSelection()
+        self.activate()
+        return False # Return `False` as we don't want to enter edit mode.
+
+    def unsetEdit(self, vobj, mode):
+        # For some reason mode is always 0.
+        # Using FreeCADGui.getUserEditMode() as a workaound.
+        if FreeCADGui.getUserEditMode() in ("Transform", "Cutting"):
+            return None
+
         return True
 
-    def activate(self,vobj):
+    def setupContextMenu(self, vobj, menu):
+        from PySide import QtCore, QtGui
+        import Draft_rc
 
-        if FreeCADGui.ActiveDocument.ActiveView.getActiveObject("Arch") == vobj.Object:
-            FreeCADGui.ActiveDocument.ActiveView.setActiveObject("Arch",None)
+        if (not hasattr(vobj,"DoubleClickActivates")) or vobj.DoubleClickActivates:
+            if FreeCADGui.ActiveDocument.ActiveView.getActiveObject("Arch") == self.Object:
+                menuTxt = translate("Arch", "Deactivate")
+            else:
+                menuTxt = translate("Arch", "Activate")
+            actionActivate = QtGui.QAction(menuTxt,
+                                           menu)
+            QtCore.QObject.connect(actionActivate,
+                                   QtCore.SIGNAL("triggered()"),
+                                   self.activate)
+            menu.addAction(actionActivate)
+
+        actionSetWorkingPlane = QtGui.QAction(QtGui.QIcon(":/icons/Draft_SelectPlane.svg"),
+                                              translate("Arch", "Set working plane"),
+                                              menu)
+        QtCore.QObject.connect(actionSetWorkingPlane,
+                               QtCore.SIGNAL("triggered()"),
+                               self.setWorkingPlane)
+        menu.addAction(actionSetWorkingPlane)
+
+        actionWriteCamera = QtGui.QAction(QtGui.QIcon(":/icons/Draft_SelectPlane.svg"),
+                                          translate("Arch", "Write camera position"),
+                                          menu)
+        QtCore.QObject.connect(actionWriteCamera,
+                               QtCore.SIGNAL("triggered()"),
+                               self.writeCamera)
+        menu.addAction(actionWriteCamera)
+
+        actionCreateGroup = QtGui.QAction(translate("Arch", "Create group..."),
+                                          menu)
+        QtCore.QObject.connect(actionCreateGroup,
+                               QtCore.SIGNAL("triggered()"),
+                               self.createGroup)
+        menu.addAction(actionCreateGroup)
+
+        actionReorder = QtGui.QAction(translate("Arch", "Reorder children alphabetically"),
+                                      menu)
+        QtCore.QObject.connect(actionReorder,
+                               QtCore.SIGNAL("triggered()"),
+                               self.reorder)
+        menu.addAction(actionReorder)
+
+        actionCloneUp = QtGui.QAction(translate("Arch", "Clone level up"),
+                                      menu)
+        QtCore.QObject.connect(actionCloneUp,
+                               QtCore.SIGNAL("triggered()"),
+                               self.cloneUp)
+        menu.addAction(actionCloneUp)
+
+    def activate(self):
+        vobj = self.Object.ViewObject
+
+        if FreeCADGui.ActiveDocument.ActiveView.getActiveObject("Arch") == self.Object:
+            FreeCADGui.ActiveDocument.ActiveView.setActiveObject("Arch", None)
             if vobj.SetWorkingPlane:
                 self.setWorkingPlane(restore=True)
-        else:
-            if (not hasattr(vobj,"DoubleClickActivates")) or vobj.DoubleClickActivates:
-                FreeCADGui.ActiveDocument.ActiveView.setActiveObject("Arch",vobj.Object)
+        elif (not hasattr(vobj,"DoubleClickActivates")) or vobj.DoubleClickActivates:
+            FreeCADGui.ActiveDocument.ActiveView.setActiveObject("Arch", self.Object)
             if vobj.SetWorkingPlane:
                 self.setWorkingPlane()
 
-    def setupContextMenu(self,vobj,menu):
-
-        from PySide import QtCore,QtGui
-        import Draft_rc
-        action1 = QtGui.QAction(QtGui.QIcon(":/icons/Draft_SelectPlane.svg"),"Set working plane",menu)
-        QtCore.QObject.connect(action1,QtCore.SIGNAL("triggered()"),self.setWorkingPlane)
-        menu.addAction(action1)
-        action2 = QtGui.QAction(QtGui.QIcon(":/icons/Draft_SelectPlane.svg"),"Write camera position",menu)
-        QtCore.QObject.connect(action2,QtCore.SIGNAL("triggered()"),self.writeCamera)
-        menu.addAction(action2)
-        action3 = QtGui.QAction(QtGui.QIcon(),"Create group...",menu)
-        QtCore.QObject.connect(action3,QtCore.SIGNAL("triggered()"),self.createGroup)
-        menu.addAction(action3)
-        action4 = QtGui.QAction(QtGui.QIcon(),"Reorder children alphabetically",menu)
-        QtCore.QObject.connect(action4,QtCore.SIGNAL("triggered()"),self.reorder)
-        menu.addAction(action4)
-        action5 = QtGui.QAction(QtGui.QIcon(),"Clone level up",menu)
-        QtCore.QObject.connect(action5,QtCore.SIGNAL("triggered()"),self.cloneUp)
-        menu.addAction(action5)
+        FreeCADGui.Selection.clearSelection()
 
     def setWorkingPlane(self,restore=False):
 

--- a/src/Mod/Arch/ArchCommands.py
+++ b/src/Mod/Arch/ArchCommands.py
@@ -98,7 +98,7 @@ def addComponents(objectsList,host):
     if hostType in ["Floor","Building","Site","Project","BuildingPart"]:
         for o in objectsList:
             host.addObject(o)
-    elif hostType in ["Wall","Structure","Window","Roof","Stairs","StructuralSystem","Panel","Component"]:
+    elif hostType in ["Wall","Structure","Precast","Window","Roof","Stairs","StructuralSystem","Panel","Component"]:
         import DraftGeomUtils
         a = host.Additions
         if hasattr(host,"Axes"):
@@ -111,7 +111,7 @@ def addComponents(objectsList,host):
                             g = o.Hosts
                             g.append(host)
                             o.Hosts = g
-                elif DraftGeomUtils.isValidPath(o.Shape) and (hostType == "Structure"):
+                elif DraftGeomUtils.isValidPath(o.Shape) and (hostType in ["Structure","Precast"]):
                     if o.Support == host:
                         o.Support = None
                     host.Tool = o
@@ -142,7 +142,7 @@ def removeComponents(objectsList,host=None):
     if not isinstance(objectsList,list):
         objectsList = [objectsList]
     if host:
-        if Draft.getType(host) in ["Wall","Structure","Window","Roof","Stairs","StructuralSystem","Panel","Component"]:
+        if Draft.getType(host) in ["Wall","Structure","Precast","Window","Roof","Stairs","StructuralSystem","Panel","Component"]:
             if hasattr(host,"Tool"):
                 if objectsList[0] == host.Tool:
                     host.Tool = None
@@ -183,7 +183,7 @@ def removeComponents(objectsList,host=None):
                        c.remove(o)
                        h.Group = c
                        o.ViewObject.show()
-               elif tp in ["Wall","Structure"]:
+               elif tp in ["Wall","Structure","Precast"]:
                    a = h.Additions
                    s = h.Subtractions
                    if o in a:

--- a/src/Mod/Arch/ArchGrid.py
+++ b/src/Mod/Arch/ArchGrid.py
@@ -298,20 +298,34 @@ class ViewProviderArchGrid:
         import Arch_rc
         return ":/icons/Arch_Grid.svg"
 
-    def setEdit(self,vobj,mode=0):
+    def attach(self, vobj):
+        self.Object = vobj.Object
+
+    def setEdit(self, vobj, mode):
+        if mode != 0:
+            return None
 
         taskd = ArchGridTaskPanel(vobj.Object)
         FreeCADGui.Control.showDialog(taskd)
         return True
 
-    def unsetEdit(self,vobj,mode):
+    def unsetEdit(self, vobj, mode):
+        if mode != 0:
+            return None
 
         FreeCADGui.Control.closeDialog()
-        return
+        return True
 
-    def doubleClicked(self,vobj):
+    def setupContextMenu(self, vobj, menu):
+        actionEdit = QtGui.QAction(translate("Arch", "Edit"),
+                                   menu)
+        QtCore.QObject.connect(actionEdit,
+                               QtCore.SIGNAL("triggered()"),
+                               self.edit)
+        menu.addAction(actionEdit)
 
-        self.setEdit(vobj)
+    def edit(self):
+        FreeCADGui.ActiveDocument.setEdit(self.Object, 0)
 
     def __getstate__(self):
 

--- a/src/Mod/Arch/ArchPanel.py
+++ b/src/Mod/Arch/ArchPanel.py
@@ -1403,19 +1403,21 @@ class ViewProviderPanelSheet(Draft._ViewProviderDraft):
 
         return ":/icons/Draft_Drawing.svg"
 
-    def setEdit(self,vobj,mode):
+    def setEdit(self, vobj, mode):
+        if mode == 1 or mode == 2:
+            return None
 
-        if mode == 0:
-            taskd = SheetTaskPanel(vobj.Object)
-            taskd.update()
-            FreeCADGui.Control.showDialog(taskd)
-            return True
-        return False
+        taskd = SheetTaskPanel(vobj.Object)
+        taskd.update()
+        FreeCADGui.Control.showDialog(taskd)
+        return True
 
-    def unsetEdit(self,vobj,mode):
+    def unsetEdit(self, vobj, mode):
+        if mode == 1 or mode == 2:
+            return None
 
         FreeCADGui.Control.closeDialog()
-        return False
+        return True
 
     def attach(self,vobj):
 

--- a/src/Mod/Arch/ArchPrecast.py
+++ b/src/Mod/Arch/ArchPrecast.py
@@ -728,30 +728,32 @@ class _ViewProviderPrecast(ArchComponent.ViewProviderComponent):
                 return ":/icons/Arch_Structure_Clone.svg"
         return ":/icons/Arch_Structure_Tree.svg"
 
-    def setEdit(self,vobj,mode):
+    def setEdit(self, vobj, mode):
+        if mode != 0:
+            return None
 
-        if mode == 0:
-            import FreeCADGui
-            taskd = ArchComponent.ComponentTaskPanel()
-            taskd.obj = self.Object
-            taskd.update()
-            if hasattr(self.Object,"Dents"):
-                self.dentd = _DentsTaskPanel()
-                self.dentd.form.show()
-                self.dentd.fillDents(self.Object.Dents)
-                taskd.form = [taskd.form,self.dentd.form]
-            FreeCADGui.Control.showDialog(taskd)
-            return True
-        return False
+        import FreeCADGui
+        taskd = ArchComponent.ComponentTaskPanel()
+        taskd.obj = self.Object
+        taskd.update()
+        if hasattr(self.Object,"Dents"):
+            self.dentd = _DentsTaskPanel()
+            self.dentd.form.show()
+            self.dentd.fillDents(self.Object.Dents)
+            taskd.form = [taskd.form,self.dentd.form]
+        FreeCADGui.Control.showDialog(taskd)
+        return True
 
-    def unsetEdit(self,vobj,mode):
+    def unsetEdit(self, vobj, mode):
+        if mode != 0:
+            return None
 
         import FreeCADGui
         if hasattr(self,"dentd"):
             self.Object.Dents = self.dentd.getValues()
             del self.dentd
         FreeCADGui.Control.closeDialog()
-        return False
+        return True
 
 
 class _PrecastTaskPanel:

--- a/src/Mod/Arch/ArchProfile.py
+++ b/src/Mod/Arch/ArchProfile.py
@@ -243,6 +243,7 @@ class _Profile(Draft._DraftObject):
     def __setstate__(self,state):
         if isinstance(state,list):
             self.Profile = state
+        self.Type = "Profile"
 
     def cleanProperties(self, obj):
 
@@ -472,17 +473,20 @@ class ViewProviderProfile(Draft._ViewProviderDraft):
         import Arch_rc
         return ":/icons/Arch_Profile.svg"
 
-    def setEdit(self,vobj,mode):
+    def setEdit(self, vobj, mode):
+        if mode == 1 or mode == 2:
+            return None
 
         taskd = ProfileTaskPanel(vobj.Object)
         FreeCADGui.Control.showDialog(taskd)
         return True
 
-    def unsetEdit(self,vobj,mode):
+    def unsetEdit(self, vobj, mode):
+        if mode == 1 or mode == 2:
+            return None
 
         FreeCADGui.Control.closeDialog()
-        FreeCAD.ActiveDocument.recompute()
-        return
+        return True
 
 
 class ProfileTaskPanel:
@@ -592,6 +596,11 @@ class ProfileTaskPanel:
 
             FreeCAD.ActiveDocument.recompute()
             FreeCADGui.ActiveDocument.resetEdit()
+        return True
+
+    def reject(self):
+
+        FreeCADGui.ActiveDocument.resetEdit()
         return True
 
     def retranslateUi(self, TaskPanel):

--- a/src/Mod/Arch/ArchRebar.py
+++ b/src/Mod/Arch/ArchRebar.py
@@ -512,24 +512,32 @@ class _ViewProviderRebar(ArchComponent.ViewProviderComponent):
         return ":/icons/Arch_Rebar_Tree.svg"
 
     def setEdit(self, vobj, mode):
+        # The Reinforcement Workbench does not implement resetEdit.
+        # Therefore unsetEdit is never called and objects would stay in
+        # edit mode if this function were to return `True`.
 
-        if mode == 0:
-            if hasattr(vobj.Object, "RebarShape"):
-                try:
-                    # Import module of RebarShape
-                    module = __import__(vobj.Object.RebarShape)
-                except ImportError:
-                    FreeCAD.Console.PrintError("Unable to import RebarShape module\n")
-                    return
-                module.editDialog(vobj)
-            elif vobj.RebarShape:
-                try:
-                    # Import module of RebarShape
-                    module = __import__(vobj.RebarShape)
-                except ImportError:
-                    FreeCAD.Console.PrintError("Unable to import RebarShape module\n")
-                    return
-                module.editDialog(vobj)
+        if mode != 0:
+            return None
+
+        if hasattr(vobj.Object, "RebarShape"):
+            try:
+                # Import module of RebarShape
+                module = __import__(vobj.Object.RebarShape)
+            except ImportError:
+                FreeCAD.Console.PrintError("Unable to import RebarShape module\n")
+                return False
+        elif vobj.RebarShape:
+            try:
+                # Import module of RebarShape
+                module = __import__(vobj.RebarShape)
+            except ImportError:
+                FreeCAD.Console.PrintError("Unable to import RebarShape module\n")
+                return False
+        else:
+            return False
+
+        module.editDialog(vobj)
+        return False
 
     def updateData(self,obj,prop):
 

--- a/src/Mod/Arch/ArchReference.py
+++ b/src/Mod/Arch/ArchReference.py
@@ -386,19 +386,6 @@ class ViewProviderArchReference:
         import Arch_rc
         return ":/icons/Arch_Reference.svg"
 
-    def setEdit(self,vobj,mode=0):
-
-        taskd = ArchReferenceTaskPanel(vobj.Object)
-        FreeCADGui.Control.showDialog(taskd)
-        return True
-
-    def unsetEdit(self,vobj,mode):
-
-        FreeCADGui.Control.closeDialog()
-        from DraftGui import todo
-        todo.delay(vobj.Proxy.recolorize,vobj)
-        return
-
     def attach(self,vobj):
 
         self.Object = vobj.Object
@@ -407,10 +394,6 @@ class ViewProviderArchReference:
         self.timer.timeout.connect(self.checkChanges)
         s = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Arch").GetInt("ReferenceCheckInterval",60)
         self.timer.start(1000*s)
-
-    def doubleClicked(self,vobj):
-
-        self.setEdit(vobj)
 
     def __getstate__(self):
 
@@ -485,14 +468,50 @@ class ViewProviderArchReference:
             del self.timer
             return True
 
-    def setupContextMenu(self,vobj,menu):
+    def setEdit(self, vobj, mode):
+        if mode != 0:
+            return None
 
-        action1 = QtGui.QAction(QtGui.QIcon(":/icons/view-refresh.svg"),"Reload reference",menu)
-        QtCore.QObject.connect(action1,QtCore.SIGNAL("triggered()"),self.onReload)
-        menu.addAction(action1)
-        action2 = QtGui.QAction(QtGui.QIcon(":/icons/document-open.svg"),"Open reference",menu)
-        QtCore.QObject.connect(action2,QtCore.SIGNAL("triggered()"),self.onOpen)
-        menu.addAction(action2)
+        taskd = ArchReferenceTaskPanel(vobj.Object)
+        FreeCADGui.Control.showDialog(taskd)
+        return True
+
+    def unsetEdit(self, vobj, mode):
+        if mode != 0:
+            return None
+
+        FreeCADGui.Control.closeDialog()
+        from DraftGui import todo
+        todo.delay(vobj.Proxy.recolorize,vobj)
+        return True
+
+    def setupContextMenu(self, vobj, menu):
+
+        actionEdit = QtGui.QAction(translate("Arch", "Edit"),
+                                   menu)
+        QtCore.QObject.connect(actionEdit,
+                               QtCore.SIGNAL("triggered()"),
+                               self.edit)
+        menu.addAction(actionEdit)
+
+        actionOnReload = QtGui.QAction(QtGui.QIcon(":/icons/view-refresh.svg"),
+                                       translate("Arch", "Reload reference"),
+                                       menu)
+        QtCore.QObject.connect(actionOnReload,
+                               QtCore.SIGNAL("triggered()"),
+                               self.onReload)
+        menu.addAction(actionOnReload)
+
+        actionOnOpen = QtGui.QAction(QtGui.QIcon(":/icons/document-open.svg"),
+                                     translate("Arch", "Open reference"),
+                                     menu)
+        QtCore.QObject.connect(actionOnOpen,
+                               QtCore.SIGNAL("triggered()"),
+                               self.onOpen)
+        menu.addAction(actionOnOpen)
+
+    def edit(self):
+        FreeCADGui.ActiveDocument.setEdit(self.Object, 0)
 
     def onReload(self):
 

--- a/src/Mod/Arch/ArchRoof.py
+++ b/src/Mod/Arch/ArchRoof.py
@@ -897,11 +897,10 @@ class _ViewProviderRoof(ArchComponent.ViewProviderComponent):
         self.Object = vobj.Object
         return
 
-    def unsetEdit(self, vobj, mode):
-        FreeCADGui.Control.closeDialog()
-        return
-
     def setEdit(self, vobj, mode=0):
+        if mode != 0:
+            return None
+
         if vobj.Object.Base.Shape.Solids:
             taskd = ArchComponent.ComponentTaskPanel()
             taskd.obj = self.Object

--- a/src/Mod/Arch/ArchSectionPlane.py
+++ b/src/Mod/Arch/ArchSectionPlane.py
@@ -1213,7 +1213,9 @@ class _ViewProviderSectionPlane:
 
         return None
 
-    def setEdit(self,vobj,mode):
+    def setEdit(self, vobj, mode):
+        if mode != 0:
+            return None
 
         taskd = SectionPlaneTaskPanel()
         taskd.obj = vobj.Object
@@ -1221,27 +1223,35 @@ class _ViewProviderSectionPlane:
         FreeCADGui.Control.showDialog(taskd)
         return True
 
-    def unsetEdit(self,vobj,mode):
+    def unsetEdit(self, vobj, mode):
+        if mode != 0:
+            return None
 
         FreeCADGui.Control.closeDialog()
-        return False
+        return True
 
-    def doubleClicked(self,vobj):
+    def doubleClicked(self, vobj):
+        self.edit()
 
-        self.setEdit(vobj,None)
+    def setupContextMenu(self, vobj, menu):
+        actionEdit = QtGui.QAction(translate("Arch", "Edit"),
+                                   menu)
+        QtCore.QObject.connect(actionEdit,
+                               QtCore.SIGNAL("triggered()"),
+                               self.edit)
+        menu.addAction(actionEdit)
 
-    def setupContextMenu(self,vobj,menu):
-        """CONTEXT MENU setup"""
-        from PySide import QtCore,QtGui
-        action1 = QtGui.QAction(QtGui.QIcon(":/icons/Draft_Edit.svg"),"Toggle Cutview",menu)
-        action1.triggered.connect(lambda f=self.contextCutview, arg=vobj:f(arg))
-        menu.addAction(action1)
+        actionToggleCutview = QtGui.QAction(QtGui.QIcon(":/icons/Draft_Edit.svg"),
+                                            translate("Arch", "Toggle Cutview"),
+                                            menu)
+        actionToggleCutview.triggered.connect(lambda f=self.toggleCutview, arg=vobj: f(arg))
+        menu.addAction(actionToggleCutview)
 
-    def contextCutview(self,vobj):
-        """CONTEXT MENU command to toggle CutView property on and off"""
-        if vobj.CutView:
-            vobj.CutView = False
-        else: vobj.CutView = True
+    def edit(self):
+        FreeCADGui.ActiveDocument.setEdit(self.Object, 0)
+
+    def toggleCutview(self, vobj):
+        vobj.CutView = not vobj.CutView
 
 
 class _ArchDrawingView:

--- a/src/Mod/Arch/ArchSite.py
+++ b/src/Mod/Arch/ArchSite.py
@@ -610,7 +610,7 @@ class _Site(ArchIFC.IfcProduct):
         if not "Elevation" in pl:
             obj.addProperty("App::PropertyLength","Elevation","Site",QT_TRANSLATE_NOOP("App::Property","The elevation of level 0 of this site"))
         if not "Url" in pl:
-            obj.addProperty("App::PropertyString","Url","Site",QT_TRANSLATE_NOOP("App::Property","A url that shows this site in a mapping website"))
+            obj.addProperty("App::PropertyString","Url","Site",QT_TRANSLATE_NOOP("App::Property","A URL that shows this site in a mapping website"))
         if not "Additions" in pl:
             obj.addProperty("App::PropertyLinkList","Additions","Site",QT_TRANSLATE_NOOP("App::Property","Other shapes that are appended to this object"))
         if not "Subtractions" in pl:

--- a/src/Mod/Arch/ArchSite.py
+++ b/src/Mod/Arch/ArchSite.py
@@ -27,6 +27,7 @@ containers for Arch objects, and also define a terrain surface.
 import FreeCAD,Draft,ArchCommands,math,re,datetime,ArchIFC
 if FreeCAD.GuiUp:
     import FreeCADGui
+    from PySide import QtGui,QtCore
     from draftutils.translate import translate
     from PySide.QtCore import QT_TRANSLATE_NOOP
 else:
@@ -609,7 +610,7 @@ class _Site(ArchIFC.IfcProduct):
         if not "Elevation" in pl:
             obj.addProperty("App::PropertyLength","Elevation","Site",QT_TRANSLATE_NOOP("App::Property","The elevation of level 0 of this site"))
         if not "Url" in pl:
-            obj.addProperty("App::PropertyString","Url","Site",QT_TRANSLATE_NOOP("App::Property","A URL that shows this site in a mapping website"))
+            obj.addProperty("App::PropertyString","Url","Site",QT_TRANSLATE_NOOP("App::Property","A url that shows this site in a mapping website"))
         if not "Additions" in pl:
             obj.addProperty("App::PropertyLinkList","Additions","Site",QT_TRANSLATE_NOOP("App::Property","Other shapes that are appended to this object"))
         if not "Subtractions" in pl:
@@ -897,47 +898,62 @@ class _ViewProviderSite:
                 objs.extend(self.Object.Subtractions)
         return objs
 
-    def setEdit(self,vobj,mode):
-        """Method called when the document requests the object to enter edit mode.
+    def setEdit(self, vobj, mode):
+        if mode == 1 or mode == 2:
+            return None
 
-        Edit mode is entered when a user double clicks on an object in the tree
-        view, or when they use the menu option [Edit -> Toggle Edit Mode].
+        import ArchComponent
+        taskd = ArchComponent.ComponentTaskPanel()
+        taskd.obj = self.Object
+        taskd.update()
+        FreeCADGui.Control.showDialog(taskd)
+        return True
 
-        Just display the standard Arch component task panel.
-
-        Parameters
-        ----------
-        mode: int or str
-            The edit mode the document has requested. Set to 0 when requested via
-            a double click or [Edit -> Toggle Edit Mode].
-
-        Returns
-        -------
-        bool
-            If edit mode was entered.
-        """
-
-        if (mode == 0) and hasattr(self,"Object"):
-            import ArchComponent
-            taskd = ArchComponent.ComponentTaskPanel()
-            taskd.obj = self.Object
-            taskd.update()
-            FreeCADGui.Control.showDialog(taskd)
-            return True
-        return False
-
-    def unsetEdit(self,vobj,mode):
-        """Method called when the document requests the object exit edit mode.
-
-        Close the Arch component edit task panel.
-
-        Returns
-        -------
-        False
-        """
+    def unsetEdit(self, vobj, mode):
+        if mode == 1 or mode == 2:
+            return None
 
         FreeCADGui.Control.closeDialog()
-        return False
+        return True
+
+    def setupContextMenu(self, vobj, menu):
+        actionEdit = QtGui.QAction(translate("Arch", "Edit"),
+                                   menu)
+        QtCore.QObject.connect(actionEdit,
+                               QtCore.SIGNAL("triggered()"),
+                               self.edit)
+        menu.addAction(actionEdit)
+
+        actionToggleSubcomponents = QtGui.QAction(QtGui.QIcon(":/icons/Arch_ToggleSubs.svg"),
+                                                  translate("Arch", "Toggle subcomponents"),
+                                                  menu)
+        QtCore.QObject.connect(actionToggleSubcomponents,
+                               QtCore.SIGNAL("triggered()"),
+                               self.toggleSubcomponents)
+        menu.addAction(actionToggleSubcomponents)
+
+        # The default Part::FeaturePython context menu contains a `Set colors`
+        # option. This option does not work well for Site objects. We therefore
+        # override this menu and have to add our own `Transform` item.
+        # To override the default menu this function must return `True`.
+        actionTransform = QtGui.QAction(FreeCADGui.getIcon("Std_TransformManip.svg"),
+                                        translate("Command", "Transform"), # Context `Command` instead of `Arch`.
+                                        menu)
+        QtCore.QObject.connect(actionTransform,
+                               QtCore.SIGNAL("triggered()"),
+                               self.transform)
+        menu.addAction(actionTransform)
+
+        return True
+
+    def edit(self):
+        FreeCADGui.ActiveDocument.setEdit(self.Object, 0)
+
+    def toggleSubcomponents(self):
+        FreeCADGui.runCommand("Arch_ToggleSubs")
+
+    def transform(self):
+        FreeCADGui.ActiveDocument.setEdit(self.Object, 1)
 
     def attach(self,vobj):
         """Add display modes' data to the coin scenegraph.

--- a/src/Mod/Arch/ArchSpace.py
+++ b/src/Mod/Arch/ArchSpace.py
@@ -723,7 +723,10 @@ class _ViewProviderSpace(ArchComponent.ViewProviderComponent):
             if hasattr(vobj,"Transparency"):
                 self.fmat.transparency.setValue(vobj.Transparency/100.0)
 
-    def setEdit(self,vobj,mode):
+    def setEdit(self, vobj, mode):
+        if mode != 0:
+            return None
+
         taskd = SpaceTaskPanel()
         taskd.obj = self.Object
         taskd.update()

--- a/src/Mod/Arch/ArchStructure.py
+++ b/src/Mod/Arch/ArchStructure.py
@@ -1128,15 +1128,15 @@ class _ViewProviderStructure(ArchComponent.ViewProviderComponent):
         else:
             ArchComponent.ViewProviderComponent.onChanged(self,vobj,prop)
 
-    def setEdit(self,vobj,mode):
+    def setEdit(self, vobj, mode):
+        if mode != 0:
+            return None
 
-        if mode == 0:
-            taskd = StructureTaskPanel(vobj.Object)
-            taskd.obj = self.Object
-            taskd.update()
-            FreeCADGui.Control.showDialog(taskd)
-            return True
-        return False
+        taskd = StructureTaskPanel(vobj.Object)
+        taskd.obj = self.Object
+        taskd.update()
+        FreeCADGui.Control.showDialog(taskd)
+        return True
 
 
 class StructureTaskPanel(ArchComponent.ComponentTaskPanel):

--- a/src/Mod/Arch/ArchWall.py
+++ b/src/Mod/Arch/ArchWall.py
@@ -1729,12 +1729,18 @@ class _ViewProviderWall(ArchComponent.ViewProviderComponent):
             return "Wireframe"
         return ArchComponent.ViewProviderComponent.setDisplayMode(self,mode)
 
-    def setupContextMenu(self,vobj,menu):
+    def setupContextMenu(self, vobj, menu):
+        super().contextMenuAddEdit(menu)
 
-        from PySide import QtCore,QtGui
-        action1 = QtGui.QAction(QtGui.QIcon(":/icons/Arch_Wall_Tree.svg"),"Flip direction",menu)
-        QtCore.QObject.connect(action1,QtCore.SIGNAL("triggered()"),self.flipDirection)
-        menu.addAction(action1)
+        actionFlipDirection = QtGui.QAction(QtGui.QIcon(":/icons/Arch_Wall_Tree.svg"),
+                                            translate("Arch", "Flip direction"),
+                                            menu)
+        QtCore.QObject.connect(actionFlipDirection,
+                               QtCore.SIGNAL("triggered()"),
+                               self.flipDirection)
+        menu.addAction(actionFlipDirection)
+
+        super().contextMenuAddToggleSubcomponents(menu)
 
     def flipDirection(self):
 

--- a/src/Mod/Draft/draftviewproviders/view_base.py
+++ b/src/Mod/Draft/draftviewproviders/view_base.py
@@ -391,14 +391,14 @@ class ViewProviderDraft(object):
         tp = utils.get_type(vobj.Object)
 
         if tp in ("Wire", "Circle", "Ellipse", "Rectangle", "Polygon",
-                  "BSpline", "BezCurve"): # Facebinder and ShapeString objects have their own setEdit.
+                  "BSpline", "BezCurve"): # Facebinder, ShapeString, PanelSheet and Profile objects have their own setEdit.
             if not "Draft_Edit" in Gui.listCommands():
                 self.wb_before_edit = Gui.activeWorkbench()
                 Gui.activateWorkbench("DraftWorkbench")
             Gui.runCommand("Draft_Edit")
             return True
 
-        if tp in ("Fillet", "Point", "Shape2DView"):
+        if tp in ("Fillet", "Point", "Shape2DView", "PanelCut"):
             Gui.runCommand("Std_TransformManip")
             return True
 
@@ -415,7 +415,7 @@ class ViewProviderDraft(object):
         tp = utils.get_type(vobj.Object)
 
         if tp in ("Wire", "Circle", "Ellipse", "Rectangle", "Polygon",
-                  "BSpline", "BezCurve"): # Facebinder and ShapeString objects have their own setEdit.
+                  "BSpline", "BezCurve"): # Facebinder, ShapeString, PanelSheet and Profile objects have their own unsetEdit.
             if hasattr(App, "activeDraftCommand") and App.activeDraftCommand:
                 App.activeDraftCommand.finish()
             Gui.Control.closeDialog()
@@ -424,7 +424,7 @@ class ViewProviderDraft(object):
                 delattr(self, "wb_before_edit")
             return True
 
-        if tp in ("Fillet", "Point", "Shape2DView"):
+        if tp in ("Fillet", "Point", "Shape2DView", "PanelCut"):
             return True
 
         return None
@@ -433,7 +433,8 @@ class ViewProviderDraft(object):
         tp = utils.get_type(self.Object)
 
         if tp in ("Wire", "Circle", "Ellipse", "Rectangle", "Polygon",
-                  "BSpline", "BezCurve", "Facebinder", "ShapeString"):
+                  "BSpline", "BezCurve", "Facebinder", "ShapeString",
+                  "PanelSheet", "Profile"):
             action_edit = QtGui.QAction(translate("draft", "Edit"),
                                         menu)
             QtCore.QObject.connect(action_edit,
@@ -455,7 +456,8 @@ class ViewProviderDraft(object):
         # have to add our own `Transform` item.
         # To override the default menu this function must return `True`.
         if tp in ("Wire", "Circle", "Ellipse", "Rectangle", "Polygon",
-                  "BSpline","BezCurve", "Fillet", "Point", "Shape2DView"):
+                  "BSpline","BezCurve", "Fillet", "Point", "Shape2DView",
+                  "PanelCut", "PanelSheet", "Profile"):
             action_transform = QtGui.QAction(Gui.getIcon("Std_TransformManip.svg"),
                                              translate("Command", "Transform"), # Context `Command` instead of `draft`.
                                              menu)


### PR DESCRIPTION
This PR tries to improve the context menus of Arch objects. Similar to what was previously done for Draft objects, see #7970.

Small improvement related to #6215:
The BIM Workbench gets loaded only once per session when double clicking components.

- [ ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

---
