### PR TITLE
Expressions: path auto-completion fixes

### DIFF
--- a/src/Gui/ExpressionCompleter.cpp
+++ b/src/Gui/ExpressionCompleter.cpp
@@ -404,7 +404,11 @@ public:
                     *count = propSize;
                 }
                 if (v) {
-                    *v = QString::fromLatin1(propName);
+                    QString res = QString::fromLatin1(propName);
+                    if (sep && propSize) {
+                        res += QLatin1Char('.');
+                    }
+                    *v = res;
                 }
                 return;
             }
@@ -435,7 +439,15 @@ public:
 
             if (v) 
             {
-                *v = QString::fromLatin1(paths[idx].getSubPathStr().c_str());
+                auto str = paths[idx].getSubPathStr();
+                if (str.size() && (str[0] == '.' || str[0] == '#')) 
+                {
+                    // skip the "."
+                    *v = QString::fromLatin1(str.c_str() + 1);
+                } else {
+                    *v = QString::fromLatin1(str.c_str());
+                }
+                
             }
         }
         return;

--- a/src/Gui/ExpressionCompleter.cpp
+++ b/src/Gui/ExpressionCompleter.cpp
@@ -491,7 +491,7 @@ public:
         return QModelIndex();
     }
 
-    // returns true if succesful, false if 'element' identifies a Leaf
+    // returns true if successful, false if 'element' identifies a Leaf
     bool modelIndexToParentInfo(QModelIndex element, Info & info) const
     {
         Info parentInfo;
@@ -676,7 +676,7 @@ QStringList ExpressionCompleter::splitPath ( const QString & input ) const
 
     int retry = 0;
     std::string lastElem;  // used to recover in case of parse failure after ".". 
-    std::string trim;      // used to delte ._self added for another recovery path 
+    std::string trim;      // used to delete ._self added for another recovery path 
     while(1) {
         try {
             // this will not work for incomplete Tokens at the end

--- a/src/Gui/ExpressionCompleter.cpp
+++ b/src/Gui/ExpressionCompleter.cpp
@@ -499,7 +499,7 @@ public:
 
                 // if my element is a contextual descendant of root (current doc object list, current object prop list)
                 // mark it as such
-                if (element.row() >= docs.size()) {
+                if (element.row() >= docs.size()*2) {
                     info.contextualHierarchy = 1;
                 }
             } else if (parentInfo.contextualHierarchy) {
@@ -508,9 +508,9 @@ public:
                 auto cdoc = App::GetApplication().getDocument(currentDoc.c_str());
 
                 if (cdoc) {
-                    auto objsSize = cdoc->getObjects().size();
+                    auto objsSize = cdoc->getObjects().size()*2;
                     int idx = parentInfo.doc - docs.size();
-                    if (idx < cdoc->getObjects().size()) {
+                    if (idx < cdoc->getObjects().size()*2) {
                         //  |-- Parent (OBJECT)        - (row 4, [-1,-1,-1,0]) = encode as element => [parent.row,-1,-1,1]
                         //      |- element (PROP)            - (row 0, [parent.row,-1,-1,1])  = encode as element => [parent.row,-1,parent.row,1]
 
@@ -678,7 +678,12 @@ QStringList ExpressionCompleter::splitPath ( const QString & input ) const
                 ++sli;
             }
             if (lastElem.size()) {
-                l << Base::Tools::fromStdString(lastElem);
+                if (lastElem != "#") {
+                    l << Base::Tools::fromStdString(lastElem);
+                } else {
+                    // add empty string 
+                    l << QString();
+                }
             }
             FC_TRACE("split path " << path
                     << " -> " << l.join(QLatin1String("/")).toUtf8().constData());
@@ -696,8 +701,10 @@ QStringList ExpressionCompleter::splitPath ( const QString & input ) const
                 if (lastElemStart != std::string::npos ) {
                     if (lastElemStart != path.size() - 1)
                         lastElem = path.substr(lastElemStart+1);
+                    else 
+                        lastElem = "#";
                     path = path.substr(0, lastElemStart);
-                } 
+                }
                 retry++;
                 continue;
             }else if(retry==1) {

--- a/src/Gui/ExpressionCompleter.cpp
+++ b/src/Gui/ExpressionCompleter.cpp
@@ -578,7 +578,8 @@ public:
         Info info;
         int row = 0;
         if(!parent.isValid()) {
-            // root.
+            // we're getting the row count for the root
+            // that is: document hierarchy _and_ contextual completion
             info = Info::root;
             row = -1;
         }else{

--- a/src/Gui/ExpressionCompleter.h
+++ b/src/Gui/ExpressionCompleter.h
@@ -95,7 +95,10 @@ Q_SIGNALS:
     void textChanged2(QString text, int pos);
 public Q_SLOTS:
     void slotTextChanged(const QString & text);
-    void slotCompleteText(const QString & completionPrefix);
+    // activated == pressed enter on the completion item
+    void slotCompleteText(const QString& completionPrefix, bool isActivated);
+    void slotCompleteTextHighlighted(const QString& completionPrefix);
+    void slotCompleteTextSelected(const QString& completionPrefix);
 protected:
     void keyPressEvent(QKeyEvent * event) override;
     void contextMenuEvent(QContextMenuEvent * event) override;


### PR DESCRIPTION
I've added support to do path completions after a property is selected in the auto completer line edit.

This allows:

<img width="223" alt="image" src="https://user-images.githubusercontent.com/7191714/213916224-2cfc9ba3-3696-4e0b-927d-607559a81ea6.png">

<img width="210" alt="image" src="https://user-images.githubusercontent.com/7191714/213916231-6e159f4f-69d9-4ba8-86f7-753f1d908121.png">

It also fixes some UX issues I had with the completer - chaining completions when pressing Enter should work.

It is not perfect, as it cannot complete sub-path components, and has other limitations.
- `Sketch.Placement.` will propose `Base.x`, `Base.y`,... `Rotation.Angle`, `Rotation.Axis.x`
- `Sketch.Placement.Rotation.A` will fail to complete as the path split "Sketch/Placement/Rotation/A" is not in the completion tree, only Sketch/Placement/Rotation.Axis.x is 
- I don't believe arrays will work, if there isn't a named structure in place the completer will not have that in the completion tree: `Object.Prop[10].Something` will not work, as `Prop[10]` is not in the tree. 

Tested:
- Constraints formula line edit
- Spreadsheet 
- x64 Windows Debug & Release builds

Video:
https://youtu.be/y-3bDFy8Pgc

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
