### PR TITLE
PD: Fix exception from InvoluteGear with zero fillets

### DIFF
--- a/src/Mod/PartDesign/PartDesignTests/TestInvoluteGear.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestInvoluteGear.py
@@ -130,6 +130,29 @@ class TestInvoluteGear(unittest.TestCase):
         self.assertNoIntersection(hub.Shape, makeCircle(tip_diameter/2 - delta), "Teeth extent below tip circle")
         self.assertNoIntersection(hub.Shape, makeCircle(root_diameter/2 + delta), "Teeth extend beyond root circle")
 
+    def testZeroFilletExternalGearProfile_BaseAboveRoot(self):
+        gear = InvoluteGearFeature.makeInvoluteGear('InvoluteGear')
+        # below 42 teeth, with default dedendum 1.25, we have some non-involute flanks
+        gear.NumberOfTeeth = 41
+        gear.RootFilletCoefficient = 0
+        self.assertSuccessfulRecompute(gear)
+        self.assertClosedWire(gear.Shape)
+
+    def testZeroFilletExternalGearProfile_BaseBelowRoot(self):
+        gear = InvoluteGearFeature.makeInvoluteGear('InvoluteGear')
+        # above 41 teeth, with default dedendum 1.25, the root is within the involute flank
+        gear.NumberOfTeeth = 42
+        gear.RootFilletCoefficient = 0
+        self.assertSuccessfulRecompute(gear)
+        self.assertClosedWire(gear.Shape)
+
+    def testZeroFilletInternalGearProfile(self):
+        gear = InvoluteGearFeature.makeInvoluteGear('InvoluteGear')
+        gear.ExternalGear = False
+        gear.RootFilletCoefficient = 0
+        self.assertSuccessfulRecompute(gear)
+        self.assertClosedWire(gear.Shape)
+
     def testUsagePadGearProfile(self):
         profile = InvoluteGearFeature.makeInvoluteGear('GearProfile')
         body = self.Doc.addObject('PartDesign::Body','GearBody')


### PR DESCRIPTION
While gears without a root fillet may have limited real-live use cases, during number-input it happens regulary to have a zero fillet radius as intermediate state. With this commit such a situation is now handled gracefully.

----

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [x]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
