### PR TITLE
Path:  Now can set parameter_functions from a postprocessor file.

### DIFF
--- a/src/Mod/Path/Path/Post/UtilsArguments.py
+++ b/src/Mod/Path/Path/Post/UtilsArguments.py
@@ -36,6 +36,8 @@ import shlex
 
 from FreeCAD import Units
 
+import Path.Post.UtilsParse as PostUtilsParse
+
 
 def add_flag_type_arguments(
     argument_group,
@@ -446,6 +448,12 @@ def init_shared_values(values):
     # any commands in the "TOOL_CHANGE" value.
     #
     values["OUTPUT_TOOL_CHANGE"] = True
+    #
+    # This dictionary/hash holds the functions that are used
+    # to process the G-code parameter values
+    #
+    values["PARAMETER_FUNCTIONS"] = {}
+    PostUtilsParse.init_parameter_functions(values["PARAMETER_FUNCTIONS"])
     #
     # This list controls the order of parameters in a line during output.
     #

--- a/src/Mod/Path/Path/Post/UtilsExport.py
+++ b/src/Mod/Path/Path/Post/UtilsExport.py
@@ -206,6 +206,7 @@ def export_common(values, objectslist, filename):
 
         # process the operation gcode
         gcode += PostUtilsParse.parse_a_group(values, obj)
+
         # do the post_op
         if values["OUTPUT_COMMENTS"]:
             comment = PostUtilsParse.create_comment(

--- a/src/Mod/Path/Path/Post/UtilsParse.py
+++ b/src/Mod/Path/Path/Post/UtilsParse.py
@@ -256,6 +256,45 @@ def format_outstring(values, strTable):
     return s
 
 
+def init_parameter_functions(parameter_functions):
+    """Initialize a list of parameter functions.
+
+    These functions are called in the PostUtilsParse.parse_a_path
+    function to return the appropriate parameter value.
+    """
+    default_parameter_functions = {
+        "A": default_axis_parameter,
+        "B": default_axis_parameter,
+        "C": default_axis_parameter,
+        "D": default_D_parameter,
+        "E": default_length_parameter,
+        "F": default_F_parameter,
+        # "G" is reserved for G-code commands
+        "H": default_int_parameter,
+        "I": default_length_parameter,
+        "J": default_length_parameter,
+        "K": default_length_parameter,
+        "L": default_int_parameter,
+        # "M" is reserved for M-code commands
+        # "N" is reserved for the line numbers
+        # "O" is reserved for the line numbers for subroutines
+        "P": default_P_parameter,
+        "Q": default_Q_parameter,
+        "R": default_length_parameter,
+        "S": default_S_parameter,
+        "T": default_int_parameter,
+        "U": default_axis_parameter,
+        "V": default_axis_parameter,
+        "W": default_axis_parameter,
+        "X": default_axis_parameter,
+        "Y": default_axis_parameter,
+        "Z": default_axis_parameter,
+        # "$" is used by LinuxCNC (and others?) to designate which spindle
+    }
+    for parameter in default_parameter_functions:
+        parameter_functions[parameter] = default_parameter_functions[parameter]
+
+
 def linenumber(values, space=None):
     """Output the next line number if appropriate."""
     if values["OUTPUT_LINE_NUMBERS"]:
@@ -265,41 +304,6 @@ def linenumber(values, space=None):
         values["line_number"] += values["LINE_INCREMENT"]
         return f"N{line_num}{space}"
     return ""
-
-
-#
-# These functions are called in the parse_a_path function
-# to return the appropriate parameter value.
-#
-parameter_functions = {
-    "A": default_axis_parameter,
-    "B": default_axis_parameter,
-    "C": default_axis_parameter,
-    "D": default_D_parameter,
-    "E": default_length_parameter,
-    "F": default_F_parameter,
-    # "G" is reserved for G-code commands
-    "H": default_int_parameter,
-    "I": default_length_parameter,
-    "J": default_length_parameter,
-    "K": default_length_parameter,
-    "L": default_int_parameter,
-    # "M" is reserved for M-code commands
-    # "N" is reserved for the beginning of line numbers
-    # "O" is reserved for the beginning of line numbers for subroutines
-    "P": default_P_parameter,
-    "Q": default_Q_parameter,
-    "R": default_length_parameter,
-    "S": default_S_parameter,
-    "T": default_int_parameter,
-    "U": default_axis_parameter,
-    "V": default_axis_parameter,
-    "W": default_axis_parameter,
-    "X": default_axis_parameter,
-    "Y": default_axis_parameter,
-    "Z": default_axis_parameter,
-    # "$" is used by LinuxCNC (and others?) to designate which spindle
-}
 
 
 def parse_a_group(values, pathobj):
@@ -366,6 +370,7 @@ def parse_a_path(values, pathobj):
                 continue
             if values["COMMENT_SYMBOL"] != "(" and len(command) > 2:
                 command = create_comment(values, command[1:-1])
+
         if (
             values["OUTPUT_ADAPTIVE"]
             and adaptiveOp
@@ -385,7 +390,7 @@ def parse_a_path(values, pathobj):
         # Now add the remaining parameters in order
         for parameter in values["PARAMETER_ORDER"]:
             if parameter in c.Parameters:
-                parameter_value = parameter_functions[parameter](
+                parameter_value = values["PARAMETER_FUNCTIONS"][parameter](
                     values, command, parameter, c.Parameters[parameter], currLocation
                 )
                 if parameter_value:

--- a/src/Mod/Path/Path/Post/UtilsParse.py
+++ b/src/Mod/Path/Path/Post/UtilsParse.py
@@ -291,8 +291,7 @@ def init_parameter_functions(parameter_functions):
         "Z": default_axis_parameter,
         # "$" is used by LinuxCNC (and others?) to designate which spindle
     }
-    for parameter in default_parameter_functions:
-        parameter_functions[parameter] = default_parameter_functions[parameter]
+    parameter_functions.update(default_parameter_functions)
 
 
 def linenumber(values, space=None):


### PR DESCRIPTION
This is part of the work for https://github.com/FreeCAD/FreeCAD/issues/6117.

This is one in a series of PR's where I am taking code from at least 4 postprocessor files partially written by different people, combining them into three files, then trying to make the code more consistent and simpler. The long term goal is to enable much simpler postprocessor files with much less copied code in each postprocessor file and much more "shared" code in the three Utils*.py files.

In this PR I create the "init_parameter_functions" routine so that it can be called from a postprocessor file to set the "values[PARAMETER_FUNCTIONS]" dictionary/hash value which is then used to call the parameter functions in the proper order.

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [x]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
