### PR TITLE
[Path] Adaptive - improve 'use outline' logic

### DIFF
--- a/src/Mod/Path/Path/Op/Adaptive.py
+++ b/src/Mod/Path/Path/Op/Adaptive.py
@@ -839,7 +839,7 @@ def _get_working_edges(op, obj):
                         face = base.Shape.getElement(sub)
                         # get outline with wire_A method used in PocketShape, but it does not play nicely later
                         # wire_A = TechDraw.findShapeOutline(face, 1, FreeCAD.Vector(0.0, 0.0, 1.0))
-                        wire_B = face.Wires[0]
+                        wire_B = face.OuterWire
                         shape = Part.Face(wire_B)
                     else:
                         shape = base.Shape.getElement(sub)


### PR DESCRIPTION
Path_Adaptive attempts to find the outline of a face using face.Wires[0], change to use face.OuterWire instead

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
