### PR TITLE
[Gui] add UI to change the NaviCube button size

### DIFF
--- a/src/Gui/DlgSettingsNavigation.cpp
+++ b/src/Gui/DlgSettingsNavigation.cpp
@@ -57,6 +57,7 @@ DlgSettingsNavigation::DlgSettingsNavigation(QWidget* parent)
     , q0(0), q1(0), q2(0), q3(1)
 {
     ui->setupUi(this);
+    ui->naviCubeButtonColor->setAllowTransparency(true);
     retranslate();
 }
 
@@ -93,6 +94,7 @@ void DlgSettingsNavigation::saveSettings()
     ui->naviCubeToNearest->onSave();
     ui->prefCubeSize->onSave();
     ui->naviCubeFontSize->onSave();
+    ui->naviCubeButtonColor->onSave();
 
     bool showNaviCube = ui->groupBoxNaviCube->isChecked();
     hGrp->SetBool("ShowNaviCube", showNaviCube);
@@ -141,6 +143,7 @@ void DlgSettingsNavigation::loadSettings()
     ui->naviCubeToNearest->onRestore();
     ui->prefCubeSize->onRestore();
     ui->naviCubeFontSize->onRestore();
+    ui->naviCubeButtonColor->onRestore();
 
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath
         ("User parameter:BaseApp/Preferences/View");

--- a/src/Gui/DlgSettingsNavigation.ui
+++ b/src/Gui/DlgSettingsNavigation.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>500</width>
-    <height>394</height>
+    <width>432</width>
+    <height>423</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -117,7 +117,7 @@
         </item>
        </widget>
       </item>
-      <item row="2" column="0" colspan="2">
+      <item row="1" column="0" colspan="2">
        <widget class="Gui::PrefCheckBox" name="naviCubeToNearest">
         <property name="toolTip">
          <string>Rotates to nearest possible state when clicking a cube face</string>
@@ -136,14 +136,14 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="3">
-       <widget class="QLabel" name="TextLabel3">
+      <item row="1" column="3">
+       <widget class="QLabel" name="FontNameLabel">
         <property name="text">
          <string>Font name:</string>
         </property>
        </widget>
       </item>
-      <item row="2" column="4">
+      <item row="1" column="4">
        <widget class="Gui::PrefComboBox" name="naviCubeFontName">
         <property name="toolTip">
          <string>Font name of the navigation cube</string>
@@ -159,14 +159,14 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="label_3">
+      <item row="2" column="0">
+       <widget class="QLabel" name="CubeSizeLabel">
         <property name="text">
          <string>Cube size</string>
         </property>
        </widget>
       </item>
-      <item row="3" column="1">
+      <item row="2" column="1">
        <widget class="Gui::PrefSpinBox" name="prefCubeSize">
         <property name="toolTip">
          <string>Size of the navigation cube</string>
@@ -194,14 +194,14 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="3">
-       <widget class="QLabel" name="TextLabel4">
+      <item row="2" column="3">
+       <widget class="QLabel" name="FontSizeLabel">
         <property name="text">
          <string>Font size:</string>
         </property>
        </widget>
       </item>
-      <item row="3" column="4">
+      <item row="2" column="4">
        <widget class="Gui::PrefSpinBox" name="naviCubeFontSize">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -226,6 +226,34 @@
         </property>
         <property name="prefEntry" stdset="0">
          <cstring>FontSize</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>NaviCube</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="ButtonColorLabel">
+        <property name="text">
+         <string>Button color</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="Gui::PrefColorButton" name="naviCubeButtonColor">
+        <property name="toolTip">
+         <string>color for all elements
+around the cube</string>
+        </property>
+        <property name="color">
+         <color alpha="128">
+          <red>226</red>
+          <green>232</green>
+          <blue>239</blue>
+         </color>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>ButtonColor</cstring>
         </property>
         <property name="prefPath" stdset="0">
          <cstring>NaviCube</cstring>
@@ -641,8 +669,18 @@ Mouse tilting is not disabled by this setting.</string>
  </widget>
  <customwidgets>
   <customwidget>
+   <class>Gui::ColorButton</class>
+   <extends>QPushButton</extends>
+   <header>Gui/Widgets.h</header>
+  </customwidget>
+  <customwidget>
    <class>Gui::PrefSpinBox</class>
    <extends>QSpinBox</extends>
+   <header>Gui/PrefWidgets.h</header>
+  </customwidget>
+  <customwidget>
+   <class>Gui::PrefColorButton</class>
+   <extends>Gui::ColorButton</extends>
    <header>Gui/PrefWidgets.h</header>
   </customwidget>
   <customwidget>

--- a/src/Gui/NaviCube.cpp
+++ b/src/Gui/NaviCube.cpp
@@ -292,6 +292,11 @@ void NaviCube::setFontSize(int size)
     m_NaviCubeImplementation->m_CubeTextSize = size;
 }
 
+void NaviCube::setButtonColor(QColor ButtonColor)
+{
+    m_NaviCubeImplementation->m_ButtonColor = ButtonColor;
+}
+
 QString NaviCube::getDefaultSansserifFont()
 {
     // Windows versions since 2017 have the 'Bahnschrift' font (a condensed
@@ -379,7 +384,12 @@ void NaviCubeImplementation::OnChange(ParameterGrp::SubjectType& rCaller,
         m_HiliteColor.setRgba(rGrp.GetUnsigned(reason, QColor(170, 226, 255, 255).rgba()));
     }
     else if (strcmp(reason, "ButtonColor") == 0) {
-        m_ButtonColor.setRgba(rGrp.GetUnsigned(reason, QColor(226, 233, 239, 128).rgba()));
+        // the color is stored in the form ARRGGBB thus we cannot read in using .rgba()
+        unsigned long col = rGrp.GetUnsigned("ButtonColor", 3806916480);
+        // 3806916480 is AAA,RRR,GGG,BBB: 128,226,233,239
+        QColor buttonColor(
+            (col >> 24) & 0xff, (col >> 16) & 0xff, (col >> 8) & 0xff, col & 0xff);
+        m_ButtonColor = buttonColor;
     }
     else if (strcmp(reason, "CornerNaviCube") == 0) {
         m_Corner = static_cast<NaviCube::Corner>(rGrp.GetInt(reason, 1));

--- a/src/Gui/NaviCube.h
+++ b/src/Gui/NaviCube.h
@@ -52,6 +52,7 @@ public:
     void setNaviStepByTurn(int steps);
     void setFont(std::string font);
     void setFontSize(int size);
+    void setButtonColor(QColor buttonColor);
     static QString getDefaultSansserifFont();
     int getDefaultFontSize();
     static void setNaviCubeCommands(const std::vector<std::string>& cmd);

--- a/src/Gui/SoTextLabel.cpp
+++ b/src/Gui/SoTextLabel.cpp
@@ -341,7 +341,7 @@ void SoStringLabel::GLRender(SoGLRenderAction *action)
 
     // text color
     SbColor color = this->textColor.getValue();
-    glColor4f(color[0], color[1], color[2],1);
+    glColor4f(color[0], color[1], color[2], 1);
     const SbMatrix & mat = SoModelMatrixElement::get(state);
     const SbMatrix & projmatrix = (mat * SoViewingMatrixElement::get(state) *
                                    SoProjectionMatrixElement::get(state));

--- a/src/Gui/View3DInventor.cpp
+++ b/src/Gui/View3DInventor.cpp
@@ -402,6 +402,9 @@ void View3DInventor::OnChange(ParameterGrp::SubjectType &rCaller,ParameterGrp::M
             "FontString", NaviCube::getDefaultSansserifFont().toStdString().c_str());
         _viewer->getNavigationCube()->setFont(font);
     }
+    else if (strcmp(Reason, "ButtonColor") == 0) {
+        _viewer->getNavigationCube()->setButtonColor(rGrp.GetUnsigned("ButtonColor", 3806916480));
+    }
     else if (strcmp(Reason,"UseVBO") == 0) {
         _viewer->setEnabledVBO(rGrp.GetBool("UseVBO", false));
     }


### PR DESCRIPTION
- it was frequently requested and people now even published videos since I documented this hidden feature in the Wiki. However, for a user it is a nightmare without a UI and users who like a bright background need to change the button color to keep the buttons visible.