### PR TITLE
Improve usage of the term 'platform' in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,15 +24,15 @@ The FreeCAD Contribution Process is expressed here with the following specific g
 ## 2. Fundamentals
 
 1. FreeCAD uses the git distributed revision control system.
-2. Source code for the main application and related subprojects is hosted on github.com in the FreeCAD organization, hereafter referred to as 'the Platform'.
+2. Source code for the main application and related subprojects is hosted on github.com in the FreeCAD organization.
 3. Problems are discrete, well-defined limitations or bugs.
-4. FreeCAD uses the Platform's issue-tracking system to track problems and contributions.  For help requests and general discussions, use the project forum. 
+4. FreeCAD uses the GitHub's issue-tracking system to track problems and contributions. For help requests and general discussions, use the project forum. 
 5. Contributions are sets of code changes that resolve a single problem.
 6. FreeCAD uses the Pull Request workflow for evaluating and accepting contributions.
 
 ## 3. Roles
 1. "User": An member of the wider FreeCAD community who uses the software.
-2. "Contributor":  A person who submits a contribution that resolves a previously identified problem. Contributors do not have commit access to the repository unless they are also Maintainers. Everyone, without distinction or discrimination, SHALL have an equal right to become a Contributor.
+2. "Contributor": A person who submits a contribution that resolves a previously identified problem. Contributors do not have commit access to the repository unless they are also Maintainers. Everyone, without distinction or discrimination, SHALL have an equal right to become a Contributor.
 3. "Maintainer": A person who merges contributions. Maintainers may or may not be Contributors. Their role is to enforce the process. Maintainers have commit access to the repository.
 4. "Administrator": Administrators have additional authority to maintain the list of designated Maintainers.
 
@@ -47,14 +47,14 @@ The FreeCAD Contribution Process is expressed here with the following specific g
 ## 5. Contribution Requirements
 
 1. Contributions are submitted in the form of Pull Requests (PR).
-2. Maintainers and Contributors MUST have a Platform account and SHOULD use their real names or a well-known alias. 
-3. If the Platform alias differs from the account alias on the FreeCAD Forum, effort SHOULD be taken to avoid confusion.
+2. Maintainers and Contributors MUST have a GitHub account and SHOULD use their real names or a well-known alias. 
+3. If the GitHub username differs from the username on the FreeCAD Forum, effort SHOULD be taken to avoid confusion.
 4. A PR SHOULD be a minimal and accurate answer to exactly one identified and agreed-on problem.
 5. A PR SHOULD refrain from adding additional dependencies to the FreeCAD project unless no other option is available.
 6. Code submissions MUST adhere to the code style guidelines of the project if these are defined.
 7. If a PR contains multiple commits, each commit MUST compile cleanly when merged with all previous commits of the same PR. Each commit SHOULD add value to the history of the project. Checkpoint commits SHOULD be squashed.
 8. A PR SHALL NOT include non-trivial code from other projects unless the Contributor is the original author of that code.
-9. A PR MUST compile cleanly and pass project self-tests on all target Platforms.
+9. A PR MUST compile cleanly and pass project self-tests on all target platforms.
 10. Each commit message in a PR MUST succinctly explain what the commit achieves. The commit message SHALL follow the suggestions in the `git commit --help` documentation, section DISCUSSION.
 11. The PR message MUST consist of a single short line, the PR Title, summarizing the problem being solved, followed by a blank line and then the proposed solution in the Body. If a PR consists of more than one commit, the PR Title MUST succinctly explain what the PR achieves. The Body MAY be as detailed as needed.
 12. A “Valid PR” is one which satisfies the above requirements.
@@ -62,15 +62,15 @@ The FreeCAD Contribution Process is expressed here with the following specific g
 ## 6. Process
 
 1. Change on the project follows the pattern of accurately identifying problems and applying minimal, accurate solutions to these problems.
-2. To request changes, a User logs an issue on the project Platform issue tracker.
-3. The User or Contributor SHOULD write the issue by describing the problem they face or observe. Links to the forum or other resources are permitted but the issue SHOULD be complete and accurate and SHOULD NOT require the reader to visit the forum or any other Platform to understand what is being described.
+2. To request changes, a User logs an issue on the project GitHub issue tracker.
+3. The User or Contributor SHOULD write the issue by describing the problem they face or observe. Links to the forum or other resources are permitted but the issue SHOULD be complete and accurate and SHOULD NOT require the reader to visit the forum or any other platform to understand what is being described.
 4. Issue authors SHOULD strive to describe the minimum acceptable condition.
 5. Issue authors SHOULD focus on User tasks and avoid comparisons to other software solutions.
 6. The User or Contributor SHOULD seek consensus on the accuracy of their observation and the value of solving the problem.
 7. To submit a solution to a problem, a Contributor SHALL create a pull request back to the project.
 8. Contributors and Maintainers SHALL NOT commit changes directly to the target branch.
-9. To discuss a proposed solution, Users MAY comment on the Platform Pull Request. Forum conversations regarding the solution SHOULD be discouraged and conversation redirected to the Pull Request or the related issue.
-10. To accept or reject a Pull Request, a Maintainer SHALL use the Platform interface.
+9. To discuss a proposed solution, Users MAY comment on the Pull Request in GitHub. Forum conversations regarding the solution SHOULD be discouraged and conversation redirected to the Pull Request or the related issue.
+10. To accept or reject a Pull Request, a Maintainer SHALL use GitHub's interface.
 11. Maintainers SHOULD NOT merge their own PRs except:
     1. in exceptional cases, such as non-responsiveness from other Maintainers for an extended period.
     2. If the Maintainer is also the primary developer of the workbench or subsystem.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ The FreeCAD Contribution Process is expressed here with the following specific g
 1. FreeCAD uses the git distributed revision control system.
 2. Source code for the main application and related subprojects is hosted on github.com in the FreeCAD organization.
 3. Problems are discrete, well-defined limitations or bugs.
-4. FreeCAD uses the GitHub's issue-tracking system to track problems and contributions. For help requests and general discussions, use the project forum. 
+4. FreeCAD uses GitHub's issue-tracking system to track problems and contributions. For help requests and general discussions, use the project forum. 
 5. Contributions are sets of code changes that resolve a single problem.
 6. FreeCAD uses the Pull Request workflow for evaluating and accepting contributions.
 


### PR DESCRIPTION
This PR improves `CONTRIBUTING.md` by replacing some instances of the term `Platform` with `GitHub` for the following reasons:

* This was unnecessary legalese which made the document harder to comprehend.
* Fixes a few ambiguous usages of the term:
  * In one usage there is ambiguity if there is a platform called "Platform".
  * Ambiguous with other usages of the word when referring to the runtime platform.
* Fixes one incorrect usage of the term, where reference to `"Platform"` was intended to refer to any platform OTHER THAN `GitHub` or `"the Platform"`.

---

- [x]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR