### PR TITLE
Gui: Add CERN OHL to default licenses list

### DIFF
--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -1594,6 +1594,18 @@ Document::Document(const char *name)
             license = "FreeArt";
             licenseUrl = "https://artlibre.org/licence/lal";
             break;
+        case 9:
+            license = "CERN Open Hardware Licence strongly-reciprocal";
+            licenseUrl = "https://cern-ohl.web.cern.ch/";
+            break;
+        case 10:
+            license = "CERN Open Hardware Licence weakly-reciprocal";
+            licenseUrl = "https://cern-ohl.web.cern.ch/";
+            break;
+        case 11:
+            license = "CERN Open Hardware Licence permissive";
+            licenseUrl = "https://cern-ohl.web.cern.ch/";
+            break;
         default:
             license = "Other";
             break;

--- a/src/Gui/DlgProjectInformationImp.cpp
+++ b/src/Gui/DlgProjectInformationImp.cpp
@@ -69,6 +69,9 @@ DlgProjectInformationImp::DlgProjectInformationImp(App::Document* doc, QWidget* 
         << "Creative Commons Attribution-NonCommercial-NoDerivatives"
         << "Public Domain"
         << "FreeArt"
+        << "CERN Open Hardware Licence strongly-reciprocal"
+        << "CERN Open Hardware Licence weakly-reciprocal"
+        << "CERN Open Hardware Licence permissive"
         << "Other";
     for (QList<QByteArray>::iterator it = rawLicenses.begin(); it != rawLicenses.end(); ++it) {
         QString text = QApplication::translate("Gui::Dialog::DlgSettingsDocument", it->constData());
@@ -169,6 +172,9 @@ void DlgProjectInformationImp::onLicenseTypeChanged(int index)
             break;
         case 8:
             ui->lineEditLicenseURL->setText(QString::fromLatin1("http://artlibre.org/licence/lal"));
+            break;
+        case 9: case 10: case 11:
+            ui->lineEditLicenseURL->setText(QString::fromLatin1("https://cern-ohl.web.cern.ch/"));
             break;
         default:
             ui->lineEditLicenseURL->setText(QString::fromUtf8(_doc->LicenseURL.getValue()));

--- a/src/Gui/DlgSettingsDocument.ui
+++ b/src/Gui/DlgSettingsDocument.ui
@@ -727,6 +727,21 @@ You can also use the form: John Doe &lt;john@doe.com&gt;</string>
         </item>
         <item>
          <property name="text">
+          <string>CERN Open Hardware Licence strongly-reciprocal</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>CERN Open Hardware Licence weakly-reciprocal</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>CERN Open Hardware Licence permissive</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
           <string>Other</string>
          </property>
         </item>

--- a/src/Gui/DlgSettingsDocumentImp.cpp
+++ b/src/Gui/DlgSettingsDocumentImp.cpp
@@ -178,6 +178,9 @@ void DlgSettingsDocumentImp::onLicenseTypeChanged(int index)
         case 8:
             ui->prefLicenseUrl->setText(QString::fromLatin1("http://artlibre.org/licence/lal"));
             break;
+        case 9: case 10: case 11:
+            ui->prefLicenseUrl->setText(QString::fromLatin1("https://cern-ohl.web.cern.ch/"));
+            break;
         default:
             ui->prefLicenseUrl->clear();
             ui->prefLicenseUrl->setReadOnly(false);


### PR DESCRIPTION
Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [x]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---

CERN maintains 3 versions of an open hardware license ([https://ohwr.org/project/cernohl/wikis/Documents/CERN-OHL-version-2](https://ohwr.org/project/cernohl/wikis/Documents/CERN-OHL-version-2)). There are [some projects](https://github.com/topics/cern-ohl) that already appear to use these licenses with .FCStd files. I suggest adding them to the application defaults.

![image](https://user-images.githubusercontent.com/37948669/218293168-874c643a-6c8b-4da9-b122-8aa6d5a446c0.png)
