### PR TITLE
[NotificationArea] Notificationarea

### DIFF
--- a/src/App/Document.h
+++ b/src/App/Document.h
@@ -71,13 +71,6 @@ public:
         IgnoreErrorOnRecompute = 12, // Don't report errors if the recompute failed
     };
 
-    enum class NotificationType {
-        Information,
-        Warning,
-        Error,
-        Critical,
-    };
-
     /** @name Properties */
     //@{
     /// holds the long name of the document (utf-8 coded)
@@ -177,8 +170,6 @@ public:
     boost::signals2::signal<void (const App::Document&, const std::vector<App::DocumentObject*>&)> signalSkipRecompute;
     boost::signals2::signal<void (const App::DocumentObject&)> signalFinishRestoreObject;
     boost::signals2::signal<void (const App::Document&,const App::Property&)> signalChangePropertyEditor;
-    // signal user message
-    boost::signals2::signal<void (const App::DocumentObject&, const QString &, NotificationType)> signalUserMessage;
     //@}
     boost::signals2::signal<void (std::string)> signalLinkXsetValue;
 

--- a/src/Base/CMakeLists.txt
+++ b/src/Base/CMakeLists.txt
@@ -231,6 +231,7 @@ SET(FreeCADBase_CPP_SRCS
     MatrixPyImp.cpp
     MemDebug.cpp
     Mutex.cpp
+    Observer.cpp
     Parameter.xsd
     Parameter.cpp
     ParameterPy.cpp

--- a/src/Base/Observer.cpp
+++ b/src/Base/Observer.cpp
@@ -1,0 +1,34 @@
+/***************************************************************************
+ *   Copyright (c) 2023 Abdullah Tahiri <abdullah.tahiri.yo@gmail.com>     *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU Library General Public License (LGPL)   *
+ *   as published by the Free Software Foundation; either version 2 of     *
+ *   the License, or (at your option) any later version.                   *
+ *   for detail see the LICENCE text file.                                 *
+ *                                                                         *
+ *   FreeCAD is distributed in the hope that it will be useful,            *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with FreeCAD; if not, write to the Free Software        *
+ *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+ *   USA                                                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "PreCompiled.h"
+
+#include "Observer.h"
+
+
+namespace Base {
+
+template class BaseExport Observer<const char*>;
+template class BaseExport Subject<const char*>;
+
+} //namespace Base

--- a/src/Base/Observer.h
+++ b/src/Base/Observer.h
@@ -216,15 +216,16 @@ protected:
   std::set<Observer <_MessageType> *> _ObserverSet;
 };
 
-#if defined (FC_OS_WIN32) || defined(FC_OS_CYGWIN)
-#   ifdef FCBase
-template class BaseExport Observer<const char*>;
-template class BaseExport Subject<const char*>;
-#   else
-extern template class BaseExport Observer<const char*>;
-extern template class BaseExport Subject<const char*>;
-#   endif
+// Workaround for MSVC
+#ifdef FreeCADBase_EXPORTS
+#  define Base_EXPORT
+#else
+#  define Base_EXPORT  BaseExport
 #endif
+
+extern template class Base_EXPORT Observer<const char*>;
+extern template class Base_EXPORT Subject<const char*>;
+
 
 } //namespace Base
 

--- a/src/Gui/CMakeLists.txt
+++ b/src/Gui/CMakeLists.txt
@@ -327,6 +327,7 @@ SET(Gui_UIC_SRCS
     DlgSettingsImage.ui
     DlgSettingsLazyLoaded.ui
     DlgSettingsMacro.ui
+    DlgSettingsNotificationArea.ui
     DlgSettingsPythonConsole.ui
     DlgCheckableMessageBox.ui
     DlgToolbars.ui
@@ -568,6 +569,7 @@ SET(Dialog_Settings_CPP_SRCS
     DlgSettingsImageImp.cpp
     DlgSettingsLazyLoadedImp.cpp
     DlgSettingsMacroImp.cpp
+    DlgSettingsNotificationArea.cpp
     DlgSettingsPythonConsole.cpp
 )
 SET(Dialog_Settings_HPP_SRCS
@@ -587,6 +589,7 @@ SET(Dialog_Settings_HPP_SRCS
     DlgSettingsImageImp.h
     DlgSettingsLazyLoadedImp.h
     DlgSettingsMacroImp.h
+    DlgSettingsNotificationArea.h
     DlgSettingsPythonConsole.h
 )
 SET(Dialog_Settings_SRCS
@@ -608,6 +611,7 @@ SET(Dialog_Settings_SRCS
     DlgSettingsImage.ui
     DlgSettingsLazyLoaded.ui
     DlgSettingsMacro.ui
+    DlgSettingsNotificationArea.ui
     DlgSettingsPythonConsole.ui
 )
 SOURCE_GROUP("Dialog\\Settings" FILES ${Dialog_Settings_SRCS})

--- a/src/Gui/CMakeLists.txt
+++ b/src/Gui/CMakeLists.txt
@@ -999,6 +999,7 @@ SET(Widget_CPP_SRCS
     MainWindow.cpp
     MainWindowPy.cpp
     NotificationBox.cpp
+    NotificationArea.cpp
     PrefWidgets.cpp
     InputField.cpp
     ProgressBar.cpp
@@ -1018,6 +1019,7 @@ SET(Widget_HPP_SRCS
     MainWindow.h
     MainWindowPy.h
     NotificationBox.h
+    NotificationArea.h
     PrefWidgets.h
     InputField.h
     ProgressBar.h

--- a/src/Gui/DlgSettingsNotificationArea.cpp
+++ b/src/Gui/DlgSettingsNotificationArea.cpp
@@ -1,0 +1,102 @@
+/***************************************************************************
+ *   Copyright (c) 2023 Abdullah Tahiri <abdullah.tahiri.yo@gmail.com>     *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "PreCompiled.h"
+
+#ifndef _PreComp_
+# include <QMessageBox>
+#endif
+
+#include "DlgSettingsNotificationArea.h"
+#include "ui_DlgSettingsNotificationArea.h"
+
+
+using namespace Gui::Dialog;
+
+/* TRANSLATOR Gui::Dialog::DlgSettingsNotificationArea */
+
+DlgSettingsNotificationArea::DlgSettingsNotificationArea(QWidget* parent)
+  : PreferencePage(parent)
+  , ui(new Ui_DlgSettingsNotificationArea)
+{
+    ui->setupUi(this);
+
+    connect(ui->NotificationAreaEnabled, &QCheckBox::stateChanged, [this](int state) {
+        if(state == Qt::CheckState::Checked) {
+            ui->NonIntrusiveNotificationsEnabled->setEnabled(true);
+            ui->maxDuration->setEnabled(true);
+            ui->maxDuration->setEnabled(true);
+            ui->minDuration->setEnabled(true);
+            ui->maxNotifications->setEnabled(true);
+            ui->maxWidgetMessages->setEnabled(true);
+            ui->autoRemoveUserNotifications->setEnabled(true);
+            QMessageBox::information(this, tr("Notification Area"),
+            tr("Activation of the Notification Area only takes effect after an application restart."));
+        }
+        else {
+            ui->NonIntrusiveNotificationsEnabled->setEnabled(false);
+            ui->maxDuration->setEnabled(false);
+            ui->maxDuration->setEnabled(false);
+            ui->minDuration->setEnabled(false);
+            ui->maxNotifications->setEnabled(false);
+            ui->maxWidgetMessages->setEnabled(false);
+            ui->autoRemoveUserNotifications->setEnabled(false);
+        // N.B: Deactivation is handled by the Notification Area itself, as it listens to all its configuration parameters.
+        }
+    });
+}
+
+DlgSettingsNotificationArea::~DlgSettingsNotificationArea()
+{
+}
+
+void DlgSettingsNotificationArea::saveSettings()
+{
+    ui->NotificationAreaEnabled->onSave();
+    ui->NonIntrusiveNotificationsEnabled->onSave();
+    ui->maxDuration->onSave();
+    ui->minDuration->onSave();
+    ui->maxNotifications->onSave();
+    ui->maxWidgetMessages->onSave();
+    ui->autoRemoveUserNotifications->onSave();
+}
+
+void DlgSettingsNotificationArea::loadSettings()
+{
+    ui->NotificationAreaEnabled->onRestore();
+    ui->NonIntrusiveNotificationsEnabled->onRestore();
+    ui->maxDuration->onRestore();
+    ui->minDuration->onRestore();
+    ui->maxNotifications->onRestore();
+    ui->maxWidgetMessages->onRestore();
+    ui->autoRemoveUserNotifications->onRestore();
+}
+
+void DlgSettingsNotificationArea::changeEvent(QEvent *e)
+{
+    if (e->type() == QEvent::LanguageChange) {
+        ui->retranslateUi(this);
+    }
+    QWidget::changeEvent(e);
+}
+
+#include "moc_DlgSettingsNotificationArea.cpp"

--- a/src/Gui/DlgSettingsNotificationArea.h
+++ b/src/Gui/DlgSettingsNotificationArea.h
@@ -1,0 +1,59 @@
+/***************************************************************************
+ *   Copyright (c) 2023 Abdullah Tahiri <abdullah.tahiri.yo@gmail.com>     *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#ifndef GUI_DIALOG_DLGSETTINGSNOTIFICATIONAREA_H
+#define GUI_DIALOG_DLGSETTINGSNOTIFICATIONAREA_H
+
+#include "PropertyPage.h"
+#include <memory>
+
+namespace Gui {
+namespace Dialog {
+class Ui_DlgSettingsNotificationArea;
+
+/**
+ * The DlgSettingsNotificationArea class implements a preference page to change settings
+ * for the Notification Area.
+ */
+class DlgSettingsNotificationArea : public PreferencePage
+{
+    Q_OBJECT
+
+public:
+    explicit DlgSettingsNotificationArea(QWidget* parent = nullptr);
+    ~DlgSettingsNotificationArea() override;
+
+    void saveSettings() override;
+    void loadSettings() override;
+
+protected:
+    void changeEvent(QEvent *e) override;
+
+private:
+    std::unique_ptr<Ui_DlgSettingsNotificationArea> ui;
+};
+
+} // namespace Dialog
+} // namespace Gui
+
+#endif // GUI_DIALOG_DLGSETTINGSNOTIFICATIONAREA_H

--- a/src/Gui/DlgSettingsNotificationArea.ui
+++ b/src/Gui/DlgSettingsNotificationArea.ui
@@ -1,0 +1,240 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Gui::Dialog::DlgSettingsNotificationArea</class>
+ <widget class="QWidget" name="Gui::Dialog::DlgSettingsNotificationArea">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>654</width>
+    <height>356</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Notification Area</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout_2">
+   <item row="1" column="0">
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Non-Intrusive Notifications</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_3">
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>Minimum Duration:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label">
+        <property name="toolTip">
+         <string/>
+        </property>
+        <property name="text">
+         <string>Maximum Duration:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="Gui::PrefSpinBox" name="maxDuration">
+        <property name="toolTip">
+         <string>Duration during which the notification will be shown (unless mouse buttons are clicked)</string>
+        </property>
+        <property name="suffix">
+         <string>s</string>
+        </property>
+        <property name="minimum">
+         <number>0</number>
+        </property>
+        <property name="maximum">
+         <number>120</number>
+        </property>
+        <property name="value">
+         <number>20</number>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>NotificationTime</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>NotificationArea</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="Gui::PrefSpinBox" name="minDuration">
+        <property name="toolTip">
+         <string>Minimum duration during which the notification will be shown (unless notification clicked)</string>
+        </property>
+        <property name="suffix">
+         <string>s</string>
+        </property>
+        <property name="value">
+         <number>5</number>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>MinimumOnScreenTime</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>NotificationArea</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_3">
+        <property name="text">
+         <string>Maximum Number of Notifications:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="Gui::PrefSpinBox" name="maxNotifications">
+        <property name="toolTip">
+         <string>Maximum number of notifications that will be simultaneously present on the screen</string>
+        </property>
+        <property name="value">
+         <number>15</number>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>MaxOpenNotifications</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>NotificationArea</cstring>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QGroupBox" name="GroupBox11">
+     <property name="title">
+      <string>Settings</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="0" column="0">
+       <widget class="Gui::PrefCheckBox" name="NotificationAreaEnabled">
+        <property name="toolTip">
+         <string>The Notification area will appear in the status bar</string>
+        </property>
+        <property name="text">
+         <string>Enable Notification Area</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>NotificationAreaEnabled</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>NotificationArea</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="Gui::PrefCheckBox" name="NonIntrusiveNotificationsEnabled">
+        <property name="toolTip">
+         <string>Non-intrusive notifications will appear next to the notification area in the status bar</string>
+        </property>
+        <property name="text">
+         <string>Enable non-intrusive notifications</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>NonIntrusiveNotificationsEnabled</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>NotificationArea</cstring>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="6" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>63</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="2" column="0">
+    <widget class="QGroupBox" name="groupBox_2">
+     <property name="title">
+      <string>Message List</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_4">
+      <item row="0" column="1">
+       <widget class="Gui::PrefSpinBox" name="maxWidgetMessages">
+        <property name="toolTip">
+         <string>Limit the number of messages that will be kept in the list. If 0 there is no limit.</string>
+        </property>
+        <property name="maximum">
+         <number>10000</number>
+        </property>
+        <property name="value">
+         <number>1000</number>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>MaxWidgetMessages</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>NotificationArea</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_4">
+        <property name="text">
+         <string>Maximum Messages (0 = no limit):</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="Gui::PrefCheckBox" name="autoRemoveUserNotifications">
+        <property name="toolTip">
+         <string>Removes the user notifications from the message list after the non-intrusive maximum duration has lapsed.</string>
+        </property>
+        <property name="text">
+         <string>Auto-remove User Notifications</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>AutoRemoveUserNotifications</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>NotificationArea</cstring>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>Gui::PrefCheckBox</class>
+   <extends>QCheckBox</extends>
+   <header>Gui/PrefWidgets.h</header>
+  </customwidget>
+  <customwidget>
+   <class>Gui::PrefSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>Gui/PrefWidgets.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -30,6 +30,7 @@
 # include <QMessageBox>
 # include <QTextStream>
 # include <QTimer>
+# include <QStatusBar>
 # include <Inventor/actions/SoSearchAction.h>
 # include <Inventor/nodes/SoSeparator.h>
 #endif
@@ -55,6 +56,7 @@
 #include "FileDialog.h"
 #include "MainWindow.h"
 #include "MDIView.h"
+#include "NotificationArea.h"
 #include "Selection.h"
 #include "Thumbnail.h"
 #include "Tree.h"
@@ -71,175 +73,6 @@ using namespace Gui;
 namespace bp = boost::placeholders;
 
 namespace Gui {
-
-/** This class is an implementation only class to handle user notifications offered by App::Document.
- *
- * It provides a mechanism requiring confirmation for critical notifications only during User initiated restore/document loading ( it
- * does not require confirmation for macro/Python initiated restore, not to interfere with automations).
- *
- * Additionally, it provides a mechanism to show autoclosing non-modal user notifications in a non-intrusive way.
- **/
-class MessageManager {
-public:
-    MessageManager() = default;
-    ~MessageManager();
-
-    void setDocument(Gui::Document * pDocument);
-    void slotUserMessage(const App::DocumentObject&, const QString &, App::Document::NotificationType);
-
-
-private:
-    void reorderAutoClosingMessages();
-    QMessageBox* createNonModalMessage(const QString & msg, App::Document::NotificationType notificationtype);
-    void pushAutoClosingMessage(const QString & msg, App::Document::NotificationType notificationtype);
-    void pushAutoClosingMessageTooManyMessages();
-
-private:
-    using Connection = boost::signals2::connection;
-    Gui::Document * pDoc;
-    Connection connectUserMessage;
-    bool requireConfirmationCriticalMessageDuringRestoring = true;
-    std::vector<QMessageBox*> openAutoClosingMessages;
-    std::mutex mutexAutoClosingMessages;
-    const int autoClosingTimeout = 5000; // ms
-    const int autoClosingMessageStackingOffset = 10;
-    const unsigned int maxNumberOfOpenAutoClosingMessages = 3;
-    bool maxNumberOfOpenAutoClosingMessagesLimitReached = false;
-};
-
-MessageManager::~MessageManager(){
-    connectUserMessage.disconnect();
-}
-
-void MessageManager::setDocument(Gui::Document * pDocument)
-{
-
-    pDoc = pDocument;
-
-    connectUserMessage = pDoc->getDocument()->signalUserMessage.connect
-        (boost::bind(&Gui::MessageManager::slotUserMessage, this, bp::_1, bp::_2, bp::_3));
-
-}
-
-void MessageManager::slotUserMessage(const App::DocumentObject& obj, const QString & msg, App::Document::NotificationType notificationtype)
-{
-    (void) obj;
-
-    auto userInitiatedRestore = Application::Instance->testStatus(Gui::Application::UserInitiatedOpenDocument);
-
-    if(notificationtype == App::Document::NotificationType::Critical && userInitiatedRestore && requireConfirmationCriticalMessageDuringRestoring) {
-        auto confirmMsg = msg + QStringLiteral("\n\n") + QObject::tr("Do you want to skip confirmation of further critical message notifications while loading the file?");
-        auto button = QMessageBox::critical(pDoc->getActiveView(), QObject::tr("Critical Message"), confirmMsg, QMessageBox::Yes | QMessageBox::No, QMessageBox::No );
-
-        if(button == QMessageBox::Yes)
-            requireConfirmationCriticalMessageDuringRestoring = false;
-    }
-    else { // Non-critical errors and warnings - auto-closing non-blocking message box
-
-        auto messageNumber =  openAutoClosingMessages.size();
-
-        // Not opening more than the number of maximum autoclosing messages
-        // If maximum reached, the mechanism only resets after all present messages are auto-closed
-        if( messageNumber < maxNumberOfOpenAutoClosingMessages) {
-            if(messageNumber == 0 && maxNumberOfOpenAutoClosingMessagesLimitReached) {
-                maxNumberOfOpenAutoClosingMessagesLimitReached = false;
-            }
-
-            if(!maxNumberOfOpenAutoClosingMessagesLimitReached) {
-                pushAutoClosingMessage(msg, notificationtype);
-            }
-        }
-        else {
-            if(!maxNumberOfOpenAutoClosingMessagesLimitReached)
-                pushAutoClosingMessageTooManyMessages();
-
-            maxNumberOfOpenAutoClosingMessagesLimitReached = true;
-        }
-    }
-}
-
-void MessageManager::pushAutoClosingMessage(const QString & msg, App::Document::NotificationType notificationtype)
-{
-    std::lock_guard<std::mutex> g(mutexAutoClosingMessages); // guard to avoid creating new messages while closing old messages (via timer)
-
-    auto msgBox = createNonModalMessage(msg, notificationtype);
-
-    msgBox->show();
-
-    int numberOpenAutoClosingMessages = openAutoClosingMessages.size();
-
-    openAutoClosingMessages.push_back(msgBox);
-
-    reorderAutoClosingMessages();
-
-    QTimer::singleShot(autoClosingTimeout*numberOpenAutoClosingMessages, [msgBox, this](){
-        std::lock_guard<std::mutex> g(mutexAutoClosingMessages); // guard to avoid closing old messages while creating new ones
-        if(msgBox) {
-            msgBox->done(0);
-            openAutoClosingMessages.erase(
-                std::remove(openAutoClosingMessages.begin(), openAutoClosingMessages.end(), msgBox),
-                openAutoClosingMessages.end());
-
-            reorderAutoClosingMessages();
-        }
-    });
-}
-
-void MessageManager::pushAutoClosingMessageTooManyMessages()
-{
-    pushAutoClosingMessage(QObject::tr("Too many message notifications. Notification temporarily stopped. Look at the report view for more information."), App::Document::NotificationType::Warning);
-}
-
-
-QMessageBox* MessageManager::createNonModalMessage(const QString & msg, App::Document::NotificationType notificationtype)
-{
-        auto parent = pDoc->getActiveView();
-
-        QMessageBox* msgBox = new QMessageBox(parent);
-        msgBox->setAttribute(Qt::WA_DeleteOnClose); // msgbox deleted automatically upon closed
-        msgBox->setStandardButtons(QMessageBox::NoButton);
-        msgBox->setWindowFlag(Qt::FramelessWindowHint,true);
-        msgBox->setText(msg);
-
-        if(notificationtype == App::Document::NotificationType::Error) {
-            msgBox->setWindowTitle(QObject::tr("Error"));
-            msgBox->setIcon(QMessageBox::Critical);
-        }
-        else if(notificationtype == App::Document::NotificationType::Warning) {
-            msgBox->setWindowTitle(QObject::tr("Warning"));
-            msgBox->setIcon(QMessageBox::Warning);
-        }
-        else if(notificationtype == App::Document::NotificationType::Information) {
-            msgBox->setWindowTitle(QObject::tr("Information"));
-            msgBox->setIcon(QMessageBox::Information);
-        }
-        else if(notificationtype == App::Document::NotificationType::Critical) {
-            msgBox->setWindowTitle(QObject::tr("Critical"));
-            msgBox->setIcon(QMessageBox::Critical);
-        }
-
-        msgBox->setModal( false ); // if you want it non-modal
-
-        return msgBox;
-}
-
-void MessageManager::reorderAutoClosingMessages()
-{
-    auto parent = pDoc->getActiveView();
-
-    int numberOpenAutoClosingMessages = openAutoClosingMessages.size();
-
-    auto x = parent->width() / 2;
-    auto y = parent->height() / 7;
-
-    int posindex = numberOpenAutoClosingMessages - 1;
-    for (auto rit = openAutoClosingMessages.rbegin(); rit != openAutoClosingMessages.rend(); ++rit, posindex--) {
-        int xw = x - (*rit)->width() / 2 + autoClosingMessageStackingOffset*posindex;;
-        int yw = y + autoClosingMessageStackingOffset*posindex;
-        (*rit)->move(xw, yw);
-        (*rit)->raise();
-    }
-}
 
 // Pimpl class
 struct DocumentP
@@ -301,8 +134,6 @@ struct DocumentP
     using ConnectionBlock = boost::signals2::shared_connection_block;
     ConnectionBlock connectActObjectBlocker;
     ConnectionBlock connectChangeDocumentBlocker;
-
-    MessageManager messageManager;
 };
 } // namespace Gui
 
@@ -384,7 +215,6 @@ Document::Document(App::Document* pcDocument,Application * app)
     d->connectTransactionRemove = pcDocument->signalTransactionRemove.connect
         (boost::bind(&Gui::Document::slotTransactionRemove, this, bp::_1, bp::_2));
 
-    d->messageManager.setDocument(this);
     // pointer to the python class
     // NOTE: As this Python object doesn't get returned to the interpreter we
     // mustn't increment it (Werner Jan-12-2006)

--- a/src/Gui/Icons/InTray.svg
+++ b/src/Gui/Icons/InTray.svg
@@ -1,0 +1,487 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="64"
+   height="64"
+   id="svg11300"
+   version="1.1"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs3">
+    <linearGradient
+       id="linearGradient3822">
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1"
+         offset="0"
+         id="stop3824" />
+      <stop
+         style="stop-color:#204a87;stop-opacity:1"
+         offset="1"
+         id="stop3826" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient5060"
+       id="radialGradient5031"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-2.774389,0,0,1.969706,112.7623,-872.8854)"
+       cx="605.71429"
+       cy="486.64789"
+       fx="605.71429"
+       fy="486.64789"
+       r="117.14286" />
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         style="stop-color:black;stop-opacity:1;"
+         offset="0"
+         id="stop5062" />
+      <stop
+         style="stop-color:black;stop-opacity:0;"
+         offset="1"
+         id="stop5064" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient5060"
+       id="radialGradient5029"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.774389,0,0,1.969706,-1891.633,-872.8854)"
+       cx="605.71429"
+       cy="486.64789"
+       fx="605.71429"
+       fy="486.64789"
+       r="117.14286" />
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         style="stop-color:black;stop-opacity:0;"
+         offset="0"
+         id="stop5050" />
+      <stop
+         id="stop5056"
+         offset="0.5"
+         style="stop-color:black;stop-opacity:1;" />
+      <stop
+         style="stop-color:black;stop-opacity:0;"
+         offset="1"
+         id="stop5052" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient5048"
+       id="linearGradient5027"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.774389,0,0,1.969706,-1892.179,-872.8854)"
+       x1="302.85715"
+       y1="366.64789"
+       x2="302.85715"
+       y2="609.50507" />
+    <linearGradient
+       id="linearGradient3284">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3286" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3288" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3260">
+      <stop
+         style="stop-color:#204a87;stop-opacity:1;"
+         offset="0"
+         id="stop3262" />
+      <stop
+         style="stop-color:#204a87;stop-opacity:0;"
+         offset="1"
+         id="stop3264" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3239">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop3241" />
+      <stop
+         style="stop-color:#d3d7cf;stop-opacity:1"
+         offset="1"
+         id="stop3243" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11520">
+      <stop
+         id="stop11522"
+         offset="0.0000000"
+         style="stop-color:#ffffff;stop-opacity:1.0000000;" />
+      <stop
+         id="stop11524"
+         offset="1.0000000"
+         style="stop-color:#dcdcdc;stop-opacity:1.0000000;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11508">
+      <stop
+         id="stop11510"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop11512"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11494">
+      <stop
+         id="stop11496"
+         offset="0"
+         style="stop-color:#ef2929;stop-opacity:1;" />
+      <stop
+         id="stop11498"
+         offset="1"
+         style="stop-color:#ef2929;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11415">
+      <stop
+         id="stop11417"
+         offset="0.0000000"
+         style="stop-color:#204a87;stop-opacity:0.0000000;" />
+      <stop
+         style="stop-color:#204a87;stop-opacity:1.0000000;"
+         offset="0.50000000"
+         id="stop11423" />
+      <stop
+         id="stop11419"
+         offset="1"
+         style="stop-color:#204a87;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11399">
+      <stop
+         id="stop11401"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop11403"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-60.28571,-0.285714)"
+       y2="34.462429"
+       x2="43.615788"
+       y1="3.774456"
+       x1="15.82836"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11425"
+       xlink:href="#linearGradient11415" />
+    <linearGradient
+       gradientTransform="translate(-60.57143,0)"
+       y2="39.033859"
+       x2="35.679932"
+       y1="9.3458843"
+       x1="9.6957054"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11427"
+       xlink:href="#linearGradient11415" />
+    <linearGradient
+       y2="33.462429"
+       x2="26.758644"
+       y1="19.774456"
+       x1="13.267134"
+       gradientTransform="translate(-60.85714,0.428571)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11439"
+       xlink:href="#linearGradient11415" />
+    <radialGradient
+       r="8.5"
+       fy="39.142857"
+       fx="12.071428"
+       cy="39.142857"
+       cx="12.071428"
+       gradientTransform="matrix(1,0,0,0.487395,0,20.06483)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient11441"
+       xlink:href="#linearGradient11399" />
+    <radialGradient
+       gradientTransform="matrix(1.243453,0,0,1.243453,-6.713754,-3.742847)"
+       gradientUnits="userSpaceOnUse"
+       r="3.8335035"
+       fy="15.048258"
+       fx="27.577173"
+       cy="15.048258"
+       cx="27.577173"
+       id="radialGradient11500"
+       xlink:href="#linearGradient11494" />
+    <radialGradient
+       r="3.8335035"
+       fy="16.049133"
+       fx="27.577173"
+       cy="16.049133"
+       cx="27.577173"
+       gradientTransform="matrix(1.243453,0,0,1.243453,-6.713754,-3.742847)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient11504"
+       xlink:href="#linearGradient11494" />
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.338462,0,29.48178)"
+       r="6.5659914"
+       fy="44.565483"
+       fx="30.203562"
+       cy="44.565483"
+       cx="30.203562"
+       id="radialGradient11514"
+       xlink:href="#linearGradient11508" />
+    <radialGradient
+       gradientTransform="matrix(1.995058,0,0,1.995058,-24.32488,-35.70087)"
+       gradientUnits="userSpaceOnUse"
+       r="20.530962"
+       fy="35.87817"
+       fx="24.44569"
+       cy="35.87817"
+       cx="24.44569"
+       id="radialGradient11526"
+       xlink:href="#linearGradient11520" />
+    <radialGradient
+       r="6.5659914"
+       fy="44.565483"
+       fx="30.203562"
+       cy="44.565483"
+       cx="30.203562"
+       gradientTransform="matrix(1,0,0,0.338462,0,29.48178)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient11532"
+       xlink:href="#linearGradient11508" />
+    <radialGradient
+       xlink:href="#linearGradient11508"
+       id="radialGradient1348"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.338462,0,29.48178)"
+       cx="30.203562"
+       cy="44.565483"
+       fx="30.203562"
+       fy="44.565483"
+       r="6.5659914" />
+    <radialGradient
+       xlink:href="#linearGradient11520"
+       id="radialGradient1350"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.995058,0,0,1.995058,-24.32488,-35.70087)"
+       cx="24.44569"
+       cy="35.87817"
+       fx="24.44569"
+       fy="35.87817"
+       r="20.530962" />
+    <radialGradient
+       xlink:href="#linearGradient11494"
+       id="radialGradient1352"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.243453,0,0,1.243453,-6.713754,-3.742847)"
+       cx="27.577173"
+       cy="16.049133"
+       fx="27.577173"
+       fy="16.049133"
+       r="3.8335035" />
+    <radialGradient
+       xlink:href="#linearGradient11494"
+       id="radialGradient1354"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.243453,0,0,1.243453,-6.713754,-3.742847)"
+       cx="27.577173"
+       cy="15.048258"
+       fx="27.577173"
+       fy="15.048258"
+       r="3.8335035" />
+    <radialGradient
+       xlink:href="#linearGradient11508"
+       id="radialGradient1356"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.338462,0,29.48178)"
+       cx="30.203562"
+       cy="44.565483"
+       fx="30.203562"
+       fy="44.565483"
+       r="6.5659914" />
+    <radialGradient
+       xlink:href="#linearGradient11520"
+       id="radialGradient1366"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.049266,0,0,2.049266,-25.65002,-37.31089)"
+       cx="24.44569"
+       cy="35.87817"
+       fx="24.44569"
+       fy="35.87817"
+       r="20.530962" />
+    <linearGradient
+       xlink:href="#linearGradient3239"
+       id="linearGradient3249"
+       gradientUnits="userSpaceOnUse"
+       x1="15.663794"
+       y1="5.1465507"
+       x2="27.11207"
+       y2="42.353451"
+       gradientTransform="matrix(1.3975903,0,0,1.3975902,-1.8915666,-17.192769)" />
+    <linearGradient
+       xlink:href="#linearGradient3260"
+       id="linearGradient3266"
+       x1="12.363961"
+       y1="11.394304"
+       x2="18.22703"
+       y2="17.58149"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3813389,0,0,1.3813389,-1.8428134,-16.461473)" />
+    <linearGradient
+       xlink:href="#linearGradient3260"
+       id="linearGradient3270"
+       gradientUnits="userSpaceOnUse"
+       x1="12.363961"
+       y1="11.394304"
+       x2="18.22703"
+       y2="17.58149"
+       gradientTransform="matrix(-1.3813389,0,0,1.3813389,65.842795,-16.461473)" />
+    <linearGradient
+       xlink:href="#linearGradient3260"
+       id="linearGradient3278"
+       gradientUnits="userSpaceOnUse"
+       x1="12.363961"
+       y1="11.394304"
+       x2="18.22703"
+       y2="17.58149"
+       gradientTransform="matrix(1.3813389,0,0,-1.3813389,-1.8428134,48.504624)" />
+    <linearGradient
+       xlink:href="#linearGradient3260"
+       id="linearGradient3280"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.3813389,0,0,-1.3813389,65.842795,48.504624)"
+       x1="12.363961"
+       y1="11.394304"
+       x2="18.22703"
+       y2="17.58149" />
+    <radialGradient
+       xlink:href="#linearGradient3284"
+       id="radialGradient3290"
+       cx="25.455845"
+       cy="43.403805"
+       fx="25.455845"
+       fy="43.403805"
+       r="20.682873"
+       gradientTransform="matrix(1,0,0,0.205128,0,34.50046)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       xlink:href="#linearGradient3822"
+       id="linearGradient3828"
+       x1="44"
+       y1="41"
+       x2="53"
+       y2="56"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       xlink:href="#linearGradient3822-6-2"
+       id="linearGradient3834-3-0"
+       gradientUnits="userSpaceOnUse"
+       x1="48"
+       y1="54"
+       x2="46"
+       y2="42"
+       gradientTransform="rotate(180,34.5,29.5)" />
+    <linearGradient
+       id="linearGradient3822-6-2">
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1"
+         offset="0"
+         id="stop3824-7-3" />
+      <stop
+         style="stop-color:#204a87;stop-opacity:1"
+         offset="1"
+         id="stop3826-5-7" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata4">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>Jakub Steiner</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:source>http://jimmac.musichall.cz</dc:source>
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/by-sa/2.0/" />
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by-sa/2.0/">
+        <cc:permits
+           rdf:resource="http://web.resource.org/cc/Reproduction" />
+        <cc:permits
+           rdf:resource="http://web.resource.org/cc/Distribution" />
+        <cc:requires
+           rdf:resource="http://web.resource.org/cc/Notice" />
+        <cc:requires
+           rdf:resource="http://web.resource.org/cc/Attribution" />
+        <cc:permits
+           rdf:resource="http://web.resource.org/cc/DerivativeWorks" />
+        <cc:requires
+           rdf:resource="http://web.resource.org/cc/ShareAlike" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     transform="translate(0,16)">
+    <g
+       style="display:inline"
+       id="g5022"
+       transform="matrix(0.03152036,0,0,0.03344397,60.035325,37.041739)">
+      <rect
+         y="-150.69685"
+         x="-1559.2523"
+         height="478.35718"
+         width="1339.6335"
+         id="rect4173"
+         style="opacity:0.40206185;color:#000000;fill:url(#linearGradient5027);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+      <path
+         id="path5058"
+         d="m -219.61876,-150.68038 c 0,0 0,478.33079 0,478.33079 142.874166,0.90045 345.40022,-107.16966 345.40014,-239.196175 0,-132.026537 -159.436816,-239.134595 -345.40014,-239.134615 z"
+         style="opacity:0.40206185;color:#000000;fill:url(#radialGradient5029);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+      <path
+         style="opacity:0.40206185;color:#000000;fill:url(#radialGradient5031);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+         d="m -1559.2523,-150.68038 c 0,0 0,478.33079 0,478.33079 -142.8742,0.90045 -345.4002,-107.16966 -345.4002,-239.196175 0,-132.026537 159.4368,-239.134595 345.4002,-239.134615 z"
+         id="path5018" />
+    </g>
+    <rect
+       style="color:#000000;fill:url(#linearGradient3249);fill-opacity:1;fill-rule:evenodd;stroke:#888a85;stroke-width:1.99999975999999990;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible"
+       id="rect2354"
+       width="58"
+       height="57.999996"
+       x="3"
+       y="-12.999999"
+       rx="2.5900114"
+       ry="2.5900111" />
+    <path
+       xlink:href="#rect2354"
+       style="color:#000000;fill:none;stroke:#ffffff;stroke-width:2.07175946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible"
+       id="path3247"
+       d="m 5.59375,-11.96875 c -0.8780988,0 -1.5625,0.684401 -1.5625,1.5625 l 0,52.8125 c 0,0.878099 0.6844012,1.5625 1.5625,1.5625 l 52.8125,0 c 0.878098,0 1.5625,-0.684402 1.5625,-1.5625 l 0,-52.8125 c 0,-0.878098 -0.684402,-1.5625 -1.5625,-1.5625 l -52.8125,0 z"
+       transform="matrix(0.96536313,0,0,0.96536312,1.10838,0.55418996)" />
+    <path
+       id="path3050-5-8"
+       d="M 12,2 V 39 H 52 V 2 C 38.666667,2 25.333333,2 12,2 Z"
+       style="fill:url(#linearGradient3834-3-0);fill-opacity:1;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
+    <path
+       id="path3820-6-9"
+       d="M 50,5 32,20 14,5 14.15625,37 H 50 Z"
+       style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  </g>
+</svg>

--- a/src/Gui/Icons/Warning.svg
+++ b/src/Gui/Icons/Warning.svg
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="64px"
+   height="64px"
+   id="svg2735"
+   sodipodi:version="0.32"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   sodipodi:docname="Warning.svg"
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   version="1.1"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs2737">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3774">
+      <stop
+         style="stop-color:#c4a000;stop-opacity:1"
+         offset="0"
+         id="stop3776" />
+      <stop
+         style="stop-color:#edd400;stop-opacity:0;"
+         offset="1"
+         id="stop3778" />
+    </linearGradient>
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 32 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="64 : 32 : 1"
+       inkscape:persp3d-origin="32 : 21.333333 : 1"
+       id="perspective2743" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3774"
+       id="linearGradient3780"
+       x1="531.31073"
+       y1="35.292263"
+       x2="517.97607"
+       y2="-14.006179"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11"
+     inkscape:cx="27.590909"
+     inkscape:cy="34.318182"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:document-units="px"
+     inkscape:grid-bbox="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="986"
+     inkscape:window-x="0"
+     inkscape:window-y="32"
+     inkscape:window-maximized="1"
+     inkscape:pagecheckerboard="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2984"
+       empspacing="2"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata2740">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer">
+    <path
+       transform="matrix(1.0590534,0,0,1.0590534,-518.49688,29.778244)"
+       style="fill:#fce94f;fill-opacity:1;fill-rule:evenodd;stroke:#302b00;stroke-width:1.88847888;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       d="m 519.80087,-21.508116 27.38295,47.211972 -54.76589,0 z"
+       id="path2644"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+    <path
+       transform="matrix(0.89990936,0,0,0.93309237,-436.1315,31.069059)"
+       style="fill:url(#linearGradient3780);fill-opacity:1;fill-rule:evenodd;stroke:#fce94f;stroke-width:2.18257069999999986;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       d="m 520.1985,-21.508115 28.3867,47.15503 -56.77339,0 z"
+       id="path2644-3"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.959166px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 30,19 29,39.24 32,42 35,39.24 34,19 Z"
+       id="path67"
+       sodipodi:nodetypes="cccccc" />
+    <circle
+       style="fill:#000000;stroke:#000000;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path91"
+       cx="31.970903"
+       cy="48.55901"
+       r="2" />
+  </g>
+</svg>

--- a/src/Gui/Icons/critical-info.svg
+++ b/src/Gui/Icons/critical-info.svg
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="64"
+   height="64"
+   id="svg2985"
+   version="1.1"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs2987">
+    <linearGradient
+       id="linearGradient3774">
+      <stop
+         style="stop-color:#d3d7cf;stop-opacity:1"
+         offset="0"
+         id="stop3776" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="1"
+         id="stop3778" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4082">
+      <stop
+         id="stop4084"
+         offset="0"
+         style="stop-color:#4e9a06;stop-opacity:1" />
+      <stop
+         id="stop4086"
+         offset="1"
+         style="stop-color:#8ae234;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3774"
+       id="linearGradient3780"
+       x1="30"
+       y1="-2"
+       x2="26"
+       y2="-26"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       xlink:href="#linearGradient3774"
+       id="linearGradient3780-9"
+       x1="30"
+       y1="-2"
+       x2="26"
+       y2="-26"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <metadata
+     id="metadata2990">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     transform="translate(0,48)">
+    <path
+       style="fill:#3465a4;fill-opacity:1;stroke:#172a04;stroke-width:2;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       id="path4250-0"
+       d="M 9.9782835,-34.857935 A 28.992303,28.993136 89.972578 1 1 54.021443,2.8584493 28.992303,28.993136 89.972578 1 1 9.9782835,-34.857935 z" />
+    <path
+       style="fill:#ce5c00;fill-opacity:1;stroke:#f57900;stroke-width:1.99999988;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       id="path4250-7-6"
+       d="M 11.490345,-33.556021 A 26.997584,26.999999 89.926009 1 1 52.50579,1.5653637 26.997584,26.999999 89.926009 0 1 11.490345,-33.556021 z" />
+    <g
+       id="g1433"
+       transform="matrix(-0.70710678,-0.70710678,-0.70710678,0.70710678,-14.170518,-20.824561)">
+      <g
+         id="g837"
+         transform="translate(-51.999999,-37.272656)">
+        <path
+           style="fill:url(#linearGradient3780);fill-opacity:1;stroke:#2e3436;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
+           d="m 25.829379,-10.556714 7.889426,7.889426 -7.718806,7.7187945 -7.739743,-8.0204581 c 3.335802,-3.335802 3.326481,-3.3451227 7.569123,-7.5877624 z"
+           id="path4088" />
+        <path
+           style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 20.96529,-2.7920778 c 3.485935,-3.4859355 -0.08089,-0.0046 4.853361,-4.9469367 l 5.079637,5.079637 L 26,2.238911 Z"
+           id="path3004" />
+      </g>
+    </g>
+    <g
+       id="g1433-7"
+       transform="matrix(-0.70710678,-0.70710678,-0.70710678,0.70710678,-14.329804,11.560252)">
+      <g
+         id="g837-0"
+         transform="translate(-51.999999,-37.272656)">
+        <path
+           style="fill:url(#linearGradient3780-9);fill-opacity:1;stroke:#2e3436;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
+           d="m 25.999999,-10.727344 11.143089,-11.143079 7.889426,7.889426 -19.032515,19.0325035 -7.739743,-8.0204581 c -0.300196,-0.169656 6.770872,-7.2407234 7.739743,-7.7583924 z"
+           id="path4088-9" />
+        <path
+           style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 20.96529,-2.7920778 c 0,0 5.004242,-4.9671833 5.03471,-5.1123582 l 11.13236,-11.148287 5.079637,5.079637 L 26,2.238911 Z"
+           id="path3004-3" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/src/Gui/Icons/info.svg
+++ b/src/Gui/Icons/info.svg
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="64"
+   height="64"
+   id="svg2985"
+   version="1.1"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs2987">
+    <linearGradient
+       id="linearGradient3774">
+      <stop
+         style="stop-color:#d3d7cf;stop-opacity:1"
+         offset="0"
+         id="stop3776" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="1"
+         id="stop3778" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4082">
+      <stop
+         id="stop4084"
+         offset="0"
+         style="stop-color:#4e9a06;stop-opacity:1" />
+      <stop
+         id="stop4086"
+         offset="1"
+         style="stop-color:#8ae234;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3774"
+       id="linearGradient3780"
+       x1="30"
+       y1="-2"
+       x2="26"
+       y2="-26"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       xlink:href="#linearGradient3774"
+       id="linearGradient3780-9"
+       x1="30"
+       y1="-2"
+       x2="26"
+       y2="-26"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <metadata
+     id="metadata2990">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     transform="translate(0,48)">
+    <path
+       style="fill:#3465a4;fill-opacity:1;stroke:#172a04;stroke-width:2;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       id="path4250-0"
+       d="M 9.9782835,-34.857935 A 28.992303,28.993136 89.972578 1 1 54.021443,2.8584493 28.992303,28.993136 89.972578 1 1 9.9782835,-34.857935 z" />
+    <path
+       style="fill:#3465a4;fill-opacity:1;stroke:#729fcf;stroke-width:1.99999988;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       id="path4250-7-6"
+       d="M 11.490345,-33.556021 A 26.997584,26.999999 89.926009 1 1 52.50579,1.5653637 26.997584,26.999999 89.926009 0 1 11.490345,-33.556021 z" />
+    <g
+       id="g1433"
+       transform="matrix(-0.70710678,-0.70710678,-0.70710678,0.70710678,-14.170518,-20.824561)">
+      <g
+         id="g837"
+         transform="translate(-51.999999,-37.272656)">
+        <path
+           style="fill:url(#linearGradient3780);fill-opacity:1;stroke:#2e3436;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
+           d="m 25.829379,-10.556714 7.889426,7.889426 -7.718806,7.7187945 -7.739743,-8.0204581 c 3.335802,-3.335802 3.326481,-3.3451227 7.569123,-7.5877624 z"
+           id="path4088" />
+        <path
+           style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 20.96529,-2.7920778 c 3.485935,-3.4859355 -0.08089,-0.0046 4.853361,-4.9469367 l 5.079637,5.079637 L 26,2.238911 Z"
+           id="path3004" />
+      </g>
+    </g>
+    <g
+       id="g1433-7"
+       transform="matrix(-0.70710678,-0.70710678,-0.70710678,0.70710678,-14.329804,11.560252)">
+      <g
+         id="g837-0"
+         transform="translate(-51.999999,-37.272656)">
+        <path
+           style="fill:url(#linearGradient3780-9);fill-opacity:1;stroke:#2e3436;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
+           d="m 25.999999,-10.727344 11.143089,-11.143079 7.889426,7.889426 -19.032515,19.0325035 -7.739743,-8.0204581 c -0.300196,-0.169656 6.770872,-7.2407234 7.739743,-7.7583924 z"
+           id="path4088-9" />
+        <path
+           style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 20.96529,-2.7920778 c 0,0 5.004242,-4.9671833 5.03471,-5.1123582 l 11.13236,-11.148287 5.079637,5.079637 L 26,2.238911 Z"
+           id="path3004-3" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/src/Gui/Icons/resource.qrc
+++ b/src/Gui/Icons/resource.qrc
@@ -74,6 +74,8 @@
         <file>edit-undo.svg</file>
         <file>edit-edit.svg</file>
         <file>edit-cleartext.svg</file>
+        <file>info.svg</file>
+        <file>critical-info.svg</file>
         <file>tree-item-drag.svg</file>
         <file>tree-goto-sel.svg</file>
         <file>tree-rec-sel.svg</file>
@@ -98,6 +100,7 @@
         <file>accessories-text-editor.svg</file>
         <file>accessories-calculator.svg</file>
         <file>internet-web-browser.svg</file>
+        <file>InTray.svg</file>
         <file>view-select.svg</file>
         <file>view-unselectable.svg</file>
         <file>view-refresh.svg</file>
@@ -251,6 +254,7 @@
         <file>Std_UserEditModeTransform.svg</file>
         <file>Std_UserEditModeCutting.svg</file>
         <file>Std_UserEditModeColor.svg</file>
+        <file>Warning.svg</file>
     </qresource>
     <!-- Demonstrating support for an embedded icon theme -->
     <!-- See also http://permalink.gmane.org/gmane.comp.lib.qt.general/26374 -->

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -80,6 +80,7 @@
 #include "DownloadManager.h"
 #include "FileDialog.h"
 #include "MenuManager.h"
+#include "NotificationArea.h"
 #include "ProgressBar.h"
 #include "PropertyView.h"
 #include "PythonConsole.h"
@@ -251,7 +252,6 @@ protected:
 
 } // namespace Gui
 
-
 /* TRANSLATOR Gui::MainWindow */
 
 MainWindow::MainWindow(QWidget * parent, Qt::WindowFlags f)
@@ -304,6 +304,17 @@ MainWindow::MainWindow(QWidget * parent, Qt::WindowFlags f)
     statusBar()->addPermanentWidget(progressBar, 0);
     statusBar()->addPermanentWidget(d->sizeLabel, 0);
 
+    auto hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/NotificationArea");
+
+    auto notificationAreaEnabled = hGrp->GetBool("NotificationAreaEnabled", true);
+
+    if(notificationAreaEnabled) {
+        NotificationArea* notificationArea = new NotificationArea(statusBar());
+        notificationArea->setObjectName(QString::fromLatin1("notificationArea"));
+        notificationArea->setIcon(QIcon(QString::fromLatin1(":/icons/InTray.svg")));
+        notificationArea->setStyleSheet(QStringLiteral("text-align:left;"));
+        statusBar()->addPermanentWidget(notificationArea);
+    }
     // clears the action label
     d->actionTimer = new QTimer( this );
     d->actionTimer->setObjectName(QString::fromLatin1("actionTimer"));

--- a/src/Gui/NotificationArea.cpp
+++ b/src/Gui/NotificationArea.cpp
@@ -1,0 +1,993 @@
+/***************************************************************************
+ *   Copyright (c) 2022 Abdullah Tahiri <abdullah.tahiri.yo@gmail.com>     *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "PreCompiled.h"
+
+#ifndef _PreComp_
+#include <QAction>
+#include <QActionEvent>
+#include <QApplication>
+#include <QEvent>
+#include <QHBoxLayout>
+#include <QHeaderView>
+#include <QMenu>
+#include <QMessageBox>
+#include <QStringList>
+#include <QThread>
+#include <QTimer>
+#include <QTreeWidget>
+#include <QWidgetAction>
+#include <memory>
+#include <mutex>
+#endif
+
+#include <App/Application.h>
+#include <Base/Console.h>
+
+#include "Application.h"
+#include "BitmapFactory.h"
+#include "MDIView.h"
+#include "MainWindow.h"
+#include "NotificationBox.h"
+
+#include "NotificationArea.h"
+
+using namespace Gui;
+
+using Connection = boost::signals2::connection;
+
+namespace bp = boost::placeholders;
+
+class NotificationAreaObserver;
+
+namespace Gui
+{
+/** PImpl idiom structure having all data necessary for the notification area */
+struct NotificationAreaP
+{
+    // Structure holding all variables necessary for the Notification Area.
+    // Preference parameters are updated by NotificationArea::ParameterObserver
+
+    /** @name Non-intrusive notifications parameters */
+    //@{
+    /// Parameter controlled
+    int maxOpenNotifications = 15;
+    /// Parameter controlled
+    unsigned int notificationExpirationTime = 10000;
+    /// minimum time that the notification will remain unclosed
+    unsigned int minimumOnScreenTime = 5000;
+    /// Parameter controlled
+    bool notificationsDisabled = false;
+    /// Control of confirmation mechanism (for Critical Messages)
+    bool requireConfirmationCriticalMessageDuringRestoring = true;
+    //@}
+
+    /** @name Widget parameters */
+    //@{
+    /// Parameter controlled - maximum number of message allowed in the notification area widget (0
+    /// means no limit)
+    int maxWidgetMessages = 1000;
+    /// User notifications get automatically removed from the Widget after the non-intrusive
+    /// notification expiration time
+    bool autoRemoveUserNotifications;
+    //@}
+
+    /** @name Notification rate control */
+    //@{
+    /* Control rate of updates of non-intrusive messages (avoids visual artifacts when messages are
+     * constantly being received) */
+    // Timer to delay notification until a minimum time between two consecutive messages have lapsed
+    QTimer inhibitTimer;
+    // The time between two consecutive messages forced by the inhibitTimer
+    const unsigned int inhibitNotificationTime = 250;
+    //@}
+
+    // Access control
+    std::mutex mutexNotification;
+
+    // Pointers to widgets (no ownership)
+    QMenu* menu;
+    QWidgetAction* notificationaction;
+
+    /** @name Resources */
+    //@{
+    /// Base::Console Message observer
+    std::unique_ptr<NotificationAreaObserver> observer;
+    Connection finishRestoreDocumentConnection;
+    /// Preference Parameter observer
+    std::unique_ptr<NotificationArea::ParameterObserver> parameterObserver;
+    //@}
+};
+
+}// namespace Gui
+
+
+/******************* Resource Management *****************************************/
+
+/** Simple class to manage Notification Area Resources*/
+class ResourceManager
+{
+
+private:
+    ResourceManager()
+    {
+        error = BitmapFactory().pixmapFromSvg(":/icons/edit_Cancel.svg", QSize(16, 16));
+        warning = BitmapFactory().pixmapFromSvg(":/icons/Warning.svg", QSize(16, 16));
+        critical = BitmapFactory().pixmapFromSvg(":/icons/critical-info.svg", QSize(16, 16));
+        info = BitmapFactory().pixmapFromSvg(":/icons/info.svg", QSize(16, 16));
+    }
+
+    inline static const auto& getResourceManager()
+    {
+        static ResourceManager manager;
+
+        return manager;
+    }
+
+public:
+    inline static auto ErrorPixmap()
+    {
+        auto rm = getResourceManager();
+        return rm.error;
+    }
+
+    inline static auto WarningPixmap()
+    {
+        auto rm = getResourceManager();
+        return rm.warning;
+    }
+
+    inline static auto CriticalPixmap()
+    {
+        auto rm = getResourceManager();
+        return rm.critical;
+    }
+
+    inline static auto InfoPixmap()
+    {
+        auto rm = getResourceManager();
+        return rm.info;
+    }
+
+private:
+    QPixmap error;
+    QPixmap warning;
+    QPixmap critical;
+    QPixmap info;
+};
+
+/******************** Console Messages Observer (Console Interface) ************************/
+
+/** This class listens to all messages sent via the console interface and
+   feeds the non-intrusive notification system and the notifications widget */
+class NotificationAreaObserver: public Base::ILogger
+{
+public:
+    NotificationAreaObserver(NotificationArea* notificationarea);
+    ~NotificationAreaObserver() override;
+
+    /// Function that is called by the console interface for this observer with the message
+    /// information
+    void SendLog(const std::string& notifiername, const std::string& msg,
+                 Base::LogStyle level) override;
+
+    /// Name of the observer
+    const char* Name() override
+    {
+        return "NotificationAreaObserver";
+    }
+
+private:
+    NotificationArea* notificationArea;
+};
+
+NotificationAreaObserver::NotificationAreaObserver(NotificationArea* notificationarea)
+    : notificationArea(notificationarea)
+{
+    Base::Console().AttachObserver(this);
+    bLog = false;                  // ignore log messages
+    bMsg = false;                  // ignore messages
+    bNotification = true;          // activate user notifications
+    bTranslatedNotification = true;// activate translated user notifications
+}
+
+NotificationAreaObserver::~NotificationAreaObserver()
+{
+    Base::Console().DetachObserver(this);
+}
+
+void NotificationAreaObserver::SendLog(const std::string& notifiername, const std::string& msg,
+                                       Base::LogStyle level)
+{
+    // 1. As notification system is shared with report view and others, the expectation is that any
+    // individual error and warning message will end in "\n". This means the string must be stripped
+    // of this character for representation in the notification area.
+    // 2. However, any message marked with the QT_TRANSLATE_NOOT macro with the "Notifications"
+    // context, shall not include
+    // "\n", as this generates problems with the translation system. Then the string must be
+    // stripped of "\n" before translation.
+
+    auto simplifiedstring =
+        QString::fromStdString(msg)
+            .trimmed();// remove any leading and trailing whitespace character ('\n')
+
+    // avoid processing empty strings
+    if(simplifiedstring.isEmpty())
+        return;
+
+    if (level == Base::LogStyle::TranslatedNotification) {
+        notificationArea->pushNotification(
+            QString::fromStdString(notifiername), simplifiedstring, level);
+    }
+    else {
+        notificationArea->pushNotification(
+            QString::fromStdString(notifiername),
+            QCoreApplication::translate("Notifications", simplifiedstring.toUtf8()),
+            level);
+    }
+}
+
+
+/******************* Notification Widget *******************************************************/
+
+/** Specialised Item class for the Widget notifications/errors/warnings
+   It holds all item specific data, including visualisation data and controls how
+   the item should appear in the widget.
+*/
+class NotificationItem: public QTreeWidgetItem
+{
+public:
+    NotificationItem(Base::LogStyle notificationtype, QString notifiername, QString message)
+        : notificationType(notificationtype),
+          notifierName(std::move(notifiername)),
+          msg(std::move(message))
+    {}
+
+    QVariant data(int column, int role) const override
+    {
+        // strings that will be displayed for each column of the widget
+        if (role == Qt::DisplayRole) {
+            switch (column) {
+                case 1:
+                    return notifierName;
+                    break;
+                case 2:
+                    return msg;
+                    break;
+            }
+        }
+        else if (column == 0 && role == Qt::DecorationRole) {
+            // Icons to be displayed for the first row
+            if (notificationType == Base::LogStyle::Error) {
+                return std::move(ResourceManager::ErrorPixmap());
+            }
+            else if (notificationType == Base::LogStyle::Warning) {
+                return std::move(ResourceManager::WarningPixmap());
+            }
+            else if (notificationType == Base::LogStyle::Critical) {
+                return std::move(ResourceManager::CriticalPixmap());
+            }
+            else {
+                return std::move(ResourceManager::InfoPixmap());
+            }
+        }
+        else if (role == Qt::FontRole) {
+            // Visualisation control of unread messages
+            static QFont font;
+            static QFont boldFont(font.family(), font.pointSize(), QFont::Bold);
+
+            if (unread) {
+                return boldFont;
+            }
+
+            return font;
+        }
+
+        return QVariant();
+    }
+
+    Base::LogStyle notificationType;
+    QString notifierName;
+    QString msg;
+
+    bool unread = true;   // item is unread in the Notification Area Widget
+    bool notifying = true;// item is to be notified or being notified as non-intrusive message
+    bool shown = false;   // item is already being notified (it is onScreen)
+};
+
+/** Drop menu Action containing the notifications widget.
+ *  It stores all the notification item information in the form
+ * of NotificationItems (QTreeWidgetItem). This information is used
+ * by the Widget and by the non-intrusive messages.
+ * It owns the notification resources and is responsible for the release
+ * of the memory resources, either directly for the intermediate fast cache
+ * or indirectly via QT for the case of the QTreeWidgetItems.
+ */
+class NotificationsAction: public QWidgetAction
+{
+public:
+    NotificationsAction(QWidget* parent)
+        : QWidgetAction(parent)
+    {}
+
+    ~NotificationsAction()
+    {
+        for (auto* item : pushedItems) {
+            if (item) {
+                delete item;
+            }
+        }
+    }
+
+public:
+    /// deletes only notifications (messages of type Notification and TranslatedNotification)
+    void deleteNotifications()
+    {
+        if (tableWidget) {
+            for (int i = tableWidget->topLevelItemCount() - 1; i >= 0; i--) {
+                auto* item = static_cast<NotificationItem*>(tableWidget->topLevelItem(i));
+                if (item->notificationType == Base::LogStyle::Notification
+                    || item->notificationType == Base::LogStyle::TranslatedNotification) {
+                    delete item;
+                }
+            }
+        }
+        for (int i = pushedItems.size() - 1; i >= 0; i--) {
+            auto* item = static_cast<NotificationItem*>(pushedItems.at(i));
+            if (item->notificationType == Base::LogStyle::Notification
+                || item->notificationType == Base::LogStyle::TranslatedNotification) {
+                delete pushedItems.takeAt(i);
+            }
+        }
+    }
+
+    /// deletes all notifications, errors and warnings
+    void deleteAll()
+    {
+        if (tableWidget) {
+            tableWidget->clear();// the parent will delete the items.
+        }
+        while (!pushedItems.isEmpty())
+            delete pushedItems.takeFirst();
+    }
+
+    /// returns the amount of unread notifications, errors and warnings
+    inline int getUnreadCount() const
+    {
+        return getCurrently([](auto* item) {
+            return item->unread;
+        });
+    }
+
+    /// returns the amount of notifications, errors and warnings currently being notified
+    inline int getCurrentlyNotifyingCount() const
+    {
+        return getCurrently([](auto* item) {
+            return item->notifying;
+        });
+    }
+
+    /// returns the amount of notifications, errors and warnings currently being shown as
+    /// non-intrusive messages (on-screen)
+    inline int getShownCount() const
+    {
+        return getCurrently([](auto* item) {
+            return item->shown;
+        });
+    }
+
+    /// marks all notifications, errors and warnings as read
+    void clearUnreadFlag()
+    {
+        for (auto i = 0; i < tableWidget->topLevelItemCount();
+             i++) {// all messages were read, so clear the unread flag
+            auto* item = static_cast<NotificationItem*>(tableWidget->topLevelItem(i));
+            item->unread = false;
+        }
+    }
+
+    /// pushes all Notification Items to the Widget, so that they can be shown
+    void synchroniseWidget()
+    {
+        tableWidget->insertTopLevelItems(0, pushedItems);
+        pushedItems.clear();
+    }
+
+    /** pushes all Notification Items to the fast cache (this also prevents all unnecessary
+     * signaling from parents) and allows to accelerate insertions and deletions
+     */
+    void shiftToCache()
+    {
+        tableWidget->blockSignals(true);
+        tableWidget->clearSelection();
+        while (tableWidget->topLevelItemCount() > 0) {
+            auto* item = tableWidget->takeTopLevelItem(0);
+            pushedItems.push_back(item);
+        }
+        tableWidget->blockSignals(false);
+    }
+
+    /// returns if there are no notifications, errors and warnings at all
+    bool isEmpty() const
+    {
+        return tableWidget->topLevelItemCount() == 0 && pushedItems.isEmpty();
+    }
+
+    /// returns the total amount of notifications, errors and warnings currently stored
+    auto count() const
+    {
+        return tableWidget->topLevelItemCount() + pushedItems.count();
+    }
+
+    /// retrieves a pointer to a given notification from storage.
+    auto getItem(int index) const
+    {
+        if (index < pushedItems.count()) {
+            return pushedItems.at(index);
+        }
+        else {
+            return tableWidget->topLevelItem(index - pushedItems.count());
+        }
+    }
+
+    /// deletes a given notification, errors or warnings by index
+    void deleteItem(int index)
+    {
+        if (index < pushedItems.count()) {
+            delete pushedItems.takeAt(index);
+        }
+        else {
+            delete tableWidget->topLevelItem(index - pushedItems.count());
+        }
+    }
+
+    /// deletes a given notification, errors or warnings by pointer
+    void deleteItem(NotificationItem* item)
+    {
+        for (int i = 0; i < count(); i++) {
+            if (getItem(i) == item) {
+                deleteItem(i);
+                return;
+            }
+        }
+    }
+
+    /// deletes the last Notification Item
+    void deleteLastItem()
+    {
+        deleteItem(count() - 1);
+    }
+
+    /// pushes a notification item to the front
+    void push_front(NotificationItem* item)
+    {
+        pushedItems.push_front(item);
+    }
+
+protected:
+    /// creates the Notifications Widget
+    QWidget* createWidget(QWidget* parent) override
+    {
+        QWidget* notificationsWidget = new QWidget(parent);
+
+        QHBoxLayout* layout = new QHBoxLayout(notificationsWidget);
+        notificationsWidget->setLayout(layout);
+
+        tableWidget = new QTreeWidget(parent);
+        tableWidget->setColumnCount(3);
+
+        QStringList headers;
+        headers << QObject::tr("Type") << QObject::tr("Notifier") << QObject::tr("Message");
+        tableWidget->setHeaderLabels(headers);
+
+        layout->addWidget(tableWidget);
+
+        tableWidget->setMaximumSize(1200, 600);
+        tableWidget->setSizeAdjustPolicy(QAbstractScrollArea::AdjustToContents);
+        tableWidget->header()->setStretchLastSection(false);
+        tableWidget->header()->setSectionResizeMode(QHeaderView::ResizeToContents);
+
+        tableWidget->setSelectionMode(QAbstractItemView::ExtendedSelection);
+        tableWidget->setContextMenuPolicy(Qt::CustomContextMenu);
+
+        // context menu on any item (row) of the widget
+        QObject::connect(
+            tableWidget, &QTreeWidget::customContextMenuRequested, [&](const QPoint& pos) {
+                // auto item = tableWidget->itemAt(pos);
+                auto selectedItems = tableWidget->selectedItems();
+
+                QMenu menu;
+
+                QAction* del = menu.addAction(tr("Delete"), this, [&]() {
+                    for (auto it : selectedItems) {
+                        delete it;
+                    }
+                });
+
+                del->setEnabled(!selectedItems.isEmpty());
+
+                menu.addSeparator();
+
+                QAction* delnotifications =
+                    menu.addAction(tr("Delete user notifications"),
+                                   this,
+                                   &NotificationsAction::deleteNotifications);
+
+                delnotifications->setEnabled(tableWidget->topLevelItemCount() > 0);
+
+                QAction* delall =
+                    menu.addAction(tr("Delete All"), this, &NotificationsAction::deleteAll);
+
+                delall->setEnabled(tableWidget->topLevelItemCount() > 0);
+
+                menu.setDefaultAction(del);
+
+                menu.exec(tableWidget->mapToGlobal(pos));
+            });
+
+        return notificationsWidget;
+    }
+
+private:
+    /// utility function to return the number of Notification Items meeting the functor/lambda
+    /// criteria
+    int getCurrently(std::function<bool(const NotificationItem*)> F) const
+    {
+        int instate = 0;
+        for (auto i = 0; i < tableWidget->topLevelItemCount(); i++) {
+            auto* item = static_cast<NotificationItem*>(tableWidget->topLevelItem(i));
+            if (F(item)) {
+                instate++;
+            }
+        }
+        for (auto i = 0; i < pushedItems.count(); i++) {
+            auto* item = static_cast<NotificationItem*>(pushedItems.at(i));
+            if (F(item)) {
+                instate++;
+            }
+        }
+        return instate;
+    }
+
+private:
+    QTreeWidget* tableWidget;
+    // Intermediate storage
+    // Note: QTreeWidget is helplessly slow to single insertions, QTreeWidget is actually only
+    // necessary when showing the widget. A single QList insertion into a QTreeWidget is actually
+    // not that slow. The use of this intermediate storage substantially accelerates non-intrusive
+    // notifications.
+    QList<QTreeWidgetItem*> pushedItems;
+};
+
+/************ Parameter Observer (preferences) **************************************/
+
+NotificationArea::ParameterObserver::ParameterObserver(NotificationArea* notificationarea)
+    : notificationArea(notificationarea)
+{
+    hGrp = App::GetApplication().GetParameterGroupByPath(
+        "User parameter:BaseApp/Preferences/NotificationArea");
+
+    parameterMap = {
+        {"NotificationAreaEnabled",
+         [this](const std::string& string) {
+             auto enabled = hGrp->GetBool(string.c_str(), true);
+             if (!enabled)
+                 notificationArea->deleteLater();
+         }},
+        {"NonIntrusiveNotificationsEnabled",
+         [this](const std::string& string) {
+             auto enabled = hGrp->GetBool(string.c_str(), true);
+             notificationArea->pImp->notificationsDisabled = !enabled;
+         }},
+        {"NotificationTime",
+         [this](const std::string& string) {
+             auto time = hGrp->GetInt(string.c_str(), 20) * 1000;
+             if (time < 0)
+                 time = 0;
+             notificationArea->pImp->notificationExpirationTime = static_cast<unsigned int>(time);
+         }},
+        {"MinimumOnScreenTime",
+         [this](const std::string& string) {
+             auto time = hGrp->GetInt(string.c_str(), 5) * 1000;
+             if (time < 0)
+                 time = 0;
+             notificationArea->pImp->minimumOnScreenTime = static_cast<unsigned int>(time);
+         }},
+        {"MaxOpenNotifications",
+         [this](const std::string& string) {
+             auto limit = hGrp->GetInt(string.c_str(), 15);
+             if (limit < 0)
+                 limit = 0;
+             notificationArea->pImp->maxOpenNotifications = static_cast<unsigned int>(limit);
+         }},
+        {"MaxWidgetMessages",
+         [this](const std::string& string) {
+             auto limit = hGrp->GetInt(string.c_str(), 1000);
+             if (limit < 0)
+                 limit = 0;
+             notificationArea->pImp->maxWidgetMessages = static_cast<unsigned int>(limit);
+         }},
+        {"AutoRemoveUserNotifications",
+         [this](const std::string& string) {
+             auto enabled = hGrp->GetBool(string.c_str(), true);
+             notificationArea->pImp->autoRemoveUserNotifications = enabled;
+         }},
+    };
+
+    for (auto& val : parameterMap) {
+        auto string = val.first;
+        auto update = val.second;
+
+        update(string);
+    }
+
+    hGrp->Attach(this);
+}
+
+NotificationArea::ParameterObserver::~ParameterObserver()
+{
+    hGrp->Detach(this);
+}
+
+void NotificationArea::ParameterObserver::OnChange(Base::Subject<const char*>& rCaller,
+                                                   const char* sReason)
+{
+    (void)rCaller;
+
+    auto key = parameterMap.find(sReason);
+
+    if (key != parameterMap.end()) {
+        auto string = key->first;
+        auto update = key->second;
+
+        update(string);
+    }
+}
+
+/************************* Notification Area *****************************************/
+
+NotificationArea::NotificationArea(QWidget* parent)
+    : QPushButton(parent)
+{
+    // QPushButton appearance
+    setText(QString());
+    setFlat(true);
+
+    // Initialisation of pImpl structure
+    pImp = std::make_unique<NotificationAreaP>();
+
+    pImp->observer = std::make_unique<NotificationAreaObserver>(this);
+    pImp->parameterObserver = std::make_unique<NotificationArea::ParameterObserver>(this);
+
+    pImp->menu = new QMenu(parent);
+    setMenu(pImp->menu);
+
+    auto na = new NotificationsAction(pImp->menu);
+
+    pImp->menu->addAction(na);
+
+    pImp->notificationaction = na;
+
+    // Signals for synchronisation of storage before showing/hiding the widget
+    QObject::connect(pImp->menu, &QMenu::aboutToHide, [&]() {
+        std::lock_guard<std::mutex> g(pImp->mutexNotification);
+        static_cast<NotificationsAction*>(pImp->notificationaction)->clearUnreadFlag();
+        static_cast<NotificationsAction*>(pImp->notificationaction)->shiftToCache();
+    });
+
+    QObject::connect(pImp->menu, &QMenu::aboutToShow, [this]() {
+        std::lock_guard<std::mutex> g(
+            pImp->mutexNotification);// guard to avoid modifying the notification list and indices
+                                     // while creating the tooltip
+        setText(QString::number(0)); // no unread notifications
+        static_cast<NotificationsAction*>(pImp->notificationaction)->synchroniseWidget();
+
+        // the position of the action has already been calculated (for a non-synchronised widget),
+        // the size could be recalculated here, but not the position according to the previous size.
+        // This resize event forces this recalculation.
+        QResizeEvent re(pImp->menu->size(), pImp->menu->size());
+        qApp->sendEvent(pImp->menu, &re);
+    });
+
+
+    // Connection to the finish restore signal to rearm Critical messages modal mode when action is
+    // user initiated
+    pImp->finishRestoreDocumentConnection =
+        App::GetApplication().signalFinishRestoreDocument.connect(
+            boost::bind(&Gui::NotificationArea::slotRestoreFinished, this, bp::_1));
+
+    // Initialisation of the timer to inhibit continuous updates of the notification system in case
+    // clusters of messages arrive (so as to delay the actual notification until the whole cluster
+    // has arrived)
+    pImp->inhibitTimer.setSingleShot(true);
+
+    pImp->inhibitTimer.callOnTimeout([this, na]() {
+        setText(QString::number(na->getUnreadCount()));
+        showInNotificationArea();
+    });
+}
+
+NotificationArea::~NotificationArea()
+{
+    pImp->finishRestoreDocumentConnection.disconnect();
+}
+
+void NotificationArea::mousePressEvent(QMouseEvent* e)
+{
+    // Contextual menu (e.g. to delete Notifications or all messages (Notifications, Errors,
+    // Warnings and Critical messages)
+    if (e->button() == Qt::RightButton && hitButton(e->pos())) {
+        QMenu menu;
+
+        NotificationsAction* na = static_cast<NotificationsAction*>(pImp->notificationaction);
+
+        QAction* delnotifications = menu.addAction(tr("Delete user notifications"), [&]() {
+            std::lock_guard<std::mutex> g(
+                pImp->mutexNotification);// guard to avoid modifying the notification list and
+                                         // indices while creating the tooltip
+            na->deleteNotifications();
+            setText(QString::number(na->getUnreadCount()));
+        });
+
+        delnotifications->setEnabled(!na->isEmpty());
+
+        QAction* delall = menu.addAction(tr("Delete All"), [&]() {
+            std::lock_guard<std::mutex> g(
+                pImp->mutexNotification);// guard to avoid modifying the notification list and
+                                         // indices while creating the tooltip
+            na->deleteAll();
+            setText(QString::number(0));
+        });
+
+        delall->setEnabled(!na->isEmpty());
+
+        menu.setDefaultAction(delall);
+
+        menu.exec(this->mapToGlobal(e->pos()));
+    }
+    QPushButton::mousePressEvent(e);
+}
+
+void NotificationArea::pushNotification(const QString& notifiername, const QString& message,
+                                        Base::LogStyle level)
+{
+    auto* item = new NotificationItem(level, notifiername, message);
+
+    bool confirmation = confirmationRequired(level);
+
+    if (confirmation) {
+        showConfirmationDialog(notifiername, message);
+    }
+
+    std::lock_guard<std::mutex> g(
+        pImp->mutexNotification);// guard to avoid modifying the notification list and indices while
+                                 // creating the tooltip
+
+    NotificationsAction* na = static_cast<NotificationsAction*>(pImp->notificationaction);
+
+    // Limit the maximum number of messages stored in the widget (0 means no limit)
+    if (pImp->maxWidgetMessages != 0 && na->count() > pImp->maxWidgetMessages) {
+        na->deleteLastItem();
+    }
+
+    na->push_front(item);
+
+    // If the non-intrusive notifications are disabled then stop here (messages added to the widget
+    // only)
+    if (pImp->notificationsDisabled) {
+        item->notifying =
+            false;// avoid mass of old notifications if feature is activated afterwards
+        setText(QString::number(
+            static_cast<NotificationsAction*>(pImp->notificationaction)->getUnreadCount()));
+        return;
+    }
+
+    // start or restart rate control (the timer is rearmed if not yet expired, expiration triggers
+    // showing of the notification messages)
+    //
+    // NOTE: The inhibition timer is created in the main thread and cannot be restarted from another
+    // QThread. A QTimer can be moved to another QThread (from the QThread in which it is). However,
+    // it can only be create in a QThread, not in any other thread.
+    //
+    // For this reason, the timer is only triggered if this QThread is the QTimer thread.
+    //
+    // But I want my message from my thread to appear in the notification area. Fine, then configure
+    // Console not to use the direct connection mode, but the Queued one:
+    // Base::Console().SetConnectionMode(ConnectionMode::Queued);
+
+    auto timer_thread = pImp->inhibitTimer.thread();
+    auto current_thread = QThread::currentThread();
+
+    if(timer_thread == current_thread)
+        pImp->inhibitTimer.start(pImp->inhibitNotificationTime);
+}
+
+bool NotificationArea::confirmationRequired(Base::LogStyle level)
+{
+    auto userInitiatedRestore =
+        Application::Instance->testStatus(Gui::Application::UserInitiatedOpenDocument);
+
+    return (level == Base::LogStyle::Critical && userInitiatedRestore
+            && pImp->requireConfirmationCriticalMessageDuringRestoring);
+}
+
+void NotificationArea::showConfirmationDialog(const QString& notifiername, const QString& message)
+{
+    auto confirmMsg = QObject::tr("Notifier: ") + notifiername + QStringLiteral("\n\n") + message
+        + QStringLiteral("\n\n")
+        + QObject::tr("Do you want to skip confirmation of further critical message notifications "
+                      "while loading the file?");
+
+    auto button = QMessageBox::critical(getMainWindow()->activeWindow(),
+                                        QObject::tr("Critical Message"),
+                                        confirmMsg,
+                                        QMessageBox::Yes | QMessageBox::No,
+                                        QMessageBox::No);
+
+    if (button == QMessageBox::Yes)
+        pImp->requireConfirmationCriticalMessageDuringRestoring = false;
+}
+
+void NotificationArea::showInNotificationArea()
+{
+    std::lock_guard<std::mutex> g(
+        pImp->mutexNotification);// guard to avoid modifying the notification list and indices while
+                                 // creating the tooltip
+
+    NotificationsAction* na = static_cast<NotificationsAction*>(pImp->notificationaction);
+
+    if (!NotificationBox::isVisible()) {
+        // The Notification Box may have been closed (by the user by popping it out or by left mouse
+        // button) ensure that old notifications are not shown again, even if the timer has not
+        // lapsed
+        int i = 0;
+        while (i < na->count() && static_cast<NotificationItem*>(na->getItem(i))->notifying) {
+            NotificationItem* item = static_cast<NotificationItem*>(na->getItem(i));
+
+            if (item->shown) {
+                item->notifying = false;
+                item->shown = false;
+            }
+
+            i++;
+        }
+    }
+
+    auto currentlyshown = na->getShownCount();
+
+    // If we cannot show more messages, we do no need to update the non-intrusive notification
+    if (currentlyshown < pImp->maxOpenNotifications) {
+        // There is space for at least one more notification
+        // We update the message with the most recent up to maxOpenNotifications
+
+        QString msgw =
+            QString::fromLatin1(
+                "<style>p { margin: 0 0 0 0 } td { padding: 0 15px }</style>                     \
+        <p style='white-space:nowrap'>                                                                                      \
+        <table>                                                                                                             \
+        <tr>                                                                                                               \
+        <th><small>%1</small></th>                                                                                        \
+        <th><small>%2</small></th>                                                                                        \
+        <th><small>%3</small></th>                                                                                        \
+        </tr>")
+                .arg(QObject::tr("Type"))
+                .arg(QObject::tr("Notifier"))
+                .arg(QObject::tr("Message"));
+
+        auto currentlynotifying = na->getCurrentlyNotifyingCount();
+
+        if (currentlynotifying > pImp->maxOpenNotifications) {
+            msgw +=
+                QString::fromLatin1(
+                    "                                                                                   \
+            <tr>                                                                                                            \
+            <td align='left'><img width=\"16\" height=\"16\" src=':/icons/Warning.svg'></td>                                \
+            <td align='left'>FreeCAD</td>                                                                                   \
+            <td align='left'>%1</td>                                                                                        \
+            </tr>")
+                    .arg(QObject::tr("Too many opened non-intrusive notifications. Notifications "
+                                     "are being omitted!"));
+        }
+
+        int i = 0;
+
+        while (i < na->count() && static_cast<NotificationItem*>(na->getItem(i))->notifying) {
+
+            if (i < pImp->maxOpenNotifications) {// show the first up to maxOpenNotifications
+                NotificationItem* item = static_cast<NotificationItem*>(na->getItem(i));
+
+                QString iconstr;
+                if (item->notificationType == Base::LogStyle::Error) {
+                    iconstr = QStringLiteral(":/icons/edit_Cancel.svg");
+                }
+                else if (item->notificationType == Base::LogStyle::Warning) {
+                    iconstr = QStringLiteral(":/icons/Warning.svg");
+                }
+                else if (item->notificationType == Base::LogStyle::Critical) {
+                    iconstr = QStringLiteral(":/icons/critical-info.svg");
+                }
+                else {
+                    iconstr = QStringLiteral(":/icons/info.svg");
+                }
+
+                msgw +=
+                    QString::fromLatin1(
+                        "                                                                                   \
+                <tr>                                                                                                            \
+                <td align='left'><img width=\"16\" height=\"16\" src='%1'></td>                                                 \
+                <td align='left'>%2</td>                                                                                        \
+                <td align='left'>%3</td>                                                                                        \
+                </tr>")
+                        .arg(iconstr)
+                        .arg(item->notifierName)
+                        .arg(item->msg);
+
+                // start a timer for each of these notifications that was not previously shown
+                if (!item->shown) {
+                    QTimer::singleShot(pImp->notificationExpirationTime, [this, item]() {
+                        std::lock_guard<std::mutex> g(
+                            pImp->mutexNotification);// guard to avoid modifying the notification
+                                                     // start index while creating the tooltip
+
+                        if (item) {
+                            item->shown = false;
+                            item->notifying = false;
+
+                            if (pImp->autoRemoveUserNotifications) {
+                                if (item->notificationType == Base::LogStyle::Notification
+                                    || item->notificationType
+                                        == Base::LogStyle::TranslatedNotification) {
+
+                                    static_cast<NotificationsAction*>(pImp->notificationaction)
+                                        ->deleteItem(item);
+                                }
+                            }
+                        }
+                    });
+                }
+
+                // We update the status to shown
+                item->shown = true;
+            }
+            else {// We do not have more space and older notifications will be too old
+                static_cast<NotificationItem*>(na->getItem(i))->notifying = false;
+                static_cast<NotificationItem*>(na->getItem(i))->shown = false;
+            }
+
+            i++;
+        }
+
+        msgw += QString::fromLatin1("</table></p>");
+
+
+        NotificationBox::showText(this->mapToGlobal(QPoint()),
+                                  msgw,
+                                  pImp->notificationExpirationTime,
+                                  pImp->minimumOnScreenTime);
+    }
+}
+
+void NotificationArea::slotRestoreFinished(const App::Document&)
+{
+    // Re-arm on restore critical message modal notifications if another document is loaded
+    pImp->requireConfirmationCriticalMessageDuringRestoring = true;
+}

--- a/src/Gui/NotificationArea.h
+++ b/src/Gui/NotificationArea.h
@@ -1,0 +1,78 @@
+/***************************************************************************
+ *   Copyright (c) 2022 Abdullah Tahiri <abdullah.tahiri.yo@gmail.com>     *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef GUI_NOTIFICATIONAREA_H
+#define GUI_NOTIFICATIONAREA_H
+
+#include <QPushButton>
+#include <QString>
+
+#include <map>
+#include <memory>
+
+#include <Base/Observer.h>
+#include <Base/Parameter.h>
+
+namespace Gui
+{
+
+struct NotificationAreaP;
+
+class NotificationArea: public QPushButton
+{
+public:
+    class ParameterObserver: public ParameterGrp::ObserverType
+    {
+    public:
+        explicit ParameterObserver(NotificationArea* notificationarea);
+        ~ParameterObserver();
+
+        void OnChange(Base::Subject<const char*>& rCaller, const char* sReason) override;
+
+    private:
+        NotificationArea* notificationArea;
+        ParameterGrp::handle hGrp;
+        std::map<std::string, std::function<void(const std::string& string)>> parameterMap;
+    };
+
+    NotificationArea(QWidget* parent = nullptr);
+    ~NotificationArea();
+
+    void pushNotification(const QString& notifiername, const QString& message,
+                          Base::LogStyle level);
+
+private:
+    void showInNotificationArea();
+    bool confirmationRequired(Base::LogStyle level);
+    void showConfirmationDialog(const QString& notifiername, const QString& message);
+    void slotRestoreFinished(const App::Document&);
+
+    void mousePressEvent(QMouseEvent* e) override;
+
+private:
+    std::unique_ptr<NotificationAreaP> pImp;
+};
+
+
+}// namespace Gui
+
+#endif// GUI_NOTIFICATIONAREA_H

--- a/src/Gui/NotificationBox.cpp
+++ b/src/Gui/NotificationBox.cpp
@@ -22,16 +22,16 @@
 
 #include "PreCompiled.h"
 #ifndef _PreComp_
-# include <memory>
-# include <mutex>
-# include <QApplication>
-# include <QEvent>
-# include <QLabel>
-# include <QScreen>
-# include <QStyleOption>
-# include <QStylePainter>
-# include <QTextDocument>
-# include <QTimer>
+#include <QApplication>
+#include <QEvent>
+#include <QLabel>
+#include <QScreen>
+#include <QStyleOption>
+#include <QStylePainter>
+#include <QTextDocument>
+#include <QTimer>
+#include <memory>
+#include <mutex>
 #endif
 
 #include "NotificationBox.h"
@@ -39,11 +39,14 @@
 
 using namespace Gui;
 
-namespace Gui {
+namespace Gui
+{
 
 // https://stackoverflow.com/questions/41402152/stdunique-ptr-and-qobjectdeletelater
-struct QObjectDeleteLater {
-    void operator()(QObject *o) {
+struct QObjectDeleteLater
+{
+    void operator()(QObject* o)
+    {
         o->deleteLater();
     }
 };
@@ -53,29 +56,31 @@ using qobject_delete_later_unique_ptr = std::unique_ptr<T, QObjectDeleteLater>;
 
 /** Class showing the notification as a label
  * */
-class NotificationLabel : public QLabel
+class NotificationLabel: public QLabel
 {
     Q_OBJECT
 public:
-    NotificationLabel(const QString &text, const QPoint &pos, int displayTime, int minShowTime = 0);
+    NotificationLabel(const QString& text, const QPoint& pos, int displayTime, int minShowTime = 0);
     /// Reuse existing notification to show a new notification (with a new text)
-    void reuseNotification(const QString &text, int displayTime, const QPoint &pos);
+    void reuseNotification(const QString& text, int displayTime, const QPoint& pos);
     /// Hide notification after a hiding timer.
     void hideNotification();
     /// Update the size of the QLabel
-    void updateSize(const QPoint &pos);
+    void updateSize(const QPoint& pos);
     /// Event filter
-    bool eventFilter(QObject *, QEvent *) override;
+    bool eventFilter(QObject*, QEvent*) override;
     /// Return true if the text provided is the same as the one of an existing notification
-    bool notificationLabelChanged(const QString &text);
+    bool notificationLabelChanged(const QString& text);
     /// Place the notification at the given position
-    void placeNotificationLabel(const QPoint &pos);
+    void placeNotificationLabel(const QPoint& pos);
 
     /// The instance
     static qobject_delete_later_unique_ptr<NotificationLabel> instance;
+
 protected:
-    void paintEvent(QPaintEvent *e) override;
-    void resizeEvent(QResizeEvent *e) override;
+    void paintEvent(QPaintEvent* e) override;
+    void resizeEvent(QResizeEvent* e) override;
+
 private:
     /// Re-start the notification expiration timer
     void restartExpireTimer(int displayTime);
@@ -90,12 +95,14 @@ private:
 
 qobject_delete_later_unique_ptr<NotificationLabel> NotificationLabel::instance = nullptr;
 
-NotificationLabel::NotificationLabel(const QString &text, const QPoint &pos, int displayTime, int minShowTime)
-: QLabel(nullptr, Qt::ToolTip | Qt::BypassGraphicsProxyWidget), minShowTime(minShowTime)
+NotificationLabel::NotificationLabel(const QString& text, const QPoint& pos, int displayTime,
+                                     int minShowTime)
+    : QLabel(nullptr, Qt::ToolTip | Qt::BypassGraphicsProxyWidget),
+      minShowTime(minShowTime)
 {
     instance.reset(this);
-    setForegroundRole(QPalette::ToolTipText); // defaults to ToolTip QPalette
-    setBackgroundRole(QPalette::ToolTipBase); // defaults to ToolTip QPalette
+    setForegroundRole(QPalette::ToolTipText);// defaults to ToolTip QPalette
+    setBackgroundRole(QPalette::ToolTipBase);// defaults to ToolTip QPalette
     setPalette(NotificationBox::palette());
     ensurePolished();
     setMargin(1 + style()->pixelMetric(QStyle::PM_ToolTipLabelFrameWidth, nullptr, this));
@@ -108,12 +115,12 @@ NotificationLabel::NotificationLabel(const QString &text, const QPoint &pos, int
     hideTimer.setSingleShot(true);
     expireTimer.setSingleShot(true);
 
-    expireTimer.callOnTimeout([this](){
+    expireTimer.callOnTimeout([this]() {
         hideTimer.stop();
         hideNotificationImmediately();
     });
 
-    hideTimer.callOnTimeout([this](){
+    hideTimer.callOnTimeout([this]() {
         expireTimer.stop();
         hideNotificationImmediately();
     });
@@ -129,21 +136,21 @@ void NotificationLabel::restartExpireTimer(int displayTime)
         time = displayTime;
     }
     else {
-        time = 10000 + 40 * qMax(0, text().length()-100);
+        time = 10000 + 40 * qMax(0, text().length() - 100);
     }
 
     expireTimer.start(time);
     hideTimer.stop();
 }
 
-void NotificationLabel::reuseNotification(const QString &text, int displayTime, const QPoint &pos)
+void NotificationLabel::reuseNotification(const QString& text, int displayTime, const QPoint& pos)
 {
     setText(text);
     updateSize(pos);
     restartExpireTimer(displayTime);
 }
 
-void NotificationLabel::updateSize(const QPoint &pos)
+void NotificationLabel::updateSize(const QPoint& pos)
 {
     // Ensure that we get correct sizeHints by placing this window on the right screen.
     QFontMetrics fm(font());
@@ -158,7 +165,7 @@ void NotificationLabel::updateSize(const QPoint &pos)
     QSize sh = sizeHint();
 
     // ### When the above WinRT code is fixed, windowhandle should be used to find the screen.
-    QScreen *screen = QGuiApplication::screenAt(pos);
+    QScreen* screen = QGuiApplication::screenAt(pos);
 
     if (!screen) {
         screen = QGuiApplication::primaryScreen();
@@ -175,7 +182,7 @@ void NotificationLabel::updateSize(const QPoint &pos)
     resize(sh + extra);
 }
 
-void NotificationLabel::paintEvent(QPaintEvent *ev)
+void NotificationLabel::paintEvent(QPaintEvent* ev)
 {
     QStylePainter p(this);
     QStyleOptionFrame opt;
@@ -185,7 +192,7 @@ void NotificationLabel::paintEvent(QPaintEvent *ev)
     QLabel::paintEvent(ev);
 }
 
-void NotificationLabel::resizeEvent(QResizeEvent *e)
+void NotificationLabel::resizeEvent(QResizeEvent* e)
 {
     QStyleHintReturnMask frameMask;
     QStyleOption option;
@@ -208,24 +215,25 @@ void NotificationLabel::hideNotification()
 
 void NotificationLabel::hideNotificationImmediately()
 {
-    close(); // to trigger QEvent::Close which stops the animation
+    close();// to trigger QEvent::Close which stops the animation
     instance = nullptr;
 }
 
-bool NotificationLabel::eventFilter(QObject *o, QEvent *e)
+bool NotificationLabel::eventFilter(QObject* o, QEvent* e)
 {
     Q_UNUSED(o)
 
     switch (e->type()) {
-        case QEvent::MouseButtonPress:
-        {
-             // If minimum on screen time has already lapsed - hide the notification no matter where the click was done
+        case QEvent::MouseButtonPress: {
+            // If minimum on screen time has already lapsed - hide the notification no matter where
+            // the click was done
             auto total = expireTimer.interval();
             auto remaining = expireTimer.remainingTime();
             auto lapsed = total - remaining;
-            // ... or if the click is inside the notification, hide it no matter if the minimum onscreen time has lapsed or not
+            // ... or if the click is inside the notification, hide it no matter if the minimum
+            // onscreen time has lapsed or not
             auto insideclick = this->underMouse();
-            if( lapsed > minShowTime || insideclick) {
+            if (lapsed > minShowTime || insideclick) {
                 hideNotification();
 
                 return insideclick;
@@ -237,10 +245,10 @@ bool NotificationLabel::eventFilter(QObject *o, QEvent *e)
     return false;
 }
 
-void NotificationLabel::placeNotificationLabel(const QPoint &pos)
+void NotificationLabel::placeNotificationLabel(const QPoint& pos)
 {
     QPoint p = pos;
-    const QScreen *screen = QGuiApplication::screenAt(pos);
+    const QScreen* screen = QGuiApplication::screenAt(pos);
     // a QScreen's handle *should* never be null, so this is a bit paranoid
     if (screen && screen->handle()) {
         const QSize cursorSize = QSize(16, 16);
@@ -271,24 +279,25 @@ void NotificationLabel::placeNotificationLabel(const QPoint &pos)
     this->move(p);
 }
 
-bool NotificationLabel::notificationLabelChanged(const QString &text)
+bool NotificationLabel::notificationLabelChanged(const QString& text)
 {
     return NotificationLabel::instance->text() != text;
 }
 
 /***************************** NotificationBox **********************************/
 
-void NotificationBox::showText(const QPoint &pos, const QString &text, int displayTime, unsigned int minShowTime)
+void NotificationBox::showText(const QPoint& pos, const QString& text, int displayTime,
+                               unsigned int minShowTime)
 {
     // a label does already exist
-    if (NotificationLabel::instance && NotificationLabel::instance->isVisible()){
-        if (text.isEmpty()){ // empty text means hide current label
+    if (NotificationLabel::instance && NotificationLabel::instance->isVisible()) {
+        if (text.isEmpty()) {// empty text means hide current label
             NotificationLabel::instance->hideNotification();
             return;
         }
         else {
             // If the label has changed, reuse the one that is showing (removes flickering)
-            if (NotificationLabel::instance->notificationLabelChanged(text)){
+            if (NotificationLabel::instance->notificationLabelChanged(text)) {
                 NotificationLabel::instance->reuseNotification(text, displayTime, pos);
                 NotificationLabel::instance->placeNotificationLabel(pos);
             }
@@ -334,18 +343,18 @@ QFont NotificationBox::font()
     return QApplication::font("NotificationLabel");
 }
 
-void NotificationBox::setPalette(const QPalette &palette)
+void NotificationBox::setPalette(const QPalette& palette)
 {
     *notificationbox_palette() = palette;
     if (NotificationLabel::instance)
         NotificationLabel::instance->setPalette(palette);
 }
 
-void NotificationBox::setFont(const QFont &font)
+void NotificationBox::setFont(const QFont& font)
 {
     QApplication::setFont(font, "NotificationLabel");
 }
 
-} // namespace Gui
+}// namespace Gui
 
 #include "NotificationBox.moc"

--- a/src/Gui/NotificationBox.h
+++ b/src/Gui/NotificationBox.h
@@ -24,52 +24,59 @@
 #define GUI_NOTIFICATIONBOX_H
 
 
+namespace Gui
+{
 
-namespace Gui {
+/** This class provides a non-intrusive tip alike notification
+ * dialog, which unlike QToolTip, is kept shown during a time.
+ *
+ * The notification is shown during minShowTime, unless pop out
+ * (i.e. clicked inside the notification).
+ *
+ * The notification will show up to a maximum of displayTime. The
+ * only event that closes the notification between minShowTime and
+ * displayTime is a mouse button click (anywhere of the screen).
+ *
+ * When displayTime is not provided, it is calculated based on the length
+ * of the text.
+ *
+ * This class interface and its implementation are based on QT's
+ * QToolTip.
+ */
+class NotificationBox
+{
+    NotificationBox() = delete;
 
-    /** This class provides a non-intrusive tip alike notification
-     * dialog, which unlike QToolTip, is kept shown during a time.
-     *
-     * The notification is shown during minShowTime, unless pop out
-     * (i.e. clicked inside the notification).
-     *
-     * The notification will show up to a maximum of displayTime. The
-     * only event that closes the notification between minShowTime and
-     * displayTime is a mouse button click (anywhere of the screen).
-     *
-     * When displayTime is not provided, it is calculated based on the length
-     * of the text.
-     *
-     * This class interface and its implementation are based on QT's
-     * QToolTip.
+public:
+    /** Shows a non-intrusive notification.
+     * @param pos Position at which the notification will be shown
+     * @param displayTime Time after which the notification will auto-close (unless it is closed by
+     * an event, see class documentation above)
+     * @param minShowTime  Time during which the notification can only be made disappear by popping
+     * it out (clicking inside it).
      */
-    class NotificationBox
+    static void showText(const QPoint& pos, const QString& text, int displayTime = -1,
+                         unsigned int minShowTime = 0);
+    /// Hides a notification.
+    static inline void hideText()
     {
-        NotificationBox() = delete;
-    public:
-        /** Shows a non-intrusive notification.
-         * @param pos Position at which the notification will be shown
-         * @param displayTime Time after which the notification will auto-close (unless it is closed by an event, see class documentation above)
-         * @param minShowTime  Time during which the notification can only be made disappear by popping it out (clicking inside it).
-         */
-        static void showText(const QPoint &pos, const QString &text, int displayTime = -1, unsigned int minShowTime = 0);
-        /// Hides a notification.
-        static inline void hideText() { showText(QPoint(), QString()); }
-        /// Returns whether a notification is being shown or not.
-        static bool isVisible();
-        /// Returns the text of the notification.
-        static QString text();
-        /// Returns the palette.
-        static QPalette palette();
-        /// Sets the palette.
-        static void setPalette(const QPalette &);
-        /// Returns the font of the notification.
-        static QFont font();
-        /// Sets the font to be used in the notification.
-        static void setFont(const QFont &);
-    };
+        showText(QPoint(), QString());
+    }
+    /// Returns whether a notification is being shown or not.
+    static bool isVisible();
+    /// Returns the text of the notification.
+    static QString text();
+    /// Returns the palette.
+    static QPalette palette();
+    /// Sets the palette.
+    static void setPalette(const QPalette&);
+    /// Returns the font of the notification.
+    static QFont font();
+    /// Sets the font to be used in the notification.
+    static void setFont(const QFont&);
+};
 
 
-} // namespace Gui
+}// namespace Gui
 
-#endif // GUI_NOTIFICATIONBOX_H
+#endif// GUI_NOTIFICATIONBOX_H

--- a/src/Gui/QtAll.h
+++ b/src/Gui/QtAll.h
@@ -191,6 +191,7 @@
 #include <QStackedWidget>
 #include <QTableWidgetItem>
 #include <QWidget>
+#include <QWidgetAction>
 
 // QtXML
 #include <QDomDocument>

--- a/src/Gui/resource.cpp
+++ b/src/Gui/resource.cpp
@@ -36,6 +36,7 @@
 #include "DlgSettingsViewColor.h"
 #include "DlgGeneralImp.h"
 #include "DlgEditorImp.h"
+#include "DlgSettingsNotificationArea.h"
 #include "DlgSettingsPythonConsole.h"
 #include "DlgSettingsMacroImp.h"
 #include "DlgSettingsUnitsImp.h"
@@ -66,19 +67,20 @@ WidgetFactorySupplier::WidgetFactorySupplier()
     // ADD YOUR PREFERENCE PAGES HERE
     //
     //
-    new PrefPageProducer<DlgGeneralImp>            ( QT_TRANSLATE_NOOP("QObject","General") );
-    new PrefPageProducer<DlgSettingsDocumentImp>   ( QT_TRANSLATE_NOOP("QObject","General") );
-    new PrefPageProducer<DlgSettingsSelection>     ( QT_TRANSLATE_NOOP("QObject","General") );
-    new PrefPageProducer<DlgSettingsCacheDirectory>( QT_TRANSLATE_NOOP("QObject","General") );
-    new PrefPageProducer<DlgSettingsEditorImp>     ( QT_TRANSLATE_NOOP("QObject","General") );
-    new PrefPageProducer<DlgSettingsPythonConsole> ( QT_TRANSLATE_NOOP("QObject","General") );
-    new PrefPageProducer<DlgReportViewImp>         ( QT_TRANSLATE_NOOP("QObject","General") );
-    new PrefPageProducer<DlgSettingsMacroImp>      ( QT_TRANSLATE_NOOP("QObject","General") );
-    new PrefPageProducer<DlgSettingsUnitsImp>      ( QT_TRANSLATE_NOOP("QObject","General") );
-    new PrefPageProducer<DlgSettings3DViewImp>     ( QT_TRANSLATE_NOOP("QObject","Display") );
-    new PrefPageProducer<DlgSettingsNavigation>    ( QT_TRANSLATE_NOOP("QObject","Display") );
-    new PrefPageProducer<DlgSettingsViewColor>     ( QT_TRANSLATE_NOOP("QObject","Display") );
-    new PrefPageProducer<DlgSettingsLazyLoadedImp> ( QT_TRANSLATE_NOOP("QObject","Workbenches") );
+    new PrefPageProducer<DlgGeneralImp>               ( QT_TRANSLATE_NOOP("QObject","General") );
+    new PrefPageProducer<DlgSettingsDocumentImp>      ( QT_TRANSLATE_NOOP("QObject","General") );
+    new PrefPageProducer<DlgSettingsSelection>        ( QT_TRANSLATE_NOOP("QObject","General") );
+    new PrefPageProducer<DlgSettingsCacheDirectory>   ( QT_TRANSLATE_NOOP("QObject","General") );
+    new PrefPageProducer<DlgSettingsEditorImp>        ( QT_TRANSLATE_NOOP("QObject","General") );
+    new PrefPageProducer<DlgSettingsNotificationArea> ( QT_TRANSLATE_NOOP("QObject","General") );
+    new PrefPageProducer<DlgSettingsPythonConsole>    ( QT_TRANSLATE_NOOP("QObject","General") );
+    new PrefPageProducer<DlgReportViewImp>            ( QT_TRANSLATE_NOOP("QObject","General") );
+    new PrefPageProducer<DlgSettingsMacroImp>         ( QT_TRANSLATE_NOOP("QObject","General") );
+    new PrefPageProducer<DlgSettingsUnitsImp>         ( QT_TRANSLATE_NOOP("QObject","General") );
+    new PrefPageProducer<DlgSettings3DViewImp>        ( QT_TRANSLATE_NOOP("QObject","Display") );
+    new PrefPageProducer<DlgSettingsNavigation>       ( QT_TRANSLATE_NOOP("QObject","Display") );
+    new PrefPageProducer<DlgSettingsViewColor>        ( QT_TRANSLATE_NOOP("QObject","Display") );
+    new PrefPageProducer<DlgSettingsLazyLoadedImp>    ( QT_TRANSLATE_NOOP("QObject","Workbenches") );
 
     // ADD YOUR CUSTOMIZE PAGES HERE
     //

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -90,7 +90,6 @@ FC_LOG_LEVEL_INIT("Sketch",true,true)
 
 PROPERTY_SOURCE(Sketcher::SketchObject, Part::Part2DObject)
 
-
 SketchObject::SketchObject()
 {
     ADD_PROPERTY_TYPE(Geometry,        (nullptr)  ,"Sketch",(App::PropertyType)(App::Prop_None),"Sketch geometry");
@@ -300,11 +299,11 @@ int SketchObject::solve(bool updateGeoAfterSolving/*=true*/)
     }
 
     if(lastHasMalformedConstraints) {
-        Base::Console().Error("Sketch %s has malformed constraints!\n",this->getNameInDocument());
+        Base::Console().Error(this->getFullLabel(), QT_TRANSLATE_NOOP("Notifications","The Sketch has malformed constraints!") "\n");
     }
 
     if(lastHasPartialRedundancies) {
-        Base::Console().Warning("Sketch %s has partially redundant constraints!\n",this->getNameInDocument());
+        Base::Console().Warning(this->getFullLabel(), QT_TRANSLATE_NOOP("Notifications","The Sketch has partially redundant constraints!") "\n");
     }
 
     lastSolveTime=solvedSketch.getSolveTime();
@@ -8313,10 +8312,7 @@ void SketchObject::migrateSketch()
 
             Constraints.setValues(std::move(newconstraints));
 
-            Base::Console().Warning("In Sketch %s, parabolas were migrated. Migrated files won't open in previous versions of FreeCAD!!\n",this->Label.getStrValue().c_str());
-
-            this->getDocument()->signalUserMessage(*this, QStringLiteral(QT_TRANSLATE_NOOP("CriticalMessages","Sketch:")) + QStringLiteral(" ") + QString::fromStdString(this->Label.getStrValue()) +
-                QStringLiteral(".\n\n") + QString::fromLatin1(QT_TRANSLATE_NOOP("CriticalMessages","Parabolas were migrated. Migrated files won't open in previous versions of FreeCAD!!")), App::Document::NotificationType::Critical);
+            Base::Console().Critical(this->getFullName(),QT_TRANSLATE_NOOP("Notifications","Parabolas were migrated. Migrated files won't open in previous versions of FreeCAD!!\n"));
         }
     }
 }


### PR DESCRIPTION
After the pre-requisites are merged, this PR brings the actual NotificationArea.

After this PR, there are two other PRs left for NotificationArea: 
- A first one relates to general functions to help WB to move from blocking QMessage::warning to the  non-intrusive framework.
- A first migration of the sketcher constraint creation to the new framework using those general functions.

What is the Notifications Area?

It consists of:
(a) Non-intrusive messages
(b) A widget showing errors, warnings, critical messages and notifications

How does it look like?

[Peek 2023-03-08 15-33.webm](https://user-images.githubusercontent.com/5249162/223741009-d9f267a6-0ea1-4a57-9590-e740c22e3fd2.webm)


