### PR TITLE
Draft: Properly remove Snap toolbar when switching workbenches

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_snapper.py
+++ b/src/Mod/Draft/draftguitools/gui_snapper.py
@@ -1589,9 +1589,9 @@ class Snapper:
 
     def hide(self):
         """Hide the toolbar."""
-        toolbar = self.get_snap_toolbar()
-        if toolbar:
-            toolbar.hide()
+        if hasattr(self, "toolbar") and self.toolbar:
+            self.toolbar.hide()
+            self.toolbar.toggleViewAction().setVisible(False)
 
 
     def setGrid(self):


### PR DESCRIPTION
The Snap toolbar was not always removed when switching workbenches.

- [ ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

---
