### PR TITLE
Improve navicube default font matching on linux

### DIFF
--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -346,6 +346,17 @@ MainWindow::MainWindow(QWidget * parent, Qt::WindowFlags f)
 
     // accept drops on the window, get handled in dropEvent, dragEnterEvent
     setAcceptDrops(true);
+
+    // setup font substitutions for NaviCube
+    // Helvetica usually gives good enough results on mac & linux
+    // in rare cases Helvetica matches a bad font on linux
+    // Nimbus Sans Narrow and Open Sans Condensed added as fallback
+    // Bahnschrift is a condensed font available on windows versions since 2017
+    // Arial added as fallback for older version
+    auto substitutions = QStringLiteral("Bahnschrift,Helvetica,Nimbus Sans Narrow,Open Sans Condensed,Arial,Sans");
+    auto family = QStringLiteral("FreeCAD NaviCube");
+    QFont::insertSubstitutions(family, substitutions.split(QLatin1Char(',')));
+
     statusBar()->showMessage(tr("Ready"), 2001);
 }
 

--- a/src/Gui/NaviCube.cpp
+++ b/src/Gui/NaviCube.cpp
@@ -299,15 +299,8 @@ void NaviCube::setButtonColor(QColor ButtonColor)
 
 QString NaviCube::getDefaultSansserifFont()
 {
-    // Windows versions since 2017 have the 'Bahnschrift' font (a condensed
-    // sans serif font, optimized for readability despite being condensed),
-    // we first check for that.
-    QFont font(QStringLiteral("Bahnschrift"));
-    if (!font.exactMatch())
-        // On systems without 'Bahnschrift' we check for 'Helvetica' or its closest match
-        // as default sans serif font. (For Windows 7 this will e.g. result in 'Arial'.)
-        font = QFont(QStringLiteral("Helvetica"));
-
+    // "FreeCAD NaviCube" family susbtitutions are set in MainWindow::MainWindow
+    QFont font(QStringLiteral("FreeCAD NaviCube"));
     font.setStyleHint(QFont::SansSerif);
     // QFontInfo is required to get the actually matched font family
     return QFontInfo(font).family();


### PR DESCRIPTION
-set several font families for better matching on multiple systems
-set SansSerif stylehint again as it is needed for proper matching
-remove hack that saves the default font to parameters even when cancelling on DlgSettingsNavigation
-change return type of getDefaultSansserifFont to QString as only the font family is really used from this.

related to #8553 and https://forum.freecad.org/viewtopic.php?p=662155#p662155

@donovaly 

@chennes I would like to know what gets matched by this on macOS if you can test, if building is too much trouble getting the result from [this python snippet](https://forum.freecad.org/viewtopic.php?p=662267#p662267) could also help me.

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [ ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
