### PR TITLE
Draft: fix typos

### DIFF
--- a/src/Mod/Draft/draftmake/make_dimension.py
+++ b/src/Mod/Draft/draftmake/make_dimension.py
@@ -195,7 +195,7 @@ def make_linear_dimension(p1, p2, dim_line=None):
         positioned from the measured segment that goes from `p1` to `p2`.
 
         If it is `None`, this point will be calculated from the intermediate
-        distance betwwen `p1` and `p2`.
+        distance between `p1` and `p2`.
 
     Returns
     -------
@@ -288,7 +288,7 @@ def make_linear_dimension_obj(edge_object, i1=1, i2=2, dim_line=None):
         positioned from the measured segment in `edge_object`.
 
         If it is `None`, this point will be calculated from the intermediate
-        distance betwwen the vertices defined by `i1` and `i2`.
+        distance between the vertices defined by `i1` and `i2`.
 
     Returns
     -------

--- a/src/Mod/Draft/draftutils/init_draft_statusbar.py
+++ b/src/Mod/Draft/draftutils/init_draft_statusbar.py
@@ -67,7 +67,7 @@ draft_scales_eng_imperial =  ["1in=10ft", "1in=20ft", "1in=30ft",
 
 def get_scales(unit_system = 0):
     """
-    returns the list of preset scales accordin to unit system.
+    returns the list of preset scales according to unit system.
 
     Parameters:
     unit_system =   0 : default from user preferences


### PR DESCRIPTION
Fixes some Draft workbench source comment typos

---

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR
