### PR TITLE
PD: Retranslate InvoluteGear's Task Panel on language change

### DIFF
--- a/src/Mod/PartDesign/InvoluteGearFeature.py
+++ b/src/Mod/PartDesign/InvoluteGearFeature.py
@@ -223,6 +223,10 @@ class _InvoluteGearTaskPanel:
         assign("DedendumCoefficient", self.form.doubleSpinBox_Dedendum, self.form.label_Dedendum)
         assign("RootFilletCoefficient", self.form.doubleSpinBox_RootFillet, self.form.label_RootFillet)
 
+    def changeEvent(self, event):
+        if event == QtCore.QEvent.LanguageChange:
+            self.assignToolTipsFromPropertyDocs()
+
     def transferTo(self):
         "Transfer from the dialog to the object"
         self.obj.NumberOfTeeth  = self.form.spinBox_NumberOfTeeth.value()


### PR DESCRIPTION
This makes use of the recent additions to `TaskPanelPython` and `UiLoader`, cf. #8602, to retranslate the UI without having to close and reopen it again.
Retranslation of the part from the UI file is now handled by FreeCAD internally, but the tool tips from the property descriptions still need to be reassigned with the translated versions.

This small addition finally completes #8247.

---

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [x]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
