### PR TITLE
Addon Manager: Add SPDX license ID to all files

### DIFF
--- a/src/Mod/AddonManager/Addon.py
+++ b/src/Mod/AddonManager/Addon.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
 # ***************************************************************************
 # *                                                                         *
 # *   Copyright (c) 2022-2023 FreeCAD Project Association                   *

--- a/src/Mod/AddonManager/AddonManager.py
+++ b/src/Mod/AddonManager/AddonManager.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+# SPDX-License-Identifier: LGPL-2.1-or-later
 # ***************************************************************************
 # *                                                                         *
 # *   Copyright (c) 2022-2023 FreeCAD Project Association                   *

--- a/src/Mod/AddonManager/AddonManagerOptions.py
+++ b/src/Mod/AddonManager/AddonManagerOptions.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
 # ***************************************************************************
 # *                                                                         *
 # *   Copyright (c) 2022 FreeCAD Project Association                        *

--- a/src/Mod/AddonManager/AddonManagerTest/app/mocks.py
+++ b/src/Mod/AddonManager/AddonManagerTest/app/mocks.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
 # ***************************************************************************
 # *                                                                         *
 # *   Copyright (c) 2022-2023 FreeCAD Project Association                   *

--- a/src/Mod/AddonManager/AddonManagerTest/app/test_addon.py
+++ b/src/Mod/AddonManager/AddonManagerTest/app/test_addon.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
 # ***************************************************************************
 # *                                                                         *
 # *   Copyright (c) 2022-2023 FreeCAD Project Association                   *

--- a/src/Mod/AddonManager/AddonManagerTest/app/test_dependency_installer.py
+++ b/src/Mod/AddonManager/AddonManagerTest/app/test_dependency_installer.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
 # ***************************************************************************
 # *                                                                         *
 # *   Copyright (c) 2022 FreeCAD Project Association                        *

--- a/src/Mod/AddonManager/AddonManagerTest/app/test_freecad_interface.py
+++ b/src/Mod/AddonManager/AddonManagerTest/app/test_freecad_interface.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
 # ***************************************************************************
 # *                                                                         *
 # *   Copyright (c) 2023 FreeCAD Project Association                        *

--- a/src/Mod/AddonManager/AddonManagerTest/app/test_git.py
+++ b/src/Mod/AddonManager/AddonManagerTest/app/test_git.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
 # ***************************************************************************
 # *                                                                         *
 # *   Copyright (c) 2022 FreeCAD Project Association                        *

--- a/src/Mod/AddonManager/AddonManagerTest/app/test_installer.py
+++ b/src/Mod/AddonManager/AddonManagerTest/app/test_installer.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
 # ***************************************************************************
 # *                                                                         *
 # *   Copyright (c) 2022 FreeCAD Project Association                        *

--- a/src/Mod/AddonManager/AddonManagerTest/app/test_macro.py
+++ b/src/Mod/AddonManager/AddonManagerTest/app/test_macro.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
 # ***************************************************************************
 # *                                                                         *
 # *   Copyright (c) 2022-2023 FreeCAD Project Association                   *

--- a/src/Mod/AddonManager/AddonManagerTest/app/test_macro_parser.py
+++ b/src/Mod/AddonManager/AddonManagerTest/app/test_macro_parser.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
 # ***************************************************************************
 # *                                                                         *
 # *   Copyright (c) 2022-2023 FreeCAD Project Association                   *

--- a/src/Mod/AddonManager/AddonManagerTest/app/test_uninstaller.py
+++ b/src/Mod/AddonManager/AddonManagerTest/app/test_uninstaller.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
 # ***************************************************************************
 # *                                                                         *
 # *   Copyright (c) 2022 FreeCAD Project Association                        *

--- a/src/Mod/AddonManager/AddonManagerTest/app/test_utilities.py
+++ b/src/Mod/AddonManager/AddonManagerTest/app/test_utilities.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
 # ***************************************************************************
 # *                                                                         *
 # *   Copyright (c) 2022-2023 FreeCAD Project Association                   *

--- a/src/Mod/AddonManager/AddonManagerTest/gui/gui_mocks.py
+++ b/src/Mod/AddonManager/AddonManagerTest/gui/gui_mocks.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
 # ***************************************************************************
 # *                                                                         *
 # *   Copyright (c) 2022-2023 FreeCAD Project Association                   *

--- a/src/Mod/AddonManager/AddonManagerTest/gui/test_gui.py
+++ b/src/Mod/AddonManager/AddonManagerTest/gui/test_gui.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
 # ***************************************************************************
 # *                                                                         *
 # *   Copyright (c) 2022-2023 FreeCAD Project Association                   *

--- a/src/Mod/AddonManager/AddonManagerTest/gui/test_installer_gui.py
+++ b/src/Mod/AddonManager/AddonManagerTest/gui/test_installer_gui.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
 # ***************************************************************************
 # *                                                                         *
 # *   Copyright (c) 2022 FreeCAD Project Association                        *

--- a/src/Mod/AddonManager/AddonManagerTest/gui/test_uninstaller_gui.py
+++ b/src/Mod/AddonManager/AddonManagerTest/gui/test_uninstaller_gui.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
 # ***************************************************************************
 # *                                                                         *
 # *   Copyright (c) 2022 FreeCAD Project Association                        *

--- a/src/Mod/AddonManager/AddonManagerTest/gui/test_update_all_gui.py
+++ b/src/Mod/AddonManager/AddonManagerTest/gui/test_update_all_gui.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
 # ***************************************************************************
 # *                                                                         *
 # *   Copyright (c) 2022 FreeCAD Project Association                        *

--- a/src/Mod/AddonManager/AddonManagerTest/gui/test_workers_startup.py
+++ b/src/Mod/AddonManager/AddonManagerTest/gui/test_workers_startup.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
 # ***************************************************************************
 # *                                                                         *
 # *   Copyright (c) 2022-2023 FreeCAD Project Association                   *

--- a/src/Mod/AddonManager/AddonManagerTest/gui/test_workers_utility.py
+++ b/src/Mod/AddonManager/AddonManagerTest/gui/test_workers_utility.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
 # ***************************************************************************
 # *                                                                         *
 # *   Copyright (c) 2022-2023 FreeCAD Project Association                   *

--- a/src/Mod/AddonManager/Init.py
+++ b/src/Mod/AddonManager/Init.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
 # FreeCAD init script of the AddonManager module
 # (c) 2001 Juergen Riegel
 # License LGPL

--- a/src/Mod/AddonManager/InitGui.py
+++ b/src/Mod/AddonManager/InitGui.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
 # AddonManager gui init module
 # (c) 2001 Juergen Riegel
 # License LGPL

--- a/src/Mod/AddonManager/NetworkManager.py
+++ b/src/Mod/AddonManager/NetworkManager.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
 # ***************************************************************************
 # *                                                                         *
 # *   Copyright (c) 2022-2023 FreeCAD Project Association                   *

--- a/src/Mod/AddonManager/TestAddonManagerApp.py
+++ b/src/Mod/AddonManager/TestAddonManagerApp.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
 # ***************************************************************************
 # *                                                                         *
 # *   Copyright (c) 2022-2023 FreeCAD Project Association                   *

--- a/src/Mod/AddonManager/TestAddonManagerGui.py
+++ b/src/Mod/AddonManager/TestAddonManagerGui.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
 # ***************************************************************************
 # *                                                                         *
 # *   Copyright (c) 2022-2023 FreeCAD Project Association                   *

--- a/src/Mod/AddonManager/addonmanager_connection_checker.py
+++ b/src/Mod/AddonManager/addonmanager_connection_checker.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
 # ***************************************************************************
 # *                                                                         *
 # *   Copyright (c) 2022 FreeCAD Project Association                        *

--- a/src/Mod/AddonManager/addonmanager_dependency_installer.py
+++ b/src/Mod/AddonManager/addonmanager_dependency_installer.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
 # ***************************************************************************
 # *                                                                         *
 # *   Copyright (c) 2022 FreeCAD Project Association                        *

--- a/src/Mod/AddonManager/addonmanager_devmode.py
+++ b/src/Mod/AddonManager/addonmanager_devmode.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
 # ***************************************************************************
 # *                                                                         *
 # *   Copyright (c) 2022 FreeCAD Project Association                        *

--- a/src/Mod/AddonManager/addonmanager_devmode_add_content.py
+++ b/src/Mod/AddonManager/addonmanager_devmode_add_content.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
 # ***************************************************************************
 # *                                                                         *
 # *   Copyright (c) 2022 FreeCAD Project Association                        *

--- a/src/Mod/AddonManager/addonmanager_devmode_license_selector.py
+++ b/src/Mod/AddonManager/addonmanager_devmode_license_selector.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
 # ***************************************************************************
 # *                                                                         *
 # *   Copyright (c) 2022 FreeCAD Project Association                        *

--- a/src/Mod/AddonManager/addonmanager_devmode_licenses_table.py
+++ b/src/Mod/AddonManager/addonmanager_devmode_licenses_table.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
 # ***************************************************************************
 # *                                                                         *
 # *   Copyright (c) 2022 FreeCAD Project Association                        *

--- a/src/Mod/AddonManager/addonmanager_devmode_metadata_checker.py
+++ b/src/Mod/AddonManager/addonmanager_devmode_metadata_checker.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
 # ***************************************************************************
 # *                                                                         *
 # *   Copyright (c) 2022 FreeCAD Project Association                        *

--- a/src/Mod/AddonManager/addonmanager_devmode_people_table.py
+++ b/src/Mod/AddonManager/addonmanager_devmode_people_table.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
 # ***************************************************************************
 # *                                                                         *
 # *   Copyright (c) 2022 FreeCAD Project Association                        *

--- a/src/Mod/AddonManager/addonmanager_devmode_person_editor.py
+++ b/src/Mod/AddonManager/addonmanager_devmode_person_editor.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
 # ***************************************************************************
 # *                                                                         *
 # *   Copyright (c) 2022 FreeCAD Project Association                        *

--- a/src/Mod/AddonManager/addonmanager_devmode_predictor.py
+++ b/src/Mod/AddonManager/addonmanager_devmode_predictor.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
 # ***************************************************************************
 # *                                                                         *
 # *   Copyright (c) 2022 FreeCAD Project Association                        *

--- a/src/Mod/AddonManager/addonmanager_devmode_validators.py
+++ b/src/Mod/AddonManager/addonmanager_devmode_validators.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
 # ***************************************************************************
 # *                                                                         *
 # *   Copyright (c) 2022 FreeCAD Project Association                        *

--- a/src/Mod/AddonManager/addonmanager_firstrun.py
+++ b/src/Mod/AddonManager/addonmanager_firstrun.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
 # ***************************************************************************
 # *                                                                         *
 # *   Copyright (c) 2022 FreeCAD Project Association                        *

--- a/src/Mod/AddonManager/addonmanager_freecad_interface.py
+++ b/src/Mod/AddonManager/addonmanager_freecad_interface.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
 # ***************************************************************************
 # *                                                                         *
 # *   Copyright (c) 2023 FreeCAD Project Association                        *

--- a/src/Mod/AddonManager/addonmanager_git.py
+++ b/src/Mod/AddonManager/addonmanager_git.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
 # ***************************************************************************
 # *                                                                         *
 # *   Copyright (c) 2022 FreeCAD Project Association                        *

--- a/src/Mod/AddonManager/addonmanager_installer.py
+++ b/src/Mod/AddonManager/addonmanager_installer.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
 # ***************************************************************************
 # *                                                                         *
 # *   Copyright (c) 2022 FreeCAD Project Association                        *

--- a/src/Mod/AddonManager/addonmanager_installer_gui.py
+++ b/src/Mod/AddonManager/addonmanager_installer_gui.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
 # ***************************************************************************
 # *                                                                         *
 # *   Copyright (c) 2022 FreeCAD Project Association                        *

--- a/src/Mod/AddonManager/addonmanager_macro.py
+++ b/src/Mod/AddonManager/addonmanager_macro.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
 # ***************************************************************************
 # *                                                                         *
 # *   Copyright (c) 2022-2023 FreeCAD Project Association                   *

--- a/src/Mod/AddonManager/addonmanager_macro_parser.py
+++ b/src/Mod/AddonManager/addonmanager_macro_parser.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
 # ***************************************************************************
 # *                                                                         *
 # *   Copyright (c) 2023 FreeCAD Project Association                        *

--- a/src/Mod/AddonManager/addonmanager_uninstaller.py
+++ b/src/Mod/AddonManager/addonmanager_uninstaller.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
 # ***************************************************************************
 # *                                                                         *
 # *   Copyright (c) 2022 FreeCAD Project Association                        *

--- a/src/Mod/AddonManager/addonmanager_uninstaller_gui.py
+++ b/src/Mod/AddonManager/addonmanager_uninstaller_gui.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
 # ***************************************************************************
 # *                                                                         *
 # *   Copyright (c) 2022 FreeCAD Project Association                        *

--- a/src/Mod/AddonManager/addonmanager_update_all_gui.py
+++ b/src/Mod/AddonManager/addonmanager_update_all_gui.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
 # ***************************************************************************
 # *                                                                         *
 # *   Copyright (c) 2022 FreeCAD Project Association                        *

--- a/src/Mod/AddonManager/addonmanager_utilities.py
+++ b/src/Mod/AddonManager/addonmanager_utilities.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
 # ***************************************************************************
 # *                                                                         *
 # *   Copyright (c) 2022-2023 FreeCAD Project Association                   *

--- a/src/Mod/AddonManager/addonmanager_workers_installation.py
+++ b/src/Mod/AddonManager/addonmanager_workers_installation.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
 # ***************************************************************************
 # *                                                                         *
 # *   Copyright (c) 2022-2023 FreeCAD Project Association                   *

--- a/src/Mod/AddonManager/addonmanager_workers_startup.py
+++ b/src/Mod/AddonManager/addonmanager_workers_startup.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
 # ***************************************************************************
 # *                                                                         *
 # *   Copyright (c) 2022-2023 FreeCAD Project Association                   *

--- a/src/Mod/AddonManager/addonmanager_workers_utility.py
+++ b/src/Mod/AddonManager/addonmanager_workers_utility.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
 # ***************************************************************************
 # *                                                                         *
 # *   Copyright (c) 2022-2023 FreeCAD Project Association                   *

--- a/src/Mod/AddonManager/change_branch.py
+++ b/src/Mod/AddonManager/change_branch.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
 # ***************************************************************************
 # *                                                                         *
 # *   Copyright (c) 2022-2023 FreeCAD Project Association                   *

--- a/src/Mod/AddonManager/install_to_toolbar.py
+++ b/src/Mod/AddonManager/install_to_toolbar.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
 # ***************************************************************************
 # *                                                                         *
 # *   Copyright (c) 2022-2023 FreeCAD Project Association                   *

--- a/src/Mod/AddonManager/loading.html
+++ b/src/Mod/AddonManager/loading.html
@@ -1,4 +1,6 @@
 <!--
+SPDX-License-Identifier: MIT
+
 Adapted from:
 https://codepen.io/MattIn4D/pen/LiKFC
 

--- a/src/Mod/AddonManager/manage_python_dependencies.py
+++ b/src/Mod/AddonManager/manage_python_dependencies.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
 # ***************************************************************************
 # *                                                                         *
 # *   Copyright (c) 2022-2023 FreeCAD Project Association                   *

--- a/src/Mod/AddonManager/package_details.py
+++ b/src/Mod/AddonManager/package_details.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
 # ***************************************************************************
 # *                                                                         *
 # *   Copyright (c) 2022-2023 FreeCAD Project Association                   *

--- a/src/Mod/AddonManager/package_list.py
+++ b/src/Mod/AddonManager/package_list.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
 # ***************************************************************************
 # *                                                                         *
 # *   Copyright (c) 2022-2023 FreeCAD Project Association                   *


### PR DESCRIPTION
This adds the machine-readable SPDX license identifier to all Addon Manager files. In all but one case this is "LGPL-2.1-or-later" (the one exception is an MIT-licensed HTML file).

---

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR