### PR TITLE
[Draft] update of Draft_Clone related to gui_utils.get_diffuse_color

### DIFF
--- a/src/Mod/Draft/draftmake/make_clone.py
+++ b/src/Mod/Draft/draftmake/make_clone.py
@@ -71,7 +71,6 @@ def make_clone(obj, delta=None, forcedraft=False):
     if (len(obj) == 1) and obj[0].isDerivedFrom("Part::Part2DObject"):
         cl = App.ActiveDocument.addObject("Part::Part2DObjectPython","Clone2D")
         cl.Label = prefix + obj[0].Label + " (2D)"
-
     elif (len(obj) == 1) and (hasattr(obj[0],"CloneOf") or (utils.get_type(obj[0]) == "BuildingPart")) and (not forcedraft):
         # arch objects can be clones
         import Arch
@@ -102,10 +101,10 @@ def make_clone(obj, delta=None, forcedraft=False):
             if App.GuiUp:
                 gui_utils.format_object(cl, base)
                 # Workaround to trigger update of DiffuseColor:
-                ToDo.delay(lambda col: setattr(cl.ViewObject, "DiffuseColor", col),
-                           cl.ViewObject.DiffuseColor)
+                ToDo.delay(reapply_diffuse_color, cl.ViewObject)
                 gui_utils.select(cl)
             return cl
+
     # fall back to Draft clone mode
     if not cl:
         cl = App.ActiveDocument.addObject("Part::FeaturePython","Clone")
@@ -122,15 +121,13 @@ def make_clone(obj, delta=None, forcedraft=False):
     if App.GuiUp:
         ViewProviderClone(cl.ViewObject)
         gui_utils.format_object(cl, obj[0])
-        if len(obj) > 1 or hasattr(obj[0], "Group"):
-            cl.ViewObject.Proxy.resetColors(cl.ViewObject)
         # Workaround to trigger update of DiffuseColor:
-        # Note: only works if obj contains 1 object.
-        ToDo.delay(reapply_DiffuseColor, cl.ViewObject)
+        ToDo.delay(reapply_diffuse_color, cl.ViewObject)
         gui_utils.select(cl)
     return cl
 
-def reapply_DiffuseColor(vobj):
+
+def reapply_diffuse_color(vobj):
     try:
         vobj.DiffuseColor = vobj.DiffuseColor
     except:

--- a/src/Mod/Draft/draftviewproviders/view_clone.py
+++ b/src/Mod/Draft/draftviewproviders/view_clone.py
@@ -27,7 +27,6 @@
 
 ## \addtogroup draftviewproviders
 # @{
-import draftutils.groups as groups
 
 
 class ViewProviderClone:
@@ -46,39 +45,10 @@ class ViewProviderClone:
         return None
 
     def getDisplayModes(self, vobj):
-        modes=[]
-        return modes
+        return []
 
     def setDisplayMode(self, mode):
         return mode
-
-    def resetColors(self, vobj):
-        colors = []
-        for o in groups.get_group_contents(vobj.Object.Objects):
-            if o.isDerivedFrom("Part::Feature"):
-                if len(o.ViewObject.DiffuseColor) == len(o.Shape.Faces):
-                    colors.extend(o.ViewObject.DiffuseColor)
-                else:
-                    c = o.ViewObject.ShapeColor
-                    c = (c[0], c[1], c[2], o.ViewObject.Transparency / 100.0)
-                    colors += [c] * len(o.Shape.Faces)
-            elif o.hasExtension("App::GeoFeatureGroupExtension"):
-                for so in o.Group:
-                    if so.isDerivedFrom("Part::Feature"):
-                        if len(so.ViewObject.DiffuseColor) == len(so.Shape.Faces):
-                            colors.extend(so.ViewObject.DiffuseColor)
-                        else:
-                            c = so.ViewObject.ShapeColor
-                            c = (c[0], c[1], c[2], so.ViewObject.Transparency / 100.0)
-                            colors += [c] * len(so.Shape.Faces)
-        if colors:
-            first_color = colors[0]
-            for next_color in colors[1:]:
-                if next_color != first_color:
-                    break
-            else:
-                colors = [first_color]
-            vobj.DiffuseColor = colors
 
 
 # Alias for compatibility with v0.18 and earlier


### PR DESCRIPTION
The `gui_utils.get_diffuse_color` function introduced with #8427 makes the `resetColors` method of the viewprovider obsolete.

Additionally:
The `reapply_diffuse_color` workaround in make_clone.py was not used for arch objects.

- [x]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

---
