### PR TITLE
[Draft] fix ang dim arrows alignment issue related to asin

### DIFF
--- a/src/Mod/Draft/draftviewproviders/view_dimension.py
+++ b/src/Mod/Draft/draftviewproviders/view_dimension.py
@@ -1032,7 +1032,7 @@ class ViewProviderAngularDimension(ViewProviderDimensionBase):
                 and vobj.ScaleMultiplier != 0 \
                 and hasattr(vobj, "FlipArrows"):
             halfarrowlength = 2 * vobj.ArrowSize.Value * vobj.ScaleMultiplier
-            arrowangle = 2 * math.asin(halfarrowlength / radius)
+            arrowangle = 2 * math.asin(min(1, halfarrowlength / radius))
             if vobj.FlipArrows:
                 arrowangle = -arrowangle
 


### PR DESCRIPTION
`math.asin(halfarrowlength / radius)` would fail if halfarrowlength was larger than radius.

- [ ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

---
