### PR TITLE
[Draft] Mitigate crash in Draft_Edit (#8749)

### DIFF
--- a/src/Mod/Draft/DraftGui.py
+++ b/src/Mod/Draft/DraftGui.py
@@ -1070,9 +1070,9 @@ class DraftToolBar:
                 if self.callback:
                     self.callback()
                 return True
-        FreeCADGui.Control.closeDialog()
+        todo.delay(FreeCADGui.Control.closeDialog,None)
         panel = TaskPanel(extra, on_close_call)
-        FreeCADGui.Control.showDialog(panel)
+        todo.delay(FreeCADGui.Control.showDialog,panel)
 
 
 #---------------------------------------------------------------------------


### PR DESCRIPTION
This mitigates the crash reported in issue #8749.  The crash happens when using Draft_Edit and using keyboard to enter a coordinate in Edit node dialog.  This change partially restores behaviour before commit fc14567, after which FreeCADGui.Control.closeDialog and showDialog calls during execution of DraftToolBar.editUi are no longer made using the todo.delay mechanism.  The crash can still be triggered by artificially slowing down key event processing, so this is not a proper fix, just a mitigation.

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
