### PR TITLE
Path: fix bug in Path Gui tests

### DIFF
--- a/src/Mod/Path/PathTests/TestPathAdaptive.py
+++ b/src/Mod/Path/PathTests/TestPathAdaptive.py
@@ -61,7 +61,7 @@ class TestPathAdaptive(PathTestBase):
         cls.job = PathJob.Create("Job", [cls.doc.Fusion], None)
         cls.job.GeometryTolerance.Value = 0.001
         if FreeCAD.GuiUp:
-            job.ViewObject.Proxy = PathJobGui.ViewProvider(job.ViewObject)
+            cls.job.ViewObject.Proxy = PathJobGui.ViewProvider(cls.job.ViewObject)
 
         # Instantiate an Adaptive operation for querying available properties
         cls.prototype = PathAdaptive.Create("Adaptive")


### PR DESCRIPTION
While I'm working at CI and especially on having GUI tests with it, below error message came :
```
======================================================================
ERROR: test00 (PathTests.TestPathAdaptive.TestPathAdaptive)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3.10/unittest/case.py", line 59, in testPartExecutor
    yield
  File "/usr/lib/python3.10/unittest/case.py", line 587, in run
    self._callSetUp()
  File "/usr/lib/python3.10/unittest/case.py", line 546, in _callSetUp
    self.setUp()
  File "/usr/local/Mod/Path/PathTests/TestPathAdaptive.py", line 95, in setUp
    self.initClass()
  File "/usr/local/Mod/Path/PathTests/TestPathAdaptive.py", line 64, in initClass
    job.ViewObject.Proxy = PathJobGui.ViewProvider(job.ViewObject)
NameError: name 'job' is not defined
```