### PR TITLE
[FEM] fix material initialization

### DIFF
--- a/src/Mod/Fem/femtaskpanels/task_material_common.py
+++ b/src/Mod/Fem/femtaskpanels/task_material_common.py
@@ -316,7 +316,8 @@ class _TaskPanel:
             FreeCAD.Console.PrintLog(
                 "Card path not in cards, material dict will be used to open Material Editor.\n"
             )
-            new_material_params = MaterialEditor.editMaterial(material=self.material)
+            new_material_params = MaterialEditor.editMaterial(
+                material=self.material, category=self.obj.Category)
         else:
             new_material_params = MaterialEditor.editMaterial(card_path=self.card_path,
                                                               category=self.obj.Category)
@@ -389,7 +390,6 @@ class _TaskPanel:
     def check_material_keys(self):
         # FreeCAD units definition is at file end of src/Base/Unit.cpp
         if not self.material:
-            FreeCAD.Console.PrintMessage("For some reason all material data is empty!\n")
             self.material["Name"] = "NoName"
         if "Density" in self.material:
             if "Density" not in str(Units.Unit(self.material["Density"])):
@@ -400,10 +400,10 @@ class _TaskPanel:
                 )
                 self.material["Density"] = "0 kg/m^3"
         else:
-            FreeCAD.Console.PrintMessage(
-                "Density not found in {}\n"
-                .format(self.material["Name"])
-            )
+            if self.material["Name"] != "NoName":
+                FreeCAD.Console.PrintMessage(
+                    "Density not found in {}\n".format(self.material["Name"])
+                )
             self.material["Density"] = "0 kg/m^3"
         if self.obj.Category == "Solid":
             # mechanical properties
@@ -417,10 +417,10 @@ class _TaskPanel:
                     )
                     self.material["YoungsModulus"] = "0 MPa"
             else:
-                FreeCAD.Console.PrintMessage(
-                    "YoungsModulus not found in {}\n"
-                    .format(self.material["Name"])
-                )
+                if self.material["Name"] != "NoName":
+                    FreeCAD.Console.PrintMessage(
+                        "YoungsModulus not found in {}\n".format(self.material["Name"])
+                    )
                 self.material["YoungsModulus"] = "0 MPa"
             if "PoissonRatio" in self.material:
                 # PoissonRatio does not have a unit, but it is checked if there is no value at all
@@ -435,10 +435,10 @@ class _TaskPanel:
                     )
                     self.material["PoissonRatio"] = "0"
             else:
-                FreeCAD.Console.PrintMessage(
-                    "PoissonRatio not found in {}\n"
-                    .format(self.material["Name"])
-                )
+                if self.material["Name"] != "NoName":
+                    FreeCAD.Console.PrintMessage(
+                        "PoissonRatio not found in {}\n".format(self.material["Name"])
+                    )
                 self.material["PoissonRatio"] = "0"
         if self.obj.Category == "Fluid":
             # Fluidic properties
@@ -452,10 +452,10 @@ class _TaskPanel:
                     )
                     self.material["KinematicViscosity"] = "0 m^2/s"
             else:
-                FreeCAD.Console.PrintMessage(
-                    "KinematicViscosity not found in {}\n"
-                    .format(self.material["Name"])
-                )
+                if self.material["Name"] != "NoName":
+                    FreeCAD.Console.PrintMessage(
+                        "KinematicViscosity not found in {}\n".format(self.material["Name"])
+                    )
                 self.material["KinematicViscosity"] = "0 m^2/s"
             if "ThermalExpansionCoefficient" in self.material:
                 vol_ther_ex_co = self.material["ThermalExpansionCoefficient"]
@@ -467,10 +467,11 @@ class _TaskPanel:
                     )
                     self.material["ThermalExpansionCoefficient"] = "0 1/K"
             else:
-                FreeCAD.Console.PrintMessage(
-                    "ThermalExpansionCoefficient not found in {}\n"
-                    .format(self.material["Name"])
-                )
+                if self.material["Name"] != "NoName":
+                    FreeCAD.Console.PrintMessage(
+                        "ThermalExpansionCoefficient not found in {}\n"
+                        .format(self.material["Name"])
+                    )
                 self.material["ThermalExpansionCoefficient"] = "0 1/K"
             if "VolumetricThermalExpansionCoefficient" in self.material:
                 # unit type VolumetricThermalExpansionCoefficient is ThermalExpansionCoefficient
@@ -513,10 +514,10 @@ class _TaskPanel:
                 )
                 self.material["ThermalConductivity"] = "0 W/m/K"
         else:
-            FreeCAD.Console.PrintMessage(
-                "ThermalConductivity not found in {}\n"
-                .format(self.material["Name"])
-            )
+            if self.material["Name"] != "NoName":
+                FreeCAD.Console.PrintMessage(
+                    "ThermalConductivity not found in {}\n".format(self.material["Name"])
+                )
             self.material["ThermalConductivity"] = "0 W/m/K"
         if "ThermalExpansionCoefficient" in self.material:
             the_ex_co = self.material["ThermalExpansionCoefficient"]
@@ -528,10 +529,10 @@ class _TaskPanel:
                 )
                 self.material["ThermalExpansionCoefficient"] = "0 um/m/K"
         else:
-            FreeCAD.Console.PrintMessage(
-                "ThermalExpansionCoefficient not found in {}\n"
-                .format(self.material["Name"])
-            )
+            if self.material["Name"] != "NoName":
+                FreeCAD.Console.PrintMessage(
+                    "ThermalExpansionCoefficient not found in {}\n".format(self.material["Name"])
+                )
             self.material["ThermalExpansionCoefficient"] = "0 um/m/K"
         if "SpecificHeat" in self.material:
             if "SpecificHeat" not in str(Units.Unit(self.material["SpecificHeat"])):
@@ -542,10 +543,10 @@ class _TaskPanel:
                 )
                 self.material["SpecificHeat"] = "0 J/kg/K"
         else:
-            FreeCAD.Console.PrintMessage(
-                "SpecificHeat not found in {}\n"
-                .format(self.material["Name"])
-            )
+            if self.material["Name"] != "NoName":
+                FreeCAD.Console.PrintMessage(
+                    "SpecificHeat not found in {}\n".format(self.material["Name"])
+                )
             self.material["SpecificHeat"] = "0 J/kg/K"
         FreeCAD.Console.PrintMessage("\n")
 


### PR DESCRIPTION
- on creating a new material object, don't pollute the console wit wrong error messages (if no material is yet selected, of course nothing can yet be found)
- fix that for new fluid materials the material editor was started with solid materials