### PR TITLE
[Gui] remove unused help button from preferences dialog

### DIFF
--- a/src/Gui/DlgPreferencesImp.cpp
+++ b/src/Gui/DlgPreferencesImp.cpp
@@ -74,6 +74,8 @@ DlgPreferencesImp::DlgPreferencesImp(QWidget* parent, Qt::WindowFlags fl)
     int length = QtTools::horizontalAdvance(fm, longestGroupName());
     ui->listBox->setFixedWidth(Base::clamp<int>(length + 20, 108, 120));
     ui->listBox->setGridSize(QSize(108, 75));
+    // remove unused help button
+    setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
     connect(ui->buttonBox, &QDialogButtonBox::clicked,
             this, &DlgPreferencesImp::onButtonBoxClicked);

--- a/src/Gui/DlgSettingsViewColor.cpp
+++ b/src/Gui/DlgSettingsViewColor.cpp
@@ -21,7 +21,6 @@
  ***************************************************************************/
 
 #include "PreCompiled.h"
-
 #ifndef _PreComp_
 # include <QPushButton>
 #endif
@@ -45,7 +44,8 @@ DlgSettingsViewColor::DlgSettingsViewColor(QWidget* parent)
     ui->setupUi(this);
     ui->HighlightColor->setEnabled(ui->checkBoxPreselection->isChecked());
     ui->SelectionColor->setEnabled(ui->checkBoxSelection->isChecked());
-    connect(ui->SwitchGradientColors, &QPushButton::pressed, this, &DlgSettingsViewColor::onSwitchGradientColorsPressed);
+    connect(ui->SwitchGradientColors, &QPushButton::pressed, this,
+        &DlgSettingsViewColor::onSwitchGradientColorsPressed);
 }
 
 /**

--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -3235,7 +3235,8 @@ void DocumentItem::slotInEdit(const Gui::ViewProviderDocumentObject& v)
 {
     (void)v;
 
-    ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/TreeView");
+    ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
+        "User parameter:BaseApp/Preferences/TreeView");
     unsigned long col = hGrp->GetUnsigned("TreeEditColor", 4294902015);
     QColor color((col >> 24) & 0xff, (col >> 16) & 0xff, (col >> 8) & 0xff);
 


### PR DESCRIPTION
- is by default in the title bar of Qt dialogs, has to be removed explicitly when unused

- also fix too long code lines