### PR TITLE
[Material] Fix typo and whitespace

### DIFF
--- a/src/Mod/Material/MaterialEditor.py
+++ b/src/Mod/Material/MaterialEditor.py
@@ -683,14 +683,14 @@ def matProperWidget(parent=None, matproperty=None, Type="String", Value=None,
         # we must strip the part after the first underscore to obtain the bound unit
         # since in cardutils.py in def get_material_template
         # the underscores were removed, we must first check for numbers
-        # and then for "Im" (denotes an imaginery value)
+        # and then for "Im" (denotes an imaginary value)
         import re
         if re.search(r'\d', matproperty):
             matpropertyNum = matproperty.rstrip('0123456789')
             matproperty = matpropertyNum
         if matproperty.find("Im") != -1:
             matproperty = matproperty.split("Im")[0]
-            
+
         if hasattr(FreeCAD.Units, matproperty):
             unit = getattr(FreeCAD.Units, matproperty)
             quantity = FreeCAD.Units.Quantity(1, unit)


### PR DESCRIPTION
Fixes for Material/MaterialEditor.py

---

- [x]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR
