### PR TITLE
[FEM] solver_taskpanel: fix bug with Edit button

### DIFF
--- a/src/Mod/Fem/femsolver/solver_taskpanel.py
+++ b/src/Mod/Fem/femsolver/solver_taskpanel.py
@@ -340,7 +340,7 @@ class ControlWidget(QtGui.QWidget):
             self._writeBtt.setDisabled(False)
             self._editBtt.setDisabled(
                 not machine.solver.Proxy.editSupported()
-                or machine.state < femsolver.run.PREPARE
+                or machine.state <= femsolver.run.PREPARE
             )
 
 ##  @}


### PR DESCRIPTION
- when an error occurred during the Write process, the Edit button must not be enabled In this case the machine state is still at femsolver.run.PREPARE. If no error occurred it went one step up.