### PR TITLE
[FEM] extend current density to 3D

### DIFF
--- a/src/Mod/Fem/Gui/Resources/ui/CurrentDensity.ui
+++ b/src/Mod/Fem/Gui/Resources/ui/CurrentDensity.ui
@@ -161,7 +161,9 @@
       </size>
      </property>
      <property name="toolTip">
-      <string>Real part of potential y-component</string>
+      <string>Real part of potential y-component
+Note: for 2D only setting for x is possible,
+          setting for y will be ignored</string>
      </property>
      <property name="keyboardTracking">
       <bool>true</bool>
@@ -205,7 +207,9 @@
       </size>
      </property>
      <property name="toolTip">
-      <string>Imaginary part of potential y-component</string>
+      <string>Imaginary part of potential y-component
+Note: for 2D only setting for x is possible,
+          setting for y will be ignored</string>
      </property>
      <property name="keyboardTracking">
       <bool>true</bool>

--- a/src/Mod/Fem/Gui/Resources/ui/CurrentDensity.ui
+++ b/src/Mod/Fem/Gui/Resources/ui/CurrentDensity.ui
@@ -6,36 +6,53 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>350</width>
-    <height>40</height>
+    <width>300</width>
+    <height>128</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Constraint Properties</string>
   </property>
-  <layout class="QHBoxLayout" name="horizontalLayout">
-   <item>
-    <widget class="QLabel" name="pressureLbl">
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0" colspan="2">
+    <widget class="QLabel" name="currDenseLbl_2">
      <property name="text">
       <string>Current density:</string>
      </property>
     </widget>
    </item>
-   <item>
-    <spacer name="horizontalSpacer">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+   <item row="1" column="1">
+    <widget class="QLabel" name="labelReal">
+     <property name="enabled">
+      <bool>true</bool>
      </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>130</width>
-       <height>19</height>
-      </size>
+     <property name="text">
+      <string>Real</string>
      </property>
-    </spacer>
+    </widget>
    </item>
-   <item>
-    <widget class="Gui::QuantitySpinBox" name="currentDensityQSB">
+   <item row="1" column="3">
+    <widget class="QLabel" name="labelImaginary">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="text">
+      <string>Imaginary</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="labelX">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="text">
+      <string>x</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="Gui::QuantitySpinBox" name="realXQSB">
      <property name="enabled">
       <bool>true</bool>
      </property>
@@ -45,11 +62,14 @@
        <height>20</height>
       </size>
      </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     <property name="toolTip">
+      <string>Real part of potential x-component</string>
      </property>
      <property name="keyboardTracking">
       <bool>true</bool>
+     </property>
+     <property name="unit" stdset="0">
+      <string notr="true"/>
      </property>
      <property name="minimum">
       <double>-1000000000000000000000.000000000000000</double>
@@ -58,10 +78,260 @@
       <double>1000000000000000000000.000000000000000</double>
      </property>
      <property name="singleStep">
-      <double>100.000000000000000</double>
+      <double>1.000000000000000</double>
      </property>
      <property name="value">
-      <double>0.000000000000000</double>
+      <double>1.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="2">
+    <widget class="QCheckBox" name="reXunspecBox">
+     <property name="toolTip">
+      <string>unspecified</string>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="3">
+    <widget class="Gui::QuantitySpinBox" name="imagXQSB">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>100</width>
+       <height>20</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string>Imaginary part of potential x-component</string>
+     </property>
+     <property name="keyboardTracking">
+      <bool>true</bool>
+     </property>
+     <property name="unit" stdset="0">
+      <string notr="true"/>
+     </property>
+     <property name="minimum">
+      <double>-1000000000000000000000.000000000000000</double>
+     </property>
+     <property name="maximum">
+      <double>1000000000000000000000.000000000000000</double>
+     </property>
+     <property name="singleStep">
+      <double>1.000000000000000</double>
+     </property>
+     <property name="value">
+      <double>1.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="4">
+    <widget class="QCheckBox" name="imXunspecBox">
+     <property name="toolTip">
+      <string>unspecified</string>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="labelY">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="text">
+      <string>y</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="Gui::QuantitySpinBox" name="realYQSB">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>100</width>
+       <height>20</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string>Real part of potential y-component</string>
+     </property>
+     <property name="keyboardTracking">
+      <bool>true</bool>
+     </property>
+     <property name="unit" stdset="0">
+      <string notr="true"/>
+     </property>
+     <property name="minimum">
+      <double>-1000000000000000000000.000000000000000</double>
+     </property>
+     <property name="maximum">
+      <double>1000000000000000000000.000000000000000</double>
+     </property>
+     <property name="singleStep">
+      <double>1.000000000000000</double>
+     </property>
+     <property name="value">
+      <double>1.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="2">
+    <widget class="QCheckBox" name="reYunspecBox">
+     <property name="toolTip">
+      <string>unspecified</string>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="3">
+    <widget class="Gui::QuantitySpinBox" name="imagYQSB">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>100</width>
+       <height>20</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string>Imaginary part of potential y-component</string>
+     </property>
+     <property name="keyboardTracking">
+      <bool>true</bool>
+     </property>
+     <property name="unit" stdset="0">
+      <string notr="true"/>
+     </property>
+     <property name="minimum">
+      <double>-1000000000000000000000.000000000000000</double>
+     </property>
+     <property name="maximum">
+      <double>1000000000000000000000.000000000000000</double>
+     </property>
+     <property name="singleStep">
+      <double>1.000000000000000</double>
+     </property>
+     <property name="value">
+      <double>1.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="4">
+    <widget class="QCheckBox" name="imYunspecBox">
+     <property name="toolTip">
+      <string>unspecified</string>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="labelZ">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="text">
+      <string>z</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="Gui::QuantitySpinBox" name="realZQSB">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>100</width>
+       <height>20</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string>Real part of potential z-component</string>
+     </property>
+     <property name="keyboardTracking">
+      <bool>true</bool>
+     </property>
+     <property name="unit" stdset="0">
+      <string notr="true"/>
+     </property>
+     <property name="minimum">
+      <double>-1000000000000000000000.000000000000000</double>
+     </property>
+     <property name="maximum">
+      <double>1000000000000000000000.000000000000000</double>
+     </property>
+     <property name="singleStep">
+      <double>1.000000000000000</double>
+     </property>
+     <property name="value">
+      <double>1.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="2">
+    <widget class="QCheckBox" name="reZunspecBox">
+     <property name="toolTip">
+      <string>unspecified</string>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="3">
+    <widget class="Gui::QuantitySpinBox" name="imagZQSB">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>100</width>
+       <height>20</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string>Imaginary part of potential z-component</string>
+     </property>
+     <property name="keyboardTracking">
+      <bool>true</bool>
+     </property>
+     <property name="unit" stdset="0">
+      <string notr="true"/>
+     </property>
+     <property name="minimum">
+      <double>-1000000000000000000000.000000000000000</double>
+     </property>
+     <property name="maximum">
+      <double>1000000000000000000000.000000000000000</double>
+     </property>
+     <property name="singleStep">
+      <double>1.000000000000000</double>
+     </property>
+     <property name="value">
+      <double>1.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="4">
+    <widget class="QCheckBox" name="imZunspecBox">
+     <property name="toolTip">
+      <string>unspecified</string>
+     </property>
+     <property name="text">
+      <string/>
      </property>
     </widget>
    </item>
@@ -75,5 +345,102 @@
   </customwidget>
  </customwidgets>
  <resources/>
- <connections/>
+ <connections>
+  <connection>
+   <sender>reXunspecBox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>realXQSB</receiver>
+   <slot>setDisabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>152</x>
+     <y>61</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>80</x>
+     <y>61</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>reYunspecBox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>realYQSB</receiver>
+   <slot>setDisabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>152</x>
+     <y>87</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>80</x>
+     <y>87</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>imZunspecBox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>imagZQSB</receiver>
+   <slot>setDisabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>297</x>
+     <y>113</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>224</x>
+     <y>113</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>imYunspecBox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>imagYQSB</receiver>
+   <slot>setDisabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>297</x>
+     <y>87</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>224</x>
+     <y>87</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>imXunspecBox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>imagXQSB</receiver>
+   <slot>setDisabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>297</x>
+     <y>61</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>224</x>
+     <y>61</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>reZunspecBox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>realZQSB</receiver>
+   <slot>setDisabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>152</x>
+     <y>113</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>80</x>
+     <y>113</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
 </ui>

--- a/src/Mod/Fem/Gui/Resources/ui/Magnetization.ui
+++ b/src/Mod/Fem/Gui/Resources/ui/Magnetization.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>313</width>
+    <width>300</width>
     <height>133</height>
    </rect>
   </property>
@@ -15,7 +15,7 @@
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="0" column="0" colspan="2">
-    <widget class="QLabel" name="pressureLbl">
+    <widget class="QLabel" name="magnetizationLbl">
      <property name="text">
       <string>Magnetization</string>
      </property>

--- a/src/Mod/Fem/femobjects/constraint_currentdensity.py
+++ b/src/Mod/Fem/femobjects/constraint_currentdensity.py
@@ -44,11 +44,101 @@ class ConstraintCurrentDensity(base_fempythonobject.BaseFemPythonObject):
         self.add_properties(obj)
 
     def add_properties(self, obj):
-        if not hasattr(obj, "CurrentDensity"):
+        if not hasattr(obj, "CurrentDensity_re_1"):
             obj.addProperty(
                 "App::PropertyCurrentDensity",
-                "CurrentDensity",
-                "Parameter",
-                "Current Density"
+                "CurrentDensity_re_1",
+                "Vector Potential",
+                "Real part of current density x-component"
             )
-            obj.CurrentDensity = 0.0
+            obj.CurrentDensity_re_1 = "0 A/m^2"
+        if not hasattr(obj, "CurrentDensity_re_2"):
+            obj.addProperty(
+                "App::PropertyCurrentDensity",
+                "CurrentDensity_re_2",
+                "Vector Potential",
+                "Real part of current density y-component"
+            )
+            obj.CurrentDensity_re_2 = "0 A/m^2"
+        if not hasattr(obj, "CurrentDensity_re_3"):
+            obj.addProperty(
+                "App::PropertyCurrentDensity",
+                "CurrentDensity_re_3",
+                "Vector Potential",
+                "Real part of current density z-component"
+            )
+            obj.CurrentDensity_re_3 = "0 A/m^2"
+        if not hasattr(obj, "CurrentDensity_im_1"):
+            obj.addProperty(
+                "App::PropertyCurrentDensity",
+                "CurrentDensity_im_1",
+                "Vector Potential",
+                "Imaginary part of current density x-component"
+            )
+            obj.CurrentDensity_im_1 = "0 A/m^2"
+        if not hasattr(obj, "CurrentDensity_im_2"):
+            obj.addProperty(
+                "App::PropertyCurrentDensity",
+                "CurrentDensity_im_2",
+                "Vector Potential",
+                "Imaginary part of current density y-component"
+            )
+            obj.CurrentDensity_im_2 = "0 A/m^2"
+        if not hasattr(obj, "CurrentDensity_im_3"):
+            obj.addProperty(
+                "App::PropertyCurrentDensity",
+                "CurrentDensity_im_3",
+                "Vector Potential",
+                "Imaginary part of current density z-component"
+            )
+            obj.CurrentDensity_im_3 = "0 A/m^2"
+
+        # now the enable bools
+        if not hasattr(obj, "CurrentDensity_re_1_Disabled"):
+            obj.addProperty(
+                "App::PropertyBool",
+                "CurrentDensity_re_1_Disabled",
+                "Vector Potential",
+                ""
+            )
+            obj.CurrentDensity_re_1_Disabled = True
+        if not hasattr(obj, "CurrentDensity_re_2_Disabled"):
+            obj.addProperty(
+                "App::PropertyBool",
+                "CurrentDensity_re_2_Disabled",
+                "Vector Potential",
+                ""
+            )
+            obj.CurrentDensity_re_2_Disabled = True
+        if not hasattr(obj, "CurrentDensity_re_3_Disabled"):
+            obj.addProperty(
+                "App::PropertyBool",
+                "CurrentDensity_re_3_Disabled",
+                "Vector Potential",
+                ""
+            )
+            obj.CurrentDensity_re_3_Disabled = True
+        if not hasattr(obj, "CurrentDensity_im_1_Disabled"):
+            obj.addProperty(
+                "App::PropertyBool",
+                "CurrentDensity_im_1_Disabled",
+                "Vector Potential",
+                ""
+            )
+            obj.CurrentDensity_im_1_Disabled = True
+        if not hasattr(obj, "CurrentDensity_im_2_Disabled"):
+            obj.addProperty(
+                "App::PropertyBool",
+                "CurrentDensity_im_2_Disabled",
+                "Vector Potential",
+                ""
+            )
+            obj.CurrentDensity_im_2_Disabled = True
+        if not hasattr(obj, "CurrentDensity_im_3_Disabled"):
+            obj.addProperty(
+                "App::PropertyBool",
+                "CurrentDensity_im_3_Disabled",
+                "Vector Potential",
+                ""
+            )
+            obj.CurrentDensity_im_3_Disabled = True

--- a/src/Mod/Fem/femsolver/elmer/equations/magnetodynamic2D_writer.py
+++ b/src/Mod/Fem/femsolver/elmer/equations/magnetodynamic2D_writer.py
@@ -144,44 +144,33 @@ class MgDyn2Dwriter:
                     )
 
     def _outputMagnetodynamic2DBodyForce(self, obj, name, equation):
-        if hasattr(obj, "CurrentDensity"):
-            currentDensity = self.write.getFromUi(
-                obj.CurrentDensity.getValueAs("A/m^2"), "A/m^2", "I/L^2"
-            )
-            currentDensity = round(currentDensity, 10) # to get rid of numerical artifacts
-            if currentDensity == 0.0:
-                # a zero density would break Elmer
-                raise general_writer.WriteError("The current density must not be zero!")
-            self.write.bodyForce(name, "Current Density", currentDensity)
-
-        if hasattr(obj, "Magnetization_im_1"):
+        if hasattr(obj, "CurrentDensity_re_1"):
+            # output only if current density is enabled and needed
+            if not obj.CurrentDensity_re_1_Disabled:
+                currentDensity = float(obj.CurrentDensity_re_1.getValueAs("A/m^2"))
+                self.write.bodyForce(name, "Current Density", currentDensity)
+            # imaginaries are only needed for harmonic equation
+            if equation.IsHarmonic:
+                if not obj.CurrentDensity_im_1_Disabled:
+                    currentDensity = float(obj.CurrentDensity_im_1.getValueAs("A/m^2"))
+                    self.write.bodyForce(name, "Current Density Im", currentDensity)
+ 
+        if hasattr(obj, "Magnetization_re_1"):
             # output only if magnetization is enabled and needed
             if not obj.Magnetization_re_1_Disabled:
-                if hasattr(obj, "Magnetization_re_1"):
-                    magnetization = float(obj.Magnetization_re_1.getValueAs("A/m"))
-                    self.write.material(name, "Magnetization 1", magnetization)
+                magnetization = float(obj.Magnetization_re_1.getValueAs("A/m"))
+                self.write.material(name, "Magnetization 1", magnetization)
             if not obj.Magnetization_re_2_Disabled:
-                if hasattr(obj, "Magnetization_re_2"):
-                    magnetization = float(obj.Magnetization_re_2.getValueAs("A/m"))
-                    self.write.material(name, "Magnetization 2", magnetization)
-            if not obj.Magnetization_re_3_Disabled:
-                if hasattr(obj, "Magnetization_re_3"):
-                    magnetization = float(obj.Magnetization_re_3.getValueAs("A/m"))
-                    self.write.material(name, "Magnetization 3", magnetization)
+                magnetization = float(obj.Magnetization_re_2.getValueAs("A/m"))
+                self.write.material(name, "Magnetization 2", magnetization)
             # imaginaries are only needed for harmonic equation
             if equation.IsHarmonic:
                 if not obj.Magnetization_im_1_Disabled:
-                    if hasattr(obj, "Magnetization_im_1"):
-                        magnetization = float(obj.Magnetization_im_1.getValueAs("A/m"))
-                        self.write.material(name, "Magnetization Im 1", magnetization)
+                    magnetization = float(obj.Magnetization_im_1.getValueAs("A/m"))
+                    self.write.material(name, "Magnetization Im 1", magnetization)
                 if not obj.Magnetization_im_2_Disabled:
-                    if hasattr(obj, "Magnetization_im_2"):
-                        magnetization = float(obj.Magnetization_im_2.getValueAs("A/m"))
-                        self.write.material(name, "Magnetization Im 2", magnetization)
-                if not obj.Magnetization_im_3_Disabled:
-                    if hasattr(obj, "Magnetization_im_3"):
-                        magnetization = float(obj.Magnetization_im_3.getValueAs("A/m"))
-                        self.write.material(name, "Magnetization Im 3", magnetization)
+                    magnetization = float(obj.Magnetization_im_2.getValueAs("A/m"))
+                    self.write.material(name, "Magnetization Im 2", magnetization)
 
     def handleMagnetodynamic2DBodyForces(self, bodies, equation):
         currentDensities = self.write.getMember("Fem::ConstraintCurrentDensity")

--- a/src/Mod/Fem/femtaskpanels/task_constraint_currentdensity.py
+++ b/src/Mod/Fem/femtaskpanels/task_constraint_currentdensity.py
@@ -102,22 +102,86 @@ class _TaskPanel(object):
                 self._part.ViewObject.hide()
 
     def _initParamWidget(self):
-        self._paramWidget.currentDensityQSB.setProperty(
-            'value', self._obj.CurrentDensity)
+        self._paramWidget.realXQSB.setProperty(
+            'value', self._obj.CurrentDensity_re_1)
         FreeCADGui.ExpressionBinding(
-            self._paramWidget.currentDensityQSB).bind(self._obj, "CurrentDensity")
-        self._paramWidget.currentDensityQSB.setProperty(
-            'value', self._obj.CurrentDensity)
+            self._paramWidget.realXQSB).bind(self._obj, "CurrentDensity_re_1")
+        self._paramWidget.realYQSB.setProperty(
+            'value', self._obj.CurrentDensity_re_2)
+        FreeCADGui.ExpressionBinding(
+            self._paramWidget.realYQSB).bind(self._obj, "CurrentDensity_re_2")
+        self._paramWidget.realZQSB.setProperty(
+            'value', self._obj.CurrentDensity_re_3)
+        FreeCADGui.ExpressionBinding(
+            self._paramWidget.realZQSB).bind(self._obj, "CurrentDensity_re_3")
+        self._paramWidget.imagXQSB.setProperty(
+            'value', self._obj.CurrentDensity_im_1)
+        FreeCADGui.ExpressionBinding(
+            self._paramWidget.imagXQSB).bind(self._obj, "CurrentDensity_im_1")
+        self._paramWidget.imagYQSB.setProperty(
+            'value', self._obj.CurrentDensity_im_2)
+        FreeCADGui.ExpressionBinding(
+            self._paramWidget.imagYQSB).bind(self._obj, "CurrentDensity_im_2")
+        self._paramWidget.imagZQSB.setProperty(
+            'value', self._obj.CurrentDensity_im_3)
+        FreeCADGui.ExpressionBinding(
+            self._paramWidget.imagZQSB).bind(self._obj, "CurrentDensity_im_3")
 
-    def _applyWidgetChanges(self):
+        self._paramWidget.reXunspecBox.setChecked(
+            self._obj.CurrentDensity_re_1_Disabled)
+        self._paramWidget.reYunspecBox.setChecked(
+            self._obj.CurrentDensity_re_2_Disabled)
+        self._paramWidget.reZunspecBox.setChecked(
+            self._obj.CurrentDensity_re_3_Disabled)
+        self._paramWidget.imXunspecBox.setChecked(
+            self._obj.CurrentDensity_im_1_Disabled)
+        self._paramWidget.imYunspecBox.setChecked(
+            self._obj.CurrentDensity_im_2_Disabled)
+        self._paramWidget.imZunspecBox.setChecked(
+            self._obj.CurrentDensity_im_3_Disabled)
+
+    def _applyCurrentDensityChanges(self, enabledBox, currentDensityQSB):
+        enabled = enabledBox.isChecked()
         currentdensity = None
         try:
-            currentdensity = self._paramWidget.currentDensityQSB.property('value')
+            currentdensity = currentDensityQSB.property('value')
         except ValueError:
             FreeCAD.Console.PrintMessage(
                 "Wrong input. Not recognised input: '{}' "
-                "Current density has not been set.\n"
-                .format(self._paramWidget.currentDensityQSB.text())
+                "Current density has not been set.\n".format(currentDensityQSB.text())
             )
-        if currentdensity is not None:
-            self._obj.CurrentDensity = currentdensity
+            currentdensity = '0.0 A/m^2'
+        return enabled, currentdensity
+
+    def _applyWidgetChanges(self):
+        # apply the current densities and their enabled state
+        self._obj.CurrentDensity_re_1_Disabled, self._obj.CurrentDensity_re_1 = \
+            self._applyCurrentDensityChanges(
+                self._paramWidget.reXunspecBox,
+                self._paramWidget.realXQSB
+            )
+        self._obj.CurrentDensity_re_2_Disabled, self._obj.CurrentDensity_re_2 = \
+            self._applyCurrentDensityChanges(
+                self._paramWidget.reYunspecBox,
+                self._paramWidget.realYQSB
+            )
+        self._obj.CurrentDensity_re_3_Disabled, self._obj.CurrentDensity_re_3 = \
+            self._applyCurrentDensityChanges(
+                self._paramWidget.reZunspecBox,
+                self._paramWidget.realZQSB
+            )
+        self._obj.CurrentDensity_im_1_Disabled, self._obj.CurrentDensity_im_1 = \
+            self._applyCurrentDensityChanges(
+                self._paramWidget.imXunspecBox,
+                self._paramWidget.imagXQSB
+            )
+        self._obj.CurrentDensity_im_2_Disabled, self._obj.CurrentDensity_im_2 = \
+            self._applyCurrentDensityChanges(
+                self._paramWidget.imYunspecBox,
+                self._paramWidget.imagYQSB
+            )
+        self._obj.CurrentDensity_im_3_Disabled, self._obj.CurrentDensity_im_3 = \
+            self._applyCurrentDensityChanges(
+                self._paramWidget.imZunspecBox,
+                self._paramWidget.imagZQSB
+            )


### PR DESCRIPTION
- to be used also for the magnetodynamic 3D equation
- use the changed current density for the existing 2D equation, this way fix issue that it was not possible to specify imaginary current density
- also fix bug that there is no z-component of magnetization for the 2D equation
- also correct a label name in magnetization UI-file