### PR TITLE
[FEM] Replacement of `std::thread::hardware_concurrency` with `QThread::idealThreadCount`

### DIFF
--- a/src/Mod/Fem/Gui/DlgSettingsFemCcxImp.cpp
+++ b/src/Mod/Fem/Gui/DlgSettingsFemCcxImp.cpp
@@ -25,7 +25,7 @@
 
 #include "PreCompiled.h"
 #ifndef _PreComp_
-# include <thread>
+# include <QThread>
 # include <QMessageBox>
 #endif
 
@@ -42,14 +42,14 @@ DlgSettingsFemCcxImp::DlgSettingsFemCcxImp(QWidget* parent)
     , ui(new Ui_DlgSettingsFemCcxImp)
 {
     ui->setupUi(this);
+
     // set ranges
     ui->dsb_ccx_analysis_time->setMaximum(FLOAT_MAX);
     ui->dsb_ccx_initial_time_step->setMaximum(FLOAT_MAX);
+
     // determine number of CPU cores
-    auto processor_count = std::thread::hardware_concurrency();
-    // hardware check might fail and then returns 0
-    if (processor_count > 0)
-        ui->sb_ccx_numcpu->setMaximum(processor_count);
+    int processor_count = QThread::idealThreadCount();
+    ui->sb_ccx_numcpu->setMaximum(processor_count);
 
     connect(ui->fc_ccx_binary_path, &Gui::PrefFileChooser::fileNameChanged,
             this, &DlgSettingsFemCcxImp::onfileNameChanged);
@@ -134,18 +134,16 @@ void DlgSettingsFemCcxImp::changeEvent(QEvent* e)
         ui->retranslateUi(this);
         ui->cb_analysis_type->setCurrentIndex(c_index);
     }
-    else {
-        QWidget::changeEvent(e);
-    }
+
+    QWidget::changeEvent(e);
 }
 
 void DlgSettingsFemCcxImp::onfileNameChanged(QString FileName)
 {
-    if (!QFileInfo::exists(FileName)) {
+    if (!QFileInfo::exists(FileName))
         QMessageBox::critical(this, tr("File does not exist"),
                               tr("The specified executable \n'%1'\n does not exist!\n"
                                  "Specify another file please.").arg(FileName));
-    }
 }
 
 #include "moc_DlgSettingsFemCcxImp.cpp"

--- a/src/Mod/Fem/Gui/DlgSettingsFemElmerImp.h
+++ b/src/Mod/Fem/Gui/DlgSettingsFemElmerImp.h
@@ -1,26 +1,26 @@
- /**************************************************************************
- *   Copyright (c) 2016 FreeCAD Developers                                 *
- *   Author: Bernd Hahnebach <bernd@bimstatik.ch>                          *
- *   Based on src/Mod/Fem/Gui/DlgSettingsFemCcx.h                          *
- *                                                                         *
- *   This file is part of the FreeCAD CAx development system.              *
- *                                                                         *
- *   This library is free software; you can redistribute it and/or         *
- *   modify it under the terms of the GNU Library General Public           *
- *   License as published by the Free Software Foundation; either          *
- *   version 2 of the License, or (at your option) any later version.      *
- *                                                                         *
- *   This library  is distributed in the hope that it will be useful,      *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU Library General Public License for more details.                  *
- *                                                                         *
- *   You should have received a copy of the GNU Library General Public     *
- *   License along with this library; see the file COPYING.LIB. If not,    *
- *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
- *   Suite 330, Boston, MA  02111-1307, USA                                *
- *                                                                         *
- ***************************************************************************/
+/**************************************************************************
+*   Copyright (c) 2016 FreeCAD Developers                                 *
+*   Author: Bernd Hahnebach <bernd@bimstatik.ch>                          *
+*   Based on src/Mod/Fem/Gui/DlgSettingsFemCcx.h                          *
+*                                                                         *
+*   This file is part of the FreeCAD CAx development system.              *
+*                                                                         *
+*   This library is free software; you can redistribute it and/or         *
+*   modify it under the terms of the GNU Library General Public           *
+*   License as published by the Free Software Foundation; either          *
+*   version 2 of the License, or (at your option) any later version.      *
+*                                                                         *
+*   This library  is distributed in the hope that it will be useful,      *
+*   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+*   GNU Library General Public License for more details.                  *
+*                                                                         *
+*   You should have received a copy of the GNU Library General Public     *
+*   License along with this library; see the file COPYING.LIB. If not,    *
+*   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+*   Suite 330, Boston, MA  02111-1307, USA                                *
+*                                                                         *
+***************************************************************************/
 
 #ifndef FEMGUI_DLGSETTINGSFEMELMERIMP_H
 #define FEMGUI_DLGSETTINGSFEMELMERIMP_H
@@ -33,25 +33,25 @@ namespace FemGui {
 class Ui_DlgSettingsFemElmerImp;
 class DlgSettingsFemElmerImp : public Gui::Dialog::PreferencePage
 {
-    Q_OBJECT
+   Q_OBJECT
 
 public:
-    explicit DlgSettingsFemElmerImp( QWidget* parent = nullptr );
-    ~DlgSettingsFemElmerImp() override;
+   explicit DlgSettingsFemElmerImp( QWidget* parent = nullptr );
+   ~DlgSettingsFemElmerImp() override;
 
 protected Q_SLOTS:
-    void onfileNameChanged(QString FileName);
-    void onfileNameChangedMT(QString FileName);
-    void onCoresValueChanged(int cores);
+   void onfileNameChanged(QString FileName);
+   void onfileNameChangedMT(QString FileName);
+   void onCoresValueChanged(int cores);
 
 protected:
-    void saveSettings() override;
-    void loadSettings() override;
-    void changeEvent(QEvent *e) override;
+   void saveSettings() override;
+   void loadSettings() override;
+   void changeEvent(QEvent *e) override;
 
 private:
-    std::unique_ptr<Ui_DlgSettingsFemElmerImp> ui;
-    unsigned int processor_count;
+   std::unique_ptr<Ui_DlgSettingsFemElmerImp> ui;
+   int processor_count;
 };
 
 } // namespace FemGui


### PR DESCRIPTION
I encountered problems with `std::thread::hardware_concurrency()` using mingw-w64 < v8.1. `QThread::idealThreadCount()` is a better alternative.

Some minor changes were made.

I just opened the files in Qt Creator, changed several lines and saved. Qt Creator seems to remove whitespaces, that's why there are so many changes in diff. I made two futile efforts to keep them, before I realized it was a waste of time as they were harmless.

---

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---


