### PR TITLE
Draft: [skip ci] fix typo in source comment

### DIFF
--- a/src/Mod/Draft/draftutils/gui_utils.py
+++ b/src/Mod/Draft/draftutils/gui_utils.py
@@ -345,7 +345,7 @@ def get_diffuse_color(objs):
     If all tuples in the result are identical a list with a single tuple is
     returned. In theory all faces of an object can be set to the same diffuse
     color that is different from its shape color, but that seems rare. The
-    function does not take that into acount.
+    function does not take that into account.
 
     Parameters
     ----------


### PR DESCRIPTION
Fixed typo in `draftutils/gui_utils.py`

---

- [x]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR