### PR TITLE
Gui: Eliminate variable reuse

### DIFF
--- a/src/Gui/Workbench.cpp
+++ b/src/Gui/Workbench.cpp
@@ -226,14 +226,15 @@ void Workbench::setName(const std::string& name)
 void Workbench::setupCustomToolbars(ToolBarItem* root, const char* toolbar) const
 {
     std::string name = this->name();
-    ParameterGrp::handle hGrp = App::GetApplication().GetUserParameter().GetGroup("BaseApp")
-        ->GetGroup("Workbench");
+    const auto workbenchGroup {
+        App::GetApplication().GetUserParameter().GetGroup("BaseApp")->GetGroup("Workbench")
+    };
     // workbench specific custom toolbars
-    if (hGrp->HasGroup(name.c_str())) {
-        hGrp = hGrp->GetGroup(name.c_str());
-        if (hGrp->HasGroup(toolbar)) {
-            hGrp = hGrp->GetGroup(toolbar);
-            setupCustomToolbars(root, hGrp);
+    if (workbenchGroup->HasGroup(name.c_str())) {
+        const auto customGroup = workbenchGroup->GetGroup(name.c_str());
+        if (customGroup->HasGroup(toolbar)) {
+            const auto customToolbarGroup = customGroup->GetGroup(toolbar);
+            setupCustomToolbars(root, customToolbarGroup);
         }
     }
 
@@ -243,18 +244,16 @@ void Workbench::setupCustomToolbars(ToolBarItem* root, const char* toolbar) cons
     }
 
     // application-wide custom toolbars
-    hGrp = App::GetApplication().GetUserParameter().GetGroup("BaseApp")
-        ->GetGroup("Workbench");
-    if (hGrp->HasGroup("Global")) {
-        hGrp = hGrp->GetGroup("Global");
-        if (hGrp->HasGroup(toolbar)) {
-            hGrp = hGrp->GetGroup(toolbar);
-            setupCustomToolbars(root, hGrp);
+    if (workbenchGroup->HasGroup("Global")) {
+        const auto globalGroup = workbenchGroup->GetGroup("Global");
+        if (globalGroup->HasGroup(toolbar)) {
+            const auto customToolbarGroup = globalGroup->GetGroup(toolbar);
+            setupCustomToolbars(root, customToolbarGroup);
         }
     }
 }
 
-void Workbench::setupCustomToolbars(ToolBarItem* root, const Base::Reference<ParameterGrp>& hGrp) const
+void Workbench::setupCustomToolbars(ToolBarItem* root, const Base::Reference<ParameterGrp> hGrp) const
 {
     std::vector<Base::Reference<ParameterGrp> > hGrps = hGrp->GetGroups();
     CommandManager& rMgr = Application::Instance->commandManager();

--- a/src/Gui/Workbench.h
+++ b/src/Gui/Workbench.h
@@ -130,7 +130,7 @@ private:
      * a ToolBarItem tree structure.
      */
     void setupCustomToolbars(ToolBarItem* root, const char* toolbar) const;
-    void setupCustomToolbars(ToolBarItem* root, const Base::Reference<ParameterGrp>& hGrp) const;
+    void setupCustomToolbars(ToolBarItem* root, const Base::Reference<ParameterGrp> hGrp) const;
     void setupCustomShortcuts() const;
 
 private:


### PR DESCRIPTION
Coverity complains about USE_AFTER_FREE here (CID 436695), and I found it was difficult to reason about the code to determine whether the analyzer was correct. To help address this, refactor to use different variables for the different parameter groups. Also change the function call to use a non-reference to `Reference`, for the same reason. @wwmayer I don't have a good sense of when I should be using a C++ reference to Base::Reference and when to just let the ref-counted copy be made, so I'd welcome any advice you have there. I don't think the changed function signature is an important part of the PR, and could be rolled back.

---

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR