### PR TITLE
[FEM] shorten too long lines in mesh code

### DIFF
--- a/src/Mod/Fem/App/FemMesh.cpp
+++ b/src/Mod/Fem/App/FemMesh.cpp
@@ -143,7 +143,8 @@ void FemMesh::copyMeshData(const FemMesh& mesh)
 {
     _Mtrx = mesh._Mtrx;
 
-    // See file SMESH_I/SMESH_Gen_i.cxx in the git repo of smesh at https://git.salome-platform.org
+    // See file SMESH_I/SMESH_Gen_i.cxx in the git repo of smesh at
+    // https://git.salome-platform.org
 #if 1
     // 1. Get source mesh
     SMESHDS_Mesh* srcMeshDS = mesh.myMesh->GetMeshDS();
@@ -180,15 +181,11 @@ void FemMesh::copyMeshData(const FemMesh& mesh)
             switch (elem->GetEntityType()) {
             case SMDSEntity_Polyhedra:
 #if SMESH_VERSION_MAJOR >= 9
-                editor.GetMeshDS()->
-                    AddPolyhedralVolumeWithID(nodes,
-                                              static_cast<const SMDS_MeshVolume*>(elem)->GetQuantities(),
-                                              ID);
+                editor.GetMeshDS()->AddPolyhedralVolumeWithID(
+                    nodes, static_cast<const SMDS_MeshVolume*>(elem)->GetQuantities(), ID);
 #else
-                editor.GetMeshDS()->
-                    AddPolyhedralVolumeWithID(nodes,
-                                              static_cast<const SMDS_VtkVolume*>(elem)->GetQuantities(),
-                                              ID);
+                editor.GetMeshDS()->AddPolyhedralVolumeWithID(
+                    nodes, static_cast<const SMDS_VtkVolume*>(elem)->GetQuantities(), ID);
 #endif
                 break;
             case SMDSEntity_Ball:
@@ -265,7 +262,8 @@ void FemMesh::copyMeshData(const FemMesh& mesh)
 #else
     SMESHDS_Mesh* meshds = this->myMesh->GetMeshDS();
 
-    // Some further information is still not copied: http://forum.freecadweb.org/viewtopic.php?f=18&t=18982#p148114
+    // Some further information is still not copied:
+    // http://forum.freecadweb.org/viewtopic.php?f=18&t=18982#p148114
     SMDS_NodeIteratorPtr aNodeIter = mesh.myMesh->GetMeshDS()->nodesIterator();
     for (;aNodeIter->more();) {
         const SMDS_MeshNode* aNode = aNodeIter->next();
@@ -316,14 +314,12 @@ void FemMesh::copyMeshData(const FemMesh& mesh)
                                       aFace->GetNode(7),
                                       aFace->GetID());
                 break;
-            default:
-                {
-                    std::vector<const SMDS_MeshNode*> aNodes;
-                    for (int i=0; aFace->NbNodes(); i++)
-                        aNodes.push_back(aFace->GetNode(0));
-                    meshds->AddPolygonalFaceWithID(aNodes, aFace->GetID());
-                }
-                break;
+            default: {
+                std::vector<const SMDS_MeshNode*> aNodes;
+                for (int i = 0; aFace->NbNodes(); i++)
+                    aNodes.push_back(aFace->GetNode(0));
+                meshds->AddPolygonalFaceWithID(aNodes, aFace->GetID());
+            } break;
         }
     }
 
@@ -436,19 +432,19 @@ void FemMesh::copyMeshData(const FemMesh& mesh)
                                         aVol->GetNode(19),
                                         aVol->GetID());
                 break;
-            default:
-                {
-                    if (aVol->IsPoly()) {
-                        const SMDS_PolyhedralVolumeOfNodes* aPolyVol = dynamic_cast<const SMDS_PolyhedralVolumeOfNodes*>(aVol);
-                        if (!aPolyVol) break;
+            default: {
+                if (aVol->IsPoly()) {
+                        const SMDS_PolyhedralVolumeOfNodes* aPolyVol =
+                            dynamic_cast<const SMDS_PolyhedralVolumeOfNodes*>(aVol);
+                        if (!aPolyVol)
+                            break;
                         std::vector<const SMDS_MeshNode*> aNodes;
-                        for (int i=0; i<aPolyVol->NbNodes(); i++)
+                        for (int i = 0; i < aPolyVol->NbNodes(); i++)
                             aNodes.push_back(aPolyVol->GetNode(i));
-                        meshds->AddPolyhedralVolumeWithID(aNodes,
-                            aPolyVol->GetQuanities(), aPolyVol->GetID());
-                    }
+                        meshds->AddPolyhedralVolumeWithID(
+                            aNodes, aPolyVol->GetQuanities(), aPolyVol->GetID());
                 }
-                break;
+            } break;
         }
     }
 
@@ -461,24 +457,28 @@ void FemMesh::copyMeshData(const FemMesh& mesh)
 
         int aId;
         if (sourceGroupDS->GetType() == SMDSAbs_Node) {
-            SMESH_Group* targetGroup = this->myMesh->AddGroup(SMDSAbs_Node, sourceGroupDS->GetStoreName(), aId);
-            if (targetGroup) {
-                SMESHDS_Group* targetGroupDS = dynamic_cast<SMESHDS_Group*>(targetGroup->GetGroupDS());
-                if (targetGroupDS) {
-                    SMDS_ElemIteratorPtr aIter = sourceGroupDS->GetElements();
-                    while (aIter->more()) {
-                        const SMDS_MeshElement* aElem = aIter->next();
-                        const SMDS_MeshNode* aNode = meshds->FindNode(aElem->GetID());
-                        if (aNode)
-                            targetGroupDS->SMDSGroup().Add(aNode);
+                SMESH_Group* targetGroup =
+                    this->myMesh->AddGroup(SMDSAbs_Node, sourceGroupDS->GetStoreName(), aId);
+                if (targetGroup) {
+                    SMESHDS_Group* targetGroupDS =
+                        dynamic_cast<SMESHDS_Group*>(targetGroup->GetGroupDS());
+                    if (targetGroupDS) {
+                        SMDS_ElemIteratorPtr aIter = sourceGroupDS->GetElements();
+                        while (aIter->more()) {
+                            const SMDS_MeshElement* aElem = aIter->next();
+                            const SMDS_MeshNode* aNode = meshds->FindNode(aElem->GetID());
+                            if (aNode)
+                                targetGroupDS->SMDSGroup().Add(aNode);
+                        }
                     }
                 }
-            }
         }
         else {
-            SMESH_Group* targetGroup = this->myMesh->AddGroup(sourceGroupDS->GetType(), sourceGroupDS->GetStoreName(), aId);
+            SMESH_Group* targetGroup = this->myMesh->AddGroup(
+                sourceGroupDS->GetType(), sourceGroupDS->GetStoreName(), aId);
             if (targetGroup) {
-                SMESHDS_Group* targetGroupDS = dynamic_cast<SMESHDS_Group*>(targetGroup->GetGroupDS());
+                SMESHDS_Group* targetGroupDS =
+                    dynamic_cast<SMESHDS_Group*>(targetGroup->GetGroupDS());
                 if (targetGroupDS) {
                     SMDS_ElemIteratorPtr aIter = sourceGroupDS->GetElements();
                     while (aIter->more()) {
@@ -593,7 +593,7 @@ void FemMesh::setStandardHypotheses()
 #endif
 
     // Apply hypothesis
-    for (int i=0; i<hyp;i++)
+    for (int i = 0; i < hyp; i++)
         myMesh->AddHypothesis(myMesh->GetShapeToMesh(), i);
 }
 
@@ -622,7 +622,8 @@ std::list<std::pair<int, int> > FemMesh::getVolumesByFace(const TopoDS_Face &fac
     std::set<int> nodes_on_face = getNodesByFace(face);
 
 #if SMESH_VERSION_MAJOR >= 7
-    // SMDS_MeshVolume::facesIterator() is broken with SMESH7 as it is impossible to iterate volume faces
+    // SMDS_MeshVolume::facesIterator() is broken with SMESH7 as it is impossible
+    // to iterate volume faces
     // In SMESH9 this function has been removed
     //
     std::map< int, std::set<int> > face_nodes;
@@ -641,8 +642,11 @@ std::list<std::pair<int, int> > FemMesh::getVolumesByFace(const TopoDS_Face &fac
         }
 
         std::vector<int> element_face_nodes;
-        std::set_intersection(nodes_on_face.begin(), nodes_on_face.end(), node_ids.begin(), node_ids.end(),
-            std::back_insert_iterator<std::vector<int> >(element_face_nodes));
+        std::set_intersection(nodes_on_face.begin(),
+                              nodes_on_face.end(),
+                              node_ids.begin(),
+                              node_ids.end(),
+                              std::back_insert_iterator<std::vector<int>>(element_face_nodes));
 
         if (element_face_nodes.size() == node_ids.size()) {
             face_nodes[face->GetID()] = node_ids;
@@ -662,8 +666,11 @@ std::list<std::pair<int, int> > FemMesh::getVolumesByFace(const TopoDS_Face &fac
 
         for (const auto& it : face_nodes) {
             std::vector<int> element_face_nodes;
-            std::set_intersection(node_ids.begin(), node_ids.end(), it.second.begin(), it.second.end(),
-                std::back_insert_iterator<std::vector<int> >(element_face_nodes));
+            std::set_intersection(node_ids.begin(),
+                                  node_ids.end(),
+                                  it.second.begin(),
+                                  it.second.end(),
+                                  std::back_insert_iterator<std::vector<int>>(element_face_nodes));
 
             // For curved faces it is possible that a volume contributes more than one face
             if (element_face_nodes.size() == it.second.size()) {
@@ -682,13 +689,16 @@ std::list<std::pair<int, int> > FemMesh::getVolumesByFace(const TopoDS_Face &fac
             int numNodes = face->NbNodes();
 
             std::set<int> face_nodes;
-            for (int i=0; i<numNodes; i++) {
+            for (int i = 0; i < numNodes; i++) {
                 face_nodes.insert(face->GetNode(i)->GetID());
             }
 
             std::vector<int> element_face_nodes;
-            std::set_intersection(nodes_on_face.begin(), nodes_on_face.end(), face_nodes.begin(), face_nodes.end(),
-                std::back_insert_iterator<std::vector<int> >(element_face_nodes));
+            std::set_intersection(nodes_on_face.begin(),
+                                  nodes_on_face.end(),
+                                  face_nodes.begin(),
+                                  face_nodes.end(),
+                                  std::back_insert_iterator<std::vector<int>>(element_face_nodes));
 
             // For curved faces it is possible that a volume contributes more than one face
             if (element_face_nodes.size() == static_cast<std::size_t>(numNodes)) {
@@ -716,13 +726,16 @@ std::list<int> FemMesh::getFacesByFace(const TopoDS_Face &face) const
         int numNodes = face->NbNodes();
 
         std::set<int> face_nodes;
-        for (int i=0; i<numNodes; i++) {
+        for (int i = 0; i < numNodes; i++) {
             face_nodes.insert(face->GetNode(i)->GetID());
         }
 
         std::vector<int> element_face_nodes;
-        std::set_intersection(nodes_on_face.begin(), nodes_on_face.end(), face_nodes.begin(), face_nodes.end(),
-            std::back_insert_iterator<std::vector<int> >(element_face_nodes));
+        std::set_intersection(nodes_on_face.begin(),
+                              nodes_on_face.end(),
+                              face_nodes.begin(),
+                              face_nodes.end(),
+                              std::back_insert_iterator<std::vector<int>>(element_face_nodes));
 
         // For curved faces it is possible that a volume contributes more than one face
         if (element_face_nodes.size() == static_cast<std::size_t>(numNodes)) {
@@ -745,13 +758,16 @@ std::list<int> FemMesh::getEdgesByEdge(const TopoDS_Edge &edge) const
         int numNodes = edge->NbNodes();
 
         std::set<int> edge_nodes;
-        for (int i=0; i<numNodes; i++) {
+        for (int i = 0; i < numNodes; i++) {
             edge_nodes.insert(edge->GetNode(i)->GetID());
         }
 
         std::vector<int> element_edge_nodes;
-        std::set_intersection(nodes_on_edge.begin(), nodes_on_edge.end(), edge_nodes.begin(), edge_nodes.end(),
-            std::back_insert_iterator<std::vector<int> >(element_edge_nodes));
+        std::set_intersection(nodes_on_edge.begin(),
+                              nodes_on_edge.end(),
+                              edge_nodes.begin(),
+                              edge_nodes.end(),
+                              std::back_insert_iterator<std::vector<int>>(element_edge_nodes));
 
         if (element_edge_nodes.size() == static_cast<std::size_t>(numNodes)) {
             result.push_back(edge->GetID());
@@ -802,15 +818,19 @@ std::map<int, int> FemMesh::getccxVolumesByFace(const TopoDS_Face &face) const
         std::vector<int> element_face_nodes;
         std::set<int> element_nodes;
         element_nodes.insert(apair.second.begin(), apair.second.end());
-        std::set_intersection(nodes_on_face.begin(), nodes_on_face.end(), element_nodes.begin(), element_nodes.end(),
-        std::back_insert_iterator<std::vector<int> >(element_face_nodes));
+        std::set_intersection(nodes_on_face.begin(),
+                              nodes_on_face.end(),
+                              element_nodes.begin(),
+                              element_nodes.end(),
+                              std::back_insert_iterator<std::vector<int>>(element_face_nodes));
 
-        if ((element_face_nodes.size() == 3 && num_of_nodes == 4) ||
-            (element_face_nodes.size() == 6 && num_of_nodes == 10)) {
+        if ((element_face_nodes.size() == 3 && num_of_nodes == 4)
+            || (element_face_nodes.size() == 6 && num_of_nodes == 10)) {
             int missing_node = 0;
-            for (int i=0; i<4; i++) {
+            for (int i = 0; i < 4; i++) {
                 // search for the ID of the volume which is not part of 'element_face_nodes'
-                if (std::find(element_face_nodes.begin(), element_face_nodes.end(), apair.second[i]) == element_face_nodes.end()) {
+                if (std::find(element_face_nodes.begin(), element_face_nodes.end(), apair.second[i])
+                    == element_face_nodes.end()) {
                     missing_node = i + 1;
                     break;
                 }
@@ -856,7 +876,8 @@ std::set<int> FemMesh::getNodesBySolid(const TopoDS_Solid &solid) const
     TopAbs_ShapeEnum shapetype = TopAbs_SHAPE;
     ShapeAnalysis_ShapeTolerance analysis;
     double limit = analysis.Tolerance(solid, 1, shapetype);
-    Base::Console().Log("The limit if a node is in or out: %.12lf in scientific: %.4e \n", limit, limit);
+    Base::Console().Log(
+        "The limit if a node is in or out: %.12lf in scientific: %.4e \n", limit, limit);
 
     // get the current transform of the FemMesh
     const Base::Matrix4D Mtrx(getTransform());
@@ -902,7 +923,10 @@ std::set<int> FemMesh::getNodesByFace(const TopoDS_Face &face) const
     std::set<int> result;
 
     Bnd_Box box;
-    BRepBndLib::Add(face, box, Standard_False);  // https://forum.freecadweb.org/viewtopic.php?f=18&t=21571&start=70#p221591
+    BRepBndLib::Add(
+        face,
+        box,
+        Standard_False);// https://forum.freecadweb.org/viewtopic.php?f=18&t=21571&start=70#p221591
     // limit where the mesh node belongs to the face:
     double limit = BRep_Tool::Tolerance(face);
     box.Enlarge(limit);
@@ -1320,7 +1344,7 @@ public:
         int id = atoi(str1.substr(8,16).c_str());
         int offset = 0;
 
-        if(id < 1000000)
+        if (id < 1000000)
             offset = 0;
         else if (id < 10000000)
             offset = 1;
@@ -1903,7 +1927,8 @@ void FemMesh::writeABAQUS(const std::string &Filename, int elemParam, bool group
     static std::map<int, std::string> faceTypeMap;
     static std::map<int, std::string> volTypeMap;
     if (elemOrderMap.empty()) {
-        // node order fits with node order in importCcxFrdResults.py module to import CalculiX result meshes
+        // node order fits with node order in importCcxFrdResults.py module to import
+        // CalculiX result meshes
 
         // dimension 1
         //
@@ -1957,7 +1982,8 @@ void FemMesh::writeABAQUS(const std::string &Filename, int elemParam, bool group
         //std::vector<int> c3d10 = boost::assign::list_of(0)(2)(1)(3)(6)(5)(4)(7)(9)(8);
 
         // since master 0.15
-        // added by werner (wmayer) March 2015, http://forum.freecadweb.org/viewtopic.php?f=18&t=10110&start=10#p81681
+        // added by werner (wmayer) March 2015,
+        // http://forum.freecadweb.org/viewtopic.php?f=18&t=10110&start=10#p81681
         // https://github.com/FreeCAD/FreeCAD/commit/5d159f5cf352a93b1aff4fb7b82e8b747ee4f35b
         // https://github.com/FreeCAD/FreeCAD/commit/b007bd19e4e4608caa4cdad350a9f480287fac6b
         // tetra4 FreeCAD --> C3D4 CalculiX
@@ -1983,7 +2009,8 @@ void FemMesh::writeABAQUS(const std::string &Filename, int elemParam, bool group
         //
         // hexa20 FreeCAD --> C3D20 CalculiX
         // N6, N7, N8, N5, N2, N3, N4, N1, N14, N15, N16, N13, N10, N11, N12, N9, N18, N19, N20, N17
-        std::vector<int> c3d20 = boost::assign::list_of(5)(6)(7)(4)(1)(2)(3)(0)(13)(14)(15)(12)(9)(10)(11)(8)(17)(18)(19)(16) ;
+        std::vector<int> c3d20 = boost::assign::list_of(5)(6)(7)(4)(1)(2)(3)(0)(13)(14)(15)(12)(9)(
+            10)(11)(8)(17)(18)(19)(16);
         //
         // penta6 FreeCAD --> C3D6 CalculiX
         // N5, N6, N4, N2, N3, N1
@@ -1991,7 +2018,7 @@ void FemMesh::writeABAQUS(const std::string &Filename, int elemParam, bool group
         //
         // penta15 FreeCAD --> C3D15 CalculiX
         // N5, N6, N4, N2, N3, N1, N11, N12, N10, N8, N9, N7, N14, N15, N13
-        std::vector<int> c3d15 = boost::assign::list_of(4)(5)(3)(1)(2)(0)(10)(11)(9)(7)(8)(6)(13)(14)(12) ;
+        std::vector<int> c3d15 = boost::assign::list_of(4)(5)(3)(1)(2)(0)(10)(11)(9)(7)(8)(6)(13)(14)(12);
 
         elemOrderMap.insert(std::make_pair("C3D4", c3d4));
         volTypeMap.insert(std::make_pair(elemOrderMap["C3D4"].size(), "C3D4"));
@@ -2041,7 +2068,8 @@ void FemMesh::writeABAQUS(const std::string &Filename, int elemParam, bool group
     }
 
     //get faces
-    ElementsMap elementsMapFac;  // empty faces map used for elemParam = 1  and elementsMapVol is not empty
+    ElementsMap elementsMapFac;  // empty faces map used for elemParam = 1
+                                 // and elementsMapVol is not empty
     if ((elemParam == 0) || (elemParam == 1 && elementsMapVol.empty())) {
         // for elemParam = 1 we only fill the elementsMapFac if the elmentsMapVol is empty
         // we're going to fill the elementsMapFac with all faces
@@ -2079,10 +2107,11 @@ void FemMesh::writeABAQUS(const std::string &Filename, int elemParam, bool group
     }
 
     // get edges
-    ElementsMap elementsMapEdg;  // empty edges map used for elemParam == 1 and either elementMapVol or elementsMapFac are not empty
+    ElementsMap elementsMapEdg;  // empty edges map used for elemParam == 1
+                                 // and either elementMapVol or elementsMapFac are not empty
     if ((elemParam == 0) || (elemParam == 1 && elementsMapVol.empty() && elementsMapFac.empty())) {
-        // for elemParam = 1 we only fill the elementsMapEdg if the elmentsMapVol and elmentsMapFac are empty
-        // we're going to fill the elementsMapEdg with all edges
+        // for elemParam = 1 we only fill the elementsMapEdg if the elmentsMapVol
+        // and elmentsMapFac are empty we're going to fill the elementsMapEdg with all edges
         SMDS_EdgeIteratorPtr aEdgeIter = myMesh->GetMeshDS()->edgesIterator();
         while (aEdgeIter->more()) {
             const SMDS_MeshEdge* aEdge = aEdgeIter->next();
@@ -2117,21 +2146,34 @@ void FemMesh::writeABAQUS(const std::string &Filename, int elemParam, bool group
     }
 
     // write all data to file
-    // take also care of special characters in path https://forum.freecadweb.org/viewtopic.php?f=10&t=37436
+    // take also care of special characters in path
+    // https://forum.freecadweb.org/viewtopic.php?f=10&t=37436
     Base::FileInfo fi(Filename);
     Base::ofstream anABAQUS_Output(fi);
-    anABAQUS_Output.precision(13);  // https://forum.freecadweb.org/viewtopic.php?f=18&t=22759#p176669
+    // https://forum.freecadweb.org/viewtopic.php?f=18&t=22759#p176669
+    anABAQUS_Output.precision(13);
 
     // add some text and make sure one of the known elemParam values is used
-    anABAQUS_Output << "** written by FreeCAD inp file writer for CalculiX,Abaqus meshes" << std::endl;
+    anABAQUS_Output << "** written by FreeCAD inp file writer for CalculiX,Abaqus meshes"
+        << std::endl;
     switch(elemParam){
-        case 0: anABAQUS_Output << "** all mesh elements." << std::endl << std::endl; break;
-        case 1: anABAQUS_Output << "** highest dimension mesh elements only." << std::endl << std::endl; break;
-        case 2: anABAQUS_Output << "** FEM mesh elements only (edges if they do not belong to faces and faces if they do not belong to volumes)." << std::endl << std::endl; break;
+        case 0:
+            anABAQUS_Output << "** all mesh elements." << std::endl << std::endl;
+            break;
+        case 1:
+            anABAQUS_Output << "** highest dimension mesh elements only." << std::endl << std::endl;
+            break;
+        case 2:
+            anABAQUS_Output << "** FEM mesh elements only (edges if they do not belong to faces "
+                               "and faces if they do not belong to volumes)."
+                            << std::endl
+                            << std::endl;
+            break;
         default:
             anABAQUS_Output << "** Problem on writing" << std::endl;
             anABAQUS_Output.close();
-            throw std::runtime_error("Unknown ABAQUS element choice parameter, [0|1|2] are allowed.");
+            throw std::runtime_error(
+                "Unknown ABAQUS element choice parameter, [0|1|2] are allowed.");
     }
 
     // write nodes
@@ -2159,7 +2201,8 @@ void FemMesh::writeABAQUS(const std::string &Filename, int elemParam, bool group
                 // Calculix allows max 16 entries in one line, a hexa20 has more !
                 int ct = 0;  // counter
                 bool first_line = true;
-                for (std::vector<int>::iterator kt = jt->second.begin(); kt != jt->second.end(); ++kt, ++ct) {
+                for (std::vector<int>::iterator kt = jt->second.begin(); kt != jt->second.end();
+                     ++kt, ++ct) {
                     if (ct < 15) {
                         anABAQUS_Output  << ", " << *kt;
                     }
@@ -2185,7 +2228,8 @@ void FemMesh::writeABAQUS(const std::string &Filename, int elemParam, bool group
             anABAQUS_Output << "*Element, TYPE=" << it->first << ", ELSET=Efaces" << std::endl;
             for (NodesMap::iterator jt = it->second.begin(); jt != it->second.end(); ++jt) {
                 anABAQUS_Output << jt->first;
-                for (std::vector<int>::iterator kt = jt->second.begin(); kt != jt->second.end(); ++kt) {
+                for (std::vector<int>::iterator kt = jt->second.begin(); kt != jt->second.end();
+                     ++kt) {
                     anABAQUS_Output << ", " << *kt;
                 }
                 anABAQUS_Output << std::endl;
@@ -2205,7 +2249,8 @@ void FemMesh::writeABAQUS(const std::string &Filename, int elemParam, bool group
             anABAQUS_Output << "*Element, TYPE=" << it->first << ", ELSET=Eedges" << std::endl;
             for (NodesMap::iterator jt = it->second.begin(); jt != it->second.end(); ++jt) {
                 anABAQUS_Output << jt->first;
-                for (std::vector<int>::iterator kt = jt->second.begin(); kt != jt->second.end(); ++kt) {
+                for (std::vector<int>::iterator kt = jt->second.begin(); kt != jt->second.end();
+                     ++kt) {
                     anABAQUS_Output << ", " << *kt;
                 }
                 anABAQUS_Output << std::endl;
@@ -2235,7 +2280,8 @@ void FemMesh::writeABAQUS(const std::string &Filename, int elemParam, bool group
         for (std::list<int>::iterator it = groupIDs.begin(); it != groupIDs.end(); ++it) {
 
             // get and write group info and group definition
-            // TODO group element type code has duplicate code of PyObject* FemMeshPy::getGroupElementType()
+            // TODO group element type code has duplicate code of
+            // PyObject* FemMeshPy::getGroupElementType()
             SMDSAbs_ElementType aElementType = myMesh->GetGroup(*it)->GetGroupDS()->GetType();
             const char* groupElementType = "";
             switch(aElementType) {
@@ -2249,7 +2295,8 @@ void FemMesh::writeABAQUS(const std::string &Filename, int elemParam, bool group
                 default                     : groupElementType = "Unknown"; break;
             }
             const char* groupName = myMesh->GetGroup(*it)->GetName();
-            anABAQUS_Output << "** GroupID: " << (*it) << " --> GroupName: " << groupName << " --> GroupElementType: " << groupElementType << std::endl;
+            anABAQUS_Output << "** GroupID: " << (*it) << " --> GroupName: " << groupName
+                            << " --> GroupElementType: " << groupElementType << std::endl;
 
             if (aElementType == SMDSAbs_Node) {
                 anABAQUS_Output << "*NSET, NSET=" << groupName << std::endl;
@@ -2315,9 +2362,12 @@ void FemMesh::write(const char *FileName) const
         // write UNV file
         myMesh->ExportUNV(File.filePath().c_str());
     }
-    else if (File.hasExtension("med") ) {
+    else if (File.hasExtension("med")) {
         Base::Console().Log("FEM mesh object will be exported to med format.\n");
-        myMesh->ExportMED(File.filePath().c_str(),File.fileNamePure().c_str(),false,2); // 2 means MED_V2_2 version !
+        myMesh->ExportMED(File.filePath().c_str(),
+                          File.fileNamePure().c_str(),
+                          false,
+                          2); // 2 means MED_V2_2 version!
     }
     else if (File.hasExtension("stl") ) {
         Base::Console().Log("FEM mesh object will be exported to stl format.\n");
@@ -2332,7 +2382,8 @@ void FemMesh::write(const char *FileName) const
     else if (File.hasExtension("inp") ) {
         Base::Console().Log("FEM mesh object will be exported to inp format.\n");
         // get Abaqus inp prefs
-        ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Fem/Abaqus");
+        ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
+            "User parameter:BaseApp/Preferences/Mod/Fem/Abaqus");
         int elemParam = hGrp->GetInt("AbaqusElementChoice", 1);
         bool groupParam = hGrp->GetBool("AbaqusWriteGroups", false);
         // write ABAQUS Output
@@ -2366,20 +2417,28 @@ void FemMesh::Save (Base::Writer &writer) const
 {
     if (!writer.isForceXML()) {
         //See SaveDocFile(), RestoreDocFile()
-        writer.Stream() << writer.ind() << "<FemMesh file=\"" ;
+        writer.Stream() << writer.ind() << "<FemMesh file=\"";
         writer.Stream() << writer.addFile("FemMesh.unv", this) << "\"";
-        writer.Stream() << " a11=\"" <<  _Mtrx[0][0] << "\" a12=\"" <<  _Mtrx[0][1] << "\" a13=\"" <<  _Mtrx[0][2] << "\" a14=\"" <<  _Mtrx[0][3] << "\"";
-        writer.Stream() << " a21=\"" <<  _Mtrx[1][0] << "\" a22=\"" <<  _Mtrx[1][1] << "\" a23=\"" <<  _Mtrx[1][2] << "\" a24=\"" <<  _Mtrx[1][3] << "\"";
-        writer.Stream() << " a31=\"" <<  _Mtrx[2][0] << "\" a32=\"" <<  _Mtrx[2][1] << "\" a33=\"" <<  _Mtrx[2][2] << "\" a34=\"" <<  _Mtrx[2][3] << "\"";
-        writer.Stream() << " a41=\"" <<  _Mtrx[3][0] << "\" a42=\"" <<  _Mtrx[3][1] << "\" a43=\"" <<  _Mtrx[3][2] << "\" a44=\"" <<  _Mtrx[3][3] << "\"";
+        writer.Stream() << " a11=\"" << _Mtrx[0][0] << "\" a12=\"" << _Mtrx[0][1] << "\" a13=\""
+                        << _Mtrx[0][2] << "\" a14=\"" << _Mtrx[0][3] << "\"";
+        writer.Stream() << " a21=\"" << _Mtrx[1][0] << "\" a22=\"" << _Mtrx[1][1] << "\" a23=\""
+                        << _Mtrx[1][2] << "\" a24=\"" << _Mtrx[1][3] << "\"";
+        writer.Stream() << " a31=\"" << _Mtrx[2][0] << "\" a32=\"" << _Mtrx[2][1] << "\" a33=\""
+                        << _Mtrx[2][2] << "\" a34=\"" << _Mtrx[2][3] << "\"";
+        writer.Stream() << " a41=\"" << _Mtrx[3][0] << "\" a42=\"" << _Mtrx[3][1] << "\" a43=\""
+                        << _Mtrx[3][2] << "\" a44=\"" << _Mtrx[3][3] << "\"";
         writer.Stream() << "/>" << std::endl;
     }
     else {
-        writer.Stream() << writer.ind() << "<FemMesh file=\"\"" ;
-        writer.Stream() << " a11=\"" <<  _Mtrx[0][0] << "\" a12=\"" <<  _Mtrx[0][1] << "\" a13=\"" <<  _Mtrx[0][2] << "\" a14=\"" <<  _Mtrx[0][3] << "\"";
-        writer.Stream() << " a21=\"" <<  _Mtrx[1][0] << "\" a22=\"" <<  _Mtrx[1][1] << "\" a23=\"" <<  _Mtrx[1][2] << "\" a24=\"" <<  _Mtrx[1][3] << "\"";
-        writer.Stream() << " a31=\"" <<  _Mtrx[2][0] << "\" a32=\"" <<  _Mtrx[2][1] << "\" a33=\"" <<  _Mtrx[2][2] << "\" a34=\"" <<  _Mtrx[2][3] << "\"";
-        writer.Stream() << " a41=\"" <<  _Mtrx[3][0] << "\" a42=\"" <<  _Mtrx[3][1] << "\" a43=\"" <<  _Mtrx[3][2] << "\" a44=\"" <<  _Mtrx[3][3] << "\"";
+        writer.Stream() << writer.ind() << "<FemMesh file=\"\"";
+        writer.Stream() << " a11=\"" << _Mtrx[0][0] << "\" a12=\"" << _Mtrx[0][1] << "\" a13=\""
+                        << _Mtrx[0][2] << "\" a14=\"" << _Mtrx[0][3] << "\"";
+        writer.Stream() << " a21=\"" << _Mtrx[1][0] << "\" a22=\"" << _Mtrx[1][1] << "\" a23=\""
+                        << _Mtrx[1][2] << "\" a24=\"" << _Mtrx[1][3] << "\"";
+        writer.Stream() << " a31=\"" << _Mtrx[2][0] << "\" a32=\"" << _Mtrx[2][1] << "\" a33=\""
+                        << _Mtrx[2][2] << "\" a34=\"" << _Mtrx[2][3] << "\"";
+        writer.Stream() << " a41=\"" << _Mtrx[3][0] << "\" a42=\"" << _Mtrx[3][1] << "\" a43=\""
+                        << _Mtrx[3][2] << "\" a44=\"" << _Mtrx[3][3] << "\"";
         writer.Stream() << "/>" << std::endl;
     }
 }
@@ -2393,7 +2452,7 @@ void FemMesh::Restore(Base::XMLReader &reader)
         // initiate a file read
         reader.addFile(file.c_str(),this);
     }
-    if( reader.hasAttribute("a11")){
+    if (reader.hasAttribute("a11")) {
         _Mtrx[0][0] = (float)reader.getAttributeAsFloat("a11");
         _Mtrx[0][1] = (float)reader.getAttributeAsFloat("a12");
         _Mtrx[0][2] = (float)reader.getAttributeAsFloat("a13");
@@ -2542,7 +2601,7 @@ struct Fem::FemMesh::FemMeshInfo FemMesh::getInfo() const{
     return rtrn;
 
 }
-//    for(unsigned int i=0;i<all_elements.size();i++)
+//    for (unsigned int i = 0; i < all_elements.size(); i++)
 //        {
 //                // an consistent data structure is only possible
 //                // if the elements are added in the right order
@@ -2591,53 +2650,77 @@ Base::Quantity FemMesh::getVolume()const
 
 
         //1,5,8,7
-        a = v4 -v0 ;
-        b = v7 -v0 ;
-        c = v6 -v0 ;
-        a_b_product.x = a.y*b.z-b.y*a.z;a_b_product.y = a.z*b.x-b.z*a.x;a_b_product.z = a.x*b.y-b.x*a.y;
-        volume += 1.0/6.0 * fabs((a_b_product.x * c.x)+ (a_b_product.y * c.y)+(a_b_product.z * c.z));
+        a = v4 - v0;
+        b = v7 - v0;
+        c = v6 - v0;
+        a_b_product.x = a.y * b.z - b.y * a.z;
+        a_b_product.y = a.z * b.x - b.z * a.x;
+        a_b_product.z = a.x * b.y - b.x * a.y;
+        volume +=
+            1.0 / 6.0 * fabs((a_b_product.x * c.x) + (a_b_product.y * c.y) + (a_b_product.z * c.z));
         //5,9,8,7
-        a = v8 -v4 ;
-        b = v7 -v4 ;
-        c = v6 -v4 ;
-        a_b_product.x = a.y*b.z-b.y*a.z;a_b_product.y = a.z*b.x-b.z*a.x;a_b_product.z = a.x*b.y-b.x*a.y;
-        volume += 1.0/6.0 * fabs((a_b_product.x * c.x)+ (a_b_product.y * c.y)+(a_b_product.z * c.z));
+        a = v8 - v4;
+        b = v7 - v4;
+        c = v6 - v4;
+        a_b_product.x = a.y * b.z - b.y * a.z;
+        a_b_product.y = a.z * b.x - b.z * a.x;
+        a_b_product.z = a.x * b.y - b.x * a.y;
+        volume +=
+            1.0 / 6.0 * fabs((a_b_product.x * c.x) + (a_b_product.y * c.y) + (a_b_product.z * c.z));
         //5,2,9,7
-        a = v1 -v4 ;
-        b = v8 -v4 ;
-        c = v6 -v4 ;
-        a_b_product.x = a.y*b.z-b.y*a.z;a_b_product.y = a.z*b.x-b.z*a.x;a_b_product.z = a.x*b.y-b.x*a.y;
-        volume += 1.0/6.0 * fabs((a_b_product.x * c.x)+ (a_b_product.y * c.y)+(a_b_product.z * c.z));
+        a = v1 - v4;
+        b = v8 - v4;
+        c = v6 - v4;
+        a_b_product.x = a.y * b.z - b.y * a.z;
+        a_b_product.y = a.z * b.x - b.z * a.x;
+        a_b_product.z = a.x * b.y - b.x * a.y;
+        volume +=
+            1.0 / 6.0 * fabs((a_b_product.x * c.x) + (a_b_product.y * c.y) + (a_b_product.z * c.z));
         //2,6,9,7
-        a = v5 -v1 ;
-        b = v8 -v1 ;
-        c = v6 -v1 ;
-        a_b_product.x = a.y*b.z-b.y*a.z;a_b_product.y = a.z*b.x-b.z*a.x;a_b_product.z = a.x*b.y-b.x*a.y;
-        volume += 1.0/6.0 * fabs((a_b_product.x * c.x)+ (a_b_product.y * c.y)+(a_b_product.z * c.z));
+        a = v5 - v1;
+        b = v8 - v1;
+        c = v6 - v1;
+        a_b_product.x = a.y * b.z - b.y * a.z;
+        a_b_product.y = a.z * b.x - b.z * a.x;
+        a_b_product.z = a.x * b.y - b.x * a.y;
+        volume +=
+            1.0 / 6.0 * fabs((a_b_product.x * c.x) + (a_b_product.y * c.y) + (a_b_product.z * c.z));
         //9,6,10,7
-        a = v5 -v8 ;
-        b = v9 -v8 ;
-        c = v6 -v8 ;
-        a_b_product.x = a.y*b.z-b.y*a.z;a_b_product.y = a.z*b.x-b.z*a.x;a_b_product.z = a.x*b.y-b.x*a.y;
-        volume += 1.0/6.0 * fabs((a_b_product.x * c.x)+ (a_b_product.y * c.y)+(a_b_product.z * c.z));
+        a = v5 - v8;
+        b = v9 - v8;
+        c = v6 - v8;
+        a_b_product.x = a.y * b.z - b.y * a.z;
+        a_b_product.y = a.z * b.x - b.z * a.x;
+        a_b_product.z = a.x * b.y - b.x * a.y;
+        volume +=
+            1.0 / 6.0 * fabs((a_b_product.x * c.x) + (a_b_product.y * c.y) + (a_b_product.z * c.z));
         //6,3,10,7
-        a = v2 -v5 ;
-        b = v9 -v5 ;
-        c = v6 -v5 ;
-        a_b_product.x = a.y*b.z-b.y*a.z;a_b_product.y = a.z*b.x-b.z*a.x;a_b_product.z = a.x*b.y-b.x*a.y;
-        volume += 1.0/6.0 * fabs((a_b_product.x * c.x)+ (a_b_product.y * c.y)+(a_b_product.z * c.z));
+        a = v2 - v5;
+        b = v9 - v5;
+        c = v6 - v5;
+        a_b_product.x = a.y * b.z - b.y * a.z;
+        a_b_product.y = a.z * b.x - b.z * a.x;
+        a_b_product.z = a.x * b.y - b.x * a.y;
+        volume +=
+            1.0 / 6.0 * fabs((a_b_product.x * c.x) + (a_b_product.y * c.y) + (a_b_product.z * c.z));
         //8,9,10,7
-        a = v8 -v7 ;
-        b = v9 -v7 ;
-        c = v6 -v7 ;
-        a_b_product.x = a.y*b.z-b.y*a.z;a_b_product.y = a.z*b.x-b.z*a.x;a_b_product.z = a.x*b.y-b.x*a.y;
-        volume += 1.0/6.0 * fabs((a_b_product.x * c.x)+ (a_b_product.y * c.y)+(a_b_product.z * c.z));
+        a = v8 - v7;
+        b = v9 - v7;
+        c = v6 - v7;
+        a_b_product.x = a.y * b.z - b.y * a.z;
+        a_b_product.y = a.z * b.x - b.z * a.x;
+        a_b_product.z = a.x * b.y - b.x * a.y;
+        volume +=
+            1.0 / 6.0 * fabs((a_b_product.x * c.x) + (a_b_product.y * c.y) + (a_b_product.z * c.z));
         //8,9,10,4
-        a = v8 -v7 ;
-        b = v9 -v7 ;
-        c = v3 -v7 ;
-        a_b_product.x = a.y*b.z-b.y*a.z;a_b_product.y = a.z*b.x-b.z*a.x;a_b_product.z = a.x*b.y-b.x*a.y;
-        volume += 1.0/6.0 * fabs((a_b_product.x * c.x)+ (a_b_product.y * c.y)+(a_b_product.z * c.z));
+        a = v8 - v7;
+        b = v9 - v7;
+        c = v3 - v7;
+        a_b_product.x = a.y * b.z - b.y * a.z;
+        a_b_product.y = a.z * b.x - b.z * a.x;
+        a_b_product.z = a.x * b.y - b.x * a.y;
+        volume +=
+            1.0 / 6.0 * fabs((a_b_product.x * c.x) + (a_b_product.y * c.y) + (a_b_product.z * c.z));
 
     }
 
@@ -2671,7 +2754,8 @@ int FemMesh::addGroup(const std::string TypeString, const std::string Name, cons
             typeStringValid = true;
     }
     if (!typeStringValid)
-        throw std::runtime_error("AddGroup: Invalid type string! Allowed: All, Node, Edge, Face, Volume, 0DElement, Ball");
+        throw std::runtime_error("AddGroup: Invalid type string! Allowed: All, Node, Edge, Face, "
+                                 "Volume, 0DElement, Ball");
     // add group to mesh
     SMESH_Group* group = this->getSMesh()->AddGroup(mapping[TypeString], Name.c_str(), aId);
     if (!group)

--- a/src/Mod/Fem/App/FemMeshObject.cpp
+++ b/src/Mod/Fem/App/FemMeshObject.cpp
@@ -39,7 +39,8 @@ PROPERTY_SOURCE(Fem::FemMeshObject, App::GeoFeature)
 FemMeshObject::FemMeshObject()
 {
     ADD_PROPERTY_TYPE(FemMesh,(), "FEM Mesh",Prop_NoRecompute,"FEM Mesh object");
-    // in the regard of recomputes see: https://forum.freecadweb.org/viewtopic.php?f=18&t=33329#p279203
+    // in the regard of recomputes see:
+    // https://forum.freecadweb.org/viewtopic.php?f=18&t=33329#p279203
 }
 
 FemMeshObject::~FemMeshObject()

--- a/src/Mod/Fem/App/FemPostFilter.cpp
+++ b/src/Mod/Fem/App/FemPostFilter.cpp
@@ -91,15 +91,18 @@ DocumentObjectExecReturn* FemPostFilter::execute() {
 vtkDataObject* FemPostFilter::getInputData() {
 
     if (Input.getValue()) {
-        if (Input.getValue()->getTypeId().isDerivedFrom(Base::Type::fromName("Fem::FemPostObject")) )
+        if (Input.getValue()->getTypeId().isDerivedFrom(Base::Type::fromName("Fem::FemPostObject")))
             return Input.getValue<FemPostObject*>()->Data.getValue();
         else
-            throw std::runtime_error("The filter's Input object is not a 'Fem::FemPostObject' object!");
+            throw std::runtime_error(
+                "The filter's Input object is not a 'Fem::FemPostObject' object!");
     }
     else {
         //get the pipeline and use the pipelinedata
-        std::vector<App::DocumentObject*> objs = getDocument()->getObjectsOfType(FemPostPipeline::getClassTypeId());
-        for (std::vector<App::DocumentObject*>::iterator it = objs.begin(); it != objs.end(); ++it) {
+        std::vector<App::DocumentObject*> objs =
+            getDocument()->getObjectsOfType(FemPostPipeline::getClassTypeId());
+        for (std::vector<App::DocumentObject*>::iterator it = objs.begin(); it != objs.end();
+             ++it) {
             if (static_cast<FemPostPipeline*>(*it)->holdsPostObject(this))
                 return static_cast<FemPostObject*>(*it)->Data.getValue();
         }
@@ -115,9 +118,18 @@ PROPERTY_SOURCE(Fem::FemPostClipFilter, Fem::FemPostFilter)
 
 FemPostClipFilter::FemPostClipFilter() : FemPostFilter() {
 
-    ADD_PROPERTY_TYPE(Function, (nullptr), "Clip", App::Prop_None, "The function object which defines the clip regions");
+    ADD_PROPERTY_TYPE(Function,
+                      (nullptr),
+                      "Clip",
+                      App::Prop_None,
+                      "The function object which defines the clip regions");
     ADD_PROPERTY_TYPE(InsideOut, (false), "Clip", App::Prop_None, "Invert the clip direction");
-    ADD_PROPERTY_TYPE(CutCells, (false), "Clip", App::Prop_None, "Decides if cells are cuttet and interpolated or if the cells are kept as a whole");
+    ADD_PROPERTY_TYPE(
+        CutCells,
+        (false),
+        "Clip",
+        App::Prop_None,
+        "Decides if cells are cuttet and interpolated or if the cells are kept as a whole");
 
     FilterPipeline clip;
     m_clipper  = vtkSmartPointer<vtkTableBasedClipDataSet>::New();
@@ -143,9 +155,12 @@ void FemPostClipFilter::onChanged(const Property* prop) {
 
     if (prop == &Function) {
 
-        if (Function.getValue() && Function.getValue()->isDerivedFrom(FemPostFunction::getClassTypeId())) {
-            m_clipper->SetClipFunction(static_cast<FemPostFunction*>(Function.getValue())->getImplicitFunction());
-            m_extractor->SetImplicitFunction(static_cast<FemPostFunction*>(Function.getValue())->getImplicitFunction());
+        if (Function.getValue()
+            && Function.getValue()->isDerivedFrom(FemPostFunction::getClassTypeId())) {
+            m_clipper->SetClipFunction(
+                static_cast<FemPostFunction*>(Function.getValue())->getImplicitFunction());
+            m_extractor->SetImplicitFunction(
+                static_cast<FemPostFunction*>(Function.getValue())->getImplicitFunction());
         }
     }
     else if (prop == &InsideOut) {
@@ -190,11 +205,25 @@ PROPERTY_SOURCE(Fem::FemPostDataAlongLineFilter, Fem::FemPostFilter)
 
 FemPostDataAlongLineFilter::FemPostDataAlongLineFilter() : FemPostFilter() {
 
-    ADD_PROPERTY_TYPE(Point1, (Base::Vector3d(0.0, 0.0, 0.0)), "DataAlongLine", App::Prop_None, "The point 1 used to define end point of line");
-    ADD_PROPERTY_TYPE(Point2, (Base::Vector3d(0.0, 0.0, 1.0)), "DataAlongLine", App::Prop_None, "The point 2 used to define end point of line");
-    ADD_PROPERTY_TYPE(Resolution, (100), "DataAlongLine", App::Prop_None, "The number of intervals between the 2 end points of line");
-    ADD_PROPERTY_TYPE(XAxisData, (0), "DataAlongLine", App::Prop_None, "X axis data values used for plotting");
-    ADD_PROPERTY_TYPE(YAxisData, (0), "DataAlongLine", App::Prop_None, "Y axis data values used for plotting");
+    ADD_PROPERTY_TYPE(Point1,
+                      (Base::Vector3d(0.0, 0.0, 0.0)),
+                      "DataAlongLine",
+                      App::Prop_None,
+                      "The point 1 used to define end point of line");
+    ADD_PROPERTY_TYPE(Point2,
+                      (Base::Vector3d(0.0, 0.0, 1.0)),
+                      "DataAlongLine",
+                      App::Prop_None,
+                      "The point 2 used to define end point of line");
+    ADD_PROPERTY_TYPE(Resolution,
+                      (100),
+                      "DataAlongLine",
+                      App::Prop_None,
+                      "The number of intervals between the 2 end points of line");
+    ADD_PROPERTY_TYPE(
+        XAxisData, (0), "DataAlongLine", App::Prop_None, "X axis data values used for plotting");
+    ADD_PROPERTY_TYPE(
+        YAxisData, (0), "DataAlongLine", App::Prop_None, "Y axis data values used for plotting");
     ADD_PROPERTY_TYPE(PlotData, (""), "DataAlongLine", App::Prop_None, "Field used for plotting");
 
     PlotData.setStatus(App::Property::ReadOnly, true);
@@ -239,7 +268,9 @@ DocumentObjectExecReturn* FemPostDataAlongLineFilter::execute() {
     return Fem::FemPostFilter::execute();
 }
 
-void FemPostDataAlongLineFilter::handleChangedPropertyType(Base::XMLReader& reader, const char* TypeName, App::Property* prop)
+void FemPostDataAlongLineFilter::handleChangedPropertyType(Base::XMLReader& reader,
+                                                           const char* TypeName,
+                                                           App::Property* prop)
 // transforms properties that had been changed
 {
     // property Point1 had the App::PropertyVector and was changed to App::PropertyVectorDistance
@@ -337,8 +368,13 @@ PROPERTY_SOURCE(Fem::FemPostDataAtPointFilter, Fem::FemPostFilter)
 
 FemPostDataAtPointFilter::FemPostDataAtPointFilter() : FemPostFilter() {
 
-    ADD_PROPERTY_TYPE(Center, (Base::Vector3d(0.0, 0.0, 0.0)), "DataAtPoint", App::Prop_None, "Center of the point");
-    ADD_PROPERTY_TYPE(Radius, (0), "DataAtPoint", App::Prop_None, "Radius around the point (unused)");
+    ADD_PROPERTY_TYPE(Center,
+                      (Base::Vector3d(0.0, 0.0, 0.0)),
+                      "DataAtPoint",
+                      App::Prop_None,
+                      "Center of the point");
+    ADD_PROPERTY_TYPE(
+        Radius, (0), "DataAtPoint", App::Prop_None, "Radius around the point (unused)");
     ADD_PROPERTY_TYPE(PointData, (0), "DataAtPoint", App::Prop_None, "Point data values");
     ADD_PROPERTY_TYPE(FieldName, (""), "DataAtPoint", App::Prop_None, "Field used for plotting");
     ADD_PROPERTY_TYPE(Unit, (""), "DataAtPoint", App::Prop_None, "Unit used for the field");
@@ -436,7 +472,8 @@ PROPERTY_SOURCE(Fem::FemPostScalarClipFilter, Fem::FemPostFilter)
 
 FemPostScalarClipFilter::FemPostScalarClipFilter() : FemPostFilter() {
 
-    ADD_PROPERTY_TYPE(Value, (0), "Clip", App::Prop_None, "The scalar value used to clip the selected field");
+    ADD_PROPERTY_TYPE(
+        Value, (0), "Clip", App::Prop_None, "The scalar value used to clip the selected field");
     ADD_PROPERTY_TYPE(Scalars, (long(0)), "Clip", App::Prop_None, "The field used to clip");
     ADD_PROPERTY_TYPE(InsideOut, (false), "Clip", App::Prop_None, "Invert the clip direction");
 
@@ -544,8 +581,13 @@ PROPERTY_SOURCE(Fem::FemPostWarpVectorFilter, Fem::FemPostFilter)
 
 FemPostWarpVectorFilter::FemPostWarpVectorFilter() : FemPostFilter() {
 
-    ADD_PROPERTY_TYPE(Factor, (0), "Warp", App::Prop_None, "The factor by which the vector is added to the node positions");
-    ADD_PROPERTY_TYPE(Vector, (long(0)), "Warp", App::Prop_None, "The field added to the node position");
+    ADD_PROPERTY_TYPE(Factor,
+                      (0),
+                      "Warp",
+                      App::Prop_None,
+                      "The factor by which the vector is added to the node positions");
+    ADD_PROPERTY_TYPE(
+        Vector, (long(0)), "Warp", App::Prop_None, "The field added to the node position");
 
     FilterPipeline warp;
     m_warp      = vtkSmartPointer<vtkWarpVector>::New();
@@ -623,7 +665,11 @@ PROPERTY_SOURCE(Fem::FemPostCutFilter, Fem::FemPostFilter)
 
 FemPostCutFilter::FemPostCutFilter() : FemPostFilter() {
 
-    ADD_PROPERTY_TYPE(Function, (nullptr), "Cut", App::Prop_None, "The function object which defines the clip cut function");
+    ADD_PROPERTY_TYPE(Function,
+                      (nullptr),
+                      "Cut",
+                      App::Prop_None,
+                      "The function object which defines the clip cut function");
 
     FilterPipeline clip;
     m_cutter    = vtkSmartPointer<vtkCutter>::New();

--- a/src/Mod/Fem/App/FemPostFilter.h
+++ b/src/Mod/Fem/App/FemPostFilter.h
@@ -122,7 +122,8 @@ public:
 protected:
     App::DocumentObjectExecReturn* execute() override;
     void onChanged(const App::Property* prop) override;
-    void handleChangedPropertyType(Base::XMLReader& reader, const char* TypeName, App::Property* prop) override;
+    void handleChangedPropertyType(Base::XMLReader& reader, const char* TypeName,
+                                   App::Property* prop) override;
 
 private:
 

--- a/src/Mod/Fem/App/FemPostObject.cpp
+++ b/src/Mod/Fem/App/FemPostObject.cpp
@@ -37,7 +37,7 @@ PROPERTY_SOURCE(Fem::FemPostObject, App::GeoFeature)
 
 FemPostObject::FemPostObject()
 {
-    ADD_PROPERTY(Data,(nullptr));
+    ADD_PROPERTY(Data, (nullptr));
 }
 
 FemPostObject::~FemPostObject()
@@ -48,10 +48,10 @@ vtkBoundingBox FemPostObject::getBoundingBox() {
 
     vtkBoundingBox box;
 
-    if(Data.getValue() && Data.getValue()->IsA("vtkDataSet"))
+    if (Data.getValue() && Data.getValue()->IsA("vtkDataSet"))
         box.AddBounds(vtkDataSet::SafeDownCast(Data.getValue())->GetBounds());
 
-    //TODO: add calculation of multiblock and Multipiece datasets
+    // TODO: add calculation of multiblock and Multipiece datasets
 
     return box;
 }

--- a/src/Mod/Fem/App/FemPostObject.h
+++ b/src/Mod/Fem/App/FemPostObject.h
@@ -32,7 +32,8 @@
 namespace Fem
 {
 
-//poly data is the only data we can visualize, hence every post processing object needs to expose it
+// poly data is the only data we can visualize, hence every post
+// processing object needs to expose it
 class FemExport FemPostObject : public App::GeoFeature
 {
     PROPERTY_HEADER_WITH_OVERRIDE(Fem::FemPostObject);

--- a/src/Mod/Fem/App/FemPostPipeline.cpp
+++ b/src/Mod/Fem/App/FemPostPipeline.cpp
@@ -55,12 +55,21 @@ const char* FemPostPipeline::ModeEnums[] = { "Serial", "Parallel", "Custom", nul
 
 FemPostPipeline::FemPostPipeline()
 {
-    ADD_PROPERTY_TYPE(Filter, (nullptr), "Pipeline", App::Prop_None, "The filter used in this pipeline");
-    ADD_PROPERTY_TYPE(Functions, (nullptr), "Pipeline", App::Prop_Hidden, "The function provider which groups all pipeline functions");
-    ADD_PROPERTY_TYPE(Mode, (long(2)), "Pipeline", App::Prop_None, "Selects the pipeline data transition mode.\n"
-        "In serial, every filter gets the output of the previous one as input.\n"
-        "In parallel, every filter gets the pipeline source as input.\n"
-        "In custom, every filter keeps its input set by the user.");
+    ADD_PROPERTY_TYPE(
+        Filter, (nullptr), "Pipeline", App::Prop_None, "The filter used in this pipeline");
+    ADD_PROPERTY_TYPE(Functions,
+                      (nullptr),
+                      "Pipeline",
+                      App::Prop_Hidden,
+                      "The function provider which groups all pipeline functions");
+    ADD_PROPERTY_TYPE(Mode,
+                      (long(2)),
+                      "Pipeline",
+                      App::Prop_None,
+                      "Selects the pipeline data transition mode.\n"
+                      "In serial, every filter gets the output of the previous one as input.\n"
+                      "In parallel, every filter gets the pipeline source as input.\n"
+                      "In custom, every filter keeps its input set by the user.");
     Mode.setEnums(ModeEnums);
 }
 
@@ -78,20 +87,21 @@ short FemPostPipeline::mustExecute() const
 
 DocumentObjectExecReturn* FemPostPipeline::execute() {
 
-    //if we are the toplevel pipeline our data object is not created by filters, we are the main source
+    // if we are the toplevel pipeline our data object is not created by filters,
+    // we are the main source
     if (!Input.getValue())
         return StdReturn;
 
-    //now if we are a filter than our data object is created by the filter we hold
+    // now if we are a filter than our data object is created by the filter we hold
 
-    //if we are in serial mode we just copy over the data of the last filter,
-    //but if we are in parallel we need to combine all filter results
+    // if we are in serial mode we just copy over the data of the last filter,
+    // but if we are in parallel we need to combine all filter results
     if (Mode.getValue() == 0) {
         //serial
         Data.setValue(getLastPostObject()->Data.getValue());
     }
     else if (Mode.getValue() == 1) {
-        //parallel, go through all filters and append the result
+        // parallel, go through all filters and append the result
         const std::vector<App::DocumentObject*>& filters = Filter.getValues();
         std::vector<App::DocumentObject*>::const_iterator it = filters.begin();
 
@@ -162,7 +172,7 @@ void FemPostPipeline::onChanged(const Property* prop)
         if (Mode.getValue() == 2) // custom
             return;
 
-        //we check if all connections are right and add new ones if needed
+        // we check if all connections are right and add new ones if needed
         std::vector<App::DocumentObject*> objs = Filter.getValues();
 
         if (objs.empty())
@@ -171,14 +181,15 @@ void FemPostPipeline::onChanged(const Property* prop)
         std::vector<App::DocumentObject*>::iterator it = objs.begin();
         FemPostFilter* filter = static_cast<FemPostFilter*>(*it);
 
-        //If we have a Input we need to ensure our filters are connected correctly
+        // If we have a Input we need to ensure our filters are connected correctly
         if (Input.getValue()) {
 
-            //the first filter is always connected to the input
+            // the first filter is always connected to the input
             if (filter->Input.getValue() != Input.getValue())
                 filter->Input.setValue(Input.getValue());
 
-            //all the others need to be connected to the previous filter or the source, dependent on the mode
+            // all the others need to be connected to the previous filter or the source,
+            // dependent on the mode
             ++it;
             for (; it != objs.end(); ++it) {
                 FemPostFilter* nextFilter = static_cast<FemPostFilter*>(*it);
@@ -195,13 +206,14 @@ void FemPostPipeline::onChanged(const Property* prop)
                 filter = nextFilter;
             };
         }
-        //if we have no input the filters are responsible of grabbing the pipeline data themself
+        // if we have no input the filters are responsible of grabbing the pipeline data themself
         else {
-            //the first filter must always grab the data
+            // the first filter must always grab the data
             if (filter->Input.getValue())
                 filter->Input.setValue(nullptr);
 
-            //all the others need to be connected to the previous filter or grab the data, dependent on mode
+            // all the others need to be connected to the previous filter or grab the data,
+            // dependent on mode
             ++it;
             for (; it != objs.end(); ++it) {
                 FemPostFilter* nextFilter = static_cast<FemPostFilter*>(*it);
@@ -259,13 +271,13 @@ void FemPostPipeline::load(FemResultObject* res) {
         return;
     }
 
-    //first copy the mesh over
+    // first copy the mesh over
     // ***************************
     const FemMesh& mesh = static_cast<FemMeshObject*>(res->Mesh.getValue())->FemMesh.getValue();
     vtkSmartPointer<vtkUnstructuredGrid> grid = vtkSmartPointer<vtkUnstructuredGrid>::New();
     FemVTKTools::exportVTKMesh(&mesh, grid);
 
-    //Now copy the point data over
+    // Now copy the point data over
     // ***************************
     FemVTKTools::exportFreeCADResult(res, grid);
 

--- a/src/Mod/Fem/App/FemVTKTools.cpp
+++ b/src/Mod/Fem/App/FemVTKTools.cpp
@@ -86,7 +86,8 @@ template<class TReader> vtkDataSet* readVTKFile(const char*fileName)
     return vtkDataSet::SafeDownCast(output);
 }
 
-template<class TWriter> void writeVTKFile(const char* filename, vtkSmartPointer<vtkUnstructuredGrid> dataset)
+template<class TWriter>
+void writeVTKFile(const char* filename, vtkSmartPointer<vtkUnstructuredGrid> dataset)
 {
     vtkSmartPointer<TWriter> writer =
       vtkSmartPointer<TWriter>::New();
@@ -103,7 +104,8 @@ void FemVTKTools::importVTKMesh(vtkSmartPointer<vtkDataSet> dataset, FemMesh* me
     Base::Console().Log("%d nodes/points and %d cells/elements found!\n", nPoints, nCells);
     Base::Console().Log("Build SMESH mesh out of the vtk mesh data.\n", nPoints, nCells);
 
-    //vtkSmartPointer<vtkCellArray> cells = dataset->GetCells();  // works only for vtkUnstructuredGrid
+    //vtkSmartPointer<vtkCellArray> cells = dataset->GetCells();
+                                            // works only for vtkUnstructuredGrid
     vtkSmartPointer<vtkIdList> idlist= vtkSmartPointer<vtkIdList>::New();
 
     //Now fill the SMESH datastructure
@@ -111,71 +113,148 @@ void FemVTKTools::importVTKMesh(vtkSmartPointer<vtkDataSet> dataset, FemMesh* me
     SMESHDS_Mesh* meshds = smesh->GetMeshDS();
     meshds->ClearMesh();
 
-    for(vtkIdType i=0; i<nPoints; i++)
-    {
+    for (vtkIdType i = 0; i < nPoints; i++) {
         double* p = dataset->GetPoint(i);
-        meshds->AddNodeWithID(p[0]*scale, p[1]*scale, p[2]*scale, i+1);
+        meshds->AddNodeWithID(p[0] * scale, p[1] * scale, p[2] * scale, i + 1);
     }
 
-    for(vtkIdType iCell=0; iCell<nCells; iCell++)
-    {
+    for (vtkIdType iCell = 0; iCell < nCells; iCell++) {
         idlist->Reset();
         idlist = dataset->GetCell(iCell)->GetPointIds();
-        vtkIdType *ids = idlist->GetPointer(0);
-        switch(dataset->GetCellType(iCell))
-        {
+        vtkIdType* ids = idlist->GetPointer(0);
+        switch (dataset->GetCellType(iCell)) {
             // 2D faces
-            case VTK_TRIANGLE:  // tria3
-                meshds->AddFaceWithID(ids[0]+1, ids[1]+1, ids[2]+1, iCell+1);
+            case VTK_TRIANGLE:// tria3
+                meshds->AddFaceWithID(ids[0] + 1, ids[1] + 1, ids[2] + 1, iCell + 1);
                 break;
-            case VTK_QUADRATIC_TRIANGLE:  // tria6
-                meshds->AddFaceWithID(ids[0]+1, ids[1]+1, ids[2]+1, ids[3]+1, ids[4]+1, ids[5]+1, iCell+1);
+            case VTK_QUADRATIC_TRIANGLE:// tria6
+                meshds->AddFaceWithID(ids[0] + 1,
+                                      ids[1] + 1,
+                                      ids[2] + 1,
+                                      ids[3] + 1,
+                                      ids[4] + 1,
+                                      ids[5] + 1,
+                                      iCell + 1);
                 break;
-            case VTK_QUAD:  // quad4
-                meshds->AddFaceWithID(ids[0]+1, ids[1]+1, ids[2]+1, ids[3]+1, iCell+1);
+            case VTK_QUAD:// quad4
+                meshds->AddFaceWithID(ids[0] + 1, ids[1] + 1, ids[2] + 1, ids[3] + 1, iCell + 1);
                 break;
-            case VTK_QUADRATIC_QUAD:  // quad8
-                meshds->AddFaceWithID(ids[0]+1, ids[1]+1, ids[2]+1, ids[3]+1, ids[4]+1, ids[5]+1, ids[6]+1, ids[7]+1, iCell+1);
+            case VTK_QUADRATIC_QUAD:// quad8
+                meshds->AddFaceWithID(ids[0] + 1,
+                                      ids[1] + 1,
+                                      ids[2] + 1,
+                                      ids[3] + 1,
+                                      ids[4] + 1,
+                                      ids[5] + 1,
+                                      ids[6] + 1,
+                                      ids[7] + 1,
+                                      iCell + 1);
                 break;
 
             // 3D volumes
-            case VTK_TETRA:  // tetra4
-                meshds->AddVolumeWithID(ids[0]+1, ids[1]+1, ids[2]+1, ids[3]+1, iCell+1);
+            case VTK_TETRA:// tetra4
+                meshds->AddVolumeWithID(ids[0] + 1, ids[1] + 1, ids[2] + 1, ids[3] + 1, iCell + 1);
                 break;
-            case VTK_QUADRATIC_TETRA:  // tetra10
-                meshds->AddVolumeWithID(ids[0]+1, ids[1]+1, ids[2]+1, ids[3]+1, ids[4]+1, ids[5]+1, ids[6]+1, ids[7]+1, ids[8]+1, ids[9]+1, iCell+1);
+            case VTK_QUADRATIC_TETRA:// tetra10
+                meshds->AddVolumeWithID(ids[0] + 1,
+                                        ids[1] + 1,
+                                        ids[2] + 1,
+                                        ids[3] + 1,
+                                        ids[4] + 1,
+                                        ids[5] + 1,
+                                        ids[6] + 1,
+                                        ids[7] + 1,
+                                        ids[8] + 1,
+                                        ids[9] + 1,
+                                        iCell + 1);
                 break;
-            case VTK_HEXAHEDRON:  // hexa8
-                meshds->AddVolumeWithID(ids[0]+1, ids[1]+1, ids[2]+1, ids[3]+1, ids[4]+1, ids[5]+1, ids[6]+1, ids[7]+1, iCell+1);
+            case VTK_HEXAHEDRON:// hexa8
+                meshds->AddVolumeWithID(ids[0] + 1,
+                                        ids[1] + 1,
+                                        ids[2] + 1,
+                                        ids[3] + 1,
+                                        ids[4] + 1,
+                                        ids[5] + 1,
+                                        ids[6] + 1,
+                                        ids[7] + 1,
+                                        iCell + 1);
                 break;
-            case VTK_QUADRATIC_HEXAHEDRON:  // hexa20
-                meshds->AddVolumeWithID(ids[0]+1, ids[1]+1, ids[2]+1, ids[3]+1, ids[4]+1, ids[5]+1, ids[6]+1, ids[7]+1, ids[8]+1, ids[9]+1,\
-                                        ids[10]+1, ids[11]+1, ids[12]+1, ids[13]+1, ids[14]+1, ids[15]+1, ids[16]+1, ids[17]+1, ids[18]+1, ids[19]+1,\
-                                        iCell+1);
+            case VTK_QUADRATIC_HEXAHEDRON:// hexa20
+                meshds->AddVolumeWithID(ids[0] + 1,
+                                        ids[1] + 1,
+                                        ids[2] + 1,
+                                        ids[3] + 1,
+                                        ids[4] + 1,
+                                        ids[5] + 1,
+                                        ids[6] + 1,
+                                        ids[7] + 1,
+                                        ids[8] + 1,
+                                        ids[9] + 1,
+                                        ids[10] + 1,
+                                        ids[11] + 1,
+                                        ids[12] + 1,
+                                        ids[13] + 1,
+                                        ids[14] + 1,
+                                        ids[15] + 1,
+                                        ids[16] + 1,
+                                        ids[17] + 1,
+                                        ids[18] + 1,
+                                        ids[19] + 1,
+                                        iCell + 1);
                 break;
-            case VTK_WEDGE:  // penta6
-                meshds->AddVolumeWithID(ids[0]+1, ids[1]+1, ids[2]+1, ids[3]+1, ids[4]+1, ids[5]+1, iCell+1);
+            case VTK_WEDGE:// penta6
+                meshds->AddVolumeWithID(ids[0] + 1,
+                                        ids[1] + 1,
+                                        ids[2] + 1,
+                                        ids[3] + 1,
+                                        ids[4] + 1,
+                                        ids[5] + 1,
+                                        iCell + 1);
                 break;
-            case VTK_QUADRATIC_WEDGE:  // penta15
-                meshds->AddVolumeWithID(ids[0]+1, ids[1]+1, ids[2]+1, ids[3]+1, ids[4]+1, ids[5]+1, ids[6]+1, ids[7]+1, ids[8]+1, ids[9]+1,\
-                                        ids[10]+1, ids[11]+1, ids[12]+1, ids[13]+1, ids[14]+1,\
-                                        iCell+1);
+            case VTK_QUADRATIC_WEDGE:// penta15
+                meshds->AddVolumeWithID(ids[0] + 1,
+                                        ids[1] + 1,
+                                        ids[2] + 1,
+                                        ids[3] + 1,
+                                        ids[4] + 1,
+                                        ids[5] + 1,
+                                        ids[6] + 1,
+                                        ids[7] + 1,
+                                        ids[8] + 1,
+                                        ids[9] + 1,
+                                        ids[10] + 1,
+                                        ids[11] + 1,
+                                        ids[12] + 1,
+                                        ids[13] + 1,
+                                        ids[14] + 1,
+                                        iCell + 1);
                 break;
-            case VTK_PYRAMID:  // pyra5
-                meshds->AddVolumeWithID(ids[0]+1, ids[1]+1, ids[2]+1, ids[3]+1, ids[4]+1, iCell+1);
+            case VTK_PYRAMID:// pyra5
+                meshds->AddVolumeWithID(
+                    ids[0] + 1, ids[1] + 1, ids[2] + 1, ids[3] + 1, ids[4] + 1, iCell + 1);
                 break;
-            case VTK_QUADRATIC_PYRAMID:  // pyra13
-                meshds->AddVolumeWithID(ids[0]+1, ids[1]+1, ids[2]+1, ids[3]+1, ids[4]+1, ids[5]+1, ids[6]+1, ids[7]+1, ids[8]+1, ids[9]+1,\
-                                        ids[10]+1, ids[11]+1, ids[12]+1,\
-                                        iCell+1);
+            case VTK_QUADRATIC_PYRAMID:// pyra13
+                meshds->AddVolumeWithID(ids[0] + 1,
+                                        ids[1] + 1,
+                                        ids[2] + 1,
+                                        ids[3] + 1,
+                                        ids[4] + 1,
+                                        ids[5] + 1,
+                                        ids[6] + 1,
+                                        ids[7] + 1,
+                                        ids[8] + 1,
+                                        ids[9] + 1,
+                                        ids[10] + 1,
+                                        ids[11] + 1,
+                                        ids[12] + 1,
+                                        iCell + 1);
                 break;
 
             // not handled cases
-            default:
-            {
-                Base::Console().Error("Only common 2D and 3D Cells are supported in VTK mesh import\n");
+            default: {
+                Base::Console().Error(
+                    "Only common 2D and 3D Cells are supported in VTK mesh import\n");
                 break;
-
             }
         }
     }
@@ -187,9 +266,8 @@ FemMesh* FemVTKTools::readVTKMesh(const char* filename, FemMesh* mesh)
     Base::Console().Log("Start: read FemMesh from VTK unstructuredGrid ======================\n");
     Base::FileInfo f(filename);
 
-    if(f.hasExtension("vtu"))
-    {
-        vtkSmartPointer<vtkDataSet> dataset  = readVTKFile<vtkXMLUnstructuredGridReader>(filename);
+    if (f.hasExtension("vtu")) {
+        vtkSmartPointer<vtkDataSet> dataset = readVTKFile<vtkXMLUnstructuredGridReader>(filename);
         if (!dataset.Get()) {
             Base::Console().Error("Failed to load file %s\n", filename);
             return nullptr;
@@ -204,8 +282,7 @@ FemMesh* FemVTKTools::readVTKMesh(const char* filename, FemMesh* mesh)
         }
         importVTKMesh(dataset, mesh);
     }
-    else if(f.hasExtension("vtk"))
-    {
+    else if (f.hasExtension("vtk")) {
         vtkSmartPointer<vtkDataSet> dataset = readVTKFile<vtkDataSetReader>(filename);
         if (!dataset.Get()) {
             Base::Console().Error("Failed to load file %s\n", filename);
@@ -213,18 +290,18 @@ FemMesh* FemVTKTools::readVTKMesh(const char* filename, FemMesh* mesh)
         }
         importVTKMesh(dataset, mesh);
     }
-    else
-    {
+    else {
         Base::Console().Error("file name extension is not supported\n");
         return nullptr;
     }
     //Mesh should link to the part feature, in order to set up FemConstraint
 
-    Base::Console().Log("    %f: Done \n",Base::TimeInfo::diffTimeF(Start,Base::TimeInfo()));
+    Base::Console().Log("    %f: Done \n", Base::TimeInfo::diffTimeF(Start, Base::TimeInfo()));
     return mesh;
 }
 
-void exportFemMeshFaces(vtkSmartPointer<vtkUnstructuredGrid> grid, const SMDS_FaceIteratorPtr& aFaceIter)
+void exportFemMeshFaces(vtkSmartPointer<vtkUnstructuredGrid> grid,
+                        const SMDS_FaceIteratorPtr& aFaceIter)
 {
     Base::Console().Log("  Start: VTK mesh builder faces.\n");
 
@@ -238,74 +315,71 @@ void exportFemMeshFaces(vtkSmartPointer<vtkUnstructuredGrid> grid, const SMDS_Fa
         const SMDS_MeshFace* aFace = aFaceIter->next();
 
         //triangle
-        if(aFace->NbNodes() == 3)
-        {
+        if (aFace->NbNodes() == 3) {
             vtkSmartPointer<vtkTriangle> tria = vtkSmartPointer<vtkTriangle>::New();
-            tria->GetPointIds()->SetId(0, aFace->GetNode(0)->GetID()-1);
-            tria->GetPointIds()->SetId(1, aFace->GetNode(1)->GetID()-1);
-            tria->GetPointIds()->SetId(2, aFace->GetNode(2)->GetID()-1);
+            tria->GetPointIds()->SetId(0, aFace->GetNode(0)->GetID() - 1);
+            tria->GetPointIds()->SetId(1, aFace->GetNode(1)->GetID() - 1);
+            tria->GetPointIds()->SetId(2, aFace->GetNode(2)->GetID() - 1);
 
             triangleArray->InsertNextCell(tria);
         }
         //quad
-        else if(aFace->NbNodes() == 4)
-        {
+        else if (aFace->NbNodes() == 4) {
             vtkSmartPointer<vtkQuad> quad = vtkSmartPointer<vtkQuad>::New();
-            quad->GetPointIds()->SetId(0, aFace->GetNode(0)->GetID()-1);
-            quad->GetPointIds()->SetId(1, aFace->GetNode(1)->GetID()-1);
-            quad->GetPointIds()->SetId(2, aFace->GetNode(2)->GetID()-1);
-            quad->GetPointIds()->SetId(3, aFace->GetNode(3)->GetID()-1);
+            quad->GetPointIds()->SetId(0, aFace->GetNode(0)->GetID() - 1);
+            quad->GetPointIds()->SetId(1, aFace->GetNode(1)->GetID() - 1);
+            quad->GetPointIds()->SetId(2, aFace->GetNode(2)->GetID() - 1);
+            quad->GetPointIds()->SetId(3, aFace->GetNode(3)->GetID() - 1);
 
             quadArray->InsertNextCell(quad);
         }
         //quadratic triangle
-        else if (aFace->NbNodes() == 6)
-        {
-            vtkSmartPointer<vtkQuadraticTriangle> tria = vtkSmartPointer<vtkQuadraticTriangle>::New();
-            tria->GetPointIds()->SetId(0, aFace->GetNode(0)->GetID()-1);
-            tria->GetPointIds()->SetId(1, aFace->GetNode(1)->GetID()-1);
-            tria->GetPointIds()->SetId(2, aFace->GetNode(2)->GetID()-1);
-            tria->GetPointIds()->SetId(3, aFace->GetNode(3)->GetID()-1);
-            tria->GetPointIds()->SetId(4, aFace->GetNode(4)->GetID()-1);
-            tria->GetPointIds()->SetId(5, aFace->GetNode(5)->GetID()-1);
+        else if (aFace->NbNodes() == 6) {
+            vtkSmartPointer<vtkQuadraticTriangle> tria =
+                vtkSmartPointer<vtkQuadraticTriangle>::New();
+            tria->GetPointIds()->SetId(0, aFace->GetNode(0)->GetID() - 1);
+            tria->GetPointIds()->SetId(1, aFace->GetNode(1)->GetID() - 1);
+            tria->GetPointIds()->SetId(2, aFace->GetNode(2)->GetID() - 1);
+            tria->GetPointIds()->SetId(3, aFace->GetNode(3)->GetID() - 1);
+            tria->GetPointIds()->SetId(4, aFace->GetNode(4)->GetID() - 1);
+            tria->GetPointIds()->SetId(5, aFace->GetNode(5)->GetID() - 1);
             quadTriangleArray->InsertNextCell(tria);
         }
         //quadratic quad
-        else if(aFace->NbNodes() == 8)
-        {
+        else if (aFace->NbNodes() == 8) {
             vtkSmartPointer<vtkQuadraticQuad> quad = vtkSmartPointer<vtkQuadraticQuad>::New();
-            quad->GetPointIds()->SetId(0, aFace->GetNode(0)->GetID()-1);
-            quad->GetPointIds()->SetId(1, aFace->GetNode(1)->GetID()-1);
-            quad->GetPointIds()->SetId(2, aFace->GetNode(2)->GetID()-1);
-            quad->GetPointIds()->SetId(3, aFace->GetNode(3)->GetID()-1);
-            quad->GetPointIds()->SetId(4, aFace->GetNode(4)->GetID()-1);
-            quad->GetPointIds()->SetId(5, aFace->GetNode(5)->GetID()-1);
-            quad->GetPointIds()->SetId(6, aFace->GetNode(6)->GetID()-1);
-            quad->GetPointIds()->SetId(7, aFace->GetNode(7)->GetID()-1);
+            quad->GetPointIds()->SetId(0, aFace->GetNode(0)->GetID() - 1);
+            quad->GetPointIds()->SetId(1, aFace->GetNode(1)->GetID() - 1);
+            quad->GetPointIds()->SetId(2, aFace->GetNode(2)->GetID() - 1);
+            quad->GetPointIds()->SetId(3, aFace->GetNode(3)->GetID() - 1);
+            quad->GetPointIds()->SetId(4, aFace->GetNode(4)->GetID() - 1);
+            quad->GetPointIds()->SetId(5, aFace->GetNode(5)->GetID() - 1);
+            quad->GetPointIds()->SetId(6, aFace->GetNode(6)->GetID() - 1);
+            quad->GetPointIds()->SetId(7, aFace->GetNode(7)->GetID() - 1);
 
             quadQuadArray->InsertNextCell(quad);
         }
-        else
-        {
+        else {
             throw std::runtime_error("Face not yet supported by FreeCAD's VTK mesh builder\n");
         }
     }
-    if(triangleArray->GetNumberOfCells()>0)
-       grid->SetCells(VTK_TRIANGLE, triangleArray);
+    if (triangleArray->GetNumberOfCells() > 0)
+        grid->SetCells(VTK_TRIANGLE, triangleArray);
 
-    if(quadArray->GetNumberOfCells()>0)
-       grid->SetCells(VTK_QUAD, quadArray);
+    if (quadArray->GetNumberOfCells() > 0)
+        grid->SetCells(VTK_QUAD, quadArray);
 
-    if(quadTriangleArray->GetNumberOfCells()>0)
-       grid->SetCells(VTK_QUADRATIC_TRIANGLE, quadTriangleArray);
+    if (quadTriangleArray->GetNumberOfCells() > 0)
+        grid->SetCells(VTK_QUADRATIC_TRIANGLE, quadTriangleArray);
 
-    if(quadQuadArray->GetNumberOfCells()>0)
-       grid->SetCells(VTK_QUADRATIC_QUAD, quadQuadArray);
+    if (quadQuadArray->GetNumberOfCells() > 0)
+        grid->SetCells(VTK_QUADRATIC_QUAD, quadQuadArray);
 
     Base::Console().Log("  End: VTK mesh builder faces.\n");
 }
 
-void exportFemMeshCells(vtkSmartPointer<vtkUnstructuredGrid> grid, const SMDS_VolumeIteratorPtr& aVolIter)
+void exportFemMeshCells(vtkSmartPointer<vtkUnstructuredGrid> grid,
+                        const SMDS_VolumeIteratorPtr& aVolIter)
 {
     Base::Console().Log("  Start: VTK mesh builder volumes.\n");
 
@@ -322,80 +396,81 @@ void exportFemMeshCells(vtkSmartPointer<vtkUnstructuredGrid> grid, const SMDS_Vo
     {
         const SMDS_MeshVolume* aVol = aVolIter->next();
 
-        if (aVol->NbNodes() == 4) { // tetra4
+        if (aVol->NbNodes() == 4) {// tetra4
             Base::Console().Log("    Volume tetra4\n");
             vtkSmartPointer<vtkTetra> cell = vtkSmartPointer<vtkTetra>::New();
-            cell->GetPointIds()->SetId(0, aVol->GetNode(0)->GetID()-1);
-            cell->GetPointIds()->SetId(1, aVol->GetNode(1)->GetID()-1);
-            cell->GetPointIds()->SetId(2, aVol->GetNode(2)->GetID()-1);
-            cell->GetPointIds()->SetId(3, aVol->GetNode(3)->GetID()-1);
+            cell->GetPointIds()->SetId(0, aVol->GetNode(0)->GetID() - 1);
+            cell->GetPointIds()->SetId(1, aVol->GetNode(1)->GetID() - 1);
+            cell->GetPointIds()->SetId(2, aVol->GetNode(2)->GetID() - 1);
+            cell->GetPointIds()->SetId(3, aVol->GetNode(3)->GetID() - 1);
             tetraArray->InsertNextCell(cell);
         }
-        else if (aVol->NbNodes() == 5) { // pyra5
+        else if (aVol->NbNodes() == 5) {// pyra5
             Base::Console().Log("    Volume pyra5\n");
             vtkSmartPointer<vtkPyramid> cell = vtkSmartPointer<vtkPyramid>::New();
-            cell->GetPointIds()->SetId(0, aVol->GetNode(0)->GetID()-1);
-            cell->GetPointIds()->SetId(1, aVol->GetNode(1)->GetID()-1);
-            cell->GetPointIds()->SetId(2, aVol->GetNode(2)->GetID()-1);
-            cell->GetPointIds()->SetId(3, aVol->GetNode(3)->GetID()-1);
-            cell->GetPointIds()->SetId(4, aVol->GetNode(4)->GetID()-1);
+            cell->GetPointIds()->SetId(0, aVol->GetNode(0)->GetID() - 1);
+            cell->GetPointIds()->SetId(1, aVol->GetNode(1)->GetID() - 1);
+            cell->GetPointIds()->SetId(2, aVol->GetNode(2)->GetID() - 1);
+            cell->GetPointIds()->SetId(3, aVol->GetNode(3)->GetID() - 1);
+            cell->GetPointIds()->SetId(4, aVol->GetNode(4)->GetID() - 1);
             pyramidArray->InsertNextCell(cell);
         }
-        else if (aVol->NbNodes() == 6) { // penta6
+        else if (aVol->NbNodes() == 6) {// penta6
             Base::Console().Log("    Volume penta6\n");
             vtkSmartPointer<vtkWedge> cell = vtkSmartPointer<vtkWedge>::New();
-            cell->GetPointIds()->SetId(0, aVol->GetNode(0)->GetID()-1);
-            cell->GetPointIds()->SetId(1, aVol->GetNode(1)->GetID()-1);
-            cell->GetPointIds()->SetId(2, aVol->GetNode(2)->GetID()-1);
-            cell->GetPointIds()->SetId(3, aVol->GetNode(3)->GetID()-1);
-            cell->GetPointIds()->SetId(4, aVol->GetNode(4)->GetID()-1);
-            cell->GetPointIds()->SetId(5, aVol->GetNode(5)->GetID()-1);
+            cell->GetPointIds()->SetId(0, aVol->GetNode(0)->GetID() - 1);
+            cell->GetPointIds()->SetId(1, aVol->GetNode(1)->GetID() - 1);
+            cell->GetPointIds()->SetId(2, aVol->GetNode(2)->GetID() - 1);
+            cell->GetPointIds()->SetId(3, aVol->GetNode(3)->GetID() - 1);
+            cell->GetPointIds()->SetId(4, aVol->GetNode(4)->GetID() - 1);
+            cell->GetPointIds()->SetId(5, aVol->GetNode(5)->GetID() - 1);
             wedgeArray->InsertNextCell(cell);
         }
-        else if (aVol->NbNodes() == 8) { // hexa8
+        else if (aVol->NbNodes() == 8) {// hexa8
             Base::Console().Log("    Volume hexa8\n");
             vtkSmartPointer<vtkHexahedron> cell = vtkSmartPointer<vtkHexahedron>::New();
-            cell->GetPointIds()->SetId(0, aVol->GetNode(0)->GetID()-1);
-            cell->GetPointIds()->SetId(1, aVol->GetNode(1)->GetID()-1);
-            cell->GetPointIds()->SetId(2, aVol->GetNode(2)->GetID()-1);
-            cell->GetPointIds()->SetId(3, aVol->GetNode(3)->GetID()-1);
-            cell->GetPointIds()->SetId(4, aVol->GetNode(4)->GetID()-1);
-            cell->GetPointIds()->SetId(5, aVol->GetNode(5)->GetID()-1);
-            cell->GetPointIds()->SetId(6, aVol->GetNode(6)->GetID()-1);
-            cell->GetPointIds()->SetId(7, aVol->GetNode(7)->GetID()-1);
+            cell->GetPointIds()->SetId(0, aVol->GetNode(0)->GetID() - 1);
+            cell->GetPointIds()->SetId(1, aVol->GetNode(1)->GetID() - 1);
+            cell->GetPointIds()->SetId(2, aVol->GetNode(2)->GetID() - 1);
+            cell->GetPointIds()->SetId(3, aVol->GetNode(3)->GetID() - 1);
+            cell->GetPointIds()->SetId(4, aVol->GetNode(4)->GetID() - 1);
+            cell->GetPointIds()->SetId(5, aVol->GetNode(5)->GetID() - 1);
+            cell->GetPointIds()->SetId(6, aVol->GetNode(6)->GetID() - 1);
+            cell->GetPointIds()->SetId(7, aVol->GetNode(7)->GetID() - 1);
             hexaArray->InsertNextCell(cell);
         }
-        else if (aVol->NbNodes() == 10) { // tetra10
+        else if (aVol->NbNodes() == 10) {// tetra10
             Base::Console().Log("    Volume tetra10\n");
             vtkSmartPointer<vtkQuadraticTetra> tetra = vtkSmartPointer<vtkQuadraticTetra>::New();
-            for(int i=0; i<10; i++){
-                tetra->GetPointIds()->SetId(i, aVol->GetNode(i)->GetID()-1);
+            for (int i = 0; i < 10; i++) {
+                tetra->GetPointIds()->SetId(i, aVol->GetNode(i)->GetID() - 1);
             }
             quadTetraArray->InsertNextCell(tetra);
         }
 
-        else if (aVol->NbNodes() == 13) { // pyra13
+        else if (aVol->NbNodes() == 13) {// pyra13
             Base::Console().Log("    Volume pyra13\n");
             vtkSmartPointer<vtkQuadraticPyramid> cell = vtkSmartPointer<vtkQuadraticPyramid>::New();
-            for(int i=0; i<13; i++){
-                cell->GetPointIds()->SetId(i, aVol->GetNode(i)->GetID()-1);
+            for (int i = 0; i < 13; i++) {
+                cell->GetPointIds()->SetId(i, aVol->GetNode(i)->GetID() - 1);
                 // Base::Console().Log("node ids: %i\n", aVol->GetNode(i)->GetID()-1);
             }
             quadPyramidArray->InsertNextCell(cell);
         }
-        else if (aVol->NbNodes() == 15) { // penta15
+        else if (aVol->NbNodes() == 15) {// penta15
             Base::Console().Log("    Volume penta15\n");
             vtkSmartPointer<vtkQuadraticWedge> cell = vtkSmartPointer<vtkQuadraticWedge>::New();
-            for(int i=0; i<15; i++){
-                cell->GetPointIds()->SetId(i, aVol->GetNode(i)->GetID()-1);
+            for (int i = 0; i < 15; i++) {
+                cell->GetPointIds()->SetId(i, aVol->GetNode(i)->GetID() - 1);
             }
             quadWedgeArray->InsertNextCell(cell);
         }
-        else if (aVol->NbNodes() == 20) { // hexa20
+        else if (aVol->NbNodes() == 20) {// hexa20
             Base::Console().Log("    Volume hexa20\n");
-            vtkSmartPointer<vtkQuadraticHexahedron> cell = vtkSmartPointer<vtkQuadraticHexahedron>::New();
-            for(int i=0; i<20; i++){
-                cell->GetPointIds()->SetId(i, aVol->GetNode(i)->GetID()-1);
+            vtkSmartPointer<vtkQuadraticHexahedron> cell =
+                vtkSmartPointer<vtkQuadraticHexahedron>::New();
+            for (int i = 0; i < 20; i++) {
+                cell->GetPointIds()->SetId(i, aVol->GetNode(i)->GetID() - 1);
             }
             quadHexaArray->InsertNextCell(cell);
         }
@@ -404,34 +479,35 @@ void exportFemMeshCells(vtkSmartPointer<vtkUnstructuredGrid> grid, const SMDS_Vo
         }
     }
 
-    if(tetraArray->GetNumberOfCells()>0)
+    if (tetraArray->GetNumberOfCells() > 0)
         grid->SetCells(VTK_TETRA, tetraArray);
 
-    if(pyramidArray->GetNumberOfCells()>0)
+    if (pyramidArray->GetNumberOfCells() > 0)
         grid->SetCells(VTK_PYRAMID, pyramidArray);
 
-    if(wedgeArray->GetNumberOfCells()>0)
+    if (wedgeArray->GetNumberOfCells() > 0)
         grid->SetCells(VTK_WEDGE, wedgeArray);
 
-    if(hexaArray->GetNumberOfCells()>0)
+    if (hexaArray->GetNumberOfCells() > 0)
         grid->SetCells(VTK_HEXAHEDRON, hexaArray);
 
-    if(quadTetraArray->GetNumberOfCells()>0)
+    if (quadTetraArray->GetNumberOfCells() > 0)
         grid->SetCells(VTK_QUADRATIC_TETRA, quadTetraArray);
 
-    if(quadPyramidArray->GetNumberOfCells()>0)
+    if (quadPyramidArray->GetNumberOfCells() > 0)
         grid->SetCells(VTK_QUADRATIC_PYRAMID, quadPyramidArray);
 
-    if(quadWedgeArray->GetNumberOfCells()>0)
+    if (quadWedgeArray->GetNumberOfCells() > 0)
         grid->SetCells(VTK_QUADRATIC_WEDGE, quadWedgeArray);
 
-    if(quadHexaArray->GetNumberOfCells()>0)
+    if (quadHexaArray->GetNumberOfCells() > 0)
         grid->SetCells(VTK_QUADRATIC_HEXAHEDRON, quadHexaArray);
 
     Base::Console().Log("  End: VTK mesh builder volumes.\n");
 }
 
-void FemVTKTools::exportVTKMesh(const FemMesh* mesh, vtkSmartPointer<vtkUnstructuredGrid> grid, float scale)
+void FemVTKTools::exportVTKMesh(const FemMesh* mesh, vtkSmartPointer<vtkUnstructuredGrid> grid,
+                                float scale)
 {
 
     Base::Console().Log("Start: VTK mesh builder ======================\n");
@@ -445,12 +521,15 @@ void FemVTKTools::exportVTKMesh(const FemMesh* mesh, vtkSmartPointer<vtkUnstruct
     SMDS_NodeIteratorPtr aNodeIter = meshDS->nodesIterator();
 
     while (aNodeIter->more()) {
-        const SMDS_MeshNode* node = aNodeIter->next();  // why float, not double?
-        double coords[3] = {double(node->X()*scale), double(node->Y()*scale), double(node->Z()*scale)};
-        points->InsertPoint(node->GetID()-1, coords);
+        const SMDS_MeshNode* node = aNodeIter->next();// why float, not double?
+        double coords[3] = {
+            double(node->X() * scale), double(node->Y() * scale), double(node->Z() * scale)};
+        points->InsertPoint(node->GetID() - 1, coords);
         // memory is allocated by VTK points size for max node id, not for point count
-        // if the SMESH mesh has gaps in node numbering, points without any element assignment will be inserted in these point gaps too
-        // this needs to be taken into account on node mapping when FreeCAD FEM results are exported to vtk
+        // if the SMESH mesh has gaps in node numbering, points without any element
+        // assignment will be inserted in these point gaps too
+        // this needs to be taken into account on node mapping when FreeCAD FEM results
+        // are exported to vtk
     }
     grid->SetPoints(points);
     // nodes debugging
@@ -482,13 +561,13 @@ void FemVTKTools::writeVTKMesh(const char* filename, const FemMesh* mesh)
     exportVTKMesh(mesh, grid);
     //vtkSmartPointer<vtkDataSet> dataset = vtkDataSet::SafeDownCast(grid);
     Base::Console().Log("Start: writing mesh data ======================\n");
-    if(f.hasExtension("vtu")){
+    if (f.hasExtension("vtu")) {
         writeVTKFile<vtkXMLUnstructuredGridWriter>(filename, grid);
     }
-    else if(f.hasExtension("vtk")){
+    else if (f.hasExtension("vtk")) {
         writeVTKFile<vtkDataSetWriter>(filename, grid);
     }
-    else{
+    else {
         Base::Console().Error("file name extension is not supported to write VTK\n");
     }
 
@@ -499,49 +578,43 @@ void FemVTKTools::writeVTKMesh(const char* filename, const FemMesh* mesh)
 App::DocumentObject* getObjectByType(const Base::Type type)
 {
     App::Document* pcDoc = App::GetApplication().getActiveDocument();
-    if(!pcDoc)
-    {
+    if (!pcDoc) {
         Base::Console().Message("No active document is found thus created\n");
         pcDoc = App::GetApplication().newDocument();
     }
     App::DocumentObject* obj = pcDoc->getActiveObject();
 
-    if(obj->getTypeId() == type)
-    {
+    if (obj->getTypeId() == type) {
         return obj;
     }
-    if(obj->getTypeId() ==  FemAnalysis::getClassTypeId())
-    {
+    if (obj->getTypeId() == FemAnalysis::getClassTypeId()) {
         std::vector<App::DocumentObject*> fem = (static_cast<FemAnalysis*>(obj))->Group.getValues();
         for (std::vector<App::DocumentObject*>::iterator it = fem.begin(); it != fem.end(); ++it) {
             if ((*it)->getTypeId().isDerivedFrom(type))
-                return static_cast<App::DocumentObject*>(*it); // return the first of that type
+                return static_cast<App::DocumentObject*>(*it);// return the first of that type
         }
     }
     return nullptr;
 }
 
+
 App::DocumentObject* createObjectByType(const Base::Type type)
 {
     App::Document* pcDoc = App::GetApplication().getActiveDocument();
-    if(!pcDoc)
-    {
+    if (!pcDoc) {
         Base::Console().Message("No active document is found thus created\n");
         pcDoc = App::GetApplication().newDocument();
     }
     App::DocumentObject* obj = pcDoc->getActiveObject();
 
-    if(obj->getTypeId() ==  FemAnalysis::getClassTypeId())
-    {
+    if (obj->getTypeId() == FemAnalysis::getClassTypeId()) {
         App::DocumentObject* newobj = pcDoc->addObject(type.getName());
         static_cast<FemAnalysis*>(obj)->addObject(newobj);
         return newobj;
     }
-    else
-    {
-        return pcDoc->addObject(type.getName()); // create in the acitive document
+    else {
+        return pcDoc->addObject(type.getName());// create in the acitive document
     }
-
 }
 
 
@@ -552,22 +625,18 @@ App::DocumentObject* FemVTKTools::readResult(const char* filename, App::Document
     Base::FileInfo f(filename);
 
     vtkSmartPointer<vtkDataSet> ds;
-    if(f.hasExtension("vtu"))
-    {
+    if (f.hasExtension("vtu")) {
         ds = readVTKFile<vtkXMLUnstructuredGridReader>(filename);
     }
-    else if(f.hasExtension("vtk"))
-    {
+    else if (f.hasExtension("vtk")) {
         ds = readVTKFile<vtkDataSetReader>(filename);
     }
-    else
-    {
+    else {
         Base::Console().Error("file name extension is not supported\n");
     }
 
     App::Document* pcDoc = App::GetApplication().getActiveDocument();
-    if(!pcDoc)
-    {
+    if (!pcDoc) {
         Base::Console().Message("No active document is found thus created\n");
         pcDoc = App::GetApplication().newDocument();
     }
@@ -576,15 +645,13 @@ App::DocumentObject* FemVTKTools::readResult(const char* filename, App::Document
     vtkSmartPointer<vtkDataSet> dataset = ds;
     App::DocumentObject* result = nullptr;
 
-    if (res)
-    {
-        Base::Console().Message("FemResultObject pointer is NULL, trying to get the active object\n");
-        if(obj->getTypeId() == Base::Type::fromName("Fem::FemResultObjectPython"))
-        {
+    if (res) {
+        Base::Console().Message(
+            "FemResultObject pointer is NULL, trying to get the active object\n");
+        if (obj->getTypeId() == Base::Type::fromName("Fem::FemResultObjectPython")) {
             result = obj;
         }
-        else
-        {
+        else {
             Base::Console().Message("the active object is not the correct type, do nothing\n");
             return nullptr;
         }
@@ -595,10 +662,10 @@ App::DocumentObject* FemVTKTools::readResult(const char* filename, App::Document
     importVTKMesh(dataset, fmesh.get());
     static_cast<PropertyFemMesh*>(mesh->getPropertyByName("FemMesh"))->setValuePtr(fmesh.release());
 
-    if (result)
-    {
+    if (result) {
         // PropertyLink is the property type to store DocumentObject pointer
-        App::PropertyLink* link = dynamic_cast<App::PropertyLink*>(result->getPropertyByName("Mesh"));
+        App::PropertyLink* link =
+            dynamic_cast<App::PropertyLink*>(result->getPropertyByName("Mesh"));
         if (link)
             link->setValue(mesh);
 
@@ -615,17 +682,15 @@ App::DocumentObject* FemVTKTools::readResult(const char* filename, App::Document
 
 
 void FemVTKTools::writeResult(const char* filename, const App::DocumentObject* res) {
-    if (!res)
-    {
+    if (!res) {
         App::Document* pcDoc = App::GetApplication().getActiveDocument();
-        if(!pcDoc)
-        {
+        if (!pcDoc) {
             Base::Console().Message("No active document is found thus do nothing and return\n");
             return;
         }
-        res = pcDoc->getActiveObject(); //type checking is done by caller
+        res = pcDoc->getActiveObject();//type checking is done by caller
     }
-    if(!res) {
+    if (!res) {
         Base::Console().Error("Result object pointer is invalid and it is not active object");
         return;
     }
@@ -636,27 +701,31 @@ void FemVTKTools::writeResult(const char* filename, const App::DocumentObject* r
 
     // mesh
     vtkSmartPointer<vtkUnstructuredGrid> grid = vtkSmartPointer<vtkUnstructuredGrid>::New();
-    App::DocumentObject* mesh = static_cast<App::PropertyLink*>(res->getPropertyByName("Mesh"))->getValue();
-    const FemMesh& fmesh = static_cast<PropertyFemMesh*>(mesh->getPropertyByName("FemMesh"))->getValue();
+    App::DocumentObject* mesh =
+        static_cast<App::PropertyLink*>(res->getPropertyByName("Mesh"))->getValue();
+    const FemMesh& fmesh =
+        static_cast<PropertyFemMesh*>(mesh->getPropertyByName("FemMesh"))->getValue();
     FemVTKTools::exportVTKMesh(&fmesh, grid);
 
-    Base::Console().Log("    %f: vtk mesh builder finished\n",Base::TimeInfo::diffTimeF(Start, Base::TimeInfo()));
+    Base::Console().Log("    %f: vtk mesh builder finished\n",
+                        Base::TimeInfo::diffTimeF(Start, Base::TimeInfo()));
 
     // result
     FemVTKTools::exportFreeCADResult(res, grid);
 
     //vtkSmartPointer<vtkDataSet> dataset = vtkDataSet::SafeDownCast(grid);
-    if(f.hasExtension("vtu")){
+    if (f.hasExtension("vtu")) {
         writeVTKFile<vtkXMLUnstructuredGridWriter>(filename, grid);
     }
-    else if(f.hasExtension("vtk")){
+    else if (f.hasExtension("vtk")) {
         writeVTKFile<vtkDataSetWriter>(filename, grid);
     }
-    else{
+    else {
         Base::Console().Error("file name extension is not supported to write VTK\n");
     }
 
-    Base::Console().Log("    %f: writing result object to vtk finished\n",Base::TimeInfo::diffTimeF(Start, Base::TimeInfo()));
+    Base::Console().Log("    %f: writing result object to vtk finished\n",
+                        Base::TimeInfo::diffTimeF(Start, Base::TimeInfo()));
     Base::Console().Log("End: write FemResult to VTK unstructuredGrid dataset =======\n");
 }
 
@@ -676,14 +745,17 @@ std::map<std::string, std::string> _getFreeCADMechResultVectorProperties() {
     return resFCVecProp;
 }
 
-// see https://forum.freecadweb.org/viewtopic.php?f=18&t=33106&start=30#p277434 for further information regarding names etc...
+// see https://forum.freecadweb.org/viewtopic.php?f=18&t=33106&start=30#p277434 for further
+// information regarding names etc...
 // some scalar list are not needed on VTK file export but they are needed for internal VTK pipeline
-// TODO some filter to only export the needed values to VTK file but have all in FreeCAD VTK pipeline
+// TODO some filter to only export the needed values to VTK file but have all
+// in FreeCAD VTK pipeline
 std::map<std::string, std::string> _getFreeCADMechResultScalarProperties() {
     // see src/Mod/Fem/femobjects/result_mechanical.py
     // App::PropertyFloatList will be a list of scalars in vtk
     std::map<std::string, std::string> resFCScalProp;
-    resFCScalProp["DisplacementLengths"] = "Displacement Magnitude";  // can be plotted in Paraview as THE DISPLACEMENT MAGNITUDE
+    resFCScalProp["DisplacementLengths"] =
+        "Displacement Magnitude";// can be plotted in Paraview as THE DISPLACEMENT MAGNITUDE
     resFCScalProp["MaxShear"] = "Tresca Stress";
     resFCScalProp["NodeStressXX"] = "Stress xx component";
     resFCScalProp["NodeStressYY"] = "Stress yy component";
@@ -703,14 +775,19 @@ std::map<std::string, std::string> _getFreeCADMechResultScalarProperties() {
     // the following three are filled in all cases
     // https://forum.freecadweb.org/viewtopic.php?f=18&t=33106&start=70#p296317
     // it might be these can be generated in paraview from stress tensor values as
-    // THE MAJOR PRINCIPAL STRESS MAGNITUDE, THE INTERMEDIATE PRINCIPAL STRESS MAGNITUDE, THE MINOR PRINCIPAL STRESS MAGNITUDE
+    // THE MAJOR PRINCIPAL STRESS MAGNITUDE, THE INTERMEDIATE PRINCIPAL STRESS MAGNITUDE,
+    // THE MINOR PRINCIPAL STRESS MAGNITUDE
     // but I do not know how (Bernd), for some help see paraview tutorial on FreeCAD wiki
-    // thus TODO they might not be exported to external file format (first I need to know how to generate them in paraview)
+    // thus TODO they might not be exported to external file format (first I need to know
+    // how to generate them in paraview)
     // but there are needed anyway because the pipeline in FreeCAD needs the principal stress values
     // https://forum.freecadweb.org/viewtopic.php?f=18&t=33106&p=416006#p412800
-    resFCScalProp["PrincipalMax"] = "Major Principal Stress";       // can be plotted in Paraview as THE MAJOR PRINCIPAL STRESS MAGNITUDE
-    resFCScalProp["PrincipalMed"] = "Intermediate Principal Stress";// can be plotted in Paraview as THE INTERMEDIATE PRINCIPAL STRESS MAGNITUDE
-    resFCScalProp["PrincipalMin"] = "Minor Principal Stress";       // can be plotted in Paraview as THE MINOR PRINCIPAL STRESS MAGNITUDE
+    resFCScalProp["PrincipalMax"] =
+        "Major Principal Stress";// can be plotted in Paraview as THE MAJOR PRINCIPAL STRESS MAGNITUDE
+    resFCScalProp["PrincipalMed"] =
+        "Intermediate Principal Stress";// can be plotted in Paraview as THE INTERMEDIATE PRINCIPAL STRESS MAGNITUDE
+    resFCScalProp["PrincipalMin"] =
+        "Minor Principal Stress";// can be plotted in Paraview as THE MINOR PRINCIPAL STRESS MAGNITUDE
     resFCScalProp["vonMises"] = "von Mises Stress";
     resFCScalProp["Temperature"] = "Temperature";
     resFCScalProp["MohrCoulomb"] = "MohrCoulomb";
@@ -726,79 +803,99 @@ std::map<std::string, std::string> _getFreeCADMechResultScalarProperties() {
 }
 
 
-void FemVTKTools::importFreeCADResult(vtkSmartPointer<vtkDataSet> dataset, App::DocumentObject* result) {
+void FemVTKTools::importFreeCADResult(vtkSmartPointer<vtkDataSet> dataset,
+                                      App::DocumentObject* result)
+{
     Base::Console().Log("Start: import vtk result file data into a FreeCAD result object.\n");
 
     std::map<std::string, std::string> vectors = _getFreeCADMechResultVectorProperties();
     std::map<std::string, std::string> scalars = _getFreeCADMechResultScalarProperties();
 
-    double ts = 0.0;  // t=0.0 for static simulation
+    double ts = 0.0;// t=0.0 for static simulation
     static_cast<App::PropertyFloat*>(result->getPropertyByName("Time"))->setValue(ts);
 
     vtkSmartPointer<vtkPointData> pd = dataset->GetPointData();
-    if(pd->GetNumberOfArrays() == 0) {
+    if (pd->GetNumberOfArrays() == 0) {
         Base::Console().Error("No point data array is found in vtk data set, do nothing\n");
-        // if pointData is empty, data may be in cellDate, cellData -> pointData interpolation is possible in VTK
+        // if pointData is empty, data may be in cellDate,
+        // cellData -> pointData interpolation is possible in VTK
         return;
     }
 
     // NodeNumbers
     const vtkIdType nPoints = dataset->GetNumberOfPoints();
     std::vector<long> nodeIds(nPoints);
-    for(vtkIdType i=0; i<nPoints; ++i) {
-        nodeIds[i] = i+1;
+    for (vtkIdType i = 0; i < nPoints; ++i) {
+        nodeIds[i] = i + 1;
     }
-    static_cast<App::PropertyIntegerList*>(result->getPropertyByName("NodeNumbers"))->setValues(nodeIds);
+    static_cast<App::PropertyIntegerList*>(result->getPropertyByName("NodeNumbers"))
+        ->setValues(nodeIds);
     Base::Console().Log("    NodeNumbers have been filled with values.\n");
 
     // vectors
-    for (std::map<std::string, std::string>::iterator it = vectors.begin(); it != vectors.end(); ++it) {
-        int dim = 3;  // Fixme: currently 3D only, here we could run into trouble, FreeCAD only supports dim 3D, I do not know about VTK
+    for (std::map<std::string, std::string>::iterator it = vectors.begin(); it != vectors.end();
+         ++it) {
+        int dim = 3;// Fixme: currently 3D only, here we could run into trouble,
+                    //        FreeCAD only supports dim 3D, I do not know about VTK
         vtkDataArray* vector_field = vtkDataArray::SafeDownCast(pd->GetArray(it->second.c_str()));
-        if(vector_field && vector_field->GetNumberOfComponents() == dim) {
-            App::PropertyVectorList* vector_list = static_cast<App::PropertyVectorList*>(result->getPropertyByName(it->first.c_str()));
-            if(vector_list) {
+        if (vector_field && vector_field->GetNumberOfComponents() == dim) {
+            App::PropertyVectorList* vector_list =
+                static_cast<App::PropertyVectorList*>(result->getPropertyByName(it->first.c_str()));
+            if (vector_list) {
                 std::vector<Base::Vector3d> vec(nPoints);
-                for(vtkIdType i=0; i<nPoints; ++i) {
-                    double *p = vector_field->GetTuple(i); // both vtkFloatArray and vtkDoubleArray return double* for GetTuple(i)
+                for (vtkIdType i = 0; i < nPoints; ++i) {
+                    double* p = vector_field->GetTuple(
+                        i);// both vtkFloatArray and vtkDoubleArray return double* for GetTuple(i)
                     vec[i] = (Base::Vector3d(p[0], p[1], p[2]));
                 }
                 // PropertyVectorList will not show up in PropertyEditor
                 vector_list->setValues(vec);
-                Base::Console().Log("    A PropertyVectorList has been filled with values: %s\n", it->first.c_str());
+                Base::Console().Log("    A PropertyVectorList has been filled with values: %s\n",
+                                    it->first.c_str());
             }
             else {
-                Base::Console().Error("static_cast<App::PropertyVectorList*>((result->getPropertyByName(\"%s\")) failed.\n", it->first.c_str());
+                Base::Console().Error("static_cast<App::PropertyVectorList*>((result->"
+                                      "getPropertyByName(\"%s\")) failed.\n",
+                                      it->first.c_str());
                 continue;
             }
         }
         else
-            Base::Console().Message("    PropertyVectorList NOT found in vkt file data: %s\n", it->first.c_str());
+            Base::Console().Message("    PropertyVectorList NOT found in vkt file data: %s\n",
+                                    it->first.c_str());
     }
 
     // scalars
-    for (std::map<std::string, std::string>::iterator it = scalars.begin(); it != scalars.end(); ++it) {
+    for (std::map<std::string, std::string>::iterator it = scalars.begin(); it != scalars.end();
+         ++it) {
         vtkDataArray* vec = vtkDataArray::SafeDownCast(pd->GetArray(it->second.c_str()));
-        if(nPoints && vec && vec->GetNumberOfComponents() == 1) {
-            App::PropertyFloatList* field = static_cast<App::PropertyFloatList*>(result->getPropertyByName(it->first.c_str()));
+        if (nPoints && vec && vec->GetNumberOfComponents() == 1) {
+            App::PropertyFloatList* field =
+                static_cast<App::PropertyFloatList*>(result->getPropertyByName(it->first.c_str()));
             if (!field) {
-                Base::Console().Error("static_cast<App::PropertyFloatList*>((result->getPropertyByName(\"%s\")) failed.\n", it->first.c_str());
+                Base::Console().Error("static_cast<App::PropertyFloatList*>((result->"
+                                      "getPropertyByName(\"%s\")) failed.\n",
+                                      it->first.c_str());
                 continue;
             }
 
-            double vmin=1.0e100, vmax=-1.0e100;
+            double vmin = 1.0e100, vmax = -1.0e100;
             std::vector<double> values(nPoints, 0.0);
-            for(vtkIdType i = 0; i < vec->GetNumberOfTuples(); i++) {
+            for (vtkIdType i = 0; i < vec->GetNumberOfTuples(); i++) {
                 double v = *(vec->GetTuple(i));
                 values[i] = v;
-                if(v > vmax) vmax = v;
-                if(v < vmin) vmin = v;
+                if (v > vmax)
+                    vmax = v;
+                if (v < vmin)
+                    vmin = v;
             }
             field->setValues(values);
-            Base::Console().Log("    A PropertyFloatList has been filled with vales: %s\n", it->first.c_str());
+            Base::Console().Log("    A PropertyFloatList has been filled with vales: %s\n",
+                                it->first.c_str());
         }
         else
-            Base::Console().Message("    PropertyFloatList NOT found in vkt file data %s\n", it->first.c_str());
+            Base::Console().Message("    PropertyFloatList NOT found in vkt file data %s\n",
+                                    it->first.c_str());
     }
 
     // stats
@@ -808,7 +905,9 @@ void FemVTKTools::importFreeCADResult(vtkSmartPointer<vtkDataSet> dataset, App::
 }
 
 
-void FemVTKTools::exportFreeCADResult(const App::DocumentObject* result, vtkSmartPointer<vtkDataSet> grid) {
+void FemVTKTools::exportFreeCADResult(const App::DocumentObject* result,
+                                      vtkSmartPointer<vtkDataSet> grid)
+{
     Base::Console().Log("Start: Create VTK result data from FreeCAD result data.\n");
 
     std::map<std::string, std::string> vectors = _getFreeCADMechResultVectorProperties();
@@ -817,8 +916,10 @@ void FemVTKTools::exportFreeCADResult(const App::DocumentObject* result, vtkSmar
     const Fem::FemResultObject* res = static_cast<const Fem::FemResultObject*>(result);
     const vtkIdType nPoints = grid->GetNumberOfPoints();
 
-    // we need the corresponding mesh to get the correct id for the result data (when the freecad smesh mesh has gaps in the points
-    // vtk has more points. Vtk does not support point gaps, thus the gaps are filled with points. Then the mapping must be correct)
+    // we need the corresponding mesh to get the correct id for the result data
+    // (when the freecad smesh mesh has gaps in the points
+    // vtk has more points. Vtk does not support point gaps, thus the gaps are
+    // filled with points. Then the mapping must be correct)
     App::DocumentObject* meshObj = res->Mesh.getValue();
     if (!meshObj || !meshObj->isDerivedFrom(FemMeshObject::getClassTypeId())) {
         Base::Console().Error("Result object does not correctly link to mesh");
@@ -832,53 +933,64 @@ void FemVTKTools::exportFreeCADResult(const App::DocumentObject* result, vtkSmar
     double factor = 1.0;
 
     // vectors
-    for (std::map<std::string, std::string>::iterator it = vectors.begin(); it != vectors.end(); ++it) {
-        const int dim = 3;  //Fixme, detect dim, but FreeCAD PropertyVectorList ATM only has DIM of 3
+    for (std::map<std::string, std::string>::iterator it = vectors.begin(); it != vectors.end();
+         ++it) {
+        const int dim = 3;//Fixme, detect dim, but FreeCAD PropertyVectorList ATM only has DIM of 3
         App::PropertyVectorList* field = nullptr;
         if (res->getPropertyByName(it->first.c_str()))
-            field = static_cast<App::PropertyVectorList*>(res->getPropertyByName(it->first.c_str()));
+            field =
+                static_cast<App::PropertyVectorList*>(res->getPropertyByName(it->first.c_str()));
         else
             Base::Console().Error("    PropertyVectorList not found: %s\n", it->first.c_str());
 
         if (field && field->getSize() > 0) {
             //if (nPoints != field->getSize())
-            //    Base::Console().Error("Size of PropertyVectorList = %d, not equal to vtk mesh node count %d \n", field->getSize(), nPoints);
+            //    Base::Console().Error("Size of PropertyVectorList = %d, not equal
+            //    to vtk mesh node count %d \n", field->getSize(), nPoints);
             const std::vector<Base::Vector3d>& vel = field->getValues();
             vtkSmartPointer<vtkDoubleArray> data = vtkSmartPointer<vtkDoubleArray>::New();
             data->SetNumberOfComponents(dim);
             data->SetNumberOfTuples(nPoints);
             data->SetName(it->second.c_str());
 
-            //we need to set values for the unused points.
-            //TODO: ensure that the result bar does not include the used 0 if it is not part of the result (e.g. does the result bar show 0 as smallest value?)
+            // we need to set values for the unused points.
+            // TODO: ensure that the result bar does not include the used 0 if it is not
+            // part of the result (e.g. does the result bar show 0 as smallest value?)
             if (nPoints != field->getSize()) {
-                double tuple[] = { 0, 0, 0 };
+                double tuple[] = {0, 0, 0};
                 for (vtkIdType i = 0; i < nPoints; ++i) {
                     data->SetTuple(i, tuple);
                 }
             }
 
             if (it->first.compare("DisplacementVectors") == 0)
-                factor = 0.001; // to get meter
+                factor = 0.001;// to get meter
             else
                 factor = 1.0;
 
             SMDS_NodeIteratorPtr aNodeIter = meshDS->nodesIterator();
-            for (std::vector<Base::Vector3d>::const_iterator jt = vel.begin(); jt != vel.end(); ++jt) {
+            for (std::vector<Base::Vector3d>::const_iterator jt = vel.begin(); jt != vel.end();
+                 ++jt) {
                 const SMDS_MeshNode* node = aNodeIter->next();
-                double tuple[] = { jt->x * factor, jt->y * factor, jt->z * factor };
+                double tuple[] = {jt->x * factor, jt->y * factor, jt->z * factor};
                 data->SetTuple(node->GetID() - 1, tuple);
             }
             grid->GetPointData()->AddArray(data);
-            Base::Console().Log("    The PropertyVectorList %s was exported to VTK vector list: %s\n", it->first.c_str(), it->second.c_str());
+            Base::Console().Log(
+                "    The PropertyVectorList %s was exported to VTK vector list: %s\n",
+                it->first.c_str(),
+                it->second.c_str());
         }
         else if (field) {
-            Base::Console().Log("    PropertyVectorList NOT exported to vtk: %s size is: %i\n", it->first.c_str(), field->getSize());
+            Base::Console().Log("    PropertyVectorList NOT exported to vtk: %s size is: %i\n",
+                                it->first.c_str(),
+                                field->getSize());
         }
     }
 
     // scalars
-    for (std::map<std::string, std::string>::iterator it = scalars.begin(); it != scalars.end(); ++it) {
+    for (std::map<std::string, std::string>::iterator it = scalars.begin(); it != scalars.end();
+         ++it) {
         App::PropertyFloatList* field = nullptr;
         if (res->getPropertyByName(it->first.c_str()))
             field = static_cast<App::PropertyFloatList*>(res->getPropertyByName(it->first.c_str()));
@@ -887,14 +999,16 @@ void FemVTKTools::exportFreeCADResult(const App::DocumentObject* result, vtkSmar
 
         if (field && field->getSize() > 0) {
             //if (nPoints != field->getSize())
-            //    Base::Console().Error("Size of PropertyFloatList = %d, not equal to vtk mesh node count %d \n", field->getSize(), nPoints);
+            //    Base::Console().Error("Size of PropertyFloatList = %d, not equal to vtk mesh
+            //    node count %d \n", field->getSize(), nPoints);
             const std::vector<double>& vec = field->getValues();
             vtkSmartPointer<vtkDoubleArray> data = vtkSmartPointer<vtkDoubleArray>::New();
             data->SetNumberOfValues(nPoints);
             data->SetName(it->second.c_str());
 
-            //we need to set values for the unused points.
-            //TODO: ensure that the result bar does not include the used 0 if it is not part of the result (e.g. does the result bar show 0 as smallest value?)
+            // we need to set values for the unused points.
+            // TODO: ensure that the result bar does not include the used 0 if it is not part
+            // of the result (e.g. does the result bar show 0 as smallest value?)
             if (nPoints != field->getSize()) {
                 for (vtkIdType i = 0; i < nPoints; ++i) {
                     data->SetValue(i, 0);
@@ -928,10 +1042,15 @@ void FemVTKTools::exportFreeCADResult(const App::DocumentObject* result, vtkSmar
             }
 
             grid->GetPointData()->AddArray(data);
-            Base::Console().Log("    The PropertyFloatList %s was exported to VTK scalar list: %s\n", it->first.c_str(), it->second.c_str());
+            Base::Console().Log(
+                "    The PropertyFloatList %s was exported to VTK scalar list: %s\n",
+                it->first.c_str(),
+                it->second.c_str());
         }
         else if (field) {
-            Base::Console().Log("    PropertyFloatList NOT exported to vtk: %s size is: %i\n", it->first.c_str(), field->getSize());
+            Base::Console().Log("    PropertyFloatList NOT exported to vtk: %s size is: %i\n",
+                                it->first.c_str(),
+                                field->getSize());
         }
     }
 

--- a/src/Mod/Fem/App/PropertyPostDataObject.cpp
+++ b/src/Mod/Fem/App/PropertyPostDataObject.cpp
@@ -220,18 +220,29 @@ unsigned int PropertyPostDataObject::getMemSize() const
     return m_dataObject ? m_dataObject->GetActualMemorySize() : 0;
 }
 
-void PropertyPostDataObject::getPaths(std::vector<App::ObjectIdentifier> & /*paths*/) const
+void PropertyPostDataObject::getPaths(std::vector<App::ObjectIdentifier>& /*paths*/) const
 {
-//     paths.push_back(App::ObjectIdentifier(getContainer()) << App::ObjectIdentifier::Component::SimpleComponent(getName())
-//                     << App::ObjectIdentifier::Component::SimpleComponent(App::ObjectIdentifier::String("ShapeType")));
-//     paths.push_back(App::ObjectIdentifier(getContainer()) << App::ObjectIdentifier::Component::SimpleComponent(getName())
-//                     << App::ObjectIdentifier::Component::SimpleComponent(App::ObjectIdentifier::String("Orientation")));
-//     paths.push_back(App::ObjectIdentifier(getContainer()) << App::ObjectIdentifier::Component::SimpleComponent(getName())
-//                     << App::ObjectIdentifier::Component::SimpleComponent(App::ObjectIdentifier::String("Length")));
-//     paths.push_back(App::ObjectIdentifier(getContainer()) << App::ObjectIdentifier::Component::SimpleComponent(getName())
-//                     << App::ObjectIdentifier::Component::SimpleComponent(App::ObjectIdentifier::String("Area")));
-//     paths.push_back(App::ObjectIdentifier(getContainer()) << App::ObjectIdentifier::Component::SimpleComponent(getName())
-//                     << App::ObjectIdentifier::Component::SimpleComponent(App::ObjectIdentifier::String("Volume")));
+ /* paths.push_back(App::ObjectIdentifier(getContainer())
+                    << App::ObjectIdentifier::Component::SimpleComponent(getName())
+                    << App::ObjectIdentifier::Component::SimpleComponent(
+                           App::ObjectIdentifier::String("ShapeType")));
+    paths.push_back(App::ObjectIdentifier(getContainer())
+                    << App::ObjectIdentifier::Component::SimpleComponent(getName())
+                    << App::ObjectIdentifier::Component::SimpleComponent(
+                           App::ObjectIdentifier::String("Orientation")));
+    paths.push_back(App::ObjectIdentifier(getContainer())
+                    << App::ObjectIdentifier::Component::SimpleComponent(getName())
+                    << App::ObjectIdentifier::Component::SimpleComponent(
+                           App::ObjectIdentifier::String("Length")));
+    paths.push_back(App::ObjectIdentifier(getContainer())
+                    << App::ObjectIdentifier::Component::SimpleComponent(getName())
+                    << App::ObjectIdentifier::Component::SimpleComponent(
+                           App::ObjectIdentifier::String("Area")));
+    paths.push_back(App::ObjectIdentifier(getContainer())
+                    << App::ObjectIdentifier::Component::SimpleComponent(getName())
+                    << App::ObjectIdentifier::Component::SimpleComponent(
+                           App::ObjectIdentifier::String("Volume")));
+    */
 }
 
 void PropertyPostDataObject::Save(Base::Writer &writer) const
@@ -371,7 +382,8 @@ void PropertyPostDataObject::RestoreDocFile(Base::Reader &reader)
     if (ulSize > 0) {
         std::string extension = xml.extension();
 
-        //TODO: read in of composite data structures need to be coded, including replace of "GetOutputAsDataSet()"
+        // TODO: read in of composite data structures need to be coded,
+        // including replace of "GetOutputAsDataSet()"
         vtkSmartPointer<vtkXMLReader> xmlReader;
         if (extension == "vtp")
             xmlReader = vtkSmartPointer<vtkXMLPolyDataReader>::New();
@@ -399,7 +411,8 @@ void PropertyPostDataObject::RestoreDocFile(Base::Reader &reader)
                                       fi.filePath().c_str(), obj->Label.getValue());
             }
             else {
-                Base::Console().Warning("Loaded Dataset file '%s' seems to be empty\n", fi.filePath().c_str());
+                Base::Console().Warning("Loaded Dataset file '%s' seems to be empty\n",
+                                        fi.filePath().c_str());
             }
         }
         else {

--- a/src/Mod/Fem/Gui/Command.cpp
+++ b/src/Mod/Fem/Gui/Command.cpp
@@ -68,10 +68,13 @@ using namespace std;
 // helpers
 bool getConstraintPrerequisits(Fem::FemAnalysis** Analysis)
 {
-    Fem::FemAnalysis* ActiveAnalysis = FemGui::ActiveAnalysisObserver::instance()->getActiveObject();
-    if (!ActiveAnalysis || !ActiveAnalysis->getTypeId().isDerivedFrom(Fem::FemAnalysis::getClassTypeId())) {
-        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("No active Analysis"),
-            QObject::tr("You need to create or activate a Analysis"));
+    Fem::FemAnalysis* ActiveAnalysis =
+        FemGui::ActiveAnalysisObserver::instance()->getActiveObject();
+    if (!ActiveAnalysis
+        || !ActiveAnalysis->getTypeId().isDerivedFrom(Fem::FemAnalysis::getClassTypeId())) {
+        QMessageBox::warning(Gui::getMainWindow(),
+                             QObject::tr("No active Analysis"),
+                             QObject::tr("You need to create or activate a Analysis"));
         return true;
     }
 
@@ -79,7 +82,6 @@ bool getConstraintPrerequisits(Fem::FemAnalysis** Analysis)
 
     // return with no error
     return false;
-
 }
 
 //OvG: Visibility automation show parts and hide meshes on activation of a constraint
@@ -304,10 +306,14 @@ void CmdFemConstraintBearing::activated(int)
     std::string FeatName = getUniqueObjectName("ConstraintBearing");
 
     openCommand(QT_TRANSLATE_NOOP("Command", "Make FEM constraint for bearing"));
-    doCommand(Doc, "App.activeDocument().addObject(\"Fem::ConstraintBearing\",\"%s\")", FeatName.c_str());
-    doCommand(Doc, "App.activeDocument().%s.addObject(App.activeDocument().%s)", Analysis->getNameInDocument(), FeatName.c_str());
+    doCommand(
+        Doc, "App.activeDocument().addObject(\"Fem::ConstraintBearing\",\"%s\")", FeatName.c_str());
+    doCommand(Doc,
+              "App.activeDocument().%s.addObject(App.activeDocument().%s)",
+              Analysis->getNameInDocument(),
+              FeatName.c_str());
 
-    doCommand(Doc, "%s", gethideMeshShowPartStr(FeatName).c_str()); //OvG: Hide meshes and show parts
+    doCommand(Doc, "%s", gethideMeshShowPartStr(FeatName).c_str());//OvG: Hide meshes and show parts
 
     updateActive();
 
@@ -345,14 +351,22 @@ void CmdFemConstraintContact::activated(int)
     std::string FeatName = getUniqueObjectName("ConstraintContact");
 
     openCommand(QT_TRANSLATE_NOOP("Command", "Make FEM constraint contact on face"));
-    doCommand(Doc, "App.activeDocument().addObject(\"Fem::ConstraintContact\",\"%s\")", FeatName.c_str());
-    doCommand(Doc, "App.activeDocument().%s.Slope = 1000000.00", FeatName.c_str()); //OvG: set default not equal to 0
-    doCommand(Doc, "App.activeDocument().%s.Friction = 0.0", FeatName.c_str()); //OvG: set default not equal to 0
-    doCommand(Doc, "App.activeDocument().%s.Scale = 1", FeatName.c_str()); //OvG: set initial scale to 1
-    doCommand(Doc, "App.activeDocument().%s.addObject(App.activeDocument().%s)",
-        Analysis->getNameInDocument(), FeatName.c_str());
+    doCommand(
+        Doc, "App.activeDocument().addObject(\"Fem::ConstraintContact\",\"%s\")", FeatName.c_str());
+    doCommand(Doc,
+              "App.activeDocument().%s.Slope = 1000000.00",
+              FeatName.c_str());//OvG: set default not equal to 0
+    doCommand(Doc,
+              "App.activeDocument().%s.Friction = 0.0",
+              FeatName.c_str());//OvG: set default not equal to 0
+    doCommand(
+        Doc, "App.activeDocument().%s.Scale = 1", FeatName.c_str());//OvG: set initial scale to 1
+    doCommand(Doc,
+              "App.activeDocument().%s.addObject(App.activeDocument().%s)",
+              Analysis->getNameInDocument(),
+              FeatName.c_str());
 
-    doCommand(Doc, "%s", gethideMeshShowPartStr(FeatName).c_str()); //OvG: Hide meshes and show parts
+    doCommand(Doc, "%s", gethideMeshShowPartStr(FeatName).c_str());//OvG: Hide meshes and show parts
 
     updateActive();
 
@@ -371,13 +385,14 @@ DEF_STD_CMD_A(CmdFemConstraintDisplacement)
 CmdFemConstraintDisplacement::CmdFemConstraintDisplacement()
     : Command("FEM_ConstraintDisplacement")
 {
-    sAppModule      = "Fem";
-    sGroup          = QT_TR_NOOP("Fem");
-    sMenuText       = QT_TR_NOOP("Constraint displacement");
-    sToolTipText    = QT_TR_NOOP("Creates a FEM constraint for a displacement acting on a geometric entity");
-    sWhatsThis      = "FEM_ConstraintDisplacement";
-    sStatusTip      = sToolTipText;
-    sPixmap         = "FEM_ConstraintDisplacement";
+    sAppModule = "Fem";
+    sGroup = QT_TR_NOOP("Fem");
+    sMenuText = QT_TR_NOOP("Constraint displacement");
+    sToolTipText =
+        QT_TR_NOOP("Creates a FEM constraint for a displacement acting on a geometric entity");
+    sWhatsThis = "FEM_ConstraintDisplacement";
+    sStatusTip = sToolTipText;
+    sPixmap = "FEM_ConstraintDisplacement";
 }
 
 void CmdFemConstraintDisplacement::activated(int)
@@ -390,12 +405,17 @@ void CmdFemConstraintDisplacement::activated(int)
     std::string FeatName = getUniqueObjectName("ConstraintDisplacement");
 
     openCommand(QT_TRANSLATE_NOOP("Command", "Make FEM constraint displacement on face"));
-    doCommand(Doc, "App.activeDocument().addObject(\"Fem::ConstraintDisplacement\",\"%s\")", FeatName.c_str());
-    doCommand(Doc, "App.activeDocument().%s.Scale = 1", FeatName.c_str()); //OvG: set initial scale to 1
-    doCommand(Doc, "App.activeDocument().%s.addObject(App.activeDocument().%s)",
-        Analysis->getNameInDocument(), FeatName.c_str());
+    doCommand(Doc,
+              "App.activeDocument().addObject(\"Fem::ConstraintDisplacement\",\"%s\")",
+              FeatName.c_str());
+    doCommand(
+        Doc, "App.activeDocument().%s.Scale = 1", FeatName.c_str());//OvG: set initial scale to 1
+    doCommand(Doc,
+              "App.activeDocument().%s.addObject(App.activeDocument().%s)",
+              Analysis->getNameInDocument(),
+              FeatName.c_str());
 
-    doCommand(Doc, "%s", gethideMeshShowPartStr(FeatName).c_str()); //OvG: Hide meshes and show parts
+    doCommand(Doc, "%s", gethideMeshShowPartStr(FeatName).c_str());//OvG: Hide meshes and show parts
 
     updateActive();
 
@@ -433,11 +453,16 @@ void CmdFemConstraintFixed::activated(int)
     std::string FeatName = getUniqueObjectName("ConstraintFixed");
 
     openCommand(QT_TRANSLATE_NOOP("Command", "Make FEM constraint fixed geometry"));
-    doCommand(Doc, "App.activeDocument().addObject(\"Fem::ConstraintFixed\",\"%s\")", FeatName.c_str());
-    doCommand(Doc, "App.activeDocument().%s.Scale = 1", FeatName.c_str()); //OvG: set initial scale to 1
-    doCommand(Doc, "App.activeDocument().%s.addObject(App.activeDocument().%s)", Analysis->getNameInDocument(), FeatName.c_str());
+    doCommand(
+        Doc, "App.activeDocument().addObject(\"Fem::ConstraintFixed\",\"%s\")", FeatName.c_str());
+    doCommand(
+        Doc, "App.activeDocument().%s.Scale = 1", FeatName.c_str());//OvG: set initial scale to 1
+    doCommand(Doc,
+              "App.activeDocument().%s.addObject(App.activeDocument().%s)",
+              Analysis->getNameInDocument(),
+              FeatName.c_str());
 
-    doCommand(Doc, "%s", gethideMeshShowPartStr(FeatName).c_str()); //OvG: Hide meshes and show parts
+    doCommand(Doc, "%s", gethideMeshShowPartStr(FeatName).c_str());//OvG: Hide meshes and show parts
 
     updateActive();
 
@@ -456,13 +481,14 @@ DEF_STD_CMD_A(CmdFemConstraintFluidBoundary)
 CmdFemConstraintFluidBoundary::CmdFemConstraintFluidBoundary()
     : Command("FEM_ConstraintFluidBoundary")
 {
-    sAppModule      = "Fem";
-    sGroup          = QT_TR_NOOP("Fem");
-    sMenuText       = QT_TR_NOOP("Fluid boundary condition");
-    sToolTipText    = QT_TR_NOOP("Create fluid boundary condition on face entity for Computional Fluid Dynamics");
-    sWhatsThis      = "FEM_ConstraintFluidBoundary";
-    sStatusTip      = sToolTipText;
-    sPixmap         = "FEM_ConstraintFluidBoundary";
+    sAppModule = "Fem";
+    sGroup = QT_TR_NOOP("Fem");
+    sMenuText = QT_TR_NOOP("Fluid boundary condition");
+    sToolTipText =
+        QT_TR_NOOP("Create fluid boundary condition on face entity for Computional Fluid Dynamics");
+    sWhatsThis = "FEM_ConstraintFluidBoundary";
+    sStatusTip = sToolTipText;
+    sPixmap = "FEM_ConstraintFluidBoundary";
 }
 
 void CmdFemConstraintFluidBoundary::activated(int)
@@ -475,13 +501,18 @@ void CmdFemConstraintFluidBoundary::activated(int)
     std::string FeatName = getUniqueObjectName("ConstraintFluidBoundary");
 
     openCommand(QT_TRANSLATE_NOOP("Command", "Create fluid boundary condition"));
-    doCommand(Doc, "App.activeDocument().addObject(\"Fem::ConstraintFluidBoundary\",\"%s\")", FeatName.c_str());
-    doCommand(Doc, "App.activeDocument().%s.Scale = 1", FeatName.c_str()); //OvG: set initial scale to 1
+    doCommand(Doc,
+              "App.activeDocument().addObject(\"Fem::ConstraintFluidBoundary\",\"%s\")",
+              FeatName.c_str());
+    doCommand(
+        Doc, "App.activeDocument().%s.Scale = 1", FeatName.c_str());//OvG: set initial scale to 1
     //BoundaryValue is already the default value, zero is acceptable
-    doCommand(Doc, "App.activeDocument().%s.addObject(App.activeDocument().%s)",
-        Analysis->getNameInDocument(), FeatName.c_str());
+    doCommand(Doc,
+              "App.activeDocument().%s.addObject(App.activeDocument().%s)",
+              Analysis->getNameInDocument(),
+              FeatName.c_str());
 
-    doCommand(Doc, "%s", gethideMeshShowPartStr(FeatName).c_str()); //OvG: Hide meshes and show parts
+    doCommand(Doc, "%s", gethideMeshShowPartStr(FeatName).c_str());//OvG: Hide meshes and show parts
     updateActive();
 
     doCommand(Gui, "Gui.activeDocument().setEdit('%s')", FeatName.c_str());
@@ -499,13 +530,13 @@ DEF_STD_CMD_A(CmdFemConstraintForce)
 CmdFemConstraintForce::CmdFemConstraintForce()
     : Command("FEM_ConstraintForce")
 {
-    sAppModule      = "Fem";
-    sGroup          = QT_TR_NOOP("Fem");
-    sMenuText       = QT_TR_NOOP("Constraint force");
-    sToolTipText    = QT_TR_NOOP("Creates a FEM constraint for a force acting on a geometric entity");
-    sWhatsThis      = "FEM_ConstraintForce";
-    sStatusTip      = sToolTipText;
-    sPixmap         = "FEM_ConstraintForce";
+    sAppModule = "Fem";
+    sGroup = QT_TR_NOOP("Fem");
+    sMenuText = QT_TR_NOOP("Constraint force");
+    sToolTipText = QT_TR_NOOP("Creates a FEM constraint for a force acting on a geometric entity");
+    sWhatsThis = "FEM_ConstraintForce";
+    sStatusTip = sToolTipText;
+    sPixmap = "FEM_ConstraintForce";
 }
 
 void CmdFemConstraintForce::activated(int)
@@ -518,13 +549,22 @@ void CmdFemConstraintForce::activated(int)
     std::string FeatName = getUniqueObjectName("ConstraintForce");
 
     openCommand(QT_TRANSLATE_NOOP("Command", "Make FEM constraint force on geometry"));
-    doCommand(Doc, "App.activeDocument().addObject(\"Fem::ConstraintForce\",\"%s\")", FeatName.c_str());
-    doCommand(Doc, "App.activeDocument().%s.Force = 1.0", FeatName.c_str()); //OvG: set default not equal to 0
-    doCommand(Doc, "App.activeDocument().%s.Reversed = False", FeatName.c_str()); //OvG: set default to False
-    doCommand(Doc, "App.activeDocument().%s.Scale = 1", FeatName.c_str()); //OvG: set initial scale to 1
-    doCommand(Doc, "App.activeDocument().%s.addObject(App.activeDocument().%s)", Analysis->getNameInDocument(), FeatName.c_str());
+    doCommand(
+        Doc, "App.activeDocument().addObject(\"Fem::ConstraintForce\",\"%s\")", FeatName.c_str());
+    doCommand(Doc,
+              "App.activeDocument().%s.Force = 1.0",
+              FeatName.c_str());//OvG: set default not equal to 0
+    doCommand(Doc,
+              "App.activeDocument().%s.Reversed = False",
+              FeatName.c_str());//OvG: set default to False
+    doCommand(
+        Doc, "App.activeDocument().%s.Scale = 1", FeatName.c_str());//OvG: set initial scale to 1
+    doCommand(Doc,
+              "App.activeDocument().%s.addObject(App.activeDocument().%s)",
+              Analysis->getNameInDocument(),
+              FeatName.c_str());
 
-    doCommand(Doc, "%s", gethideMeshShowPartStr(FeatName).c_str()); //OvG: Hide meshes and show parts
+    doCommand(Doc, "%s", gethideMeshShowPartStr(FeatName).c_str());//OvG: Hide meshes and show parts
 
     updateActive();
 
@@ -561,11 +601,15 @@ void CmdFemConstraintGear::activated(int)
     std::string FeatName = getUniqueObjectName("ConstraintGear");
 
     openCommand(QT_TRANSLATE_NOOP("Command", "Make FEM constraint for gear"));
-    doCommand(Doc, "App.activeDocument().addObject(\"Fem::ConstraintGear\",\"%s\")", FeatName.c_str());
+    doCommand(
+        Doc, "App.activeDocument().addObject(\"Fem::ConstraintGear\",\"%s\")", FeatName.c_str());
     doCommand(Doc, "App.activeDocument().%s.Diameter = 100.0", FeatName.c_str());
-    doCommand(Doc, "App.activeDocument().%s.addObject(App.activeDocument().%s)", Analysis->getNameInDocument(), FeatName.c_str());
+    doCommand(Doc,
+              "App.activeDocument().%s.addObject(App.activeDocument().%s)",
+              Analysis->getNameInDocument(),
+              FeatName.c_str());
 
-    doCommand(Doc, "%s", gethideMeshShowPartStr(FeatName).c_str()); //OvG: Hide meshes and show parts
+    doCommand(Doc, "%s", gethideMeshShowPartStr(FeatName).c_str());//OvG: Hide meshes and show parts
 
     updateActive();
 
@@ -603,14 +647,23 @@ void CmdFemConstraintHeatflux::activated(int)
     std::string FeatName = getUniqueObjectName("ConstraintHeatflux");
 
     openCommand(QT_TRANSLATE_NOOP("Command", "Make FEM constraint heatflux on face"));
-    doCommand(Doc, "App.activeDocument().addObject(\"Fem::ConstraintHeatflux\",\"%s\")", FeatName.c_str());
-    doCommand(Doc, "App.activeDocument().%s.AmbientTemp = 300.0", FeatName.c_str()); //OvG: set default not equal to 0
-    doCommand(Doc, "App.activeDocument().%s.FilmCoef = 10.0", FeatName.c_str()); //OvG: set default not equal to 0
-    doCommand(Doc, "App.activeDocument().%s.Scale = 1", FeatName.c_str()); //OvG: set initial scale to 1
-    doCommand(Doc, "App.activeDocument().%s.addObject(App.activeDocument().%s)",
-        Analysis->getNameInDocument(), FeatName.c_str());
+    doCommand(Doc,
+              "App.activeDocument().addObject(\"Fem::ConstraintHeatflux\",\"%s\")",
+              FeatName.c_str());
+    doCommand(Doc,
+              "App.activeDocument().%s.AmbientTemp = 300.0",
+              FeatName.c_str());//OvG: set default not equal to 0
+    doCommand(Doc,
+              "App.activeDocument().%s.FilmCoef = 10.0",
+              FeatName.c_str());//OvG: set default not equal to 0
+    doCommand(
+        Doc, "App.activeDocument().%s.Scale = 1", FeatName.c_str());//OvG: set initial scale to 1
+    doCommand(Doc,
+              "App.activeDocument().%s.addObject(App.activeDocument().%s)",
+              Analysis->getNameInDocument(),
+              FeatName.c_str());
 
-    doCommand(Doc, "%s", gethideMeshShowPartStr().c_str()); //OvG: Hide meshes and show parts
+    doCommand(Doc, "%s", gethideMeshShowPartStr().c_str());//OvG: Hide meshes and show parts
 
     updateActive();
 
@@ -629,13 +682,13 @@ DEF_STD_CMD_A(CmdFemConstraintInitialTemperature)
 CmdFemConstraintInitialTemperature::CmdFemConstraintInitialTemperature()
     : Command("FEM_ConstraintInitialTemperature")
 {
-    sAppModule      = "Fem";
-    sGroup          = QT_TR_NOOP("Fem");
-    sMenuText       = QT_TR_NOOP("Constraint initial temperature");
-    sToolTipText    = QT_TR_NOOP("Creates a FEM constraint for initial temperature acting on a body");
-    sWhatsThis      = "FEM_ConstraintInitialTemperature";
-    sStatusTip      = sToolTipText;
-    sPixmap         = "FEM_ConstraintInitialTemperature";
+    sAppModule = "Fem";
+    sGroup = QT_TR_NOOP("Fem");
+    sMenuText = QT_TR_NOOP("Constraint initial temperature");
+    sToolTipText = QT_TR_NOOP("Creates a FEM constraint for initial temperature acting on a body");
+    sWhatsThis = "FEM_ConstraintInitialTemperature";
+    sStatusTip = sToolTipText;
+    sPixmap = "FEM_ConstraintInitialTemperature";
 }
 
 void CmdFemConstraintInitialTemperature::activated(int)
@@ -648,12 +701,17 @@ void CmdFemConstraintInitialTemperature::activated(int)
     std::string FeatName = getUniqueObjectName("ConstraintInitialTemperature");
 
     openCommand(QT_TRANSLATE_NOOP("Command", "Make FEM constraint initial temperature on body"));
-    doCommand(Doc, "App.activeDocument().addObject(\"Fem::ConstraintInitialTemperature\",\"%s\")", FeatName.c_str());
-    doCommand(Doc, "App.activeDocument().%s.Scale = 1", FeatName.c_str()); //OvG: set initial scale to 1
-    doCommand(Doc, "App.activeDocument().%s.addObject(App.activeDocument().%s)",
-        Analysis->getNameInDocument(), FeatName.c_str());
+    doCommand(Doc,
+              "App.activeDocument().addObject(\"Fem::ConstraintInitialTemperature\",\"%s\")",
+              FeatName.c_str());
+    doCommand(
+        Doc, "App.activeDocument().%s.Scale = 1", FeatName.c_str());//OvG: set initial scale to 1
+    doCommand(Doc,
+              "App.activeDocument().%s.addObject(App.activeDocument().%s)",
+              Analysis->getNameInDocument(),
+              FeatName.c_str());
 
-    doCommand(Doc, "%s", gethideMeshShowPartStr().c_str()); //OvG: Hide meshes and show parts
+    doCommand(Doc, "%s", gethideMeshShowPartStr().c_str());//OvG: Hide meshes and show parts
 
     updateActive();
 
@@ -691,11 +749,17 @@ void CmdFemConstraintPlaneRotation::activated(int)
     std::string FeatName = getUniqueObjectName("ConstraintPlaneRotation");
 
     openCommand(QT_TRANSLATE_NOOP("Command", "Make FEM constraint Plane Rotation face"));
-    doCommand(Doc, "App.activeDocument().addObject(\"Fem::ConstraintPlaneRotation\",\"%s\")", FeatName.c_str());
-    doCommand(Doc, "App.activeDocument().%s.Scale = 1", FeatName.c_str()); //OvG: set initial scale to 1
-    doCommand(Doc, "App.activeDocument().%s.addObject(App.activeDocument().%s)", Analysis->getNameInDocument(), FeatName.c_str());
+    doCommand(Doc,
+              "App.activeDocument().addObject(\"Fem::ConstraintPlaneRotation\",\"%s\")",
+              FeatName.c_str());
+    doCommand(
+        Doc, "App.activeDocument().%s.Scale = 1", FeatName.c_str());//OvG: set initial scale to 1
+    doCommand(Doc,
+              "App.activeDocument().%s.addObject(App.activeDocument().%s)",
+              Analysis->getNameInDocument(),
+              FeatName.c_str());
 
-    doCommand(Doc, "%s", gethideMeshShowPartStr(FeatName).c_str()); //OvG: Hide meshes and show parts
+    doCommand(Doc, "%s", gethideMeshShowPartStr(FeatName).c_str());//OvG: Hide meshes and show parts
 
     updateActive();
 
@@ -733,14 +797,23 @@ void CmdFemConstraintPressure::activated(int)
     std::string FeatName = getUniqueObjectName("ConstraintPressure");
 
     openCommand(QT_TRANSLATE_NOOP("Command", "Make FEM constraint pressure on face"));
-    doCommand(Doc, "App.activeDocument().addObject(\"Fem::ConstraintPressure\",\"%s\")", FeatName.c_str());
-    doCommand(Doc, "App.activeDocument().%s.Pressure = 0.1", FeatName.c_str()); //OvG: set default not equal to 0
-    doCommand(Doc, "App.activeDocument().%s.Reversed = False", FeatName.c_str()); //OvG: set default to False
-    doCommand(Doc, "App.activeDocument().%s.Scale = 1", FeatName.c_str()); //OvG: set initial scale to 1
-    doCommand(Doc, "App.activeDocument().%s.addObject(App.activeDocument().%s)",
-        Analysis->getNameInDocument(), FeatName.c_str());
+    doCommand(Doc,
+              "App.activeDocument().addObject(\"Fem::ConstraintPressure\",\"%s\")",
+              FeatName.c_str());
+    doCommand(Doc,
+              "App.activeDocument().%s.Pressure = 0.1",
+              FeatName.c_str());//OvG: set default not equal to 0
+    doCommand(Doc,
+              "App.activeDocument().%s.Reversed = False",
+              FeatName.c_str());//OvG: set default to False
+    doCommand(
+        Doc, "App.activeDocument().%s.Scale = 1", FeatName.c_str());//OvG: set initial scale to 1
+    doCommand(Doc,
+              "App.activeDocument().%s.addObject(App.activeDocument().%s)",
+              Analysis->getNameInDocument(),
+              FeatName.c_str());
 
-    doCommand(Doc, "%s", gethideMeshShowPartStr(FeatName).c_str()); //OvG: Hide meshes and show parts
+    doCommand(Doc, "%s", gethideMeshShowPartStr(FeatName).c_str());//OvG: Hide meshes and show parts
 
     updateActive();
 
@@ -778,14 +851,22 @@ void CmdFemConstraintSpring::activated(int)
     std::string FeatName = getUniqueObjectName("ConstraintSpring");
 
     openCommand(QT_TRANSLATE_NOOP("Command", "Make FEM constraint spring on face"));
-    doCommand(Doc, "App.activeDocument().addObject(\"Fem::ConstraintSpring\",\"%s\")", FeatName.c_str());
-    doCommand(Doc, "App.activeDocument().%s.normalStiffness = 1.0", FeatName.c_str()); //OvG: set default not equal to 0
-    doCommand(Doc, "App.activeDocument().%s.tangentialStiffness = 0.0", FeatName.c_str()); //OvG: set default to False
-    doCommand(Doc, "App.activeDocument().%s.Scale = 1", FeatName.c_str()); //OvG: set initial scale to 1
-    doCommand(Doc, "App.activeDocument().%s.addObject(App.activeDocument().%s)",
-        Analysis->getNameInDocument(), FeatName.c_str());
+    doCommand(
+        Doc, "App.activeDocument().addObject(\"Fem::ConstraintSpring\",\"%s\")", FeatName.c_str());
+    doCommand(Doc,
+              "App.activeDocument().%s.normalStiffness = 1.0",
+              FeatName.c_str());//OvG: set default not equal to 0
+    doCommand(Doc,
+              "App.activeDocument().%s.tangentialStiffness = 0.0",
+              FeatName.c_str());//OvG: set default to False
+    doCommand(
+        Doc, "App.activeDocument().%s.Scale = 1", FeatName.c_str());//OvG: set initial scale to 1
+    doCommand(Doc,
+              "App.activeDocument().%s.addObject(App.activeDocument().%s)",
+              Analysis->getNameInDocument(),
+              FeatName.c_str());
 
-    doCommand(Doc, "%s", gethideMeshShowPartStr(FeatName).c_str()); //OvG: Hide meshes and show parts
+    doCommand(Doc, "%s", gethideMeshShowPartStr(FeatName).c_str());//OvG: Hide meshes and show parts
 
     updateActive();
 
@@ -823,15 +904,19 @@ void CmdFemConstraintPulley::activated(int)
     std::string FeatName = getUniqueObjectName("ConstraintPulley");
 
     openCommand(QT_TRANSLATE_NOOP("Command", "Make FEM constraint for pulley"));
-    doCommand(Doc, "App.activeDocument().addObject(\"Fem::ConstraintPulley\",\"%s\")", FeatName.c_str());
+    doCommand(
+        Doc, "App.activeDocument().addObject(\"Fem::ConstraintPulley\",\"%s\")", FeatName.c_str());
     doCommand(Doc, "App.activeDocument().%s.Diameter = 300.0", FeatName.c_str());
     doCommand(Doc, "App.activeDocument().%s.OtherDiameter = 100.0", FeatName.c_str());
     doCommand(Doc, "App.activeDocument().%s.CenterDistance = 500.0", FeatName.c_str());
     doCommand(Doc, "App.activeDocument().%s.Force = 100.0", FeatName.c_str());
     doCommand(Doc, "App.activeDocument().%s.TensionForce = 100.0", FeatName.c_str());
-    doCommand(Doc, "App.activeDocument().%s.addObject(App.activeDocument().%s)", Analysis->getNameInDocument(), FeatName.c_str());
+    doCommand(Doc,
+              "App.activeDocument().%s.addObject(App.activeDocument().%s)",
+              Analysis->getNameInDocument(),
+              FeatName.c_str());
 
-    doCommand(Doc, "%s", gethideMeshShowPartStr(FeatName).c_str()); //OvG: Hide meshes and show parts
+    doCommand(Doc, "%s", gethideMeshShowPartStr(FeatName).c_str());//OvG: Hide meshes and show parts
 
     updateActive();
 
@@ -850,13 +935,14 @@ DEF_STD_CMD_A(CmdFemConstraintTemperature)
 CmdFemConstraintTemperature::CmdFemConstraintTemperature()
     : Command("FEM_ConstraintTemperature")
 {
-    sAppModule      = "Fem";
-    sGroup          = QT_TR_NOOP("Fem");
-    sMenuText       = QT_TR_NOOP("Constraint temperature");
-    sToolTipText    = QT_TR_NOOP("Creates a FEM constraint for a temperature/concentrated heat flux acting on a face");
-    sWhatsThis      = "FEM_ConstraintTemperature";
-    sStatusTip      = sToolTipText;
-    sPixmap         = "FEM_ConstraintTemperature";
+    sAppModule = "Fem";
+    sGroup = QT_TR_NOOP("Fem");
+    sMenuText = QT_TR_NOOP("Constraint temperature");
+    sToolTipText = QT_TR_NOOP(
+        "Creates a FEM constraint for a temperature/concentrated heat flux acting on a face");
+    sWhatsThis = "FEM_ConstraintTemperature";
+    sStatusTip = sToolTipText;
+    sPixmap = "FEM_ConstraintTemperature";
 }
 
 void CmdFemConstraintTemperature::activated(int)
@@ -869,12 +955,17 @@ void CmdFemConstraintTemperature::activated(int)
     std::string FeatName = getUniqueObjectName("ConstraintTemperature");
 
     openCommand(QT_TRANSLATE_NOOP("Command", "Make FEM constraint temperature on face"));
-    doCommand(Doc, "App.activeDocument().addObject(\"Fem::ConstraintTemperature\",\"%s\")", FeatName.c_str());
-    doCommand(Doc, "App.activeDocument().%s.Scale = 1", FeatName.c_str()); //OvG: set initial scale to 1
-    doCommand(Doc, "App.activeDocument().%s.addObject(App.activeDocument().%s)",
-        Analysis->getNameInDocument(), FeatName.c_str());
+    doCommand(Doc,
+              "App.activeDocument().addObject(\"Fem::ConstraintTemperature\",\"%s\")",
+              FeatName.c_str());
+    doCommand(
+        Doc, "App.activeDocument().%s.Scale = 1", FeatName.c_str());//OvG: set initial scale to 1
+    doCommand(Doc,
+              "App.activeDocument().%s.addObject(App.activeDocument().%s)",
+              Analysis->getNameInDocument(),
+              FeatName.c_str());
 
-    doCommand(Doc, "%s", gethideMeshShowPartStr().c_str()); //OvG: Hide meshes and show parts
+    doCommand(Doc, "%s", gethideMeshShowPartStr().c_str());//OvG: Hide meshes and show parts
 
     updateActive();
 
@@ -912,15 +1003,19 @@ void CmdFemConstraintTransform::activated(int)
     std::string FeatName = getUniqueObjectName("ConstraintTransform");
 
     openCommand(QT_TRANSLATE_NOOP("Command", "Make FEM constraint transform on face"));
-    doCommand(Doc, "App.activeDocument().addObject(\"Fem::ConstraintTransform\",\"%s\")", FeatName.c_str());
+    doCommand(Doc,
+              "App.activeDocument().addObject(\"Fem::ConstraintTransform\",\"%s\")",
+              FeatName.c_str());
     doCommand(Doc, "App.activeDocument().%s.X_rot = 0.0", FeatName.c_str());
     doCommand(Doc, "App.activeDocument().%s.Y_rot = 0.0", FeatName.c_str());
     doCommand(Doc, "App.activeDocument().%s.Z_rot = 0.0", FeatName.c_str());
     doCommand(Doc, "App.activeDocument().%s.Scale = 1", FeatName.c_str());
-    doCommand(Doc, "App.activeDocument().%s.addObject(App.activeDocument().%s)",
-        Analysis->getNameInDocument(), FeatName.c_str());
+    doCommand(Doc,
+              "App.activeDocument().%s.addObject(App.activeDocument().%s)",
+              Analysis->getNameInDocument(),
+              FeatName.c_str());
 
-    doCommand(Doc, "%s", gethideMeshShowPartStr(FeatName).c_str()); //OvG: Hide meshes and show parts
+    doCommand(Doc, "%s", gethideMeshShowPartStr(FeatName).c_str());//OvG: Hide meshes and show parts
 
     updateActive();
 
@@ -971,11 +1066,13 @@ void DefineNodesCallback(void* ud, SoEventCallback* n)
         polygon.Add(Base::Vector2d((*it)[0], (*it)[1]));
 
 
-    std::vector<App::DocumentObject*> docObj = Gui::Selection().getObjectsOfType(Fem::FemMeshObject::getClassTypeId());
+    std::vector<App::DocumentObject*> docObj =
+        Gui::Selection().getObjectsOfType(Fem::FemMeshObject::getClassTypeId());
     if (docObj.size() != 1)
         return;
 
-    const SMESHDS_Mesh* data = static_cast<Fem::FemMeshObject*>(docObj[0])->FemMesh.getValue().getSMesh()->GetMeshDS();
+    const SMESHDS_Mesh* data =
+        static_cast<Fem::FemMeshObject*>(docObj[0])->FemMesh.getValue().getSMesh()->GetMeshDS();
 
     SMDS_NodeIteratorPtr aNodeIter = data->nodesIterator();
     Base::Vector3f pt2d;
@@ -1001,9 +1098,13 @@ void DefineNodesCallback(void* ud, SoEventCallback* n)
 
 
     Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Place robot"));
-    Gui::Command::doCommand(Gui::Command::Doc, "App.ActiveDocument.addObject('Fem::FemSetNodesObject','NodeSet')");
-    Gui::Command::doCommand(Gui::Command::Doc, "App.ActiveDocument.ActiveObject.Nodes = %s", set.str().c_str());
-    Gui::Command::doCommand(Gui::Command::Doc, "App.activeDocument().%s.addObject(App.activeDocument().NodeSet)", Analysis->getNameInDocument());
+    Gui::Command::doCommand(Gui::Command::Doc,
+                            "App.ActiveDocument.addObject('Fem::FemSetNodesObject','NodeSet')");
+    Gui::Command::doCommand(
+        Gui::Command::Doc, "App.ActiveDocument.ActiveObject.Nodes = %s", set.str().c_str());
+    Gui::Command::doCommand(Gui::Command::Doc,
+                            "App.activeDocument().%s.addObject(App.activeDocument().NodeSet)",
+                            Analysis->getNameInDocument());
     // Gui::Command::updateActive();
     Gui::Command::commitCommand();
 
@@ -1040,9 +1141,11 @@ CmdFemDefineNodesSet::CmdFemDefineNodesSet()
 
 void CmdFemDefineNodesSet::activated(int)
 {
-    std::vector<App::DocumentObject*> docObj = Gui::Selection().getObjectsOfType(Fem::FemMeshObject::getClassTypeId());
+    std::vector<App::DocumentObject*> docObj =
+        Gui::Selection().getObjectsOfType(Fem::FemMeshObject::getClassTypeId());
 
-    for (std::vector<App::DocumentObject*>::iterator it = docObj.begin(); it != docObj.end(); ++it) {
+    for (std::vector<App::DocumentObject*>::iterator it = docObj.begin(); it != docObj.end();
+         ++it) {
         if (it == docObj.begin()) {
             Gui::Document* doc = getActiveGuiDocument();
             Gui::MDIView* view = doc->getActiveView();
@@ -1100,24 +1203,31 @@ void CmdFemCreateNodesSet::activated(int)
     Gui::SelectionFilter FemMeshFilter("SELECT Fem::FemMeshObject COUNT 1");
 
     if (ObjectFilter.match()) {
-        Fem::FemSetNodesObject* NodesObj = static_cast<Fem::FemSetNodesObject*>(ObjectFilter.Result[0][0].getObject());
+        Fem::FemSetNodesObject* NodesObj =
+            static_cast<Fem::FemSetNodesObject*>(ObjectFilter.Result[0][0].getObject());
         openCommand(QT_TRANSLATE_NOOP("Command", "Edit nodes set"));
         doCommand(Gui, "Gui.activeDocument().setEdit('%s')", NodesObj->getNameInDocument());
     }
     else if (FemMeshFilter.match()) {
-        Fem::FemMeshObject* MeshObj = static_cast<Fem::FemMeshObject*>(FemMeshFilter.Result[0][0].getObject());
+        Fem::FemMeshObject* MeshObj =
+            static_cast<Fem::FemMeshObject*>(FemMeshFilter.Result[0][0].getObject());
 
         std::string FeatName = getUniqueObjectName("NodesSet");
 
         openCommand(QT_TRANSLATE_NOOP("Command", "Create nodes set"));
-        doCommand(Doc, "App.activeDocument().addObject('Fem::FemSetNodesObject','%s')", FeatName.c_str());
-        doCommand(Gui, "App.activeDocument().%s.FemMesh = App.activeDocument().%s", FeatName.c_str(), MeshObj->getNameInDocument());
+        doCommand(
+            Doc, "App.activeDocument().addObject('Fem::FemSetNodesObject','%s')", FeatName.c_str());
+        doCommand(Gui,
+                  "App.activeDocument().%s.FemMesh = App.activeDocument().%s",
+                  FeatName.c_str(),
+                  MeshObj->getNameInDocument());
         doCommand(Gui, "Gui.activeDocument().setEdit('%s')", FeatName.c_str());
     }
     else {
         QMessageBox::warning(Gui::getMainWindow(),
-            qApp->translate("CmdFemCreateNodesSet", "Wrong selection"),
-            qApp->translate("CmdFemCreateNodesSet", "Select a single FEM mesh or nodes set, please."));
+                             qApp->translate("CmdFemCreateNodesSet", "Wrong selection"),
+                             qApp->translate("CmdFemCreateNodesSet",
+                                             "Select a single FEM mesh or nodes set, please."));
     }
 }
 
@@ -1244,13 +1354,16 @@ bool CmdFemCompEmConstraints::isActive()
 // helper vtk post processing
 
 void setupFilter(Gui::Command* cmd, std::string Name) {
-    // In the isActive() functions it is already assured that the filters are only active on allowed objects
-    // For the case the clip filter is set by Python code, we check that the input is a post object
-    // and issue an error if not.
+    // In the isActive() functions it is already assured that the filters are
+    // only active on allowed objects
+    // For the case the clip filter is set by Python code, we check that the input
+    // is a post object and issue an error if not.
 
     if (Gui::Selection().getSelection().size() > 1) {
-        QMessageBox::warning(Gui::getMainWindow(),
-            qApp->translate("setupFilter", "Error: A filter can only be applied to a single object."),
+        QMessageBox::warning(
+            Gui::getMainWindow(),
+            qApp->translate("setupFilter",
+                            "Error: A filter can only be applied to a single object."),
             qApp->translate("setupFilter", "The filter could not be set up."));
         return;
     }
@@ -1273,7 +1386,8 @@ void setupFilter(Gui::Command* cmd, std::string Name) {
 
     std::string FeatName = cmd->getUniqueObjectName(Name.c_str());
 
-    // at first we must determine the pipeline of the selection object (which can be a pipeline itself)
+    // at first we must determine the pipeline of the selection object
+    // (which can be a pipeline itself)
     bool selectionIsPipeline = false;
     Fem::FemPostPipeline* pipeline = nullptr;
     if (selObject->getTypeId() == Base::Type::fromName("Fem::FemPostPipeline")) {
@@ -1328,12 +1442,27 @@ void setupFilter(Gui::Command* cmd, std::string Name) {
 
 std::string Plot()
 {
-    auto xAxisLabel = QCoreApplication::translate("CmdFemPostLinearizedStressesFilter", "Thickness [mm]", "Plot X-Axis Label").toStdString();
-    auto yAxisLabel = QCoreApplication::translate("CmdFemPostLinearizedStressesFilter", "Stress [MPa]", "Plot Y-Axis Label").toStdString();
-    auto titleLabel = QCoreApplication::translate("CmdFemPostLinearizedStressesFilter", "Linearized Stresses", "Plot title").toStdString();
-    auto legendEntryA = QCoreApplication::translate("CmdFemPostLinearizedStressesFilter", "Membrane", "Plot legend item label").toStdString();
-    auto legendEntryB = QCoreApplication::translate("CmdFemPostLinearizedStressesFilter", "Membrane and Bending", "Plot legend item label").toStdString();
-    auto legendEntryC = QCoreApplication::translate("CmdFemPostLinearizedStressesFilter", "Total", "Plot legend item label").toStdString();
+    auto xAxisLabel = QCoreApplication::translate("CmdFemPostLinearizedStressesFilter",
+                                                  "Thickness [mm]",
+                                                  "Plot X-Axis Label")
+                          .toStdString();
+    auto yAxisLabel = QCoreApplication::translate(
+                          "CmdFemPostLinearizedStressesFilter", "Stress [MPa]", "Plot Y-Axis Label")
+                          .toStdString();
+    auto titleLabel = QCoreApplication::translate(
+                          "CmdFemPostLinearizedStressesFilter", "Linearized Stresses", "Plot title")
+                          .toStdString();
+    auto legendEntryA = QCoreApplication::translate("CmdFemPostLinearizedStressesFilter",
+                                                    "Membrane",
+                                                    "Plot legend item label")
+                            .toStdString();
+    auto legendEntryB = QCoreApplication::translate("CmdFemPostLinearizedStressesFilter",
+                                                    "Membrane and Bending",
+                                                    "Plot legend item label")
+                            .toStdString();
+    auto legendEntryC = QCoreApplication::translate(
+                            "CmdFemPostLinearizedStressesFilter", "Total", "Plot legend item label")
+                            .toStdString();
 
     std::ostringstream oss;
     oss << "t=t_coords[len(t_coords)-1]\n\
@@ -1365,7 +1494,8 @@ import FreeCAD\n\
 from PySide import QtCore\n\
 import numpy as np\n\
 from matplotlib import pyplot as plt\n\
-plt.figure(\"" << titleLabel << "\")\n\
+plt.figure(\""
+        << titleLabel << "\")\n\
 plt.plot(t_coords, membrane, \"k--\")\n\
 plt.plot(t_coords, mb, \"b*-\")\n\
 plt.plot(t_coords, peak, \"r-x\")\n\
@@ -1385,10 +1515,15 @@ FreeCAD.Console.PrintError([str(round(peak[0],2))])\n\
 FreeCAD.Console.PrintError('Total stress max = ')\n\
 FreeCAD.Console.PrintError([str(round(peak[len(t_coords)-1],2))])\n\
 plt.ioff()\n\
-plt.legend([\"" << legendEntryA << "\", \"" << legendEntryB << "\", \"" << legendEntryC << "\"], loc = \"best\")\n\
-plt.xlabel(\"" << xAxisLabel << "\")\n\
-plt.ylabel(\"" << yAxisLabel << "\")\n\
-plt.title(\"" << titleLabel << "\")\n\
+plt.legend([\""
+        << legendEntryA << "\", \"" << legendEntryB << "\", \"" << legendEntryC
+        << "\"], loc = \"best\")\n\
+plt.xlabel(\""
+        << xAxisLabel << "\")\n\
+plt.ylabel(\""
+        << yAxisLabel << "\")\n\
+plt.title(\""
+        << titleLabel << "\")\n\
 plt.grid()\n\
 fig_manager = plt.get_current_fig_manager()\n\
 fig_manager.window.setParent(FreeCADGui.getMainWindow())\n\
@@ -1404,13 +1539,14 @@ DEF_STD_CMD_A(CmdFemPostClipFilter)
 CmdFemPostClipFilter::CmdFemPostClipFilter()
     : Command("FEM_PostFilterClipRegion")
 {
-    sAppModule      = "Fem";
-    sGroup          = QT_TR_NOOP("Fem");
-    sMenuText       = QT_TR_NOOP("Region clip filter");
-    sToolTipText    = QT_TR_NOOP("Define/create a clip filter which uses functions to define the cliped region");
-    sWhatsThis      = "FEM_PostFilterClipRegion";
-    sStatusTip      = sToolTipText;
-    sPixmap         = "FEM_PostFilterClipRegion";
+    sAppModule = "Fem";
+    sGroup = QT_TR_NOOP("Fem");
+    sMenuText = QT_TR_NOOP("Region clip filter");
+    sToolTipText =
+        QT_TR_NOOP("Define/create a clip filter which uses functions to define the cliped region");
+    sWhatsThis = "FEM_PostFilterClipRegion";
+    sStatusTip = sToolTipText;
+    sPixmap = "FEM_PostFilterClipRegion";
 }
 
 void CmdFemPostClipFilter::activated(int)
@@ -1423,7 +1559,8 @@ bool CmdFemPostClipFilter::isActive()
     // only allow one object
     if (getSelection().getSelection().size() > 1)
         return false;
-    // only activate if a result is either a post pipeline, scalar, cut or warp filter, itself or along line filter
+    // only activate if a result is either a post pipeline, scalar, cut or warp filter,
+    // itself or along line filter
     if (getSelection().getObjectsOfType<Fem::FemPostPipeline>().size() == 1)
         return true;
     else if (getSelection().getObjectsOfType<Fem::FemPostScalarClipFilter>().size() == 1)
@@ -1466,7 +1603,8 @@ bool CmdFemPostCutFilter::isActive()
     // only allow one object
     if (getSelection().getSelection().size() > 1)
         return false;
-    // only activate if a result is either a post pipeline, scalar, clip or warp filter, itself, or along line filter
+    // only activate if a result is either a post pipeline, scalar, clip or warp filter,
+    // itself, or along line filter
     if (getSelection().getObjectsOfType<Fem::FemPostPipeline>().size() == 1)
         return true;
     else if (getSelection().getObjectsOfType<Fem::FemPostScalarClipFilter>().size() == 1)
@@ -1552,7 +1690,8 @@ bool CmdFemPostDataAtPointFilter::isActive()
     // only allow one object
     if (getSelection().getSelection().size() > 1)
         return false;
-    // only activate if a result is either a post pipeline, scalar, cut, clip, warp or along line filter
+    // only activate if a result is either a post pipeline, scalar, cut, clip,
+    // warp or along line filter
     if (getSelection().getObjectsOfType<Fem::FemPostPipeline>().size() == 1)
         return true;
     else if (getSelection().getObjectsOfType<Fem::FemPostScalarClipFilter>().size() == 1)
@@ -1591,7 +1730,9 @@ void CmdFemPostLinearizedStressesFilter::activated(int)
     Gui::SelectionFilter DataAlongLineFilter("SELECT Fem::FemPostDataAlongLineFilter COUNT 1");
 
     if (DataAlongLineFilter.match()) {
-        Fem::FemPostDataAlongLineFilter* DataAlongLine = static_cast<Fem::FemPostDataAlongLineFilter*>(DataAlongLineFilter.Result[0][0].getObject());
+        Fem::FemPostDataAlongLineFilter* DataAlongLine =
+            static_cast<Fem::FemPostDataAlongLineFilter*>(
+                DataAlongLineFilter.Result[0][0].getObject());
         std::string FieldName = DataAlongLine->PlotData.getValue();
         if (
             (FieldName == "Tresca Stress")
@@ -1599,7 +1740,8 @@ void CmdFemPostLinearizedStressesFilter::activated(int)
             || (FieldName == "Major Principal Stress")
             || (FieldName == "Intermediate Principal Stress")
             || (FieldName == "Minor Principal Stress")
-            // names need to match with names in FemVTKTools.cpp, this is not failsafe, but ATM there is no better way for test on a stress result in vtk pipeline
+            // names need to match with names in FemVTKTools.cpp, this is not failsafe,
+            // but at the moment there is no better way for test on a stress result in vtk pipeline
             ) {
             // TODO FIXME only works if the data along the line object has the name DataAlongLine
             // we should get the selected data along the line object
@@ -1610,15 +1752,21 @@ void CmdFemPostLinearizedStressesFilter::activated(int)
             Gui::doCommandT(Gui::Command::Doc, Plot().c_str());
         }
         else {
-            QMessageBox::warning(Gui::getMainWindow(),
+            QMessageBox::warning(
+                Gui::getMainWindow(),
                 qApp->translate("CmdFemPostLinearizedStressesFilter", "Wrong selection"),
-                qApp->translate("CmdFemPostLinearizedStressesFilter", "Select a Clip filter which clips a STRESS field along a line, please."));
+                qApp->translate(
+                    "CmdFemPostLinearizedStressesFilter",
+                    "Select a Clip filter which clips a STRESS field along a line, please."));
         }
     }
     else {
-        QMessageBox::warning(Gui::getMainWindow(),
+        QMessageBox::warning(
+            Gui::getMainWindow(),
             qApp->translate("CmdFemPostLinearizedStressesFilter", "Wrong selection"),
-            qApp->translate("CmdFemPostLinearizedStressesFilter", "Select a Clip filter which clips a STRESS field along a line, please."));
+            qApp->translate(
+                "CmdFemPostLinearizedStressesFilter",
+                "Select a Clip filter which clips a STRESS field along a line, please."));
     }
 }
 
@@ -1640,13 +1788,14 @@ DEF_STD_CMD_A(CmdFemPostScalarClipFilter)
 CmdFemPostScalarClipFilter::CmdFemPostScalarClipFilter()
     : Command("FEM_PostFilterClipScalar")
 {
-    sAppModule      = "Fem";
-    sGroup          = QT_TR_NOOP("Fem");
-    sMenuText       = QT_TR_NOOP("Scalar clip filter");
-    sToolTipText    = QT_TR_NOOP("Define/create a clip filter which clips a field with a scalar value");
-    sWhatsThis      = "FEM_PostFilterClipScalar";
-    sStatusTip      = sToolTipText;
-    sPixmap         = "FEM_PostFilterClipScalar";
+    sAppModule = "Fem";
+    sGroup = QT_TR_NOOP("Fem");
+    sMenuText = QT_TR_NOOP("Scalar clip filter");
+    sToolTipText =
+        QT_TR_NOOP("Define/create a clip filter which clips a field with a scalar value");
+    sWhatsThis = "FEM_PostFilterClipScalar";
+    sStatusTip = sToolTipText;
+    sPixmap = "FEM_PostFilterClipScalar";
 }
 
 void CmdFemPostScalarClipFilter::activated(int)
@@ -1742,27 +1891,39 @@ void CmdFemPostFunctions::activated(int iMsg)
     else
         return;
 
-    //create the object
-    std::vector<Fem::FemPostPipeline*> pipelines = App::GetApplication().getActiveDocument()->getObjectsOfType<Fem::FemPostPipeline>();
+    // create the object
+    std::vector<Fem::FemPostPipeline*> pipelines =
+        App::GetApplication().getActiveDocument()->getObjectsOfType<Fem::FemPostPipeline>();
     if (!pipelines.empty()) {
         Fem::FemPostPipeline* pipeline = pipelines.front();
 
         openCommand(QT_TRANSLATE_NOOP("Command", "Create function"));
 
-        //check if the pipeline has a filter provider and add one if needed
+        // check if the pipeline has a filter provider and add one if needed
         Fem::FemPostFunctionProvider* provider;
-        if (!pipeline->Functions.getValue() || pipeline->Functions.getValue()->getTypeId() != Fem::FemPostFunctionProvider::getClassTypeId()) {
+        if (!pipeline->Functions.getValue()
+            || pipeline->Functions.getValue()->getTypeId()
+                != Fem::FemPostFunctionProvider::getClassTypeId()) {
             std::string FuncName = getUniqueObjectName("Functions");
-            doCommand(Doc, "App.ActiveDocument.addObject('Fem::FemPostFunctionProvider','%s')", FuncName.c_str());
-            doCommand(Doc, "App.ActiveDocument.%s.Functions = App.ActiveDocument.%s", pipeline->getNameInDocument(), FuncName.c_str());
-            provider = static_cast<Fem::FemPostFunctionProvider*>(getDocument()->getObject(FuncName.c_str()));
+            doCommand(Doc,
+                      "App.ActiveDocument.addObject('Fem::FemPostFunctionProvider','%s')",
+                      FuncName.c_str());
+            doCommand(Doc,
+                      "App.ActiveDocument.%s.Functions = App.ActiveDocument.%s",
+                      pipeline->getNameInDocument(),
+                      FuncName.c_str());
+            provider = static_cast<Fem::FemPostFunctionProvider*>(
+                getDocument()->getObject(FuncName.c_str()));
         }
         else
             provider = static_cast<Fem::FemPostFunctionProvider*>(pipeline->Functions.getValue());
 
-        //build the object
+        // build the object
         std::string FeatName = getUniqueObjectName(name.c_str());
-        doCommand(Doc, "App.activeDocument().addObject('Fem::FemPost%sFunction','%s')", name.c_str(), FeatName.c_str());
+        doCommand(Doc,
+                  "App.activeDocument().addObject('Fem::FemPost%sFunction','%s')",
+                  name.c_str(),
+                  FeatName.c_str());
         doCommand(Doc, "__list__ = App.ActiveDocument.%s.Functions", provider->getNameInDocument());
         doCommand(Doc, "__list__.append(App.ActiveDocument.%s)", FeatName.c_str());
         doCommand(Doc, "App.ActiveDocument.%s.Functions = __list__", provider->getNameInDocument());
@@ -1775,12 +1936,23 @@ void CmdFemPostFunctions::activated(int iMsg)
         box.GetCenter(center);
 
         if (iMsg == 0)
-            doCommand(Doc, "App.ActiveDocument.%s.Origin = App.Vector(%f, %f, %f)", FeatName.c_str(), center[0],
-                center[1], center[2]);
+            doCommand(Doc,
+                      "App.ActiveDocument.%s.Origin = App.Vector(%f, %f, %f)",
+                      FeatName.c_str(),
+                      center[0],
+                      center[1],
+                      center[2]);
         else if (iMsg == 1) {
-            doCommand(Doc, "App.ActiveDocument.%s.Center = App.Vector(%f, %f, %f)", FeatName.c_str(), center[0],
-                center[1] + box.GetLength(1) / 2, center[2] + box.GetLength(2) / 2);
-            doCommand(Doc, "App.ActiveDocument.%s.Radius = %f", FeatName.c_str(), box.GetDiagonalLength() / 2);
+            doCommand(Doc,
+                      "App.ActiveDocument.%s.Center = App.Vector(%f, %f, %f)",
+                      FeatName.c_str(),
+                      center[0],
+                      center[1] + box.GetLength(1) / 2,
+                      center[2] + box.GetLength(2) / 2);
+            doCommand(Doc,
+                      "App.ActiveDocument.%s.Radius = %f",
+                      FeatName.c_str(),
+                      box.GetDiagonalLength() / 2);
         }
 
 
@@ -1837,12 +2009,14 @@ void CmdFemPostFunctions::languageChange()
 
     QAction* cmd = a[0];
     cmd->setText(QApplication::translate("CmdFemPostFunctions", "Plane"));
-    cmd->setToolTip(QApplication::translate("FEM_PostCreateFunctions", "Create a plane function, defined by its origin and normal"));
+    cmd->setToolTip(QApplication::translate(
+        "FEM_PostCreateFunctions", "Create a plane function, defined by its origin and normal"));
     cmd->setStatusTip(cmd->toolTip());
 
     cmd = a[1];
     cmd->setText(QApplication::translate("CmdFemPostFunctions", "Sphere"));
-    cmd->setToolTip(QApplication::translate("FEM_PostCreateFunctions", "Create a sphere function, defined by its center and radius"));
+    cmd->setToolTip(QApplication::translate(
+        "FEM_PostCreateFunctions", "Create a sphere function, defined by its center and radius"));
     cmd->setStatusTip(cmd->toolTip());
 
 }
@@ -1862,14 +2036,14 @@ DEF_STD_CMD_AC(CmdFemPostApllyChanges)
 CmdFemPostApllyChanges::CmdFemPostApllyChanges()
     : Command("FEM_PostApplyChanges")
 {
-    sAppModule      = "Fem";
-    sGroup          = QT_TR_NOOP("Fem");
-    sMenuText       = QT_TR_NOOP("Apply changes to pipeline");
-    sToolTipText    = QT_TR_NOOP("Apply changes to parameters directly and not on recompute only...");
-    sWhatsThis      = "FEM_PostApplyChanges";
-    sStatusTip      = sToolTipText;
-    sPixmap         = "view-refresh";
-    eType           = eType|ForEdit;
+    sAppModule = "Fem";
+    sGroup = QT_TR_NOOP("Fem");
+    sMenuText = QT_TR_NOOP("Apply changes to pipeline");
+    sToolTipText = QT_TR_NOOP("Apply changes to parameters directly and not on recompute only...");
+    sWhatsThis = "FEM_PostApplyChanges";
+    sStatusTip = sToolTipText;
+    sPixmap = "view-refresh";
+    eType = eType | ForEdit;
 }
 
 void CmdFemPostApllyChanges::activated(int iMsg)
@@ -1916,7 +2090,8 @@ void CmdFemPostPipelineFromResult::activated(int)
     Gui::SelectionFilter ResultFilter("SELECT Fem::FemResultObject COUNT 1");
     if (ResultFilter.match()) {
         Base::Console().Message("Debug: `SELECT Fem::FemResultObject COUNT 1` has matched obj");
-        Fem::FemResultObject* result = static_cast<Fem::FemResultObject*>(ResultFilter.Result[0][0].getObject());
+        Fem::FemResultObject* result =
+         static_cast<Fem::FemResultObject*>(ResultFilter.Result[0][0].getObject());
         //static_cast failed here
         Base::Console().Message("Debug: FemResultObject pointer = %p", result );
 
@@ -1925,16 +2100,20 @@ void CmdFemPostPipelineFromResult::activated(int)
     // go through active document change some Visibility
     Gui::Document* doc = Gui::Application::Instance->activeDocument();
     App::Document* app = doc->getDocument();
-    const std::vector<App::DocumentObject*> obj = app->getObjectsOfType
-    (App::DocumentObject::getClassTypeId());
+    const std::vector<App::DocumentObject*> obj =
+        app->getObjectsOfType(App::DocumentObject::getClassTypeId());
 
-    for (std::vector<App::DocumentObject*>::const_iterator it = obj.begin(); it != obj.end(); ++it) {
-        doCommand(Gui, "Gui.getDocument(\"%s\").getObject(\"%s\").Visibility=False"
-            , app->getName(), (*it)->getNameInDocument());
+    for (std::vector<App::DocumentObject*>::const_iterator it = obj.begin(); it != obj.end();
+         ++it) {
+        doCommand(Gui,
+                  "Gui.getDocument(\"%s\").getObject(\"%s\").Visibility=False",
+                  app->getName(),
+                  (*it)->getNameInDocument());
     }
 
     // we need single result object to attach the pipeline to
-    std::vector<Fem::FemResultObject*> results = getSelection().getObjectsOfType<Fem::FemResultObject>();
+    std::vector<Fem::FemResultObject*> results =
+        getSelection().getObjectsOfType<Fem::FemResultObject>();
     if (results.size() == 1) {
         // the pipeline should be inside the analysis container if possible
         bool foundAnalysis = false;
@@ -1954,16 +2133,19 @@ void CmdFemPostPipelineFromResult::activated(int)
         if (foundAnalysis)
             pcAnalysis->addObject("Fem::FemPostPipeline", FeatName.c_str());
         else
-            doCommand(Doc, "App.activeDocument().addObject('Fem::FemPostPipeline','%s')", FeatName.c_str());
+            doCommand(Doc,
+                      "App.activeDocument().addObject('Fem::FemPostPipeline','%s')",
+                      FeatName.c_str());
         // load the contents of the result object to the pipeline
         doCommand(Doc, "App.activeDocument().ActiveObject.load("
             "App.activeDocument().getObject(\"%s\"))", results[0]->getNameInDocument());
         // set display to assure the user sees the new object
         doCommand(Doc, "App.activeDocument().ActiveObject.ViewObject.DisplayMode = \"Surface\"");
         // Set SelectionStyle to BoundBox because the idea is that the user gets the useful result
-        // from the colors. The default would be to highlight the shape but then the colors are changed
-        // by every highlighting leading to confusions for the user.
-        doCommand(Doc, "App.activeDocument().ActiveObject.ViewObject.SelectionStyle = \"BoundBox\"");
+        // from the colors. The default would be to highlight the shape but then the colors are
+        // changed by every highlighting leading to confusions for the user.
+        doCommand(Doc,
+                  "App.activeDocument().ActiveObject.ViewObject.SelectionStyle = \"BoundBox\"");
         commitCommand();
 
         this->updateActive();
@@ -1979,7 +2161,8 @@ void CmdFemPostPipelineFromResult::activated(int)
 bool CmdFemPostPipelineFromResult::isActive()
 {
     // only activate if a result object is selected from which the pipeline can be loaded
-    std::vector<Fem::FemResultObject*> results = getSelection().getObjectsOfType<Fem::FemResultObject>();
+    std::vector<Fem::FemResultObject*> results =
+        getSelection().getObjectsOfType<Fem::FemResultObject>();
     return (results.size() == 1) ? true : false;
 }
 
@@ -1995,7 +2178,8 @@ void CreateFemCommands()
     // part, analysis, solver
     //rcCmdMgr.addCommand(new CmdFemAddPart()); // not implemented as GUI menu or click icon
     //rcCmdMgr.addCommand(new CmdFemCreateAnalysis()); // Analysis is created in python
-    //rcCmdMgr.addCommand(new CmdFemCreateSolver());  // Solver will be extended and created in python
+    //rcCmdMgr.addCommand(new CmdFemCreateSolver());  // Solver will be extended and created
+                                                      // in python
 
     // constraints
     rcCmdMgr.addCommand(new CmdFemConstraintBearing());

--- a/src/Mod/Fem/Gui/TaskObjectName.cpp
+++ b/src/Mod/Fem/Gui/TaskObjectName.cpp
@@ -52,7 +52,8 @@ TaskObjectName::TaskObjectName(App::DocumentObject *pcObject,QWidget *parent)
 
     this->groupLayout()->addWidget(proxy);
 
-    QObject::connect(ui->lineEdit_ObjectName, &QLineEdit::textChanged, this, &TaskObjectName::TextChanged);
+    QObject::connect(
+        ui->lineEdit_ObjectName, &QLineEdit::textChanged, this, &TaskObjectName::TextChanged);
 
     if (strcmp(pcObject->Label.getValue(),"") != 0)
         ui->lineEdit_ObjectName->setText(QString::fromUtf8(pcObject->Label.getValue()));

--- a/src/Mod/Fem/Gui/TaskPostBoxes.cpp
+++ b/src/Mod/Fem/Gui/TaskPostBoxes.cpp
@@ -101,8 +101,18 @@ void PointMarker::customEvent(QEvent*)
 
     if (!m_name.empty()) {
         Q_EMIT PointsChanged(pt1[0], pt1[1], pt1[2], pt2[0], pt2[1], pt2[2]);
-        Gui::Command::doCommand(Gui::Command::Doc, "App.ActiveDocument.%s.Point1 = App.Vector(%f, %f, %f)", m_name.c_str(), pt1[0], pt1[1], pt1[2]);
-        Gui::Command::doCommand(Gui::Command::Doc, "App.ActiveDocument.%s.Point2 = App.Vector(%f, %f, %f)", m_name.c_str(), pt2[0], pt2[1], pt2[2]);
+        Gui::Command::doCommand(Gui::Command::Doc,
+                                "App.ActiveDocument.%s.Point1 = App.Vector(%f, %f, %f)",
+                                m_name.c_str(),
+                                pt1[0],
+                                pt1[1],
+                                pt1[2]);
+        Gui::Command::doCommand(Gui::Command::Doc,
+                                "App.ActiveDocument.%s.Point2 = App.Vector(%f, %f, %f)",
+                                m_name.c_str(),
+                                pt2[0],
+                                pt2[1],
+                                pt2[2]);
     }
     Gui::Command::doCommand(Gui::Command::Doc, ObjectInvisible().c_str());
 }
@@ -169,7 +179,12 @@ void DataMarker::customEvent(QEvent*)
 
     if (!m_name.empty()) {
         Q_EMIT PointsChanged(pt1[0], pt1[1], pt1[2]);
-        Gui::Command::doCommand(Gui::Command::Doc, "App.ActiveDocument.%s.Center = App.Vector(%f, %f, %f)", m_name.c_str(), pt1[0], pt1[1], pt1[2]);
+        Gui::Command::doCommand(Gui::Command::Doc,
+                                "App.ActiveDocument.%s.Center = App.Vector(%f, %f, %f)",
+                                m_name.c_str(),
+                                pt1[0],
+                                pt1[1],
+                                pt1[2]);
     }
     Gui::Command::doCommand(Gui::Command::Doc, ObjectInvisible().c_str());
 }
@@ -191,7 +206,11 @@ ViewProviderDataMarker::ViewProviderDataMarker()
     pCoords->ref();
     pCoords->point.setNum(0);
     pMarker = new SoMarkerSet();
-    pMarker->markerIndex = Gui::Inventor::MarkerBitmaps::getMarkerIndex("CIRCLE_FILLED", App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/View")->GetInt("MarkerSize", 9));
+    pMarker->markerIndex = Gui::Inventor::MarkerBitmaps::getMarkerIndex(
+        "CIRCLE_FILLED",
+        App::GetApplication()
+            .GetParameterGroupByPath("User parameter:BaseApp/Preferences/View")
+            ->GetInt("MarkerSize", 9));
     pMarker->numPoints = 0;
     pMarker->ref();
 
@@ -244,7 +263,8 @@ void TaskDlgPost::connectSlots()
     QObject* sender = nullptr;
     int indexSignal = 0;
     for (const auto dlg : m_boxes) {
-        indexSignal = dlg->metaObject()->indexOfSignal(QMetaObject::normalizedSignature("emitAddedFunction()"));
+        indexSignal = dlg->metaObject()->indexOfSignal(
+            QMetaObject::normalizedSignature("emitAddedFunction()"));
         if (indexSignal >= 0) {
             sender = dlg;
             break;
@@ -253,7 +273,8 @@ void TaskDlgPost::connectSlots()
 
     if (sender) {
         for (const auto dlg : m_boxes) {
-            int indexSlot = dlg->metaObject()->indexOfSlot(QMetaObject::normalizedSignature("slotAddedFunction()"));
+            int indexSlot = dlg->metaObject()->indexOfSlot(
+                QMetaObject::normalizedSignature("slotAddedFunction()"));
             if (indexSlot >= 0) {
                 connect(sender, sender->metaObject()->method(indexSignal),
                         dlg, dlg->metaObject()->method(indexSlot));
@@ -322,7 +343,8 @@ void TaskDlgPost::modifyStandardButtons(QDialogButtonBox* box) {
 
 // ***************************************************************************
 // some task box methods
-TaskPostBox::TaskPostBox(Gui::ViewProviderDocumentObject* view, const QPixmap& icon, const QString& title, QWidget* parent)
+TaskPostBox::TaskPostBox(Gui::ViewProviderDocumentObject* view, const QPixmap& icon,
+                         const QString& title, QWidget* parent)
     : TaskBox(icon, title, true, parent)
     , m_object(view->getObject())
     , m_view(view)
@@ -373,17 +395,18 @@ void TaskPostBox::updateEnumerationList(App::PropertyEnumeration& prop, QComboBo
 // ***************************************************************************
 // post pipeline results
 TaskPostDisplay::TaskPostDisplay(Gui::ViewProviderDocumentObject* view, QWidget* parent)
-    : TaskPostBox(view, Gui::BitmapFactory().pixmap("FEM_ResultShow"), tr("Result display options"), parent)
+    : TaskPostBox(view, Gui::BitmapFactory().pixmap("FEM_ResultShow"), tr("Result display options"),
+                  parent)
     , ui(new Ui_TaskPostDisplay)
 {
-    //we need a separate container widget to add all controls to
+    // we need a separate container widget to add all controls to
     proxy = new QWidget(this);
     ui->setupUi(proxy);
     QMetaObject::connectSlotsByName(this);
 
     this->groupLayout()->addWidget(proxy);
 
-    //update all fields
+    // update all fields
     updateEnumerationList(getTypedView<ViewProviderFemPostObject>()->DisplayMode, ui->Representation);
     updateEnumerationList(getTypedView<ViewProviderFemPostObject>()->Field, ui->Field);
     updateEnumerationList(getTypedView<ViewProviderFemPostObject>()->VectorMode, ui->VectorMode);
@@ -437,9 +460,11 @@ void TaskPostDisplay::applyPythonCode() {
 
 // ***************************************************************************
 // ?
-// the icon fem-post-geo-plane might be wrong but I do not know any better since the plane is one of the implicit functions
+// the icon fem-post-geo-plane might be wrong but I do not know any better since the plane is one
+// of the implicit functions
 TaskPostFunction::TaskPostFunction(ViewProviderDocumentObject* view, QWidget* parent)
-    : TaskPostBox(view, Gui::BitmapFactory().pixmap("fem-post-geo-plane"), tr("Implicit function"), parent)
+    : TaskPostBox(view, Gui::BitmapFactory().pixmap("fem-post-geo-plane"), tr("Implicit function"),
+                  parent)
 {
 
     assert(view->isDerivedFrom(ViewProviderFemPostFunction::getClassTypeId()));
@@ -463,9 +488,11 @@ void TaskPostFunction::applyPythonCode() {
 
 // ***************************************************************************
 // region clip filter
-TaskPostClip::TaskPostClip(ViewProviderDocumentObject* view, App::PropertyLink* function, QWidget* parent)
-    : TaskPostBox(view, Gui::BitmapFactory().pixmap("FEM_PostFilterClipRegion"), tr("Clip region, choose implicit function"), parent)
-    , ui(new Ui_TaskPostClip)
+TaskPostClip::TaskPostClip(ViewProviderDocumentObject* view, App::PropertyLink* function,
+                           QWidget* parent)
+    : TaskPostBox(view, Gui::BitmapFactory().pixmap("FEM_PostFilterClipRegion"),
+                  tr("Clip region, choose implicit function"), parent),
+      ui(new Ui_TaskPostClip)
 {
 
     assert(view->isDerivedFrom(ViewProviderFemPostClip::getClassTypeId()));
@@ -495,8 +522,10 @@ TaskPostClip::TaskPostClip(ViewProviderDocumentObject* view, App::PropertyLink* 
     ui->CreateButton->setPopupMode(QToolButton::InstantPopup);
 
     //load the default values
-    ui->CutCells->setChecked(static_cast<Fem::FemPostClipFilter*>(getObject())->CutCells.getValue());
-    ui->InsideOut->setChecked(static_cast<Fem::FemPostClipFilter*>(getObject())->InsideOut.getValue());
+    ui->CutCells->setChecked(
+        static_cast<Fem::FemPostClipFilter*>(getObject())->CutCells.getValue());
+    ui->InsideOut->setChecked(
+        static_cast<Fem::FemPostClipFilter*>(getObject())->InsideOut.getValue());
 }
 
 TaskPostClip::~TaskPostClip() {
@@ -513,15 +542,17 @@ void TaskPostClip::collectImplicitFunctions() {
     pipelines = getDocument()->getObjectsOfType<Fem::FemPostPipeline>();
     if (!pipelines.empty()) {
         Fem::FemPostPipeline* pipeline = pipelines.front();
-        if (pipeline->Functions.getValue() &&
-            pipeline->Functions.getValue()->getTypeId() == Fem::FemPostFunctionProvider::getClassTypeId()) {
+        if (pipeline->Functions.getValue() && pipeline->Functions.getValue()->getTypeId()
+                == Fem::FemPostFunctionProvider::getClassTypeId()) {
 
             ui->FunctionBox->clear();
             QStringList items;
             std::size_t currentItem = 0;
-            App::DocumentObject* currentFunction = static_cast<Fem::FemPostClipFilter*>(getObject())->Function.getValue();
-            const std::vector<App::DocumentObject*>& funcs = static_cast<Fem::FemPostFunctionProvider*>(
-                pipeline->Functions.getValue())->Functions.getValues();
+            App::DocumentObject* currentFunction =
+                static_cast<Fem::FemPostClipFilter*>(getObject())->Function.getValue();
+            const std::vector<App::DocumentObject*>& funcs =
+                static_cast<Fem::FemPostFunctionProvider*>(pipeline->Functions.getValue())
+                    ->Functions.getValues();
             for (std::size_t i = 0; i < funcs.size(); ++i) {
                 items.push_back(QString::fromLatin1(funcs[i]->getNameInDocument()));
                 if (currentFunction == funcs[i])
@@ -559,11 +590,12 @@ void TaskPostClip::on_FunctionBox_currentIndexChanged(int idx) {
     pipelines = getDocument()->getObjectsOfType<Fem::FemPostPipeline>();
     if (!pipelines.empty()) {
         Fem::FemPostPipeline* pipeline = pipelines.front();
-        if (pipeline->Functions.getValue() &&
-            pipeline->Functions.getValue()->getTypeId() == Fem::FemPostFunctionProvider::getClassTypeId()) {
+        if (pipeline->Functions.getValue() && pipeline->Functions.getValue()->getTypeId()
+                == Fem::FemPostFunctionProvider::getClassTypeId()) {
 
-            const std::vector<App::DocumentObject*>& funcs = static_cast<Fem::FemPostFunctionProvider*>(
-                pipeline->Functions.getValue())->Functions.getValues();
+            const std::vector<App::DocumentObject*>& funcs =
+                static_cast<Fem::FemPostFunctionProvider*>(pipeline->Functions.getValue())
+                    ->Functions.getValues();
             if (idx >= 0)
                 static_cast<Fem::FemPostClipFilter*>(getObject())->Function.setValue(funcs[idx]);
             else
@@ -606,8 +638,9 @@ void TaskPostClip::on_InsideOut_toggled(bool val) {
 // ***************************************************************************
 // data along a line
 TaskPostDataAlongLine::TaskPostDataAlongLine(ViewProviderDocumentObject* view, QWidget* parent)
-    : TaskPostBox(view, Gui::BitmapFactory().pixmap("FEM_PostFilterDataAlongLine"), tr("Data along a line options"), parent)
-    , ui(new Ui_TaskPostDataAlongLine)
+    : TaskPostBox(view, Gui::BitmapFactory().pixmap("FEM_PostFilterDataAlongLine"),
+                  tr("Data along a line options"), parent),
+      ui(new Ui_TaskPostDataAlongLine)
 {
 
     assert(view->isDerivedFrom(ViewProviderFemPostDataAlongLine::getClassTypeId()));
@@ -636,7 +669,8 @@ TaskPostDataAlongLine::TaskPostDataAlongLine(ViewProviderDocumentObject* view, Q
     ui->point2Y->setDecimals(UserDecimals);
     ui->point2Z->setDecimals(UserDecimals);
 
-    Base::Unit lengthUnit = static_cast<Fem::FemPostDataAlongLineFilter*>(getObject())->Point1.getUnit();
+    Base::Unit lengthUnit =
+        static_cast<Fem::FemPostDataAlongLineFilter*>(getObject())->Point1.getUnit();
     ui->point1X->setUnit(lengthUnit);
     ui->point1Y->setUnit(lengthUnit);
     ui->point1Z->setUnit(lengthUnit);
@@ -645,12 +679,14 @@ TaskPostDataAlongLine::TaskPostDataAlongLine(ViewProviderDocumentObject* view, Q
     ui->point2Y->setUnit(lengthUnit);
     ui->point2Z->setUnit(lengthUnit);
 
-    const Base::Vector3d& vec1 = static_cast<Fem::FemPostDataAlongLineFilter*>(getObject())->Point1.getValue();
+    const Base::Vector3d& vec1 =
+        static_cast<Fem::FemPostDataAlongLineFilter*>(getObject())->Point1.getValue();
     ui->point1X->setValue(vec1.x);
     ui->point1Y->setValue(vec1.y);
     ui->point1Z->setValue(vec1.z);
 
-    const Base::Vector3d& vec2 = static_cast<Fem::FemPostDataAlongLineFilter*>(getObject())->Point2.getValue();
+    const Base::Vector3d& vec2 =
+        static_cast<Fem::FemPostDataAlongLineFilter*>(getObject())->Point2.getValue();
     ui->point2X->setValue(vec2.x);
     ui->point2Y->setValue(vec2.y);
     ui->point2Z->setValue(vec2.z);
@@ -674,7 +710,8 @@ TaskPostDataAlongLine::TaskPostDataAlongLine(ViewProviderDocumentObject* view, Q
             this, &TaskPostDataAlongLine::resolutionChanged);
 
     //update all fields
-    updateEnumerationList(getTypedView<ViewProviderFemPostObject>()->DisplayMode, ui->Representation);
+    updateEnumerationList(getTypedView<ViewProviderFemPostObject>()->DisplayMode,
+                          ui->Representation);
     updateEnumerationList(getTypedView<ViewProviderFemPostObject>()->Field, ui->Field);
     updateEnumerationList(getTypedView<ViewProviderFemPostObject>()->VectorMode, ui->VectorMode);
 }
@@ -752,7 +789,9 @@ void TaskPostDataAlongLine::on_CreatePlot_clicked() {
     recompute();
 }
 
-void TaskPostDataAlongLine::onChange(double x1, double y1, double z1, double x2, double y2, double z2) {
+void TaskPostDataAlongLine::onChange(double x1, double y1, double z1, double x2, double y2,
+                                     double z2)
+{
 
     // call point1Changed only once
     ui->point1X->blockSignals(true);
@@ -840,7 +879,8 @@ void TaskPostDataAlongLine::pointCallback(void* ud, SoEventCallback* n)
     Gui::View3DInventorViewer* view = static_cast<Gui::View3DInventorViewer*>(n->getUserData());
     PointMarker* pm = static_cast<PointMarker*>(ud);
 
-    // Mark all incoming mouse button events as handled, especially, to deactivate the selection node
+    // Mark all incoming mouse button events as handled, especially,
+    // to deactivate the selection node
     n->getAction()->setHandled();
 
     if (mbe->getButton() == SoMouseButtonEvent::BUTTON1 && mbe->getState() == SoButtonEvent::DOWN) {
@@ -860,7 +900,8 @@ void TaskPostDataAlongLine::pointCallback(void* ud, SoEventCallback* n)
             view->removeEventCallback(SoMouseButtonEvent::getClassTypeId(), pointCallback, ud);
         }
     }
-    else if (mbe->getButton() != SoMouseButtonEvent::BUTTON1 && mbe->getState() == SoButtonEvent::UP) {
+    else if (mbe->getButton() != SoMouseButtonEvent::BUTTON1
+             && mbe->getState() == SoButtonEvent::UP) {
         n->setHandled();
         view->setEditing(false);
         view->removeEventCallback(SoMouseButtonEvent::getClassTypeId(), pointCallback, ud);
@@ -913,8 +954,9 @@ plt.show()\n";
 // ***************************************************************************
 // data at point
 TaskPostDataAtPoint::TaskPostDataAtPoint(ViewProviderDocumentObject* view, QWidget* parent)
-    : TaskPostBox(view, Gui::BitmapFactory().pixmap("FEM_PostFilterDataAtPoint"), tr("Data at point options"), parent)
-    , ui(new Ui_TaskPostDataAtPoint)
+    : TaskPostBox(view, Gui::BitmapFactory().pixmap("FEM_PostFilterDataAtPoint"),
+                  tr("Data at point options"), parent),
+      ui(new Ui_TaskPostDataAtPoint)
 {
 
     assert(view->isDerivedFrom(ViewProviderFemPostDataAtPoint::getClassTypeId()));
@@ -937,12 +979,14 @@ TaskPostDataAtPoint::TaskPostDataAtPoint(ViewProviderDocumentObject* view, QWidg
     ui->centerY->setDecimals(UserDecimals);
     ui->centerZ->setDecimals(UserDecimals);
 
-    const Base::Unit lengthUnit = static_cast<Fem::FemPostDataAtPointFilter*>(getObject())->Center.getUnit();
+    const Base::Unit lengthUnit =
+        static_cast<Fem::FemPostDataAtPointFilter*>(getObject())->Center.getUnit();
     ui->centerX->setUnit(lengthUnit);
     ui->centerY->setUnit(lengthUnit);
     ui->centerZ->setUnit(lengthUnit);
 
-    const Base::Vector3d& vec = static_cast<Fem::FemPostDataAtPointFilter*>(getObject())->Center.getValue();
+    const Base::Vector3d& vec =
+        static_cast<Fem::FemPostDataAtPointFilter*>(getObject())->Center.getValue();
     ui->centerX->setValue(vec.x);
     ui->centerY->setValue(vec.y);
     ui->centerZ->setValue(vec.z);
@@ -952,7 +996,8 @@ TaskPostDataAtPoint::TaskPostDataAtPoint(ViewProviderDocumentObject* view, QWidg
 
     // read in point value
     auto pointValue = static_cast<Fem::FemPostDataAtPointFilter *>(getObject())->PointData[0];
-    showValue(pointValue, static_cast<Fem::FemPostDataAtPointFilter *>(getObject())->Unit.getValue());
+    showValue(pointValue,
+              static_cast<Fem::FemPostDataAtPointFilter*>(getObject())->Unit.getValue());
 
     connect(ui->centerX, qOverload<double>(&Gui::QuantitySpinBox::valueChanged),
             this, &TaskPostDataAtPoint::centerChanged);
@@ -1072,7 +1117,8 @@ void TaskPostDataAtPoint::pointCallback(void* ud, SoEventCallback* n)
     Gui::View3DInventorViewer* view = static_cast<Gui::View3DInventorViewer*>(n->getUserData());
     DataMarker* pm = static_cast<DataMarker*>(ud);
 
-    // Mark all incoming mouse button events as handled, especially, to deactivate the selection node
+    // Mark all incoming mouse button events as handled, especially,
+    // to deactivate the selection node
     n->getAction()->setHandled();
 
     if (mbe->getButton() == SoMouseButtonEvent::BUTTON1 && mbe->getState() == SoButtonEvent::DOWN) {
@@ -1092,7 +1138,8 @@ void TaskPostDataAtPoint::pointCallback(void* ud, SoEventCallback* n)
             view->removeEventCallback(SoMouseButtonEvent::getClassTypeId(), pointCallback, ud);
         }
     }
-    else if (mbe->getButton() != SoMouseButtonEvent::BUTTON1 && mbe->getState() == SoButtonEvent::UP) {
+    else if (mbe->getButton() != SoMouseButtonEvent::BUTTON1
+             && mbe->getState() == SoButtonEvent::UP) {
         n->setHandled();
         view->setEditing(false);
         view->removeEventCallback(SoMouseButtonEvent::getClassTypeId(), pointCallback, ud);
@@ -1176,7 +1223,8 @@ void TaskPostDataAtPoint::on_Field_activated(int i) {
     }
 
     auto pointValue = static_cast<Fem::FemPostDataAtPointFilter*>(getObject())->PointData[0];
-    showValue(pointValue, static_cast<Fem::FemPostDataAtPointFilter*>(getObject())->Unit.getValue());
+    showValue(pointValue,
+              static_cast<Fem::FemPostDataAtPointFilter*>(getObject())->Unit.getValue());
 }
 
 void TaskPostDataAtPoint::showValue(double pointValue, const char* unitStr)
@@ -1200,8 +1248,9 @@ std::string TaskPostDataAtPoint::toString(double val) const
     // for display we must therefore convert large and small numbers to scientific notation
     // if pointValue is in the range [1e-2, 1e+4] -> fixed notation, else scientific
     bool scientific = (val < 1e-2) || (val > 1e4);
-    std::ios::fmtflags flags = scientific ? (std::ios::scientific | std::ios::showpoint | std::ios::showpos)
-                                          : (std::ios::fixed | std::ios::showpoint | std::ios::showpos);
+    std::ios::fmtflags flags = scientific
+        ? (std::ios::scientific | std::ios::showpoint | std::ios::showpos)
+        : (std::ios::fixed | std::ios::showpoint | std::ios::showpos);
     std::stringstream valueStream;
     valueStream.precision(Base::UnitsApi::getDecimals());
     valueStream.setf(flags);
@@ -1212,9 +1261,10 @@ std::string TaskPostDataAtPoint::toString(double val) const
 
 // ***************************************************************************
 // scalar clip filter
-TaskPostScalarClip::TaskPostScalarClip(ViewProviderDocumentObject* view, QWidget* parent) :
-    TaskPostBox(view, Gui::BitmapFactory().pixmap("FEM_PostFilterClipScalar"), tr("Scalar clip options"), parent)
-    , ui(new Ui_TaskPostScalarClip)
+TaskPostScalarClip::TaskPostScalarClip(ViewProviderDocumentObject* view, QWidget* parent)
+    : TaskPostBox(view, Gui::BitmapFactory().pixmap("FEM_PostFilterClipScalar"),
+                  tr("Scalar clip options"), parent),
+      ui(new Ui_TaskPostScalarClip)
 {
 
     assert(view->isDerivedFrom(ViewProviderFemPostScalarClip::getClassTypeId()));
@@ -1227,8 +1277,10 @@ TaskPostScalarClip::TaskPostScalarClip(ViewProviderDocumentObject* view, QWidget
 
     //load the default values
     updateEnumerationList(getTypedObject<Fem::FemPostScalarClipFilter>()->Scalars, ui->Scalar);
-    ui->InsideOut->setChecked(static_cast<Fem::FemPostScalarClipFilter*>(getObject())->InsideOut.getValue());
-    App::PropertyFloatConstraint& scalar_prop = static_cast<Fem::FemPostScalarClipFilter*>(getObject())->Value;
+    ui->InsideOut->setChecked(
+        static_cast<Fem::FemPostScalarClipFilter*>(getObject())->InsideOut.getValue());
+    App::PropertyFloatConstraint& scalar_prop =
+        static_cast<Fem::FemPostScalarClipFilter*>(getObject())->Value;
     double scalar_factor = scalar_prop.getValue();
 
     // set spinbox scalar_factor, don't forget to sync the slider
@@ -1248,7 +1300,8 @@ TaskPostScalarClip::TaskPostScalarClip(ViewProviderDocumentObject* view, QWidget
     ui->Slider->blockSignals(true);
     ui->Slider->setValue(slider_value);
     ui->Slider->blockSignals(false);
-    Base::Console().Log("init: scalar_factor, slider_value: %f, %i: \n", scalar_factor, slider_value);
+    Base::Console().Log(
+        "init: scalar_factor, slider_value: %f, %i: \n", scalar_factor, slider_value);
 }
 
 TaskPostScalarClip::~TaskPostScalarClip() {
@@ -1265,7 +1318,8 @@ void TaskPostScalarClip::on_Scalar_currentIndexChanged(int idx) {
     recompute();
 
     // update constraints and values
-    App::PropertyFloatConstraint& scalar_prop = static_cast<Fem::FemPostScalarClipFilter*>(getObject())->Value;
+    App::PropertyFloatConstraint& scalar_prop =
+        static_cast<Fem::FemPostScalarClipFilter*>(getObject())->Value;
     double scalar_factor = scalar_prop.getValue();
     double min = scalar_prop.getConstraints()->LowerBound;
     double max = scalar_prop.getConstraints()->UpperBound;
@@ -1287,8 +1341,10 @@ void TaskPostScalarClip::on_Scalar_currentIndexChanged(int idx) {
 
 void TaskPostScalarClip::on_Slider_valueChanged(int v) {
 
-    App::PropertyFloatConstraint& value = static_cast<Fem::FemPostScalarClipFilter*>(getObject())->Value;
-    double val = value.getConstraints()->LowerBound * (1 - double(v) / 100.) + double(v) / 100. * value.getConstraints()->UpperBound;
+    App::PropertyFloatConstraint& value =
+        static_cast<Fem::FemPostScalarClipFilter*>(getObject())->Value;
+    double val = value.getConstraints()->LowerBound * (1 - double(v) / 100.)
+        + double(v) / 100. * value.getConstraints()->UpperBound;
 
     value.setValue(val);
     recompute();
@@ -1301,13 +1357,17 @@ void TaskPostScalarClip::on_Slider_valueChanged(int v) {
 
 void TaskPostScalarClip::on_Value_valueChanged(double v) {
 
-    App::PropertyFloatConstraint& value = static_cast<Fem::FemPostScalarClipFilter*>(getObject())->Value;
+    App::PropertyFloatConstraint& value =
+        static_cast<Fem::FemPostScalarClipFilter*>(getObject())->Value;
     value.setValue(v);
     recompute();
 
     //don't forget to sync the slider
     ui->Slider->blockSignals(true);
-    ui->Slider->setValue(int(((v - value.getConstraints()->LowerBound) / (value.getConstraints()->UpperBound - value.getConstraints()->LowerBound)) * 100.));
+    ui->Slider->setValue(
+        int(((v - value.getConstraints()->LowerBound)
+             / (value.getConstraints()->UpperBound - value.getConstraints()->LowerBound))
+            * 100.));
     ui->Slider->blockSignals(false);
 }
 
@@ -1322,9 +1382,10 @@ void TaskPostScalarClip::on_InsideOut_toggled(bool val) {
 // warp filter
 // spinbox min, slider, spinbox max
 // spinbox warp factor
-TaskPostWarpVector::TaskPostWarpVector(ViewProviderDocumentObject* view, QWidget* parent) :
-    TaskPostBox(view, Gui::BitmapFactory().pixmap("FEM_PostFilterWarp"), tr("Warp options"), parent)
-    , ui(new Ui_TaskPostWarpVector)
+TaskPostWarpVector::TaskPostWarpVector(ViewProviderDocumentObject* view, QWidget* parent)
+    : TaskPostBox(view, Gui::BitmapFactory().pixmap("FEM_PostFilterWarp"), tr("Warp options"),
+                  parent),
+      ui(new Ui_TaskPostWarpVector)
 {
 
     assert(view->isDerivedFrom(ViewProviderFemPostWarpVector::getClassTypeId()));
@@ -1337,7 +1398,8 @@ TaskPostWarpVector::TaskPostWarpVector(ViewProviderDocumentObject* view, QWidget
 
     // load the default values for warp display
     updateEnumerationList(getTypedObject<Fem::FemPostWarpVectorFilter>()->Vector, ui->Vector);
-    double warp_factor = static_cast<Fem::FemPostWarpVectorFilter*>(getObject())->Factor.getValue(); // get the standard warp factor
+    double warp_factor = static_cast<Fem::FemPostWarpVectorFilter*>(getObject())
+                             ->Factor.getValue();// get the standard warp factor
 
     // set spinbox warp_factor, don't forget to sync the slider
     ui->Value->blockSignals(true);
@@ -1362,7 +1424,8 @@ TaskPostWarpVector::TaskPostWarpVector(ViewProviderDocumentObject* view, QWidget
     // slider_value = ----------------------- x 100
     //                     ( max - min )
     //
-    int slider_value = (warp_factor - ui->Min->value()) / (ui->Max->value() - ui->Min->value()) * 100.;
+    int slider_value =
+        (warp_factor - ui->Min->value()) / (ui->Max->value() - ui->Min->value()) * 100.;
     ui->Slider->setValue(slider_value);
     ui->Slider->blockSignals(false);
     Base::Console().Log("init: warp_factor, slider_value: %f, %i: \n", warp_factor, slider_value);
@@ -1391,7 +1454,8 @@ void TaskPostWarpVector::on_Slider_valueChanged(int slider_value) {
     // warp_factor = min + ( slider_value x --------------- )
     //                                            100
     //
-    double warp_factor = ui->Min->value() + ((ui->Max->value() - ui->Min->value()) / 100.) * slider_value;
+    double warp_factor =
+        ui->Min->value() + ((ui->Max->value() - ui->Min->value()) / 100.) * slider_value;
     static_cast<Fem::FemPostWarpVectorFilter*>(getObject())->Factor.setValue(warp_factor);
     recompute();
 
@@ -1405,14 +1469,16 @@ void TaskPostWarpVector::on_Slider_valueChanged(int slider_value) {
 void TaskPostWarpVector::on_Value_valueChanged(double warp_factor) {
     // spinbox changed, change warp factor and sync slider
 
-    // TODO warp factor should not be smaller than min and greater than max, but problems on automate change of warp_factor, see on_Max_valueChanged
+    // TODO warp factor should not be smaller than min and greater than max,
+    // but problems on automate change of warp_factor, see on_Max_valueChanged
 
     static_cast<Fem::FemPostWarpVectorFilter*>(getObject())->Factor.setValue(warp_factor);
     recompute();
 
     // sync the slider, see above for formula
     ui->Slider->blockSignals(true);
-    int slider_value = (warp_factor - ui->Min->value()) / (ui->Max->value() - ui->Min->value()) * 100.;
+    int slider_value =
+        (warp_factor - ui->Min->value()) / (ui->Max->value() - ui->Min->value()) * 100.;
     ui->Slider->setValue(slider_value);
     ui->Slider->blockSignals(false);
     Base::Console().Log("Change: warp_factor, slider_value: %f, %i: \n", warp_factor, slider_value);
@@ -1422,16 +1488,18 @@ void TaskPostWarpVector::on_Max_valueChanged(double) {
 
     // TODO max should be greater than min, see a few lines later on problem on input characters
     ui->Slider->blockSignals(true);
-    ui->Slider->setValue((ui->Value->value() - ui->Min->value()) / (ui->Max->value() - ui->Min->value()) * 100.);
+    ui->Slider->setValue((ui->Value->value() - ui->Min->value())
+                         / (ui->Max->value() - ui->Min->value()) * 100.);
     ui->Slider->blockSignals(false);
 
     /*
      * problem, if warp_factor is 2000 one would like to input 4000 as max, one starts to input 4
-     * immediately the warp_factor is changed to 4 because 4 < 2000, but one has just input one character of their 4000
-     * I do not know how to solve this, but the code to set slider and spinbox is fine thus I leave it ...
+     * immediately the warp_factor is changed to 4 because 4 < 2000, but one has just input
+     * one character of their 4000. * I do not know how to solve this, but the code to set slider
+     * and spinbox is fine thus I leave it ...
      *
-     * mhh it works if "apply changes to pipeline directly" button is deactivated, still it really confuses if
-     * the button is active. More investigation is needed.
+     * mhh it works if "apply changes to pipeline directly" button is deactivated,
+     * still it really confuses if the button is active. More investigation is needed.
      *
     // set warp factor to max, if warp factor > max
     if (ui->Value->value() > ui->Max->value()) {
@@ -1441,7 +1509,8 @@ void TaskPostWarpVector::on_Max_valueChanged(double) {
 
         // sync the slider, see above for formula
         ui->Slider->blockSignals(true);
-        int slider_value = (warp_factor - ui->Min->value()) / (ui->Max->value() - ui->Min->value()) * 100.;
+        int slider_value = (warp_factor - ui->Min->value())
+                           / (ui->Max->value() - ui->Min->value()) * 100.;
         ui->Slider->setValue(slider_value);
         ui->Slider->blockSignals(false);
         // sync the spinbox, see above for formula
@@ -1458,16 +1527,19 @@ void TaskPostWarpVector::on_Min_valueChanged(double) {
     // TODO min should be smaller than max
     // TODO if warp factor is smaller than min, warp factor should be min, don't forget to sync
     ui->Slider->blockSignals(true);
-    ui->Slider->setValue((ui->Value->value() - ui->Min->value()) / (ui->Max->value() - ui->Min->value()) * 100.);
+    ui->Slider->setValue((ui->Value->value() - ui->Min->value())
+                         / (ui->Max->value() - ui->Min->value()) * 100.);
     ui->Slider->blockSignals(false);
 }
 
 
 // ***************************************************************************
 // function clip filter
-TaskPostCut::TaskPostCut(ViewProviderDocumentObject* view, App::PropertyLink* function, QWidget* parent)
-    : TaskPostBox(view, Gui::BitmapFactory().pixmap("FEM_PostFilterCutFunction"), tr("Function cut, choose implicit function"), parent)
-    , ui(new Ui_TaskPostCut)
+TaskPostCut::TaskPostCut(ViewProviderDocumentObject* view, App::PropertyLink* function,
+                         QWidget* parent)
+    : TaskPostBox(view, Gui::BitmapFactory().pixmap("FEM_PostFilterCutFunction"),
+                  tr("Function cut, choose implicit function"), parent),
+      ui(new Ui_TaskPostCut)
 {
 
     assert(view->isDerivedFrom(ViewProviderFemPostCut::getClassTypeId()));
@@ -1511,15 +1583,18 @@ void TaskPostCut::collectImplicitFunctions() {
     pipelines = getDocument()->getObjectsOfType<Fem::FemPostPipeline>();
     if (!pipelines.empty()) {
         Fem::FemPostPipeline* pipeline = pipelines.front();
-        if (pipeline->Functions.getValue() &&
-            pipeline->Functions.getValue()->getTypeId() == Fem::FemPostFunctionProvider::getClassTypeId()) {
+        if (pipeline->Functions.getValue()
+            && pipeline->Functions.getValue()->getTypeId()
+                == Fem::FemPostFunctionProvider::getClassTypeId()) {
 
             ui->FunctionBox->clear();
             QStringList items;
             std::size_t currentItem = 0;
-            App::DocumentObject* currentFunction = static_cast<Fem::FemPostClipFilter*>(getObject())->Function.getValue();
-            const std::vector<App::DocumentObject*>& funcs = static_cast<Fem::FemPostFunctionProvider*>(
-                pipeline->Functions.getValue())->Functions.getValues();
+            App::DocumentObject* currentFunction =
+                static_cast<Fem::FemPostClipFilter*>(getObject())->Function.getValue();
+            const std::vector<App::DocumentObject*>& funcs =
+                static_cast<Fem::FemPostFunctionProvider*>(pipeline->Functions.getValue())
+                    ->Functions.getValues();
             for (std::size_t i = 0; i < funcs.size(); ++i) {
                 items.push_back(QString::fromLatin1(funcs[i]->getNameInDocument()));
                 if (currentFunction == funcs[i])
@@ -1557,11 +1632,13 @@ void TaskPostCut::on_FunctionBox_currentIndexChanged(int idx) {
     pipelines = getDocument()->getObjectsOfType<Fem::FemPostPipeline>();
     if (!pipelines.empty()) {
         Fem::FemPostPipeline* pipeline = pipelines.front();
-        if (pipeline->Functions.getValue() &&
-            pipeline->Functions.getValue()->getTypeId() == Fem::FemPostFunctionProvider::getClassTypeId()) {
+        if (pipeline->Functions.getValue()
+            && pipeline->Functions.getValue()->getTypeId()
+                == Fem::FemPostFunctionProvider::getClassTypeId()) {
 
-            const std::vector<App::DocumentObject*>& funcs = static_cast<Fem::FemPostFunctionProvider*>(
-                pipeline->Functions.getValue())->Functions.getValues();
+            const std::vector<App::DocumentObject*>& funcs =
+                static_cast<Fem::FemPostFunctionProvider*>(pipeline->Functions.getValue())
+                    ->Functions.getValues();
             if (idx >= 0)
                 static_cast<Fem::FemPostCutFilter*>(getObject())->Function.setValue(funcs[idx]);
             else

--- a/src/Mod/Fem/Gui/TaskPostBoxes.h
+++ b/src/Mod/Fem/Gui/TaskPostBoxes.h
@@ -137,11 +137,14 @@ class TaskPostBox : public Gui::TaskView::TaskBox {
     Q_OBJECT
 
 public:
-    TaskPostBox(Gui::ViewProviderDocumentObject* view, const QPixmap &icon, const QString &title, QWidget *parent = nullptr);
+    TaskPostBox(Gui::ViewProviderDocumentObject* view, const QPixmap& icon, const QString& title,
+                QWidget* parent = nullptr);
     ~TaskPostBox() override;
 
     virtual void applyPythonCode() = 0;
-    virtual bool isGuiTaskOnly() {return false;} //return true if only gui properties are manipulated
+    virtual bool isGuiTaskOnly() {
+        return false;
+    } // return true if only gui properties are manipulated
 
 protected:
     App::DocumentObject* getObject() const {
@@ -254,7 +257,8 @@ class TaskPostClip : public TaskPostBox {
     Q_OBJECT
 
 public:
-    TaskPostClip(Gui::ViewProviderDocumentObject* view, App::PropertyLink* function, QWidget* parent = nullptr);
+    TaskPostClip(Gui::ViewProviderDocumentObject* view, App::PropertyLink* function,
+                 QWidget* parent = nullptr);
     ~TaskPostClip() override;
 
     void applyPythonCode() override;
@@ -283,7 +287,8 @@ class TaskPostDataAlongLine: public TaskPostBox {
     Q_OBJECT
 
 public:
-    explicit TaskPostDataAlongLine(Gui::ViewProviderDocumentObject* view, QWidget* parent = nullptr);
+    explicit TaskPostDataAlongLine(Gui::ViewProviderDocumentObject* view,
+                                   QWidget* parent = nullptr);
     ~TaskPostDataAlongLine() override;
 
     void applyPythonCode() override;
@@ -388,7 +393,8 @@ class TaskPostCut : public TaskPostBox {
     Q_OBJECT
 
 public:
-    TaskPostCut(Gui::ViewProviderDocumentObject* view, App::PropertyLink* function, QWidget* parent = nullptr);
+    TaskPostCut(Gui::ViewProviderDocumentObject* view, App::PropertyLink* function,
+                QWidget* parent = nullptr);
     ~TaskPostCut() override;
 
     void applyPythonCode() override;

--- a/src/Mod/Fem/Gui/ViewProviderFemPostObject.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemPostObject.cpp
@@ -92,7 +92,8 @@ public:
             views.erase(it);
     }
 
-    void selectionChanged(const Gui::SelectionChanges& msg) {
+    void selectionChanged(const Gui::SelectionChanges& msg)
+    {
         Gui::SelectionObject obj(msg);
         auto findVP = std::find_if(views.begin(), views.end(), [&obj](const auto& vp) {
             return obj.getObject() == vp->getObject();
@@ -128,8 +129,16 @@ PROPERTY_SOURCE(FemGui::ViewProviderFemPostObject, Gui::ViewProviderDocumentObje
 ViewProviderFemPostObject::ViewProviderFemPostObject() : m_blockPropertyChanges(false)
 {
     //initialize the properties
-    ADD_PROPERTY_TYPE(Field, ((long)0), "Coloring", App::Prop_None, "Select the field used for calculating the color");
-    ADD_PROPERTY_TYPE(VectorMode, ((long)0), "Coloring", App::Prop_None, "Select what to show for a vector field");
+    ADD_PROPERTY_TYPE(Field,
+                      ((long)0),
+                      "Coloring",
+                      App::Prop_None,
+                      "Select the field used for calculating the color");
+    ADD_PROPERTY_TYPE(VectorMode,
+                      ((long)0),
+                      "Coloring",
+                      App::Prop_None,
+                      "Select what to show for a vector field");
     ADD_PROPERTY(Transparency, (0));
 
     sPixmap = "fem-femmesh-from-shape";
@@ -230,7 +239,8 @@ void ViewProviderFemPostObject::attach(App::DocumentObject* pcObj)
     m_seperator->addChild(m_faces);
 
     // Check for an already existing color bar
-    Gui::SoFCColorBar* pcBar = ((Gui::SoFCColorBar*)findFrontRootOfType(Gui::SoFCColorBar::getClassTypeId()));
+    Gui::SoFCColorBar* pcBar =
+        ((Gui::SoFCColorBar*)findFrontRootOfType(Gui::SoFCColorBar::getClassTypeId()));
     if (pcBar) {
         float fMin = m_colorBar->getMinValue();
         float fMax = m_colorBar->getMaxValue();
@@ -478,7 +488,9 @@ void ViewProviderFemPostObject::update3D() {
         m_markers->coordIndex.setNum(0);
 }
 
-void ViewProviderFemPostObject::WritePointData(vtkPoints* points, vtkDataArray* normals, vtkDataArray* tcoords) {
+void ViewProviderFemPostObject::WritePointData(vtkPoints* points, vtkDataArray* normals,
+                                               vtkDataArray* tcoords)
+{
 
     Q_UNUSED(tcoords);
 
@@ -543,11 +555,13 @@ void ViewProviderFemPostObject::WriteColorData(bool ResetColorBarRange) {
         return;
     };
 
-    int array = Field.getValue() - 1; //0 is none
+    int array = Field.getValue() - 1; // 0 is none
     vtkPolyData* pd = m_currentAlgorithm->GetOutput();
     vtkDataArray* data = pd->GetPointData()->GetArray(array);
 
-    int component = VectorMode.getValue() - 1; //0 is either "Not a vector" or magnitude, for -1 is correct for magnitude. x y and z are one number too high
+    int component = VectorMode.getValue() - 1; // 0 is either "Not a vector" or magnitude,
+                                               // for -1 is correct for magnitude.
+                                               // x y and z are one number too high
     if (strcmp(VectorMode.getValueAsString(), "Not a vector") == 0)
         component = 0;
 
@@ -656,12 +670,16 @@ void ViewProviderFemPostObject::onChanged(const App::Property* prop) {
 }
 
 bool ViewProviderFemPostObject::doubleClicked() {
-    // work around for a problem in VTK implementation: https://forum.freecadweb.org/viewtopic.php?t=10587&start=130#p125688
+    // work around for a problem in VTK implementation:
+    // https://forum.freecadweb.org/viewtopic.php?t=10587&start=130#p125688
     // check if backlight is enabled
-    ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/View");
+    ParameterGrp::handle hGrp =
+        App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/View");
     bool isBackLightEnabled = hGrp->GetBool("EnableBacklight", false);
     if (!isBackLightEnabled)
-        Base::Console().Error("Backlight is not enabled. Due to a VTK implementation problem you really should consider to enable backlight in FreeCAD display preferences if you work with VTK post processing.\n");
+        Base::Console().Error("Backlight is not enabled. Due to a VTK implementation problem you "
+                              "really should consider to enable backlight in FreeCAD display "
+                              "preferences if you work with VTK post processing.\n");
     // set edit
     Gui::Application::Instance->activeDocument()->setEdit(this, (int)ViewProvider::Default);
     return true;
@@ -784,7 +802,8 @@ bool ViewProviderFemPostObject::onDelete(const std::vector<std::string>&)
         QString bodyMessage;
         QTextStream bodyMessageStream(&bodyMessage);
         bodyMessageStream << qApp->translate("Std_Delete",
-            "The pipeline is not empty, therefore the\nfollowing referencing objects might be lost:");
+                                             "The pipeline is not empty, therefore the\nfollowing "
+                                             "referencing objects might be lost:");
         bodyMessageStream << '\n';
         for (auto ObjIterator : objs)
             bodyMessageStream << '\n' << QString::fromUtf8(ObjIterator->Label.getValue());

--- a/src/Mod/Fem/Gui/ViewProviderFemPostPipeline.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemPostPipeline.cpp
@@ -79,16 +79,18 @@ void ViewProviderFemPostPipeline::updateData(const App::Property* prop) {
 
 void ViewProviderFemPostPipeline::updateFunctionSize() {
 
-    //we need to get the bounding box and set the function provider size
+    // we need to get the bounding box and set the function provider size
     Fem::FemPostPipeline* obj = static_cast<Fem::FemPostPipeline*>(getObject());
 
     if (!obj->Functions.getValue()
-        || !obj->Functions.getValue()->isDerivedFrom(Fem::FemPostFunctionProvider::getClassTypeId()))
+        || !obj->Functions.getValue()->isDerivedFrom(
+            Fem::FemPostFunctionProvider::getClassTypeId()))
         return;
 
-    //get the function provider
-    FemGui::ViewProviderFemPostFunctionProvider* vp = static_cast<FemGui::ViewProviderFemPostFunctionProvider*>(
-        Gui::Application::Instance->getViewProvider(obj->Functions.getValue()));
+    // get the function provider
+    FemGui::ViewProviderFemPostFunctionProvider* vp =
+        static_cast<FemGui::ViewProviderFemPostFunctionProvider*>(
+            Gui::Application::Instance->getViewProvider(obj->Functions.getValue()));
 
     if (obj->Data.getValue() && obj->Data.getValue()->IsA("vtkDataSet")) {
         vtkBoundingBox box = obj->getBoundingBox();
@@ -105,8 +107,8 @@ void ViewProviderFemPostPipeline::onSelectionChanged(const Gui::SelectionChanges
         ViewProviderFemAnalysis* analyzeView = nullptr;
         App::DocumentObject* grp = App::GroupExtension::getGroupOfObject(obj);
         if (Fem::FemAnalysis* analyze = Base::freecad_dynamic_cast<Fem::FemAnalysis>(grp)) {
-            analyzeView = Base::freecad_dynamic_cast<ViewProviderFemAnalysis>
-                                                   (Gui::Application::Instance->getViewProvider(analyze));
+            analyzeView = Base::freecad_dynamic_cast<ViewProviderFemAnalysis>(
+                Gui::Application::Instance->getViewProvider(analyze));
         }
         return analyzeView;
     };
@@ -182,9 +184,10 @@ void ViewProviderFemPostPipeline::transformField(char *FieldName, double FieldFa
         scaleField(dset, pdata, FieldFactor);
 }
 
-void ViewProviderFemPostPipeline::scaleField(vtkDataSet *dset, vtkDataArray *pdata, double FieldFactor)
+void ViewProviderFemPostPipeline::scaleField(vtkDataSet* dset, vtkDataArray* pdata,
+                                             double FieldFactor)
 {
-    //safe guard
+    // safe guard
     if (!dset || !pdata)
         return;
 


### PR DESCRIPTION
- reformatting was done by the MSVC formatter according to our current clang file