### PR TITLE
Fix selection in sketcher development/toponaming

### DIFF
--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -3442,25 +3442,28 @@ void ViewProviderSketch::clearSelectPoints(void)
     selection.SelPointSet.clear();
 }
 
-bool ViewProviderSketch::isSelected(std::string &subNameSuffix) const
+bool ViewProviderSketch::isSelected(const std::string &subNameSuffix) const
 {
-    subNameSuffix = editSubName + getSketchObject()->convertSubName(subNameSuffix);
-    return Gui::Selection().isSelected(editDocName.c_str(), editObjName.c_str(), subNameSuffix.c_str());
+    std::string subNameSuffix_ = editSubName + getSketchObject()->convertSubName(subNameSuffix);
+    return Gui::Selection().isSelected(editDocName.c_str(), editObjName.c_str(), subNameSuffix_.c_str());
 }
 
 void ViewProviderSketch::rmvSelection(const std::string &subNameSuffix) const
 {
-    Gui::Selection().rmvSelection(editDocName.c_str(), editObjName.c_str(), subNameSuffix.c_str());
+    std::string subNameSuffix_ = editSubName + getSketchObject()->convertSubName(subNameSuffix);
+    Gui::Selection().rmvSelection(editDocName.c_str(), editObjName.c_str(), subNameSuffix_.c_str());
 }
 
 bool ViewProviderSketch::addSelection(const std::string &subNameSuffix, float x, float y, float z) const
 {
-     return Gui::Selection().addSelection(editDocName.c_str(), editObjName.c_str(), (editSubName+subNameSuffix).c_str(), x , y, z);
+     std::string subNameSuffix_ = editSubName + getSketchObject()->convertSubName(subNameSuffix);
+     return Gui::Selection().addSelection(editDocName.c_str(), editObjName.c_str(), subNameSuffix_.c_str(), x , y, z);
 }
 
 bool ViewProviderSketch::addSelection2(const std::string &subNameSuffix, float x, float y, float z) const
 {
-     return Gui::Selection().addSelection2(editDocName.c_str(), editObjName.c_str(), (editSubName+subNameSuffix).c_str(), x , y, z);
+     std::string subNameSuffix_ = editSubName + getSketchObject()->convertSubName(subNameSuffix);
+     return Gui::Selection().addSelection2(editDocName.c_str(), editObjName.c_str(), subNameSuffix_.c_str(), x , y, z);
 }
 
 bool ViewProviderSketch::addSelectionElement(const char *element, int index) const

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.h
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.h
@@ -636,7 +636,7 @@ private:
     void removeSelectPoint(int SelectPoint);
     void clearSelectPoints(void);
 
-    bool isSelected(std::string & ss) const;
+    bool isSelected(const std::string &ss) const;
     void rmvSelection(const std::string &subNameSuffix) const;
     bool addSelection(const std::string &subNameSuffix, float x = 0, float y = 0, float z = 0) const;
     bool addSelection2(const std::string &subNameSuffix, float x = 0, float y = 0, float z = 0) const;


### PR DESCRIPTION
https://forum.freecadweb.org/viewtopic.php?p=650988#p650988

* The function ViewProviderSketch::isSelected should not modifiy its incoming parameter
* ViewProviderSketch::rmvSelection, ViewProviderSketch::addSelection, ViewProviderSketch::addSelection2 have not called the convertSubName function.
* Should the convertSubName not be called inside the function ViewProviderSketch::mouseButtonPressed, because now the convertSubName is called two times?
