### PR TITLE
Arch: Placeholder modules to handle files containing NativeIFC objects

### DIFF
--- a/src/Mod/Arch/CMakeLists.txt
+++ b/src/Mod/Arch/CMakeLists.txt
@@ -59,6 +59,8 @@ SET(Arch_SRCS
     ArchCurtainWall.py
     importSHP.py
     exportIFCStructuralTools.py
+    ifc_objects.py
+    ifc_viewproviders.py
 )
 
 SET(Dice3DS_SRCS

--- a/src/Mod/Arch/ifc_objects.py
+++ b/src/Mod/Arch/ifc_objects.py
@@ -1,0 +1,33 @@
+#***************************************************************************
+#*                                                                         *
+#*   Copyright (c) 2022 Yorik van Havre <yorik@uncreated.net>              *
+#*                                                                         *
+#*   This program is free software; you can redistribute it and/or modify  *
+#*   it under the terms of the GNU General Public License (GPL)            *
+#*   as published by the Free Software Foundation; either version 3 of     *
+#*   the License, or (at your option) any later version.                   *
+#*   for detail see the LICENCE text file.                                 *
+#*                                                                         *
+#*   This program is distributed in the hope that it will be useful,       *
+#*   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+#*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+#*   GNU General Public License for more details.                          *
+#*                                                                         *
+#*   You should have received a copy of the GNU Library General Public     *
+#*   License along with this program; if not, write to the Free Software   *
+#*   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+#*   USA                                                                   *
+#*                                                                         *
+#***************************************************************************
+
+class ifc_object:
+    """NativeIFC class placeholder"""
+    def __init__(self):
+        pass
+    def onDocumentRestored(self, obj):
+            obj.Type = [obj.IfcType]
+            obj.Type = obj.IfcType
+    def __getstate__(self):
+        return None
+    def __setstate__(self, state):
+        return None

--- a/src/Mod/Arch/ifc_viewproviders.py
+++ b/src/Mod/Arch/ifc_viewproviders.py
@@ -1,0 +1,48 @@
+#***************************************************************************
+#*                                                                         *
+#*   Copyright (c) 2022 Yorik van Havre <yorik@uncreated.net>              *
+#*                                                                         *
+#*   This program is free software; you can redistribute it and/or modify  *
+#*   it under the terms of the GNU General Public License (GPL)            *
+#*   as published by the Free Software Foundation; either version 3 of     *
+#*   the License, or (at your option) any later version.                   *
+#*   for detail see the LICENCE text file.                                 *
+#*                                                                         *
+#*   This program is distributed in the hope that it will be useful,       *
+#*   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+#*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+#*   GNU General Public License for more details.                          *
+#*                                                                         *
+#*   You should have received a copy of the GNU Library General Public     *
+#*   License along with this program; if not, write to the Free Software   *
+#*   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+#*   USA                                                                   *
+#*                                                                         *
+#***************************************************************************
+
+import FreeCAD
+
+class ifc_vp_object:
+    """NativeIFC class placeholder"""
+    def __init__(self):
+        pass
+    def attach(self, vobj):
+        return
+    def getDisplayModes(self, obj):
+        return []
+    def getDefaultDisplayMode(self):
+        return "FlatLines"
+    def setDisplayMode(self,mode):
+        return mode
+    def __getstate__(self):
+        return None
+    def __setstate__(self, state):
+        return None
+
+class ifc_vp_document(ifc_vp_object):
+    """NativeIFC class placeholder"""
+    def __init__(self):
+        pass
+    def attach(self, vobj):
+        FreeCAD.Console.PrintWarning("Warning: Object "+vobj.Object.Label+" depends on the NativeIFC addon which is not installed, and will not display correctly in the 3D view\n")
+        return


### PR DESCRIPTION
This commit adds two placeholder files to the Arch workbench, to allow opening files containing [NativeIFC](https://github.com/yorikvanhavre/FreeCAD-NativeIFC) objects without errors, same as we did already for the ArchSketch WB.

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [ ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
