### PR TITLE
Draft: subelement mode ignored nesting

### DIFF
--- a/src/Mod/Draft/draftfunctions/move.py
+++ b/src/Mod/Draft/draftfunctions/move.py
@@ -169,6 +169,7 @@ def move_vertex(object, vertex_index, vector):
     Needed for SubObjects modifiers.
     Implemented by Dion Moult during 0.19 dev cycle (works only with Draft Wire).
     """
+    vector = object.getGlobalPlacement().inverse().Rotation.multVec(vector)
     points = object.Points
     points[vertex_index] = points[vertex_index].add(vector)
     object.Points = points
@@ -182,11 +183,11 @@ def move_edge(object, edge_index, vector):
     Needed for SubObjects modifiers.
     Implemented by Dion Moult during 0.19 dev cycle (works only with Draft Wire).
     """
-    moveVertex(object, edge_index, vector)
+    move_vertex(object, edge_index, vector)
     if utils.isClosedEdge(edge_index, object):
-        moveVertex(object, 0, vector)
+        move_vertex(object, 0, vector)
     else:
-        moveVertex(object, edge_index+1, vector)
+        move_vertex(object, edge_index+1, vector)
 
 
 moveEdge = move_edge
@@ -211,11 +212,11 @@ def copy_moved_edge(object, edge_index, vector):
     Needed for SubObjects modifiers.
     Implemented by Dion Moult during 0.19 dev cycle (works only with Draft Wire).
     """
-    vertex1 = object.Placement.multVec(object.Points[edge_index]).add(vector)
+    vertex1 = object.getGlobalPlacement().multVec(object.Points[edge_index]).add(vector)
     if utils.isClosedEdge(edge_index, object):
-        vertex2 = object.Placement.multVec(object.Points[0]).add(vector)
+        vertex2 = object.getGlobalPlacement().multVec(object.Points[0]).add(vector)
     else:
-        vertex2 = object.Placement.multVec(object.Points[edge_index+1]).add(vector)
+        vertex2 = object.getGlobalPlacement().multVec(object.Points[edge_index+1]).add(vector)
     return make_line.make_line(vertex1, vertex2)
 
 ## @}

--- a/src/Mod/Draft/draftfunctions/rotate.py
+++ b/src/Mod/Draft/draftfunctions/rotate.py
@@ -174,9 +174,9 @@ def rotate_vertex(object, vertex_index, angle, center, axis):
     Implemented by Dion Moult during 0.19 dev cycle (works only with Draft Wire).
     """
     points = object.Points
-    points[vertex_index] = object.Placement.inverse().multVec(
+    points[vertex_index] = object.getGlobalPlacement().inverse().multVec(
         rotate_vector_from_center(
-            object.Placement.multVec(points[vertex_index]),
+            object.getGlobalPlacement().multVec(points[vertex_index]),
             angle, axis, center))
     object.Points = points
 
@@ -202,11 +202,11 @@ def rotate_edge(object, edge_index, angle, center, axis):
     Needed for SubObjects modifiers.
     Implemented by Dion Moult during 0.19 dev cycle (works only with Draft Wire).
     """
-    rotateVertex(object, edge_index, angle, center, axis)
+    rotate_vertex(object, edge_index, angle, center, axis)
     if utils.isClosedEdge(edge_index, object):
-        rotateVertex(object, 0, angle, center, axis)
+        rotate_vertex(object, 0, angle, center, axis)
     else:
-        rotateVertex(object, edge_index+1, angle, center, axis)
+        rotate_vertex(object, edge_index+1, angle, center, axis)
 
 
 rotateEdge = rotate_edge
@@ -233,15 +233,15 @@ def copy_rotated_edge(object, edge_index, angle, center, axis):
     Implemented by Dion Moult during 0.19 dev cycle (works only with Draft Wire).
     """
     vertex1 = rotate_vector_from_center(
-        object.Placement.multVec(object.Points[edge_index]),
+        object.getGlobalPlacement().multVec(object.Points[edge_index]),
         angle, axis, center)
     if utils.isClosedEdge(edge_index, object):
         vertex2 = rotate_vector_from_center(
-            object.Placement.multVec(object.Points[0]),
+            object.getGlobalPlacement().multVec(object.Points[0]),
             angle, axis, center)
     else:
         vertex2 = rotate_vector_from_center(
-            object.Placement.multVec(object.Points[edge_index+1]),
+            object.getGlobalPlacement().multVec(object.Points[edge_index+1]),
             angle, axis, center)
     return make_line.make_line(vertex1, vertex2)
 

--- a/src/Mod/Draft/draftfunctions/scale.py
+++ b/src/Mod/Draft/draftfunctions/scale.py
@@ -147,9 +147,9 @@ def scale_vertex(obj, vertex_index, scale, center):
     Implemented by Dion Moult during 0.19 dev cycle (works only with Draft Wire).
     """
     points = obj.Points
-    points[vertex_index] = obj.Placement.inverse().multVec(
+    points[vertex_index] = obj.getGlobalPlacement().inverse().multVec(
         scale_vector_from_center(
-            obj.Placement.multVec(points[vertex_index]),
+            obj.getGlobalPlacement().multVec(points[vertex_index]),
             scale, center))
     obj.Points = points
 
@@ -189,15 +189,15 @@ def copy_scaled_edge(obj, edge_index, scale, center):
     Implemented by Dion Moult during 0.19 dev cycle (works only with Draft Wire).
     """
     vertex1 = scale_vector_from_center(
-        obj.Placement.multVec(obj.Points[edge_index]),
+        obj.getGlobalPlacement().multVec(obj.Points[edge_index]),
         scale, center)
     if utils.is_closed_edge(edge_index, obj):
         vertex2 = scale_vector_from_center(
-            obj.Placement.multVec(obj.Points[0]),
+            obj.getGlobalPlacement().multVec(obj.Points[0]),
             scale, center)
     else:
         vertex2 = scale_vector_from_center(
-            obj.Placement.multVec(obj.Points[edge_index+1]),
+            obj.getGlobalPlacement().multVec(obj.Points[edge_index+1]),
             scale, center)
     return make_line.make_line(vertex1, vertex2)
 

--- a/src/Mod/Draft/draftguitools/gui_move.py
+++ b/src/Mod/Draft/draftguitools/gui_move.py
@@ -192,10 +192,11 @@ class Move(gui_base_original.Modifier):
         import Part
 
         ghosts = []
-        for object in self.selected_subelements:
-            for subelement in object.SubObjects:
-                if isinstance(subelement, (Part.Vertex, Part.Edge)):
-                    ghosts.append(trackers.ghostTracker(subelement))
+        for sel in Gui.Selection.getSelectionEx("", 0):
+            for sub in sel.SubElementNames if sel.SubElementNames else [""]:
+                if "Vertex" in sub or "Edge" in sub:
+                    shape = Part.getShape(sel.Object, sub, needSubElement=True, retType=0)
+                    ghosts.append(trackers.ghostTracker(shape))
         return ghosts
 
     def move(self, is_copy=False):
@@ -239,7 +240,7 @@ class Move(gui_base_original.Modifier):
                 arguments.append(_cmd)
 
         all_args = ', '.join(arguments)
-        command.append('Draft.copyMovedEdges([' + all_args + '])')
+        command.append('Draft.copy_moved_edges([' + all_args + '])')
         command.append('FreeCAD.ActiveDocument.recompute()')
         return command
 
@@ -254,7 +255,7 @@ class Move(gui_base_original.Modifier):
             for index, subelement in enumerate(obj.SubObjects):
                 if isinstance(subelement, Part.Vertex):
                     _vertex_index = int(obj.SubElementNames[index][V:]) - 1
-                    _cmd = 'Draft.moveVertex'
+                    _cmd = 'Draft.move_vertex'
                     _cmd += '('
                     _cmd += 'FreeCAD.ActiveDocument.'
                     _cmd += obj.ObjectName + ', '
@@ -264,7 +265,7 @@ class Move(gui_base_original.Modifier):
                     command.append(_cmd)
                 elif isinstance(subelement, Part.Edge):
                     _edge_index = int(obj.SubElementNames[index][E:]) - 1
-                    _cmd = 'Draft.moveEdge'
+                    _cmd = 'Draft.move_edge'
                     _cmd += '('
                     _cmd += 'FreeCAD.ActiveDocument.'
                     _cmd += obj.ObjectName + ', '

--- a/src/Mod/Draft/draftguitools/gui_rotate.py
+++ b/src/Mod/Draft/draftguitools/gui_rotate.py
@@ -249,10 +249,11 @@ class Rotate(gui_base_original.Modifier):
         import Part
 
         ghosts = []
-        for object in self.selected_subelements:
-            for subelement in object.SubObjects:
-                if isinstance(subelement, (Part.Vertex, Part.Edge)):
-                    ghosts.append(trackers.ghostTracker(subelement))
+        for sel in Gui.Selection.getSelectionEx("", 0):
+            for sub in sel.SubElementNames if sel.SubElementNames else [""]:
+                if "Vertex" in sub or "Edge" in sub:
+                    shape = Part.getShape(sel.Object, sub, needSubElement=True, retType=0)
+                    ghosts.append(trackers.ghostTracker(shape))
         return ghosts
 
     def finish(self, cont=False):
@@ -318,7 +319,7 @@ class Rotate(gui_base_original.Modifier):
                 arguments.append(_cmd)
 
         all_args = ', '.join(arguments)
-        command.append('Draft.copyRotatedEdges([' + all_args + '])')
+        command.append('Draft.copy_rotated_edges([' + all_args + '])')
         command.append('FreeCAD.ActiveDocument.recompute()')
         return command
 
@@ -334,7 +335,7 @@ class Rotate(gui_base_original.Modifier):
             for index, subelement in enumerate(obj.SubObjects):
                 if isinstance(subelement, Part.Vertex):
                     _vertex_index = int(obj.SubElementNames[index][V:]) - 1
-                    _cmd = 'Draft.rotateVertex'
+                    _cmd = 'Draft.rotate_vertex'
                     _cmd += '('
                     _cmd += 'FreeCAD.ActiveDocument.'
                     _cmd += obj.ObjectName + ', '
@@ -346,7 +347,7 @@ class Rotate(gui_base_original.Modifier):
                     command.append(_cmd)
                 elif isinstance(subelement, Part.Edge):
                     _edge_index = int(obj.SubElementNames[index][E:]) - 1
-                    _cmd = 'Draft.rotateEdge'
+                    _cmd = 'Draft.rotate_edge'
                     _cmd += '('
                     _cmd += 'FreeCAD.ActiveDocument.'
                     _cmd += obj.ObjectName + ', '

--- a/src/Mod/Draft/draftguitools/gui_scale.py
+++ b/src/Mod/Draft/draftguitools/gui_scale.py
@@ -27,7 +27,7 @@
 The scale operation can also be done with subelements.
 
 The subelements operations only really work with polylines (Wires)
-because internally the functions `scaleVertex` and `scaleEdge`
+because internally the functions `scale_vertex` and `scale_edge`
 only work with polylines that have a `Points` property.
 """
 ## @package gui_scale
@@ -121,10 +121,11 @@ class Scale(gui_base_original.Modifier):
         import Part
 
         ghosts = []
-        for object in self.selected_subelements:
-            for subelement in object.SubObjects:
-                if isinstance(subelement, (Part.Vertex, Part.Edge)):
-                    ghosts.append(trackers.ghostTracker(subelement))
+        for sel in Gui.Selection.getSelectionEx("", 0):
+            for sub in sel.SubElementNames if sel.SubElementNames else [""]:
+                if "Vertex" in sub or "Edge" in sub:
+                    shape = Part.getShape(sel.Object, sub, needSubElement=True, retType=0)
+                    ghosts.append(trackers.ghostTracker(shape))
         return ghosts
 
     def pickRef(self):
@@ -190,12 +191,12 @@ class Scale(gui_base_original.Modifier):
         """Scale only the subelements if the appropriate option is set.
 
         The subelements operations only really work with polylines (Wires)
-        because internally the functions `scaleVertex` and `scaleEdge`
+        because internally the functions `scale_vertex` and `scale_edge`
         only work with polylines that have a `Points` property.
 
         BUG: the code should not cause an error. It should check that
         the selected object is not a rectangle or another object
-        that can't be used with `scaleVertex` and `scaleEdge`.
+        that can't be used with `scale_vertex` and `scale_edge`.
         """
         Gui.addModule("Draft")
         try:
@@ -271,7 +272,7 @@ class Scale(gui_base_original.Modifier):
                 _cmd += ']'
                 arguments.append(_cmd)
         all_args = ', '.join(arguments)
-        command.append('Draft.copyScaledEdges([' + all_args + '])')
+        command.append('Draft.copy_scaled_edges([' + all_args + '])')
         command.append('FreeCAD.ActiveDocument.recompute()')
         return command
 
@@ -286,7 +287,7 @@ class Scale(gui_base_original.Modifier):
             for index, subelement in enumerate(obj.SubObjects):
                 if isinstance(subelement, Part.Vertex):
                     _vertex_index = int(obj.SubElementNames[index][V:]) - 1
-                    _cmd = 'Draft.scaleVertex'
+                    _cmd = 'Draft.scale_vertex'
                     _cmd += '('
                     _cmd += 'FreeCAD.ActiveDocument.'
                     _cmd += obj.ObjectName + ', '
@@ -297,7 +298,7 @@ class Scale(gui_base_original.Modifier):
                     command.append(_cmd)
                 elif isinstance(subelement, Part.Edge):
                     _edge_index = int(obj.SubElementNames[index][E:]) - 1
-                    _cmd = 'Draft.scaleEdge'
+                    _cmd = 'Draft.scale_edge'
                     _cmd += '('
                     _cmd += 'FreeCAD.ActiveDocument.'
                     _cmd += obj.ObjectName + ', '


### PR DESCRIPTION
Subelement mode of Draft_Move, Draft_Rotate and Draft_Scale ignored the nesting of the selected elements.

- [x]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

---
