### PR TITLE
[Part] Tweak mesh generation

### DIFF
--- a/src/Mod/Part/App/Tools.cpp
+++ b/src/Mod/Part/App/Tools.cpp
@@ -639,7 +639,7 @@ Handle (Poly_Triangulation) Part::Tools::triangulationOfFace(const TopoDS_Face& 
     TopoDS_Shape shape = mkBuilder.Shape();
     shape.Location(loc);
 
-    BRepMesh_IncrementalMesh(shape, 0.1);
+    BRepMesh_IncrementalMesh(shape, 0.005, false, 1, true);
     return BRep_Tool::Triangulation(TopoDS::Face(shape), loc);
 }
 
@@ -665,7 +665,7 @@ Handle(Poly_Polygon3D) Part::Tools::polygonOfEdge(const TopoDS_Edge& edge, TopLo
     TopLoc_Location inv = loc.Inverted();
     shape.Location(inv);
 
-    BRepMesh_IncrementalMesh(shape, 0.1);
+    BRepMesh_IncrementalMesh(shape, 0.005, false, 1, true);
     TopLoc_Location tmp;
     return BRep_Tool::Polygon3D(TopoDS::Edge(shape), tmp);
 }

--- a/src/Mod/Part/App/Tools.cpp
+++ b/src/Mod/Part/App/Tools.cpp
@@ -639,7 +639,7 @@ Handle (Poly_Triangulation) Part::Tools::triangulationOfFace(const TopoDS_Face& 
     TopoDS_Shape shape = mkBuilder.Shape();
     shape.Location(loc);
 
-    BRepMesh_IncrementalMesh(shape, 0.005, false, 1, true);
+    BRepMesh_IncrementalMesh(shape, 0.005, false, 0.1, true);
     return BRep_Tool::Triangulation(TopoDS::Face(shape), loc);
 }
 
@@ -665,7 +665,7 @@ Handle(Poly_Polygon3D) Part::Tools::polygonOfEdge(const TopoDS_Edge& edge, TopLo
     TopLoc_Location inv = loc.Inverted();
     shape.Location(inv);
 
-    BRepMesh_IncrementalMesh(shape, 0.005, false, 1, true);
+    BRepMesh_IncrementalMesh(shape, 0.005, false, 0.1, true);
     TopLoc_Location tmp;
     return BRep_Tool::Polygon3D(TopoDS::Edge(shape), tmp);
 }


### PR DESCRIPTION
Mesh generation parameters are taken from PrusaSlicer's STEP importer, which does a just-in-time STEP->STL conversion in memory.

Resulting meshes have better geometry, but are a little larger as a result.

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
