### PR TITLE
[TD]add light text on dark page mode 

### DIFF
--- a/src/Mod/TechDraw/App/DrawPage.cpp
+++ b/src/Mod/TechDraw/App/DrawPage.cpp
@@ -23,9 +23,9 @@
 #include "PreCompiled.h"
 
 #ifndef _PreComp_
-# include <iostream>
-# include <sstream>
-# include <Precision.hxx>
+#include <Precision.hxx>
+#include <iostream>
+#include <sstream>
 #endif
 
 #include <App/Application.h>
@@ -34,7 +34,7 @@
 #include <Base/Parameter.h>
 
 #include "DrawPage.h"
-#include "DrawPagePy.h"  // generated from DrawPagePy.xml
+#include "DrawPagePy.h"// generated from DrawPagePy.xml
 #include "DrawProjGroup.h"
 #include "DrawTemplate.h"
 #include "DrawView.h"
@@ -50,49 +50,59 @@ using namespace TechDraw;
 // DrawPage
 //===========================================================================
 
-App::PropertyFloatConstraint::Constraints DrawPage::scaleRange = {Precision::Confusion(),
-                                                                  std::numeric_limits<double>::max(),
-                                                                  (0.1)}; // increment by 0.1
+App::PropertyFloatConstraint::Constraints DrawPage::scaleRange = {
+    Precision::Confusion(), std::numeric_limits<double>::max(), (0.1)};// increment by 0.1
 
 PROPERTY_SOURCE(TechDraw::DrawPage, App::DocumentObject)
 
-const char* DrawPage::ProjectionTypeEnums[] = { "First Angle",
-                                                "Third Angle",
-                                                nullptr };
+const char* DrawPage::ProjectionTypeEnums[] = {"First Angle", "Third Angle", nullptr};
 
 DrawPage::DrawPage(void)
 {
-    static const char *group = "Page";
+    static const char* group = "Page";
     nowUnsetting = false;
     forceRedraw(false);
 
-    ADD_PROPERTY_TYPE(KeepUpdated, (Preferences::keepPagesUpToDate()),
-                                             group, (App::PropertyType)(App::Prop_Output), "Keep page in sync with model");
-    ADD_PROPERTY_TYPE(Template, (nullptr), group, (App::PropertyType)(App::Prop_None), "Attached Template");
+    ADD_PROPERTY_TYPE(KeepUpdated,
+                      (Preferences::keepPagesUpToDate()),
+                      group,
+                      (App::PropertyType)(App::Prop_Output),
+                      "Keep page in sync with model");
+    ADD_PROPERTY_TYPE(
+        Template, (nullptr), group, (App::PropertyType)(App::Prop_None), "Attached Template");
     Template.setScope(App::LinkScope::Global);
-    ADD_PROPERTY_TYPE(Views, (nullptr), group, (App::PropertyType)(App::Prop_None), "Attached Views");
+    ADD_PROPERTY_TYPE(
+        Views, (nullptr), group, (App::PropertyType)(App::Prop_None), "Attached Views");
     Views.setScope(App::LinkScope::Global);
 
     // Projection Properties
     ProjectionType.setEnums(ProjectionTypeEnums);
     ADD_PROPERTY(ProjectionType, ((long)Preferences::projectionAngle()));
 
-    Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter().
-                                         GetGroup("BaseApp")->GetGroup("Preferences")->
-                                         GetGroup("Mod/TechDraw/General");
+    Base::Reference<ParameterGrp> hGrp = App::GetApplication()
+                                             .GetUserParameter()
+                                             .GetGroup("BaseApp")
+                                             ->GetGroup("Preferences")
+                                             ->GetGroup("Mod/TechDraw/General");
     double defScale = hGrp->GetFloat("DefaultScale", 1.0);
-    ADD_PROPERTY_TYPE(Scale, (defScale), group, (App::PropertyType)(App::Prop_None), "Scale factor for this Page");
+    ADD_PROPERTY_TYPE(Scale,
+                      (defScale),
+                      group,
+                      (App::PropertyType)(App::Prop_None),
+                      "Scale factor for this Page");
 
-    ADD_PROPERTY_TYPE(NextBalloonIndex, (1), group, (App::PropertyType)(App::Prop_None),
-                     "Auto-numbering for Balloons");
+    ADD_PROPERTY_TYPE(NextBalloonIndex,
+                      (1),
+                      group,
+                      (App::PropertyType)(App::Prop_None),
+                      "Auto-numbering for Balloons");
 
     Scale.setConstraints(&scaleRange);
     balloonParent = nullptr;
 }
 
 DrawPage::~DrawPage()
-{
-}
+{}
 
 void DrawPage::onBeforeChange(const App::Property* prop)
 {
@@ -101,53 +111,56 @@ void DrawPage::onBeforeChange(const App::Property* prop)
 
 void DrawPage::onChanged(const App::Property* prop)
 {
-    if ((prop == &KeepUpdated)  &&
-         KeepUpdated.getValue()) {
-        if (!isRestoring() &&
-            !isUnsetting()) {
+    if ((prop == &KeepUpdated) && KeepUpdated.getValue()) {
+        if (!isRestoring() && !isUnsetting()) {
             //would be nice if this message was displayed immediately instead of after the recomputeFeature
-            Base::Console().Message("Rebuilding Views for: %s/%s\n", getNameInDocument(), Label.getValue());
+            Base::Console().Message(
+                "Rebuilding Views for: %s/%s\n", getNameInDocument(), Label.getValue());
             updateAllViews();
             purgeTouched();
         }
-    } else if (prop == &Template) {
-        if (!isRestoring() &&
-            !isUnsetting()) {
+    }
+    else if (prop == &Template) {
+        if (!isRestoring() && !isUnsetting()) {
             //nothing to page to do??
         }
-    } else if(prop == &Scale) {
+    }
+    else if (prop == &Scale) {
         // touch all views in the Page as they may be dependent on this scale
         // WF: not sure this loop is required.  Views figure out their scale as required. but maybe
         //     this is needed just to mark the Views to recompute??
         if (!isRestoring()) {
-            const std::vector<App::DocumentObject*> &vals = Views.getValues();
-            for(std::vector<App::DocumentObject *>::const_iterator it = vals.begin(); it < vals.end(); ++it) {
-                TechDraw::DrawView *view = dynamic_cast<TechDraw::DrawView *>(*it);
+            const std::vector<App::DocumentObject*>& vals = Views.getValues();
+            for (std::vector<App::DocumentObject*>::const_iterator it = vals.begin();
+                 it < vals.end();
+                 ++it) {
+                TechDraw::DrawView* view = dynamic_cast<TechDraw::DrawView*>(*it);
                 if (view && view->ScaleType.isValue("Page")) {
-                    if(std::abs(view->Scale.getValue() - Scale.getValue()) > FLT_EPSILON) {
-                       view->Scale.setValue(Scale.getValue());
+                    if (std::abs(view->Scale.getValue() - Scale.getValue()) > FLT_EPSILON) {
+                        view->Scale.setValue(Scale.getValue());
                     }
                 }
             }
         }
-    } else if (prop == &ProjectionType) {
-      // touch all ortho views in the Page as they may be dependent on Projection Type  //(is this true?)
-      const std::vector<App::DocumentObject*> &vals = Views.getValues();
-      for(std::vector<App::DocumentObject *>::const_iterator it = vals.begin(); it < vals.end(); ++it) {
-          TechDraw::DrawProjGroup *view = dynamic_cast<TechDraw::DrawProjGroup *>(*it);
-          if (view && view->ProjectionType.isValue("Default")) {
-              view->ProjectionType.touch();
-          }
-      }
+    }
+    else if (prop == &ProjectionType) {
+        // touch all ortho views in the Page as they may be dependent on Projection Type  //(is this true?)
+        const std::vector<App::DocumentObject*>& vals = Views.getValues();
+        for (std::vector<App::DocumentObject*>::const_iterator it = vals.begin(); it < vals.end();
+             ++it) {
+            TechDraw::DrawProjGroup* view = dynamic_cast<TechDraw::DrawProjGroup*>(*it);
+            if (view && view->ProjectionType.isValue("Default")) {
+                view->ProjectionType.touch();
+            }
+        }
 
-      // TODO: Also update Template graphic.
-
+        // TODO: Also update Template graphic.
     }
     App::DocumentObject::onChanged(prop);
 }
 
 //Page is just a container. It doesn't "do" anything.
-App::DocumentObjectExecReturn *DrawPage::execute(void)
+App::DocumentObjectExecReturn* DrawPage::execute(void)
 {
     return App::DocumentObject::execute();
 }
@@ -157,10 +170,8 @@ short DrawPage::mustExecute() const
 {
     short result = 0;
     if (!isRestoring()) {
-        result  =  (Views.isTouched()  ||
-                    Scale.isTouched()  ||
-                    ProjectionType.isTouched() ||
-                    Template.isTouched());
+        result = (Views.isTouched() || Scale.isTouched() || ProjectionType.isTouched()
+                  || Template.isTouched());
         if (result) {
             return result;
         }
@@ -168,9 +179,9 @@ short DrawPage::mustExecute() const
     return App::DocumentObject::mustExecute();
 }
 
-PyObject *DrawPage::getPyObject(void)
+PyObject* DrawPage::getPyObject(void)
 {
-    if (PythonObject.is(Py::_None())){
+    if (PythonObject.is(Py::_None())) {
         // ref counter is set to 1
         PythonObject = Py::Object(new DrawPagePy(this), true);
     }
@@ -180,13 +191,12 @@ PyObject *DrawPage::getPyObject(void)
 
 bool DrawPage::hasValidTemplate() const
 {
-    App::DocumentObject *obj = nullptr;
+    App::DocumentObject* obj = nullptr;
     obj = Template.getValue();
 
-    if(obj && obj->isDerivedFrom(TechDraw::DrawTemplate::getClassTypeId())) {
-        TechDraw::DrawTemplate *templ = static_cast<TechDraw::DrawTemplate *>(obj);
-        if (templ->getWidth() > 0. &&
-            templ->getHeight() > 0.) {
+    if (obj && obj->isDerivedFrom(TechDraw::DrawTemplate::getClassTypeId())) {
+        TechDraw::DrawTemplate* templ = static_cast<TechDraw::DrawTemplate*>(obj);
+        if (templ->getWidth() > 0. && templ->getHeight() > 0.) {
             return true;
         }
     }
@@ -196,11 +206,11 @@ bool DrawPage::hasValidTemplate() const
 
 double DrawPage::getPageWidth() const
 {
-    App::DocumentObject *obj = nullptr;
+    App::DocumentObject* obj = nullptr;
     obj = Template.getValue();
 
-    if( obj && obj->isDerivedFrom(TechDraw::DrawTemplate::getClassTypeId()) ) {
-        TechDraw::DrawTemplate *templ = static_cast<TechDraw::DrawTemplate *>(obj);
+    if (obj && obj->isDerivedFrom(TechDraw::DrawTemplate::getClassTypeId())) {
+        TechDraw::DrawTemplate* templ = static_cast<TechDraw::DrawTemplate*>(obj);
         return templ->getWidth();
     }
 
@@ -209,12 +219,12 @@ double DrawPage::getPageWidth() const
 
 double DrawPage::getPageHeight() const
 {
-    App::DocumentObject *obj = nullptr;
+    App::DocumentObject* obj = nullptr;
     obj = Template.getValue();
 
-    if(obj) {
-        if(obj->isDerivedFrom(TechDraw::DrawTemplate::getClassTypeId())) {
-            TechDraw::DrawTemplate *templ = static_cast<TechDraw::DrawTemplate *>(obj);
+    if (obj) {
+        if (obj->isDerivedFrom(TechDraw::DrawTemplate::getClassTypeId())) {
+            TechDraw::DrawTemplate* templ = static_cast<TechDraw::DrawTemplate*>(obj);
             return templ->getHeight();
         }
     }
@@ -223,16 +233,16 @@ double DrawPage::getPageHeight() const
 }
 
 //orientation as text
-const char * DrawPage::getPageOrientation() const
+const char* DrawPage::getPageOrientation() const
 {
-    App::DocumentObject *obj;
+    App::DocumentObject* obj;
     obj = Template.getValue();
 
-    if(obj) {
-        if(obj->isDerivedFrom(TechDraw::DrawTemplate::getClassTypeId())) {
-          TechDraw::DrawTemplate *templ = static_cast<TechDraw::DrawTemplate *>(obj);
+    if (obj) {
+        if (obj->isDerivedFrom(TechDraw::DrawTemplate::getClassTypeId())) {
+            TechDraw::DrawTemplate* templ = static_cast<TechDraw::DrawTemplate*>(obj);
 
-          return templ->Orientation.getValueAsString();
+            return templ->Orientation.getValueAsString();
         }
     }
     throw Base::RuntimeError("Template not set for Page");
@@ -241,41 +251,43 @@ const char * DrawPage::getPageOrientation() const
 //orientation as 0(Portrait) or 1(Landscape)
 int DrawPage::getOrientation() const
 {
-    App::DocumentObject *obj;
+    App::DocumentObject* obj;
     obj = Template.getValue();
 
-    if(obj) {
-        if(obj->isDerivedFrom(TechDraw::DrawTemplate::getClassTypeId())) {
-          TechDraw::DrawTemplate *templ = static_cast<TechDraw::DrawTemplate *>(obj);
+    if (obj) {
+        if (obj->isDerivedFrom(TechDraw::DrawTemplate::getClassTypeId())) {
+            TechDraw::DrawTemplate* templ = static_cast<TechDraw::DrawTemplate*>(obj);
 
-          return templ->Orientation.getValue();
+            return templ->Orientation.getValue();
         }
     }
     throw Base::RuntimeError("Template not set for Page");
 }
 
-int DrawPage::addView(App::DocumentObject *docObj)
+int DrawPage::addView(App::DocumentObject* docObj)
 {
-    if(!docObj->isDerivedFrom(TechDraw::DrawView::getClassTypeId()))
+    if (!docObj->isDerivedFrom(TechDraw::DrawView::getClassTypeId())) {
         return -1;
+    }
     DrawView* view = static_cast<DrawView*>(docObj);
 
-      //position all new views in center of Page (exceptDVDimension)
-    if (!docObj->isDerivedFrom(TechDraw::DrawViewDimension::getClassTypeId()) &&
-        !docObj->isDerivedFrom(TechDraw::DrawViewBalloon::getClassTypeId())) {
-        view->X.setValue(getPageWidth()/2.0);
-        view->Y.setValue(getPageHeight()/2.0);
+    //position all new views in center of Page (exceptDVDimension)
+    if (!docObj->isDerivedFrom(TechDraw::DrawViewDimension::getClassTypeId())
+        && !docObj->isDerivedFrom(TechDraw::DrawViewBalloon::getClassTypeId())) {
+        view->X.setValue(getPageWidth() / 2.0);
+        view->Y.setValue(getPageHeight() / 2.0);
     }
 
     //add view to list
-    const std::vector<App::DocumentObject *> currViews = Views.getValues();
-    std::vector<App::DocumentObject *> newViews(currViews);
+    const std::vector<App::DocumentObject*> currViews = Views.getValues();
+    std::vector<App::DocumentObject*> newViews(currViews);
     newViews.push_back(docObj);
     Views.setValues(newViews);
 
     //check if View fits on Page
-    if ( !view->checkFit(this) ) {
-        Base::Console().Warning("%s is larger than page. Will be scaled.\n", view->getNameInDocument());
+    if (!view->checkFit(this)) {
+        Base::Console().Warning("%s is larger than page. Will be scaled.\n",
+                                view->getNameInDocument());
         view->ScaleType.setValue("Automatic");
     }
 
@@ -285,10 +297,11 @@ int DrawPage::addView(App::DocumentObject *docObj)
 }
 
 //Note Views might be removed from document elsewhere so need to check if a View is still in Document here
-int DrawPage::removeView(App::DocumentObject *docObj)
+int DrawPage::removeView(App::DocumentObject* docObj)
 {
-    if(!docObj->isDerivedFrom(TechDraw::DrawView::getClassTypeId()))
+    if (!docObj->isDerivedFrom(TechDraw::DrawView::getClassTypeId())) {
         return -1;
+    }
 
     App::Document* doc = docObj->getDocument();
     if (!doc) {
@@ -297,7 +310,7 @@ int DrawPage::removeView(App::DocumentObject *docObj)
 
     const char* name = docObj->getNameInDocument();
     if (!name) {
-         return -1;
+        return -1;
     }
     const std::vector<App::DocumentObject*> currViews = Views.getValues();
     std::vector<App::DocumentObject*> newViews;
@@ -334,7 +347,7 @@ void DrawPage::onDocumentRestored()
 
 void DrawPage::redrawCommand()
 {
-//    Base::Console().Message("DP::redrawCommand()\n");
+    //    Base::Console().Message("DP::redrawCommand()\n");
     forceRedraw(true);
     updateAllViews();
     forceRedraw(false);
@@ -342,12 +355,13 @@ void DrawPage::redrawCommand()
 
 void DrawPage::updateAllViews()
 {
-//    Base::Console().Message("DP::updateAllViews()\n");
-    std::vector<App::DocumentObject*> featViews = getAllViews();  //unordered list of views within page
+    //    Base::Console().Message("DP::updateAllViews()\n");
+    std::vector<App::DocumentObject*> featViews =
+        getAllViews();//unordered list of views within page
 
     //first, make sure all the Parts have been executed so GeometryObjects exist
-    for(auto& v: featViews) {
-        TechDraw::DrawViewPart *part = dynamic_cast<TechDraw::DrawViewPart *>(v);
+    for (auto& v : featViews) {
+        TechDraw::DrawViewPart* part = dynamic_cast<TechDraw::DrawViewPart*>(v);
         if (part) {
             //view, section, detail, dpgi
             part->recomputeFeature();
@@ -355,8 +369,8 @@ void DrawPage::updateAllViews()
     }
     //second, do the rest of the views that may depend on a part view
     //TODO: check if we have 2 layers of dependency (ex. leader > weld > tile?)
-    for(auto& v: featViews) {
-        TechDraw::DrawViewPart *part = dynamic_cast<TechDraw::DrawViewPart *>(v);
+    for (auto& v : featViews) {
+        TechDraw::DrawViewPart* part = dynamic_cast<TechDraw::DrawViewPart*>(v);
         if (part) {
             continue;
         }
@@ -371,15 +385,15 @@ void DrawPage::updateAllViews()
 
 std::vector<App::DocumentObject*> DrawPage::getAllViews(void)
 {
-    auto views = Views.getValues();   //list of docObjects
+    auto views = Views.getValues();//list of docObjects
     std::vector<App::DocumentObject*> allViews;
-    for (auto& v: views) {
+    for (auto& v : views) {
         allViews.push_back(v);
         if (v->isDerivedFrom(TechDraw::DrawProjGroup::getClassTypeId())) {
             TechDraw::DrawProjGroup* dpg = static_cast<TechDraw::DrawProjGroup*>(v);
-            if (dpg) {                                              //can't really happen!
-              std::vector<App::DocumentObject*> pgViews = dpg->Views.getValues();
-              allViews.insert(allViews.end(), pgViews.begin(), pgViews.end());
+            if (dpg) {//can't really happen!
+                std::vector<App::DocumentObject*> pgViews = dpg->Views.getValues();
+                allViews.insert(allViews.end(), pgViews.begin(), pgViews.end());
             }
         }
     }
@@ -397,31 +411,34 @@ void DrawPage::unsetupObject()
 
     try {
         const std::vector<App::DocumentObject*> currViews = Views.getValues();
-        for (auto& v: currViews) {
+        for (auto& v : currViews) {
             //NOTE: the order of objects in Page.Views does not reflect the object hierarchy
             //      this means that a ProjGroup could be deleted before it's child ProjGroupItems.
             //      this causes problems when removing objects from document
             if (v->isAttachedToDocument()) {
                 std::string viewName = v->getNameInDocument();
                 Base::Interpreter().runStringArg("App.getDocument(\"%s\").removeObject(\"%s\")",
-                                                  docName.c_str(), viewName.c_str());
-            } else {
-                Base::Console().Log("DP::unsetupObject - v(%s) is not in document. skipping\n", pageName.c_str());
+                                                 docName.c_str(),
+                                                 viewName.c_str());
+            }
+            else {
+                Base::Console().Log("DP::unsetupObject - v(%s) is not in document. skipping\n",
+                                    pageName.c_str());
             }
         }
-        std::vector<App::DocumentObject*> emptyViews;      //probably superfluous
+        std::vector<App::DocumentObject*> emptyViews;//probably superfluous
         Views.setValues(emptyViews);
-
-   }
-   catch (...) {
-       Base::Console().Warning("DP::unsetupObject - %s - error while deleting children\n", getNameInDocument());
-   }
+    }
+    catch (...) {
+        Base::Console().Warning("DP::unsetupObject - %s - error while deleting children\n",
+                                getNameInDocument());
+    }
 
     App::DocumentObject* tmp = Template.getValue();
     if (tmp) {
         std::string templateName = Template.getValue()->getNameInDocument();
-        Base::Interpreter().runStringArg("App.getDocument(\"%s\").removeObject(\"%s\")",
-                                              docName.c_str(), templateName.c_str());
+        Base::Interpreter().runStringArg(
+            "App.getDocument(\"%s\").removeObject(\"%s\")", docName.c_str(), templateName.c_str());
     }
     Template.setValue(nullptr);
 }
@@ -434,21 +451,23 @@ int DrawPage::getNextBalloonIndex(void)
     return result;
 }
 
-void DrawPage::handleChangedPropertyType(
-        Base::XMLReader &reader, const char * TypeName, App::Property * prop)
+void DrawPage::handleChangedPropertyType(Base::XMLReader& reader, const char* TypeName,
+                                         App::Property* prop)
 {
     if (prop == &Scale) {
         App::PropertyFloat tmp;
-        if (strcmp(tmp.getTypeId().getName(), TypeName)==0) {                   //property in file is Float
+        if (strcmp(tmp.getTypeId().getName(), TypeName) == 0) {//property in file is Float
             tmp.setContainer(this);
             tmp.Restore(reader);
             double tmpValue = tmp.getValue();
             if (tmpValue > 0.0) {
                 Scale.setValue(tmpValue);
-            } else {
+            }
+            else {
                 Scale.setValue(1.0);
             }
-        } else {
+        }
+        else {
             // has Scale prop that isn't Float!
             Base::Console().Log("DrawPage::Restore - old Document Scale is Not Float!\n");
             // no idea
@@ -459,12 +478,10 @@ void DrawPage::handleChangedPropertyType(
 bool DrawPage::canUpdate() const
 {
     bool result = false;
-    if (GlobalUpdateDrawings() &&
-        KeepUpdated.getValue())  {
+    if (GlobalUpdateDrawings() && KeepUpdated.getValue()) {
         result = true;
-    } else if (!GlobalUpdateDrawings() &&
-                AllowPageOverride()    &&
-                KeepUpdated.getValue()) {
+    }
+    else if (!GlobalUpdateDrawings() && AllowPageOverride() && KeepUpdated.getValue()) {
         result = true;
     }
     return result;
@@ -486,8 +503,11 @@ bool DrawPage::hasObject(App::DocumentObject* obj)
 //allow/prevent drawing updates for all Pages
 bool DrawPage::GlobalUpdateDrawings(void)
 {
-    Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter()
-          .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/TechDraw/General");
+    Base::Reference<ParameterGrp> hGrp = App::GetApplication()
+                                             .GetUserParameter()
+                                             .GetGroup("BaseApp")
+                                             ->GetGroup("Preferences")
+                                             ->GetGroup("Mod/TechDraw/General");
     bool result = hGrp->GetBool("GlobalUpdateDrawings", true);
     return result;
 }
@@ -495,8 +515,11 @@ bool DrawPage::GlobalUpdateDrawings(void)
 //allow/prevent a single page to update despite GlobalUpdateDrawings setting
 bool DrawPage::AllowPageOverride(void)
 {
-    Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter()
-          .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/TechDraw/General");
+    Base::Reference<ParameterGrp> hGrp = App::GetApplication()
+                                             .GetUserParameter()
+                                             .GetGroup("BaseApp")
+                                             ->GetGroup("Preferences")
+                                             ->GetGroup("Mod/TechDraw/General");
     bool result = hGrp->GetBool("AllowPageOverride", true);
     return result;
 }
@@ -504,14 +527,16 @@ bool DrawPage::AllowPageOverride(void)
 
 // Python Drawing feature ---------------------------------------------------------
 
-namespace App {
+namespace App
+{
 /// @cond DOXERR
 PROPERTY_SOURCE_TEMPLATE(TechDraw::DrawPagePython, TechDraw::DrawPage)
-template<> const char* TechDraw::DrawPagePython::getViewProviderName(void) const {
+template<> const char* TechDraw::DrawPagePython::getViewProviderName(void) const
+{
     return "TechDrawGui::ViewProviderPage";
 }
 /// @endcond
 
 // explicit template instantiation
 template class TechDrawExport FeaturePythonT<TechDraw::DrawPage>;
-}
+}// namespace App

--- a/src/Mod/TechDraw/App/DrawViewAnnotation.cpp
+++ b/src/Mod/TechDraw/App/DrawViewAnnotation.cpp
@@ -53,7 +53,7 @@ DrawViewAnnotation::DrawViewAnnotation()
     ADD_PROPERTY_TYPE(Text ,("Default Text"), vgroup, App::Prop_None, "Annotation text");
     ADD_PROPERTY_TYPE(Font ,(Preferences::labelFont().c_str()),
                              vgroup, App::Prop_None, "Font name");
-    ADD_PROPERTY_TYPE(TextColor, (0.0f, 0.0f, 0.0f), vgroup, App::Prop_None, "Text color");
+    ADD_PROPERTY_TYPE(TextColor, (Preferences::normalColor()), vgroup, App::Prop_None, "Text color");
     ADD_PROPERTY_TYPE(TextSize, (Preferences::labelFontSizeMM()),
                                  vgroup, App::Prop_None, "Text size");
     ADD_PROPERTY_TYPE(MaxWidth, (-1.0), vgroup, App::Prop_None, "Maximum width of the annotation block.\n -1 means no maximum width.");

--- a/src/Mod/TechDraw/App/DrawViewSymbol.cpp
+++ b/src/Mod/TechDraw/App/DrawViewSymbol.cpp
@@ -23,19 +23,19 @@
 #include "PreCompiled.h"
 
 #ifndef _PreComp_
-# include <sstream>
-# include <QDomDocument>
-# include "QDomNodeModel.h"
-# include <QXmlQuery>
-# include <QXmlResultItems>
+#include "QDomNodeModel.h"
+#include <QDomDocument>
+#include <QXmlQuery>
+#include <QXmlResultItems>
+#include <sstream>
 #endif
 
 #include <Base/Console.h>
 
-#include "DrawViewSymbol.h"
-#include "DrawViewSymbolPy.h"  // generated from DrawViewSymbolPy.xml
 #include "DrawPage.h"
 #include "DrawUtil.h"
+#include "DrawViewSymbol.h"
+#include "DrawViewSymbolPy.h"// generated from DrawViewSymbolPy.xml
 
 
 using namespace TechDraw;
@@ -49,18 +49,17 @@ PROPERTY_SOURCE(TechDraw::DrawViewSymbol, TechDraw::DrawView)
 
 DrawViewSymbol::DrawViewSymbol()
 {
-    static const char *vgroup = "Drawing view";
+    static const char* vgroup = "Drawing view";
 
     ADD_PROPERTY_TYPE(Symbol, (""), vgroup, App::Prop_None, "The SVG code defining this symbol");
-    ADD_PROPERTY_TYPE(EditableTexts, (""), vgroup, App::Prop_None, "Substitution values for the editable strings in this symbol");
+    ADD_PROPERTY_TYPE(EditableTexts, (""), vgroup, App::Prop_None,
+                      "Substitution values for the editable strings in this symbol");
     ScaleType.setValue("Custom");
     Scale.setStatus(App::Property::ReadOnly, false);
     Symbol.setStatus(App::Property::Hidden, true);
 }
 
-DrawViewSymbol::~DrawViewSymbol()
-{
-}
+DrawViewSymbol::~DrawViewSymbol() {}
 
 void DrawViewSymbol::onChanged(const App::Property* prop)
 {
@@ -69,7 +68,8 @@ void DrawViewSymbol::onChanged(const App::Property* prop)
             std::vector<std::string> editables = getEditableFields();
             EditableTexts.setValues(editables);
         }
-    } else if (prop == &EditableTexts) {
+    }
+    else if (prop == &EditableTexts) {
         //this will change Symbol, which will call onChanged(Symbol),
         //which will change EditableTexts, but the loop stops after
         //1 cycle
@@ -79,7 +79,7 @@ void DrawViewSymbol::onChanged(const App::Property* prop)
     TechDraw::DrawView::onChanged(prop);
 }
 
-App::DocumentObjectExecReturn *DrawViewSymbol::execute()
+App::DocumentObjectExecReturn* DrawViewSymbol::execute()
 {
     //nothing to do. DVS is just a container for properties.
     //the action takes place on the Gui side.
@@ -88,9 +88,9 @@ App::DocumentObjectExecReturn *DrawViewSymbol::execute()
 
 QRectF DrawViewSymbol::getRect() const
 {
-        double w = 64.0;         //must default to something
-        double h = 64.0;
-        return (QRectF(0, 0,w, h));
+    double w = 64.0;//must default to something
+    double h = 64.0;
+    return (QRectF(0, 0, w, h));
 }
 
 //!Assume all svg files fit the page and/or the user will scale manually
@@ -117,15 +117,15 @@ std::vector<std::string> DrawViewSymbol::getEditableFields()
 
         // XPath query to select all <tspan> nodes whose <text> parent
         // has "freecad:editable" attribute
-        query.setQuery(QString::fromUtf8(
-            "declare default element namespace \"" SVG_NS_URI "\"; "
-            "declare namespace freecad=\"" FREECAD_SVG_NS_URI "\"; "
-            "//text[@freecad:editable]/tspan"));
+        query.setQuery(QString::fromUtf8("declare default element namespace \"" SVG_NS_URI "\"; "
+                                         "declare namespace freecad=\"" FREECAD_SVG_NS_URI "\"; "
+                                         "//text[@freecad:editable]/tspan"));
 
         query.evaluateTo(&queryResult);
 
         while (!queryResult.next().isNull()) {
-            QDomElement tspan = model.toDomNode(queryResult.current().toNodeModelIndex()).toElement();
+            QDomElement tspan =
+                model.toDomNode(queryResult.current().toNodeModelIndex()).toElement();
             QString editableValue = tspan.firstChild().nodeValue();
             editables.emplace_back(editableValue.toUtf8().constData());
         }
@@ -153,19 +153,19 @@ void DrawViewSymbol::updateFieldsInSymbol()
 
         // XPath query to select all <tspan> nodes whose <text> parent
         // has "freecad:editable" attribute
-        query.setQuery(QString::fromUtf8(
-            "declare default element namespace \"" SVG_NS_URI "\"; "
-            "declare namespace freecad=\"" FREECAD_SVG_NS_URI "\"; "
-            "//text[@freecad:editable]/tspan"));
+        query.setQuery(QString::fromUtf8("declare default element namespace \"" SVG_NS_URI "\"; "
+                                         "declare namespace freecad=\"" FREECAD_SVG_NS_URI "\"; "
+                                         "//text[@freecad:editable]/tspan"));
         query.evaluateTo(&queryResult);
 
         unsigned int count = 0;
-        while (!queryResult.next().isNull())
-        {
-            QDomElement tspanElement = model.toDomNode(queryResult.current().toNodeModelIndex()).toElement();
+        while (!queryResult.next().isNull()) {
+            QDomElement tspanElement =
+                model.toDomNode(queryResult.current().toNodeModelIndex()).toElement();
 
             // Keep all spaces in the text node
-            tspanElement.setAttribute(QString::fromUtf8("xml:space"), QString::fromUtf8("preserve"));
+            tspanElement.setAttribute(QString::fromUtf8("xml:space"),
+                                      QString::fromUtf8("preserve"));
 
             // Remove all child nodes (if any)
             while (!tspanElement.lastChild().isNull()) {
@@ -173,8 +173,8 @@ void DrawViewSymbol::updateFieldsInSymbol()
             }
 
             // Finally append text node with editable replacement as the only <tspan> descendant
-            tspanElement.appendChild(symbolDocument.createTextNode(
-                             QString::fromUtf8(editText[count].c_str())));
+            tspanElement.appendChild(
+                symbolDocument.createTextNode(QString::fromUtf8(editText[count].c_str())));
             ++count;
         }
         Symbol.setValue(symbolDocument.toString(1).toStdString());
@@ -186,6 +186,9 @@ bool DrawViewSymbol::loadQDomDocument(QDomDocument& symbolDocument)
 {
     const char* symbol = Symbol.getValue();
     QByteArray qba(symbol);
+    if (qba.isEmpty()) {
+        return false;
+    }
     QString errorMsg;
     int errorLine;
     int errorCol;
@@ -193,15 +196,16 @@ bool DrawViewSymbol::loadQDomDocument(QDomDocument& symbolDocument)
     bool rc = symbolDocument.setContent(qba, nsProcess, &errorMsg, &errorLine, &errorCol);
     if (!rc) {
         //invalid SVG message
-        Base::Console().Warning("DrawViewSymbol - %s - SVG for Symbol is not valid. See log.\n");
+        Base::Console().Warning("DrawViewSymbol - %s - SVG for Symbol is not valid. See log.\n",
+                                getNameInDocument());
         Base::Console().Log("DrawViewSymbol - %s - len: %d rc: %d error: %s line: %d col: %d\n",
-                             getNameInDocument(), strlen(symbol), rc,
-                             qPrintable(errorMsg), errorLine, errorCol);
+                            getNameInDocument(), strlen(symbol), rc, qPrintable(errorMsg),
+                            errorLine, errorCol);
     }
     return rc;
 }
 
-PyObject *DrawViewSymbol::getPyObject()
+PyObject* DrawViewSymbol::getPyObject()
 {
     if (PythonObject.is(Py::_None())) {
         // ref counter is set to 1
@@ -212,14 +216,16 @@ PyObject *DrawViewSymbol::getPyObject()
 
 // Python Drawing feature ---------------------------------------------------------
 
-namespace App {
+namespace App
+{
 /// @cond DOXERR
 PROPERTY_SOURCE_TEMPLATE(TechDraw::DrawViewSymbolPython, TechDraw::DrawViewSymbol)
-template<> const char* TechDraw::DrawViewSymbolPython::getViewProviderName() const {
+template<> const char* TechDraw::DrawViewSymbolPython::getViewProviderName() const
+{
     return "TechDrawGui::ViewProviderSymbol";
 }
 /// @endcond
 
 // explicit template instantiation
 template class TechDrawExport FeaturePythonT<TechDraw::DrawViewSymbol>;
-}
+}// namespace App

--- a/src/Mod/TechDraw/App/Preferences.cpp
+++ b/src/Mod/TechDraw/App/Preferences.cpp
@@ -23,8 +23,8 @@
 #include "PreCompiled.h"
 
 #ifndef _PreComp_
-#include <string>
 #include <QString>
+#include <string>
 #endif
 
 #include <App/Application.h>
@@ -45,9 +45,11 @@ const double Preferences::DefaultFontSizeInMM = 5.0;
 
 std::string Preferences::labelFont()
 {
-    Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter().
-                                         GetGroup("BaseApp")->GetGroup("Preferences")->
-                                         GetGroup("Mod/TechDraw/Labels");
+    Base::Reference<ParameterGrp> hGrp = App::GetApplication()
+                                             .GetUserParameter()
+                                             .GetGroup("BaseApp")
+                                             ->GetGroup("Preferences")
+                                             ->GetGroup("Mod/TechDraw/Labels");
     std::string fontName = hGrp->GetASCII("LabelFont", "osifont");
     return fontName;
 }
@@ -60,40 +62,50 @@ QString Preferences::labelFontQString()
 
 double Preferences::labelFontSizeMM()
 {
-    Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter().
-                                         GetGroup("BaseApp")->GetGroup("Preferences")->
-                                         GetGroup("Mod/TechDraw/Labels");
+    Base::Reference<ParameterGrp> hGrp = App::GetApplication()
+                                             .GetUserParameter()
+                                             .GetGroup("BaseApp")
+                                             ->GetGroup("Preferences")
+                                             ->GetGroup("Mod/TechDraw/Labels");
     return hGrp->GetFloat("LabelSize", DefaultFontSizeInMM);
 }
 
 double Preferences::dimFontSizeMM()
 {
-    Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter().
-                                         GetGroup("BaseApp")->GetGroup("Preferences")->
-                                         GetGroup("Mod/TechDraw/Dimensions");
+    Base::Reference<ParameterGrp> hGrp = App::GetApplication()
+                                             .GetUserParameter()
+                                             .GetGroup("BaseApp")
+                                             ->GetGroup("Preferences")
+                                             ->GetGroup("Mod/TechDraw/Dimensions");
     return hGrp->GetFloat("FontSize", DefaultFontSizeInMM);
 }
 
 App::Color Preferences::normalColor()
 {
-    Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter().
-           GetGroup("BaseApp")->GetGroup("Preferences")->
-           GetGroup("Mod/TechDraw/Colors");
+    Base::Reference<ParameterGrp> hGrp = App::GetApplication()
+                                             .GetUserParameter()
+                                             .GetGroup("BaseApp")
+                                             ->GetGroup("Preferences")
+                                             ->GetGroup("Mod/TechDraw/Colors");
     App::Color fcColor;
-    fcColor.setPackedValue(hGrp->GetUnsigned("NormalColor", 0x000000FF));     //#000000 black
+    fcColor.setPackedValue(hGrp->GetUnsigned("NormalColor", 0x000000FF));//#000000 black
     return fcColor;
 }
 
 App::Color Preferences::selectColor()
 {
-    Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter().
-                                         GetGroup("BaseApp")->GetGroup("Preferences")->
-                                         GetGroup("View");
-    unsigned int defColor = hGrp->GetUnsigned("SelectionColor", 0x00FF00FF);  //#00FF00 lime
+    Base::Reference<ParameterGrp> hGrp = App::GetApplication()
+                                             .GetUserParameter()
+                                             .GetGroup("BaseApp")
+                                             ->GetGroup("Preferences")
+                                             ->GetGroup("View");
+    unsigned int defColor = hGrp->GetUnsigned("SelectionColor", 0x00FF00FF);//#00FF00 lime
 
-    hGrp = App::GetApplication().GetUserParameter().
-           GetGroup("BaseApp")->GetGroup("Preferences")->
-           GetGroup("Mod/TechDraw/Colors");
+    hGrp = App::GetApplication()
+               .GetUserParameter()
+               .GetGroup("BaseApp")
+               ->GetGroup("Preferences")
+               ->GetGroup("Mod/TechDraw/Colors");
     App::Color fcColor;
     fcColor.setPackedValue(hGrp->GetUnsigned("SelectColor", defColor));
     return fcColor;
@@ -101,14 +113,18 @@ App::Color Preferences::selectColor()
 
 App::Color Preferences::preselectColor()
 {
-    Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter().
-                                         GetGroup("BaseApp")->GetGroup("Preferences")->
-                                         GetGroup("View");
-    unsigned int defColor = hGrp->GetUnsigned("HighlightColor", 0xFFFF00FF);  //#FFFF00 yellow
+    Base::Reference<ParameterGrp> hGrp = App::GetApplication()
+                                             .GetUserParameter()
+                                             .GetGroup("BaseApp")
+                                             ->GetGroup("Preferences")
+                                             ->GetGroup("View");
+    unsigned int defColor = hGrp->GetUnsigned("HighlightColor", 0xFFFF00FF);//#FFFF00 yellow
 
-    hGrp = App::GetApplication().GetUserParameter().
-           GetGroup("BaseApp")->GetGroup("Preferences")->
-           GetGroup("Mod/TechDraw/Colors");
+    hGrp = App::GetApplication()
+               .GetUserParameter()
+               .GetGroup("BaseApp")
+               ->GetGroup("Preferences")
+               ->GetGroup("Mod/TechDraw/Colors");
     App::Color fcColor;
     fcColor.setPackedValue(hGrp->GetUnsigned("PreSelectColor", defColor));
     return fcColor;
@@ -116,26 +132,34 @@ App::Color Preferences::preselectColor()
 
 App::Color Preferences::vertexColor()
 {
-    Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter().
-           GetGroup("BaseApp")->GetGroup("Preferences")->
-           GetGroup("Mod/TechDraw/Decorations");
+    Base::Reference<ParameterGrp> hGrp = App::GetApplication()
+                                             .GetUserParameter()
+                                             .GetGroup("BaseApp")
+                                             ->GetGroup("Preferences")
+                                             ->GetGroup("Mod/TechDraw/Decorations");
     App::Color fcColor;
-    fcColor.setPackedValue(hGrp->GetUnsigned("VertexColor", 0x000000FF));     //#000000 black
+    fcColor.setPackedValue(hGrp->GetUnsigned("VertexColor", 0x000000FF));//#000000 black
     return fcColor;
 }
 
 double Preferences::vertexScale()
 {
-    Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter().GetGroup("BaseApp")->
-                                         GetGroup("Preferences")->GetGroup("Mod/TechDraw/General");
+    Base::Reference<ParameterGrp> hGrp = App::GetApplication()
+                                             .GetUserParameter()
+                                             .GetGroup("BaseApp")
+                                             ->GetGroup("Preferences")
+                                             ->GetGroup("Mod/TechDraw/General");
     double result = hGrp->GetFloat("VertexScale", 3.0);
     return result;
 }
 
 int Preferences::scaleType()
 {
-    Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter()
-          .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/TechDraw/General");
+    Base::Reference<ParameterGrp> hGrp = App::GetApplication()
+                                             .GetUserParameter()
+                                             .GetGroup("BaseApp")
+                                             ->GetGroup("Preferences")
+                                             ->GetGroup("Mod/TechDraw/General");
     int result = hGrp->GetInt("DefaultScaleType", 0);
     return result;
 }
@@ -143,25 +167,32 @@ int Preferences::scaleType()
 double Preferences::scale()
 {
     int prefScaleType = scaleType();
-    if (prefScaleType == 0) {       //page scale
-        Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter()
-              .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/TechDraw/General");
+    if (prefScaleType == 0) {//page scale
+        Base::Reference<ParameterGrp> hGrp = App::GetApplication()
+                                                 .GetUserParameter()
+                                                 .GetGroup("BaseApp")
+                                                 ->GetGroup("Preferences")
+                                                 ->GetGroup("Mod/TechDraw/General");
         return hGrp->GetFloat("DefaultPageScale", 1.0);
-    } else if (prefScaleType == 1) {    //custom scale
-        Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter()
-              .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/TechDraw/General");
+    }
+    else if (prefScaleType == 1) {//custom scale
+        Base::Reference<ParameterGrp> hGrp = App::GetApplication()
+                                                 .GetUserParameter()
+                                                 .GetGroup("BaseApp")
+                                                 ->GetGroup("Preferences")
+                                                 ->GetGroup("Mod/TechDraw/General");
         return hGrp->GetFloat("DefaultViewScale", 1.0);
     }
     return 1.0;
 }
 
-//lightgray #D3D3D3
-
 bool Preferences::keepPagesUpToDate()
 {
-    Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter().
-                                         GetGroup("BaseApp")->GetGroup("Preferences")->
-                                         GetGroup("Mod/TechDraw/General");
+    Base::Reference<ParameterGrp> hGrp = App::GetApplication()
+                                             .GetUserParameter()
+                                             .GetGroup("BaseApp")
+                                             ->GetGroup("Preferences")
+                                             ->GetGroup("Mod/TechDraw/General");
     bool autoUpdate = hGrp->GetBool("KeepPagesUpToDate", true);
     return autoUpdate;
 }
@@ -169,45 +200,55 @@ bool Preferences::keepPagesUpToDate()
 bool Preferences::useGlobalDecimals()
 {
     bool result = false;
-    Base::Reference<ParameterGrp> hGrp = App::GetApplication().
-                                         GetUserParameter().GetGroup("BaseApp")->
-                                         GetGroup("Preferences")->GetGroup("Mod/TechDraw/Dimensions");
+    Base::Reference<ParameterGrp> hGrp = App::GetApplication()
+                                             .GetUserParameter()
+                                             .GetGroup("BaseApp")
+                                             ->GetGroup("Preferences")
+                                             ->GetGroup("Mod/TechDraw/Dimensions");
     result = hGrp->GetBool("UseGlobalDecimals", true);
     return result;
 }
 
 int Preferences::projectionAngle()
 {
-    Base::Reference<ParameterGrp>  hGrp = App::GetApplication().GetUserParameter().
-                                          GetGroup("BaseApp")->GetGroup("Preferences")->
-                                          GetGroup("Mod/TechDraw/General");
-    int projType = hGrp->GetInt("ProjectionAngle", 0);    //First Angle
+    Base::Reference<ParameterGrp> hGrp = App::GetApplication()
+                                             .GetUserParameter()
+                                             .GetGroup("BaseApp")
+                                             ->GetGroup("Preferences")
+                                             ->GetGroup("Mod/TechDraw/General");
+    int projType = hGrp->GetInt("ProjectionAngle", 0);//First Angle
     return projType;
 }
 
 int Preferences::lineGroup()
 {
-    Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter().
-                                         GetGroup("BaseApp")->GetGroup("Preferences")->
-                                         GetGroup("Mod/TechDraw/Decorations");
-    int lgInt = hGrp->GetInt("LineGroup", 3); // FC 0.70mm
+    Base::Reference<ParameterGrp> hGrp = App::GetApplication()
+                                             .GetUserParameter()
+                                             .GetGroup("BaseApp")
+                                             ->GetGroup("Preferences")
+                                             ->GetGroup("Mod/TechDraw/Decorations");
+    int lgInt = hGrp->GetInt("LineGroup", 3);// FC 0.70mm
     return lgInt;
 }
 
 int Preferences::balloonArrow()
 {
-    Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter().
-                                         GetGroup("BaseApp")->GetGroup("Preferences")->
-                                         GetGroup("Mod/TechDraw/Decorations");
+    Base::Reference<ParameterGrp> hGrp = App::GetApplication()
+                                             .GetUserParameter()
+                                             .GetGroup("BaseApp")
+                                             ->GetGroup("Preferences")
+                                             ->GetGroup("Mod/TechDraw/Decorations");
     int end = hGrp->GetInt("BalloonArrow", 0);
     return end;
 }
 
 QString Preferences::defaultTemplate()
 {
-    Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter().
-                                         GetGroup("BaseApp")->GetGroup("Preferences")->
-                                         GetGroup("Mod/TechDraw/Files");
+    Base::Reference<ParameterGrp> hGrp = App::GetApplication()
+                                             .GetUserParameter()
+                                             .GetGroup("BaseApp")
+                                             ->GetGroup("Preferences")
+                                             ->GetGroup("Mod/TechDraw/Files");
     std::string defaultDir = App::Application::getResourceDir() + "Mod/TechDraw/Templates/";
     std::string defaultFileName = defaultDir + "A4_LandscapeTD.svg";
     std::string prefFileName = hGrp->GetASCII("TemplateFile", defaultFileName.c_str());
@@ -225,8 +266,11 @@ QString Preferences::defaultTemplate()
 
 QString Preferences::defaultTemplateDir()
 {
-    Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter()
-        .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/TechDraw/Files");
+    Base::Reference<ParameterGrp> hGrp = App::GetApplication()
+                                             .GetUserParameter()
+                                             .GetGroup("BaseApp")
+                                             ->GetGroup("Preferences")
+                                             ->GetGroup("Mod/TechDraw/Files");
 
     std::string defaultDir = App::Application::getResourceDir() + "Mod/TechDraw/Templates";
     std::string prefTemplateDir = hGrp->GetASCII("TemplateDir", defaultDir.c_str());
@@ -236,17 +280,20 @@ QString Preferences::defaultTemplateDir()
     QString templateDir = QString::fromStdString(prefTemplateDir);
     Base::FileInfo fi(prefTemplateDir);
     if (!fi.isReadable()) {
-        Base::Console().Warning("Template Directory: %s is not readable\n", prefTemplateDir.c_str());
+        Base::Console().Warning("Template Directory: %s is not readable\n",
+                                prefTemplateDir.c_str());
         templateDir = QString::fromStdString(defaultDir);
-   }
+    }
     return templateDir;
 }
 
 std::string Preferences::lineGroupFile()
 {
-    Base::Reference<ParameterGrp> hGrp = App::GetApplication().
-                                         GetUserParameter().GetGroup("BaseApp")->
-                                         GetGroup("Preferences")->GetGroup("Mod/TechDraw/Files");
+    Base::Reference<ParameterGrp> hGrp = App::GetApplication()
+                                             .GetUserParameter()
+                                             .GetGroup("BaseApp")
+                                             ->GetGroup("Preferences")
+                                             ->GetGroup("Mod/TechDraw/Files");
     std::string defaultDir = App::Application::getResourceDir() + "Mod/TechDraw/LineGroup/";
     std::string defaultFileName = defaultDir + "LineGroup.csv";
     std::string lgFileName = hGrp->GetASCII("LineGroupFile", defaultFileName.c_str());
@@ -263,31 +310,42 @@ std::string Preferences::lineGroupFile()
 
 std::string Preferences::formatSpec()
 {
-    Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter()
-                                         .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/TechDraw/Dimensions");
+    Base::Reference<ParameterGrp> hGrp = App::GetApplication()
+                                             .GetUserParameter()
+                                             .GetGroup("BaseApp")
+                                             ->GetGroup("Preferences")
+                                             ->GetGroup("Mod/TechDraw/Dimensions");
     return hGrp->GetASCII("formatSpec", "%.2w");
 }
 
 int Preferences::altDecimals()
 {
-    Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter()
-                                         .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/TechDraw/Dimensions");
+    Base::Reference<ParameterGrp> hGrp = App::GetApplication()
+                                             .GetUserParameter()
+                                             .GetGroup("BaseApp")
+                                             ->GetGroup("Preferences")
+                                             ->GetGroup("Mod/TechDraw/Dimensions");
     return hGrp->GetInt("AltDecimals", 2);
 }
 
 int Preferences::mattingStyle()
 {
-    Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter().
-                                         GetGroup("BaseApp")->GetGroup("Preferences")->
-                                         GetGroup("Mod/TechDraw/Decorations");
+    Base::Reference<ParameterGrp> hGrp = App::GetApplication()
+                                             .GetUserParameter()
+                                             .GetGroup("BaseApp")
+                                             ->GetGroup("Preferences")
+                                             ->GetGroup("Mod/TechDraw/Decorations");
     int style = hGrp->GetInt("MattingStyle", 0);
     return style;
 }
 
 std::string Preferences::svgFile()
 {
-    Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter()
-        .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/TechDraw/Files");
+    Base::Reference<ParameterGrp> hGrp = App::GetApplication()
+                                             .GetUserParameter()
+                                             .GetGroup("BaseApp")
+                                             ->GetGroup("Preferences")
+                                             ->GetGroup("Mod/TechDraw/Files");
 
     std::string defaultDir = App::Application::getResourceDir() + "Mod/TechDraw/Patterns/";
     std::string defaultFileName = defaultDir + "simple.svg";
@@ -305,8 +363,11 @@ std::string Preferences::svgFile()
 
 std::string Preferences::patFile()
 {
-    Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter()
-        .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/TechDraw/PAT");
+    Base::Reference<ParameterGrp> hGrp = App::GetApplication()
+                                             .GetUserParameter()
+                                             .GetGroup("BaseApp")
+                                             ->GetGroup("Preferences")
+                                             ->GetGroup("Mod/TechDraw/PAT");
 
     std::string defaultDir = App::Application::getResourceDir() + "Mod/TechDraw/PAT/";
     std::string defaultFileName = defaultDir + "FCPAT.pat";
@@ -325,8 +386,11 @@ std::string Preferences::patFile()
 
 std::string Preferences::bitmapFill()
 {
-    Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter()
-        .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/TechDraw/Files");
+    Base::Reference<ParameterGrp> hGrp = App::GetApplication()
+                                             .GetUserParameter()
+                                             .GetGroup("BaseApp")
+                                             ->GetGroup("Preferences")
+                                             ->GetGroup("Mod/TechDraw/Files");
 
     std::string defaultDir = App::Application::getResourceDir() + "Mod/TechDraw/Patterns/";
     std::string defaultFileName = defaultDir + "default.png";
@@ -344,27 +408,130 @@ std::string Preferences::bitmapFill()
 
 double Preferences::GapISO()
 {
-    Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter()
-                                         .GetGroup("BaseApp")->GetGroup("Preferences")->
-                                         GetGroup("Mod/TechDraw/Dimensions");
+    Base::Reference<ParameterGrp> hGrp = App::GetApplication()
+                                             .GetUserParameter()
+                                             .GetGroup("BaseApp")
+                                             ->GetGroup("Preferences")
+                                             ->GetGroup("Mod/TechDraw/Dimensions");
     double factor = hGrp->GetFloat("GapISO", 8.0);
     return factor;
 }
 
 double Preferences::GapASME()
 {
-    Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter()
-                                         .GetGroup("BaseApp")->GetGroup("Preferences")->
-                                         GetGroup("Mod/TechDraw/Dimensions");
+    Base::Reference<ParameterGrp> hGrp = App::GetApplication()
+                                             .GetUserParameter()
+                                             .GetGroup("BaseApp")
+                                             ->GetGroup("Preferences")
+                                             ->GetGroup("Mod/TechDraw/Dimensions");
     double factor = hGrp->GetFloat("GapASME", 6.0);
     return factor;
 }
 
 bool Preferences::reportProgress()
 {
-    Base::Reference<ParameterGrp>  hGrp = App::GetApplication().GetUserParameter().
-                                          GetGroup("BaseApp")->GetGroup("Preferences")->
-                                          GetGroup("Mod/TechDraw/General");
+    Base::Reference<ParameterGrp> hGrp = App::GetApplication()
+                                             .GetUserParameter()
+                                             .GetGroup("BaseApp")
+                                             ->GetGroup("Preferences")
+                                             ->GetGroup("Mod/TechDraw/General");
     bool report = hGrp->GetBool("ReportProgress", false);
     return report;
+}
+
+bool Preferences::lightOnDark()
+{
+    Base::Reference<ParameterGrp> hGrp = App::GetApplication()
+                                             .GetUserParameter()
+                                             .GetGroup("BaseApp")
+                                             ->GetGroup("Preferences")
+                                             ->GetGroup("Mod/TechDraw/Colors");
+    bool light = hGrp->GetBool("LightOnDark", false);
+    return light;
+}
+
+void Preferences::lightOnDark(bool state)
+{
+    Base::Console().Message("Pref::useLightText - set to %d\n", state);
+    Base::Reference<ParameterGrp> hGrp = App::GetApplication()
+                                             .GetUserParameter()
+                                             .GetGroup("BaseApp")
+                                             ->GetGroup("Preferences")
+                                             ->GetGroup("Mod/TechDraw/Colors");
+    hGrp->SetBool("LightOnDark", state);
+}
+
+bool Preferences::monochrome()
+{
+    Base::Reference<ParameterGrp> hGrp = App::GetApplication()
+                                             .GetUserParameter()
+                                             .GetGroup("BaseApp")
+                                             ->GetGroup("Preferences")
+                                             ->GetGroup("Mod/TechDraw/Colors");
+    bool mono = hGrp->GetBool("Monochrome", false);
+    return mono;
+}
+
+void Preferences::monochrome(bool state)
+{
+    Base::Console().Message("Pref::useLightText - set to %d\n", state);
+    Base::Reference<ParameterGrp> hGrp = App::GetApplication()
+                                             .GetUserParameter()
+                                             .GetGroup("BaseApp")
+                                             ->GetGroup("Preferences")
+                                             ->GetGroup("Mod/TechDraw/Colors");
+    hGrp->SetBool("Monochrome", state);
+}
+
+App::Color Preferences::lightTextColor()
+{
+    Base::Reference<ParameterGrp> hGrp = App::GetApplication()
+                                             .GetUserParameter()
+                                             .GetGroup("BaseApp")
+                                             ->GetGroup("Preferences")
+                                             ->GetGroup("Mod/TechDraw/Colors");
+    App::Color result;
+    result.setPackedValue(hGrp->GetUnsigned("LightTextColor", 0xFFFFFFFF));//#FFFFFFFF white
+    return result;
+}
+
+App::Color Preferences::lightenColor(App::Color orig)
+{
+    // get component colours on [0, 255]
+    uchar red = orig.r * 255;
+    uchar blue = orig.b * 255;
+    uchar green = orig.g * 255;
+    //    uchar alpha = orig.a * 255;
+
+    // shift color values
+    uchar m = std::min({red, blue, green});
+    red -= m;
+    blue -= m;
+    green -= m;
+
+    // calculate chroma (colour range)
+    uchar chroma = std::max({red, blue, green});
+
+    // calculate lightened colour value
+    uchar newm = 255 - chroma - m;
+    red += newm;
+    green += newm;
+    blue += newm;
+
+    double redF = (float)red / 255.0;
+    double greenF = (float)green / 255.0;
+    double blueF = (float)blue / 255.0;
+
+    return App::Color(redF, greenF, blueF, orig.a);
+}
+
+App::Color Preferences::getAccessibleColor(App::Color orig)
+{
+    if (Preferences::lightOnDark() && Preferences::monochrome()) {
+        return lightTextColor();
+    }
+    if (Preferences::lightOnDark()) {
+        return lightenColor(orig);
+    }
+    return orig;
 }

--- a/src/Mod/TechDraw/App/Preferences.h
+++ b/src/Mod/TechDraw/App/Preferences.h
@@ -29,6 +29,7 @@
 
 
 class QString;
+class QColor;
 
 namespace App
 {
@@ -39,50 +40,59 @@ namespace TechDraw
 {
 
 //getters for parameters used in multiple places.
-class TechDrawExport Preferences {
+class TechDrawExport Preferences
+{
 
 public:
-static std::string labelFont();
-static QString     labelFontQString();
-static double      labelFontSizeMM();
-static double      dimFontSizeMM();
+    static std::string labelFont();
+    static QString labelFontQString();
+    static double labelFontSizeMM();
+    static double dimFontSizeMM();
 
-static App::Color  normalColor();
-static App::Color  selectColor();
-static App::Color  preselectColor();
-static App::Color  vertexColor();
-static double      vertexScale();
-static int         scaleType();
-static double      scale();
-static bool        useGlobalDecimals();
-static bool        keepPagesUpToDate();
+    static App::Color normalColor();
+    static App::Color selectColor();
+    static App::Color preselectColor();
+    static App::Color vertexColor();
+    static double vertexScale();
+    static int scaleType();
+    static double scale();
+    static bool useGlobalDecimals();
+    static bool keepPagesUpToDate();
 
-static int         projectionAngle();
-static int         lineGroup();
+    static int projectionAngle();
+    static int lineGroup();
 
-static int         balloonArrow();
+    static int balloonArrow();
 
-static QString     defaultTemplate();
-static QString     defaultTemplateDir();
-static std::string lineGroupFile();
+    static QString defaultTemplate();
+    static QString defaultTemplateDir();
+    static std::string lineGroupFile();
 
-static const double DefaultFontSizeInMM;
+    static const double DefaultFontSizeInMM;
 
-static std::string  formatSpec();
-static int          altDecimals();
+    static std::string formatSpec();
+    static int altDecimals();
 
-static int         mattingStyle();
+    static int mattingStyle();
 
-static std::string svgFile();
-static std::string patFile();
+    static std::string svgFile();
+    static std::string patFile();
 
-static std::string bitmapFill();
+    static std::string bitmapFill();
 
-static double      GapISO();
-static double      GapASME();
+    static double GapISO();
+    static double GapASME();
 
-static bool        reportProgress();
+    static bool reportProgress();
+
+    static bool lightOnDark();
+    static void lightOnDark(bool state);
+    static bool monochrome();
+    static void monochrome(bool state);
+    static App::Color lightTextColor();
+    static App::Color lightenColor(App::Color orig);
+    static App::Color getAccessibleColor(App::Color orig);
 };
 
-} //end namespace TechDraw
+}//end namespace TechDraw
 #endif

--- a/src/Mod/TechDraw/Gui/CMakeLists.txt
+++ b/src/Mod/TechDraw/Gui/CMakeLists.txt
@@ -49,6 +49,7 @@ set(TechDrawGui_LIBS
 qt_add_resources(TechDrawGui_SRCS Resources/TechDraw.qrc)
 
 set(TechDrawGui_UIC_SRCS
+    DlgStringListEditor.ui
     DlgPageChooser.ui
     DlgPrefsTechDrawAdvanced.ui
     DlgPrefsTechDrawAnnotation.ui
@@ -115,6 +116,9 @@ SET(TechDrawGui_SRCS
     TaskProjGroup.ui
     TaskProjGroup.cpp
     TaskProjGroup.h
+    DlgStringListEditor.ui
+    DlgStringListEditor.cpp
+    DlgStringListEditor.h
     DlgPageChooser.ui
     DlgPageChooser.cpp
     DlgPageChooser.h

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawColors.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawColors.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>440</width>
-    <height>368</height>
+    <height>400</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -49,60 +49,16 @@
      <layout class="QVBoxLayout" name="verticalLayout">
       <item>
        <layout class="QGridLayout" name="gridLayout">
-        <item row="0" column="0">
-         <widget class="QLabel" name="lbl_Normal">
-          <property name="font">
-           <font>
-            <italic>true</italic>
-           </font>
-          </property>
-          <property name="text">
-           <string>Normal</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="Gui::PrefColorButton" name="pcb_Normal">
+        <item row="10" column="1">
+         <widget class="Gui::PrefColorButton" name="pcbLightTextColor">
           <property name="toolTip">
-           <string>Normal line color</string>
-          </property>
-          <property name="color">
-           <color>
-            <red>0</red>
-            <green>0</green>
-            <blue>0</blue>
-           </color>
+           <string>Monochrome text color</string>
           </property>
           <property name="prefEntry" stdset="0">
-           <cstring>NormalColor</cstring>
+           <cstring>LightTextColor</cstring>
           </property>
           <property name="prefPath" stdset="0">
            <cstring>Mod/TechDraw/Colors</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="2">
-         <spacer name="horizontalSpacer_3">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item row="0" column="3">
-         <widget class="QLabel" name="lbl_Hidden">
-          <property name="font">
-           <font>
-            <italic>true</italic>
-           </font>
-          </property>
-          <property name="text">
-           <string>Hidden Line</string>
           </property>
          </widget>
         </item>
@@ -126,114 +82,8 @@
           </property>
          </widget>
         </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="lbl_PreSelect">
-          <property name="font">
-           <font>
-            <italic>true</italic>
-           </font>
-          </property>
-          <property name="text">
-           <string>Preselected</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="Gui::PrefColorButton" name="pcb_PreSelect">
-          <property name="toolTip">
-           <string>Preselection color</string>
-          </property>
-          <property name="color">
-           <color>
-            <red>255</red>
-            <green>255</green>
-            <blue>0</blue>
-           </color>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>PreSelectColor</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/Colors</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="3">
-         <widget class="QLabel" name="label_3">
-          <property name="font">
-           <font>
-            <italic>true</italic>
-           </font>
-          </property>
-          <property name="text">
-           <string>Section Face</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="4">
-         <widget class="Gui::PrefColorButton" name="pcb_Surface">
-          <property name="toolTip">
-           <string>Section face color</string>
-          </property>
-          <property name="color">
-           <color>
-            <red>211</red>
-            <green>211</green>
-            <blue>211</blue>
-           </color>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>CutSurfaceColor</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/Colors</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="lbl_Select">
-          <property name="font">
-           <font>
-            <italic>true</italic>
-           </font>
-          </property>
-          <property name="text">
-           <string>Selected</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="Gui::PrefColorButton" name="pcb_Select">
-          <property name="toolTip">
-           <string>Selected item color</string>
-          </property>
-          <property name="color">
-           <color>
-            <red>0</red>
-            <green>255</green>
-            <blue>0</blue>
-           </color>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>SelectColor</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/Colors</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="3">
-         <widget class="QLabel" name="label_14">
-          <property name="text">
-           <string>Section Line</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="4">
-         <widget class="Gui::PrefColorButton" name="pcbSectionLine">
-          <property name="toolTip">
-           <string>Section line color</string>
-          </property>
+        <item row="6" column="1">
+         <widget class="Gui::PrefColorButton" name="pcbHighlight">
           <property name="color">
            <color>
             <red>0</red>
@@ -242,81 +92,10 @@
            </color>
           </property>
           <property name="prefEntry" stdset="0">
-           <cstring>SectionColor</cstring>
+           <cstring>HighlightColor</cstring>
           </property>
           <property name="prefPath" stdset="0">
            <cstring>/Mod/TechDraw/Decorations</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="label_4">
-          <property name="font">
-           <font>
-            <italic>true</italic>
-           </font>
-          </property>
-          <property name="text">
-           <string>Background</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="1">
-         <widget class="Gui::PrefColorButton" name="pcb_Background">
-          <property name="toolTip">
-           <string>Background color around pages</string>
-          </property>
-          <property name="color">
-           <color>
-            <red>211</red>
-            <green>211</green>
-            <blue>211</blue>
-           </color>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>Background</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>/Mod/TechDraw/Colors</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="3">
-         <widget class="QLabel" name="label_5">
-          <property name="font">
-           <font>
-            <italic>true</italic>
-           </font>
-          </property>
-          <property name="text">
-           <string>Hatch</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="4">
-         <widget class="Gui::PrefColorButton" name="pcb_Hatch">
-          <property name="toolTip">
-           <string>Hatch image color</string>
-          </property>
-          <property name="color">
-           <color>
-            <red>0</red>
-            <green>0</green>
-            <blue>0</blue>
-           </color>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>Hatch</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>/Mod/TechDraw/Colors</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="0">
-         <widget class="QLabel" name="label_13">
-          <property name="text">
-           <string>Dimension</string>
           </property>
          </widget>
         </item>
@@ -340,6 +119,200 @@
           </property>
          </widget>
         </item>
+        <item row="3" column="0">
+         <widget class="QLabel" name="label_4">
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="text">
+           <string>Background</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="lbl_PreSelect">
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="text">
+           <string>Preselected</string>
+          </property>
+         </widget>
+        </item>
+        <item row="7" column="0">
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>Grid Color</string>
+          </property>
+         </widget>
+        </item>
+        <item row="6" column="0">
+         <widget class="QLabel" name="label_18">
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="text">
+           <string>Detail Highlight</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="lbl_Select">
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="text">
+           <string>Selected</string>
+          </property>
+         </widget>
+        </item>
+        <item row="9" column="0">
+         <widget class="Gui::PrefCheckBox" name="pcbLightOnDark">
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Check this to use light text and lines on dark backgrounds.  Set Page Color to a dark color. Transparent or light color faces are recommended with this option.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="text">
+           <string>Light on dark</string>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>LightOnDark</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>/Mod/TechDraw/Colors</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="4">
+         <widget class="Gui::PrefColorButton" name="pcb_Hatch">
+          <property name="toolTip">
+           <string>Hatch image color</string>
+          </property>
+          <property name="color">
+           <color>
+            <red>0</red>
+            <green>0</green>
+            <blue>0</blue>
+           </color>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>Hatch</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>/Mod/TechDraw/Colors</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="6" column="4">
+         <widget class="Gui::PrefColorButton" name="pcbMarkup">
+          <property name="toolTip">
+           <string>Default color for leader lines</string>
+          </property>
+          <property name="color">
+           <color>
+            <red>0</red>
+            <green>0</green>
+            <blue>0</blue>
+           </color>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>Color</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/Markups</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="10" column="3">
+         <widget class="QLabel" name="label_2">
+          <property name="text">
+           <string>Page Color</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="1">
+         <widget class="Gui::PrefColorButton" name="pcb_Background">
+          <property name="toolTip">
+           <string>Background color around pages</string>
+          </property>
+          <property name="color">
+           <color>
+            <red>211</red>
+            <green>211</green>
+            <blue>211</blue>
+           </color>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>Background</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>/Mod/TechDraw/Colors</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="3">
+         <widget class="QLabel" name="label_3">
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="text">
+           <string>Section Face</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="3">
+         <widget class="QLabel" name="label_14">
+          <property name="text">
+           <string>Section Line</string>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="0">
+         <widget class="QLabel" name="label_15">
+          <property name="text">
+           <string>Centerline</string>
+          </property>
+         </widget>
+        </item>
+        <item row="7" column="1">
+         <widget class="Gui::PrefColorButton" name="pcb_Grid">
+          <property name="color">
+           <color>
+            <red>0</red>
+            <green>0</green>
+            <blue>0</blue>
+           </color>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>gridColor</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>/Mod/TechDraw/Colors</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="2">
+         <spacer name="horizontalSpacer_3">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
         <item row="4" column="3">
          <widget class="QLabel" name="label_7">
           <property name="font">
@@ -352,10 +325,34 @@
           </property>
          </widget>
         </item>
-        <item row="4" column="4">
-         <widget class="Gui::PrefColorButton" name="pcb_GeomHatch">
+        <item row="6" column="3">
+         <widget class="QLabel" name="label_17">
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="text">
+           <string>Leaderline</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="3">
+         <widget class="QLabel" name="label_5">
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="text">
+           <string>Hatch</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="4">
+         <widget class="Gui::PrefColorButton" name="pcbSectionLine">
           <property name="toolTip">
-           <string>Geometric hatch pattern color</string>
+           <string>Section line color</string>
           </property>
           <property name="color">
            <color>
@@ -365,17 +362,102 @@
            </color>
           </property>
           <property name="prefEntry" stdset="0">
-           <cstring>GeomHatch</cstring>
+           <cstring>SectionColor</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>/Mod/TechDraw/Decorations</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="7" column="4">
+         <widget class="Gui::PrefColorButton" name="pcb_Face">
+          <property name="toolTip">
+           <string>Face color (if not transparent)</string>
+          </property>
+          <property name="color">
+           <color>
+            <red>255</red>
+            <green>255</green>
+            <blue>255</blue>
+           </color>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>FaceColor</cstring>
           </property>
           <property name="prefPath" stdset="0">
            <cstring>/Mod/TechDraw/Colors</cstring>
           </property>
          </widget>
         </item>
-        <item row="5" column="0">
-         <widget class="QLabel" name="label_15">
+        <item row="1" column="1">
+         <widget class="Gui::PrefColorButton" name="pcb_PreSelect">
+          <property name="toolTip">
+           <string>Preselection color</string>
+          </property>
+          <property name="color">
+           <color>
+            <red>255</red>
+            <green>255</green>
+            <blue>0</blue>
+           </color>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>PreSelectColor</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/Colors</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="3">
+         <widget class="QLabel" name="lbl_Hidden">
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
+          </property>
           <property name="text">
-           <string>Centerline</string>
+           <string>Hidden Line</string>
+          </property>
+         </widget>
+        </item>
+        <item row="10" column="4">
+         <widget class="Gui::PrefColorButton" name="pcbPageColor">
+          <property name="toolTip">
+           <string>Use a light color for dark text and dark color for light text.</string>
+          </property>
+          <property name="color">
+           <color>
+            <red>255</red>
+            <green>255</green>
+            <blue>255</blue>
+           </color>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>PageColor</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/Colors</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="Gui::PrefColorButton" name="pcb_Select">
+          <property name="toolTip">
+           <string>Selected item color</string>
+          </property>
+          <property name="color">
+           <color>
+            <red>0</red>
+            <green>255</green>
+            <blue>0</blue>
+           </color>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>SelectColor</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/Colors</cstring>
           </property>
          </widget>
         </item>
@@ -406,6 +488,46 @@
           </property>
          </widget>
         </item>
+        <item row="0" column="1">
+         <widget class="Gui::PrefColorButton" name="pcb_Normal">
+          <property name="toolTip">
+           <string>Normal line color</string>
+          </property>
+          <property name="color">
+           <color>
+            <red>0</red>
+            <green>0</green>
+            <blue>0</blue>
+           </color>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>NormalColor</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/Colors</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="4">
+         <widget class="Gui::PrefColorButton" name="pcb_Surface">
+          <property name="toolTip">
+           <string>Section face color</string>
+          </property>
+          <property name="color">
+           <color>
+            <red>211</red>
+            <green>211</green>
+            <blue>211</blue>
+           </color>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>CutSurfaceColor</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/Colors</cstring>
+          </property>
+         </widget>
+        </item>
         <item row="5" column="4">
          <widget class="Gui::PrefColorButton" name="pcbVertexColor">
           <property name="toolTip">
@@ -426,92 +548,7 @@
           </property>
          </widget>
         </item>
-        <item row="6" column="0">
-         <widget class="QLabel" name="label_18">
-          <property name="font">
-           <font>
-            <italic>true</italic>
-           </font>
-          </property>
-          <property name="text">
-           <string>Detail Highlight</string>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="1">
-         <widget class="Gui::PrefColorButton" name="pcbHighlight">
-          <property name="color">
-           <color>
-            <red>0</red>
-            <green>0</green>
-            <blue>0</blue>
-           </color>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>HighlightColor</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>/Mod/TechDraw/Decorations</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="3">
-         <widget class="QLabel" name="label_17">
-          <property name="font">
-           <font>
-            <italic>true</italic>
-           </font>
-          </property>
-          <property name="text">
-           <string>Leaderline</string>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="4">
-         <widget class="Gui::PrefColorButton" name="pcbMarkup">
-          <property name="toolTip">
-           <string>Default color for leader lines</string>
-          </property>
-          <property name="color">
-           <color>
-            <red>0</red>
-            <green>0</green>
-            <blue>0</blue>
-           </color>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>Color</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/Markups</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="7" column="0">
-         <widget class="QLabel" name="label">
-          <property name="text">
-           <string>Grid Color</string>
-          </property>
-         </widget>
-        </item>
-        <item row="7" column="1">
-         <widget class="Gui::PrefColorButton" name="pcb_Grid">
-          <property name="color">
-           <color>
-            <red>0</red>
-            <green>0</green>
-            <blue>0</blue>
-           </color>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>gridColor</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>/Mod/TechDraw/Colors</cstring>
-          </property>
-         </widget>
-        </item>
-       <item row="8" column="0">
+        <item row="7" column="3">
          <widget class="Gui::PrefCheckBox" name="pcb_PaintFaces">
           <property name="minimumSize">
            <size>
@@ -538,27 +575,69 @@
           </property>
          </widget>
         </item>
-        <item row="8" column="1">
-         <widget class="Gui::PrefColorButton" name="pcb_Face">
+        <item row="4" column="4">
+         <widget class="Gui::PrefColorButton" name="pcb_GeomHatch">
           <property name="toolTip">
-           <string>Face color (if not transparent)</string>
+           <string>Geometric hatch pattern color</string>
           </property>
           <property name="color">
            <color>
-            <red>255</red>
-            <green>255</green>
-            <blue>255</blue>
+            <red>0</red>
+            <green>0</green>
+            <blue>0</blue>
            </color>
           </property>
           <property name="prefEntry" stdset="0">
-           <cstring>FaceColor</cstring>
+           <cstring>GeomHatch</cstring>
           </property>
           <property name="prefPath" stdset="0">
            <cstring>/Mod/TechDraw/Colors</cstring>
           </property>
          </widget>
         </item>
-        </layout>
+        <item row="0" column="0">
+         <widget class="QLabel" name="lbl_Normal">
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="text">
+           <string>Normal</string>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="0">
+         <widget class="QLabel" name="label_13">
+          <property name="text">
+           <string>Dimension</string>
+          </property>
+         </widget>
+        </item>
+        <item row="10" column="0">
+         <widget class="Gui::PrefCheckBox" name="pcbMonochrome">
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If checked FreeCAD will use a single colour for all text and lines.  If unchecked FreeCAD will attempt to use lighter versions of preferred colours.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="text">
+           <string>Monochrome</string>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>Monochrome</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>/Mod/TechDraw/Colors</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="8" column="0">
+         <widget class="QLabel" name="label_6">
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
      </layout>
     </widget>
@@ -572,7 +651,7 @@
       </font>
      </property>
      <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=" font-weight:600;"&gt;Note:&lt;/span&gt; Items in &lt;span style=" font-style:italic;"&gt;italics&lt;/span&gt; are default values for new objects. They have no effect on existing objects.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Note:&lt;/span&gt; Items in &lt;span style=&quot; font-style:italic;&quot;&gt;italics&lt;/span&gt; are default values for new objects. They have no effect on existing objects.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawColorsImp.cpp
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawColorsImp.cpp
@@ -61,6 +61,10 @@ void DlgPrefsTechDrawColorsImp::saveSettings()
     ui->pcbMarkup->onSave();
     ui->pcbHighlight->onSave();
     ui->pcb_Grid->onSave();
+    ui->pcbPageColor->onSave();
+    ui->pcbLightOnDark->onSave();
+    ui->pcbMonochrome->onSave();
+    ui->pcbLightTextColor->onSave();
 }
 
 void DlgPrefsTechDrawColorsImp::loadSettings()
@@ -82,6 +86,10 @@ void DlgPrefsTechDrawColorsImp::loadSettings()
     ui->pcbMarkup->onRestore();
     ui->pcbHighlight->onRestore();
     ui->pcb_Grid->onRestore();
+    ui->pcbPageColor->onRestore();
+    ui->pcbLightOnDark->onRestore();
+    ui->pcbMonochrome->onRestore();
+    ui->pcbLightTextColor->onRestore();
 }
 
 /**

--- a/src/Mod/TechDraw/Gui/DlgStringListEditor.cpp
+++ b/src/Mod/TechDraw/Gui/DlgStringListEditor.cpp
@@ -1,0 +1,140 @@
+/****************************************************************************
+ *   Copyright (c) 2022 Wanderer Fan <wandererfan@gmail.com>                *
+ *                                                                          *
+ *   This file is part of the FreeCAD CAx development system.               *
+ *                                                                          *
+ *   This library is free software; you can redistribute it and/or          *
+ *   modify it under the terms of the GNU Library General Public            *
+ *   License as published by the Free Software Foundation; either           *
+ *   version 2 of the License, or (at your option) any later version.       *
+ *                                                                          *
+ *   This library  is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *   GNU Library General Public License for more details.                   *
+ *                                                                          *
+ *   You should have received a copy of the GNU Library General Public      *
+ *   License along with this library; see the file COPYING.LIB. If not,     *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,          *
+ *   Suite 330, Boston, MA  02111-1307, USA                                 *
+ *                                                                          *
+ ****************************************************************************/
+
+#include "PreCompiled.h"
+#ifndef _PreComp_
+#include <QList>
+#include <QListWidgetItem>
+#endif
+
+#include <Base/Console.h>// for FC_LOG_LEVEL_INIT
+#include <Base/Tools.h>
+
+#include "DlgStringListEditor.h"
+#include "ui_DlgStringListEditor.h"
+
+using namespace TechDrawGui;
+
+/* TRANSLATOR Gui::DlgStringListEditor */
+
+DlgStringListEditor::DlgStringListEditor(const std::vector<std::string> texts, QWidget* parent,
+                                         Qt::WindowFlags fl)
+    : QDialog(parent, fl),
+      ui(new Ui_DlgStringListEditor)
+{
+    ui->setupUi(this);
+    ui->lwTexts->setSortingEnabled(false);
+
+    fillList(texts);
+
+    connect(ui->lwTexts,
+            SIGNAL(itemActivated(QListWidgetItem*)),
+            this,
+            SLOT(slotItemActivated(QListWidgetItem*)));
+    connect(ui->pbAdd, SIGNAL(clicked()), this, SLOT(slotAddItem()));
+    connect(ui->pbRemove, SIGNAL(clicked()), this, SLOT(slotRemoveItem()));
+    connect(ui->bbButtons, SIGNAL(accepted()), this, SLOT(accept()));
+    connect(ui->bbButtons, SIGNAL(rejected()), this, SLOT(reject()));
+}
+
+/**
+ *  Destroys the object and frees any allocated resources
+ */
+DlgStringListEditor::~DlgStringListEditor()
+{
+    // no need to delete child widgets, Qt does it all for us
+    delete ui;
+}
+
+void DlgStringListEditor::fillList(std::vector<std::string> texts)
+{
+    QString qText;
+    int textCount = texts.size();
+    int i = 0;
+    for (; i < textCount; i++) {
+        qText = Base::Tools::fromStdString(texts[i]);
+        QListWidgetItem* item = new QListWidgetItem(qText);
+        item->setFlags(item->flags() | Qt::ItemIsEditable);
+        ui->lwTexts->addItem(item);
+    }
+    //add a blank line at the end to allow extending the list
+    QListWidgetItem* item = new QListWidgetItem(QString::fromUtf8(""));
+    item->setFlags(item->flags() | Qt::ItemIsEditable);
+    ui->lwTexts->addItem(item);
+}
+
+void DlgStringListEditor::slotItemActivated(QListWidgetItem* item)
+{
+    ui->lwTexts->editItem(item);
+}
+
+void DlgStringListEditor::slotAddItem()
+{
+    QString newText = ui->leNewItem->text();
+    QListWidgetItem* item = new QListWidgetItem(newText);
+    item->setFlags(item->flags() | Qt::ItemIsEditable);
+    int row = ui->lwTexts->currentRow();
+    if (row < 0) {
+        //no location set yet, add to end of list
+        ui->lwTexts->addItem(item);
+    }
+    else {
+        //insert item at current row and push the rest down 1 position
+        ui->lwTexts->insertItem(row, item);
+    }
+    ui->leNewItem->clear();
+    //TODO: how to append to end of list?
+}
+
+void DlgStringListEditor::slotRemoveItem()
+{
+    int row = ui->lwTexts->currentRow();
+    if (row >= 0) {
+        auto item = ui->lwTexts->takeItem(row);
+        delete item;
+    }
+}
+
+std::vector<std::string> DlgStringListEditor::getTexts() const
+{
+    std::vector<std::string> outTexts;
+    for (int iRow = 0; iRow < ui->lwTexts->count(); iRow++) {
+        QString itemText = ui->lwTexts->item(iRow)->text();
+        outTexts.push_back(Base::Tools::toStdString(itemText));
+    }
+    if (outTexts.back().empty()) {
+        outTexts.pop_back();
+    }
+    return outTexts;
+}
+
+void DlgStringListEditor::accept()
+{
+    QDialog::accept();
+}
+
+void DlgStringListEditor::reject()
+{
+    QDialog::reject();
+}
+
+#include "moc_DlgStringListEditor.cpp"

--- a/src/Mod/TechDraw/Gui/DlgStringListEditor.h
+++ b/src/Mod/TechDraw/Gui/DlgStringListEditor.h
@@ -1,0 +1,62 @@
+/****************************************************************************
+ *   Copyright (c) 2022 Wanderer Fan <wandererfan@gmail.com>                *
+ *                                                                          *
+ *   This file is part of the FreeCAD CAx development system.               *
+ *                                                                          *
+ *   This library is free software; you can redistribute it and/or          *
+ *   modify it under the terms of the GNU Library General Public            *
+ *   License as published by the Free Software Foundation; either           *
+ *   version 2 of the License, or (at your option) any later version.       *
+ *                                                                          *
+ *   This library  is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *   GNU Library General Public License for more details.                   *
+ *                                                                          *
+ *   You should have received a copy of the GNU Library General Public      *
+ *   License along with this library; see the file COPYING.LIB. If not,     *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,          *
+ *   Suite 330, Boston, MA  02111-1307, USA                                 *
+ *                                                                          *
+ ****************************************************************************/
+#ifndef GUI_DLGEDITABLETEXT_H
+#define GUI_DLGEDITABLETEXT_H
+
+#include <Mod/TechDraw/TechDrawGlobal.h>
+
+#include <QDialog>
+
+class QListWidgetItem;
+
+namespace TechDrawGui {
+
+class Ui_DlgStringListEditor;
+class TechDrawGuiExport DlgStringListEditor : public QDialog
+{
+    Q_OBJECT
+
+public:
+    DlgStringListEditor(const std::vector<std::string> texts,
+                   QWidget* parent = nullptr, Qt::WindowFlags fl = Qt::WindowFlags());
+    ~DlgStringListEditor();
+
+    std::vector<std::string> getTexts() const;
+    void accept();
+    void reject();
+
+public Q_SLOTS:
+    void slotItemActivated(QListWidgetItem* item);
+    void slotAddItem();
+    void slotRemoveItem();
+
+private:
+    void fillList(std::vector<std::string> texts);
+
+    Ui_DlgStringListEditor* ui;
+};
+
+} // namespace Gui
+
+
+#endif // GUI_DLGEDITABLETEXT_H
+

--- a/src/Mod/TechDraw/Gui/DlgStringListEditor.ui
+++ b/src/Mod/TechDraw/Gui/DlgStringListEditor.ui
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>TechDrawGui::DlgStringListEditor</class>
+ <widget class="QDialog" name="TechDrawGui::DlgStringListEditor">
+  <property name="windowModality">
+   <enum>Qt::WindowModal</enum>
+  </property>
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>360</width>
+    <height>331</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>String List Editor</string>
+  </property>
+  <property name="toolTip">
+   <string/>
+  </property>
+  <property name="modal">
+   <bool>true</bool>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QVBoxLayout" name="verticalLayout_2">
+     <item>
+      <widget class="QListWidget" name="lwTexts">
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Double click to edit a line.  New lines are added at the current location in the list.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="editTriggers">
+        <set>QAbstractItemView::DoubleClicked|QAbstractItemView::EditKeyPressed|QAbstractItemView::SelectedClicked</set>
+       </property>
+       <property name="alternatingRowColors">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <item>
+        <widget class="QPushButton" name="pbAdd">
+         <property name="icon">
+          <iconset>
+           <normalon>:/icons/list-add.svg</normalon>
+          </iconset>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLineEdit" name="leNewItem"/>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout_2">
+       <item>
+        <widget class="QPushButton" name="pbRemove">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="icon">
+          <iconset resource="../../../Gui/Icons/resource.qrc">
+           <normaloff>:/icons/list-remove.svg</normaloff>:/icons/list-remove.svg</iconset>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="bbButtons">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+     <property name="centerButtons">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources>
+  <include location="Resources/TechDraw.qrc"/>
+  <include location="../../../Gui/Icons/resource.qrc"/>
+ </resources>
+ <connections>
+  <connection>
+   <sender>bbButtons</sender>
+   <signal>accepted()</signal>
+   <receiver>TechDrawGui::DlgStringListEditor</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>179</x>
+     <y>228</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>179</x>
+     <y>139</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>bbButtons</sender>
+   <signal>rejected()</signal>
+   <receiver>TechDrawGui::DlgStringListEditor</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>179</x>
+     <y>228</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>179</x>
+     <y>139</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/Mod/TechDraw/Gui/MDIViewPage.cpp
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.cpp
@@ -24,21 +24,21 @@
 #include "PreCompiled.h"
 
 #ifndef _PreComp_
-# include <cmath>
-# include <QAction>
-# include <QApplication>
-# include <QContextMenuEvent>
-# include <QMenu>
-# include <QMessageBox>
-# include <QPageLayout>
-# include <QPageSize>
-# include <QPaintEngine>
-# include <QPainter>
-# include <QPdfWriter>
-# include <QPrinter>
-# include <QPrintDialog>
-# include <QPrintPreviewDialog>
-# include <boost_signals2.hpp>
+#include <QAction>
+#include <QApplication>
+#include <QContextMenuEvent>
+#include <QMenu>
+#include <QMessageBox>
+#include <QPageLayout>
+#include <QPageSize>
+#include <QPaintEngine>
+#include <QPainter>
+#include <QPdfWriter>
+#include <QPrintDialog>
+#include <QPrintPreviewDialog>
+#include <QPrinter>
+#include <boost_signals2.hpp>
+#include <cmath>
 #endif
 
 #include <App/Application.h>
@@ -65,6 +65,7 @@
 #include "MDIViewPage.h"
 #include "QGIEdge.h"
 #include "QGIFace.h"
+#include "QGITemplate.h"
 #include "QGIVertex.h"
 #include "QGIView.h"
 #include "QGIViewBalloon.h"
@@ -84,13 +85,9 @@ namespace bp = boost::placeholders;
 
 TYPESYSTEM_SOURCE_ABSTRACT(TechDrawGui::MDIViewPage, Gui::MDIView)
 
-MDIViewPage::MDIViewPage(ViewProviderPage *pageVp, Gui::Document* doc, QWidget* parent)
-  : Gui::MDIView(doc, parent),
-    m_vpPage(pageVp),
-    m_orientation(QPageLayout::Landscape),
-    m_paperSize(QPageSize::A4),
-    m_pagewidth(0.0),
-    m_pageheight(0.0)
+MDIViewPage::MDIViewPage(ViewProviderPage* pageVp, Gui::Document* doc, QWidget* parent)
+    : Gui::MDIView(doc, parent), m_vpPage(pageVp), m_orientation(QPageLayout::Landscape),
+      m_paperSize(QPageSize::A4), m_pagewidth(0.0), m_pageheight(0.0)
 {
     setMouseTracking(true);
 
@@ -124,17 +121,13 @@ MDIViewPage::MDIViewPage(ViewProviderPage *pageVp, Gui::Document* doc, QWidget* 
     connectDeletedObject = appDoc->signalDeletedObject.connect(bnd);
 }
 
-MDIViewPage::~MDIViewPage()
-{
-    connectDeletedObject.disconnect();
-}
+MDIViewPage::~MDIViewPage() { connectDeletedObject.disconnect(); }
 
 void MDIViewPage::setScene(QGSPage* scene, QGVPage* viewWidget)
 {
     m_scene = scene;
-    setCentralWidget(viewWidget);            //this makes viewWidget a Qt child of MDIViewPage
-    QObject::connect(m_scene, SIGNAL(selectionChanged()),
-                    this, SLOT  (sceneSelectionChanged()));
+    setCentralWidget(viewWidget);//this makes viewWidget a Qt child of MDIViewPage
+    QObject::connect(m_scene, SIGNAL(selectionChanged()), this, SLOT(sceneSelectionChanged()));
 }
 
 void MDIViewPage::setDocumentObject(const std::string& name)
@@ -143,17 +136,15 @@ void MDIViewPage::setDocumentObject(const std::string& name)
     setObjectName(Base::Tools::fromStdString(name));
 }
 
-void MDIViewPage::setDocumentName(const std::string& name)
-{
-    m_documentName = name;
-}
+void MDIViewPage::setDocumentName(const std::string& name) { m_documentName = name; }
 
 void MDIViewPage::closeEvent(QCloseEvent* event)
 {
-//    Base::Console().Message("MDIVP::closeEvent()\n");
+    //    Base::Console().Message("MDIVP::closeEvent()\n");
     MDIView::closeEvent(event);
-    if (!event->isAccepted())
+    if (!event->isAccepted()) {
         return;
+    }
     detachSelection();
 
     blockSceneSelection(true);
@@ -163,8 +154,9 @@ void MDIViewPage::closeEvent(QCloseEvent* event)
         if (doc) {
             App::DocumentObject* obj = doc->getObject(m_objectName.c_str());
             Gui::ViewProvider* vp = _pcDocument->getViewProvider(obj);
-            if (vp)
+            if (vp) {
                 vp->hide();
+            }
         }
     }
     blockSceneSelection(false);
@@ -175,31 +167,36 @@ void MDIViewPage::onDeleteObject(const App::DocumentObject& obj)
     //if this page has a QView for this obj, delete it.
     blockSceneSelection(true);
     if (obj.isDerivedFrom(TechDraw::DrawView::getClassTypeId())) {
-        (void) m_scene->removeQViewByName(obj.getNameInDocument());
+        (void)m_scene->removeQViewByName(obj.getNameInDocument());
     }
     blockSceneSelection(false);
 }
 
-bool MDIViewPage::onMsg(const char *pMsg, const char **)
+bool MDIViewPage::onMsg(const char* pMsg, const char**)
 {
-    Gui::Document *doc(getGuiDocument());
+    Gui::Document* doc(getGuiDocument());
 
     if (!doc) {
         return false;
-    } else if (strcmp("ViewFit", pMsg) == 0) {
+    }
+    else if (strcmp("ViewFit", pMsg) == 0) {
         viewAll();
         return true;
-    } else if (strcmp("Save", pMsg) == 0 ) {
+    }
+    else if (strcmp("Save", pMsg) == 0) {
         doc->save();
         return true;
-    } else if (strcmp("SaveAs", pMsg) == 0 ) {
+    }
+    else if (strcmp("SaveAs", pMsg) == 0) {
         doc->saveAs();
         return true;
-    } else if (strcmp("Undo", pMsg) == 0 ) {
+    }
+    else if (strcmp("Undo", pMsg) == 0) {
         doc->undo(1);
         Gui::Command::updateActive();
         return true;
-    } else if (strcmp("Redo", pMsg) == 0 ) {
+    }
+    else if (strcmp("Redo", pMsg) == 0) {
         doc->redo(1);
         Gui::Command::updateActive();
         return true;
@@ -210,24 +207,33 @@ bool MDIViewPage::onMsg(const char *pMsg, const char **)
 
 bool MDIViewPage::onHasMsg(const char* pMsg) const
 {
-    if (strcmp("ViewFit", pMsg) == 0)
+    if (strcmp("ViewFit", pMsg) == 0) {
         return true;
-    else if(strcmp("Redo", pMsg) == 0 && getAppDocument()->getAvailableRedos() > 0)
+    }
+    else if (strcmp("Redo", pMsg) == 0 && getAppDocument()->getAvailableRedos() > 0) {
         return true;
-    else if(strcmp("Undo", pMsg) == 0 && getAppDocument()->getAvailableUndos() > 0)
+    }
+    else if (strcmp("Undo", pMsg) == 0 && getAppDocument()->getAvailableUndos() > 0) {
         return true;
-    else if (strcmp("Print", pMsg) == 0)
+    }
+    else if (strcmp("Print", pMsg) == 0) {
         return true;
-    else if (strcmp("Save", pMsg) == 0)
+    }
+    else if (strcmp("Save", pMsg) == 0) {
         return true;
-    else if (strcmp("SaveAs", pMsg) == 0)
+    }
+    else if (strcmp("SaveAs", pMsg) == 0) {
         return true;
-    else if (strcmp("PrintPreview", pMsg) == 0)
+    }
+    else if (strcmp("PrintPreview", pMsg) == 0) {
         return true;
-    else if (strcmp("PrintPdf",pMsg) == 0)
+    }
+    else if (strcmp("PrintPdf", pMsg) == 0) {
         return true;
-    else if (strcmp("PrintAll",pMsg) == 0)
+    }
+    else if (strcmp("PrintAll", pMsg) == 0) {
         return true;
+    }
     return false;
 }
 
@@ -235,8 +241,7 @@ bool MDIViewPage::onHasMsg(const char* pMsg) const
 void MDIViewPage::setTabText(std::string tabText)
 {
     if (!isPassive() && !tabText.empty()) {
-        QString cap = QString::fromLatin1("%1 [*]")
-            .arg(QString::fromUtf8(tabText.c_str()));
+        QString cap = QString::fromLatin1("%1 [*]").arg(QString::fromUtf8(tabText.c_str()));
         setWindowTitle(cap);
     }
 }
@@ -245,16 +250,18 @@ void MDIViewPage::setTabText(std::string tabText)
 
 void MDIViewPage::getPaperAttributes()
 {
-    App::DocumentObject *obj = m_vpPage->getDrawPage()->Template.getValue();
-    auto pageTemplate( dynamic_cast<TechDraw::DrawTemplate *>(obj) );
-    if( pageTemplate ) {
-      m_pagewidth  =  pageTemplate->Width.getValue();
-      m_pageheight =  pageTemplate->Height.getValue();
+    App::DocumentObject* obj = m_vpPage->getDrawPage()->Template.getValue();
+    auto pageTemplate(dynamic_cast<TechDraw::DrawTemplate*>(obj));
+    if (pageTemplate) {
+        m_pagewidth = pageTemplate->Width.getValue();
+        m_pageheight = pageTemplate->Height.getValue();
     }
-    m_paperSize = QPageSize::id(QSizeF(m_pagewidth, m_pageheight), QPageSize::Millimeter, QPageSize::FuzzyOrientationMatch);
+    m_paperSize = QPageSize::id(QSizeF(m_pagewidth, m_pageheight), QPageSize::Millimeter,
+                                QPageSize::FuzzyOrientationMatch);
     if (m_pagewidth > m_pageheight) {
         m_orientation = QPageLayout::Landscape;
-    } else {
+    }
+    else {
         m_orientation = QPageLayout::Portrait;
     }
 }
@@ -264,10 +271,11 @@ void MDIViewPage::printPdf()
     QStringList filter;
     filter << QObject::tr("PDF (*.pdf)");
     filter << QObject::tr("All Files (*.*)");
-    QString fn = Gui::FileDialog::getSaveFileName(Gui::getMainWindow(), QObject::tr("Export Page As PDF"),
-                                                  QString(), filter.join(QLatin1String(";;")));
+    QString fn =
+        Gui::FileDialog::getSaveFileName(Gui::getMainWindow(), QObject::tr("Export Page As PDF"),
+                                         QString(), filter.join(QLatin1String(";;")));
     if (fn.isEmpty()) {
-      return;
+        return;
     }
 
     Gui::WaitCursor wc;
@@ -288,14 +296,16 @@ void MDIViewPage::printPdf(std::string file)
     printer.setFullPage(true);
     printer.setOutputFileName(filename);
 
-    if (m_paperSize == QPageSize::Ledger)  {
-        printer.setPageOrientation((QPageLayout::Orientation) (1 - m_orientation));  //reverse 0/1
-    } else {
+    if (m_paperSize == QPageSize::Ledger) {
+        printer.setPageOrientation((QPageLayout::Orientation)(1 - m_orientation));//reverse 0/1
+    }
+    else {
         printer.setPageOrientation(m_orientation);
     }
     if (m_paperSize == QPageSize::Custom) {
         printer.setPageSize(QPageSize(QSizeF(m_pagewidth, m_pageheight), QPageSize::Millimeter));
-    } else {
+    }
+    else {
         printer.setPageSize(QPageSize(m_paperSize));
     }
     print(&printer);
@@ -303,14 +313,15 @@ void MDIViewPage::printPdf(std::string file)
 
 void MDIViewPage::print()
 {
-//    Base::Console().Message("MDIVP::print()\n");
+    //    Base::Console().Message("MDIVP::print()\n");
     getPaperAttributes();
 
     QPrinter printer(QPrinter::HighResolution);
     printer.setFullPage(true);
     if (m_paperSize == QPageSize::Custom) {
         printer.setPageSize(QPageSize(QSizeF(m_pagewidth, m_pageheight), QPageSize::Millimeter));
-    } else {
+    }
+    else {
         printer.setPageSize(QPageSize(m_paperSize));
     }
     printer.setPageOrientation(m_orientation);
@@ -329,21 +340,21 @@ void MDIViewPage::printPreview()
     printer.setFullPage(true);
     if (m_paperSize == QPageSize::Custom) {
         printer.setPageSize(QPageSize(QSizeF(m_pagewidth, m_pageheight), QPageSize::Millimeter));
-    } else {
+    }
+    else {
         printer.setPageSize(QPageSize(m_paperSize));
     }
     printer.setPageOrientation(m_orientation);
 
     QPrintPreviewDialog dlg(&printer, this);
-    connect(&dlg, SIGNAL(paintRequested(QPrinter*)),
-            this, SLOT(print(QPrinter*)));
+    connect(&dlg, SIGNAL(paintRequested(QPrinter*)), this, SLOT(print(QPrinter*)));
     dlg.exec();
 }
 
 
 void MDIViewPage::print(QPrinter* printer)
 {
-//    Base::Console().Message("MDIVP::print(printer)\n");
+    //    Base::Console().Message("MDIVP::print(printer)\n");
     getPaperAttributes();
 
     // As size of the render area paperRect() should be used. When performing a real
@@ -366,27 +377,32 @@ void MDIViewPage::print(QPrinter* printer)
         bool doPrint = paintType != QPaintEngine::Picture;
 
         if (doPrint && printer->pageLayout().orientation() != m_orientation) {
-            int ret = QMessageBox::warning(this, tr("Different orientation"),
+            int ret = QMessageBox::warning(
+                this, tr("Different orientation"),
                 tr("The printer uses a different orientation  than the drawing.\n"
                    "Do you want to continue?"),
-                   QMessageBox::Yes | QMessageBox::No);
-            if (ret != QMessageBox::Yes)
+                QMessageBox::Yes | QMessageBox::No);
+            if (ret != QMessageBox::Yes) {
                 return;
+            }
         }
         if (doPrint && psPrtSetting != m_paperSize) {
-            int ret = QMessageBox::warning(this, tr("Different paper size"),
+            int ret = QMessageBox::warning(
+                this, tr("Different paper size"),
                 tr("The printer uses a different paper size than the drawing.\n"
                    "Do you want to continue?"),
-                   QMessageBox::Yes | QMessageBox::No);
-            if (ret != QMessageBox::Yes)
+                QMessageBox::Yes | QMessageBox::No);
+            if (ret != QMessageBox::Yes) {
                 return;
+            }
         }
     }
 
     QPainter p(printer);
     if (!p.isActive() && !printer->outputFileName().isEmpty()) {
         qApp->setOverrideCursor(Qt::ArrowCursor);
-        QMessageBox::critical(this, tr("Opening file failed"),
+        QMessageBox::critical(
+            this, tr("Opening file failed"),
             tr("Can not open file %1 for writing.").arg(printer->outputFileName()));
         qApp->restoreOverrideCursor();
         return;
@@ -397,12 +413,13 @@ void MDIViewPage::print(QPrinter* printer)
 #ifdef Q_OS_WIN32
     // On Windows the preview looks broken when using paperRect as render area.
     // Although the picture is scaled when using pageRect, it looks just fine.
-    if (paintType == QPaintEngine::Picture)
+    if (paintType == QPaintEngine::Picture) {
         targetRect = printer->pageLayout().paintRectPixels(printer->resolution());
+    }
 #endif
 
     //bool block =
-    static_cast<void> (blockSelection(true)); // avoid to be notified by itself
+    static_cast<void>(blockSelection(true));// avoid to be notified by itself
     Gui::Selection().clearSelection();
 
     bool saveState = m_vpPage->getFrameState();
@@ -412,48 +429,57 @@ void MDIViewPage::print(QPrinter* printer)
 
     Gui::Selection().clearSelection();
 
-    App::DocumentObject *obj = m_vpPage->getDrawPage()->Template.getValue();
-    auto pageTemplate( dynamic_cast<TechDraw::DrawTemplate *>(obj) );
-    double width  =  0.0;
-    double height =  0.0;
-    if( pageTemplate ) {
-      width  =  Rez::guiX(pageTemplate->Width.getValue());
-      height =  Rez::guiX(pageTemplate->Height.getValue());
+    App::DocumentObject* obj = m_vpPage->getDrawPage()->Template.getValue();
+    auto pageTemplate(dynamic_cast<TechDraw::DrawTemplate*>(obj));
+    double width = 0.0;
+    double height = 0.0;
+    if (pageTemplate) {
+        width = Rez::guiX(pageTemplate->Width.getValue());
+        height = Rez::guiX(pageTemplate->Height.getValue());
     }
     QRectF sourceRect(0.0, -height, width, height);
 
+    //scene might be drawn in light text.  we need to redraw in normal text.
+    bool saveLightOnDark = Preferences::lightOnDark();
+    if (Preferences::lightOnDark()) {
+        Preferences::lightOnDark(false);
+        m_vpPage->getQGSPage()->redrawAllViews();
+        m_vpPage->getQTemplate()->updateView();
+    }
     m_scene->render(&p, targetRect, sourceRect);
 
     // Reset
     m_vpPage->setFrameState(saveState);
     m_vpPage->setTemplateMarkers(saveState);
+    Preferences::lightOnDark(saveLightOnDark);
     m_scene->refreshViews();
+    m_vpPage->getQTemplate()->updateView();
     //bool block =
-    static_cast<void> (blockSelection(false));
+    static_cast<void>(blockSelection(false));
 }
 
 //static routine to print all pages in a document
-void MDIViewPage::printAll(QPrinter* printer,
-                           App::Document* doc)
+void MDIViewPage::printAll(QPrinter* printer, App::Document* doc)
 {
-//    Base::Console().Message("MDIVP::printAll()\n");
+    //    Base::Console().Message("MDIVP::printAll()\n");
     QPainter painter(printer);
     QPageLayout pageLayout = printer->pageLayout();
     bool firstTime = true;
-    std::vector<App::DocumentObject*> docObjs = doc->getObjectsOfType(TechDraw::DrawPage::getClassTypeId());
-    for (auto& obj: docObjs) {
+    std::vector<App::DocumentObject*> docObjs =
+        doc->getObjectsOfType(TechDraw::DrawPage::getClassTypeId());
+    for (auto& obj : docObjs) {
         Gui::ViewProvider* vp = Gui::Application::Instance->getViewProvider(obj);
         if (!vp) {
-            continue;   // can't print this one
+            continue;// can't print this one
         }
         TechDrawGui::ViewProviderPage* vpp = dynamic_cast<TechDrawGui::ViewProviderPage*>(vp);
         if (!vpp) {
-            continue;   // can't print this one
+            continue;// can't print this one
         }
 
         TechDraw::DrawPage* dp = static_cast<TechDraw::DrawPage*>(obj);
-        double width  =  297.0;   //default to A4 Landscape 297 x 210
-        double height =  210.0;
+        double width = 297.0;//default to A4 Landscape 297 x 210
+        double height = 210.0;
         setPageLayout(pageLayout, dp, width, height);
         printer->setPageLayout(pageLayout);
 
@@ -475,10 +501,9 @@ void MDIViewPage::printAll(QPrinter* printer,
 }
 
 //static routine to print all pages in a document to pdf
-void MDIViewPage::printAllPdf(QPrinter* printer,
-                              App::Document* doc)
+void MDIViewPage::printAllPdf(QPrinter* printer, App::Document* doc)
 {
-//    Base::Console().Message("MDIVP::printAllPdf()\n");
+    //    Base::Console().Message("MDIVP::printAllPdf()\n");
     QString outputFile = printer->outputFileName();
     QString documentName = QString::fromUtf8(doc->getName());
     QPdfWriter pdfWriter(outputFile);
@@ -489,20 +514,21 @@ void MDIViewPage::printAllPdf(QPrinter* printer,
 
     double dpmm = printer->resolution() / 25.4;
     bool firstTime = true;
-    std::vector<App::DocumentObject*> docObjs = doc->getObjectsOfType(TechDraw::DrawPage::getClassTypeId());
-    for (auto& obj: docObjs) {
+    std::vector<App::DocumentObject*> docObjs =
+        doc->getObjectsOfType(TechDraw::DrawPage::getClassTypeId());
+    for (auto& obj : docObjs) {
         Gui::ViewProvider* vp = Gui::Application::Instance->getViewProvider(obj);
         if (!vp) {
-            continue;   // can't print this one
+            continue;// can't print this one
         }
         TechDrawGui::ViewProviderPage* vpp = dynamic_cast<TechDrawGui::ViewProviderPage*>(vp);
         if (!vpp) {
-            continue;   // can't print this one
+            continue;// can't print this one
         }
 
         TechDraw::DrawPage* dp = static_cast<TechDraw::DrawPage*>(obj);
-        double width  =  297.0;   //default to A4 Landscape 297 x 210
-        double height =  210.0;
+        double width = 297.0;//default to A4 Landscape 297 x 210
+        double height = 210.0;
         setPageLayout(pageLayout, dp, width, height);
         pdfWriter.setPageLayout(pageLayout);
 
@@ -524,10 +550,8 @@ void MDIViewPage::printAllPdf(QPrinter* printer,
 }
 
 //static
-void MDIViewPage::printBannerPage(QPrinter* printer, QPainter& painter,
-                                  QPageLayout& pageLayout,
-                                  App::Document* doc,
-                                  std::vector<App::DocumentObject*>& docObjs)
+void MDIViewPage::printBannerPage(QPrinter* printer, QPainter& painter, QPageLayout& pageLayout,
+                                  App::Document* doc, std::vector<App::DocumentObject*>& docObjs)
 {
     QFont savePainterFont = painter.font();
     QFont painterFont;
@@ -540,79 +564,87 @@ void MDIViewPage::printBannerPage(QPrinter* printer, QPainter& painter,
 
     //print a header
     QString docLine = QObject::tr("Document Name: ") + QString::fromUtf8(doc->getName());
-    int leftMargin = pageLayout.margins().left() * dpmm + 5 * dpmm;    //layout margin + 5mm
-    int verticalPos = pageLayout.margins().top() * dpmm + 20 * dpmm;   //layout margin + 20mm
-    int verticalSpacing = 2;    //double space
+    int leftMargin = pageLayout.margins().left() * dpmm + 5 * dpmm; //layout margin + 5mm
+    int verticalPos = pageLayout.margins().top() * dpmm + 20 * dpmm;//layout margin + 20mm
+    int verticalSpacing = 2;                                        //double space
     painter.drawText(leftMargin, verticalPos, docLine);
 
     //leave some blank space between document name and page entries
     verticalPos += 2 * verticalSpacing * fontSizePx;
     for (auto& obj : docObjs) {
         //print a line for each page
-        QString pageLine = QString::fromUtf8(obj->getNameInDocument()) +
-                           QString::fromUtf8(" / ") +
-                           QString::fromUtf8(obj->Label.getValue());
+        QString pageLine = QString::fromUtf8(obj->getNameInDocument()) + QString::fromUtf8(" / ")
+            + QString::fromUtf8(obj->Label.getValue());
         painter.drawText(leftMargin, verticalPos, pageLine);
         verticalPos += verticalSpacing * fontSizePx;
     }
-    painter.setFont(savePainterFont);       //restore the original font
+    painter.setFont(savePainterFont);//restore the original font
 }
 
 //static
-void MDIViewPage::renderPage(ViewProviderPage* vpp,
-                             QPainter& painter,
-                             QRectF& sourceRect,
+void MDIViewPage::renderPage(ViewProviderPage* vpp, QPainter& painter, QRectF& sourceRect,
                              QRect& targetRect)
 {
-        bool saveState = vpp->getFrameState();
-        //turn off view frames for print
-        vpp->setFrameState(false);
-        vpp->setTemplateMarkers(false);
-        vpp->getQGSPage()->refreshViews();
-        vpp->getQGSPage()->render(&painter, targetRect, sourceRect);
-        // Reset
-        vpp->setFrameState(saveState);
-        vpp->setTemplateMarkers(saveState);
-        vpp->getQGSPage()->refreshViews();
+    //turn off view frames for print
+    bool saveState = vpp->getFrameState();
+    vpp->setFrameState(false);
+    vpp->setTemplateMarkers(false);
+
+    //scene might be drawn in light text.  we need to redraw in normal text.
+    bool saveLightOnDark = Preferences::lightOnDark();
+    if (Preferences::lightOnDark()) {
+        Preferences::lightOnDark(false);
+        vpp->getQGSPage()->redrawAllViews();
+    }
+
+    vpp->getQGSPage()->refreshViews();
+    vpp->getQGSPage()->render(&painter, targetRect, sourceRect);
+
+    // Reset
+    vpp->setFrameState(saveState);
+    vpp->setTemplateMarkers(saveState);
+    Preferences::lightOnDark(saveLightOnDark);
+
+    vpp->getQGSPage()->refreshViews();
 }
 
 //static
-void MDIViewPage::setPageLayout(QPageLayout& pageLayout,
-                                TechDraw::DrawPage* dPage,
-                                double& width, double& height)
+void MDIViewPage::setPageLayout(QPageLayout& pageLayout, TechDraw::DrawPage* dPage, double& width,
+                                double& height)
 {
-    auto pageTemplate( dynamic_cast<TechDraw::DrawTemplate *>(dPage->Template.getValue()) );
-    if( pageTemplate ) {
-        width  =  pageTemplate->Width.getValue();
-        height =  pageTemplate->Height.getValue();
+    auto pageTemplate(dynamic_cast<TechDraw::DrawTemplate*>(dPage->Template.getValue()));
+    if (pageTemplate) {
+        width = pageTemplate->Width.getValue();
+        height = pageTemplate->Height.getValue();
     }
     //Qt's page size determination assumes Portrait orientation. To get the right paper size
     //we need to ask in the proper form.
     QPageSize::PageSizeId paperSizeID =
-                        QPageSize::id(QSizeF(std::min(width, height), std::max(width, height)),
-                                      QPageSize::Millimeter,
-                                      QPageSize::FuzzyOrientationMatch);
+        QPageSize::id(QSizeF(std::min(width, height), std::max(width, height)),
+                      QPageSize::Millimeter, QPageSize::FuzzyOrientationMatch);
     if (paperSizeID == QPageSize::Custom) {
         pageLayout.setPageSize(QPageSize(QSizeF(std::min(width, height), std::max(width, height)),
                                          QPageSize::Millimeter));
-    } else {
+    }
+    else {
         pageLayout.setPageSize(QPageSize(paperSizeID));
     }
-    pageLayout.setOrientation((QPageLayout::Orientation) dPage->getOrientation());
+    pageLayout.setOrientation((QPageLayout::Orientation)dPage->getOrientation());
 }
 
 PyObject* MDIViewPage::getPyObject()
 {
-    if (!pythonObject)
+    if (!pythonObject) {
         pythonObject = new MDIViewPagePy(this);
+    }
 
     Py_INCREF(pythonObject);
     return pythonObject;
 }
 
-void MDIViewPage::contextMenuEvent(QContextMenuEvent *event)
+void MDIViewPage::contextMenuEvent(QContextMenuEvent* event)
 {
-//    Base::Console().Message("MDIVP::contextMenuEvent() - reason: %d\n", event->reason());
+    //    Base::Console().Message("MDIVP::contextMenuEvent() - reason: %d\n", event->reason());
     QMenu menu;
     menu.addAction(m_toggleFrameAction);
     menu.addAction(m_toggleKeepUpdatedAction);
@@ -623,10 +655,7 @@ void MDIViewPage::contextMenuEvent(QContextMenuEvent *event)
     menu.exec(event->globalPos());
 }
 
-void MDIViewPage::toggleFrame()
-{
-    m_vpPage->toggleFrameState();
-}
+void MDIViewPage::toggleFrame() { m_vpPage->toggleFrameState(); }
 
 void MDIViewPage::toggleKeepUpdated()
 {
@@ -644,12 +673,13 @@ void MDIViewPage::saveSVG()
     QStringList filter;
     filter << QObject::tr("SVG (*.svg)");
     filter << QObject::tr("All Files (*.*)");
-    QString fn = Gui::FileDialog::getSaveFileName(Gui::getMainWindow(), QObject::tr("Export page as SVG"),
-                                                  QString(), filter.join(QLatin1String(";;")));
+    QString fn =
+        Gui::FileDialog::getSaveFileName(Gui::getMainWindow(), QObject::tr("Export page as SVG"),
+                                         QString(), filter.join(QLatin1String(";;")));
     if (fn.isEmpty()) {
-      return;
+        return;
     }
-    static_cast<void> (blockSelection(true)); // avoid to be notified by itself
+    static_cast<void>(blockSelection(true));// avoid to be notified by itself
 
     m_scene->saveSvg(fn);
 }
@@ -667,10 +697,9 @@ void MDIViewPage::saveSVG(std::string file)
 void MDIViewPage::saveDXF()
 {
     QString defaultDir;
-    QString fileName = Gui::FileDialog::getSaveFileName(Gui::getMainWindow(),
-                                                   QString::fromUtf8(QT_TR_NOOP("Save DXF file")),
-                                                   defaultDir,
-                                                   QString::fromUtf8(QT_TR_NOOP("DXF (*.dxf)")));
+    QString fileName = Gui::FileDialog::getSaveFileName(
+        Gui::getMainWindow(), QString::fromUtf8(QT_TR_NOOP("Save DXF file")), defaultDir,
+        QString::fromUtf8(QT_TR_NOOP("DXF (*.dxf)")));
     if (fileName.isEmpty()) {
         return;
     }
@@ -686,25 +715,20 @@ void MDIViewPage::saveDXF(std::string fileName)
     fileName = Base::Tools::escapeEncodeFilename(fileName);
     Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Save page to dxf"));
     Gui::Command::doCommand(Gui::Command::Doc, "import TechDraw");
-    Gui::Command::doCommand(Gui::Command::Doc, "TechDraw.writeDXFPage(App.activeDocument().%s, u\"%s\")",
+    Gui::Command::doCommand(Gui::Command::Doc,
+                            "TechDraw.writeDXFPage(App.activeDocument().%s, u\"%s\")",
                             PageName.c_str(), (const char*)fileName.c_str());
     Gui::Command::commitCommand();
 }
 
-void MDIViewPage::savePDF()
-{
-    printPdf();
-}
+void MDIViewPage::savePDF() { printPdf(); }
 
-void MDIViewPage::savePDF(std::string file)
-{
-    printPdf(file);
-}
+void MDIViewPage::savePDF(std::string file) { printPdf(file); }
 
 //mdiviewpage method for printAll action
 void MDIViewPage::printAll()
 {
-//    Base::Console().Message("MDIVP::printAll()\n");
+    //    Base::Console().Message("MDIVP::printAll()\n");
     printAllPages();
 }
 
@@ -722,7 +746,8 @@ void MDIViewPage::printAllPages()
         }
         if (printer.outputFileName().isEmpty()) {
             printAll(&printer, doc);
-        } else {
+        }
+        else {
             printAllPdf(&printer, doc);
         }
     }
@@ -732,95 +757,88 @@ void MDIViewPage::printAllPages()
 // wf: this is never executed???
 // needs a signal from Scene? hoverEvent?  Scene does not emit signal for "preselect"
 // there is no "preSelect" signal from Gui either.
-void MDIViewPage::preSelectionChanged(const QPoint &pos)
+void MDIViewPage::preSelectionChanged(const QPoint& pos)
 {
-    QObject *obj = QObject::sender();
+    QObject* obj = QObject::sender();
 
-    if(!obj)
+    if (!obj) {
         return;
+    }
 
-    auto view( dynamic_cast<QGIView *>(obj) );
-    if(!view)
-            return;
+    auto view(dynamic_cast<QGIView*>(obj));
+    if (!view) {
+        return;
+    }
 
     QGraphicsItem* parent = view->parentItem();
-    if(!parent)
+    if (!parent) {
         return;
+    }
 
-    TechDraw::DrawView *viewObj = view->getViewObject();
+    TechDraw::DrawView* viewObj = view->getViewObject();
     std::stringstream ss;
 
-    QGIFace *face   = dynamic_cast<QGIFace *>(obj);
-    QGIEdge *edge   = dynamic_cast<QGIEdge *>(obj);
-    QGIVertex *vert = dynamic_cast<QGIVertex *>(obj);
-    if(edge) {
+    QGIFace* face = dynamic_cast<QGIFace*>(obj);
+    QGIEdge* edge = dynamic_cast<QGIEdge*>(obj);
+    QGIVertex* vert = dynamic_cast<QGIVertex*>(obj);
+    if (edge) {
         ss << "Edge" << edge->getProjIndex();
         //bool accepted =
-        static_cast<void> (Gui::Selection().setPreselect(viewObj->getDocument()->getName()
-                                     ,viewObj->getNameInDocument()
-                                     ,ss.str().c_str()
-                                     ,pos.x()
-                                     ,pos.y()
-                                     ,0));
-    } else if(vert) {
+        static_cast<void>(Gui::Selection().setPreselect(viewObj->getDocument()->getName(),
+                                                        viewObj->getNameInDocument(),
+                                                        ss.str().c_str(), pos.x(), pos.y(), 0));
+    }
+    else if (vert) {
         ss << "Vertex" << vert->getProjIndex();
         //bool accepted =
-        static_cast<void> (Gui::Selection().setPreselect(viewObj->getDocument()->getName()
-                                     ,viewObj->getNameInDocument()
-                                     ,ss.str().c_str()
-                                     ,pos.x()
-                                     ,pos.y()
-                                     ,0));
-    } else if(face) {
-        ss << "Face" << face->getProjIndex();      //TODO: SectionFaces have ProjIndex = -1. (but aren't selectable?) Problem?
+        static_cast<void>(Gui::Selection().setPreselect(viewObj->getDocument()->getName(),
+                                                        viewObj->getNameInDocument(),
+                                                        ss.str().c_str(), pos.x(), pos.y(), 0));
+    }
+    else if (face) {
+        ss << "Face"
+           << face->getProjIndex();//TODO: SectionFaces have ProjIndex = -1. (but aren't selectable?) Problem?
         //bool accepted =
-        static_cast<void> (Gui::Selection().setPreselect(viewObj->getDocument()->getName()
-                                     ,viewObj->getNameInDocument()
-                                     ,ss.str().c_str()
-                                     ,pos.x()
-                                     ,pos.y()
-                                     ,0));
-    } else {
+        static_cast<void>(Gui::Selection().setPreselect(viewObj->getDocument()->getName(),
+                                                        viewObj->getNameInDocument(),
+                                                        ss.str().c_str(), pos.x(), pos.y(), 0));
+    }
+    else {
         ss << "";
-        Gui::Selection().setPreselect(viewObj->getDocument()->getName()
-                                     ,viewObj->getNameInDocument()
-                                     ,ss.str().c_str()
-                                     ,pos.x()
-                                     ,pos.y()
-                                     ,0);
+        Gui::Selection().setPreselect(viewObj->getDocument()->getName(),
+                                      viewObj->getNameInDocument(), ss.str().c_str(), pos.x(),
+                                      pos.y(), 0);
     }
 }
 
 //flag to prevent selection activity within mdivp
-void MDIViewPage::blockSceneSelection(const bool isBlocked)
-{
-    isSelectionBlocked = isBlocked;
-}
+void MDIViewPage::blockSceneSelection(const bool isBlocked) { isSelectionBlocked = isBlocked; }
 
 
 //Set all QGIViews to unselected state
 void MDIViewPage::clearSceneSelection()
 {
-//    Base::Console().Message("MDIVP::clearSceneSelection()\n");
+    //    Base::Console().Message("MDIVP::clearSceneSelection()\n");
     blockSceneSelection(true);
     m_qgSceneSelected.clear();
 
-    std::vector<QGIView *> views = m_scene->getViews();
+    std::vector<QGIView*> views = m_scene->getViews();
 
     // Iterate through all views and unselect all
-    for (std::vector<QGIView *>::iterator it = views.begin(); it != views.end(); ++it) {
-        QGIView *item = *it;
+    for (std::vector<QGIView*>::iterator it = views.begin(); it != views.end(); ++it) {
+        QGIView* item = *it;
         bool state = item->isSelected();
 
         //handle oddballs
         QGIViewDimension* dim = dynamic_cast<QGIViewDimension*>(*it);
         if (dim) {
             state = dim->getDatumLabel()->isSelected();
-        } else {
+        }
+        else {
             QGIViewBalloon* bal = dynamic_cast<QGIViewBalloon*>(*it);
-                if (bal) {
-                    state = bal->getBalloonLabel()->isSelected();
-                }
+            if (bal) {
+                state = bal->getBalloonLabel()->isSelected();
+            }
         }
 
         if (state) {
@@ -833,12 +851,12 @@ void MDIViewPage::clearSceneSelection()
 }
 
 //!Update QGIView's selection state based on Selection made outside Drawing Interface
-void MDIViewPage::selectQGIView(App::DocumentObject *obj, const bool isSelected)
+void MDIViewPage::selectQGIView(App::DocumentObject* obj, const bool isSelected)
 {
-    QGIView *view = m_scene->findQViewForDocObj(obj);
+    QGIView* view = m_scene->findQViewForDocObj(obj);
 
     blockSceneSelection(true);
-    if(view) {
+    if (view) {
         view->setGroupSelection(isSelected);
         view->updateView();
     }
@@ -849,28 +867,32 @@ void MDIViewPage::selectQGIView(App::DocumentObject *obj, const bool isSelected)
 //really "onTreeSelectionChanged"
 void MDIViewPage::onSelectionChanged(const Gui::SelectionChanges& msg)
 {
-//    Base::Console().Message("MDIVP::onSelectionChanged()\n");
-    std::vector<Gui::SelectionSingleton::SelObj> selObjs = Gui::Selection().getSelection(msg.pDocName);
+    //    Base::Console().Message("MDIVP::onSelectionChanged()\n");
+    std::vector<Gui::SelectionSingleton::SelObj> selObjs =
+        Gui::Selection().getSelection(msg.pDocName);
     if (msg.Type == Gui::SelectionChanges::ClrSelection) {
         clearSceneSelection();
-    } else if(msg.Type == Gui::SelectionChanges::SetSelection) {                     //replace entire selection set
+    }
+    else if (msg.Type == Gui::SelectionChanges::SetSelection) {//replace entire selection set
         clearSceneSelection();
         blockSceneSelection(true);
-        for (auto& so: selObjs){
+        for (auto& so : selObjs) {
             if (so.pObject->isDerivedFrom(TechDraw::DrawView::getClassTypeId())) {
                 selectQGIView(so.pObject, true);
             }
         }
         blockSceneSelection(false);
-    } else if(msg.Type == Gui::SelectionChanges::AddSelection) {
+    }
+    else if (msg.Type == Gui::SelectionChanges::AddSelection) {
         blockSceneSelection(true);
-        for (auto& so: selObjs){
+        for (auto& so : selObjs) {
             if (so.pObject->isDerivedFrom(TechDraw::DrawView::getClassTypeId())) {
                 selectQGIView(so.pObject, true);
             }
         }
         blockSceneSelection(false);
-    } else {
+    }
+    else {
         Base::Console().Log("MDIVP::onSelectionChanged - unhandled: %d\n", msg.Type);
     }
 }
@@ -878,26 +900,25 @@ void MDIViewPage::onSelectionChanged(const Gui::SelectionChanges& msg)
 //! maintain QGScene selected items in selection order
 void MDIViewPage::sceneSelectionManager()
 {
-//    Base::Console().Message("MDIVP::sceneSelectionManager()\n");
+    //    Base::Console().Message("MDIVP::sceneSelectionManager()\n");
     QList<QGraphicsItem*> sceneSel = m_scene->selectedItems();
 
     if (sceneSel.isEmpty()) {
-        m_qgSceneSelected.clear(); //TODO: need to signal somebody?  Tree? handled elsewhere
+        m_qgSceneSelected.clear();//TODO: need to signal somebody?  Tree? handled elsewhere
         //clearSelection
         return;
     }
 
-    if (m_qgSceneSelected.isEmpty() &&
-        !sceneSel.isEmpty()) {
+    if (m_qgSceneSelected.isEmpty() && !sceneSel.isEmpty()) {
         m_qgSceneSelected.push_back(sceneSel.front());
         return;
     }
 
     //add to m_qgSceneSelected anything that is in q_sceneSel
-    for (auto qts: sceneSel) {
+    for (auto qts : sceneSel) {
         bool found = false;
-        for (auto ms: qAsConst(m_qgSceneSelected)) {
-            if ( qts == ms ) {
+        for (auto ms : qAsConst(m_qgSceneSelected)) {
+            if (qts == ms) {
                 found = true;
                 break;
             }
@@ -910,8 +931,8 @@ void MDIViewPage::sceneSelectionManager()
 
     //remove items from m_qgSceneSelected that are not in q_sceneSel
     QList<QGraphicsItem*> m_new;
-    for (auto m: qAsConst(m_qgSceneSelected)) {
-        for (auto q: sceneSel)  {
+    for (auto m : qAsConst(m_qgSceneSelected)) {
+        for (auto q : sceneSel) {
             if (m == q) {
                 m_new.push_back(m);
                 break;
@@ -927,7 +948,7 @@ void MDIViewPage::sceneSelectionChanged()
 {
     sceneSelectionManager();
 
-    if(isSelectionBlocked)  {
+    if (isSelectionBlocked) {
         return;
     }
 
@@ -946,148 +967,153 @@ void MDIViewPage::sceneSelectionChanged()
 //Note: Qt says: "no guarantee of selection order"!!!
 void MDIViewPage::setTreeToSceneSelect()
 {
-//    Base::Console().Message("MDIVP::setTreeToSceneSelect()\n");
-    bool saveBlock = blockSelection(true); // block selectionChanged signal from Tree/Observer
+    //    Base::Console().Message("MDIVP::setTreeToSceneSelect()\n");
+    bool saveBlock = blockSelection(true);// block selectionChanged signal from Tree/Observer
     blockSceneSelection(true);
     Gui::Selection().clearSelection();
     QList<QGraphicsItem*> sceneSel = m_qgSceneSelected;
     for (QList<QGraphicsItem*>::iterator it = sceneSel.begin(); it != sceneSel.end(); ++it) {
-        QGIView *itemView = dynamic_cast<QGIView *>(*it);
+        QGIView* itemView = dynamic_cast<QGIView*>(*it);
         if (!itemView) {
-            QGIEdge *edge = dynamic_cast<QGIEdge *>(*it);
-            if(edge) {
-                QGraphicsItem*parent = edge->parentItem();
-                if(!parent)
+            QGIEdge* edge = dynamic_cast<QGIEdge*>(*it);
+            if (edge) {
+                QGraphicsItem* parent = edge->parentItem();
+                if (!parent) {
                     continue;
+                }
 
-                QGIView *viewItem = dynamic_cast<QGIView *>(parent);
-                if(!viewItem)
-                  continue;
+                QGIView* viewItem = dynamic_cast<QGIView*>(parent);
+                if (!viewItem) {
+                    continue;
+                }
 
-                TechDraw::DrawView *viewObj = viewItem->getViewObject();
+                TechDraw::DrawView* viewObj = viewItem->getViewObject();
 
                 std::stringstream ss;
                 ss << "Edge" << edge->getProjIndex();
                 //bool accepted =
-                static_cast<void> (Gui::Selection().addSelection(viewObj->getDocument()->getName(),
-                                              viewObj->getNameInDocument(),
-                                              ss.str().c_str()));
-                showStatusMsg(viewObj->getDocument()->getName(),
-                                              viewObj->getNameInDocument(),
-                                              ss.str().c_str());
+                static_cast<void>(Gui::Selection().addSelection(viewObj->getDocument()->getName(),
+                                                                viewObj->getNameInDocument(),
+                                                                ss.str().c_str()));
+                showStatusMsg(viewObj->getDocument()->getName(), viewObj->getNameInDocument(),
+                              ss.str().c_str());
                 continue;
             }
 
-            QGIVertex *vert = dynamic_cast<QGIVertex *>(*it);
-            if(vert) {
-                QGraphicsItem*parent = vert->parentItem();
-                if(!parent)
+            QGIVertex* vert = dynamic_cast<QGIVertex*>(*it);
+            if (vert) {
+                QGraphicsItem* parent = vert->parentItem();
+                if (!parent) {
                     continue;
+                }
 
-                QGIView *viewItem = dynamic_cast<QGIView *>(parent);
-                if(!viewItem)
-                  continue;
+                QGIView* viewItem = dynamic_cast<QGIView*>(parent);
+                if (!viewItem) {
+                    continue;
+                }
 
-                TechDraw::DrawView *viewObj = viewItem->getViewObject();
+                TechDraw::DrawView* viewObj = viewItem->getViewObject();
 
                 std::stringstream ss;
                 ss << "Vertex" << vert->getProjIndex();
                 //bool accepted =
-                static_cast<void> (Gui::Selection().addSelection(viewObj->getDocument()->getName(),
-                                              viewObj->getNameInDocument(),
-                                              ss.str().c_str()));
-                showStatusMsg(viewObj->getDocument()->getName(),
-                                              viewObj->getNameInDocument(),
-                                              ss.str().c_str());
+                static_cast<void>(Gui::Selection().addSelection(viewObj->getDocument()->getName(),
+                                                                viewObj->getNameInDocument(),
+                                                                ss.str().c_str()));
+                showStatusMsg(viewObj->getDocument()->getName(), viewObj->getNameInDocument(),
+                              ss.str().c_str());
                 continue;
             }
 
-            QGIFace *face = dynamic_cast<QGIFace *>(*it);
-            if(face) {
-                QGraphicsItem*parent = face->parentItem();
-                if(!parent)
+            QGIFace* face = dynamic_cast<QGIFace*>(*it);
+            if (face) {
+                QGraphicsItem* parent = face->parentItem();
+                if (!parent) {
                     continue;
+                }
 
-                QGIView *viewItem = dynamic_cast<QGIView *>(parent);
-                if(!viewItem)
-                  continue;
+                QGIView* viewItem = dynamic_cast<QGIView*>(parent);
+                if (!viewItem) {
+                    continue;
+                }
 
-                TechDraw::DrawView *viewObj = viewItem->getViewObject();
+                TechDraw::DrawView* viewObj = viewItem->getViewObject();
 
                 std::stringstream ss;
                 ss << "Face" << face->getProjIndex();
                 //bool accepted =
-                static_cast<void> (Gui::Selection().addSelection(viewObj->getDocument()->getName(),
-                                              viewObj->getNameInDocument(),
-                                              ss.str().c_str()));
-                showStatusMsg(viewObj->getDocument()->getName(),
-                                              viewObj->getNameInDocument(),
-                                              ss.str().c_str());
+                static_cast<void>(Gui::Selection().addSelection(viewObj->getDocument()->getName(),
+                                                                viewObj->getNameInDocument(),
+                                                                ss.str().c_str()));
+                showStatusMsg(viewObj->getDocument()->getName(), viewObj->getNameInDocument(),
+                              ss.str().c_str());
                 continue;
             }
 
-            QGIDatumLabel *dimLabel = dynamic_cast<QGIDatumLabel*>(*it);
-            if(dimLabel) {
-                QGraphicsItem*dimParent = dimLabel->QGraphicsItem::parentItem();
-                if(!dimParent)
+            QGIDatumLabel* dimLabel = dynamic_cast<QGIDatumLabel*>(*it);
+            if (dimLabel) {
+                QGraphicsItem* dimParent = dimLabel->QGraphicsItem::parentItem();
+                if (!dimParent) {
                     continue;
+                }
 
-                QGIView *dimItem = dynamic_cast<QGIView *>(dimParent);
+                QGIView* dimItem = dynamic_cast<QGIView*>(dimParent);
 
-                if(!dimItem)
-                  continue;
+                if (!dimItem) {
+                    continue;
+                }
 
-                TechDraw::DrawView *dimObj = dimItem->getViewObject();
+                TechDraw::DrawView* dimObj = dimItem->getViewObject();
                 if (!dimObj) {
                     continue;
                 }
                 const char* name = dimObj->getNameInDocument();
-                if (!name) {                                   //can happen during undo/redo if Dim is selected???
+                if (!name) {//can happen during undo/redo if Dim is selected???
                     //Base::Console().Log("INFO - MDIVP::sceneSelectionChanged - dimObj name is null!\n");
                     continue;
                 }
 
                 //bool accepted =
-                static_cast<void> (Gui::Selection().addSelection(dimObj->getDocument()->getName(), dimObj->getNameInDocument()));
+                static_cast<void>(Gui::Selection().addSelection(dimObj->getDocument()->getName(),
+                                                                dimObj->getNameInDocument()));
             }
 
-            QGMText *mText = dynamic_cast<QGMText*>(*it);
-            if(mText) {
+            QGMText* mText = dynamic_cast<QGMText*>(*it);
+            if (mText) {
                 QGraphicsItem* textParent = mText->QGraphicsItem::parentItem();
-                if(!textParent) {
+                if (!textParent) {
                     continue;
                 }
 
-                QGIView *parent = dynamic_cast<QGIView *>(textParent);
+                QGIView* parent = dynamic_cast<QGIView*>(textParent);
 
-                if(!parent) {
-                  continue;
-                  }
+                if (!parent) {
+                    continue;
+                }
 
-                TechDraw::DrawView *parentFeat = parent->getViewObject();
+                TechDraw::DrawView* parentFeat = parent->getViewObject();
                 if (!parentFeat) {
                     continue;
                 }
                 const char* name = parentFeat->getNameInDocument();
-                if (!name) {                                   //can happen during undo/redo if Dim is selected???
+                if (!name) {//can happen during undo/redo if Dim is selected???
                     continue;
                 }
 
                 //bool accepted =
-                static_cast<void> (Gui::Selection().addSelection(parentFeat->getDocument()->getName(), parentFeat->getNameInDocument()));
+                static_cast<void>(Gui::Selection().addSelection(
+                    parentFeat->getDocument()->getName(), parentFeat->getNameInDocument()));
             }
+        }
+        else {
 
-        } else {
-
-            TechDraw::DrawView *viewObj = itemView->getViewObject();
+            TechDraw::DrawView* viewObj = itemView->getViewObject();
             if (viewObj && !viewObj->isRemoving()) {
                 std::string doc_name = viewObj->getDocument()->getName();
                 std::string obj_name = viewObj->getNameInDocument();
 
                 Gui::Selection().addSelection(doc_name.c_str(), obj_name.c_str());
-                showStatusMsg(doc_name.c_str(),
-                              obj_name.c_str(),
-                              "");
+                showStatusMsg(doc_name.c_str(), obj_name.c_str(), "");
             }
         }
     }
@@ -1096,15 +1122,18 @@ void MDIViewPage::setTreeToSceneSelect()
     blockSelection(saveBlock);
 }
 
-bool MDIViewPage::compareSelections(std::vector<Gui::SelectionObject> treeSel, QList<QGraphicsItem*> sceneSel)
+bool MDIViewPage::compareSelections(std::vector<Gui::SelectionObject> treeSel,
+                                    QList<QGraphicsItem*> sceneSel)
 {
     bool result = true;
 
     if (treeSel.empty() && sceneSel.empty()) {
         return true;
-    } else if (treeSel.empty() && !sceneSel.empty()) {
+    }
+    else if (treeSel.empty() && !sceneSel.empty()) {
         return false;
-    } else if (!treeSel.empty() && sceneSel.empty()) {
+    }
+    else if (!treeSel.empty() && sceneSel.empty()) {
         return false;
     }
 
@@ -1114,7 +1143,7 @@ bool MDIViewPage::compareSelections(std::vector<Gui::SelectionObject> treeSel, Q
     std::vector<std::string> treeNames;
     std::vector<std::string> sceneNames;
 
-    for (auto tn: treeSel) {
+    for (auto tn : treeSel) {
         if (tn.getObject()->isDerivedFrom(TechDraw::DrawView::getClassTypeId())) {
             std::string s = tn.getObject()->getNameInDocument();
             treeNames.push_back(s);
@@ -1124,18 +1153,18 @@ bool MDIViewPage::compareSelections(std::vector<Gui::SelectionObject> treeSel, Q
     treeCount = treeNames.size();
 
     for (auto sn : sceneSel) {
-        QGIView *itemView = dynamic_cast<QGIView *>(sn);
+        QGIView* itemView = dynamic_cast<QGIView*>(sn);
         if (!itemView) {
-            QGIDatumLabel *dl = dynamic_cast<QGIDatumLabel *>(sn);
-            QGIPrimPath *pp = dynamic_cast<QGIPrimPath *>(sn);//count Vertex/Edge/Face
+            QGIDatumLabel* dl = dynamic_cast<QGIDatumLabel*>(sn);
+            QGIPrimPath* pp = dynamic_cast<QGIPrimPath*>(sn);//count Vertex/Edge/Face
             if (pp) {
                 ppCount++;
             }
             else if (dl) {
                 //get dim associated with this label
-                QGraphicsItem *qgi = dl->parentItem();
+                QGraphicsItem* qgi = dl->parentItem();
                 if (qgi) {
-                    QGIViewDimension *vd = dynamic_cast<QGIViewDimension *>(qgi);
+                    QGIViewDimension* vd = dynamic_cast<QGIViewDimension*>(qgi);
                     if (vd) {
                         std::string s = vd->getViewNameAsString();
                         sceneNames.push_back(s);
@@ -1156,13 +1185,14 @@ bool MDIViewPage::compareSelections(std::vector<Gui::SelectionObject> treeSel, Q
         return false;
     }
 
-// even of counts match, have to check that names in scene == names in tree
+    // even of counts match, have to check that names in scene == names in tree
     auto treePtr = treeNames.begin();
-    for (auto& s: sceneNames){
+    for (auto& s : sceneNames) {
         if (s == (*treePtr)) {
             treePtr++;
             continue;
-        } else {
+        }
+        else {
             return false;
         }
     }
@@ -1180,10 +1210,8 @@ bool MDIViewPage::compareSelections(std::vector<Gui::SelectionObject> treeSel, Q
 void MDIViewPage::showStatusMsg(const char* string1, const char* string2, const char* string3) const
 {
     QString msg = QString::fromLatin1("%1 %2.%3.%4 ")
-            .arg(tr("Selected:"),
-                 QString::fromUtf8(string1),
-                 QString::fromUtf8(string2),
-                 QString::fromUtf8(string3));
+                      .arg(tr("Selected:"), QString::fromUtf8(string1), QString::fromUtf8(string2),
+                           QString::fromUtf8(string3));
     if (Gui::getMainWindow()) {
         Gui::getMainWindow()->showMessage(msg, 6000);
     }
@@ -1200,25 +1228,23 @@ void MDIViewPagePy::init_type()
     behaviors().supportGetattr();
     behaviors().supportSetattr();
 
-    add_varargs_method("getPage", &MDIViewPagePy::getPage, "getPage() returns the page being displayed");
-    add_varargs_method("cast_to_base", &MDIViewPagePy::cast_to_base, "cast_to_base() cast to MDIView class");
+    add_varargs_method("getPage", &MDIViewPagePy::getPage,
+                       "getPage() returns the page being displayed");
+    add_varargs_method("cast_to_base", &MDIViewPagePy::cast_to_base,
+                       "cast_to_base() cast to MDIView class");
     behaviors().readyType();
 }
 
-MDIViewPagePy::MDIViewPagePy(MDIViewPage *mdi)
-  : base(mdi)
-{
-}
+MDIViewPagePy::MDIViewPagePy(MDIViewPage* mdi) : base(mdi) {}
 
-MDIViewPagePy::~MDIViewPagePy()
-{
-}
+MDIViewPagePy::~MDIViewPagePy() {}
 
 Py::Object MDIViewPagePy::repr()
 {
     std::ostringstream s_out;
-    if (!getMDIViewPagePtr())
+    if (!getMDIViewPagePtr()) {
         throw Py::RuntimeError("Cannot print representation of deleted object");
+    }
     s_out << "MDI view page";
     return Py::String(s_out.str());
 }
@@ -1227,14 +1253,14 @@ Py::Object MDIViewPagePy::repr()
 // a trick is to use MDIViewPy as class member and override getattr() to
 // join the attributes of both classes. This way all methods of MDIViewPy
 // appear for SheetViewPy, too.
-Py::Object MDIViewPagePy::getattr(const char * attrName)
+Py::Object MDIViewPagePy::getattr(const char* attrName)
 {
     if (!getMDIViewPagePtr()) {
         std::ostringstream s_out;
         s_out << "Cannot access attribute '" << attrName << "' of deleted object";
         throw Py::RuntimeError(s_out.str());
     }
-    std::string name( attrName );
+    std::string name(attrName);
     if (name == "__dict__" || name == "__class__") {
         Py::Dict dict_self(BaseType::getattr("__dict__"));
         Py::Dict dict_base(base.getattr("__dict__"));
@@ -1260,8 +1286,9 @@ MDIViewPage* MDIViewPagePy::getMDIViewPagePtr()
 
 Py::Object MDIViewPagePy::getPage(const Py::Tuple& args)
 {
-    if (!PyArg_ParseTuple(args.ptr(), ""))
+    if (!PyArg_ParseTuple(args.ptr(), "")) {
         throw Py::Exception();
+    }
     return Py::asObject(new TechDraw::DrawPagePy(getMDIViewPagePtr()->getPage()));
 }
 

--- a/src/Mod/TechDraw/Gui/PreferencesGui.cpp
+++ b/src/Mod/TechDraw/Gui/PreferencesGui.cpp
@@ -91,7 +91,12 @@ App::Color PreferencesGui::sectionLineColor()
 
 QColor PreferencesGui::sectionLineQColor()
 {
-    return sectionLineColor().asValue<QColor>();
+//if the App::Color version has already lightened the color, we don't want to do it agin
+    Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter()
+        .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/TechDraw/Decorations");
+    App::Color fcColor;
+    fcColor.setPackedValue(hGrp->GetUnsigned("SectionColor", 0x000000FF));
+    return fcColor.asValue<QColor>();
 }
 
 App::Color PreferencesGui::centerColor()
@@ -105,7 +110,11 @@ App::Color PreferencesGui::centerColor()
 
 QColor PreferencesGui::centerQColor()
 {
-    return centerColor().asValue<QColor>();
+    Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter().
+                                         GetGroup("BaseApp")->GetGroup("Preferences")->
+                                         GetGroup("Mod/TechDraw/Decorations");
+    App::Color fcColor = App::Color((uint32_t) hGrp->GetUnsigned("CenterColor", 0x000000FF));
+    return fcColor.asValue<QColor>();
 }
 
 QColor PreferencesGui::vertexQColor()
@@ -118,30 +127,39 @@ App::Color PreferencesGui::dimColor()
     Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter().
                                          GetGroup("BaseApp")->GetGroup("Preferences")->
                                          GetGroup("Mod/TechDraw/Dimensions");
-    App::Color result;
-    result.setPackedValue(hGrp->GetUnsigned("Color", 0x000000FF));  //#000000 black
-    return result;
+    App::Color fcColor;
+    fcColor.setPackedValue(hGrp->GetUnsigned("Color", 0x000000FF));  //#000000 black
+    return fcColor;
 }
 
 QColor PreferencesGui::dimQColor()
 {
-    return PreferencesGui::dimColor().asValue<QColor>();
+    Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter().
+                                         GetGroup("BaseApp")->GetGroup("Preferences")->
+                                         GetGroup("Mod/TechDraw/Dimensions");
+    App::Color fcColor;
+    fcColor.setPackedValue(hGrp->GetUnsigned("Color", 0x000000FF));  //#000000 black
+    return fcColor.asValue<QColor>();
 }
-
 
 App::Color PreferencesGui::leaderColor()
 {
     Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter().
                                          GetGroup("BaseApp")->GetGroup("Preferences")->
                                          GetGroup("Mod/TechDraw/LeaderLine");
-    App::Color result;
-    result.setPackedValue(hGrp->GetUnsigned("Color", 0x000000FF));  //#000000 black
-    return result;
+    App::Color fcColor;
+    fcColor.setPackedValue(hGrp->GetUnsigned("Color", 0x000000FF));  //#000000 black
+    return fcColor;
 }
 
 QColor PreferencesGui::leaderQColor()
 {
-    return PreferencesGui::leaderColor().asValue<QColor>();
+    Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter().
+                                         GetGroup("BaseApp")->GetGroup("Preferences")->
+                                         GetGroup("Mod/TechDraw/LeaderLine");
+    App::Color fcColor;
+    fcColor.setPackedValue(hGrp->GetUnsigned("Color", 0x000000FF));  //#000000 black
+    return fcColor.asValue<QColor>();
 }
 
 int PreferencesGui::dimArrowStyle()
@@ -208,20 +226,24 @@ QString PreferencesGui::weldingDirectory()
     return qSymbolDir;
 }
 
-
 App::Color PreferencesGui::gridColor()
 {
     Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter().
                                          GetGroup("BaseApp")->GetGroup("Preferences")->
                                          GetGroup("Mod/TechDraw/Colors");
-    App::Color result;
-    result.setPackedValue(hGrp->GetUnsigned("gridColor", 0x000000FF));  //#000000 black
-    return result;
+    App::Color fcColor;
+    fcColor.setPackedValue(hGrp->GetUnsigned("gridColor", 0x000000FF));  //#000000 black
+    return fcColor;
 }
 
 QColor PreferencesGui::gridQColor()
 {
-    return PreferencesGui::gridColor().asValue<QColor>();
+    Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter().
+                                         GetGroup("BaseApp")->GetGroup("Preferences")->
+                                         GetGroup("Mod/TechDraw/Colors");
+    App::Color fcColor;
+    fcColor.setPackedValue(hGrp->GetUnsigned("gridColor", 0x000000FF));  //#000000 black
+    return fcColor.asValue<QColor>();
 }
 
 double PreferencesGui::gridSpacing()
@@ -240,4 +262,71 @@ bool PreferencesGui::showGrid()
                                          GetGroup("Mod/TechDraw/General");
     bool show = hGrp->GetBool("showGrid", false);
     return show;
+}
+
+App::Color PreferencesGui::pageColor()
+{
+    Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter().
+                                         GetGroup("BaseApp")->GetGroup("Preferences")->
+                                         GetGroup("Mod/TechDraw/Colors");
+    App::Color result;
+    result.setPackedValue(hGrp->GetUnsigned("PageColor", 0xFFFFFFFF));  //#FFFFFFFF white
+    return result;
+}
+
+QColor PreferencesGui::pageQColor()
+{
+    return PreferencesGui::pageColor().asValue<QColor>();
+}
+
+QColor PreferencesGui::getAccessibleQColor(QColor orig)
+{
+    if (Preferences::lightOnDark() && Preferences::monochrome()) {
+        return lightTextQColor();
+    }
+    if (Preferences::lightOnDark()) {
+        return lightenColor(orig);
+    }
+    return orig;
+}
+
+QColor PreferencesGui::lightTextQColor()
+{
+    return Preferences::lightTextColor().asValue<QColor>();
+}
+
+QColor PreferencesGui::reverseColor(QColor orig)
+{
+    int revRed = 255 - orig.red();
+    int revBlue = 255 - orig.blue();
+    int revGreen = 255 - orig.green();
+    return QColor(revRed, revGreen, revBlue);
+}
+
+// largely based on code from https://invent.kde.org/graphics/okular and
+// https://en.wikipedia.org/wiki/HSL_and_HSV#HSL_to_RGB
+QColor PreferencesGui::lightenColor(QColor orig)
+{
+    // get component colours on [0, 255]
+    uchar red = orig.red();
+    uchar blue = orig.blue();
+    uchar green = orig.green();
+    uchar alpha = orig.alpha();
+
+    // shift color values
+    uchar m = std::min( {red, blue, green} );
+    red -= m;
+    blue -= m;
+    green -= m;
+
+    // calculate chroma (colour range)
+    uchar chroma = std::max( {red, blue, green} );
+
+    // calculate lightened colour value
+    uchar newm = 255 - chroma - m;
+    red += newm;
+    green += newm;
+    blue += newm;
+
+    return QColor(red, green, blue, alpha);
 }

--- a/src/Mod/TechDraw/Gui/PreferencesGui.h
+++ b/src/Mod/TechDraw/Gui/PreferencesGui.h
@@ -55,6 +55,8 @@ static App::Color  leaderColor();
 static QColor      leaderQColor();
 static App::Color  dimColor();
 static QColor      dimQColor();
+static App::Color  pageColor();
+static QColor      pageQColor();
 
 static int         dimArrowStyle();
 static double      dimArrowSize();
@@ -71,6 +73,10 @@ static App::Color gridColor();
 static QColor gridQColor();
 static double gridSpacing();
 
+static QColor       getAccessibleQColor(QColor orig);
+static QColor       lightTextQColor();
+static QColor       reverseColor(QColor orig);
+static QColor       lightenColor(QColor orig);
 };
 
 } //end namespace TechDrawGui

--- a/src/Mod/TechDraw/Gui/QGEPath.cpp
+++ b/src/Mod/TechDraw/Gui/QGEPath.cpp
@@ -234,7 +234,7 @@ void QGEPath::showMarkers(std::vector<QPointF> points)
 //TODO: double r = getMarkerSize();
 //      v->setRadius(r);
         v->setRadius(50.0);
-        v->setNormalColor(QColor(Qt::black));
+        v->setNormalColor(PreferencesGui::getAccessibleQColor(QColor(Qt::black)));
         v->setZValue(ZVALUE::VERTEX);
         v->setPos(p);
         v->show();

--- a/src/Mod/TechDraw/Gui/QGICMark.cpp
+++ b/src/Mod/TechDraw/Gui/QGICMark.cpp
@@ -34,7 +34,7 @@
 #include <Base/Parameter.h>
 
 #include "QGICMark.h"
-
+#include "PreferencesGui.h"
 
 using namespace TechDrawGui;
 
@@ -68,10 +68,7 @@ void QGICMark::setThick(float t)
 
 QColor QGICMark::getCMarkColor()
 {
-    Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter()
-        .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/TechDraw/Colors");
-    App::Color fcColor = App::Color((uint32_t) hGrp->GetUnsigned("CMarkColor", 0x08080800));
-    return fcColor.asValue<QColor>();
+    return PreferencesGui::centerQColor();
 }
 
 void QGICMark::setPrettyNormal() {

--- a/src/Mod/TechDraw/Gui/QGIEdge.cpp
+++ b/src/Mod/TechDraw/Gui/QGIEdge.cpp
@@ -85,7 +85,7 @@ QColor QGIEdge::getHiddenColor()
     Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter()
         .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/TechDraw/Colors");
     App::Color fcColor = App::Color((uint32_t) hGrp->GetUnsigned("HiddenColor", 0x000000FF));
-    return fcColor.asValue<QColor>();
+    return PreferencesGui::getAccessibleQColor(fcColor.asValue<QColor>());
 }
 
 Qt::PenStyle QGIEdge::getHiddenStyle()

--- a/src/Mod/TechDraw/Gui/QGIFace.cpp
+++ b/src/Mod/TechDraw/Gui/QGIFace.cpp
@@ -38,6 +38,7 @@
 #include <Base/Parameter.h>
 #include <Mod/TechDraw/App/DrawUtil.h>
 
+#include "PreferencesGui.h"
 #include "QGIFace.h"
 #include <QByteArrayMatcher>
 #include "QGCustomImage.h"
@@ -47,7 +48,6 @@
 #include "QGIPrimPath.h"
 #include "Rez.h"
 #include "ZVALUE.h"
-
 
 using namespace TechDrawGui;
 using namespace TechDraw;
@@ -64,7 +64,7 @@ QGIFace::QGIFace(int index) :
 
     //setStyle(Qt::NoPen);    //don't draw face lines, just fill for debugging
     setStyle(Qt::DashLine);
-    m_geomColor = QColor(Qt::black);
+    m_geomColor = PreferencesGui::getAccessibleQColor(QColor(Qt::black));
     setLineWeight(0.5);                   //0 = cosmetic
 
     setPrettyNormal();

--- a/src/Mod/TechDraw/Gui/QGILeaderLine.cpp
+++ b/src/Mod/TechDraw/Gui/QGILeaderLine.cpp
@@ -22,13 +22,13 @@
 
 #include "PreCompiled.h"
 #ifndef _PreComp_
-# include <cmath>
+#include <cmath>
 
-# include <QGraphicsScene>
-# include <QGraphicsSceneMouseEvent>
-# include <QPainter>
-# include <QPainterPath>
-# include <QVector2D>
+#include <QGraphicsScene>
+#include <QGraphicsSceneMouseEvent>
+#include <QPainter>
+#include <QPainterPath>
+#include <QVector2D>
 #endif
 
 #include <Base/Console.h>
@@ -37,10 +37,10 @@
 #include <Mod/TechDraw/App/DrawUtil.h>
 #include <Mod/TechDraw/App/LineGroup.h>
 
-#include "QGILeaderLine.h"
 #include "PreferencesGui.h"
 #include "QGEPath.h"
 #include "QGIArrow.h"
+#include "QGILeaderLine.h"
 #include "QGIPrimPath.h"
 #include "Rez.h"
 #include "ViewProviderLeader.h"
@@ -51,14 +51,14 @@ using namespace TechDrawGui;
 using namespace TechDraw;
 
 //**************************************************************
-QGILeaderLine::QGILeaderLine() :
-    m_parentItem(nullptr),
-    m_lineColor(Qt::black),
-    m_lineStyle(Qt::SolidLine),
-    m_hasHover(false),
-    m_saveX(0.0),
-    m_saveY(0.0),
-    m_blockDraw(false)
+QGILeaderLine::QGILeaderLine()
+    : m_parentItem(nullptr),
+      m_lineColor(Qt::black),
+      m_lineStyle(Qt::SolidLine),
+      m_hasHover(false),
+      m_saveX(0.0),
+      m_saveY(0.0),
+      m_blockDraw(false)
 
 {
     setHandlesChildEvents(false);
@@ -96,16 +96,16 @@ QGILeaderLine::QGILeaderLine() :
 
     setZValue(ZVALUE::DIMENSION);
 
-    QObject::connect(
-        m_editPath, SIGNAL(pointsUpdated(QPointF, std::vector<QPointF>)),
-        this  , SLOT  (onLineEditFinished(QPointF, std::vector<QPointF>))
-            );
+    QObject::connect(m_editPath,
+                     SIGNAL(pointsUpdated(QPointF, std::vector<QPointF>)),
+                     this,
+                     SLOT(onLineEditFinished(QPointF, std::vector<QPointF>)));
 }
 
 void QGILeaderLine::setLeaderFeature(TechDraw::DrawLeaderLine* feat)
 {
-//    Base::Console().Message("QGILL::setLeaderFeature()\n");
-    setViewFeature(static_cast<TechDraw::DrawView *>(feat));
+    //    Base::Console().Message("QGILL::setLeaderFeature()\n");
+    setViewFeature(static_cast<TechDraw::DrawView*>(feat));
 
     float x = Rez::guiX(feat->X.getValue());
     float y = Rez::guiX(-feat->Y.getValue());
@@ -117,39 +117,41 @@ void QGILeaderLine::setLeaderFeature(TechDraw::DrawLeaderLine* feat)
     updateView();
 }
 
-QVariant QGILeaderLine::itemChange(GraphicsItemChange change, const QVariant &value)
+QVariant QGILeaderLine::itemChange(GraphicsItemChange change, const QVariant& value)
 {
-//    Base::Console().Message("QGILL::itemChange(%d)\n", change);
+    //    Base::Console().Message("QGILL::itemChange(%d)\n", change);
     if (change == ItemSelectedHasChanged && scene()) {
-        if(isSelected()) {
+        if (isSelected()) {
             setPrettySel();
-        } else {
+        }
+        else {
             setPrettyNormal();
         }
         draw();
-    } else if(change == ItemSceneChange && scene()) {
+    }
+    else if (change == ItemSceneChange && scene()) {
         // nothing special!
     }
     return QGIView::itemChange(change, value);
 }
 
 //QGILL isn't draggable so skip QGIV::mousePress have event
-void QGILeaderLine::mousePressEvent(QGraphicsSceneMouseEvent * event)
+void QGILeaderLine::mousePressEvent(QGraphicsSceneMouseEvent* event)
 {
-//    Base::Console().Message("QGILL::mousePressEvent() - %s\n", getViewName());
+    //    Base::Console().Message("QGILL::mousePressEvent() - %s\n", getViewName());
     QGraphicsItem::mousePressEvent(event);
 }
 
 //QGILL isn't draggable so skip QGIV::mouseRelease
-void QGILeaderLine::mouseReleaseEvent(QGraphicsSceneMouseEvent * event)
+void QGILeaderLine::mouseReleaseEvent(QGraphicsSceneMouseEvent* event)
 {
-//    Base::Console().Message("QGILL::mouseReleaseEvent() - %s\n", getViewName());
+    //    Base::Console().Message("QGILL::mouseReleaseEvent() - %s\n", getViewName());
     QGraphicsItem::mouseReleaseEvent(event);
 }
 
-void QGILeaderLine::hoverEnterEvent(QGraphicsSceneHoverEvent *event)
+void QGILeaderLine::hoverEnterEvent(QGraphicsSceneHoverEvent* event)
 {
-//    Base::Console().Message("QGILL::hoverEnter() - selected; %d\n", isSelected());
+    //    Base::Console().Message("QGILL::hoverEnter() - selected; %d\n", isSelected());
     m_hasHover = true;
     if (!isSelected()) {
         setPrettyPre();
@@ -157,11 +159,11 @@ void QGILeaderLine::hoverEnterEvent(QGraphicsSceneHoverEvent *event)
     QGIView::hoverEnterEvent(event);
 }
 
-void QGILeaderLine::hoverLeaveEvent(QGraphicsSceneHoverEvent *event)
+void QGILeaderLine::hoverLeaveEvent(QGraphicsSceneHoverEvent* event)
 {
-//    Base::Console().Message("QGILL::hoverLeave() - selected; %d\n", isSelected());
+    //    Base::Console().Message("QGILL::hoverLeave() - selected; %d\n", isSelected());
     m_hasHover = false;
-    if(!isSelected()) {
+    if (!isSelected()) {
         setPrettyNormal();
     }
     QGIView::hoverLeaveEvent(event);
@@ -169,45 +171,51 @@ void QGILeaderLine::hoverLeaveEvent(QGraphicsSceneHoverEvent *event)
 
 void QGILeaderLine::onSourceChange(TechDraw::DrawView* newParent)
 {
-//    Base::Console().Message("QGILL::onSoureChange(%s)\n", newParent->getNameInDocument());
+    //    Base::Console().Message("QGILL::onSoureChange(%s)\n", newParent->getNameInDocument());
     std::string parentName = newParent->getNameInDocument();
     QGIView* qgiParent = getQGIVByName(parentName);
     if (qgiParent) {
         m_parentItem = qgiParent;
         setParentItem(m_parentItem);
         draw();
-    } else {
-        Base::Console().Warning("QGILL::onSourceChange - new parent %s has no QGIView\n", parentName.c_str());
+    }
+    else {
+        Base::Console().Warning("QGILL::onSourceChange - new parent %s has no QGIView\n",
+                                parentName.c_str());
     }
 }
 
 void QGILeaderLine::setNormalColorAll()
 {
-//    Base::Console().Message("QGILL::setNormalColorAll - normal color: %s\n", qPrintable(getNormalColor().name()));
-    m_line->setNormalColor(getNormalColor());
-    m_editPath->setNormalColor(getNormalColor());
-    m_arrow1->setNormalColor(getNormalColor());
-    m_arrow1->setFillColor(getNormalColor());
-    m_arrow2->setNormalColor(getNormalColor());
-    m_arrow2->setFillColor(getNormalColor());
+    //    Base::Console().Message("QGILL::setNormalColorAll - normal color: %s\n", qPrintable(getNormalColor().name()));
+    QColor qc = prefNormalColor();
+    m_line->setNormalColor(qc);
+    m_editPath->setNormalColor(qc);
+    m_arrow1->setNormalColor(qc);
+    m_arrow1->setFillColor(qc);
+    m_arrow2->setNormalColor(qc);
+    m_arrow2->setFillColor(qc);
 }
 
-void QGILeaderLine::setPrettyNormal() {
-//    Base::Console().Message("QGILL::setPrettyNormal()\n");
+void QGILeaderLine::setPrettyNormal()
+{
+    //    Base::Console().Message("QGILL::setPrettyNormal()\n");
     m_line->setPrettyNormal();
     m_arrow1->setPrettyNormal();
     m_arrow2->setPrettyNormal();
 }
 
-void QGILeaderLine::setPrettyPre() {
-//    Base::Console().Message("QGILL::setPrettyPre()\n");
+void QGILeaderLine::setPrettyPre()
+{
+    //    Base::Console().Message("QGILL::setPrettyPre()\n");
     m_line->setPrettyPre();
     m_arrow1->setPrettyPre();
     m_arrow2->setPrettyPre();
 }
 
-void QGILeaderLine::setPrettySel() {
-//    Base::Console().Message("QGILL::setPrettySel()\n");
+void QGILeaderLine::setPrettySel()
+{
+    //    Base::Console().Message("QGILL::setPrettySel()\n");
     m_line->setPrettySel();
     m_arrow1->setPrettySel();
     m_arrow2->setPrettySel();
@@ -216,36 +224,35 @@ void QGILeaderLine::setPrettySel() {
 
 void QGILeaderLine::closeEdit()
 {
-//    Base::Console().Message("QGIL::closeEdit()\n");
+    //    Base::Console().Message("QGIL::closeEdit()\n");
     if (m_editPath) {
-        m_editPath->onEndEdit();   //tell QEPath that edit session ended
+        m_editPath->onEndEdit();//tell QEPath that edit session ended
     }
 }
 
 //signaled from QEPath
 void QGILeaderLine::onLineEditFinished(QPointF tipDisplace, std::vector<QPointF> points)
 {
-//    Base::Console().Message("QGILL::onLineEditFinished(%s, %d)\n",
-//                            TechDraw::DrawUtil::formatVector(tipDisplace).c_str(),
-//                            points.size());
+    //    Base::Console().Message("QGILL::onLineEditFinished(%s, %d)\n",
+    //                            TechDraw::DrawUtil::formatVector(tipDisplace).c_str(),
+    //                            points.size());
     m_blockDraw = true;
     auto featLeader = getFeature();
-    if (!featLeader)
+    if (!featLeader) {
         return;
+    }
     double baseScale = featLeader->getBaseScale();
 
-    if ( !(TechDraw::DrawUtil::fpCompare(tipDisplace.x(), 0.0) &&
-           TechDraw::DrawUtil::fpCompare(tipDisplace.y(), 0.0))  )  {
+    if (!(TechDraw::DrawUtil::fpCompare(tipDisplace.x(), 0.0)
+          && TechDraw::DrawUtil::fpCompare(tipDisplace.y(), 0.0))) {
         //tip was moved. need to change AttachPoint
         QPointF oldAttach = getAttachFromFeature();
         QPointF newAttach = oldAttach + (tipDisplace / baseScale);
-        featLeader->setPosition(Rez::appX(newAttach.x()),
-                                  Rez::appX(- newAttach.y()),
-                                  true);
+        featLeader->setPosition(Rez::appX(newAttach.x()), Rez::appX(-newAttach.y()), true);
     }
 
     std::vector<Base::Vector3d> waypoints;
-    for (auto& p: points) {
+    for (auto& p : points) {
         QPointF moved = p - tipDisplace;
         Base::Vector3d v(moved.x(), moved.y(), 0.0);
         waypoints.push_back(v);
@@ -257,7 +264,7 @@ void QGILeaderLine::onLineEditFinished(QPointF tipDisplace, std::vector<QPointF>
         featLeader->adjustLastSegment();
     }
 
-    Q_EMIT editComplete();           //tell task editing is complete
+    Q_EMIT editComplete();//tell task editing is complete
 
     m_blockDraw = false;
     m_editPath->hide();
@@ -267,9 +274,10 @@ void QGILeaderLine::onLineEditFinished(QPointF tipDisplace, std::vector<QPointF>
 void QGILeaderLine::startPathEdit()
 {
     saveState();
-    auto featLeader( dynamic_cast<TechDraw::DrawLeaderLine*>(getViewObject()) );
-    if (!featLeader)
+    auto featLeader(dynamic_cast<TechDraw::DrawLeaderLine*>(getViewObject()));
+    if (!featLeader) {
         return;
+    }
 
     double scale = featLeader->getScale();
     m_editPath->setScale(scale);
@@ -280,7 +288,7 @@ void QGILeaderLine::startPathEdit()
 
 void QGILeaderLine::saveState()
 {
-//    Base::Console().Message("QGILL::saveState()\n");
+    //    Base::Console().Message("QGILL::saveState()\n");
     auto featLeader = getFeature();
     if (featLeader) {
         m_savePoints = featLeader->WayPoints.getValues();
@@ -291,7 +299,7 @@ void QGILeaderLine::saveState()
 
 void QGILeaderLine::restoreState()
 {
-//    Base::Console().Message("QGILL::restoreState()\n");
+    //    Base::Console().Message("QGILL::restoreState()\n");
     auto featLeader = getFeature();
     if (featLeader) {
         featLeader->WayPoints.setValues(m_savePoints);
@@ -305,52 +313,61 @@ void QGILeaderLine::restoreState()
 
 void QGILeaderLine::updateView(bool update)
 {
-//    Base::Console().Message("QGIL::updateView() %s\n", getViewObject()->getNameInDocument());
+    //    Base::Console().Message("QGIL::updateView() %s\n", getViewObject()->getNameInDocument());
     Q_UNUSED(update);
-    auto featLeader( dynamic_cast<TechDraw::DrawLeaderLine*>(getViewObject()) );
+    auto featLeader(dynamic_cast<TechDraw::DrawLeaderLine*>(getViewObject()));
     if (!featLeader) {
         Base::Console().Warning("QGILL::updateView - no feature!\n");
         return;
     }
 
     auto vp = static_cast<ViewProviderLeader*>(getViewProvider(getViewObject()));
-    if (!vp)
+    if (!vp) {
         return;
+    }
     draw();
 }
 
 void QGILeaderLine::draw()
 {
-//    Base::Console().Message("QGILL::draw()- %s\n", getViewObject()->getNameInDocument());
-    if (m_blockDraw)
+    //    Base::Console().Message("QGILL::draw()- %s\n", getViewObject()->getNameInDocument());
+    if (m_blockDraw) {
         return;
-    if (!isVisible())
+    }
+    if (!isVisible()) {
         return;
+    }
     TechDraw::DrawLeaderLine* featLeader = getFeature();
-    if (!featLeader)
+    if (!featLeader) {
         return;
+    }
     auto vp = static_cast<ViewProviderLeader*>(getViewProvider(getViewObject()));
-    if (!vp)
+    if (!vp) {
         return;
+    }
 
     double scale = 1.0;
     TechDraw::DrawView* parent = featLeader->getBaseView();
-    if (parent)
+    if (parent) {
         scale = parent->getScale();
+    }
 
-    if (m_editPath->inEdit())
+    if (m_editPath->inEdit()) {
         return;
+    }
 
-//********
-    if (featLeader->isLocked())
+    //********
+    if (featLeader->isLocked()) {
         setFlag(QGraphicsItem::ItemIsMovable, false);
-    else
+    }
+    else {
         setFlag(QGraphicsItem::ItemIsMovable, true);
+    }
 
     m_lineStyle = static_cast<Qt::PenStyle>(vp->LineStyle.getValue());
     double baseScale = featLeader->getBaseScale();
     double x = Rez::guiX(featLeader->X.getValue());
-    double y = - Rez::guiX(featLeader->Y.getValue());
+    double y = -Rez::guiX(featLeader->Y.getValue());
     QPointF aPoint(x, y);
     aPoint *= baseScale;
     setPos(aPoint);
@@ -359,7 +376,7 @@ void QGILeaderLine::draw()
     m_line->setStyle(m_lineStyle);
     m_line->setWidth(getLineWidth());
 
-    m_line->setPos(0, 0);                          //make m_line coords == leader coords
+    m_line->setPos(0, 0);//make m_line coords == leader coords
 
     std::vector<QPointF> qPoints = getWayPointsFromFeature();
     if (featLeader->Scalable.getValue()) {
@@ -374,9 +391,11 @@ void QGILeaderLine::draw()
 
     if (isSelected()) {
         setPrettySel();
-    } else if (m_hasHover) {
+    }
+    else if (m_hasHover) {
         setPrettyPre();
-    } else {
+    }
+    else {
         setPrettyNormal();
     }
     update(boundingRect());
@@ -384,23 +403,23 @@ void QGILeaderLine::draw()
 
 QPainterPath QGILeaderLine::makeLeaderPath(std::vector<QPointF> qPoints)
 {
-//    Base::Console().Message("QGILeaderLine::makeLeaderPath()\n");
+    //    Base::Console().Message("QGILeaderLine::makeLeaderPath()\n");
     QPainterPath result;
     DrawLeaderLine* featLeader = getFeature();
     if (!featLeader) {
         Base::Console().Message("QGILL::makeLeaderPath - featLeader is nullptr\n");
-        return  result;
+        return result;
     }
 
     QPointF startAdjVec(0.0, 0.0);
-    double  startAdjLength(0.0);
+    double startAdjLength(0.0);
     QPointF endAdjVec(0.0, 0.0);
-    double  endAdjLength(0.0);
+    double endAdjLength(0.0);
     if (qPoints.size() > 1) {
         //make path adjustment to hide leaderline ends behind arrowheads
         if (featLeader->StartSymbol.getValue() != ArrowType::NONE) {
             startAdjLength = QGIArrow::getOverlapAdjust(featLeader->StartSymbol.getValue(),
-                                                            QGIArrow::getPrefArrowSize());
+                                                        QGIArrow::getPrefArrowSize());
         }
         if (featLeader->EndSymbol.getValue() != ArrowType::NONE) {
             endAdjLength = QGIArrow::getOverlapAdjust(featLeader->EndSymbol.getValue(),
@@ -409,7 +428,7 @@ QPainterPath QGILeaderLine::makeLeaderPath(std::vector<QPointF> qPoints)
 
         //get adjustment directions
         startAdjVec = qPoints.at(1) - qPoints.front();
-        endAdjVec = (*(qPoints.end() - 2))- qPoints.back();
+        endAdjVec = (*(qPoints.end() - 2)) - qPoints.back();
 
         //get adjustment vectors
         QVector2D startTemp(startAdjVec);
@@ -420,26 +439,26 @@ QPainterPath QGILeaderLine::makeLeaderPath(std::vector<QPointF> qPoints)
         endAdjVec = endTemp.toPointF() * endAdjLength;
 
         qPoints.front() += startAdjVec;
-        qPoints.back()  += endAdjVec;
+        qPoints.back() += endAdjVec;
         result.moveTo(qPoints.front());
         for (int i = 1; i < (int)qPoints.size(); i++) {
             result.lineTo(qPoints.at(i));
         }
-   }
-   return result;
+    }
+    return result;
 }
 
 QPointF QGILeaderLine::getAttachFromFeature()
 {
-//    Base::Console().Message("QGILL::getAttachFromFeature()\n");
+    //    Base::Console().Message("QGILL::getAttachFromFeature()\n");
     QPointF result;
     TechDraw::DrawLeaderLine* featLeader = getFeature();
-    if((!featLeader) ) {
+    if ((!featLeader)) {
         Base::Console().Message("QGIL::getAttachFromLeader - no feature\n");
         return result;
     }
     double x = Rez::guiX(featLeader->X.getValue());
-    double y = - Rez::guiX(featLeader->Y.getValue());
+    double y = -Rez::guiX(featLeader->Y.getValue());
     result = QPointF(x, y);
     return result;
 }
@@ -451,11 +470,11 @@ std::vector<QPointF> QGILeaderLine::getWayPointsFromFeature()
     DrawLeaderLine* featLeader = getFeature();
     if (!featLeader) {
         Base::Console().Message("QGILL::getWayPointsFromFeature - featLeader is nullptr\n");
-        return  qPoints;
+        return qPoints;
     }
 
     std::vector<Base::Vector3d> vPoints = featLeader->WayPoints.getValues();
-    for (auto& d: vPoints) {
+    for (auto& d : vPoints) {
         QPointF temp(d.x, d.y);
         qPoints.push_back(temp);
     }
@@ -467,7 +486,7 @@ std::vector<QPointF> QGILeaderLine::getWayPointsFromFeature()
 
 void QGILeaderLine::setArrows(std::vector<QPointF> pathPoints)
 {
-//    Base::Console().Message("QGILL::setArrows()\n");
+    //    Base::Console().Message("QGILL::setArrows()\n");
     Base::Vector3d stdX(1.0, 0.0, 0.0);
     TechDraw::DrawLeaderLine* featLeader = getFeature();
 
@@ -476,7 +495,7 @@ void QGILeaderLine::setArrows(std::vector<QPointF> pathPoints)
     if (featLeader->StartSymbol.getValue() != ArrowType::NONE) {
         m_arrow1->setStyle(featLeader->StartSymbol.getValue());
         m_arrow1->setWidth(getLineWidth());
-//        TODO: variable size arrow heads
+        //        TODO: variable size arrow heads
         m_arrow1->setSize(QGIArrow::getPrefArrowSize());
         m_arrow1->setDirMode(true);
         m_arrow1->setDirection(stdX);
@@ -491,7 +510,8 @@ void QGILeaderLine::setArrows(std::vector<QPointF> pathPoints)
         }
         m_arrow1->draw();
         m_arrow1->show();
-    } else {
+    }
+    else {
         m_arrow1->hide();
     }
 
@@ -511,15 +531,16 @@ void QGILeaderLine::setArrows(std::vector<QPointF> pathPoints)
         }
         m_arrow2->draw();
         m_arrow2->show();
-    } else {
+    }
+    else {
         m_arrow2->hide();
     }
 }
 
 void QGILeaderLine::drawBorder()
 {
-////Leaders have no border!
-//    QGIView::drawBorder();   //good for debugging
+    ////Leaders have no border!
+    //    QGIView::drawBorder();   //good for debugging
 }
 
 //******************************************************************************
@@ -527,7 +548,7 @@ void QGILeaderLine::drawBorder()
 
 void QGILeaderLine::abandonEdit()
 {
-//    Base::Console().Message("QGIL::abandonEdit()\n");
+    //    Base::Console().Message("QGIL::abandonEdit()\n");
     m_editPath->clearMarkers();
     m_editPath->hide();
     restoreState();
@@ -536,15 +557,15 @@ void QGILeaderLine::abandonEdit()
 double QGILeaderLine::getLineWidth()
 {
     auto vp = static_cast<ViewProviderLeader*>(getViewProvider(getViewObject()));
-    if (!vp)
+    if (!vp) {
         return Rez::guiX(LineGroup::getDefaultWidth("Graphic"));
+    }
     return Rez::guiX(vp->LineWidth.getValue());
 }
 
 TechDraw::DrawLeaderLine* QGILeaderLine::getFeature()
 {
-    TechDraw::DrawLeaderLine* result =
-         static_cast<TechDraw::DrawLeaderLine*>(getViewObject());
+    TechDraw::DrawLeaderLine* result = static_cast<TechDraw::DrawLeaderLine*>(getViewObject());
     return result;
 }
 
@@ -555,12 +576,13 @@ double QGILeaderLine::getEdgeFuzz() const
 
 QColor QGILeaderLine::prefNormalColor()
 {
-//    Base::Console().Message("QGILL::getNormalColor()\n");
+    //    Base::Console().Message("QGILL::getNormalColor()\n");
     setNormalColor(PreferencesGui::leaderQColor());
 
     auto vp = dynamic_cast<ViewProviderLeader*>(getViewProvider(getViewObject()));
     if (vp) {
-        setNormalColor(vp->Color.getValue().asValue<QColor>());
+        QColor normal = vp->Color.getValue().asValue<QColor>();
+        setNormalColor(PreferencesGui::getAccessibleQColor(normal));
     }
     return getNormalColor();
 }
@@ -570,14 +592,16 @@ QRectF QGILeaderLine::boundingRect() const
     return childrenBoundingRect();
 }
 
-void QGILeaderLine::paint ( QPainter * painter, const QStyleOptionGraphicsItem * option, QWidget * widget) {
+void QGILeaderLine::paint(QPainter* painter, const QStyleOptionGraphicsItem* option,
+                          QWidget* widget)
+{
     QStyleOptionGraphicsItem myOption(*option);
     myOption.state &= ~QStyle::State_Selected;
 
-//    painter->setPen(Qt::blue);
-//    painter->drawRect(boundingRect());          //good for debugging
+    //    painter->setPen(Qt::blue);
+    //    painter->drawRect(boundingRect());          //good for debugging
 
-    QGIView::paint (painter, &myOption, widget);
+    QGIView::paint(painter, &myOption, widget);
 }
 
 #include <Mod/TechDraw/Gui/moc_QGILeaderLine.cpp>

--- a/src/Mod/TechDraw/Gui/QGILeaderLine.h
+++ b/src/Mod/TechDraw/Gui/QGILeaderLine.h
@@ -36,10 +36,11 @@
 #include "QGIView.h"
 
 
-namespace TechDraw {
+namespace TechDraw
+{
 class DrawLeaderLine;
 class DrawView;
-}
+}// namespace TechDraw
 
 namespace TechDrawGui
 {
@@ -50,20 +51,25 @@ class QGEPath;
 
 //*******************************************************************
 
-class TechDrawGuiExport QGILeaderLine : public QGIView
+class TechDrawGuiExport QGILeaderLine: public QGIView
 {
     Q_OBJECT
 
 public:
-    enum {Type = QGraphicsItem::UserType + 232};
+    enum
+    {
+        Type = QGraphicsItem::UserType + 232
+    };
 
     explicit QGILeaderLine();
     ~QGILeaderLine() = default;
 
-    int type() const override { return Type;}
-    void paint( QPainter * painter,
-                        const QStyleOptionGraphicsItem * option,
-                        QWidget * widget = nullptr ) override;
+    int type() const override
+    {
+        return Type;
+    }
+    void paint(QPainter* painter, const QStyleOptionGraphicsItem* option,
+               QWidget* widget = nullptr) override;
     QRectF boundingRect() const override;
 
     void drawBorder() override;
@@ -80,10 +86,10 @@ public:
     double getLineWidth();
     double getEdgeFuzz() const;
 
-    void mousePressEvent(QGraphicsSceneMouseEvent * event) override;
-    void mouseReleaseEvent(QGraphicsSceneMouseEvent * event) override;
-    void hoverEnterEvent(QGraphicsSceneHoverEvent *event) override;
-    void hoverLeaveEvent(QGraphicsSceneHoverEvent *event) override;
+    void mousePressEvent(QGraphicsSceneMouseEvent* event) override;
+    void mouseReleaseEvent(QGraphicsSceneMouseEvent* event) override;
+    void hoverEnterEvent(QGraphicsSceneHoverEvent* event) override;
+    void hoverLeaveEvent(QGraphicsSceneHoverEvent* event) override;
 
     void setPrettyNormal();
     void setPrettyPre();
@@ -92,11 +98,12 @@ public:
     void setLeaderFeature(TechDraw::DrawLeaderLine* feat);
 
 public Q_SLOTS:
-    void onLineEditFinished(QPointF tipDisplace, std::vector<QPointF> points);    //QGEPath is finished editing points
+    void onLineEditFinished(QPointF tipDisplace,
+                            std::vector<QPointF> points);//QGEPath is finished editing points
     void onSourceChange(TechDraw::DrawView* newParent) override;
 
 Q_SIGNALS:
-    void editComplete();  //tell caller that edit session is finished
+    void editComplete();//tell caller that edit session is finished
 
 protected:
     void draw() override;
@@ -104,8 +111,7 @@ protected:
     std::vector<QPointF> getWayPointsFromFeature();
     QPointF getAttachFromFeature();
 
-    QVariant itemChange( GraphicsItemChange change,
-                                 const QVariant &value ) override;
+    QVariant itemChange(GraphicsItemChange change, const QVariant& value) override;
 
     void saveState();
     void restoreState();
@@ -116,13 +122,13 @@ protected:
 private:
     std::vector<QPointF> m_pathPoints;
     QGraphicsItem* m_parentItem;
-    QGIPrimPath* m_line;               //actual leader line
+    QGIPrimPath* m_line;//actual leader line
     QColor m_lineColor;
     Qt::PenStyle m_lineStyle;
     QGIArrow* m_arrow1;
     QGIArrow* m_arrow2;
 
-    QGEPath* m_editPath;               //line editor
+    QGEPath* m_editPath;//line editor
     QColor m_editPathColor;
 
     bool m_hasHover;
@@ -131,9 +137,9 @@ private:
     double m_saveY;
     std::vector<Base::Vector3d> m_savePoints;
 
-    bool m_blockDraw;    //prevent redraws while updating.
+    bool m_blockDraw;//prevent redraws while updating.
 };
 
-}
+}// namespace TechDrawGui
 
-#endif // DRAWINGGUI_QGRAPHICSITEMLEADERLINE_H
+#endif// DRAWINGGUI_QGRAPHICSITEMLEADERLINE_H

--- a/src/Mod/TechDraw/Gui/QGISVGTemplate.cpp
+++ b/src/Mod/TechDraw/Gui/QGISVGTemplate.cpp
@@ -23,35 +23,36 @@
 #include "PreCompiled.h"
 
 #ifndef _PreComp_
-# include <QDomDocument>
-# include <QFile>
-# include <QGraphicsSvgItem>
-# include <QPen>
-# include <QSvgRenderer>
-# include <QXmlQuery>
-# include <QXmlResultItems>
-#endif // #ifndef _PreComp_
+#include <QDomDocument>
+#include <QFile>
+#include <QGraphicsColorizeEffect>
+#include <QGraphicsEffect>
+#include <QGraphicsSvgItem>
+#include <QPen>
+#include <QSvgRenderer>
+#include <QXmlQuery>
+#include <QXmlResultItems>
+#endif// #ifndef _PreComp_
 
 #include <App/Application.h>
 #include <Base/Console.h>
 #include <Base/Parameter.h>
 
-#include <Mod/TechDraw/App/DrawUtil.h>
 #include <Mod/TechDraw/App/DrawSVGTemplate.h>
+#include <Mod/TechDraw/App/DrawUtil.h>
 #include <Mod/TechDraw/App/QDomNodeModel.h>
 
+#include "PreferencesGui.h"
 #include "QGISVGTemplate.h"
 #include "QGSPage.h"
 #include "Rez.h"
 #include "TemplateTextField.h"
 #include "ZVALUE.h"
 
-
 using namespace TechDrawGui;
+using namespace TechDraw;
 
-QGISVGTemplate::QGISVGTemplate(QGSPage* scene)
-    : QGITemplate(scene),
-      firstTime(true)
+QGISVGTemplate::QGISVGTemplate(QGSPage* scene) : QGITemplate(scene), firstTime(true)
 {
 
     m_svgItem = new QGraphicsSvgItem(this);
@@ -66,22 +67,15 @@ QGISVGTemplate::QGISVGTemplate(QGSPage* scene)
 
     m_svgItem->setZValue(ZVALUE::SVGTEMPLATE);
     setZValue(ZVALUE::SVGTEMPLATE);
-
 }
 
-QGISVGTemplate::~QGISVGTemplate()
-{
-    delete m_svgRender;
-}
+QGISVGTemplate::~QGISVGTemplate() { delete m_svgRender; }
 
-void QGISVGTemplate::openFile(const QFile &file)
-{
-    Q_UNUSED(file);
-}
+void QGISVGTemplate::openFile(const QFile& file) { Q_UNUSED(file); }
 
-void QGISVGTemplate::load(const QByteArray &svgCode)
+void QGISVGTemplate::load(const QByteArray& svgCode)
 {
-     m_svgRender->load(svgCode);
+    m_svgRender->load(svgCode);
 
     QSize size = m_svgRender->defaultSize();
     m_svgItem->setSharedRenderer(m_svgRender);
@@ -92,31 +86,48 @@ void QGISVGTemplate::load(const QByteArray &svgCode)
     }
 
     //convert from pixels or mm or inches in svg file to mm page size
-    TechDraw::DrawSVGTemplate *tmplte = getSVGTemplate();
+    TechDraw::DrawSVGTemplate* tmplte = getSVGTemplate();
     double xaspect, yaspect;
     xaspect = tmplte->getWidth() / static_cast<double>(size.width());
     yaspect = tmplte->getHeight() / static_cast<double>(size.height());
 
     QTransform qtrans;
     qtrans.translate(0.0, Rez::guiX(-tmplte->getHeight()));
-    qtrans.scale(Rez::guiX(xaspect) , Rez::guiX(yaspect));
+    qtrans.scale(Rez::guiX(xaspect), Rez::guiX(yaspect));
     m_svgItem->setTransform(qtrans);
+
+    if (Preferences::lightOnDark()) {
+        QColor color = PreferencesGui::getAccessibleQColor(QColor(Qt::black));
+        QGraphicsColorizeEffect* colorizeEffect = new QGraphicsColorizeEffect();
+        colorizeEffect->setColor(color);
+        m_svgItem->setGraphicsEffect(colorizeEffect);
+    }
+    else {
+        //remove and delete any existing graphics effect
+        if (m_svgItem->graphicsEffect()) {
+            m_svgItem->setGraphicsEffect(nullptr);
+        }
+    }
 }
 
-TechDraw::DrawSVGTemplate * QGISVGTemplate::getSVGTemplate()
+TechDraw::DrawSVGTemplate* QGISVGTemplate::getSVGTemplate()
 {
-    if(pageTemplate && pageTemplate->isDerivedFrom(TechDraw::DrawSVGTemplate::getClassTypeId()))
-        return static_cast<TechDraw::DrawSVGTemplate *>(pageTemplate);
-    else
+    if (pageTemplate && pageTemplate->isDerivedFrom(TechDraw::DrawSVGTemplate::getClassTypeId())) {
+        return static_cast<TechDraw::DrawSVGTemplate*>(pageTemplate);
+    }
+    else {
         return nullptr;
+    }
 }
 
 void QGISVGTemplate::draw()
 {
-    TechDraw::DrawSVGTemplate *tmplte = getSVGTemplate();
-    if(!tmplte)
+    TechDraw::DrawSVGTemplate* tmplte = getSVGTemplate();
+    if (!tmplte) {
         throw Base::RuntimeError("Template Feature not set for QGISVGTemplate");
-    load(tmplte->processTemplate().toUtf8());
+    }
+    QString templateSvg = tmplte->processTemplate();
+    load(templateSvg.toUtf8());
 }
 
 void QGISVGTemplate::updateView(bool update)
@@ -127,7 +138,7 @@ void QGISVGTemplate::updateView(bool update)
 
 void QGISVGTemplate::createClickHandles()
 {
-    TechDraw::DrawSVGTemplate *svgTemplate = getSVGTemplate();
+    TechDraw::DrawSVGTemplate* svgTemplate = getSVGTemplate();
     if (svgTemplate->isRestoring()) {
         //the embedded file is not available yet, so just return
         return;
@@ -141,8 +152,9 @@ void QGISVGTemplate::createClickHandles()
 
     QFile file(templateFilename);
     if (!file.open(QIODevice::ReadOnly)) {
-        Base::Console().Error("QGISVGTemplate::createClickHandles - error opening template file %s\n",
-                              svgTemplate->PageResult.getValue());
+        Base::Console().Error(
+            "QGISVGTemplate::createClickHandles - error opening template file %s\n",
+            svgTemplate->PageResult.getValue());
         return;
     }
 
@@ -160,37 +172,41 @@ void QGISVGTemplate::createClickHandles()
     query.setFocus(QXmlItem(model.fromDomNode(templateDocElem)));
 
     // XPath query to select all <text> nodes with "freecad:editable" attribute
-    query.setQuery(QString::fromUtf8(
-        "declare default element namespace \"" SVG_NS_URI "\"; "
-        "declare namespace freecad=\"" FREECAD_SVG_NS_URI "\"; "
-        "//text[@freecad:editable]"));
+    query.setQuery(QString::fromUtf8("declare default element namespace \"" SVG_NS_URI "\"; "
+                                     "declare namespace freecad=\"" FREECAD_SVG_NS_URI "\"; "
+                                     "//text[@freecad:editable]"));
 
     QXmlResultItems queryResult;
     query.evaluateTo(&queryResult);
 
     //TODO: Find location of special fields (first/third angle) and make graphics items for them
 
-    Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter()
-        .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/TechDraw/General");
+    Base::Reference<ParameterGrp> hGrp = App::GetApplication()
+                                             .GetUserParameter()
+                                             .GetGroup("BaseApp")
+                                             ->GetGroup("Preferences")
+                                             ->GetGroup("Mod/TechDraw/General");
     double editClickBoxSize = Rez::guiX(hGrp->GetFloat("TemplateDotSize", 3.0));
 
     QColor editClickBoxColor = Qt::green;
-    editClickBoxColor.setAlpha(128);              //semi-transparent
+    editClickBoxColor.setAlpha(128);//semi-transparent
 
     double width = editClickBoxSize;
     double height = editClickBoxSize;
 
-    while (!queryResult.next().isNull())
-    {
-        QDomElement textElement = model.toDomNode(queryResult.current().toNodeModelIndex()).toElement();
+    while (!queryResult.next().isNull()) {
+        QDomElement textElement =
+            model.toDomNode(queryResult.current().toNodeModelIndex()).toElement();
 
         QString name = textElement.attribute(QString::fromUtf8("freecad:editable"));
-        double x = Rez::guiX(textElement.attribute(QString::fromUtf8("x"), QString::fromUtf8("0.0")).toDouble());
-        double y = Rez::guiX(textElement.attribute(QString::fromUtf8("y"), QString::fromUtf8("0.0")).toDouble());
+        double x = Rez::guiX(
+            textElement.attribute(QString::fromUtf8("x"), QString::fromUtf8("0.0")).toDouble());
+        double y = Rez::guiX(
+            textElement.attribute(QString::fromUtf8("y"), QString::fromUtf8("0.0")).toDouble());
 
         if (name.isEmpty()) {
-            Base::Console().Warning("QGISVGTemplate::createClickHandles - no name for editable text at %f, %f\n",
-                                    x, y);
+            Base::Console().Warning(
+                "QGISVGTemplate::createClickHandles - no name for editable text at %f, %f\n", x, y);
             continue;
         }
 
@@ -198,12 +214,12 @@ void QGISVGTemplate::createClickHandles()
 
         double pad = 1.0;
         item->setRect(x - pad, Rez::guiX(-svgTemplate->getHeight()) + y - height - pad,
-                      width + 2.0*pad, height + 2.0*pad);
+                      width + 2.0 * pad, height + 2.0 * pad);
 
         QPen myPen;
         myPen.setStyle(Qt::SolidLine);
         myPen.setColor(editClickBoxColor);
-        myPen.setWidth(0);  // 0 means "cosmetic pen" - always 1px
+        myPen.setWidth(0);// 0 means "cosmetic pen" - always 1px
         item->setPen(myPen);
 
         QBrush myBrush(editClickBoxColor, Qt::SolidPattern);

--- a/src/Mod/TechDraw/Gui/QGISVGTemplate.h
+++ b/src/Mod/TechDraw/Gui/QGISVGTemplate.h
@@ -32,7 +32,8 @@ class QSvgRenderer;
 class QFile;
 class QString;
 
-namespace TechDraw {
+namespace TechDraw
+{
 class DrawSVGTemplate;
 }
 
@@ -42,33 +43,36 @@ namespace TechDrawGui
 {
 class QGSPage;
 
-class TechDrawGuiExport QGISVGTemplate : public QGITemplate
+class TechDrawGuiExport QGISVGTemplate: public QGITemplate
 {
     Q_OBJECT
 
 public:
     explicit QGISVGTemplate(QGSPage* scene);
-    virtual ~QGISVGTemplate();
+    ~QGISVGTemplate() override;
 
-    enum {Type = QGraphicsItem::UserType + 153};
+    enum
+    {
+        Type = QGraphicsItem::UserType + 153
+    };
     int type() const { return Type; }
 
     void draw();
-    virtual void updateView(bool update = false);
+    void updateView(bool update = false) override;
 
-    TechDraw::DrawSVGTemplate *getSVGTemplate();
+    TechDraw::DrawSVGTemplate* getSVGTemplate();
 
 protected:
-    void openFile(const QFile &file);
-    void load (const QByteArray& svgCode);
+    void openFile(const QFile& file);
+    void load(const QByteArray& svgCode);
     void createClickHandles(void);
 
 protected:
     bool firstTime;
-    QGraphicsSvgItem *m_svgItem;
-    QSvgRenderer *m_svgRender;
-};  // class QGISVGTemplate
+    QGraphicsSvgItem* m_svgItem;
+    QSvgRenderer* m_svgRender;
+};// class QGISVGTemplate
 
-}
+}// namespace TechDrawGui
 
-#endif // DRAWINGGUI_QGRAPHICSITEMSVGTEMPLATE_H
+#endif// DRAWINGGUI_QGRAPHICSITEMSVGTEMPLATE_H

--- a/src/Mod/TechDraw/Gui/QGITile.cpp
+++ b/src/Mod/TechDraw/Gui/QGITile.cpp
@@ -325,7 +325,7 @@ QColor QGITile::getTileColor() const
     Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter()
         .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/TechDraw/Colors");
     App::Color fcColor = App::Color((uint32_t) hGrp->GetUnsigned("TileColor", 0x00000000));
-    return fcColor.asValue<QColor>();
+    return PreferencesGui::getAccessibleQColor( fcColor.asValue<QColor>());
 }
 
 double QGITile::getSymbolWidth() const

--- a/src/Mod/TechDraw/Gui/QGIView.cpp
+++ b/src/Mod/TechDraw/Gui/QGIView.cpp
@@ -200,7 +200,7 @@ QVariant QGIView::itemChange(GraphicsItemChange change, const QVariant &value)
             m_colCurrent = getSelectColor();
 //            m_selectState = 2;
         } else {
-            m_colCurrent = PreferencesGui::normalQColor();
+            m_colCurrent = PreferencesGui::getAccessibleQColor(PreferencesGui::normalQColor());
 //            m_selectState = 0;
         }
         drawBorder();
@@ -268,7 +268,7 @@ void QGIView::hoverLeaveEvent(QGraphicsSceneHoverEvent *event)
     if(isSelected()) {
         m_colCurrent = getSelectColor();
     } else {
-        m_colCurrent = PreferencesGui::normalQColor();
+        m_colCurrent = PreferencesGui::getAccessibleQColor(PreferencesGui::normalQColor());
     }
     drawBorder();
 }
@@ -709,17 +709,17 @@ void QGIView::setStackFromVP()
 
 QColor QGIView::prefNormalColor()
 {
-    return PreferencesGui::normalQColor();
+    return PreferencesGui::getAccessibleQColor(PreferencesGui::normalQColor());
 }
 
 QColor QGIView::getPreColor()
 {
-    return PreferencesGui::preselectQColor();
+    return PreferencesGui::getAccessibleQColor(PreferencesGui::preselectQColor());
 }
 
 QColor QGIView::getSelectColor()
 {
-    return PreferencesGui::selectQColor();
+    return PreferencesGui::getAccessibleQColor(PreferencesGui::selectQColor());
 }
 
 Base::Reference<ParameterGrp> QGIView::getParmGroupCol()

--- a/src/Mod/TechDraw/Gui/QGIViewBalloon.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewBalloon.cpp
@@ -23,15 +23,15 @@
 
 #include "PreCompiled.h"
 #ifndef _PreComp_
-# include <cmath>
-# include <string>
+#include <cmath>
+#include <string>
 
-# include <QGraphicsScene>
-# include <QGraphicsSceneMouseEvent>
-# include <QPaintDevice>
-# include <QPainter>
-# include <QPainterPath>
-# include <QSvgGenerator>
+#include <QGraphicsScene>
+#include <QGraphicsSceneMouseEvent>
+#include <QPaintDevice>
+#include <QPainter>
+#include <QPainterPath>
+#include <QSvgGenerator>
 #endif
 
 #include <App/Application.h>
@@ -41,15 +41,15 @@
 #include <Gui/Tools.h>
 #include <Mod/TechDraw/App/ArrowPropEnum.h>
 #include <Mod/TechDraw/App/DrawPage.h>
+#include <Mod/TechDraw/App/DrawUtil.h>
 #include <Mod/TechDraw/App/DrawViewBalloon.h>
 #include <Mod/TechDraw/App/DrawViewPart.h>
-#include <Mod/TechDraw/App/DrawUtil.h>
 #include <Mod/TechDraw/App/Geometry.h>
 
-#include "QGIViewBalloon.h"
 #include "PreferencesGui.h"
 #include "QGIArrow.h"
 #include "QGIDimLines.h"
+#include "QGIViewBalloon.h"
 #include "Rez.h"
 #include "ViewProviderBalloon.h"
 #include "ViewProviderViewPart.h"
@@ -82,18 +82,20 @@ QGIBalloonLabel::QGIBalloonLabel()
     parent = nullptr;
 }
 
-QVariant QGIBalloonLabel::itemChange(GraphicsItemChange change, const QVariant &value)
+QVariant QGIBalloonLabel::itemChange(GraphicsItemChange change, const QVariant& value)
 {
     if (change == ItemSelectedHasChanged && scene()) {
-        if(isSelected()) {
+        if (isSelected()) {
             Q_EMIT selected(true);
             setPrettySel();
-        } else {
+        }
+        else {
             Q_EMIT selected(false);
             setPrettyNormal();
         }
         update();
-    } else if(change == ItemPositionHasChanged && scene()) {
+    }
+    else if (change == ItemPositionHasChanged && scene()) {
         setLabelCenter();
         if (m_drag) {
             Q_EMIT dragging(m_ctrl);
@@ -103,20 +105,19 @@ QVariant QGIBalloonLabel::itemChange(GraphicsItemChange change, const QVariant &
     return QGraphicsItem::itemChange(change, value);
 }
 
-void QGIBalloonLabel::mousePressEvent(QGraphicsSceneMouseEvent * event)
+void QGIBalloonLabel::mousePressEvent(QGraphicsSceneMouseEvent* event)
 {
     m_ctrl = false;
     m_drag = true;
-    if(event->modifiers() & Qt::ControlModifier) {
+    if (event->modifiers() & Qt::ControlModifier) {
         m_ctrl = true;
     }
     QGraphicsItem::mousePressEvent(event);
 }
 
-void QGIBalloonLabel::mouseReleaseEvent(QGraphicsSceneMouseEvent * event)
+void QGIBalloonLabel::mouseReleaseEvent(QGraphicsSceneMouseEvent* event)
 {
-    if (QLineF(event->screenPos(), event->buttonDownScreenPos(Qt::LeftButton))
-        .length() > 0) {
+    if (QLineF(event->screenPos(), event->buttonDownScreenPos(Qt::LeftButton)).length() > 0) {
         if (scene() && this == scene()->mouseGrabberItem()) {
             Q_EMIT dragFinished();
         }
@@ -126,7 +127,7 @@ void QGIBalloonLabel::mouseReleaseEvent(QGraphicsSceneMouseEvent * event)
     QGraphicsItem::mouseReleaseEvent(event);
 }
 
-void QGIBalloonLabel::mouseDoubleClickEvent(QGraphicsSceneMouseEvent * event)
+void QGIBalloonLabel::mouseDoubleClickEvent(QGraphicsSceneMouseEvent* event)
 {
     QGIViewBalloon* qgivBalloon = dynamic_cast<QGIViewBalloon*>(parentItem());
     if (!qgivBalloon) {
@@ -134,7 +135,8 @@ void QGIBalloonLabel::mouseDoubleClickEvent(QGraphicsSceneMouseEvent * event)
         return;
     }
 
-    auto ViewProvider = dynamic_cast<ViewProviderBalloon*>(qgivBalloon->getViewProvider(qgivBalloon->getViewObject()));
+    auto ViewProvider = dynamic_cast<ViewProviderBalloon*>(
+        qgivBalloon->getViewProvider(qgivBalloon->getViewObject()));
     if (!ViewProvider) {
         qWarning() << "QGIBalloonLabel::mouseDoubleClickEvent: No valid view provider";
         return;
@@ -144,21 +146,22 @@ void QGIBalloonLabel::mouseDoubleClickEvent(QGraphicsSceneMouseEvent * event)
     QGraphicsItem::mouseDoubleClickEvent(event);
 }
 
-void QGIBalloonLabel::hoverEnterEvent(QGraphicsSceneHoverEvent *event)
+void QGIBalloonLabel::hoverEnterEvent(QGraphicsSceneHoverEvent* event)
 {
     Q_EMIT hover(true);
     hasHover = true;
     if (!isSelected()) {
         setPrettyPre();
-    } else {
+    }
+    else {
         setPrettySel();
     }
     QGraphicsItem::hoverEnterEvent(event);
 }
 
-void QGIBalloonLabel::hoverLeaveEvent(QGraphicsSceneHoverEvent *event)
+void QGIBalloonLabel::hoverLeaveEvent(QGraphicsSceneHoverEvent* event)
 {
-    QGIView *view = dynamic_cast<QGIView *> (parentItem());
+    QGIView* view = dynamic_cast<QGIView*>(parentItem());
     assert(view);
     Q_UNUSED(view);
 
@@ -166,7 +169,8 @@ void QGIBalloonLabel::hoverLeaveEvent(QGraphicsSceneHoverEvent *event)
     hasHover = false;
     if (!isSelected()) {
         setPrettyNormal();
-    } else {
+    }
+    else {
         setPrettySel();
     }
     QGraphicsItem::hoverLeaveEvent(event);
@@ -177,7 +181,8 @@ QRectF QGIBalloonLabel::boundingRect() const
     return childrenBoundingRect();
 }
 
-void QGIBalloonLabel::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget)
+void QGIBalloonLabel::paint(QPainter* painter, const QStyleOptionGraphicsItem* option,
+                            QWidget* widget)
 {
     Q_UNUSED(widget);
     Q_UNUSED(painter);
@@ -187,10 +192,11 @@ void QGIBalloonLabel::paint(QPainter *painter, const QStyleOptionGraphicsItem *o
     //QGraphicsObject/QGraphicsItem::paint gives link error.
 }
 
-void QGIBalloonLabel::setPosFromCenter(const double &xCenter, const double &yCenter)
+void QGIBalloonLabel::setPosFromCenter(const double& xCenter, const double& yCenter)
 {
     //set label's Qt position(top, left) given boundingRect center point
-    setPos(xCenter - m_labelText->boundingRect().width() / 2., yCenter - m_labelText->boundingRect().height() / 2.);
+    setPos(xCenter - m_labelText->boundingRect().width() / 2.,
+           yCenter - m_labelText->boundingRect().height() / 2.);
 }
 
 void QGIBalloonLabel::setLabelCenter()
@@ -240,13 +246,13 @@ void QGIBalloonLabel::setColor(QColor color)
 }
 
 //**************************************************************
-QGIViewBalloon::QGIViewBalloon() :
-    dvBalloon(nullptr),
-    hasHover(false),
-    m_lineWidth(0.0),
-    m_obtuse(false),
-    parent(nullptr),
-    m_dragInProgress(false)
+QGIViewBalloon::QGIViewBalloon()
+    : dvBalloon(nullptr),
+      hasHover(false),
+      m_lineWidth(0.0),
+      m_obtuse(false),
+      parent(nullptr),
+      m_dragInProgress(false)
 {
     m_ctrl = false;
 
@@ -269,7 +275,7 @@ QGIViewBalloon::QGIViewBalloon() :
     balloonShape = new QGIDimLines();
     addToGroup(balloonShape);
     balloonShape->setNormalColor(prefNormalColor());
-    balloonShape->setFill(Qt::white, Qt::SolidPattern);
+    balloonShape->setFill(Qt::transparent, Qt::SolidPattern);
     balloonShape->setFillOverride(true);
     balloonShape->setPrettyNormal();
 
@@ -286,37 +292,30 @@ QGIViewBalloon::QGIViewBalloon() :
     balloonLines->setZValue(ZVALUE::DIMENSION);
     balloonLines->setStyle(Qt::SolidLine);
 
-    balloonShape->setZValue(ZVALUE::DIMENSION + 1);    //above balloonLines!
+    balloonShape->setZValue(ZVALUE::DIMENSION + 1);//above balloonLines!
     balloonShape->setStyle(Qt::SolidLine);
 
     balloonLabel->setPosFromCenter(0, 0);
 
     // connecting the needed slots and signals
-    QObject::connect(
-        balloonLabel, SIGNAL(dragging(bool)),
-        this  , SLOT  (balloonLabelDragged(bool)));
+    QObject::connect(balloonLabel, SIGNAL(dragging(bool)), this, SLOT(balloonLabelDragged(bool)));
 
-    QObject::connect(
-        balloonLabel, SIGNAL(dragFinished()),
-        this  , SLOT  (balloonLabelDragFinished()));
+    QObject::connect(balloonLabel, SIGNAL(dragFinished()), this, SLOT(balloonLabelDragFinished()));
 
-    QObject::connect(
-        balloonLabel, SIGNAL(selected(bool)),
-        this  , SLOT  (select(bool)));
+    QObject::connect(balloonLabel, SIGNAL(selected(bool)), this, SLOT(select(bool)));
 
-    QObject::connect(
-        balloonLabel, SIGNAL(hover(bool)),
-        this  , SLOT  (hover(bool)));
+    QObject::connect(balloonLabel, SIGNAL(hover(bool)), this, SLOT(hover(bool)));
 
     setZValue(ZVALUE::DIMENSION);
 }
 
-QVariant QGIViewBalloon::itemChange(GraphicsItemChange change, const QVariant &value)
+QVariant QGIViewBalloon::itemChange(GraphicsItemChange change, const QVariant& value)
 {
-   if (change == ItemSelectedHasChanged && scene()) {
-        if(isSelected()) {
+    if (change == ItemSelectedHasChanged && scene()) {
+        if (isSelected()) {
             balloonLabel->setSelected(true);
-        } else {
+        }
+        else {
             balloonLabel->setSelected(false);
         }
         draw();
@@ -327,7 +326,7 @@ QVariant QGIViewBalloon::itemChange(GraphicsItemChange change, const QVariant &v
 //Set selection state for this and it's children
 void QGIViewBalloon::setGroupSelection(bool isSelected)
 {
-//    Base::Console().Message("QGIVB::setGroupSelection(%d)\n", b);
+    //    Base::Console().Message("QGIVB::setGroupSelection(%d)\n", b);
     setSelected(isSelected);
     balloonLabel->setSelected(isSelected);
     balloonLines->setSelected(isSelected);
@@ -336,7 +335,7 @@ void QGIViewBalloon::setGroupSelection(bool isSelected)
 
 void QGIViewBalloon::select(bool state)
 {
-//    Base::Console().Message("QGIVBall::select(%d)\n", state);
+    //    Base::Console().Message("QGIVBall::select(%d)\n", state);
     setSelected(state);
     draw();
 }
@@ -347,13 +346,14 @@ void QGIViewBalloon::hover(bool state)
     draw();
 }
 
-void QGIViewBalloon::setViewPartFeature(TechDraw::DrawViewBalloon *balloonFeat)
+void QGIViewBalloon::setViewPartFeature(TechDraw::DrawViewBalloon* balloonFeat)
 {
-//    Base::Console().Message("QGIVB::setViewPartFeature()\n");
-    if (!balloonFeat)
+    //    Base::Console().Message("QGIVB::setViewPartFeature()\n");
+    if (!balloonFeat) {
         return;
+    }
 
-    setViewFeature(static_cast<TechDraw::DrawView *>(balloonFeat));
+    setViewFeature(static_cast<TechDraw::DrawView*>(balloonFeat));
     dvBalloon = balloonFeat;
 
     DrawView* balloonParent = nullptr;
@@ -361,11 +361,12 @@ void QGIViewBalloon::setViewPartFeature(TechDraw::DrawViewBalloon *balloonFeat)
     App::DocumentObject* docObj = balloonFeat->SourceView.getValue();
     if (docObj) {
         balloonParent = dynamic_cast<DrawView*>(docObj);
-        if (balloonParent)
+        if (balloonParent) {
             scale = balloonParent->getScale();
+        }
     }
 
-    float x = Rez::guiX(balloonFeat->X.getValue() * scale) ;
+    float x = Rez::guiX(balloonFeat->X.getValue() * scale);
     float y = Rez::guiX(-balloonFeat->Y.getValue() * scale);
 
     balloonLabel->setColor(prefNormalColor());
@@ -381,25 +382,22 @@ void QGIViewBalloon::setViewPartFeature(TechDraw::DrawViewBalloon *balloonFeat)
 
 void QGIViewBalloon::updateView(bool update)
 {
-//    Base::Console().Message("QGIVB::updateView()\n");
+    //    Base::Console().Message("QGIVB::updateView()\n");
     Q_UNUSED(update);
-    auto balloon( dynamic_cast<TechDraw::DrawViewBalloon*>(getViewObject()) );
-    if (!balloon)
+    auto balloon(dynamic_cast<TechDraw::DrawViewBalloon*>(getViewObject()));
+    if (!balloon) {
         return;
+    }
 
     auto vp = static_cast<ViewProviderBalloon*>(getViewProvider(getViewObject()));
-    if (!vp)
+    if (!vp) {
         return;
+    }
 
     if (update) {
         QString labelText = QString::fromUtf8(balloon->Text.getStrValue().data());
         balloonLabel->setDimString(labelText, Rez::guiX(balloon->TextWrapLen.getValue()));
-        balloonLabel->setColor(getNormalColor());
-        balloonLines->setNormalColor(getNormalColor());
-        balloonShape->setNormalColor(getNormalColor());
-        arrow->setNormalColor(getNormalColor());
-        arrow->setFillColor(getNormalColor());
-
+        setNormalColorAll();
     }
 
     updateBalloon();
@@ -409,9 +407,9 @@ void QGIViewBalloon::updateView(bool update)
 //update the bubble contents
 void QGIViewBalloon::updateBalloon(bool obtuse)
 {
-//    Base::Console().Message("QGIVB::updateBalloon()\n");
-    (void) obtuse;
-    const auto balloon( dynamic_cast<TechDraw::DrawViewBalloon *>(getViewObject()) );
+    //    Base::Console().Message("QGIVB::updateBalloon()\n");
+    (void)obtuse;
+    const auto balloon(dynamic_cast<TechDraw::DrawViewBalloon*>(getViewObject()));
     if (!balloon) {
         return;
     }
@@ -419,15 +417,14 @@ void QGIViewBalloon::updateBalloon(bool obtuse)
     if (!vp) {
         return;
     }
-    const TechDraw::DrawViewPart *refObj = balloon->getViewPart();
+    const TechDraw::DrawViewPart* refObj = balloon->getViewPart();
     if (!refObj) {
         return;
     }
 
     QFont font;
     font.setFamily(QString::fromUtf8(vp->Font.getValue()));
-    font.setPixelSize(exactFontSize(vp->Font.getValue(),
-                                    vp->Fontsize.getValue()));
+    font.setPixelSize(exactFontSize(vp->Font.getValue(), vp->Fontsize.getValue()));
     balloonLabel->setFont(font);
 
     QString labelText = QString::fromUtf8(balloon->Text.getStrValue().data());
@@ -455,27 +452,30 @@ void QGIViewBalloon::updateBalloon(bool obtuse)
 void QGIViewBalloon::balloonLabelDragged(bool ctrl)
 {
     m_ctrl = ctrl;
-    auto dvb( dynamic_cast<TechDraw::DrawViewBalloon *>(getViewObject()) );
-    if (!dvb)
+    auto dvb(dynamic_cast<TechDraw::DrawViewBalloon*>(getViewObject()));
+    if (!dvb) {
         return;
+    }
 
-    if (!m_dragInProgress) {           //first drag movement
+    if (!m_dragInProgress) {//first drag movement
         m_dragInProgress = true;
-        if (ctrl) {             //moving whole thing, remember Origin offset from Bubble
+        if (ctrl) {//moving whole thing, remember Origin offset from Bubble
             m_saveOffset = dvb->getOriginOffset();
         }
     }
 
     // store if origin is also moving to be able to later calc new origin and update feature
-    if (ctrl)
+    if (ctrl) {
         m_originDragged = true;
+    }
 
     DrawView* balloonParent = getSourceView();
-    if (balloonParent)
+    if (balloonParent) {
         // redraw the balloon at the new position
         // note that we don't store the new position to the X/Y properties
         // since the dragging is not yet finished
         drawBalloon(true);
+    }
 }
 
 void QGIViewBalloon::balloonLabelDragFinished()
@@ -483,29 +483,36 @@ void QGIViewBalloon::balloonLabelDragFinished()
     // stores the final drag position for undo
 
     auto dvb(dynamic_cast<TechDraw::DrawViewBalloon*>(getViewObject()));
-    if (!dvb)
+    if (!dvb) {
         return;
+    }
 
     double scale = 1.0;
     DrawView* balloonParent = getSourceView();
-    if (balloonParent)
+    if (balloonParent) {
         scale = balloonParent->getScale();
+    }
 
     //set feature position (x, y) from graphic position
-    double x = Rez::appX(balloonLabel->X() / scale),
-           y = Rez::appX(balloonLabel->Y() / scale);
+    double x = Rez::appX(balloonLabel->X() / scale), y = Rez::appX(balloonLabel->Y() / scale);
     Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Drag Balloon"));
-    Gui::Command::doCommand(Gui::Command::Doc, "App.ActiveDocument.%s.X = %f", dvb->getNameInDocument(), x);
-    Gui::Command::doCommand(Gui::Command::Doc, "App.ActiveDocument.%s.Y = %f", dvb->getNameInDocument(), -y);
+    Gui::Command::doCommand(
+        Gui::Command::Doc, "App.ActiveDocument.%s.X = %f", dvb->getNameInDocument(), x);
+    Gui::Command::doCommand(
+        Gui::Command::Doc, "App.ActiveDocument.%s.Y = %f", dvb->getNameInDocument(), -y);
 
     // for the case that origin was also dragged, calc new origin and update feature
     if (m_originDragged) {
         Base::Vector3d pos(x, -y, 0.0);
         Base::Vector3d newOrg = pos - m_saveOffset;
-        Gui::Command::doCommand(Gui::Command::Doc, "App.ActiveDocument.%s.OriginX = %f",
-                                dvb->getNameInDocument(), newOrg.x);
-        Gui::Command::doCommand(Gui::Command::Doc, "App.ActiveDocument.%s.OriginY = %f",
-                                dvb->getNameInDocument(), newOrg.y);
+        Gui::Command::doCommand(Gui::Command::Doc,
+                                "App.ActiveDocument.%s.OriginX = %f",
+                                dvb->getNameInDocument(),
+                                newOrg.x);
+        Gui::Command::doCommand(Gui::Command::Doc,
+                                "App.ActiveDocument.%s.OriginY = %f",
+                                dvb->getNameInDocument(),
+                                newOrg.y);
     }
 
     Gui::Command::commitCommand();
@@ -517,9 +524,9 @@ void QGIViewBalloon::balloonLabelDragFinished()
 //from QGVP::mouseReleaseEvent - pos = eventPos in scene coords?
 void QGIViewBalloon::placeBalloon(QPointF pos)
 {
-//    Base::Console().Message("QGIVB::placeBalloon(%s)\n",
-//                            DrawUtil::formatVector(pos).c_str());
-    auto balloon( dynamic_cast<TechDraw::DrawViewBalloon*>(getViewObject()) );
+    //    Base::Console().Message("QGIVB::placeBalloon(%s)\n",
+    //                            DrawUtil::formatVector(pos).c_str());
+    auto balloon(dynamic_cast<TechDraw::DrawViewBalloon*>(getViewObject()));
     if (!balloon) {
         return;
     }
@@ -546,13 +553,13 @@ void QGIViewBalloon::placeBalloon(QPointF pos)
     if (partVP) {
         qgivParent = partVP->getQView();
         if (qgivParent) {
-        //tip position is mouse release pos in parentView coords ==> OriginX, OriginY
-        //bubble pos is some arbitrary shift from tip position ==> X, Y
+            //tip position is mouse release pos in parentView coords ==> OriginX, OriginY
+            //bubble pos is some arbitrary shift from tip position ==> X, Y
             viewPos = qgivParent->mapFromScene(pos);
             balloon->OriginX.setValue(Rez::appX(viewPos.x()) / balloonParent->getScale());
             balloon->OriginY.setValue(-Rez::appX(viewPos.y()) / balloonParent->getScale());
-            balloon->X.setValue(Rez::appX((viewPos.x() +  200.0) / balloonParent->getScale() ));
-            balloon->Y.setValue(- Rez::appX((viewPos.y() - 200.0) / balloonParent->getScale() ));
+            balloon->X.setValue(Rez::appX((viewPos.x() + 200.0) / balloonParent->getScale()));
+            balloon->Y.setValue(-Rez::appX((viewPos.y() - 200.0) / balloonParent->getScale()));
         }
     }
 
@@ -563,8 +570,7 @@ void QGIViewBalloon::placeBalloon(QPointF pos)
     QFont font = balloonLabel->getFont();
     font.setPixelSize(calculateFontPixelSize(vp->Fontsize.getValue()));
     font.setFamily(QString::fromUtf8(vp->Font.getValue()));
-    font.setPixelSize(exactFontSize(vp->Font.getValue(),
-                                    vp->Fontsize.getValue()));
+    font.setPixelSize(exactFontSize(vp->Font.getValue(), vp->Fontsize.getValue()));
     balloonLabel->setFont(font);
 
     prepareGeometryChange();
@@ -584,14 +590,14 @@ void QGIViewBalloon::draw()
 
 void QGIViewBalloon::drawBalloon(bool dragged)
 {
-//    Base::Console().Message("QGIVB::draw()\n");
+    //    Base::Console().Message("QGIVB::draw()\n");
     if (!isVisible()) {
         return;
     }
 
-    TechDraw::DrawViewBalloon *balloon = dynamic_cast<TechDraw::DrawViewBalloon *>(getViewObject());
-    if((!balloon) ||                                                       //nothing to draw, don't try
-       (!balloon->isDerivedFrom(TechDraw::DrawViewBalloon::getClassTypeId()))) {
+    TechDraw::DrawViewBalloon* balloon = dynamic_cast<TechDraw::DrawViewBalloon*>(getViewObject());
+    if ((!balloon) ||//nothing to draw, don't try
+        (!balloon->isDerivedFrom(TechDraw::DrawViewBalloon::getClassTypeId()))) {
         balloonLabel->hide();
         hide();
         return;
@@ -600,11 +606,11 @@ void QGIViewBalloon::drawBalloon(bool dragged)
     balloonLabel->show();
     show();
 
-    const TechDraw::DrawViewPart *refObj = balloon->getViewPart();
+    const TechDraw::DrawViewPart* refObj = balloon->getViewPart();
     if (!refObj) {
         return;
     }
-    if(!refObj->hasGeometry()) { // nothing to draw yet (restoring)
+    if (!refObj->hasGeometry()) {// nothing to draw yet (restoring)
         balloonLabel->hide();
         hide();
         return;
@@ -646,110 +652,143 @@ void QGIViewBalloon::drawBalloon(bool dragged)
 
     if (balloon->isLocked()) {
         balloonLabel->setFlag(QGraphicsItem::ItemIsMovable, false);
-    } else
+    }
+    else {
         balloonLabel->setFlag(QGraphicsItem::ItemIsMovable, true);
+    }
 
     Base::Vector3d dLineStart;
     Base::Vector3d kinkPoint;
     double kinkLength = Rez::guiX(balloon->KinkLength.getValue());
 
-    const char *balloonType = balloon->BubbleShape.getValueAsString();
+    const char* balloonType = balloon->BubbleShape.getValueAsString();
 
     float scale = balloon->ShapeScale.getValue();
-    double offsetLR     = 0;
-    double offsetUD     = 0;
+    double offsetLR = 0;
+    double offsetUD = 0;
     QPainterPath balloonPath;
 
     if (strcmp(balloonType, "Circular") == 0) {
         double balloonRadius = sqrt(pow((textHeight / 2.0), 2) + pow((textWidth / 2.0), 2));
         balloonRadius = balloonRadius * scale;
         balloonPath.moveTo(lblCenter.x, lblCenter.y);
-        balloonPath.addEllipse(lblCenter.x - balloonRadius, lblCenter.y - balloonRadius, balloonRadius * 2, balloonRadius * 2);
-        offsetLR     = balloonRadius;
-    } else if (strcmp(balloonType, "None") == 0) {
+        balloonPath.addEllipse(lblCenter.x - balloonRadius,
+                               lblCenter.y - balloonRadius,
+                               balloonRadius * 2,
+                               balloonRadius * 2);
+        offsetLR = balloonRadius;
+    }
+    else if (strcmp(balloonType, "None") == 0) {
         balloonPath = QPainterPath();
-        offsetLR     = (textWidth / 2.0) + Rez::guiX(2.0);
-    } else if (strcmp(balloonType, "Rectangle") == 0) {
+        offsetLR = (textWidth / 2.0) + Rez::guiX(2.0);
+    }
+    else if (strcmp(balloonType, "Rectangle") == 0) {
         //Add some room
         textHeight = (textHeight * scale) + Rez::guiX(1.0);
         // we add some textWidth later because we first need to handle the text separators
         if (balloonLabel->getVerticalSep()) {
             for (auto& sep : balloonLabel->getSeps()) {
-                balloonPath.moveTo(lblCenter.x - (textWidth / 2.0) + sep, lblCenter.y - (textHeight / 2.0));
-                balloonPath.lineTo(lblCenter.x - (textWidth / 2.0) + sep, lblCenter.y + (textHeight / 2.0));
+                balloonPath.moveTo(lblCenter.x - (textWidth / 2.0) + sep,
+                                   lblCenter.y - (textHeight / 2.0));
+                balloonPath.lineTo(lblCenter.x - (textWidth / 2.0) + sep,
+                                   lblCenter.y + (textHeight / 2.0));
             }
         }
         textWidth = (textWidth * scale) + Rez::guiX(2.0);
-        balloonPath.addRect(lblCenter.x - (textWidth / 2.0), lblCenter.y - (textHeight / 2.0), textWidth, textHeight);
-        offsetLR     = (textWidth / 2.0);
-    } else if (strcmp(balloonType, "Triangle") == 0) {
+        balloonPath.addRect(lblCenter.x - (textWidth / 2.0),
+                            lblCenter.y - (textHeight / 2.0),
+                            textWidth,
+                            textHeight);
+        offsetLR = (textWidth / 2.0);
+    }
+    else if (strcmp(balloonType, "Triangle") == 0) {
         double radius = sqrt(pow((textHeight / 2.0), 2) + pow((textWidth / 2.0), 2));
         radius = radius * scale;
         radius += Rez::guiX(3.0);
-        offsetLR     = (tan(30 * M_PI / 180) * radius);
+        offsetLR = (tan(30 * M_PI / 180) * radius);
         QPolygonF triangle;
         double startAngle = -M_PI / 2;
         double angle = startAngle;
         for (int i = 0; i < 4; i++) {
-            triangle += QPointF(lblCenter.x + (radius * cos(angle)), lblCenter.y + (radius * sin(angle)));
+            triangle +=
+                QPointF(lblCenter.x + (radius * cos(angle)), lblCenter.y + (radius * sin(angle)));
             angle += (2 * M_PI / 3);
         }
-        balloonPath.moveTo(lblCenter.x + (radius * cos(startAngle)), lblCenter.y + (radius * sin(startAngle)));
+        balloonPath.moveTo(lblCenter.x + (radius * cos(startAngle)),
+                           lblCenter.y + (radius * sin(startAngle)));
         balloonPath.addPolygon(triangle);
-    } else if (strcmp(balloonType, "Inspection") == 0) {
+    }
+    else if (strcmp(balloonType, "Inspection") == 0) {
         //Add some room
         textWidth = (textWidth * scale) + Rez::guiX(2.0);
         textHeight = (textHeight * scale) + Rez::guiX(1.0);
         QPointF textBoxCorner(lblCenter.x - (textWidth / 2.0), lblCenter.y - (textHeight / 2.0));
         balloonPath.moveTo(textBoxCorner);
         balloonPath.lineTo(textBoxCorner.x() + textWidth, textBoxCorner.y());
-        balloonPath.arcTo(textBoxCorner.x() + textWidth - (textHeight / 2.0), textBoxCorner.y(), textHeight, textHeight, 90, -180);
+        balloonPath.arcTo(textBoxCorner.x() + textWidth - (textHeight / 2.0),
+                          textBoxCorner.y(),
+                          textHeight,
+                          textHeight,
+                          90,
+                          -180);
         balloonPath.lineTo(textBoxCorner.x(), textBoxCorner.y() + textHeight);
-        balloonPath.arcTo(textBoxCorner.x() - (textHeight / 2), textBoxCorner.y(), textHeight, textHeight, -90, -180);
-        offsetLR     = (textWidth / 2.0) + (textHeight / 2.0);
-    } else if (strcmp(balloonType, "Square") == 0) {
+        balloonPath.arcTo(textBoxCorner.x() - (textHeight / 2),
+                          textBoxCorner.y(),
+                          textHeight,
+                          textHeight,
+                          -90,
+                          -180);
+        offsetLR = (textWidth / 2.0) + (textHeight / 2.0);
+    }
+    else if (strcmp(balloonType, "Square") == 0) {
         //Add some room
         textWidth = (textWidth * scale) + Rez::guiX(2.0);
         textHeight = (textHeight * scale) + Rez::guiX(1.0);
         double max = std::max(textWidth, textHeight);
-        balloonPath.addRect(lblCenter.x -(max / 2.0), lblCenter.y - (max / 2.0), max, max);
-        offsetLR     = (max / 2.0);
-    } else if (strcmp(balloonType, "Hexagon") == 0) {
+        balloonPath.addRect(lblCenter.x - (max / 2.0), lblCenter.y - (max / 2.0), max, max);
+        offsetLR = (max / 2.0);
+    }
+    else if (strcmp(balloonType, "Hexagon") == 0) {
         double radius = sqrt(pow((textHeight / 2.0), 2) + pow((textWidth / 2.0), 2));
         radius = radius * scale;
         radius += Rez::guiX(1.0);
-        offsetLR     = radius;
+        offsetLR = radius;
         QPolygonF triangle;
         double startAngle = -2 * M_PI / 3;
         double angle = startAngle;
         for (int i = 0; i < 7; i++) {
-            triangle += QPointF(lblCenter.x + (radius * cos(angle)), lblCenter.y + (radius * sin(angle)));
+            triangle +=
+                QPointF(lblCenter.x + (radius * cos(angle)), lblCenter.y + (radius * sin(angle)));
             angle += (2 * M_PI / 6);
         }
-        balloonPath.moveTo(lblCenter.x + (radius * cos(startAngle)), lblCenter.y + (radius * sin(startAngle)));
+        balloonPath.moveTo(lblCenter.x + (radius * cos(startAngle)),
+                           lblCenter.y + (radius * sin(startAngle)));
         balloonPath.addPolygon(triangle);
     }
     else if (strcmp(balloonType, "Line") == 0) {
-        textHeight = textHeight*scale + Rez::guiX(0.5);
-        textWidth = textWidth*scale + Rez::guiX(1.0);
+        textHeight = textHeight * scale + Rez::guiX(0.5);
+        textWidth = textWidth * scale + Rez::guiX(1.0);
 
-        offsetLR = textWidth/2.0;
-        offsetUD = textHeight/2.0;
+        offsetLR = textWidth / 2.0;
+        offsetUD = textHeight / 2.0;
 
-        balloonPath.moveTo(lblCenter.x - textWidth/2.0, lblCenter.y + offsetUD);
-        balloonPath.lineTo(lblCenter.x + textWidth/2.0, lblCenter.y + offsetUD);
+        balloonPath.moveTo(lblCenter.x - textWidth / 2.0, lblCenter.y + offsetUD);
+        balloonPath.lineTo(lblCenter.x + textWidth / 2.0, lblCenter.y + offsetUD);
     }
 
     balloonShape->setPath(balloonPath);
 
-    offsetLR     = (lblCenter.x < arrowTipX) ? offsetLR     : -offsetLR    ;
+    offsetLR = (lblCenter.x < arrowTipX) ? offsetLR : -offsetLR;
 
-    if (DrawUtil::fpCompare(kinkLength, 0.0) && strcmp(balloonType, "Line")) {   //if no kink, then dLine start sb on line from center to arrow
+    if (DrawUtil::fpCompare(kinkLength, 0.0)
+        && strcmp(balloonType,
+                  "Line")) {//if no kink, then dLine start sb on line from center to arrow
         dLineStart = lblCenter;
         kinkPoint = dLineStart;
-    } else {
+    }
+    else {
         dLineStart.y = lblCenter.y + offsetUD;
-        dLineStart.x = lblCenter.x + offsetLR    ;
+        dLineStart.x = lblCenter.x + offsetLR;
         kinkLength = (lblCenter.x < arrowTipX) ? kinkLength : -kinkLength;
         kinkPoint.y = dLineStart.y;
         kinkPoint.x = dLineStart.x + kinkLength;
@@ -762,41 +801,45 @@ void QGIViewBalloon::drawBalloon(bool dragged)
     double xAdj = 0.0;
     double yAdj = 0.0;
     int endType = balloon->EndType.getValue();
-    double arrowAdj = QGIArrow::getOverlapAdjust(endType,
-                                                 balloon->EndTypeScale.getValue()*QGIArrow::getPrefArrowSize());
+    double arrowAdj = QGIArrow::getOverlapAdjust(
+        endType, balloon->EndTypeScale.getValue() * QGIArrow::getPrefArrowSize());
 
     if (endType == ArrowType::NONE) {
         arrow->hide();
-    } else {
+    }
+    else {
         arrow->setStyle(endType);
 
-        arrow->setSize(balloon->EndTypeScale.getValue()*QGIArrow::getPrefArrowSize());
+        arrow->setSize(balloon->EndTypeScale.getValue() * QGIArrow::getPrefArrowSize());
         arrow->draw();
 
         Base::Vector3d arrowTipPos(arrowTipX, arrowTipY, 0.0);
         Base::Vector3d dirballoonLinesLine;
         if (!DrawUtil::fpCompare(kinkLength, 0.0)) {
             dirballoonLinesLine = (arrowTipPos - kinkPoint).Normalize();
-        } else {
+        }
+        else {
             dirballoonLinesLine = (arrowTipPos - dLineStart).Normalize();
         }
 
         float arAngle = atan2(dirballoonLinesLine.y, dirballoonLinesLine.x) * 180 / M_PI;
 
         arrow->setPos(arrowTipX, arrowTipY);
-        if ( (endType == ArrowType::FILLED_TRIANGLE) &&
-             (prefOrthoPyramid()) ) {
+        if ((endType == ArrowType::FILLED_TRIANGLE) && (prefOrthoPyramid())) {
             if (arAngle < 0.0) {
                 arAngle += 360.0;
             }
             //set the angle to closest cardinal direction
-            if ( (45.0 < arAngle) && (arAngle < 135.0) ) {
+            if ((45.0 < arAngle) && (arAngle < 135.0)) {
                 arAngle = 90.0;
-            } else if ( (135.0 < arAngle) && (arAngle < 225.0) ) {
+            }
+            else if ((135.0 < arAngle) && (arAngle < 225.0)) {
                 arAngle = 180.0;
-            } else if ( (225.0 < arAngle) && (arAngle < 315.0) ) {
+            }
+            else if ((225.0 < arAngle) && (arAngle < 315.0)) {
                 arAngle = 270.0;
-            } else {
+            }
+            else {
                 arAngle = 0;
             }
             double radAngle = arAngle * M_PI / 180.0;
@@ -820,15 +863,18 @@ void QGIViewBalloon::drawBalloon(bool dragged)
     // redraw the Balloon and the parent View
     if (hasHover && !isSelected()) {
         setPrettyPre();
-    } else if (isSelected()) {
+    }
+    else if (isSelected()) {
         setPrettySel();
-    } else {
+    }
+    else {
         setPrettyNormal();
     }
 
     if (parentItem()) {
         parentItem()->update();
-    } else {
+    }
+    else {
         Base::Console().Log("INFO - QGIVB::draw - no parent to update\n");
     }
 }
@@ -838,16 +884,16 @@ void QGIViewBalloon::setPrettyPre(void)
     arrow->setPrettyPre();
     //TODO: primPath needs override for fill
     //balloonShape->setFillOverride(true);   //don't fill with pre or select colours.
-//    balloonShape->setFill(Qt::white, Qt::NoBrush);
+    //    balloonShape->setFill(Qt::white, Qt::NoBrush);
     balloonShape->setPrettyPre();
     balloonLines->setPrettyPre();
 }
 
 void QGIViewBalloon::setPrettySel(void)
 {
-//    Base::Console().Message("QGIVBal::setPrettySel()\n");
+    //    Base::Console().Message("QGIVBal::setPrettySel()\n");
     arrow->setPrettySel();
-//    balloonShape->setFill(Qt::white, Qt::NoBrush);
+    //    balloonShape->setFill(Qt::white, Qt::NoBrush);
     balloonShape->setPrettySel();
     balloonLines->setPrettySel();
 }
@@ -855,7 +901,7 @@ void QGIViewBalloon::setPrettySel(void)
 void QGIViewBalloon::setPrettyNormal(void)
 {
     arrow->setPrettyNormal();
-//    balloonShape->setFill(Qt::white, Qt::SolidPattern);
+    //    balloonShape->setFill(Qt::white, Qt::SolidPattern);
     balloonShape->setPrettyNormal();
     balloonLines->setPrettyNormal();
 }
@@ -863,11 +909,13 @@ void QGIViewBalloon::setPrettyNormal(void)
 
 void QGIViewBalloon::drawBorder(void)
 {
-//Dimensions have no border!
-//    Base::Console().Message("TRACE - QGIViewDimension::drawBorder - doing nothing!\n");
+    //Dimensions have no border!
+    //    Base::Console().Message("TRACE - QGIViewDimension::drawBorder - doing nothing!\n");
 }
 
-void QGIViewBalloon::paint ( QPainter * painter, const QStyleOptionGraphicsItem * option, QWidget * widget) {
+void QGIViewBalloon::paint(QPainter* painter, const QStyleOptionGraphicsItem* option,
+                           QWidget* widget)
+{
     QStyleOptionGraphicsItem myOption(*option);
     myOption.state &= ~QStyle::State_Selected;
 
@@ -876,19 +924,20 @@ void QGIViewBalloon::paint ( QPainter * painter, const QStyleOptionGraphicsItem 
     setPens();
     if (svg) {
         setSvgPens();
-    } else {
+    }
+    else {
         setPens();
     }
-    QGIView::paint (painter, &myOption, widget);
+    QGIView::paint(painter, &myOption, widget);
     setPens();
 }
 
 void QGIViewBalloon::setSvgPens(void)
 {
-    double svgLineFactor = 3.0;                     //magic number.  should be a setting somewhere.
-    balloonLines->setWidth(m_lineWidth/svgLineFactor);
-    balloonShape->setWidth(m_lineWidth/svgLineFactor);
-    arrow->setWidth(arrow->getWidth()/svgLineFactor);
+    double svgLineFactor = 3.0;//magic number.  should be a setting somewhere.
+    balloonLines->setWidth(m_lineWidth / svgLineFactor);
+    balloonShape->setWidth(m_lineWidth / svgLineFactor);
+    arrow->setWidth(arrow->getWidth() / svgLineFactor);
 }
 
 void QGIViewBalloon::setPens(void)
@@ -898,16 +947,26 @@ void QGIViewBalloon::setPens(void)
     arrow->setWidth(m_lineWidth);
 }
 
+void QGIViewBalloon::setNormalColorAll()
+{
+    QColor qc = prefNormalColor();
+    balloonLabel->setColor(qc);
+    balloonLines->setNormalColor(qc);
+    balloonShape->setNormalColor(qc);
+    arrow->setNormalColor(qc);
+    arrow->setFillColor(qc);
+}
+
 QColor QGIViewBalloon::prefNormalColor()
 {
-    setNormalColor(PreferencesGui::dimQColor());
+    setNormalColor(PreferencesGui::getAccessibleQColor(PreferencesGui::dimQColor()));
 
     ViewProviderBalloon* vpBalloon = nullptr;
     Gui::ViewProvider* vp = getViewProvider(getBalloonFeat());
     if (vp) {
         vpBalloon = dynamic_cast<ViewProviderBalloon*>(vp);
         if (vpBalloon) {
-            App::Color fcColor = vpBalloon->Color.getValue();
+            App::Color fcColor = Preferences::getAccessibleColor(vpBalloon->Color.getValue());
             setNormalColor(fcColor.asValue<QColor>());
         }
     }
@@ -924,9 +983,11 @@ int QGIViewBalloon::prefDefaultArrow() const
 //when would you want a crooked pyramid?
 bool QGIViewBalloon::prefOrthoPyramid() const
 {
-    Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter()
-                                        .GetGroup("BaseApp")->GetGroup("Preferences")->
-                                        GetGroup("Mod/TechDraw/Decorations");
+    Base::Reference<ParameterGrp> hGrp = App::GetApplication()
+                                             .GetUserParameter()
+                                             .GetGroup("BaseApp")
+                                             ->GetGroup("Preferences")
+                                             ->GetGroup("Mod/TechDraw/Decorations");
     bool ortho = hGrp->GetBool("PyramidOrtho", true);
     return ortho;
 }

--- a/src/Mod/TechDraw/Gui/QGIViewBalloon.h
+++ b/src/Mod/TechDraw/Gui/QGIViewBalloon.h
@@ -38,15 +38,17 @@
 #include "QGIView.h"
 
 
-namespace TechDraw {
+namespace TechDraw
+{
 class DrawViewBalloon;
 class DrawView;
-}
+}// namespace TechDraw
 
-namespace TechDraw {
+namespace TechDraw
+{
 class BaseGeom;
 class AOC;
-}
+}// namespace TechDraw
 
 namespace TechDrawGui
 {
@@ -54,29 +56,43 @@ class QGIArrow;
 class QGIDimLines;
 class QGIViewBalloon;
 
-class QGIBalloonLabel : public QGraphicsObject
+class QGIBalloonLabel: public QGraphicsObject
 {
-Q_OBJECT
+    Q_OBJECT
 
 public:
     QGIBalloonLabel();
     ~QGIBalloonLabel() = default;
 
-    enum {Type = QGraphicsItem::UserType + 141};
-    int type() const override { return Type;}
+    enum
+    {
+        Type = QGraphicsItem::UserType + 141
+    };
+    int type() const override
+    {
+        return Type;
+    }
 
     QRectF boundingRect() const override;
-    void mouseReleaseEvent(QGraphicsSceneMouseEvent *event) override;
-    void paint( QPainter *painter,
-                        const QStyleOptionGraphicsItem *option,
-                        QWidget *widget = nullptr ) override;
+    void mouseReleaseEvent(QGraphicsSceneMouseEvent* event) override;
+    void paint(QPainter* painter, const QStyleOptionGraphicsItem* option,
+               QWidget* widget = nullptr) override;
     void setLabelCenter();
-    void setPosFromCenter(const double &xCenter, const double &yCenter);
-    double X() const { return posX; }
-    double Y() const { return posY; }              //minus posY?
+    void setPosFromCenter(const double& xCenter, const double& yCenter);
+    double X() const
+    {
+        return posX;
+    }
+    double Y() const
+    {
+        return posY;
+    }//minus posY?
 
     void setFont(QFont font);
-    QFont getFont() { return m_labelText->font(); }
+    QFont getFont()
+    {
+        return m_labelText->font();
+    }
     void setDimString(QString text);
     void setDimString(QString text, qreal maxWidth);
     void setPrettySel();
@@ -84,16 +100,37 @@ public:
     void setPrettyNormal();
     void setColor(QColor color);
 
-    void setQBalloon(QGIViewBalloon* qBalloon) { parent = qBalloon;}
+    void setQBalloon(QGIViewBalloon* qBalloon)
+    {
+        parent = qBalloon;
+    }
 
 
-    QGCustomText* getDimText() { return m_labelText; }
+    QGCustomText* getDimText()
+    {
+        return m_labelText;
+    }
 
-    void setDimText(QGCustomText* newText) { m_labelText = newText; }
-    bool getVerticalSep() const { return verticalSep; }
-    void setVerticalSep(bool sep) { verticalSep = sep; }
-    std::vector<int> getSeps() const { return seps; }
-    void setSeps(std::vector<int> newSeps) { seps = newSeps; }
+    void setDimText(QGCustomText* newText)
+    {
+        m_labelText = newText;
+    }
+    bool getVerticalSep() const
+    {
+        return verticalSep;
+    }
+    void setVerticalSep(bool sep)
+    {
+        verticalSep = sep;
+    }
+    std::vector<int> getSeps() const
+    {
+        return seps;
+    }
+    void setSeps(std::vector<int> newSeps)
+    {
+        seps = newSeps;
+    }
 
 Q_SIGNALS:
     void dragging(bool state);
@@ -102,16 +139,16 @@ Q_SIGNALS:
     void dragFinished();
 
 protected:
-    QVariant itemChange(GraphicsItemChange change, const QVariant &value) override;
-    void mousePressEvent(QGraphicsSceneMouseEvent *event) override;
-    void hoverEnterEvent(QGraphicsSceneHoverEvent *event) override;
-    void hoverLeaveEvent(QGraphicsSceneHoverEvent *event) override;
-    void mouseDoubleClickEvent(QGraphicsSceneMouseEvent *event) override;
+    QVariant itemChange(GraphicsItemChange change, const QVariant& value) override;
+    void mousePressEvent(QGraphicsSceneMouseEvent* event) override;
+    void hoverEnterEvent(QGraphicsSceneHoverEvent* event) override;
+    void hoverLeaveEvent(QGraphicsSceneHoverEvent* event) override;
+    void mouseDoubleClickEvent(QGraphicsSceneMouseEvent* event) override;
 
 private:
     bool hasHover;
 
-    QGIViewBalloon *parent;
+    QGIViewBalloon* parent;
     bool verticalSep;
     std::vector<int> seps;
 
@@ -126,24 +163,29 @@ private:
 
 //*******************************************************************
 
-class TechDrawGuiExport QGIViewBalloon : public QGIView
+class TechDrawGuiExport QGIViewBalloon: public QGIView
 {
     Q_OBJECT
 
 public:
-    enum {Type = QGraphicsItem::UserType + 140};
+    enum
+    {
+        Type = QGraphicsItem::UserType + 140
+    };
 
     explicit QGIViewBalloon();
     ~QGIViewBalloon() = default;
 
-    void setViewPartFeature(TechDraw::DrawViewBalloon *balloonFeat);
-    int type() const override { return Type;}
+    void setViewPartFeature(TechDraw::DrawViewBalloon* balloonFeat);
+    int type() const override
+    {
+        return Type;
+    }
 
     void drawBorder() override;
     void updateView(bool update = false) override;
-    void paint( QPainter * painter,
-                        const QStyleOptionGraphicsItem * option,
-                        QWidget * widget = nullptr ) override;
+    void paint(QPainter* painter, const QStyleOptionGraphicsItem* option,
+               QWidget* widget = nullptr) override;
 
     QString getLabelText();
     void placeBalloon(QPointF pos);
@@ -152,12 +194,20 @@ public:
     void setPrettyNormal();
 
     void setGroupSelection(bool isSelected) override;
-    virtual QGIBalloonLabel* getBalloonLabel() { return balloonLabel; }
+    virtual QGIBalloonLabel* getBalloonLabel()
+    {
+        return balloonLabel;
+    }
 
+    void setNormalColorAll();
     QColor prefNormalColor();
     int prefDefaultArrow() const;
     bool prefOrthoPyramid() const;
-    TechDraw::DrawViewBalloon* getBalloonFeat() { return dvBalloon; }
+
+    TechDraw::DrawViewBalloon* getBalloonFeat()
+    {
+        return dvBalloon;
+    }
 
 public Q_SLOTS:
     void balloonLabelDragged(bool ctrl);
@@ -169,16 +219,15 @@ public Q_SLOTS:
 protected:
     void draw() override;
     void drawBalloon(bool dragged = false);
-    QVariant itemChange( GraphicsItemChange change,
-                                 const QVariant &value ) override;
+    QVariant itemChange(GraphicsItemChange change, const QVariant& value) override;
     virtual void setSvgPens();
     virtual void setPens();
     QString getPrecision();
-    void parentViewMousePressed(QGIView *view, QPointF pos);
+    void parentViewMousePressed(QGIView* view, QPointF pos);
     TechDraw::DrawView* getSourceView() const;
 
 private:
-    TechDraw::DrawViewBalloon *dvBalloon;
+    TechDraw::DrawViewBalloon* dvBalloon;
     bool hasHover;
     QGIBalloonLabel* balloonLabel;
     QGIDimLines* balloonLines;
@@ -186,7 +235,7 @@ private:
     QGIArrow* arrow;
     double m_lineWidth;
     bool m_obtuse;
-    QGIView *parent;           //used to create edit dialog
+    QGIView* parent;//used to create edit dialog
 
     bool m_dragInProgress;
     bool m_originDragged = false;
@@ -194,6 +243,6 @@ private:
     Base::Vector3d m_saveOffset;
 };
 
-} // namespace
+}// namespace TechDrawGui
 
-#endif // TECHDRAWGUI_QGIVBALLOON_H
+#endif// TECHDRAWGUI_QGIVBALLOON_H

--- a/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
@@ -23,18 +23,18 @@
 #include "PreCompiled.h"
 
 #ifdef FC_OS_WIN32
-# define _USE_MATH_DEFINES            //re Windows & M_PI issues
+#define _USE_MATH_DEFINES//re Windows & M_PI issues
 #endif
 
 #ifndef _PreComp_
-# include <cmath>
+#include <cmath>
 
-# include <QGraphicsScene>
-# include <QGraphicsSceneMouseEvent>
-# include <QPaintDevice>
-# include <QPainter>
-# include <QPainterPath>
-# include <QSvgGenerator>
+#include <QGraphicsScene>
+#include <QGraphicsSceneMouseEvent>
+#include <QPaintDevice>
+#include <QPainter>
+#include <QPainterPath>
+#include <QSvgGenerator>
 #endif
 
 #include <App/Application.h>
@@ -49,11 +49,11 @@
 #include <Mod/TechDraw/App/DrawViewPart.h>
 #include <Mod/TechDraw/App/Geometry.h>
 
-#include "QGIViewDimension.h"
 #include "PreferencesGui.h"
 #include "QGIArrow.h"
 #include "QGIDimLines.h"
 #include "QGIVertex.h"
+#include "QGIViewDimension.h"
 #include "ViewProviderDimension.h"
 #include "ZVALUE.h"
 
@@ -68,20 +68,22 @@
 using namespace TechDraw;
 using namespace TechDrawGui;
 
-enum SnapMode{
-        NoSnap,
-        VerticalSnap,
-        HorizontalSnap
-    };
+enum SnapMode
+{
+    NoSnap,
+    VerticalSnap,
+    HorizontalSnap
+};
 
-enum DragState {
+enum DragState
+{
     NoDrag,
     DragStarted,
-    Dragging };
+    Dragging
+};
 
 
-QGIDatumLabel::QGIDatumLabel() :
-    m_dragState(NoDrag)
+QGIDatumLabel::QGIDatumLabel() : m_dragState(NoDrag)
 {
     verticalSep = false;
     posX = 0;
@@ -115,12 +117,13 @@ QGIDatumLabel::QGIDatumLabel() :
     m_lineWidth = Rez::guiX(0.5);
 }
 
-QVariant QGIDatumLabel::itemChange(GraphicsItemChange change, const QVariant &value)
+QVariant QGIDatumLabel::itemChange(GraphicsItemChange change, const QVariant& value)
 {
     if (change == ItemSelectedHasChanged && scene()) {
-        if(isSelected()) {
+        if (isSelected()) {
             setPrettySel();
-        } else {
+        }
+        else {
             setPrettyNormal();
             if (m_dragState == Dragging) {
                 //stop the drag if we are no longer selected.
@@ -128,8 +131,8 @@ QVariant QGIDatumLabel::itemChange(GraphicsItemChange change, const QVariant &va
                 Q_EMIT dragFinished();
             }
         }
-
-    } else if(change == ItemPositionHasChanged && scene()) {
+    }
+    else if (change == ItemPositionHasChanged && scene()) {
         setLabelCenter();
         m_dragState = Dragging;
         Q_EMIT dragging(m_ctrl);
@@ -138,18 +141,18 @@ QVariant QGIDatumLabel::itemChange(GraphicsItemChange change, const QVariant &va
     return QGraphicsItem::itemChange(change, value);
 }
 
-void QGIDatumLabel::mousePressEvent(QGraphicsSceneMouseEvent * event)
+void QGIDatumLabel::mousePressEvent(QGraphicsSceneMouseEvent* event)
 {
-    if(event->modifiers() & Qt::ControlModifier) {
+    if (event->modifiers() & Qt::ControlModifier) {
         m_ctrl = true;
     }
 
     QGraphicsItem::mousePressEvent(event);
 }
 
-void QGIDatumLabel::mouseReleaseEvent(QGraphicsSceneMouseEvent * event)
+void QGIDatumLabel::mouseReleaseEvent(QGraphicsSceneMouseEvent* event)
 {
-//    Base::Console().Message("QGIDL::mouseReleaseEvent()\n");
+    //    Base::Console().Message("QGIDL::mouseReleaseEvent()\n");
     m_ctrl = false;
     if (m_dragState == Dragging) {
         m_dragState = NoDrag;
@@ -167,7 +170,8 @@ void QGIDatumLabel::mouseDoubleClickEvent(QGraphicsSceneMouseEvent* event)
         return;
     }
 
-    auto ViewProvider = dynamic_cast<ViewProviderDimension*>(qgivDimension->getViewProvider(qgivDimension->getViewObject()));
+    auto ViewProvider = dynamic_cast<ViewProviderDimension*>(
+        qgivDimension->getViewProvider(qgivDimension->getViewObject()));
     if (!ViewProvider) {
         qWarning() << "QGIDatumLabel::mouseDoubleClickEvent: No valid view provider";
         return;
@@ -177,23 +181,25 @@ void QGIDatumLabel::mouseDoubleClickEvent(QGraphicsSceneMouseEvent* event)
     QGraphicsItem::mouseDoubleClickEvent(event);
 }
 
-void QGIDatumLabel::hoverEnterEvent(QGraphicsSceneHoverEvent *event)
+void QGIDatumLabel::hoverEnterEvent(QGraphicsSceneHoverEvent* event)
 {
     Q_EMIT hover(true);
     if (!isSelected()) {
         setPrettyPre();
-    } else {
+    }
+    else {
         setPrettySel();
     }
     QGraphicsItem::hoverEnterEvent(event);
 }
 
-void QGIDatumLabel::hoverLeaveEvent(QGraphicsSceneHoverEvent *event)
+void QGIDatumLabel::hoverLeaveEvent(QGraphicsSceneHoverEvent* event)
 {
     Q_EMIT hover(false);
     if (!isSelected()) {
         setPrettyNormal();
-    } else {
+    }
+    else {
         setPrettySel();
     }
 
@@ -203,19 +209,20 @@ void QGIDatumLabel::hoverLeaveEvent(QGraphicsSceneHoverEvent *event)
 QRectF QGIDatumLabel::boundingRect() const
 {
     QRectF result = childrenBoundingRect();
-    result.adjust(-m_lineWidth*4.0, 0.0, 0.0, 0.0);
+    result.adjust(-m_lineWidth * 4.0, 0.0, 0.0, 0.0);
     return result;
 }
 
-void QGIDatumLabel::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget)
+void QGIDatumLabel::paint(QPainter* painter, const QStyleOptionGraphicsItem* option,
+                          QWidget* widget)
 {
     Q_UNUSED(widget);
     Q_UNUSED(painter);
     QStyleOptionGraphicsItem myOption(*option);
     myOption.state &= ~QStyle::State_Selected;
 
-//    painter->setPen(Qt::blue);
-//    painter->drawRect(boundingRect());          //good for debugging
+    //    painter->setPen(Qt::blue);
+    //    painter->drawRect(boundingRect());          //good for debugging
 
     if (m_isFramed) {
         QPen prevPen = painter->pen();
@@ -230,22 +237,24 @@ void QGIDatumLabel::paint(QPainter *painter, const QStyleOptionGraphicsItem *opt
     }
 }
 
-void QGIDatumLabel::setPosFromCenter(const double &xCenter, const double &yCenter)
+void QGIDatumLabel::setPosFromCenter(const double& xCenter, const double& yCenter)
 {
     prepareGeometryChange();
     QGIViewDimension* qgivd = dynamic_cast<QGIViewDimension*>(parentItem());
-    if (!qgivd)
+    if (!qgivd) {
         return;
-    const auto dim( dynamic_cast<TechDraw::DrawViewDimension *>(qgivd->getViewObject()) );
-    if (!dim)
+    }
+    const auto dim(dynamic_cast<TechDraw::DrawViewDimension*>(qgivd->getViewObject()));
+    if (!dim) {
         return;
+    }
 
     //set label's Qt position(top, left) given boundingRect center point
-    setPos(xCenter - m_dimText->boundingRect().width() / 2., yCenter - m_dimText->boundingRect().height() / 2.);
+    setPos(xCenter - m_dimText->boundingRect().width() / 2.,
+           yCenter - m_dimText->boundingRect().height() / 2.);
 
     QString uText = m_unitText->toPlainText();
-    if ( (uText.size() > 0) &&
-         (uText.at(0) != QChar::fromLatin1(' ')) ) {
+    if ((uText.size() > 0) && (uText.at(0) != QChar::fromLatin1(' '))) {
         QString vText = m_dimText->toPlainText();
         vText = vText + uText;
         m_dimText->setPlainText(vText);
@@ -254,7 +263,7 @@ void QGIDatumLabel::setPosFromCenter(const double &xCenter, const double &yCente
 
     QRectF labelBox = m_dimText->boundingRect();
     double right = labelBox.right();
-    double top   = labelBox.top();
+    double top = labelBox.top();
     double bottom = labelBox.bottom();
     double middle = (top + bottom) / 2.0;
 
@@ -267,7 +276,7 @@ void QGIDatumLabel::setPosFromCenter(const double &xCenter, const double &yCente
 
     //set tolerance position
     QRectF overBox = m_tolTextOver->boundingRect();
-    double overWidth  = overBox.width();
+    double overWidth = overBox.width();
     QRectF underBox = m_tolTextUnder->boundingRect();
     double underWidth = underBox.width();
     double width = underWidth;
@@ -280,7 +289,8 @@ void QGIDatumLabel::setPosFromCenter(const double &xCenter, const double &yCente
     QPointF tol_adj = m_tolTextOver->tightBoundingAdjust();
     m_tolTextOver->justifyRightAt(tolRight + tol_adj.x(), middle - tol_adj.y(), false);
     tol_adj = m_tolTextUnder->tightBoundingAdjust();
-    m_tolTextUnder->justifyRightAt(tolRight + tol_adj.x(), middle + overBox.height() - tol_adj.y(), false);
+    m_tolTextUnder->justifyRightAt(tolRight + tol_adj.x(), middle + overBox.height() - tol_adj.y(),
+                                   false);
 }
 
 void QGIDatumLabel::setLabelCenter()
@@ -298,7 +308,7 @@ void QGIDatumLabel::setFont(QFont font)
     QFont tFont(font);
     double fontSize = font.pixelSize();
     double tolAdj = getTolAdjust();
-    tFont.setPixelSize((int) (fontSize * tolAdj));
+    tFont.setPixelSize((int)(fontSize * tolAdj));
     m_tolTextOver->setFont(tFont);
     m_tolTextUnder->setFont(tFont);
 }
@@ -320,13 +330,16 @@ void QGIDatumLabel::setToleranceString()
 {
     prepareGeometryChange();
     QGIViewDimension* qgivd = dynamic_cast<QGIViewDimension*>(parentItem());
-    if (!qgivd)
+    if (!qgivd) {
         return;
-    const auto dim( dynamic_cast<TechDraw::DrawViewDimension *>(qgivd->getViewObject()) );
+    }
+    const auto dim(dynamic_cast<TechDraw::DrawViewDimension*>(qgivd->getViewObject()));
     if (!dim) {
         return;
         // don't show if both are zero or if EqualTolerance is true
-    } else if (!dim->hasOverUnderTolerance() || dim->EqualTolerance.getValue() || dim->TheoreticalExact.getValue()) {
+    }
+    else if (!dim->hasOverUnderTolerance() || dim->EqualTolerance.getValue()
+             || dim->TheoreticalExact.getValue()) {
         m_tolTextOver->hide();
         m_tolTextUnder->hide();
         // we must explicitly empty the text otherwise the frame drawn for
@@ -339,29 +352,33 @@ void QGIDatumLabel::setToleranceString()
     std::pair<std::string, std::string> labelTexts, unitTexts;
 
     if (dim->ArbitraryTolerances.getValue()) {
-        labelTexts = dim->getFormattedToleranceValues(1);  //copy tolerance spec
+        labelTexts = dim->getFormattedToleranceValues(1);//copy tolerance spec
         unitTexts.first = "";
         unitTexts.second = "";
-    } else {
+    }
+    else {
         if (dim->isMultiValueSchema()) {
-            labelTexts = dim->getFormattedToleranceValues(0); //don't format multis
+            labelTexts = dim->getFormattedToleranceValues(0);//don't format multis
             unitTexts.first = "";
             unitTexts.second = "";
-        } else {
-            labelTexts = dim->getFormattedToleranceValues(1); // prefix value [unit] postfix
-            unitTexts  = dim->getFormattedToleranceValues(2); //just the unit
+        }
+        else {
+            labelTexts = dim->getFormattedToleranceValues(1);// prefix value [unit] postfix
+            unitTexts = dim->getFormattedToleranceValues(2); //just the unit
         }
     }
 
     if (labelTexts.first.empty()) {
         m_tolTextUnder->hide();
-    } else {
+    }
+    else {
         m_tolTextUnder->setPlainText(QString::fromUtf8(labelTexts.first.c_str()));
         m_tolTextUnder->show();
     }
     if (labelTexts.second.empty()) {
         m_tolTextOver->hide();
-    }else {
+    }
+    else {
         m_tolTextOver->setPlainText(QString::fromUtf8(labelTexts.second.c_str()));
         m_tolTextOver->show();
     }
@@ -374,7 +391,8 @@ void QGIDatumLabel::setUnitString(QString text)
     prepareGeometryChange();
     if (text.isEmpty()) {
         m_unitText->hide();
-    } else {
+    }
+    else {
         m_unitText->setPlainText(text);
         m_unitText->show();
     }
@@ -388,10 +406,13 @@ int QGIDatumLabel::getPrecision()
     global = Preferences::useGlobalDecimals();
     if (global) {
         precision = Base::UnitsApi::getDecimals();
-    } else {
-        Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter().
-                                             GetGroup("BaseApp")->GetGroup("Preferences")->
-                                             GetGroup("Mod/TechDraw/Dimensions");
+    }
+    else {
+        Base::Reference<ParameterGrp> hGrp = App::GetApplication()
+                                                 .GetUserParameter()
+                                                 .GetGroup("BaseApp")
+                                                 ->GetGroup("Preferences")
+                                                 ->GetGroup("Mod/TechDraw/Dimensions");
         precision = hGrp->GetInt("AltDecimals", 2);
     }
     return precision;
@@ -400,8 +421,11 @@ int QGIDatumLabel::getPrecision()
 double QGIDatumLabel::getTolAdjust()
 {
     double adjust;
-    Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter()
-        .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/TechDraw/Dimensions");
+    Base::Reference<ParameterGrp> hGrp = App::GetApplication()
+                                             .GetUserParameter()
+                                             .GetGroup("BaseApp")
+                                             ->GetGroup("Preferences")
+                                             ->GetGroup("Mod/TechDraw/Dimensions");
     adjust = hGrp->GetFloat("TolSizeAdjust", 0.50);
     return adjust;
 }
@@ -409,7 +433,7 @@ double QGIDatumLabel::getTolAdjust()
 
 void QGIDatumLabel::setPrettySel()
 {
-//    Base::Console().Message("QGIDL::setPrettySel()\n");
+    //    Base::Console().Message("QGIDL::setPrettySel()\n");
     m_dimText->setPrettySel();
     m_tolTextOver->setPrettySel();
     m_tolTextUnder->setPrettySel();
@@ -419,7 +443,7 @@ void QGIDatumLabel::setPrettySel()
 
 void QGIDatumLabel::setPrettyPre()
 {
-//    Base::Console().Message("QGIDL::setPrettyPre()\n");
+    //    Base::Console().Message("QGIDL::setPrettyPre()\n");
     m_dimText->setPrettyPre();
     m_tolTextOver->setPrettyPre();
     m_tolTextUnder->setPrettyPre();
@@ -429,7 +453,7 @@ void QGIDatumLabel::setPrettyPre()
 
 void QGIDatumLabel::setPrettyNormal()
 {
-//    Base::Console().Message("QGIDL::setPrettyNormal()\n");
+    //    Base::Console().Message("QGIDL::setPrettyNormal()\n");
     m_dimText->setPrettyNormal();
     m_tolTextOver->setPrettyNormal();
     m_tolTextUnder->setPrettyNormal();
@@ -439,7 +463,7 @@ void QGIDatumLabel::setPrettyNormal()
 
 void QGIDatumLabel::setColor(QColor color)
 {
-//    Base::Console().Message("QGIDL::setColor(%s)\n", qPrintable(c.name()));
+    //    Base::Console().Message("QGIDL::setColor(%s)\n", qPrintable(c.name()));
     m_colNormal = color;
     m_dimText->setColor(m_colNormal);
     m_tolTextOver->setColor(m_colNormal);
@@ -448,10 +472,7 @@ void QGIDatumLabel::setColor(QColor color)
 }
 
 //**************************************************************
-QGIViewDimension::QGIViewDimension() :
-    dvDimension(nullptr),
-    hasHover(false),
-    m_lineWidth(0.0)
+QGIViewDimension::QGIViewDimension() : dvDimension(nullptr), hasHover(false), m_lineWidth(0.0)
 {
     setHandlesChildEvents(false);
     setFlag(QGraphicsItem::ItemIsMovable, false);
@@ -480,38 +501,29 @@ QGIViewDimension::QGIViewDimension() :
     dimLines->setStyle(Qt::SolidLine);
 
     // connecting the needed slots and signals
-    QObject::connect(
-        datumLabel, SIGNAL(dragging(bool)),
-        this  , SLOT  (datumLabelDragged(bool)));
+    QObject::connect(datumLabel, SIGNAL(dragging(bool)), this, SLOT(datumLabelDragged(bool)));
 
-    QObject::connect(
-        datumLabel, SIGNAL(dragFinished()),
-        this  , SLOT  (datumLabelDragFinished()));
+    QObject::connect(datumLabel, SIGNAL(dragFinished()), this, SLOT(datumLabelDragFinished()));
 
-    QObject::connect(
-        datumLabel, SIGNAL(selected(bool)),
-        this  , SLOT  (select(bool)));
+    QObject::connect(datumLabel, SIGNAL(selected(bool)), this, SLOT(select(bool)));
 
-    QObject::connect(
-        datumLabel, SIGNAL(hover(bool)),
-        this  , SLOT  (hover(bool)));
+    QObject::connect(datumLabel, SIGNAL(hover(bool)), this, SLOT(hover(bool)));
 
-    QObject::connect(
-        datumLabel, SIGNAL(setPretty(int)),
-        this  , SLOT  (onPrettyChanged(int)));
+    QObject::connect(datumLabel, SIGNAL(setPretty(int)), this, SLOT(onPrettyChanged(int)));
 
-    setZValue(ZVALUE::DIMENSION);         //note: this won't paint dimensions over another View if it stacks
-                                          //above this Dimension's parent view.   need Layers?
+    setZValue(ZVALUE::DIMENSION);//note: this won't paint dimensions over another View if it stacks
+                                 //above this Dimension's parent view.   need Layers?
     hideFrame();
 }
 
-QVariant QGIViewDimension::itemChange(GraphicsItemChange change, const QVariant &value)
+QVariant QGIViewDimension::itemChange(GraphicsItemChange change, const QVariant& value)
 {
-   if (change == ItemSelectedHasChanged && scene()) {
-        if(isSelected()) {
+    if (change == ItemSelectedHasChanged && scene()) {
+        if (isSelected()) {
             setSelected(false);
             datumLabel->setSelected(true);
-        } else {
+        }
+        else {
             datumLabel->setSelected(false);
         }
         draw();
@@ -522,7 +534,7 @@ QVariant QGIViewDimension::itemChange(GraphicsItemChange change, const QVariant 
 //Set selection state for this and it's children
 void QGIViewDimension::setGroupSelection(bool isSelected)
 {
-//    Base::Console().Message("QGIVD::setGroupSelection(%d)\n", b);
+    //    Base::Console().Message("QGIVD::setGroupSelection(%d)\n", b);
     setSelected(isSelected);
     datumLabel->setSelected(isSelected);
     dimLines->setSelected(isSelected);
@@ -533,8 +545,8 @@ void QGIViewDimension::setGroupSelection(bool isSelected)
 void QGIViewDimension::select(bool state)
 {
     Q_UNUSED(state)
-//    setSelected(state);
-//    draw();
+    //    setSelected(state);
+    //    draw();
 }
 
 //surrogate for hover enter (true), hover leave (false) events
@@ -544,13 +556,14 @@ void QGIViewDimension::hover(bool state)
     draw();
 }
 
-void QGIViewDimension::setViewPartFeature(TechDraw::DrawViewDimension *obj)
+void QGIViewDimension::setViewPartFeature(TechDraw::DrawViewDimension* obj)
 {
-//    Base::Console().Message("QGIVD::setViewPartFeature()\n");
-    if (!obj)
+    //    Base::Console().Message("QGIVD::setViewPartFeature()\n");
+    if (!obj) {
         return;
+    }
 
-    setViewFeature(static_cast<TechDraw::DrawView *>(obj));
+    setViewFeature(static_cast<TechDraw::DrawView*>(obj));
     dvDimension = obj;
 
     // Set the QGIGroup Properties based on the DrawView
@@ -579,20 +592,20 @@ void QGIViewDimension::setNormalColorAll()
 
 //QGIViewDimension does not behave the same as other QGIView derived classes
 //and so mouse events need to be ignored.  Only the QGIDatumLabel mouse events are relevant.
-void QGIViewDimension::mousePressEvent(QGraphicsSceneMouseEvent * event)
+void QGIViewDimension::mousePressEvent(QGraphicsSceneMouseEvent* event)
 {
-//    Base::Console().Message("QGIVD::mousePressEvent() - %s\n", getViewName());
+    //    Base::Console().Message("QGIVD::mousePressEvent() - %s\n", getViewName());
     QGraphicsItem::mousePressEvent(event);
 }
 
-void QGIViewDimension::mouseMoveEvent(QGraphicsSceneMouseEvent * event)
+void QGIViewDimension::mouseMoveEvent(QGraphicsSceneMouseEvent* event)
 {
     QGraphicsItem::mouseMoveEvent(event);
 }
 
-void QGIViewDimension::mouseReleaseEvent(QGraphicsSceneMouseEvent * event)
+void QGIViewDimension::mouseReleaseEvent(QGraphicsSceneMouseEvent* event)
 {
-//    Base::Console().Message("QGIVDim::mouseReleaseEvent() - %s\n", getViewName());
+    //    Base::Console().Message("QGIVDim::mouseReleaseEvent() - %s\n", getViewName());
     QGraphicsItem::mouseReleaseEvent(event);
 }
 
@@ -600,27 +613,29 @@ void QGIViewDimension::updateView(bool update)
 {
     Q_UNUSED(update);
     auto dim(dynamic_cast<TechDraw::DrawViewDimension*>(getViewObject()));
-    if (!dim)
+    if (!dim) {
         return;
+    }
 
     auto vp = static_cast<ViewProviderDimension*>(getViewProvider(getViewObject()));
-    if (!vp)
+    if (!vp) {
         return;
+    }
 
-    if (update||
-        dim->X.isTouched() ||
-        dim->Y.isTouched()) {
+    if (update || dim->X.isTouched() || dim->Y.isTouched()) {
         float x = Rez::guiX(dim->X.getValue());
         float y = Rez::guiX(dim->Y.getValue());
         datumLabel->setPosFromCenter(x, -y);
         updateDim();
-    } else if(vp->Fontsize.isTouched() ||
-        vp->Font.isTouched()) {
+    }
+    else if (vp->Fontsize.isTouched() || vp->Font.isTouched()) {
         updateDim();
-    } else if (vp->LineWidth.isTouched()) {
+    }
+    else if (vp->LineWidth.isTouched()) {
         m_lineWidth = vp->LineWidth.getValue();
         updateDim();
-    } else {
+    }
+    else {
         updateDim();
     }
 
@@ -629,21 +644,25 @@ void QGIViewDimension::updateView(bool update)
 
 void QGIViewDimension::updateDim()
 {
-    const auto dim( dynamic_cast<TechDraw::DrawViewDimension *>(getViewObject()) );
-    if (!dim)
+    const auto dim(dynamic_cast<TechDraw::DrawViewDimension*>(getViewObject()));
+    if (!dim) {
         return;
+    }
     auto vp = static_cast<ViewProviderDimension*>(getViewProvider(getViewObject()));
-    if (!vp)
+    if (!vp) {
         return;
+    }
 
-    QString labelText= QString::fromUtf8(dim->getFormattedDimensionValue(1).c_str()); // pre value [unit] post
-    if (dim->isMultiValueSchema())
-        labelText = QString::fromUtf8(dim->getFormattedDimensionValue(0).c_str()); //don't format multis
+    QString labelText =
+        QString::fromUtf8(dim->getFormattedDimensionValue(1).c_str());// pre value [unit] post
+    if (dim->isMultiValueSchema()) {
+        labelText =
+            QString::fromUtf8(dim->getFormattedDimensionValue(0).c_str());//don't format multis
+    }
 
     QFont font = datumLabel->getFont();
     font.setFamily(QString::fromUtf8(vp->Font.getValue()));
-    int fontSize = QGIView::exactFontSize(vp->Font.getValue(),
-                                          vp->Fontsize.getValue());
+    int fontSize = QGIView::exactFontSize(vp->Font.getValue(), vp->Fontsize.getValue());
     font.setPixelSize(fontSize);
     datumLabel->setFont(font);
 
@@ -664,16 +683,18 @@ void QGIViewDimension::datumLabelDragged(bool ctrl)
 
 void QGIViewDimension::datumLabelDragFinished()
 {
-    auto dim( dynamic_cast<TechDraw::DrawViewDimension *>(getViewObject()) );
+    auto dim(dynamic_cast<TechDraw::DrawViewDimension*>(getViewObject()));
 
-    if (!dim)
+    if (!dim) {
         return;
+    }
 
-    double x = Rez::appX(datumLabel->X()),
-           y = Rez::appX(datumLabel->Y());
+    double x = Rez::appX(datumLabel->X()), y = Rez::appX(datumLabel->Y());
     Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Drag Dimension"));
-    Gui::Command::doCommand(Gui::Command::Doc, "App.ActiveDocument.%s.X = %f", dim->getNameInDocument(), x);
-    Gui::Command::doCommand(Gui::Command::Doc, "App.ActiveDocument.%s.Y = %f", dim->getNameInDocument(), -y);
+    Gui::Command::doCommand(Gui::Command::Doc, "App.ActiveDocument.%s.X = %f",
+                            dim->getNameInDocument(), x);
+    Gui::Command::doCommand(Gui::Command::Doc, "App.ActiveDocument.%s.Y = %f",
+                            dim->getNameInDocument(), -y);
     Gui::Command::commitCommand();
 }
 
@@ -686,7 +707,8 @@ QString QGIViewDimension::getLabelText()
     QString third = datumLabel->getTolTextUnder()->toPlainText();
     if (second.length() > third.length()) {
         result = first + second;
-    } else {
+    }
+    else {
         result = first + third;
     }
 
@@ -700,19 +722,20 @@ void QGIViewDimension::draw()
         return;
     }
 
-    TechDraw::DrawViewDimension *dim = dynamic_cast<TechDraw::DrawViewDimension *>(getViewObject());
+    TechDraw::DrawViewDimension* dim = dynamic_cast<TechDraw::DrawViewDimension*>(getViewObject());
     if (!dim ||//nothing to draw, don't try
-        !dim->isDerivedFrom(TechDraw::DrawViewDimension::getClassTypeId()) ||
-        !dim->has2DReferences()) {
+        !dim->isDerivedFrom(TechDraw::DrawViewDimension::getClassTypeId())
+        || !dim->has2DReferences()) {
         datumLabel->hide();
         hide();
         return;
     }
 
-    const TechDraw::DrawViewPart *refObj = dim->getViewPart();
-    if (!refObj)
+    const TechDraw::DrawViewPart* refObj = dim->getViewPart();
+    if (!refObj) {
         return;
-    if (!refObj->hasGeometry()) {                                       //nothing to draw yet (restoring)
+    }
+    if (!refObj->hasGeometry()) {//nothing to draw yet (restoring)
         datumLabel->hide();
         hide();
         return;
@@ -734,10 +757,10 @@ void QGIViewDimension::draw()
 
     if (vp->RenderingExtent.getValue() > ViewProviderDimension::REND_EXTENT_NONE) {
         // We are expected to draw something, not just display the value
-        const char *dimType = dim->Type.getValueAsString();
+        const char* dimType = dim->Type.getValueAsString();
 
-        if (strcmp(dimType, "Distance") == 0
-            || strcmp(dimType, "DistanceX") == 0 || strcmp(dimType, "DistanceY") == 0) {
+        if (strcmp(dimType, "Distance") == 0 || strcmp(dimType, "DistanceX") == 0
+            || strcmp(dimType, "DistanceY") == 0) {
             drawDistance(dim, vp);
         }
         else if (strcmp(dimType, "Diameter") == 0) {
@@ -763,12 +786,14 @@ void QGIViewDimension::draw()
     if (parentItem()) {
         //TODO: parent redraw still required with new frame/label??
         parentItem()->update();
-    } else {
+    }
+    else {
         Base::Console().Log("INFO - QGIVD::draw - no parent to update\n");
     }
 }
 
-double QGIViewDimension::getAnglePlacementFactor(double testAngle, double endAngle, double startRotation)
+double QGIViewDimension::getAnglePlacementFactor(double testAngle, double endAngle,
+                                                 double startRotation)
 {
     if (startRotation > 0.0) {
         startRotation = -startRotation;
@@ -798,8 +823,9 @@ double QGIViewDimension::getAnglePlacementFactor(double testAngle, double endAng
     return 0.0;
 }
 
-int QGIViewDimension::compareAngleStraightness(double straightAngle, double leftAngle, double rightAngle,
-                                               double leftStrikeFactor, double rightStrikeFactor)
+int QGIViewDimension::compareAngleStraightness(double straightAngle, double leftAngle,
+                                               double rightAngle, double leftStrikeFactor,
+                                               double rightStrikeFactor)
 {
     double leftDelta = DrawUtil::angleComposition(M_PI, straightAngle - leftAngle);
     double rightDelta = DrawUtil::angleComposition(rightAngle, -straightAngle);
@@ -821,29 +847,32 @@ int QGIViewDimension::compareAngleStraightness(double straightAngle, double left
 double QGIViewDimension::getIsoStandardLinePlacement(double labelAngle)
 {
     // According to ISO 129-1 Standard Figure 23, the bordering angle is 1/2 PI, resp. -1/2 PI
-    return labelAngle < -M_PI/2.0 || labelAngle > +M_PI/2.0
-           ? +1.0 : -1.0;
+    return labelAngle < -M_PI / 2.0 || labelAngle > +M_PI / 2.0 ? +1.0 : -1.0;
 }
 
-Base::Vector2d QGIViewDimension::getIsoRefOutsetPoint(const Base::BoundBox2d &labelRectangle, bool right) const
+Base::Vector2d QGIViewDimension::getIsoRefOutsetPoint(const Base::BoundBox2d& labelRectangle,
+                                                      bool right) const
 {
     return Base::Vector2d(right ? labelRectangle.MinX - getDefaultIsoReferenceLineOverhang()
                                 : labelRectangle.MaxX + getDefaultIsoReferenceLineOverhang(),
                           labelRectangle.MinY - getDefaultIsoDimensionLineSpacing());
 }
 
-Base::Vector2d QGIViewDimension::getIsoRefJointPoint(const Base::BoundBox2d &labelRectangle, bool right) const
+Base::Vector2d QGIViewDimension::getIsoRefJointPoint(const Base::BoundBox2d& labelRectangle,
+                                                     bool right) const
 {
     return getIsoRefOutsetPoint(labelRectangle, !right);
 }
 
-Base::Vector2d QGIViewDimension::getAsmeRefOutsetPoint(const Base::BoundBox2d &labelRectangle, bool right) const
+Base::Vector2d QGIViewDimension::getAsmeRefOutsetPoint(const Base::BoundBox2d& labelRectangle,
+                                                       bool right) const
 {
     return Base::Vector2d(right ? labelRectangle.MaxX : labelRectangle.MinX,
                           labelRectangle.GetCenter().y);
 }
 
-Base::Vector2d QGIViewDimension::getAsmeRefJointPoint(const Base::BoundBox2d &labelRectangle, bool right) const
+Base::Vector2d QGIViewDimension::getAsmeRefJointPoint(const Base::BoundBox2d& labelRectangle,
+                                                      bool right) const
 {
     return Base::Vector2d(right ? labelRectangle.MaxX + getDefaultAsmeHorizontalLeaderLength()
                                 : labelRectangle.MinX - getDefaultAsmeHorizontalLeaderLength(),
@@ -856,12 +885,13 @@ Base::Vector2d QGIViewDimension::getAsmeRefJointPoint(const Base::BoundBox2d &la
 //a*b is the magnitude of the projection of a onto b
 //so we project a vector linePoint-perpendicularPoint onto unit vector in lineAngle direction giving
 //the distance from linePoint to intersection, then make a displacement vector and add it to linePoint
-Base::Vector2d QGIViewDimension::computePerpendicularIntersection(const Base::Vector2d &linePoint,
-                                     const Base::Vector2d &perpendicularPoint, double lineAngle)
+Base::Vector2d QGIViewDimension::computePerpendicularIntersection(
+    const Base::Vector2d& linePoint, const Base::Vector2d& perpendicularPoint, double lineAngle)
 {
     return linePoint
-           + Base::Vector2d::FromPolar((perpendicularPoint - linePoint)*Base::Vector2d::FromPolar(1.0, lineAngle),
-                                       lineAngle);
+        + Base::Vector2d::FromPolar((perpendicularPoint - linePoint)
+                                        * Base::Vector2d::FromPolar(1.0, lineAngle),
+                                    lineAngle);
 }
 
 //calculate the end points of 1 extension line
@@ -870,9 +900,11 @@ Base::Vector2d QGIViewDimension::computePerpendicularIntersection(const Base::Ve
 //            onto dimension line
 //1 extension line end point is the return value
 //1 extension line end point is modified parameter startPoint
-Base::Vector2d QGIViewDimension::computeExtensionLinePoints(const Base::Vector2d &originPoint,
-                                     const Base::Vector2d &linePoint, double hintAngle, double overhangSize,
-                                     double gapSize, Base::Vector2d &startPoint)
+Base::Vector2d QGIViewDimension::computeExtensionLinePoints(const Base::Vector2d& originPoint,
+                                                            const Base::Vector2d& linePoint,
+                                                            double hintAngle, double overhangSize,
+                                                            double gapSize,
+                                                            Base::Vector2d& startPoint)
 {
     Base::Vector2d direction(linePoint - originPoint);
     double rawLength = direction.Length();
@@ -881,23 +913,24 @@ Base::Vector2d QGIViewDimension::computeExtensionLinePoints(const Base::Vector2d
         direction = Base::Vector2d::FromPolar(1.0, hintAngle);
     }
     else {
-        direction = direction/rawLength;
+        direction = direction / rawLength;
     }
 
     if (overhangSize > rawLength - gapSize) {
         // The extension line would be smaller than extension line overhang, keep it at least so long
-        startPoint = linePoint - overhangSize*direction;
+        startPoint = linePoint - overhangSize * direction;
     }
     else {
-        startPoint = linePoint - (rawLength - gapSize)*direction;
+        startPoint = linePoint - (rawLength - gapSize) * direction;
     }
 
-    return linePoint + overhangSize*direction;
+    return linePoint + overhangSize * direction;
 }
 
-double QGIViewDimension::computeLineAndLabelAngles(const Base::Vector2d &rotationCenter,
-                             const Base::Vector2d &labelCenter, double lineLabelDistance,
-                             double &lineAngle, double &labelAngle)
+double QGIViewDimension::computeLineAndLabelAngles(const Base::Vector2d& rotationCenter,
+                                                   const Base::Vector2d& labelCenter,
+                                                   double lineLabelDistance, double& lineAngle,
+                                                   double& labelAngle)
 {
     // By default horizontal line and no label rotation
     lineAngle = 0.0;
@@ -905,7 +938,7 @@ double QGIViewDimension::computeLineAndLabelAngles(const Base::Vector2d &rotatio
 
     Base::Vector2d rawDirection(labelCenter - rotationCenter);
     double rawDistance = rawDirection.Length();
-    if (rawDistance <= Precision::Confusion()) { // Almost single point, can't tell
+    if (rawDistance <= Precision::Confusion()) {// Almost single point, can't tell
         return 0.0;
     }
 
@@ -918,7 +951,7 @@ double QGIViewDimension::computeLineAndLabelAngles(const Base::Vector2d &rotatio
     }
 
     // Rotate the line by angle between the label rectangle center and label bottom side center
-    double devAngle = getIsoStandardLinePlacement(rawAngle)*asin(lineLabelDistance/rawDistance);
+    double devAngle = getIsoStandardLinePlacement(rawAngle) * asin(lineLabelDistance / rawDistance);
     lineAngle = DrawUtil::angleComposition(lineAngle, devAngle);
 
     labelAngle = devAngle < 0.0 ? lineAngle : DrawUtil::angleComposition(lineAngle, M_PI);
@@ -926,9 +959,10 @@ double QGIViewDimension::computeLineAndLabelAngles(const Base::Vector2d &rotatio
     return devAngle;
 }
 
-double QGIViewDimension::computeLineStrikeFactor(const Base::BoundBox2d &labelRectangle,
-                             const Base::Vector2d &lineOrigin, double lineAngle,
-                             const std::vector<std::pair<double, bool>> &drawMarking)
+double
+QGIViewDimension::computeLineStrikeFactor(const Base::BoundBox2d& labelRectangle,
+                                          const Base::Vector2d& lineOrigin, double lineAngle,
+                                          const std::vector<std::pair<double, bool>>& drawMarking)
 {
     if (drawMarking.size() < 2) {
         return 0.0;
@@ -944,8 +978,9 @@ double QGIViewDimension::computeLineStrikeFactor(const Base::BoundBox2d &labelRe
                 double segmentBase = drawMarking[startIndex].first;
                 double segmentLength = drawMarking[currentIndex].first - segmentBase;
 
-                DrawUtil::findLineSegmentRectangleIntersections(lineOrigin, lineAngle, segmentBase, segmentLength,
-                                                                labelRectangle, intersectionPoints);
+                DrawUtil::findLineSegmentRectangleIntersections(lineOrigin, lineAngle, segmentBase,
+                                                                segmentLength, labelRectangle,
+                                                                intersectionPoints);
             }
 
             startIndex = currentIndex;
@@ -957,9 +992,10 @@ double QGIViewDimension::computeLineStrikeFactor(const Base::BoundBox2d &labelRe
     return intersectionPoints.size() >= 2 ? 1.0 : 0.0;
 }
 
-double QGIViewDimension::computeArcStrikeFactor(const Base::BoundBox2d &labelRectangle,
-                             const Base::Vector2d &arcCenter, double arcRadius,
-                             const std::vector<std::pair<double, bool>> &drawMarking)
+double
+QGIViewDimension::computeArcStrikeFactor(const Base::BoundBox2d& labelRectangle,
+                                         const Base::Vector2d& arcCenter, double arcRadius,
+                                         const std::vector<std::pair<double, bool>>& drawMarking)
 {
     if (drawMarking.empty()) {
         return 0.0;
@@ -973,7 +1009,8 @@ double QGIViewDimension::computeArcStrikeFactor(const Base::BoundBox2d &labelRec
     std::vector<Base::Vector2d> intersectionPoints;
 
     if (entryIndex >= drawMarking.size()) {
-        DrawUtil::findCircleRectangleIntersections(arcCenter, arcRadius, labelRectangle, intersectionPoints);
+        DrawUtil::findCircleRectangleIntersections(arcCenter, arcRadius, labelRectangle,
+                                                   intersectionPoints);
     }
     else {
         unsigned int startIndex = entryIndex;
@@ -990,20 +1027,20 @@ double QGIViewDimension::computeArcStrikeFactor(const Base::BoundBox2d &labelRec
                         arcRotation += M_2PI;
                     }
 
-                    DrawUtil::findCircularArcRectangleIntersections(arcCenter, arcRadius, arcAngle, arcRotation,
-                                                                    labelRectangle, intersectionPoints);
+                    DrawUtil::findCircularArcRectangleIntersections(arcCenter, arcRadius, arcAngle,
+                                                                    arcRotation, labelRectangle,
+                                                                    intersectionPoints);
                 }
 
                 startIndex = currentIndex;
             }
-        }
-        while (currentIndex != entryIndex);
+        } while (currentIndex != entryIndex);
     }
 
     return intersectionPoints.size() >= 2 ? 1.0 : 0.0;
 }
 
-double QGIViewDimension::normalizeStartPosition(double &startPosition, double &lineAngle)
+double QGIViewDimension::normalizeStartPosition(double& startPosition, double& lineAngle)
 {
     if (startPosition > 0.0) {
         startPosition = -startPosition;
@@ -1014,7 +1051,7 @@ double QGIViewDimension::normalizeStartPosition(double &startPosition, double &l
     return +1.0;
 }
 
-double QGIViewDimension::normalizeStartRotation(double &startRotation)
+double QGIViewDimension::normalizeStartRotation(double& startRotation)
 {
     if (copysign(1.0, startRotation) > 0.0) {
         startRotation = -startRotation;
@@ -1024,25 +1061,27 @@ double QGIViewDimension::normalizeStartRotation(double &startRotation)
     return 1.0;
 }
 
-bool QGIViewDimension::constructDimensionLine(const Base::Vector2d &targetPoint, double lineAngle,
-                           double startPosition, double jointPosition, const Base::BoundBox2d &labelRectangle,
-                           int arrowCount, int standardStyle, bool flipArrows,
-                           std::vector<std::pair<double, bool>> &outputMarking) const
+bool QGIViewDimension::constructDimensionLine(
+    const Base::Vector2d& targetPoint, double lineAngle, double startPosition, double jointPosition,
+    const Base::BoundBox2d& labelRectangle, int arrowCount, int standardStyle, bool flipArrows,
+    std::vector<std::pair<double, bool>>& outputMarking) const
 {
     // The start position > 0 is not expected, the caller must handle this
     if (startPosition > 0.0) {
-        Base::Console().Error("QGIVD::constructDimLine - Start Position must not be positive! Received: %f\n",
-                              startPosition);
+        Base::Console().Error(
+            "QGIVD::constructDimLine - Start Position must not be positive! Received: %f\n",
+            startPosition);
         return false;
     }
 
     double labelBorder = 0.0;
     if (standardStyle == ViewProviderDimension::STD_STYLE_ISO_ORIENTED) {
-        labelBorder = labelRectangle.Width()*0.5 + getDefaultIsoReferenceLineOverhang();
+        labelBorder = labelRectangle.Width() * 0.5 + getDefaultIsoReferenceLineOverhang();
     }
     else if (standardStyle == ViewProviderDimension::STD_STYLE_ASME_INLINED) {
         std::vector<Base::Vector2d> intersectionPoints;
-        DrawUtil::findLineRectangleIntersections(targetPoint, lineAngle, labelRectangle, intersectionPoints);
+        DrawUtil::findLineRectangleIntersections(targetPoint, lineAngle, labelRectangle,
+                                                 intersectionPoints);
 
         if (intersectionPoints.size() >= 2) {
             labelBorder = (intersectionPoints[0] - labelRectangle.GetCenter()).Length();
@@ -1077,29 +1116,33 @@ bool QGIViewDimension::constructDimensionLine(const Base::Vector2d &targetPoint,
 
     // For ASME Inlined, cut out the part of line occupied by the value
     if (standardStyle == ViewProviderDimension::STD_STYLE_ASME_INLINED) {
-        DrawUtil::intervalMarkLinear(outputMarking, jointPosition - labelBorder, labelBorder*2.0, false);
+        DrawUtil::intervalMarkLinear(outputMarking, jointPosition - labelBorder, labelBorder * 2.0,
+                                     false);
     }
 
     // Add the arrow tails - these are drawn always
     double placementFactor = flipArrows ? +1.0 : -1.0;
-    DrawUtil::intervalMarkLinear(outputMarking, 0.0, placementFactor*getDefaultArrowTailLength(), true);
+    DrawUtil::intervalMarkLinear(outputMarking, 0.0, placementFactor * getDefaultArrowTailLength(),
+                                 true);
     if (arrowCount > 1) {
         DrawUtil::intervalMarkLinear(outputMarking, startPosition,
-                                     -placementFactor*getDefaultArrowTailLength(), true);
+                                     -placementFactor * getDefaultArrowTailLength(), true);
     }
 
     return flipArrows;
 }
 
-bool QGIViewDimension::constructDimensionArc(const Base::Vector2d &arcCenter, double arcRadius, double endAngle,
-                           double startRotation, double handednessFactor, double jointRotation,
-                           const Base::BoundBox2d &labelRectangle, int arrowCount, int standardStyle, bool flipArrows,
-                           std::vector<std::pair<double, bool>> &outputMarking) const
+bool QGIViewDimension::constructDimensionArc(
+    const Base::Vector2d& arcCenter, double arcRadius, double endAngle, double startRotation,
+    double handednessFactor, double jointRotation, const Base::BoundBox2d& labelRectangle,
+    int arrowCount, int standardStyle, bool flipArrows,
+    std::vector<std::pair<double, bool>>& outputMarking) const
 {
     // The start rotation > 0 is not expected, the caller must handle this
     if (startRotation > 0.0) {
-        Base::Console().Error("QGIVD::constructDimArc - Start Rotation must not be positive! Received: %f\n",
-                              startRotation);
+        Base::Console().Error(
+            "QGIVD::constructDimArc - Start Rotation must not be positive! Received: %f\n",
+            startRotation);
         return false;
     }
 
@@ -1116,20 +1159,24 @@ bool QGIViewDimension::constructDimensionArc(const Base::Vector2d &arcCenter, do
         }
 
         // ISO oriented labels are symmetrical along their center axis
-        startDelta = atan((labelRectangle.Width()*0.5 + getDefaultIsoReferenceLineOverhang())/borderRadius);
+        startDelta = atan((labelRectangle.Width() * 0.5 + getDefaultIsoReferenceLineOverhang())
+                          / borderRadius);
         endDelta = startDelta;
     }
     else if (standardStyle == ViewProviderDimension::STD_STYLE_ASME_INLINED) {
         std::vector<Base::Vector2d> intersectionPoints;
 
-        DrawUtil::findCircleRectangleIntersections(arcCenter, arcRadius, labelRectangle, intersectionPoints);
+        DrawUtil::findCircleRectangleIntersections(arcCenter, arcRadius, labelRectangle,
+                                                   intersectionPoints);
 
         // We do not want to handle other cases than 2 intersection points - if so, act as if there were none
         if (intersectionPoints.size() == 2) {
-            double zeroAngle = (labelRectangle.GetCenter()- arcCenter).Angle();
+            double zeroAngle = (labelRectangle.GetCenter() - arcCenter).Angle();
 
-            startDelta = DrawUtil::angleDifference(zeroAngle, (intersectionPoints[0] - arcCenter).Angle());
-            endDelta = DrawUtil::angleDifference(zeroAngle, (intersectionPoints[1] - arcCenter).Angle());
+            startDelta =
+                DrawUtil::angleDifference(zeroAngle, (intersectionPoints[0] - arcCenter).Angle());
+            endDelta =
+                DrawUtil::angleDifference(zeroAngle, (intersectionPoints[1] - arcCenter).Angle());
 
             // End delta is the angle in the end point direction, start delta in the opposite
             // Keep orientation and the computation sign in sync
@@ -1145,13 +1192,15 @@ bool QGIViewDimension::constructDimensionArc(const Base::Vector2d &arcCenter, do
     bool autoFlipArrows = false;
     if (jointRotation + endDelta > 0.0) {
         // If label exceeds end angle ray, extend the dimension arc and flip arrows
-        DrawUtil::intervalMarkCircular(outputMarking, endAngle, handednessFactor*(jointRotation + endDelta), true);
+        DrawUtil::intervalMarkCircular(outputMarking, endAngle,
+                                       handednessFactor * (jointRotation + endDelta), true);
         autoFlipArrows = true;
     }
 
     if (jointRotation - startDelta < startRotation) {
-        DrawUtil::intervalMarkCircular(outputMarking, endAngle + handednessFactor*startRotation,
-                                       handednessFactor*(jointRotation - startDelta - startRotation), true);
+        DrawUtil::intervalMarkCircular(
+            outputMarking, endAngle + handednessFactor * startRotation,
+            handednessFactor * (jointRotation - startDelta - startRotation), true);
 
         // For only one arrow and zero width line skip flipping, it already points correctly
         if (arrowCount > 1 || startRotation < 0.0) {
@@ -1165,24 +1214,27 @@ bool QGIViewDimension::constructDimensionArc(const Base::Vector2d &arcCenter, do
             && standardStyle != ViewProviderDimension::STD_STYLE_ASME_REFERENCING)) {
         // If arrows point outside, or ASME standard is not followed,
         // add the arc part between start and end
-        DrawUtil::intervalMarkCircular(outputMarking, endAngle, handednessFactor*startRotation, true);
+        DrawUtil::intervalMarkCircular(outputMarking, endAngle, handednessFactor * startRotation,
+                                       true);
     }
 
     // For ASME Inlined, cut out the part of arc occupied by the value
     if (standardStyle == ViewProviderDimension::STD_STYLE_ASME_INLINED) {
-        DrawUtil::intervalMarkCircular(outputMarking, endAngle + handednessFactor*(jointRotation - startDelta),
-                                       handednessFactor*(startDelta + endDelta), false);
+        DrawUtil::intervalMarkCircular(outputMarking,
+                                       endAngle + handednessFactor * (jointRotation - startDelta),
+                                       handednessFactor * (startDelta + endDelta), false);
     }
 
     // Add the arrow tails - these are drawn always
-    double tailDelta = arcRadius >= Precision::Confusion() ? getDefaultArrowTailLength()/arcRadius : M_PI_4;
+    double tailDelta =
+        arcRadius >= Precision::Confusion() ? getDefaultArrowTailLength() / arcRadius : M_PI_4;
     double placementFactor = flipArrows ? +1.0 : -1.0;
 
     DrawUtil::intervalMarkCircular(outputMarking, endAngle,
-                                   placementFactor*handednessFactor*tailDelta, true);
+                                   placementFactor * handednessFactor * tailDelta, true);
     if (arrowCount > 1) {
-        DrawUtil::intervalMarkCircular(outputMarking, endAngle + handednessFactor*startRotation,
-                                       -placementFactor*handednessFactor*tailDelta, true);
+        DrawUtil::intervalMarkCircular(outputMarking, endAngle + handednessFactor * startRotation,
+                                       -placementFactor * handednessFactor * tailDelta, true);
     }
 
     return flipArrows;
@@ -1199,15 +1251,16 @@ void QGIViewDimension::resetArrows() const
     aHead2->setFlipped(false);
 }
 
-void QGIViewDimension::drawArrows(int count, const Base::Vector2d positions[], double angles[], bool flipped) const
+void QGIViewDimension::drawArrows(int count, const Base::Vector2d positions[], double angles[],
+                                  bool flipped) const
 {
     const int arrowCount = 2;
-    QGIArrow *arrows[arrowCount] = { aHead1, aHead2 };
+    QGIArrow* arrows[arrowCount] = {aHead1, aHead2};
 
     arrowPositionsToFeature(positions);
 
     for (int i = 0; i < arrowCount; ++i) {
-        QGIArrow *arrow = arrows[i];
+        QGIArrow* arrow = arrows[i];
 
         if (positions && angles) {
             arrow->setPos(toQtGui(positions[i]));
@@ -1223,26 +1276,29 @@ void QGIViewDimension::drawArrows(int count, const Base::Vector2d positions[], d
         arrow->setSize(QGIArrow::getPrefArrowSize());
         arrow->setFlipped(flipped);
 
-        if (QGIArrow::getPrefArrowStyle() != 7) { // if not "None"
+        if (QGIArrow::getPrefArrowStyle() != 7) {// if not "None"
             arrow->draw();
             arrow->show();
         }
-        else
+        else {
             arrow->hide();
+        }
     }
 }
 
 void QGIViewDimension::arrowPositionsToFeature(const Base::Vector2d positions[]) const
 {
-    auto dim( dynamic_cast<TechDraw::DrawViewDimension*>(getViewObject()) );
-    if (!dim)
+    auto dim(dynamic_cast<TechDraw::DrawViewDimension*>(getViewObject()));
+    if (!dim) {
         return;
+    }
 
     dim->saveArrowPositions(positions);
 }
 
-void QGIViewDimension::drawSingleLine(QPainterPath &painterPath, const Base::Vector2d &lineOrigin, double lineAngle,
-                                      double startPosition, double endPosition) const
+void QGIViewDimension::drawSingleLine(QPainterPath& painterPath, const Base::Vector2d& lineOrigin,
+                                      double lineAngle, double startPosition,
+                                      double endPosition) const
 {
     if (endPosition == startPosition) {
         return;
@@ -1255,8 +1311,9 @@ void QGIViewDimension::drawSingleLine(QPainterPath &painterPath, const Base::Vec
 
 //adds line segments to painterPath from lineOrigin along lineAngle
 //segment length is determined by drawMarking entries
-void QGIViewDimension::drawMultiLine(QPainterPath &painterPath, const Base::Vector2d &lineOrigin, double lineAngle,
-                                     const std::vector<std::pair<double, bool>> &drawMarking) const
+void QGIViewDimension::drawMultiLine(QPainterPath& painterPath, const Base::Vector2d& lineOrigin,
+                                     double lineAngle,
+                                     const std::vector<std::pair<double, bool>>& drawMarking) const
 {
     if (drawMarking.size() < 2) {
         return;
@@ -1267,8 +1324,8 @@ void QGIViewDimension::drawMultiLine(QPainterPath &painterPath, const Base::Vect
     while (currentIndex < drawMarking.size()) {
         if (drawMarking[currentIndex].second != drawMarking[startIndex].second) {
             if (drawMarking[startIndex].second) {
-                drawSingleLine(painterPath, lineOrigin, lineAngle,
-                               drawMarking[startIndex].first, drawMarking[currentIndex].first);
+                drawSingleLine(painterPath, lineOrigin, lineAngle, drawMarking[startIndex].first,
+                               drawMarking[currentIndex].first);
             }
 
             startIndex = currentIndex;
@@ -1278,8 +1335,8 @@ void QGIViewDimension::drawMultiLine(QPainterPath &painterPath, const Base::Vect
     }
 }
 
-void QGIViewDimension::drawSingleArc(QPainterPath &painterPath, const Base::Vector2d &arcCenter, double arcRadius,
-                                     double startAngle, double endAngle) const
+void QGIViewDimension::drawSingleArc(QPainterPath& painterPath, const Base::Vector2d& arcCenter,
+                                     double arcRadius, double startAngle, double endAngle) const
 {
     if (endAngle == startAngle) {
         return;
@@ -1288,16 +1345,18 @@ void QGIViewDimension::drawSingleArc(QPainterPath &painterPath, const Base::Vect
         endAngle += M_2PI;
     }
 
-    QRectF qtArcRectangle(toQtGui(Base::BoundBox2d(arcCenter.x - arcRadius, arcCenter.y - arcRadius,
-                                                   arcCenter.x + arcRadius, arcCenter.y + arcRadius)));
+    QRectF qtArcRectangle(
+        toQtGui(Base::BoundBox2d(arcCenter.x - arcRadius, arcCenter.y - arcRadius,
+                                 arcCenter.x + arcRadius, arcCenter.y + arcRadius)));
 
     // In arc drawing are for some reason Qt's angles counterclockwise as in our computations...
     painterPath.arcMoveTo(qtArcRectangle, toDeg(startAngle));
     painterPath.arcTo(qtArcRectangle, toDeg(startAngle), toDeg(endAngle - startAngle));
 }
 
-void QGIViewDimension::drawMultiArc(QPainterPath &painterPath, const Base::Vector2d &arcCenter, double arcRadius,
-                                    const std::vector<std::pair<double, bool>> &drawMarking) const
+void QGIViewDimension::drawMultiArc(QPainterPath& painterPath, const Base::Vector2d& arcCenter,
+                                    double arcRadius,
+                                    const std::vector<std::pair<double, bool>>& drawMarking) const
 {
     if (drawMarking.empty()) {
         return;
@@ -1321,14 +1380,13 @@ void QGIViewDimension::drawMultiArc(QPainterPath &painterPath, const Base::Vecto
 
         if (drawMarking[currentIndex].second != drawMarking[startIndex].second) {
             if (drawMarking[startIndex].second) {
-                drawSingleArc(painterPath, arcCenter, arcRadius,
-                              drawMarking[startIndex].first, drawMarking[currentIndex].first);
+                drawSingleArc(painterPath, arcCenter, arcRadius, drawMarking[startIndex].first,
+                              drawMarking[currentIndex].first);
             }
 
             startIndex = currentIndex;
         }
-    }
-    while (currentIndex != entryIndex);
+    } while (currentIndex != entryIndex);
 }
 
 
@@ -1336,17 +1394,19 @@ void QGIViewDimension::drawMultiArc(QPainterPath &painterPath, const Base::Vecto
 //dimension line starts at targetPoint and continues for a distance (startPosition?) along lineAngle
 //jointPosition - distance of reference line from 1 extension line??
 //lineAngle - Clockwise angle of distance line with horizontal
-void QGIViewDimension::drawDimensionLine(QPainterPath &painterPath, const Base::Vector2d &targetPoint, double lineAngle,
-                           double startPosition, double jointPosition, const Base::BoundBox2d &labelRectangle,
-                           int arrowCount, int standardStyle, bool flipArrows) const
+void QGIViewDimension::drawDimensionLine(QPainterPath& painterPath,
+                                         const Base::Vector2d& targetPoint, double lineAngle,
+                                         double startPosition, double jointPosition,
+                                         const Base::BoundBox2d& labelRectangle, int arrowCount,
+                                         int standardStyle, bool flipArrows) const
 {
     // Keep the convention start position <= 0
     jointPosition *= normalizeStartPosition(startPosition, lineAngle);
 
     std::vector<std::pair<double, bool>> drawMarks;
-    flipArrows = constructDimensionLine(targetPoint, lineAngle, startPosition, jointPosition,
-                                        labelRectangle, arrowCount, standardStyle, flipArrows,
-                                        drawMarks);
+    flipArrows =
+        constructDimensionLine(targetPoint, lineAngle, startPosition, jointPosition, labelRectangle,
+                               arrowCount, standardStyle, flipArrows, drawMarks);
 
     drawMultiLine(painterPath, targetPoint, lineAngle, drawMarks);
 
@@ -1361,34 +1421,35 @@ void QGIViewDimension::drawDimensionLine(QPainterPath &painterPath, const Base::
     drawArrows(arrowCount, arrowPositions, arrowAngles, flipArrows);
 }
 
-void QGIViewDimension::drawDimensionArc(QPainterPath &painterPath, const Base::Vector2d &arcCenter, double arcRadius,
-                           double endAngle, double startRotation, double jointAngle,
-                           const Base::BoundBox2d &labelRectangle,
-                           int arrowCount, int standardStyle, bool flipArrows) const
+void QGIViewDimension::drawDimensionArc(QPainterPath& painterPath, const Base::Vector2d& arcCenter,
+                                        double arcRadius, double endAngle, double startRotation,
+                                        double jointAngle, const Base::BoundBox2d& labelRectangle,
+                                        int arrowCount, int standardStyle, bool flipArrows) const
 {
     // Keep the convention start rotation <= 0
     double handednessFactor = normalizeStartRotation(startRotation);
 
     // Split the rest of 2PI minus the angle and assign joint offset so > 0 is closer to end arc side
-    double jointRotation = handednessFactor*(jointAngle - endAngle);
-    if (fabs(jointRotation - startRotation*0.5) > M_PI) {
+    double jointRotation = handednessFactor * (jointAngle - endAngle);
+    if (fabs(jointRotation - startRotation * 0.5) > M_PI) {
         jointRotation += jointRotation < 0.0 ? +M_2PI : -M_2PI;
     }
 
     std::vector<std::pair<double, bool>> drawMarks;
-    flipArrows = constructDimensionArc(arcCenter, arcRadius, endAngle, startRotation, handednessFactor, jointRotation,
-                                       labelRectangle, arrowCount, standardStyle, flipArrows,
-                                       drawMarks);
+    flipArrows = constructDimensionArc(arcCenter, arcRadius, endAngle, startRotation,
+                                       handednessFactor, jointRotation, labelRectangle, arrowCount,
+                                       standardStyle, flipArrows, drawMarks);
 
     drawMultiArc(painterPath, arcCenter, arcRadius, drawMarks);
 
     Base::Vector2d arrowPositions[2];
     arrowPositions[0] = arcCenter + Base::Vector2d::FromPolar(arcRadius, endAngle);
-    arrowPositions[1] = arcCenter + Base::Vector2d::FromPolar(arcRadius, endAngle + handednessFactor*startRotation);
+    arrowPositions[1] = arcCenter
+        + Base::Vector2d::FromPolar(arcRadius, endAngle + handednessFactor * startRotation);
 
     double arrowAngles[2];
-    arrowAngles[0] = endAngle + handednessFactor*M_PI_2;
-    arrowAngles[1] = endAngle + handednessFactor*(startRotation - M_PI_2);
+    arrowAngles[0] = endAngle + handednessFactor * M_PI_2;
+    arrowAngles[1] = endAngle + handednessFactor * (startRotation - M_PI_2);
 
     drawArrows(arrowCount, arrowPositions, arrowAngles, flipArrows);
 }
@@ -1401,9 +1462,11 @@ void QGIViewDimension::drawDimensionArc(QPainterPath &painterPath, const Base::V
 //dimension line - main annotation line
 //reference line - line under dimension text in referenced styles
 //joint points - ends of reference line
-void QGIViewDimension::drawDistanceExecutive(const Base::Vector2d &startPoint, const Base::Vector2d &endPoint,
-                                             double lineAngle, const Base::BoundBox2d &labelRectangle,
-                                             int standardStyle, int renderExtent, bool flipArrows) const
+void QGIViewDimension::drawDistanceExecutive(const Base::Vector2d& startPoint,
+                                             const Base::Vector2d& endPoint, double lineAngle,
+                                             const Base::BoundBox2d& labelRectangle,
+                                             int standardStyle, int renderExtent,
+                                             bool flipArrows) const
 {
     QPainterPath distancePath;
 
@@ -1414,8 +1477,9 @@ void QGIViewDimension::drawDistanceExecutive(const Base::Vector2d &startPoint, c
     Base::Vector2d startCross;
     Base::Vector2d endCross;
     int arrowCount = renderExtent >= ViewProviderDimension::REND_EXTENT_NORMAL
-                         || renderExtent == ViewProviderDimension::REND_EXTENT_CONFINED
-                     ? 2 : 1;
+            || renderExtent == ViewProviderDimension::REND_EXTENT_CONFINED
+        ? 2
+        : 1;
 
     if (standardStyle == ViewProviderDimension::STD_STYLE_ISO_REFERENCING
         || standardStyle == ViewProviderDimension::STD_STYLE_ASME_REFERENCING) {
@@ -1440,7 +1504,8 @@ void QGIViewDimension::drawDistanceExecutive(const Base::Vector2d &startPoint, c
 
         // Compute and normalize (i.e. make < 0) the start position
         Base::Vector2d lineDirection(Base::Vector2d::FromPolar(1.0, lineAngle));
-        double startPosition = arrowCount > 1 ? lineDirection*(startPoint - targetPoints[0]) : 0.0;
+        double startPosition =
+            arrowCount > 1 ? lineDirection * (startPoint - targetPoints[0]) : 0.0;
         lineDirection *= normalizeStartPosition(startPosition, lineAngle);
 
         // Find the positions where the reference line attaches to the dimension line
@@ -1448,13 +1513,15 @@ void QGIViewDimension::drawDistanceExecutive(const Base::Vector2d &startPoint, c
         //targetPoints - projection of reference line on to extension line
         //jointPositions - displacement of jointPoints from ext line
         double jointPositions[2];
-        jointPositions[0] = lineDirection*(jointPoints[0] - targetPoints[0]);
-        jointPositions[1] = lineDirection*(jointPoints[1] - targetPoints[1]);
+        jointPositions[0] = lineDirection * (jointPoints[0] - targetPoints[0]);
+        jointPositions[1] = lineDirection * (jointPoints[1] - targetPoints[1]);
 
         // Orient the leader line angle correctly towards the target point
         double angles[2];
-        angles[0] = jointPositions[0] > 0.0 ? DrawUtil::angleComposition(lineAngle, M_PI) : lineAngle;
-        angles[1] = jointPositions[1] > 0.0 ? DrawUtil::angleComposition(lineAngle, M_PI) : lineAngle;
+        angles[0] =
+            jointPositions[0] > 0.0 ? DrawUtil::angleComposition(lineAngle, M_PI) : lineAngle;
+        angles[1] =
+            jointPositions[1] > 0.0 ? DrawUtil::angleComposition(lineAngle, M_PI) : lineAngle;
 
         // Select the placement, where the label is not obscured by the leader line
         // or (if both behave the same) the one that  bends the reference line less
@@ -1463,19 +1530,22 @@ void QGIViewDimension::drawDistanceExecutive(const Base::Vector2d &startPoint, c
         std::vector<std::pair<double, bool>> lineMarking;
         constructDimensionLine(targetPoints[0], lineAngle, startPosition, jointPositions[0],
                                labelRectangle, arrowCount, standardStyle, flipArrows, lineMarking);
-        strikeFactors[0] = computeLineStrikeFactor(labelRectangle, targetPoints[0], lineAngle, lineMarking);
+        strikeFactors[0] =
+            computeLineStrikeFactor(labelRectangle, targetPoints[0], lineAngle, lineMarking);
 
         lineMarking.clear();
         constructDimensionLine(targetPoints[1], lineAngle, startPosition, jointPositions[1],
                                labelRectangle, arrowCount, standardStyle, flipArrows, lineMarking);
-        strikeFactors[1] = computeLineStrikeFactor(labelRectangle, targetPoints[1], lineAngle, lineMarking);
+        strikeFactors[1] =
+            computeLineStrikeFactor(labelRectangle, targetPoints[1], lineAngle, lineMarking);
 
-        int selected = compareAngleStraightness(0.0, angles[0], angles[1], strikeFactors[0], strikeFactors[1]);
+        int selected =
+            compareAngleStraightness(0.0, angles[0], angles[1], strikeFactors[0], strikeFactors[1]);
         if (selected == 0) {
             // Select the side closer, so the label is on the outer side of the dimension line
             Base::Vector2d perpendicularDir(lineDirection.Perpendicular());
-            if (fabs((jointPoints[0] - endPoint)*perpendicularDir)
-                > fabs((jointPoints[1] - endPoint)*perpendicularDir)) {
+            if (fabs((jointPoints[0] - endPoint) * perpendicularDir)
+                > fabs((jointPoints[1] - endPoint) * perpendicularDir)) {
                 selected = 1;
             }
         }
@@ -1487,12 +1557,14 @@ void QGIViewDimension::drawDistanceExecutive(const Base::Vector2d &startPoint, c
         endCross = targetPoints[selected];
         startCross = targetPoints[selected] + Base::Vector2d::FromPolar(startPosition, lineAngle);
 
-        drawDimensionLine(distancePath, endCross, lineAngle, startPosition, jointPositions[selected],
-                          labelRectangle, arrowCount, standardStyle, flipArrows);
+        drawDimensionLine(distancePath, endCross, lineAngle, startPosition,
+                          jointPositions[selected], labelRectangle, arrowCount, standardStyle,
+                          flipArrows);
 
-        Base::Vector2d outsetPoint(standardStyle == ViewProviderDimension::STD_STYLE_ISO_REFERENCING
-                                   ? getIsoRefOutsetPoint(labelRectangle, selected == 1)  // 0 = left, 1 = right
-                                   : getAsmeRefOutsetPoint(labelRectangle, selected == 1));
+        Base::Vector2d outsetPoint(
+            standardStyle == ViewProviderDimension::STD_STYLE_ISO_REFERENCING
+                ? getIsoRefOutsetPoint(labelRectangle, selected == 1)// 0 = left, 1 = right
+                : getAsmeRefOutsetPoint(labelRectangle, selected == 1));
 
         //add the reference line to the QPainterPath
         distancePath.moveTo(toQtGui(outsetPoint));
@@ -1502,15 +1574,16 @@ void QGIViewDimension::drawDistanceExecutive(const Base::Vector2d &startPoint, c
     else if (standardStyle == ViewProviderDimension::STD_STYLE_ISO_ORIENTED) {
         // We may rotate the label so no leader and reference lines are needed
         double placementFactor = getIsoStandardLinePlacement(lineAngle);
-        labelAngle = placementFactor > 0.0 ? DrawUtil::angleComposition(lineAngle, M_PI) : lineAngle;
+        labelAngle =
+            placementFactor > 0.0 ? DrawUtil::angleComposition(lineAngle, M_PI) : lineAngle;
 
         // Find out the projection of label center on the line with given angle
         Base::Vector2d labelProjection(
-                           labelCenter
-                           + Base::Vector2d::FromPolar(
-                                 placementFactor*(labelRectangle.Height()*0.5
-                                                  + getDefaultIsoDimensionLineSpacing()),
-                                 lineAngle + M_PI_2));
+            labelCenter
+            + Base::Vector2d::FromPolar(
+                placementFactor
+                    * (labelRectangle.Height() * 0.5 + getDefaultIsoDimensionLineSpacing()),
+                lineAngle + M_PI_2));
 
         // Compute the dimensional line start and end crossings with (virtual) extension lines
         //check for isometric direction and if iso compute non-perpendicular intersection of dim line and ext lines
@@ -1519,8 +1592,8 @@ void QGIViewDimension::drawDistanceExecutive(const Base::Vector2d &startPoint, c
         endCross = computePerpendicularIntersection(labelProjection, endPoint, lineAngle);
 
         // Find linear coefficients of crossings
-        double startPosition = arrowCount > 1 ? lineDirection*(startCross - endCross) : 0.0;
-        double labelPosition = lineDirection*(labelProjection - endCross);
+        double startPosition = arrowCount > 1 ? lineDirection * (startCross - endCross) : 0.0;
+        double labelPosition = lineDirection * (labelProjection - endCross);
 
         drawDimensionLine(distancePath, endCross, lineAngle, startPosition, labelPosition,
                           labelRectangle, arrowCount, standardStyle, flipArrows);
@@ -1533,15 +1606,16 @@ void QGIViewDimension::drawDistanceExecutive(const Base::Vector2d &startPoint, c
         endCross = computePerpendicularIntersection(labelCenter, endPoint, lineAngle);
 
         // Find linear coefficients of crossings
-        double startPosition = arrowCount > 1 ? lineDirection*(startCross - endCross) : 0.0;
-        double labelPosition = lineDirection*(labelCenter - endCross);
+        double startPosition = arrowCount > 1 ? lineDirection * (startCross - endCross) : 0.0;
+        double labelPosition = lineDirection * (labelCenter - endCross);
 
         drawDimensionLine(distancePath, endCross, lineAngle, startPosition, labelPosition,
                           labelRectangle, arrowCount, standardStyle, flipArrows);
     }
     else {
-        Base::Console().Error("QGIVD::drawDistanceExecutive - this Standard&Style is not supported: %d\n",
-                              standardStyle);
+        Base::Console().Error(
+            "QGIVD::drawDistanceExecutive - this Standard&Style is not supported: %d\n",
+            standardStyle);
         arrowCount = 0;
     }
 
@@ -1562,15 +1636,17 @@ void QGIViewDimension::drawDistanceExecutive(const Base::Vector2d &startPoint, c
         }
 
         Base::Vector2d extensionOrigin;
-        Base::Vector2d extensionTarget(computeExtensionLinePoints(endPoint, endCross, lineAngle + M_PI_2,
-                                       getDefaultExtensionLineOverhang(), gapSize, extensionOrigin));
+        Base::Vector2d extensionTarget(computeExtensionLinePoints(
+            endPoint, endCross, lineAngle + M_PI_2, getDefaultExtensionLineOverhang(), gapSize,
+            extensionOrigin));
         //draw 1st extension line
         distancePath.moveTo(toQtGui(extensionOrigin));
         distancePath.lineTo(toQtGui(extensionTarget));
 
         if (arrowCount > 1) {
             extensionTarget = computeExtensionLinePoints(startPoint, startCross, lineAngle + M_PI_2,
-                                  getDefaultExtensionLineOverhang(), gapSize, extensionOrigin);
+                                                         getDefaultExtensionLineOverhang(), gapSize,
+                                                         extensionOrigin);
             //draw second extension line
             distancePath.moveTo(toQtGui(extensionOrigin));
             distancePath.lineTo(toQtGui(extensionTarget));
@@ -1587,9 +1663,11 @@ void QGIViewDimension::drawDistanceExecutive(const Base::Vector2d &startPoint, c
 //startPoint, endPoint - ends of actual distance line
 //lineAngle - desired angle of dimension line with horizontal
 //extensionAngle - desired angle of extension lines with horizontal
-void QGIViewDimension::drawDistanceOverride(const Base::Vector2d &startPoint, const Base::Vector2d &endPoint,
-                                             double lineAngle, const Base::BoundBox2d &labelRectangle,
-                                             int standardStyle, int renderExtent, bool flipArrows, double extensionAngle) const
+void QGIViewDimension::drawDistanceOverride(const Base::Vector2d& startPoint,
+                                            const Base::Vector2d& endPoint, double lineAngle,
+                                            const Base::BoundBox2d& labelRectangle,
+                                            int standardStyle, int renderExtent, bool flipArrows,
+                                            double extensionAngle) const
 {
     QPainterPath distancePath;
 
@@ -1603,8 +1681,9 @@ void QGIViewDimension::drawDistanceOverride(const Base::Vector2d &startPoint, co
     Base::Vector2d extensionDirection(Base::Vector2d::FromPolar(1.0, extensionAngle));
 
     int arrowCount = renderExtent >= ViewProviderDimension::REND_EXTENT_NORMAL
-                         || renderExtent == ViewProviderDimension::REND_EXTENT_CONFINED
-                     ? 2 : 1;
+            || renderExtent == ViewProviderDimension::REND_EXTENT_CONFINED
+        ? 2
+        : 1;
 
     if (standardStyle == ViewProviderDimension::STD_STYLE_ISO_REFERENCING
         || standardStyle == ViewProviderDimension::STD_STYLE_ASME_REFERENCING) {
@@ -1624,10 +1703,14 @@ void QGIViewDimension::drawDistanceOverride(const Base::Vector2d &startPoint, co
 
         //targetPoints are the projection of reference line endpoints onto endPoint's extension line
         Base::Vector2d targetPoints[2];
-        targetPoints[0] = DrawUtil::Intersect2d(refEndPoints[0], lineDirection, endPoint, extensionDirection);
-        targetPoints[1] = DrawUtil::Intersect2d(refEndPoints[1], lineDirection, endPoint, extensionDirection);
-        Base::Vector2d pointOnStartExtension = DrawUtil::Intersect2d(endPoint, lineDirection, startPoint, extensionDirection);
-        double startPosition = arrowCount > 1 ? lineDirection*( pointOnStartExtension - endPoint) : 0.0;
+        targetPoints[0] =
+            DrawUtil::Intersect2d(refEndPoints[0], lineDirection, endPoint, extensionDirection);
+        targetPoints[1] =
+            DrawUtil::Intersect2d(refEndPoints[1], lineDirection, endPoint, extensionDirection);
+        Base::Vector2d pointOnStartExtension =
+            DrawUtil::Intersect2d(endPoint, lineDirection, startPoint, extensionDirection);
+        double startPosition =
+            arrowCount > 1 ? lineDirection * (pointOnStartExtension - endPoint) : 0.0;
 
         // Compute and normalize (i.e. make < 0) the start position
         lineDirection *= normalizeStartPosition(startPosition, lineAngle);
@@ -1637,13 +1720,15 @@ void QGIViewDimension::drawDistanceOverride(const Base::Vector2d &startPoint, co
         //targetPoints - projection of reference line on to extension line
         //jointPositions - displacement of refEndPoints from extension line
         double jointPositions[2];
-        jointPositions[0] = lineDirection*(refEndPoints[0] - targetPoints[0]);
-        jointPositions[1] = lineDirection*(refEndPoints[1] - targetPoints[1]);
+        jointPositions[0] = lineDirection * (refEndPoints[0] - targetPoints[0]);
+        jointPositions[1] = lineDirection * (refEndPoints[1] - targetPoints[1]);
 
         // Orient the leader line angle correctly towards the target point
         double angles[2];
-        angles[0] = jointPositions[0] > 0.0 ? DrawUtil::angleComposition(lineAngle, M_PI) : lineAngle;
-        angles[1] = jointPositions[1] > 0.0 ? DrawUtil::angleComposition(lineAngle, M_PI) : lineAngle;
+        angles[0] =
+            jointPositions[0] > 0.0 ? DrawUtil::angleComposition(lineAngle, M_PI) : lineAngle;
+        angles[1] =
+            jointPositions[1] > 0.0 ? DrawUtil::angleComposition(lineAngle, M_PI) : lineAngle;
 
         // Select the placement, where the label is not obscured by the leader line
         // or (if both behave the same) the one that  bends the reference line less
@@ -1652,19 +1737,22 @@ void QGIViewDimension::drawDistanceOverride(const Base::Vector2d &startPoint, co
         std::vector<std::pair<double, bool>> lineMarking;
         constructDimensionLine(targetPoints[0], lineAngle, startPosition, jointPositions[0],
                                labelRectangle, arrowCount, standardStyle, flipArrows, lineMarking);
-        strikeFactors[0] = computeLineStrikeFactor(labelRectangle, targetPoints[0], lineAngle, lineMarking);
+        strikeFactors[0] =
+            computeLineStrikeFactor(labelRectangle, targetPoints[0], lineAngle, lineMarking);
 
         lineMarking.clear();
         constructDimensionLine(targetPoints[1], lineAngle, startPosition, jointPositions[1],
                                labelRectangle, arrowCount, standardStyle, flipArrows, lineMarking);
-        strikeFactors[1] = computeLineStrikeFactor(labelRectangle, targetPoints[1], lineAngle, lineMarking);
+        strikeFactors[1] =
+            computeLineStrikeFactor(labelRectangle, targetPoints[1], lineAngle, lineMarking);
 
-        int selected = compareAngleStraightness(0.0, angles[0], angles[1], strikeFactors[0], strikeFactors[1]);
+        int selected =
+            compareAngleStraightness(0.0, angles[0], angles[1], strikeFactors[0], strikeFactors[1]);
         if (selected == 0) {
             // Select the side closer, so the label is on the outer side of the dimension line
             Base::Vector2d perpendicularDir(lineDirection.Perpendicular());
-            if (fabs((refEndPoints[0] - endPoint)*perpendicularDir)
-                > fabs((refEndPoints[1] - endPoint)*perpendicularDir)) {
+            if (fabs((refEndPoints[0] - endPoint) * perpendicularDir)
+                > fabs((refEndPoints[1] - endPoint) * perpendicularDir)) {
                 selected = 1;
             }
         }
@@ -1674,15 +1762,19 @@ void QGIViewDimension::drawDistanceOverride(const Base::Vector2d &startPoint, co
 
         //find points where extension lines meet dimension line
         Base::Vector2d pointOnDimLine(refEndPoints[selected].x, refEndPoints[selected].y);
-        startCross = DrawUtil::Intersect2d(startPoint, extensionDirection, pointOnDimLine, lineDirection);
-        endCross = DrawUtil::Intersect2d(endPoint, extensionDirection, pointOnDimLine, lineDirection);
+        startCross =
+            DrawUtil::Intersect2d(startPoint, extensionDirection, pointOnDimLine, lineDirection);
+        endCross =
+            DrawUtil::Intersect2d(endPoint, extensionDirection, pointOnDimLine, lineDirection);
 
-        drawDimensionLine(distancePath, endCross, lineAngle, startPosition, jointPositions[selected],
-                          labelRectangle, arrowCount, standardStyle, flipArrows);
+        drawDimensionLine(distancePath, endCross, lineAngle, startPosition,
+                          jointPositions[selected], labelRectangle, arrowCount, standardStyle,
+                          flipArrows);
 
-        Base::Vector2d outsetPoint(standardStyle == ViewProviderDimension::STD_STYLE_ISO_REFERENCING
-                                   ? getIsoRefOutsetPoint(labelRectangle, selected == 1)  // 0 = left, 1 = right
-                                   : getAsmeRefOutsetPoint(labelRectangle, selected == 1));
+        Base::Vector2d outsetPoint(
+            standardStyle == ViewProviderDimension::STD_STYLE_ISO_REFERENCING
+                ? getIsoRefOutsetPoint(labelRectangle, selected == 1)// 0 = left, 1 = right
+                : getAsmeRefOutsetPoint(labelRectangle, selected == 1));
 
         //add the reference line to the QPainterPath
         distancePath.moveTo(toQtGui(outsetPoint));
@@ -1692,23 +1784,26 @@ void QGIViewDimension::drawDistanceOverride(const Base::Vector2d &startPoint, co
     else if (standardStyle == ViewProviderDimension::STD_STYLE_ISO_ORIENTED) {
         // We may rotate the label so no leader and reference lines are needed
         double placementFactor = getIsoStandardLinePlacement(lineAngle);
-        labelAngle = placementFactor > 0.0 ? DrawUtil::angleComposition(lineAngle, M_PI) : lineAngle;
+        labelAngle =
+            placementFactor > 0.0 ? DrawUtil::angleComposition(lineAngle, M_PI) : lineAngle;
 
         // Find out the projection of label center on the line with given angle
         Base::Vector2d labelProjection(
-                           labelCenter
-                           + Base::Vector2d::FromPolar(
-                                 placementFactor*(labelRectangle.Height()*0.5
-                                                  + getDefaultIsoDimensionLineSpacing()),
-                                 lineAngle + M_PI_2));
+            labelCenter
+            + Base::Vector2d::FromPolar(
+                placementFactor
+                    * (labelRectangle.Height() * 0.5 + getDefaultIsoDimensionLineSpacing()),
+                lineAngle + M_PI_2));
 
         // Compute the dimensional line start and end crossings with (virtual) extension lines
-        startCross = DrawUtil::Intersect2d(startPoint, extensionDirection, labelProjection, lineDirection);
-        endCross = DrawUtil::Intersect2d(endPoint, extensionDirection, labelProjection, lineDirection);
+        startCross =
+            DrawUtil::Intersect2d(startPoint, extensionDirection, labelProjection, lineDirection);
+        endCross =
+            DrawUtil::Intersect2d(endPoint, extensionDirection, labelProjection, lineDirection);
 
         // Find linear coefficients of crossings
-        double startPosition = arrowCount > 1 ? lineDirection*(startCross - endCross) : 0.0;
-        double labelPosition = lineDirection*(labelProjection - endCross);
+        double startPosition = arrowCount > 1 ? lineDirection * (startCross - endCross) : 0.0;
+        double labelPosition = lineDirection * (labelProjection - endCross);
 
         drawDimensionLine(distancePath, endCross, lineAngle, startPosition, labelPosition,
                           labelRectangle, arrowCount, standardStyle, flipArrows);
@@ -1716,19 +1811,21 @@ void QGIViewDimension::drawDistanceOverride(const Base::Vector2d &startPoint, co
 
     else if (standardStyle == ViewProviderDimension::STD_STYLE_ASME_INLINED) {
         // Text must remain horizontal, but it may split the leader line
-        startCross = DrawUtil::Intersect2d(startPoint, extensionDirection, labelCenter, lineDirection);
+        startCross =
+            DrawUtil::Intersect2d(startPoint, extensionDirection, labelCenter, lineDirection);
         endCross = DrawUtil::Intersect2d(endPoint, extensionDirection, labelCenter, lineDirection);
 
         // Find linear coefficients of crossings
-        double startPosition = arrowCount > 1 ? lineDirection*(startCross - endCross) : 0.0;
-        double labelPosition = lineDirection*(labelCenter - endCross);
+        double startPosition = arrowCount > 1 ? lineDirection * (startCross - endCross) : 0.0;
+        double labelPosition = lineDirection * (labelCenter - endCross);
 
         drawDimensionLine(distancePath, endCross, lineAngle, startPosition, labelPosition,
                           labelRectangle, arrowCount, standardStyle, flipArrows);
     }
     else {
-        Base::Console().Error("QGIVD::drawDistanceExecutive - this Standard&Style is not supported: %d\n",
-                              standardStyle);
+        Base::Console().Error(
+            "QGIVD::drawDistanceExecutive - this Standard&Style is not supported: %d\n",
+            standardStyle);
         arrowCount = 0;
     }
 
@@ -1750,15 +1847,17 @@ void QGIViewDimension::drawDistanceOverride(const Base::Vector2d &startPoint, co
 
 
         Base::Vector2d extensionOrigin;
-        Base::Vector2d extensionTarget(computeExtensionLinePoints(endPoint, endCross, lineAngle + M_PI_2,
-                                       getDefaultExtensionLineOverhang(), gapSize, extensionOrigin));
+        Base::Vector2d extensionTarget(computeExtensionLinePoints(
+            endPoint, endCross, lineAngle + M_PI_2, getDefaultExtensionLineOverhang(), gapSize,
+            extensionOrigin));
         //draw 1st extension line
         distancePath.moveTo(toQtGui(extensionOrigin));
         distancePath.lineTo(toQtGui(extensionTarget));
 
         if (arrowCount > 1) {
             extensionTarget = computeExtensionLinePoints(startPoint, startCross, lineAngle + M_PI_2,
-                                  getDefaultExtensionLineOverhang(), gapSize, extensionOrigin);
+                                                         getDefaultExtensionLineOverhang(), gapSize,
+                                                         extensionOrigin);
             //draw second extension line
             distancePath.moveTo(toQtGui(extensionOrigin));
             distancePath.lineTo(toQtGui(extensionTarget));
@@ -1771,10 +1870,12 @@ void QGIViewDimension::drawDistanceOverride(const Base::Vector2d &startPoint, co
     dimLines->setPath(distancePath);
 }
 
-void QGIViewDimension::drawRadiusExecutive(const Base::Vector2d &centerPoint, const Base::Vector2d &midPoint,
-                           double radius, double endAngle, double startRotation,
-                           const Base::BoundBox2d &labelRectangle, double centerOverhang,
-                           int standardStyle, int renderExtent, bool flipArrow) const
+void QGIViewDimension::drawRadiusExecutive(const Base::Vector2d& centerPoint,
+                                           const Base::Vector2d& midPoint, double radius,
+                                           double endAngle, double startRotation,
+                                           const Base::BoundBox2d& labelRectangle,
+                                           double centerOverhang, int standardStyle,
+                                           int renderExtent, bool flipArrow) const
 {
     QPainterPath radiusPath;
 
@@ -1805,13 +1906,17 @@ void QGIViewDimension::drawRadiusExecutive(const Base::Vector2d &centerPoint, co
         angleFactors[1] = getAnglePlacementFactor(lineAngles[1], endAngle, startRotation);
 
         // Orient the leader line angle correctly towards the point on arc
-        if (angleFactors[0] < 0.0) lineAngles[0] = DrawUtil::angleComposition(lineAngles[0], M_PI);
-        if (angleFactors[1] < 0.0) lineAngles[1] = DrawUtil::angleComposition(lineAngles[1], M_PI);
+        if (angleFactors[0] < 0.0) {
+            lineAngles[0] = DrawUtil::angleComposition(lineAngles[0], M_PI);
+        }
+        if (angleFactors[1] < 0.0) {
+            lineAngles[1] = DrawUtil::angleComposition(lineAngles[1], M_PI);
+        }
 
         // Find the positions where the reference line attaches to the dimension line
         double jointPositions[2];
-        jointPositions[0] = angleFactors[0]*jointDirections[0].Length() - radius;
-        jointPositions[1] = angleFactors[1]*jointDirections[1].Length() - radius;
+        jointPositions[0] = angleFactors[0] * jointDirections[0].Length() - radius;
+        jointPositions[1] = angleFactors[1] * jointDirections[1].Length() - radius;
 
         Base::Vector2d targetPoints[2];
         targetPoints[0] = centerPoint + Base::Vector2d::FromPolar(radius, lineAngles[0]);
@@ -1824,26 +1929,32 @@ void QGIViewDimension::drawRadiusExecutive(const Base::Vector2d &centerPoint, co
             // perpendicularly to the arc, i.e. in direction to the center
             if (angleFactors[0] && angleFactors[1]) {
                 // Both are acceptable, so choose the more convenient one
-                double strikeFactors[2] = { 0.0, 0.0 };
+                double strikeFactors[2] = {0.0, 0.0};
 
                 if (renderExtent >= ViewProviderDimension::REND_EXTENT_NORMAL) {
                     std::vector<std::pair<double, bool>> lineMarking;
-                    constructDimensionLine(targetPoints[0], lineAngles[0], -radius, jointPositions[0],
-                                           labelRectangle, 1, standardStyle, flipArrow, lineMarking);
+                    constructDimensionLine(targetPoints[0], lineAngles[0], -radius,
+                                           jointPositions[0], labelRectangle, 1, standardStyle,
+                                           flipArrow, lineMarking);
                     strikeFactors[0] = computeLineStrikeFactor(labelRectangle, targetPoints[0],
                                                                lineAngles[0], lineMarking);
 
                     lineMarking.clear();
-                    constructDimensionLine(targetPoints[1], lineAngles[1], -radius, jointPositions[1],
-                                           labelRectangle, 1, standardStyle, flipArrow, lineMarking);
+                    constructDimensionLine(targetPoints[1], lineAngles[1], -radius,
+                                           jointPositions[1], labelRectangle, 1, standardStyle,
+                                           flipArrow, lineMarking);
                     strikeFactors[1] = computeLineStrikeFactor(labelRectangle, targetPoints[1],
                                                                lineAngles[1], lineMarking);
                 }
 
-                if (compareAngleStraightness(0.0,
-                        jointPositions[0] > 0.0 ? DrawUtil::angleComposition(lineAngles[0], M_PI) : lineAngles[0],
-                        jointPositions[1] > 0.0 ? DrawUtil::angleComposition(lineAngles[1], M_PI) : lineAngles[1],
-                        strikeFactors[0], strikeFactors[1]) > 0) {
+                if (compareAngleStraightness(
+                        0.0,
+                        jointPositions[0] > 0.0 ? DrawUtil::angleComposition(lineAngles[0], M_PI)
+                                                : lineAngles[0],
+                        jointPositions[1] > 0.0 ? DrawUtil::angleComposition(lineAngles[1], M_PI)
+                                                : lineAngles[1],
+                        strikeFactors[0], strikeFactors[1])
+                    > 0) {
                     selected = 1;
                 }
             }
@@ -1853,10 +1964,10 @@ void QGIViewDimension::drawRadiusExecutive(const Base::Vector2d &centerPoint, co
 
             arcPoint = targetPoints[selected];
         }
-        else { //  Both joint points lay outside the vertical angles
+        else {//  Both joint points lay outside the vertical angles
             arcPoint = midPoint;
 
-            if (labelCenter.x < arcPoint.x) { // Place the dimensional value left
+            if (labelCenter.x < arcPoint.x) {// Place the dimensional value left
                 selected = 1;
             }
 
@@ -1868,13 +1979,14 @@ void QGIViewDimension::drawRadiusExecutive(const Base::Vector2d &centerPoint, co
         drawDimensionLine(radiusPath, arcPoint, lineAngles[selected],
                           // If not reduced rendering and at least in one arc wedge, draw to center
                           (angleFactors[0] || angleFactors[1])
-                          && renderExtent >= ViewProviderDimension::REND_EXTENT_NORMAL
-                          ? -radius - centerOverhang : 0.0,
+                                  && renderExtent >= ViewProviderDimension::REND_EXTENT_NORMAL
+                              ? -radius - centerOverhang
+                              : 0.0,
                           jointPositions[selected], labelRectangle, 1, standardStyle, flipArrow);
 
         Base::Vector2d outsetPoint(standardStyle == ViewProviderDimension::STD_STYLE_ISO_REFERENCING
-                                   ? getIsoRefOutsetPoint(labelRectangle, selected == 1)
-                                   : getAsmeRefOutsetPoint(labelRectangle, selected == 1));
+                                       ? getIsoRefOutsetPoint(labelRectangle, selected == 1)
+                                       : getAsmeRefOutsetPoint(labelRectangle, selected == 1));
 
         radiusPath.moveTo(toQtGui(outsetPoint));
         radiusPath.lineTo(toQtGui(centerPoint + jointDirections[selected]));
@@ -1883,7 +1995,9 @@ void QGIViewDimension::drawRadiusExecutive(const Base::Vector2d &centerPoint, co
         // We may rotate the label so no reference line is needed
         double lineAngle;
         double devAngle = computeLineAndLabelAngles(centerPoint, labelCenter,
-                              labelRectangle.Height()*0.5 + getDefaultIsoDimensionLineSpacing(), lineAngle, labelAngle);
+                                                    labelRectangle.Height() * 0.5
+                                                        + getDefaultIsoDimensionLineSpacing(),
+                                                    lineAngle, labelAngle);
 
         // Is there point on the arc, where line from center intersects it perpendicularly?
         double angleFactor = getAnglePlacementFactor(lineAngle, endAngle, startRotation);
@@ -1897,23 +2011,27 @@ void QGIViewDimension::drawRadiusExecutive(const Base::Vector2d &centerPoint, co
             arcPoint = centerPoint + Base::Vector2d::FromPolar(radius, lineAngle);
 
             // Correct the label center distance projected on the leader line and subtract radius
-            labelPosition = angleFactor*cos(devAngle)*((labelCenter - centerPoint).Length()) - radius;
+            labelPosition =
+                angleFactor * cos(devAngle) * ((labelCenter - centerPoint).Length()) - radius;
         }
         else {
             // Leader line outside both arc wedges
             arcPoint = midPoint;
 
             devAngle = computeLineAndLabelAngles(arcPoint, labelCenter,
-                           labelRectangle.Height()*0.5 + getDefaultIsoDimensionLineSpacing(), lineAngle, labelAngle);
+                                                 labelRectangle.Height() * 0.5
+                                                     + getDefaultIsoDimensionLineSpacing(),
+                                                 lineAngle, labelAngle);
             lineAngle = DrawUtil::angleComposition(lineAngle, M_PI);
 
-            labelPosition = -cos(devAngle)*((labelCenter - arcPoint).Length());
+            labelPosition = -cos(devAngle) * ((labelCenter - arcPoint).Length());
         }
 
         drawDimensionLine(radiusPath, arcPoint, lineAngle,
                           // If not reduced rendering and at least in one arc wedge, draw to center
                           angleFactor && renderExtent >= ViewProviderDimension::REND_EXTENT_NORMAL
-                          ? -radius - centerOverhang : 0.0,
+                              ? -radius - centerOverhang
+                              : 0.0,
                           labelPosition, labelRectangle, 1, standardStyle, flipArrow);
     }
     else if (standardStyle == ViewProviderDimension::STD_STYLE_ASME_INLINED) {
@@ -1932,7 +2050,7 @@ void QGIViewDimension::drawRadiusExecutive(const Base::Vector2d &centerPoint, co
         if (angleFactor) {
             arcPoint = centerPoint + Base::Vector2d::FromPolar(radius, lineAngle);
 
-            labelPosition = angleFactor*labelDirection.Length() - radius;
+            labelPosition = angleFactor * labelDirection.Length() - radius;
         }
         else {
             // Leader line outside both arc wedges
@@ -1946,11 +2064,14 @@ void QGIViewDimension::drawRadiusExecutive(const Base::Vector2d &centerPoint, co
         drawDimensionLine(radiusPath, arcPoint, lineAngle,
                           // If not reduced rendering and at least in one arc wedge, draw to center
                           angleFactor && renderExtent >= ViewProviderDimension::REND_EXTENT_NORMAL
-                          ? -radius - centerOverhang : 0.0,
+                              ? -radius - centerOverhang
+                              : 0.0,
                           labelPosition, labelRectangle, 1, standardStyle, flipArrow);
     }
     else {
-        Base::Console().Error("QGIVD::drawRadiusExecutive - this Standard&Style is not supported: %d\n", standardStyle);
+        Base::Console().Error(
+            "QGIVD::drawRadiusExecutive - this Standard&Style is not supported: %d\n",
+            standardStyle);
     }
 
     datumLabel->setTransformOriginPoint(datumLabel->boundingRect().center());
@@ -1959,12 +2080,14 @@ void QGIViewDimension::drawRadiusExecutive(const Base::Vector2d &centerPoint, co
     dimLines->setPath(radiusPath);
 }
 
-void QGIViewDimension::drawDistance(TechDraw::DrawViewDimension *dimension, ViewProviderDimension *viewProvider) const
+void QGIViewDimension::drawDistance(TechDraw::DrawViewDimension* dimension,
+                                    ViewProviderDimension* viewProvider) const
 {
-    Base::BoundBox2d labelRectangle(fromQtGui(mapRectFromItem(datumLabel, datumLabel->boundingRect())));
+    Base::BoundBox2d labelRectangle(
+        fromQtGui(mapRectFromItem(datumLabel, datumLabel->boundingRect())));
 
     pointPair linePoints = dimension->getLinearPoints();
-    const char *dimensionType = dimension->Type.getValueAsString();
+    const char* dimensionType = dimension->Type.getValueAsString();
 
     double lineAngle;
     if (strcmp(dimensionType, "DistanceX") == 0) {
@@ -1984,46 +2107,50 @@ void QGIViewDimension::drawDistance(TechDraw::DrawViewDimension *dimension, View
 
     if (dimension->AngleOverride.getValue()) {
         drawDistanceOverride(fromQtApp(linePoints.first), fromQtApp(linePoints.second),
-                             dimension->LineAngle.getValue() * M_PI / 180.0,
-                             labelRectangle, standardStyle, renderExtent, flipArrows,
+                             dimension->LineAngle.getValue() * M_PI / 180.0, labelRectangle,
+                             standardStyle, renderExtent, flipArrows,
                              dimension->ExtensionAngle.getValue() * M_PI / 180.0);
-
-    } else {
+    }
+    else {
         drawDistanceExecutive(fromQtApp(linePoints.first), fromQtApp(linePoints.second), lineAngle,
                               labelRectangle, standardStyle, renderExtent, flipArrows);
     }
 }
 
-void QGIViewDimension::drawRadius(TechDraw::DrawViewDimension *dimension, ViewProviderDimension *viewProvider) const
+void QGIViewDimension::drawRadius(TechDraw::DrawViewDimension* dimension,
+                                  ViewProviderDimension* viewProvider) const
 {
-    Base::BoundBox2d labelRectangle(fromQtGui(mapRectFromItem(datumLabel, datumLabel->boundingRect())));
+    Base::BoundBox2d labelRectangle(
+        fromQtGui(mapRectFromItem(datumLabel, datumLabel->boundingRect())));
     arcPoints curvePoints = dimension->getArcPoints();
 
     double endAngle;
     double startRotation;
     if (curvePoints.isArc) {
         endAngle = (fromQtApp(curvePoints.arcEnds.second) - fromQtApp(curvePoints.center)).Angle();
-        startRotation = (fromQtApp(curvePoints.arcEnds.first) - fromQtApp(curvePoints.center)).Angle()
-                        - endAngle;
-
+        startRotation =
+            (fromQtApp(curvePoints.arcEnds.first) - fromQtApp(curvePoints.center)).Angle()
+            - endAngle;
         if (startRotation != 0.0 && ((startRotation > 0.0) != curvePoints.arcCW)) {
             startRotation += curvePoints.arcCW ? +M_2PI : -M_2PI;
         }
     }
-    else { // A circle arc covers the whole plane
+    else {// A circle arc covers the whole plane
         endAngle = M_PI;
         startRotation = -M_2PI;
     }
 
-    drawRadiusExecutive(fromQtApp(curvePoints.center), fromQtApp(curvePoints.midArc),
-                        curvePoints.radius, endAngle, startRotation, labelRectangle, 0.0,
-                        viewProvider->StandardAndStyle.getValue(), viewProvider->RenderingExtent.getValue(),
-                        viewProvider->FlipArrowheads.getValue());
+    drawRadiusExecutive(
+        fromQtApp(curvePoints.center), fromQtApp(curvePoints.midArc), curvePoints.radius, endAngle,
+        startRotation, labelRectangle, 0.0, viewProvider->StandardAndStyle.getValue(),
+        viewProvider->RenderingExtent.getValue(), viewProvider->FlipArrowheads.getValue());
 }
 
-void QGIViewDimension::drawDiameter(TechDraw::DrawViewDimension *dimension, ViewProviderDimension *viewProvider) const
+void QGIViewDimension::drawDiameter(TechDraw::DrawViewDimension* dimension,
+                                    ViewProviderDimension* viewProvider) const
 {
-    Base::BoundBox2d labelRectangle(fromQtGui(mapRectFromItem(datumLabel, datumLabel->boundingRect())));
+    Base::BoundBox2d labelRectangle(
+        fromQtGui(mapRectFromItem(datumLabel, datumLabel->boundingRect())));
     Base::Vector2d labelCenter(labelRectangle.GetCenter());
 
     arcPoints curvePoints = dimension->getArcPoints();
@@ -2072,30 +2199,41 @@ void QGIViewDimension::drawDiameter(TechDraw::DrawViewDimension *dimension, View
             double strikeFactors[2];
 
             std::vector<std::pair<double, bool>> lineMarking;
-            constructDimensionLine(targetPoints[0], lineAngles[0], -curveRadius*2.0, jointPositions[0],
-                                   labelRectangle, 2, standardStyle, flipArrows, lineMarking);
-            strikeFactors[0] = computeLineStrikeFactor(labelRectangle, targetPoints[0], lineAngles[0], lineMarking);
+            constructDimensionLine(targetPoints[0], lineAngles[0], -curveRadius * 2.0,
+                                   jointPositions[0], labelRectangle, 2, standardStyle, flipArrows,
+                                   lineMarking);
+            strikeFactors[0] = computeLineStrikeFactor(labelRectangle, targetPoints[0],
+                                                       lineAngles[0], lineMarking);
 
             lineMarking.clear();
-            constructDimensionLine(targetPoints[1], lineAngles[1], -curveRadius*2.0, jointPositions[1],
-                                   labelRectangle, 2, standardStyle, flipArrows, lineMarking);
-            strikeFactors[1] = computeLineStrikeFactor(labelRectangle, targetPoints[1], lineAngles[1], lineMarking);
+            constructDimensionLine(targetPoints[1], lineAngles[1], -curveRadius * 2.0,
+                                   jointPositions[1], labelRectangle, 2, standardStyle, flipArrows,
+                                   lineMarking);
+            strikeFactors[1] = computeLineStrikeFactor(labelRectangle, targetPoints[1],
+                                                       lineAngles[1], lineMarking);
 
             int selected = 0;
-            if (compareAngleStraightness(0.0,
-                jointPositions[0] > 0.0 ? DrawUtil::angleComposition(lineAngles[0], M_PI) : lineAngles[0],
-                jointPositions[1] > 0.0 ? DrawUtil::angleComposition(lineAngles[1], M_PI) : lineAngles[1],
-                strikeFactors[0], strikeFactors[1]) > 0) {
+            if (compareAngleStraightness(
+                    0.0,
+                    jointPositions[0] > 0.0 ? DrawUtil::angleComposition(lineAngles[0], M_PI)
+                                            : lineAngles[0],
+                    jointPositions[1] > 0.0 ? DrawUtil::angleComposition(lineAngles[1], M_PI)
+                                            : lineAngles[1],
+                    strikeFactors[0], strikeFactors[1])
+                > 0) {
                 selected = 1;
             }
 
-            drawDimensionLine(diameterPath, curveCenter + Base::Vector2d::FromPolar(curveRadius, lineAngles[selected]),
-                              lineAngles[selected], -curveRadius*2.0, jointPositions[selected],
+            drawDimensionLine(diameterPath,
+                              curveCenter
+                                  + Base::Vector2d::FromPolar(curveRadius, lineAngles[selected]),
+                              lineAngles[selected], -curveRadius * 2.0, jointPositions[selected],
                               labelRectangle, 2, standardStyle, flipArrows);
 
-            Base::Vector2d outsetPoint(standardStyle == ViewProviderDimension::STD_STYLE_ISO_REFERENCING
-                                       ? getIsoRefOutsetPoint(labelRectangle, selected == 1)
-                                       : getAsmeRefOutsetPoint(labelRectangle, selected == 1));
+            Base::Vector2d outsetPoint(standardStyle
+                                               == ViewProviderDimension::STD_STYLE_ISO_REFERENCING
+                                           ? getIsoRefOutsetPoint(labelRectangle, selected == 1)
+                                           : getAsmeRefOutsetPoint(labelRectangle, selected == 1));
 
             diameterPath.moveTo(toQtGui(outsetPoint));
             diameterPath.lineTo(toQtGui(curveCenter + jointDirections[selected]));
@@ -2104,26 +2242,32 @@ void QGIViewDimension::drawDiameter(TechDraw::DrawViewDimension *dimension, View
             // We may rotate the label so no reference line is needed
             double lineAngle;
             double devAngle = computeLineAndLabelAngles(curveCenter, labelCenter,
-                                  labelRectangle.Height()*0.5 + getDefaultIsoDimensionLineSpacing(),
-                                  lineAngle, labelAngle);
+                                                        labelRectangle.Height() * 0.5
+                                                            + getDefaultIsoDimensionLineSpacing(),
+                                                        lineAngle, labelAngle);
 
             // Correct the label center distance projected on the leader line and subtract radius
-            double labelPosition = cos(devAngle)*((labelCenter - curveCenter).Length()) - curveRadius;
+            double labelPosition =
+                cos(devAngle) * ((labelCenter - curveCenter).Length()) - curveRadius;
 
-            drawDimensionLine(diameterPath, curveCenter + Base::Vector2d::FromPolar(curveRadius, lineAngle), lineAngle,
-                              -curveRadius*2.0, labelPosition, labelRectangle, 2, standardStyle, flipArrows);
+            drawDimensionLine(diameterPath,
+                              curveCenter + Base::Vector2d::FromPolar(curveRadius, lineAngle),
+                              lineAngle, -curveRadius * 2.0, labelPosition, labelRectangle, 2,
+                              standardStyle, flipArrows);
         }
         else if (standardStyle == ViewProviderDimension::STD_STYLE_ASME_INLINED) {
             // Text must remain horizontal, but it may split the leader line
             double lineAngle = (labelCenter - curveCenter).Angle();
-          //Base::Vector2d lineDirection(Base::Vector2d::FromPolar(1.0, lineAngle));
+            //Base::Vector2d lineDirection(Base::Vector2d::FromPolar(1.0, lineAngle));
 
-            drawDimensionLine(diameterPath, curveCenter + Base::Vector2d::FromPolar(curveRadius, lineAngle), lineAngle,
-                              -curveRadius*2.0, (labelCenter - curveCenter).Length() - curveRadius,
-                              labelRectangle, 2, standardStyle, flipArrows);
+            drawDimensionLine(
+                diameterPath, curveCenter + Base::Vector2d::FromPolar(curveRadius, lineAngle),
+                lineAngle, -curveRadius * 2.0, (labelCenter - curveCenter).Length() - curveRadius,
+                labelRectangle, 2, standardStyle, flipArrows);
         }
         else {
-            Base::Console().Error("QGIVD::drawRadius - this Standard&Style is not supported: %d\n", standardStyle);
+            Base::Console().Error("QGIVD::drawRadius - this Standard&Style is not supported: %d\n",
+                                  standardStyle);
         }
 
         datumLabel->setTransformOriginPoint(datumLabel->boundingRect().center());
@@ -2136,41 +2280,44 @@ void QGIViewDimension::drawDiameter(TechDraw::DrawViewDimension *dimension, View
         Base::Vector2d startPoint(curveCenter);
         Base::Vector2d endPoint(curveCenter);
 
-        if ((lineAngle >= M_PI_4 && lineAngle <= 3.0*M_PI_4) || (lineAngle <= -M_PI_4 && lineAngle >= -3.0*M_PI_4)) {
+        if ((lineAngle >= M_PI_4 && lineAngle <= 3.0 * M_PI_4)
+            || (lineAngle <= -M_PI_4 && lineAngle >= -3.0 * M_PI_4)) {
             // Horizontal dimension line
             startPoint.x -= curveRadius;
             endPoint.x += curveRadius;
             lineAngle = 0.0;
         }
-        else { // Vertical dimension line
+        else {// Vertical dimension line
             startPoint.y -= curveRadius;
             endPoint.y += curveRadius;
             lineAngle = M_PI_2;
-         }
+        }
 
-//        lineAngle = DrawUtil::angleComposition((labelCenter - curveCenter).Angle(), +M_PI_2);
-//        startPoint = curveCenter - Base::Vector2d::FromPolar(curveRadius, lineAngle);
-//        endPoint = curveCenter + Base::Vector2d::FromPolar(curveRadius, lineAngle);
+        //        lineAngle = DrawUtil::angleComposition((labelCenter - curveCenter).Angle(), +M_PI_2);
+        //        startPoint = curveCenter - Base::Vector2d::FromPolar(curveRadius, lineAngle);
+        //        endPoint = curveCenter + Base::Vector2d::FromPolar(curveRadius, lineAngle);
 
-        drawDistanceExecutive(startPoint, endPoint, lineAngle, labelRectangle,
-                              standardStyle, ViewProviderDimension::REND_EXTENT_NORMAL, flipArrows);
+        drawDistanceExecutive(startPoint, endPoint, lineAngle, labelRectangle, standardStyle,
+                              ViewProviderDimension::REND_EXTENT_NORMAL, flipArrows);
     }
     else if (renderExtent <= ViewProviderDimension::REND_EXTENT_REDUCED) {
-      renderExtent = renderExtent <= ViewProviderDimension::REND_EXTENT_CONFINED
-                     ? ViewProviderDimension::REND_EXTENT_REDUCED
-                     : ViewProviderDimension::REND_EXTENT_NORMAL;
+        renderExtent = renderExtent <= ViewProviderDimension::REND_EXTENT_CONFINED
+            ? ViewProviderDimension::REND_EXTENT_REDUCED
+            : ViewProviderDimension::REND_EXTENT_NORMAL;
 
-      drawRadiusExecutive(curveCenter, Rez::guiX(curvePoints.midArc, true),
-                          curveRadius, M_PI, -M_2PI, labelRectangle, getDefaultExtensionLineOverhang(),
-                          standardStyle, renderExtent, flipArrows);
+        drawRadiusExecutive(curveCenter, Rez::guiX(curvePoints.midArc, true), curveRadius, M_PI,
+                            -M_2PI, labelRectangle, getDefaultExtensionLineOverhang(),
+                            standardStyle, renderExtent, flipArrows);
     }
 }
 
-void QGIViewDimension::drawAngle(TechDraw::DrawViewDimension *dimension, ViewProviderDimension *viewProvider) const
+void QGIViewDimension::drawAngle(TechDraw::DrawViewDimension* dimension,
+                                 ViewProviderDimension* viewProvider) const
 {
     QPainterPath anglePath;
 
-    Base::BoundBox2d labelRectangle(fromQtGui(mapRectFromItem(datumLabel, datumLabel->boundingRect())));
+    Base::BoundBox2d labelRectangle(
+        fromQtGui(mapRectFromItem(datumLabel, datumLabel->boundingRect())));
     Base::Vector2d labelCenter(labelRectangle.GetCenter());
     double labelAngle = 0.0;
 
@@ -2189,11 +2336,13 @@ void QGIViewDimension::drawAngle(TechDraw::DrawViewDimension *dimension, ViewPro
     bool flipArrows = viewProvider->FlipArrowheads.getValue();
 
     int arrowCount = renderExtent >= ViewProviderDimension::REND_EXTENT_NORMAL
-                         || renderExtent == ViewProviderDimension::REND_EXTENT_CONFINED
-                     ? 2 : 1;
+            || renderExtent == ViewProviderDimension::REND_EXTENT_CONFINED
+        ? 2
+        : 1;
 
     // Inverted dimensions display reflex angles (fi > PI), regular ones oblique angles (fi <= PI/2)
-    double startRotation = DrawUtil::angleDifference(startAngle, endAngle, dimension->Inverted.getValue());
+    double startRotation =
+        DrawUtil::angleDifference(startAngle, endAngle, dimension->Inverted.getValue());
     if (arrowCount < 2) {
         // For single arrow, the effective angle span is 0, but still we need to know
         // the angle orientation. Floating point positive/negative zero comes to rescue...
@@ -2226,14 +2375,14 @@ void QGIViewDimension::drawAngle(TechDraw::DrawViewDimension *dimension, ViewPro
 
         double handednessFactor = normalizeStartRotation(startRotation);
         double jointRotations[2];
-        jointRotations[0] = handednessFactor*(jointAngles[0] - endAngle);
-        jointRotations[1] = handednessFactor*(jointAngles[1] - endAngle);
+        jointRotations[0] = handednessFactor * (jointAngles[0] - endAngle);
+        jointRotations[1] = handednessFactor * (jointAngles[1] - endAngle);
 
         // Compare the offset with half of the rest of 2PI minus the angle and eventually fix the values
-        if (fabs(jointRotations[0] - startRotation*0.5) > M_PI) {
+        if (fabs(jointRotations[0] - startRotation * 0.5) > M_PI) {
             jointRotations[0] += jointRotations[0] < 0.0 ? +M_2PI : -M_2PI;
         }
-        if (fabs(jointRotations[1] - startRotation*0.5) > M_PI) {
+        if (fabs(jointRotations[1] - startRotation * 0.5) > M_PI) {
             jointRotations[1] += jointRotations[1] < 0.0 ? +M_2PI : -M_2PI;
         }
 
@@ -2241,22 +2390,28 @@ void QGIViewDimension::drawAngle(TechDraw::DrawViewDimension *dimension, ViewPro
         double strikeFactors[2];
 
         std::vector<std::pair<double, bool>> arcMarking;
-        constructDimensionArc(angleVertex, arcRadii[0], endAngle, startRotation, handednessFactor, jointRotations[0],
-                              labelRectangle, arrowCount, standardStyle, flipArrows, arcMarking);
-        strikeFactors[0] = computeArcStrikeFactor(labelRectangle, angleVertex, arcRadii[0], arcMarking);
+        constructDimensionArc(angleVertex, arcRadii[0], endAngle, startRotation, handednessFactor,
+                              jointRotations[0], labelRectangle, arrowCount, standardStyle,
+                              flipArrows, arcMarking);
+        strikeFactors[0] =
+            computeArcStrikeFactor(labelRectangle, angleVertex, arcRadii[0], arcMarking);
 
         arcMarking.clear();
-        constructDimensionArc(angleVertex, arcRadii[1], endAngle, startRotation, handednessFactor, jointRotations[1],
-                              labelRectangle, arrowCount, standardStyle, flipArrows, arcMarking);
-        strikeFactors[1] = computeArcStrikeFactor(labelRectangle, angleVertex, arcRadii[1], arcMarking);
+        constructDimensionArc(angleVertex, arcRadii[1], endAngle, startRotation, handednessFactor,
+                              jointRotations[1], labelRectangle, arrowCount, standardStyle,
+                              flipArrows, arcMarking);
+        strikeFactors[1] =
+            computeArcStrikeFactor(labelRectangle, angleVertex, arcRadii[1], arcMarking);
 
         int selected = 0;
-        if (compareAngleStraightness(0.0,
-                DrawUtil::angleComposition(jointAngles[0],
-                                           handednessFactor*jointRotations[0] > 0.0 ? -M_PI_2 : +M_PI_2),
-                DrawUtil::angleComposition(jointAngles[1],
-                                           handednessFactor*jointRotations[1] > 0.0 ? -M_PI_2 : +M_PI_2),
-                                     strikeFactors[0], strikeFactors[1]) > 0) {
+        if (compareAngleStraightness(
+                0.0,
+                DrawUtil::angleComposition(
+                    jointAngles[0], handednessFactor * jointRotations[0] > 0.0 ? -M_PI_2 : +M_PI_2),
+                DrawUtil::angleComposition(
+                    jointAngles[1], handednessFactor * jointRotations[1] > 0.0 ? -M_PI_2 : +M_PI_2),
+                strikeFactors[0], strikeFactors[1])
+            > 0) {
             selected = 1;
         }
 
@@ -2264,11 +2419,12 @@ void QGIViewDimension::drawAngle(TechDraw::DrawViewDimension *dimension, ViewPro
         startRotation = copysign(startRotation, -handednessFactor);
 
         drawDimensionArc(anglePath, angleVertex, arcRadius, endAngle, startRotation,
-                         jointAngles[selected], labelRectangle, arrowCount, standardStyle, flipArrows);
+                         jointAngles[selected], labelRectangle, arrowCount, standardStyle,
+                         flipArrows);
 
         Base::Vector2d outsetPoint(standardStyle == ViewProviderDimension::STD_STYLE_ISO_REFERENCING
-                                   ? getIsoRefOutsetPoint(labelRectangle, selected == 1)
-                                   : getAsmeRefOutsetPoint(labelRectangle, selected == 1));
+                                       ? getIsoRefOutsetPoint(labelRectangle, selected == 1)
+                                       : getAsmeRefOutsetPoint(labelRectangle, selected == 1));
 
         anglePath.moveTo(toQtGui(outsetPoint));
         anglePath.lineTo(toQtGui(angleVertex + jointDirections[selected]));
@@ -2280,10 +2436,12 @@ void QGIViewDimension::drawAngle(TechDraw::DrawViewDimension *dimension, ViewPro
 
         labelAngle = DrawUtil::angleComposition(radiusAngle, M_PI_2);
         double placementFactor = getIsoStandardLinePlacement(labelAngle);
-        labelAngle = placementFactor > 0.0 ? DrawUtil::angleComposition(labelAngle, M_PI) : labelAngle;
+        labelAngle =
+            placementFactor > 0.0 ? DrawUtil::angleComposition(labelAngle, M_PI) : labelAngle;
 
         arcRadius = labelDirection.Length()
-                    - placementFactor*(labelRectangle.Height()*0.5 + getDefaultIsoDimensionLineSpacing());
+            - placementFactor
+                * (labelRectangle.Height() * 0.5 + getDefaultIsoDimensionLineSpacing());
         if (arcRadius < 0.0) {
             arcRadius = labelDirection.Length();
         }
@@ -2296,11 +2454,13 @@ void QGIViewDimension::drawAngle(TechDraw::DrawViewDimension *dimension, ViewPro
         Base::Vector2d labelDirection(labelCenter - angleVertex);
         arcRadius = labelDirection.Length();
 
-        drawDimensionArc(anglePath, angleVertex, arcRadius, endAngle, startRotation, labelDirection.Angle(),
-                         labelRectangle, arrowCount, standardStyle, flipArrows);
+        drawDimensionArc(anglePath, angleVertex, arcRadius, endAngle, startRotation,
+                         labelDirection.Angle(), labelRectangle, arrowCount, standardStyle,
+                         flipArrows);
     }
     else {
-        Base::Console().Error("QGIVD::drawAngle - this Standard&Style is not supported: %d\n", standardStyle);
+        Base::Console().Error("QGIVD::drawAngle - this Standard&Style is not supported: %d\n",
+                              standardStyle);
         arrowCount = 0;
     }
 
@@ -2322,17 +2482,16 @@ void QGIViewDimension::drawAngle(TechDraw::DrawViewDimension *dimension, ViewPro
 
 
         Base::Vector2d extensionOrigin;
-        Base::Vector2d extensionTarget(computeExtensionLinePoints(endPoint,
-                           angleVertex + Base::Vector2d::FromPolar(arcRadius, endAngle), endAngle,
-                           getDefaultExtensionLineOverhang(), gapSize, extensionOrigin));
+        Base::Vector2d extensionTarget(computeExtensionLinePoints(
+            endPoint, angleVertex + Base::Vector2d::FromPolar(arcRadius, endAngle), endAngle,
+            getDefaultExtensionLineOverhang(), gapSize, extensionOrigin));
         anglePath.moveTo(toQtGui(extensionOrigin));
         anglePath.lineTo(toQtGui(extensionTarget));
 
         if (arrowCount > 1) {
-            extensionTarget = computeExtensionLinePoints(startPoint,
-                                  angleVertex + Base::Vector2d::FromPolar(arcRadius, startAngle),
-                                  startAngle, getDefaultExtensionLineOverhang(),
-                                  gapSize, extensionOrigin);
+            extensionTarget = computeExtensionLinePoints(
+                startPoint, angleVertex + Base::Vector2d::FromPolar(arcRadius, startAngle),
+                startAngle, getDefaultExtensionLineOverhang(), gapSize, extensionOrigin);
             anglePath.moveTo(toQtGui(extensionOrigin));
             anglePath.lineTo(toQtGui(extensionTarget));
         }
@@ -2346,14 +2505,14 @@ void QGIViewDimension::drawAngle(TechDraw::DrawViewDimension *dimension, ViewPro
 
 QColor QGIViewDimension::prefNormalColor()
 {
-    setNormalColor(PreferencesGui::dimQColor());
-
+    setNormalColor(PreferencesGui::getAccessibleQColor(PreferencesGui::dimQColor()));
     ViewProviderDimension* vpDim = nullptr;
     Gui::ViewProvider* vp = getViewProvider(getDimFeat());
     if (vp) {
         vpDim = dynamic_cast<ViewProviderDimension*>(vp);
         if (vpDim) {
             App::Color fcColor = vpDim->Color.getValue();
+            fcColor = Preferences::getAccessibleColor(fcColor);
             setNormalColor(fcColor.asValue<QColor>());
         }
     }
@@ -2363,14 +2522,14 @@ QColor QGIViewDimension::prefNormalColor()
 //! find the closest isometric axis given an ortho vector
 Base::Vector3d QGIViewDimension::findIsoDir(Base::Vector3d ortho) const
 {
-    std::vector<Base::Vector3d> isoDirs = { Base::Vector3d(0.866, 0.5, 0.0),     //iso X
-                                            Base::Vector3d(-0.866, -0.5, 0.0),   //iso -X
-                                            Base::Vector3d(-0.866, 0.5, 0.0),    //iso -Y?
-                                            Base::Vector3d(0.866, -0.5, 0.0),    //iso +Y?
-                                            Base::Vector3d(0.0, -1.0, 0.0),      //iso -Z
-                                            Base::Vector3d(0.0, 1.0, 0.0) };     //iso Z
+    std::vector<Base::Vector3d> isoDirs = {Base::Vector3d(0.866, 0.5, 0.0),  //iso X
+                                           Base::Vector3d(-0.866, -0.5, 0.0),//iso -X
+                                           Base::Vector3d(-0.866, 0.5, 0.0), //iso -Y?
+                                           Base::Vector3d(0.866, -0.5, 0.0), //iso +Y?
+                                           Base::Vector3d(0.0, -1.0, 0.0),   //iso -Z
+                                           Base::Vector3d(0.0, 1.0, 0.0)};   //iso Z
     std::vector<double> angles;
-    for (auto& iso: isoDirs) {
+    for (auto& iso : isoDirs) {
         angles.push_back(ortho.GetAngle(iso));
     }
     int idx = 0;
@@ -2387,27 +2546,34 @@ Base::Vector3d QGIViewDimension::findIsoDir(Base::Vector3d ortho) const
 //! find the iso extension direction corresponding to an iso dist direction
 Base::Vector3d QGIViewDimension::findIsoExt(Base::Vector3d dir) const
 {
-    Base::Vector3d dirExt(1, 0,0);
-    Base::Vector3d isoX(0.866, 0.5, 0.0);     //iso X
-    Base::Vector3d isoXr(-0.866, -0.5, 0.0);  //iso -X
-    Base::Vector3d isoY(-0.866, 0.5, 0.0);    //iso -Y?
-    Base::Vector3d isoYr(0.866, -0.5, 0.0);   //iso +Y?
-    Base::Vector3d isoZ(0.0, 1.0, 0.0);       //iso Z
-    Base::Vector3d isoZr(0.0, -1.0, 0.0);     //iso -Z
+    Base::Vector3d dirExt(1, 0, 0);
+    Base::Vector3d isoX(0.866, 0.5, 0.0);   //iso X
+    Base::Vector3d isoXr(-0.866, -0.5, 0.0);//iso -X
+    Base::Vector3d isoY(-0.866, 0.5, 0.0);  //iso -Y?
+    Base::Vector3d isoYr(0.866, -0.5, 0.0); //iso +Y?
+    Base::Vector3d isoZ(0.0, 1.0, 0.0);     //iso Z
+    Base::Vector3d isoZr(0.0, -1.0, 0.0);   //iso -Z
     if (dir.IsEqual(isoX, FLT_EPSILON)) {
         dirExt = isoY;
-    } else if (dir.IsEqual(-isoX, FLT_EPSILON)) {
+    }
+    else if (dir.IsEqual(-isoX, FLT_EPSILON)) {
         dirExt = -isoY;
-    } else if (dir.IsEqual(isoY, FLT_EPSILON)) {
+    }
+    else if (dir.IsEqual(isoY, FLT_EPSILON)) {
         dirExt = isoZ;
-    } else if (dir.IsEqual(-isoY, FLT_EPSILON)) {
+    }
+    else if (dir.IsEqual(-isoY, FLT_EPSILON)) {
         dirExt = -isoZ;
-    } else if (dir.IsEqual(isoZ, FLT_EPSILON)) {
+    }
+    else if (dir.IsEqual(isoZ, FLT_EPSILON)) {
         dirExt = isoX;
-    } else if (dir.IsEqual(-isoZ, FLT_EPSILON)) {
+    }
+    else if (dir.IsEqual(-isoZ, FLT_EPSILON)) {
         dirExt = -isoX;
-    } else { //tarfu
-        Base::Console().Message("QGIVD::findIsoExt - %s - input is not iso axis\n", getViewObject()->getNameInDocument());
+    }
+    else {//tarfu
+        Base::Console().Message("QGIVD::findIsoExt - %s - input is not iso axis\n",
+                                getViewObject()->getNameInDocument());
     }
 
     return dirExt;
@@ -2415,12 +2581,14 @@ Base::Vector3d QGIViewDimension::findIsoExt(Base::Vector3d dir) const
 
 void QGIViewDimension::onPrettyChanged(int state)
 {
-//    Base::Console().Message("QGIVD::onPrettyChange(%d)\n", state);
+    //    Base::Console().Message("QGIVD::onPrettyChange(%d)\n", state);
     if (state == NORMAL) {
         setPrettyNormal();
-    } else if (state == PRE) {
+    }
+    else if (state == PRE) {
         setPrettyPre();
-    } else {                //if state = SEL
+    }
+    else {//if state = SEL
         setPrettySel();
     }
 }
@@ -2448,39 +2616,39 @@ void QGIViewDimension::setPrettyNormal()
 
 void QGIViewDimension::drawBorder()
 {
-//Dimensions have no border!
-//    Base::Console().Message("TRACE - QGIViewDimension::drawBorder - doing nothing!\n");
+    //Dimensions have no border!
+    //    Base::Console().Message("TRACE - QGIViewDimension::drawBorder - doing nothing!\n");
 }
 
 double QGIViewDimension::getDefaultExtensionLineOverhang() const
 {
     // 8x Line Width according to ISO 129-1 Standard section 5.4, not specified by ASME Y14.5M
-    return Rez::appX(m_lineWidth*8.0);
+    return Rez::appX(m_lineWidth * 8.0);
 }
 
 double QGIViewDimension::getDefaultArrowTailLength() const
 {
     // Arrow length shall be equal to font height and both ISO and ASME seem
     // to have arrow tail twice the arrow length, so let's make it twice arrow size
-    return QGIArrow::getPrefArrowSize()*2.0;
+    return QGIArrow::getPrefArrowSize() * 2.0;
 }
 
 double QGIViewDimension::getDefaultIsoDimensionLineSpacing() const
 {
     // Not specified directly, but seems to be 2x Line Width according to ISO 129-1 Annex A
-    return Rez::appX(m_lineWidth*2.0);
+    return Rez::appX(m_lineWidth * 2.0);
 }
 
 double QGIViewDimension::getDefaultIsoReferenceLineOverhang() const
 {
     // Not specified directly but seems to be exactly Line Width according to ISO 129-1 Annex A
-    return Rez::appX(m_lineWidth*1.0);
+    return Rez::appX(m_lineWidth * 1.0);
 }
 
 double QGIViewDimension::getDefaultAsmeHorizontalLeaderLength() const
 {
     // Not specified by ASME Y14.5M, this is a best guess
-    return Rez::appX(m_lineWidth*12);
+    return Rez::appX(m_lineWidth * 12);
 }
 
 //frame, border, caption are never shown in QGIVD, so shouldn't be in bRect
@@ -2497,7 +2665,9 @@ QRectF QGIViewDimension::boundingRect() const
     return result;
 }
 
-void QGIViewDimension::paint ( QPainter * painter, const QStyleOptionGraphicsItem * option, QWidget * widget) {
+void QGIViewDimension::paint(QPainter* painter, const QStyleOptionGraphicsItem* option,
+                             QWidget* widget)
+{
     QStyleOptionGraphicsItem myOption(*option);
     myOption.state &= ~QStyle::State_Selected;
 
@@ -2507,24 +2677,25 @@ void QGIViewDimension::paint ( QPainter * painter, const QStyleOptionGraphicsIte
     //double arrowSaveWidth = aHead1->getWidth();
     if (svg) {
         setSvgPens();
-    } else {
+    }
+    else {
         setPens();
     }
 
-//    painter->setPen(Qt::red);
-//    painter->drawRect(boundingRect());          //good for debugging
+    //    painter->setPen(Qt::red);
+    //    painter->drawRect(boundingRect());          //good for debugging
 
-//    QGIView::paint (painter, &myOption, widget);
+    //    QGIView::paint (painter, &myOption, widget);
     QGraphicsItemGroup::paint(painter, &myOption, widget);
     setPens();
 }
 
 void QGIViewDimension::setSvgPens()
 {
-    double svgLineFactor = 3.0;                     //magic number.  should be a setting somewhere.
-    dimLines->setWidth(m_lineWidth/svgLineFactor);
-    aHead1->setWidth(aHead1->getWidth()/svgLineFactor);
-    aHead2->setWidth(aHead2->getWidth()/svgLineFactor);
+    double svgLineFactor = 3.0;//magic number.  should be a setting somewhere.
+    dimLines->setWidth(m_lineWidth / svgLineFactor);
+    aHead1->setWidth(aHead1->getWidth() / svgLineFactor);
+    aHead2->setWidth(aHead2->getWidth() / svgLineFactor);
 }
 
 void QGIViewDimension::setPens()
@@ -2534,20 +2705,11 @@ void QGIViewDimension::setPens()
     aHead2->setWidth(m_lineWidth);
 }
 
-double QGIViewDimension::toDeg(double angle)
-{
-    return angle*180/M_PI;
-}
+double QGIViewDimension::toDeg(double angle) { return angle * 180 / M_PI; }
 
-double QGIViewDimension::toQtRad(double angle)
-{
-    return -angle;
-}
+double QGIViewDimension::toQtRad(double angle) { return -angle; }
 
-double QGIViewDimension::toQtDeg(double angle)
-{
-    return -angle*180.0/M_PI;
-}
+double QGIViewDimension::toQtDeg(double angle) { return -angle * 180.0 / M_PI; }
 
 void QGIViewDimension::makeMarkC(double xPos, double yPos, QColor color) const
 {

--- a/src/Mod/TechDraw/Gui/QGIViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewPart.cpp
@@ -482,8 +482,7 @@ void QGIViewPart::drawViewPart()
     }
 
     // Draw Edges
-    QColor edgeColor = PreferencesGui::normalQColor();
-
+    QColor edgeColor = PreferencesGui::getAccessibleQColor(PreferencesGui::normalQColor());
     const TechDraw::BaseGeomPtrVector& geoms = viewPart->getEdgeGeometry();
     TechDraw::BaseGeomPtrVector::const_iterator itGeom = geoms.begin();
     QGIEdge* item;
@@ -530,7 +529,8 @@ void QGIViewPart::drawViewPart()
             else {
                 TechDraw::GeomFormat* gf = viewPart->getGeomFormatBySelection(i);
                 if (gf) {
-                    item->setNormalColor(gf->m_format.m_color.asValue<QColor>());
+                    App::Color  color = Preferences::getAccessibleColor(gf->m_format.m_color);
+                    item->setNormalColor(color.asValue<QColor>());
                     item->setWidth(gf->m_format.m_weight * lineScaleFactor);
                     item->setStyle(gf->m_format.m_style);
                     showItem = gf->m_format.m_visible;
@@ -571,8 +571,7 @@ void QGIViewPart::drawViewPart()
                                              ->GetGroup("Preferences")
                                              ->GetGroup("Mod/TechDraw/General");
     double vertexScaleFactor = hGrp->GetFloat("VertexScale", 3.0);
-    QColor vertexColor = PreferencesGui::vertexQColor();
-
+    QColor vertexColor = PreferencesGui::getAccessibleQColor(PreferencesGui::vertexQColor());
     bool showVertices = true;
     bool showCenterMarks = true;
     if (getFrameState()) {//frames are on
@@ -637,7 +636,8 @@ bool QGIViewPart::formatGeomFromCosmetic(std::string cTag, QGIEdge* item)
     auto partFeat(dynamic_cast<TechDraw::DrawViewPart*>(getViewObject()));
     TechDraw::CosmeticEdge* ce = partFeat ? partFeat->getCosmeticEdge(cTag) : nullptr;
     if (ce) {
-        item->setNormalColor(ce->m_format.m_color.asValue<QColor>());
+        App::Color color = Preferences::getAccessibleColor(ce->m_format.m_color);
+        item->setNormalColor(color.asValue<QColor>());
         item->setWidth(ce->m_format.m_weight * lineScaleFactor);
         item->setStyle(ce->m_format.m_style);
         result = ce->m_format.m_visible;
@@ -653,7 +653,8 @@ bool QGIViewPart::formatGeomFromCenterLine(std::string cTag, QGIEdge* item)
     auto partFeat(dynamic_cast<TechDraw::DrawViewPart*>(getViewObject()));
     TechDraw::CenterLine* cl = partFeat ? partFeat->getCenterLine(cTag) : nullptr;
     if (cl) {
-        item->setNormalColor(cl->m_format.m_color.asValue<QColor>());
+        App::Color color = Preferences::getAccessibleColor(cl->m_format.m_color);
+        item->setNormalColor(color.asValue<QColor>());
         item->setWidth(cl->m_format.m_weight * lineScaleFactor);
         item->setStyle(cl->m_format.m_style);
         result = cl->m_format.m_visible;
@@ -800,7 +801,8 @@ void QGIViewPart::drawSectionLine(TechDraw::DrawViewSection* viewSection, bool b
         addToGroup(sectionLine);
         sectionLine->setSymbol(const_cast<char*>(viewSection->SectionSymbol.getValue()));
         sectionLine->setSectionStyle(vp->SectionLineStyle.getValue());
-        sectionLine->setSectionColor(vp->SectionLineColor.getValue().asValue<QColor>());
+        App::Color color = Preferences::getAccessibleColor(vp->SectionLineColor.getValue());
+        sectionLine->setSectionColor(color.asValue<QColor>());
         sectionLine->setPathMode(false);
 
         //find the ends of the section line
@@ -883,7 +885,8 @@ void QGIViewPart::drawComplexSectionLine(TechDraw::DrawViewSection* viewSection,
     addToGroup(sectionLine);
     sectionLine->setSymbol(const_cast<char*>(viewSection->SectionSymbol.getValue()));
     sectionLine->setSectionStyle(vp->SectionLineStyle.getValue());
-    sectionLine->setSectionColor(vp->SectionLineColor.getValue().asValue<QColor>());
+    App::Color color = Preferences::getAccessibleColor(vp->SectionLineColor.getValue());
+    sectionLine->setSectionColor(color.asValue<QColor>());
     sectionLine->setPathMode(true);
     sectionLine->setPath(wirePath);
     sectionLine->setEnds(vStart, vEnd);
@@ -988,7 +991,8 @@ void QGIViewPart::drawHighlight(TechDraw::DrawViewDetail* viewDetail, bool b)
         scene()->addItem(highlight);
         highlight->setReference(viewDetail->Reference.getValue());
         highlight->setStyle((Qt::PenStyle)vp->HighlightLineStyle.getValue());
-        highlight->setColor(vp->HighlightLineColor.getValue().asValue<QColor>());
+        App::Color color = Preferences::getAccessibleColor(vp->HighlightLineColor.getValue());
+        highlight->setColor(color.asValue<QColor>());
         highlight->setFeatureName(viewDetail->getNameInDocument());
         highlight->setInteractive(true);
 

--- a/src/Mod/TechDraw/Gui/QGTracker.cpp
+++ b/src/Mod/TechDraw/Gui/QGTracker.cpp
@@ -39,6 +39,7 @@
 #include <Base/Console.h>
 #include <Mod/TechDraw/App/DrawUtil.h>
 
+#include "PreferencesGui.h"
 #include "QGTracker.h"
 #include "QGIView.h"
 #include "QGSPage.h"
@@ -480,7 +481,7 @@ QColor QGTracker::getTrackerColor()
     Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter().GetGroup("BaseApp")->
                                                     GetGroup("Preferences")->GetGroup("Mod/TechDraw/Tracker");
     App::Color trackColor = App::Color((uint32_t) hGrp->GetUnsigned("TrackerColor", 0xFF000000));
-    result = trackColor.asValue<QColor>();
+    result = PreferencesGui::getAccessibleQColor(trackColor.asValue<QColor>());
     return result;
 }
 

--- a/src/Mod/TechDraw/Gui/QGVPage.cpp
+++ b/src/Mod/TechDraw/Gui/QGVPage.cpp
@@ -338,7 +338,7 @@ void QGVPage::drawBackground(QPainter *painter, const QRectF &)
     QRectF paperRect(0, -pageHeight, pageWidth, pageHeight);
     QPolygon poly = mapFromScene(paperRect);
 
-    QBrush pageBrush(Qt::white);
+    QBrush pageBrush(PreferencesGui::pageQColor());
     painter->setBrush(pageBrush);
 
     painter->drawRect(poly.boundingRect());

--- a/src/Mod/TechDraw/Gui/ViewProviderPage.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderPage.cpp
@@ -25,14 +25,14 @@
 #include "PreCompiled.h"
 
 #ifndef _PreComp_
-# include <QAction>
-# include <QList>
-# include <QMenu>
-# include <QMessageBox>
-# include <QPointer>
-# include <QTextStream>
-# include <boost_signals2.hpp>
-# include <boost/signals2/connection.hpp>
+#include <QAction>
+#include <QList>
+#include <QMenu>
+#include <QMessageBox>
+#include <QPointer>
+#include <QTextStream>
+#include <boost/signals2/connection.hpp>
+#include <boost_signals2.hpp>
 #endif
 
 #include <App/Document.h>
@@ -44,14 +44,15 @@
 #include <Gui/MainWindow.h>
 #include <Gui/ViewProviderDocumentObject.h>
 
-#include <Mod/TechDraw/App/DrawPage.h>
-#include <Mod/TechDraw/App/DrawView.h>
-#include <Mod/TechDraw/App/DrawProjGroupItem.h>
-#include <Mod/TechDraw/App/DrawViewDimension.h>
-#include <Mod/TechDraw/App/DrawViewBalloon.h>
-#include <Mod/TechDraw/App/DrawLeaderLine.h>
-#include <Mod/TechDraw/App/DrawRichAnno.h>
 #include <Mod/TechDraw/App/DrawHatch.h>
+#include <Mod/TechDraw/App/DrawLeaderLine.h>
+#include <Mod/TechDraw/App/DrawPage.h>
+#include <Mod/TechDraw/App/DrawProjGroupItem.h>
+#include <Mod/TechDraw/App/DrawRichAnno.h>
+#include <Mod/TechDraw/App/DrawTemplate.h>
+#include <Mod/TechDraw/App/DrawView.h>
+#include <Mod/TechDraw/App/DrawViewBalloon.h>
+#include <Mod/TechDraw/App/DrawViewDimension.h>
 #include <Mod/TechDraw/App/DrawWeldSymbol.h>
 
 #include "MDIViewPage.h"
@@ -59,9 +60,9 @@
 #include "QGITemplate.h"
 #include "QGSPage.h"
 #include "QGVPage.h"
-#include "ViewProviderTemplate.h"
 #include "ViewProviderPage.h"
 #include "ViewProviderPageExtension.h"
+#include "ViewProviderTemplate.h"
 
 using namespace TechDrawGui;
 using namespace TechDraw;
@@ -77,38 +78,38 @@ PROPERTY_SOURCE(TechDrawGui::ViewProviderPage, Gui::ViewProviderDocumentObject)
 // Construction/Destruction
 
 ViewProviderPage::ViewProviderPage()
-  : m_mdiView(nullptr),
-    m_pageName(""),
-    m_graphicsView(nullptr),
-    m_graphicsScene(nullptr)
+    : m_mdiView(nullptr), m_pageName(""), m_graphicsView(nullptr), m_graphicsScene(nullptr)
 {
     initExtension(this);
 
     sPixmap = "TechDraw_TreePage";
-    static const char *group = "Grid";
+    static const char* group = "Grid";
 
-    ADD_PROPERTY_TYPE(ShowFrames ,(true), group, App::Prop_None, "Show or hide View frames and Labels on this Page");
-    ADD_PROPERTY_TYPE(ShowGrid ,(PreferencesGui::showGrid()), group, App::Prop_None, "Show or hide a grid on this Page");
-    ADD_PROPERTY_TYPE(GridSpacing, (PreferencesGui::gridSpacing()), group, (App::PropertyType::Prop_None),
-                     "Grid line spacing in mm");
+    ADD_PROPERTY_TYPE(ShowFrames, (true), group, App::Prop_None,
+                      "Show or hide View frames and Labels on this Page");
+    ADD_PROPERTY_TYPE(ShowGrid, (PreferencesGui::showGrid()), group, App::Prop_None,
+                      "Show or hide a grid on this Page");
+    ADD_PROPERTY_TYPE(GridSpacing, (PreferencesGui::gridSpacing()), group,
+                      (App::PropertyType::Prop_None), "Grid line spacing in mm");
 
     ShowFrames.setStatus(App::Property::Hidden, true);
     DisplayMode.setStatus(App::Property::Hidden, true);
 
     m_graphicsScene = new QGSPage(this);
-    m_graphicsScene->setItemIndexMethod(QGraphicsScene::NoIndex); //this prevents crash when deleting dims.
-                                                          //scene(view?) indices of dirty regions gets
-                                                          //out of sync.  missing prepareGeometryChange
-                                                          //somewhere???? QTBUG-18021???
+    m_graphicsScene->setItemIndexMethod(
+        QGraphicsScene::NoIndex);//this prevents crash when deleting dims.
+                                 //scene(view?) indices of dirty regions gets
+                                 //out of sync.  missing prepareGeometryChange
+                                 //somewhere???? QTBUG-18021???
 }
 
 ViewProviderPage::~ViewProviderPage()
 {
-    removeMDIView();                    //if the MDIViewPage is still in MainWindow, remove it.
+    removeMDIView();//if the MDIViewPage is still in MainWindow, remove it.
     m_graphicsScene->deleteLater();
 }
 
-void ViewProviderPage::attach(App::DocumentObject *pcFeat)
+void ViewProviderPage::attach(App::DocumentObject* pcFeat)
 {
     ViewProviderDocumentObject::attach(pcFeat);
 
@@ -118,7 +119,8 @@ void ViewProviderPage::attach(App::DocumentObject *pcFeat)
         connectGuiRepaint = feature->signalGuiPaint.connect(bnd);
         m_pageName = feature->getNameInDocument();
         m_graphicsScene->setObjectName(QString::fromLocal8Bit(m_pageName.c_str()));
-    } else {
+    }
+    else {
         Base::Console().Log("VPP::attach has no Feature!\n");
     }
 }
@@ -136,13 +138,15 @@ std::vector<std::string> ViewProviderPage::getDisplayModes() const
     return StrList;
 }
 
-void ViewProviderPage::onChanged(const App::Property *prop)
+void ViewProviderPage::onChanged(const App::Property* prop)
 {
     if (prop == &(ShowGrid)) {
         setGrid();
-    } else if (prop == &(GridSpacing)) {
+    }
+    else if (prop == &(GridSpacing)) {
         setGrid();
-    } else if (prop == &Visibility) {
+    }
+    else if (prop == &Visibility) {
         //Visibility changes are handled in VPDO::onChanged -> show() or hide()
     }
 
@@ -157,25 +161,28 @@ void ViewProviderPage::updateData(const App::Property* prop)
         return;
     }
     if (prop == &(page->KeepUpdated)) {
-       if (getDrawPage()->KeepUpdated.getValue()) {
-           sPixmap = "TechDraw_TreePage";
-       } else {
-           sPixmap = "TechDraw_TreePageUnsync";
-       }
-       signalChangeIcon();
-    //if the template is changed, rebuild the visual
-    } else if (prop == &(page->Template)) {
-       if (!page->isUnsetting()) {
-           //check if a template has been added to scene first?
+        if (getDrawPage()->KeepUpdated.getValue()) {
+            sPixmap = "TechDraw_TreePage";
+        }
+        else {
+            sPixmap = "TechDraw_TreePageUnsync";
+        }
+        signalChangeIcon();
+        //if the template is changed, rebuild the visual
+    }
+    else if (prop == &(page->Template)) {
+        if (!page->isUnsetting()) {
+            //check if a template has been added to scene first?
             m_graphicsScene->matchSceneRectToTemplate();
             m_graphicsScene->updateTemplate();
         }
-    } else if (prop == &(page->Label)) {
-       if (m_mdiView &&
-          !page->isUnsetting()) {
-           m_mdiView->setTabText(page->Label.getValue());
-       }
-    } else if (prop == &page->Views) {
+    }
+    else if (prop == &(page->Label)) {
+        if (m_mdiView && !page->isUnsetting()) {
+            m_mdiView->setTabText(page->Label.getValue());
+        }
+    }
+    else if (prop == &page->Views) {
         if (!page->isUnsetting())
             m_graphicsScene->fixOrphans();
     }
@@ -183,7 +190,7 @@ void ViewProviderPage::updateData(const App::Property* prop)
     Gui::ViewProviderDocumentObject::updateData(prop);
 }
 
-bool ViewProviderPage::onDelete(const std::vector<std::string> &)
+bool ViewProviderPage::onDelete(const std::vector<std::string>&)
 {
     // warn the user if the Page is not empty
     // but don't do this if there is just the template
@@ -202,25 +209,26 @@ bool ViewProviderPage::onDelete(const std::vector<std::string> &)
             isTemplate = false;
     }
 
-    if (!objs.empty() && !isTemplate)
-    {
+    if (!objs.empty() && !isTemplate) {
         // generate dialog
         QString bodyMessage;
         QTextStream bodyMessageStream(&bodyMessage);
-        bodyMessageStream << qApp->translate("Std_Delete",
+        bodyMessageStream << qApp->translate(
+            "Std_Delete",
             "The page is not empty, therefore the\nfollowing referencing objects might be lost:");
         bodyMessageStream << '\n';
         for (auto ObjIterator : objs)
             bodyMessageStream << '\n' << QString::fromUtf8(ObjIterator->Label.getValue());
         bodyMessageStream << "\n\n" << QObject::tr("Are you sure you want to continue?");
         // show and evaluate the dialog
-        int DialogResult = QMessageBox::warning(Gui::getMainWindow(),
-            qApp->translate("Std_Delete", "Object dependencies"), bodyMessage,
+        int DialogResult = QMessageBox::warning(
+            Gui::getMainWindow(), qApp->translate("Std_Delete", "Object dependencies"), bodyMessage,
             QMessageBox::Yes, QMessageBox::No);
         if (DialogResult == QMessageBox::Yes) {
             removeMDIView();
             return true;
-        } else
+        }
+        else
             return false;
     }
     else {
@@ -233,24 +241,26 @@ void ViewProviderPage::setupContextMenu(QMenu* menu, QObject* receiver, const ch
 {
     Gui::ViewProviderDocumentObject::setupContextMenu(menu, receiver, member);
     QAction* act = menu->addAction(QObject::tr("Show drawing"), receiver, member);
-    act->setData(QVariant((int) _SHOWDRAWING));
+    act->setData(QVariant((int)_SHOWDRAWING));
     QAction* act2 = menu->addAction(QObject::tr("Toggle KeepUpdated"), receiver, member);
-    act2->setData(QVariant((int) _TOGGLEUPDATE));
+    act2->setData(QVariant((int)_TOGGLEUPDATE));
 }
 
 bool ViewProviderPage::setEdit(int ModNum)
 {
     if (ModNum == _SHOWDRAWING) {
-        showMDIViewPage();   // show the drawing
-        return false;  //finished editing
-    } else if (ModNum == _TOGGLEUPDATE) {
-         auto page = getDrawPage();
-         if (page) {
-             page->KeepUpdated.setValue(!page->KeepUpdated.getValue());
-             page->recomputeFeature();
-         }
-         return false;
-    } else {
+        showMDIViewPage();// show the drawing
+        return false;     //finished editing
+    }
+    else if (ModNum == _TOGGLEUPDATE) {
+        auto page = getDrawPage();
+        if (page) {
+            page->KeepUpdated.setValue(!page->KeepUpdated.getValue());
+            page->recomputeFeature();
+        }
+        return false;
+    }
+    else {
         return Gui::ViewProviderDocumentObject::setEdit(ModNum);
     }
 }
@@ -279,7 +289,7 @@ void ViewProviderPage::show(void)
 void ViewProviderPage::hide(void)
 {
     if (getMDIView()) {
-        getMDIView()->hide();     //this doesn't remove the mdiViewPage from the mainWindow
+        getMDIView()->hide();//this doesn't remove the mdiViewPage from the mainWindow
         removeMDIView();
     }
     ViewProviderDocumentObject::hide();
@@ -287,15 +297,17 @@ void ViewProviderPage::hide(void)
 
 bool ViewProviderPage::showMDIViewPage()
 {
-    if (m_mdiView.isNull()){
+    if (m_mdiView.isNull()) {
         createMDIViewPage();
         m_graphicsScene->addChildrenToPage();
         m_graphicsScene->updateTemplate(true);
         m_graphicsScene->redrawAllViews();
         m_graphicsScene->fixOrphans(true);
-    } else {
+    }
+    else {
         m_graphicsScene->redrawAllViews();
         m_graphicsScene->fixOrphans(true);
+        m_graphicsView->update();
     }
     m_graphicsView->centerOnPage();
 
@@ -311,8 +323,7 @@ bool ViewProviderPage::showMDIViewPage()
 
 void ViewProviderPage::createMDIViewPage()
 {
-    Gui::Document* doc = Gui::Application::Instance->getDocument
-        (pcObject->getDocument());
+    Gui::Document* doc = Gui::Application::Instance->getDocument(pcObject->getDocument());
     m_mdiView = new MDIViewPage(this, doc, Gui::getMainWindow());
     if (!m_graphicsView) {
         m_graphicsView = new QGVPage(this, m_graphicsScene, m_mdiView);
@@ -334,13 +345,15 @@ void ViewProviderPage::createMDIViewPage()
 //NOTE: removing MDIViewPage (parent) destroys QGVPage (eventually)
 void ViewProviderPage::removeMDIView(void)
 {
-    if (!m_mdiView.isNull()) {                                //m_mdiView is a QPointer
-        QList<QWidget*> wList= Gui::getMainWindow()->windows();
+    if (!m_mdiView.isNull()) {//m_mdiView is a QPointer
+        QList<QWidget*> wList = Gui::getMainWindow()->windows();
         if (wList.contains(m_mdiView)) {
             Gui::getMainWindow()->removeWindow(m_mdiView);
-            m_mdiView = nullptr;            //m_mdiView will eventually be deleted and
-            m_graphicsView = nullptr;       //will take m_graphicsView with it
-            Gui::MDIView* aw = Gui::getMainWindow()->activeWindow();  //WF: this bit should be in the remove window logic, not here.
+            m_mdiView = nullptr;     //m_mdiView will eventually be deleted and
+            m_graphicsView = nullptr;//will take m_graphicsView with it
+            Gui::MDIView* aw =
+                Gui::getMainWindow()
+                    ->activeWindow();//WF: this bit should be in the remove window logic, not here.
             if (aw)
                 aw->showMaximized();
         }
@@ -355,11 +368,30 @@ MDIViewPage* ViewProviderPage::getMDIViewPage() const
     return m_mdiView;
 }
 
+DrawTemplate* ViewProviderPage::getTemplate() const
+{
+    return dynamic_cast<DrawTemplate*>(getDrawPage()->Template.getValue());
+}
+
+
+QGITemplate* ViewProviderPage::getQTemplate() const
+{
+    Gui::Document* guiDoc = Gui::Application::Instance->getDocument(getDrawPage()->getDocument());
+    if (guiDoc) {
+        Gui::ViewProvider* vp = guiDoc->getViewProvider(getTemplate());
+        auto vpTemplate = dynamic_cast<ViewProviderTemplate*>(vp);
+        if (vpTemplate) {
+            return vpTemplate->getQTemplate();
+        }
+    }
+    return nullptr;
+}
+
 std::vector<App::DocumentObject*> ViewProviderPage::claimChildren(void) const
 {
     std::vector<App::DocumentObject*> temp;
 
-    App::DocumentObject *templateFeat = nullptr;
+    App::DocumentObject* templateFeat = nullptr;
     templateFeat = getDrawPage()->Template.getValue();
 
     if (templateFeat) {
@@ -376,58 +408,51 @@ std::vector<App::DocumentObject*> ViewProviderPage::claimChildren(void) const
     //                                               DrawHatch
     //                                               DrawWeldSymbol
 
-    const std::vector<App::DocumentObject *> &views = getDrawPage()->Views.getValues();
+    const std::vector<App::DocumentObject*>& views = getDrawPage()->Views.getValues();
 
     try {
-        for (std::vector<App::DocumentObject *>::const_iterator it = views.begin(); it != views.end(); ++it) {
-            TechDraw::DrawView* featView = dynamic_cast<TechDraw::DrawView*> (*it);
-            App::DocumentObject *docObj = *it;
+        for (std::vector<App::DocumentObject*>::const_iterator it = views.begin();
+             it != views.end(); ++it) {
+            TechDraw::DrawView* featView = dynamic_cast<TechDraw::DrawView*>(*it);
+            App::DocumentObject* docObj = *it;
             //DrawRichAnno with no parent is child of Page
-            TechDraw::DrawRichAnno* dra = dynamic_cast<TechDraw::DrawRichAnno*> (*it);
+            TechDraw::DrawRichAnno* dra = dynamic_cast<TechDraw::DrawRichAnno*>(*it);
             if (dra) {
                 if (!dra->AnnoParent.getValue()) {
-                    temp.push_back(*it); //no parent, belongs to page
+                    temp.push_back(*it);//no parent, belongs to page
                 }
-                continue; //has a parent somewhere else
+                continue;//has a parent somewhere else
             }
 
             // Don't collect if dimension, projection group item, hatch or member of ClipGroup as these should be grouped elsewhere
-            if (docObj->isDerivedFrom(TechDraw::DrawProjGroupItem::getClassTypeId())    ||
-                docObj->isDerivedFrom(TechDraw::DrawViewDimension::getClassTypeId())    ||
-                docObj->isDerivedFrom(TechDraw::DrawHatch::getClassTypeId())            ||
-                docObj->isDerivedFrom(TechDraw::DrawViewBalloon::getClassTypeId())      ||
-                docObj->isDerivedFrom(TechDraw::DrawRichAnno::getClassTypeId())         ||
-                docObj->isDerivedFrom(TechDraw::DrawLeaderLine::getClassTypeId())       ||
-                docObj->isDerivedFrom(TechDraw::DrawWeldSymbol::getClassTypeId())       ||
-                (featView && featView->isInClip()) )
+            if (docObj->isDerivedFrom(TechDraw::DrawProjGroupItem::getClassTypeId())
+                || docObj->isDerivedFrom(TechDraw::DrawViewDimension::getClassTypeId())
+                || docObj->isDerivedFrom(TechDraw::DrawHatch::getClassTypeId())
+                || docObj->isDerivedFrom(TechDraw::DrawViewBalloon::getClassTypeId())
+                || docObj->isDerivedFrom(TechDraw::DrawRichAnno::getClassTypeId())
+                || docObj->isDerivedFrom(TechDraw::DrawLeaderLine::getClassTypeId())
+                || docObj->isDerivedFrom(TechDraw::DrawWeldSymbol::getClassTypeId())
+                || (featView && featView->isInClip()))
                 continue;
             else
                 temp.push_back(*it);
         }
         return temp;
-    } catch (...) {
+    }
+    catch (...) {
         return std::vector<App::DocumentObject*>();
     }
 }
 
-bool ViewProviderPage::isShow(void) const
-{
-    return Visibility.getValue();
-}
+bool ViewProviderPage::isShow(void) const { return Visibility.getValue(); }
 
-bool ViewProviderPage::getFrameState()
-{
-    return ShowFrames.getValue();
-}
+bool ViewProviderPage::getFrameState() { return ShowFrames.getValue(); }
 
-void ViewProviderPage::setFrameState(bool state)
-{
-    ShowFrames.setValue(state);
-}
+void ViewProviderPage::setFrameState(bool state) { ShowFrames.setValue(state); }
 
 void ViewProviderPage::toggleFrameState()
 {
-//    Base::Console().Message("VPP::toggleFrameState()\n");
+    //    Base::Console().Message("VPP::toggleFrameState()\n");
     if (m_graphicsScene) {
         setFrameState(!getFrameState());
         m_graphicsScene->refreshViews();
@@ -437,8 +462,8 @@ void ViewProviderPage::toggleFrameState()
 
 void ViewProviderPage::setTemplateMarkers(bool state)
 {
-//    Base::Console().Message("VPP::setTemplateMarkers(%d)\n", state);
-    App::DocumentObject *templateFeat = nullptr;
+    //    Base::Console().Message("VPP::setTemplateMarkers(%d)\n", state);
+    App::DocumentObject* templateFeat = nullptr;
     templateFeat = getDrawPage()->Template.getValue();
     Gui::Document* guiDoc = Gui::Application::Instance->getDocument(templateFeat->getDocument());
     Gui::ViewProvider* vp = guiDoc->getViewProvider(templateFeat);
@@ -452,7 +477,7 @@ void ViewProviderPage::setTemplateMarkers(bool state)
     }
 }
 
-bool ViewProviderPage::canDelete(App::DocumentObject *obj) const
+bool ViewProviderPage::canDelete(App::DocumentObject* obj) const
 {
     // deletions from a page don't necessarily destroy anything
     // thus we can pass this action
@@ -472,11 +497,11 @@ bool ViewProviderPage::canDragObject(App::DocumentObject* docObj) const
     return getVPPExtension()->extensionCanDragObject(docObj);
 }
 
-bool ViewProviderPage::canDropObjectEx(App::DocumentObject* obj, App::DocumentObject *owner,
-        const char *subname, const std::vector<std::string> &elements) const
+bool ViewProviderPage::canDropObjectEx(App::DocumentObject* obj, App::DocumentObject* owner,
+                                       const char* subname,
+                                       const std::vector<std::string>& elements) const
 {
     return getVPPExtension()->extensionCanDropObjectEx(obj, owner, subname, elements);
-
 }
 
 bool ViewProviderPage::canDropObject(App::DocumentObject* docObj) const
@@ -510,12 +535,9 @@ TechDraw::DrawPage* ViewProviderPage::getDrawPage() const
     return dynamic_cast<TechDraw::DrawPage*>(pcObject);
 }
 
-Gui::MDIView *ViewProviderPage::getMDIView() const
-{
-    return m_mdiView.data();
-}
+Gui::MDIView* ViewProviderPage::getMDIView() const { return m_mdiView.data(); }
 
-void  ViewProviderPage::setGrid()
+void ViewProviderPage::setGrid()
 {
     TechDraw::DrawPage* dp = getDrawPage();
     if (!dp) {
@@ -533,7 +555,8 @@ void  ViewProviderPage::setGrid()
         if (ShowGrid.getValue()) {
             widget->showGrid(true);
             widget->makeGrid(pageWidth, pageHeight, gridStep);
-        } else {
+        }
+        else {
             widget->showGrid(false);
         }
         widget->updateViewport();
@@ -547,7 +570,4 @@ ViewProviderPageExtension* ViewProviderPage::getVPPExtension() const
     return vppe;
 }
 
-const char*  ViewProviderPage::whoAmI() const
-{
-    return m_pageName.c_str();
-}
+const char* ViewProviderPage::whoAmI() const { return m_pageName.c_str(); }

--- a/src/Mod/TechDraw/Gui/ViewProviderPage.h
+++ b/src/Mod/TechDraw/Gui/ViewProviderPage.h
@@ -26,26 +26,30 @@
 
 #include <Mod/TechDraw/TechDrawGlobal.h>
 
-#include <boost_signals2.hpp>
-#include <QPointer>
 #include <QObject>
+#include <QPointer>
+#include <boost_signals2.hpp>
 
 #include <App/PropertyUnits.h>
 #include <Gui/ViewProviderDocumentObject.h>
 #include <ViewProviderPageExtension.h>
 
-namespace TechDraw{
-    class DrawPage;
-}
+namespace TechDraw
+{
+class DrawPage;
+class DrawTemplate;
+}// namespace TechDraw
 
-namespace TechDrawGui {
+namespace TechDrawGui
+{
 
 class MDIViewPage;
 class QGVPage;
 class QGSPage;
+class QGITemplate;
 
-class TechDrawGuiExport ViewProviderPage : public Gui::ViewProviderDocumentObject,
-                                           public ViewProviderPageExtension
+class TechDrawGuiExport ViewProviderPage: public Gui::ViewProviderDocumentObject,
+                                          public ViewProviderPageExtension
 {
     PROPERTY_HEADER_WITH_OVERRIDE(TechDrawGui::ViewProviderPage);
 
@@ -55,11 +59,11 @@ public:
     /// destructor
     ~ViewProviderPage() override;
 
-    App::PropertyBool  ShowFrames;
-    App::PropertyBool  ShowGrid;
+    App::PropertyBool ShowFrames;
+    App::PropertyBool ShowGrid;
     App::PropertyDistance GridSpacing;
 
-    void attach(App::DocumentObject *) override;
+    void attach(App::DocumentObject*) override;
     void setDisplayMode(const char* ModeName) override;
 
     bool canDragObjects() const override;
@@ -69,10 +73,10 @@ public:
     void dropObject(App::DocumentObject* docObj) override;
     void constDropObject(App::DocumentObject* docObj) const;
 
-    bool canDropObjectEx(App::DocumentObject *obj, App::DocumentObject *owner,
-            const char *subname, const std::vector<std::string> &elements) const override;
+    bool canDropObjectEx(App::DocumentObject* obj, App::DocumentObject* owner, const char* subname,
+                         const std::vector<std::string>& elements) const override;
 
-    bool useNewSelectionModel() const override {return false;}
+    bool useNewSelectionModel() const override { return false; }
     /// returns a list of all possible modes
     std::vector<std::string> getDisplayModes() const override;
     /// Hides the view provider
@@ -87,11 +91,13 @@ public:
     /// Is called by the tree if the user double click on the object
     bool doubleClicked() override;
     void setupContextMenu(QMenu*, QObject*, const char*) override;
-    bool onDelete(const std::vector<std::string> &) override;
-    void onChanged(const App::Property *prop) override;
+    bool onDelete(const std::vector<std::string>&) override;
+    void onChanged(const App::Property* prop) override;
     void updateData(const App::Property* prop) override;
 
     TechDraw::DrawPage* getDrawPage() const;
+    TechDraw::DrawTemplate* getTemplate() const;
+    QGITemplate* getQTemplate(void) const;
 
     //slots & connections
     void onGuiRepaint(const TechDraw::DrawPage* dp);
@@ -103,7 +109,7 @@ public:
     bool showMDIViewPage();
     void removeMDIView();
 
-    Gui::MDIView *getMDIView() const override;
+    Gui::MDIView* getMDIView() const override;
 
     bool getFrameState();
     void setFrameState(bool state);
@@ -112,10 +118,10 @@ public:
 
     bool canDelete(App::DocumentObject* obj) const override;
 
-    void  setGrid();
+    void setGrid();
 
-    QGSPage* getQGSPage(void) {return m_graphicsScene;}
-    QGVPage* getQGVPage(void) {return m_graphicsView;}
+    QGSPage* getQGSPage(void) { return m_graphicsScene; }
+    QGVPage* getQGVPage(void) { return m_graphicsView; }
 
     ViewProviderPageExtension* getVPPExtension() const;
 
@@ -132,7 +138,7 @@ private:
     QGSPage* m_graphicsScene;
 };
 
-} // namespace TechDrawGui
+}// namespace TechDrawGui
 
 
-#endif // DRAWINGGUI_VIEWPROVIDERPAGE_H
+#endif// DRAWINGGUI_VIEWPROVIDERPAGE_H


### PR DESCRIPTION
This PR addresses issue #8062 light text on dark and partially addresses #8093 for TechDraw Annotations.

- some visually impaired users need white graphics on dark page.
- revise Annotation dialog to respect dark style

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [ ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
