### PR TITLE
[Gui] Move _ActionWidget to fix regressions

### DIFF
--- a/src/Gui/ToolBarManager.cpp
+++ b/src/Gui/ToolBarManager.cpp
@@ -183,10 +183,10 @@ void ToolBarManager::setup(ToolBarItem* toolBarItems)
     if (!_ActionWidget) {
         _ActionWidget = new QWidget(getMainWindow());
         _ActionWidget->setObjectName(QStringLiteral("_fc_action_widget_"));
-		// Although _ActionWidget has zero size, on MacOS it somehow has a
-		// 'phantom' size without any visible content and will block the top
-		// left tool buttons of the application main window. So we move it out
-		// of the way.
+		/* Although _ActionWidget has zero size, it somehow has a
+		'phantom' size without any visible content and will block the top
+		left tool buttons and menus of the application main window.
+		Therefore it is moved out of the way. */
 		_ActionWidget->move(QPoint(-100,-100));
     }
     else {

--- a/src/Gui/ToolBarManager.cpp
+++ b/src/Gui/ToolBarManager.cpp
@@ -182,6 +182,12 @@ void ToolBarManager::setup(ToolBarItem* toolBarItems)
     static QPointer<QWidget> _ActionWidget;
     if (!_ActionWidget) {
         _ActionWidget = new QWidget(getMainWindow());
+        _ActionWidget->setObjectName(QStringLiteral("_fc_action_widget_"));
+		// Although _ActionWidget has zero size, on MacOS it somehow has a
+		// 'phantom' size without any visible content and will block the top
+		// left tool buttons of the application main window. So we move it out
+		// of the way.
+		_ActionWidget->move(QPoint(-100,-100));
     }
     else {
         for (auto action : _ActionWidget->actions())


### PR DESCRIPTION
On Linux https://github.com/FreeCAD/FreeCAD/issues/7965 is fixed by this PR.
A Windows user who can compile this PR is required to ensure https://github.com/FreeCAD/FreeCAD/issues/8440 is also fixed.
There is another possible regression on MacOS see https://forum.freecad.org/viewtopic.php?p=662850#p662850 that may benefit from this PR.

In my testing I've not encountered any negative effects from this change and I've been using it daily for the past week.


Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [ ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
