### PR TITLE
[FEM] improve visualization of pvtu files

### DIFF
--- a/src/Mod/Fem/Gui/ViewProviderFemPostObject.h
+++ b/src/Mod/Fem/Gui/ViewProviderFemPostObject.h
@@ -28,6 +28,7 @@
 #include <Mod/Fem/FemGlobal.h>
 
 #include <vtkAppendPolyData.h>
+#include <vtkDataObject.h>
 #include <vtkExtractEdges.h>
 #include <vtkGeometryFilter.h>
 #include <vtkOutlineCornerFilter.h>
@@ -150,6 +151,7 @@ protected:
     vtkSmartPointer<vtkVertexGlyphFilter>       m_points, m_pointsSurface;
 
 private:
+    void filterArtifacts(vtkDataObject* data);
     void updateProperties();
     void update3D();
     void WritePointData(vtkPoints *points, vtkDataArray *normals,


### PR DESCRIPTION
- To speed up analyses one calculates on several CPU cores. The result is a partial VTU (*.ptvu) file. Unfortunately when applying a transparency the boundaries of the volumes computed by each CPU core are always visible. This makes it often unusable for visualizations. The solution is to filter the results the same way a clip filter does.