### PR TITLE
[FEM] improve messages in mesh generation

### DIFF
--- a/src/Mod/Fem/femmesh/gmshtools.py
+++ b/src/Mod/Fem/femmesh/gmshtools.py
@@ -394,11 +394,11 @@ class GmshTools():
                     self.group_elements[ge] = new_group_elements[ge]
                 else:
                     Console.PrintError("  A group with this name exists already.\n")
-        else:
-            Console.PrintMessage("  No Group meshing for analysis.\n")
+        #else:
+        #    Console.PrintMessage("  No Group meshing for analysis.\n")
 
-        if self.group_elements:
-            Console.PrintMessage("  {}\n".format(self.group_elements))
+        #if self.group_elements:
+        #    Console.PrintMessage("  {}\n".format(self.group_elements))
 
     def get_gmsh_version(self):
         self.get_gmsh_command()
@@ -447,7 +447,7 @@ class GmshTools():
             # print("  No mesh regions.")
             pass
         else:
-            Console.PrintMessage("  Mesh regions, we need to get the elements.\n")
+            #Console.PrintMessage("  Mesh regions, we need to get the elements.\n")
             # by the use of MeshRegion object and a BooleanSplitCompound
             # there could be problems with node numbers see
             # http://forum.freecadweb.org/viewtopic.php?f=18&t=18780&start=40#p149467
@@ -461,17 +461,7 @@ class GmshTools():
                     or femutils.is_of_type(part, "FeatureXOR")
                 )
             ):
-                error_message = (
-                    "  The mesh to shape is a boolean split tools Compound "
-                    "and the mesh has mesh region list. "
-                    "Gmsh could return unexpected meshes in such circumstances. "
-                    "It is strongly recommended to extract the shape to mesh "
-                    "from the Compound and use this one."
-                )
-                Console.PrintError(error_message + "\n")
-                # TODO: no gui popup because FreeCAD will be in a endless output loop
-                #       as long as the pop up is on --> maybe find a better solution for
-                #       either of both --> thus the pop up is in task panel
+                self.outputCompoundWarning
             for mr_obj in self.mesh_obj.MeshRegionList:
                 # print(mr_obj.Name)
                 # print(mr_obj.CharacteristicLength)
@@ -540,8 +530,8 @@ class GmshTools():
                 ele_shape = geomtools.get_element(self.part_obj, eleml)
                 ele_vertexes = geomtools.get_vertexes_by_element(self.part_obj.Shape, ele_shape)
                 self.ele_node_map[eleml] = ele_vertexes
-            Console.PrintMessage("  {}\n".format(self.ele_length_map))
-            Console.PrintMessage("  {}\n".format(self.ele_node_map))
+            #Console.PrintMessage("  {}\n".format(self.ele_length_map))
+            #Console.PrintMessage("  {}\n".format(self.ele_node_map))
 
     def get_boundary_layer_data(self):
         # mesh boundary layer
@@ -553,16 +543,11 @@ class GmshTools():
             # print("  No mesh boundary layer setting document object.")
             pass
         else:
-            Console.PrintMessage("  Mesh boundary layers, we need to get the elements.\n")
+            #Console.PrintMessage("  Mesh boundary layers, we need to get the elements.\n")
             if self.part_obj.Shape.ShapeType == "Compound":
                 # see http://forum.freecadweb.org/viewtopic.php?f=18&t=18780&start=40#p149467 and
                 # http://forum.freecadweb.org/viewtopic.php?f=18&t=18780&p=149520#p149520
-                err = (
-                    "Gmsh could return unexpected meshes for a boolean split tools Compound. "
-                    "It is strongly recommended to extract the shape to mesh "
-                    "from the Compound and use this one."
-                )
-                Console.PrintError(err + "\n")
+                self.outputCompoundWarning
             for mr_obj in self.mesh_obj.MeshBoundaryLayerList:
                 if mr_obj.MinimumThickness and Units.Quantity(mr_obj.MinimumThickness).Value > 0:
                     if mr_obj.References:
@@ -959,6 +944,17 @@ class GmshTools():
             Console.PrintMessage("  New mesh was added to the mesh object.\n")
         else:
             Console.PrintError("No mesh was created.\n")
+
+    def outputCompoundWarning(self):
+        error_message = (
+            "The mesh to shape is a Boolean Split Tools compound "
+            "and the mesh has mesh region list.\n"
+            "Gmsh could return unexpected meshes in such circumstances.\n"
+            "If this is the case, use the part workbench and "
+            "apply a Compound Filter on the compound.\n"
+            "Use the Compound Filter as input for the mesh."
+        )
+        Console.PrintWarning(error_message + "\n")
 
 ##  @}
 

--- a/src/Mod/Fem/femviewprovider/view_mesh_gmsh.py
+++ b/src/Mod/Fem/femviewprovider/view_mesh_gmsh.py
@@ -36,7 +36,6 @@ import FemGui
 from PySide import QtGui
 from femtaskpanels import task_mesh_gmsh
 from femtools.femutils import is_of_type
-# from . import view_base_femobject
 
 
 # TODO use VPBaseFemObject from view_base_femobject


### PR DESCRIPTION
- no longer output an error on mesh from a BooleanFragments. There are cases when this fails, but other cases where one must use a BoopleanFragments compound and this works well, see https://forum.freecad.org/viewtopic.php?t=71070. Therefore a warning is sufficient.
- disable log messages not important for the average users.
- avoid code duplication