### PR TITLE
[FEM] Replacement of `std::thread::hardware_concurrency` with `QThread::idealThreadCount`

### DIFF
--- a/src/Mod/Fem/Gui/DlgSettingsFemCcxImp.cpp
+++ b/src/Mod/Fem/Gui/DlgSettingsFemCcxImp.cpp
@@ -25,7 +25,7 @@
 
 #include "PreCompiled.h"
 #ifndef _PreComp_
-# include <thread>
+# include <QThread>
 # include <QMessageBox>
 #endif
 
@@ -46,10 +46,8 @@ DlgSettingsFemCcxImp::DlgSettingsFemCcxImp(QWidget* parent)
     ui->dsb_ccx_analysis_time->setMaximum(FLOAT_MAX);
     ui->dsb_ccx_initial_time_step->setMaximum(FLOAT_MAX);
     // determine number of CPU cores
-    auto processor_count = std::thread::hardware_concurrency();
-    // hardware check might fail and then returns 0
-    if (processor_count > 0)
-        ui->sb_ccx_numcpu->setMaximum(processor_count);
+    int processor_count = QThread::idealThreadCount();
+    ui->sb_ccx_numcpu->setMaximum(processor_count);
 
     connect(ui->fc_ccx_binary_path, &Gui::PrefFileChooser::fileNameChanged,
             this, &DlgSettingsFemCcxImp::onfileNameChanged);

--- a/src/Mod/Fem/Gui/DlgSettingsFemElmerImp.cpp
+++ b/src/Mod/Fem/Gui/DlgSettingsFemElmerImp.cpp
@@ -24,7 +24,7 @@
 
 #include "PreCompiled.h"
 #ifndef _PreComp_
-# include <thread>
+# include <QThread>
 # include <QMessageBox>
 #endif
 
@@ -41,10 +41,8 @@ DlgSettingsFemElmerImp::DlgSettingsFemElmerImp(QWidget* parent)
     ui->setupUi(this);
 
     // determine number of CPU cores
-    processor_count = std::thread::hardware_concurrency();
-    // hardware check might fail and then returns 0
-    if (processor_count > 0)
-        ui->sb_elmer_num_cores->setMaximum(processor_count);
+    processor_count = QThread::idealThreadCount();
+    ui->sb_elmer_num_cores->setMaximum(processor_count);
 
     connect(ui->fc_grid_binary_path, &Gui::PrefFileChooser::fileNameChanged,
             this, &DlgSettingsFemElmerImp::onfileNameChanged);
@@ -109,10 +107,7 @@ void DlgSettingsFemElmerImp::onfileNameChanged(QString FileName)
 
 void DlgSettingsFemElmerImp::onfileNameChangedMT(QString FileName)
 {
-    // reset in case it was previously set to 1
-    // (hardware check might fail and then returns 0)
-    if (processor_count > 0)
-        ui->sb_elmer_num_cores->setMaximum(processor_count);
+    ui->sb_elmer_num_cores->setMaximum(processor_count);
 
     if (ui->sb_elmer_num_cores->value() == 1)
         return;

--- a/src/Mod/Fem/Gui/DlgSettingsFemElmerImp.h
+++ b/src/Mod/Fem/Gui/DlgSettingsFemElmerImp.h
@@ -51,7 +51,7 @@ protected:
 
 private:
     std::unique_ptr<Ui_DlgSettingsFemElmerImp> ui;
-    unsigned int processor_count;
+    int processor_count;
 };
 
 } // namespace FemGui


### PR DESCRIPTION
I encountered problems with `std::thread::hardware_concurrency()` with mingw-w64 < v8.1.

`QThread::idealThreadCount()` is a better alternative.

I'm pushing another commit. In the first I did not set git right and Qt Creator made too many changes. I fixed the settings, remade the commit and now everything seems alright.

---

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
