### PR TITLE
[FEM] change hiding logic on calling task panels

### DIFF
--- a/src/Mod/Fem/femviewprovider/view_base_femobject.py
+++ b/src/Mod/Fem/femviewprovider/view_base_femobject.py
@@ -81,23 +81,15 @@ class VPBaseFemObject(object):
             # avoid edit mode by return False
             # https://forum.freecadweb.org/viewtopic.php?t=12139&start=10#p161062
             return False
-        if hide_mesh is True:
-            # hide all FEM meshes and VTK FemPost* objects
-            for o in vobj.Object.Document.Objects:
+        if hide_mesh:
+            # hide all FEM meshes and FemPost function objects
+            for obj in vobj.Object.Document.Objects:
                 if (
-                    o.isDerivedFrom("Fem::FemMeshObject")
-                    or o.isDerivedFrom("Fem::FemPostPipeline")
-                    or o.isDerivedFrom("Fem::FemPostClipFilter")
-                    or o.isDerivedFrom("Fem::FemPostScalarClipFilter")
-                    or o.isDerivedFrom("Fem::FemPostWarpVectorFilter")
-                    or o.isDerivedFrom("Fem::FemPostDataAlongLineFilter")
-                    or o.isDerivedFrom("Fem::FemPostDataAtPointFilter")
-                    or o.isDerivedFrom("Fem::FemPostCutFilter")
-                    or o.isDerivedFrom("Fem::FemPostDataAlongLineFilter")
-                    or o.isDerivedFrom("Fem::FemPostPlaneFunction")
-                    or o.isDerivedFrom("Fem::FemPostSphereFunction")
+                    obj.isDerivedFrom("Fem::FemMeshObject")
+                    or obj.isDerivedFrom("Fem::FemPostPlaneFunction")
+                    or obj.isDerivedFrom("Fem::FemPostSphereFunction")
                 ):
-                    o.ViewObject.hide()
+                    obj.ViewObject.hide()
         # show task panel
         task = TaskPanel(vobj.Object)
         FreeCADGui.Control.showDialog(task)


### PR DESCRIPTION
- the typical workflow is to change e.g. a constraint setting or material property and to check how and if this change changes the simulation result. It is therefore very annoying that on every call of a task panel the results are hidden.
- This PR changes this to hide only meshes and the filter functions but to keep the results. If a user don't like to see results for example to select faces, he hides results anyway.