### PR TITLE
[FEM] use magnetization constraint for 2D

### DIFF
--- a/src/Mod/Fem/femsolver/elmer/writer.py
+++ b/src/Mod/Fem/femsolver/elmer/writer.py
@@ -564,8 +564,8 @@ class Writer(object):
         if activeIn:
             MgDyn2D.handleMagnetodynamic2DConstants()
             MgDyn2D.handleMagnetodynamic2DBndConditions()
-            MgDyn2D.handleMagnetodynamic2DBodyForces(activeIn)
-            MgDyn2D.handleMagnetodynamic2DMaterial(activeIn, equation)
+            MgDyn2D.handleMagnetodynamic2DBodyForces(activeIn, equation)
+            MgDyn2D.handleMagnetodynamic2DMaterial(activeIn)
 
     #-------------------------------------------------------------------------------------------
     # Solver handling

--- a/src/Mod/Fem/femtaskpanels/task_constraint_magnetization.py
+++ b/src/Mod/Fem/femtaskpanels/task_constraint_magnetization.py
@@ -51,7 +51,7 @@ class _TaskPanel(object):
         # magnetization is always a body force for 3D, therefore only allow solid
         self._selectionWidget = selection_widgets.GeometryElementsSelection(
             obj.References,
-            ["Solid"],
+            ["Solid", "Face"],
             True,
             False
         )
@@ -128,17 +128,17 @@ class _TaskPanel(object):
             self._paramWidget.imagZQSB).bind(self._obj, "Magnetization_im_3")
 
         self._paramWidget.reXunspecBox.setChecked(
-            self._obj.Magnetization_re_1)
+            self._obj.Magnetization_re_1_Disabled)
         self._paramWidget.reYunspecBox.setChecked(
-            self._obj.Magnetization_re_2)
+            self._obj.Magnetization_re_2_Disabled)
         self._paramWidget.reZunspecBox.setChecked(
-            self._obj.Magnetization_re_3)
+            self._obj.Magnetization_re_3_Disabled)
         self._paramWidget.imXunspecBox.setChecked(
-            self._obj.Magnetization_im_1)
+            self._obj.Magnetization_im_1_Disabled)
         self._paramWidget.imYunspecBox.setChecked(
-            self._obj.Magnetization_im_2)
+            self._obj.Magnetization_im_2_Disabled)
         self._paramWidget.imZunspecBox.setChecked(
-            self._obj.Magnetization_im_3)
+            self._obj.Magnetization_im_3_Disabled)
 
     def _applyMagnetizationChanges(self, enabledBox, magnetizationQSB):
         enabled = enabledBox.isChecked()

--- a/src/Mod/Material/MaterialEditor.py
+++ b/src/Mod/Material/MaterialEditor.py
@@ -682,15 +682,12 @@ def matProperWidget(parent=None, matproperty=None, Type="String", Value=None,
         # for properties with an underscored number (vectorial values),
         # we must strip the part after the first underscore to obtain the bound unit
         # since in cardutils.py in def get_material_template
-        # the underscores were removed, we must first check for numbers
-        # and then for "Im" (denotes an imaginery value)
+        # the underscores were removed, we must check for numbers
         import re
         if re.search(r'\d', matproperty):
             matpropertyNum = matproperty.rstrip('0123456789')
             matproperty = matpropertyNum
-        if matproperty.find("Im") != -1:
-            matproperty = matproperty.split("Im")[0]
-            
+
         if hasattr(FreeCAD.Units, matproperty):
             unit = getattr(FreeCAD.Units, matproperty)
             quantity = FreeCAD.Units.Quantity(1, unit)

--- a/src/Mod/Material/StandardMaterial/TEMPLATE.FCMat
+++ b/src/Mod/Material/StandardMaterial/TEMPLATE.FCMat
@@ -123,15 +123,6 @@ ElectricalConductivity =
 ; https://en.wikipedia.org/wiki/Permeability_(electromagnetism)
 RelativePermeability =
 
-; The magnetization in [FreeCAD Magnetization unit]"
-; https://en.wikipedia.org/wiki/Magnetization
-Magnetization_1 =
-Magnetization_2 =
-Magnetization_3 =
-Magnetization_Im_1 =
-Magnetization_Im_2 =
-Magnetization_Im_3 =
-
 [Architectural]
 ; Description to be updated
 Color =

--- a/src/Mod/Material/Templatematerial.yml
+++ b/src/Mod/Material/Templatematerial.yml
@@ -168,30 +168,6 @@
       Type: 'Float'
       URL: 'https://en.wikipedia.org/wiki/Permeability_(electromagnetism)'
       Description: "The ratio to the permeability of the vacuum"
-    Magnetization_1:
-      Type: 'Quantity'
-      URL: 'https://en.wikipedia.org/wiki/Magnetization'
-      Description: "Magnetization in x-direction in [FreeCAD Magnetization unit]"
-    Magnetization_2:
-      Type: 'Quantity'
-      URL: 'https://en.wikipedia.org/wiki/Magnetization'
-      Description: "Magnetization in y-direction in [FreeCAD Magnetization unit]"
-    Magnetization_3:
-      Type: 'Quantity'
-      URL: 'https://en.wikipedia.org/wiki/Magnetization'
-      Description: "Magnetization in z-direction in [FreeCAD Magnetization unit]"
-    Magnetization_Im_1:
-      Type: 'Quantity'
-      URL: 'https://en.wikipedia.org/wiki/Magnetization'
-      Description: "Magnetization, imagaginary part, in x-direction in [FreeCAD Magnetization unit]"
-    Magnetization_Im_2:
-      Type: 'Quantity'
-      URL: 'https://en.wikipedia.org/wiki/Magnetization'
-      Description: "Magnetization, imagaginary part, in y-direction in [FreeCAD Magnetization unit]"
-    Magnetization_Im_3:
-      Type: 'Quantity'
-      URL: 'https://en.wikipedia.org/wiki/Magnetization'
-      Description: "Magnetization, imagaginary part, in z-direction in [FreeCAD Magnetization unit]"
 - Architectural:
     Color:
       Type:  'String'

--- a/src/Mod/Material/materialtools/cardutils.py
+++ b/src/Mod/Material/materialtools/cardutils.py
@@ -239,9 +239,6 @@ def get_material_template(withSpaces=False):
                 new_proper = re.sub(r"(\w)([A-Z]+)", r"\1 \2", proper)
                 # strip underscores of vectorial properties
                 new_proper = new_proper.replace("_", " ")
-                # this can lead to double spaces for imaginary properties
-                # e.g. "_Im_1", therefore remove one
-                new_proper = new_proper.replace("  ", " ")
                 new_group[gg][new_proper] = group[gg][proper]
             new_template.append(new_group)
         template_data = new_template


### PR DESCRIPTION
- uses the constraint for 2D magnetodynamics to perform e.g. Elmer's tutorial non. 15

- modify the Material manager to get rid of magnetization but keep the vectorial functionality because in future there will be support for e.g. birefringence materials etc.