### PR TITLE
Spreadsheet: Fix unintended copies

### DIFF
--- a/src/Mod/Spreadsheet/App/Sheet.cpp
+++ b/src/Mod/Spreadsheet/App/Sheet.cpp
@@ -1234,7 +1234,7 @@ void Sheet::insertColumns(int col, int count)
 void Sheet::removeColumns(int col, int count)
 {
     // Remove aliases, if defined
-    for (auto address : cells.getColumns(col, count)) {
+    for (const auto &address : cells.getColumns(col, count)) {
         auto cell = getCell(address);
         std::string aliasStr;
         if (cell && cell->getAlias(aliasStr))
@@ -1270,7 +1270,7 @@ void Sheet::insertRows(int row, int count)
 void Sheet::removeRows(int row, int count)
 {
     // Remove aliases, if defined
-    for (auto address : cells.getRows(row, count)) {
+    for (const auto &address : cells.getRows(row, count)) {
         auto cell = getCell(address);
         std::string aliasStr;
         if (cell && cell->getAlias(aliasStr))
@@ -1573,7 +1573,7 @@ void Sheet::setCopyOrCutRanges(const std::vector<App::Range> &ranges, bool copy)
     std::set<Range> rangeSet(copyCutRanges.begin(), copyCutRanges.end());
     copyCutRanges = ranges;
     rangeSet.insert(copyCutRanges.begin(), copyCutRanges.end());
-    for(auto range : rangeSet)
+    for(const auto &range : rangeSet)
         rangeUpdated(range);
     hasCopyRange = copy;
 }

--- a/src/Mod/Spreadsheet/Gui/SheetTableView.cpp
+++ b/src/Mod/Spreadsheet/Gui/SheetTableView.cpp
@@ -709,7 +709,7 @@ void SheetTableView::pasteClipboard()
             return;
 
         if(!copy) {
-            for(auto range : ranges) {
+            for(auto &range : ranges) {
                 do {
                     sheet->clear(*range);
                 } while (range.next());


### PR DESCRIPTION
Coverity identifies a few places in Spreadsheet where we could be using a reference instead of a copy in `for` loops: in some cases it's not correct because the object in question is a Range (which is a linked list and modifies itself via its `next()` calls and we do need the copy), but in some cases it is correct. This PR addresses CIDs:
* [356650](https://scan8.scan.coverity.com/reports.htm#v44815/p11555/fileInstanceId=71280029&defectInstanceId=12830097&mergedDefectId=356650)
* [356633](https://scan8.scan.coverity.com/reports.htm#v44815/p11555/fileInstanceId=71280029&defectInstanceId=12830083&mergedDefectId=356633)
* [356605](https://scan8.scan.coverity.com/reports.htm#v44815/p11555/fileInstanceId=71280029&defectInstanceId=12829772&mergedDefectId=356605)
* [356559](https://scan8.scan.coverity.com/reports.htm#v44815/p11555/fileInstanceId=71281807&defectInstanceId=12829960&mergedDefectId=356559)
---

- [X]  This Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR