### PR TITLE
Bug fixes and improvements for workbenches settings

### DIFF
--- a/src/Gui/DlgSettingsLazyLoaded.ui
+++ b/src/Gui/DlgSettingsLazyLoaded.ui
@@ -54,17 +54,17 @@
      </column>
      <column>
       <property name="text">
-       <string>Workbench Name</string>
+       <string/>
       </property>
      </column>
      <column>
       <property name="text">
-       <string>Autoload?</string>
+       <string/>
       </property>
      </column>
      <column>
       <property name="text">
-       <string>Load Now</string>
+       <string/>
       </property>
      </column>
     </widget>

--- a/src/Gui/DlgSettingsLazyLoadedImp.cpp
+++ b/src/Gui/DlgSettingsLazyLoadedImp.cpp
@@ -38,6 +38,14 @@ using namespace Gui::Dialog;
 
 const uint DlgSettingsLazyLoadedImp::WorkbenchNameRole = Qt::UserRole;
 
+// this enum defines the order of the columns
+enum Column {
+    Icon,
+    Name,
+    CheckBox,
+    Load
+};
+
 /* TRANSLATOR Gui::Dialog::DlgSettingsLazyLoadedImp */
 
 /**
@@ -117,12 +125,19 @@ void DlgSettingsLazyLoadedImp::buildUnloadedWorkbenchList()
     _autoloadCheckboxes.clear(); // setRowCount(0) just invalidated all of these pointers
     ui->workbenchTable->setColumnCount(4);
     ui->workbenchTable->setSelectionMode(QAbstractItemView::SelectionMode::NoSelection);
-    ui->workbenchTable->horizontalHeader()->setSectionResizeMode(0, QHeaderView::ResizeMode::ResizeToContents);
-    ui->workbenchTable->horizontalHeader()->setSectionResizeMode(1, QHeaderView::ResizeMode::Stretch);
-    ui->workbenchTable->horizontalHeader()->setSectionResizeMode(2, QHeaderView::ResizeMode::ResizeToContents);
-    ui->workbenchTable->horizontalHeader()->setSectionResizeMode(3, QHeaderView::ResizeMode::ResizeToContents);
+    ui->workbenchTable->horizontalHeader()->setSectionResizeMode(Icon, QHeaderView::ResizeMode::ResizeToContents);
+    ui->workbenchTable->horizontalHeader()->setSectionResizeMode(Name, QHeaderView::ResizeMode::Stretch);
+    ui->workbenchTable->horizontalHeader()->setSectionResizeMode(CheckBox, QHeaderView::ResizeMode::ResizeToContents);
+    ui->workbenchTable->horizontalHeader()->setSectionResizeMode(Load, QHeaderView::ResizeMode::ResizeToContents);
     QStringList columnHeaders;
-    columnHeaders << QString() << tr("Workbench") << tr("Autoload") << QString();
+    for (int i = 0; i < 4; i++) {
+        switch (i) {
+            case Icon    : columnHeaders << QString();            break;
+            case Name    : columnHeaders << tr("Workbench Name"); break;
+            case CheckBox: columnHeaders << tr("Autoload?");      break;
+            case Load    : columnHeaders << QString();            break;
+        }
+    }
     ui->workbenchTable->setHorizontalHeaderLabels(columnHeaders);
 
     unsigned int rowNumber = 0;
@@ -139,13 +154,13 @@ void DlgSettingsLazyLoadedImp::buildUnloadedWorkbenchList()
         iconLabel->setPixmap(wbIcon.scaled(QSize(20,20), Qt::AspectRatioMode::KeepAspectRatio, Qt::TransformationMode::SmoothTransformation));
         iconLabel->setToolTip(wbTooltip);
         iconLabel->setContentsMargins(5, 3, 3, 3); // Left, top, right, bottom
-        ui->workbenchTable->setCellWidget(rowNumber, 0, iconLabel);
+        ui->workbenchTable->setCellWidget(rowNumber, Icon, iconLabel);
 
         // Column 2: Workbench Display Name
         auto wbDisplayName = Application::Instance->workbenchMenuText(wbName);
         auto textLabel = new QLabel(wbDisplayName);
         textLabel->setToolTip(wbTooltip);
-        ui->workbenchTable->setCellWidget(rowNumber, 1, textLabel);
+        ui->workbenchTable->setCellWidget(rowNumber, Name, textLabel);
 
         // Column 3: Autoloaded checkbox
         //
@@ -174,18 +189,18 @@ void DlgSettingsLazyLoadedImp::buildUnloadedWorkbenchList()
         else {
             _autoloadCheckboxes.insert(std::make_pair(wbName, autoloadCheckbox));
         }
-        ui->workbenchTable->setCellWidget(rowNumber, 2, checkWidget);
+        ui->workbenchTable->setCellWidget(rowNumber, CheckBox, checkWidget);
 
         // Column 4: Load button/loaded indicator
         if (WorkbenchManager::instance()->getWorkbench(wbName.toStdString())) {
             auto label = new QLabel(tr("Loaded"));
             label->setAlignment(Qt::AlignCenter);
-            ui->workbenchTable->setCellWidget(rowNumber, 3, label);
+            ui->workbenchTable->setCellWidget(rowNumber, Load, label);
         }
         else {
             auto button = new QPushButton(tr("Load now"));
             connect(button, &QPushButton::clicked, this, [this,wbName]() { onLoadClicked(wbName); });
-            ui->workbenchTable->setCellWidget(rowNumber, 3, button);
+            ui->workbenchTable->setCellWidget(rowNumber, Load, button);
         }
 
         ++rowNumber;

--- a/src/Gui/DlgSettingsLazyLoadedImp.cpp
+++ b/src/Gui/DlgSettingsLazyLoadedImp.cpp
@@ -69,11 +69,11 @@ DlgSettingsLazyLoadedImp::~DlgSettingsLazyLoadedImp()
 void DlgSettingsLazyLoadedImp::saveSettings()
 {
     std::ostringstream csv;
-    for (const auto& checkbox : _autoloadCheckboxes) {
-        if (checkbox.second->isChecked()) {
+    for (const auto& checkBox : _autoloadCheckBoxes) {
+        if (checkBox.second->isChecked()) {
             if (!csv.str().empty())
                 csv << ",";
-            csv << checkbox.first.toStdString();
+            csv << checkBox.first.toStdString();
         }
     }
     App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/General")->
@@ -134,7 +134,7 @@ void DlgSettingsLazyLoadedImp::buildUnloadedWorkbenchList()
 
     ui->workbenchTable->horizontalHeader()->setDefaultAlignment(Qt::AlignLeft);
     ui->workbenchTable->setRowCount(0);
-    _autoloadCheckboxes.clear(); // setRowCount(0) just invalidated all of these pointers
+    _autoloadCheckBoxes.clear(); // setRowCount(0) just invalidated all of these pointers
     ui->workbenchTable->setColumnCount(4);
     ui->workbenchTable->setSelectionMode(QAbstractItemView::SelectionMode::NoSelection);
     ui->workbenchTable->horizontalHeader()->setSectionResizeMode(Icon, QHeaderView::ResizeMode::ResizeToContents);
@@ -174,30 +174,30 @@ void DlgSettingsLazyLoadedImp::buildUnloadedWorkbenchList()
         textLabel->setToolTip(wbTooltip);
         ui->workbenchTable->setCellWidget(rowNumber, Name, textLabel);
 
-        // Column 3: Autoloaded checkbox
+        // Column 3: Autoloaded checkBox
         //
-        // To get the checkbox centered, we have to jump through some hoops...
+        // To get the checkBox centered, we have to jump through some hoops...
         auto checkWidget = new QWidget(this);
-        auto autoloadCheckbox = new QCheckBox(this);
-        autoloadCheckbox->setToolTip(tr("If checked, %1 will be loaded automatically when FreeCAD starts up").arg(wbDisplayName));
+        auto autoloadCheckBox = new QCheckBox(this);
+        autoloadCheckBox->setToolTip(tr("If checked, %1 will be loaded automatically when FreeCAD starts up").arg(wbDisplayName));
         auto checkLayout = new QHBoxLayout(checkWidget);
-        checkLayout->addWidget(autoloadCheckbox);
+        checkLayout->addWidget(autoloadCheckBox);
         checkLayout->setAlignment(Qt::AlignCenter);
         checkLayout->setContentsMargins(0, 0, 0, 0);
 
-        // Figure out whether to check and/or disable this checkbox:
+        // Figure out whether to check and/or disable this checkBox:
         if (wbName.toStdString() == _startupModule) {
-            autoloadCheckbox->setChecked(true);
-            autoloadCheckbox->setEnabled(false);
-            autoloadCheckbox->setToolTip(tr("This is the current startup module, and must be autoloaded. See Preferences/General/Autoload to change."));
+            autoloadCheckBox->setChecked(true);
+            autoloadCheckBox->setEnabled(false);
+            autoloadCheckBox->setToolTip(tr("This is the current startup module, and must be autoloaded. See Preferences/General/Autoload to change."));
         }
         else if (std::find(_backgroundAutoloadedModules.begin(), _backgroundAutoloadedModules.end(),
                            wbName.toStdString()) != _backgroundAutoloadedModules.end()) {
-            autoloadCheckbox->setChecked(true);
-            _autoloadCheckboxes.insert(std::make_pair(wbName, autoloadCheckbox));
+            autoloadCheckBox->setChecked(true);
+            _autoloadCheckBoxes.insert(std::make_pair(wbName, autoloadCheckBox));
         }
         else {
-            _autoloadCheckboxes.insert(std::make_pair(wbName, autoloadCheckbox));
+            _autoloadCheckBoxes.insert(std::make_pair(wbName, autoloadCheckBox));
         }
         ui->workbenchTable->setCellWidget(rowNumber, CheckBox, checkWidget);
 

--- a/src/Gui/DlgSettingsLazyLoadedImp.cpp
+++ b/src/Gui/DlgSettingsLazyLoadedImp.cpp
@@ -115,7 +115,7 @@ void DlgSettingsLazyLoadedImp::onLoadClicked(const QString &wbName)
     for (int i = 0; i < ui->workbenchTable->rowCount(); i++) {
         QWidget* widget = ui->workbenchTable->cellWidget(i, Name);
         auto textLabel = dynamic_cast<QLabel*>(widget);
-        if (textLabel->text() == wbDisplayName) {
+        if (textLabel && textLabel->text() == wbDisplayName) {
             auto label = new QLabel(tr("Loaded"));
             label->setAlignment(Qt::AlignCenter);
             ui->workbenchTable->setCellWidget(i, Load, label);

--- a/src/Gui/DlgSettingsLazyLoadedImp.cpp
+++ b/src/Gui/DlgSettingsLazyLoadedImp.cpp
@@ -105,10 +105,22 @@ void DlgSettingsLazyLoadedImp::loadSettings()
 
 void DlgSettingsLazyLoadedImp::onLoadClicked(const QString &wbName)
 {
+    // activate selected workbench
     Workbench* originalActiveWB = WorkbenchManager::instance()->active();
     Application::Instance->activateWorkbench(wbName.toStdString().c_str());
     Application::Instance->activateWorkbench(originalActiveWB->name().c_str());
-    buildUnloadedWorkbenchList();
+
+    // replace load button with loaded indicator
+    auto wbDisplayName = Application::Instance->workbenchMenuText(wbName);
+    for (int i = 0; i < ui->workbenchTable->rowCount(); i++) {
+        QWidget* widget = ui->workbenchTable->cellWidget(i, Name);
+        auto textLabel = dynamic_cast<QLabel*>(widget);
+        if (textLabel->text() == wbDisplayName) {
+            auto label = new QLabel(tr("Loaded"));
+            label->setAlignment(Qt::AlignCenter);
+            ui->workbenchTable->setCellWidget(i, Load, label);
+       }
+    }
 }
 
 

--- a/src/Gui/DlgSettingsLazyLoadedImp.cpp
+++ b/src/Gui/DlgSettingsLazyLoadedImp.cpp
@@ -119,7 +119,8 @@ void DlgSettingsLazyLoadedImp::onLoadClicked(const QString &wbName)
             auto label = new QLabel(tr("Loaded"));
             label->setAlignment(Qt::AlignCenter);
             ui->workbenchTable->setCellWidget(i, Load, label);
-       }
+            break;
+        }
     }
 }
 

--- a/src/Gui/DlgSettingsLazyLoadedImp.cpp
+++ b/src/Gui/DlgSettingsLazyLoadedImp.cpp
@@ -40,10 +40,10 @@ const uint DlgSettingsLazyLoadedImp::WorkbenchNameRole = Qt::UserRole;
 
 // this enum defines the order of the columns
 enum Column {
-    Icon,
-    Name,
+    Load,
     CheckBox,
-    Load
+    Icon,
+    Name
 };
 
 /* TRANSLATOR Gui::Dialog::DlgSettingsLazyLoadedImp */

--- a/src/Gui/DlgSettingsLazyLoadedImp.cpp
+++ b/src/Gui/DlgSettingsLazyLoadedImp.cpp
@@ -179,9 +179,7 @@ void DlgSettingsLazyLoadedImp::buildUnloadedWorkbenchList()
         // To get the checkbox centered, we have to jump through some hoops...
         auto checkWidget = new QWidget(this);
         auto autoloadCheckbox = new QCheckBox(this);
-        autoloadCheckbox->setToolTip(tr("If checked") +
-                                     QString::fromUtf8(", ") + wbDisplayName + QString::fromUtf8(" ") +
-                                     tr("will be loaded automatically when FreeCAD starts up"));
+        autoloadCheckbox->setToolTip(tr("If checked, %1 will be loaded automatically when FreeCAD starts up").arg(wbDisplayName));
         auto checkLayout = new QHBoxLayout(checkWidget);
         checkLayout->addWidget(autoloadCheckbox);
         checkLayout->setAlignment(Qt::AlignCenter);

--- a/src/Gui/DlgSettingsLazyLoadedImp.h
+++ b/src/Gui/DlgSettingsLazyLoadedImp.h
@@ -63,7 +63,7 @@ private:
 
     std::vector<std::string> _backgroundAutoloadedModules;
     std::string _startupModule;
-    std::map<QString, QCheckBox*> _autoloadCheckboxes;
+    std::map<QString, QCheckBox*> _autoloadCheckBoxes;
 };
 
 } // namespace Dialog


### PR DESCRIPTION
Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
I added some improvements to the workbench settings:

- Bugfix: When loading workbenches in the settings dialog, manually selected autoload checkboxes were unselected. A faster implementation that only replaces the load button with the loaded indicator fixed this issue.
- Selecting the correct checkboxes for autoload or buttons for loading was difficult because the checkboxes and buttons were so far away from the icons and names that I often clicked the wrong ones. Therefore I changed the column order to bring them closer together.
- The i18n of the tooltip text was too inflexible for translators to put the argument at the right position (as seen in the German L10n).