### PR TITLE
Draft: add delay in the Draft_Clone unit test

### DIFF
--- a/src/Mod/Draft/drafttests/test_modification.py
+++ b/src/Mod/Draft/drafttests/test_modification.py
@@ -568,6 +568,27 @@ class DraftModification(unittest.TestCase):
         _msg("  object: '{0}' ({1})".format(box.Shape.ShapeType, box.TypeId))
 
         obj = Draft.make_clone(box)
+
+        # Code below by Chris Hennes.
+        # https://forum.freecadweb.org/viewtopic.php?p=656362#p656362
+        # This code is required because of the DiffuseColor workaround which
+        # reapplies the DiffuseColor with a delay. Without the code below the
+        # active document may get deleted beforehand resulting in an error.
+        if App.GuiUp:
+            from PySide import QtCore
+            class DelayEnder:
+                def __init__(self):
+                    self.delay_is_done = False
+                def stop(self):
+                    self.delay_is_done = True
+            ender = DelayEnder()
+            timer = QtCore.QTimer()
+            timer.timeout.connect(ender.stop)
+            timer.setSingleShot(True)
+            timer.start(100) # 100ms timer guarantees the loop below runs at least that long
+            while not ender.delay_is_done:
+                QtCore.QCoreApplication.processEvents(QtCore.QEventLoop.AllEvents)
+
         _msg("  clone: '{0}' ({1})".format(obj.Proxy.Type, obj.TypeId))
         self.assertTrue(obj, "'{}' failed".format(operation))
         self.assertTrue(obj.hasExtension("Part::AttachExtension"),


### PR DESCRIPTION
The DiffuseColor workaround requires a delay in the Draft_Clone unit test.

See https://forum.freecadweb.org/viewtopic.php?p=656362#p656362

- [x]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

---
