### PR TITLE
PD: Improve InvoluteGear's fillets

### DIFF
--- a/src/Mod/PartDesign/PartDesignTests/TestInvoluteGear.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestInvoluteGear.py
@@ -166,12 +166,13 @@ class TestInvoluteGear(unittest.TestCase):
         created_with = f"created with {self.Doc.getProgramVersion()}"
         gear = self.Doc.InvoluteGear # from fixture
         fixture_length = 187.752 # from fixture, rounded to micrometer
-        length_delta = 0.001
         self.assertClosedWire(gear.Shape) # no recompute yet, i.e. check original
-        self.assertAlmostEqual(fixture_length, gear.Shape.Length, delta=length_delta,
+        self.assertAlmostEqual(fixture_length, gear.Shape.Length, places=3,
             msg=f"Total wire length does not match fixture for gear {created_with}")
         gear.enforceRecompute()
         self.assertSuccessfulRecompute(gear, msg=f"Cannot recompute gear {created_with}")
+        relative_tolerance_per_tooth = 1e-3 # wild guess: changes of <0.1%/tooth are ok
+        length_delta = fixture_length * relative_tolerance_per_tooth * gear.NumberOfTeeth
         self.assertAlmostEqual(fixture_length, gear.Shape.Length, delta=length_delta,
             msg=f"Total wire length changed after recomputing gear {created_with}")
 
@@ -181,12 +182,13 @@ class TestInvoluteGear(unittest.TestCase):
         created_with = f"created with {self.Doc.getProgramVersion()}"
         gear = self.Doc.InvoluteGear # from fixture
         fixture_length = 165.408 # from fixture, rounded to micrometer
-        length_delta = 0.001
         self.assertClosedWire(gear.Shape) # no recompute yet, i.e. check original
-        self.assertAlmostEqual(fixture_length, gear.Shape.Length, delta=length_delta,
+        self.assertAlmostEqual(fixture_length, gear.Shape.Length, places=3,
             msg=f"Total wire length does not match fixture for gear {created_with}")
         gear.enforceRecompute()
         self.assertSuccessfulRecompute(gear, msg=f"Cannot recompute gear {created_with}")
+        relative_tolerance_per_tooth = 1e-3 # wild guess: changes of <0.1%/tooth are ok
+        length_delta = fixture_length * relative_tolerance_per_tooth * gear.NumberOfTeeth
         self.assertAlmostEqual(fixture_length, gear.Shape.Length, delta=length_delta,
             msg=f"Total wire length changed after recomputing gear {created_with}")
 


### PR DESCRIPTION
Previously, the fillet started at a fixed value, tailored at 20° pressure angle, a fillet radius of 0.375 and a dedendum of 1.25. With PR #8184 those values became user-adjustable and thus the assumptions of the original code are not fullfilled any more. This resulted in significant artefacts, especially for higher pressure angles or smaller dedendums as commonly found in splines.

This commit actually calculates the junction between fillet and involute so that the tangents of the both curves match. The mathematical approach is described in source code comments.

The change in the fillet calculation also affects compatibility with files generated by earlier versions of FreeCAD. Those changes are way below 0.1% per tooth, however the earlier test required absolute equality down to the micron. This was relaxed and also changed to a relative, per tooth, tolerance.

There is one particular case where the new algorithm performs slightly worse, though. That is when the fillet radius is too large to the dedendum, i.e. resulting in a single arc instead of two fillets, and effectively cannibalizes some of the clearance. This happens with internal gears having less than 25 teeth. At about 15 teeth it becomes visible that the fillet is not 100% tanget any more. However, as such a low number of teeth is highly unusual for internal gears and the effect,
although noticeable, is minor, the overall benefits of the new algorithm outweighs the drawbacks. And now with the fillet radius being adjustable it is easy to fix, too.  
The technical reason is that the tangency is calculated correctly, but the fillet circle is displaced afterwards to avoid an overlap of the two fillets. For the new fillet position, the tangets do not align any more.

<img width="433" alt="image" src="https://user-images.githubusercontent.com/865266/218209700-bd26ff10-7cf6-453a-856e-257bc8b06664.png">
<img width="489" alt="image" src="https://user-images.githubusercontent.com/865266/218211355-992c4561-dc16-4e60-9e26-e448816d456c.png">

----

Strictly speaking the changes to the standalone svg exporter are independent of the fillet generation. I just made them during my work on the fillets for allow for faster visual inspection. If you want, I can split this off into a dedicated PR.

----

- [x]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
