### PR TITLE
[FEM] Contours: fix task panel logic

### DIFF
--- a/src/Mod/Fem/App/FemPostFilter.cpp
+++ b/src/Mod/Fem/App/FemPostFilter.cpp
@@ -477,7 +477,8 @@ FemPostContoursFilter::FemPostContoursFilter()
     ADD_PROPERTY_TYPE(Field, (long(0)), "Clip", App::Prop_None, "The field used to clip");
     ADD_PROPERTY_TYPE(
         VectorMode, ((long)0), "Contours", App::Prop_None, "Select what vector field");
-    ADD_PROPERTY_TYPE(NoColor, (false), "Contours", App::Prop_None, "Don't color the contours");
+    ADD_PROPERTY_TYPE(NoColor, (false), "Contours",
+        PropertyType(Prop_Hidden), "Don't color the contours");
 
     m_contourConstraints.LowerBound = 1;
     m_contourConstraints.UpperBound = 1000;

--- a/src/Mod/Fem/Gui/TaskPostBoxes.h
+++ b/src/Mod/Fem/Gui/TaskPostBoxes.h
@@ -385,7 +385,7 @@ private:
     QWidget* proxy;
     std::unique_ptr<Ui_TaskPostContours> ui;
     bool blockVectorUpdate = false;
-    void updateFields(int idx);
+    void updateFields();
 };
 
 


### PR DESCRIPTION
- the ViewProvider sorting of the field can be different from the sorting in the dialog

- also hide a Contours property (I forgot this when the contours filter was added)