### PR TITLE
Remove misleading message

### DIFF
--- a/cMake/FreeCAD_Helpers/ChooseQtVersion.cmake
+++ b/cMake/FreeCAD_Helpers/ChooseQtVersion.cmake
@@ -77,7 +77,7 @@ macro(ChooseQtVersion)
       find_package(Qt6 QUIET COMPONENTS Core)
       if (NOT Qt6_FOUND)
         message(FATAL_ERROR
-          "Could not find a valid Qt installation. Consider setting Qt5_DIR or Qt6_DIR (as needed).")
+          "Could not find a valid Qt installation.")
       endif ()
       set(_FREECAD_QT_VERSION 6)
     endif ()


### PR DESCRIPTION
From commit message: (added by luzpaz)
> " Consider setting Qt5_DIR or Qt6_DIR (as needed)."
>Qt5_DIR is only used in libpacks
>Qt6_DIR is never referenced.

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [ ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
