### PR TITLE
Sketcher: Fonts  and parameter updates

### DIFF
--- a/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
@@ -148,6 +148,8 @@ void EditModeCoinManager::ParameterObserver::initParameters()
             [this, drawingParameters = Client.drawingParameters](const std::string & param){updateColor(drawingParameters.PreselectColor, param);}},
         {"SelectionColor",
             [this, drawingParameters = Client.drawingParameters](const std::string & param){updateColor(drawingParameters.SelectColor, param);}},
+        {"CursorTextColor",
+            [this, drawingParameters = Client.drawingParameters](const std::string & param){updateColor(drawingParameters.CursorTextColor, param);}},
     };
 
     for( auto & val : str2updatefunction){
@@ -230,12 +232,12 @@ void EditModeCoinManager::ParameterObserver::updateElementSizeParameters(const s
     // simple scaling factor for hardcoded pixel values in the Sketcher
     Client.drawingParameters.pixelScalingFactor = viewScalingFactor * dpi / 96; // 96 ppi is the standard pixel density for which pixel quantities were calculated
 
-    // Coin documentation indicates the size of a font is:
-    // SoSFFloat SoFont::size        Size of font. Defaults to 10.0.
+    // About sizes:
+    // SoDatumLabel takes the size in points, not in pixels. This is because it uses QFont internally.
+    // Coin, at least our coin at this time, takes pixels, not points.
     //
-    // For 2D rendered bitmap fonts (like for SoText2), this value is the height of a character in screen pixels. For 3D text, this value is the world-space coordinates height of a character in the current units setting (see documentation for SoUnits node).
-    //
-    // However, with hdpi monitors, the coin font labels do not respect the size passed in pixels:
+    // DPI considerations:
+    // With hdpi monitors, the coin font labels do not respect the size passed in pixels:
     // https://forum.freecadweb.org/viewtopic.php?f=3&t=54347&p=467610#p467610
     // https://forum.freecadweb.org/viewtopic.php?f=10&t=49972&start=40#p467471
     //
@@ -247,7 +249,8 @@ void EditModeCoinManager::ParameterObserver::updateElementSizeParameters(const s
     // This means that the following correction does not have a documented basis, but appears necessary so that the Sketcher is usable in
     // HDPI monitors.
 
-    Client.drawingParameters.coinFontSize = std::lround(sketcherfontSize * 96.0f / dpi);
+    Client.drawingParameters.coinFontSize = std::lround(sketcherfontSize * 96.0f / dpi); // this is in pixels
+    Client.drawingParameters.labelFontSize = std::lround(sketcherfontSize * 72.0f / dpi); // this is in points, as SoDatumLabel uses points
     Client.drawingParameters.constraintIconSize = std::lround(0.8 * sketcherfontSize);
 
     // For marker size the global default is used.
@@ -269,6 +272,8 @@ void EditModeCoinManager::ParameterObserver::updateColor(SbColor &sbcolor, const
     unsigned long color = (unsigned long)(sbcolor.getPackedValue());
     color = hGrp->GetUnsigned(parametername.c_str(), color);
     sbcolor.setPackedValue((uint32_t)color, transparency);
+
+    Client.updateInventorColors();
 }
 
 void EditModeCoinManager::ParameterObserver::subscribeToParameters()
@@ -705,13 +710,6 @@ void EditModeCoinManager::createEditModeInventorNodes()
     editModeScenegraphNodes.EditCurveSet->setName("EditCurveLineSet");
     editCurvesRoot->addChild(editModeScenegraphNodes.EditCurveSet);
 
-    ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/View");
-    float transparency;
-    SbColor cursorTextColor(0,0,1);
-    cursorTextColor.setPackedValue((uint32_t)hGrp->GetUnsigned("CursorTextColor", cursorTextColor.getPackedValue()), transparency);
-    int defaultFontSizePixels = defaultApplicationFontSizePixels(); // returns height in pixels, not points
-    int cursorFontSize = hGrp->GetInt("EditSketcherFontSize", defaultFontSizePixels);
-
     // stuff for the EditMarkers +++++++++++++++++++++++++++++++++++++++
     SoSeparator* editMarkersRoot = new SoSeparator;
     editModeScenegraphNodes.EditRoot->addChild(editMarkersRoot);
@@ -742,15 +740,16 @@ void EditModeCoinManager::createEditModeInventorNodes()
     // no caching for frequently-changing data structures
     Coordsep->renderCaching = SoSeparator::OFF;
 
-    SoMaterial *CoordTextMaterials = new SoMaterial;
-    CoordTextMaterials->setName("CoordTextMaterials");
-    CoordTextMaterials->diffuseColor = cursorTextColor;
-    Coordsep->addChild(CoordTextMaterials);
+    editModeScenegraphNodes.textMaterial = new SoMaterial;
+    editModeScenegraphNodes.textMaterial->setName("CoordTextMaterials");
+    editModeScenegraphNodes.textMaterial->diffuseColor = drawingParameters.CursorTextColor;
+    Coordsep->addChild(editModeScenegraphNodes.textMaterial);
 
-    SoFont *font = new SoFont();
-    font->size.setValue(cursorFontSize);
+    editModeScenegraphNodes.textFont = new SoFont();
+    editModeScenegraphNodes.textFont->name.setValue("Helvetica");
+    editModeScenegraphNodes.textFont->size.setValue(drawingParameters.coinFontSize);
 
-    Coordsep->addChild(font);
+    Coordsep->addChild(editModeScenegraphNodes.textFont);
 
     editModeScenegraphNodes.textPos = new SoTranslation();
     Coordsep->addChild(editModeScenegraphNodes.textPos);
@@ -830,7 +829,16 @@ void EditModeCoinManager::updateInventorNodeSizes()
     editModeScenegraphNodes.ConstraintDrawStyle->lineWidth = 1 * drawingParameters.pixelScalingFactor;
     editModeScenegraphNodes.InformationDrawStyle->lineWidth = 1 * drawingParameters.pixelScalingFactor;
 
+    editModeScenegraphNodes.textFont->size.setValue(drawingParameters.coinFontSize);
+
     pEditModeConstraintCoinManager->rebuildConstraintNodes();
+}
+
+void EditModeCoinManager::updateInventorColors()
+{
+    editModeScenegraphNodes.RootCrossMaterials->diffuseColor.set1Value(0, drawingParameters.CrossColorH);
+    editModeScenegraphNodes.RootCrossMaterials->diffuseColor.set1Value(1, drawingParameters.CrossColorV);
+    editModeScenegraphNodes.textMaterial->diffuseColor = drawingParameters.CursorTextColor;
 }
 
 /************************ Edit node access ************************/

--- a/src/Mod/Sketcher/Gui/EditModeCoinManager.h
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManager.h
@@ -262,6 +262,8 @@ private:
 
     void updateInventorNodeSizes();
 
+    void updateInventorColors();
+
     /** @name coin nodes creation*/
     void createEditModeInventorNodes();
     //@}

--- a/src/Mod/Sketcher/Gui/EditModeCoinManagerParameters.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManagerParameters.cpp
@@ -51,5 +51,6 @@ SbColor DrawingParameters::ConstrIcoColor                           (1.0f,  0.14
 SbColor DrawingParameters::NonDrivingConstrDimColor                 (0.0f,  0.149f, 1.0f);   // #0026FF -> (  0, 38,255)
 SbColor DrawingParameters::ExprBasedConstrDimColor                  (1.0f,  0.5f,   0.149f);   // #FF7F26 -> (255, 127,38)
 SbColor DrawingParameters::DeactivatedConstrDimColor                (0.8f,  0.8f,   0.8f);     // #CCCCCC -> (204,204,204)
+SbColor DrawingParameters::CursorTextColor                          (0.0f,  0.0f,   1.0f);  // #0000FF -> (0,0,255)
 
 const MultiFieldId MultiFieldId::Invalid = MultiFieldId();

--- a/src/Mod/Sketcher/Gui/EditModeCoinManagerParameters.h
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManagerParameters.h
@@ -31,6 +31,7 @@
 #include <Inventor/SbColor.h>
 #include <Inventor/nodes/SoDrawStyle.h>
 #include <Inventor/nodes/SoCoordinate3.h>
+#include <Inventor/nodes/SoFont.h>
 #include <Inventor/nodes/SoGroup.h>
 #include <Inventor/nodes/SoLineSet.h>
 #include <Inventor/nodes/SoMarkerSet.h>
@@ -38,6 +39,7 @@
 #include <Inventor/nodes/SoPickStyle.h>
 #include <Inventor/nodes/SoText2.h>
 #include <Inventor/nodes/SoTranslation.h>
+
 
 #include <Gui/Inventor/SmSwitchboard.h>
 #include <Mod/Sketcher/App/GeoList.h>
@@ -112,12 +114,14 @@ struct DrawingParameters {
     static SbColor NonDrivingConstrDimColor;                    // Color used for non-driving (reference) dimensional constraints
     static SbColor ExprBasedConstrDimColor;                     // Color used for expression based dimensional constraints
     static SbColor DeactivatedConstrDimColor;                   // Color used for deactivated dimensional constraints
+    static SbColor CursorTextColor;                              // Color used by the edit mode cursor
     //@}
 
     /** @name Rendering sizes (also to support HDPI monitors) **/
     //@{
     double pixelScalingFactor = 1.0;    // Scaling factor to be used for pixels
     int coinFontSize = 17;              // Font size to be used by coin
+    int labelFontSize = 17;             // Font size to be used by SoDatumLabel, which uses a QPainter and a QFont internally
     int constraintIconSize = 15;        // Size of constraint icons
     int markerSize = 7;                 // Size used for markers
     //@}
@@ -326,6 +330,8 @@ struct EditModeScenegraphNodes {
     //@{
     SoText2       *textX;
     SoTranslation *textPos;
+    SoFont        *textFont;
+    SoMaterial    *textMaterial;
     //@}
 
     /** @name Constraint nodes*/

--- a/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
@@ -1440,7 +1440,7 @@ void EditModeConstraintCoinManager::rebuildConstraintNodes(const GeoListFacade &
                                             drawingParameters.ConstrDimColor
                                             :drawingParameters.NonDrivingConstrDimColor)
                                         :drawingParameters.DeactivatedConstrDimColor;
-                text->size.setValue(drawingParameters.coinFontSize);
+                text->size.setValue(drawingParameters.labelFontSize);
                 text->lineWidth = 2 * drawingParameters.pixelScalingFactor;
                 text->useAntialiasing = false;
                 SoAnnotation *anno = new SoAnnotation();

--- a/src/Mod/Sketcher/Gui/EditModeInformationOverlayCoinConverter.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeInformationOverlayCoinConverter.cpp
@@ -365,9 +365,9 @@ void EditModeInformationOverlayCoinConverter::addNode(const Result & result) {
             else
                 setText(result.strings[i], text);
 
-            sep->addChild(translate);
             sep->addChild(mat);
             sep->addChild(font);
+            sep->addChild(translate);
             sep->addChild(text);
 
             sw->addChild(sep);


### PR DESCRIPTION
This PR contains a fix associated to:
https://github.com/FreeCAD/FreeCAD/pull/8481

Several parameters from preferences where being observed, but not updated. This also affected the stored preferences, as the observer is initialised after the inventor nodes are created.

It did affect some font and some colours.

Regarding fonts, the code now provides for a differentiated size for SoDatumLabels (the dimension of constraints), as unlike the rest of coin nodes, works with Points (as it uses QFont internally). The rest of coin font sizes are in pixels.

