### PR TITLE
Draft: Fix and improve Draft_AnnotationStyleEditor

### DIFF
--- a/src/Mod/Draft/Draft.py
+++ b/src/Mod/Draft/Draft.py
@@ -91,7 +91,9 @@ from draftutils.utils import (string_encode_coin,
                               svg_patterns,
                               svgpatterns,
                               get_rgb,
-                              getrgb)
+                              getrgb,
+                              argb_to_rgba,
+                              rgba_to_argb)
 
 from draftfunctions.svg import (get_svg,
                                 getSVG)

--- a/src/Mod/Draft/Resources/ui/dialog_AnnotationStyleEditor.ui
+++ b/src/Mod/Draft/Resources/ui/dialog_AnnotationStyleEditor.ui
@@ -193,40 +193,57 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="0">
+          <item row="1" column="0">
            <widget class="QLabel" name="label_2">
             <property name="toolTip">
-             <string>Font size in the system units</string>
+             <string>The font size in system units</string>
             </property>
             <property name="text">
              <string>Font size</string>
             </property>
            </widget>
           </item>
-          <item row="2" column="1">
+          <item row="1" column="1">
            <widget class="Gui::InputField" name="FontSize">
             <property name="toolTip">
-             <string>Font size in the system units</string>
+             <string>The font size in system units</string>
             </property>
-            <property name="quantity" stdset="0">
-             <double>12.000000000000000</double>
+            <property name="unit" stdset="0">
+             <string notr="true"/>
             </property>
            </widget>
           </item>
-          <item row="4" column="0">
+          <item row="2" column="0">
            <widget class="QLabel" name="label_3">
             <property name="toolTip">
-             <string>Line spacing in system units</string>
+             <string>The line spacing (relative to the font size)</string>
             </property>
             <property name="text">
              <string>Line spacing</string>
             </property>
            </widget>
           </item>
-          <item row="4" column="1">
+          <item row="2" column="1">
            <widget class="QDoubleSpinBox" name="LineSpacing">
-            <property name="value">
-             <double>1.000000000000000</double>
+            <property name="toolTip">
+             <string>The line spacing (relative to the font size)</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="label_16">
+            <property name="toolTip">
+             <string>The color of texts, dimension texts and label texts</string>
+            </property>
+            <property name="text">
+             <string>Text color</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="Gui::ColorButton" name="TextColor">
+            <property name="toolTip">
+             <string>The color of texts, dimension texts and label texts</string>
             </property>
            </widget>
           </item>
@@ -253,12 +270,6 @@
            <widget class="QDoubleSpinBox" name="ScaleMultiplier">
             <property name="toolTip">
              <string>A multiplier factor that affects the size of texts and markers</string>
-            </property>
-            <property name="decimals">
-             <number>4</number>
-            </property>
-            <property name="value">
-             <double>1.000000000000000</double>
             </property>
            </widget>
           </item>
@@ -317,9 +328,6 @@
             <property name="toolTip">
              <string>The number of decimals to show for dimension values</string>
             </property>
-            <property name="value">
-             <number>2</number>
-            </property>
            </widget>
           </item>
           </layout>
@@ -328,7 +336,7 @@
        <item>
         <widget class="QGroupBox" name="groupBox_4">
          <property name="title">
-          <string>Line and arrows</string>
+          <string>Lines and arrows</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_3">
           <item row="0" column="0">
@@ -337,12 +345,12 @@
              <string>If it is checked it will display the dimension line</string>
             </property>
             <property name="text">
-             <string>Show lines</string>
+             <string>Show line</string>
             </property>
            </widget>
           </item>
           <item row="0" column="1">
-           <widget class="QCheckBox" name="ShowLines">
+           <widget class="QCheckBox" name="ShowLine">
             <property name="toolTip">
              <string>If it is checked it will display the dimension line</string>
             </property>
@@ -360,7 +368,7 @@
           <item row="2" column="0">
            <widget class="QLabel" name="label_14">
             <property name="toolTip">
-             <string>The width of the dimension lines</string>
+             <string>The width of the lines</string>
             </property>
             <property name="text">
              <string>Line width</string>
@@ -370,51 +378,24 @@
           <item row="2" column="1">
            <widget class="QSpinBox" name="LineWidth">
             <property name="toolTip">
-             <string>The width of the dimension lines</string>
+             <string>The width of the lines</string>
             </property>
             <property name="suffix">
-             <string>px</string>
-            </property>
-            <property name="value">
-             <number>1</number>
+             <string> px</string>
             </property>
            </widget>
           </item>
           <item row="3" column="0">
-           <widget class="QLabel" name="label_15">
-            <property name="toolTip">
-             <string>The color of dimension lines, arrows and texts</string>
-            </property>
-            <property name="text">
-             <string>Line / text color</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="1">
-           <widget class="Gui::ColorButton" name="LineColor">
-            <property name="toolTip">
-             <string>The color of dimension lines, arrows and texts</string>
-            </property>
-            <property name="color">
-             <color>
-              <red>0</red>
-              <green>0</green>
-              <blue>0</blue>
-             </color>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="0">
            <widget class="QLabel" name="label_9">
             <property name="toolTip">
-             <string>The type of arrows or markers to use at the end of dimension lines</string>
+             <string>The type of arrows or markers to use for dimensions and labels</string>
             </property>
             <property name="text">
              <string>Arrow type</string>
             </property>
            </widget>
           </item>
-          <item row="4" column="1">
+          <item row="3" column="1">
            <widget class="QComboBox" name="ArrowType">
             <property name="sizePolicy">
              <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
@@ -429,7 +410,7 @@
              </size>
             </property>
             <property name="toolTip">
-             <string>The type of arrows or markers to use at the end of dimension lines</string>
+             <string>The type of arrows or markers to use for dimensions and labels</string>
             </property>
             <item>
              <property name="text">
@@ -458,30 +439,47 @@
             </item>
            </widget>
           </item>
-          <item row="5" column="0">
+          <item row="4" column="0">
            <widget class="QLabel" name="label_8">
             <property name="toolTip">
-             <string>The size of the dimension arrows or markers in system units</string>
+             <string>The size of the arrows or markers in system units</string>
             </property>
             <property name="text">
              <string>Arrow size</string>
             </property>
            </widget>
           </item>
-          <item row="5" column="1">
+          <item row="4" column="1">
            <widget class="Gui::InputField" name="ArrowSize">
             <property name="toolTip">
-             <string>The size of the dimension arrows or markers in system units</string>
+             <string>The size of the arrows or markers in system units</string>
             </property>
-            <property name="quantity" stdset="0">
-             <double>5.000000000000000</double>
+            <property name="unit" stdset="0">
+             <string notr="true"/>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="0">
+           <widget class="QLabel" name="label_15">
+            <property name="toolTip">
+             <string>The color of lines and arrows</string>
+            </property>
+            <property name="text">
+             <string>Line and arrow color</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="1">
+           <widget class="Gui::ColorButton" name="LineColor">
+            <property name="toolTip">
+             <string>The color of lines and arrows</string>
             </property>
            </widget>
           </item>
           <item row="6" column="0">
            <widget class="QLabel" name="label_10">
             <property name="toolTip">
-             <string>The distance that the dimension line is additionally extended</string>
+             <string>The distance the dimension line is additionally extended</string>
             </property>
             <property name="text">
              <string>Dimension overshoot</string>
@@ -489,12 +487,12 @@
            </widget>
           </item>
           <item row="6" column="1">
-           <widget class="Gui::InputField" name="DimensionOvershoot">
+           <widget class="Gui::InputField" name="DimOvershoot">
             <property name="toolTip">
-             <string>The distance that the dimension line is additionally extended</string>
+             <string>The distance the dimension line is additionally extended</string>
             </property>
-            <property name="quantity" stdset="0">
-             <double>1.000000000000000</double>
+            <property name="unit" stdset="0">
+             <string notr="true"/>
             </property>
            </widget>
           </item>
@@ -509,19 +507,19 @@
            </widget>
           </item>
           <item row="7" column="1">
-           <widget class="Gui::InputField" name="ExtensionLines">
+           <widget class="Gui::InputField" name="ExtLines">
             <property name="toolTip">
              <string>The length of the extension lines</string>
             </property>
-            <property name="quantity" stdset="0">
-             <double>10.000000000000000</double>
+            <property name="unit" stdset="0">
+             <string notr="true"/>
             </property>
            </widget>
           </item>
           <item row="8" column="0">
            <widget class="QLabel" name="label_12">
             <property name="toolTip">
-             <string>The distance that the extension lines are additionally extended beyond the dimension line</string>
+             <string>The distance the extension lines are additionally extended beyond the dimension line</string>
             </property>
             <property name="text">
              <string>Extension overshoot</string>
@@ -529,12 +527,12 @@
            </widget>
           </item>
           <item row="8" column="1">
-           <widget class="Gui::InputField" name="ExtensionOvershoot">
+           <widget class="Gui::InputField" name="ExtOvershoot">
             <property name="toolTip">
-             <string>The distance that the extension lines are additionally extended beyond the dimension line</string>
+             <string>The distance the extension lines are additionally extended beyond the dimension line</string>
             </property>
-            <property name="quantity" stdset="0">
-             <double>1.000000000000000</double>
+            <property name="unit" stdset="0">
+             <string notr="true"/>
             </property>
            </widget>
           </item>

--- a/src/Mod/Draft/draftfunctions/svg.py
+++ b/src/Mod/Draft/draftfunctions/svg.py
@@ -37,7 +37,6 @@ import draftutils.utils as utils
 import draftfunctions.svgtext as svgtext
 
 from draftfunctions.svgshapes import get_proj, get_circle, get_path
-from draftutils.utils import param
 from draftutils.messages import _wrn, _err
 
 # Delay import of module until first use because it is heavy
@@ -51,6 +50,7 @@ DraftGeomUtils = lz.LazyLoader("DraftGeomUtils", globals(), "DraftGeomUtils")
 
 def get_line_style(line_style, scale):
     """Return a linestyle scaled by a factor."""
+    param = App.ParamGet("User parameter:BaseApp/Preferences/Mod/Draft")
     style = None
 
     if line_style == "Dashed":

--- a/src/Mod/Draft/draftfunctions/svgshapes.py
+++ b/src/Mod/Draft/draftfunctions/svgshapes.py
@@ -34,7 +34,6 @@ import FreeCAD as App
 import DraftVecUtils
 import draftutils.utils as utils
 
-from draftutils.utils import param
 from draftutils.messages import _msg, _wrn
 
 # Delay import of module until first use because it is heavy
@@ -90,6 +89,7 @@ def getProj(vec, plane=None):
 
 def get_discretized(edge, plane):
     """Get a discretized edge on a plane."""
+    param = App.ParamGet("User parameter:BaseApp/Preferences/Mod/Draft")
     pieces = param.GetFloat("svgDiscretization", 10.0)
 
     if pieces == 0:

--- a/src/Mod/Draft/draftutils/utils.py
+++ b/src/Mod/Draft/draftutils/utils.py
@@ -53,27 +53,29 @@ if App.GuiUp:
     # The module is used to prevent complaints from code checkers (flake8)
     True if Draft_rc else False
 
-param = App.ParamGet("User parameter:BaseApp/Preferences/Mod/Draft")
-
 ARROW_TYPES = ["Dot", "Circle", "Arrow", "Tick", "Tick-2"]
 arrowtypes = ARROW_TYPES
 
+param_draft = App.ParamGet("User parameter:BaseApp/Preferences/Mod/Draft")
+param_view  = App.ParamGet("User parameter:BaseApp/Preferences/View")
+
 ANNOTATION_STYLE = {
-    "FontName": ("font", param.GetString("textfont", "Sans")),
-    "FontSize": ("str", str(param.GetFloat("textheight", 100))),
-    "LineSpacing": ("float", 1),
+    "FontName":        ("font",  param_draft.GetString("textfont", "Sans")),
+    "FontSize":        ("float", param_draft.GetFloat("textheight", 100)),
+    "LineSpacing":     ("float", param_draft.GetFloat("LineSpacing", 1)),
+    "TextColor":       ("color", param_draft.GetUnsigned("DefaultTextColor", 255)),
     "ScaleMultiplier": ("float", 1),
-    "ShowUnit": ("bool", False),
-    "UnitOverride": ("str", ""),
-    "Decimals": ("int", 2),
-    "ShowLines": ("bool", True),
-    "LineWidth": ("int", param.GetInt("linewidth", 1)),
-    "LineColor": ("color", param.GetInt("color", 255)),
-    "ArrowType": ("index", param.GetInt("dimsymbol", 0)),
-    "ArrowSize": ("str", str(param.GetFloat("arrowsize", 20))),
-    "DimensionOvershoot": ("str", str(param.GetFloat("dimovershoot", 20))),
-    "ExtensionLines": ("str", str(param.GetFloat("extlines", 300))),
-    "ExtensionOvershoot": ("str", str(param.GetFloat("extovershoot", 20))),
+    "ShowUnit":        ("bool",  param_draft.GetBool("showUnit", True)),
+    "UnitOverride":    ("str",   param_draft.GetString("overrideUnit", "")),
+    "Decimals":        ("int",   param_draft.GetInt("dimPrecision", 2)),
+    "ShowLine":        ("bool",  True),
+    "LineWidth":       ("int",   param_view.GetInt("DefaultShapeLineWidth", 1)),
+    "ArrowType":       ("index", param_draft.GetInt("dimsymbol", 0)),
+    "ArrowSize":       ("float", param_draft.GetFloat("arrowsize", 20)),
+    "LineColor":       ("color", param_view.GetUnsigned("DefaultShapeLineColor", 255)),
+    "DimOvershoot":    ("float", param_draft.GetFloat("dimovershoot", 20)),
+    "ExtLines":        ("float", param_draft.GetFloat("extlines", 300)),
+    "ExtOvershoot":    ("float", param_draft.GetFloat("extovershoot", 20)),
 }
 
 
@@ -797,8 +799,10 @@ def get_rgb(color, testbw=True):
 
     Parameters
     ----------
+    color : list or tuple with RGB values
+        The values must be in the 0.0-1.0 range.
     testwb : bool (default = True)
-        pure white will be converted into pure black
+        Pure white will be converted into pure black.
     """
     r = str(hex(int(color[0]*255)))[2:].zfill(2)
     g = str(hex(int(color[1]*255)))[2:].zfill(2)
@@ -813,6 +817,29 @@ def get_rgb(color, testbw=True):
 
 
 getrgb = get_rgb
+
+
+def argb_to_rgba(color):
+    """Change byte order of a 4 byte color int from ARGB (Qt) to RGBA (FreeCAD).
+
+    Alpha in both integers is always 255.
+    Alpha in color properties, although ignored, is always zero however.
+
+    Usage:
+
+        freecad_int = argb_to_rgba(qt_int)
+        FreeCAD.ParamGet("User parameter:BaseApp/Preferences/View")\
+            .SetUnsigned("DefaultShapeColor", freecad_int)
+
+        obj.ViewObject.ShapeColor = freecad_int & 0xFFFFFF00
+    """
+    return ((color & 0xFFFFFF) << 8) + ((color & 0xFF000000) >> 24)
+
+
+def rgba_to_argb(color):
+    """Change byte order of a 4 byte color int from RGBA (FreeCAD) to ARGB (Qt).
+    """
+    return ((color & 0xFFFFFF00) >> 8) + ((color & 0xFF) << 24)
 
 
 def filter_objects_for_modifiers(objects, isCopied=False):

--- a/src/Mod/Draft/draftviewproviders/view_draft_annotation.py
+++ b/src/Mod/Draft/draftviewproviders/view_draft_annotation.py
@@ -217,18 +217,16 @@ class ViewProviderDraftAnnotation(object):
                     style = styles[vobj.AnnotationStyle]
                     for visprop in style.keys():
                         if visprop in properties:
-                            try:
-                                getattr(vobj, visprop).setValue(style[visprop])
-                                _msg("setValue: "
-                                     "'{}', '{}'".format(visprop,
-                                                         style[visprop]))
-                            except AttributeError:
-                                setattr(vobj, visprop, style[visprop])
-                                _msg("setattr: "
-                                     "'{}', '{}'".format(visprop,
-                                                         style[visprop]))
                             # make property read-only
-                            vobj.setPropertyStatus(visprop, 'ReadOnly')
+                            vobj.setPropertyStatus(visprop, "ReadOnly")
+                            value = style[visprop]
+                            try:
+                                if vobj.getTypeIdOfProperty(visprop) == "App::PropertyColor":
+                                    value = value & 0xFFFFFF00
+                                setattr(vobj, visprop, value)
+                                _msg("setattr: '{}', '{}'".format(visprop, value))
+                            except:
+                                pass
 
     def execute(self, vobj):
         """Execute when the object is created or recomputed."""


### PR DESCRIPTION
This PR fixes multiple issues with the [Draft_AnnotationStyleEditor](https://wiki.freecadweb.org/Draft_AnnotationStyleEditor) command. A button was added for the text color. The line color button was moved.

![dialog_AnnotationStyleEditor](https://user-images.githubusercontent.com/70520633/213154459-5fa91fb0-047a-432a-9033-1fd539699388.png)

Forum topic:
https://forum.freecadweb.org/viewtopic.php?f=3&t=73222

It is probably a good idea to look at the Draft_AnnotationStyleEditor and [Draft_SetStyle](https://wiki.freecadweb.org/Draft_SetStyle) commands together at some later date. There is a lot of overlap as well as some inconsistencies.

- [ ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

---
