### PR TITLE
[Draft] increase number spinboxes max in array task panels to 1 million

### DIFF
--- a/src/Mod/Draft/Resources/ui/TaskPanel_CircularArray.ui
+++ b/src/Mod/Draft/Resources/ui/TaskPanel_CircularArray.ui
@@ -115,6 +115,9 @@ It must be at least 2.</string>
           <property name="minimum">
            <number>2</number>
           </property>
+          <property name="maximum">
+           <number>1000000</number>
+          </property>
           <property name="value">
            <number>3</number>
           </property>

--- a/src/Mod/Draft/Resources/ui/TaskPanel_OrthoArray.ui
+++ b/src/Mod/Draft/Resources/ui/TaskPanel_OrthoArray.ui
@@ -69,6 +69,9 @@ The number must be at least 1 in each direction.</string>
              <property name="minimum">
               <number>1</number>
              </property>
+             <property name="maximum">
+              <number>1000000</number>
+             </property>
              <property name="value">
               <number>2</number>
              </property>
@@ -86,6 +89,9 @@ The number must be at least 1 in each direction.</string>
              <property name="minimum">
               <number>1</number>
              </property>
+             <property name="maximum">
+              <number>1000000</number>
+             </property>
              <property name="value">
               <number>2</number>
              </property>
@@ -102,6 +108,9 @@ The number must be at least 1 in each direction.</string>
             <widget class="QSpinBox" name="spinbox_n_Z">
              <property name="minimum">
               <number>1</number>
+             </property>
+             <property name="maximum">
+              <number>1000000</number>
              </property>
              <property name="value">
               <number>1</number>

--- a/src/Mod/Draft/Resources/ui/TaskPanel_PolarArray.ui
+++ b/src/Mod/Draft/Resources/ui/TaskPanel_PolarArray.ui
@@ -100,6 +100,9 @@ It must be at least 2.</string>
           <property name="minimum">
            <number>2</number>
           </property>
+          <property name="maximum">
+           <number>1000000</number>
+          </property>
           <property name="value">
            <number>5</number>
           </property>


### PR DESCRIPTION
The default max for spinboxes is 99. This PR increases it to 1 million for the number spin boxes of the array task panels.

- [x]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

---
