### PR TITLE
[Gui] allow to specify font for NaviCube

### DIFF
--- a/src/Gui/DlgSettingsNavigation.ui
+++ b/src/Gui/DlgSettingsNavigation.ui
@@ -7,13 +7,13 @@
     <x>0</x>
     <y>0</y>
     <width>500</width>
-    <height>391</height>
+    <height>394</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Navigation</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_2">
+  <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <widget class="QGroupBox" name="groupBoxNaviCube">
      <property name="title">
@@ -117,7 +117,7 @@
         </item>
        </widget>
       </item>
-      <item row="1" column="0" colspan="2">
+      <item row="2" column="0" colspan="2">
        <widget class="Gui::PrefCheckBox" name="naviCubeToNearest">
         <property name="toolTip">
          <string>Rotates to nearest possible state when clicking a cube face</string>
@@ -136,14 +136,37 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="0">
+      <item row="2" column="3">
+       <widget class="QLabel" name="TextLabel3">
+        <property name="text">
+         <string>Font name:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="4">
+       <widget class="Gui::PrefComboBox" name="naviCubeFontName">
+        <property name="toolTip">
+         <string>Corner where navigation cube is shown</string>
+        </property>
+        <property name="currentIndex">
+         <number>-1</number>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>FontString</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>NaviCube</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
        <widget class="QLabel" name="label_3">
         <property name="text">
          <string>Cube size</string>
         </property>
        </widget>
       </item>
-      <item row="2" column="1">
+      <item row="3" column="1">
        <widget class="Gui::PrefSpinBox" name="prefCubeSize">
         <property name="toolTip">
          <string>Size of the navigation cube</string>
@@ -165,6 +188,44 @@
         </property>
         <property name="prefEntry" stdset="0">
          <cstring>CubeSize</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>NaviCube</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="3">
+       <widget class="QLabel" name="TextLabel4">
+        <property name="text">
+         <string>Font size:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="4">
+       <widget class="Gui::PrefSpinBox" name="naviCubeFontSize">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Font size for the NaviCube text&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="minimum">
+         <number>1</number>
+        </property>
+        <property name="maximum">
+         <number>999</number>
+        </property>
+        <property name="singleStep">
+         <number>5</number>
+        </property>
+        <property name="value">
+         <number>100</number>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>FontSize</cstring>
         </property>
         <property name="prefPath" stdset="0">
          <cstring>NaviCube</cstring>

--- a/src/Gui/NaviCube.h
+++ b/src/Gui/NaviCube.h
@@ -41,22 +41,18 @@ public:
         BottomLeftCorner,
         BottomRightCorner
     };
-    NaviCube(Gui::View3DInventorViewer* viewer) ;
+    NaviCube(Gui::View3DInventorViewer* viewer);
     virtual ~NaviCube();
     void drawNaviCube();
     void createContextMenu(const std::vector<std::string>& cmd);
     bool processSoEvent(const SoEvent* ev);
     void setCorner(Corner);
+    static QFont getDefaultSansserifFont();
     static void setNaviCubeCommands(const std::vector<std::string>& cmd);
     static void setNaviCubeLabels(const std::vector<std::string>& labels);
+
 private:
     NaviCubeImplementation* m_NaviCubeImplementation;
-};
-
-class HuuhaaClassPy : public Py::PythonExtension<HuuhaaClassPy> {
-public:
-    Py::Object huuhaa(const Py::Tuple&);
-    static void init_type() ;
 };
 
 #endif /* SRC_GUI_NAVICUBE_H_ */

--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -1176,6 +1176,23 @@ NaviCube* View3DInventorViewer::getNavigationCube() const
     return naviCube;
 }
 
+void View3DInventorViewer::createNavigationCube()
+{
+    if (!naviCube) {
+        naviCube = new NaviCube(this);
+        naviCubeEnabled = true;
+    }
+}
+
+void View3DInventorViewer::deleteNavigationCube()
+{
+    if (naviCube) {
+        delete naviCube;
+        naviCube = nullptr;
+        naviCubeEnabled = false;
+    }
+}
+
 void View3DInventorViewer::setAxisCross(bool on)
 {
     SoNode* scene = getSceneGraph();

--- a/src/Gui/View3DInventorViewer.h
+++ b/src/Gui/View3DInventorViewer.h
@@ -387,6 +387,8 @@ public:
     bool isEnabledNaviCube() const;
     void setNaviCubeCorner(int);
     NaviCube* getNavigationCube() const;
+    void createNavigationCube();
+    void deleteNavigationCube();
     void setEnabledVBO(bool b);
     bool isEnabledVBO() const;
     void setRenderCache(int);


### PR DESCRIPTION
- the problem is that depending on the OS, the font of the NaviCube is hardly readable. For example under Windows 11, there is no Helvetica font and therefore an ugly replacement font is used. On some laptop screens the font is too large or too small etc.
- as solution this PR add the change the NaviCube's font and font size

- the PR also fixes an issue that the position (corner) of the NaviCube was not respected when the NaviCube is recreated. This fix is necessary for the PR therefore included

- as by-product the PR fixes #8082 since every change in the preferences now properly recreates the NaviCube

- the PR also removes the strange and unused class "HuuhaaClassPy"

Here is the new NaviCube settings implemented by this PR:
![FreeCAD_g5i4BUqQct](https://user-images.githubusercontent.com/1828501/214753617-d1e9053b-56d3-4a9e-ba1c-afee406fbb67.gif)
