### PR TITLE
[FEM] fix material dialog logic

### DIFF
--- a/src/Mod/Fem/Gui/Resources/ui/Material.ui
+++ b/src/Mod/Fem/Gui/Resources/ui/Material.ui
@@ -158,6 +158,9 @@
         </item>
         <item row="4" column="1">
          <widget class="Gui::InputField" name="input_fd_density">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
           <property name="sizePolicy">
            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
             <horstretch>0</horstretch>
@@ -224,6 +227,9 @@
         </item>
         <item row="0" column="1">
          <widget class="Gui::InputField" name="input_fd_young_modulus">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
           <property name="sizePolicy">
            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
             <horstretch>0</horstretch>
@@ -268,6 +274,9 @@
         </item>
         <item row="1" column="1">
          <widget class="QDoubleSpinBox" name="spinBox_poisson_ratio">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
           <property name="sizePolicy">
            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
             <horstretch>0</horstretch>
@@ -328,6 +337,9 @@
         </item>
         <item row="0" column="1">
          <widget class="Gui::InputField" name="input_fd_kinematic_viscosity">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
           <property name="sizePolicy">
            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
             <horstretch>0</horstretch>
@@ -394,6 +406,9 @@
         </item>
         <item row="0" column="1">
          <widget class="Gui::InputField" name="input_fd_thermal_conductivity">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
           <property name="sizePolicy">
            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
             <horstretch>0</horstretch>
@@ -438,6 +453,9 @@
         </item>
         <item row="1" column="1">
          <widget class="Gui::InputField" name="input_fd_expansion_coefficient">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
           <property name="sizePolicy">
            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
             <horstretch>0</horstretch>
@@ -482,6 +500,9 @@
         </item>
         <item row="2" column="1">
          <widget class="Gui::InputField" name="input_fd_specific_heat">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
           <property name="sizePolicy">
            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
             <horstretch>0</horstretch>
@@ -526,6 +547,9 @@
         </item>
         <item row="3" column="1">
          <widget class="Gui::InputField" name="input_fd_vol_expansion_coefficient">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
           <property name="sizePolicy">
            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
             <horstretch>0</horstretch>
@@ -589,5 +613,150 @@
   </customwidget>
  </customwidgets>
  <resources/>
- <connections/>
+ <connections>
+  <connection>
+   <sender>chbu_allow_edit</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>input_fd_density</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>272</x>
+     <y>162</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>250</x>
+     <y>364</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>chbu_allow_edit</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>input_fd_young_modulus</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>272</x>
+     <y>162</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>242</x>
+     <y>425</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>chbu_allow_edit</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>spinBox_poisson_ratio</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>272</x>
+     <y>162</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>242</x>
+     <y>451</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>chbu_allow_edit</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>input_fd_kinematic_viscosity</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>272</x>
+     <y>162</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>247</x>
+     <y>512</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>chbu_allow_edit</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>input_fd_thermal_conductivity</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>272</x>
+     <y>162</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>254</x>
+     <y>573</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>chbu_allow_edit</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>input_fd_expansion_coefficient</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>272</x>
+     <y>162</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>254</x>
+     <y>599</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>chbu_allow_edit</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>input_fd_specific_heat</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>272</x>
+     <y>162</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>254</x>
+     <y>625</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>chbu_allow_edit</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>label_vol_expansion_coefficient</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>272</x>
+     <y>162</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>67</x>
+     <y>651</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>chbu_allow_edit</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>pushButton_editMat</receiver>
+   <slot>setDisabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>272</x>
+     <y>162</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>91</x>
+     <y>162</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
 </ui>


### PR DESCRIPTION
- when the option "use this task panel" is not checked the edit fields must be disabled. This also fixes the often hard to understand issue that while scrolling to the end of the dialog the material suddenly changes to "_transient" because the scroll wheel can trigger to change the edit fields.