### PR TITLE
[Draft] some arrays did not have a Count property

### DIFF
--- a/src/Mod/Draft/draftobjects/array.py
+++ b/src/Mod/Draft/draftobjects/array.py
@@ -39,6 +39,9 @@ from PySide.QtCore import QT_TRANSLATE_NOOP
 import FreeCAD as App
 import DraftVecUtils
 
+from draftutils.messages import _wrn
+from draftutils.translate import translate
+
 from draftobjects.draftlink import DraftLink
 
 
@@ -59,6 +62,17 @@ class Array(DraftLink):
         """Set up the properties when the object is attached."""
         self.set_properties(obj)
         super(Array, self).attach(obj)
+
+    def onDocumentRestored(self, obj):
+        if hasattr(obj, "Count"):
+            return
+        self.update_properties_0v21(obj)
+
+    def update_properties_0v21(self, obj):
+        self.set_general_properties(obj)
+        self.execute(obj) # Required to update Count to the correct value.
+        _wrn("v0.21, " + obj.Label + ", "
+             + translate("draft", "added property 'Count'"))
 
     def set_properties(self, obj):
         """Set properties only if they don't exist."""
@@ -111,6 +125,20 @@ class Array(DraftLink):
                             "Objects",
                             _tip)
             obj.Fuse = False
+
+        if "Count" not in properties:
+            _tip = QT_TRANSLATE_NOOP("App::Property",
+                                     "Total number of elements "
+                                     "in the array.\n"
+                                     "This property is read-only, "
+                                     "as the number depends "
+                                     "on the parameters of the array.")
+            obj.addProperty("App::PropertyInteger",
+                            "Count",
+                            "Objects",
+                            _tip)
+            obj.Count = 0
+            obj.setEditorMode("Count", 1)  # Read only
 
     def set_ortho_properties(self, obj):
         """Set orthogonal properties only if they don't exist."""
@@ -299,20 +327,6 @@ class Array(DraftLink):
         properties = obj.PropertiesList
 
         if self.use_link:
-            if "Count" not in properties:
-                _tip = QT_TRANSLATE_NOOP("App::Property",
-                                         "Total number of elements "
-                                         "in the array.\n"
-                                         "This property is read-only, "
-                                         "as the number depends "
-                                         "on the parameters of the array.")
-                obj.addProperty("App::PropertyInteger",
-                                "Count",
-                                "Objects",
-                                _tip)
-                obj.Count = 0
-                obj.setEditorMode("Count", 1)  # Read only
-
             if "ExpandArray" not in properties:
                 _tip = QT_TRANSLATE_NOOP("App::Property",
                                          "Show the individual array elements "

--- a/src/Mod/Draft/draftobjects/draftlink.py
+++ b/src/Mod/Draft/draftobjects/draftlink.py
@@ -186,12 +186,14 @@ class DraftLink(DraftObject):
 
     def buildShape(self, obj, pl, pls):
         """Build the shape of the link object."""
+        if obj.Count != len(pls):
+            obj.Count = len(pls)
+
         if self.use_link:
-            if not getattr(obj, 'ExpandArray', False) or obj.Count != len(pls):
+            if not getattr(obj, 'ExpandArray', False):
                 obj.setPropertyStatus('PlacementList', '-Immutable')
                 obj.PlacementList = pls
                 obj.setPropertyStatus('PlacementList', 'Immutable')
-                obj.Count = len(pls)
             if getattr(obj, 'ExpandArray', False) \
                     and getattr(obj, 'AlwaysSyncPlacement', False):
                 for pla,child in zip(pls,obj.ElementList):


### PR DESCRIPTION
The non-Link versions of Draft_OrthoArray, Draft_PolarArray and Draft_CircularArray did not have a `Count` property. This has been remarked upon before (in a Fasteners BOM related discussion). But the property can also used 'internally', for example when generating a `DiffuseColor` value.

- [x]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

---
