### PR TITLE
Start: Added option to hide start page scrollbars

### DIFF
--- a/src/Mod/Start/Gui/DlgStartPreferences.ui
+++ b/src/Mod/Start/Gui/DlgStartPreferences.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>482</width>
-    <height>795</height>
+    <width>537</width>
+    <height>942</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -42,10 +42,25 @@
       <string>Contents</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_17">
+      <item row="4" column="1">
+       <widget class="Gui::PrefCheckBox" name="checkBox_7">
+        <property name="toolTip">
+         <string>Displays help tips in the Start workbench Documents tab</string>
+        </property>
+        <property name="layoutDirection">
+         <enum>Qt::RightToLeft</enum>
+        </property>
         <property name="text">
-         <string>Show notepad</string>
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>ShowTips</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Start</cstring>
         </property>
        </widget>
       </item>
@@ -62,6 +77,63 @@
         </property>
         <property name="prefEntry" stdset="0">
          <cstring>ShowNotes</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Start</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_17">
+        <property name="text">
+         <string>Show notepad</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="Gui::PrefFileChooser" name="fileChooser_3">
+        <property name="toolTip">
+         <string>An optional custom folder to be displayed at the bottom of the first page.
+By using &quot;;;&quot; to separate paths, you can add several folders here</string>
+        </property>
+        <property name="mode">
+         <enum>Gui::FileChooser::Directory</enum>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>ShowCustomFolder</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Start</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="label_19">
+        <property name="text">
+         <string>Show tips</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="label_14">
+        <property name="text">
+         <string>Show forum</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="Gui::PrefCheckBox" name="checkBox_4">
+        <property name="toolTip">
+         <string>If this is checked, the latest posts from the FreeCAD forum will be displayed on the Activity tab</string>
+        </property>
+        <property name="layoutDirection">
+         <enum>Qt::RightToLeft</enum>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>ShowForum</cstring>
         </property>
         <property name="prefPath" stdset="0">
          <cstring>Mod/Start</cstring>
@@ -104,63 +176,17 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="1">
-       <widget class="Gui::PrefFileChooser" name="fileChooser_3">
-        <property name="toolTip">
-         <string>An optional custom folder to be displayed at the bottom of the first page.
-By using ";;" to separate paths, you can add several folders here</string>
-        </property>
-        <property name="mode">
-         <enum>Gui::FileChooser::Directory</enum>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>ShowCustomFolder</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Start</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="label_14">
+      <item row="5" column="0">
+       <widget class="QLabel" name="label_20">
         <property name="text">
-         <string>Show forum</string>
+         <string>Show scrollbars</string>
         </property>
        </widget>
       </item>
-      <item row="3" column="1">
-       <widget class="Gui::PrefCheckBox" name="checkBox_4">
-        <property name="toolTip">
-         <string>If this is checked, the latest posts from the FreeCAD forum will be displayed on the Activity tab</string>
-        </property>
+      <item row="5" column="1">
+       <widget class="Gui::PrefCheckBox" name="checkBox_8">
         <property name="layoutDirection">
          <enum>Qt::RightToLeft</enum>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>ShowForum</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Start</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0">
-       <widget class="QLabel" name="label_19">
-        <property name="text">
-         <string>Show tips</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="1">
-       <widget class="Gui::PrefCheckBox" name="checkBox_7">
-        <property name="layoutDirection">
-         <enum>Qt::RightToLeft</enum>
-        </property>
-        <property name="toolTip">
-         <string>Displays help tips in the Start workbench Documents tab</string>
         </property>
         <property name="text">
          <string/>
@@ -169,7 +195,7 @@ By using ";;" to separate paths, you can add several folders here</string>
          <bool>true</bool>
         </property>
         <property name="prefEntry" stdset="0">
-         <cstring>ShowTips</cstring>
+         <cstring>ShowScrollBars</cstring>
         </property>
         <property name="prefPath" stdset="0">
          <cstring>Mod/Start</cstring>

--- a/src/Mod/Start/Gui/DlgStartPreferencesImp.cpp
+++ b/src/Mod/Start/Gui/DlgStartPreferencesImp.cpp
@@ -110,6 +110,7 @@ void DlgStartPreferencesImp::saveSettings()
     ui->checkBox_5->onSave();
     ui->checkBox_6->onSave();
     ui->checkBox_7->onSave();
+    ui->checkBox_8->onSave();
     ui->lineEdit->onSave();
     ui->spinBox->onSave();
 }
@@ -141,6 +142,7 @@ void DlgStartPreferencesImp::loadSettings()
     ui->checkBox_5->onRestore();
     ui->checkBox_6->onRestore();
     ui->checkBox_7->onRestore();
+    ui->checkBox_8->onRestore();
     ui->lineEdit->onRestore();
     ui->spinBox->onRestore();
 }

--- a/src/Mod/Start/StartPage/StartPage.css
+++ b/src/Mod/Start/StartPage/StartPage.css
@@ -4,6 +4,9 @@ body {
     font-family: FONTFAMILY;
     font-size: FONTSIZE;
 }
+body::-webkit-scrollbar {
+    display: OVERFLOW;
+}
 a, a:link, a:visited {
     text-decoration: none;
     color: LINKCOLOR;

--- a/src/Mod/Start/StartPage/StartPage.py
+++ b/src/Mod/Start/StartPage/StartPage.py
@@ -563,6 +563,7 @@ def handle():
     BOXCOLOR  = gethexcolor(p.GetUnsigned("BoxColor",3722305023))
     TEXTCOLOR = gethexcolor(p.GetUnsigned("PageTextColor",255))
     BGTCOLOR = gethexcolor(p.GetUnsigned("BackgroundTextColor",4294703103))
+    OVERFLOW = "normal" if p.GetBool("ShowScrollBars",True) else "none"
     SHADOW = "#888888"
     if QtGui.QColor(BASECOLOR).valueF() < 0.5: # dark page - we need to make darker shadows
         SHADOW = "#000000"
@@ -579,6 +580,7 @@ def handle():
     HTML = HTML.replace("SHADOW",SHADOW)
     HTML = HTML.replace("FONTFAMILY",FONTFAMILY)
     HTML = HTML.replace("FONTSIZE",str(FONTSIZE)+"px")
+    HTML = HTML.replace("OVERFLOW",OVERFLOW)
 
     # enable web access if permitted
 


### PR DESCRIPTION
This adds an option to the Start preferences that allow to hide the scrollbars on the start page. They are drawn in a different style than the other FreeCAD scrollbars, so they are ugly :) Scrolling with the mousewheel still works.

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [x]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
