### PR TITLE
[Draft] typo: Mirror object name should be capitalized

### DIFF
--- a/src/Mod/Draft/draftfunctions/mirror.py
+++ b/src/Mod/Draft/draftfunctions/mirror.py
@@ -109,8 +109,8 @@ def mirror(objlist, p1, p2):
     result = []
 
     for obj in objlist:
-        mir = App.ActiveDocument.addObject("Part::Mirroring", "mirror")
-        mir.Label = obj.Label + " (" + translate("draft","mirrored") + ") "
+        mir = App.ActiveDocument.addObject("Part::Mirroring", "Mirror")
+        mir.Label = obj.Label + " (" + translate("draft", "mirrored") + ")"
         mir.Source = obj
         mir.Base = p1
         mir.Normal = pnorm


### PR DESCRIPTION
Typo.

- [ ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

---
