### PR TITLE
Arch, Draft: Remove use of six module

### DIFF
--- a/src/Mod/Arch/ArchAxis.py
+++ b/src/Mod/Arch/ArchAxis.py
@@ -19,7 +19,6 @@
 #*                                                                         *
 #***************************************************************************
 
-import six
 
 import FreeCAD, Part, Draft, math, ArchCommands
 from FreeCAD import Vector

--- a/src/Mod/Arch/exportIFC.py
+++ b/src/Mod/Arch/exportIFC.py
@@ -30,7 +30,6 @@ Internally it uses IfcOpenShell, which must be installed before using.
 
 from __future__ import print_function
 
-import six
 import os
 import time
 import tempfile

--- a/src/Mod/Arch/importIFC.py
+++ b/src/Mod/Arch/importIFC.py
@@ -30,7 +30,6 @@ Internally it uses IfcOpenShell, which must be installed before using.
 
 from __future__ import print_function
 
-import six
 import os
 import math
 import time

--- a/src/Mod/Arch/importIFCHelper.py
+++ b/src/Mod/Arch/importIFCHelper.py
@@ -21,7 +21,6 @@
 """Helper functions that are used by IFC importer and exporter."""
 import sys
 import math
-import six
 
 import FreeCAD
 import Arch

--- a/src/Mod/Arch/importJSON.py
+++ b/src/Mod/Arch/importJSON.py
@@ -23,7 +23,6 @@
 
 import FreeCAD, Mesh, Draft, Part
 import json
-import six
 
 if FreeCAD.GuiUp:
     import FreeCADGui

--- a/src/Mod/Arch/importWebGL.py
+++ b/src/Mod/Arch/importWebGL.py
@@ -37,7 +37,12 @@
 
 """FreeCAD WebGL Exporter"""
 
-import FreeCAD,Mesh,Draft,Part,OfflineRenderingUtils,json,six
+import FreeCAD
+import Mesh
+import Draft
+import Part
+import OfflineRenderingUtils
+import json
 import textwrap
 
 if FreeCAD.GuiUp:

--- a/src/Mod/Draft/draftfunctions/svgtext.py
+++ b/src/Mod/Draft/draftfunctions/svgtext.py
@@ -27,7 +27,6 @@
 # \brief Provides functions to return the SVG representation of text elements.
 
 import math
-import six
 
 import FreeCAD as App
 import draftutils.utils as utils

--- a/src/Mod/Draft/draftutils/todo.py
+++ b/src/Mod/Draft/draftutils/todo.py
@@ -34,8 +34,6 @@ to execute the instructions stored in internal lists.
 # \ingroup draftutils
 # \brief Provides the ToDo static class to run commands with a time delay.
 
-import six
-import sys
 import traceback
 import PySide.QtCore as QtCore
 

--- a/src/Mod/Draft/draftutils/translate.py
+++ b/src/Mod/Draft/draftutils/translate.py
@@ -34,7 +34,6 @@ using the QtCore module.
 # @{
 import PySide.QtCore as QtCore
 import PySide.QtGui as QtGui
-import six
 
 Qtranslate = QtCore.QCoreApplication.translate
 

--- a/src/Mod/Draft/importDWG.py
+++ b/src/Mod/Draft/importDWG.py
@@ -44,7 +44,6 @@ https://knowledge.autodesk.com/support/autocad/downloads/
 # *                                                                         *
 # ***************************************************************************
 
-import six
 import FreeCAD
 from FreeCAD import Console as FCC
 

--- a/src/Mod/Draft/importDXF.py
+++ b/src/Mod/Draft/importDXF.py
@@ -50,11 +50,17 @@ texts, colors,layers (from groups)
 TEXTSCALING = 1.35
 CURRENTDXFLIB = 1.40
 
-import sys, os, math, re
-import six
+import sys
+import os
+import math
+import re
 import FreeCAD
-import Part, Draft, Mesh
-import DraftVecUtils, DraftGeomUtils, WorkingPlane
+import Part
+import Draft
+import Mesh
+import DraftVecUtils
+import DraftGeomUtils
+import WorkingPlane
 from Draft import _Dimension
 from FreeCAD import Vector
 from FreeCAD import Console as FCC
@@ -263,22 +269,16 @@ def deformat(text):
     sts = re.split("\\\\(U\+....)", t)
     ns = u""
     for ss in sts:
-        # print(ss, type(ss))
-        if ss.startswith("U+"):
-            ucode = "0x" + ss[2:]
-            # In Python3 unichr doesn't exist anymore
-            ns += six.unichr(eval(ucode))
-        else:
+        try:
+            ns += ss.decode("utf8")
+        except UnicodeError:
             try:
-                ns += ss.decode("utf8")
+                ns += ss.decode("latin1")
             except UnicodeError:
-                try:
-                    ns += ss.decode("latin1")
-                except UnicodeError:
-                    print("unable to decode text: ", text)
-            except AttributeError:
-                # this is python3 (nothing to do)
-                ns += ss
+                print("unable to decode text: ", text)
+        except AttributeError:
+            # this is python3 (nothing to do)
+            ns += ss
     t = ns
     # replace degrees, diameters chars
     t = re.sub('%%d', u'°', t)


### PR DESCRIPTION
There were several unused remnants of uses of the python six module throughout Draft and Arch. This PR removes them.

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [ ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
