### PR TITLE
[Mesh] Minor code update

### DIFF
--- a/src/Mod/Mesh/App/Core/Builder.cpp
+++ b/src/Mod/Mesh/App/Core/Builder.cpp
@@ -336,7 +336,7 @@ void MeshFastBuilder::Finish ()
     }
 
     //std::sort(verts.begin(), verts.end());
-    int threads = std::max(1, QThread::idealThreadCount());
+    int threads = QThread::idealThreadCount();
     MeshCore::parallel_sort(verts.begin(), verts.end(), std::less<Private::Vertex>(), threads);
 
     QVector<FacetIndex> indices(ulCtPts);

--- a/src/Mod/Mesh/App/Core/Evaluation.cpp
+++ b/src/Mod/Mesh/App/Core/Evaluation.cpp
@@ -966,7 +966,7 @@ void MeshKernel::RebuildNeighbours (FacetIndex index)
 
     // sort the edges
     //std::sort(edges.begin(), edges.end(), Edge_Less());
-    int threads = std::max(1, QThread::idealThreadCount());
+    int threads = QThread::idealThreadCount();
     MeshCore::parallel_sort(edges.begin(), edges.end(), Edge_Less(), threads);
 
     PointIndex p0 = POINT_INDEX_MAX, p1 = POINT_INDEX_MAX;


### PR DESCRIPTION
Removal of unnecessary comparison.

`QThread::idealThreadCount()` returns the ideal number of threads that the process can run in parallel or 1 if it fails to determine it.

---

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
