### PR TITLE
[Gui] fix initialization of NaviCube colors

### DIFF
--- a/src/Gui/View3DInventor.cpp
+++ b/src/Gui/View3DInventor.cpp
@@ -403,22 +403,32 @@ void View3DInventor::OnChange(ParameterGrp::SubjectType &rCaller,ParameterGrp::M
         _viewer->getNavigationCube()->setFont(font);
     }
     else if (strcmp(Reason, "TextColor") == 0) {
-        _viewer->getNavigationCube()->setTextColor(rGrp.GetUnsigned("TextColor", 255));
+        unsigned long col = rGrp.GetUnsigned("TextColor", 255);
+        QColor textColor((col >> 24) & 0xff, (col >> 16) & 0xff, (col >> 8) & 0xff, col & 0xff);
+        _viewer->getNavigationCube()->setTextColor(textColor);
     }
     else if (strcmp(Reason, "FrontColor") == 0) {
-        _viewer->getNavigationCube()->setFrontColor(rGrp.GetUnsigned("FrontColor", 3806916544));
+        unsigned long col = rGrp.GetUnsigned("FrontColor", 3806916544);
+        QColor frontColor((col >> 24) & 0xff, (col >> 16) & 0xff, (col >> 8) & 0xff, col & 0xff);
+        _viewer->getNavigationCube()->setFrontColor(frontColor);
     }
     else if (strcmp(Reason, "HiliteColor") == 0) {
-        _viewer->getNavigationCube()->setHiliteColor(rGrp.GetUnsigned("HiliteColor", 2867003391));
+        unsigned long col = rGrp.GetUnsigned("HiliteColor", 2867003391);
+        QColor hiliteColor((col >> 24) & 0xff, (col >> 16) & 0xff, (col >> 8) & 0xff, col & 0xff);
+        _viewer->getNavigationCube()->setHiliteColor(hiliteColor);
     }
     else if (strcmp(Reason, "ButtonColor") == 0) {
-        _viewer->getNavigationCube()->setButtonColor(rGrp.GetUnsigned("ButtonColor", 3806916480));
+        unsigned long col = rGrp.GetUnsigned("ButtonColor", 3806916480);
+        QColor buttonColor((col >> 24) & 0xff, (col >> 16) & 0xff, (col >> 8) & 0xff, col & 0xff);
+        _viewer->getNavigationCube()->setButtonColor(buttonColor);
     }
     else if (strcmp(Reason, "BorderWidth") == 0) {
         _viewer->getNavigationCube()->setBorderWidth(rGrp.GetFloat("BorderWidth", 1.1));
     }
     else if (strcmp(Reason, "BorderColor") == 0) {
-        _viewer->getNavigationCube()->setBorderColor(rGrp.GetUnsigned("BorderColor", 842150655));
+        unsigned long col = rGrp.GetUnsigned("BorderColor", 842150655);
+        QColor borderColor((col >> 24) & 0xff, (col >> 16) & 0xff, (col >> 8) & 0xff, col & 0xff);
+        _viewer->getNavigationCube()->setBorderColor(borderColor);
     }
     else if (strcmp(Reason,"UseVBO") == 0) {
         _viewer->setEnabledVBO(rGrp.GetBool("UseVBO", false));


### PR DESCRIPTION
- the color is stored in for RRGGBBAA and must be passed in form AARRGGBB to QColor. In NaviCube.cpp this is already done right and the same is necessary for View3DInventor.cpp

