### PR TITLE
Arch: fix incorrect indentation in ArchStairs.py

### DIFF
--- a/src/Mod/Arch/ArchStairs.py
+++ b/src/Mod/Arch/ArchStairs.py
@@ -236,7 +236,7 @@ class _CommandStairs:
 
         FreeCADGui.addModule("Draft")
         for obj in stairs:
-                Draft.autogroup(obj) # seems not working?
+            Draft.autogroup(obj) # seems not working?
 
         FreeCAD.ActiveDocument.commitTransaction()
         FreeCAD.ActiveDocument.recompute()


### PR DESCRIPTION
Bad indentation in `src/Mod/Arch/ArchStairs.py`

---

- [x]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

