### PR TITLE
[workaround][GUI][Spreadsheet] Disable Accessibility on the SpreadSheetTableView

### DIFF
--- a/src/Mod/Spreadsheet/Gui/CMakeLists.txt
+++ b/src/Mod/Spreadsheet/Gui/CMakeLists.txt
@@ -66,6 +66,8 @@ SET(SpreadsheetGui_SRCS
     SpreadsheetDelegate.cpp
     SheetTableView.cpp
     SheetTableView.h
+    SheetTableViewAccessibleInterface.h
+    SheetTableViewAccessibleInterface.cpp
     SheetModel.h
     SheetModel.cpp
     PreCompiled.cpp

--- a/src/Mod/Spreadsheet/Gui/SheetTableViewAccessibleInterface.cpp
+++ b/src/Mod/Spreadsheet/Gui/SheetTableViewAccessibleInterface.cpp
@@ -1,0 +1,85 @@
+/***************************************************************************
+ *   Copyright (c) 2023 Adrian Popescu                                     *
+ *   <adrian-constantin.popescu@outlook.com>                               *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "PreCompiled.h"
+
+#ifndef _PreComp_
+# include <QAction>
+# include <QApplication>
+# include <QClipboard>
+# include <QKeyEvent>
+# include <QMessageBox>
+# include <QMenu>
+# include <QMimeData>
+#endif
+
+#include "SheetTableViewAccessibleInterface.h"
+
+namespace SpreadsheetGui {
+
+    SheetTableViewAccessibleInterface::SheetTableViewAccessibleInterface(
+    SpreadsheetGui::SheetTableView* w)
+    : QAccessibleWidget(w)
+    {
+    }
+
+    QString SheetTableViewAccessibleInterface::text(QAccessible::Text t) const
+    {
+        if (t == QAccessible::Help)
+            return QString::fromLatin1("Implement me");
+        return QAccessibleWidget::text(t);
+    }
+
+    QAccessibleInterface* SheetTableViewAccessibleInterface::childAt(int x, int y) const
+    {
+        return (QAccessibleInterface*)this;
+    }
+
+    int SheetTableViewAccessibleInterface::indexOfChild(const QAccessibleInterface*) const
+    {
+        return 0;
+    }
+
+    int SheetTableViewAccessibleInterface::childCount() const
+    {
+        return 0;
+    }
+
+    QAccessibleInterface* SheetTableViewAccessibleInterface::focusChild() const
+    {
+        return (QAccessibleInterface*)this;
+    }
+
+    QAccessibleInterface* SheetTableViewAccessibleInterface::child(int index) const
+    {
+        return (QAccessibleInterface*)this;
+    }
+
+    QAccessibleInterface* SheetTableViewAccessibleInterface::ifactory(const QString& key, QObject* o)
+    {
+        if (key == QString::fromUtf8("SpreadsheetGui::SheetTableView"))
+            return new SheetTableViewAccessibleInterface(
+                static_cast<SpreadsheetGui::SheetTableView*>(o));
+        return 0;
+    }
+}

--- a/src/Mod/Spreadsheet/Gui/SheetTableViewAccessibleInterface.h
+++ b/src/Mod/Spreadsheet/Gui/SheetTableViewAccessibleInterface.h
@@ -1,0 +1,58 @@
+/***************************************************************************
+ *   Copyright (c) 2023 Adrian Popescu                                     *
+ *   <adrian-constantin.popescu@outlook.com>                               *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef SHEETTABLEVIEW_INTERFACE_H
+#define SHEETTABLEVIEW_INTERFACE_H
+
+#include <Mod/Spreadsheet/Gui/SheetTableView.h>
+#include <QtWidgets/qaccessiblewidget.h>
+
+namespace SpreadsheetGui {
+
+    // Currently SheetTableViewAccessibleInterface below deactivates the  
+    // built-in QAccessibleTable interface, and all the accessibility 
+    // features.
+    // 
+    // For a proper implementation, start by extending that
+    // and ensure you're not queue-ing empty cells, or counting empty cells
+    // 
+    // Otherwise it will hang - https://github.com/FreeCAD/FreeCAD/issues/8265
+
+    class SheetTableViewAccessibleInterface : public QAccessibleWidget
+    {
+    public:
+        SheetTableViewAccessibleInterface(SpreadsheetGui::SheetTableView* w);
+
+        QString text(QAccessible::Text t) const override;
+       
+        QAccessibleInterface* childAt(int x, int y) const override;
+        int indexOfChild(const QAccessibleInterface*) const override;
+        int childCount() const override;
+        QAccessibleInterface* focusChild() const override;
+        QAccessibleInterface* child(int index) const override;
+
+        static QAccessibleInterface* ifactory(const QString& key, QObject* o);
+    };
+}
+
+#endif // SHEETTABLEVIEW_INTERFACE_H


### PR DESCRIPTION
Windows Accesibility will try to navigate through all the cells of the table, causing memory use and a 30 second freeze in the application. It can be reproduced by copying or selecting in an empty spreadsheet.

Issue Ref: https://github.com/FreeCAD/FreeCAD/issues/8265 

The proper solution is to implement a correct accessible interface for the SheetTableView, rather than rely on the built-in QT one.

This PR is the alternate solution - a workaround :( to disable the built-in accessibility support :( which is causing the delay.

APPSpreadSheetGui.cpp was reformatted using the latest rules.

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [x]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
