### PR TITLE
[Sketcher] Prevent dereferencing `nullptr` in `ConstraintView`

### DIFF
--- a/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
@@ -450,7 +450,7 @@ void ConstraintView::contextMenuEvent (QContextMenuEvent* event)
     bool didRelease = SketcherGui::ReleaseHandler(doc);
 
     // Sync the FreeCAD selection with the selection in the ConstraintView widget
-    if (didRelease) {
+    if (didRelease && item) {
         Gui::Selection().clearSelection();
         std::string doc_name = static_cast<ConstraintItem*>(item)->sketchView->getSketchObject()->getDocument()->getName();
         std::string obj_name = static_cast<ConstraintItem*>(item)->sketchView->getSketchObject()->getNameInDocument();


### PR DESCRIPTION
Fixes #8104.

As described in that issue, a crash happens under the following conditions:
1. A `DrawSketchHandler` is active.
2. No constraint is selected.
3. Context menu on the `ConstraintView` is triggered.