### PR TITLE
[BugFix] Expression: always add space char before unit when converting to string

### DIFF
--- a/src/App/Expression.cpp
+++ b/src/App/Expression.cpp
@@ -1578,6 +1578,7 @@ void OperatorExpression::_toString(std::ostream &s, bool persistent,int) const
         s << " >= ";
         break;
     case UNIT:
+        s << " ";
         break;
     default:
         assert(0);


### PR DESCRIPTION
Fixes #8562