### PR TITLE
[Material] fix conductivity of Copper

### DIFF
--- a/src/Mod/Material/StandardMaterial/Copper-Generic.FCMat
+++ b/src/Mod/Material/StandardMaterial/Copper-Generic.FCMat
@@ -23,5 +23,5 @@ ThermalConductivity = 398.0 W/m/K
 ThermalExpansionCoefficient = 16.5 µm/m/K
 
 [Electromagnetic]
-ElectricalConductivity = 588235.3 S/m
+ElectricalConductivity = 59.59 MS/m
 RelativePermeability = 0.999994


### PR DESCRIPTION
- the conductivity was by a factor 100 too low, use a common value as fix