### PR TITLE
App: Add None=0 to enumeration

### DIFF
--- a/src/App/Link.h
+++ b/src/App/Link.h
@@ -332,6 +332,8 @@ public:
      * Multiple options can be combined by bitwise or operator
      */
     enum class OnChangeCopyOptions {
+        /// No options set
+        None = 0,
         /// If set, then exclude the input from object list to copy on change, or else, include the input object.
         Exclude = 1,
         /// If set , then apply the setting to all links to the input object, or else, apply only to this link.

--- a/src/Gui/ViewProviderLink.cpp
+++ b/src/Gui/ViewProviderLink.cpp
@@ -2447,7 +2447,7 @@ void ViewProviderLink::setupContextMenu(QMenu* menu, QObject* receiver, const ch
                     bool applyAll = box->isChecked();
                     App::LinkParams::setCopyOnChangeApplyToAll(applyAll);
 
-                    App::Link::OnChangeCopyOptions options;
+                    App::Link::OnChangeCopyOptions options {App::Link::OnChangeCopyOptions::None};
                     if (applyAll)
                         options |= App::Link::OnChangeCopyOptions::ApplyAll;
 


### PR DESCRIPTION
Addresses Coverity [CID 356649](https://scan8.scan.coverity.com/reports.htm#v44798/p11555/fileInstanceId=71281382&defectInstanceId=12830107&mergedDefectId=356649), uninitialized scalar. This PR adds an explicit "None" option to the `App::Link::OnChangeCopyOptions` enumeration with a value of zero. The code that creates that type directly now initializes to that new (zero) option. It is not clear how many compilers were performing this initialization automatically, but doing so is not required by the C++ standard (as near as I can tell).

---

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR