### PR TITLE
Sketcher: Snap initial implementation. 

### DIFF
--- a/src/Mod/Sketcher/Gui/CMakeLists.txt
+++ b/src/Mod/Sketcher/Gui/CMakeLists.txt
@@ -144,6 +144,8 @@ SET(SketcherGui_SRCS
     SketchRectangularArrayDialog.cpp
     SketcherRegularPolygonDialog.h
     SketcherRegularPolygonDialog.cpp
+    SnapManager.cpp
+    SnapManager.h
     TaskDlgEditSketch.cpp
     TaskDlgEditSketch.h
     ViewProviderPython.cpp

--- a/src/Mod/Sketcher/Gui/Command.cpp
+++ b/src/Mod/Sketcher/Gui/Command.cpp
@@ -1212,7 +1212,7 @@ public:
                 }
             };
 
-            ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher/General");
+            ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher/Snap");
 
             updateCheckBox(snapToObjects, hGrp->GetBool("SnapToObjects", true));
 
@@ -1271,7 +1271,7 @@ protected:
             auto* sketchView = getView();
 
             if (sketchView) {
-                ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher/General");
+                ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher/Snap");
                 hGrp->SetBool("SnapToObjects", state == Qt::Checked);
             }
         });
@@ -1279,7 +1279,7 @@ protected:
         QObject::connect(snapToGrid, &QCheckBox::stateChanged, [this](int state) {
             auto* sketchView = getView();
             if (sketchView) {
-                ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher/General");
+                ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher/Snap");
                 hGrp->SetBool("SnapToGrid", state == Qt::Checked);
             }
         });
@@ -1288,7 +1288,7 @@ protected:
             auto* sketchView = getView();
 
             if (sketchView) {
-                ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher/General");
+                ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher/Snap");
                 hGrp->SetFloat("SnapAngle", val);
             }
         });
@@ -1362,7 +1362,7 @@ void CmdSketcherSnap::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
 
-    ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher/General");
+    ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher/Snap");
     bool value = !hGrp->GetBool("Snap", true);
     
     hGrp->SetBool("Snap", value);
@@ -1398,7 +1398,7 @@ Gui::Action* CmdSketcherSnap::createAction()
     });
 
     // set the right pixmap
-    ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher/General");
+    ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher/Snap");
     updateIcon(hGrp->GetBool("Snap", true));
 
     return pcAction;
@@ -1423,7 +1423,7 @@ bool CmdSketcherSnap::isActive()
     auto* vp = getInactiveHandlerEditModeSketchViewProvider();
 
     if (vp) {
-        ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher/General");
+        ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher/Snap");
         bool value = hGrp->GetBool("Snap", true);
 
         updateIcon(value);

--- a/src/Mod/Sketcher/Gui/Command.cpp
+++ b/src/Mod/Sketcher/Gui/Command.cpp
@@ -1217,7 +1217,7 @@ public:
             }
         };
 
-        ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher/Snap");
+        ParameterGrp::handle hGrp = getParameterPath();
 
         updateCheckBox(snapToObjects, hGrp->GetBool("SnapToObjects", true));
 
@@ -1271,17 +1271,17 @@ protected:
         languageChange();
 
         QObject::connect(snapToObjects, &QCheckBox::stateChanged, [this](int state) {
-            ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher/Snap");
+            ParameterGrp::handle hGrp = this->getParameterPath();
             hGrp->SetBool("SnapToObjects", state == Qt::Checked);
         });
 
         QObject::connect(snapToGrid, &QCheckBox::stateChanged, [this](int state) {
-            ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher/Snap");
+            ParameterGrp::handle hGrp = this->getParameterPath();
             hGrp->SetBool("SnapToGrid", state == Qt::Checked);
         });
 
         QObject::connect(snapAngle, qOverload<double>(&Gui::QuantitySpinBox::valueChanged), [this](double val) {
-            ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher/Snap");
+            ParameterGrp::handle hGrp = this->getParameterPath();
             hGrp->SetFloat("SnapAngle", val);
         });
 
@@ -1289,14 +1289,8 @@ protected:
     }
 
 private:
-    ViewProviderSketch* getView() {
-        Gui::Document* doc = Gui::Application::Instance->activeDocument();
-
-        if (doc) {
-            return dynamic_cast<SketcherGui::ViewProviderSketch*>(doc->getInEdit());
-        }
-
-        return nullptr;
+    ParameterGrp::handle getParameterPath() {
+        return App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher/Snap");
     }
 
 private:

--- a/src/Mod/Sketcher/Gui/Command.cpp
+++ b/src/Mod/Sketcher/Gui/Command.cpp
@@ -995,8 +995,6 @@ public:
                 updateCheckBox(checkbox, propvalue);
             };
 
-            ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher/General");
-
             updateCheckBoxFromProperty(gridAutoSpacing, sketchView->GridAuto);
 
             gridSizeBox->setValue(sketchView->GridSize.getValue());

--- a/src/Mod/Sketcher/Gui/Command.cpp
+++ b/src/Mod/Sketcher/Gui/Command.cpp
@@ -1073,13 +1073,13 @@ class CmdSketcherGrid : public Gui::Command
 public:
     CmdSketcherGrid();
     virtual ~CmdSketcherGrid(){}
-    virtual const char* className() const
+    virtual const char* className() const override
     { return "CmdSketcherGrid"; }
-    virtual void languageChange();
+    virtual void languageChange() override;
 protected:
-    virtual void activated(int iMsg);
-    virtual bool isActive(void);
-    virtual Gui::Action * createAction(void);
+    virtual void activated(int iMsg) override;
+    virtual bool isActive(void) override;
+    virtual Gui::Action * createAction(void) override;
 private:
     void updateIcon(bool value);
     void updateInactiveHandlerIcon();
@@ -1304,17 +1304,17 @@ class CmdSketcherSnap : public Gui::Command, public ParameterGrp::ObserverType
 public:
     CmdSketcherSnap();
     virtual ~CmdSketcherSnap();
-    virtual const char* className() const
+    virtual const char* className() const override
     {
         return "CmdSketcherSnap";
     }
-    virtual void languageChange();
+    virtual void languageChange() override;
 
     void OnChange(Base::Subject<const char*> &rCaller, const char * sReason) override;
 protected:
-    virtual void activated(int iMsg);
-    virtual bool isActive(void);
-    virtual Gui::Action* createAction(void);
+    virtual void activated(int iMsg) override;
+    virtual bool isActive(void) override;
+    virtual Gui::Action* createAction(void) override;
 private:
     void updateIcon(bool value);
 

--- a/src/Mod/Sketcher/Gui/Command.cpp
+++ b/src/Mod/Sketcher/Gui/Command.cpp
@@ -1208,13 +1208,22 @@ public:
             }
         };
 
+        auto updateSpinBox = [](Gui::QuantitySpinBox* spinbox, double value) {
+            auto currentvalue = spinbox->rawValue();
+
+            if (currentvalue != value) {
+                const QSignalBlocker blocker(spinbox);
+                spinbox->setValue(value);
+            }
+        };
+
         ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher/Snap");
 
         updateCheckBox(snapToObjects, hGrp->GetBool("SnapToObjects", true));
 
         updateCheckBox(snapToGrid, hGrp->GetBool("SnapToGrid", false));
 
-        snapAngle->setValue(hGrp->GetFloat("SnapAngle", 5.0));
+        updateSpinBox(snapAngle, hGrp->GetFloat("SnapAngle", 5.0));
 
         bool snapActivated = hGrp->GetBool("Snap", true);
         snapToObjects->setEnabled(snapActivated);

--- a/src/Mod/Sketcher/Gui/Command.cpp
+++ b/src/Mod/Sketcher/Gui/Command.cpp
@@ -1199,38 +1199,32 @@ public:
 
     void updateWidget() {
 
-        auto* sketchView = getView();
+        auto updateCheckBox = [](QCheckBox* checkbox, bool value) {
+            auto checked = checkbox->checkState() == Qt::Checked;
 
-        if (sketchView) {
+            if (value != checked) {
+                const QSignalBlocker blocker(checkbox);
+                checkbox->setChecked(value);
+            }
+        };
 
-            auto updateCheckBox = [](QCheckBox* checkbox, bool value) {
-                auto checked = checkbox->checkState() == Qt::Checked;
+        ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher/Snap");
 
-                if (value != checked) {
-                    const QSignalBlocker blocker(checkbox);
-                    checkbox->setChecked(value);
-                }
-            };
+        updateCheckBox(snapToObjects, hGrp->GetBool("SnapToObjects", true));
 
-            ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher/Snap");
+        updateCheckBox(snapToGrid, hGrp->GetBool("SnapToGrid", false));
 
-            updateCheckBox(snapToObjects, hGrp->GetBool("SnapToObjects", true));
+        snapAngle->setValue(hGrp->GetFloat("SnapAngle", 5.0));
 
-            updateCheckBox(snapToGrid, hGrp->GetBool("SnapToGrid", false));
-
-            snapAngle->setValue(hGrp->GetFloat("SnapAngle", 5.0));
-
-            bool snapActivated = hGrp->GetBool("Snap", true);
-            snapToObjects->setEnabled(snapActivated);
-            snapToGrid->setEnabled(snapActivated);
-            angleLabel->setEnabled(snapActivated);
-            snapAngle->setEnabled(snapActivated);
-        }
+        bool snapActivated = hGrp->GetBool("Snap", true);
+        snapToObjects->setEnabled(snapActivated);
+        snapToGrid->setEnabled(snapActivated);
+        angleLabel->setEnabled(snapActivated);
+        snapAngle->setEnabled(snapActivated);
     }
 
     void languageChange()
     {
-
         snapToObjects->setText(tr("Snap to objects"));
         snapToObjects->setToolTip(tr("New points will snap to the currently preselected object. It will also snap to the middle of lines and arcs."));
         snapToObjects->setStatusTip(snapToObjects->toolTip());
@@ -1268,29 +1262,18 @@ protected:
         languageChange();
 
         QObject::connect(snapToObjects, &QCheckBox::stateChanged, [this](int state) {
-            auto* sketchView = getView();
-
-            if (sketchView) {
-                ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher/Snap");
-                hGrp->SetBool("SnapToObjects", state == Qt::Checked);
-            }
+            ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher/Snap");
+            hGrp->SetBool("SnapToObjects", state == Qt::Checked);
         });
 
         QObject::connect(snapToGrid, &QCheckBox::stateChanged, [this](int state) {
-            auto* sketchView = getView();
-            if (sketchView) {
-                ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher/Snap");
-                hGrp->SetBool("SnapToGrid", state == Qt::Checked);
-            }
+            ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher/Snap");
+            hGrp->SetBool("SnapToGrid", state == Qt::Checked);
         });
 
         QObject::connect(snapAngle, qOverload<double>(&Gui::QuantitySpinBox::valueChanged), [this](double val) {
-            auto* sketchView = getView();
-
-            if (sketchView) {
-                ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher/Snap");
-                hGrp->SetFloat("SnapAngle", val);
-            }
+            ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher/Snap");
+            hGrp->SetFloat("SnapAngle", val);
         });
 
         return snapW;

--- a/src/Mod/Sketcher/Gui/DrawSketchHandler.cpp
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandler.cpp
@@ -114,6 +114,11 @@ inline int ViewProviderSketchDrawSketchHandlerAttorney::getPreselectCross(const 
     return vp.getPreselectCross();
 }
 
+inline void ViewProviderSketchDrawSketchHandlerAttorney::setAngleSnapping(ViewProviderSketch &vp, bool enable, Base::Vector2d referencePoint)
+{
+    vp.setAngleSnapping(enable, referencePoint);
+}
+
 
 /**************************** CurveConverter **********************************************/
 
@@ -250,6 +255,7 @@ void DrawSketchHandler::deactivate()
     drawEditMarkers(std::vector<Base::Vector2d>());
     resetPositionText();
     unsetCursor();
+    setAngleSnapping(false);
 }
 
 void DrawSketchHandler::preActivated()
@@ -992,3 +998,7 @@ Sketcher::SketchObject * DrawSketchHandler::getSketchObject()
     return sketchgui->getSketchObject();
 }
 
+void DrawSketchHandler::setAngleSnapping(bool enable, Base::Vector2d referencePoint)
+{
+    ViewProviderSketchDrawSketchHandlerAttorney::setAngleSnapping(*sketchgui, enable, referencePoint);
+}

--- a/src/Mod/Sketcher/Gui/DrawSketchHandler.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandler.h
@@ -86,10 +86,12 @@ private:
     static inline void setAxisPickStyle(ViewProviderSketch &vp, bool on);
     static inline void moveCursorToSketchPoint(ViewProviderSketch &vp, Base::Vector2d point);
     static inline void preselectAtPoint(ViewProviderSketch &vp, Base::Vector2d point);
+    static inline void setAngleSnapping(ViewProviderSketch &vp, bool enable, Base::Vector2d referencePoint = Base::Vector2d(0., 0.));
 
     static inline int getPreselectPoint(const ViewProviderSketch &vp);
     static inline int getPreselectCurve(const ViewProviderSketch &vp);
     static inline int getPreselectCross(const ViewProviderSketch &vp);
+
 
     friend class DrawSketchHandler;
 };
@@ -202,6 +204,8 @@ protected:
     int getPreselectCross() const;
 
     Sketcher::SketchObject * getSketchObject();
+
+    void setAngleSnapping(bool enable, Base::Vector2d referencePoint = Base::Vector2d(0., 0.));
 
 private:
     void setSvgCursor(const QString &svgName, int x, int y,

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArc.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArc.h
@@ -131,6 +131,7 @@ public:
             CenterPoint = onSketchPos;
             EditCurve.resize(34);
             EditCurve[0] = onSketchPos;
+            setAngleSnapping(true, EditCurve[0]);
             Mode = STATUS_SEEK_Second;
         }
         else if (Mode==STATUS_SEEK_Second){
@@ -158,6 +159,7 @@ public:
 
             drawEdit(EditCurve);
             applyCursor();
+            setAngleSnapping(false);
             Mode = STATUS_End;
         }
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfEllipse.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfEllipse.h
@@ -176,6 +176,7 @@ public:
         if (Mode==STATUS_SEEK_First){
             EditCurve[0] = onSketchPos;
             centerPoint = onSketchPos;
+            setAngleSnapping(true, centerPoint);
             Mode = STATUS_SEEK_Second;
         }
         else if(Mode==STATUS_SEEK_Second) {
@@ -192,6 +193,7 @@ public:
         else { // Fourth
             endPoint = onSketchPos;
 
+            setAngleSnapping(false);
             Mode = STATUS_Close;
         }
         return true;

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerEllipse.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerEllipse.h
@@ -216,10 +216,12 @@ public:
         if (method == PERIAPSIS_APOAPSIS_B) {
             if (mode == STATUS_SEEK_PERIAPSIS) {
                 periapsis = onSketchPos;
+                setAngleSnapping(true, periapsis);
                 mode = STATUS_SEEK_APOAPSIS;
             }
             else if (mode == STATUS_SEEK_APOAPSIS) {
                 apoapsis = onSketchPos;
+                setAngleSnapping(false);
                 mode = STATUS_SEEK_B;
             }
             else {
@@ -228,10 +230,12 @@ public:
         } else { // method is CENTER_PERIAPSIS_B
             if (mode == STATUS_SEEK_CENTROID) {
                 centroid = onSketchPos;
+                setAngleSnapping(true, centroid);
                 mode = STATUS_SEEK_PERIAPSIS;
             }
             else if (mode == STATUS_SEEK_PERIAPSIS) {
                 periapsis = onSketchPos;
+                setAngleSnapping(false);
                 mode = STATUS_SEEK_B;
             }
             else {

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerLine.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerLine.h
@@ -76,11 +76,13 @@ public:
         if (Mode==STATUS_SEEK_First){
             EditCurve[0] = onSketchPos;
 
+            setAngleSnapping(true, EditCurve[0]);
             Mode = STATUS_SEEK_Second;
         }
         else {
             EditCurve[1] = onSketchPos;
             drawEdit(EditCurve);
+            setAngleSnapping(false);
             Mode = STATUS_End;
         }
         return true;

--- a/src/Mod/Sketcher/Gui/Resources/Sketcher.qrc
+++ b/src/Mod/Sketcher/Gui/Resources/Sketcher.qrc
@@ -106,6 +106,8 @@
         <file>icons/general/Sketcher_ViewSketch.svg</file>
         <file>icons/general/Sketcher_GridToggle.svg</file>
         <file>icons/general/Sketcher_GridToggle_Deactivated.svg</file>
+        <file>icons/general/Sketcher_Snap.svg</file>
+        <file>icons/general/Sketcher_Snap_Deactivated.svg</file>
     </qresource>
     <qresource>
         <file>icons/geometry/Sketcher_AlterFillet.svg</file>

--- a/src/Mod/Sketcher/Gui/Resources/icons/general/Sketcher_Snap.svg
+++ b/src/Mod/Sketcher/Gui/Resources/icons/general/Sketcher_Snap.svg
@@ -1,0 +1,386 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="64px"
+   height="64px"
+   id="svg3364"
+   version="1.1"
+   sodipodi:docname="Sketcher_Snap.svg"
+   inkscape:version="1.1-beta1 (77e7b44db3, 2021-03-28)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview55"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     objecttolerance="10.0"
+     gridtolerance="10.0"
+     guidetolerance="10.0"
+     inkscape:pageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="11.765625"
+     inkscape:cx="39.861886"
+     inkscape:cy="27.580345"
+     inkscape:window-width="1725"
+     inkscape:window-height="1013"
+     inkscape:window-x="1213"
+     inkscape:window-y="293"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3364" />
+  <defs
+     id="defs3366">
+    <linearGradient
+       id="linearGradient3864">
+      <stop
+         id="stop3866"
+         offset="0"
+         style="stop-color:#71b2f8;stop-opacity:1" />
+      <stop
+         id="stop3868"
+         offset="1"
+         style="stop-color:#002795;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient3864"
+       id="radialGradient2571"
+       gradientUnits="userSpaceOnUse"
+       cx="342.58258"
+       cy="27.256668"
+       fx="342.58258"
+       fy="27.256668"
+       r="19.571428"
+       gradientTransform="matrix(1.6258409,0.5434973,-8.8819886e-2,0.2656996,-215.02413,-170.90186)" />
+    <radialGradient
+       xlink:href="#linearGradient3593"
+       id="radialGradient3352"
+       gradientUnits="userSpaceOnUse"
+       cx="345.28433"
+       cy="15.560534"
+       fx="345.28433"
+       fy="15.560534"
+       r="19.571428"
+       gradientTransform="translate(-0.1767767,-2.6516504)" />
+    <linearGradient
+       id="linearGradient3593">
+      <stop
+         style="stop-color:#c8e0f9;stop-opacity:1"
+         offset="0"
+         id="stop3595" />
+      <stop
+         style="stop-color:#637dca;stop-opacity:1"
+         offset="1"
+         id="stop3597" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient3593"
+       id="radialGradient3354"
+       gradientUnits="userSpaceOnUse"
+       cx="330.63791"
+       cy="39.962704"
+       fx="330.63791"
+       fy="39.962704"
+       r="19.571428"
+       gradientTransform="translate(-0.1767767,-2.6516504)" />
+    <radialGradient
+       xlink:href="#linearGradient3864"
+       id="radialGradient3369"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.6258409,0.5434973,-8.8819886e-2,0.2656996,-461.81066,-173.06271)"
+       cx="342.58258"
+       cy="27.256668"
+       fx="342.58258"
+       fy="27.256668"
+       r="19.571428" />
+    <radialGradient
+       xlink:href="#linearGradient3593"
+       id="radialGradient3372"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0012324,0,0,0.9421773,-327.50313,-4.3316646)"
+       cx="345.28433"
+       cy="15.560534"
+       fx="345.28433"
+       fy="15.560534"
+       r="19.571428" />
+    <radialGradient
+       xlink:href="#linearGradient3593"
+       id="radialGradient3375"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0012324,0,0,0.9421773,-287.81791,-28.143054)"
+       cx="330.63791"
+       cy="39.962704"
+       fx="330.63791"
+       fy="39.962704"
+       r="19.571428" />
+    <radialGradient
+       xlink:href="#linearGradient3864"
+       id="radialGradient3380"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9829174,1.3240854,-1.2330051,0.8105158,-131.04134,-483.74563)"
+       cx="320.44025"
+       cy="113.23357"
+       fx="320.44025"
+       fy="113.23357"
+       r="19.571428" />
+    <linearGradient
+       xlink:href="#linearGradient3864"
+       id="linearGradient3914"
+       x1="6.94525"
+       y1="36.838673"
+       x2="48.691113"
+       y2="36.838673"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0012324,0,0,0.9421773,-4.8699606,-2.3863162)" />
+    <radialGradient
+       xlink:href="#linearGradient3794"
+       id="radialGradient3800"
+       cx="1"
+       cy="45"
+       fx="1"
+       fy="45"
+       r="41"
+       gradientTransform="matrix(0.93348213,-2.2905276e-8,0,0.28687573,0.06651751,32.090592)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3794">
+      <stop
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0"
+         id="stop3796" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1"
+         id="stop3798" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(0,-9)"
+       xlink:href="#linearGradient3777"
+       id="linearGradient3783"
+       x1="53.896763"
+       y1="51.179787"
+       x2="48"
+       y2="32"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3777">
+      <stop
+         style="stop-color:#204a87;stop-opacity:1"
+         offset="0"
+         id="stop3779" />
+      <stop
+         style="stop-color:#3465a4;stop-opacity:1"
+         offset="1"
+         id="stop3781" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(22,-17)"
+       xlink:href="#linearGradient3767"
+       id="linearGradient3773"
+       x1="22.116516"
+       y1="55.717518"
+       x2="19"
+       y2="33"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3767">
+      <stop
+         style="stop-color:#3465a4;stop-opacity:1"
+         offset="0"
+         id="stop3769" />
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1"
+         offset="1"
+         id="stop3771" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-2,-11)"
+       xlink:href="#linearGradient3777-6"
+       id="linearGradient3783-3"
+       x1="53.896763"
+       y1="51.179787"
+       x2="48"
+       y2="32"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3777-6">
+      <stop
+         style="stop-color:#204a87;stop-opacity:1"
+         offset="0"
+         id="stop3779-7" />
+      <stop
+         style="stop-color:#3465a4;stop-opacity:1"
+         offset="1"
+         id="stop3781-5" />
+    </linearGradient>
+    <linearGradient
+       y2="32"
+       x2="48"
+       y1="51.179787"
+       x1="53.896763"
+       gradientTransform="translate(-24,-13)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3066"
+       xlink:href="#linearGradient3777-6" />
+    <linearGradient
+       y2="5"
+       x2="-22"
+       y1="18"
+       x1="-18"
+       gradientTransform="matrix(0.53559025,0,0,0.53556875,-6.4812797,2.8041108)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3323-4"
+       xlink:href="#linearGradient3836-9-3-7-2-7-7-2-6" />
+    <linearGradient
+       id="linearGradient3836-9-3-7-2-7-7-2-6">
+      <stop
+         style="stop-color:#a40000;stop-opacity:1"
+         offset="0"
+         id="stop3838-8-5-4-4-6-4-4-61" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1"
+         offset="1"
+         id="stop3840-1-6-0-5-1-0-5-8" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3836-9-3-7-2-7-7-2-6"
+       id="linearGradient898"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.53559025,0,0,0.53556875,-6.4812797,2.8041108)"
+       x1="-18"
+       y1="18"
+       x2="-22"
+       y2="5" />
+    <linearGradient
+       y2="5"
+       x2="-22"
+       y1="18"
+       x1="-18"
+       gradientTransform="matrix(0.53559025,0,0,0.53556875,-6.4812797,2.8041108)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3323-3"
+       xlink:href="#linearGradient3836-9-3-7-2-7-7-2-6" />
+  </defs>
+  <metadata
+     id="metadata3369">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[wmayer]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:date>2011-10-10</dc:date>
+        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier>FreeCAD/src/Mod/Part/Gui/Resources/icons/Part_Section.svg</dc:identifier>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>[agryson] Alexander Gryson</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     style="fill:none;stroke:#363636;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:6, 3;stroke-dashoffset:0;stroke-opacity:1"
+     d="M 2.3798139,32.218121 H 61.620186"
+     id="path985-9" />
+  <path
+     style="fill:none;stroke:#363636;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:6, 3;stroke-dashoffset:0;stroke-opacity:1"
+     d="M 2.2324867,51.127858 H 61.472858"
+     id="path985-6" />
+  <path
+     style="fill:none;stroke:#4ce642;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:6, 3;stroke-dashoffset:0;stroke-opacity:1"
+     d="M 12.221742,61.620185 V 2.3798148"
+     id="path985-92" />
+  <path
+     style="fill:none;stroke:#363636;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:6, 3;stroke-dashoffset:0;stroke-opacity:1"
+     d="M 31.131479,61.620186 V 2.3798143"
+     id="path985-9-8" />
+  <path
+     style="fill:none;stroke:#363636;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:6, 3;stroke-dashoffset:0;stroke-opacity:1"
+     d="M 50.041216,61.620185 V 2.3798148"
+     id="path985-6-2" />
+  <path
+     style="fill:none;stroke:#4ce642;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:6, 3;stroke-dashoffset:0;stroke-opacity:1"
+     d="M 2.2324859,13.308385 H 61.472857"
+     id="path985" />
+  <g
+     transform="rotate(63.326802,46.528624,-2.5779449)"
+     id="g3529-7">
+    <path
+       id="path3491-7"
+       d="M 56,8 V 32"
+       style="fill:none;stroke:#172a04;stroke-width:8;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       id="path3491-4-7"
+       d="M 56,8 V 32"
+       style="fill:none;stroke:#73d216;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       id="path3491-4-1-3"
+       d="M 55,8 V 32"
+       style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  </g>
+  <g
+     style="stroke-width:6.44377;stroke-miterlimit:4;stroke-dasharray:none"
+     transform="matrix(0.35922387,0.71507028,-0.71505986,0.35921864,53.759702,19.45672)"
+     id="g3797-7-2-9-5-4-9-5-96">
+    <path
+       style="fill:#ef2929;stroke:#280000;stroke-width:2.4993;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path4250-6-9-4-1-2-4-1-3"
+       d="m -21.570202,4.8706993 a 6.2460052,6.2456584 0.01677682 1 1 9.488239,8.1250407 6.2460052,6.2456584 0.01677682 1 1 -9.488239,-8.1250407 z" />
+    <path
+       style="fill:url(#linearGradient898);fill-opacity:1;stroke:#ef2929;stroke-width:2.4993;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path4250-7-0-1-8-7-3-8-7-7"
+       d="m -19.674789,6.4961011 a 3.7491316,3.7489813 0 1 1 5.695246,4.8771099 3.7491316,3.7489813 0 0 1 -5.695246,-4.8771099 z" />
+  </g>
+  <g
+     style="stroke-width:6.44377;stroke-miterlimit:4;stroke-dasharray:none"
+     transform="matrix(0.35922387,0.71507028,-0.71505986,0.35921864,32.313746,30.230346)"
+     id="g3797-7-2-9-5-4-9-5-96-5">
+    <path
+       style="fill:#ef2929;stroke:#280000;stroke-width:2.4993;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path4250-6-9-4-1-2-4-1-3-7"
+       d="m -21.570202,4.8706993 a 6.2460052,6.2456584 0.01677682 1 1 9.488239,8.1250407 6.2460052,6.2456584 0.01677682 1 1 -9.488239,-8.1250407 z" />
+    <path
+       style="fill:url(#linearGradient3323-4);fill-opacity:1;stroke:#ef2929;stroke-width:2.4993;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path4250-7-0-1-8-7-3-8-7-7-5"
+       d="m -19.674789,6.4961011 a 3.7491316,3.7489813 0 1 1 5.695246,4.8771099 3.7491316,3.7489813 0 0 1 -5.695246,-4.8771099 z" />
+  </g>
+  <g
+     id="g4273"
+     transform="translate(-89.528258,0.54055521)">
+    <path
+       style="fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 108.96148,19.97344 c 4.28933,11.161025 8.9416,20.384136 14.87384,32.552457 l 5.94954,-11.134131 12.749,12.154051 c 3.39402,0.638464 5.31688,-1.489816 4.75963,-4.504649 l -13.00398,-11.814076 8.49933,-6.629483 z"
+       id="path1052"
+       sodipodi:nodetypes="cccccccc" />
+    <path
+       style="fill:#d3d7cf;fill-opacity:1;stroke:#ffffff;stroke-width:1.285;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 112.59215,23.233162 c 3.72959,10.062766 6.25342,13.924184 11.41153,24.895126 l 5.26419,-9.586262 13.8638,13.109482 c 1.42608,0.530564 2.84842,-0.286358 2.07091,-2.088013 l -13.80942,-12.277572 7.29489,-5.92068 z"
+       id="path1052-8"
+       sodipodi:nodetypes="cccccccc" />
+  </g>
+</svg>

--- a/src/Mod/Sketcher/Gui/Resources/icons/general/Sketcher_Snap_Deactivated.svg
+++ b/src/Mod/Sketcher/Gui/Resources/icons/general/Sketcher_Snap_Deactivated.svg
@@ -1,0 +1,377 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="64px"
+   height="64px"
+   id="svg3364"
+   version="1.1"
+   sodipodi:docname="Sketcher_Snap_Deactivated.svg"
+   inkscape:version="1.1-beta1 (77e7b44db3, 2021-03-28)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview55"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     objecttolerance="10.0"
+     gridtolerance="10.0"
+     guidetolerance="10.0"
+     inkscape:pageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="5.8828125"
+     inkscape:cx="56.180611"
+     inkscape:cy="32.63745"
+     inkscape:window-width="1720"
+     inkscape:window-height="1112"
+     inkscape:window-x="743"
+     inkscape:window-y="334"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3364" />
+  <defs
+     id="defs3366">
+    <linearGradient
+       id="linearGradient3864">
+      <stop
+         id="stop3866"
+         offset="0"
+         style="stop-color:#71b2f8;stop-opacity:1" />
+      <stop
+         id="stop3868"
+         offset="1"
+         style="stop-color:#002795;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient3864"
+       id="radialGradient2571"
+       gradientUnits="userSpaceOnUse"
+       cx="342.58258"
+       cy="27.256668"
+       fx="342.58258"
+       fy="27.256668"
+       r="19.571428"
+       gradientTransform="matrix(1.6258409,0.5434973,-8.8819886e-2,0.2656996,-215.02413,-170.90186)" />
+    <radialGradient
+       xlink:href="#linearGradient3593"
+       id="radialGradient3352"
+       gradientUnits="userSpaceOnUse"
+       cx="345.28433"
+       cy="15.560534"
+       fx="345.28433"
+       fy="15.560534"
+       r="19.571428"
+       gradientTransform="translate(-0.1767767,-2.6516504)" />
+    <linearGradient
+       id="linearGradient3593">
+      <stop
+         style="stop-color:#c8e0f9;stop-opacity:1"
+         offset="0"
+         id="stop3595" />
+      <stop
+         style="stop-color:#637dca;stop-opacity:1"
+         offset="1"
+         id="stop3597" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient3593"
+       id="radialGradient3354"
+       gradientUnits="userSpaceOnUse"
+       cx="330.63791"
+       cy="39.962704"
+       fx="330.63791"
+       fy="39.962704"
+       r="19.571428"
+       gradientTransform="translate(-0.1767767,-2.6516504)" />
+    <radialGradient
+       xlink:href="#linearGradient3864"
+       id="radialGradient3369"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.6258409,0.5434973,-8.8819886e-2,0.2656996,-461.81066,-173.06271)"
+       cx="342.58258"
+       cy="27.256668"
+       fx="342.58258"
+       fy="27.256668"
+       r="19.571428" />
+    <radialGradient
+       xlink:href="#linearGradient3593"
+       id="radialGradient3372"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0012324,0,0,0.9421773,-327.50313,-4.3316646)"
+       cx="345.28433"
+       cy="15.560534"
+       fx="345.28433"
+       fy="15.560534"
+       r="19.571428" />
+    <radialGradient
+       xlink:href="#linearGradient3593"
+       id="radialGradient3375"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0012324,0,0,0.9421773,-287.81791,-28.143054)"
+       cx="330.63791"
+       cy="39.962704"
+       fx="330.63791"
+       fy="39.962704"
+       r="19.571428" />
+    <radialGradient
+       xlink:href="#linearGradient3864"
+       id="radialGradient3380"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9829174,1.3240854,-1.2330051,0.8105158,-131.04134,-483.74563)"
+       cx="320.44025"
+       cy="113.23357"
+       fx="320.44025"
+       fy="113.23357"
+       r="19.571428" />
+    <linearGradient
+       xlink:href="#linearGradient3864"
+       id="linearGradient3914"
+       x1="6.94525"
+       y1="36.838673"
+       x2="48.691113"
+       y2="36.838673"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0012324,0,0,0.9421773,-4.8699606,-2.3863162)" />
+    <radialGradient
+       xlink:href="#linearGradient3794"
+       id="radialGradient3800"
+       cx="1"
+       cy="45"
+       fx="1"
+       fy="45"
+       r="41"
+       gradientTransform="matrix(0.93348213,-2.2905276e-8,0,0.28687573,0.06651751,32.090592)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3794">
+      <stop
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0"
+         id="stop3796" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1"
+         id="stop3798" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(0,-9)"
+       xlink:href="#linearGradient3777"
+       id="linearGradient3783"
+       x1="53.896763"
+       y1="51.179787"
+       x2="48"
+       y2="32"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3777">
+      <stop
+         style="stop-color:#204a87;stop-opacity:1"
+         offset="0"
+         id="stop3779" />
+      <stop
+         style="stop-color:#3465a4;stop-opacity:1"
+         offset="1"
+         id="stop3781" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(22,-17)"
+       xlink:href="#linearGradient3767"
+       id="linearGradient3773"
+       x1="22.116516"
+       y1="55.717518"
+       x2="19"
+       y2="33"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3767">
+      <stop
+         style="stop-color:#3465a4;stop-opacity:1"
+         offset="0"
+         id="stop3769" />
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1"
+         offset="1"
+         id="stop3771" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-2,-11)"
+       xlink:href="#linearGradient3777-6"
+       id="linearGradient3783-3"
+       x1="53.896763"
+       y1="51.179787"
+       x2="48"
+       y2="32"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3777-6">
+      <stop
+         style="stop-color:#204a87;stop-opacity:1"
+         offset="0"
+         id="stop3779-7" />
+      <stop
+         style="stop-color:#3465a4;stop-opacity:1"
+         offset="1"
+         id="stop3781-5" />
+    </linearGradient>
+    <linearGradient
+       y2="32"
+       x2="48"
+       y1="51.179787"
+       x1="53.896763"
+       gradientTransform="translate(-24,-13)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3066"
+       xlink:href="#linearGradient3777-6" />
+    <linearGradient
+       y2="5"
+       x2="-22"
+       y1="18"
+       x1="-18"
+       gradientTransform="matrix(0.53559025,0,0,0.53556875,-6.4812797,2.8041108)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3323-3"
+       xlink:href="#linearGradient3836-9-3-7-2-7-7-2-13" />
+    <linearGradient
+       id="linearGradient3836-9-3-7-2-7-7-2-13">
+      <stop
+         style="stop-color:#a40000;stop-opacity:1"
+         offset="0"
+         id="stop3838-8-5-4-4-6-4-4-8" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1"
+         offset="1"
+         id="stop3840-1-6-0-5-1-0-5-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3836-9-3-7-2-7-7-2-13"
+       id="linearGradient1092"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.53559025,0,0,0.53556875,-6.4812797,2.8041108)"
+       x1="-18"
+       y1="18"
+       x2="-22"
+       y2="5" />
+  </defs>
+  <metadata
+     id="metadata3369">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[wmayer]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:date>2011-10-10</dc:date>
+        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier>FreeCAD/src/Mod/Part/Gui/Resources/icons/Part_Section.svg</dc:identifier>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>[agryson] Alexander Gryson</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     style="fill:none;stroke:#363636;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:6, 3;stroke-dashoffset:0;stroke-opacity:1"
+     d="M 2.3798139,32.218121 H 61.620186"
+     id="path985-9" />
+  <path
+     style="fill:none;stroke:#363636;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:6, 3;stroke-dashoffset:0;stroke-opacity:1"
+     d="M 2.2324867,51.127858 H 61.472858"
+     id="path985-6" />
+  <path
+     style="fill:none;stroke:#363636;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:6, 3;stroke-dashoffset:0;stroke-opacity:1"
+     d="M 12.221742,61.620185 V 2.3798148"
+     id="path985-92" />
+  <path
+     style="fill:none;stroke:#363636;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:6, 3;stroke-dashoffset:0;stroke-opacity:1"
+     d="M 31.131479,61.620186 V 2.3798143"
+     id="path985-9-8" />
+  <path
+     style="fill:none;stroke:#363636;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:6, 3;stroke-dashoffset:0;stroke-opacity:1"
+     d="M 50.041216,61.620185 V 2.3798148"
+     id="path985-6-2" />
+  <path
+     style="fill:none;stroke:#363636;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:6, 3;stroke-dashoffset:0;stroke-opacity:1"
+     d="M 2.2324859,13.308385 H 61.472857"
+     id="path985" />
+  <g
+     id="g4273"
+     transform="translate(-85.253531,6.1052318)">
+    <path
+       style="fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 108.96148,19.97344 c 4.28933,11.161025 8.9416,20.384136 14.87384,32.552457 l 5.94954,-11.134131 12.749,12.154051 c 3.39402,0.638464 5.31688,-1.489816 4.75963,-4.504649 l -13.00398,-11.814076 8.49933,-6.629483 z"
+       id="path1052"
+       sodipodi:nodetypes="cccccccc" />
+    <path
+       style="fill:#d3d7cf;fill-opacity:1;stroke:#ffffff;stroke-width:1.285;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 112.59215,23.233162 c 3.72959,10.062766 6.25342,13.924184 11.41153,24.895126 l 5.26419,-9.586262 13.8638,13.109482 c 1.42608,0.530564 2.84842,-0.286358 2.07091,-2.088013 l -13.80942,-12.277572 7.29489,-5.92068 z"
+       id="path1052-8"
+       sodipodi:nodetypes="cccccccc" />
+  </g>
+  <g
+     transform="rotate(63.436651,45.794909,-8.4224816)"
+     id="g3529-4">
+    <path
+       id="path3491-6"
+       d="M 56,8 V 32"
+       style="fill:none;stroke:#2e3436;stroke-width:8;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       id="path3491-4-07"
+       d="M 56,8 V 32"
+       style="fill:none;stroke:#d3d7cf;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       id="path3491-4-1-17"
+       d="M 55,8 V 32"
+       style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  </g>
+  <g
+     style="stroke-width:6.44377;stroke-miterlimit:4;stroke-dasharray:none"
+     transform="matrix(0.35785226,0.71575769,-0.71574725,0.35784704,48.084512,16.896405)"
+     id="g3797-7-2-9-5-4-9-5-4">
+    <path
+       style="fill:#ef2929;stroke:#280000;stroke-width:2.4993;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path4250-6-9-4-1-2-4-1-4"
+       d="m -21.570202,4.8706993 a 6.2460052,6.2456584 0.01677682 1 1 9.488239,8.1250407 6.2460052,6.2456584 0.01677682 1 1 -9.488239,-8.1250407 z" />
+    <path
+       style="fill:url(#linearGradient1092);fill-opacity:1;stroke:#ef2929;stroke-width:2.4993;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path4250-7-0-1-8-7-3-8-7-6"
+       d="m -19.674789,6.4961011 a 3.7491316,3.7489813 0 1 1 5.695246,4.8771099 3.7491316,3.7489813 0 0 1 -5.695246,-4.8771099 z" />
+  </g>
+  <g
+     style="stroke-width:6.44377;stroke-miterlimit:4;stroke-dasharray:none"
+     transform="matrix(0.35785226,0.71575769,-0.71574725,0.35784704,26.61794,27.628894)"
+     id="g3797-7-2-9-5-4-9-5-4-0">
+    <path
+       style="fill:#ef2929;stroke:#280000;stroke-width:2.4993;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path4250-6-9-4-1-2-4-1-4-1"
+       d="m -21.570202,4.8706993 a 6.2460052,6.2456584 0.01677682 1 1 9.488239,8.1250407 6.2460052,6.2456584 0.01677682 1 1 -9.488239,-8.1250407 z" />
+    <path
+       style="fill:url(#linearGradient3323-3);fill-opacity:1;stroke:#ef2929;stroke-width:2.4993;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path4250-7-0-1-8-7-3-8-7-6-6"
+       d="m -19.674789,6.4961011 a 3.7491316,3.7489813 0 1 1 5.695246,4.8771099 3.7491316,3.7489813 0 0 1 -5.695246,-4.8771099 z" />
+  </g>
+</svg>

--- a/src/Mod/Sketcher/Gui/SnapManager.cpp
+++ b/src/Mod/Sketcher/Gui/SnapManager.cpp
@@ -153,7 +153,7 @@ void SnapManager::ParameterObserver::OnChange(Base::Subject<const char*>& rCalle
 
 ParameterGrp::handle SnapManager::ParameterObserver::getParameterGrpHandle()
 {
-    return App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher/General");
+    return App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher/Snap");
 }
 
 //**************************** SnapManager class ******************************

--- a/src/Mod/Sketcher/Gui/SnapManager.cpp
+++ b/src/Mod/Sketcher/Gui/SnapManager.cpp
@@ -158,7 +158,7 @@ ParameterGrp::handle SnapManager::ParameterObserver::getParameterGrpHandle()
 
 //**************************** SnapManager class ******************************
 
-SnapManager::SnapManager(ViewProviderSketch &vp):viewProvider(vp), angleSnapEnabled(false), referencePoint(Base::Vector2d(0.,0.)), lastMouseAngle(0.0)
+SnapManager::SnapManager(ViewProviderSketch &vp):viewProvider(vp), angleSnapRequested(false), referencePoint(Base::Vector2d(0.,0.)), lastMouseAngle(0.0)
 {
     // Create parameter observer and initialise watched parameters
     pObserver = std::make_unique<SnapManager::ParameterObserver>(*this);
@@ -176,7 +176,7 @@ bool SnapManager::snap(double& x, double& y)
     //In order of priority :
 
     // 1 - Snap at an angle
-    if (angleSnapEnabled && QApplication::keyboardModifiers() == Qt::ControlModifier) {
+    if (angleSnapRequested && QApplication::keyboardModifiers() == Qt::ControlModifier) {
         return snapAtAngle(x, y);
     }
     else {
@@ -365,6 +365,6 @@ bool SnapManager::snapToArcMiddle(Base::Vector3d& pointToOverride, const Part::G
 
 void SnapManager::setAngleSnapping(bool enable, Base::Vector2d referencepoint)
 {
-    angleSnapEnabled = enable;
+    angleSnapRequested = enable;
     referencePoint = referencepoint;
 }

--- a/src/Mod/Sketcher/Gui/SnapManager.cpp
+++ b/src/Mod/Sketcher/Gui/SnapManager.cpp
@@ -362,3 +362,9 @@ bool SnapManager::snapToArcMiddle(Base::Vector3d& pointToOverride, const Part::G
 
     return false;
 }
+
+void SnapManager::setAngleSnapping(bool enable, Base::Vector2d referencepoint)
+{
+    angleSnapEnabled = enable;
+    referencePoint = referencepoint;
+}

--- a/src/Mod/Sketcher/Gui/SnapManager.cpp
+++ b/src/Mod/Sketcher/Gui/SnapManager.cpp
@@ -1,0 +1,364 @@
+/***************************************************************************
+ *   Copyright (c) 2023 Pierre-Louis Boyer <pierrelouis.boyer@gmail.com>   *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "PreCompiled.h"
+#ifndef _PreComp_
+#include <QApplication>
+#endif  // #ifndef _PreComp_
+
+#include <Mod/Sketcher/App/SketchObject.h>
+
+#include "SnapManager.h"
+#include "ViewProviderSketch.h"
+
+
+using namespace SketcherGui;
+using namespace Sketcher;
+
+/************************************ Attorney *******************************************/
+
+inline int ViewProviderSketchSnapAttorney::getPreselectPoint(const ViewProviderSketch& vp)
+{
+    return vp.getPreselectPoint();
+}
+
+inline int ViewProviderSketchSnapAttorney::getPreselectCross(const ViewProviderSketch& vp)
+{
+    return vp.getPreselectCross();
+}
+
+inline int ViewProviderSketchSnapAttorney::getPreselectCurve(const ViewProviderSketch& vp)
+{
+    return vp.getPreselectCurve();
+}
+
+/**************************** ParameterObserver nested class *****************************/
+SnapManager::ParameterObserver::ParameterObserver(SnapManager& client) : client(client)
+{
+    initParameters();
+    subscribeToParameters();
+}
+
+SnapManager::ParameterObserver::~ParameterObserver()
+{
+    unsubscribeToParameters();
+}
+
+void SnapManager::ParameterObserver::initParameters()
+{
+    // static map to avoid substantial if/else branching
+    //
+    // key->first               => String of parameter,
+    // key->second              => Update function to be called for the parameter,
+    str2updatefunction = {
+        {"Snap",
+            [this](const std::string& param) {updateSnapParameter(param); }},
+        {"SnapToObjects",
+            [this](const std::string& param) {updateSnapToObjectParameter(param); }},
+        {"SnapToGrid",
+            [this](const std::string& param) {updateSnapToGridParameter(param); }},
+        {"SnapAngle",
+            [this](const std::string& param) {updateSnapAngleParameter(param); }},
+    };
+
+    for (auto& val : str2updatefunction) {
+        auto string = val.first;
+        auto function = val.second;
+
+        function(string);
+    }
+}
+
+void SnapManager::ParameterObserver::updateSnapParameter(const std::string& parametername)
+{
+    ParameterGrp::handle hGrp = getParameterGrpHandle();
+
+    client.snapRequested = hGrp->GetBool(parametername.c_str(), true);
+}
+
+void SnapManager::ParameterObserver::updateSnapToObjectParameter(const std::string& parametername)
+{
+    ParameterGrp::handle hGrp = getParameterGrpHandle();
+
+    client.snapToObjectsRequested = hGrp->GetBool(parametername.c_str(), true);
+}
+
+void SnapManager::ParameterObserver::updateSnapToGridParameter(const std::string& parametername)
+{
+    ParameterGrp::handle hGrp = getParameterGrpHandle();
+
+    client.snapToGridRequested = hGrp->GetBool(parametername.c_str(), false);
+}
+
+void SnapManager::ParameterObserver::updateSnapAngleParameter(const std::string& parametername)
+{
+    ParameterGrp::handle hGrp = getParameterGrpHandle();
+
+    client.snapAngle = fmod(hGrp->GetFloat(parametername.c_str(), 5.) * M_PI / 180, 2 * M_PI);
+}
+
+void SnapManager::ParameterObserver::subscribeToParameters()
+{
+    try {
+        ParameterGrp::handle hGrp = getParameterGrpHandle();
+        hGrp->Attach(this);
+    }
+    catch (const Base::ValueError& e) { // ensure that if parameter strings are not well-formed, the exception is not propagated
+        Base::Console().Error("SnapManager: Malformed parameter string: %s\n", e.what());
+    }
+}
+
+void SnapManager::ParameterObserver::unsubscribeToParameters()
+{
+    try {
+        ParameterGrp::handle hGrp = getParameterGrpHandle();
+        hGrp->Detach(this);
+    }
+    catch (const Base::ValueError& e) {// ensure that if parameter strings are not well-formed, the program is not terminated when calling the noexcept destructor.
+        Base::Console().Error("SnapManager: Malformed parameter string: %s\n", e.what());
+    }
+}
+
+void SnapManager::ParameterObserver::OnChange(Base::Subject<const char*>& rCaller, const char* sReason)
+{
+    (void)rCaller;
+
+    auto key = str2updatefunction.find(sReason);
+    if (key != str2updatefunction.end()) {
+        auto string = key->first;
+        auto function = key->second;
+
+        function(string);
+    }
+}
+
+ParameterGrp::handle SnapManager::ParameterObserver::getParameterGrpHandle()
+{
+    return App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher/General");
+}
+
+//**************************** SnapManager class ******************************
+
+SnapManager::SnapManager(ViewProviderSketch &vp):viewProvider(vp), angleSnapEnabled(false), referencePoint(Base::Vector2d(0.,0.)), lastMouseAngle(0.0)
+{
+    // Create parameter observer and initialise watched parameters
+    pObserver = std::make_unique<SnapManager::ParameterObserver>(*this);
+}
+
+SnapManager::~SnapManager() {}
+
+bool SnapManager::snap(double& x, double& y)
+{
+    if (!snapRequested)
+    {
+        return false;
+    }
+
+    //In order of priority :
+
+    // 1 - Snap at an angle
+    if (angleSnapEnabled && QApplication::keyboardModifiers() == Qt::ControlModifier) {
+        return snapAtAngle(x, y);
+    }
+    else {
+        lastMouseAngle = 0.0;
+    }
+
+    // 2 - Snap to objects
+    if (snapToObjectsRequested
+        && snapToObject(x, y)) {
+        return true;
+    }
+    
+    // 3 - Snap to grid
+    if (snapToGridRequested /*&& viewProvider.ShowGrid.getValue() */ ) { //Snap to grid is enabled even if the grid is not visible.
+        return snapToGrid(x, y);
+    }
+
+    return false;
+}
+
+bool SnapManager::snapAtAngle(double& x, double& y)
+{
+    Base::Vector2d pointToOverride(x, y);
+    double length = (pointToOverride - referencePoint).Length();
+
+    double angle1 = (pointToOverride - referencePoint).Angle();
+    double angle2 = angle1 + (angle1 < 0. ? 2 : -2) * M_PI;
+    lastMouseAngle = abs(angle1 - lastMouseAngle) < abs(angle2 - lastMouseAngle) ? angle1 : angle2;
+
+    double angle = round(lastMouseAngle / snapAngle) * snapAngle;
+    pointToOverride = referencePoint + length * Base::Vector2d(cos(angle), sin(angle));
+    x = pointToOverride.x;
+    y = pointToOverride.y;
+
+    return true;
+}
+
+bool SnapManager::snapToObject(double& x, double& y)
+{
+    Sketcher::SketchObject* Obj = viewProvider.getSketchObject();
+    int geoId = GeoEnum::GeoUndef;
+    Sketcher::PointPos posId = Sketcher::PointPos::none;
+
+    int VtId = ViewProviderSketchSnapAttorney::getPreselectPoint(viewProvider);
+    int CrsId = ViewProviderSketchSnapAttorney::getPreselectCross(viewProvider);
+    int CrvId = ViewProviderSketchSnapAttorney::getPreselectCurve(viewProvider);
+
+    if (CrsId == 0 || VtId >= 0) {
+        if (CrsId == 0) {
+            geoId = Sketcher::GeoEnum::RtPnt;
+            posId = Sketcher::PointPos::start;
+        }
+        else if (VtId >= 0) {
+            Obj->getGeoVertexIndex(VtId, geoId, posId);
+        }
+
+        x = Obj->getPoint(geoId, posId).x;
+        y = Obj->getPoint(geoId, posId).y;
+        return true;
+    }
+    else if (CrsId == 1) { //H_Axis
+        y = 0;
+        return true;
+    }
+    else if (CrsId == 2) { //V_Axis
+        x = 0;
+        return true;
+    }
+    else if (CrvId >= 0 || CrvId <= Sketcher::GeoEnum::RefExt) { //Curves
+
+        const Part::Geometry* geo = Obj->getGeometry(CrvId);
+
+        Base::Vector3d pointToOverride(x, y, 0.);
+
+        double pointParam = 0.0;
+        auto curve = dynamic_cast<const Part::GeomCurve*>(geo);
+        if (curve) {
+            try {
+                curve->closestParameter(pointToOverride, pointParam);
+                pointToOverride = curve->pointAtParameter(pointParam);
+            }
+            catch (Base::CADKernelError& e) {
+                e.ReportException();
+                return false;
+            }
+
+            //If it is a line, then we check if we need to snap to the middle.
+            if (geo->getTypeId() == Part::GeomLineSegment::getClassTypeId()) {
+                const Part::GeomLineSegment* line = static_cast<const Part::GeomLineSegment*>(geo);
+                snapToLineMiddle(pointToOverride, line);
+            }
+
+            //If it is an arc, then we check if we need to snap to the middle (not the center).
+            if (geo->getTypeId() == Part::GeomArcOfCircle::getClassTypeId()) {
+                const Part::GeomArcOfCircle* arc = static_cast<const Part::GeomArcOfCircle*>(geo);
+                snapToArcMiddle(pointToOverride, arc);
+            }
+
+            x = pointToOverride.x;
+            y = pointToOverride.y;
+
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool SnapManager::snapToGrid(double& x, double& y)
+{
+    // Snap Tolerance in pixels
+    const double snapTol = viewProvider.getGridSize() / 5;
+
+    double tmpX = x, tmpY = y;
+
+    viewProvider.getClosestGridPoint(tmpX, tmpY);
+
+    bool snapped = false;
+
+    // Check if x within snap tolerance
+    if (x < tmpX + snapTol && x > tmpX - snapTol) {
+        x = tmpX; // Snap X Mouse Position
+        snapped = true;
+    }
+
+     // Check if y within snap tolerance
+    if (y < tmpY + snapTol && y > tmpY - snapTol) {
+        y = tmpY; // Snap Y Mouse Position
+        snapped = true;
+    }
+
+    return snapped;
+}
+
+bool SnapManager::snapToLineMiddle(Base::Vector3d& pointToOverride, const Part::GeomLineSegment* line)
+{
+    Base::Vector3d startPoint = line->getStartPoint();
+    Base::Vector3d endPoint = line->getEndPoint();
+    Base::Vector3d midPoint = (startPoint + endPoint) / 2;
+
+    //Check if we are at middle of the line and if so snap to it.
+    if ((pointToOverride - midPoint).Length() < (endPoint - startPoint).Length() * 0.05) {
+        pointToOverride = midPoint;
+        return true;
+    }
+
+    return false;
+}
+
+bool SnapManager::snapToArcMiddle(Base::Vector3d& pointToOverride, const Part::GeomArcOfCircle* arc)
+{
+    Base::Vector3d centerPoint = arc->getCenter();
+    Base::Vector3d startVec = (arc->getStartPoint() - centerPoint);
+    Base::Vector3d middleVec = startVec + (arc->getEndPoint() - centerPoint);
+
+    /* Handle the case of arc angle = 180 */
+    if (middleVec.Length() < Precision::Confusion()) {
+        middleVec.x = startVec.y;
+        middleVec.y = -startVec.x;
+    }
+    else {
+        middleVec = middleVec / middleVec.Length() * arc->getRadius();
+    }
+
+    Base::Vector2d mVec = Base::Vector2d(middleVec.x, middleVec.y);
+    Base::Vector3d pointVec = pointToOverride - centerPoint;
+    Base::Vector2d pVec = Base::Vector2d(pointVec.x, pointVec.y);
+
+    double u, v;
+    arc->getRange(u, v, true);
+    if (v < u)
+        v += 2 * M_PI;
+    double angle = v - u;
+    int revert = angle < M_PI ? 1 : -1;
+
+    /*To know if we are close to the middle of the arc, we are going to compare the angle of the
+    * (mouse cursor - center) to the angle of the middle of the arc. If it's less than 10% of the arc angle, then we snap.
+    */
+    if (fabs(pVec.Angle() - (revert * mVec).Angle()) < 0.10 * angle) {
+        pointToOverride = centerPoint + middleVec * revert;
+        return true;
+    }
+
+    return false;
+}

--- a/src/Mod/Sketcher/Gui/SnapManager.h
+++ b/src/Mod/Sketcher/Gui/SnapManager.h
@@ -99,8 +99,7 @@ public:
     bool snapToLineMiddle(Base::Vector3d& pointToOverride, const Part::GeomLineSegment* line);
     bool snapToArcMiddle(Base::Vector3d& pointToOverride, const Part::GeomArcOfCircle* arc);
 
-    bool angleSnapEnabled;
-    Base::Vector2d referencePoint;
+    void setAngleSnapping(bool enable, Base::Vector2d referencepoint);
 
 private:
     double snapAngle;
@@ -109,6 +108,9 @@ private:
     bool snapRequested;
     bool snapToObjectsRequested;
     bool snapToGridRequested;
+
+    bool angleSnapEnabled;
+    Base::Vector2d referencePoint;
 
     /// Reference to ViewProviderSketch in order to access the public and the Attorney Interface
     ViewProviderSketch & viewProvider;

--- a/src/Mod/Sketcher/Gui/SnapManager.h
+++ b/src/Mod/Sketcher/Gui/SnapManager.h
@@ -104,15 +104,16 @@ public:
 private:
     /// Reference to ViewProviderSketch in order to access the public and the Attorney Interface
     ViewProviderSketch & viewProvider;
+
     bool angleSnapEnabled;
+    bool snapRequested;
+    bool snapToObjectsRequested;
+    bool snapToGridRequested;
+
     Base::Vector2d referencePoint;
     double lastMouseAngle;
 
     double snapAngle;
-
-    bool snapRequested;
-    bool snapToObjectsRequested;
-    bool snapToGridRequested;
 
     /// Observer to track all the needed parameters.
     std::unique_ptr<SnapManager::ParameterObserver> pObserver;

--- a/src/Mod/Sketcher/Gui/SnapManager.h
+++ b/src/Mod/Sketcher/Gui/SnapManager.h
@@ -102,18 +102,17 @@ public:
     void setAngleSnapping(bool enable, Base::Vector2d referencepoint);
 
 private:
-    double snapAngle;
+    /// Reference to ViewProviderSketch in order to access the public and the Attorney Interface
+    ViewProviderSketch & viewProvider;
+    bool angleSnapEnabled;
+    Base::Vector2d referencePoint;
     double lastMouseAngle;
+
+    double snapAngle;
 
     bool snapRequested;
     bool snapToObjectsRequested;
     bool snapToGridRequested;
-
-    bool angleSnapEnabled;
-    Base::Vector2d referencePoint;
-
-    /// Reference to ViewProviderSketch in order to access the public and the Attorney Interface
-    ViewProviderSketch & viewProvider;
 
     /// Observer to track all the needed parameters.
     std::unique_ptr<SnapManager::ParameterObserver> pObserver;

--- a/src/Mod/Sketcher/Gui/SnapManager.h
+++ b/src/Mod/Sketcher/Gui/SnapManager.h
@@ -105,7 +105,7 @@ private:
     /// Reference to ViewProviderSketch in order to access the public and the Attorney Interface
     ViewProviderSketch & viewProvider;
 
-    bool angleSnapEnabled;
+    bool angleSnapRequested;
     bool snapRequested;
     bool snapToObjectsRequested;
     bool snapToGridRequested;

--- a/src/Mod/Sketcher/Gui/SnapManager.h
+++ b/src/Mod/Sketcher/Gui/SnapManager.h
@@ -1,0 +1,125 @@
+/***************************************************************************
+ *   Copyright (c) 2023 Pierre-Louis Boyer <pierrelouis.boyer@gmail.com>   *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ *   SnapManager initially funded by the Open Toolchain Foundation         *
+ ***************************************************************************/
+
+#ifndef SKETCHERGUI_SnapManager_H
+#define SKETCHERGUI_SnapManager_H
+
+
+#include <App/Application.h>
+
+
+namespace SketcherGui {
+
+class ViewProviderSketch;
+
+
+class ViewProviderSketchSnapAttorney {
+private:
+
+    static inline int getPreselectPoint(const ViewProviderSketch& vp);
+    static inline int getPreselectCross(const ViewProviderSketch& vp);
+    static inline int getPreselectCurve(const ViewProviderSketch& vp);
+
+    friend class SnapManager;
+};
+
+/* This class is used to manage the overriding of mouse pointer coordinates in Sketcher
+*  (in Edit-Mode) depending on the situation. Those situations are in priority order :
+*  1 - Snap at angle: For tools like Slot, Arc, Line, Ellipse, this enables to constrain the angle at steps of 5° (or customized angle).
+*  This is useful to make features at a certain angle (45° for example)
+*  2 - Snap to object: This snaps the mouse pointer onto objects.
+*  3 - Snap to grid: This snaps the mouse pointer on the grid.
+*/
+class SnapManager
+{
+
+    /** @brief      Class for monitoring changes in parameters affecting Snapping
+    *  @details
+    *
+    * This nested class is a helper responsible for attaching to the parameters relevant for
+    * SnapManager, initialising the SnapManager to the current configuration
+    * and handle in real time any change to their values.
+    */
+    class ParameterObserver : public ParameterGrp::ObserverType
+    {
+    public:
+        explicit ParameterObserver(SnapManager& client);
+        ~ParameterObserver() override;
+
+        void subscribeToParameters();
+
+        void unsubscribeToParameters();
+
+        /** Observer for parameter group. */
+        void OnChange(Base::Subject<const char*>& rCaller, const char* sReason) override;
+
+    private:
+        void initParameters();
+        void updateSnapParameter(const std::string& parametername);
+        void updateSnapToObjectParameter(const std::string& parametername);
+        void updateSnapToGridParameter(const std::string& parametername);
+        void updateSnapAngleParameter(const std::string& parametername);
+
+        static ParameterGrp::handle getParameterGrpHandle();
+
+    private:
+        std::map<std::string, std::function<void(const std::string&)>> str2updatefunction;
+        SnapManager& client;
+    };
+
+public:
+    explicit SnapManager(ViewProviderSketch &vp);
+    ~SnapManager();
+
+    bool snap(double& x, double& y);
+    bool snapAtAngle(double& x, double& y);
+    bool snapToObject(double& x, double& y);
+    bool snapToGrid(double& x, double& y);
+
+    bool snapToLineMiddle(Base::Vector3d& pointToOverride, const Part::GeomLineSegment* line);
+    bool snapToArcMiddle(Base::Vector3d& pointToOverride, const Part::GeomArcOfCircle* arc);
+
+    bool angleSnapEnabled;
+    Base::Vector2d referencePoint;
+
+private:
+    double snapAngle;
+    double lastMouseAngle;
+
+    bool snapRequested;
+    bool snapToObjectsRequested;
+    bool snapToGridRequested;
+
+    /// Reference to ViewProviderSketch in order to access the public and the Attorney Interface
+    ViewProviderSketch & viewProvider;
+
+    /// Observer to track all the needed parameters.
+    std::unique_ptr<SnapManager::ParameterObserver> pObserver;
+};
+
+
+} // namespace SketcherGui
+
+
+#endif // SKETCHERGUI_SnapManager_H
+

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -556,8 +556,7 @@ bool ViewProviderSketch::keyPressed(bool pressed, int key)
 void ViewProviderSketch::setAngleSnapping(bool enable, Base::Vector2d referencePoint)
 {
     assert(snapManager);
-    snapManager->angleSnapEnabled = enable;
-    snapManager->referencePoint = referencePoint;
+    snapManager->setAngleSnapping(enable, referencePoint);
 }
 
 void ViewProviderSketch::getProjectingLine(const SbVec2s& pnt, const Gui::View3DInventorViewer *viewer, SbLine& line) const

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.h
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.h
@@ -85,14 +85,8 @@ namespace Sketcher {
 namespace SketcherGui {
 
 class EditModeCoinManager;
+class SnapManager;
 class DrawSketchHandler;
-
-enum class SnapMode { // to be moved to SnapManager
-    None,
-    SnapToObject,
-    SnapToAngle,
-    SnapToGrid,
-};
 
 using GeoList = Sketcher::GeoList;
 using GeoListFacade = Sketcher::GeoListFacade;
@@ -484,8 +478,10 @@ public:
     void onSelectionChanged(const Gui::SelectionChanges& msg) override;
     //@}
 
-    void setSnapMode(SnapMode mode);
-    SnapMode getSnapMode() const;
+    /** @name Toggle angle snapping and set the reference point */
+    //@{
+    /// Toggle angle snapping and set the reference point
+    void setAngleSnapping(bool enable, Base::Vector2d referencePoint = Base::Vector2d(0., 0.));
 
     /** @name Access to Sketch and Solver objects */
     //@{
@@ -566,6 +562,7 @@ public:
     //@{
     friend class ViewProviderSketchDrawSketchHandlerAttorney;
     friend class ViewProviderSketchCoinAttorney;
+    friend class ViewProviderSketchSnapAttorney;
     friend class ViewProviderSketchShortcutListenerAttorney;
     //@}
 protected:
@@ -660,9 +657,6 @@ private:
 
     /** @name miscelanea utilities */
     //@{
-    /// snap points x,y (mouse coordinates) onto grid if enabled
-    void snapToGrid(double &x, double &y);
-
     /// moves a selected constraint
     void moveConstraint(int constNum, const Base::Vector2d &toPos);
 
@@ -784,6 +778,8 @@ private:
 
     std::unique_ptr<EditModeCoinManager> editCoinManager;
 
+    std::unique_ptr<SnapManager> snapManager;
+
     std::unique_ptr<ViewProviderSketch::ParameterObserver> pObserver;
 
     std::unique_ptr<DrawSketchHandler> sketchHandler;
@@ -792,8 +788,6 @@ private:
 
     SoNodeSensor cameraSensor;
     int viewOrientationFactor; // stores if sketch viewed from front or back
-
-    SnapMode snapMode = SnapMode::None; // temporary - to be moved to SnapManager
 };
 
 } // namespace PartGui

--- a/src/Mod/Sketcher/Gui/Workbench.cpp
+++ b/src/Mod/Sketcher/Gui/Workbench.cpp
@@ -188,7 +188,8 @@ inline void SketcherAddWorkbenchSketchEditModeActions(Gui::ToolBarItem& sketch)
     sketch  << "Sketcher_LeaveSketch"
             << "Sketcher_ViewSketch"
             << "Sketcher_ViewSection"
-            << "Sketcher_Grid";
+            << "Sketcher_Grid"
+            << "Sketcher_Snap";
 }
 
 template <typename T>


### PR DESCRIPTION
- This PR creates a SnapManager which centralize the snapping features.
- Grid snap is moved to this SnapManager.
- Snap to object is added. A preference setting is added to toggle it.
- Snap at angle is added. A preference setting let user customize the angle. Snap at angle for arc and line only now.

The priority order is : snap at angle, then snap to object, then snap to grid. This is the order that makes sense in term of UX.
- Grid snap is activated by a toggle as before it didn't change.
- Snap to object is on by default and can be disabled in preferences, though it's not likely that users will need to disable it. This setting should perhaps be paired with auto-constraint?
- Snap at angle is activated by holding CTRL. The use of CTRL is software standard to snap movement along an axis/angle. It does not interfer with other uses of CTRL (ie camera panning/rotation, rubberband selection.)

**Future improvement ideas :**
1 - Enable snapping to object when dragging a point.
2 - Snap to inifite lines rather than line segment.
3 - Snap to bisecting angles between 2 lines.

https://forum.freecad.org/viewtopic.php?t=75856

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [x]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
