### PR TITLE
[FEM] make pvtu file filtering optional

### DIFF
--- a/src/Mod/Fem/Gui/DlgSettingsFemElmer.ui
+++ b/src/Mod/Fem/Gui/DlgSettingsFemElmer.ui
@@ -6,15 +6,15 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
-    <height>203</height>
+    <width>350</width>
+    <height>259</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Elmer</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
-   <item>
+  <layout class="QGridLayout" name="gridLayout_3">
+   <item row="0" column="0">
     <widget class="QGroupBox" name="gb_gmsh_param">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -39,6 +39,46 @@
         </property>
        </widget>
       </item>
+      <item row="3" column="1">
+       <widget class="Gui::PrefFileChooser" name="fc_elmer_binary_path">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="sizeIncrement">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="baseSize">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Leave blank to use default Elmer elmer binary file&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Note:&lt;/span&gt; To use multithreading you must specify here&lt;br&gt; the executable variant with the suffix &amp;quot;_mpi&amp;quot;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>elmerBinaryPath</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Fem/Elmer</cstring>
+        </property>
+       </widget>
+      </item>
       <item row="0" column="1">
        <widget class="Gui::PrefCheckBox" name="cb_grid_binary_std">
         <property name="text">
@@ -52,22 +92,6 @@
         </property>
         <property name="prefPath" stdset="0">
          <cstring>Mod/Fem/Elmer</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="l_grid_binary_path">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>100</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>ElmerGrid binary path</string>
         </property>
        </widget>
       </item>
@@ -134,6 +158,22 @@
         </property>
        </widget>
       </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="l_grid_binary_path">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>100</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>ElmerGrid binary path</string>
+        </property>
+       </widget>
+      </item>
       <item row="3" column="0">
        <widget class="QLabel" name="l_elmer_binary_path">
         <property name="enabled">
@@ -150,54 +190,23 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="1">
-       <widget class="Gui::PrefFileChooser" name="fc_elmer_binary_path">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="sizeIncrement">
-         <size>
-          <width>0</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="baseSize">
-         <size>
-          <width>0</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Leave blank to use default Elmer elmer binary file&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Note:&lt;/span&gt; To use multithreading you must specify here&lt;br&gt; the executable variant with the suffix &amp;quot;_mpi&amp;quot;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>elmerBinaryPath</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Fem/Elmer</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0">
-       <widget class="QLabel" name="l_elmer_binary_std_2">
+     </layout>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QGroupBox" name="gb_elmer_options">
+     <property name="title">
+      <string>Options</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_2">
+      <item row="0" column="0">
+       <widget class="QLabel" name="l_elmer_multithreading">
         <property name="text">
          <string>Multithreading:</string>
         </property>
        </widget>
       </item>
-      <item row="4" column="1">
+      <item row="0" column="1">
        <layout class="QHBoxLayout" name="horizontalLayout">
         <item>
          <widget class="QLabel" name="label_cores">
@@ -246,10 +255,37 @@
         </item>
        </layout>
       </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="l_elmer_multiCPU">
+        <property name="text">
+         <string>Multi-CPU core support:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="Gui::PrefCheckBox" name="cb_elmer_filtering">
+        <property name="toolTip">
+         <string>The mesh volume regions processed by each CPU core
+will be merged to make the volume boundaries invisible.</string>
+        </property>
+        <property name="text">
+         <string>Filter results</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>FilterMultiCPUResults</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Fem/Elmer</cstring>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
-   <item>
+   <item row="2" column="0">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>

--- a/src/Mod/Fem/Gui/DlgSettingsFemElmerImp.cpp
+++ b/src/Mod/Fem/Gui/DlgSettingsFemElmerImp.cpp
@@ -70,6 +70,7 @@ void DlgSettingsFemElmerImp::saveSettings()
     ui->fc_grid_binary_path->onSave();
 
     ui->sb_elmer_num_cores->onSave();
+    ui->cb_elmer_filtering->onSave();
 }
 
 void DlgSettingsFemElmerImp::loadSettings()
@@ -81,6 +82,7 @@ void DlgSettingsFemElmerImp::loadSettings()
     ui->fc_grid_binary_path->onRestore();
 
     ui->sb_elmer_num_cores->onRestore();
+    ui->cb_elmer_filtering->onRestore();
 }
 
 /**

--- a/src/Mod/Fem/Gui/ViewProviderFemPostObject.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemPostObject.cpp
@@ -706,9 +706,14 @@ void ViewProviderFemPostObject::filterArtifacts(vtkDataObject* data)
     m_wireframe->SetInputData(data);
     m_points->SetInputData(data);
 
-    // filter artifacts
-    // only necessary for the surface filter
-    filterArtifacts(data);
+    // filtering artifacts is only necessary for the surface filter
+    auto hGrp = App::GetApplication().GetParameterGroupByPath(
+        "User parameter:BaseApp/Preferences/Mod/Fem/Elmer");
+    bool FilterMultiCPUResults = hGrp->GetBool("FilterMultiCPUResults", 1);
+    if (FilterMultiCPUResults)
+        filterArtifacts(data);
+    else
+        m_surface->SetInputData(data);
 
     return true;
 }


### PR DESCRIPTION
- it is sensible to filter by default, however, it turned out that on some complex models Elmer fails to compute if the CPU mesh volume regions are too small (in most cases) or at a certain mesh region. By disabling the filtering, one gets at least for the latter case a visual feedback where the mesh volume of the different CPU are (by also setting a transparency to the result pipeline).