### PR TITLE
PD: Make InvoluteGear's property descriptions translatable and reuse them as task panel tooltips

### DIFF
--- a/src/Mod/PartDesign/InvoluteGearFeature.py
+++ b/src/Mod/PartDesign/InvoluteGearFeature.py
@@ -21,12 +21,13 @@
 
 import pathlib
 import FreeCAD, Part
+from PySide import QtCore
 from fcgear import involute
 from fcgear import fcgear
 
 if FreeCAD.GuiUp:
     import FreeCADGui
-    from PySide import QtCore, QtGui
+    from PySide import QtGui
 
 __title__="PartDesign InvoluteGearObject management"
 __author__ = "Juergen Riegel"
@@ -91,29 +92,35 @@ class _InvoluteGear:
                 else:
                     setattr(obj, name, default)
 
+        # for details about the property's docstring translation,
+        # see https://tracker.freecadweb.org/view.php?id=2524
         ensure_property("App::PropertyInteger", "NumberOfTeeth",
-            doc="Number of gear teeth",
+            doc=QtCore.QT_TRANSLATE_NOOP("App::Property", "Number of gear teeth"),
             default=26)
         ensure_property("App::PropertyLength", "Modules",
-            doc="Modules of the gear",
+            doc=QtCore.QT_TRANSLATE_NOOP("App::Property", "Modules of the gear"),
             default="2.5 mm")
         ensure_property("App::PropertyAngle", "PressureAngle",
-            doc="Pressure angle of gear teeth",
+            doc=QtCore.QT_TRANSLATE_NOOP("App::Property", "Pressure angle of gear teeth"),
             default="20 deg")
         ensure_property("App::PropertyBool", "HighPrecision",
-            doc="True=2 curves with each 3 control points False=1 curve with 4 control points.",
+            doc=QtCore.QT_TRANSLATE_NOOP("App::Property",
+                "True=2 curves with each 3 control points False=1 curve with 4 control points."),
             default=True)
         ensure_property("App::PropertyBool", "ExternalGear",
-            doc="True=external Gear False=internal Gear",
+            doc=QtCore.QT_TRANSLATE_NOOP("App::Property", "True=external Gear False=internal Gear"),
             default=True)
         ensure_property("App::PropertyFloat", "AddendumCoefficient",
-            doc="The height of the tooth from the pitch circle up to its tip, normalized by the module.",
+            doc=QtCore.QT_TRANSLATE_NOOP("App::Property",
+                "The height of the tooth from the pitch circle up to its tip, normalized by the module."),
             default=lambda: 1.0 if obj.ExternalGear else 0.6)
         ensure_property("App::PropertyFloat","DedendumCoefficient",
-            doc="The height of the tooth from the pitch circle down to its root, normalized by the module.",
+            doc=QtCore.QT_TRANSLATE_NOOP("App::Property",
+                "The height of the tooth from the pitch circle down to its root, normalized by the module."),
             default=1.25)
         ensure_property("App::PropertyFloat","RootFilletCoefficient",
-            doc="The radius of the fillet at the root of the tooth, normalized by the module.",
+            doc=QtCore.QT_TRANSLATE_NOOP("App::Property",
+                "The radius of the fillet at the root of the tooth, normalized by the module."),
             default=lambda: 0.375 if is_restore else 0.38)
 
     def execute(self,obj):
@@ -202,8 +209,9 @@ class _InvoluteGearTaskPanel:
     def assignToolTipsFromPropertyDocs(self):
         def assign(property_name, *widgets):
             doc = self.obj.getDocumentationOfProperty(property_name)
+            translated_doc = QtGui.QApplication.translate("App::Property", doc)
             for w in widgets:
-                w.setToolTip(doc)
+                w.setToolTip(translated_doc)
 
         # we assign the tool tip to both, the label and the input field, for user convenience
         assign("Modules", self.form.Quantity_Modules, self.form.label_Modules)

--- a/src/Mod/PartDesign/InvoluteGearFeature.py
+++ b/src/Mod/PartDesign/InvoluteGearFeature.py
@@ -166,6 +166,7 @@ class _InvoluteGearTaskPanel:
 
         self.form=FreeCADGui.PySideUic.loadUi(str(pathlib.Path(__file__).with_suffix(".ui")))
         self.form.setWindowIcon(QtGui.QIcon(":/icons/PartDesign_InternalExternalGear.svg"))
+        self.assignToolTipsFromPropertyDocs()
 
         def assignValue(property_name, fitView=False):
             """Returns a function that takes a single value and assigns it to the given property"""
@@ -197,6 +198,22 @@ class _InvoluteGearTaskPanel:
         if mode == 0: # fresh created
             self.obj.Proxy.execute(self.obj)  # calculate once
             FreeCAD.Gui.SendMsgToActiveView("ViewFit")
+
+    def assignToolTipsFromPropertyDocs(self):
+        def assign(property_name, *widgets):
+            doc = self.obj.getDocumentationOfProperty(property_name)
+            for w in widgets:
+                w.setToolTip(doc)
+
+        # we assign the tool tip to both, the label and the input field, for user convenience
+        assign("Modules", self.form.Quantity_Modules, self.form.label_Modules)
+        assign("PressureAngle", self.form.Quantity_PressureAngle, self.form.label_PressureAngle)
+        assign("NumberOfTeeth", self.form.spinBox_NumberOfTeeth, self.form.label_NumberOfTeeth)
+        assign("HighPrecision", self.form.comboBox_HighPrecision, self.form.label_HighPrecision)
+        assign("ExternalGear", self.form.comboBox_ExternalGear, self.form.label_ExternalGear)
+        assign("AddendumCoefficient", self.form.doubleSpinBox_Addendum, self.form.label_Addendum)
+        assign("DedendumCoefficient", self.form.doubleSpinBox_Dedendum, self.form.label_Dedendum)
+        assign("RootFilletCoefficient", self.form.doubleSpinBox_RootFillet, self.form.label_RootFillet)
 
     def transferTo(self):
         "Transfer from the dialog to the object"

--- a/src/Mod/PartDesign/InvoluteGearFeature.ui
+++ b/src/Mod/PartDesign/InvoluteGearFeature.ui
@@ -15,7 +15,7 @@
   </property>
   <layout class="QFormLayout" name="formLayout">
    <item row="0" column="0">
-    <widget class="QLabel" name="label_9">
+    <widget class="QLabel" name="label_NumberOfTeeth">
      <property name="text">
       <string>Number of teeth:</string>
      </property>
@@ -35,7 +35,7 @@
     </widget>
    </item>
    <item row="1" column="0">
-    <widget class="QLabel" name="label_8">
+    <widget class="QLabel" name="label_Modules">
      <property name="text">
       <string>Module:</string>
      </property>
@@ -79,7 +79,7 @@
     </widget>
    </item>
    <item row="2" column="0">
-    <widget class="QLabel" name="label_6">
+    <widget class="QLabel" name="label_PressureAngle">
      <property name="text">
       <string>Pressure angle:</string>
      </property>
@@ -120,7 +120,7 @@
     </widget>
    </item>
    <item row="3" column="0">
-    <widget class="QLabel" name="label_7">
+    <widget class="QLabel" name="label_HighPrecision">
      <property name="text">
       <string>High precision:</string>
      </property>
@@ -147,7 +147,7 @@
     </widget>
    </item>
    <item row="4" column="0">
-    <widget class="QLabel" name="label_10">
+    <widget class="QLabel" name="label_ExternalGear">
      <property name="text">
       <string>External gear:</string>
      </property>
@@ -174,7 +174,7 @@
     </widget>
    </item>
    <item row="5" column="0">
-    <widget class="QLabel" name="label">
+    <widget class="QLabel" name="label_Addendum">
      <property name="text">
       <string>Addendum Coefficient</string>
      </property>
@@ -194,7 +194,7 @@
     </widget>
    </item>
    <item row="6" column="0">
-    <widget class="QLabel" name="label_2">
+    <widget class="QLabel" name="label_Dedendum">
      <property name="text">
       <string>Dedendum Coefficient</string>
      </property>
@@ -214,7 +214,7 @@
     </widget>
    </item>
    <item row="7" column="0">
-    <widget class="QLabel" name="label_3">
+    <widget class="QLabel" name="label_RootFillet">
      <property name="text">
       <string>Root Fillet Coefficient</string>
      </property>


### PR DESCRIPTION
This is a follow-up to #8184, extending the task panel with tool tips.

For the tool tips, the property descriptions are reused. This avoids maintaining the same information in two places. The property descriptions have been made translatable, too, to ensure a fully translatable UI.

Overall, this PR follows the same methodology as #5321. However, I did not managed to make an *open* task panel retranslate itself in case the UI language is changed. In C++ this is done by overwriting the TaskPanel's `changeEvent`, but this does not seem to be exposed to Python. @wwmayer, any ideas?

I did not find any Python task panel reacting on language-change while open. When closing and reopening the task panel, the new language setting is used, though.

---

- [x]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
