### PR TITLE
Gui: fix regression with the default visibility of toolbars

### DIFF
--- a/src/Gui/ToolBarManager.cpp
+++ b/src/Gui/ToolBarManager.cpp
@@ -226,7 +226,8 @@ void ToolBarManager::setup(ToolBarItem* toolBarItems)
             toolbars.removeAt(index);
         }
 
-        bool visible = hPref->GetBool(toolbarName.c_str(), true) && (*it)->visibility == ToolBarItem::HideStyle::VISIBLE;
+        bool visible = hPref->GetBool(toolbarName.c_str(), (*it)->visibility == ToolBarItem::HideStyle::VISIBLE);
+        visible &= (*it)->visibility != ToolBarItem::HideStyle::FORCE_HIDE;
         toolbar->setVisible(visible);
         toolbar->toggleViewAction()->setVisible((*it)->visibility != ToolBarItem::HideStyle::FORCE_HIDE);
 


### PR DESCRIPTION
If the user e.g. activates the Clipboard toolbar then it should not be hidden any more if the user switches to another workbench. The way it is now the user has to make this toolbar visible over and over again when changing the workbench. This also has the negative effect that the workbench selector changes its position

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [ ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
