### PR TITLE
[FEM] fix material handling of fluids

### DIFF
--- a/src/Mod/Fem/femtaskpanels/task_material_common.py
+++ b/src/Mod/Fem/femtaskpanels/task_material_common.py
@@ -174,7 +174,6 @@ class _TaskPanel:
                 self.card_path
             )
             index = self.parameterWidget.cb_materials.findData(self.card_path)
-            # print(index)
             # fill input fields and set the current material in the cb widget
             self.choose_material(index)
         else:
@@ -184,7 +183,6 @@ class _TaskPanel:
                 "We will use this material.\n"
             )
             index = self.parameterWidget.cb_materials.findData(self.card_path)
-            # print(index)
             # fill input fields and set the current material in the cb widget
             self.choose_material(index)
 
@@ -320,7 +318,8 @@ class _TaskPanel:
             )
             new_material_params = MaterialEditor.editMaterial(material=self.material)
         else:
-            new_material_params = MaterialEditor.editMaterial(card_path=self.card_path)
+            new_material_params = MaterialEditor.editMaterial(card_path=self.card_path,
+                                                              category=self.obj.Category)
         # material editor returns the mat_dict only, not a card_path
         # if the material editor was canceled a empty dict will be returned
         # do not change the self.material
@@ -331,7 +330,6 @@ class _TaskPanel:
             if checkunits(new_material_params) is True:
                 self.material = new_material_params
                 self.card_path = self.get_material_card(self.material)
-                # print("card_path: " + self.card_path)
                 self.check_material_keys()
                 self.set_mat_params_in_input_fields(self.material)
                 if not self.card_path:
@@ -353,7 +351,6 @@ class _TaskPanel:
                         "The found material card will be used.\n"
                     )
                     index = self.parameterWidget.cb_materials.findData(self.card_path)
-                    # print(index)
                     # set the current material in the cb widget
                     self.choose_material(index)
             else:

--- a/src/Mod/Fem/femtaskpanels/task_material_reinforced.py
+++ b/src/Mod/Fem/femtaskpanels/task_material_reinforced.py
@@ -122,7 +122,6 @@ class _TaskPanel:
                 self.card_path_m
             )
             index = self.parameterWidget.cb_materials_m.findData(self.card_path_m)
-            # print(index)
             # fill input fields and set the current material in the cb widget
             self.choose_material_m(index)
         else:
@@ -162,7 +161,6 @@ class _TaskPanel:
                 "We will use this material.\n"
             )
             index = self.parameterWidget.cb_materials_r.findData(self.card_path_r)
-            # print(index)
             # fill input fields and set the current material in the cb widget
             self.choose_material_r(index)
 
@@ -336,7 +334,6 @@ class _TaskPanel:
                         "The found material card will be used.\n"
                     )
                     index = self.parameterWidget.cb_materials_m.findData(self.card_path_m)
-                    # print(index)
                     # set the current material in the cb widget
                 self.choose_material_m(index)
             else:
@@ -389,7 +386,6 @@ class _TaskPanel:
                         "The found material card will be used.\n"
                     )
                     index = self.parameterWidget.cb_materials_r.findData(self.card_path_r)
-                    # print(index)
                     # set the current material in the cb widget
                 self.choose_material_r(index)
             else:

--- a/src/Mod/Material/MaterialEditor.py
+++ b/src/Mod/Material/MaterialEditor.py
@@ -39,13 +39,14 @@ unicode = str
 # ************************************************************************************************
 class MaterialEditor:
 
-    def __init__(self, obj=None, prop=None, material=None, card_path=""):
+    def __init__(self, obj=None, prop=None, material=None, card_path="", category="Solid"):
 
         """Initializes, optionally with an object name and a material property
         name to edit, or directly with a material dictionary."""
 
         self.obj = obj
         self.prop = prop
+        self.category = category
         self.material = material
         self.customprops = []
         self.internalprops = []
@@ -62,10 +63,10 @@ class MaterialEditor:
         self.widget = FreeCADGui.PySideUic.loadUi(filePath + "materials-editor.ui")      
 
         # restore size and position
-        p = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Material")
-        w = p.GetInt("MaterialEditorWidth", 441)
-        h = p.GetInt("MaterialEditorHeight", 626)
-        self.widget.resize(w, h)
+        param = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Material")
+        width = param.GetInt("MaterialEditorWidth", 441)
+        height = param.GetInt("MaterialEditorHeight", 626)
+        self.widget.resize(width, height)
 
         # additional UI fixes and tweaks
         widget = self.widget
@@ -242,7 +243,7 @@ class MaterialEditor:
 
         # get all available materials (fill self.materials, self.cards and self.icons)
         from materialtools.cardutils import import_materials as getmats
-        self.materials, self.cards, self.icons = getmats()
+        self.materials, self.cards, self.icons = getmats(category=self.category)
 
         card_name_list = []  # [ [card_name, card_path, icon_path], ... ]
 
@@ -508,7 +509,6 @@ class MaterialEditor:
         )
         self.card_path = filetuple[0]
         index = self.widget.ComboMaterial.findData(self.card_path)
-        print(index)
 
         # check if card_path is in known path, means it is in combo box already
         # if not print message, and give some feedbach that the card parameter are loaded
@@ -765,7 +765,7 @@ def openEditor(obj=None, prop=None):
     editor.exec_()
 
 
-def editMaterial(material=None, card_path=None):
+def editMaterial(material=None, card_path=None, category="Solid"):
     """editMaterial(material): opens the editor to edit the contents
     of the given material dictionary. Returns the modified material dictionary."""
     # if the material editor is opened with this def and the card_path is None
@@ -775,7 +775,7 @@ def editMaterial(material=None, card_path=None):
     # TODO: add some text in combo box, may be "custom material data" or "user material data"
     # TODO: if card_path is None, all known cards could be checked,
     # if one fits exact ALL provided data, this card name could be displayed
-    editor = MaterialEditor(material=material, card_path=card_path)
+    editor = MaterialEditor(material=material, card_path=card_path, category=category)
     result = editor.exec_()
     if result:
         return editor.getDict()


### PR DESCRIPTION
- the material editor failed for Fluid materials because this info was not passed to it. Instead always solid materials were loaded.

- also fix warning about too long variable name and remove unnecessary debug code