### PR TITLE
[FEM] Elmer: extend potential constraint

### DIFF
--- a/src/Mod/Fem/Gui/Resources/ui/ElectrostaticPotential.ui
+++ b/src/Mod/Fem/Gui/Resources/ui/ElectrostaticPotential.ui
@@ -6,15 +6,15 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>350</width>
-    <height>137</height>
+    <width>317</width>
+    <height>303</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Constraint Properties</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
-   <item>
+  <layout class="QGridLayout" name="gridLayout_4">
+   <item row="0" column="0">
     <layout class="QGridLayout" name="gridLayout">
      <item row="0" column="0">
       <widget class="QLabel" name="potentialLbl">
@@ -48,7 +48,7 @@
         </size>
        </property>
        <property name="toolTip">
-        <string>Electric potential in V</string>
+        <string>Electric potential</string>
        </property>
        <property name="keyboardTracking">
         <bool>true</bool>
@@ -82,7 +82,441 @@
      </item>
     </layout>
    </item>
-   <item>
+   <item row="1" column="0">
+    <widget class="QCheckBox" name="vectorFieldBox">
+     <property name="toolTip">
+      <string>To define a vector field</string>
+     </property>
+     <property name="text">
+      <string>Vector Field</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QGroupBox" name="vectorFieldGB">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="toolTip">
+      <string>Imaginary part is only used for equations
+with a harmonic/oscillating driving force</string>
+     </property>
+     <property name="checkable">
+      <bool>false</bool>
+     </property>
+     <property name="checked">
+      <bool>false</bool>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_3">
+      <item row="0" column="1">
+       <widget class="QLabel" name="labelReal">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="text">
+         <string>Real</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="3">
+       <widget class="QLabel" name="labelImaginary">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="text">
+         <string>Imaginary</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="labelScalar">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="text">
+         <string>Scalar</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="Gui::QuantitySpinBox" name="realScalarQSB">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>100</width>
+          <height>20</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>Potential as specified above</string>
+        </property>
+        <property name="readOnly">
+         <bool>true</bool>
+        </property>
+        <property name="keyboardTracking">
+         <bool>true</bool>
+        </property>
+        <property name="unit" stdset="0">
+         <string notr="true">V</string>
+        </property>
+        <property name="minimum">
+         <double>-1000000000000000000000.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>1000000000000000000000.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>1.000000000000000</double>
+        </property>
+        <property name="value">
+         <double>1.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="3">
+       <widget class="Gui::QuantitySpinBox" name="imagScalarQSB">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>100</width>
+          <height>20</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>Imaginary part of scalar potential</string>
+        </property>
+        <property name="keyboardTracking">
+         <bool>true</bool>
+        </property>
+        <property name="unit" stdset="0">
+         <string notr="true">V</string>
+        </property>
+        <property name="minimum">
+         <double>-1000000000000000000000.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>1000000000000000000000.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>1.000000000000000</double>
+        </property>
+        <property name="value">
+         <double>1.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="4">
+       <widget class="QCheckBox" name="imScalarunspecBox">
+        <property name="toolTip">
+         <string>unspecified</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="labelX">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="text">
+         <string>x</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="Gui::QuantitySpinBox" name="realXQSB">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>100</width>
+          <height>20</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>Real part of potential x-component</string>
+        </property>
+        <property name="keyboardTracking">
+         <bool>true</bool>
+        </property>
+        <property name="unit" stdset="0">
+         <string notr="true">V</string>
+        </property>
+        <property name="minimum">
+         <double>-1000000000000000000000.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>1000000000000000000000.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>1.000000000000000</double>
+        </property>
+        <property name="value">
+         <double>1.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="2">
+       <widget class="QCheckBox" name="reXunspecBox">
+        <property name="toolTip">
+         <string>unspecified</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="3">
+       <widget class="Gui::QuantitySpinBox" name="imagXQSB">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>100</width>
+          <height>20</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>Imaginary part of potential x-component</string>
+        </property>
+        <property name="keyboardTracking">
+         <bool>true</bool>
+        </property>
+        <property name="unit" stdset="0">
+         <string notr="true">V</string>
+        </property>
+        <property name="minimum">
+         <double>-1000000000000000000000.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>1000000000000000000000.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>1.000000000000000</double>
+        </property>
+        <property name="value">
+         <double>1.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="4">
+       <widget class="QCheckBox" name="imXunspecBox">
+        <property name="toolTip">
+         <string>unspecified</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="labelY">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="text">
+         <string>y</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="Gui::QuantitySpinBox" name="realYQSB">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>100</width>
+          <height>20</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>Real part of potential y-component</string>
+        </property>
+        <property name="keyboardTracking">
+         <bool>true</bool>
+        </property>
+        <property name="unit" stdset="0">
+         <string notr="true">V</string>
+        </property>
+        <property name="minimum">
+         <double>-1000000000000000000000.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>1000000000000000000000.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>1.000000000000000</double>
+        </property>
+        <property name="value">
+         <double>1.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="2">
+       <widget class="QCheckBox" name="reYunspecBox">
+        <property name="toolTip">
+         <string>unspecified</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="3">
+       <widget class="Gui::QuantitySpinBox" name="imagYQSB">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>100</width>
+          <height>20</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>Imaginary part of potential y-component</string>
+        </property>
+        <property name="keyboardTracking">
+         <bool>true</bool>
+        </property>
+        <property name="unit" stdset="0">
+         <string notr="true">V</string>
+        </property>
+        <property name="minimum">
+         <double>-1000000000000000000000.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>1000000000000000000000.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>1.000000000000000</double>
+        </property>
+        <property name="value">
+         <double>1.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="4">
+       <widget class="QCheckBox" name="imYunspecBox">
+        <property name="toolTip">
+         <string>unspecified</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="labelZ">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="text">
+         <string>z</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="Gui::QuantitySpinBox" name="realZQSB">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>100</width>
+          <height>20</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>Real part of potential z-component</string>
+        </property>
+        <property name="keyboardTracking">
+         <bool>true</bool>
+        </property>
+        <property name="unit" stdset="0">
+         <string notr="true">V</string>
+        </property>
+        <property name="minimum">
+         <double>-1000000000000000000000.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>1000000000000000000000.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>1.000000000000000</double>
+        </property>
+        <property name="value">
+         <double>1.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="2">
+       <widget class="QCheckBox" name="reZunspecBox">
+        <property name="toolTip">
+         <string>unspecified</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="3">
+       <widget class="Gui::QuantitySpinBox" name="imagZQSB">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>100</width>
+          <height>20</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>Imaginary part of potential z-component</string>
+        </property>
+        <property name="keyboardTracking">
+         <bool>true</bool>
+        </property>
+        <property name="unit" stdset="0">
+         <string notr="true">V</string>
+        </property>
+        <property name="minimum">
+         <double>-1000000000000000000000.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>1000000000000000000000.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>1.000000000000000</double>
+        </property>
+        <property name="value">
+         <double>1.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="4">
+       <widget class="QCheckBox" name="imZunspecBox">
+        <property name="toolTip">
+         <string>unspecified</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="3" column="0">
     <widget class="QCheckBox" name="potentialConstantBox">
      <property name="toolTip">
       <string>Whether the constraint defines a constant potential</string>
@@ -92,7 +526,7 @@
      </property>
     </widget>
    </item>
-   <item>
+   <item row="4" column="0">
     <widget class="QCheckBox" name="electricInfinityBox">
      <property name="enabled">
       <bool>true</bool>
@@ -105,7 +539,7 @@
      </property>
     </widget>
    </item>
-   <item>
+   <item row="5" column="0">
     <widget class="QCheckBox" name="electricForcecalculationBox">
      <property name="toolTip">
       <string>Whether the constraint is for the electric force</string>
@@ -115,7 +549,7 @@
      </property>
     </widget>
    </item>
-   <item>
+   <item row="6" column="0">
     <layout class="QGridLayout" name="gridLayout_2">
      <item row="0" column="0">
       <widget class="QLabel" name="capacityBody_label">
@@ -208,6 +642,134 @@
     <hint type="destinationlabel">
      <x>206</x>
      <y>19</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>potentialQSB</sender>
+   <signal>valueChanged(Base::Quantity)</signal>
+   <receiver>realScalarQSB</receiver>
+   <slot>setValue(Base::Quantity)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>126</x>
+     <y>19</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>103</x>
+     <y>98</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>reZunspecBox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>realZQSB</receiver>
+   <slot>setDisabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>179</x>
+     <y>178</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>103</x>
+     <y>176</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>reYunspecBox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>realYQSB</receiver>
+   <slot>setDisabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>179</x>
+     <y>148</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>103</x>
+     <y>150</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>imXunspecBox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>imagXQSB</receiver>
+   <slot>setDisabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>339</x>
+     <y>128</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>258</x>
+     <y>127</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>reXunspecBox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>realXQSB</receiver>
+   <slot>setDisabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>179</x>
+     <y>128</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>103</x>
+     <y>124</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>imZunspecBox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>imagZQSB</receiver>
+   <slot>setDisabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>339</x>
+     <y>178</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>258</x>
+     <y>179</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>imYunspecBox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>imagYQSB</receiver>
+   <slot>setDisabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>339</x>
+     <y>148</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>258</x>
+     <y>153</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>imScalarunspecBox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>imagScalarQSB</receiver>
+   <slot>setDisabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>339</x>
+     <y>98</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>258</x>
+     <y>101</y>
     </hint>
    </hints>
   </connection>

--- a/src/Mod/Fem/femobjects/constraint_electrostaticpotential.py
+++ b/src/Mod/Fem/femobjects/constraint_electrostaticpotential.py
@@ -1,6 +1,7 @@
 # ***************************************************************************
 # *   Copyright (c) 2017 Markus Hovorka <m.hovorka@live.de>                 *
 # *   Copyright (c) 2020 Bernd Hahnebach <bernd@bimstatik.org>              *
+# *   Copyright (c) 2023 Uwe Stöhr <uwestoehr@lyx.org>                      *
 # *                                                                         *
 # *   This file is part of the FreeCAD CAx development system.              *
 # *                                                                         *
@@ -23,7 +24,7 @@
 # ***************************************************************************
 
 __title__ = "FreeCAD FEM constraint electrostatic potential document object"
-__author__ = "Markus Hovorka, Bernd Hahnebach"
+__author__ = "Markus Hovorka, Bernd Hahnebach, Uwe Stöhr"
 __url__ = "https://www.freecadweb.org"
 
 ## @package constraint_electrostaticpotential
@@ -56,6 +57,64 @@ class ConstraintElectrostaticPotential(base_fempythonobject.BaseFemPythonObject)
             # and the constraint holds usually Volts
             obj.Potential = "1 V"
 
+        if not hasattr(obj, "AV_re_1"):
+            obj.addProperty(
+                "App::PropertyElectricPotential",
+                "AV_re_1",
+                "Vector Potential",
+                "Real part of potential x-component"
+            )
+            obj.AV_re_1 = "0 V"
+        if not hasattr(obj, "AV_re_2"):
+            obj.addProperty(
+                "App::PropertyElectricPotential",
+                "AV_re_2",
+                "Vector Potential",
+                "Real part of potential y-component"
+            )
+            obj.AV_re_2 = "0 V"
+        if not hasattr(obj, "AV_re_3"):
+            obj.addProperty(
+                "App::PropertyElectricPotential",
+                "AV_re_3",
+                "Vector Potential",
+                "Real part of potential z-component"
+            )
+            obj.AV_re_3 = "0 V"
+        if not hasattr(obj, "AV_im"):
+            obj.addProperty(
+                "App::PropertyElectricPotential",
+                "AV_im",
+                "Vector Potential",
+                "Imaginary part of scalar potential"
+            )
+            obj.AV_im = "0 V"
+        if not hasattr(obj, "AV_im_1"):
+            obj.addProperty(
+                "App::PropertyElectricPotential",
+                "AV_im_1",
+                "Vector Potential",
+                "Imaginary part of potential x-component"
+            )
+            obj.AV_im_1 = "0 V"
+        if not hasattr(obj, "AV_im_2"):
+            obj.addProperty(
+                "App::PropertyElectricPotential",
+                "AV_im_2",
+                "Vector Potential",
+                "Imaginary part of potential y-component"
+            )
+            obj.AV_im_2 = "0 V"
+        if not hasattr(obj, "AV_im_3"):
+            obj.addProperty(
+                "App::PropertyElectricPotential",
+                "AV_im_3",
+                "Vector Potential",
+                "Imaginary part of potential z-component"
+            )
+            obj.AV_im_3 = "0 V"
+
+        # now the enable bools
         if not hasattr(obj, "PotentialEnabled"):
             obj.addProperty(
                 "App::PropertyBool",
@@ -64,6 +123,62 @@ class ConstraintElectrostaticPotential(base_fempythonobject.BaseFemPythonObject)
                 "Potential Enabled"
             )
             obj.PotentialEnabled = True
+        if not hasattr(obj, "AV_re_1_Disabled"):
+            obj.addProperty(
+                "App::PropertyBool",
+                "AV_re_1_Disabled",
+                "Vector Potential",
+                ""
+            )
+            obj.AV_re_1_Disabled = True
+        if not hasattr(obj, "AV_re_2_Disabled"):
+            obj.addProperty(
+                "App::PropertyBool",
+                "AV_re_2_Disabled",
+                "Vector Potential",
+                ""
+            )
+            obj.AV_re_2_Disabled = True
+        if not hasattr(obj, "AV_re_3_Disabled"):
+            obj.addProperty(
+                "App::PropertyBool",
+                "AV_re_3_Disabled",
+                "Vector Potential",
+                ""
+            )
+            obj.AV_re_3_Disabled = True
+        if not hasattr(obj, "AV_im_Disabled"):
+            obj.addProperty(
+                "App::PropertyBool",
+                "AV_im_Disabled",
+                "Vector Potential",
+                ""
+            )
+            obj.AV_im_Disabled = True
+        if not hasattr(obj, "AV_im_1_Disabled"):
+            obj.addProperty(
+                "App::PropertyBool",
+                "AV_im_1_Disabled",
+                "Vector Potential",
+                ""
+            )
+            obj.AV_im_1_Disabled = True
+        if not hasattr(obj, "AV_im_2_Disabled"):
+            obj.addProperty(
+                "App::PropertyBool",
+                "AV_im_2_Disabled",
+                "Vector Potential",
+                ""
+            )
+            obj.AV_im_2_Disabled = True
+        if not hasattr(obj, "AV_im_3_Disabled"):
+            obj.addProperty(
+                "App::PropertyBool",
+                "AV_im_3_Disabled",
+                "Vector Potential",
+                ""
+            )
+            obj.AV_im_3_Disabled = True
 
         if not hasattr(obj, "PotentialConstant"):
             obj.addProperty(

--- a/src/Mod/Fem/femtaskpanels/task_constraint_electrostaticpotential.py
+++ b/src/Mod/Fem/femtaskpanels/task_constraint_electrostaticpotential.py
@@ -1,6 +1,7 @@
 # ***************************************************************************
 # *   Copyright (c) 2017 Markus Hovorka <m.hovorka@live.de>                 *
 # *   Copyright (c) 2020 Bernd Hahnebach <bernd@bimstatik.org>              *
+# *   Copyright (c) 2023 Uwe Stöhr <uwestoehr@lyx.org>                      *
 # *                                                                         *
 # *   This file is part of the FreeCAD CAx development system.              *
 # *                                                                         *
@@ -23,12 +24,14 @@
 # ***************************************************************************
 
 __title__ = "FreeCAD FEM constraint electrostatic potential task panel for the document object"
-__author__ = "Markus Hovorka, Bernd Hahnebach"
+__author__ = "Markus Hovorka, Bernd Hahnebach, Uwe Stöhr"
 __url__ = "https://www.freecadweb.org"
 
 ## @package task_constraint_electrostaticpotential
 #  \ingroup FEM
 #  \brief task panel for constraint electrostatic potential object
+
+from PySide import QtCore
 
 import FreeCAD
 import FreeCADGui
@@ -69,6 +72,24 @@ class _TaskPanel(object):
         self._partVisible = None
         self._meshVisible = None
 
+        # start with vector inputs hidden if no vector is set
+        if self._obj.AV_re_1_Disabled and \
+            self._obj.AV_re_2_Disabled and \
+            self._obj.AV_re_3_Disabled and \
+            self._obj.AV_im_Disabled and \
+            self._obj.AV_im_1_Disabled and \
+            self._obj.AV_im_2_Disabled and \
+            self._obj.AV_im_3_Disabled:
+            self._vectorField_visibility(False)
+        QtCore.QObject.connect(
+            self._paramWidget.vectorFieldBox,
+            QtCore.SIGNAL("toggled(bool)"),
+            self._vectorField_visibility
+        )
+
+    def _vectorField_visibility(self, visible):
+        self._paramWidget.vectorFieldGB.setVisible(visible)
+
     def open(self):
         if self._mesh is not None and self._part is not None:
             self._meshVisible = self._mesh.ViewObject.isVisible()
@@ -108,6 +129,57 @@ class _TaskPanel(object):
             self._paramWidget.potentialQSB).bind(self._obj, "Potential")
         self._paramWidget.potentialBox.setChecked(
             not self._obj.PotentialEnabled)
+
+        # the vector potentials
+        # realScalarQSB always the same value as potentialQSB
+        self._paramWidget.realScalarQSB.setProperty(
+            'value', self._obj.Potential)
+        FreeCADGui.ExpressionBinding(
+            self._paramWidget.realScalarQSB).bind(self._obj, "Potential")
+        self._paramWidget.realXQSB.setProperty(
+            'value', self._obj.AV_re_1)
+        FreeCADGui.ExpressionBinding(
+            self._paramWidget.realXQSB).bind(self._obj, "AV_re_1")
+        self._paramWidget.realYQSB.setProperty(
+            'value', self._obj.AV_re_2)
+        FreeCADGui.ExpressionBinding(
+            self._paramWidget.realYQSB).bind(self._obj, "AV_re_2")
+        self._paramWidget.realZQSB.setProperty(
+            'value', self._obj.AV_re_3)
+        FreeCADGui.ExpressionBinding(
+            self._paramWidget.realZQSB).bind(self._obj, "AV_re_3")
+        self._paramWidget.imagScalarQSB.setProperty(
+            'value', self._obj.AV_im)
+        FreeCADGui.ExpressionBinding(
+            self._paramWidget.imagScalarQSB).bind(self._obj, "AV_im")
+        self._paramWidget.imagXQSB.setProperty(
+            'value', self._obj.AV_im_1)
+        FreeCADGui.ExpressionBinding(
+            self._paramWidget.imagXQSB).bind(self._obj, "AV_im_1")
+        self._paramWidget.imagYQSB.setProperty(
+            'value', self._obj.AV_im_2)
+        FreeCADGui.ExpressionBinding(
+            self._paramWidget.imagYQSB).bind(self._obj, "AV_im_2")
+        self._paramWidget.imagZQSB.setProperty(
+            'value', self._obj.AV_im_3)
+        FreeCADGui.ExpressionBinding(
+            self._paramWidget.imagZQSB).bind(self._obj, "AV_im_3")
+
+        self._paramWidget.reXunspecBox.setChecked(
+            self._obj.AV_re_1_Disabled)
+        self._paramWidget.reYunspecBox.setChecked(
+            self._obj.AV_re_2_Disabled)
+        self._paramWidget.reZunspecBox.setChecked(
+            self._obj.AV_re_3_Disabled)
+        self._paramWidget.imScalarunspecBox.setChecked(
+            self._obj.AV_im_Disabled)
+        self._paramWidget.imXunspecBox.setChecked(
+            self._obj.AV_im_1_Disabled)
+        self._paramWidget.imYunspecBox.setChecked(
+            self._obj.AV_im_2_Disabled)
+        self._paramWidget.imZunspecBox.setChecked(
+            self._obj.AV_im_3_Disabled)
+
         self._paramWidget.potentialConstantBox.setChecked(
             self._obj.PotentialConstant)
 
@@ -124,21 +196,63 @@ class _TaskPanel(object):
         self._paramWidget.capacitanceBody_spinBox.setEnabled(
             not self._paramWidget.capacitanceBodyBox.isChecked())
 
+    def _applyPotentialChanges(self, enabledBox, potentialQSB):
+        enabled = enabledBox.isChecked()
+        potential = None
+        try:
+            potential = potentialQSB.property('value')
+        except ValueError:
+            FreeCAD.Console.PrintMessage(
+                "Wrong input. Not recognised input: '{}' "
+                "Potential has not been set.\n".format(potentialQSB.text())
+            )
+            potential = '0.0 mm^2*kg/(s^3*A)'
+        return enabled, potential
+
     def _applyWidgetChanges(self):
-        self._obj.PotentialEnabled = \
-            not self._paramWidget.potentialBox.isChecked()
-        if self._obj.PotentialEnabled:
-            potential = None
-            try:
-                potential = self._paramWidget.potentialQSB.property('value')
-            except ValueError:
-                FreeCAD.Console.PrintMessage(
-                    "Wrong input. Not recognised input: '{}' "
-                    "Potential has not been set.\n"
-                    .format(self._paramWidget.potentialQSB.text())
-                )
-            if potential is not None:
-                self._obj.Potential = potential
+        # apply the voltages and their enabled state
+        self._obj.PotentialEnabled, self._obj.Potential = \
+            self._applyPotentialChanges(
+                self._paramWidget.potentialBox,
+                self._paramWidget.potentialQSB
+            )
+        self._obj.AV_re_1_Disabled, self._obj.AV_re_1 = \
+            self._applyPotentialChanges(
+                self._paramWidget.reXunspecBox,
+                self._paramWidget.realXQSB
+            )
+        self._obj.AV_re_2_Disabled, self._obj.AV_re_2 = \
+            self._applyPotentialChanges(
+                self._paramWidget.reYunspecBox,
+                self._paramWidget.realYQSB
+            )
+        self._obj.AV_re_3_Disabled, self._obj.AV_re_3 = \
+            self._applyPotentialChanges(
+                self._paramWidget.reZunspecBox,
+                self._paramWidget.realZQSB
+            )
+        self._obj.AV_im_Disabled, self._obj.AV_im = \
+            self._applyPotentialChanges(
+                self._paramWidget.imScalarunspecBox,
+                self._paramWidget.imagScalarQSB
+            )
+        self._obj.AV_im_1_Disabled, self._obj.AV_im_1 = \
+            self._applyPotentialChanges(
+                self._paramWidget.imXunspecBox,
+                self._paramWidget.imagXQSB
+            )
+        self._obj.AV_im_2_Disabled, self._obj.AV_im_2 = \
+            self._applyPotentialChanges(
+                self._paramWidget.imYunspecBox,
+                self._paramWidget.imagYQSB
+            )
+        self._obj.AV_im_3_Disabled, self._obj.AV_im_3 = \
+            self._applyPotentialChanges(
+                self._paramWidget.imZunspecBox,
+                self._paramWidget.imagZQSB
+            )
+        # because this is an enable the others are disabled, reverse
+        self._obj.PotentialEnabled = not self._obj.PotentialEnabled
 
         self._obj.PotentialConstant = self._paramWidget.potentialConstantBox.isChecked()
 


### PR DESCRIPTION
- it is now possible to specify an electric potential vector field, necessary for electromagnetic analyses
- existing electrostatic analyses are not affected since the new values are not evaluated for them