### PR TITLE
Add offset options to Draft PathArray

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_patharray.py
+++ b/src/Mod/Draft/draftguitools/gui_patharray.py
@@ -113,6 +113,8 @@ class PathArray(gui_base_original.Modifier):
             force_vertical = False
             vertical_vector = App.Vector(0, 0, 1)
             use_link = self.use_link
+            start_offset = 0.0
+            end_offset = 0.0
 
             _edge_list_str = list()
             _edge_list_str = ["'" + edge + "'" for edge in subelements]
@@ -134,7 +136,9 @@ class PathArray(gui_base_original.Modifier):
             _cmd += "tan_vector=" + DraftVecUtils.toString(tan_vector) + ", "
             _cmd += "force_vertical=" + str(force_vertical) + ", "
             _cmd += "vertical_vector=" + vertical_vector_str + ", "
-            _cmd += "use_link=" + str(use_link)
+            _cmd += "use_link=" + str(use_link) + ", "
+            _cmd += "start_offset=" + str(start_offset) + ", "
+            _cmd += "end_offset=" + str(end_offset)
             _cmd += ")"
 
             _cmd_list = ["_obj_ = " + _cmd,

--- a/src/Mod/Draft/draftguitools/gui_patharray.py
+++ b/src/Mod/Draft/draftguitools/gui_patharray.py
@@ -112,9 +112,9 @@ class PathArray(gui_base_original.Modifier):
             tan_vector = App.Vector(1, 0, 0)
             force_vertical = False
             vertical_vector = App.Vector(0, 0, 1)
-            use_link = self.use_link
             start_offset = 0.0
             end_offset = 0.0
+            use_link = self.use_link
 
             _edge_list_str = list()
             _edge_list_str = ["'" + edge + "'" for edge in subelements]
@@ -136,9 +136,9 @@ class PathArray(gui_base_original.Modifier):
             _cmd += "tan_vector=" + DraftVecUtils.toString(tan_vector) + ", "
             _cmd += "force_vertical=" + str(force_vertical) + ", "
             _cmd += "vertical_vector=" + vertical_vector_str + ", "
-            _cmd += "use_link=" + str(use_link) + ", "
             _cmd += "start_offset=" + str(start_offset) + ", "
-            _cmd += "end_offset=" + str(end_offset)
+            _cmd += "end_offset=" + str(end_offset) + ", "
+            _cmd += "use_link=" + str(use_link)
             _cmd += ")"
 
             _cmd_list = ["_obj_ = " + _cmd,

--- a/src/Mod/Draft/draftmake/make_patharray.py
+++ b/src/Mod/Draft/draftmake/make_patharray.py
@@ -57,7 +57,9 @@ def make_path_array(base_object, path_object, count=4,
                     tan_vector=App.Vector(1, 0, 0),
                     force_vertical=False,
                     vertical_vector=App.Vector(0, 0, 1),
-                    use_link=True):
+                    use_link=True,
+                    start_offset=0.0,
+                    end_offset=0.0):
     """Make a Draft PathArray object.
 
     Distribute copies of a `base_object` along `path_object`
@@ -144,6 +146,15 @@ def make_path_array(base_object, path_object, count=4,
         It defaults to `True`, in which case the copies are `App::Link`
         elements. Otherwise, the copies are shape copies which makes
         the resulting array heavier.
+    
+    start_offset: float, optional
+        It defaults to 0.0.
+        It is the distance from the beginning of the path to offset the first copy.
+
+    end_offset: float, optional
+        It defaults to 0.0.
+        It is the distance from the end of the path to offset the last copy.
+
 
     Returns
     -------
@@ -278,6 +289,25 @@ def make_path_array(base_object, path_object, count=4,
         new_obj = doc.addObject("Part::FeaturePython", "PathArray")
         PathArray(new_obj)
 
+    _msg("start_offset: {}".format(start_offset))
+    try:
+        utils.type_check([(start_offset, (int, float))],
+                         name=_name)
+    except TypeError:
+        _err(translate("draft","Wrong input: must be a number."))
+        return None
+    start_offset = float(start_offset)
+
+    _msg("end_offset: {}".format(end_offset))
+    try:
+        utils.type_check([(end_offset, (int, float))],
+                         name=_name)
+    except TypeError:
+        _err(translate("draft","Wrong input: must be a number."))
+        return None
+    end_offset = float(end_offset)
+
+
     new_obj.Base = base_object
     new_obj.PathObject = path_object
     new_obj.Count = count
@@ -288,6 +318,8 @@ def make_path_array(base_object, path_object, count=4,
     new_obj.TangentVector = tan_vector
     new_obj.ForceVertical = force_vertical
     new_obj.VerticalVector = vertical_vector
+    new_obj.StartOffset = start_offset
+    new_obj.EndOffset = end_offset
 
     if App.GuiUp:
         if use_link:

--- a/src/Mod/Draft/draftmake/make_patharray.py
+++ b/src/Mod/Draft/draftmake/make_patharray.py
@@ -57,9 +57,8 @@ def make_path_array(base_object, path_object, count=4,
                     tan_vector=App.Vector(1, 0, 0),
                     force_vertical=False,
                     vertical_vector=App.Vector(0, 0, 1),
-                    use_link=True,
-                    start_offset=0.0,
-                    end_offset=0.0):
+                    start_offset=0.0, end_offset=0.0,
+                    use_link=True):
     """Make a Draft PathArray object.
 
     Distribute copies of a `base_object` along `path_object`
@@ -142,19 +141,18 @@ def make_path_array(base_object, path_object, count=4,
         It will force this vector to be the vertical direction
         when `force_vertical` is `True`.
 
+    start_offset: float, optional
+        It defaults to 0.0.
+        It is the length from the start of the path to the first copy.
+
+    end_offset: float, optional
+        It defaults to 0.0.
+        It is the length from the end of the path to the last copy.
+
     use_link: bool, optional
         It defaults to `True`, in which case the copies are `App::Link`
         elements. Otherwise, the copies are shape copies which makes
         the resulting array heavier.
-    
-    start_offset: float, optional
-        It defaults to 0.0.
-        It is the distance from the beginning of the path to offset the first copy.
-
-    end_offset: float, optional
-        It defaults to 0.0.
-        It is the distance from the end of the path to offset the last copy.
-
 
     Returns
     -------
@@ -277,18 +275,6 @@ def make_path_array(base_object, path_object, count=4,
         _err(translate("draft","Wrong input: must be a vector."))
         return None
 
-    use_link = bool(use_link)
-    _msg("use_link: {}".format(use_link))
-
-    if use_link:
-        # The PathArray class must be called in this special way
-        # to make it a PathLinkArray
-        new_obj = doc.addObject("Part::FeaturePython", "PathArray",
-                                PathArray(None), None, True)
-    else:
-        new_obj = doc.addObject("Part::FeaturePython", "PathArray")
-        PathArray(new_obj)
-
     _msg("start_offset: {}".format(start_offset))
     try:
         utils.type_check([(start_offset, (int, float))],
@@ -307,6 +293,17 @@ def make_path_array(base_object, path_object, count=4,
         return None
     end_offset = float(end_offset)
 
+    use_link = bool(use_link)
+    _msg("use_link: {}".format(use_link))
+
+    if use_link:
+        # The PathArray class must be called in this special way
+        # to make it a PathLinkArray
+        new_obj = doc.addObject("Part::FeaturePython", "PathArray",
+                                PathArray(None), None, True)
+    else:
+        new_obj = doc.addObject("Part::FeaturePython", "PathArray")
+        PathArray(new_obj)
 
     new_obj.Base = base_object
     new_obj.PathObject = path_object


### PR DESCRIPTION
Allows user to specify a starting and ending offset to items in Draft PathArrays. The offsets must be positive. They specify the distance from the beginning or end that the start or end items are placed along the path.

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
