### PR TITLE
CI various improvements

### DIFF
--- a/.github/workflows/CI_master.yml
+++ b/.github/workflows/CI_master.yml
@@ -37,13 +37,13 @@ jobs:
     with:
       artifactBasename: Prepare-${{ github.run_id }}
 
-  Build2004:
+  Ubuntu_20-04:
     needs: [Prepare]
     uses: ./.github/workflows/sub_buildUbuntu2004.yml
     with:
       artifactBasename: Build2004-${{ github.run_id }}
 
-  Build2204:
+  Ubuntu_22-04:
     needs: [Prepare]
     uses: ./.github/workflows/sub_buildUbuntu2204.yml
     with:
@@ -59,7 +59,7 @@ jobs:
       changedPythonFiles: ${{ needs.Prepare.outputs.changedPythonFiles }}
 
   WrapUp:
-    needs: [Prepare, Build2004, Build2204, Lint]
+    needs: [Prepare, Ubuntu_20-04, Ubuntu_22-04, Lint]
     if: always()
     uses: ./.github/workflows/sub_wrapup.yml
     with:

--- a/.github/workflows/actions/linux/build/action.yml
+++ b/.github/workflows/actions/linux/build/action.yml
@@ -1,0 +1,75 @@
+# ***************************************************************************
+# *   Copyright (c) 2023 0penBrain                               *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   This program is distributed in the hope that it will be useful,       *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with this program; if not, write to the Free Software   *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+
+name: build
+description: "Linux: build application"
+
+inputs:
+  builddir:
+    description: "Directory where build will happen"
+    required: true
+  logFile:
+    description: "Path for log file"
+    required: true
+  errorFile:
+    description: "Path to error file"
+    required: true
+  reportFile:
+    description: "Path for report file"
+    required: true
+  extraParameters:
+    description: "Extra parameters to CMake build"
+    required: false
+
+runs:
+  using: "composite"
+  steps:
+    - name: Build
+      id: build
+      shell: bash
+      run: |
+        cmake --build ${{ inputs.builddir }} -j$(nproc) ${{ inputs.extraParameters }} > ${{ inputs.logFile }} 2> ${{ inputs.errorFile }}
+    - name: Write report
+      shell: bash
+      if: always()
+      run: |
+        if [ ${{ steps.build.outcome }} == 'success' ]
+        then
+          echo "<details><summary>:heavy_check_mark: CMake build succeeded</summary>" >> ${{ inputs.reportFile }}
+        else
+          echo "<details><summary>:fire: CMake build failed</summary>" >> ${{ inputs.reportFile }}
+        fi
+        echo "" >> ${{ inputs.reportFile }}
+        echo "Build Error Log (stderr output):" >> ${{ inputs.reportFile }}
+        echo '```' >> ${{ inputs.reportFile }}
+        cat ${{ inputs.errorFile }} >> ${{ inputs.reportFile }}
+        echo '```' >> ${{ inputs.reportFile }}
+        echo "Build Log (stdout output trimmed to the last 100 Lines):" >> ${{ inputs.reportFile }}
+        echo '```' >> ${{ inputs.reportFile }}
+        tail -n 50 ${{ inputs.logFile }} >> ${{ inputs.reportFile }}
+        echo '```' >> ${{ inputs.reportFile }}
+        echo "</details>">> ${{ inputs.reportFile }}
+        echo "" >> ${{ inputs.reportFile }}
+        # Print the Log to the console
+        cat ${{ inputs.errorFile }}
+        echo "::group::Build Log"
+        cat ${{ inputs.logFile }}
+        echo "::endgroup::"

--- a/.github/workflows/actions/linux/build/action.yml
+++ b/.github/workflows/actions/linux/build/action.yml
@@ -46,7 +46,8 @@ runs:
       id: build
       shell: bash
       run: |
-        cmake --build ${{ inputs.builddir }} -j$(nproc) ${{ inputs.extraParameters }} > ${{ inputs.logFile }} 2> ${{ inputs.errorFile }}
+        (stdbuf -oL -eL cmake --build ${{ inputs.builddir }} -j$(nproc) ${{ inputs.extraParameters }}) \
+        2> >(tee -a ${{ inputs.errorFile }}) | tee -a ${{ inputs.logFile }}
     - name: Write report
       shell: bash
       if: always()
@@ -68,8 +69,3 @@ runs:
         echo '```' >> ${{ inputs.reportFile }}
         echo "</details>">> ${{ inputs.reportFile }}
         echo "" >> ${{ inputs.reportFile }}
-        # Print the Log to the console
-        cat ${{ inputs.errorFile }}
-        echo "::group::Build Log"
-        cat ${{ inputs.logFile }}
-        echo "::endgroup::"

--- a/.github/workflows/actions/linux/configure/action.yml
+++ b/.github/workflows/actions/linux/configure/action.yml
@@ -1,0 +1,79 @@
+# ***************************************************************************
+# *   Copyright (c) 2023 0penBrain                               *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   This program is distributed in the hope that it will be useful,       *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with this program; if not, write to the Free Software   *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+
+name: configure
+description: "Linux: configure CMake"
+
+inputs:
+  sourcedir:
+    description: "Directory where sources are stored"
+    required: false
+    default: ./
+  builddir:
+    description: "Directory where build will happen"
+    required: true
+  logFile:
+    description: "Path for log file"
+    required: true
+  errorFile:
+    description: "Path to error file"
+    required: true
+  reportFile:
+    description: "Path for report file"
+    required: true
+  extraParameters:
+    description: "Extra parameters to CMake configure"
+    required: false
+
+runs:
+  using: "composite"
+  steps:
+    - name: Configure CMake
+      id: configure
+      shell: bash
+      run: |
+        cmake -S ${{ inputs.sourcedir }} -B ${{ inputs.builddir }} -D CMAKE_EXPORT_COMPILE_COMMANDS:BOOL=TRUE ${{inputs.extraParameters }} > ${{ inputs.logFile }} 2> ${{ inputs.errorFile }}
+    - name: Write report
+      shell: bash
+      if: always()
+      run: |
+        if [ ${{ steps.configure.outcome }} == 'success' ]
+        then
+          echo "<details><summary>:heavy_check_mark: CMake configure succeeded</summary>" >> ${{ inputs.reportFile }}
+        else
+          echo "<details><summary>:fire: CMake configure failed</summary>" >> ${{ inputs.reportFile }}
+        fi
+        echo "" >> ${{ inputs.reportFile }}
+        echo "Configure Error Log (stderr output):" >> ${{ inputs.reportFile }}
+        echo '```' >> ${{ inputs.reportFile }}
+        cat ${{ inputs.errorFile }} >> ${{ inputs.reportFile }}
+        echo '```' >> ${{ inputs.reportFile }}
+        echo "Configure Log (stdout output):" >> ${{ inputs.reportFile }}
+        echo '```' >> ${{ inputs.reportFile }}
+        tail -n 60 ${{ inputs.logFile }} >> ${{ inputs.reportFile }}
+        echo '```' >> ${{ inputs.reportFile }}
+        echo "</details>">> ${{ inputs.reportFile }}
+        echo "" >> ${{ inputs.reportFile }}
+        # Print the Log to the console
+        cat ${{ inputs.errorFile }}
+        echo "::group::Configure Log"
+        cat ${{ inputs.logFile }}
+        echo "::endgroup::"

--- a/.github/workflows/actions/linux/configure/action.yml
+++ b/.github/workflows/actions/linux/configure/action.yml
@@ -50,7 +50,8 @@ runs:
       id: configure
       shell: bash
       run: |
-        cmake -S ${{ inputs.sourcedir }} -B ${{ inputs.builddir }} -D CMAKE_EXPORT_COMPILE_COMMANDS:BOOL=TRUE ${{inputs.extraParameters }} > ${{ inputs.logFile }} 2> ${{ inputs.errorFile }}
+        (stdbuf -oL -eL cmake -S ${{ inputs.sourcedir }} -B ${{ inputs.builddir }} -D CMAKE_EXPORT_COMPILE_COMMANDS:BOOL=TRUE ${{inputs.extraParameters }}) \
+        2> >(tee -a ${{ inputs.errorFile }}) | tee -a ${{ inputs.logFile }}
     - name: Write report
       shell: bash
       if: always()
@@ -72,8 +73,3 @@ runs:
         echo '```' >> ${{ inputs.reportFile }}
         echo "</details>">> ${{ inputs.reportFile }}
         echo "" >> ${{ inputs.reportFile }}
-        # Print the Log to the console
-        cat ${{ inputs.errorFile }}
-        echo "::group::Configure Log"
-        cat ${{ inputs.logFile }}
-        echo "::endgroup::"

--- a/.github/workflows/actions/linux/install/action.yml
+++ b/.github/workflows/actions/linux/install/action.yml
@@ -1,0 +1,75 @@
+# ***************************************************************************
+# *   Copyright (c) 2023 0penBrain                               *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   This program is distributed in the hope that it will be useful,       *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with this program; if not, write to the Free Software   *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+
+name: install
+description: "Linux: install application"
+
+inputs:
+  builddir:
+    description: "Directory where build is stored"
+    required: true
+  logFile:
+    description: "Path for log file"
+    required: true
+  errorFile:
+    description: "Path to error file"
+    required: true
+  reportFile:
+    description: "Path for report file"
+    required: true
+  extraParameters:
+    description: "Extra parameters to CMake install"
+    required: false
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install
+      id: install
+      shell: bash
+      run: |
+        sudo cmake --install ${{ inputs.builddir }} ${{ inputs.extraParameters }} >> ${{ inputs.logFile }} 2>> ${{ inputs.errorFile }}
+    - name: Write report
+      shell: bash
+      if: always()
+      run: |
+        if [ ${{ steps.install.outcome }} == 'success' ]
+        then
+          echo "<details><summary>:heavy_check_mark: CMake install succeeded</summary>" >> ${{ inputs.reportFile }}
+        else
+          echo "<details><summary>:fire: CMake install failed</summary>" >> ${{ inputs.reportFile }}
+        fi
+        echo "" >> ${{ inputs.reportFile }}
+        echo "Install Error Log (stderr output):" >> ${{ inputs.reportFile }}
+        echo '```' >> ${{ inputs.reportFile }}
+        cat ${{ inputs.errorFile }} >> ${{ inputs.reportFile }}
+        echo '```' >> ${{ inputs.reportFile }}
+        echo "Install Error Log (stdout output trimmed to the last 100 Lines):" >> ${{ inputs.reportFile }}
+        echo '```' >> ${{ inputs.reportFile }}
+        tail -n 100 ${{ inputs.logFile }} >> ${{ inputs.reportFile }}
+        echo '```' >> ${{ inputs.reportFile }}
+        echo "</details>">> ${{ inputs.reportFile }}
+        echo "" >> ${{ inputs.reportFile }}
+        # Print the Log to the console
+        cat ${{ inputs.errorFile }}
+        echo "::group::Install Log"
+        cat ${{ inputs.logFile }}
+        echo "::endgroup::"

--- a/.github/workflows/actions/linux/install/action.yml
+++ b/.github/workflows/actions/linux/install/action.yml
@@ -46,7 +46,8 @@ runs:
       id: install
       shell: bash
       run: |
-        sudo cmake --install ${{ inputs.builddir }} ${{ inputs.extraParameters }} >> ${{ inputs.logFile }} 2>> ${{ inputs.errorFile }}
+        (stdbuf -oL -eL sudo cmake --install ${{ inputs.builddir }} ${{ inputs.extraParameters }}) \
+        2> >(tee -a ${{ inputs.errorFile }}) | tee -a ${{ inputs.logFile }}
     - name: Write report
       shell: bash
       if: always()
@@ -68,8 +69,3 @@ runs:
         echo '```' >> ${{ inputs.reportFile }}
         echo "</details>">> ${{ inputs.reportFile }}
         echo "" >> ${{ inputs.reportFile }}
-        # Print the Log to the console
-        cat ${{ inputs.errorFile }}
-        echo "::group::Install Log"
-        cat ${{ inputs.logFile }}
-        echo "::endgroup::"

--- a/.github/workflows/actions/runTests/action.yml
+++ b/.github/workflows/actions/runTests/action.yml
@@ -43,7 +43,7 @@ runs:
       id: runTests
       shell: bash
       run: |
-        stdbuf -oL -eL ${{ inputs.testCommand }} |& sed -E '/[[:blank:]]*\([[:digit:]]{1,3} %\)[[:blank:]]*/d' | tee ${{ inputs.logFile }}
+        stdbuf -oL -eL ${{ inputs.testCommand }} |& sed -E '/[[:blank:]]*\([[:digit:]]{1,3} %\)[[:blank:]]*/d' | tee -a ${{ inputs.logFile }}
     - name: Write report
       shell: bash
       if: always()

--- a/.github/workflows/actions/runTests/action.yml
+++ b/.github/workflows/actions/runTests/action.yml
@@ -19,7 +19,7 @@
 # *                                                                         *
 # ***************************************************************************
 
-name: generateCacheKey
+name: runTests
 description: "Linux: run unit tests, generate log and report"
 
 inputs:

--- a/.github/workflows/sub_buildUbuntu2004.yml
+++ b/.github/workflows/sub_buildUbuntu2004.yml
@@ -166,37 +166,12 @@ jobs:
           ccache -z
           ccache -p
       - name: CMake Configure
-        run: |
-          set +e
-          cmake \
-          -D CMAKE_EXPORT_COMPILE_COMMANDS:BOOL=TRUE \
-          -B ${{ env.builddir }} > ${{ env.logdir }}Cmake.log 2> ${{ env.logdir }}CmakeErrors.log
-          exitCode=$?
-          # Write the configure report
-          if [ $exitCode -eq 0 ]
-          then
-            echo "<details><summary>:heavy_check_mark: CMake configure succeeded</summary>" >> ${{env.reportdir}}${{ env.reportfilename }}
-          else
-            echo "<details><summary>:fire: CMake configure failed</summary>" >> ${{env.reportdir}}${{ env.reportfilename }}
-          fi
-          echo "" >> ${{env.reportdir}}${{ env.reportfilename }}
-          echo "Configure Error Log (stderr output):" >> ${{env.reportdir}}${{ env.reportfilename }}
-          echo '```' >> ${{env.reportdir}}${{ env.reportfilename }}
-          cat ${{ env.logdir }}CmakeErrors.log >> ${{env.reportdir}}${{ env.reportfilename }}
-          echo '```' >> ${{env.reportdir}}${{ env.reportfilename }}
-          echo "Configure Log (stdout output):" >> ${{env.reportdir}}${{ env.reportfilename }}
-          echo '```' >> ${{env.reportdir}}${{ env.reportfilename }}
-          tail -n 60 ${{ env.logdir }}Cmake.log >> ${{env.reportdir}}${{ env.reportfilename }}
-          echo '```' >> ${{env.reportdir}}${{ env.reportfilename }}
-          echo "</details>">> ${{env.reportdir}}${{ env.reportfilename }}
-          echo "" >> ${{env.reportdir}}${{ env.reportfilename }}
-          # Print the Log to the console
-          cat ${{ env.logdir }}CmakeErrors.log
-          echo "::group::Configure Log"
-          cat ${{ env.logdir }}Cmake.log
-          echo "::endgroup::"
-          # Exit the step with the exit code of the configure
-          exit $exitCode
+        uses: ./.github/workflows/actions/linux/configure
+        with:
+          builddir: ${{ env.builddir }}
+          logFile: ${{ env.logdir }}Cmake.log
+          errorFile: ${{ env.logdir }}CmakeErrors.log
+          reportFile: ${{env.reportdir}}${{ env.reportfilename }}
       - name: CMake Build
         run: |
           set +e

--- a/.github/workflows/sub_buildUbuntu2004.yml
+++ b/.github/workflows/sub_buildUbuntu2004.yml
@@ -199,35 +199,12 @@ jobs:
           logFile: ${{ env.logdir }}TestGUIBuild.log
           reportFile: ${{env.reportdir}}${{ env.reportfilename }}
       - name: CMake Install
-        run: |
-          set +e
-          sudo cmake --install ${{ env.builddir }} >> ${{ env.logdir }}Install.log 2>> ${{ env.logdir }}InstallErrors.log
-          exitCode=$?
-          # Write the install report
-          if [ $exitCode -eq 0 ]
-          then
-            echo "<details><summary>:heavy_check_mark: CMake install succeeded</summary>" >> ${{env.reportdir}}${{ env.reportfilename }}
-          else
-            echo "<details><summary>:fire: CMake install failed</summary>" >> ${{env.reportdir}}${{ env.reportfilename }}
-          fi
-          echo "" >> ${{env.reportdir}}${{ env.reportfilename }}
-          echo "Install Error Log (stderr output):" >> ${{env.reportdir}}${{ env.reportfilename }}
-          echo '```' >> ${{env.reportdir}}${{ env.reportfilename }}
-          cat ${{ env.logdir }}InstallErrors.log >> ${{env.reportdir}}${{ env.reportfilename }}
-          echo '```' >> ${{env.reportdir}}${{ env.reportfilename }}
-          echo "Install Error Log (stdout output trimmed to the last 100 Lines):" >> ${{env.reportdir}}${{ env.reportfilename }}
-          echo '```' >> ${{env.reportdir}}${{ env.reportfilename }}
-          tail -n 100 ${{ env.logdir }}Install.log >> ${{env.reportdir}}${{ env.reportfilename }}
-          echo '```' >> ${{env.reportdir}}${{ env.reportfilename }}
-          echo "</details>">> ${{env.reportdir}}${{ env.reportfilename }}
-          echo "" >> ${{env.reportdir}}${{ env.reportfilename }}
-          # Print the Log to the console
-          cat ${{ env.logdir }}InstallErrors.log
-          echo "::group::Install Log"
-          cat ${{ env.logdir }}Install.log
-          echo "::endgroup::"
-          # Exit the step with the exit code of the install
-          exit $exitCode
+        uses: ./.github/workflows/actions/linux/install
+        with:
+          builddir: ${{ env.builddir }}
+          logFile: ${{ env.logdir }}Install.log
+          errorFile: ${{ env.logdir }}InstallErrors.log
+          reportFile: ${{env.reportdir}}${{ env.reportfilename }}
       - name: FreeCAD CLI tests on install
         uses: ./.github/workflows/actions/runTests
         with:

--- a/.github/workflows/sub_buildUbuntu2004.yml
+++ b/.github/workflows/sub_buildUbuntu2004.yml
@@ -173,35 +173,12 @@ jobs:
           errorFile: ${{ env.logdir }}CmakeErrors.log
           reportFile: ${{env.reportdir}}${{ env.reportfilename }}
       - name: CMake Build
-        run: |
-          set +e
-          cmake --build ${{ env.builddir}} -j$(nproc) > ${{ env.logdir }}Build.log 2> ${{ env.logdir }}BuildErrors.log
-          exitCode=$?
-          # Write the build report
-          if [ $exitCode -eq 0 ]
-          then
-            echo "<details><summary>:heavy_check_mark: CMake build succeeded</summary>" >> ${{env.reportdir}}${{ env.reportfilename }}
-          else
-            echo "<details><summary>:fire: CMake build failed</summary>" >> ${{env.reportdir}}${{ env.reportfilename }}
-          fi
-          echo "" >> ${{env.reportdir}}${{ env.reportfilename }}
-          echo "Build Error Log (stderr output):" >> ${{env.reportdir}}${{ env.reportfilename }}
-          echo '```' >> ${{env.reportdir}}${{ env.reportfilename }}
-          cat ${{ env.logdir }}BuildErrors.log >> ${{env.reportdir}}${{ env.reportfilename }}
-          echo '```' >> ${{env.reportdir}}${{ env.reportfilename }}
-          echo "Build Log (stdout output trimmed to the last 100 Lines):" >> ${{env.reportdir}}${{ env.reportfilename }}
-          echo '```' >> ${{env.reportdir}}${{ env.reportfilename }}
-          tail -n 50 ${{ env.logdir }}Build.log >> ${{env.reportdir}}${{ env.reportfilename }}
-          echo '```' >> ${{env.reportdir}}${{ env.reportfilename }}
-          echo "</details>">> ${{env.reportdir}}${{ env.reportfilename }}
-          echo "" >> ${{env.reportdir}}${{ env.reportfilename }}
-          # Print the Log to the console
-          cat ${{ env.logdir }}BuildErrors.log
-          echo "::group::Build Log"
-          cat ${{ env.logdir }}Build.log
-          echo "::endgroup::"
-          # Exit the step with the exit code of the build
-          exit $exitCode
+        uses: ./.github/workflows/actions/linux/build
+        with:
+          builddir: ${{ env.builddir }}
+          logFile: ${{ env.logdir }}Build.log
+          errorFile: ${{ env.logdir }}BuildErrors.log
+          reportFile: ${{env.reportdir}}${{ env.reportfilename }}
       - name: Print ccache statistics after Build
         run: |
           ccache -s

--- a/.github/workflows/sub_buildUbuntu2204.yml
+++ b/.github/workflows/sub_buildUbuntu2204.yml
@@ -208,35 +208,12 @@ jobs:
           logFile: ${{ env.logdir }}TestGUIBuild.log
           reportFile: ${{env.reportdir}}${{ env.reportfilename }}
       - name: CMake Install
-        run: |
-          set +e
-          sudo cmake --install ${{ env.builddir }} >> ${{ env.logdir }}Install.log 2>> ${{ env.logdir }}InstallErrors.log
-          exitCode=$?
-          # Write the install report
-          if [ $exitCode -eq 0 ]
-          then
-            echo "<details><summary>:heavy_check_mark: CMake install succeeded</summary>" >> ${{env.reportdir}}${{ env.reportfilename }}
-          else
-            echo "<details><summary>:fire: CMake install failed</summary>" >> ${{env.reportdir}}${{ env.reportfilename }}
-          fi
-          echo "" >> ${{env.reportdir}}${{ env.reportfilename }}
-          echo "Install Error Log (stderr output):" >> ${{env.reportdir}}${{ env.reportfilename }}
-          echo '```' >> ${{env.reportdir}}${{ env.reportfilename }}
-          cat ${{ env.logdir }}InstallErrors.log >> ${{env.reportdir}}${{ env.reportfilename }}
-          echo '```' >> ${{env.reportdir}}${{ env.reportfilename }}
-          echo "Install Error Log (stdout output trimmed to the last 100 Lines):" >> ${{env.reportdir}}${{ env.reportfilename }}
-          echo '```' >> ${{env.reportdir}}${{ env.reportfilename }}
-          tail -n 100 ${{ env.logdir }}Install.log >> ${{env.reportdir}}${{ env.reportfilename }}
-          echo '```' >> ${{env.reportdir}}${{ env.reportfilename }}
-          echo "</details>">> ${{env.reportdir}}${{ env.reportfilename }}
-          echo "" >> ${{env.reportdir}}${{ env.reportfilename }}
-          # Print the Log to the console
-          cat ${{ env.logdir }}InstallErrors.log
-          echo "::group::Install Log"
-          cat ${{ env.logdir }}Install.log
-          echo "::endgroup::"
-          # Exit the step with the exit code of the install
-          exit $exitCode
+        uses: ./.github/workflows/actions/linux/install
+        with:
+          builddir: ${{ env.builddir }}
+          logFile: ${{ env.logdir }}Install.log
+          errorFile: ${{ env.logdir }}InstallErrors.log
+          reportFile: ${{env.reportdir}}${{ env.reportfilename }}
       - name: FreeCAD CLI tests on install
         uses: ./.github/workflows/actions/runTests
         with:

--- a/.github/workflows/sub_buildUbuntu2204.yml
+++ b/.github/workflows/sub_buildUbuntu2204.yml
@@ -175,37 +175,12 @@ jobs:
           ccache -z
           ccache -p
       - name: CMake Configure
-        run: |
-          set +e
-          cmake \
-          -D CMAKE_EXPORT_COMPILE_COMMANDS:BOOL=TRUE \
-          -B ${{ env.builddir }} > ${{ env.logdir }}Cmake.log 2> ${{ env.logdir }}CmakeErrors.log
-          exitCode=$?
-          # Write the configure report
-          if [ $exitCode -eq 0 ]
-          then
-            echo "<details><summary>:heavy_check_mark: CMake configure succeeded</summary>" >> ${{env.reportdir}}${{ env.reportfilename }}
-          else
-            echo "<details><summary>:fire: CMake configure failed</summary>" >> ${{env.reportdir}}${{ env.reportfilename }}
-          fi
-          echo "" >> ${{env.reportdir}}${{ env.reportfilename }}
-          echo "Configure Error Log (stderr output):" >> ${{env.reportdir}}${{ env.reportfilename }}
-          echo '```' >> ${{env.reportdir}}${{ env.reportfilename }}
-          cat ${{ env.logdir }}CmakeErrors.log >> ${{env.reportdir}}${{ env.reportfilename }}
-          echo '```' >> ${{env.reportdir}}${{ env.reportfilename }}
-          echo "Configure Log (stdout output):" >> ${{env.reportdir}}${{ env.reportfilename }}
-          echo '```' >> ${{env.reportdir}}${{ env.reportfilename }}
-          tail -n 60 ${{ env.logdir }}Cmake.log >> ${{env.reportdir}}${{ env.reportfilename }}
-          echo '```' >> ${{env.reportdir}}${{ env.reportfilename }}
-          echo "</details>">> ${{env.reportdir}}${{ env.reportfilename }}
-          echo "" >> ${{env.reportdir}}${{ env.reportfilename }}
-          # Print the Log to the console
-          cat ${{ env.logdir }}CmakeErrors.log
-          echo "::group::Configure Log"
-          cat ${{ env.logdir }}Cmake.log
-          echo "::endgroup::"
-          # Exit the step with the exit code of the configure
-          exit $exitCode
+        uses: ./.github/workflows/actions/linux/configure
+        with:
+          builddir: ${{ env.builddir }}
+          logFile: ${{ env.logdir }}Cmake.log
+          errorFile: ${{ env.logdir }}CmakeErrors.log
+          reportFile: ${{env.reportdir}}${{ env.reportfilename }}
       - name: CMake Build
         run: |
           set +e

--- a/.github/workflows/sub_buildUbuntu2204.yml
+++ b/.github/workflows/sub_buildUbuntu2204.yml
@@ -182,35 +182,12 @@ jobs:
           errorFile: ${{ env.logdir }}CmakeErrors.log
           reportFile: ${{env.reportdir}}${{ env.reportfilename }}
       - name: CMake Build
-        run: |
-          set +e
-          cmake --build ${{ env.builddir}} -j$(nproc) > ${{ env.logdir }}Build.log 2> ${{ env.logdir }}BuildErrors.log
-          exitCode=$?
-          # Write the build report
-          if [ $exitCode -eq 0 ]
-          then
-            echo "<details><summary>:heavy_check_mark: CMake build succeeded</summary>" >> ${{env.reportdir}}${{ env.reportfilename }}
-          else
-            echo "<details><summary>:fire: CMake build failed</summary>" >> ${{env.reportdir}}${{ env.reportfilename }}
-          fi
-          echo "" >> ${{env.reportdir}}${{ env.reportfilename }}
-          echo "Build Error Log (stderr output):" >> ${{env.reportdir}}${{ env.reportfilename }}
-          echo '```' >> ${{env.reportdir}}${{ env.reportfilename }}
-          cat ${{ env.logdir }}BuildErrors.log >> ${{env.reportdir}}${{ env.reportfilename }}
-          echo '```' >> ${{env.reportdir}}${{ env.reportfilename }}
-          echo "Build Log (stdout output trimmed to the last 100 Lines):" >> ${{env.reportdir}}${{ env.reportfilename }}
-          echo '```' >> ${{env.reportdir}}${{ env.reportfilename }}
-          tail -n 50 ${{ env.logdir }}Build.log >> ${{env.reportdir}}${{ env.reportfilename }}
-          echo '```' >> ${{env.reportdir}}${{ env.reportfilename }}
-          echo "</details>">> ${{env.reportdir}}${{ env.reportfilename }}
-          echo "" >> ${{env.reportdir}}${{ env.reportfilename }}
-          # Print the Log to the console
-          cat ${{ env.logdir }}BuildErrors.log
-          echo "::group::Build Log"
-          cat ${{ env.logdir }}Build.log
-          echo "::endgroup::"
-          # Exit the step with the exit code of the build
-          exit $exitCode
+        uses: ./.github/workflows/actions/linux/build
+        with:
+          builddir: ${{ env.builddir }}
+          logFile: ${{ env.logdir }}Build.log
+          errorFile: ${{ env.logdir }}BuildErrors.log
+          reportFile: ${{env.reportdir}}${{ env.reportfilename }}
       - name: Print ccache statistics after Build
         run: |
           ccache -s

--- a/.github/workflows/sub_lint.yml
+++ b/.github/workflows/sub_lint.yml
@@ -131,7 +131,7 @@ on:
         type: string
         required: false
       codespellFailSilent:
-        default: false
+        default: true
         type: boolean
         required: false
       checkClangTidy:

--- a/.github/workflows/sub_wrapup.yml
+++ b/.github/workflows/sub_wrapup.yml
@@ -108,6 +108,7 @@ jobs:
           echo "EOD" >> $GITHUB_ENV
           cat report.md >> $GITHUB_STEP_SUMMARY
       - name: Delete used artifacts
+        continue-on-error: true
         uses: geekyeggo/delete-artifact@v2
         with:
           name: |

--- a/.github/workflows/sub_wrapup.yml
+++ b/.github/workflows/sub_wrapup.yml
@@ -66,7 +66,7 @@ jobs:
           for step in $(jq -r "keys_unsorted | .[]" data)
           do
             echo "Processing step $step"
-            result=$(jq -r ".$step.result" data)
+            result=$(jq -r ".\"$step\".result" data)
             icon=":heavy_check_mark:"
             if [ $result == 'failure' ]
             then
@@ -87,7 +87,7 @@ jobs:
             then
               echo "Step was cancelled when executing, report may be incomplete" | tee -a report.md
             fi
-            report=$(jq -r ".$step.outputs.reportFile" data)
+            report=$(jq -r ".\"$step\".outputs.reportFile" data)
             if [ $report ]
             then
               echo "Report for step $step is $report"


### PR DESCRIPTION
This PR brings some improvements to CI.

Structure:
* Cmake configure, build & install steps are factorized in a composite action for both Linux jobs

Performance:
* Logging is improved for configure, build & install steps
  * Line buffered output for stdout & stderr
  * Full log contains both stdout & stderr (previously only stdout) so errors can be looked at contextually

Other:
* Rename Ubuntu build jobs for better comprehension
* Spell checker (lint) will silently fail. Not failing the workflow anymore, but still reporting errors
* In wrapup job, deleting used artifact is allowed to fail (already happened that it failed a job)