### PR TITLE
properly report Shiboken and PySide if found

### DIFF
--- a/cMake/FreeCAD_Helpers/PrintFinalReport.cmake
+++ b/cMake/FreeCAD_Helpers/PrintFinalReport.cmake
@@ -148,8 +148,8 @@ macro(PrintFinalReport)
     else()
         simple(QtWebKitWidgets "not needed")
     endif()
-    conditional(Shiboken Shiboken_FOUND "not found" "${SHIBOKEN_VERSION} Base: [${SHIBOKEN_BASEDIR}]")
-    conditional(PySide PySide_FOUND "not found" "${PYSIDE_VERSION} [${PYSIDE_INCLUDE_DIR}]")
+    conditional(Shiboken Shiboken${SHIBOKEN_MAJOR_VERSION}_FOUND "not found" "${Shiboken_VERSION} [${SHIBOKEN_INCLUDE_DIR}]")
+    conditional(PySide PySide${PYSIDE_MAJOR_VERSION}_FOUND "not found" "${PySide_VERSION} [${PYSIDE_INCLUDE_DIR}]")
     conditional(PySideTools PYSIDE_TOOLS_FOUND
                 "not found"
                 "v: ${PySideTools_VERSION}  uic: [${PYSIDE_UIC_EXECUTABLE}]  rcc: [${PYSIDE_RCC_EXECUTABLE}]"


### PR DESCRIPTION
The patch fixes a small issue, with the PrintFinalReport macro, where Shiboken and PySide where not properly reported.

Closes: https://github.com/FreeCAD/FreeCAD/issues/8573

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [ X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
