### PR TITLE
[App] License.cpp: add missing include

### DIFF
--- a/src/App/License.cpp
+++ b/src/App/License.cpp
@@ -22,7 +22,8 @@
 
 #include "PreCompiled.h"
 #ifndef _PreComp_
-#include <algorithm>
+# include <algorithm>
+# include <iterator>
 #endif
 
 #include "License.h"


### PR DESCRIPTION
- does otherwise not compile on Windows