### PR TITLE
[Draft] fix diffuse color issue when creating arrays

### DIFF
--- a/src/Mod/Draft/draftmake/make_array.py
+++ b/src/Mod/Draft/draftmake/make_array.py
@@ -39,6 +39,7 @@ from draftutils.translate import translate
 from draftobjects.array import Array
 
 if App.GuiUp:
+    from draftutils.todo import ToDo
     from draftviewproviders.view_array import ViewProviderDraftArray
     from draftviewproviders.view_draftlink import ViewProviderDraftLink
 
@@ -128,13 +129,13 @@ def make_array(base_object,
         if use_link:
             ViewProviderDraftLink(new_obj.ViewObject)
         else:
+            if new_obj.ArrayType == "circular":
+                new_obj.Proxy.execute(new_obj) # Updates Count which is required for correct DiffuseColor.
             ViewProviderDraftArray(new_obj.ViewObject)
             gui_utils.format_object(new_obj, new_obj.Base)
-
-            if hasattr(new_obj.Base.ViewObject, "DiffuseColor"):
-                if len(new_obj.Base.ViewObject.DiffuseColor) > 1:
-                    new_obj.ViewObject.Proxy.resetColors(new_obj.ViewObject)
-
+            new_obj.ViewObject.Proxy.resetColors(new_obj.ViewObject)
+            # Workaround to trigger update of DiffuseColor:
+            ToDo.delay(reapply_diffuse_color, new_obj.ViewObject)
         new_obj.Base.ViewObject.hide()
         gui_utils.select(new_obj)
 
@@ -153,5 +154,12 @@ def makeArray(baseobject,
     return make_array(baseobject,
                       arg1, arg2, arg3,
                       arg4, arg5, arg6, use_link)
+
+
+def reapply_diffuse_color(vobj):
+    try:
+        vobj.DiffuseColor = vobj.DiffuseColor
+    except:
+        pass
 
 ## @}

--- a/src/Mod/Draft/draftmake/make_patharray.py
+++ b/src/Mod/Draft/draftmake/make_patharray.py
@@ -46,6 +46,7 @@ from draftobjects.patharray import PathArray
 from draftobjects.pathtwistedarray import PathTwistedArray
 
 if App.GuiUp:
+    from draftutils.todo import ToDo
     from draftviewproviders.view_array import ViewProviderDraftArray
     from draftviewproviders.view_draftlink import ViewProviderDraftLink
 
@@ -294,11 +295,9 @@ def make_path_array(base_object, path_object, count=4,
         else:
             ViewProviderDraftArray(new_obj.ViewObject)
             gui_utils.formatObject(new_obj, new_obj.Base)
-
-            if hasattr(new_obj.Base.ViewObject, "DiffuseColor"):
-                if len(new_obj.Base.ViewObject.DiffuseColor) > 1:
-                    new_obj.ViewObject.Proxy.resetColors(new_obj.ViewObject)
-
+            new_obj.ViewObject.Proxy.resetColors(new_obj.ViewObject)
+            # Workaround to trigger update of DiffuseColor:
+            ToDo.delay(reapply_diffuse_color, new_obj.ViewObject)
         new_obj.Base.ViewObject.hide()
         gui_utils.select(new_obj)
 
@@ -384,14 +383,19 @@ def make_path_twisted_array(base_object, path_object,
         else:
             ViewProviderDraftArray(new_obj.ViewObject)
             gui_utils.formatObject(new_obj, new_obj.Base)
-
-        if hasattr(new_obj.Base.ViewObject, "DiffuseColor"):
-            if len(new_obj.Base.ViewObject.DiffuseColor) > 1:
-                new_obj.ViewObject.Proxy.resetColors(new_obj.ViewObject)
-
+            new_obj.ViewObject.Proxy.resetColors(new_obj.ViewObject)
+            # Workaround to trigger update of DiffuseColor:
+            ToDo.delay(reapply_diffuse_color, new_obj.ViewObject)
         new_obj.Base.ViewObject.hide()
         gui_utils.select(new_obj)
 
     return new_obj
+
+
+def reapply_diffuse_color(vobj):
+    try:
+        vobj.DiffuseColor = vobj.DiffuseColor
+    except:
+        pass
 
 ## @}

--- a/src/Mod/Draft/draftmake/make_pointarray.py
+++ b/src/Mod/Draft/draftmake/make_pointarray.py
@@ -43,6 +43,7 @@ from draftutils.translate import translate
 from draftobjects.pointarray import PointArray
 
 if App.GuiUp:
+    from draftutils.todo import ToDo
     from draftviewproviders.view_array import ViewProviderDraftArray
     from draftviewproviders.view_draftlink import ViewProviderDraftLink
 
@@ -152,13 +153,12 @@ def make_point_array(base_object, point_object, extra=None, use_link=True):
         if use_link:
             ViewProviderDraftLink(new_obj.ViewObject)
         else:
+            new_obj.Proxy.execute(new_obj) # Updates Count which is required for correct DiffuseColor.
             ViewProviderDraftArray(new_obj.ViewObject)
             gui_utils.format_object(new_obj, new_obj.Base)
-
-            if hasattr(new_obj.Base.ViewObject, "DiffuseColor"):
-                if len(new_obj.Base.ViewObject.DiffuseColor) > 1:
-                    new_obj.ViewObject.Proxy.resetColors(new_obj.ViewObject)
-
+            new_obj.ViewObject.Proxy.resetColors(new_obj.ViewObject)
+            # Workaround to trigger update of DiffuseColor:
+            ToDo.delay(reapply_diffuse_color, new_obj.ViewObject)
         new_obj.Base.ViewObject.hide()
         gui_utils.select(new_obj)
 
@@ -170,5 +170,12 @@ def makePointArray(base, ptlst):
     utils.use_instead('make_point_array')
 
     return make_point_array(base, ptlst)
+
+
+def reapply_diffuse_color(vobj):
+    try:
+        vobj.DiffuseColor = vobj.DiffuseColor
+    except:
+        pass
 
 ## @}

--- a/src/Mod/Draft/draftviewproviders/view_array.py
+++ b/src/Mod/Draft/draftviewproviders/view_array.py
@@ -28,6 +28,7 @@
 ## \addtogroup draftviewproviders
 # @{
 from draftviewproviders.view_base import ViewProviderDraft
+from draftutils import gui_utils
 
 
 class ViewProviderDraftArray(ViewProviderDraft):
@@ -52,26 +53,22 @@ class ViewProviderDraftArray(ViewProviderDraft):
             return ":/icons/Draft_PathArray.svg"
 
     def resetColors(self, vobj):
-        colors = []
-        if vobj.Object.Base:
-            if vobj.Object.Base.isDerivedFrom("Part::Feature"):
-                if len(vobj.Object.Base.ViewObject.DiffuseColor) > 1:
-                    colors = vobj.Object.Base.ViewObject.DiffuseColor
-                else:
-                    c = vobj.Object.Base.ViewObject.ShapeColor
-                    c = (c[0],c[1],c[2],vobj.Object.Base.ViewObject.Transparency/100.0)
-                    colors += [c] * len(vobj.Object.Base.Shape.Faces)
-        if colors:
-            n = 1
-            if hasattr(vobj.Object,"ArrayType"):
-                if vobj.Object.ArrayType == "ortho":
-                    n = vobj.Object.NumberX * vobj.Object.NumberY * vobj.Object.NumberZ
-                else:
-                    n = vobj.Object.NumberPolar
-            elif hasattr(vobj.Object,"Count"):
-                n = vobj.Object.Count
-            colors = colors * n
-            vobj.DiffuseColor = colors
+        obj = vobj.Object
+        if obj.Base is not None:
+            colors = gui_utils.get_diffuse_color(obj.Base)
+            if colors:
+                n = 1
+                if hasattr(obj, "ArrayType"):
+                    if obj.ArrayType == "ortho":
+                        n = obj.NumberX * obj.NumberY * obj.NumberZ
+                    elif obj.ArrayType == "polar":
+                        n = obj.NumberPolar
+                    else: # "circular"
+                        n = obj.Count
+                elif hasattr(obj, "Count"):
+                    n = obj.Count
+                colors = colors * n
+                vobj.DiffuseColor = colors
 
 
 # Alias for compatibility with v0.18 and earlier


### PR DESCRIPTION
Applying the DiffuseColor when creating arrays would fail. In some cases the value was incorrect for the number of faces of the array object. In all cases a workaround is required to actually show the applied color.

- [ ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

---
