### PR TITLE
Sketcher: Silence Coverity warning

### DIFF
--- a/src/Mod/Sketcher/App/SketchAnalysis.cpp
+++ b/src/Mod/Sketcher/App/SketchAnalysis.cpp
@@ -655,11 +655,14 @@ int SketchAnalysis::detectMissingEqualityConstraints(double precision)
     std::vector<Sketcher::Constraint*> constraint = sketch->Constraints.getValues();
     for (std::vector<Sketcher::Constraint*>::iterator it = constraint.begin(); it != constraint.end(); ++it) {
         if ((*it)->Type == Sketcher::Equal) {
-            ConstraintIds id;
-            id.First = (*it)->First;
-            id.FirstPos = (*it)->FirstPos;
-            id.Second = (*it)->Second;
-            id.SecondPos = (*it)->SecondPos;
+            ConstraintIds id {
+                Base::Vector3d{},
+                (*it)->First,
+                (*it)->Second,
+                (*it)->FirstPos,
+                (*it)->SecondPos,
+                (*it)->Type
+            };
 
             std::list<ConstraintIds>::iterator pos = std::find_if
                 (equallines.begin(), equallines.end(), Constraint_Equal(id));


### PR DESCRIPTION
Coverity [CID 350580](https://scan8.scan.coverity.com/reports.htm#v44798/p11555/fileInstanceId=71280783&defectInstanceId=12830055&mergedDefectId=350580): Uninitialized scalar variable. The analyzer doesn't like the incomplete construction of the ConstraintId object (the 'Type' field was uninitialized). This PR switches to Uniform Initialization and explicitly spells out each field, including Type, which is unused in the following comparison. This should not affect the run of the code. I believe it is unlikely to represent a measurable speed difference, however if it is possible to check that, it might be a good idea.

---

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR