### PR TITLE
Arch: ArchSectionPlane should trigger SVG update in execute

### DIFF
--- a/src/Mod/Arch/ArchSectionPlane.py
+++ b/src/Mod/Arch/ArchSectionPlane.py
@@ -948,13 +948,8 @@ class _SectionPlane:
             p.reverse()
         p.Placement = obj.Placement
         obj.Shape = p
-
-    def onChanged(self,obj,prop):
-
-        # clean svg cache if needed
-        if prop in ["Placement","Objects","OnlySolids","UseMaterialColorForFill","Clip"]:
-            self.svgcache = None
-            self.shapecache = None
+        self.svgcache = None
+        self.shapecache = None
 
     def getNormal(self,obj):
 


### PR DESCRIPTION
The SVG result of an ArchSectionPlane would not update after moving a window for example. You would have to change a property of the plane first.

Forum topic:
https://forum.freecadweb.org/viewtopic.php?p=652810#p652810

- [ ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

---
