### PR TITLE
[NotificationArea pre-requisite] Console refactor and extension

### DIFF
--- a/src/App/DocumentObject.cpp
+++ b/src/App/DocumentObject.cpp
@@ -282,6 +282,16 @@ std::string DocumentObject::getFullName() const {
     return name;
 }
 
+std::string DocumentObject::getFullLabel() const {
+    if(!getDocument())
+        return "?";
+
+    auto name = getDocument()->Label.getStrValue();
+    name += "#";
+    name += Label.getStrValue();
+    return name;
+}
+
 const char *DocumentObject::getNameInDocument() const
 {
     // Note: It can happen that we query the internal name of an object even if it is not

--- a/src/App/DocumentObject.h
+++ b/src/App/DocumentObject.h
@@ -140,6 +140,8 @@ public:
     std::string getExportName(bool forced=false) const;
     /// Return the object full name of the form DocName#ObjName
     std::string getFullName() const override;
+    /// Return the object full label in the form DocName#ObjName
+    std::string getFullLabel() const;
     bool isAttachedToDocument() const override;
     const char* detachFromDocument() override;
     /// gets the document in which this Object is handled

--- a/src/App/FreeCADInit.py
+++ b/src/App/FreeCADInit.py
@@ -302,6 +302,9 @@ Log = FreeCAD.Console.PrintLog
 Msg = FreeCAD.Console.PrintMessage
 Err = FreeCAD.Console.PrintError
 Wrn = FreeCAD.Console.PrintWarning
+Crt = FreeCAD.Console.PrintCritical
+Ntf = FreeCAD.Console.PrintNotification
+Tnf = FreeCAD.Console.PrintTranslatedNotification
 test_ascii = lambda s: all(ord(c) < 128 for c in s)
 
 #store the cmake variales

--- a/src/Base/Builder3D.cpp
+++ b/src/Base/Builder3D.cpp
@@ -987,7 +987,7 @@ void Builder3D::saveToLog()
 {
     ILogger* obs = Base::Console().Get("StatusBar");
     if (obs){
-        obs->SendLog(result.str().c_str(), Base::LogStyle::Log);
+        obs->SendLog("Builder3D",result.str().c_str(), Base::LogStyle::Log);
     }
 }
 

--- a/src/Base/CMakeLists.txt
+++ b/src/Base/CMakeLists.txt
@@ -61,6 +61,7 @@ include_directories(
 )
 list(APPEND FreeCADBase_LIBS ${QtCore_LIBRARIES})
 
+list(APPEND FreeCADBase_LIBS fmt::fmt)
 
 if (BUILD_DYNAMIC_LINK_PYTHON)
     list(APPEND FreeCADBase_LIBS ${PYTHON_LIBRARIES})

--- a/src/Base/ConsoleObserver.cpp
+++ b/src/Base/ConsoleObserver.cpp
@@ -58,8 +58,10 @@ ConsoleObserverFile::~ConsoleObserverFile()
     cFileStream.close();
 }
 
-void ConsoleObserverFile::SendLog(const std::string& msg, LogStyle level)
+void ConsoleObserverFile::SendLog(const std::string& notifiername, const std::string& msg, LogStyle level)
 {
+    (void) notifiername;
+    
     std::string prefix;
     switch(level){
         case LogStyle::Warning:
@@ -73,6 +75,11 @@ void ConsoleObserverFile::SendLog(const std::string& msg, LogStyle level)
             break;
         case LogStyle::Log:
             prefix = "Log: ";
+            break;
+        case LogStyle::Critical:
+            prefix = "Critical: ";
+            break;
+        default:
             break;
     }
 
@@ -94,8 +101,10 @@ ConsoleObserverStd::ConsoleObserverStd() :
 
 ConsoleObserverStd::~ConsoleObserverStd() = default;
 
-void ConsoleObserverStd::SendLog(const std::string& msg, LogStyle level)
+void ConsoleObserverStd::SendLog(const std::string& notifiername, const std::string& msg, LogStyle level)
 {
+    (void) notifiername;
+    
     switch(level){
         case LogStyle::Warning:
             this->Warning(msg.c_str());
@@ -108,6 +117,11 @@ void ConsoleObserverStd::SendLog(const std::string& msg, LogStyle level)
             break;
         case LogStyle::Log:
             this->Log(msg.c_str());
+            break;
+        case LogStyle::Critical:
+            this->Critical(msg.c_str());
+            break;
+        default:
             break;
     }
 }
@@ -177,6 +191,27 @@ void ConsoleObserverStd::Log    (const char *sErr)
 #   elif defined(FC_OS_LINUX) || defined(FC_OS_MACOSX) || defined(FC_OS_BSD)
         fprintf(stderr, "\033[0m");
 #   endif
+    }
+}
+
+void ConsoleObserverStd::Critical(const char *sCritical)
+{
+    if (useColorStderr) {
+        #   if defined(FC_OS_WIN32)
+        ::SetConsoleTextAttribute(::GetStdHandle(STD_ERROR_HANDLE), FOREGROUND_GREEN | FOREGROUND_BLUE);
+        #   elif defined(FC_OS_LINUX) || defined(FC_OS_MACOSX) || defined(FC_OS_BSD)
+        fprintf(stderr, "\033[1;33m");
+        #   endif
+    }
+
+    fprintf(stderr, "%s", sCritical);
+
+    if (useColorStderr) {
+        #   if defined(FC_OS_WIN32)
+        ::SetConsoleTextAttribute(::GetStdHandle(STD_ERROR_HANDLE),FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE );
+        #   elif defined(FC_OS_LINUX) || defined(FC_OS_MACOSX) || defined(FC_OS_BSD)
+        fprintf(stderr, "\033[0m");
+        #   endif
     }
 }
 

--- a/src/Base/ConsoleObserver.h
+++ b/src/Base/ConsoleObserver.h
@@ -39,10 +39,10 @@ namespace Base {
 class BaseExport ConsoleObserverFile : public ILogger
 {
 public:
-    ConsoleObserverFile(const char *sFileName);
+    explicit ConsoleObserverFile(const char *sFileName);
     ~ConsoleObserverFile() override;
 
-    void SendLog(const std::string& message, LogStyle level) override;
+    void SendLog(const std::string& notifiername, const std::string& message, LogStyle level) override;
     const char* Name() override {return "File";}
 
 protected:
@@ -57,15 +57,16 @@ class BaseExport ConsoleObserverStd: public ILogger
 public:
     ConsoleObserverStd();
     ~ConsoleObserverStd() override;
-    void SendLog(const std::string& message, LogStyle level) override;
+    void SendLog(const std::string& notifiername, const std::string& message, LogStyle level) override;
     const char* Name() override {return "Console";}
 protected:
     bool useColorStderr;
 private:
-    void Warning(const char *sWarn);
-    void Message(const char *sMsg);
-    void Error  (const char *sErr);
-    void Log    (const char *sErr);
+    void Warning        (const char *sWarn);
+    void Message        (const char *sMsg);
+    void Error          (const char *sErr);
+    void Log            (const char *sLog);
+    void Critical(const char *sCritical);
 };
 
 /** The ILoggerBlocker class
@@ -77,7 +78,8 @@ class BaseExport ILoggerBlocker
 public:
     // Constructor that will block message types passed as parameter. By default, all types are blocked.
     inline explicit ILoggerBlocker(const char* co, ConsoleMsgFlags msgTypes =
-        ConsoleSingleton::MsgType_Txt | ConsoleSingleton::MsgType_Log | ConsoleSingleton::MsgType_Wrn | ConsoleSingleton::MsgType_Err);
+        ConsoleSingleton::MsgType_Txt | ConsoleSingleton::MsgType_Log | ConsoleSingleton::MsgType_Wrn | ConsoleSingleton::MsgType_Err |
+        ConsoleSingleton::MsgType_Critical | ConsoleSingleton::MsgType_Notification | ConsoleSingleton::MsgType_TranslatedNotification);
     // Disable copy & move constructors
     ILoggerBlocker(ILoggerBlocker const&) = delete;
     ILoggerBlocker(ILoggerBlocker const &&) = delete;

--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -1117,7 +1117,7 @@ void Application::setActiveDocument(Gui::Document* pcDocument)
     // May be useful for error detection
     if (d->activeDocument) {
         App::Document* doc = d->activeDocument->getDocument();
-        Base::Console().Log("Active document is %s (at %p)\n",doc->getName(), doc);
+        Base::Console().Log("Active document is %s (at %p)\n",doc->getName(), static_cast<void *>(doc));
     }
     else {
         Base::Console().Log("No active document\n");
@@ -1192,7 +1192,7 @@ void Application::viewActivated(MDIView* pcView)
 #ifdef FC_DEBUG
     // May be useful for error detection
     Base::Console().Log("Active view is %s (at %p)\n",
-                 (const char*)pcView->windowTitle().toUtf8(),pcView);
+                 (const char*)pcView->windowTitle().toUtf8(),static_cast<void *>(pcView));
 #endif
 
     signalActivateView(pcView);

--- a/src/Gui/GuiConsole.cpp
+++ b/src/Gui/GuiConsole.cpp
@@ -81,7 +81,7 @@ GUIConsole::~GUIConsole (void)
       FreeConsole();
 }
 
-void GUIConsole::SendLog(const std::string& msg, Base::LogStyle level)
+void GUIConsole::SendLog(const std::string& notifiername, const std::string& msg, Base::LogStyle level)
 {
     int color = -1;
     switch(level){
@@ -97,6 +97,9 @@ void GUIConsole::SendLog(const std::string& msg, Base::LogStyle level)
         case Base::LogStyle::Log:
             color = FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE;
             break;
+        case Base::LogStyle::Critical:
+            color = FOREGROUND_RED | FOREGROUND_GREEN;
+            break;
     }
 
     ::SetConsoleTextAttribute(::GetStdHandle(STD_OUTPUT_HANDLE), color);
@@ -109,8 +112,10 @@ void GUIConsole::SendLog(const std::string& msg, Base::LogStyle level)
 // safely ignore GUIConsole::s_nMaxLines and  GUIConsole::s_nRefCount
 GUIConsole::GUIConsole () {}
 GUIConsole::~GUIConsole () {}
-void GUIConsole::SendLog(const std::string& msg, Base::LogStyle level)
+void GUIConsole::SendLog(const std::string& notifiername, const std::string& msg, Base::LogStyle level)
 {
+    (void) notifiername;
+    
     switch(level){
         case Base::LogStyle::Warning:
             std::cerr << "Warning: " << msg;
@@ -123,6 +128,11 @@ void GUIConsole::SendLog(const std::string& msg, Base::LogStyle level)
             break;
         case Base::LogStyle::Log:
             std::clog << msg;
+            break;
+        case Base::LogStyle::Critical:
+            std::cout << "Critical: " << msg;
+            break;
+        default:
             break;
     }
 }

--- a/src/Gui/GuiConsole.h
+++ b/src/Gui/GuiConsole.h
@@ -47,7 +47,7 @@ public:
   GUIConsole();
   /// Destructor
   ~GUIConsole() override;
-  void SendLog(const std::string& msg, Base::LogStyle level) override;
+  void SendLog(const std::string& notifiername, const std::string& msg, Base::LogStyle level) override;
   const char* Name() override {return "GUIConsole";}
 
 protected:

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -2146,10 +2146,16 @@ void StatusBarObserver::OnChange(Base::Subject<const char*> &rCaller, const char
         unsigned long col = rclGrp.GetUnsigned( sReason );
         this->err = format.arg(App::Color::fromPackedRGB<QColor>(col).name());
     }
+    else if (strcmp(sReason, "colorCritical") == 0) {
+        unsigned long col = rclGrp.GetUnsigned( sReason );
+        this->critical = format.arg(QColor((col >> 24) & 0xff,(col >> 16) & 0xff,(col >> 8) & 0xff).name());
+    }
 }
 
-void StatusBarObserver::SendLog(const std::string& msg, Base::LogStyle level)
+void StatusBarObserver::SendLog(const std::string& notifiername, const std::string& msg, Base::LogStyle level)
 {
+    (void) notifiername;
+
     int messageType = -1;
     switch(level){
         case Base::LogStyle::Warning:
@@ -2163,6 +2169,11 @@ void StatusBarObserver::SendLog(const std::string& msg, Base::LogStyle level)
             break;
         case Base::LogStyle::Log:
             messageType = MainWindow::Log;
+            break;
+        case Base::LogStyle::Critical:
+            messageType = MainWindow::Critical;
+            break;
+        default:
             break;
     }
 

--- a/src/Gui/MainWindow.h
+++ b/src/Gui/MainWindow.h
@@ -201,7 +201,7 @@ public:
 
     void updateActions(bool delay = false);
 
-    enum StatusType {None, Err, Wrn, Pane, Msg, Log, Tmp};
+    enum StatusType {None, Err, Wrn, Pane, Msg, Log, Tmp, Critical};
     void showStatus(int type, const QString & message);
 
 
@@ -371,14 +371,14 @@ public:
     /** Observes its parameter group. */
     void OnChange(Base::Subject<const char*> &rCaller, const char * sReason) override;
 
-    void SendLog(const std::string& msg, Base::LogStyle level) override;
+    void SendLog(const std::string& notifiername, const std::string& msg, Base::LogStyle level) override;
 
     /// name of the observer
     const char *Name() override {return "StatusBar";}
 
     friend class MainWindow;
 private:
-    QString msg, wrn, err;
+    QString msg, wrn, err, critical;
 };
 
 // -------------------------------------------------------------

--- a/src/Gui/ReportView.cpp
+++ b/src/Gui/ReportView.cpp
@@ -170,6 +170,9 @@ void ReportHighlighter::highlightBlock (const QString & text)
         case LogText:
             setFormat(start, it.length-start, logCol);
             break;
+        case Critical:
+            setFormat(start, it.length-start, criticalCol);
+            break;
         default:
             break;
         }
@@ -201,6 +204,11 @@ void ReportHighlighter::setWarningColor( const QColor& col )
 void ReportHighlighter::setErrorColor( const QColor& col )
 {
     errCol = col;
+}
+
+void ReportHighlighter::setCriticalColor( const QColor& col )
+{
+    criticalCol = col;
 }
 
 // ----------------------------------------------------------------------------
@@ -244,6 +252,15 @@ public:
     {
         bool show = showOnError();
         getGroup()->SetBool("checkShowReportViewOnError", !show);
+    }
+    static bool showOnCritical()
+    {
+        return getGroup()->GetBool("checkShowReportViewOnCritical", false);
+    }
+    static void toggleShowOnCritical()
+    {
+        bool show = showOnMessage();
+        getGroup()->SetBool("checkShowReportViewOnCritical", !show);
     }
 
 private:
@@ -326,6 +343,11 @@ bool ReportOutputObserver::eventFilter(QObject *obj, QEvent *event)
             }
             else if (msgType == ReportHighlighter::LogText) {
                 if (ReportOutputParameter::showOnLogMessage()) {
+                    showReportView();
+                }
+            }
+            else if (msgType == ReportHighlighter::Critical) {
+                if (ReportOutputParameter::showOnCritical()) {
                     showReportView();
                 }
             }
@@ -450,8 +472,10 @@ void ReportOutput::restoreFont()
     setFont(serifFont);
 }
 
-void ReportOutput::SendLog(const std::string& msg, Base::LogStyle level)
+void ReportOutput::SendLog(const std::string& notifiername, const std::string& msg, Base::LogStyle level)
 {
+    (void) notifiername;
+
     ReportHighlighter::Paragraph style = ReportHighlighter::LogText;
     switch (level) {
         case Base::LogStyle::Warning:
@@ -465,6 +489,11 @@ void ReportOutput::SendLog(const std::string& msg, Base::LogStyle level)
             break;
         case Base::LogStyle::Log:
             style = ReportHighlighter::LogText;
+            break;
+        case Base::LogStyle::Critical:
+            style = ReportHighlighter::Critical;
+            break;
+        default:
             break;
     }
 
@@ -544,6 +573,7 @@ void ReportOutput::contextMenuEvent ( QContextMenuEvent * e )
     bool bShowOnNormal = ReportOutputParameter::showOnMessage();
     bool bShowOnWarn = ReportOutputParameter::showOnWarning();
     bool bShowOnError = ReportOutputParameter::showOnError();
+    bool bShowOnCritical = ReportOutputParameter::showOnCritical();
 
     auto menu = new QMenu(this);
     auto optionMenu = new QMenu( menu );
@@ -571,6 +601,10 @@ void ReportOutput::contextMenuEvent ( QContextMenuEvent * e )
     errAct->setCheckable(true);
     errAct->setChecked(bErr);
 
+    QAction* logCritical = displayMenu->addAction(tr("Critical messages"), this, &ReportOutput::onToggleCritical);
+    logCritical->setCheckable(true);
+    logCritical->setChecked(bCritical);
+
     auto showOnMenu = new QMenu (optionMenu);
     showOnMenu->setTitle(tr("Show Report view on"));
     optionMenu->addMenu(showOnMenu);
@@ -590,6 +624,10 @@ void ReportOutput::contextMenuEvent ( QContextMenuEvent * e )
     QAction* showErrAct = showOnMenu->addAction(tr("Errors"), this, &ReportOutput::onToggleShowReportViewOnError);
     showErrAct->setCheckable(true);
     showErrAct->setChecked(bShowOnError);
+
+    QAction* showCriticalAct = showOnMenu->addAction(tr("Critical messages"), this, SLOT(onToggleShowReportViewOnCritical()));
+    showCriticalAct->setCheckable(true);
+    showCriticalAct->setChecked(bShowOnCritical);
 
     optionMenu->addSeparator();
 
@@ -664,6 +702,12 @@ bool ReportOutput::isNormalMessage() const
     return bMsg;
 }
 
+
+bool ReportOutput::isCritical() const
+{
+    return bCritical;
+}
+
 void ReportOutput::onToggleError()
 {
     bErr = bErr ? false : true;
@@ -688,6 +732,12 @@ void ReportOutput::onToggleNormalMessage()
     getWindowParameter()->SetBool( "checkMessage", bMsg );
 }
 
+void ReportOutput::onToggleCritical()
+{
+    bCritical = bCritical ? false : true;
+    getWindowParameter()->SetBool( "checkCritical", bCritical );
+}
+
 void ReportOutput::onToggleShowReportViewOnWarning()
 {
     ReportOutputParameter::toggleShowOnWarning();
@@ -701,6 +751,11 @@ void ReportOutput::onToggleShowReportViewOnError()
 void ReportOutput::onToggleShowReportViewOnNormalMessage()
 {
     ReportOutputParameter::toggleShowOnMessage();
+}
+
+void ReportOutput::onToggleShowReportViewOnCritical()
+{
+    ReportOutputParameter::toggleShowOnCritical();
 }
 
 void ReportOutput::onToggleShowReportViewOnLogMessage()
@@ -761,9 +816,16 @@ void ReportOutput::OnChange(Base::Subject<const char*> &rCaller, const char * sR
     else if (strcmp(sReason, "checkMessage") == 0) {
         bMsg = rclGrp.GetBool( sReason, bMsg );
     }
+    else if (strcmp(sReason, "checkCritical") == 0) {
+        bMsg = rclGrp.GetBool( sReason, bMsg );
+    }
     else if (strcmp(sReason, "colorText") == 0) {
         unsigned long col = rclGrp.GetUnsigned( sReason );
         reportHl->setTextColor(App::Color::fromPackedRGB<QColor>(col));
+    }
+    else if (strcmp(sReason, "colorCriticalText") == 0) {
+        unsigned long col = rclGrp.GetUnsigned( sReason );
+        reportHl->setTextColor( QColor( (col >> 24) & 0xff,(col >> 16) & 0xff,(col >> 8) & 0xff) );
     }
     else if (strcmp(sReason, "colorLogging") == 0) {
         unsigned long col = rclGrp.GetUnsigned( sReason );

--- a/src/Gui/ReportView.h
+++ b/src/Gui/ReportView.h
@@ -70,10 +70,11 @@ class GuiExport ReportHighlighter : public QSyntaxHighlighter
 {
 public:
     enum Paragraph {
-        Message  = 0, /**< normal text */
-        Warning  = 1, /**< Warning */
-        Error    = 2, /**< Error text */
-        LogText  = 3  /**< Log text */
+        Message          = 0, /**< normal text */
+        Warning          = 1, /**< Warning */
+        Error            = 2, /**< Error text */
+        LogText          = 3,  /**< Log text */
+        Critical         = 4, /**< critical text */
     };
 
 public:
@@ -87,6 +88,7 @@ public:
      * @see ReportOutput::Message
      * @see ReportOutput::Warning
      * @see ReportOutput::Error
+     * @see ReportOutput::Critical
      */
     void setParagraphType(Paragraph);
 
@@ -110,11 +112,16 @@ public:
      */
     void setErrorColor( const QColor& col );
 
+    /**
+     * Sets the text color to  \a col.
+     */
+    void setCriticalColor( const QColor& col );
+
 private:
     /** @name for internal use only */
     //@{
     Paragraph type;
-    QColor txtCol, logCol, warnCol, errCol;
+    QColor txtCol, logCol, warnCol, errCol, criticalCol;
     //@}
 };
 
@@ -134,7 +141,7 @@ public:
     /** Observes its parameter group. */
     void OnChange(Base::Subject<const char*> &rCaller, const char * sReason) override;
 
-    void SendLog(const std::string& msg, Base::LogStyle level) override;
+    void SendLog(const std::string& notifiername, const std::string& msg, Base::LogStyle level) override;
 
     /// returns the name for observer handling
     const char* Name() override {return "ReportOutput";}
@@ -150,6 +157,8 @@ public:
     bool isLogMessage() const;
     /** Returns true whether normal messages are reported. */
     bool isNormalMessage() const;
+    /** Returns true whether critical messages are reported. */
+    bool isCritical() const;
 
 protected:
     /** For internal use only */
@@ -172,12 +181,16 @@ public Q_SLOTS:
     void onToggleLogMessage();
     /** Toggles the report of normal messages. */
     void onToggleNormalMessage();
+    /** Toggles the report of normal messages. */
+    void onToggleCritical();
     /** Toggles whether to show report view on warnings*/
     void onToggleShowReportViewOnWarning();
     /** Toggles whether to show report view on errors*/
     void onToggleShowReportViewOnError();
     /** Toggles whether to show report view on normal messages*/
     void onToggleShowReportViewOnNormalMessage();
+    /** Toggles whether to show report view on normal messages*/
+    void onToggleShowReportViewOnCritical();
     /** Toggles whether to show report view on log messages*/
     void onToggleShowReportViewOnLogMessage();
     /** Toggles the redirection of Python stdout. */

--- a/src/Gui/Splashscreen.cpp
+++ b/src/Gui/Splashscreen.cpp
@@ -123,8 +123,10 @@ public:
     {
         return "SplashObserver";
     }
-    void SendLog(const std::string& msg, Base::LogStyle level) override
+    void SendLog(const std::string& notifiername, const std::string& msg, Base::LogStyle level) override
     {
+        Q_UNUSED(notifiername)
+        
 #ifdef FC_DEBUG
         Log(msg.c_str());
         Q_UNUSED(level)

--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -70,11 +70,11 @@ FC_LOG_LEVEL_INIT("Tree", false, true, true)
 
 #define _TREE_PRINT(_level,_func,_msg) \
     _FC_PRINT(FC_LOG_INSTANCE,_level,_func, '['<<getTreeName()<<"] " << _msg)
-#define TREE_MSG(_msg) _TREE_PRINT(FC_LOGLEVEL_MSG,NotifyMessage,_msg)
-#define TREE_WARN(_msg) _TREE_PRINT(FC_LOGLEVEL_WARN,NotifyWarning,_msg)
-#define TREE_ERR(_msg) _TREE_PRINT(FC_LOGLEVEL_ERR,NotifyError,_msg)
-#define TREE_LOG(_msg) _TREE_PRINT(FC_LOGLEVEL_LOG,NotifyLog,_msg)
-#define TREE_TRACE(_msg) _TREE_PRINT(FC_LOGLEVEL_TRACE,NotifyLog,_msg)
+#define TREE_MSG(_msg) _TREE_PRINT(FC_LOGLEVEL_MSG,Notify<Base::LogStyle::Message>,_msg)
+#define TREE_WARN(_msg) _TREE_PRINT(FC_LOGLEVEL_WARN,Notify<Base::LogStyle::Warning>,_msg)
+#define TREE_ERR(_msg) _TREE_PRINT(FC_LOGLEVEL_ERR,Notify<Base::LogStyle::Error>,_msg)
+#define TREE_LOG(_msg) _TREE_PRINT(FC_LOGLEVEL_LOG,Notify<Base::LogStyle::Log>,_msg)
+#define TREE_TRACE(_msg) _TREE_PRINT(FC_LOGLEVEL_TRACE,Notify<Base::LogStyle::Log>,_msg)
 
 using namespace Gui;
 namespace bp = boost::placeholders;

--- a/src/Mod/Import/App/ImportOCAF2.cpp
+++ b/src/Mod/Import/App/ImportOCAF2.cpp
@@ -147,7 +147,7 @@ static void printLabel(TDF_Label label, Handle(XCAFDoc_ShapeTool) aShapeTool,
     }
 
     ss << std::endl;
-    Base::Console().NotifyLog(ss.str().c_str());
+    Base::Console().Notify<Base::LogStyle::Log>("ImportOCAF2",ss.str().c_str());
 }
 
 static void dumpLabels(TDF_Label label, Handle(XCAFDoc_ShapeTool) aShapeTool,

--- a/src/Mod/Import/App/dxf/ImpExpDxf.cpp
+++ b/src/Mod/Import/App/dxf/ImpExpDxf.cpp
@@ -568,7 +568,7 @@ void ImpExpDxfWrite::exportShape(const TopoDS_Shape input)
         } else if (adapt.GetType() == GeomAbs_Line) {
             exportLine(adapt);
         } else {
-            Base::Console().Warning("ImpExpDxf - unknown curve type: %d\n",adapt.GetType());
+            Base::Console().Warning("ImpExpDxf - unknown curve type: %d\n", static_cast<int>(adapt.GetType()));
         }
     }
 

--- a/src/Mod/Part/App/TopoShapePyImp.cpp
+++ b/src/Mod/Part/App/TopoShapePyImp.cpp
@@ -2596,7 +2596,7 @@ PyObject* TopoShapePy::distToShape(PyObject *args)
                     break;
                 default:
                     Base::Console().Message("distToShape: supportType1 is unknown: %d \n",
-                                            supportType1);
+                                            static_cast<int>(supportType1));
                     suppType1 = Py::String("Unknown");
                     suppIndex1 = -1;
                     param1 = Py::None();
@@ -2631,7 +2631,7 @@ PyObject* TopoShapePy::distToShape(PyObject *args)
                     break;
                 default:
                     Base::Console().Message("distToShape: supportType2 is unknown: %d \n",
-                                            supportType2);
+                                            static_cast<int>(supportType2));
                     suppType2 = Py::String("Unknown");
                     suppIndex2 = -1;
                     param2 = Py::None();

--- a/src/Mod/Sketcher/App/planegcs/GCS.cpp
+++ b/src/Mod/Sketcher/App/planegcs/GCS.cpp
@@ -285,10 +285,7 @@ SolverReportingManager& SolverReportingManager::Manager()
 
 void SolverReportingManager::LogToConsole(const std::string& str)
 {
-    if(str.size() < Base::Console().BufferSize)
-        Base::Console().Log(str.c_str());
-    else
-        Base::Console().Log("SolverReportingManager - Overly long string suppressed");
+    Base::Console().Log(str.c_str());
 }
 
 void SolverReportingManager::LogToFile(const std::string& str)

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -1088,7 +1088,7 @@ void ViewProviderSketch::editDoubleClicked()
         Base::Console().Log("double click edge:%d\n",preselection.PreselectCurve);
     }
     else if (preselection.isCrossPreselected()) {
-        Base::Console().Log("double click cross:%d\n",preselection.PreselectCross);
+        Base::Console().Log("double click cross:%d\n",static_cast<int>(preselection.PreselectCross));
     }
     else if (!preselection.PreselectConstraintSet.empty()) {
         // Find the constraint

--- a/src/Mod/TechDraw/App/Cosmetic.cpp
+++ b/src/Mod/TechDraw/App/Cosmetic.cpp
@@ -461,7 +461,7 @@ void CosmeticEdge::Save(Base::Writer &writer) const
         TechDraw::AOCPtr aoc = std::static_pointer_cast<TechDraw::AOC>(m_geometry);
         aoc->Save(writer);
     } else {
-        Base::Console().Warning("CE::Save - unimplemented geomType: %d\n", m_geometry->getGeomType());
+        Base::Console().Warning("CE::Save - unimplemented geomType: %d\n", static_cast<int>(m_geometry->getGeomType()));
     }
 }
 
@@ -507,7 +507,7 @@ void CosmeticEdge::Restore(Base::XMLReader &reader)
         permaEnd   = aoc->endPnt;
         permaRadius = aoc->radius;
     } else {
-        Base::Console().Warning("CE::Restore - unimplemented geomType: %d\n", gType);
+        Base::Console().Warning("CE::Restore - unimplemented geomType: %d\n", static_cast<int>(gType));
     }
 }
 
@@ -1262,7 +1262,7 @@ void CenterLine::Save(Base::Writer &writer) const
         TechDraw::AOCPtr aoc = std::static_pointer_cast<TechDraw::AOC>(m_geometry);
         aoc->Save(writer);
     } else {
-        Base::Console().Message("CL::Save - unimplemented geomType: %d\n", m_geometry->getGeomType());
+        Base::Console().Message("CL::Save - unimplemented geomType: %d\n", static_cast<int>(m_geometry->getGeomType()));
     }
 }
 
@@ -1362,7 +1362,7 @@ void CenterLine::Restore(Base::XMLReader &reader)
         aoc->setOCCEdge(GeometryUtils::edgeFromCircleArc(aoc));
         m_geometry = aoc;
     } else {
-        Base::Console().Warning("CL::Restore - unimplemented geomType: %d\n", gType);
+        Base::Console().Warning("CL::Restore - unimplemented geomType: %d\n", static_cast<int>(gType));
     }
 }
 

--- a/src/Mod/TechDraw/App/DrawComplexSection.cpp
+++ b/src/Mod/TechDraw/App/DrawComplexSection.cpp
@@ -820,7 +820,7 @@ TopoDS_Wire DrawComplexSection::makeSectionLineWire()
         else {
             //probably can't happen as cut profile has been checked before this
             Base::Console().Message("DCS::makeSectionLineGeometry - profile is type: %d\n",
-                                    sScaled.ShapeType());
+                                    static_cast<int>(sScaled.ShapeType()));
             return TopoDS_Wire();
         }
     }

--- a/src/Mod/TechDraw/App/DrawUtil.cpp
+++ b/src/Mod/TechDraw/App/DrawUtil.cpp
@@ -1670,13 +1670,13 @@ void DrawUtil::dumpEdge(const char* label, int i, TopoDS_Edge e)
         vEnd.X(),
         vEnd.Y(),
         vEnd.Z(),
-        e.Orientation());
+        static_cast<int>(e.Orientation()));
     double edgeLength = GCPnts_AbscissaPoint::Length(adapt, Precision::Confusion());
     Base::Console().Message(">>>>>>> length: %.3f  distance: %.3f ration: %.3f type: %d\n",
                             edgeLength,
                             vStart.Distance(vEnd),
                             edgeLength / vStart.Distance(vEnd),
-                            adapt.GetType());
+                            static_cast<int>(adapt.GetType()));
 }
 
 const char* DrawUtil::printBool(bool b)

--- a/src/Mod/TechDraw/App/GeometryObject.cpp
+++ b/src/Mod/TechDraw/App/GeometryObject.cpp
@@ -498,7 +498,7 @@ void GeometryObject::extractGeometry(edgeClass category, bool hlrVisible)
             default:
                 Base::Console().Warning(
                     "GeometryObject::ExtractGeometry - unsupported hlrVisible edgeClass: %d\n",
-                    category);
+                    static_cast<int>(category));
                 return;
         }
     }
@@ -522,7 +522,7 @@ void GeometryObject::extractGeometry(edgeClass category, bool hlrVisible)
             default:
                 Base::Console().Warning(
                     "GeometryObject::ExtractGeometry - unsupported hidden edgeClass: %d\n",
-                    category);
+                    static_cast<int>(category));
                 return;
         }
     }

--- a/src/Mod/TechDraw/Gui/QGIViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewPart.cpp
@@ -331,7 +331,7 @@ QPainterPath QGIViewPart::geomToPainterPath(BaseGeomPtr baseGeom, double rot)
         } break;
         default: {
             Base::Console().Error("Error - geomToPainterPath - UNKNOWN geomType: %d\n",
-                                  baseGeom->getGeomType());
+                                  static_cast<int>(baseGeom->getGeomType()));
         } break;
     }//sb end of switch
 
@@ -1257,8 +1257,8 @@ void QGIViewPart::dumpPath(const char* text, QPainterPath path)
             typeName = "CurveData";
         }
         Base::Console().Message(">>>>> element %d: type:%d/%s pos(%.3f, %.3f) M:%d L:%d C:%d\n",
-                                iElem, elem.type, typeName, elem.x, elem.y, elem.isMoveTo(),
-                                elem.isLineTo(), elem.isCurveTo());
+                                iElem, static_cast<int>(elem.type), typeName, elem.x, elem.y, static_cast<int>(elem.isMoveTo()),
+                                static_cast<int>(elem.isLineTo()), static_cast<int>(elem.isCurveTo()));
     }
 }
 

--- a/src/Mod/Test/Gui/AppTestGui.cpp
+++ b/src/Mod/Test/Gui/AppTestGui.cpp
@@ -40,7 +40,8 @@ public:
 
     void flush() {buffer.str("");buffer.clear();}
 
-    void SendLog(const std::string& msg, Base::LogStyle level) override{
+    void SendLog(const std::string& notifiername, const std::string& msg, Base::LogStyle level) override{
+        (void) notifiername;
         (void) msg;
         switch(level){
             case Base::LogStyle::Warning:
@@ -55,6 +56,11 @@ public:
             case Base::LogStyle::Log:
                 buffer << "LOG";
                 break;
+            case Base::LogStyle::Critical:
+                buffer << "CMS";
+                break;
+            default:
+                break;
         }
     }
 
@@ -65,44 +71,45 @@ public:
         Base::Console().Message("MSG");
         Base::Console().Warning("WRN");
         Base::Console().Error("ERR");
+        Base::Console().Critical("CMS");
         if (buffer.str() != expectedResult)
             throw Py::RuntimeError("ILoggerTest: " + buffer.str() + " different from " + expectedResult);
     }
 
     void runTest()
     {
-        runSingleTest("Print all message types", "LOGMSGWRNERR");
+        runSingleTest("Print all message types", "LOGMSGWRNERRCMS");
         {
             Base::ILoggerBlocker blocker("ILoggerBlockerTest");
             runSingleTest("All types blocked", "");
         }
-        runSingleTest("Print all", "LOGMSGWRNERR");
+        runSingleTest("Print all", "LOGMSGWRNERRCMS");
         {
             Base::ILoggerBlocker blocker("ILoggerBlockerTest", Base::ConsoleSingleton::MsgType_Err | Base::ConsoleSingleton::MsgType_Wrn);
-            runSingleTest("Error & Warning blocked", "LOGMSG");
+            runSingleTest("Error & Warning blocked", "LOGMSGCMS");
         }
-        runSingleTest("Print all", "LOGMSGWRNERR");
+        runSingleTest("Print all", "LOGMSGWRNERRCMS");
         {
             Base::ILoggerBlocker blocker("ILoggerBlockerTest", Base::ConsoleSingleton::MsgType_Log | Base::ConsoleSingleton::MsgType_Txt);
-            runSingleTest("Log & Message blocked", "WRNERR");
+            runSingleTest("Log & Message blocked", "WRNERRCMS");
         }
-        runSingleTest("Print all", "LOGMSGWRNERR");
+        runSingleTest("Print all", "LOGMSGWRNERRCMS");
         {
             Base::ILoggerBlocker blocker("ILoggerBlockerTest", Base::ConsoleSingleton::MsgType_Err);
-            runSingleTest("Nested : Error blocked", "LOGMSGWRN");
+            runSingleTest("Nested : Error blocked", "LOGMSGWRNCMS");
             {
                 Base::ILoggerBlocker blocker2("ILoggerBlockerTest", Base::ConsoleSingleton::MsgType_Err | Base::ConsoleSingleton::MsgType_Wrn);
-                runSingleTest("Nested : Warning blocked + Error (from nesting) + Error (redundancy)", "LOGMSG");
+                runSingleTest("Nested : Warning blocked + Error (from nesting) + Error (redundancy)", "LOGMSGCMS");
             }
-            runSingleTest("Nested : Error still blocked", "LOGMSGWRN");
+            runSingleTest("Nested : Error still blocked", "LOGMSGWRNCMS");
         }
-        runSingleTest("Print all", "LOGMSGWRNERR");
+        runSingleTest("Print all", "LOGMSGWRNERRCMS");
         {
             Base::ILoggerBlocker blocker("ILoggerBlockerTest");
             Base::Console().SetEnabledMsgType("ILoggerBlockerTest", Base::ConsoleSingleton::MsgType_Log, true);
             runSingleTest("Log is enabled but a warning is triggered in debug mode", "LOG");
         }
-        runSingleTest("Print all", "LOGMSGWRNERR");
+        runSingleTest("Print all", "LOGMSGWRNERRCMS");
     }
 
 private:


### PR DESCRIPTION
This PR is the first of a series to introduce NotificationArea.

This PR is mostly directed to refactor Console and Extend it to new messages. It could have been great to first refactor and then extend, but actually the refactor became advisable during the extension.

The core of the refactor/extension lies in Console.h and Console.cpp. The rest of the changes are a consequence of it. When reviewing it makes sense to start there.

Console:
* For refactor:
- variadic functions are substituted with template functions with parameter packs.
- To provide support for the c style printf, fmt library is used.
- Template functions with parameter packs were moved to header file.

* For extension:
- Messages are extended to include a Notifier string, to indicate the originator of the message/notification.
- CriticalMessages are added. This is intended to substitute the signal-slot mechanism for critical messages in a subsequent PR.
- Notifications and TranslatedNotification messages are added. These are intended to convey user notifications, both already translated ones or to be translated ones (see commit description). These will be used by the NotificationArea PR.
