### PR TITLE
Spreadsheet: Fix possible null dereference

### DIFF
--- a/src/Mod/Spreadsheet/Gui/SheetTableView.cpp
+++ b/src/Mod/Spreadsheet/Gui/SheetTableView.cpp
@@ -609,7 +609,7 @@ bool SheetTableView::event(QEvent* event)
             kevent->accept();
         }
     }
-    else if (event->type() == QEvent::LanguageChange) {
+    else if (event && event->type() == QEvent::LanguageChange) {
         actionProperties->setText(tr("Properties..."));
         actionRecompute->setText(tr("Recompute"));
         actionConf->setText(tr("Configuration table..."));


### PR DESCRIPTION
Fixes Coverity CID 184299. It's not clear to me that any of these `event==nullptr` checks are actually necessary, though. Is it really possible for `event` to be null here?

---

- [X]  This Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR