### PR TITLE
Start: Allow to change the default import module for a filetype

### DIFF
--- a/src/Mod/Start/StartPage/LoadCustom.py
+++ b/src/Mod/Start/StartPage/LoadCustom.py
@@ -35,10 +35,9 @@ if cfolders:
     if not os.path.isdir(cfolder):
         cfolder = os.path.dirname(cfolder)
     f = unquote(filename).replace("+", " ")
-    if f.lower().endswith(".fcstd"):
-        FreeCAD.open(os.path.join(cfolder, f))
-    else:
-        FreeCAD.loadFile(os.path.join(cfolder, f))
+    ext = os.path.splitext(filename)[1].lower().strip(".")
+    mod = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Start").GetString("DefaultImport"+ext,"")
+    FreeCAD.loadFile(os.path.join(cfolder, f),mod)
     FreeCADGui.activeDocument().sendMsgToViews("ViewFit")
 
     from StartPage import StartPage

--- a/src/Mod/Start/StartPage/LoadMRU.py
+++ b/src/Mod/Start/StartPage/LoadMRU.py
@@ -19,10 +19,16 @@
 #*                                                                         *
 #***************************************************************************
 
+import os
+import FreeCAD
 import FreeCADGui
+
 # MRU will be given before this script is run
-rf=FreeCAD.ParamGet("User parameter:BaseApp/Preferences/RecentFiles")
-FreeCADGui.loadFile(rf.GetString("MRU"+str(MRU)))
+rf = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/RecentFiles")
+filename = rf.GetString("MRU"+str(MRU))
+ext = os.path.splitext(filename)[1].lower().strip(".")
+mod = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Start").GetString("DefaultImport"+ext, "")
+FreeCADGui.loadFile(filename, mod)
 
 from StartPage import StartPage
 StartPage.postStart()


### PR DESCRIPTION
By setting a DefaultImportXXX preferences parameter under Mod/Start, one can specify a default import module to use when clicking a .XXX file on the Start page. This is specially useful for filetypes that have several importers, and the Start page would not let users choose which importer to use.

Later on if this proves useful we can set up an UI to let the user set their preferences better.

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [x]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
