### PR TITLE
AddonMgr: switch pref entry/path to const string

### DIFF
--- a/src/Mod/AddonManager/AddonManagerOptions.ui
+++ b/src/Mod/AddonManager/AddonManagerOptions.ui
@@ -367,10 +367,10 @@ installed addons will be checked for available updates
          <string>Disable git (fall back to ZIP downloads only)</string>
         </property>
         <property name="prefEntry" stdset="0">
-         <string>disableGit</string>
+         <cstring>disableGit</cstring>
         </property>
         <property name="prefPath" stdset="0">
-         <string>Addons</string>
+         <cstring>Addons</cstring>
         </property>
        </widget>
       </item>
@@ -383,10 +383,10 @@ installed addons will be checked for available updates
          <string>Addon developer mode</string>
         </property>
         <property name="prefPath" stdset="0">
-         <string>Addons</string>
+         <cstring>Addons</cstring>
         </property>
         <property name="prefEntry" stdset="0">
-         <string>developerMode</string>
+         <cstring>developerMode</cstring>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
This PR switches pref entry/path from string to constant string for 2 AddonManager preferences were it was faulty.

The current situation has 2 problems :
 * The 2 prefs entry/path are translatable (and translated) which can lead to different issues (non ASCII chars, preferences loss when changing language, ...)
 * When opening the preference editor, 2 "Widget is already attached" warning messages are displayed

@chennes May you check this commit doesn't conflict with your current dev and either merge or cherry-pick ?