### PR TITLE
OpenSCAD: Linter cleanup

### DIFF
--- a/src/Mod/OpenSCAD/importCSG.py
+++ b/src/Mod/OpenSCAD/importCSG.py
@@ -67,6 +67,8 @@ original_root_objects = []
 import tokrules
 from tokrules import tokens
 
+translate = FreeCAD.Qt.translate
+
 
 def shallHide(subject):
     for obj in subject.OutListRecursive:
@@ -105,20 +107,6 @@ def fixVisibility():
             root_object.ViewObject.Visibility = True
             for obj in root_object.OutListRecursive:
                 obj.ViewObject.Visibility = False
-
-
-if gui:
-    try:
-        _encoding = QtGui.QApplication.UnicodeUTF8
-        def translate(context, text):
-            "convenience function for Qt translator"
-            from PySide import QtGui
-            return QtGui.QApplication.translate(context, text, None, _encoding)
-    except AttributeError:
-        def translate(context, text):
-            "convenience function for Qt translator"
-            from PySide import QtGui
-            return QtGui.QApplication.translate(context, text, None)
 
 
 def open(filename):


### PR DESCRIPTION
Move all imports to the top of the file, and replace the old hand-coded translate function with FreeCAD's. Also begin migration from the custom executable finder to the one built into shutil since Python 3.3.

---

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR