### PR TITLE
Part: SectionCutting cutTransparency initialization

### DIFF
--- a/src/Mod/Part/Gui/SectionCutting.cpp
+++ b/src/Mod/Part/Gui/SectionCutting.cpp
@@ -603,7 +603,7 @@ void SectionCut::startCutting(bool isInitial)
 
     // store color and transparency of first object
     App::Color cutColor;
-    int cutTransparency;
+    int cutTransparency {0};
     bool autoColor = true;
     bool autoTransparency = true;
     auto vpFirstObject = dynamic_cast<Gui::ViewProviderGeometryObject*>(


### PR DESCRIPTION
Addresses Coverity [CID 356563](https://scan8.scan.coverity.com/reports.htm#v44798/p11555/fileInstanceId=71281803&defectInstanceId=12830295&mergedDefectId=356563): Uninitialized scalar. `cutTransparency` is later used, from the static analyzer's point of view possibly uninitialized, in a comparison operation. I don't think it's actually possible for that to happen given the logic of the code, but initialize the POD type anyway, for good measure. I chose a value that it can't be given so that if this analysis is incorrect, it should be obvious what happened when stepping through the code.

---

- [X]  This Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR