### PR TITLE
[Sketch] Constraints.h: fix 2 compiler warnings

### DIFF
--- a/src/Mod/Sketcher/App/planegcs/Constraints.h
+++ b/src/Mod/Sketcher/App/planegcs/Constraints.h
@@ -251,10 +251,9 @@ namespace GCS
         void rescale(double coef=1.) override;
         double error() override;
         double grad(double *) override;
-        void setupInputs();
         size_t numpoints;
         BSpline& bsp;
-        unsigned int startpole;
+        size_t startpole;
     };
 
     // Difference


### PR DESCRIPTION
- the type change fixes this error: \src\Mod\Sketcher\App\planegcs\Constraints.cpp(509,54): warning C4267: '=': conversion from 'size_t' to 'unsigned int', possible loss of data
- the scone change removes a non-existing definition