### PR TITLE
Trailing comments will mess up format if extend beyond 100 columns

### DIFF
--- a/src/3rdParty/libE57Format/extern/CRCpp/inc/CRC.h
+++ b/src/3rdParty/libE57Format/extern/CRCpp/inc/CRC.h
@@ -52,7 +52,7 @@
                                                           multiplication in the bit-by-bit calculation instead of a small conditional. The branchless implementation
                                                           may be faster on processor architectures which support single-instruction integer multiplication.
         #define CRCPP_USE_CPP11                         - Define to enables C++11 features (move semantics, constexpr, static_assert, etc.).
-        #define CRCPP_INCLUDE_ESOTERIC_CRC_DEFINITIONS  - Define to include definitions for little-used CRCs. 
+        #define CRCPP_INCLUDE_ESOTERIC_CRC_DEFINITIONS  - Define to include definitions for little-used CRCs.
 */
 
 #ifndef CRCPP_CRC_H_
@@ -156,7 +156,8 @@ public:
         CRCType initialValue; ///< Initial CRC value
         CRCType finalXOR;     ///< Value to XOR with the final CRC
         bool reflectInput;    ///< true to reflect all input bytes
-        bool reflectOutput;   ///< true to reflect the output CRC (reflection occurs before the final XOR)
+        ///< true to reflect the output CRC (reflection occurs before the final XOR)
+        bool reflectOutput;
 
         Table<CRCType, CRCWidth> MakeTable() const;
     };

--- a/src/3rdParty/libE57Format/include/E57SimpleData.h
+++ b/src/3rdParty/libE57Format/include/E57SimpleData.h
@@ -96,7 +96,8 @@ namespace e57
    //! @brief Defines a rigid body transform in cartesian coordinates.
    struct E57_DLL RigidBodyTransform
    {
-      Quaternion rotation;     //!< A unit quaternion representing the rotation, R, of the transform
+      //!< A unit quaternion representing the rotation, R, of the transform
+      Quaternion rotation;
       Translation translation; //!< The translation point vector, t, of the transform
 
       bool operator==( const RigidBodyTransform &rhs ) const
@@ -117,12 +118,18 @@ namespace e57
    //! @brief Specifies an axis-aligned box in local cartesian coordinates.
    struct E57_DLL CartesianBounds
    {
-      double xMinimum{ -E57_DOUBLE_MAX }; //!< The minimum extent of the bounding box in the X direction
-      double xMaximum{ E57_DOUBLE_MAX };  //!< The maximum extent of the bounding box in the X direction
-      double yMinimum{ -E57_DOUBLE_MAX }; //!< The minimum extent of the bounding box in the Y direction
-      double yMaximum{ E57_DOUBLE_MAX };  //!< The maximum extent of the bounding box in the Y direction
-      double zMinimum{ -E57_DOUBLE_MAX }; //!< The minimum extent of the bounding box in the Z direction
-      double zMaximum{ E57_DOUBLE_MAX };  //!< The maximum extent of the bounding box in the Z direction
+      //!< The minimum extent of the bounding box in the X direction
+      double xMinimum{ -E57_DOUBLE_MAX };
+      //!< The maximum extent of the bounding box in the X direction
+      double xMaximum{ E57_DOUBLE_MAX };
+      //!< The minimum extent of the bounding box in the Y direction
+      double yMinimum{ -E57_DOUBLE_MAX };
+      //!< The maximum extent of the bounding box in the Y direction
+      double yMaximum{ E57_DOUBLE_MAX };
+      //!< The minimum extent of the bounding box in the Z direction
+      double zMinimum{ -E57_DOUBLE_MAX };
+      //!< The maximum extent of the bounding box in the Z direction
+      double zMaximum{ E57_DOUBLE_MAX };
 
       bool operator==( const CartesianBounds &rhs ) const
       {
@@ -138,13 +145,20 @@ namespace e57
    //! @brief Stores the bounds of some data in spherical coordinates.
    struct E57_DLL SphericalBounds
    {
-      SphericalBounds();       // constructor in the cpp to avoid exposing M_PI
-      double rangeMinimum;     //!< The minimum extent of the bounding region in the r direction
-      double rangeMaximum;     //!< The maximum extent of the bounding region in the r direction
-      double elevationMinimum; //!< The minimum extent of the bounding region from the horizontal plane
-      double elevationMaximum; //!< The maximum extent of the bounding region from the horizontal plane
-      double azimuthStart; //!< The starting azimuth angle defining the extent of the bounding region around the z axis
-      double azimuthEnd;   //!< The ending azimuth angle defining the extent of the bounding region around the z axis
+      // constructor in the cpp to avoid exposing M_PI
+      SphericalBounds();
+      //!< The minimum extent of the bounding region in the r direction
+      double rangeMinimum;
+      //!< The maximum extent of the bounding region in the r direction
+      double rangeMaximum;
+      //!< The minimum extent of the bounding region from the horizontal plane
+      double elevationMinimum;
+      //!< The maximum extent of the bounding region from the horizontal plane
+      double elevationMaximum;
+      //!< The starting azimuth angle defining the extent of the bounding region around the z axis
+      double azimuthStart;
+      //!< The ending azimuth angle defining the extent of the bounding region around the z axis
+      double azimuthEnd;
 
       bool operator==( const SphericalBounds &rhs ) const
       {
@@ -161,8 +175,10 @@ namespace e57
    //! @brief Stores the minimum and maximum of rowIndex, columnIndex, and returnIndex fields for a set of points.
    struct E57_DLL IndexBounds
    {
-      int64_t rowMinimum{ 0 }; //!< The minimum rowIndex value of any point represented by this IndexBounds object.
-      int64_t rowMaximum{ 0 }; //!< The maximum rowIndex value of any point represented by this IndexBounds object.
+      //!< The minimum rowIndex value of any point represented by this IndexBounds object.
+      int64_t rowMinimum{ 0 };
+      //!< The maximum rowIndex value of any point represented by this IndexBounds object.
+      int64_t rowMaximum{ 0 };
       int64_t columnMinimum{
          0
       }; //!< The minimum columnIndex value of any point represented by this IndexBounds object.
@@ -191,8 +207,10 @@ namespace e57
    //! @brief Specifies the limits for the value of signal intensity that a sensor is capable of producing
    struct E57_DLL IntensityLimits
    {
-      double intensityMinimum{ 0. }; //!< The minimum producible intensity value. Unit is unspecified.
-      double intensityMaximum{ 0. }; //!< The maximum producible intensity value. Unit is unspecified.
+      //!< The minimum producible intensity value. Unit is unspecified.
+      double intensityMinimum{ 0. };
+      //!< The maximum producible intensity value. Unit is unspecified.
+      double intensityMaximum{ 0. };
 
       bool operator==( const IntensityLimits &rhs ) const
       {
@@ -207,12 +225,18 @@ namespace e57
    //! @brief Specifies the limits for the value of red, green, and blue color that a sensor is capable of producing.
    struct E57_DLL ColorLimits
    {
-      double colorRedMinimum{ 0. };   //!< The minimum producible red color value. Unit is unspecified.
-      double colorRedMaximum{ 0. };   //!< The maximum producible red color value. Unit is unspecified.
-      double colorGreenMinimum{ 0. }; //!< The minimum producible green color value. Unit is unspecified.
-      double colorGreenMaximum{ 0. }; //!< The maximum producible green color value. Unit is unspecified.
-      double colorBlueMinimum{ 0. };  //!< The minimum producible blue color value. Unit is unspecified.
-      double colorBlueMaximum{ 0. };  //!< The maximum producible blue color value. Unit is unspecified.
+      //!< The minimum producible red color value. Unit is unspecified.
+      double colorRedMinimum{ 0. };
+      //!< The maximum producible red color value. Unit is unspecified.
+      double colorRedMaximum{ 0. };
+      //!< The minimum producible green color value. Unit is unspecified.
+      double colorGreenMinimum{ 0. };
+      //!< The maximum producible green color value. Unit is unspecified.
+      double colorGreenMaximum{ 0. };
+      //!< The minimum producible blue color value. Unit is unspecified.
+      double colorBlueMinimum{ 0. };
+      //!< The maximum producible blue color value. Unit is unspecified.
+      double colorBlueMaximum{ 0. };
 
       bool operator==( const ColorLimits &rhs ) const
       {
@@ -254,15 +278,21 @@ namespace e57
    struct E57_DLL E57Root
    {
       ustring formatName;         //!< Contains the string "ASTM E57 3D Image File"
-      ustring guid;               //!< A globally unique identification string for the current version of the file
+      //!< A globally unique identification string for the current version of the file
+      ustring guid;
       uint32_t versionMajor{ 1 }; //!< Major version number, should be 1
       uint32_t versionMinor{ 0 }; //!< Minor version number, should be 0
-      ustring e57LibraryVersion;  //!< The version identifier for the E57 file format library that wrote the file.
-      DateTime creationDateTime;  //!< Date/time that the file was created
-      int64_t data3DSize{ 0 };    //!< Size of the Data3D vector for storing 3D imaging data
-      int64_t images2DSize{ 0 };  //!< Size of the A heterogeneous Vector of Images2D Structures for storing 2D images
+      //!< The version identifier for the E57 file format library that wrote the file.
+      ustring e57LibraryVersion;
+      //!< Date/time that the file was created
+      DateTime creationDateTime;
+      //!< Size of the Data3D vector for storing 3D imaging data
+      int64_t data3DSize{ 0 };
+      //!< Size of the A heterogeneous Vector of Images2D Structures for storing 2D images
+      int64_t images2DSize{ 0 };
                                   //!< from a camera or similar device.
-      ustring coordinateMetadata; //!< Information describing the Coordinate Reference System to be used for the file
+      //!< Information describing the Coordinate Reference System to be used for the file
+      ustring coordinateMetadata;
    };
 
    //! @brief Stores information about a single group of points in a row or column
@@ -277,19 +307,24 @@ namespace e57
       int64_t pointCount{
          0
       }; //!< The number of PointRecords in the group. Shall be in the interval [1, 2^63). May be zero.
-      CartesianBounds cartesianBounds; //!< The bounding box (in Cartesian coordinates) of all points in the group
+      //!< The bounding box (in Cartesian coordinates) of all points in the group
+      CartesianBounds cartesianBounds;
                                        //!< (in the local coordinate system of the points).
-      SphericalBounds sphericalBounds; //!< The bounding region (in spherical coordinates) of all the points in the
+      //!< The bounding region (in spherical coordinates) of all the points in the
+      SphericalBounds sphericalBounds;
                                        //!< group (in the local coordinate system of the points).
    };
 
    //! @brief Stores a set of point groups organized by the rowIndex or columnIndex attribute of the PointRecord
    struct E57_DLL GroupingByLine
    {
-      ustring idElementName;   //!< The name of the PointRecord element that identifies which group the point is in. The
+      //!< The name of the PointRecord element that identifies which group the point is in. The
+      ustring idElementName;
                                //!< value of this string must be "rowIndex" or "columnIndex"
-      int64_t groupsSize{ 0 }; //!< Size of the groups compressedVector of LineGroupRecord structures
-      int64_t pointCountSize{ 0 }; //!< This is the size value for the LineGroupRecord::pointCount.
+      //!< Size of the groups compressedVector of LineGroupRecord structures
+      int64_t groupsSize{ 0 };
+      //!< This is the size value for the LineGroupRecord::pointCount.
+      int64_t pointCountSize{ 0 };
    };
 
    //! @brief Supports the division of points within an Data3D into logical groupings
@@ -301,68 +336,90 @@ namespace e57
    //! @brief Used to interrogate if standardized fields are available
    struct E57_DLL PointStandardizedFieldsAvailable
    {
-      bool cartesianXField{ false }; //!< Indicates that the PointRecord cartesianX field is active
-      bool cartesianYField{ false }; //!< Indicates that the PointRecord cartesianY field is active
-      bool cartesianZField{ false }; //!< Indicates that the PointRecord cartesianZ field is active
+      //!< Indicates that the PointRecord cartesianX field is active
+      bool cartesianXField{ false };
+      //!< Indicates that the PointRecord cartesianY field is active
+      bool cartesianYField{ false };
+      //!< Indicates that the PointRecord cartesianZ field is active
+      bool cartesianZField{ false };
       bool cartesianInvalidStateField{
          false
       }; //!< Indicates that the PointRecord cartesianInvalidState field is active
 
-      bool sphericalRangeField{ false };     //!< Indicates that the PointRecord sphericalRange field is active
-      bool sphericalAzimuthField{ false };   //!< Indicates that the PointRecord sphericalAzimuth field is active
-      bool sphericalElevationField{ false }; //!< Indicates that the PointRecord sphericalElevation field is active
+      //!< Indicates that the PointRecord sphericalRange field is active
+      bool sphericalRangeField{ false };
+      //!< Indicates that the PointRecord sphericalAzimuth field is active
+      bool sphericalAzimuthField{ false };
+      //!< Indicates that the PointRecord sphericalElevation field is active
+      bool sphericalElevationField{ false };
       bool sphericalInvalidStateField{
          false
-      }; //!< Indicates that the PointRecord sphericalInvalidState field is active
+      };
+      //!< Indicates that the PointRecord sphericalInvalidState field is active
 
       double pointRangeMinimum{
          E57_FLOAT_MIN
-      }; //!< Indicates that the PointRecord cartesian and range fields should be configured with this minimum value
+      };
+      //!< Indicates that the PointRecord cartesian and range fields should be configured with this minimum value
          //!< -E57_FLOAT_MAX or -E57_DOUBLE_MAX. If using a ScaledIntegerNode then this needs to be a minimum range
          //!< value.
       double pointRangeMaximum{
          E57_FLOAT_MAX
-      }; //!< Indicates that the PointRecord cartesian and range fields should be configured with this maximum value
+      };
+      //!< Indicates that the PointRecord cartesian and range fields should be configured with this maximum value
          //!< E57_FLOAT_MAX or E57_DOUBLE_MAX. If using a ScaledIntegerNode then this needs to be a maximum range value.
       double pointRangeScaledInteger{
          E57_NOT_SCALED_USE_FLOAT
-      }; //!< Indicates that the PointRecord cartesain and range fields should be configured as a ScaledIntegerNode with
+      };
+      //!< Indicates that the PointRecord cartesain and range fields should be configured as a ScaledIntegerNode with
          //!< this scale setting. If 0. then use FloatNode.
 
       double angleMinimum{
          E57_FLOAT_MIN
-      }; //!< Indicates that the PointRecord angle fields should be configured with this minimum value -E57_FLOAT_MAX or
+      };
+      //!< Indicates that the PointRecord angle fields should be configured with this minimum value -E57_FLOAT_MAX or
          //!< -E57_DOUBLE_MAX. If using a ScaledIntegerNode then this needs to be a minimum angle value.
       double angleMaximum{
          E57_FLOAT_MAX
-      }; //!< Indicates that the PointRecord angle fields should be configured with this maximum value E57_FLOAT_MAX or
+      };
+      //!< Indicates that the PointRecord angle fields should be configured with this maximum value E57_FLOAT_MAX or
          //!< E57_DOUBLE_MAX. If using a ScaledIntegerNode then this needs to be a maximum angle value.
       double angleScaledInteger{
          E57_NOT_SCALED_USE_FLOAT
-      }; //!< Indicates that the PointRecord angle fields should be configured as a ScaledIntegerNode with this scale
+      };
+      //!< Indicates that the PointRecord angle fields should be configured as a ScaledIntegerNode with this scale
          //!< setting. If 0. then use FloatNode.
 
-      bool rowIndexField{ false };                //!< Indicates that the PointRecord rowIndex field is active
-      uint32_t rowIndexMaximum{ E57_UINT32_MAX }; //!< Indicates that the PointRecord index fields should be configured
+      //!< Indicates that the PointRecord rowIndex field is active
+      bool rowIndexField{ false };
+      //!< Indicates that the PointRecord index fields should be configured
+      uint32_t rowIndexMaximum{ E57_UINT32_MAX };
                                                   //!< with this maximum value where the minimum will be set to 0.
-      bool columnIndexField{ false };             //!< Indicates that the PointRecord columnIndex field is active
+      //!< Indicates that the PointRecord columnIndex field is active
+      bool columnIndexField{ false };
       uint32_t columnIndexMaximum{
          E57_UINT32_MAX
       }; //!< Indicates that the PointRecord index fields should be configured with this maximum value where the minimum
          //!< will be set to 0.
 
-      bool returnIndexField{ false };         //!< Indicates that the PointRecord returnIndex field is active
-      bool returnCountField{ false };         //!< Indicates that the PointRecord returnCount field is active
-      uint8_t returnMaximum{ E57_UINT8_MAX }; //!< Indicates that the PointRecord return fields should be configured
+      //!< Indicates that the PointRecord returnIndex field is active
+      bool returnIndexField{ false };
+      //!< Indicates that the PointRecord returnCount field is active
+      bool returnCountField{ false };
+      //!< Indicates that the PointRecord return fields should be configured
+      uint8_t returnMaximum{ E57_UINT8_MAX };
                                               //!< with this maximum value where the minimum will be set to 0.
 
-      bool timeStampField{ false };          //!< Indicates that the PointRecord timeStamp field is active
-      bool isTimeStampInvalidField{ false }; //!< Indicates that the PointRecord isTimeStampInvalid field is active
+      //!< Indicates that the PointRecord timeStamp field is active
+      bool timeStampField{ false };
+      //!< Indicates that the PointRecord isTimeStampInvalid field is active
+      bool isTimeStampInvalidField{ false };
       double timeMaximum{
          E57_DOUBLE_MAX
       }; //!< Indicates that the PointRecord timeStamp fields should be configured with this maximum value. like
          //!< E57_UINT32_MAX, E57_FLOAT_MAX or E57_DOUBLE_MAX
-      double timeMinimum{ E57_DOUBLE_MIN }; //!< Indicates that the PointRecord timeStamp fields should be configured
+      //!< Indicates that the PointRecord timeStamp fields should be configured
+      double timeMinimum{ E57_DOUBLE_MIN };
                                             //!< with this minimum value -E57_FLOAT_MAX or -E57_DOUBLE_MAX. If using a
                                             //!< ScaledIntegerNode then this needs to be a minimum time value.
       double timeScaledInteger{
@@ -370,17 +427,23 @@ namespace e57
       }; //!< Indicates that the PointRecord timeStamp fields should be configured as a ScaledIntegerNode with this
          //!< scale setting. If 0. then use FloatNode, if -1. use IntegerNode.
 
-      bool intensityField{ false };          //!< Indicates that the PointRecord intensity field is active
-      bool isIntensityInvalidField{ false }; //!< Indicates that the PointRecord isIntensityInvalid field is active
+      //!< Indicates that the PointRecord intensity field is active
+      bool intensityField{ false };
+      //!< Indicates that the PointRecord isIntensityInvalid field is active
+      bool isIntensityInvalidField{ false };
       double intensityScaledInteger{
          E57_NOT_SCALED_USE_INTEGER
       }; //!< Indicates that the PointRecord intensity fields should be configured as a ScaledIntegerNode with this
          //!< setting. If 0. then use FloatNode, if -1. use IntegerNode
 
-      bool colorRedField{ false };       //!< indicates that the PointRecord colorRed field is active
-      bool colorGreenField{ false };     //!< indicates that the PointRecord colorGreen field is active
-      bool colorBlueField{ false };      //!< indicates that the PointRecord colorBlue field is active
-      bool isColorInvalidField{ false }; //!< Indicates that the PointRecord isColorInvalid field is active
+      //!< indicates that the PointRecord colorRed field is active
+      bool colorRedField{ false };
+      //!< indicates that the PointRecord colorGreen field is active
+      bool colorGreenField{ false };
+      //!< indicates that the PointRecord colorBlue field is active
+      bool colorBlueField{ false };
+      //!< Indicates that the PointRecord isColorInvalid field is active
+      bool isColorInvalidField{ false };
 
       bool normalX{ false }; //!< Indicates that the PointRecord nor:normalX field is active
       bool normalY{ false }; //!< Indicates that the PointRecord nor:normalY field is active
@@ -391,46 +454,62 @@ namespace e57
    struct E57_DLL Data3D
    {
       ustring name; //!< A user-defined name for the Data3D.
-      ustring guid; //!< A globally unique identification string for the current version of the Data3D object
-      std::vector<ustring> originalGuids; //!< A vector of globally unique identification Strings from which the points
+      //!< A globally unique identification string for the current version of the Data3D object
+      ustring guid;
+      //!< A vector of globally unique identification Strings from which the points
+      std::vector<ustring> originalGuids;
                                           //!< in this Data3D originated.
       ustring description;                //!< A user-defined description of the Image
 
-      ustring sensorVendor; //!< The name of the manufacturer for the sensor used to collect the points in this Data3D.
+      //!< The name of the manufacturer for the sensor used to collect the points in this Data3D.
+      ustring sensorVendor;
       ustring sensorModel;  //!< The model name or number for the sensor.
       ustring sensorSerialNumber;    //!< The serial number for the sensor.
-      ustring sensorHardwareVersion; //!< The version number for the sensor hardware at the time of data collection.
-      ustring sensorSoftwareVersion; //!< The version number for the software used for the data collection.
-      ustring sensorFirmwareVersion; //!< The version number for the firmware installed in the sensor at the time of
+      //!< The version number for the sensor hardware at the time of data collection.
+      ustring sensorHardwareVersion;
+      //!< The version number for the software used for the data collection.
+      ustring sensorSoftwareVersion;
+      //!< The version number for the firmware installed in the sensor at the time of
+      ustring sensorFirmwareVersion;
                                      //!< data collection.
 
-      float temperature{ E57_FLOAT_MAX };      //!< The ambient temperature, measured at the sensor, at the time of data
+      //!< The ambient temperature, measured at the sensor, at the time of data
+      float temperature{ E57_FLOAT_MAX };
                                                //!< collection (in degrees Celsius).
-      float relativeHumidity{ E57_FLOAT_MAX }; //!< The percentage relative humidity, measured at the sensor, at the
+      //!< The percentage relative humidity, measured at the sensor, at the
+      float relativeHumidity{ E57_FLOAT_MAX };
                                                //!< time of data collection. Shall be in the interval [0, 100].
-      float atmosphericPressure{ E57_FLOAT_MAX }; //!< The atmospheric pressure, measured at the sensor, at the time of
+      //!< The atmospheric pressure, measured at the sensor, at the time of
+      float atmosphericPressure{ E57_FLOAT_MAX };
                                                   //!< data collection (in Pascals). Shall be positive.
 
       DateTime acquisitionStart; //!< The start date and time that the data was acquired.
       DateTime acquisitionEnd;   //!< The end date and time that the data was acquired.
 
-      RigidBodyTransform pose; //!< A rigid body transform that describes the coordinate frame of the 3D imaging
+      //!< A rigid body transform that describes the coordinate frame of the 3D imaging
+      RigidBodyTransform pose;
                                //!< system origin in the file-level coordinate system.
-      IndexBounds indexBounds; //!< The bounds of the row, column, and return number of all the points in this Data3D.
-      CartesianBounds cartesianBounds; //!< The bounding region (in cartesian coordinates) of all the points in
+      //!< The bounds of the row, column, and return number of all the points in this Data3D.
+      IndexBounds indexBounds;
+      //!< The bounding region (in cartesian coordinates) of all the points in
+      CartesianBounds cartesianBounds;
                                        //!< this Data3D (in the local coordinate system of the points).
-      SphericalBounds sphericalBounds; //!< The bounding region (in spherical coordinates) of all the points in
+      //!< The bounding region (in spherical coordinates) of all the points in
+      SphericalBounds sphericalBounds;
                                        //!< this Data3D (in the local coordinate system of the points).
-      IntensityLimits
-         intensityLimits; //!< The limits for the value of signal intensity that the sensor is capable of producing.
-      ColorLimits colorLimits; //!< The limits for the value of red, green, and blue color that the sensor is
+      //!< The limits for the value of signal intensity that the sensor is capable of producing.
+      IntensityLimits intensityLimits;
+      //!< The limits for the value of red, green, and blue color that the sensor is
+      ColorLimits colorLimits;
                                //!< capable of producing.
 
-      PointGroupingSchemes pointGroupingSchemes; //!< The defined schemes that group points in different ways
+      //!< The defined schemes that group points in different ways
+      PointGroupingSchemes pointGroupingSchemes;
       PointStandardizedFieldsAvailable
          pointFields; //!< This defines the active fields used in the WritePoints function.
 
-      int64_t pointsSize{ 0 }; //!< Total size of the compressed vector of PointRecord structures referring to the
+      //!< Total size of the compressed vector of PointRecord structures referring to the
+      int64_t pointsSize{ 0 };
                                //!< binary data that actually stores the point data
    };
 
@@ -446,15 +525,22 @@ namespace e57
       COORDTYPE *cartesianZ{
          nullptr
       }; //!< pointer to a buffer with the Z coordinate (in meters) of the point in Cartesian coordinates
-      int8_t *cartesianInvalidState{ nullptr }; //!< Value = 0 if the point is considered valid, 1 otherwise
+      //!< Value = 0 if the point is considered valid, 1 otherwise
+      int8_t *cartesianInvalidState{ nullptr };
 
-      float *intensity{ nullptr }; //!< pointer to a buffer with the Point response intensity. Unit is unspecified
-      int8_t *isIntensityInvalid{ nullptr }; //!< Value = 0 if the intensity is considered valid, 1 otherwise
+      //!< pointer to a buffer with the Point response intensity. Unit is unspecified
+      float *intensity{ nullptr };
+      //!< Value = 0 if the intensity is considered valid, 1 otherwise
+      int8_t *isIntensityInvalid{ nullptr };
 
-      uint8_t *colorRed{ nullptr };      //!< pointer to a buffer with the Red color coefficient. Unit is unspecified
-      uint8_t *colorGreen{ nullptr };    //!< pointer to a buffer with the Green color coefficient. Unit is unspecified
-      uint8_t *colorBlue{ nullptr };     //!< pointer to a buffer with the Blue color coefficient. Unit is unspecified
-      int8_t *isColorInvalid{ nullptr }; //!< Value = 0 if the color is considered valid, 1 otherwise
+      //!< pointer to a buffer with the Red color coefficient. Unit is unspecified
+      uint8_t *colorRed{ nullptr };
+      //!< pointer to a buffer with the Green color coefficient. Unit is unspecified
+      uint8_t *colorGreen{ nullptr };
+      //!< pointer to a buffer with the Blue color coefficient. Unit is unspecified
+      uint8_t *colorBlue{ nullptr };
+      //!< Value = 0 if the color is considered valid, 1 otherwise
+      int8_t *isColorInvalid{ nullptr };
 
       COORDTYPE *sphericalRange{
          nullptr
@@ -465,9 +551,11 @@ namespace e57
       COORDTYPE *sphericalElevation{
          nullptr
       }; //!< pointer to a buffer with the Elevation angle (in radians) of point in spherical coordinates
-      int8_t *sphericalInvalidState{ nullptr }; //!< Value = 0 if the range is considered valid, 1 otherwise
+      //!< Value = 0 if the range is considered valid, 1 otherwise
+      int8_t *sphericalInvalidState{ nullptr };
 
-      int32_t *rowIndex{ nullptr }; //!< pointer to a buffer with the row number of point (zero based). This is useful
+      //!< pointer to a buffer with the row number of point (zero based). This is useful
+      int32_t *rowIndex{ nullptr };
                                     //!< for data that is stored in a regular grid.  Shall be in the interval (0, 2^31).
       int32_t *columnIndex{
          nullptr
@@ -486,12 +574,16 @@ namespace e57
          nullptr
       }; //!< pointer to a buffer with the time (in seconds) since the start time for the data, which is given by
          //!< acquisitionStart in the parent Data3D Structure. Shall be non-negative
-      int8_t *isTimeStampInvalid{ nullptr }; //!< Value = 0 if the timeStamp is considered valid, 1 otherwise
+      //!< Value = 0 if the timeStamp is considered valid, 1 otherwise
+      int8_t *isTimeStampInvalid{ nullptr };
 
       // E57_EXT_surface_normals
-      float *normalX{ nullptr }; //!< The X component of a surface normal vector (E57_EXT_surface_normals).
-      float *normalY{ nullptr }; //!< The Y component of a surface normal vector (E57_EXT_surface_normals).
-      float *normalZ{ nullptr }; //!< The Z component of a surface normal vector (E57_EXT_surface_normals).
+      //!< The X component of a surface normal vector (E57_EXT_surface_normals).
+      float *normalX{ nullptr };
+      //!< The Y component of a surface normal vector (E57_EXT_surface_normals).
+      float *normalY{ nullptr };
+      //!< The Z component of a surface normal vector (E57_EXT_surface_normals).
+      float *normalZ{ nullptr };
    };
 
    typedef Data3DPointsData_t<float> Data3DPointsData;
@@ -527,13 +619,16 @@ namespace e57
       int32_t imageWidth{ 0 };    //!< The image width (in pixels). Shall be positive
       int32_t imageHeight{ 0 };   //!< The image height (in pixels). Shall be positive
       double focalLength{ 0. };   //!< The camera's focal length (in meters). Shall be positive
-      double pixelWidth{ 0. };    //!< The width of the pixels in the camera (in meters). Shall be positive
-      double pixelHeight{ 0. };   //!< The height of the pixels in the camera (in meters). Shall be positive
+      //!< The width of the pixels in the camera (in meters). Shall be positive
+      double pixelWidth{ 0. };
+      //!< The height of the pixels in the camera (in meters). Shall be positive
+      double pixelHeight{ 0. };
       double principalPointX{
          0.
       }; //!< The X coordinate in the image of the principal point, (in pixels). The principal point is the intersection
          //!< of the z axis of the camera coordinate frame with the image plane.
-      double principalPointY{ 0. }; //!< The Y coordinate in the image of the principal point (in pixels).
+      //!< The Y coordinate in the image of the principal point (in pixels).
+      double principalPointY{ 0. };
 
       bool operator==( const PinholeRepresentation &rhs ) const
       {
@@ -557,8 +652,10 @@ namespace e57
       int64_t imageMaskSize{ 0 }; //!< Size of PNG format image mask in BlobNode.
       int32_t imageWidth{ 0 };    //!< The image width (in pixels). Shall be positive
       int32_t imageHeight{ 0 };   //!< The image height (in pixels). Shall be positive
-      double pixelWidth{ 0. };    //!< The width of a pixel in the image (in radians). Shall be positive
-      double pixelHeight{ 0. };   //!< The height of a pixel in the image (in radians). Shall be positive.
+      //!< The width of a pixel in the image (in radians). Shall be positive
+      double pixelWidth{ 0. };
+      //!< The height of a pixel in the image (in radians). Shall be positive.
+      double pixelHeight{ 0. };
 
       bool operator==( const SphericalRepresentation &rhs ) const
       {
@@ -581,11 +678,15 @@ namespace e57
       int64_t imageMaskSize{ 0 }; //!< Size of PNG format image mask in Blob.
       int32_t imageWidth{ 0 };    //!< The image width (in pixels). Shall be positive
       int32_t imageHeight{ 0 };   //!< The image height (in pixels). Shall be positive
-      double pixelWidth{ 0. };    //!< The width of a pixel in the image (in radians). Shall be positive
-      double pixelHeight{ 0. };   //!< The height of a pixel in the image (in meters). Shall be positive
-      double radius{ 0. }; //!< The closest distance from the cylindrical image surface to the center of projection
+      //!< The width of a pixel in the image (in radians). Shall be positive
+      double pixelWidth{ 0. };
+      //!< The height of a pixel in the image (in meters). Shall be positive
+      double pixelHeight{ 0. };
+      //!< The closest distance from the cylindrical image surface to the center of projection
+      double radius{ 0. };
                            //!< (that is, the radius of the cylinder) (in meters). Shall be non-negative
-      double principalPointY{ 0. }; //!< The Y coordinate in the image of the principal point (in pixels). This is the
+      //!< The Y coordinate in the image of the principal point (in pixels). This is the
+      double principalPointY{ 0. };
                                     //!< intersection of the z = 0 plane with the image
 
       bool operator==( const CylindricalRepresentation &rhs ) const
@@ -606,29 +707,37 @@ namespace e57
    struct E57_DLL Image2D
    {
       ustring name;        //!< A user-defined name for the Image2D.
-      ustring guid;        //!< A globally unique identification string for the current version of the Image2D object
+      //!< A globally unique identification string for the current version of the Image2D object
+      ustring guid;
       ustring description; //!< A user-defined description of the Image2D
       DateTime acquisitionDateTime; //!< The date and time that the image was taken
 
-      ustring associatedData3DGuid; //!< The globally unique identification string (guid element) for the Data3D that
+      //!< The globally unique identification string (guid element) for the Data3D that
+      ustring associatedData3DGuid;
                                     //!< was being acquired when the picture was taken
 
-      ustring sensorVendor; //!< The name of the manufacturer for the sensor used to collect the points in this Data3D.
+      //!< The name of the manufacturer for the sensor used to collect the points in this Data3D.
+      ustring sensorVendor;
       ustring sensorModel;  //!< The model name or number for the sensor.
       ustring sensorSerialNumber; //!< The serial number for the sensor.
 
-      RigidBodyTransform pose; //!< A rigid body transform that describes the coordinate frame of the camera in the
+      //!< A rigid body transform that describes the coordinate frame of the camera in the
+      RigidBodyTransform pose;
                                //!< file-level coordinate system
 
       VisualReferenceRepresentation
-         visualReferenceRepresentation; //!< Representation for an image that does not define any camera projection
+         //!< Representation for an image that does not define any camera projection
+         visualReferenceRepresentation;
                                         //!< model. The image is to be used for visual reference only
       PinholeRepresentation
-         pinholeRepresentation; //!< Representation for an image using the pinhole camera projection model
+         //!< Representation for an image using the pinhole camera projection model
+         pinholeRepresentation;
       SphericalRepresentation
-         sphericalRepresentation; //!< Representation for an image using the spherical camera projection model.
+         //!< Representation for an image using the spherical camera projection model.
+         sphericalRepresentation;
       CylindricalRepresentation
-         cylindricalRepresentation; //!< Representation for an image using the cylindrical camera projection model
+         //!< Representation for an image using the cylindrical camera projection model
+         cylindricalRepresentation;
    };
 
    //! @brief Identifies the format representation for the image data

--- a/src/3rdParty/libE57Format/src/CheckedFile.h
+++ b/src/3rdParty/libE57Format/src/CheckedFile.h
@@ -42,7 +42,8 @@ namespace e57
    class CheckedFile
    {
    public:
-      static constexpr size_t physicalPageSizeLog2 = 10; // physical page size is 2 raised to this power
+      // physical page size is 2 raised to this power
+      static constexpr size_t physicalPageSizeLog2 = 10;
       static constexpr size_t physicalPageSize = 1 << physicalPageSizeLog2;
       static constexpr uint64_t physicalPageSizeMask = physicalPageSize - 1;
       static constexpr size_t logicalPageSize = physicalPageSize - 4;

--- a/src/3rdParty/libE57Format/src/CompressedVectorWriterImpl.cpp
+++ b/src/3rdParty/libE57Format/src/CompressedVectorWriterImpl.cpp
@@ -190,8 +190,10 @@ namespace e57
       /// Prepare CompressedVectorSectionHeader
       CompressedVectorSectionHeader header;
       header.sectionLogicalLength = sectionLogicalLength_;
-      header.dataPhysicalOffset = dataPhysicalOffset_;      ///??? can be zero, if no data written ???not set yet
-      header.indexPhysicalOffset = topIndexPhysicalOffset_; ///??? can be zero, if no data written ???not set
+      ///??? can be zero, if no data written ???not set yet
+      header.dataPhysicalOffset = dataPhysicalOffset_;
+      ///??? can be zero, if no data written ???not set
+      header.indexPhysicalOffset = topIndexPhysicalOffset_;
                                                             /// yet
 #ifdef E57_MAX_VERBOSE
       std::cout << "  CompressedVectorSectionHeader:" << std::endl;
@@ -369,7 +371,8 @@ namespace e57
             {
                //!!! For now, process up to 50 records at a time
                uint64_t recordCount = endRecordIndex - bytestream->currentRecordIndex();
-               recordCount = ( recordCount < 50ULL ) ? recordCount : 50ULL; // min(recordCount, 50ULL);
+               // min(recordCount, 50ULL);
+               recordCount = ( recordCount < 50ULL ) ? recordCount : 50ULL;
                bytestream->processRecords( static_cast<unsigned>( recordCount ) );
             }
          }

--- a/src/3rdParty/libE57Format/src/Decoder.cpp
+++ b/src/3rdParty/libE57Format/src/Decoder.cpp
@@ -64,7 +64,8 @@ std::shared_ptr<Decoder> Decoder::DecoderFactory( unsigned bytestreamNumber, //!
             std::static_pointer_cast<IntegerNodeImpl>( decodeNode ); // downcast to correct type
 
          /// Get pointer to parent ImageFileImpl, to call bitsNeeded()
-         ImageFileImplSharedPtr imf( decodeNode->destImageFile_ ); //??? should be function for this,
+         //??? should be function for this,
+         ImageFileImplSharedPtr imf( decodeNode->destImageFile_ );
                                                                    // imf->parentFile()
                                                                    //--> ImageFile?
 
@@ -109,10 +110,12 @@ std::shared_ptr<Decoder> Decoder::DecoderFactory( unsigned bytestreamNumber, //!
       case E57_SCALED_INTEGER:
       {
          std::shared_ptr<ScaledIntegerNodeImpl> sini =
-            std::static_pointer_cast<ScaledIntegerNodeImpl>( decodeNode ); // downcast to correct type
+            // downcast to correct type
+            std::static_pointer_cast<ScaledIntegerNodeImpl>( decodeNode );
 
          /// Get pointer to parent ImageFileImpl, to call bitsNeeded()
-         ImageFileImplSharedPtr imf( decodeNode->destImageFile_ ); //??? should be function for this,
+         //??? should be function for this,
+         ImageFileImplSharedPtr imf( decodeNode->destImageFile_ );
                                                                    // imf->parentFile()
                                                                    //--> ImageFile?
 

--- a/src/3rdParty/libE57Format/src/Encoder.cpp
+++ b/src/3rdParty/libE57Format/src/Encoder.cpp
@@ -68,7 +68,8 @@ std::shared_ptr<Encoder> Encoder::EncoderFactory( unsigned bytestreamNumber,
             std::static_pointer_cast<IntegerNodeImpl>( encodeNode ); // downcast to correct type
 
          /// Get pointer to parent ImageFileImpl, to call bitsNeeded()
-         ImageFileImplSharedPtr imf( encodeNode->destImageFile_ ); //??? should be function for this,
+         //??? should be function for this,
+         ImageFileImplSharedPtr imf( encodeNode->destImageFile_ );
                                                                    // imf->parentFile()
                                                                    //--> ImageFile?
 
@@ -113,10 +114,12 @@ std::shared_ptr<Encoder> Encoder::EncoderFactory( unsigned bytestreamNumber,
       case E57_SCALED_INTEGER:
       {
          std::shared_ptr<ScaledIntegerNodeImpl> sini =
-            std::static_pointer_cast<ScaledIntegerNodeImpl>( encodeNode ); // downcast to correct type
+            // downcast to correct type
+            std::static_pointer_cast<ScaledIntegerNodeImpl>( encodeNode );
 
          /// Get pointer to parent ImageFileImpl, to call bitsNeeded()
-         ImageFileImplSharedPtr imf( encodeNode->destImageFile_ ); //??? should be function for this,
+         //??? should be function for this,
+         ImageFileImplSharedPtr imf( encodeNode->destImageFile_ );
                                                                    // imf->parentFile()
                                                                    //--> ImageFile?
 
@@ -165,7 +168,8 @@ std::shared_ptr<Encoder> Encoder::EncoderFactory( unsigned bytestreamNumber,
       case E57_FLOAT:
       {
          std::shared_ptr<FloatNodeImpl> fni =
-            std::static_pointer_cast<FloatNodeImpl>( encodeNode ); // downcast to correct type
+            // downcast to correct type
+            std::static_pointer_cast<FloatNodeImpl>( encodeNode );
 
          //!!! need to pick smarter channel buffer sizes, here and elsewhere
          std::shared_ptr<Encoder> encoder(

--- a/src/3rdParty/libE57Format/src/Encoder.h
+++ b/src/3rdParty/libE57Format/src/Encoder.h
@@ -46,8 +46,10 @@ namespace e57
       virtual float bitsPerRecord() = 0;
       virtual bool registerFlushToOutput() = 0;
 
-      virtual size_t outputAvailable() const = 0;                        /// number of bytes that can be read
-      virtual void outputRead( char *dest, const size_t byteCount ) = 0; /// get data from encoder
+      /// number of bytes that can be read
+      virtual size_t outputAvailable() const = 0;
+      /// get data from encoder
+      virtual void outputRead( char *dest, const size_t byteCount ) = 0;
       virtual void outputClear() = 0;
 
       virtual void sourceBufferSetNew( std::vector<SourceDestBuffer> &sbufs ) = 0;

--- a/src/3rdParty/libE57Format/src/NodeImpl.cpp
+++ b/src/3rdParty/libE57Format/src/NodeImpl.cpp
@@ -35,7 +35,8 @@ using namespace e57;
 NodeImpl::NodeImpl( ImageFileImplWeakPtr destImageFile ) : destImageFile_( destImageFile ), isAttached_( false )
 {
    checkImageFileOpen( __FILE__, __LINE__,
-                       static_cast<const char *>( __FUNCTION__ ) ); // does checking for all node type ctors
+                       // does checking for all node type ctors
+                       static_cast<const char *>( __FUNCTION__ ) );
 }
 
 void NodeImpl::checkImageFileOpen( const char *srcFileName, int srcLineNumber, const char *srcFunctionName ) const

--- a/src/3rdParty/libE57Format/src/SourceDestBufferImpl.h
+++ b/src/3rdParty/libE57Format/src/SourceDestBufferImpl.h
@@ -114,19 +114,28 @@ namespace e57
 
       //??? verify alignment
       ImageFileImplWeakPtr destImageFile_;
-      ustring pathName_;                          /// Pathname from CompressedVectorNode to source/dest
+      /// Pathname from CompressedVectorNode to source/dest
+      ustring pathName_;
                                                   /// object, e.g. "Indices/0"
-      MemoryRepresentation memoryRepresentation_; /// Type of element (e.g. E57_INT8, E57_UINT64,
+      /// Type of element (e.g. E57_INT8, E57_UINT64,
+      MemoryRepresentation memoryRepresentation_;
                                                   /// DOUBLE...)
-      char *base_ = nullptr;                      /// Address of first element, for non-ustring buffers
-      size_t capacity_ = 0;                       /// Total number of elements in array
-      bool doConversion_ = false;                 /// Convert memory representation to/from disk representation
-      bool doScaling_ = false;                    /// Apply scale factor for integer type
-      size_t stride_ = 0;                         /// Distance between each element (different than size_
+      /// Address of first element, for non-ustring buffers
+      char *base_ = nullptr;
+      /// Total number of elements in array
+      size_t capacity_ = 0;
+      /// Convert memory representation to/from disk representation
+      bool doConversion_ = false;
+      /// Apply scale factor for integer type
+      bool doScaling_ = false;
+      /// Distance between each element (different than size_
+      size_t stride_ = 0;
                                                   /// if elements not contiguous)
-      unsigned nextIndex_ = 0;                    /// Number of elements that have been set (dest
+      /// Number of elements that have been set (dest
+      unsigned nextIndex_ = 0;
                                                   /// buffer) or read (source buffer) since rewind().
-      StringList *ustrings_ = nullptr;            /// Optional array of ustrings (used if
+      /// Optional array of ustrings (used if
+      StringList *ustrings_ = nullptr;
                                                   /// memoryRepresentation_==E57_USTRING) ???ownership
    };
 }

--- a/src/3rdParty/libkdtree/examples/test_hayne.cpp
+++ b/src/3rdParty/libkdtree/examples/test_hayne.cpp
@@ -8,7 +8,7 @@
 
 using namespace std;
 
-struct duplet 
+struct duplet
 {
    typedef int value_type;
 
@@ -95,7 +95,8 @@ int main()
 
       assert(*will == *should);
 
-      dupl_tree_test.erase(element_to_erase); //erase() : will probably erase wrong element sooner or later
+      //erase() : will probably erase wrong element sooner or later
+      dupl_tree_test.erase(element_to_erase);
       //dupl_tree_test.erase_exact(element_to_erase); --> this works
 
       // now check that it cannot find the element UNLESS there is another one with the identical location in the list...

--- a/src/3rdParty/salomesmesh/inc/Rn.h
+++ b/src/3rdParty/salomesmesh/inc/Rn.h
@@ -62,7 +62,7 @@ typedef char Nom[1+24];
 //=========
 #ifndef PCLINUX64
 typedef unsigned long int N;
-#else 
+#else
 typedef unsigned int N;
 #endif
 
@@ -80,11 +80,12 @@ typedef double R;
 
 //le type XPoint  des coordonnees d'un pixel dans une fenetre
 //==============
-//typedef struct { short int x,y } XPoint;  //en fait ce type est defini dans X11-Window
+//en fait ce type est defini dans X11-Window
+//typedef struct { short int x,y } XPoint;
                                             // #include <X11/Xlib.h>
 //la classe R2
 //============
-class R2 
+class R2
 {
   friend std::ostream& operator << (std::ostream& f, const R2 & P)
   { f << P.x << ' ' << P.y ; return f; }
@@ -135,9 +136,9 @@ class R3
   friend std::istream& operator >> (std::istream& f, R3 * P)
   { f >> P->x >> P->y >> P->z ; return f; }
 
-public:  
+public:
   R  x,y,z;  //les 3 coordonnees
- 
+
   R3 () :x(0),y(0),z(0) {}  //les constructeurs
   R3 (R a,R b,R c):x(a),y(b),z(c)  {}                  //Point ou Vecteur (a,b,c)
   R3 (R3 A,R3 B):x(B.x-A.x),y(B.y-A.y),z(B.z-A.z)  {}  //Vecteur AB
@@ -188,9 +189,9 @@ class R4: public R3
   friend std::istream& operator >>(std::istream& f,  R4 * P)
   { f >> P->x >>  P->y >>  P->z >> P->omega ; return f; }
 
-public:  
+public:
   R  omega;  //la donnee du poids supplementaire
- 
+
   R4 () :omega(1.0) {}  //les constructeurs
   R4 (R a,R b,R c,R d):R3(a,b,c),omega(d) {}
   R4 (R4 A,R4 B) :R3(B.x-A.x,B.y-A.y,B.z-A.z),omega(B.omega-A.omega) {}
@@ -212,7 +213,7 @@ public:
 
 //quelques fonctions supplementaires sur ces classes
 //==================================================
-inline R Aire2d(const R2 A,const R2 B,const R2 C){return (B-A)^(C-A);} 
+inline R Aire2d(const R2 A,const R2 B,const R2 C){return (B-A)^(C-A);}
 inline R Angle2d(R2 P){ return atan2(P.y,P.x);}
 
 inline R Norme2_2(const R2 & A){ return (A,A);}
@@ -228,9 +229,9 @@ inline R Norme2(const R4 & A){ return sqrt((A,A));}
 inline R NormeInfinie(const R4 & A){return Max(Abs(A.x),Abs(A.y),Abs(A.z),Abs(A.omega));}
 
 inline R2 XY(R3 P) {return R2(P.x, P.y);}  //restriction a R2 d'un R3 par perte de z
-inline R3 Min(R3 P, R3 Q) 
+inline R3 Min(R3 P, R3 Q)
 {return R3(P.x<Q.x ? P.x : Q.x, P.y<Q.y ? P.y : Q.y, P.z<Q.z ? P.z : Q.z);} //Pt de xyz Min
-inline R3 Max(R3 P, R3 Q) 
+inline R3 Max(R3 P, R3 Q)
 {return R3(P.x>Q.x ? P.x : Q.x, P.y>Q.y ? P.y : Q.y, P.z>Q.z ? P.z : Q.z);} //Pt de xyz Max
 
 #endif

--- a/src/3rdParty/salomesmesh/src/SMDS/SMDS_Downward.cpp
+++ b/src/3rdParty/salomesmesh/src/SMDS/SMDS_Downward.cpp
@@ -236,7 +236,8 @@ void SMDS_Down1D::compactStorage()
     sizeUpCells += _upCellIdsVector[i].size();
   _upCellIds.resize(sizeUpCells, -1);
   _upCellTypes.resize(sizeUpCells);
-  _upCellIndex.resize(_maxId + 1, -1); // id and types of rank i correspond to [ _upCellIndex[i], _upCellIndex[i+1] [
+  // id and types of rank i correspond to [ _upCellIndex[i], _upCellIndex[i+1] [
+  _upCellIndex.resize(_maxId + 1, -1);
   int current = 0;
   for (int i = 0; i < _maxId; i++)
     {
@@ -2242,4 +2243,3 @@ void SMDS_DownQuadHexa::computeFacesWithNodes(int cellId, ListElemByNodesType& f
 }
 
 // ---------------------------------------------------------------------------
-

--- a/src/3rdParty/salomesmesh/src/SMESH/DriverMED_R_SMESHDS_Mesh.cpp
+++ b/src/3rdParty/salomesmesh/src/SMESH/DriverMED_R_SMESHDS_Mesh.cpp
@@ -110,7 +110,8 @@ Driver_Mesh::Status DriverMED_R_SMESHDS_Mesh::Perform()
 #endif
     myFamilies.clear();
     if(MYDEBUG) MESSAGE("Perform - myFile : "<<myFile);
-    PWrapper aMed = CrWrapper(myFile,false); // We are using the internal MED file version checker instead of an external reader
+    // We are using the internal MED file version checker instead of an external reader
+    PWrapper aMed = CrWrapper(myFile,false);
 
     aResult = DRS_EMPTY;
     TInt aNbMeshes = aMed->GetNbMeshes();
@@ -423,13 +424,13 @@ Driver_Mesh::Status DriverMED_R_SMESHDS_Mesh::Perform()
                 {
                   aNodeIds[iNode++] = aConnSlice[iConn];
                 }
-#endif          
+#endif
               }
 
               bool isRenum = false;
               SMDS_MeshElement* anElement = NULL;
               TInt aFamNum = aPolyedreInfo->GetFamNum(iElem);
-                
+
 #ifndef _DEXCEPT_
               try{
 #endif
@@ -450,7 +451,7 @@ Driver_Mesh::Status DriverMED_R_SMESHDS_Mesh::Perform()
               }catch(...){
                 aResult = DRS_FAIL;
               }
-#endif          
+#endif
               if(!anElement){
                 aResult = DRS_WARN_SKIP_ELEM;
               }else{
@@ -527,7 +528,7 @@ Driver_Mesh::Status DriverMED_R_SMESHDS_Mesh::Perform()
                 INFOS("Unknown exception was caught !!!");
                 aResult = addMessage( "Unknown exception", /*isFatal=*/true );
               }
-#endif          
+#endif
               if(!anIsValidConnect)
                 continue;
 
@@ -1237,7 +1238,7 @@ bool DriverMED::buildMeshGrille(const MED::PWrapper&  theWrapper,
           aFamily->SetType(SMDSAbs_Node);
         }
     }
-    
+
   }
 
   SMDS_MeshElement* anElement = NULL;

--- a/src/3rdParty/salomesmesh/src/SMESH/SMESH_MeshEditor.cpp
+++ b/src/3rdParty/salomesmesh/src/SMESH/SMESH_MeshEditor.cpp
@@ -469,7 +469,7 @@ int SMESH_MeshEditor::Remove (const list< int >& theIDs,
 /*!
  * \brief Create 0D elements on all nodes of the given object except those
  *        nodes on which a 0D element already exists.
- *  \param elements - Elements on whose nodes to create 0D elements; if empty, 
+ *  \param elements - Elements on whose nodes to create 0D elements; if empty,
  *                    the all mesh is treated
  *  \param all0DElems - returns all 0D elements found or created on nodes of \a elements
  */
@@ -636,7 +636,7 @@ static int nbEdgeConnectivity(const SMDS_MeshNode* theNode)
 
 //=======================================================================
 //function : getNodesFromTwoTria
-//purpose  : 
+//purpose  :
 //=======================================================================
 
 static bool getNodesFromTwoTria(const SMDS_MeshElement * theTria1,
@@ -867,7 +867,7 @@ static bool findTriangles(const SMDS_MeshNode *    theNode1,
       {
         theTria1 = elem;
       }
-      else  
+      else
       {
         theTria2 = elem;
         // theTria1 must be element with minimum ID
@@ -1607,7 +1607,7 @@ void SMESH_MeshEditor::QuadTo4Tri (TIDSortedElemSet & theElems)
     // create 4 triangles
 
     GetMeshDS()->RemoveFreeElement( quad, subMeshDS, /*fromGroups=*/false );
-    
+
     helper.SetIsQuadratic  ( nodes.size() > 4 );
     helper.SetIsBiQuadratic( nodes.size() == 9 );
     if ( helper.GetIsQuadratic() )
@@ -2460,7 +2460,7 @@ void SMESH_MeshEditor::SplitVolumes (const TFacetOfElem & theElems,
           GetMeshDS()->RemoveNode( volNodes[i] );
     }
   } // loop on volumes to split
-  
+
   myLastCreatedNodes = newNodes;
   myLastCreatedElems = newElems;
 }
@@ -2617,7 +2617,7 @@ void SMESH_MeshEditor::GetHexaFacetsToSplit( TIDSortedElemSet& theHexas,
       fIt = facetsToCheck.begin();
 
       vTool.Set( hex );
-      if ( vTool.IsFreeFace( lateralFacet, &curHex ) || 
+      if ( vTool.IsFreeFace( lateralFacet, &curHex ) ||
            curHex->GetGeomType() != SMDSGeom_HEXA )
         continue;
       if ( !allHex && !theHexas.count( curHex ))
@@ -7182,7 +7182,7 @@ SMESH_MeshEditor::generateGroups(const SMESH_SequenceOfElemPtr& nodeGens,
  *  \param [in,out] theNodes - the nodes to treat
  *  \param [in]     theTolerance - the tolerance
  *  \param [out]    theGroupsOfNodes - the result groups of coincident nodes
- *  \param [in]     theSeparateCornersAndMedium - if \c true, in quadratic mesh puts 
+ *  \param [in]     theSeparateCornersAndMedium - if \c true, in quadratic mesh puts
  *         corner and medium nodes in separate groups
  */
 //================================================================================
@@ -7442,7 +7442,7 @@ void SMESH_MeshEditor::MergeNodes (TListOfListOfNodes & theGroupsOfNodes)
             SMDS_MeshCell::applyInterlace // interlace medium and corner nodes
               ( SMDS_MeshCell::interlacedSmdsOrder( SMDSEntity_Quad_Polygon, nbNodes ), curNodes );
 #else
-            throw SALOME_Exception("Quadratic polygon not supported with VTK <6.2");  
+            throw SALOME_Exception("Quadratic polygon not supported with VTK <6.2");
 #endif
           }
 
@@ -7472,7 +7472,7 @@ void SMESH_MeshEditor::MergeNodes (TListOfListOfNodes & theGroupsOfNodes)
                     ( SMDS_MeshCell::interlacedSmdsOrder( SMDSEntity_Quad_Polygon,
                                                           nbNewNodes ), face_nodes );
 #else
-                throw SALOME_Exception("Quadratic polygon not supported with VTK <6.2");  
+                throw SALOME_Exception("Quadratic polygon not supported with VTK <6.2");
 #endif
               }
               elemType.SetPoly(( nbNewNodes / ( elemType.myIsQuad + 1 ) > 4 ));
@@ -9444,7 +9444,7 @@ void SMESH_MeshEditor::ConvertToQuadratic(const bool theForce3d, const bool theT
     {
       const SMDS_MeshFace* face = aFaceItr->next();
       if ( !face ) continue;
-      
+
       const SMDSAbs_EntityType type = face->GetEntityType();
       bool alreadyOK;
       switch( type )
@@ -11222,9 +11222,11 @@ bool SMESH_MeshEditor::DoubleNodesOnGroupBoundaries( const std::vector<TIDSorted
   //     build the list of cells with only a node or an edge on the border, with their domain and volume indexes
   //     build the list of nodes shared by 2 or more domains, with their domain indexes
 
-  std::map<DownIdType, std::map<int,int>, DownIdCompare> faceDomains; // face --> (id domain --> id volume)
+  // face --> (id domain --> id volume)
+  std::map<DownIdType, std::map<int,int>, DownIdCompare> faceDomains;
   std::map<int,int>celldom; // cell vtkId --> domain
-  std::map<DownIdType, std::map<int,int>, DownIdCompare> cellDomains;  // oldNode --> (id domain --> id cell)
+  // oldNode --> (id domain --> id cell)
+  std::map<DownIdType, std::map<int,int>, DownIdCompare> cellDomains;
   std::map<int, std::map<int,int> > nodeDomains; // oldId -->  (domainId --> newId)
   faceDomains.clear();
   celldom.clear();
@@ -11298,7 +11300,8 @@ bool SMESH_MeshEditor::DoubleNodesOnGroupBoundaries( const std::vector<TIDSorted
                   {
                     // MESSAGE("Domain " << idombis);
                     const TIDSortedElemSet& domainbis = theElems[idombis];
-                    if ( domainbis.count(elem)) ok = true ; // neighbor is in a correct domain : face is kept
+                    // neighbor is in a correct domain : face is kept
+                    if ( domainbis.count(elem)) ok = true ;
                   }
                   if ( ok || onAllBoundaries ) // the characteristics of the face is stored
                   {
@@ -11380,9 +11383,11 @@ bool SMESH_MeshEditor::DoubleNodesOnGroupBoundaries( const std::vector<TIDSorted
   //     junction elements of type prism or hexa. the key is the pair of nodesId (lower first)
   //     the value is the ordered domain ids. (more than 4 domains not taken into account)
 
-  std::map<std::vector<int>, std::vector<int> > edgesMultiDomains; // nodes of edge --> ordered domains
+  // nodes of edge --> ordered domains
+  std::map<std::vector<int>, std::vector<int> > edgesMultiDomains;
   std::map<int, std::vector<int> > mutipleNodes; // nodes multi domains with domain order
-  std::map<int, std::vector<int> > mutipleNodesToFace; // nodes multi domains with domain order to transform in Face (junction between 3 or more 2D domains)
+  // nodes multi domains with domain order to transform in Face (junction between 3 or more 2D domains)
+  std::map<int, std::vector<int> > mutipleNodesToFace;
 
   MESSAGE(".. Duplication of the nodes");
   for (int idomain = idom0; idomain < nbDomains; idomain++)
@@ -11509,8 +11514,10 @@ bool SMESH_MeshEditor::DoubleNodesOnGroupBoundaries( const std::vector<TIDSorted
                               gp_Pnt p1(coords[0], coords[1], coords[2]);
                               gp_Pnt gref;
                               int vtkVolIds[1000];  // an edge can belong to a lot of volumes
-                              map<int, SMDS_VtkVolume*> domvol; // domain --> a volume with the edge
-                              map<int, double> angleDom; // oriented angles between planes defined by edge and volume centers
+                              // domain --> a volume with the edge
+                              map<int, SMDS_VtkVolume*> domvol;
+                              // oriented angles between planes defined by edge and volume centers
+                              map<int, double> angleDom;
                               int nbvol = grid->GetParentVolumes(vtkVolIds, downEdgeIds[ie], edgeType[ie]);
                               for (int id=0; id < doms.size(); id++)
                                 {
@@ -11695,7 +11702,8 @@ bool SMESH_MeshEditor::DoubleNodesOnGroupBoundaries( const std::vector<TIDSorted
   //     associate these faces or edges to their corresponding domain.
   //     only the first domain found is kept when a face or edge is shared
 
-  std::map<DownIdType, std::map<int,int>, DownIdCompare> faceOrEdgeDom; // cellToModify --> (id domain --> id cell)
+  // cellToModify --> (id domain --> id cell)
+  std::map<DownIdType, std::map<int,int>, DownIdCompare> faceOrEdgeDom;
   std::map<int,int> feDom; // vtk id of cell to modify --> id domain
   faceOrEdgeDom.clear();
   feDom.clear();
@@ -11725,7 +11733,8 @@ bool SMESH_MeshEditor::DoubleNodesOnGroupBoundaries( const std::vector<TIDSorted
                     {
                       feDom[vtkId] = idomain;
                       faceOrEdgeDom[aCell] = emptyMap;
-                      faceOrEdgeDom[aCell][idomain] = vtkId; // affect face or edge to the first domain only
+                      // affect face or edge to the first domain only
+                      faceOrEdgeDom[aCell][idomain] = vtkId;
                       //MESSAGE("affect cell " << this->GetMeshDS()->fromVtkToSmds(vtkId) << " domain " << idomain
                       //        << " type " << vtkType << " downId " << downId);
                     }
@@ -11782,7 +11791,8 @@ bool SMESH_MeshEditor::DoubleNodesOnGroupBoundaries( const std::vector<TIDSorted
       myMesh->RemoveGroup( name_group->second->GetGroupDS()->GetID() );
   }
 
-  meshDS->CleanDownWardConnectivity(); // Mesh has been modified, downward connectivity is no more usable, free memory
+  // Mesh has been modified, downward connectivity is no more usable, free memory
+  meshDS->CleanDownWardConnectivity();
   grid->BuildLinks();
 
   CHRONOSTOP(50);
@@ -12279,8 +12289,10 @@ void SMESH_MeshEditor::CreateHoleSkin(double radius,
   //     fill group of SMDS faces inside the volume (when several volume shapes)
   //     fill group of SMDS faces on the skin of the global volume (if skin)
 
-  std::map<DownIdType, int, DownIdCompare> boundaryFaces; // boundary faces inside the volume --> corresponding cell
-  std::map<DownIdType, int, DownIdCompare> skinFaces;     // faces on the skin of the global volume --> corresponding cell
+  // boundary faces inside the volume --> corresponding cell
+  std::map<DownIdType, int, DownIdCompare> boundaryFaces;
+  // faces on the skin of the global volume --> corresponding cell
+  std::map<DownIdType, int, DownIdCompare> skinFaces;
   std::set<int>::iterator it = setOfInsideVol.begin();
   for (; it != setOfInsideVol.end(); ++it)
     {
@@ -12351,7 +12363,8 @@ void SMESH_MeshEditor::CreateHoleSkin(double radius,
       shapeIdToVtkIdSet[shapeId].insert(vtkId);
     }
 
-  std::map<int, std::set<DownIdType, DownIdCompare> > shapeIdToEdges; // shapeId --> set of downward edges
+  // shapeId --> set of downward edges
+  std::map<int, std::set<DownIdType, DownIdCompare> > shapeIdToEdges;
   std::set<DownIdType, DownIdCompare> emptyEdges;
   emptyEdges.clear();
 
@@ -12399,7 +12412,8 @@ void SMESH_MeshEditor::CreateHoleSkin(double radius,
       order.clear();
       if (nodesEdges.size() > 0)
         {
-          order.push_back(nodesEdges[0]); MESSAGE("       --- back " << order.back()+1); // SMDS id = VTK id + 1;
+          // SMDS id = VTK id + 1;
+          order.push_back(nodesEdges[0]); MESSAGE("       --- back " << order.back()+1);
           nodesEdges[0] = -1;
           order.push_back(nodesEdges[1]); MESSAGE("       --- back " << order.back()+1);
           nodesEdges[1] = -1; // do not reuse this edge
@@ -12746,7 +12760,7 @@ int SMESH_MeshEditor::MakeBoundaryMesh(const TIDSortedElemSet& elements,
                                                                    missType,
                                                                    /*noMedium=*/false))
           continue;
-        SMDS_MeshElement* newElem = 
+        SMDS_MeshElement* newElem =
           tgtEditor.AddElement( nodes, elemKind.SetPoly( nodes.size()/(iQuad+1) > 4 ));
         nbAddedBnd += bool( newElem );
 

--- a/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_Import_1D.cpp
+++ b/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_Import_1D.cpp
@@ -698,7 +698,8 @@ bool StdMeshers_Import_1D::Compute(SMESH_Mesh & theMesh, const TopoDS_Shape & th
     SMDS_ElemIteratorPtr srcElems = srcGroup->GetElements();
     vector<const SMDS_MeshNode*> newNodes;
     SMDS_MeshNode *tmpNode = helper.AddNode(0,0,0);
-    double u = 0.314159; // "random" value between 0 and 1, avoid 0 and 1, false detection possible on edge restrictions
+    // "random" value between 0 and 1, avoid 0 and 1, false detection possible on edge restrictions
+    double u = 0.314159;
     while ( srcElems->more() ) // loop on group contents
     {
       const SMDS_MeshElement* edge = srcElems->next();
@@ -1098,4 +1099,3 @@ SMESH_subMesh* StdMeshers_Import_1D::getSubMeshOfCopiedMesh( SMESH_Mesh& tgtMesh
   SMESH_subMesh* sm = tgtMesh.GetSubMeshContaining( iData->_importMeshSubID );
   return sm;
 }
-

--- a/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_Quadrangle_2D.cpp
+++ b/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_Quadrangle_2D.cpp
@@ -115,7 +115,7 @@ StdMeshers_Quadrangle_2D::~StdMeshers_Quadrangle_2D()
 
 //=============================================================================
 /*!
- *  
+ *
  */
 //=============================================================================
 
@@ -161,7 +161,7 @@ bool StdMeshers_Quadrangle_2D::CheckHypothesis
     }
     else if (strcmp("TrianglePreference", aHyp->GetName()) == 0){
       isFirstParams = false;
-      myTrianglePreference = true; 
+      myTrianglePreference = true;
     }
     else {
       isFirstParams = false;
@@ -174,17 +174,17 @@ bool StdMeshers_Quadrangle_2D::CheckHypothesis
     if (isFirstParams) {
       if (strcmp("QuadranglePreference", aHyp->GetName()) == 0) {
         myQuadranglePreference = true;
-        myTrianglePreference = false; 
+        myTrianglePreference = false;
         myQuadType = QUAD_STANDARD;
       }
       else if (strcmp("TrianglePreference", aHyp->GetName()) == 0){
         myQuadranglePreference = false;
-        myTrianglePreference = true; 
+        myTrianglePreference = true;
         myQuadType = QUAD_STANDARD;
       }
     }
     else {
-      const StdMeshers_QuadrangleParams* aHyp2 = 
+      const StdMeshers_QuadrangleParams* aHyp2 =
         (const StdMeshers_QuadrangleParams*)aHyp;
       myTriaVertexID = aHyp2->GetTriaVertex();
 
@@ -206,7 +206,7 @@ bool StdMeshers_Quadrangle_2D::CheckHypothesis
 
 //=============================================================================
 /*!
- *  
+ *
  */
 //=============================================================================
 
@@ -441,7 +441,7 @@ bool StdMeshers_Quadrangle_2D::computeQuadDominant(SMESH_Mesh&         aMesh,
       uvPnt.node        = meshDS->AddNode(P.X(), P.Y(), P.Z());
       meshDS->SetNodeOnFace( uvPnt.node, geomFaceID, uvPnt.u, uvPnt.v );
     }
-  
+
   // mesh faces
 
   //             [2]
@@ -455,15 +455,15 @@ bool StdMeshers_Quadrangle_2D::computeQuadDominant(SMESH_Mesh&         aMesh,
   //     0 > > > > > > > > nbhoriz
   //              i
   //             [0]
-  
+
   int ilow = 0;
   int iup = nbhoriz - 1;
   if (quad->nbNodeOut(3)) { ilow++; } else { if (quad->nbNodeOut(1)) iup--; }
-  
+
   int jlow = 0;
   int jup = nbvertic - 1;
   if (quad->nbNodeOut(0)) { jlow++; } else { if (quad->nbNodeOut(2)) jup--; }
-  
+
   // regular quadrangles
   for (i = ilow; i < iup; i++) {
     for (j = jlow; j < jup; j++) {
@@ -477,7 +477,7 @@ bool StdMeshers_Quadrangle_2D::computeQuadDominant(SMESH_Mesh&         aMesh,
   }
 
   // Boundary elements (must always be on an outer boundary of the FACE)
-  
+
   const vector<UVPtStruct>& uv_e0 = quad->side[0].grid->GetUVPtStruct();
   const vector<UVPtStruct>& uv_e1 = quad->side[1].grid->GetUVPtStruct();
   const vector<UVPtStruct>& uv_e2 = quad->side[2].grid->GetUVPtStruct();
@@ -496,18 +496,18 @@ bool StdMeshers_Quadrangle_2D::computeQuadDominant(SMESH_Mesh&         aMesh,
   if (quad->nbNodeOut(0) && nbvertic == 2) // this should not occure
   {
     // Down edge is out
-    // 
+    //
     // |___|___|___|___|___|___|
     // |   |   |   |   |   |   |
     // |___|___|___|___|___|___|
     // |   |   |   |   |   |   |
     // |___|___|___|___|___|___| __ first row of the regular grid
     // .  .  .  .  .  .  .  .  . __ down edge nodes
-    // 
+    //
     // >->->->->->->->->->->->-> -- direction of processing
-      
+
     int g = 0; // number of last processed node in the regular grid
-    
+
     // number of last node of the down edge to be processed
     int stop = nbdown - 1;
     // if right edge is out, we will stop at a node, previous to the last one
@@ -524,7 +524,7 @@ bool StdMeshers_Quadrangle_2D::computeQuadDominant(SMESH_Mesh&         aMesh,
       a = uv_e0[i].node;
       b = uv_e0[i + 1].node;
       gp_Pnt pb (b->X(), b->Y(), b->Z());
-      
+
       // find node c in the regular grid, which will be linked with node b
       int near = g;
       if (i == stop - 1) {
@@ -536,7 +536,7 @@ bool StdMeshers_Quadrangle_2D::computeQuadDominant(SMESH_Mesh&         aMesh,
         // find in the grid node c, nearest to the b
         double mind = RealLast();
         for (int k = g; k <= iup; k++) {
-          
+
           const SMDS_MeshNode *nk;
           if (k < ilow) // this can be, if left edge is out
             nk = uv_e3[1].node; // get node from the left edge
@@ -564,7 +564,7 @@ bool StdMeshers_Quadrangle_2D::computeQuadDominant(SMESH_Mesh&         aMesh,
         else
           d = quad->uv_grid[nbhoriz + near - 1].node;
         //SMDS_MeshFace* face = meshDS->AddFace(a, b, c, d);
-        
+
         if (!myTrianglePreference){
           myHelper->AddFace(a, b, c, d);
         }
@@ -590,9 +590,9 @@ bool StdMeshers_Quadrangle_2D::computeQuadDominant(SMESH_Mesh&         aMesh,
     if (quad->nbNodeOut(2) && nbvertic == 2)
     {
       // Up edge is out
-      // 
+      //
       // <-<-<-<-<-<-<-<-<-<-<-<-< -- direction of processing
-      // 
+      //
       // .  .  .  .  .  .  .  .  . __ up edge nodes
       //  ___ ___ ___ ___ ___ ___  __ first row of the regular grid
       // |   |   |   |   |   |   |
@@ -1045,7 +1045,7 @@ static bool twoEdgesMeatAtVertex(const TopoDS_Edge& e1,
 
 //=============================================================================
 /*!
- *  
+ *
  */
 //=============================================================================
 
@@ -1174,7 +1174,7 @@ FaceQuadStruct::Ptr StdMeshers_Quadrangle_2D::CheckNbEdges(SMESH_Mesh &         
 
 //=============================================================================
 /*!
- *  
+ *
  */
 //=============================================================================
 
@@ -1403,7 +1403,7 @@ namespace
 
 //=============================================================================
 /*!
- *  
+ *
  */
 //=============================================================================
 
@@ -2534,7 +2534,7 @@ bool StdMeshers_Quadrangle_2D::evaluateQuadPref(SMESH_Mesh &        aMesh,
 
   if (dh>=dv) {
     if (nt>nb) {
-      // it is a base case => not shift 
+      // it is a base case => not shift
     }
     else {
       // we have to shift on 2
@@ -2585,7 +2585,7 @@ bool StdMeshers_Quadrangle_2D::evaluateQuadPref(SMESH_Mesh &        aMesh,
     // insert to left
     dl = nbv - nl;
   }
-  
+
   int nnn = Min(nr,nl);
 
   int nbNodes = 0;
@@ -2639,7 +2639,7 @@ bool StdMeshers_Quadrangle_2D::evaluateQuadPref(SMESH_Mesh &        aMesh,
 
 //=============================================================================
 /*! Split quadrangle in to 2 triangles by smallest diagonal
- *   
+ *
  */
 //=============================================================================
 
@@ -2683,7 +2683,7 @@ namespace
     double xBot = uv_eb[ iBot ].normParam + ( rBot - iBot ) * ( uv_eb[ iBot+1 ].normParam - uv_eb[ iBot ].normParam );
     double xTop = uv_et[ iTop ].normParam + ( rTop - iTop ) * ( uv_et[ iTop+1 ].normParam - uv_et[ iTop ].normParam );
     double x = xBot + y * ( xTop - xBot );
-    
+
     gp_UV uv = calcUV(/*x,y=*/x, y,
                       /*a0,...=*/UVs[UV_A0], UVs[UV_A1], UVs[UV_A2], UVs[UV_A3],
                       /*p0=*/quad->side[QUAD_BOTTOM_SIDE].grid->Value2d( x ).XY(),
@@ -3016,7 +3016,7 @@ bool StdMeshers_Quadrangle_2D::computeReduced (SMESH_Mesh &        aMesh,
     for (i=1; i<=dl; i++) {
       npl.InsertAfter(1,npl.Value(2)-dpr);
     }
-  
+
     gp_XY a0 (uv_eb.front().u, uv_eb.front().v);
     gp_XY a1 (uv_eb.back().u,  uv_eb.back().v);
     gp_XY a2 (uv_et.back().u,  uv_et.back().v);
@@ -3037,7 +3037,7 @@ bool StdMeshers_Quadrangle_2D::computeReduced (SMESH_Mesh &        aMesh,
       NodesL.SetValue(1,j,uv_el[j-1].node);
     if (dl>0) {
       // add top nodes
-      for (i=1; i<=dl; i++) 
+      for (i=1; i<=dl; i++)
         NodesL.SetValue(i+1,nl,uv_et[i].node);
       // create and add needed nodes
       TColgp_SequenceOfXY UVtmp;
@@ -3082,15 +3082,15 @@ bool StdMeshers_Quadrangle_2D::computeReduced (SMESH_Mesh &        aMesh,
         UVL.Append(gp_UV (uv_el[i].u, uv_el[i].v));
       }
     }
-    
+
     // step2: create faces for right domain
     StdMeshers_Array2OfNode NodesR(1,dr+1,1,nr);
     // add right nodes
-    for (j=1; j<=nr; j++) 
+    for (j=1; j<=nr; j++)
       NodesR.SetValue(1,j,uv_er[nr-j].node);
     if (dr>0) {
       // add top nodes
-      for (i=1; i<=dr; i++) 
+      for (i=1; i<=dr; i++)
         NodesR.SetValue(i+1,1,uv_et[nt-1-i].node);
       // create and add needed nodes
       TColgp_SequenceOfXY UVtmp;
@@ -3135,7 +3135,7 @@ bool StdMeshers_Quadrangle_2D::computeReduced (SMESH_Mesh &        aMesh,
         UVR.Append(gp_UV(uv_er[i].u, uv_er[i].v));
       }
     }
-    
+
     // step3: create faces for central domain
     StdMeshers_Array2OfNode NodesC(1,nb,1,nbv);
     // add first line using NodesL
@@ -3149,7 +3149,7 @@ bool StdMeshers_Quadrangle_2D::computeReduced (SMESH_Mesh &        aMesh,
     for (i=1; i<nr; i++)
       NodesC.SetValue(nb,dr+i+1,NodesR(dr+1,nr-i));
     // add top nodes (last columns)
-    for (i=dl+2; i<nbh-dr; i++) 
+    for (i=dl+2; i<nbh-dr; i++)
       NodesC.SetValue(i-dl,nbv,uv_et[i-1].node);
     // add bottom nodes (first columns)
     for (i=2; i<nb; i++)
@@ -3231,7 +3231,8 @@ bool StdMeshers_Quadrangle_2D::computeReduced (SMESH_Mesh &        aMesh,
     // maximum number of bottom elements for "tree" simple reduce 4->2
     int max_tree42 = 0;
     // number of rows needed to reduce ncol_bot to ncol_top using simple 4->2 "tree"
-    int nrows_tree42 = int( log( (double)(ncol_bot / ncol_top) )/log((double)2)  ); // needed to avoid overflow at pow(2) while computing max_tree42
+    // needed to avoid overflow at pow(2) while computing max_tree42
+    int nrows_tree42 = int( log( (double)(ncol_bot / ncol_top) )/log((double)2)  );
     if (nrows_tree42 < nrows) {
       max_tree42 = npair_top * pow(2.0, nrows + 1);
       if ( ncol_top > npair_top * 2 ) {
@@ -3549,7 +3550,7 @@ bool StdMeshers_Quadrangle_2D::computeReduced (SMESH_Mesh &        aMesh,
           const SMDS_MeshNode*& Nf = next_base[++next_base_len].node;
           if ( !Nf )
             Nf = makeNode( next_base[ next_base_len ], y, quad, uv, myHelper, S );
-          
+
           myHelper->AddFace(curr_base[ j ].node,
                             curr_base[ j+1 ].node,
                             Nf,
@@ -4313,7 +4314,7 @@ int StdMeshers_Quadrangle_2D::getCorners(const TopoDS_Face&          theFace,
       if ( myTriaVertexID < 1 )
         return error(COMPERR_BAD_PARMETERS,
                      "No Base vertex provided for a trilateral geometrical face");
-        
+
       TComm comment("Invalid Base vertex: ");
       comment << myTriaVertexID << " its ID is not among [ ";
       multimap<double, TopoDS_Vertex>::iterator a2v = vertexByAngle.begin();

--- a/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_ViscousLayers.cpp
+++ b/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_ViscousLayers.cpp
@@ -216,7 +216,7 @@ namespace VISCOUS_3D
       mesh->GetSubMesh(solid)->DeleteEventListener( _ViscousListener::Get() );
     }
   };
-  
+
   //================================================================================
   /*!
    * \brief sets a sub-mesh event listener to clear sub-meshes of sub-shapes of
@@ -441,8 +441,8 @@ namespace VISCOUS_3D
       double D = _dir.Crossed( hp._dir );
       if ( fabs(D) < std::numeric_limits<double>::min())
         return false;
-      gp_XY vec21 = _pos - hp._pos; 
-      double u = hp._dir.Crossed( vec21 ) / D; 
+      gp_XY vec21 = _pos - hp._pos;
+      double u = hp._dir.Crossed( vec21 ) / D;
       intPnt = _pos + _dir * u;
       return true;
     }
@@ -542,7 +542,7 @@ namespace VISCOUS_3D
 
   //--------------------------------------------------------------------------------
   /*!
-   * \brief Convex FACE whose radius of curvature is less than the thickness of 
+   * \brief Convex FACE whose radius of curvature is less than the thickness of
    *        layers. It is used to detect distortion of prisms based on a convex
    *        FACE and to update normals to enable further increasing the thickness
    */
@@ -1550,7 +1550,7 @@ SMESH_ComputeErrorPtr _ViscousBuilder::Compute(SMESH_Mesh&         theMesh,
 
   PyDump debugDump( theMesh );
 
-  // TODO: ignore already computed SOLIDs 
+  // TODO: ignore already computed SOLIDs
   if ( !findSolidsWithLayers())
     return _error;
 
@@ -1564,7 +1564,7 @@ SMESH_ComputeErrorPtr _ViscousBuilder::Compute(SMESH_Mesh&         theMesh,
 
     if ( _sdVec[i]._n2eMap.size() == 0 )
       continue;
-    
+
     if ( ! inflate(_sdVec[i]) )
       return _error;
 
@@ -1665,7 +1665,7 @@ bool _ViscousBuilder::findSolidsWithLayers()
 
 //================================================================================
 /*!
- * \brief 
+ * \brief
  */
 //================================================================================
 
@@ -3097,7 +3097,7 @@ gp_XYZ _ViscousBuilder::getFaceNormal(const SMDS_MeshNode* node,
     GeomAPI_ProjectPointOnSurf& projector = helper.GetProjector( face, loc, 1e-7 );
 
     if ( !loc.IsIdentity() ) p.Transform( loc.Transformation().Inverted() );
-    
+
     projector.Perform( p );
     if ( !projector.IsDone() || projector.NbPoints() < 1 )
     {
@@ -3485,7 +3485,7 @@ void _LayerEdge::SetCosin( double cosin )
 
 //================================================================================
 /*!
- * \brief Fills a vector<_Simplex > 
+ * \brief Fills a vector<_Simplex >
  */
 //================================================================================
 
@@ -4485,7 +4485,7 @@ bool _ViscousBuilder::updateNormals( _SolidData&         data,
   for ( size_t iS = 0; iS < data._edgesOnShape.size(); ++iS )
   {
     _EdgesOnShape& eos = data._edgesOnShape[ iS ];
-    if (( eos.ShapeType() != TopAbs_EDGE ) && 
+    if (( eos.ShapeType() != TopAbs_EDGE ) &&
         ( eos._sWOL.IsNull() || eos.SWOLType() != TopAbs_FACE ))
       continue;
     for ( size_t i = 0; i < eos._edges.size(); ++i )
@@ -5158,7 +5158,7 @@ bool _CentralCurveOnEdge::FindNewNormal( const gp_Pnt& center, gp_XYZ& newNormal
     double d1 = center.SquareDistance( _curvaCenters[ i ]);
     if ( d1 > sl2 )
       continue;
-    
+
     double d2 = center.SquareDistance( _curvaCenters[ i+1 ]);
     if ( d2 > sl2 || d2 + d1 < 1e-100 )
       continue;
@@ -5340,7 +5340,7 @@ gp_Ax1 _LayerEdge::LastSegment(double& segLen, _EdgesOnShape& eos) const
 
 //================================================================================
 /*!
- * \brief Return the last position of the target node on a FACE. 
+ * \brief Return the last position of the target node on a FACE.
  *  \param [in] F - the FACE this _LayerEdge is inflated along
  *  \return gp_XY - result UV
  */
@@ -5444,7 +5444,7 @@ bool _LayerEdge::SmoothOnEdge(Handle(Geom_Surface)& surface,
   SMDS_MeshNode* tgtNode = const_cast<SMDS_MeshNode*>( _nodes.back() );
   SMESH_TNodeXYZ oldPos( tgtNode );
   double dist01, distNewOld;
-  
+
   SMESH_TNodeXYZ p0( _2neibors->tgtNode(0));
   SMESH_TNodeXYZ p1( _2neibors->tgtNode(1));
   dist01 = p0.Distance( _2neibors->tgtNode(1) );
@@ -6924,8 +6924,10 @@ bool _ViscousBuilder::prepareEdgeToShrink( _LayerEdge&            edge,
 
   if ( eos.SWOLType() == TopAbs_FACE )
   {
-    gp_XY srcUV ( edge._pos[0].X(), edge._pos[0].Y() );          //helper.GetNodeUV( F, srcNode );
-    gp_XY tgtUV = edge.LastUV( TopoDS::Face( eos._sWOL ), eos ); //helper.GetNodeUV( F, tgtNode );
+    //helper.GetNodeUV( F, srcNode );
+    gp_XY srcUV ( edge._pos[0].X(), edge._pos[0].Y() );
+    //helper.GetNodeUV( F, tgtNode );
+    gp_XY tgtUV = edge.LastUV( TopoDS::Face( eos._sWOL ), eos );
     gp_Vec2d uvDir( srcUV, tgtUV );
     double uvLen = uvDir.Magnitude();
     uvDir /= uvLen;
@@ -7081,7 +7083,7 @@ void _ViscousBuilder::fixBadFaces(const TopoDS_Face&          F,
   // find couples of faces to swap diagonal
 
   typedef pair < const SMDS_MeshElement* , const SMDS_MeshElement* > T2Trias;
-  vector< T2Trias > triaCouples; 
+  vector< T2Trias > triaCouples;
 
   TIDSortedElemSet involvedFaces, emptySet;
   for ( size_t iTia = 0; iTia < badTrias.size(); ++iTia )
@@ -7587,7 +7589,7 @@ void _Shrinker1D::Compute(bool set3D, SMESH_MesherHelper& helper)
       f = helper.GetNodeU( _geomEdge, _edges[0]->_nodes.back(), _nodes[0] );
     if ( _edges[1] )
       l = helper.GetNodeU( _geomEdge, _edges[1]->_nodes.back(), _nodes.back() );
-    
+
     for ( size_t i = 0; i < _nodes.size(); ++i )
     {
       if ( !_nodes[i] ) continue;
@@ -7719,7 +7721,7 @@ bool _ViscousBuilder::addBoundaryElements()
       // Find out orientation and type of face to create
 
       bool reverse = false, isOnFace;
-      
+
       map< TGeomID, TopoDS_Shape >::iterator e2f =
         data._shrinkShape2Shape.find( getMeshDS()->ShapeToIndex( E ));
       TopoDS_Shape F;

--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -3354,7 +3354,8 @@ std::string Application::FindHomePath(const char* call)
         uint32_t sz = 0;
         char *buf;
 
-        _NSGetExecutablePath(NULL, &sz); //function only returns "sz" if first arg is to small to hold value
+        //function only returns "sz" if first arg is to small to hold value
+        _NSGetExecutablePath(NULL, &sz);
         buf = new char[++sz];
 
         if (_NSGetExecutablePath(buf, &sz) == 0) {

--- a/src/App/ExtensionContainer.h
+++ b/src/App/ExtensionContainer.h
@@ -120,11 +120,14 @@ public:
     ~ExtensionContainer() override;
 
     void registerExtension(Base::Type extension, App::Extension* ext);
-    bool hasExtension(Base::Type, bool derived=true) const; //returns first of type (or derived from if set to true) and throws otherwise
-    bool hasExtension(const std::string& name) const; //this version does not check derived classes
+    //returns first of type (or derived from if set to true) and throws otherwise
+    bool hasExtension(Base::Type, bool derived=true) const;
+    //this version does not check derived classes
+    bool hasExtension(const std::string& name) const;
     bool hasExtensions() const;
     App::Extension* getExtension(Base::Type, bool derived = true, bool no_except=false) const;
-    App::Extension* getExtension(const std::string& name) const; //this version does not check derived classes
+    //this version does not check derived classes
+    App::Extension* getExtension(const std::string& name) const;
 
     //returns first of type (or derived from) and throws otherwise
     template<typename ExtensionT>

--- a/src/App/Metadata.h
+++ b/src/App/Metadata.h
@@ -66,7 +66,8 @@ struct AppExport License {
     License() = default;
     License(std::string name, boost::filesystem::path file);
     explicit License(const XERCES_CPP_NAMESPACE::DOMElement* elem);
-    std::string name;//< Short name of license, e.g. "LGPL2", "MIT", "Mozilla Public License", etc.
+    //< Short name of license, e.g. "LGPL2", "MIT", "Mozilla Public License", etc.
+    std::string name;
     boost::filesystem::path
         file;//< Optional path to the license file, relative to the XML file's location
     bool operator==(const License& rhs) const;
@@ -146,11 +147,13 @@ struct AppExport Dependency {
     std::string
         version_lt;//< Optional: The dependency to the package is restricted to versions less than the stated version number.
     std::string
-        version_lte;//< Optional: The dependency to the package is restricted to versions less or equal than the stated version number.
+        //< Optional: The dependency to the package is restricted to versions less or equal than the stated version number.
+        version_lte;
     std::string
         version_eq;//< Optional: The dependency to the package is restricted to a version equal than the stated version number.
     std::string
-        version_gte;//< Optional: The dependency to the package is restricted to versions greater or equal than the stated version number.
+        //< Optional: The dependency to the package is restricted to versions greater or equal than the stated version number.
+        version_gte;
     std::string
         version_gt;//< Optional: The dependency to the package is restricted to versions greater than the stated version number.
     std::string condition;        //< Optional: Conditional expression as documented in REP149.

--- a/src/Base/DualQuaternion.cpp
+++ b/src/Base/DualQuaternion.cpp
@@ -151,7 +151,8 @@ Base::DualQuat Base::DualQuat::pow(double t, bool shorten) const
     //to screw coordinates
     double theta = self.theta();
     double pitch = -2.0 * self.w.du * normmult;
-    DualQuat l = self.real().vec() * normmult; //abusing DualQuat to store vectors. Very handy in this case.
+    //abusing DualQuat to store vectors. Very handy in this case.
+    DualQuat l = self.real().vec() * normmult;
     DualQuat m = (self.dual().vec() - pitch/2*cos(theta/2)*l)*normmult;
 
     //interpolate

--- a/src/Base/Parameter.cpp
+++ b/src/Base/Parameter.cpp
@@ -625,7 +625,7 @@ void ParameterGrp::_Notify(ParamType Type, const char *Name, const char *Value)
 }
 
 void ParameterGrp::_SetAttribute(ParamType T, const char *Name, const char *Value)
-{ 
+{
     const char *Type = TypeName(T);
     if (!Type)
         return;
@@ -1012,7 +1012,8 @@ std::vector<std::string> ParameterGrp::GetASCIIs(const char * sFilter) const
             if (pcElem2)
                 vrValues.emplace_back(StrXUTF8(pcElem2->getNodeValue()).c_str() );
             else
-                vrValues.emplace_back(""); // For a string, an empty value is possible and allowed
+                // For a string, an empty value is possible and allowed
+                vrValues.emplace_back("");
         }
         pcTemp = FindNextElement(pcTemp,"FCText");
     }
@@ -1038,7 +1039,8 @@ std::vector<std::pair<std::string,std::string> > ParameterGrp::GetASCIIMap(const
             if (pcElem2)
                 vrValues.emplace_back(Name, std::string(StrXUTF8(pcElem2->getNodeValue()).c_str()));
             else
-                vrValues.emplace_back(Name, std::string()); // For a string, an empty value is possible and allowed
+                // For a string, an empty value is possible and allowed
+                vrValues.emplace_back(Name, std::string());
         }
         pcTemp = FindNextElement(pcTemp,"FCText");
     }

--- a/src/Base/Quantity.cpp
+++ b/src/Base/Quantity.cpp
@@ -353,12 +353,14 @@ const Quantity Quantity::MilliNewton      (1.0           ,Unit(1,1,-2));
 const Quantity Quantity::KiloNewton       (1e+6          ,Unit(1,1,-2));
 const Quantity Quantity::MegaNewton       (1e+9          ,Unit(1,1,-2));
 
-const Quantity Quantity::NewtonPerMeter        (1.00         ,Unit(0,1,-2)); //Newton per meter (N/m or kg/s^2)
+//Newton per meter (N/m or kg/s^2)
+const Quantity Quantity::NewtonPerMeter        (1.00         ,Unit(0,1,-2));
 const Quantity Quantity::MilliNewtonPerMeter   (1e-3         ,Unit(0,1,-2));
 const Quantity Quantity::KiloNewtonPerMeter    (1e3          ,Unit(0,1,-2));
 const Quantity Quantity::MegaNewtonPerMeter    (1e6          ,Unit(0,1,-2));
 
-const Quantity Quantity::Pascal           (0.001         ,Unit(-1,1,-2)); // Pascal (kg/m/s^2 or N/m^2)
+// Pascal (kg/m/s^2 or N/m^2)
+const Quantity Quantity::Pascal           (0.001         ,Unit(-1,1,-2));
 const Quantity Quantity::KiloPascal       (1.00          ,Unit(-1,1,-2));
 const Quantity Quantity::MegaPascal       (1000.0        ,Unit(-1,1,-2));
 const Quantity Quantity::GigaPascal       (1e+6          ,Unit(-1,1,-2));
@@ -366,9 +368,12 @@ const Quantity Quantity::GigaPascal       (1e+6          ,Unit(-1,1,-2));
 const Quantity Quantity::MilliBar         (0.1           ,Unit(-1,1,-2));
 const Quantity Quantity::Bar              (100.0         ,Unit(-1,1,-2)); // 1 bar = 100 kPa
 
-const Quantity Quantity::Torr             (101.325/760.0 ,Unit(-1,1,-2)); // Torr is a defined fraction of Pascal (kg/m/s^2 or N/m^2)
-const Quantity Quantity::mTorr            (0.101325/760.0,Unit(-1,1,-2)); // Torr is a defined fraction of Pascal (kg/m/s^2 or N/m^2)
-const Quantity Quantity::yTorr            (0.000101325/760.0 ,Unit(-1,1,-2)); // Torr is a defined fraction of Pascal (kg/m/s^2 or N/m^2)
+// Torr is a defined fraction of Pascal (kg/m/s^2 or N/m^2)
+const Quantity Quantity::Torr             (101.325/760.0 ,Unit(-1,1,-2));
+// Torr is a defined fraction of Pascal (kg/m/s^2 or N/m^2)
+const Quantity Quantity::mTorr            (0.101325/760.0,Unit(-1,1,-2));
+// Torr is a defined fraction of Pascal (kg/m/s^2 or N/m^2)
+const Quantity Quantity::yTorr            (0.000101325/760.0 ,Unit(-1,1,-2));
 
 const Quantity Quantity::PSI              (6.894744825494,Unit(-1,1,-2)); // pounds/in^2
 const Quantity Quantity::KSI              (6894.744825494,Unit(-1,1,-2)); // 1000 x pounds/in^2
@@ -377,19 +382,23 @@ const Quantity Quantity::MPSI             (6894744.825494,Unit(-1,1,-2)); // 100
 const Quantity Quantity::Watt             (1e+6          ,Unit(2,1,-3)); // Watt (kg*m^2/s^3)
 const Quantity Quantity::MilliWatt        (1e+3          ,Unit(2,1,-3));
 const Quantity Quantity::KiloWatt         (1e+9          ,Unit(2,1,-3));
-const Quantity Quantity::VoltAmpere       (1e+6          ,Unit(2,1,-3)); // VoltAmpere (kg*m^2/s^3)
+// VoltAmpere (kg*m^2/s^3)
+const Quantity Quantity::VoltAmpere       (1e+6          ,Unit(2,1,-3));
 
-const Quantity Quantity::Volt             (1e+6          ,Unit(2,1,-3,-1)); // Volt (kg*m^2/A/s^3)
+// Volt (kg*m^2/A/s^3)
+const Quantity Quantity::Volt             (1e+6          ,Unit(2,1,-3,-1));
 const Quantity Quantity::MilliVolt        (1e+3          ,Unit(2,1,-3,-1));
 const Quantity Quantity::KiloVolt         (1e+9          ,Unit(2,1,-3,-1));
 
 const Quantity Quantity::MegaSiemens      (1.0           ,Unit(-2,-1,3,2));
 const Quantity Quantity::KiloSiemens      (1e-3          ,Unit(-2,-1,3,2));
-const Quantity Quantity::Siemens          (1e-6          ,Unit(-2,-1,3,2)); // Siemens (A^2*s^3/kg/m^2)
+// Siemens (A^2*s^3/kg/m^2)
+const Quantity Quantity::Siemens          (1e-6          ,Unit(-2,-1,3,2));
 const Quantity Quantity::MilliSiemens     (1e-9          ,Unit(-2,-1,3,2));
 const Quantity Quantity::MicroSiemens     (1e-12         ,Unit(-2,-1,3,2));
 
-const Quantity Quantity::Ohm              (1e+6          ,Unit(2,1,-3,-2)); // Ohm (kg*m^2/A^2/s^3)
+// Ohm (kg*m^2/A^2/s^3)
+const Quantity Quantity::Ohm              (1e+6          ,Unit(2,1,-3,-2));
 const Quantity Quantity::KiloOhm          (1e+9          ,Unit(2,1,-3,-2));
 const Quantity Quantity::MegaOhm          (1e+12         ,Unit(2,1,-3,-2));
 
@@ -398,7 +407,8 @@ const Quantity Quantity::Coulomb          (1.0           ,Unit(0,0,1,1)); // Cou
 const Quantity Quantity::Tesla            (1.0           ,Unit(0,1,-2,-1)); // Tesla (kg/s^2/A)
 const Quantity Quantity::Gauss            (1e-4          ,Unit(0,1,-2,-1)); // 1 G = 1e-4 T
 
-const Quantity Quantity::Weber            (1e6           ,Unit(2,1,-2,-1)); // Weber (kg*m^2/s^2/A)
+// Weber (kg*m^2/s^2/A)
+const Quantity Quantity::Weber            (1e6           ,Unit(2,1,-2,-1));
 
 // disable Oersted because people need to input e.g. a field strength of
 // 1 ampere per meter -> 1 A/m and not get the recalculation to Oersted
@@ -408,12 +418,14 @@ const Quantity Quantity::PicoFarad        (1e-18         ,Unit(-2,-1,4,2));
 const Quantity Quantity::NanoFarad        (1e-15         ,Unit(-2,-1,4,2));
 const Quantity Quantity::MicroFarad       (1e-12         ,Unit(-2,-1,4,2));
 const Quantity Quantity::MilliFarad       (1e-9          ,Unit(-2,-1,4,2));
-const Quantity Quantity::Farad            (1e-6          ,Unit(-2,-1,4,2)); // Farad (s^4*A^2/m^2/kg)
+// Farad (s^4*A^2/m^2/kg)
+const Quantity Quantity::Farad            (1e-6          ,Unit(-2,-1,4,2));
 
 const Quantity Quantity::NanoHenry        (1e-3          ,Unit(2,1,-2,-2));
 const Quantity Quantity::MicroHenry       (1.0           ,Unit(2,1,-2,-2));
 const Quantity Quantity::MilliHenry       (1e+3          ,Unit(2,1,-2,-2));
-const Quantity Quantity::Henry            (1e+6          ,Unit(2,1,-2,-2)); // Henry (kg*m^2/s^2/A^2)
+// Henry (kg*m^2/s^2/A^2)
+const Quantity Quantity::Henry            (1e+6          ,Unit(2,1,-2,-2));
 
 const Quantity Quantity::Joule            (1e+6            ,Unit(2,1,-2));  // Joule (kg*m^2/s^2)
 const Quantity Quantity::MilliJoule       (1e+3            ,Unit(2,1,-2));
@@ -422,7 +434,8 @@ const Quantity Quantity::NewtonMeter      (1e+6            ,Unit(2,1,-2));  // J
 const Quantity Quantity::VoltAmpereSecond (1e+6            ,Unit(2,1,-2));  // Joule (kg*m^2/s^2)
 const Quantity Quantity::WattSecond       (1e+6            ,Unit(2,1,-2));  // Joule (kg*m^2/s^2)
 const Quantity Quantity::KiloWattHour     (3.6e+12         ,Unit(2,1,-2));  // 1 kWh = 3.6e6 J
-const Quantity Quantity::ElectronVolt     (1.602176634e-13 ,Unit(2,1,-2));  // 1 eV = 1.602176634e-19 J
+// 1 eV = 1.602176634e-19 J
+const Quantity Quantity::ElectronVolt     (1.602176634e-13 ,Unit(2,1,-2));
 const Quantity Quantity::KiloElectronVolt (1.602176634e-10 ,Unit(2,1,-2));
 const Quantity Quantity::MegaElectronVolt (1.602176634e-7  ,Unit(2,1,-2));
 const Quantity Quantity::Calorie          (4.1868e+6       ,Unit(2,1,-2));  // 1 cal = 4.1868 J
@@ -433,7 +446,8 @@ const Quantity Quantity::MPH              (447.04        ,Unit(1,0,-1));  // Mil
 
 const Quantity Quantity::AngMinute        (1.0/60.0      ,Unit(0,0,0,0,0,0,0,1)); // angular minute
 const Quantity Quantity::AngSecond        (1.0/3600.0    ,Unit(0,0,0,0,0,0,0,1)); // angular second
-const Quantity Quantity::Degree           (1.0           ,Unit(0,0,0,0,0,0,0,1)); // degree         (internal standard angle)
+// degree         (internal standard angle)
+const Quantity Quantity::Degree           (1.0           ,Unit(0,0,0,0,0,0,0,1));
 const Quantity Quantity::Radian           (180/M_PI      ,Unit(0,0,0,0,0,0,0,1)); // radian
 const Quantity Quantity::Gon              (360.0/400.0   ,Unit(0,0,0,0,0,0,0,1)); // gon
 

--- a/src/Base/Rotation.cpp
+++ b/src/Base/Rotation.cpp
@@ -220,7 +220,7 @@ void Rotation::setValue(const double q[4])
 
 void Rotation::setValue(const Matrix4D & m)
 {
-    
+
     auto type = m.hasScale();
     if (type == Base::ScaleType::Other) {
         THROWM(Base::ValueError, "setValue(matrix): Could not determine the rotation.");
@@ -609,7 +609,8 @@ Rotation Rotation::makeRotationByAxes(Vector3d xdir, Vector3d ydir, Vector3d zdi
         else
             dropPriority(1);
         if (i == 1)
-            hintDir = Vector3d(); //no vector can be used as hint direction. Zero it out, to indicate that a guess is needed.
+            //no vector can be used as hint direction. Zero it out, to indicate that a guess is needed.
+            hintDir = Vector3d();
     }
     if (hintDir.Length() == 0.0){
         switch (order[0]){
@@ -811,8 +812,8 @@ bool Rotation::isNull() const
 namespace { // anonymous namespace
 //=======================================================================
 //function : translateEulerSequence
-//purpose  : 
-// Code supporting conversion between quaternion and generalized 
+//purpose  :
+// Code supporting conversion between quaternion and generalized
 // Euler angles (sequence of three rotations) is based on
 // algorithm by Ken Shoemake, published in Graphics Gems IV, p. 222-22
 // http://tog.acm.org/resources/GraphicsGems/gemsiv/euler_angle/EulerAngles.c
@@ -824,18 +825,18 @@ struct EulerSequence_Parameters
     int j;           // next axis of rotation
     int k;           // third axis
     bool isOdd;       // true if order of two first rotation axes is odd permutation, e.g. XZ
-    bool isTwoAxes;   // true if third rotation is about the same axis as first 
+    bool isTwoAxes;   // true if third rotation is about the same axis as first
     bool isExtrinsic; // true if rotations are made around fixed axes
 
-    EulerSequence_Parameters (int theAx1, 
-                              bool theisOdd, 
+    EulerSequence_Parameters (int theAx1,
+                              bool theisOdd,
                               bool theisTwoAxes,
                               bool theisExtrinsic)
-        : i(theAx1), 
-        j(1 + (theAx1 + (theisOdd ? 1 : 0)) % 3), 
-        k(1 + (theAx1 + (theisOdd ? 0 : 1)) % 3), 
-        isOdd(theisOdd), 
-        isTwoAxes(theisTwoAxes), 
+        : i(theAx1),
+        j(1 + (theAx1 + (theisOdd ? 1 : 0)) % 3),
+        k(1 + (theAx1 + (theisOdd ? 0 : 1)) % 3),
+        isOdd(theisOdd),
+        isTwoAxes(theisTwoAxes),
         isExtrinsic(theisExtrinsic)
         {}
 };
@@ -978,36 +979,36 @@ void Rotation::setEulerAngles(EulerSequence theOrder,
     if ( o.isOdd )
         b = -b;
 
-    double ti = 0.5 * a; 
-    double tj = 0.5 * b; 
+    double ti = 0.5 * a;
+    double tj = 0.5 * b;
     double th = 0.5 * c;
-    double ci = cos (ti);  
-    double cj = cos (tj);  
+    double ci = cos (ti);
+    double cj = cos (tj);
     double ch = cos (th);
     double si = sin (ti);
     double sj = sin (tj);
     double sh = sin (th);
-    double cc = ci * ch; 
-    double cs = ci * sh; 
-    double sc = si * ch; 
+    double cc = ci * ch;
+    double cs = ci * sh;
+    double sc = si * ch;
     double ss = si * sh;
 
     double values[4]; // w, x, y, z
-    if ( o.isTwoAxes ) 
+    if ( o.isTwoAxes )
     {
         values[o.i] = cj * (cs + sc);
         values[o.j] = sj * (cc + ss);
         values[o.k] = sj * (cs - sc);
         values[0]   = cj * (cc - ss);
-    } 
-    else 
+    }
+    else
     {
         values[o.i] = cj * sc - sj * cs;
         values[o.j] = cj * ss + sj * cc;
         values[o.k] = cj * cs - sj * sc;
         values[0]   = cj * cc + sj * ss;
     }
-    if ( o.isOdd ) 
+    if ( o.isOdd )
         values[o.j] = -values[o.j];
 
     quat[0] = values[1];
@@ -1025,45 +1026,45 @@ void Rotation::getEulerAngles(EulerSequence theOrder,
     getValue(M);
 
     EulerSequence_Parameters o = translateEulerSequence (theOrder);
-    if ( o.isTwoAxes ) 
+    if ( o.isTwoAxes )
     {
         double sy = sqrt (M(o.i, o.j) * M(o.i, o.j) + M(o.i, o.k) * M(o.i, o.k));
-        if (sy > 16 * DBL_EPSILON) 
+        if (sy > 16 * DBL_EPSILON)
         {
             theAlpha = atan2 (M(o.i, o.j),  M(o.i, o.k));
             theGamma = atan2 (M(o.j, o.i), -M(o.k, o.i));
-        } 
-        else 
+        }
+        else
         {
             theAlpha = atan2 (-M(o.j, o.k), M(o.j, o.j));
             theGamma = 0.;
         }
         theBeta = atan2 (sy, M(o.i, o.i));
-    } 
-    else 
+    }
+    else
     {
         double cy = sqrt (M(o.i, o.i) * M(o.i, o.i) + M(o.j, o.i) * M(o.j, o.i));
-        if (cy > 16 * DBL_EPSILON) 
+        if (cy > 16 * DBL_EPSILON)
         {
             theAlpha = atan2 (M(o.k, o.j), M(o.k, o.k));
             theGamma = atan2 (M(o.j, o.i), M(o.i, o.i));
-        } 
-        else 
+        }
+        else
         {
             theAlpha = atan2 (-M(o.j, o.k), M(o.j, o.j));
             theGamma = 0.;
         }
         theBeta = atan2 (-M(o.k, o.i), cy);
     }
-    if ( o.isOdd ) 
+    if ( o.isOdd )
     {
         theAlpha = -theAlpha;
         theBeta  = -theBeta;
         theGamma = -theGamma;
     }
-    if ( ! o.isExtrinsic ) 
-    { 
-        double aFirst = theAlpha; 
+    if ( ! o.isExtrinsic )
+    {
+        double aFirst = theAlpha;
         theAlpha = theGamma;
         theGamma = aFirst;
     }

--- a/src/Base/StackWalker.cpp
+++ b/src/Base/StackWalker.cpp
@@ -1,5 +1,5 @@
 /**********************************************************************
- * 
+ *
  * StackWalker.cpp
  * http://stackwalker.codeplex.com/
  *
@@ -9,14 +9,14 @@
  *                       http://www.codeproject.com/threads/StackWalker.asp
  *  2005-07-28   v2    - Changed the params of the constructor and ShowCallstack
  *                       (to simplify the usage)
- *  2005-08-01   v3    - Changed to use 'CONTEXT_FULL' instead of CONTEXT_ALL 
+ *  2005-08-01   v3    - Changed to use 'CONTEXT_FULL' instead of CONTEXT_ALL
  *                       (should also be enough)
  *                     - Changed to compile correctly with the PSDK of VC7.0
  *                       (GetFileVersionInfoSizeA and GetFileVersionInfoA is wrongly defined:
  *                        it uses LPSTR instead of LPCSTR as first parameter)
  *                     - Added declarations to support VC5/6 without using 'dbghelp.h'
- *                     - Added a 'pUserData' member to the ShowCallstack function and the 
- *                       PReadProcessMemoryRoutine declaration (to pass some user-defined data, 
+ *                     - Added a 'pUserData' member to the ShowCallstack function and the
+ *                       PReadProcessMemoryRoutine declaration (to pass some user-defined data,
  *                       which can be used in the readMemoryFunction-callback)
  *  2005-08-02   v4    - OnSymInit now also outputs the OS-Version by default
  *                     - Added example for doing an exception-callstack-walking in main.cpp
@@ -56,26 +56,26 @@
  *   Copyright (c) 2005-2013, Jochen Kalmbach
  *   All rights reserved.
  *
- *   Redistribution and use in source and binary forms, with or without modification, 
+ *   Redistribution and use in source and binary forms, with or without modification,
  *   are permitted provided that the following conditions are met:
  *
- *   Redistributions of source code must retain the above copyright notice, 
- *   this list of conditions and the following disclaimer. 
- *   Redistributions in binary form must reproduce the above copyright notice, 
- *   this list of conditions and the following disclaimer in the documentation 
- *   and/or other materials provided with the distribution. 
- *   Neither the name of Jochen Kalmbach nor the names of its contributors may be 
- *   used to endorse or promote products derived from this software without 
- *   specific prior written permission. 
- *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
- *   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, 
- *   THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
- *   ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE 
- *   FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES 
- *   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- *   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND 
- *   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
- *   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS 
+ *   Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *   Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *   Neither the name of Jochen Kalmbach nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ *   THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *   ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ *   FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ *   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  *   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  **********************************************************************/
@@ -102,7 +102,7 @@
 // Some missing defines (for VC5/6):
 #ifndef INVALID_FILE_ATTRIBUTES
 #define INVALID_FILE_ATTRIBUTES ((DWORD)-1)
-#endif  
+#endif
 
 
 static void MyStrCpy(char* szDest, size_t nMaxDestSize, const char* szSrc)
@@ -263,7 +263,7 @@ public:
       m_szSymPath = _strdup(szSymPath);
     if (!this->pSI(m_hProcess, m_szSymPath, FALSE))
       this->m_parent->OnDbgHelpErr("SymInitialize", GetLastError(), 0);
-      
+
     DWORD symOptions = this->pSGO();  // SymGetOptions
     symOptions |= SYMOPT_LOAD_LINES;
     symOptions |= SYMOPT_FAIL_CRITICAL_ERRORS;
@@ -378,11 +378,11 @@ typedef struct IMAGEHLP_MODULE64_V2 {
   tSSO pSSO;
 
   // StackWalk64()
-  typedef BOOL (__stdcall *tSW)( 
-    DWORD MachineType, 
+  typedef BOOL (__stdcall *tSW)(
+    DWORD MachineType,
     HANDLE hProcess,
-    HANDLE hThread, 
-    LPSTACKFRAME64 StackFrame, 
+    HANDLE hThread,
+    LPSTACKFRAME64 StackFrame,
     PVOID ContextRecord,
     PREAD_PROCESS_MEMORY_ROUTINE64 ReadMemoryRoutine,
     PFUNCTION_TABLE_ACCESS_ROUTINE64 FunctionTableAccessRoutine,
@@ -680,7 +680,8 @@ public:
     }
     // First try to use the larger ModuleInfo-Structure
     pModuleInfo->SizeOfStruct = sizeof(IMAGEHLP_MODULE64_V3);
-    void *pData = malloc(4096); // reserve enough memory, so the bug in v6.3.5.1 does not lead to memory-overwrites...
+    // reserve enough memory, so the bug in v6.3.5.1 does not lead to memory-overwrites...
+    void *pData = malloc(4096);
     if (pData == NULL)
     {
       SetLastError(ERROR_NOT_ENOUGH_MEMORY);
@@ -869,7 +870,7 @@ BOOL StackWalker::LoadModules()
 
 // The following is used to pass the "userData"-Pointer to the user-provided readMemoryFunction
 // This has to be done due to a problem with the "hProcess"-parameter in x64...
-// Because this class is in no case multi-threading-enabled (because of the limitations 
+// Because this class is in no case multi-threading-enabled (because of the limitations
 // of dbghelp.dll) it is "safe" to use a static-variable
 static StackWalker::PReadProcessMemoryRoutine s_readMemoryFunction = NULL;
 static LPVOID s_readMemoryFunction_UserData = NULL;
@@ -1079,7 +1080,7 @@ BOOL StackWalker::ShowCallstack(HANDLE hThread, const CONTEXT *context, PReadPro
       et = firstEntry;
     bLastEntryCalled = false;
     this->OnCallstackEntry(et, csEntry);
-    
+
     if (s.AddrReturn.Offset == 0)
     {
       bLastEntryCalled = true;

--- a/src/Base/UnitsApi.cpp
+++ b/src/Base/UnitsApi.cpp
@@ -130,7 +130,8 @@ void UnitsApi::setSchema(UnitSystem system)
         currentSystem = UnitSystem::SI1;
     }
 
-    UserPrefSystem->setSchemaUnits(); // if necessary a unit schema can change the constants in Quantity (e.g. mi=1.8km rather then 1.6km).
+    // if necessary a unit schema can change the constants in Quantity (e.g. mi=1.8km rather then 1.6km).
+    UserPrefSystem->setSchemaUnits();
 }
 
 QString UnitsApi::toString(const Base::Quantity& quantity, const QuantityFormat& format)

--- a/src/Gui/3Dconnexion/GuiNativeEventLinuxX11.cpp
+++ b/src/Gui/3Dconnexion/GuiNativeEventLinuxX11.cpp
@@ -248,7 +248,8 @@ bool Gui::GuiNativeEvent::x11EventFilter(XEvent *event)
         flushEvent.format = 8;
         flushEvent.message_type = motion_flush_event;
 
-        XSendEvent (display, flushEvent.window, False, 0, (XEvent*)&flushEvent); // siehe spnavd, False, 0
+        // siehe spnavd, False, 0
+        XSendEvent (display, flushEvent.window, False, 0, (XEvent*)&flushEvent);
 
         return true;
     }

--- a/src/Gui/Action.cpp
+++ b/src/Gui/Action.cpp
@@ -1156,7 +1156,8 @@ void RecentMacrosAction::setFiles(const QStringList& files)
     ParameterGrp::handle hGrp = App::GetApplication().GetUserParameter().GetGroup("BaseApp")
                                 ->GetGroup("Preferences")->GetGroup("RecentMacros");
     this->shortcut_modifiers = hGrp->GetASCII("ShortcutModifiers","Ctrl+Shift+");
-    this->shortcut_count = std::min<int>(hGrp->GetInt("ShortcutCount",3),9);//max = 9, e.g. Ctrl+Shift+9
+    //max = 9, e.g. Ctrl+Shift+9
+    this->shortcut_count = std::min<int>(hGrp->GetInt("ShortcutCount",3),9);
     this->visibleItems = hGrp->GetInt("RecentMacros",12);
     QList<QAction*> recentFiles = groupAction()->actions();
 

--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -659,7 +659,8 @@ void Application::importFrom(const char* FileName, const char* DocName, const ch
             QString filename = QString::fromUtf8(File.filePath().c_str());
             auto parameterGroup = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/General");
             bool addToRecent = parameterGroup->GetBool("RecentIncludesImported", true);
-            parameterGroup->SetBool("RecentIncludesImported", addToRecent); // Make sure it gets added to the parameter list
+            // Make sure it gets added to the parameter list
+            parameterGroup->SetBool("RecentIncludesImported", addToRecent);
             if (addToRecent) {
                 getMainWindow()->appendRecentFile(filename);
             }
@@ -720,7 +721,8 @@ void Application::exportTo(const char* FileName, const char* DocName, const char
 
             auto parameterGroup = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/General");
             bool addToRecent = parameterGroup->GetBool("RecentIncludesExported", false);
-            parameterGroup->SetBool("RecentIncludesExported", addToRecent); // Make sure it gets added to the parameter list
+            // Make sure it gets added to the parameter list
+            parameterGroup->SetBool("RecentIncludesExported", addToRecent);
             if (addToRecent) {
                 // search for a module that is able to open the exported file because otherwise
                 // it doesn't need to be added to the recent files list (#0002047)

--- a/src/Gui/Application.h
+++ b/src/Gui/Application.h
@@ -269,18 +269,30 @@ public:
     // python exports goes here +++++++++++++++++++++++++++++++++++++++++++
     //---------------------------------------------------------------------
     // static python wrapper of the exported functions
-    static PyObject* sActivateWorkbenchHandler (PyObject *self,PyObject *args); // activates a workbench object
-    static PyObject* sAddWorkbenchHandler      (PyObject *self,PyObject *args); // adds a new workbench handler to a list
-    static PyObject* sRemoveWorkbenchHandler   (PyObject *self,PyObject *args); // removes a workbench handler from the list
-    static PyObject* sGetWorkbenchHandler      (PyObject *self,PyObject *args); // retrieves the workbench handler
-    static PyObject* sListWorkbenchHandlers    (PyObject *self,PyObject *args); // retrieves a list of all workbench handlers
-    static PyObject* sActiveWorkbenchHandler   (PyObject *self,PyObject *args); // retrieves the active workbench object
-    static PyObject* sAddResPath               (PyObject *self,PyObject *args); // adds a path where to find resources
-    static PyObject* sAddLangPath              (PyObject *self,PyObject *args); // adds a path to a qm file
-    static PyObject* sAddIconPath              (PyObject *self,PyObject *args); // adds a path to an icon file
-    static PyObject* sAddIcon                  (PyObject *self,PyObject *args); // adds an icon to the cache
-    static PyObject* sGetIcon                  (PyObject *self,PyObject *args); // get an icon from the cache
-    static PyObject* sIsIconCached             (PyObject *self,PyObject *args); // check if an icon is cached
+    // activates a workbench object
+    static PyObject* sActivateWorkbenchHandler (PyObject *self,PyObject *args);
+    // adds a new workbench handler to a list
+    static PyObject* sAddWorkbenchHandler      (PyObject *self,PyObject *args);
+    // removes a workbench handler from the list
+    static PyObject* sRemoveWorkbenchHandler   (PyObject *self,PyObject *args);
+    // retrieves the workbench handler
+    static PyObject* sGetWorkbenchHandler      (PyObject *self,PyObject *args);
+    // retrieves a list of all workbench handlers
+    static PyObject* sListWorkbenchHandlers    (PyObject *self,PyObject *args);
+    // retrieves the active workbench object
+    static PyObject* sActiveWorkbenchHandler   (PyObject *self,PyObject *args);
+    // adds a path where to find resources
+    static PyObject* sAddResPath               (PyObject *self,PyObject *args);
+    // adds a path to a qm file
+    static PyObject* sAddLangPath              (PyObject *self,PyObject *args);
+    // adds a path to an icon file
+    static PyObject* sAddIconPath              (PyObject *self,PyObject *args);
+    // adds an icon to the cache
+    static PyObject* sAddIcon                  (PyObject *self,PyObject *args);
+    // get an icon from the cache
+    static PyObject* sGetIcon                  (PyObject *self,PyObject *args);
+    // check if an icon is cached
+    static PyObject* sIsIconCached             (PyObject *self,PyObject *args);
 
     static PyObject* sSendActiveView           (PyObject *self,PyObject *args);
     static PyObject* sSendFocusView            (PyObject *self,PyObject *args);
@@ -299,14 +311,19 @@ public:
 
     static PyObject* sHide                     (PyObject *self,PyObject *args); // deprecated
     static PyObject* sShow                     (PyObject *self,PyObject *args); // deprecated
-    static PyObject* sHideObject               (PyObject *self,PyObject *args); // hide view provider object
-    static PyObject* sShowObject               (PyObject *self,PyObject *args); // show view provider object
+    // hide view provider object
+    static PyObject* sHideObject               (PyObject *self,PyObject *args);
+    // show view provider object
+    static PyObject* sShowObject               (PyObject *self,PyObject *args);
 
-    static PyObject* sOpen                     (PyObject *self,PyObject *args); // open Python scripts
-    static PyObject* sInsert                   (PyObject *self,PyObject *args); // open Python scripts
+    // open Python scripts
+    static PyObject* sOpen                     (PyObject *self,PyObject *args);
+    // open Python scripts
+    static PyObject* sInsert                   (PyObject *self,PyObject *args);
     static PyObject* sExport                   (PyObject *self,PyObject *args);
     static PyObject* sReload                   (PyObject *self,PyObject *args); // reload FCStd file
-    static PyObject* sLoadFile                 (PyObject *self,PyObject *args); // open all types of files
+    // open all types of files
+    static PyObject* sLoadFile                 (PyObject *self,PyObject *args);
 
     static PyObject* sCoinRemoveAllChildren    (PyObject *self,PyObject *args);
 

--- a/src/Gui/AutoSaver.cpp
+++ b/src/Gui/AutoSaver.cpp
@@ -151,8 +151,10 @@ void AutoSaver::saveDocument(const std::string& name, AutoSaveProperty& saver)
             str << "<?xml version='1.0' encoding='utf-8'?>\n"
                 << "<AutoRecovery SchemaVersion=\"1\">\n";
             str << "  <Status>Created</Status>\n";
-            str << "  <Label>" << QString::fromUtf8(doc->Label.getValue()) << "</Label>\n"; // store the document's current label
-            str << "  <FileName>" << QString::fromUtf8(doc->FileName.getValue()) << "</FileName>\n"; // store the document's current filename
+            // store the document's current label
+            str << "  <Label>" << QString::fromUtf8(doc->Label.getValue()) << "</Label>\n";
+            // store the document's current filename
+            str << "  <FileName>" << QString::fromUtf8(doc->FileName.getValue()) << "</FileName>\n";
             str << "</AutoRecovery>\n";
             file.close();
         }

--- a/src/Gui/CallTips.cpp
+++ b/src/Gui/CallTips.cpp
@@ -633,7 +633,8 @@ bool CallTipsList::eventFilter(QObject * watched, QEvent * event)
             }
             else if (ke->key() == Qt::Key_Tab) {
                 // enable call completion for activating items
-                Temporary<bool> tmp( this->doCallCompletion, true ); //< previous state restored on scope exit
+                //< previous state restored on scope exit
+                Temporary<bool> tmp( this->doCallCompletion, true );
                 Q_EMIT itemActivated( currentItem() );
                 return true;
             }
@@ -701,14 +702,16 @@ void CallTipsList::callTipItemActivated(QListWidgetItem *item)
     if (this->doCallCompletion
      && (callTip.type == CallTip::Method || callTip.type == CallTip::Class))
     {
-      cursor.insertText( QLatin1String("()") ); //< just append parenthesis to identifier even inserted.
+      //< just append parenthesis to identifier even inserted.
+      cursor.insertText( QLatin1String("()") );
 
       /**
        * Try to find out if call needs arguments.
        * For this we search the description for appropriate hints ...
        */
       QRegularExpression argumentMatcher( QRegularExpression::escape( callTip.name ) + QLatin1String("\\s*\\(\\s*\\w+.*\\)") );
-      argumentMatcher.setPatternOptions( QRegularExpression::InvertedGreedinessOption ); //< set regex non-greedy!
+      //< set regex non-greedy!
+      argumentMatcher.setPatternOptions( QRegularExpression::InvertedGreedinessOption );
       if (argumentMatcher.match( callTip.description ).hasMatch())
       {
         // if arguments are needed, we just move the cursor one left, to between the parentheses.

--- a/src/Gui/CoinRiftWidget.cpp
+++ b/src/Gui/CoinRiftWidget.cpp
@@ -150,7 +150,8 @@ CoinRiftWidget::CoinRiftWidget() : QGLWidget()
     cfg.OGL.Header.Multisample = backBufferMultisample;
     cfg.OGL.Window = reinterpret_cast<HWND>(winId());
     makeCurrent();
-    //cfg.OGL.WglContext = wglGetCurrentContext(); // http://stackoverflow.com/questions/17532033/qglwidget-get-gl-contextes-for-windows
+    //cfg.OGL.WglContext = wglGetCurrentContext();
+    // http://stackoverflow.com/questions/17532033/qglwidget-get-gl-contextes-for-windows
     cfg.OGL.DC = wglGetCurrentDC();
     qDebug() << "Window:" << cfg.OGL.Window;
     //qDebug() << "Context:" << cfg.OGL.WglContext;
@@ -376,7 +377,8 @@ void CoinRiftWidget::paintGL()
 #endif
 #ifdef USE_FRAMEBUFFER
         // Clear state pollution from OVR SDK.
-        glBindTexture(GL_TEXTURE_2D, 0); // You need this, at least if (hmdDesc.DistortionCaps & ovrDistortion_Chromatic).
+        glBindTexture(GL_TEXTURE_2D, 0);
+        // You need this, at least if (hmdDesc.DistortionCaps & ovrDistortion_Chromatic).
         OVR::CAPI::GL::glUseProgram(0); // You need this even more.
 
         GLint oldfb;

--- a/src/Gui/CommandFeat.cpp
+++ b/src/Gui/CommandFeat.cpp
@@ -175,7 +175,8 @@ void StdCmdSendToPythonConsole::activated(int iMsg)
             const auto geoObj = static_cast<const App::GeoFeature*>(obj);
             const App::PropertyGeometry* geo = geoObj->getPropertyOfGeometry();
             if (geo){
-                cmd = QString::fromLatin1("shp = obj.") + QLatin1String(geo->getName()); //"Shape", "Mesh", "Points", etc.
+                //"Shape", "Mesh", "Points", etc.
+                cmd = QString::fromLatin1("shp = obj.") + QLatin1String(geo->getName());
                 Gui::Command::runCommand(Gui::Command::Gui, cmd.toLatin1());
                 if (sels[0].hasSubNames()) {
                     std::vector<std::string> subnames = sels[0].getSubNames();

--- a/src/Gui/DAGView/DAGModel.cpp
+++ b/src/Gui/DAGView/DAGModel.cpp
@@ -651,21 +651,26 @@ void Model::updateSlot()
       cheat = rowHeight;
 
     auto visiblePixmap = (*theGraph)[currentVertex].visibleIcon.get();
-    visiblePixmap->setTransform(QTransform::fromTranslate(0.0, rowHeight * currentRow + cheat)); //calculate x location later.
+    //calculate x location later.
+    visiblePixmap->setTransform(QTransform::fromTranslate(0.0, rowHeight * currentRow + cheat));
 
     auto statePixmap = (*theGraph)[currentVertex].stateIcon.get();
-    statePixmap->setTransform(QTransform::fromTranslate(0.0, rowHeight * currentRow + cheat)); //calculate x location later.
+    //calculate x location later.
+    statePixmap->setTransform(QTransform::fromTranslate(0.0, rowHeight * currentRow + cheat));
 
     auto pixmap = (*theGraph)[currentVertex].icon.get();
-    pixmap->setTransform(QTransform::fromTranslate(0.0, rowHeight * currentRow + cheat)); //calculate x location later.
+    //calculate x location later.
+    pixmap->setTransform(QTransform::fromTranslate(0.0, rowHeight * currentRow + cheat));
 
     auto text = (*theGraph)[currentVertex].text.get();
     text->setPlainText(QString::fromUtf8(findRecord(currentVertex, *graphLink).DObject->Label.getValue()));
     text->setDefaultTextColor(currentBrush.color());
     maxTextLength = std::max(maxTextLength, static_cast<float>(text->boundingRect().width()));
     text->setTransform(QTransform::fromTranslate
-      (0.0, rowHeight * currentRow - verticalSpacing * 2.0 + cheat)); //calculate x location later.
-    (*theGraph)[currentVertex].lastVisibleState = VisibilityState::None; //force visual update for color.
+      //calculate x location later.
+      (0.0, rowHeight * currentRow - verticalSpacing * 2.0 + cheat));
+    //force visual update for color.
+    (*theGraph)[currentVertex].lastVisibleState = VisibilityState::None;
 
     //store column and row int the graph. use for connectors later.
     (*theGraph)[currentVertex].row = currentRow;

--- a/src/Gui/DAGView/DAGModel.h
+++ b/src/Gui/DAGView/DAGModel.h
@@ -118,19 +118,32 @@ namespace Gui
 
     //! @name View Constants for spacing
     //@{
-      float fontHeight;                           //!< height of the current qApp default font.
-      float direction;                            //!< controls top to bottom or bottom to top direction.
-      float verticalSpacing;                      //!< pixels between top and bottom of text to background rectangle.
-      float rowHeight;                            //!< height of background rectangle.
-      float iconSize;                             //!< size of icon to match font.
-      float pointSize;                            //!< size of the connection point.
-      float pointSpacing;                         //!< spacing between pofloat columns.
-      float pointToIcon;                          //!< spacing from last column points to first icon.
-      float iconToIcon;                           //!< spacing between icons.
-      float iconToText;                           //!< spacing between last icon and text.
-      float rowPadding;                           //!< spaces added to rectangle background width ends.
-      std::vector<QBrush> backgroundBrushes;      //!< brushes to paint background rectangles.
-      std::vector<QBrush> forgroundBrushes;       //!< brushes to paint points, connectors, text.
+      //!< height of the current qApp default font.
+      float fontHeight;
+      //!< controls top to bottom or bottom to top direction.
+      float direction;
+      //!< pixels between top and bottom of text to background rectangle.
+      float verticalSpacing;
+      //!< height of background rectangle.
+      float rowHeight;
+      //!< size of icon to match font.
+      float iconSize;
+      //!< size of the connection point.
+      float pointSize;
+      //!< spacing between pofloat columns.
+      float pointSpacing;
+      //!< spacing from last column points to first icon.
+      float pointToIcon;
+      //!< spacing between icons.
+      float iconToIcon;
+      //!< spacing between last icon and text.
+      float iconToText;
+      //!< spaces added to rectangle background width ends.
+      float rowPadding;
+      //!< brushes to paint background rectangles.
+      std::vector<QBrush> backgroundBrushes;
+      //!< brushes to paint points, connectors, text.
+      std::vector<QBrush> forgroundBrushes;
       void setupViewConstants();
     //@}
 
@@ -143,7 +156,8 @@ namespace Gui
       };
       SelectionMode selectionMode;
       std::vector<Vertex> getAllSelected();
-      void visiblyIsolate(Vertex sourceIn); //!< hide any connected feature and turn on sourceIn.
+      //!< hide any connected feature and turn on sourceIn.
+      void visiblyIsolate(Vertex sourceIn);
 
       QPointF lastPick;
       bool lastPickValid = false;
@@ -153,7 +167,8 @@ namespace Gui
       QPixmap passPixmap;
       QPixmap failPixmap;
       QPixmap pendingPixmap;
-      Vertex lastAddedVertex = Graph::null_vertex(); //!< needed because python objects are not ready.
+      //!< needed because python objects are not ready.
+      Vertex lastAddedVertex = Graph::null_vertex();
 
       QAction *renameAction;
       QAction *editingFinishedAction;

--- a/src/Gui/DlgCustomizeImp.cpp
+++ b/src/Gui/DlgCustomizeImp.cpp
@@ -79,7 +79,8 @@ DlgCustomizeImp::DlgCustomizeImp(QWidget* parent, Qt::WindowFlags fl)
     customLayout->addLayout( layout, 1, 0 );
 
     tabWidget = new QTabWidget( this );
-    tabWidget->setObjectName(QString::fromLatin1("Gui__Dialog__TabWidget"));//so we can find it in DlgMacroExecuteImp
+    //so we can find it in DlgMacroExecuteImp
+    tabWidget->setObjectName(QString::fromLatin1("Gui__Dialog__TabWidget"));
 
     // make sure that pages are ready to create
     GetWidgetFactorySupplier();

--- a/src/Gui/DlgMacroExecuteImp.cpp
+++ b/src/Gui/DlgMacroExecuteImp.cpp
@@ -467,7 +467,8 @@ Note: your changes will be applied when you next switch workbenches\n"));
         return;
 
     QString fn = item->text(0);
-    QString bareFileName = QFileInfo(fn).baseName(); //for use as default menu text (filename without extension)
+    //for use as default menu text (filename without extension)
+    QString bareFileName = QFileInfo(fn).baseName();
 
     /** check if user already has custom toolbar, so we can tailor instructions accordingly **/
     bool hasCustomToolbar = true;
@@ -532,7 +533,8 @@ Note: your changes will be applied when you next switch workbenches\n"));
             Base::Console().Warning("Toolbar walkthrough: Unable to find actionMacros combo box\n");
         } else {
             int macroIndex = macroListBox->findText(fn); //fn is the macro filename
-            macroListBox->setCurrentIndex(macroIndex); //select it for the user so they don't have to
+            //select it for the user so they don't have to
+            macroListBox->setCurrentIndex(macroIndex);
         }
 
         auto menuText = setupCustomMacrosPage->findChild<QLineEdit*>(QString::fromLatin1("actionMenu"));
@@ -768,7 +770,8 @@ void DlgMacroExecuteImp::on_duplicateButton_clicked()
     QString last3 = baseName.right(3);
     bool ok = true; //was conversion to int successful?
     int nLast3 = last3.toInt(&ok);
-    last3 = QString::fromStdString("001"); //increment beginning with 001 unless from001 = false
+    //increment beginning with 001 unless from001 = false
+    last3 = QString::fromStdString("001");
     if (ok ){
         //last3 were all digits, so we strip them from the base name
         if (baseName.size()>3){ //if <= 3 leave be (e.g. 2.py becomes 2@001.py)
@@ -777,7 +780,8 @@ void DlgMacroExecuteImp::on_duplicateButton_clicked()
             }
             baseName = baseName.left(baseName.size()-3); //strip digits
             if (baseName.endsWith(neutralSymbol)){
-                baseName = baseName.left(baseName.size()-1); //trim the "@", will be added back later
+                //trim the "@", will be added back later
+                baseName = baseName.left(baseName.size()-1);
             }
         }
     }
@@ -824,7 +828,7 @@ void DlgMacroExecuteImp::on_duplicateButton_clicked()
 
     // give user a chance to pick a different name from digitized name suggested
     QString fn = QInputDialog::getText(this, tr("Duplicate Macro"),
-        tr("Enter new name:"), QLineEdit::Normal, oldNameDigitized, 
+        tr("Enter new name:"), QLineEdit::Normal, oldNameDigitized,
         nullptr, Qt::MSWindowsFixedSizeDialogHint);
     if (replaceSpaces){
         fn = fn.replace(QString::fromStdString(" "),QString::fromStdString("_"));

--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -160,7 +160,8 @@ void MessageManager::slotUserMessage(const App::DocumentObject& obj, const QStri
 
 void MessageManager::pushAutoClosingMessage(const QString & msg, App::Document::NotificationType notificationtype)
 {
-    std::lock_guard<std::mutex> g(mutexAutoClosingMessages); // guard to avoid creating new messages while closing old messages (via timer)
+    // guard to avoid creating new messages while closing old messages (via timer)
+    std::lock_guard<std::mutex> g(mutexAutoClosingMessages);
 
     auto msgBox = createNonModalMessage(msg, notificationtype);
 
@@ -173,7 +174,8 @@ void MessageManager::pushAutoClosingMessage(const QString & msg, App::Document::
     reorderAutoClosingMessages();
 
     QTimer::singleShot(autoClosingTimeout*numberOpenAutoClosingMessages, [msgBox, this](){
-        std::lock_guard<std::mutex> g(mutexAutoClosingMessages); // guard to avoid closing old messages while creating new ones
+        // guard to avoid closing old messages while creating new ones
+        std::lock_guard<std::mutex> g(mutexAutoClosingMessages);
         if(msgBox) {
             msgBox->done(0);
             openAutoClosingMessages.erase(

--- a/src/Gui/DownloadItem.h
+++ b/src/Gui/DownloadItem.h
@@ -96,8 +96,10 @@ public:
     explicit NetworkAccessManager(QObject *parent = nullptr);
 
 private Q_SLOTS:
-    void authenticationRequired(QNetworkReply *reply, QAuthenticator *auth);  // clazy:exclude=overridden-signal
-    void proxyAuthenticationRequired(const QNetworkProxy &proxy, QAuthenticator *auth);  // clazy:exclude=overridden-signal
+    // clazy:exclude=overridden-signal
+    void authenticationRequired(QNetworkReply *reply, QAuthenticator *auth);
+    // clazy:exclude=overridden-signal
+    void proxyAuthenticationRequired(const QNetworkProxy &proxy, QAuthenticator *auth);
 };
 
 #include "ui_DownloadItem.h"

--- a/src/Gui/ExpressionCompleter.cpp
+++ b/src/Gui/ExpressionCompleter.cpp
@@ -563,7 +563,8 @@ public:
                         //      |- element (PROP) - (row 0, [parent.row,-1,-1,1]) = encode as element => [parent.row,-1,parent.row,1]
 
                         info.doc = parentInfo.doc;
-                        info.obj = -1;// object information is determined by the DOC index actually
+                        // object information is determined by the DOC index actually
+                        info.obj = -1;
                         info.prop = element.row();
                         info.contextualHierarchy = 1;
                     }

--- a/src/Gui/FileDialog.cpp
+++ b/src/Gui/FileDialog.cpp
@@ -680,7 +680,8 @@ FileChooser::FileChooser ( QWidget * parent )
     button = new QPushButton(QLatin1String("..."), this);
 
 #if defined (Q_OS_MAC)
-    button->setAttribute(Qt::WA_LayoutUsesWidgetRect); // layout size from QMacStyle was not correct
+    // layout size from QMacStyle was not correct
+    button->setAttribute(Qt::WA_LayoutUsesWidgetRect);
 #endif
 
     layout->addWidget(button);
@@ -1071,4 +1072,3 @@ SelectModule::Dict SelectModule::importHandler(const QStringList& fileNames, con
 
 
 #include "moc_FileDialog.cpp"
-

--- a/src/Gui/GestureNavigationStyle.cpp
+++ b/src/Gui/GestureNavigationStyle.cpp
@@ -256,7 +256,8 @@ public:
         switch (ns.getViewingMode()) {
             case NavigationStyle::SEEK_WAIT_MODE:{
                 if (ev.isPress(1)) {
-                    ns.seekToPoint(ev.inventor_event->getPosition()); // implicitly calls interactiveCountInc()
+                    // implicitly calls interactiveCountInc()
+                    ns.seekToPoint(ev.inventor_event->getPosition());
                     ns.setViewingMode(NavigationStyle::SEEK_MODE);
                     ev.flags->processed = true;
                     return transit<NS::AwaitingReleaseState>();
@@ -588,7 +589,8 @@ public:
     }
     virtual ~StickyPanState(){
         auto &ns = this->outermost_context().ns;
-        ns.button2down = false; //a workaround for dealing with Qt not sending UP event after a tap-hold-drag sequence.
+        //a workaround for dealing with Qt not sending UP event after a tap-hold-drag sequence.
+        ns.button2down = false;
     }
 
     sc::result react(const NS::Event& ev){
@@ -1011,7 +1013,8 @@ void GestureNavigationStyle::onRollGesture(int direction)
 void GestureNavigationStyle::onSetRotationCenter(SbVec2s cursor){
     SbBool ret = NavigationStyle::lookAtPoint(cursor);
     if(!ret){
-        this->interactiveCountDec(); //this was in original gesture nav. Not sure what is it needed for --DeepSOIC
+        //this was in original gesture nav. Not sure what is it needed for --DeepSOIC
+        this->interactiveCountDec();
         Base::Console().Log(
             "No object under cursor! Can't set new center of rotation.\n");
     }

--- a/src/Gui/Inventor/SoAutoZoomTranslation.cpp
+++ b/src/Gui/Inventor/SoAutoZoomTranslation.cpp
@@ -98,7 +98,8 @@ void SoAutoZoomTranslation::doAction(SoAction * action)
     auto state = action->getState();
     SbRotation r,so;
     SbVec3f s,t;
-    SbMatrix matrix = SoModelMatrixElement::get(action->getState()); // clazy:exclude=rule-of-two-soft
+    // clazy:exclude=rule-of-two-soft
+    SbMatrix matrix = SoModelMatrixElement::get(action->getState());
     matrix.getTransform(t,r,s,so);
     matrix.multVecMatrix(SbVec3f(0,0,0),t);
     // reset current model scale factor

--- a/src/Gui/MDIView.cpp
+++ b/src/Gui/MDIView.cpp
@@ -394,7 +394,8 @@ void MDIView::setCurrentViewMode(ViewMode mode)
                         showNormal();
 
 #if defined(Q_WS_X11)
-                    //extern void qt_x11_wait_for_window_manager( QWidget* w ); // defined in qwidget_x11.cpp
+                    // defined in qwidget_x11.cpp
+                    //extern void qt_x11_wait_for_window_manager( QWidget* w );
                     qt_x11_wait_for_window_manager(this);
 #endif
                     activateWindow();

--- a/src/Gui/MayaGestureNavigationStyle.cpp
+++ b/src/Gui/MayaGestureNavigationStyle.cpp
@@ -133,7 +133,8 @@ SbBool MayaGestureNavigationStyle::processSoEvent(const SoEvent * const ev)
     bool evIsButton = type.isDerivedFrom(SoMouseButtonEvent::getClassTypeId());
     bool evIsKeyboard = type.isDerivedFrom(SoKeyboardEvent::getClassTypeId());
     bool evIsLoc2 = type.isDerivedFrom(SoLocation2Event::getClassTypeId());//mouse movement
-    bool evIsLoc3 = type.isDerivedFrom(SoMotion3Event::getClassTypeId());//spaceball/joystick movement
+    //spaceball/joystick movement
+    bool evIsLoc3 = type.isDerivedFrom(SoMotion3Event::getClassTypeId());
     bool evIsGesture = type.isDerivedFrom(SoGestureEvent::getClassTypeId());//touchscreen gesture
 
     const SbVec2f prevnormalized = this->lastmouseposition;
@@ -217,7 +218,8 @@ SbBool MayaGestureNavigationStyle::processSoEvent(const SoEvent * const ev)
                   +(comboAfter & BUTTON2DOWN ? 1 : 0 )
                   +(comboAfter & BUTTON3DOWN ? 1 : 0 );
     if (cntMBAfter>=2) this->thisClickIsComplex = true;
-    //if (cntMBAfter==0) this->thisClickIsComplex = false;//don't reset the flag now, we need to know that this mouseUp was an end of a click that was complex. The flag will reset by the before-check in the next event.
+    //don't reset the flag now, we need to know that this mouseUp was an end of a click that was complex. The flag will reset by the before-check in the next event.
+    //if (cntMBAfter==0) this->thisClickIsComplex = false;
 
     //test for move detection
     if (evIsLoc2 || evIsButton){
@@ -251,8 +253,10 @@ SbBool MayaGestureNavigationStyle::processSoEvent(const SoEvent * const ev)
     }
     if (evIsButton) {
         if(inGesture){
-            inGesture = false;//reset the flag when mouse clicks are received, to ensure enabling mouse navigation back.
-            setViewingMode(NavigationStyle::SELECTION);//exit navigation asap, to proceed with regular processing of the click
+            //reset the flag when mouse clicks are received, to ensure enabling mouse navigation back.
+            inGesture = false;
+            //exit navigation asap, to proceed with regular processing of the click
+            setViewingMode(NavigationStyle::SELECTION);
         }
     }
 
@@ -264,8 +268,10 @@ SbBool MayaGestureNavigationStyle::processSoEvent(const SoEvent * const ev)
 
     //----------all this were preparations. Now comes the event handling! ----------
 
-    SbBool processed = false;//a return value for the  BlahblahblahNavigationStyle::processSoEvent
-    bool propagated = false;//an internal flag indicating that the event has been already passed to inherited, to suppress the automatic doing of this at the end.
+    //a return value for the  BlahblahblahNavigationStyle::processSoEvent
+    SbBool processed = false;
+    //an internal flag indicating that the event has been already passed to inherited, to suppress the automatic doing of this at the end.
+    bool propagated = false;
     //goto finalize = return processed. Might be important to do something before done (none now).
 
     // give the nodes in the foreground root the chance to handle events (e.g color bar)
@@ -369,13 +375,15 @@ SbBool MayaGestureNavigationStyle::processSoEvent(const SoEvent * const ev)
                         this->mouseMoveThresholdBroken = false;
                         pan(viewer->getSoRenderManager()->getCamera());//set up panningplane
                         int &cnt = this->mousedownConsumedCount;
-                        this->mousedownConsumedEvents[cnt] = *event;//hopefully, a shallow copy is enough. There are no pointers stored in events, apparently. Will lose a subclass, though.
+                        //hopefully, a shallow copy is enough. There are no pointers stored in events, apparently. Will lose a subclass, though.
+                        this->mousedownConsumedEvents[cnt] = *event;
                         cnt++;
                         assert(cnt<=2);
                         if(cnt>static_cast<int>(sizeof(mousedownConsumedEvents))){
                             cnt=sizeof(mousedownConsumedEvents);//we are in trouble
                         }
-                        processed = true;//just consume this event, and wait for the move threshold to be broken to start dragging/panning
+                        //just consume this event, and wait for the move threshold to be broken to start dragging/panning
+                        processed = true;
                     }
                 } else {//release
                     if (button == SoMouseButtonEvent::BUTTON2 && !this->thisClickIsComplex) {
@@ -387,10 +395,12 @@ SbBool MayaGestureNavigationStyle::processSoEvent(const SoEvent * const ev)
                     if(! processed) {
                         //re-synthesize all previously-consumed mouseDowns, if any. They might have been re-synthesized already when threshold was broken.
                         for( int i=0;   i < this->mousedownConsumedCount;   i++ ){
-                            inherited::processSoEvent(& (this->mousedownConsumedEvents[i]));//simulate the previously-comsumed mousedown.
+                            //simulate the previously-comsumed mousedown.
+                            inherited::processSoEvent(& (this->mousedownConsumedEvents[i]));
                         }
                         this->mousedownConsumedCount = 0;
-                        processed = inherited::processSoEvent(ev);//explicitly, just for clarity that we are sending a full click sequence.
+                        //explicitly, just for clarity that we are sending a full click sequence.
+                        processed = inherited::processSoEvent(ev);
                         propagated = true;
                     }
                 }
@@ -432,15 +442,18 @@ SbBool MayaGestureNavigationStyle::processSoEvent(const SoEvent * const ev)
                     //no, we are not entering navigation.
                     //re-synthesize all previously-consumed mouseDowns, if any, and propagate this mousemove.
                     for( int i=0;   i < this->mousedownConsumedCount;   i++ ){
-                        inherited::processSoEvent(& (this->mousedownConsumedEvents[i]));//simulate the previously-comsumed mousedown.
+                        //simulate the previously-comsumed mousedown.
+                        inherited::processSoEvent(& (this->mousedownConsumedEvents[i]));
                     }
                     this->mousedownConsumedCount = 0;
-                    processed = inherited::processSoEvent(ev);//explicitly, just for clarity that we are sending a full click sequence.
+                    //explicitly, just for clarity that we are sending a full click sequence.
+                    processed = inherited::processSoEvent(ev);
                     propagated = true;
                 }
             }
             if (mousedownConsumedCount  > 0)
-                processed = true;//if we are still deciding if it's a drag or not, consume mouseMoves.
+                //if we are still deciding if it's a drag or not, consume mouseMoves.
+                processed = true;
         }
 
         //gesture start

--- a/src/Gui/NavigationStyle.h
+++ b/src/Gui/NavigationStyle.h
@@ -368,14 +368,20 @@ public:
 protected:
     SbBool processSoEvent(const SoEvent * const ev) override;
 
-    SbVec2s mousedownPos;//the position where some mouse button was pressed (local pixel coordinates).
-    short mouseMoveThreshold;//setting. Minimum move required to consider it a move (in pixels).
-    bool mouseMoveThresholdBroken;//a flag that the move threshold was surpassed since last mousedown.
-    int mousedownConsumedCount;//a flag for remembering that a mousedown of button1/button2 was consumed.
-    SoMouseButtonEvent mousedownConsumedEvents[5];//the event that was consumed and is to be refired. 2 should be enough, but just for a case of the maximum 5 buttons...
+    //the position where some mouse button was pressed (local pixel coordinates).
+    SbVec2s mousedownPos;
+    //setting. Minimum move required to consider it a move (in pixels).
+    short mouseMoveThreshold;
+    //a flag that the move threshold was surpassed since last mousedown.
+    bool mouseMoveThresholdBroken;
+    //a flag for remembering that a mousedown of button1/button2 was consumed.
+    int mousedownConsumedCount;
+    //the event that was consumed and is to be refired. 2 should be enough, but just for a case of the maximum 5 buttons...
+    SoMouseButtonEvent mousedownConsumedEvents[5];
     bool testMoveThreshold(const SbVec2s currentPos) const;
 
-    bool thisClickIsComplex;//a flag that becomes set when a complex clicking pattern is detected (i.e., two or more mouse buttons were down at the same time).
+    //a flag that becomes set when a complex clicking pattern is detected (i.e., two or more mouse buttons were down at the same time).
+    bool thisClickIsComplex;
     bool inGesture; //a flag that is used to filter out mouse events during gestures.
 };
 

--- a/src/Gui/PrefWidgets.cpp
+++ b/src/Gui/PrefWidgets.cpp
@@ -826,10 +826,12 @@ void PrefFontBox::restorePreferences()
   QFont currFont = currentFont();                         //QFont from selector widget
   QString currName = currFont.family();
 
-  std::string prefName = getWindowParameter()->GetASCII(entryName(), currName.toUtf8());  //font name from cfg file
+  //font name from cfg file
+  std::string prefName = getWindowParameter()->GetASCII(entryName(), currName.toUtf8());
 
   currFont.setFamily(QString::fromStdString(prefName));
-  setCurrentFont(currFont);                               //set selector widget to name from cfg file
+  //set selector widget to name from cfg file
+  setCurrentFont(currFont);
 }
 
 void PrefFontBox::savePreferences()

--- a/src/Gui/PreferencePackManager.cpp
+++ b/src/Gui/PreferencePackManager.cpp
@@ -339,7 +339,8 @@ void PreferencePackManager::toggleVisibility(const std::string& addonName, const
     }
     else {
         auto groupName = (*hiddenPack)->GetGroupName();
-        hiddenPacks.clear(); // To decrement the reference count of the group we are about the remove...
+        // To decrement the reference count of the group we are about the remove...
+        hiddenPacks.clear();
         pref->RemoveGrp(groupName);
     }
     rescan();

--- a/src/Gui/PythonConsole.cpp
+++ b/src/Gui/PythonConsole.cpp
@@ -602,7 +602,8 @@ void PythonConsole::keyPressEvent(QKeyEvent * e)
          *   - roam the history by Up/Down keys
          *   - show call tips on period
          */
-        QTextBlock inputBlock = inputLineBegin.block();              //< get the last paragraph's text
+        //< get the last paragraph's text
+        QTextBlock inputBlock = inputLineBegin.block();
         QString    inputLine  = inputBlock.text();
         QString    inputStrg  = stripPromptFrom( inputLine );
         if (this->_sourceDrain && !this->_sourceDrain->isEmpty()) {
@@ -616,8 +617,10 @@ void PythonConsole::keyPressEvent(QKeyEvent * e)
               // disable current input string - i.e. put it to history but don't execute it.
               if (!inputStrg.isEmpty())
               {
-                  d->history.append( QLatin1String("# ") + inputStrg );  //< put commented string to history ...
-                  inputLineBegin.insertText( QString::fromLatin1("# ") ); //< and comment it on console
+                  //< put commented string to history ...
+                  d->history.append( QLatin1String("# ") + inputStrg );
+                  //< and comment it on console
+                  inputLineBegin.insertText( QString::fromLatin1("# ") );
                   setTextCursor( inputLineBegin );
                   printPrompt(d->interpreter->hasPendingInput()          //< print adequate prompt
                       ? PythonConsole::Incomplete
@@ -1298,7 +1301,8 @@ void PythonConsole::overrideCursor(const QString& txt)
     QTextCursor cursor = this->inputBegin();
     int blockLength = this->textCursor().block().text().length();
 
-    cursor.movePosition( QTextCursor::Right, QTextCursor::KeepAnchor, blockLength ); //<< select text to override
+    //<< select text to override
+    cursor.movePosition( QTextCursor::Right, QTextCursor::KeepAnchor, blockLength );
     cursor.removeSelectedText();
     cursor.insertText(txt);
     // move cursor to the end
@@ -1436,7 +1440,8 @@ QString PythonConsole::readline( )
         PyErr_SetInterrupt();
     }            //< send SIGINT to python
     this->_sourceDrain = nullptr;             //< disable source drain
-    return inputBuffer.append(QChar::fromLatin1('\n')); //< pass a newline here, since the readline-caller may need it!
+    //< pass a newline here, since the readline-caller may need it!
+    return inputBuffer.append(QChar::fromLatin1('\n'));
 }
 
 /**

--- a/src/Gui/Quarter/Mouse.cpp
+++ b/src/Gui/Quarter/Mouse.cpp
@@ -1,22 +1,22 @@
 /**************************************************************************\
  * Copyright (c) Kongsberg Oil & Gas Technologies AS
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
  * met:
- * 
+ *
  * Redistributions of source code must retain the above copyright notice,
  * this list of conditions and the following disclaimer.
- * 
+ *
  * Redistributions in binary form must reproduce the above copyright
  * notice, this list of conditions and the following disclaimer in the
  * documentation and/or other materials provided with the distribution.
- * 
+ *
  * Neither the name of the copyright holder nor the names of its
  * contributors may be used to endorse or promote products derived from
  * this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -168,7 +168,8 @@ MouseP::mouseWheelEvent(QWheelEvent * event)
 #endif
   // the following corrects for high-dpi displays (e.g. mac retina)
   pos *= publ->quarter->devicePixelRatio();
-  this->location2->setPosition(pos); //I don't know why location2 is assigned here, I assumed it important  --DeepSOIC
+  //I don't know why location2 is assigned here, I assumed it important  --DeepSOIC
+  this->location2->setPosition(pos);
   this->wheel->setPosition(pos);
 
   // QWheelEvent::delta() returns the distance that the wheel is

--- a/src/Gui/SelectionView.cpp
+++ b/src/Gui/SelectionView.cpp
@@ -126,7 +126,8 @@ void SelectionView::onSelectionChanged(const SelectionChanges &Reason)
     ParameterGrp::handle hGrp = App::GetApplication().GetUserParameter().GetGroup("BaseApp")
         ->GetGroup("Preferences")->GetGroup("Selection");
     bool autoShow = hGrp->GetBool("AutoShowSelectionView", false);
-    hGrp->SetBool("AutoShowSelectionView", autoShow); // Remove this line once the preferences window item is implemented
+    // Remove this line once the preferences window item is implemented
+    hGrp->SetBool("AutoShowSelectionView", autoShow);
 
     if (autoShow) {
         if (!parentWidget()->isVisible() && Selection().hasSelection()) {

--- a/src/Gui/SoFCCSysDragger.h
+++ b/src/Gui/SoFCCSysDragger.h
@@ -204,7 +204,8 @@ public:
      * a traditional scale and a value of 1.0 is a good place to start.
      */
     SoSFFloat draggerSize;
-    SoSFFloat autoScaleResult; //!< result of autoscale calculation and used by childdraggers. Don't use.
+    //!< result of autoscale calculation and used by childdraggers. Don't use.
+    SoSFFloat autoScaleResult;
 
     SoIdleSensor idleSensor; //!< might be overkill, but want to make sure of performance.
     void setUpAutoScale(SoCamera *cameraIn); //!< used to setup the auto scaling of dragger.
@@ -250,7 +251,8 @@ protected:
     static void rotationSensorCB(void *f, SoSensor *);
     static void valueChangedCB(void *, SoDragger *d);
     static void cameraCB(void *data, SoSensor *);
-    static void idleCB(void *data, SoSensor *); //!< scheduled from cameraCB to auto scale dragger.
+    //!< scheduled from cameraCB to auto scale dragger.
+    static void idleCB(void *data, SoSensor *);
     static void finishDragCB(void *data, SoDragger *);
 
 

--- a/src/Gui/SoFCOffscreenRenderer.cpp
+++ b/src/Gui/SoFCOffscreenRenderer.cpp
@@ -585,7 +585,8 @@ SoQtOffscreenRenderer::makeFrameBuffer(int width, int height, int samples)
     fmt.setInternalTextureFormat(this->texFormat);
 
     framebuffer = new QtGLFramebufferObject(width, height, fmt);
-    cache_context = SoGLCacheContextElement::getUniqueCacheContext(); // unique per pixel buffer object, just to be sure
+    // unique per pixel buffer object, just to be sure
+    cache_context = SoGLCacheContextElement::getUniqueCacheContext();
 }
 
 SbBool

--- a/src/Gui/SoTouchEvents.h
+++ b/src/Gui/SoTouchEvents.h
@@ -115,7 +115,8 @@ public:
 
 class GesturesDevice : public Quarter::InputDevice {
 public:
-    explicit GesturesDevice(QWidget* widget);//it needs to know the widget to do coordinate translation
+    //it needs to know the widget to do coordinate translation
+    explicit GesturesDevice(QWidget* widget);
 
     ~GesturesDevice() override  {}
     const SoEvent* translateEvent(QEvent* event) override;

--- a/src/Gui/Splashscreen.cpp
+++ b/src/Gui/Splashscreen.cpp
@@ -369,7 +369,8 @@ void AboutDialog::setupLabels()
     it = config.find("BuildRevisionHash");
     if (it != config.end()) {
         QString hash = ui->labelBuildHash->text();
-        hash.replace(QString::fromLatin1("Unknown"), QString::fromLatin1(it->second.c_str()).left(7)); // Use the 7-char abbreviated hash
+        // Use the 7-char abbreviated hash
+        hash.replace(QString::fromLatin1("Unknown"), QString::fromLatin1(it->second.c_str()).left(7));
         ui->labelBuildHash->setText(hash);
         if (auto url_itr = config.find("BuildRepositoryURL"); url_itr != config.end()) {
             auto url = QString::fromStdString(url_itr->second);
@@ -423,7 +424,7 @@ void AboutDialog::showCredits()
     creditsHTML += tr("Credits");
     creditsHTML += QString::fromLatin1("</h1><p>");
     creditsHTML += tr("FreeCAD would not be possible without the contributions of");
-    creditsHTML += QString::fromLatin1(":</p><h2>"); 
+    creditsHTML += QString::fromLatin1(":</p><h2>");
     //: Header for the list of individual people in the Credits list.
     creditsHTML += tr("Individuals");
     creditsHTML += QString::fromLatin1("</h2><ul>");
@@ -816,7 +817,7 @@ void AboutDialog::on_copyButton_clicked()
             auto disablingFile = mod.path() / "ADDON_DISABLED";
             if (fs::exists(disablingFile))
                 str << " (Disabled)";
-            
+
             str << "\n";
         }
     }

--- a/src/Gui/SplitView3DInventor.cpp
+++ b/src/Gui/SplitView3DInventor.cpp
@@ -140,7 +140,8 @@ void AbstractSplitView::OnChange(ParameterGrp::SubjectType &rCaller,ParameterGrp
 {
     const ParameterGrp& rGrp = static_cast<ParameterGrp&>(rCaller);
     if (strcmp(Reason,"HeadlightColor") == 0) {
-        unsigned long headlight = rGrp.GetUnsigned("HeadlightColor",ULONG_MAX); // default color (white)
+        // default color (white)
+        unsigned long headlight = rGrp.GetUnsigned("HeadlightColor",ULONG_MAX);
         float transparency;
         SbColor headlightColor;
         headlightColor.setPackedValue((uint32_t)headlight, transparency);
@@ -168,7 +169,8 @@ void AbstractSplitView::OnChange(ParameterGrp::SubjectType &rCaller,ParameterGrp
             (*it)->setBacklight(rGrp.GetBool("EnableBacklight", false));
     }
     else if (strcmp(Reason,"BacklightColor") == 0) {
-        unsigned long backlight = rGrp.GetUnsigned("BacklightColor",ULONG_MAX); // default color (white)
+        // default color (white)
+        unsigned long backlight = rGrp.GetUnsigned("BacklightColor",ULONG_MAX);
         float transparency;
         SbColor backlightColor;
         backlightColor.setPackedValue((uint32_t)backlight, transparency);
@@ -293,9 +295,12 @@ void AbstractSplitView::OnChange(ParameterGrp::SubjectType &rCaller,ParameterGrp
     }
     else {
         unsigned long col1 = rGrp.GetUnsigned("BackgroundColor",3940932863UL);
-        unsigned long col2 = rGrp.GetUnsigned("BackgroundColor2",859006463UL); // default color (dark blue)
-        unsigned long col3 = rGrp.GetUnsigned("BackgroundColor3",2880160255UL); // default color (blue/grey)
-        unsigned long col4 = rGrp.GetUnsigned("BackgroundColor4",1869583359UL); // default color (blue/grey)
+        // default color (dark blue)
+        unsigned long col2 = rGrp.GetUnsigned("BackgroundColor2",859006463UL);
+        // default color (blue/grey)
+        unsigned long col3 = rGrp.GetUnsigned("BackgroundColor3",2880160255UL);
+        // default color (blue/grey)
+        unsigned long col4 = rGrp.GetUnsigned("BackgroundColor4",1869583359UL);
         float r1,g1,b1,r2,g2,b2,r3,g3,b3,r4,g4,b4;
         r1 = ((col1 >> 24) & 0xff) / 255.0; g1 = ((col1 >> 16) & 0xff) / 255.0; b1 = ((col1 >> 8) & 0xff) / 255.0;
         r2 = ((col2 >> 24) & 0xff) / 255.0; g2 = ((col2 >> 16) & 0xff) / 255.0; b2 = ((col2 >> 8) & 0xff) / 255.0;

--- a/src/Gui/View3DInventor.cpp
+++ b/src/Gui/View3DInventor.cpp
@@ -527,10 +527,12 @@ bool View3DInventor::setCamera(const char* pCamera)
     SoOrthographicCamera * CamViewerO = nullptr;
 
     if (CamViewer->getTypeId() == SoPerspectiveCamera::getClassTypeId()) {
-        CamViewerP = static_cast<SoPerspectiveCamera *>(CamViewer);  // safe downward cast, knows the type
+        // safe downward cast, knows the type
+        CamViewerP = static_cast<SoPerspectiveCamera *>(CamViewer);
     }
     else if (CamViewer->getTypeId() == SoOrthographicCamera::getClassTypeId()) {
-        CamViewerO = static_cast<SoOrthographicCamera *>(CamViewer);  // safe downward cast, knows the type
+        // safe downward cast, knows the type
+        CamViewerO = static_cast<SoOrthographicCamera *>(CamViewer);
     }
 
     if (Cam->getTypeId() == SoPerspectiveCamera::getClassTypeId()) {

--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -3199,7 +3199,8 @@ void View3DInventorViewer::drawAxisCross()
 
     glEnable(GL_BLEND);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-    glPixelZoom((float)axiscrossSize/30, (float)axiscrossSize/30); // 30 = 3 (character pixmap ratio) * 10 (default axiscrossSize)
+    // 30 = 3 (character pixmap ratio) * 10 (default axiscrossSize)
+    glPixelZoom((float)axiscrossSize/30, (float)axiscrossSize/30);
     glRasterPos2d(xpos[0], xpos[1]);
     glDrawPixels(XPM_WIDTH, XPM_HEIGHT, GL_RGBA, GL_UNSIGNED_BYTE, XPM_PIXEL_DATA);
     glRasterPos2d(ypos[0], ypos[1]);

--- a/src/Gui/View3DPy.cpp
+++ b/src/Gui/View3DPy.cpp
@@ -88,7 +88,8 @@ void View3DInventorPy::init_type()
     add_varargs_method("viewRear",&View3DInventorPy::viewRear,"viewRear()");
     add_varargs_method("viewRight",&View3DInventorPy::viewRight,"viewRight()");
     add_varargs_method("viewTop",&View3DInventorPy::viewTop,"viewTop()");
-    add_varargs_method("viewAxometric",&View3DInventorPy::viewIsometric,"viewAxonometric()"); // for backward compatibility
+    // for backward compatibility
+    add_varargs_method("viewAxometric",&View3DInventorPy::viewIsometric,"viewAxonometric()");
     add_varargs_method("viewAxonometric",&View3DInventorPy::viewIsometric,"viewAxonometric()");
     add_varargs_method("viewIsometric",&View3DInventorPy::viewIsometric,"viewIsometric()");
     add_varargs_method("viewDimetric",&View3DInventorPy::viewDimetric,"viewDimetric()");
@@ -2685,7 +2686,8 @@ Py::Object View3DInventorPy::setCornerCrossVisible(const Py::Tuple& args)
     if (!PyArg_ParseTuple(args.ptr(), "i", &ok))
         throw Py::Exception();
     getView3DIventorPtr()->getViewer()->setFeedbackVisibility(ok!=0);
-    getView3DIventorPtr()->getViewer()->redraw(); // added because isViewing() returns False when focus is in Python Console
+    // added because isViewing() returns False when focus is in Python Console
+    getView3DIventorPtr()->getViewer()->redraw();
     return Py::None();
 }
 
@@ -2703,7 +2705,8 @@ Py::Object View3DInventorPy::setCornerCrossSize(const Py::Tuple& args)
     if (!PyArg_ParseTuple(args.ptr(), "i", &size))
         throw Py::Exception();
     getView3DIventorPtr()->getViewer()->setFeedbackSize(size);
-    getView3DIventorPtr()->getViewer()->redraw(); // added because isViewing() returns False when focus is in Python Console
+    // added because isViewing() returns False when focus is in Python Console
+    getView3DIventorPtr()->getViewer()->redraw();
     return Py::None();
 }
 

--- a/src/Gui/View3DSettings.cpp
+++ b/src/Gui/View3DSettings.cpp
@@ -100,7 +100,8 @@ void View3DSettings::OnChange(ParameterGrp::SubjectType &rCaller,ParameterGrp::M
 {
     const ParameterGrp& rGrp = static_cast<ParameterGrp&>(rCaller);
     if (strcmp(Reason,"HeadlightColor") == 0) {
-        unsigned long headlight = rGrp.GetUnsigned("HeadlightColor",ULONG_MAX); // default color (white)
+        // default color (white)
+        unsigned long headlight = rGrp.GetUnsigned("HeadlightColor",ULONG_MAX);
         float transparency;
         SbColor headlightColor;
         headlightColor.setPackedValue((uint32_t)headlight, transparency);
@@ -124,7 +125,8 @@ void View3DSettings::OnChange(ParameterGrp::SubjectType &rCaller,ParameterGrp::M
         _viewer->setBacklight(rGrp.GetBool("EnableBacklight", false));
     }
     else if (strcmp(Reason,"BacklightColor") == 0) {
-        unsigned long backlight = rGrp.GetUnsigned("BacklightColor",ULONG_MAX); // default color (white)
+        // default color (white)
+        unsigned long backlight = rGrp.GetUnsigned("BacklightColor",ULONG_MAX);
         float transparency;
         SbColor backlightColor;
         backlightColor.setPackedValue((uint32_t)backlight, transparency);
@@ -289,9 +291,12 @@ void View3DSettings::OnChange(ParameterGrp::SubjectType &rCaller,ParameterGrp::M
     }
     else {
         unsigned long col1 = rGrp.GetUnsigned("BackgroundColor",3940932863UL);
-        unsigned long col2 = rGrp.GetUnsigned("BackgroundColor2",859006463UL); // default color (dark blue)
-        unsigned long col3 = rGrp.GetUnsigned("BackgroundColor3",2880160255UL); // default color (blue/grey)
-        unsigned long col4 = rGrp.GetUnsigned("BackgroundColor4",1869583359UL); // default color (blue/grey)
+        // default color (dark blue)
+        unsigned long col2 = rGrp.GetUnsigned("BackgroundColor2",859006463UL);
+        // default color (blue/grey)
+        unsigned long col3 = rGrp.GetUnsigned("BackgroundColor3",2880160255UL);
+        // default color (blue/grey)
+        unsigned long col4 = rGrp.GetUnsigned("BackgroundColor4",1869583359UL);
         float r1,g1,b1,r2,g2,b2,r3,g3,b3,r4,g4,b4;
         r1 = ((col1 >> 24) & 0xff) / 255.0; g1 = ((col1 >> 16) & 0xff) / 255.0; b1 = ((col1 >> 8) & 0xff) / 255.0;
         r2 = ((col2 >> 24) & 0xff) / 255.0; g2 = ((col2 >> 16) & 0xff) / 255.0; b2 = ((col2 >> 8) & 0xff) / 255.0;

--- a/src/Gui/ViewProviderGeoFeatureGroupExtension.cpp
+++ b/src/Gui/ViewProviderGeoFeatureGroupExtension.cpp
@@ -79,7 +79,8 @@ std::vector<App::DocumentObject*> ViewProviderGeoFeatureGroupExtension::extensio
 
     auto* group = getExtendedViewProvider()->getObject()->getExtensionByType<App::GeoFeatureGroupExtension>();
     const std::vector<App::DocumentObject*> &model = group->Group.getValues ();
-    std::set<App::DocumentObject*> outSet; //< set of objects not to claim (childrens of childrens)
+    //< set of objects not to claim (childrens of childrens)
+    std::set<App::DocumentObject*> outSet;
 
     // search for objects handled (claimed) by the features
     for (auto obj: model) {

--- a/src/Gui/ViewProviderGeometryObject.cpp
+++ b/src/Gui/ViewProviderGeometryObject.cpp
@@ -70,13 +70,14 @@ ViewProviderGeometryObject::ViewProviderGeometryObject()
         b = (float)rand() / fMax;
     }
     else {
-        unsigned long shcol = hGrp->GetUnsigned("DefaultShapeColor", 3435973887UL); // light gray (204,204,204)
+        // light gray (204,204,204)
+        unsigned long shcol = hGrp->GetUnsigned("DefaultShapeColor", 3435973887UL);
         r = ((shcol >> 24) & 0xff) / 255.0;
         g = ((shcol >> 16) & 0xff) / 255.0;
         b = ((shcol >> 8) & 0xff) / 255.0;
     }
 
-    int initialTransparency = hGrp->GetInt("DefaultShapeTransparency", 0); 
+    int initialTransparency = hGrp->GetInt("DefaultShapeTransparency", 0);
 
     static const char *dogroup = "Display Options";
     static const char *sgroup = "Selection";
@@ -224,14 +225,16 @@ SoPickedPoint* ViewProviderGeometryObject::getPickedPoint(const SbVec2s& pos, co
 
     // returns a copy of the point
     SoPickedPoint* pick = rp.getPickedPoint();
-    //return (pick ? pick->copy() : 0); // needs the same instance of CRT under MS Windows
+    // needs the same instance of CRT under MS Windows
+    //return (pick ? pick->copy() : 0);
     return (pick ? new SoPickedPoint(*pick) : nullptr);
 }
 
 unsigned long ViewProviderGeometryObject::getBoundColor() const
 {
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/View");
-    unsigned long bbcol = hGrp->GetUnsigned("BoundingBoxColor",4294967295UL); // white (255,255,255)
+    // white (255,255,255)
+    unsigned long bbcol = hGrp->GetUnsigned("BoundingBoxColor",4294967295UL);
     return bbcol;
 }
 

--- a/src/Gui/ViewProviderOriginFeature.cpp
+++ b/src/Gui/ViewProviderOriginFeature.cpp
@@ -49,8 +49,10 @@ ViewProviderOriginFeature::ViewProviderOriginFeature () {
     ADD_PROPERTY_TYPE ( Size, (ViewProviderOrigin::defaultSize()), 0, App::Prop_ReadOnly,
     QT_TRANSLATE_NOOP("App::Property", "Visual size of the feature"));
 
-    ShapeColor.setValue ( 50.f/255, 150.f/255, 250.f/255 ); // Set default color for origin (light-blue)
-    BoundingBox.setStatus(App::Property::Hidden, true); // Hide Boundingbox from the user due to it doesn't make sense
+    // Set default color for origin (light-blue)
+    ShapeColor.setValue ( 50.f/255, 150.f/255, 250.f/255 );
+    // Hide Boundingbox from the user due to it doesn't make sense
+    BoundingBox.setStatus(App::Property::Hidden, true);
 
     // Create node for scaling the origin
     pScale = new SoScale ();

--- a/src/Gui/Widgets.cpp
+++ b/src/Gui/Widgets.cpp
@@ -878,7 +878,7 @@ UrlLabel::UrlLabel(QWidget* parent, Qt::WindowFlags f)
     , _url (QStringLiteral("http://localhost"))
     , _launchExternal(true)
 {
-    setToolTip(this->_url);    
+    setToolTip(this->_url);
     setCursor(Qt::PointingHandCursor);
     if (qApp->styleSheet().isEmpty())
         setStyleSheet(QStringLiteral("Gui--UrlLabel {color: #0000FF;text-decoration: underline;}"));
@@ -945,9 +945,9 @@ void StatefulLabel::setParameterGroup(const std::string& groupName)
 {
     if (_parameterGroup.isValid())
         _parameterGroup->Detach(this);
-        
+
     // Attach to the Parametergroup so we know when it changes
-    _parameterGroup = App::GetApplication().GetParameterGroupByPath(groupName.c_str());    
+    _parameterGroup = App::GetApplication().GetParameterGroupByPath(groupName.c_str());
     if (_parameterGroup.isValid())
         _parameterGroup->Attach(this);
 }
@@ -1089,7 +1089,8 @@ LabelButton::LabelButton (QWidget * parent)
 
     button = new QPushButton(QLatin1String("..."), this);
 #if defined (Q_OS_MAC)
-    button->setAttribute(Qt::WA_LayoutUsesWidgetRect); // layout size from QMacStyle was not correct
+    // layout size from QMacStyle was not correct
+    button->setAttribute(Qt::WA_LayoutUsesWidgetRect);
 #endif
     layout->addWidget(button);
 
@@ -1456,7 +1457,8 @@ LabelEditor::LabelEditor (QWidget * parent)
 
     button = new QPushButton(QLatin1String("..."), this);
 #if defined (Q_OS_MAC)
-    button->setAttribute(Qt::WA_LayoutUsesWidgetRect); // layout size from QMacStyle was not correct
+    // layout size from QMacStyle was not correct
+    button->setAttribute(Qt::WA_LayoutUsesWidgetRect);
 #endif
     layout->addWidget(button);
 

--- a/src/Gui/propertyeditor/PropertyItem.cpp
+++ b/src/Gui/propertyeditor/PropertyItem.cpp
@@ -554,13 +554,13 @@ void PropertyItem::setPropertyValue(const QString& value)
         else if (parent->isDerivedFrom(App::DocumentObject::getClassTypeId())) {
             auto obj = static_cast<App::DocumentObject*>(parent);
             App::Document* doc = obj->getDocument();
-            ss << "FreeCAD.getDocument('" << doc->getName() << "').getObject('" 
+            ss << "FreeCAD.getDocument('" << doc->getName() << "').getObject('"
                << obj->getNameInDocument() << "').";
         }
         else if (parent->isDerivedFrom(ViewProviderDocumentObject::getClassTypeId())) {
             App::DocumentObject* obj = static_cast<ViewProviderDocumentObject*>(parent)->getObject();
             App::Document* doc = obj->getDocument();
-            ss << "FreeCADGui.getDocument('" << doc->getName() << "').getObject('" 
+            ss << "FreeCADGui.getDocument('" << doc->getName() << "').getObject('"
                << obj->getNameInDocument() << "').";
         }
         else {
@@ -604,7 +604,7 @@ QVariant PropertyItem::data(int column, int role) const
                 && !propertyItems.front()->testStatus(App::Property::LockDynamic))
             {
                 return role==Qt::BackgroundRole
-                    ? QVariant::fromValue(QColor(0xFF,0xFF,0x99)) 
+                    ? QVariant::fromValue(QColor(0xFF,0xFF,0x99))
                     : QVariant::fromValue(QColor(0,0,0));
             }
             return QVariant();
@@ -647,7 +647,7 @@ QVariant PropertyItem::data(int column, int role) const
             else if (role == Qt::DisplayRole) {
                 QVariant val = parent->property(qPrintable(objectName()));
                 return toString(val);
-            } 
+            }
             else if (role == Qt::ForegroundRole) {
                 if (hasExpression())
                     return QVariant::fromValue(QApplication::palette().color(QPalette::Link));
@@ -779,7 +779,7 @@ QWidget* PropertyStringItem::createEditor(QWidget* parent, const QObject* receiv
         le->bind(getPath());
         le->setAutoApply(autoApply());
     }
-        
+
     return le;
 }
 
@@ -854,9 +854,9 @@ PROPERTYITEM_SOURCE(Gui::PropertyEditor::PropertySeparatorItem)
 
 QWidget* PropertySeparatorItem::createEditor(QWidget* parent, const QObject* receiver, const char* method) const
 {
-    Q_UNUSED(parent); 
-    Q_UNUSED(receiver); 
-    Q_UNUSED(method); 
+    Q_UNUSED(parent);
+    Q_UNUSED(receiver);
+    Q_UNUSED(method);
     return nullptr;
 }
 
@@ -1125,14 +1125,14 @@ QWidget* PropertyUnitItem::createEditor(QWidget* parent, const QObject* receiver
     infield->setFrame(false);
     infield->setMinimumHeight(0);
     infield->setReadOnly(isReadOnly());
-    
+
     //if we are bound to an expression we need to bind it to the input field
     if (isBound()) {
         infield->bind(getPath());
         infield->setAutoApply(autoApply());
     }
 
-    
+
     QObject::connect(infield, SIGNAL(valueChanged(double)), receiver, method);
     return infield;
 }
@@ -1309,7 +1309,7 @@ PropertyBoolItem::PropertyBoolItem()
 QVariant PropertyBoolItem::value(const App::Property* prop) const
 {
     assert(prop && prop->getTypeId().isDerivedFrom(App::PropertyBool::getClassTypeId()));
-    
+
     bool value = static_cast<const App::PropertyBool*>(prop)->getValue();
     return QVariant(value);
 }
@@ -1518,7 +1518,8 @@ PropertyEditorWidget::PropertyEditorWidget (QWidget * parent)
 
     button = new QPushButton(QLatin1String("..."), this);
 #if defined (Q_OS_MAC)
-    button->setAttribute(Qt::WA_LayoutUsesWidgetRect); // layout size from QMacStyle was not correct
+    // layout size from QMacStyle was not correct
+    button->setAttribute(Qt::WA_LayoutUsesWidgetRect);
 #endif
     layout->addWidget(button);
 
@@ -1701,7 +1702,7 @@ PropertyVectorDistanceItem::PropertyVectorDistanceItem()
 QVariant PropertyVectorDistanceItem::toString(const QVariant& prop) const
 {
     const Base::Vector3d& value = prop.value<Base::Vector3d>();
-    QString data = QString::fromLatin1("[") + 
+    QString data = QString::fromLatin1("[") +
            Base::Quantity(value.x, Base::Unit::Length).getUserString() + QString::fromLatin1("  ") +
            Base::Quantity(value.y, Base::Unit::Length).getUserString() + QString::fromLatin1("  ") +
            Base::Quantity(value.z, Base::Unit::Length).getUserString() + QString::fromLatin1("]");
@@ -2765,10 +2766,10 @@ void PropertyPlacementItem::propertyBound()
     if (isBound()) {
         m_a->bind(App::ObjectIdentifier(getPath())<<App::ObjectIdentifier::String("Rotation")
                                                   <<App::ObjectIdentifier::String("Angle"));
-   
+
         m_d->bind(App::ObjectIdentifier(getPath())<<App::ObjectIdentifier::String("Rotation")
                                                   <<App::ObjectIdentifier::String("Axis"));
-        
+
         m_p->bind(App::ObjectIdentifier(getPath())<<App::ObjectIdentifier::String("Base"));
     }
 }
@@ -2791,7 +2792,7 @@ PropertyEnumItem::PropertyEnumItem()
 
 void PropertyEnumItem::propertyBound()
 {
-    if (m_enum && isBound()) 
+    if (m_enum && isBound())
         m_enum->bind(App::ObjectIdentifier(getPath())<<App::ObjectIdentifier::String("Enum"));
 }
 
@@ -4294,7 +4295,7 @@ void LinkSelection::select()
 
 LinkLabel::LinkLabel (QWidget * parent, const App::Property *prop)
     : QWidget(parent), objProp(prop), dlg(nullptr)
-{   
+{
     auto layout = new QHBoxLayout(this);
     layout->setContentsMargins(0, 0, 0, 0);
     layout->setSpacing(1);
@@ -4308,16 +4309,17 @@ LinkLabel::LinkLabel (QWidget * parent, const App::Property *prop)
 
     editButton = new QPushButton(QLatin1String("..."), this);
 #if defined (Q_OS_MAC)
-    editButton->setAttribute(Qt::WA_LayoutUsesWidgetRect); // layout size from QMacStyle was not correct
+    // layout size from QMacStyle was not correct
+    editButton->setAttribute(Qt::WA_LayoutUsesWidgetRect);
 #endif
     editButton->setToolTip(tr("Change the linked object"));
     layout->addWidget(editButton);
 
     this->setFocusPolicy(Qt::StrongFocus);
     this->setFocusProxy(label);
-    
+
     // setLayout(layout);
-    
+
     connect(label, &QLabel::linkActivated,
             this, &LinkLabel::onLinkActivated);
     connect(editButton, &QPushButton::clicked,
@@ -4518,4 +4520,3 @@ QByteArray PropertyItemEditorFactory::valuePropertyName (int /*type*/) const
 }
 
 #include "moc_PropertyItem.cpp"
-

--- a/src/Mod/Draft/App/AppDraftUtilsPy.cpp
+++ b/src/Mod/Draft/App/AppDraftUtilsPy.cpp
@@ -39,7 +39,8 @@ public:
             "NOTE: DraftUtils.readDXF is removed. "
             "Use Import.readDxf instead."
         );
-        initialize("The DraftUtils module contains utility functions for the Draft module."); // register with Python
+        // register with Python
+        initialize("The DraftUtils module contains utility functions for the Draft module.");
     }
 
     ~Module() override {}

--- a/src/Mod/Drawing/App/ProjectionAlgos.h
+++ b/src/Mod/Drawing/App/ProjectionAlgos.h
@@ -60,7 +60,8 @@ public:
                        XmlAttributes H_style=XmlAttributes(),
                        XmlAttributes H0_style=XmlAttributes(),
                        XmlAttributes H1_style=XmlAttributes());
-    std::string getDXF(ExtractionType type, double scale, double tolerance);//added by Dan Falck 2011/09/25
+    //added by Dan Falck 2011/09/25
+    std::string getDXF(ExtractionType type, double scale, double tolerance);
 
 
     const TopoDS_Shape &Input;

--- a/src/Mod/Drawing/Gui/TaskOrthoViews.cpp
+++ b/src/Mod/Drawing/Gui/TaskOrthoViews.cpp
@@ -82,11 +82,13 @@ void pagesize(string & page_template, int dims[4], int block[4])
         {
             if (line.find("<!-- Working space") != string::npos)
             {
-                (void)sscanf(line.c_str(), "%*s %*s %*s %d %d %d %d", &dims[0], &dims[1], &dims[2], &dims[3]);        //eg "    <!-- Working space 10 10 410 287 -->"
+                //eg "    <!-- Working space 10 10 410 287 -->"
+                (void)sscanf(line.c_str(), "%*s %*s %*s %d %d %d %d", &dims[0], &dims[1], &dims[2], &dims[3]);
                 getline (file,line);
 
                 if (line.find("<!-- Title block") != string::npos)
-                    (void)sscanf(line.c_str(), "%*s %*s %*s %d %d %d %d", &t0, &t1, &t2, &t3);    //eg "    <!-- Working space 10 10 410 287 -->"
+                    //eg "    <!-- Working space 10 10 410 287 -->"
+                    (void)sscanf(line.c_str(), "%*s %*s %*s %d %d %d %d", &t0, &t1, &t2, &t3);
 
                 break;
             }
@@ -164,7 +166,8 @@ void orthoview::set_data(int r_x, int r_y)
     rel_y = r_y;
 
     char label[15];
-    sprintf(label, "Ortho_%i_%i", rel_x, rel_y);         // label name for view, based on relative position
+    // label name for view, based on relative position
+    sprintf(label, "Ortho_%i_%i", rel_x, rel_y);
 
     this_view->Label.setValue(label);
     ortho = ((rel_x * rel_y) == 0);
@@ -393,12 +396,16 @@ void OrthoViews::calc_layout_size()                         // calculate the rea
 
 void OrthoViews::choose_page()                              // chooses which bit of page space to use depending upon layout & titleblock
 {
-    int   h = abs(*horiz);                                                                  // how many views in direction of title block  (horiz points to min_r_x or max_r_x)
+    // how many views in direction of title block  (horiz points to min_r_x or max_r_x)
+    int   h = abs(*horiz);
     int   v = abs(*vert);
-    float layout_corner_width = (1 + floor(h / 2.0)) * width + ceil(h / 2.0) * depth;       // from (0, 0) view inclusively, how wide and tall is the layout in the direction of the title block
+    // from (0, 0) view inclusively, how wide and tall is the layout in the direction of the title block
+    float layout_corner_width = (1 + floor(h / 2.0)) * width + ceil(h / 2.0) * depth;
     float layout_corner_height = (1 + floor(v / 2.0)) * height + ceil(v / 2.0) * depth;
-    float rel_space_x = layout_corner_width / layout_width - 1.0 * block[2] / large[2];     // relative to respective sizes, how much space between (0, 0) and title block,
-    float rel_space_y = layout_corner_height / layout_height - 1.0 * block[3] / large[3];   //                      can be -ve if block extends into / beyond (0, 0) view
+    // relative to respective sizes, how much space between (0, 0) and title block,
+    float rel_space_x = layout_corner_width / layout_width - 1.0 * block[2] / large[2];
+    //                      can be -ve if block extends into / beyond (0, 0) view
+    float rel_space_y = layout_corner_height / layout_height - 1.0 * block[3] / large[3];
     float view_x, view_y, v_x_r, v_y_r;
     bool  interferes = false;
     float a, b;
@@ -407,10 +414,13 @@ void OrthoViews::choose_page()                              // chooses which bit
         for (int j = min_r_y; j <= max_r_y; j++)
             if (index(i, j) != -1)                                    // is there a view in this position?
             {
-                a = i * block[0] * 0.5;                                 // reflect i and j so as +ve is in direction of title block ##
+                // reflect i and j so as +ve is in direction of title block ##
+                a = i * block[0] * 0.5;
                 b = j * block[1] * 0.5;
-                view_x = ceil(a + 0.5) * width + ceil(a) * depth;       // extreme coords of view in direction of block, measured from far corner of (0, 0) view,
-                view_y = ceil(b + 0.5) * height + ceil(b) * depth;      //                      can be -ve if view is on opposite side of (0, 0) from title block
+                // extreme coords of view in direction of block, measured from far corner of (0, 0) view,
+                view_x = ceil(a + 0.5) * width + ceil(a) * depth;
+                //                      can be -ve if view is on opposite side of (0, 0) from title block
+                view_y = ceil(b + 0.5) * height + ceil(b) * depth;
                 v_x_r = view_x / layout_width;                          // make relative
                 v_y_r = view_y / layout_height;
                 if (v_x_r > rel_space_x && v_y_r > rel_space_y)         // ## so that can use > in this condition regardless of position of block
@@ -440,17 +450,21 @@ void OrthoViews::calc_scale()                               // compute scale req
     //which gives the largest scale for which the min_space requirements can be met, but we want a 'sensible' scale, rather than 0.28457239...
     //eg if working_scale = 0.115, then we want to use 0.1, similarly 7.65 -> 5, and 76.5 -> 50
 
-    float exponent = floor(log10(working_scale));                       //if working_scale = a * 10^b, what is b?
-    working_scale *= pow(10, -exponent);                                //now find what 'a' is.
+    //if working_scale = a * 10^b, what is b?
+    float exponent = floor(log10(working_scale));
+    //now find what 'a' is.
+    working_scale *= pow(10, -exponent);
 
     float valid_scales[2][8] = {{1, 1.25, 2, 2.5, 3.75, 5, 7.5, 10},    //equate to 1:10, 1:8, 1:5, 1:4, 3:8, 1:2, 3:4, 1:1
-                                {1, 1.5, 2, 3, 4, 5, 8, 10}};           //equate to 1:1, 3:2, 2:1, 3:1, 4:1, 5:1, 8:1, 10:1
+                                //equate to 1:1, 3:2, 2:1, 3:1, 4:1, 5:1, 8:1, 10:1
+                                {1, 1.5, 2, 3, 4, 5, 8, 10}};
 
     int i = 7;
     while (valid_scales[(exponent>=0)][i] > working_scale)              //choose closest value smaller than 'a' from list.
         i -= 1;                                                         //choosing top list if exponent -ve, bottom list for +ve exponent
 
-    scale = valid_scales[(exponent>=0)][i] * pow(10, exponent);         //now have the appropriate scale, reapply the *10^b
+    //now have the appropriate scale, reapply the *10^b
+    scale = valid_scales[(exponent>=0)][i] * pow(10, exponent);
 }
 
 void OrthoViews::calc_offsets()                             // calcs SVG coords for centre of upper left view
@@ -545,7 +559,8 @@ void OrthoViews::set_primary(gp_Dir facing, gp_Dir right)   // set the orientati
     else
     {
         views[0]->set_projection(primary);
-        set_all_orientations();                 // reorient all other views appropriately
+        // reorient all other views appropriately
+        set_all_orientations();
         process_views();
     }
 }
@@ -554,7 +569,8 @@ void OrthoViews::set_orientation(int index)                 // set orientation o
 {
     double  rotation;
     int     n;                                              // how many 90* rotations from primary view?
-    gp_Dir  dir;                                            // rotate about primary x axis (if in a relative y position) or y axis?
+    // rotate about primary x axis (if in a relative y position) or y axis?
+    gp_Dir  dir;
     gp_Ax2  cs;
 
     if (views[index]->ortho)
@@ -570,7 +586,8 @@ void OrthoViews::set_orientation(int index)                 // set orientation o
             n = -views[index]->rel_y;
         }
 
-        rotation = n * rotate_coeff * M_PI / 2;             // rotate_coeff is -1 or 1 for 1st or 3rd angle
+        // rotate_coeff is -1 or 1 for 1st or 3rd angle
+        rotation = n * rotate_coeff * M_PI / 2;
         cs = primary.Rotated(gp_Ax1(gp_Pnt(0, 0, 0), dir), rotation);
         views[index]->set_projection(cs);
     }
@@ -645,7 +662,8 @@ void OrthoViews::del_view(int rel_x, int rel_y)             // remove a view fro
 
         for (unsigned int i = 1; i < views.size(); i++)              // start from 1 - the 0 is the primary view
         {
-            min_r_x = min(min_r_x, views[i]->rel_x);                // calculate extremes from remaining views
+            // calculate extremes from remaining views
+            min_r_x = min(min_r_x, views[i]->rel_x);
             max_r_x = max(max_r_x, views[i]->rel_x);
             min_r_y = min(min_r_y, views[i]->rel_y);
             max_r_y = max(max_r_y, views[i]->rel_y);
@@ -763,7 +781,8 @@ void OrthoViews::set_Axo(int rel_x, int rel_y)              // set view to defau
 
     if (num != -1)
     {
-        gp_Dir up = primary.YDirection();                   // default to view from up and right
+        // default to view from up and right
+        gp_Dir up = primary.YDirection();
         gp_Dir right = primary.XDirection();
         bool away = false;
 
@@ -1072,14 +1091,17 @@ void TaskOrthoViews::projectionChanged(int index)
 
 void TaskOrthoViews::setPrimary(int /*dir*/)
 {
-    int p_sel = ui->view_from->currentIndex();      // index for entry selected for 'view from'
-    int r_sel = ui->axis_right->currentIndex();     // index for entry selected for 'rightwards axis'
+    // index for entry selected for 'view from'
+    int p_sel = ui->view_from->currentIndex();
+    // index for entry selected for 'rightwards axis'
+    int r_sel = ui->axis_right->currentIndex();
 
     int p_vec[3] = {0, 0, 0};                       // will be the vector for 'view from'
     int r_vec[3] = {0, 0, 0};                       // will be vector for 'rightwards axis'
     int r[2] = {0, 1};
 
-    int pos = 1 - 2 * int(p_sel / 3);               // 1 if p_sel = 0, 1, 2  or -1 if p_sel = 3, 4, 5
+    // 1 if p_sel = 0, 1, 2  or -1 if p_sel = 3, 4, 5
+    int pos = 1 - 2 * int(p_sel / 3);
     p_sel = p_sel % 3;                              // p_sel = 0, 1, 2
     p_vec[p_sel] = pos;
 
@@ -1228,7 +1250,8 @@ void TaskOrthoViews::setup_axo_tab()
 void TaskOrthoViews::change_axo(int /*p*/)
 {
     int u_sel = ui->axoUp->currentIndex();        // index for entry selected for 'view from'
-    int r_sel = ui->axoRight->currentIndex();         // index for entry selected for 'rightwards axis'
+    // index for entry selected for 'rightwards axis'
+    int r_sel = ui->axoRight->currentIndex();
 
     int u_vec[3] = {0, 0, 0};               // will be the vector for 'view from'
     int r_vec[3] = {0, 0, 0};               // will be vector for 'rightwards axis'
@@ -1298,7 +1321,8 @@ bool TaskOrthoViews::user_input()
         return true;                    // return that we were editing
     }
     else
-        return false;                   // return that we weren't editing ---> treat as clicking OK... we can close the GUI
+        // return that we weren't editing ---> treat as clicking OK... we can close the GUI
+        return false;
 }
 
 void TaskOrthoViews::text_return()

--- a/src/Mod/Drawing/Gui/TaskOrthoViews.h
+++ b/src/Mod/Drawing/Gui/TaskOrthoViews.h
@@ -68,7 +68,8 @@ public:     // these aren't used by orthoView, but just informational, hence pub
     int     rel_x, rel_y;   // relative position of this view
     bool    away, tri;      // binary parameters for axonometric view
     int     axo;            // 0 / 1 / 2 = iso / di / tri metric
-    gp_Dir  up, right;      // directions prior to rotations (ie, what was used to orientate the projection)
+    // directions prior to rotations (ie, what was used to orientate the projection)
+    gp_Dir  up, right;
 
 private:
     App::Document *             parent_doc;
@@ -79,7 +80,8 @@ private:
     float   cx, cy, cz;             // coords of bbox centre in 3D space
     float   pageX, pageY;           // required coords of centre of bbox projection on page
     float   scale;                  // scale of projection
-    gp_Dir  X_dir, Y_dir, Z_dir;    // directions of projection, X_dir makes x on page, Y_dir is y on page, Z_dir is out of page
+    // directions of projection, X_dir makes x on page, Y_dir is y on page, Z_dir is out of page
+    gp_Dir  X_dir, Y_dir, Z_dir;
 };
 
 
@@ -109,9 +111,12 @@ public:
 private:
     void    set_orientation(int index);
     void    load_page();                        // get page / titleblock dims from template
-    void    choose_page();                      // determine correct portion of page to use to avoid interference with title block
-    void    set_all_orientations();             // update orientations of all views following change in primary view
-    void    calc_layout_size();                 // what's the real world size of chosen layout, excluding spaces
+    // determine correct portion of page to use to avoid interference with title block
+    void    choose_page();
+    // update orientations of all views following change in primary view
+    void    set_all_orientations();
+    // what's the real world size of chosen layout, excluding spaces
+    void    calc_layout_size();
     void    calc_offsets();
     void    set_views();
     void    calc_scale();
@@ -127,12 +132,17 @@ private:
     App::DocumentObject *   part;
     App::DocumentObject *   page;
 
-    int     large[4];                       // arrays containing page size info [margin_x, margin_y, size_x, size_y] = [x1, y1, x2-x1, y2-y1]
-    int     small_h[4], small_v[4];         // page size avoiding title block, using maximum horizontal / vertical space
-    int *   page_dims;                      // points to one of above arrays for which set of page dimensions to use
-    int     block[4];                       // title block info [corner x, corner y, width, height], eg [-1, 1, w, h] is in top left corner
+    // arrays containing page size info [margin_x, margin_y, size_x, size_y] = [x1, y1, x2-x1, y2-y1]
+    int     large[4];
+    // page size avoiding title block, using maximum horizontal / vertical space
+    int     small_h[4], small_v[4];
+    // points to one of above arrays for which set of page dimensions to use
+    int *   page_dims;
+    // title block info [corner x, corner y, width, height], eg [-1, 1, w, h] is in top left corner
+    int     block[4];
     bool    title;
-    int *   horiz, * vert;                  // points to min or max r_x / r_y depending upon which corner title block is in
+    // points to min or max r_x / r_y depending upon which corner title block is in
+    int *   horiz, * vert;
 
     int     rotate_coeff;                   // 1st (= -1) or 3rd (= 1) angle
     int     min_r_x, max_r_x;               // extreme relative positions of views
@@ -142,7 +152,8 @@ private:
     float   gap_x, gap_y, min_space;        // required spacing between views
     float   offset_x, offset_y;             // coords of centre of upper left view
     float   scale;
-    int     num_gaps_x, num_gaps_y;         // how many gaps between views/edges? = num of views in given direction + 1
+    // how many gaps between views/edges? = num of views in given direction + 1
+    int     num_gaps_x, num_gaps_y;
     gp_Ax2  primary;                        // coord system of primary view
 
     bool    hidden, smooth;
@@ -195,7 +206,8 @@ private:
 
     float   data[5];                    // scale, x_pos, y_pos, horiz, vert
     int     axo_r_x, axo_r_y;           // relative position of axo view currently being edited
-    bool    txt_return;                 // flag to show if return was pressed while editing a text box;
+    // flag to show if return was pressed while editing a text box;
+    bool    txt_return;
 };
 
 
@@ -227,4 +239,3 @@ private:
 
 
 #endif // GUI_TASKVIEW_OrthoViews_H
-

--- a/src/Mod/Fem/App/AppFemPy.cpp
+++ b/src/Mod/Fem/App/AppFemPy.cpp
@@ -234,7 +234,8 @@ private:
             FemVTKTools::readResult(EncodedName.c_str(), obj);
         }
         else
-            FemVTKTools::readResult(EncodedName.c_str());  // assuming activeObject can hold Result
+            // assuming activeObject can hold Result
+            FemVTKTools::readResult(EncodedName.c_str());
 
         return Py::None();
     }

--- a/src/Mod/Fem/App/FemConstraint.cpp
+++ b/src/Mod/Fem/App/FemConstraint.cpp
@@ -74,7 +74,8 @@ Constraint::Constraint()
 {
     ADD_PROPERTY_TYPE(References, (nullptr, nullptr), "Constraint", (App::PropertyType)(App::Prop_None), "Elements where the constraint is applied");
     ADD_PROPERTY_TYPE(NormalDirection, (Base::Vector3d(0, 0, 1)), "Constraint", App::PropertyType(App::Prop_ReadOnly | App::Prop_Output), "Normal direction pointing outside of solid");
-    ADD_PROPERTY_TYPE(Scale, (1), "Base", App::PropertyType(App::Prop_Output), "Scale used for drawing constraints"); //OvG: Add scale parameter inherited by all derived constraints
+    //OvG: Add scale parameter inherited by all derived constraints
+    ADD_PROPERTY_TYPE(Scale, (1), "Base", App::PropertyType(App::Prop_Output), "Scale used for drawing constraints");
 
     References.setScope(App::LinkScope::Global);
 }
@@ -187,7 +188,8 @@ bool Constraint::getPoints(std::vector<Base::Vector3d> &points, std::vector<Base
             GProp_GProps props;
             BRepGProp::VolumeProperties(toposhape.getShape(), props);
             double lx = props.Mass();
-            *scale = this->calcDrawScaleFactor(sqrt(lx)*0.5); //OvG: setup draw scale for constraint
+            //OvG: setup draw scale for constraint
+            *scale = this->calcDrawScaleFactor(sqrt(lx)*0.5);
         }
         else if (sh.ShapeType() == TopAbs_EDGE) {
             BRepAdaptor_Curve curve(TopoDS::Edge(sh));
@@ -215,7 +217,8 @@ bool Constraint::getPoints(std::vector<Base::Vector3d> &points, std::vector<Base
                 *scale = this->calcDrawScaleFactor(); //OvG: setup draw scale for constraint
             }
 
-            steps = steps>CONSTRAINTSTEPLIMIT?CONSTRAINTSTEPLIMIT:steps; //OvG: Place upper limit on number of steps
+            //OvG: Place upper limit on number of steps
+            steps = steps>CONSTRAINTSTEPLIMIT?CONSTRAINTSTEPLIMIT:steps;
             double step = (lp - fp) / steps;
             for (int i = 0; i < steps + 1; i++) {
                 // Parameter values must be in the range [fp, lp] (#0003683)
@@ -304,7 +307,8 @@ bool Constraint::getPoints(std::vector<Base::Vector3d> &points, std::vector<Base
                 *scale = this->calcDrawScaleFactor(); //OvG: setup draw scale for constraint
             }
 
-            stepsv = stepsv>CONSTRAINTSTEPLIMIT?CONSTRAINTSTEPLIMIT:stepsv; //OvG: Place upper limit on number of steps
+            //OvG: Place upper limit on number of steps
+            stepsv = stepsv>CONSTRAINTSTEPLIMIT?CONSTRAINTSTEPLIMIT:stepsv;
             int stepsu;
             if (lu >= 30) //OvG: Increase 10 units distance proportionately to lu for larger objects.
             {
@@ -323,7 +327,8 @@ bool Constraint::getPoints(std::vector<Base::Vector3d> &points, std::vector<Base
                 *scale = this->calcDrawScaleFactor(); //OvG: setup draw scale for constraint
             }
 
-            stepsu = stepsu>CONSTRAINTSTEPLIMIT?CONSTRAINTSTEPLIMIT:stepsu; //OvG: Place upper limit on number of steps
+            //OvG: Place upper limit on number of steps
+            stepsu = stepsu>CONSTRAINTSTEPLIMIT?CONSTRAINTSTEPLIMIT:stepsu;
             double stepv = (vlp - vfp) / stepsv;
             double stepu = (ulp - ufp) / stepsu;
             // Create points and normals

--- a/src/Mod/Fem/App/FemConstraintFluidBoundary.cpp
+++ b/src/Mod/Fem/App/FemConstraintFluidBoundary.cpp
@@ -78,7 +78,8 @@ ConstraintFluidBoundary::ConstraintFluidBoundary()
     /// turbulence model setup for boundary
     ADD_PROPERTY_TYPE(TurbulenceSpecification,(1),"Turbulence",(App::PropertyType)(App::Prop_None),
                       "Method to specify burbulence magnitude on the boundary");
-    TurbulenceSpecification.setEnums(TurbulenceSpecifications); // Turbulence Specification Method
+    // Turbulence Specification Method
+    TurbulenceSpecification.setEnums(TurbulenceSpecifications);
     ADD_PROPERTY_TYPE(TurbulentIntensityValue,(0.0),"Turbulence",(App::PropertyType)(App::Prop_None),
                       "Scaler value for Turbulent intensity etc");
     ADD_PROPERTY_TYPE(TurbulentLengthValue,(0.0),"Turbulence",(App::PropertyType)(App::Prop_None),
@@ -99,7 +100,8 @@ ConstraintFluidBoundary::ConstraintFluidBoundary()
     Points.setValues(std::vector<Base::Vector3d>());
     ADD_PROPERTY_TYPE(DirectionVector,(Base::Vector3d(0,0,1)),"FluidBoundary",App::PropertyType(App::Prop_ReadOnly|App::Prop_Output),
                       "Direction of arrows");
-    naturalDirectionVector = Base::Vector3d(0,0,0); // by default use the null vector to indicate an invalid value
+    // by default use the null vector to indicate an invalid value
+    naturalDirectionVector = Base::Vector3d(0,0,0);
     // property from: FemConstraintFixed object
     ADD_PROPERTY_TYPE(Normals,(Base::Vector3d()),"FluidBoundary",App::PropertyType(App::Prop_ReadOnly|App::Prop_Output),
                       "Normals where symbols are drawn");

--- a/src/Mod/Fem/App/FemConstraintForce.cpp
+++ b/src/Mod/Fem/App/FemConstraintForce.cpp
@@ -44,7 +44,8 @@ ConstraintForce::ConstraintForce()
                       "Points where arrows are drawn");
     ADD_PROPERTY_TYPE(DirectionVector,(Base::Vector3d(0,0,1)),"ConstraintForce",App::PropertyType(App::Prop_ReadOnly|App::Prop_Output),
                       "Direction of arrows");
-    naturalDirectionVector = Base::Vector3d(0,0,0); // by default use the null vector to indicate an invalid value
+    // by default use the null vector to indicate an invalid value
+    naturalDirectionVector = Base::Vector3d(0,0,0);
     Points.setValues(std::vector<Base::Vector3d>());
 }
 
@@ -64,7 +65,8 @@ void ConstraintForce::onChanged(const App::Property* prop)
         std::vector<Base::Vector3d> normals;
         int scale = 1; //OvG: Enforce use of scale
         if (getPoints(points, normals, &scale)) {
-            Points.setValues(points); // We don't use the normals because all arrows should have the same direction
+            // We don't use the normals because all arrows should have the same direction
+            Points.setValues(points);
             Scale.setValue(scale); //OvG Scale
             Points.touch();
         }

--- a/src/Mod/Fem/App/FemMesh.cpp
+++ b/src/Mod/Fem/App/FemMesh.cpp
@@ -1109,7 +1109,8 @@ std::set<int> FemMesh::getEdgesOnly() const
             std::set_intersection(aFaceNodes.begin(), aFaceNodes.end(),
                                   aEdgeNodes.begin(), aEdgeNodes.end(),
                                   std::back_inserter(inodes));
-            std::set<int> intersection_nodes(inodes.begin(), inodes.end());  // convert vector to set
+            // convert vector to set
+            std::set<int> intersection_nodes(inodes.begin(), inodes.end());
             if (aEdgeNodes == intersection_nodes) {
                 edgeBelongsToAFace = true;
                 break;
@@ -1168,7 +1169,8 @@ std::set<int> FemMesh::getFacesOnly() const
             std::set_intersection(aVolNodes.begin(), aVolNodes.end(),
                                   aFaceNodes.begin(), aFaceNodes.end(),
                                   std::back_inserter(inodes));
-            std::set<int> intersection_nodes(inodes.begin(), inodes.end());  // convert vector to set
+            // convert vector to set
+            std::set<int> intersection_nodes(inodes.begin(), inodes.end());
             if (aFaceNodes == intersection_nodes) {
                 faceBelongsToAVolume = true;
                 break;
@@ -1821,7 +1823,8 @@ void FemMesh::readAbaqus(const std::string &FileName)
         if (PyObject_TypeCheck(mesh.ptr(), &FemMeshPy::Type)) {
             FemMeshPy* fempy = static_cast<FemMeshPy*>(mesh.ptr());
             FemMesh* fem = fempy->getFemMeshPtr();
-            *this = *fem; // the deep copy should be avoided, a pointer swap method could be implemented
+            // the deep copy should be avoided, a pointer swap method could be implemented
+            *this = *fem;
                           // see https://forum.freecadweb.org/viewtopic.php?f=10&t=31999&start=10#p274241
         }
         else {
@@ -1857,7 +1860,8 @@ void FemMesh::readZ88(const std::string &FileName)
         if (PyObject_TypeCheck(mesh.ptr(), &FemMeshPy::Type)) {
             FemMeshPy* fempy = static_cast<FemMeshPy*>(mesh.ptr());
             FemMesh* fem = fempy->getFemMeshPtr();
-            *this = *fem; // the deep copy should be avoided, a pointer swap method could be implemented
+            // the deep copy should be avoided, a pointer swap method could be implemented
+            *this = *fem;
                           // see https://forum.freecadweb.org/viewtopic.php?f=10&t=31999&start=10#p274241
         }
         else {
@@ -2816,4 +2820,3 @@ bool FemMesh::removeGroup(int GroupId)
 {
     return this->getSMesh()->RemoveGroup(GroupId);
 }
-

--- a/src/Mod/Fem/App/FemVTKTools.cpp
+++ b/src/Mod/Fem/App/FemVTKTools.cpp
@@ -783,11 +783,14 @@ std::map<std::string, std::string> _getFreeCADMechResultScalarProperties() {
     // but there are needed anyway because the pipeline in FreeCAD needs the principal stress values
     // https://forum.freecadweb.org/viewtopic.php?f=18&t=33106&p=416006#p412800
     resFCScalProp["PrincipalMax"] =
-        "Major Principal Stress";// can be plotted in Paraview as THE MAJOR PRINCIPAL STRESS MAGNITUDE
+        // can be plotted in Paraview as THE MAJOR PRINCIPAL STRESS MAGNITUDE
+        "Major Principal Stress";
     resFCScalProp["PrincipalMed"] =
-        "Intermediate Principal Stress";// can be plotted in Paraview as THE INTERMEDIATE PRINCIPAL STRESS MAGNITUDE
+        // can be plotted in Paraview as THE INTERMEDIATE PRINCIPAL STRESS MAGNITUDE
+        "Intermediate Principal Stress";
     resFCScalProp["PrincipalMin"] =
-        "Minor Principal Stress";// can be plotted in Paraview as THE MINOR PRINCIPAL STRESS MAGNITUDE
+        // can be plotted in Paraview as THE MINOR PRINCIPAL STRESS MAGNITUDE
+        "Minor Principal Stress";
     resFCScalProp["vonMises"] = "von Mises Stress";
     resFCScalProp["Temperature"] = "Temperature";
     resFCScalProp["MohrCoulomb"] = "MohrCoulomb";
@@ -935,7 +938,8 @@ void FemVTKTools::exportFreeCADResult(const App::DocumentObject* result,
     // vectors
     for (std::map<std::string, std::string>::iterator it = vectors.begin(); it != vectors.end();
          ++it) {
-        const int dim = 3;//Fixme, detect dim, but FreeCAD PropertyVectorList ATM only has DIM of 3
+        //Fixme, detect dim, but FreeCAD PropertyVectorList ATM only has DIM of 3
+        const int dim = 3;
         App::PropertyVectorList* field = nullptr;
         if (res->getPropertyByName(it->first.c_str()))
             field =

--- a/src/Mod/Fem/Gui/Command.cpp
+++ b/src/Mod/Fem/Gui/Command.cpp
@@ -313,7 +313,8 @@ void CmdFemConstraintBearing::activated(int)
               Analysis->getNameInDocument(),
               FeatName.c_str());
 
-    doCommand(Doc, "%s", gethideMeshShowPartStr(FeatName).c_str());//OvG: Hide meshes and show parts
+    //OvG: Hide meshes and show parts
+    doCommand(Doc, "%s", gethideMeshShowPartStr(FeatName).c_str());
 
     updateActive();
 
@@ -360,13 +361,15 @@ void CmdFemConstraintContact::activated(int)
               "App.activeDocument().%s.Friction = 0.0",
               FeatName.c_str());//OvG: set default not equal to 0
     doCommand(
-        Doc, "App.activeDocument().%s.Scale = 1", FeatName.c_str());//OvG: set initial scale to 1
+        //OvG: set initial scale to 1
+        Doc, "App.activeDocument().%s.Scale = 1", FeatName.c_str());
     doCommand(Doc,
               "App.activeDocument().%s.addObject(App.activeDocument().%s)",
               Analysis->getNameInDocument(),
               FeatName.c_str());
 
-    doCommand(Doc, "%s", gethideMeshShowPartStr(FeatName).c_str());//OvG: Hide meshes and show parts
+    //OvG: Hide meshes and show parts
+    doCommand(Doc, "%s", gethideMeshShowPartStr(FeatName).c_str());
 
     updateActive();
 
@@ -409,13 +412,15 @@ void CmdFemConstraintDisplacement::activated(int)
               "App.activeDocument().addObject(\"Fem::ConstraintDisplacement\",\"%s\")",
               FeatName.c_str());
     doCommand(
-        Doc, "App.activeDocument().%s.Scale = 1", FeatName.c_str());//OvG: set initial scale to 1
+        //OvG: set initial scale to 1
+        Doc, "App.activeDocument().%s.Scale = 1", FeatName.c_str());
     doCommand(Doc,
               "App.activeDocument().%s.addObject(App.activeDocument().%s)",
               Analysis->getNameInDocument(),
               FeatName.c_str());
 
-    doCommand(Doc, "%s", gethideMeshShowPartStr(FeatName).c_str());//OvG: Hide meshes and show parts
+    //OvG: Hide meshes and show parts
+    doCommand(Doc, "%s", gethideMeshShowPartStr(FeatName).c_str());
 
     updateActive();
 
@@ -456,13 +461,15 @@ void CmdFemConstraintFixed::activated(int)
     doCommand(
         Doc, "App.activeDocument().addObject(\"Fem::ConstraintFixed\",\"%s\")", FeatName.c_str());
     doCommand(
-        Doc, "App.activeDocument().%s.Scale = 1", FeatName.c_str());//OvG: set initial scale to 1
+        //OvG: set initial scale to 1
+        Doc, "App.activeDocument().%s.Scale = 1", FeatName.c_str());
     doCommand(Doc,
               "App.activeDocument().%s.addObject(App.activeDocument().%s)",
               Analysis->getNameInDocument(),
               FeatName.c_str());
 
-    doCommand(Doc, "%s", gethideMeshShowPartStr(FeatName).c_str());//OvG: Hide meshes and show parts
+    //OvG: Hide meshes and show parts
+    doCommand(Doc, "%s", gethideMeshShowPartStr(FeatName).c_str());
 
     updateActive();
 
@@ -505,14 +512,16 @@ void CmdFemConstraintFluidBoundary::activated(int)
               "App.activeDocument().addObject(\"Fem::ConstraintFluidBoundary\",\"%s\")",
               FeatName.c_str());
     doCommand(
-        Doc, "App.activeDocument().%s.Scale = 1", FeatName.c_str());//OvG: set initial scale to 1
+        //OvG: set initial scale to 1
+        Doc, "App.activeDocument().%s.Scale = 1", FeatName.c_str());
     //BoundaryValue is already the default value, zero is acceptable
     doCommand(Doc,
               "App.activeDocument().%s.addObject(App.activeDocument().%s)",
               Analysis->getNameInDocument(),
               FeatName.c_str());
 
-    doCommand(Doc, "%s", gethideMeshShowPartStr(FeatName).c_str());//OvG: Hide meshes and show parts
+    //OvG: Hide meshes and show parts
+    doCommand(Doc, "%s", gethideMeshShowPartStr(FeatName).c_str());
     updateActive();
 
     doCommand(Gui, "Gui.activeDocument().setEdit('%s')", FeatName.c_str());
@@ -558,13 +567,15 @@ void CmdFemConstraintForce::activated(int)
               "App.activeDocument().%s.Reversed = False",
               FeatName.c_str());//OvG: set default to False
     doCommand(
-        Doc, "App.activeDocument().%s.Scale = 1", FeatName.c_str());//OvG: set initial scale to 1
+        //OvG: set initial scale to 1
+        Doc, "App.activeDocument().%s.Scale = 1", FeatName.c_str());
     doCommand(Doc,
               "App.activeDocument().%s.addObject(App.activeDocument().%s)",
               Analysis->getNameInDocument(),
               FeatName.c_str());
 
-    doCommand(Doc, "%s", gethideMeshShowPartStr(FeatName).c_str());//OvG: Hide meshes and show parts
+    //OvG: Hide meshes and show parts
+    doCommand(Doc, "%s", gethideMeshShowPartStr(FeatName).c_str());
 
     updateActive();
 
@@ -609,7 +620,8 @@ void CmdFemConstraintGear::activated(int)
               Analysis->getNameInDocument(),
               FeatName.c_str());
 
-    doCommand(Doc, "%s", gethideMeshShowPartStr(FeatName).c_str());//OvG: Hide meshes and show parts
+    //OvG: Hide meshes and show parts
+    doCommand(Doc, "%s", gethideMeshShowPartStr(FeatName).c_str());
 
     updateActive();
 
@@ -657,13 +669,15 @@ void CmdFemConstraintHeatflux::activated(int)
               "App.activeDocument().%s.FilmCoef = 10.0",
               FeatName.c_str());//OvG: set default not equal to 0
     doCommand(
-        Doc, "App.activeDocument().%s.Scale = 1", FeatName.c_str());//OvG: set initial scale to 1
+        //OvG: set initial scale to 1
+        Doc, "App.activeDocument().%s.Scale = 1", FeatName.c_str());
     doCommand(Doc,
               "App.activeDocument().%s.addObject(App.activeDocument().%s)",
               Analysis->getNameInDocument(),
               FeatName.c_str());
 
-    doCommand(Doc, "%s", gethideMeshShowPartStr().c_str());//OvG: Hide meshes and show parts
+    //OvG: Hide meshes and show parts
+    doCommand(Doc, "%s", gethideMeshShowPartStr().c_str());
 
     updateActive();
 
@@ -705,13 +719,15 @@ void CmdFemConstraintInitialTemperature::activated(int)
               "App.activeDocument().addObject(\"Fem::ConstraintInitialTemperature\",\"%s\")",
               FeatName.c_str());
     doCommand(
-        Doc, "App.activeDocument().%s.Scale = 1", FeatName.c_str());//OvG: set initial scale to 1
+        //OvG: set initial scale to 1
+        Doc, "App.activeDocument().%s.Scale = 1", FeatName.c_str());
     doCommand(Doc,
               "App.activeDocument().%s.addObject(App.activeDocument().%s)",
               Analysis->getNameInDocument(),
               FeatName.c_str());
 
-    doCommand(Doc, "%s", gethideMeshShowPartStr().c_str());//OvG: Hide meshes and show parts
+    //OvG: Hide meshes and show parts
+    doCommand(Doc, "%s", gethideMeshShowPartStr().c_str());
 
     updateActive();
 
@@ -753,13 +769,15 @@ void CmdFemConstraintPlaneRotation::activated(int)
               "App.activeDocument().addObject(\"Fem::ConstraintPlaneRotation\",\"%s\")",
               FeatName.c_str());
     doCommand(
-        Doc, "App.activeDocument().%s.Scale = 1", FeatName.c_str());//OvG: set initial scale to 1
+        //OvG: set initial scale to 1
+        Doc, "App.activeDocument().%s.Scale = 1", FeatName.c_str());
     doCommand(Doc,
               "App.activeDocument().%s.addObject(App.activeDocument().%s)",
               Analysis->getNameInDocument(),
               FeatName.c_str());
 
-    doCommand(Doc, "%s", gethideMeshShowPartStr(FeatName).c_str());//OvG: Hide meshes and show parts
+    //OvG: Hide meshes and show parts
+    doCommand(Doc, "%s", gethideMeshShowPartStr(FeatName).c_str());
 
     updateActive();
 
@@ -807,13 +825,15 @@ void CmdFemConstraintPressure::activated(int)
               "App.activeDocument().%s.Reversed = False",
               FeatName.c_str());//OvG: set default to False
     doCommand(
-        Doc, "App.activeDocument().%s.Scale = 1", FeatName.c_str());//OvG: set initial scale to 1
+        //OvG: set initial scale to 1
+        Doc, "App.activeDocument().%s.Scale = 1", FeatName.c_str());
     doCommand(Doc,
               "App.activeDocument().%s.addObject(App.activeDocument().%s)",
               Analysis->getNameInDocument(),
               FeatName.c_str());
 
-    doCommand(Doc, "%s", gethideMeshShowPartStr(FeatName).c_str());//OvG: Hide meshes and show parts
+    //OvG: Hide meshes and show parts
+    doCommand(Doc, "%s", gethideMeshShowPartStr(FeatName).c_str());
 
     updateActive();
 
@@ -860,13 +880,15 @@ void CmdFemConstraintSpring::activated(int)
               "App.activeDocument().%s.tangentialStiffness = 0.0",
               FeatName.c_str());//OvG: set default to False
     doCommand(
-        Doc, "App.activeDocument().%s.Scale = 1", FeatName.c_str());//OvG: set initial scale to 1
+        //OvG: set initial scale to 1
+        Doc, "App.activeDocument().%s.Scale = 1", FeatName.c_str());
     doCommand(Doc,
               "App.activeDocument().%s.addObject(App.activeDocument().%s)",
               Analysis->getNameInDocument(),
               FeatName.c_str());
 
-    doCommand(Doc, "%s", gethideMeshShowPartStr(FeatName).c_str());//OvG: Hide meshes and show parts
+    //OvG: Hide meshes and show parts
+    doCommand(Doc, "%s", gethideMeshShowPartStr(FeatName).c_str());
 
     updateActive();
 
@@ -916,7 +938,8 @@ void CmdFemConstraintPulley::activated(int)
               Analysis->getNameInDocument(),
               FeatName.c_str());
 
-    doCommand(Doc, "%s", gethideMeshShowPartStr(FeatName).c_str());//OvG: Hide meshes and show parts
+    //OvG: Hide meshes and show parts
+    doCommand(Doc, "%s", gethideMeshShowPartStr(FeatName).c_str());
 
     updateActive();
 
@@ -959,13 +982,15 @@ void CmdFemConstraintTemperature::activated(int)
               "App.activeDocument().addObject(\"Fem::ConstraintTemperature\",\"%s\")",
               FeatName.c_str());
     doCommand(
-        Doc, "App.activeDocument().%s.Scale = 1", FeatName.c_str());//OvG: set initial scale to 1
+        //OvG: set initial scale to 1
+        Doc, "App.activeDocument().%s.Scale = 1", FeatName.c_str());
     doCommand(Doc,
               "App.activeDocument().%s.addObject(App.activeDocument().%s)",
               Analysis->getNameInDocument(),
               FeatName.c_str());
 
-    doCommand(Doc, "%s", gethideMeshShowPartStr().c_str());//OvG: Hide meshes and show parts
+    //OvG: Hide meshes and show parts
+    doCommand(Doc, "%s", gethideMeshShowPartStr().c_str());
 
     updateActive();
 
@@ -1015,7 +1040,8 @@ void CmdFemConstraintTransform::activated(int)
               Analysis->getNameInDocument(),
               FeatName.c_str());
 
-    doCommand(Doc, "%s", gethideMeshShowPartStr(FeatName).c_str());//OvG: Hide meshes and show parts
+    //OvG: Hide meshes and show parts
+    doCommand(Doc, "%s", gethideMeshShowPartStr(FeatName).c_str());
 
     updateActive();
 

--- a/src/Mod/Fem/Gui/TaskFemConstraint.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraint.cpp
@@ -171,7 +171,8 @@ void TaskFemConstraint::onButtonWizOk()
     for (int b = 0; b < buttons->count(); b++)
         buttons->itemAt(b)->widget()->show();
 
-    Gui::Application::Instance->activeDocument()->resetEdit(); // Reaches ViewProviderFemConstraint::unsetEdit() eventually
+    // Reaches ViewProviderFemConstraint::unsetEdit() eventually
+    Gui::Application::Instance->activeDocument()->resetEdit();
 }
 
 void TaskFemConstraint::onButtonWizCancel()
@@ -241,7 +242,8 @@ bool TaskFemConstraint::KeyEvent(QEvent *e)
 void TaskDlgFemConstraint::open()
 {
     ConstraintView->setVisible(true);
-    Gui::Command::runCommand(Gui::Command::Doc,ViewProviderFemConstraint::gethideMeshShowPartStr((static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument()).c_str()); //OvG: Hide meshes and show parts
+    //OvG: Hide meshes and show parts
+    Gui::Command::runCommand(Gui::Command::Doc,ViewProviderFemConstraint::gethideMeshShowPartStr((static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument()).c_str());
 }
 
 bool TaskDlgFemConstraint::accept()

--- a/src/Mod/Fem/Gui/TaskFemConstraintContact.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintContact.cpp
@@ -137,7 +137,8 @@ void TaskFemConstraintContact::updateUI()
 void TaskFemConstraintContact::addToSelectionSlave()
 {
     int rows = ui->lw_referencesSlave->model()->rowCount();
-    std::vector<Gui::SelectionObject> selection = Gui::Selection().getSelectionEx();//gets vector of selected objects of active document
+    //gets vector of selected objects of active document
+    std::vector<Gui::SelectionObject> selection = Gui::Selection().getSelectionEx();
     if (rows == 1){
         QMessageBox::warning(this, tr("Selection error"), tr("Only one master face and one slave face for a contact constraint!"));
         Gui::Selection().clearSelection();
@@ -198,7 +199,8 @@ void TaskFemConstraintContact::addToSelectionSlave()
 
 void TaskFemConstraintContact::removeFromSelectionSlave()
 {
-    std::vector<Gui::SelectionObject> selection = Gui::Selection().getSelectionEx(); //gets vector of selected objects of active document
+    //gets vector of selected objects of active document
+    std::vector<Gui::SelectionObject> selection = Gui::Selection().getSelectionEx();
     if (selection.empty()){
         QMessageBox::warning(this, tr("Selection error"), tr("Nothing selected!"));
         return;
@@ -244,7 +246,8 @@ void TaskFemConstraintContact::removeFromSelectionSlave()
 void TaskFemConstraintContact::addToSelectionMaster()
 {
     int rows = ui->lw_referencesMaster->model()->rowCount();
-    std::vector<Gui::SelectionObject> selection = Gui::Selection().getSelectionEx();//gets vector of selected objects of active document
+    //gets vector of selected objects of active document
+    std::vector<Gui::SelectionObject> selection = Gui::Selection().getSelectionEx();
     if (rows == 1){
         QMessageBox::warning(this, tr("Selection error"), tr("Only one master face and one slave face for a contact constraint!"));
         Gui::Selection().clearSelection();
@@ -304,7 +307,8 @@ void TaskFemConstraintContact::addToSelectionMaster()
 
 void TaskFemConstraintContact::removeFromSelectionMaster()
 {
-    std::vector<Gui::SelectionObject> selection = Gui::Selection().getSelectionEx(); //gets vector of selected objects of active document
+    //gets vector of selected objects of active document
+    std::vector<Gui::SelectionObject> selection = Gui::Selection().getSelectionEx();
     if (selection.empty()){
         QMessageBox::warning(this, tr("Selection error"), tr("Nothing selected!"));
         return;
@@ -407,7 +411,8 @@ void TaskDlgFemConstraintContact::open()
         QString msg = QObject::tr("Constraint Contact");
         Gui::Command::openCommand((const char*)msg.toUtf8());
         ConstraintView->setVisible(true);
-        Gui::Command::runCommand(Gui::Command::Doc,ViewProviderFemConstraint::gethideMeshShowPartStr((static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument()).c_str()); //OvG: Hide meshes and show parts
+        //OvG: Hide meshes and show parts
+        Gui::Command::runCommand(Gui::Command::Doc,ViewProviderFemConstraint::gethideMeshShowPartStr((static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument()).c_str());
     }
 }
 
@@ -423,7 +428,8 @@ bool TaskDlgFemConstraintContact::accept()
         Gui::Command::doCommand(Gui::Command::Doc,"App.ActiveDocument.%s.Friction = %f",
             name.c_str(), parameterContact->get_Friction());
         std::string scale = parameterContact->getScale();  //OvG: determine modified scale
-        Gui::Command::doCommand(Gui::Command::Doc,"App.ActiveDocument.%s.Scale = %s", name.c_str(), scale.c_str()); //OvG: implement modified scale
+        //OvG: implement modified scale
+        Gui::Command::doCommand(Gui::Command::Doc,"App.ActiveDocument.%s.Scale = %s", name.c_str(), scale.c_str());
     }
     catch (const Base::Exception& e) {
         QMessageBox::warning(parameter, tr("Input error"), QString::fromLatin1(e.what()));

--- a/src/Mod/Fem/Gui/TaskFemConstraintDisplacement.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintDisplacement.cpp
@@ -375,7 +375,8 @@ void TaskFemConstraintDisplacement::rotfreez(int val) {
 
 void TaskFemConstraintDisplacement::addToSelection()
 {
-    std::vector<Gui::SelectionObject> selection = Gui::Selection().getSelectionEx(); //gets vector of selected objects of active document
+    //gets vector of selected objects of active document
+    std::vector<Gui::SelectionObject> selection = Gui::Selection().getSelectionEx();
     if (selection.empty()) {
         QMessageBox::warning(this, tr("Selection error"), tr("Nothing selected!"));
         return;
@@ -432,7 +433,8 @@ void TaskFemConstraintDisplacement::addToSelection()
 
 void TaskFemConstraintDisplacement::removeFromSelection()
 {
-    std::vector<Gui::SelectionObject> selection = Gui::Selection().getSelectionEx(); //gets vector of selected objects of active document
+    //gets vector of selected objects of active document
+    std::vector<Gui::SelectionObject> selection = Gui::Selection().getSelectionEx();
     if (selection.empty()) {
         QMessageBox::warning(this, tr("Selection error"), tr("Nothing selected!"));
         return;
@@ -479,7 +481,8 @@ void TaskFemConstraintDisplacement::removeFromSelection()
 }
 
 void TaskFemConstraintDisplacement::onReferenceDeleted() {
-    TaskFemConstraintDisplacement::removeFromSelection(); //OvG: On right-click face is automatically selected, so just remove
+    //OvG: On right-click face is automatically selected, so just remove
+    TaskFemConstraintDisplacement::removeFromSelection();
 }
 
 const std::string TaskFemConstraintDisplacement::getReferences() const
@@ -557,7 +560,8 @@ void TaskDlgFemConstraintDisplacement::open()
         QString msg = QObject::tr("Constraint displacement");
         Gui::Command::openCommand((const char*)msg.toUtf8());
         ConstraintView->setVisible(true);
-        Gui::Command::doCommand(Gui::Command::Doc, ViewProviderFemConstraint::gethideMeshShowPartStr((static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument()).c_str()); //OvG: Hide meshes and show parts
+        //OvG: Hide meshes and show parts
+        Gui::Command::doCommand(Gui::Command::Doc, ViewProviderFemConstraint::gethideMeshShowPartStr((static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument()).c_str());
     }
 }
 
@@ -605,7 +609,8 @@ bool TaskDlgFemConstraintDisplacement::accept()
             name.c_str(), parameterDisplacement->get_rotzfix() ? "True" : "False");
 
         std::string scale = parameterDisplacement->getScale();  //OvG: determine modified scale
-        Gui::Command::doCommand(Gui::Command::Doc, "App.ActiveDocument.%s.Scale = %s", name.c_str(), scale.c_str()); //OvG: implement modified scale
+        //OvG: implement modified scale
+        Gui::Command::doCommand(Gui::Command::Doc, "App.ActiveDocument.%s.Scale = %s", name.c_str(), scale.c_str());
     }
     catch (const Base::Exception& e) {
         QMessageBox::warning(parameter, tr("Input error"), QString::fromLatin1(e.what()));

--- a/src/Mod/Fem/Gui/TaskFemConstraintFixed.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintFixed.cpp
@@ -102,7 +102,8 @@ void TaskFemConstraintFixed::updateUI()
 
 void TaskFemConstraintFixed::addToSelection()
 {
-    std::vector<Gui::SelectionObject> selection = Gui::Selection().getSelectionEx(); //gets vector of selected objects of active document
+    //gets vector of selected objects of active document
+    std::vector<Gui::SelectionObject> selection = Gui::Selection().getSelectionEx();
     if (selection.empty()) {
         QMessageBox::warning(this, tr("Selection error"), tr("Nothing selected!"));
         return;
@@ -159,7 +160,8 @@ void TaskFemConstraintFixed::addToSelection()
 
 void TaskFemConstraintFixed::removeFromSelection()
 {
-    std::vector<Gui::SelectionObject> selection = Gui::Selection().getSelectionEx(); //gets vector of selected objects of active document
+    //gets vector of selected objects of active document
+    std::vector<Gui::SelectionObject> selection = Gui::Selection().getSelectionEx();
     if (selection.empty()) {
         QMessageBox::warning(this, tr("Selection error"), tr("Nothing selected!"));
         return;
@@ -258,7 +260,8 @@ void TaskDlgFemConstraintFixed::open()
         QString msg = QObject::tr("Constraint fixed");
         Gui::Command::openCommand((const char*)msg.toUtf8());
         ConstraintView->setVisible(true);
-        Gui::Command::doCommand(Gui::Command::Doc, ViewProviderFemConstraint::gethideMeshShowPartStr((static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument()).c_str()); //OvG: Hide meshes and show parts
+        //OvG: Hide meshes and show parts
+        Gui::Command::doCommand(Gui::Command::Doc, ViewProviderFemConstraint::gethideMeshShowPartStr((static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument()).c_str());
     }
 }
 
@@ -267,7 +270,8 @@ bool TaskDlgFemConstraintFixed::accept()
     std::string name = ConstraintView->getObject()->getNameInDocument();
     const TaskFemConstraintFixed* parameters = static_cast<const TaskFemConstraintFixed*>(parameter);
     std::string scale = parameters->getScale();  //OvG: determine modified scale
-    Gui::Command::doCommand(Gui::Command::Doc, "App.ActiveDocument.%s.Scale = %s", name.c_str(), scale.c_str()); //OvG: implement modified scale
+    //OvG: implement modified scale
+    Gui::Command::doCommand(Gui::Command::Doc, "App.ActiveDocument.%s.Scale = %s", name.c_str(), scale.c_str());
     return TaskDlgFemConstraint::accept();
 }
 

--- a/src/Mod/Fem/Gui/TaskFemConstraintFluidBoundary.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintFluidBoundary.cpp
@@ -211,7 +211,8 @@ TaskFemConstraintFluidBoundary::TaskFemConstraintFluidBoundary(ViewProviderFemCo
                 else if (shapeType == TopAbs_EDGE || shapeType == TopAbs_WIRE)
                     dimension = 1;
                 else
-                    dimension = -1;  // Vertex (0D) can not make mesh, Compound type might contain any types
+                    // Vertex (0D) can not make mesh, Compound type might contain any types
+                    dimension = -1;
             }
         }
     }
@@ -293,7 +294,8 @@ TaskFemConstraintFluidBoundary::TaskFemConstraintFluidBoundary(ViewProviderFemCo
 
     // Fill data into dialog elements
     double f = pcConstraint->BoundaryValue.getValue();
-    ui->spinBoundaryValue->setMinimum(FLOAT_MIN);  // previous set the min to ZERO is not flexible
+    // previous set the min to ZERO is not flexible
+    ui->spinBoundaryValue->setMinimum(FLOAT_MIN);
     ui->spinBoundaryValue->setMaximum(FLOAT_MAX);
     ui->spinBoundaryValue->setValue(f);
     ui->listReferences->clear();
@@ -343,7 +345,8 @@ void TaskFemConstraintFluidBoundary::updateBoundaryTypeUI()
     else if (boundaryType == "inlet") {
         ui->tabBasicBoundary->setEnabled(true);
         pcConstraint->Subtype.setEnums(InletSubtypes);
-        ui->labelBoundaryValue->setText(QString::fromUtf8("Pressure [Pa]")); // default to pressure
+        // default to pressure
+        ui->labelBoundaryValue->setText(QString::fromUtf8("Pressure [Pa]"));
         pcConstraint->Reversed.setValue(true); // inlet must point into volume
     }
     else if (boundaryType == "outlet") {
@@ -517,7 +520,8 @@ void TaskFemConstraintFluidBoundary::onBoundaryTypeChanged(void)
 
 void TaskFemConstraintFluidBoundary::onSubtypeChanged(void)
 {
-    updateSubtypeUI();  // todo: change color for different kind of subtype,  Fem::ConstraintFluidBoundary::onChanged() and viewProvider
+    // todo: change color for different kind of subtype,  Fem::ConstraintFluidBoundary::onChanged() and viewProvider
+    updateSubtypeUI();
 }
 
 void TaskFemConstraintFluidBoundary::onBoundaryValueChanged(double)
@@ -539,7 +543,8 @@ void TaskFemConstraintFluidBoundary::onThermalBoundaryTypeChanged(void)
 }
 
 void TaskFemConstraintFluidBoundary::onReferenceDeleted() {
-    TaskFemConstraintFluidBoundary::removeFromSelection(); //On right-click face is automatically selected, so just remove
+    //On right-click face is automatically selected, so just remove
+    TaskFemConstraintFluidBoundary::removeFromSelection();
 }
 
 void TaskFemConstraintFluidBoundary::onButtonDirection(const bool pressed)
@@ -726,7 +731,8 @@ TaskFemConstraintFluidBoundary::~TaskFemConstraintFluidBoundary()
 
 void TaskFemConstraintFluidBoundary::addToSelection()
 {
-    std::vector<Gui::SelectionObject> selection = Gui::Selection().getSelectionEx(); //gets vector of selected objects of active document
+    //gets vector of selected objects of active document
+    std::vector<Gui::SelectionObject> selection = Gui::Selection().getSelectionEx();
     if (selection.empty()) {
         QMessageBox::warning(this, tr("Selection error"), tr("Nothing selected!"));
         return;
@@ -784,7 +790,8 @@ void TaskFemConstraintFluidBoundary::addToSelection()
 
 void TaskFemConstraintFluidBoundary::removeFromSelection()
 {
-    std::vector<Gui::SelectionObject> selection = Gui::Selection().getSelectionEx(); //gets vector of selected objects of active document
+    //gets vector of selected objects of active document
+    std::vector<Gui::SelectionObject> selection = Gui::Selection().getSelectionEx();
     if (selection.empty()) {
         QMessageBox::warning(this, tr("Selection error"), tr("Nothing selected!"));
         return;
@@ -920,7 +927,8 @@ bool TaskDlgFemConstraintFluidBoundary::accept()
         //Gui::Command::doCommand(Gui::Command::Doc,"App.ActiveDocument.%s.Reversed = %s", name.c_str(), boundary->getReverse() ? "True" : "False");
 
         std::string scale = boundary->getScale();  //OvG: determine modified scale
-        Gui::Command::doCommand(Gui::Command::Doc, "App.ActiveDocument.%s.Scale = %s", name.c_str(), scale.c_str()); //OvG: implement modified scale
+        //OvG: implement modified scale
+        Gui::Command::doCommand(Gui::Command::Doc, "App.ActiveDocument.%s.Scale = %s", name.c_str(), scale.c_str());
 
         // solver specific setting, physical model selection
         const Fem::FemSolverObject* pcSolver = boundary->getFemSolver();

--- a/src/Mod/Fem/Gui/TaskFemConstraintForce.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintForce.cpp
@@ -123,7 +123,8 @@ void TaskFemConstraintForce::updateUI()
 
 void TaskFemConstraintForce::addToSelection()
 {
-    std::vector<Gui::SelectionObject> selection = Gui::Selection().getSelectionEx(); //gets vector of selected objects of active document
+    //gets vector of selected objects of active document
+    std::vector<Gui::SelectionObject> selection = Gui::Selection().getSelectionEx();
     if (selection.empty()) {
         QMessageBox::warning(this, tr("Selection error"), tr("Nothing selected!"));
         return;
@@ -181,7 +182,8 @@ void TaskFemConstraintForce::addToSelection()
 
 void TaskFemConstraintForce::removeFromSelection()
 {
-    std::vector<Gui::SelectionObject> selection = Gui::Selection().getSelectionEx(); //gets vector of selected objects of active document
+    //gets vector of selected objects of active document
+    std::vector<Gui::SelectionObject> selection = Gui::Selection().getSelectionEx();
     if (selection.empty()) {
         QMessageBox::warning(this, tr("Selection error"), tr("Nothing selected!"));
         return;
@@ -234,7 +236,8 @@ void TaskFemConstraintForce::onForceChanged(double f)
 }
 
 void TaskFemConstraintForce::onReferenceDeleted() {
-    TaskFemConstraintForce::removeFromSelection(); //OvG: On right-click face is automatically selected, so just remove
+    //OvG: On right-click face is automatically selected, so just remove
+    TaskFemConstraintForce::removeFromSelection();
 }
 
 std::pair<App::DocumentObject*, std::string>
@@ -413,7 +416,8 @@ void TaskDlgFemConstraintForce::open()
         QString msg = QObject::tr("Constraint force");
         Gui::Command::openCommand((const char*)msg.toUtf8());
         ConstraintView->setVisible(true);
-        Gui::Command::doCommand(Gui::Command::Doc, ViewProviderFemConstraint::gethideMeshShowPartStr((static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument()).c_str()); //OvG: Hide meshes and show parts
+        //OvG: Hide meshes and show parts
+        Gui::Command::doCommand(Gui::Command::Doc, ViewProviderFemConstraint::gethideMeshShowPartStr((static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument()).c_str());
     }
 }
 
@@ -453,7 +457,8 @@ bool TaskDlgFemConstraintForce::accept()
         Gui::Command::doCommand(Gui::Command::Doc, "App.ActiveDocument.%s.Reversed = %s", name.c_str(), parameterForce->getReverse() ? "True" : "False");
 
         scale = parameterForce->getScale();  //OvG: determine modified scale
-        Gui::Command::doCommand(Gui::Command::Doc, "App.ActiveDocument.%s.Scale = %s", name.c_str(), scale.c_str()); //OvG: implement modified scale
+        //OvG: implement modified scale
+        Gui::Command::doCommand(Gui::Command::Doc, "App.ActiveDocument.%s.Scale = %s", name.c_str(), scale.c_str());
     }
     catch (const Base::Exception& e) {
         QMessageBox::warning(parameter, tr("Input error"), QString::fromLatin1(e.what()));

--- a/src/Mod/Fem/Gui/TaskFemConstraintHeatflux.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintHeatflux.cpp
@@ -196,7 +196,8 @@ void TaskFemConstraintHeatflux::Flux()
 
 void TaskFemConstraintHeatflux::addToSelection()
 {
-    std::vector<Gui::SelectionObject> selection = Gui::Selection().getSelectionEx(); //gets vector of selected objects of active document
+    //gets vector of selected objects of active document
+    std::vector<Gui::SelectionObject> selection = Gui::Selection().getSelectionEx();
     if (selection.empty()) {
         QMessageBox::warning(this, tr("Selection error"), tr("Nothing selected!"));
         return;
@@ -249,7 +250,8 @@ void TaskFemConstraintHeatflux::addToSelection()
 
 void TaskFemConstraintHeatflux::removeFromSelection()
 {
-    std::vector<Gui::SelectionObject> selection = Gui::Selection().getSelectionEx(); //gets vector of selected objects of active document
+    //gets vector of selected objects of active document
+    std::vector<Gui::SelectionObject> selection = Gui::Selection().getSelectionEx();
     if (selection.empty()) {
         QMessageBox::warning(this, tr("Selection error"), tr("Nothing selected!"));
         return;
@@ -393,7 +395,8 @@ void TaskDlgFemConstraintHeatflux::open()
         QString msg = QObject::tr("Constraint heat flux");
         Gui::Command::openCommand((const char*)msg.toUtf8());
         ConstraintView->setVisible(true);
-        Gui::Command::doCommand(Gui::Command::Doc, ViewProviderFemConstraint::gethideMeshShowPartStr((static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument()).c_str()); //OvG: Hide meshes and show parts
+        //OvG: Hide meshes and show parts
+        Gui::Command::doCommand(Gui::Command::Doc, ViewProviderFemConstraint::gethideMeshShowPartStr((static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument()).c_str());
     }
 }
 

--- a/src/Mod/Fem/Gui/TaskFemConstraintInitialTemperature.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintInitialTemperature.cpp
@@ -101,7 +101,8 @@ void TaskDlgFemConstraintInitialTemperature::open()
         QString msg = QObject::tr("Constraint initial temperature");
         Gui::Command::openCommand((const char*)msg.toUtf8());
         ConstraintView->setVisible(true);
-        Gui::Command::doCommand(Gui::Command::Doc, ViewProviderFemConstraint::gethideMeshShowPartStr((static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument()).c_str()); //OvG: Hide meshes and show parts
+        //OvG: Hide meshes and show parts
+        Gui::Command::doCommand(Gui::Command::Doc, ViewProviderFemConstraint::gethideMeshShowPartStr((static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument()).c_str());
     }
 }
 
@@ -115,7 +116,8 @@ bool TaskDlgFemConstraintInitialTemperature::accept()
             name.c_str(), parameterTemperature->get_temperature());
 
         std::string scale = parameterTemperature->getScale();  //OvG: determine modified scale
-        Gui::Command::doCommand(Gui::Command::Doc, "App.ActiveDocument.%s.Scale = %s", name.c_str(), scale.c_str()); //OvG: implement modified scale
+        //OvG: implement modified scale
+        Gui::Command::doCommand(Gui::Command::Doc, "App.ActiveDocument.%s.Scale = %s", name.c_str(), scale.c_str());
     }
     catch (const Base::Exception& e) {
         QMessageBox::warning(parameter, tr("Input error"), QString::fromLatin1(e.what()));

--- a/src/Mod/Fem/Gui/TaskFemConstraintPlaneRotation.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintPlaneRotation.cpp
@@ -115,7 +115,8 @@ void TaskFemConstraintPlaneRotation::addToSelection()
         return;
     }
     else {
-        std::vector<Gui::SelectionObject> selection = Gui::Selection().getSelectionEx(); //gets vector of selected objects of active document
+        //gets vector of selected objects of active document
+        std::vector<Gui::SelectionObject> selection = Gui::Selection().getSelectionEx();
         if (selection.empty()) {
             QMessageBox::warning(this, tr("Selection error"), tr("Nothing selected!"));
             return;
@@ -176,7 +177,8 @@ void TaskFemConstraintPlaneRotation::addToSelection()
 
 void TaskFemConstraintPlaneRotation::removeFromSelection()
 {
-    std::vector<Gui::SelectionObject> selection = Gui::Selection().getSelectionEx(); //gets vector of selected objects of active document
+    //gets vector of selected objects of active document
+    std::vector<Gui::SelectionObject> selection = Gui::Selection().getSelectionEx();
     if (selection.empty()) {
         QMessageBox::warning(this, tr("Selection error"), tr("Nothing selected!"));
         return;
@@ -267,7 +269,8 @@ void TaskDlgFemConstraintPlaneRotation::open()
         QString msg = QObject::tr("Constraint planerotation");
         Gui::Command::openCommand((const char*)msg.toUtf8());
         ConstraintView->setVisible(true);
-        Gui::Command::doCommand(Gui::Command::Doc, ViewProviderFemConstraint::gethideMeshShowPartStr((static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument()).c_str()); //OvG: Hide meshes and show parts
+        //OvG: Hide meshes and show parts
+        Gui::Command::doCommand(Gui::Command::Doc, ViewProviderFemConstraint::gethideMeshShowPartStr((static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument()).c_str());
     }
 }
 
@@ -276,7 +279,8 @@ bool TaskDlgFemConstraintPlaneRotation::accept()
     std::string name = ConstraintView->getObject()->getNameInDocument();
     const TaskFemConstraintPlaneRotation* parameters = static_cast<const TaskFemConstraintPlaneRotation*>(parameter);
     std::string scale = parameters->getScale();  //OvG: determine modified scale
-    Gui::Command::doCommand(Gui::Command::Doc, "App.ActiveDocument.%s.Scale = %s", name.c_str(), scale.c_str()); //OvG: implement modified scale
+    //OvG: implement modified scale
+    Gui::Command::doCommand(Gui::Command::Doc, "App.ActiveDocument.%s.Scale = %s", name.c_str(), scale.c_str());
     return TaskDlgFemConstraint::accept();
 }
 

--- a/src/Mod/Fem/Gui/TaskFemConstraintPressure.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintPressure.cpp
@@ -117,7 +117,8 @@ void TaskFemConstraintPressure::onCheckReverse(const bool pressed)
 
 void TaskFemConstraintPressure::addToSelection()
 {
-    std::vector<Gui::SelectionObject> selection = Gui::Selection().getSelectionEx(); //gets vector of selected objects of active document
+    //gets vector of selected objects of active document
+    std::vector<Gui::SelectionObject> selection = Gui::Selection().getSelectionEx();
     if (selection.empty()) {
         QMessageBox::warning(this, tr("Selection error"), tr("Nothing selected!"));
         return;
@@ -163,7 +164,8 @@ void TaskFemConstraintPressure::addToSelection()
 
 void TaskFemConstraintPressure::removeFromSelection()
 {
-    std::vector<Gui::SelectionObject> selection = Gui::Selection().getSelectionEx(); //gets vector of selected objects of active document
+    //gets vector of selected objects of active document
+    std::vector<Gui::SelectionObject> selection = Gui::Selection().getSelectionEx();
     if (selection.empty()) {
         QMessageBox::warning(this, tr("Selection error"), tr("Nothing selected!"));
         return;
@@ -275,7 +277,8 @@ void TaskDlgFemConstraintPressure::open()
         QString msg = QObject::tr("Constraint pressure");
         Gui::Command::openCommand((const char*)msg.toUtf8());
         ConstraintView->setVisible(true);
-        Gui::Command::doCommand(Gui::Command::Doc, ViewProviderFemConstraint::gethideMeshShowPartStr((static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument()).c_str()); //OvG: Hide meshes and show parts
+        //OvG: Hide meshes and show parts
+        Gui::Command::doCommand(Gui::Command::Doc, ViewProviderFemConstraint::gethideMeshShowPartStr((static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument()).c_str());
     }
 }
 
@@ -291,7 +294,8 @@ bool TaskDlgFemConstraintPressure::accept()
         Gui::Command::doCommand(Gui::Command::Doc, "App.ActiveDocument.%s.Reversed = %s",
             name.c_str(), parameterPressure->get_Reverse() ? "True" : "False");
         std::string scale = parameterPressure->getScale();  //OvG: determine modified scale
-        Gui::Command::doCommand(Gui::Command::Doc, "App.ActiveDocument.%s.Scale = %s", name.c_str(), scale.c_str()); //OvG: implement modified scale
+        //OvG: implement modified scale
+        Gui::Command::doCommand(Gui::Command::Doc, "App.ActiveDocument.%s.Scale = %s", name.c_str(), scale.c_str());
     }
     catch (const Base::Exception& e) {
         QMessageBox::warning(parameter, tr("Input error"), QString::fromLatin1(e.what()));

--- a/src/Mod/Fem/Gui/TaskFemConstraintPulley.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintPulley.cpp
@@ -186,7 +186,8 @@ void TaskDlgFemConstraintPulley::open()
         QString msg = QObject::tr("Constraint pulley");
         Gui::Command::openCommand((const char*)msg.toUtf8());
         ConstraintView->setVisible(true);
-        Gui::Command::doCommand(Gui::Command::Doc, ViewProviderFemConstraint::gethideMeshShowPartStr((static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument()).c_str()); //OvG: Hide meshes and show parts
+        //OvG: Hide meshes and show parts
+        Gui::Command::doCommand(Gui::Command::Doc, ViewProviderFemConstraint::gethideMeshShowPartStr((static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument()).c_str());
     }
 }
 

--- a/src/Mod/Fem/Gui/TaskFemConstraintSpring.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintSpring.cpp
@@ -69,13 +69,15 @@ TaskFemConstraintSpring::TaskFemConstraintSpring(ViewProviderFemConstraintSpring
     std::vector<std::string> SubElements = pcConstraint->References.getSubValues();
 
     // Fill data into dialog elements
-    ui->if_norm->setMinimum(0); // TODO fix this -------------------------------------------------------------------
+    // TODO fix this -------------------------------------------------------------------
+    ui->if_norm->setMinimum(0);
     ui->if_norm->setMaximum(FLOAT_MAX);
     Base::Quantity ns = Base::Quantity((pcConstraint->normalStiffness.getValue()), Base::Unit::Stiffness);
     ui->if_norm->setValue(ns);
 
     // Fill data into dialog elements
-    ui->if_tan->setMinimum(0); // TODO fix this -------------------------------------------------------------------
+    // TODO fix this -------------------------------------------------------------------
+    ui->if_tan->setMinimum(0);
     ui->if_tan->setMaximum(FLOAT_MAX);
     Base::Quantity ts = Base::Quantity((pcConstraint->tangentialStiffness.getValue()), Base::Unit::Stiffness);
     ui->if_tan->setValue(ts);
@@ -114,7 +116,8 @@ void TaskFemConstraintSpring::updateUI()
 
 void TaskFemConstraintSpring::addToSelection()
 {
-    std::vector<Gui::SelectionObject> selection = Gui::Selection().getSelectionEx(); //gets vector of selected objects of active document
+    //gets vector of selected objects of active document
+    std::vector<Gui::SelectionObject> selection = Gui::Selection().getSelectionEx();
     if (selection.empty()) {
         QMessageBox::warning(this, tr("Selection error"), tr("Nothing selected!"));
         return;
@@ -160,7 +163,8 @@ void TaskFemConstraintSpring::addToSelection()
 
 void TaskFemConstraintSpring::removeFromSelection()
 {
-    std::vector<Gui::SelectionObject> selection = Gui::Selection().getSelectionEx(); //gets vector of selected objects of active document
+    //gets vector of selected objects of active document
+    std::vector<Gui::SelectionObject> selection = Gui::Selection().getSelectionEx();
     if (selection.empty()) {
         QMessageBox::warning(this, tr("Selection error"), tr("Nothing selected!"));
         return;
@@ -275,7 +279,8 @@ void TaskDlgFemConstraintSpring::open()
         QString msg = QObject::tr("Constraint spring");
         Gui::Command::openCommand((const char*)msg.toUtf8());
         ConstraintView->setVisible(true);
-        Gui::Command::doCommand(Gui::Command::Doc, ViewProviderFemConstraint::gethideMeshShowPartStr((static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument()).c_str()); //OvG: Hide meshes and show parts
+        //OvG: Hide meshes and show parts
+        Gui::Command::doCommand(Gui::Command::Doc, ViewProviderFemConstraint::gethideMeshShowPartStr((static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument()).c_str());
     }
 }
 
@@ -292,7 +297,8 @@ bool TaskDlgFemConstraintSpring::accept()
         Gui::Command::doCommand(Gui::Command::Doc, "App.ActiveDocument.%s.tangentialStiffness = %f",
             name.c_str(), parameterStiffness->get_tangentialStiffness());
         std::string scale = parameterStiffness->getScale();  //OvG: determine modified scale
-        Gui::Command::doCommand(Gui::Command::Doc, "App.ActiveDocument.%s.Scale = %s", name.c_str(), scale.c_str()); //OvG: implement modified scale
+        //OvG: implement modified scale
+        Gui::Command::doCommand(Gui::Command::Doc, "App.ActiveDocument.%s.Scale = %s", name.c_str(), scale.c_str());
     }
     catch (const Base::Exception& e) {
         QMessageBox::warning(parameter, tr("Input error"), QString::fromLatin1(e.what()));

--- a/src/Mod/Fem/Gui/TaskFemConstraintTemperature.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintTemperature.cpp
@@ -168,7 +168,8 @@ void TaskFemConstraintTemperature::Flux()
 
 void TaskFemConstraintTemperature::addToSelection()
 {
-    std::vector<Gui::SelectionObject> selection = Gui::Selection().getSelectionEx(); //gets vector of selected objects of active document
+    //gets vector of selected objects of active document
+    std::vector<Gui::SelectionObject> selection = Gui::Selection().getSelectionEx();
     if (selection.empty()) {
         QMessageBox::warning(this, tr("Selection error"), tr("Nothing selected!"));
         return;
@@ -209,7 +210,8 @@ void TaskFemConstraintTemperature::addToSelection()
 
 void TaskFemConstraintTemperature::removeFromSelection()
 {
-    std::vector<Gui::SelectionObject> selection = Gui::Selection().getSelectionEx(); //gets vector of selected objects of active document
+    //gets vector of selected objects of active document
+    std::vector<Gui::SelectionObject> selection = Gui::Selection().getSelectionEx();
     if (selection.empty()) {
         QMessageBox::warning(this, tr("Selection error"), tr("Nothing selected!"));
         return;
@@ -337,7 +339,8 @@ void TaskDlgFemConstraintTemperature::open()
         QString msg = QObject::tr("Constraint temperature");
         Gui::Command::openCommand((const char*)msg.toUtf8());
         ConstraintView->setVisible(true);
-        Gui::Command::doCommand(Gui::Command::Doc, ViewProviderFemConstraint::gethideMeshShowPartStr((static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument()).c_str()); //OvG: Hide meshes and show parts
+        //OvG: Hide meshes and show parts
+        Gui::Command::doCommand(Gui::Command::Doc, ViewProviderFemConstraint::gethideMeshShowPartStr((static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument()).c_str());
     }
 }
 
@@ -348,7 +351,8 @@ bool TaskDlgFemConstraintTemperature::accept()
 
     try {
         std::string scale = parameterTemperature->getScale();  //OvG: determine modified scale
-        Gui::Command::doCommand(Gui::Command::Doc, "App.ActiveDocument.%s.Scale = %s", name.c_str(), scale.c_str()); //OvG: implement modified scale
+        //OvG: implement modified scale
+        Gui::Command::doCommand(Gui::Command::Doc, "App.ActiveDocument.%s.Scale = %s", name.c_str(), scale.c_str());
     }
     catch (const Base::Exception& e) {
         QMessageBox::warning(parameter, tr("Input error"), QString::fromLatin1(e.what()));

--- a/src/Mod/Fem/Gui/TaskFemConstraintTransform.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintTransform.cpp
@@ -229,7 +229,8 @@ void TaskFemConstraintTransform::Cyl() {
 void TaskFemConstraintTransform::addToSelection()
 {
     int rows = ui->lw_Rect->model()->rowCount();
-    std::vector<Gui::SelectionObject> selection = Gui::Selection().getSelectionEx(); //gets vector of selected objects of active document
+    //gets vector of selected objects of active document
+    std::vector<Gui::SelectionObject> selection = Gui::Selection().getSelectionEx();
     if (selection.empty()) {
         QMessageBox::warning(this, tr("Selection error"), tr("Nothing selected!"));
         return;
@@ -349,7 +350,8 @@ void TaskFemConstraintTransform::addToSelection()
 
 void TaskFemConstraintTransform::removeFromSelection()
 {
-    std::vector<Gui::SelectionObject> selection = Gui::Selection().getSelectionEx(); //gets vector of selected objects of active document
+    //gets vector of selected objects of active document
+    std::vector<Gui::SelectionObject> selection = Gui::Selection().getSelectionEx();
     if (selection.empty()) {
         QMessageBox::warning(this, tr("Selection error"), tr("Nothing selected!"));
         return;
@@ -490,7 +492,8 @@ void TaskDlgFemConstraintTransform::open()
         QString msg = QObject::tr("Constraint transform");
         Gui::Command::openCommand((const char*)msg.toUtf8());
         ConstraintView->setVisible(true);
-        Gui::Command::doCommand(Gui::Command::Doc, ViewProviderFemConstraint::gethideMeshShowPartStr((static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument()).c_str()); //OvG: Hide meshes and show parts
+        //OvG: Hide meshes and show parts
+        Gui::Command::doCommand(Gui::Command::Doc, ViewProviderFemConstraint::gethideMeshShowPartStr((static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument()).c_str());
     }
 }
 
@@ -510,7 +513,8 @@ bool TaskDlgFemConstraintTransform::accept()
         Gui::Command::doCommand(Gui::Command::Doc, "App.ActiveDocument.%s.TransformType = %s",
             name.c_str(), parameters->get_transform_type().c_str());
         std::string scale = parameters->getScale();  //OvG: determine modified scale
-        Gui::Command::doCommand(Gui::Command::Doc, "App.ActiveDocument.%s.Scale = %s", name.c_str(), scale.c_str()); //OvG: implement modified scale
+        //OvG: implement modified scale
+        Gui::Command::doCommand(Gui::Command::Doc, "App.ActiveDocument.%s.Scale = %s", name.c_str(), scale.c_str());
 
     }
     catch (const Base::Exception& e) {

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraint.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraint.cpp
@@ -548,7 +548,8 @@ void ViewProviderFemConstraint::checkForWizard()
     QScrollArea* sa = sw->findChild<QScrollArea*>();
     if (!sa)
         return;
-    QWidget* wd = sa->widget(); // This is the reason why we cannot use findChildByName() right away!!!
+    // This is the reason why we cannot use findChildByName() right away!!!
+    QWidget* wd = sa->widget();
     if (!wd)
         return;
     QObject* wiz = findChildByName(wd, QString::fromLatin1("ShaftWizard"));

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintContact.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintContact.cpp
@@ -100,7 +100,8 @@ void ViewProviderFemConstraintContact::updateData(const App::Property* prop)
 {
     // Gets called whenever a property of the attached object changes
     Fem::ConstraintContact* pcConstraint = static_cast<Fem::ConstraintContact*>(this->getObject());
-    float scaledlength = LENGTH * pcConstraint->Scale.getValue(); //OvG: Calculate scaled values once only
+    //OvG: Calculate scaled values once only
+    float scaledlength = LENGTH * pcConstraint->Scale.getValue();
     float scaledheight = HEIGHT * pcConstraint->Scale.getValue();
     float scaledwidth = WIDTH * pcConstraint->Scale.getValue();
 
@@ -137,7 +138,8 @@ void ViewProviderFemConstraintContact::updateData(const App::Property* prop)
             //define color of shape
             SoMaterial *myMaterial = new SoMaterial;
             myMaterial->diffuseColor.set1Value(0, SbColor(1, 1, 1));//RGB
-            //myMaterial->diffuseColor.set1Value(1,SbColor(0,0,1));//possible to adjust sides separately
+            //possible to adjust sides separately
+            //myMaterial->diffuseColor.set1Value(1,SbColor(0,0,1));
             sep->addChild(myMaterial);
 
             //draw a cube

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintDisplacement.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintDisplacement.cpp
@@ -98,7 +98,8 @@ void ViewProviderFemConstraintDisplacement::updateData(const App::Property* prop
     // Gets called whenever a property of the attached object changes
     Fem::ConstraintDisplacement *pcConstraint =
         static_cast<Fem::ConstraintDisplacement *>(this->getObject());
-    float scaledwidth = WIDTH * pcConstraint->Scale.getValue(); //OvG: Calculate scaled values once only
+    //OvG: Calculate scaled values once only
+    float scaledwidth = WIDTH * pcConstraint->Scale.getValue();
     float scaledheight = HEIGHT * pcConstraint->Scale.getValue();
     bool xFree = pcConstraint->xFree.getValue();
     bool yFree = pcConstraint->yFree.getValue();

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintFixed.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintFixed.cpp
@@ -110,7 +110,8 @@ void ViewProviderFemConstraintFixed::updateData(const App::Property* prop)
 {
     // Gets called whenever a property of the attached object changes
     Fem::ConstraintFixed *pcConstraint = static_cast<Fem::ConstraintFixed *>(this->getObject());
-    float scaledwidth = WIDTH * pcConstraint->Scale.getValue(); //OvG: Calculate scaled values once only
+    //OvG: Calculate scaled values once only
+    float scaledwidth = WIDTH * pcConstraint->Scale.getValue();
     float scaledheight = HEIGHT * pcConstraint->Scale.getValue();
 
 #ifdef USE_MULTIPLE_COPY

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintFluidBoundary.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintFluidBoundary.cpp
@@ -115,10 +115,12 @@ void ViewProviderFemConstraintFluidBoundary::updateData(const App::Property* pro
 {
     // Gets called whenever a property of the attached object changes
     Fem::ConstraintFluidBoundary* pcConstraint = static_cast<Fem::ConstraintFluidBoundary*>(this->getObject());
-    float scaledwidth = WIDTH * pcConstraint->Scale.getValue(); //OvG: Calculate scaled values once only
+    //OvG: Calculate scaled values once only
+    float scaledwidth = WIDTH * pcConstraint->Scale.getValue();
     float scaledheight = HEIGHT * pcConstraint->Scale.getValue();
 
-    float scaledheadradius = ARROWHEADRADIUS * pcConstraint->Scale.getValue(); //OvG: Calculate scaled values once only
+    //OvG: Calculate scaled values once only
+    float scaledheadradius = ARROWHEADRADIUS * pcConstraint->Scale.getValue();
     float scaledlength = ARROWLENGTH * pcConstraint->Scale.getValue();
 
     std::string boundaryType = pcConstraint->BoundaryType.getValueAsString();

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintForce.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintForce.cpp
@@ -112,7 +112,8 @@ void ViewProviderFemConstraintForce::updateData(const App::Property* prop)
 {
     // Gets called whenever a property of the attached object changes
     Fem::ConstraintForce* pcConstraint = static_cast<Fem::ConstraintForce*>(this->getObject());
-    float scaledheadradius = ARROWHEADRADIUS * pcConstraint->Scale.getValue(); //OvG: Calculate scaled values once only
+    //OvG: Calculate scaled values once only
+    float scaledheadradius = ARROWHEADRADIUS * pcConstraint->Scale.getValue();
     float scaledlength = ARROWLENGTH * pcConstraint->Scale.getValue();
 
 #ifdef USE_MULTIPLE_COPY

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintHeatflux.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintHeatflux.cpp
@@ -99,7 +99,8 @@ void ViewProviderFemConstraintHeatflux::updateData(const App::Property* prop)
 {
     // Gets called whenever a property of the attached object changes
     Fem::ConstraintHeatflux* pcConstraint = static_cast<Fem::ConstraintHeatflux*>(this->getObject());
-    float scaledradius = RADIUS * pcConstraint->Scale.getValue(); //OvG: Calculate scaled values once only
+    //OvG: Calculate scaled values once only
+    float scaledradius = RADIUS * pcConstraint->Scale.getValue();
     float scaledheight = HEIGHT * pcConstraint->Scale.getValue();
     //float ambienttemp = pcConstraint->AmbientTemp.getValue();
     // //float facetemp = pcConstraint->FaceTemp.getValue();
@@ -139,7 +140,8 @@ void ViewProviderFemConstraintHeatflux::updateData(const App::Property* prop)
             //define color of shape
             SoMaterial *myMaterial = new SoMaterial;
             myMaterial->diffuseColor.set1Value(0, SbColor(0.65f, 0.1f, 0.25f));//RGB
-            //myMaterial->diffuseColor.set1Value(1,SbColor(.1,.1,.1));//possible to adjust sides separately
+            //possible to adjust sides separately
+            //myMaterial->diffuseColor.set1Value(1,SbColor(.1,.1,.1));
             sep->addChild(myMaterial);
 
             //draw a sphere

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintPlaneRotation.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintPlaneRotation.cpp
@@ -102,7 +102,8 @@ void ViewProviderFemConstraintPlaneRotation::updateData(const App::Property* pro
     // Gets called whenever a property of the attached object changes
     Fem::ConstraintPlaneRotation *pcConstraint =
         static_cast<Fem::ConstraintPlaneRotation *>(this->getObject());
-    float scaledradius = RADIUS * pcConstraint->Scale.getValue(); //OvG: Calculate scaled values once only
+    //OvG: Calculate scaled values once only
+    float scaledradius = RADIUS * pcConstraint->Scale.getValue();
     float scaledheight = HEIGHT * pcConstraint->Scale.getValue();
 
     if (strcmp(prop->getName(),"Points") == 0) {
@@ -147,7 +148,8 @@ void ViewProviderFemConstraintPlaneRotation::updateData(const App::Property* pro
             //define color of shape
             SoMaterial *myMaterial = new SoMaterial;
             myMaterial->diffuseColor.set1Value(0, SbColor(0, 1, 0)); //RGB
-            //myMaterial->diffuseColor.set1Value(1,SbColor(0,0,1));//possible to adjust sides separately
+            //possible to adjust sides separately
+            //myMaterial->diffuseColor.set1Value(1,SbColor(0,0,1));
             sep->addChild(myMaterial);
 
             //draw a sphere

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintPressure.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintPressure.cpp
@@ -96,7 +96,8 @@ void ViewProviderFemConstraintPressure::updateData(const App::Property* prop)
     // Gets called whenever a property of the attached object changes
     Fem::ConstraintPressure *pcConstraint =
         static_cast<Fem::ConstraintPressure *>(this->getObject());
-    float scaledheadradius = ARROWHEADRADIUS * pcConstraint->Scale.getValue(); //OvG: Calculate scaled values once only
+    //OvG: Calculate scaled values once only
+    float scaledheadradius = ARROWHEADRADIUS * pcConstraint->Scale.getValue();
     float scaledlength = ARROWLENGTH * pcConstraint->Scale.getValue();
 
 #ifdef USE_MULTIPLE_COPY

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintSpring.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintSpring.cpp
@@ -96,7 +96,8 @@ void ViewProviderFemConstraintSpring::updateData(const App::Property* prop)
 {
     // Gets called whenever a property of the attached object changes
     Fem::ConstraintSpring *pcConstraint = static_cast<Fem::ConstraintSpring *>(this->getObject());
-    float scaledwidth = WIDTH * pcConstraint->Scale.getValue(); //OvG: Calculate scaled values once only
+    //OvG: Calculate scaled values once only
+    float scaledwidth = WIDTH * pcConstraint->Scale.getValue();
     float scaledlength = LENGTH * pcConstraint->Scale.getValue();
 
 #ifdef USE_MULTIPLE_COPY

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintTemperature.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintTemperature.cpp
@@ -100,7 +100,8 @@ void ViewProviderFemConstraintTemperature::updateData(const App::Property* prop)
     // Gets called whenever a property of the attached object changes
     Fem::ConstraintTemperature *pcConstraint =
         static_cast<Fem::ConstraintTemperature *>(this->getObject());
-    float scaledradius = RADIUS * pcConstraint->Scale.getValue(); //OvG: Calculate scaled values once only
+    //OvG: Calculate scaled values once only
+    float scaledradius = RADIUS * pcConstraint->Scale.getValue();
     float scaledheight = HEIGHT * pcConstraint->Scale.getValue();
     //float temperature = pcConstraint->temperature.getValue();
 
@@ -139,7 +140,8 @@ void ViewProviderFemConstraintTemperature::updateData(const App::Property* prop)
             //define color of shape
             SoMaterial *myMaterial = new SoMaterial;
             myMaterial->diffuseColor.set1Value(0, SbColor(1, 0, 0)); //RGB
-            //myMaterial->diffuseColor.set1Value(1,SbColor(.1,.1,.1));//possible to adjust sides separately
+            //possible to adjust sides separately
+            //myMaterial->diffuseColor.set1Value(1,SbColor(.1,.1,.1));
             sep->addChild(myMaterial);
 
             //draw a sphere

--- a/src/Mod/Fem/Gui/ViewProviderFemPostFunction.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemPostFunction.cpp
@@ -437,7 +437,8 @@ void ViewProviderFemPostPlaneFunction::onChanged(const App::Property* prop)
             // get current matrix
             SbVec3f t, s;
             SbRotation r, so;
-            SbMatrix matrix = getManipulator()->getDragger()->getMotionMatrix(); // clazy:exclude=rule-of-two-soft
+            // clazy:exclude=rule-of-two-soft
+            SbMatrix matrix = getManipulator()->getDragger()->getMotionMatrix();
             matrix.getTransform(t, r, s, so);
 
             float scale = static_cast<float>(Scale.getValue());

--- a/src/Mod/Image/Gui/OpenGLImageBox.cpp
+++ b/src/Mod/Image/Gui/OpenGLImageBox.cpp
@@ -225,7 +225,8 @@ void GLImageBox::drawImage()
 
         // Draw in the back buffer, using the following parameters
         //glDrawBuffer(GL_BACK); // this is an invalid call!
-        glPixelStorei(GL_UNPACK_ROW_LENGTH, _image.getWidth()); // defines number of pixels in a row
+        // defines number of pixels in a row
+        glPixelStorei(GL_UNPACK_ROW_LENGTH, _image.getWidth());
         glPixelStorei(GL_UNPACK_ALIGNMENT, 1); // defines byte alignment of rows
         glPixelZoom(_zoomFactor, -_zoomFactor); // defines the zoom factors to draw at
 

--- a/src/Mod/Import/App/dxf/dxf.cpp
+++ b/src/Mod/Import/App/dxf/dxf.cpp
@@ -1113,7 +1113,8 @@ void CDxfWrite::writeLinearDim(const double* textMidPoint, const double* lineDef
     if ( (type == HORIZONTAL) ||
          (type == VERTICAL) ) {
         (*m_ssEntity) << " 70"          << endl;
-        (*m_ssEntity) << 32             << endl;  // dimType0 = Aligned + 32 (bit for unique block)?
+        // dimType0 = Aligned + 32 (bit for unique block)?
+        (*m_ssEntity) << 32             << endl;
     }
 //    (*m_ssEntity) << " 71"          << endl;    // not R12
 //    (*m_ssEntity) << 1              << endl;    // attachPoint ??1 = topleft

--- a/src/Mod/Import/App/dxf/dxf.h
+++ b/src/Mod/Import/App/dxf/dxf.h
@@ -158,7 +158,7 @@ protected:
     int m_blockHandle;
     int m_blkRecordHandle;
     bool m_polyOverride;
-    
+
     std::string m_saveModelSpaceHandle;
     std::string m_savePaperSpaceHandle;
     std::string m_saveBlockRecordTableHandle;
@@ -173,7 +173,7 @@ protected:
 public:
     ImportExport CDxfWrite(const char* filepath);
     ImportExport ~CDxfWrite();
-    
+
     ImportExport void init(void);
     ImportExport void endRun(void);
 
@@ -290,7 +290,8 @@ public:
     ImportExport virtual ~CDxfRead(); // this closes the file
 
     ImportExport bool Failed(){return m_fail;}
-    ImportExport void DoRead(const bool ignore_errors = false); // this reads the file and calls the following functions
+    // this reads the file and calls the following functions
+    ImportExport void DoRead(const bool ignore_errors = false);
 
     ImportExport double mm( double value ) const;
 

--- a/src/Mod/Measure/App/Measurement.h
+++ b/src/Mod/Measure/App/Measurement.h
@@ -73,13 +73,15 @@ public:
 
   // Methods for distances (edge length, two points, edge and a point
   double length() const;
-  Base::Vector3d delta() const;                                                 //when would client use delta??
+  //when would client use delta??
+  Base::Vector3d delta() const;
 
   // Calculates the radius for an arc or circular edge
   double radius() const;
 
   // Calculates the angle between two edges
-  double angle(const Base::Vector3d &param = Base::Vector3d(0,0,0)) const;      //param is never used???
+  //param is never used???
+  double angle(const Base::Vector3d &param = Base::Vector3d(0,0,0)) const;
 
   // Calculate volumetric/mass properties
   Base::Vector3d massCenter() const;

--- a/src/Mod/Mesh/App/Core/Algorithm.cpp
+++ b/src/Mod/Mesh/App/Core/Algorithm.cpp
@@ -1420,7 +1420,8 @@ bool MeshAlgorithm::CutWithPlane (const Base::Vector3f &clBase, const Base::Vect
   aulFacets.erase(std::unique(aulFacets.begin(), aulFacets.end()), aulFacets.end());
 
   // intersect all facets with plane
-  std::list<std::pair<Base::Vector3f, Base::Vector3f> > clTempPoly;  // Field with intersection lines (unsorted, not chained)
+  // Field with intersection lines (unsorted, not chained)
+  std::list<std::pair<Base::Vector3f, Base::Vector3f> > clTempPoly;
 
   for (std::vector<FacetIndex>::iterator pF = aulFacets.begin(); pF != aulFacets.end(); ++pF)
   {

--- a/src/Mod/Mesh/App/Core/MeshIO.cpp
+++ b/src/Mod/Mesh/App/Core/MeshIO.cpp
@@ -1428,7 +1428,8 @@ bool MeshInput::LoadNastran (std::istream &rstrIn)
                 badElementCounter++;
                 continue;
             }
-            index = indexCheck.get() - 1; // Minus one so we are zero-indexed to match existing code
+            // Minus one so we are zero-indexed to match existing code
+            index = indexCheck.get() - 1;
 
             // Get the high-precision versions first
             auto x = boost::convert<double>(xString, converter);
@@ -1488,7 +1489,8 @@ bool MeshInput::LoadNastran (std::istream &rstrIn)
                     badElementCounter++;
                     continue;
                 }
-                index = indexCheck.get() - 1; // Minus one so we are zero-indexed to match existing code
+                // Minus one so we are zero-indexed to match existing code
+                index = indexCheck.get() - 1;
 
                 auto x = boost::convert<float>(xString, converter);
                 auto y = boost::convert<float>(yString, converter);

--- a/src/Mod/Mesh/App/Core/SetOperations.cpp
+++ b/src/Mod/Mesh/App/Core/SetOperations.cpp
@@ -528,7 +528,8 @@ bool SetOperations::CollectFacetVisitor::AllowVisit (const MeshFacet& rclFacet, 
             if (_addFacets == -1) {
                 // determine if the facets should add or not only once
                 MeshGeomFacet facet = _mesh.GetFacet(rclFrom); // triangulated facet
-                MeshGeomFacet facetOther = it->second.facets[1-_side][0]; // triangulated facet from same edge and other mesh
+                // triangulated facet from same edge and other mesh
+                MeshGeomFacet facetOther = it->second.facets[1-_side][0];
                 Vector3f normalOther = facetOther.GetNormal();
                 //Vector3f normal = facet.GetNormal();
 

--- a/src/Mod/Mesh/App/Core/SetOperations.h
+++ b/src/Mod/Mesh/App/Core/SetOperations.h
@@ -134,7 +134,8 @@ private:
   //    std::map<Edge, EdgeInfo>   &_edges;
   //    int                         _side;
   //    float                       _mult;
-  //    int                         _addFacets; // 0: add facets to the result 1: do not add facets to the result
+  // 0: add facets to the result 1: do not add facets to the result
+  //    int                         _addFacets;
   //    Base::Builder3D& _builder;
 
   //    CollectFacetVisitor (MeshKernel& mesh, std::vector<unsigned long>& facets, std::map<Edge, EdgeInfo>& edges, int side, float mult, Base::Builder3D& builder);
@@ -150,7 +151,8 @@ private:
       std::map<Edge, EdgeInfo>   &_edges;
       int                         _side;
       float                       _mult;
-      int                         _addFacets; // 0: add facets to the result 1: do not add facets to the result
+      // 0: add facets to the result 1: do not add facets to the result
+      int                         _addFacets;
       Base::Builder3D& _builder;
 
       CollectFacetVisitor (const MeshKernel& mesh, std::vector<FacetIndex>& facets, std::map<Edge, EdgeInfo>& edges, int side, float mult, Base::Builder3D& builder);

--- a/src/Mod/Mesh/App/Core/Tools.h
+++ b/src/Mod/Mesh/App/Core/Tools.h
@@ -60,8 +60,10 @@ public:
 protected:
   /** Subsamples the mesh. */
   void SampleAllFacets ();
-  inline bool CheckDistToFacet (const MeshFacet &rclF);     // check distance to facet, add points inner radius
-  bool AccumulateNeighbours (const MeshFacet &rclF, FacetIndex ulFIdx); // accumulate the sample neighbours facet
+  // check distance to facet, add points inner radius
+  inline bool CheckDistToFacet (const MeshFacet &rclF);
+  // accumulate the sample neighbours facet
+  bool AccumulateNeighbours (const MeshFacet &rclF, FacetIndex ulFIdx);
   inline bool InnerPoint (const Base::Vector3f &rclPt) const;
   inline bool TriangleCutsSphere (const MeshFacet &rclF) const;
   bool ExpandRadius (unsigned long ulMinPoints);
@@ -198,4 +200,3 @@ private:
 
 
 #endif  // MESH_TOOLS_H
-

--- a/src/Mod/Mesh/App/Core/TopoAlgorithm.cpp
+++ b/src/Mod/Mesh/App/Core/TopoAlgorithm.cpp
@@ -64,7 +64,8 @@ bool MeshTopoAlgorithm::InsertVertex(FacetIndex ulFacetPos, const Base::Vector3f
   FacetIndex ulSize  = _rclMesh._aclFacetArray.size();
 
   if ( ulPtInd < ulPtCnt )
-    return false; // the given point is already part of the mesh => creating new facets would be an illegal operation
+    // the given point is already part of the mesh => creating new facets would be an illegal operation
+    return false;
 
   // adjust the facets
   //
@@ -726,7 +727,8 @@ bool MeshTopoAlgorithm::SplitOpenEdge(FacetIndex ulFacetPos, unsigned short uSid
     FacetIndex ulSize = _rclMesh._aclFacetArray.size();
 
     if (uPtInd < uPtCnt)
-        return false; // the given point is already part of the mesh => creating new facets would be an illegal operation
+        // the given point is already part of the mesh => creating new facets would be an illegal operation
+        return false;
 
     // adjust the neighbourhood
     if (rclF._aulNeighbours[(uSide+1)%3] != FACET_INDEX_MAX)

--- a/src/Mod/Mesh/App/MeshProperties.cpp
+++ b/src/Mod/Mesh/App/MeshProperties.cpp
@@ -865,7 +865,8 @@ Base::Matrix4D PropertyMeshKernel::getTransform() const
 PyObject *PropertyMeshKernel::getPyObject()
 {
     if (!meshPyObject) {
-        meshPyObject = new MeshPy(&*_meshObject); // Lgtm[cpp/resource-not-released-in-destructor] ** Not destroyed in this class because it is reference-counted and destroyed elsewhere
+        // Lgtm[cpp/resource-not-released-in-destructor] ** Not destroyed in this class because it is reference-counted and destroyed elsewhere
+        meshPyObject = new MeshPy(&*_meshObject);
         meshPyObject->setConst(); // set immutable
         meshPyObject->parentProperty = this;
     }

--- a/src/Mod/Mesh/Gui/DlgEvaluateMeshImp.cpp
+++ b/src/Mod/Mesh/Gui/DlgEvaluateMeshImp.cpp
@@ -1107,7 +1107,8 @@ void DlgEvaluateMeshImp::on_repairAllTogether_clicked()
                         run = true;
                     }
                     else {
-                        self = false; // once no self-intersections found do not repeat it later on
+                        // once no self-intersections found do not repeat it later on
+                        self = false;
                     }
                     qApp->processEvents();
                 }
@@ -1319,4 +1320,3 @@ QSize DockEvaluateMeshImp::sizeHint () const
 }
 
 #include "moc_DlgEvaluateMeshImp.cpp"
-

--- a/src/Mod/Mesh/Gui/SoFCIndexedFaceSet.cpp
+++ b/src/Mod/Mesh/Gui/SoFCIndexedFaceSet.cpp
@@ -756,7 +756,8 @@ void SoFCIndexedFaceSet::generateGLArrays(SoGLRenderAction * action)
     SoNormalBindingElement::Binding normbind = SoNormalBindingElement::get(state);
     if (normbind == SoNormalBindingElement::PER_VERTEX_INDEXED) {
         if (matbind == SoMaterialBindingElement::PER_FACE) {
-            face_vertices.reserve(3 * numTria * 10); // duplicate each vertex (rgba, normal, vertex)
+            // duplicate each vertex (rgba, normal, vertex)
+            face_vertices.reserve(3 * numTria * 10);
             face_indices.resize(3 * numTria);
 
             if (numcolors != static_cast<int>(numTria)) {
@@ -794,7 +795,8 @@ void SoFCIndexedFaceSet::generateGLArrays(SoGLRenderAction * action)
             }
         }
         else if (matbind == SoMaterialBindingElement::PER_VERTEX_INDEXED) {
-            face_vertices.reserve(3 * numTria * 10); // duplicate each vertex (rgba, normal, vertex)
+            // duplicate each vertex (rgba, normal, vertex)
+            face_vertices.reserve(3 * numTria * 10);
             face_indices.resize(3 * numTria);
 
             if (numcolors != coords->getNum()) {
@@ -967,8 +969,10 @@ void SoFCIndexedFaceSet::startSelection(SoAction * action)
     int bufSize = 5*(this->coordIndex.getNum()/4); // make the buffer big enough
     this->selectBuf = new GLuint[bufSize];
 
-    SbMatrix view = SoViewingMatrixElement::get(action->getState()); // clazy:exclude=rule-of-two-soft
-    SbMatrix proj = SoProjectionMatrixElement::get(action->getState()); // clazy:exclude=rule-of-two-soft
+    // clazy:exclude=rule-of-two-soft
+    SbMatrix view = SoViewingMatrixElement::get(action->getState());
+    // clazy:exclude=rule-of-two-soft
+    SbMatrix proj = SoProjectionMatrixElement::get(action->getState());
 
     glSelectBuffer(bufSize, selectBuf);
     glRenderMode(GL_SELECT);
@@ -1050,8 +1054,10 @@ void SoFCIndexedFaceSet::renderSelectionGeometry(const SbVec3f * coords3d)
 
 void SoFCIndexedFaceSet::startVisibility(SoAction * action)
 {
-    SbMatrix view = SoViewingMatrixElement::get(action->getState()); // clazy:exclude=rule-of-two-soft
-    SbMatrix proj = SoProjectionMatrixElement::get(action->getState()); // clazy:exclude=rule-of-two-soft
+    // clazy:exclude=rule-of-two-soft
+    SbMatrix view = SoViewingMatrixElement::get(action->getState());
+    // clazy:exclude=rule-of-two-soft
+    SbMatrix proj = SoProjectionMatrixElement::get(action->getState());
 
     glMatrixMode(GL_PROJECTION);
     glPushMatrix();

--- a/src/Mod/Mesh/Gui/ViewProviderCurvature.cpp
+++ b/src/Mod/Mesh/Gui/ViewProviderCurvature.cpp
@@ -222,7 +222,8 @@ void ViewProviderMeshCurvature::slotChangedObject(const App::DocumentObject& Obj
             const Mesh::MeshObject& kernel = mesh.getValue();
             pcColorMat->diffuseColor.setNum((int)kernel.countPoints());
             pcColorMat->transparency.setNum((int)kernel.countPoints());
-            static_cast<Mesh::Curvature*>(pcObject)->Source.touch(); // make sure to recompute the feature
+            // make sure to recompute the feature
+            static_cast<Mesh::Curvature*>(pcObject)->Source.touch();
         }
     }
 }

--- a/src/Mod/MeshPart/App/CurveProjector.cpp
+++ b/src/Mod/MeshPart/App/CurveProjector.cpp
@@ -125,7 +125,8 @@ void CurveProjectorShape::projectCurve( const TopoDS_Edge& aEdge,
                                               (float)gpPt.Z());
   Base::Vector3f cResultPoint, cSplitPoint, cPlanePnt, cPlaneNormal;
   MeshCore::FacetIndex uStartFacetIdx,uCurFacetIdx;
-  MeshCore::FacetIndex uLastFacetIdx=MeshCore::FACET_INDEX_MAX-1; // use another value as FACET_INDEX_MAX
+  // use another value as FACET_INDEX_MAX
+  MeshCore::FacetIndex uLastFacetIdx=MeshCore::FACET_INDEX_MAX-1;
   MeshCore::FacetIndex auNeighboursIdx[3];
   bool GoOn;
 
@@ -415,7 +416,8 @@ void CurveProjectorSimple::projectCurve( const TopoDS_Edge& aEdge,
   Base::Vector3f cStartPoint = Base::Vector3f(gpPt.X(),gpPt.Y(),gpPt.Z());
   Base::Vector3f cResultPoint, cSplitPoint, cPlanePnt, cPlaneNormal,TempResultPoint;
   MeshCore::FacetIndex uStartFacetIdx,uCurFacetIdx;
-  MeshCore::FacetIndex uLastFacetIdx=MeshCore::FACET_INDEX_MAX-1; // use another value as FACET_INDEX_MAX
+  // use another value as FACET_INDEX_MAX
+  MeshCore::FacetIndex uLastFacetIdx=MeshCore::FACET_INDEX_MAX-1;
   MeshCore::FacetIndex auNeighboursIdx[3];
   bool GoOn;
 
@@ -501,7 +503,8 @@ void CurveProjectorSimple::projectCurve( const TopoDS_Edge& aEdge,
   Base::Vector3f cStartPoint = Base::Vector3f(gpPt.X(),gpPt.Y(),gpPt.Z());
   Base::Vector3f cResultPoint, cSplitPoint, cPlanePnt, cPlaneNormal;
   MeshCore::FacetIndex uStartFacetIdx,uCurFacetIdx;
-  MeshCore::FacetIndex uLastFacetIdx=MeshCore::FACET_INDEX_MAX-1; // use another value as FACET_INDEX_MAX
+  // use another value as FACET_INDEX_MAX
+  MeshCore::FacetIndex uLastFacetIdx=MeshCore::FACET_INDEX_MAX-1;
   MeshCore::FacetIndex auNeighboursIdx[3];
   bool GoOn;
 

--- a/src/Mod/Part/App/AppPartPy.cpp
+++ b/src/Mod/Part/App/AppPartPy.cpp
@@ -245,7 +245,8 @@ class BRepFeatModule : public Py::ExtensionModule<BRepFeatModule>
 public:
     BRepFeatModule() : Py::ExtensionModule<BRepFeatModule>("BRepFeat")
     {
-        initialize("This is a module working with the BRepFeat package."); // register with Python
+        // register with Python
+        initialize("This is a module working with the BRepFeat package.");
     }
 
     ~BRepFeatModule() override {}
@@ -256,7 +257,8 @@ class BRepOffsetAPIModule : public Py::ExtensionModule<BRepOffsetAPIModule>
 public:
     BRepOffsetAPIModule() : Py::ExtensionModule<BRepOffsetAPIModule>("BRepOffsetAPI")
     {
-        initialize("This is a module working with the BRepOffsetAPI package."); // register with Python
+        // register with Python
+        initialize("This is a module working with the BRepOffsetAPI package.");
     }
 
     ~BRepOffsetAPIModule() override {}
@@ -278,7 +280,8 @@ class GeomPlateModule : public Py::ExtensionModule<GeomPlateModule>
 public:
     GeomPlateModule() : Py::ExtensionModule<GeomPlateModule>("GeomPlate")
     {
-        initialize("This is a module working with the GeomPlate framework."); // register with Python
+        // register with Python
+        initialize("This is a module working with the GeomPlate framework.");
     }
 
     ~GeomPlateModule() override {}
@@ -289,7 +292,8 @@ class HLRBRepModule : public Py::ExtensionModule<HLRBRepModule>
 public:
     HLRBRepModule() : Py::ExtensionModule<HLRBRepModule>("HLRBRep")
     {
-        initialize("This is a module working with the HLRBRep framework."); // register with Python
+        // register with Python
+        initialize("This is a module working with the HLRBRep framework.");
     }
 
     ~HLRBRepModule() override {}
@@ -318,7 +322,8 @@ public:
             "leastEdgeSize(shape)\n"
             "Calculate size of least edge"
         );
-        initialize("This is a module working with the ShapeFix framework."); // register with Python
+        // register with Python
+        initialize("This is a module working with the ShapeFix framework.");
     }
 
     ~ShapeFixModule() override {}
@@ -388,7 +393,8 @@ class ShapeUpgradeModule : public Py::ExtensionModule<ShapeUpgradeModule>
 public:
     ShapeUpgradeModule() : Py::ExtensionModule<ShapeUpgradeModule>("ShapeUpgrade")
     {
-        initialize("This is a module working with the ShapeUpgrade framework."); // register with Python
+        // register with Python
+        initialize("This is a module working with the ShapeUpgrade framework.");
     }
 
     ~ShapeUpgradeModule() override {}
@@ -399,7 +405,8 @@ class ChFi2dModule : public Py::ExtensionModule<ChFi2dModule>
 public:
     ChFi2dModule() : Py::ExtensionModule<ChFi2dModule>("ChFi2d")
     {
-        initialize("This is a module working with the ChFi2d framework."); // register with Python
+        // register with Python
+        initialize("This is a module working with the ChFi2d framework.");
     }
 
     ~ChFi2dModule() override {}
@@ -636,7 +643,8 @@ public:
         add_varargs_method("joinSubname",&Module::joinSubname,
             "joinSubname(sub,mapped,subElement) -> subname\n"
         );
-        initialize("This is a module working with shapes."); // register with Python
+        // register with Python
+        initialize("This is a module working with shapes.");
 
         PyModule_AddObject(m_module, "BRepFeat", brepFeat.module().ptr());
         PyModule_AddObject(m_module, "BRepOffsetAPI", brepOffsetApi.module().ptr());

--- a/src/Mod/Part/App/AttachEnginePyImp.cpp
+++ b/src/Mod/Part/App/AttachEnginePyImp.cpp
@@ -281,7 +281,8 @@ PyObject* AttachEnginePy::getModeInfo(PyObject* args)
             Py::Module module(PyImport_ImportModule("PartGui"),true);
             if (module.isNull() || !module.hasAttr("AttachEngineResources")) {
                 // in v0.14+, the GUI module can be loaded in console mode (but doesn't have all its document methods)
-                throw Py::RuntimeError("Gui is not up");//DeepSOIC: wanted to throw ImportError here, but it's not defined, so I don't know...
+                //DeepSOIC: wanted to throw ImportError here, but it's not defined, so I don't know...
+                throw Py::RuntimeError("Gui is not up");
             }
             Py::Object submod(module.getAttr("AttachEngineResources"));
             Py::Callable method(submod.getAttr("getModeStrings"));
@@ -367,7 +368,8 @@ PyObject* AttachEnginePy::getRefTypeInfo(PyObject* args)
             Py::Module module(PyImport_ImportModule("PartGui"),true);
             if (module.isNull() || !module.hasAttr("AttachEngineResources")) {
                 // in v0.14+, the GUI module can be loaded in console mode (but doesn't have all its document methods)
-                throw Py::RuntimeError("Gui is not up");//DeepSOIC: wanted to throw ImportError here, but it's not defined, so I don't know...
+                //DeepSOIC: wanted to throw ImportError here, but it's not defined, so I don't know...
+                throw Py::RuntimeError("Gui is not up");
             }
             Py::Object submod(module.getAttr("AttachEngineResources"));
             Py::Callable method(submod.getAttr("getRefTypeUserFriendlyName"));
@@ -561,4 +563,3 @@ int AttachEnginePy::setCustomAttributes(const char*,PyObject*)
 {
     return 0;
 }
-

--- a/src/Mod/Part/App/AttachExtension.cpp
+++ b/src/Mod/Part/App/AttachExtension.cpp
@@ -201,7 +201,8 @@ void AttachExtension::extensionOnChanged(const App::Property* prop)
             this->MapPathParameter.setStatus(App::Property::Status::Hidden, !bAttached || !(modeIsPointOnCurve && hasOneRef));
             this->MapReversed.setStatus(App::Property::Status::Hidden, !bAttached);
             this->AttachmentOffset.setStatus(App::Property::Status::Hidden, !bAttached);
-            getPlacement().setReadOnly(bAttached && mmode != mmTranslate); //for mmTranslate, orientation should remain editable even when attached.
+            //for mmTranslate, orientation should remain editable even when attached.
+            getPlacement().setReadOnly(bAttached && mmode != mmTranslate);
         }
 
     }
@@ -246,7 +247,8 @@ void AttachExtension::onExtendedDocumentRestored()
         this->MapPathParameter.setStatus(App::Property::Status::Hidden, !bAttached || !(modeIsPointOnCurve && hasOneRef));
         this->MapReversed.setStatus(App::Property::Status::Hidden, !bAttached);
         this->AttachmentOffset.setStatus(App::Property::Status::Hidden, !bAttached);
-        getPlacement().setReadOnly(bAttached && mmode != mmTranslate); //for mmTranslate, orientation should remain editable even when attached.
+        //for mmTranslate, orientation should remain editable even when attached.
+        getPlacement().setReadOnly(bAttached && mmode != mmTranslate);
     }
     catch (Base::Exception&) {
     }
@@ -309,4 +311,3 @@ namespace App {
 // explicit template instantiation
   template class PartExport ExtensionPythonT<Part::AttachExtension>;
 }
-

--- a/src/Mod/Part/App/Attacher.cpp
+++ b/src/Mod/Part/App/Attacher.cpp
@@ -345,7 +345,8 @@ void AttachEngine::suggestMapModes(SuggestResult &result) const
             continue;
         const refTypeStringList &listStrings = modeRefTypes[iMode];
         for (std::size_t iStr = 0; iStr < listStrings.size(); ++iStr) {
-            int score = 1; //-1 = topo incompatible, 0 = topo compatible, geom incompatible; 1+ = compatible (the higher - the more specific is the mode for the support)
+            //-1 = topo incompatible, 0 = topo compatible, geom incompatible; 1+ = compatible (the higher - the more specific is the mode for the support)
+            int score = 1;
             const refTypeString &str = listStrings[iStr];
             for (std::size_t iChr = 0; iChr < str.size() && iChr < typeStr.size(); ++iChr) {
                 int match = AttachEngine::isShapeOfType(typeStr[iChr], str[iChr]);
@@ -431,7 +432,8 @@ eRefType AttachEngine::getShapeType(const TopoDS_Shape& sh)
     break;
     case TopAbs_COMPOUND:{
         const TopoDS_Compound &cmpd = TopoDS::Compound(sh);
-        TopoDS_Iterator it (cmpd, Standard_False, Standard_False);//don't mess with placements, to hopefully increase speed
+        //don't mess with placements, to hopefully increase speed
+        TopoDS_Iterator it (cmpd, Standard_False, Standard_False);
         if (! it.More())//empty compound
             return rtAnything;
         const TopoDS_Shape &sh1 = it.Value();
@@ -981,7 +983,8 @@ Base::Placement AttachEngine3D::calculateAttachedPlacement(const Base::Placement
 {
     const eMapMode mmode = this->mapMode;
     if (mmode == mmDeactivated)
-        throw ExceptionCancel();//to be handled in positionBySupport, to not do anything if disabled
+        //to be handled in positionBySupport, to not do anything if disabled
+        throw ExceptionCancel();
     std::vector<App::GeoFeature*> parts;
     std::vector<const TopoDS_Shape*> shapes;
     std::vector<TopoDS_Shape> copiedShapeStorage;
@@ -1291,7 +1294,8 @@ Base::Placement AttachEngine3D::calculateAttachedPlacement(const Base::Placement
 
             gp_Vec T,N,B;//Frenet?Serret axes: tangent, normal, binormal
             T = d.Normalized();
-            N = dd.Subtracted(T.Multiplied(dd.Dot(T)));//take away the portion of dd that is along tangent
+            //take away the portion of dd that is along tangent
+            N = dd.Subtracted(T.Multiplied(dd.Dot(T)));
             if (N.Magnitude() > Precision::SquareConfusion()) {
                 N.Normalize();
                 B = T.Crossed(N);
@@ -1305,7 +1309,8 @@ Base::Placement AttachEngine3D::calculateAttachedPlacement(const Base::Placement
             switch (mmode){
             case mmFrenetNB:
             case mmRevolutionSection:
-                SketchNormal = T.Reversed();//to avoid sketches upside-down for regular curves like circles
+                //to avoid sketches upside-down for regular curves like circles
+                SketchNormal = T.Reversed();
                 SketchXAxis = N.Reversed();
                 break;
             case mmFrenetTN:
@@ -1318,7 +1323,8 @@ Base::Placement AttachEngine3D::calculateAttachedPlacement(const Base::Placement
             case mmFrenetTB:
                 if (N.Magnitude() == 0.0)
                     throw Base::ValueError("AttachEngine3D::calculateAttachedPlacement: Frenet-Serret normal is undefined. Can't align to TB plane.");
-                SketchNormal = N.Reversed();//it is more convenient to sketch on something looking at it so it is convex.
+                //it is more convenient to sketch on something looking at it so it is convex.
+                SketchNormal = N.Reversed();
                 SketchXAxis = T;
                 break;
             default:
@@ -1330,13 +1336,15 @@ Base::Placement AttachEngine3D::calculateAttachedPlacement(const Base::Placement
                     throw Base::ValueError("AttachEngine3D::calculateAttachedPlacement: path has infinite radius of curvature at the point. Can't align for revolving.");
                 double curvature = dd.Dot(N) / pow(d.Magnitude(), 2);
                 gp_Vec pv (p.XYZ());
-                pv.Add(N.Multiplied(1/curvature));//shift the point along curvature by radius of curvature
+                //shift the point along curvature by radius of curvature
+                pv.Add(N.Multiplied(1/curvature));
                 SketchBasePoint = gp_Pnt(pv.XYZ());
                 //it would have been cool to have the curve attachment point available inside sketch... Leave for future.
             }
         } else if (mmode == mmNormalToPath){//mmNormalToPath
             //align sketch origin to the origin of support
-            SketchNormal = gp_Dir(d.Reversed());//sketch normal looks at user. It is natural to have the curve directed away from user, so reversed.
+            //sketch normal looks at user. It is natural to have the curve directed away from user, so reversed.
+            SketchNormal = gp_Dir(d.Reversed());
         }
 
     } break;
@@ -1391,7 +1399,8 @@ Base::Placement AttachEngine3D::calculateAttachedPlacement(const Base::Placement
             //SketchBasePoint = (p0+p1+p2)/3.0
             SketchBasePoint = gp_Pnt(gp_Vec(p0.XYZ()).Added(p1.XYZ()).Added(p2.XYZ()).Multiplied(1.0/3.0).XYZ());
         } else if (mmode == mmThreePointsNormal) {
-            norm = vec02.Subtracted(vec01.Multiplied(vec02.Dot(vec01))).Reversed();//norm = vec02 forced perpendicular to vec01.
+            //norm = vec02 forced perpendicular to vec01.
+            norm = vec02.Subtracted(vec01.Multiplied(vec02.Dot(vec01))).Reversed();
             if (norm.Magnitude() < Precision::Confusion())
                 throw Base::ValueError("AttachEngine3D::calculateAttachedPlacement: points are collinear. Can't make a plane");
             //SketchBasePoint = (p0+p1)/2.0
@@ -1433,7 +1442,8 @@ Base::Placement AttachEngine3D::calculateAttachedPlacement(const Base::Placement
 
         //figure out the common starting point (variable p)
         gp_Pnt p, p1, p2, p3, p4;
-        double signs[4] = {0,0,0,0};//flags whether to reverse line directions, for all directions to point away from the common vertex
+        //flags whether to reverse line directions, for all directions to point away from the common vertex
+        double signs[4] = {0,0,0,0};
         p1 = adapts[0].Value(adapts[0].FirstParameter());
         p2 = adapts[0].Value(adapts[0].LastParameter());
         p3 = adapts[1].Value(adapts[1].FirstParameter());
@@ -1713,7 +1723,8 @@ Base::Placement AttachEngineLine::calculateAttachedPlacement(const Base::Placeme
     Base::Placement presuperPlacement;
     switch(mmode){
     case mmDeactivated:
-        throw ExceptionCancel();//to be handled in positionBySupport, to not do anything if disabled
+        //to be handled in positionBySupport, to not do anything if disabled
+        throw ExceptionCancel();
     case mm1AxisX:
         mmode = mmObjectYZ;
         break;
@@ -1921,7 +1932,8 @@ Base::Placement AttachEngineLine::calculateAttachedPlacement(const Base::Placeme
         AttachEngine3D attacher3D;
         attacher3D.setUp(*this);
         attacher3D.mapMode = mmode;
-        attacher3D.attachmentOffset = Base::Placement(); //AttachmentOffset is applied separately here, afterwards. So we are resetting it in sub-attacher to avoid applying it twice!
+        //AttachmentOffset is applied separately here, afterwards. So we are resetting it in sub-attacher to avoid applying it twice!
+        attacher3D.attachmentOffset = Base::Placement();
         plm = attacher3D.calculateAttachedPlacement(origPlacement);
         plm *= presuperPlacement;
     }
@@ -1981,7 +1993,8 @@ Base::Placement AttachEnginePoint::calculateAttachedPlacement(const Base::Placem
     bool bReUsed = true;
     switch(mmode){
     case mmDeactivated:
-        throw ExceptionCancel();//to be handled in positionBySupport, to not do anything if disabled
+        //to be handled in positionBySupport, to not do anything if disabled
+        throw ExceptionCancel();
     case mm0Origin:
         mmode = mmObjectXY;
         break;
@@ -2090,7 +2103,8 @@ Base::Placement AttachEnginePoint::calculateAttachedPlacement(const Base::Placem
         AttachEngine3D attacher3D;
         attacher3D.setUp(*this);
         attacher3D.mapMode = mmode;
-        attacher3D.attachmentOffset = Base::Placement(); //AttachmentOffset is applied separately here, afterwards. So we are resetting it in sub-attacher to avoid applying it twice!
+        //AttachmentOffset is applied separately here, afterwards. So we are resetting it in sub-attacher to avoid applying it twice!
+        attacher3D.attachmentOffset = Base::Placement();
         plm = attacher3D.calculateAttachedPlacement(origPlacement);
     }
     plm *= this->attachmentOffset;

--- a/src/Mod/Part/App/Attacher.h
+++ b/src/Mod/Part/App/Attacher.h
@@ -145,8 +145,10 @@ enum eRefType {
 };
 
 
-using refTypeString = std::vector<eRefType>; //a sequence of ref types, according to Support contents for example
-using refTypeStringList = std::vector<refTypeString>; //a set of type strings, defines which selection sets are supported by a certain mode
+//a sequence of ref types, according to Support contents for example
+using refTypeString = std::vector<eRefType>;
+//a set of type strings, defines which selection sets are supported by a certain mode
+using refTypeStringList = std::vector<refTypeString>;
 
 
 /**
@@ -377,7 +379,8 @@ public: //members
      */
     std::vector<bool> modeEnabled;
 
-    std::vector<refTypeStringList> modeRefTypes; //a complete data structure, containing info on which modes support what selection
+    //a complete data structure, containing info on which modes support what selection
+    std::vector<refTypeStringList> modeRefTypes;
 
 protected:
     refTypeString cat(eRefType rt1){

--- a/src/Mod/Part/App/BSplineCurvePyImp.cpp
+++ b/src/Mod/Part/App/BSplineCurvePyImp.cpp
@@ -1245,7 +1245,8 @@ PyObject* BSplineCurvePy::buildFromPolesMultsKnots(PyObject *args, PyObject *key
             for (Py::Sequence::iterator it = multssq.begin(); it != multssq.end() && index <= occmults.Length(); ++it) {
                 Py::Long mult(*it);
                 if (index < occmults.Length() || !Base::asBoolean(periodic)) {
-                    sum_of_mults += static_cast<int>(mult); //sum up the mults to compare them against the number of poles later
+                    //sum up the mults to compare them against the number of poles later
+                    sum_of_mults += static_cast<int>(mult);
                 }
                 occmults(index++) = static_cast<int>(mult);
             }

--- a/src/Mod/Part/App/BSplineSurfacePyImp.cpp
+++ b/src/Mod/Part/App/BSplineSurfacePyImp.cpp
@@ -1371,7 +1371,8 @@ PyObject* BSplineSurfacePy::buildFromPolesMultsKnots(PyObject *args, PyObject *k
                 Base::Vector3d pnt = v.toVector();
                 gp_Pnt newPoint(pnt.x,pnt.y,pnt.z);
                 occpoles.SetValue(index1, index2, newPoint);
-                if (genweights) occweights.SetValue(index1, index2, 1.0); //set weights if they are not given
+                //set weights if they are not given
+                if (genweights) occweights.SetValue(index1, index2, 1.0);
             }
         }
         if (occpoles.RowLength() < 2 || occpoles.ColLength() < 2) {
@@ -1413,7 +1414,8 @@ PyObject* BSplineSurfacePy::buildFromPolesMultsKnots(PyObject *args, PyObject *k
         for (Py::Sequence::iterator it = umultssq.begin(); it != umultssq.end() && index <= occumults.Length(); ++it) {
             Py::Long mult(*it);
             if (index < occumults.Length() || !Base::asBoolean(uperiodic)) {
-                sum_of_umults += static_cast<int>(mult); //sum up the mults to compare them against the number of poles later
+                //sum up the mults to compare them against the number of poles later
+                sum_of_umults += static_cast<int>(mult);
             }
             occumults(index++) = static_cast<int>(mult);
         }
@@ -1422,7 +1424,8 @@ PyObject* BSplineSurfacePy::buildFromPolesMultsKnots(PyObject *args, PyObject *k
         for (Py::Sequence::iterator it = vmultssq.begin(); it != vmultssq.end() && index <= occvmults.Length(); ++it) {
             Py::Long mult(*it);
             if (index < occvmults.Length() || !Base::asBoolean(vperiodic)) {
-                sum_of_vmults += static_cast<int>(mult); //sum up the mults to compare them against the number of poles later
+                //sum up the mults to compare them against the number of poles later
+                sum_of_vmults += static_cast<int>(mult);
             }
             occvmults(index++) = static_cast<int>(mult);
         }

--- a/src/Mod/Part/App/FT2FC.cpp
+++ b/src/Mod/Part/App/FT2FC.cpp
@@ -167,7 +167,8 @@ PyObject* FT2FC(const Py_UNICODE *PyUString,
         throw std::runtime_error(ErrorMsg.str());
     }
 
-    scalefactor = (stringheight/float(FTFace->height))/10;  // divide scale by 10 to offset the 10X increased scale in FT_Set_Char_Size above
+    // divide scale by 10 to offset the 10X increased scale in FT_Set_Char_Size above
+    scalefactor = (stringheight/float(FTFace->height))/10;
     for (i=0; i<length; i++) {
         currchar = PyUString[i];
         error = FT_Load_Char(FTFace,

--- a/src/Mod/Part/App/FeatureExtrusion.cpp
+++ b/src/Mod/Part/App/FeatureExtrusion.cpp
@@ -68,7 +68,8 @@ Extrusion::Extrusion()
     ADD_PROPERTY_TYPE(Symmetric, (false), "Extrude", App::Prop_None, "If true, extrusion is done in both directions to a total of LengthFwd. LengthRev is ignored.");
     ADD_PROPERTY_TYPE(TaperAngle, (0.0), "Extrude", App::Prop_None, "Sets the angle of slope (draft) to apply to the sides. The angle is for outward taper; negative value yields inward tapering.");
     ADD_PROPERTY_TYPE(TaperAngleRev, (0.0), "Extrude", App::Prop_None, "Taper angle of reverse part of extrusion.");
-    ADD_PROPERTY_TYPE(FaceMakerClass, ("Part::FaceMakerExtrusion"), "Extrude", App::Prop_None, "If Solid is true, this sets the facemaker class to use when converting wires to faces. Otherwise, ignored."); //default for old documents. See setupObject for default for new extrusions.
+    //default for old documents. See setupObject for default for new extrusions.
+    ADD_PROPERTY_TYPE(FaceMakerClass, ("Part::FaceMakerExtrusion"), "Extrude", App::Prop_None, "If Solid is true, this sets the facemaker class to use when converting wires to faces. Otherwise, ignored.");
 }
 
 short Extrusion::mustExecute() const
@@ -232,7 +233,8 @@ Base::Vector3d Extrusion::calculateShapeNormal(const App::PropertyLink& shapeLin
 TopoShape Extrusion::extrudeShape(const TopoShape& source, const Extrusion::ExtrusionParameters& params)
 {
     TopoDS_Shape result;
-    gp_Vec vec = gp_Vec(params.dir).Multiplied(params.lengthFwd + params.lengthRev);//total vector of extrusion
+    //total vector of extrusion
+    gp_Vec vec = gp_Vec(params.dir).Multiplied(params.lengthFwd + params.lengthRev);
 
     if (std::fabs(params.taperAngleFwd) >= Precision::Angular() ||
         std::fabs(params.taperAngleRev) >= Precision::Angular()) {
@@ -247,7 +249,8 @@ TopoShape Extrusion::extrudeShape(const TopoShape& source, const Extrusion::Extr
         myShape = BRepBuilderAPI_Copy(myShape).Shape();
 
         std::list<TopoDS_Shape> drafts;
-        bool isPartDesign = false; // there is an OCC bug with single-edge wires (circles) we need to treat differently for PD and Part
+        // there is an OCC bug with single-edge wires (circles) we need to treat differently for PD and Part
+        bool isPartDesign = false;
         ExtrusionHelper::makeDraft(myShape, params.dir, params.lengthFwd, params.lengthRev,
                                    params.taperAngleFwd, params.taperAngleRev, params.solid, drafts, isPartDesign);
         if (drafts.empty()) {
@@ -406,5 +409,6 @@ void FaceMakerExtrusion::Build()
 void Part::Extrusion::setupObject()
 {
     Part::Feature::setupObject();
-    this->FaceMakerClass.setValue("Part::FaceMakerBullseye"); //default for newly created features
+    //default for newly created features
+    this->FaceMakerClass.setValue("Part::FaceMakerBullseye");
 }

--- a/src/Mod/Part/App/FeatureFace.cpp
+++ b/src/Mod/Part/App/FeatureFace.cpp
@@ -38,7 +38,8 @@ PROPERTY_SOURCE(Part::Face, Part::Feature)
 Face::Face()
 {
     ADD_PROPERTY(Sources,(nullptr));
-    ADD_PROPERTY(FaceMakerClass,("Part::FaceMakerCheese"));//default value here is for legacy documents. Default for new objects is set in setupObject.
+    //default value here is for legacy documents. Default for new objects is set in setupObject.
+    ADD_PROPERTY(FaceMakerClass,("Part::FaceMakerCheese"));
     Sources.setSize(0);
 }
 
@@ -97,4 +98,3 @@ App::DocumentObjectExecReturn *Face::execute()
 
     return App::DocumentObject::StdReturn;
 }
-

--- a/src/Mod/Part/App/FeatureOffset.cpp
+++ b/src/Mod/Part/App/FeatureOffset.cpp
@@ -105,7 +105,8 @@ PROPERTY_SOURCE(Part::Offset2D, Part::Offset)
 Offset2D::Offset2D()
 {
     this->SelfIntersection.setStatus(App::Property::Status::Hidden, true);
-    this->Mode.setValue(1); //switch to Pipe mode by default, because skin mode does not function properly on closed profiles.
+    //switch to Pipe mode by default, because skin mode does not function properly on closed profiles.
+    this->Mode.setValue(1);
 }
 
 Offset2D::~Offset2D()

--- a/src/Mod/Part/App/FeaturePartBox.cpp
+++ b/src/Mod/Part/App/FeaturePartBox.cpp
@@ -203,7 +203,8 @@ void Box::Restore(Base::XMLReader &reader)
     if (location_xyz) {
         plm.setPosition(Base::Vector3d(x.getValue(),y.getValue(),z.getValue()));
         this->Placement.setValue(this->Placement.getValue() * plm);
-        this->Shape.setStatus(App::Property::User1, true); // override the shape's location later on
+        // override the shape's location later on
+        this->Shape.setStatus(App::Property::User1, true);
     }
     // for 0.8 releases
     else if (location_axis) {
@@ -214,7 +215,8 @@ void Box::Restore(Base::XMLReader &reader)
         plm.setRotation(rot);
         plm.setPosition(Base::Vector3d(p.x,p.y,p.z));
         this->Placement.setValue(this->Placement.getValue() * plm);
-        this->Shape.setStatus(App::Property::User1, true); // override the shape's location later on
+        // override the shape's location later on
+        this->Shape.setStatus(App::Property::User1, true);
     }
 
     reader.readEndElement("Properties");

--- a/src/Mod/Part/App/FeaturePartCommon.cpp
+++ b/src/Mod/Part/App/FeaturePartCommon.cpp
@@ -177,9 +177,11 @@ App::DocumentObjectExecReturn *MultiCommon::execute()
                     for(std::pair<const int,ShapeHistory::List> &histitem: history[iChild].shapeMap){ //loop over elements of history - that is - over faces of the child of source compound
                         int iFaceInChild = histitem.first;
                         ShapeHistory::List &iFacesInResult = histitem.second;
-                        TopoDS_Shape srcFace = facesOfChild(iFaceInChild + 1); //+1 to convert our 0-based to OCC 1-bsed conventions
+                        //+1 to convert our 0-based to OCC 1-bsed conventions
+                        TopoDS_Shape srcFace = facesOfChild(iFaceInChild + 1);
                         int iFaceInCompound = facesOfCompound.FindIndex(srcFace)-1;
-                        overallHist.shapeMap[iFaceInCompound] = iFacesInResult; //this may overwrite existing info if the same face is used in several children of compound. This shouldn't be a problem, because the histories should match anyway...
+                        //this may overwrite existing info if the same face is used in several children of compound. This shouldn't be a problem, because the histories should match anyway...
+                        overallHist.shapeMap[iFaceInCompound] = iFacesInResult;
                     }
                 }
                 history.clear();

--- a/src/Mod/Part/App/FeaturePartFuse.cpp
+++ b/src/Mod/Part/App/FeaturePartFuse.cpp
@@ -175,9 +175,11 @@ App::DocumentObjectExecReturn *MultiFuse::execute()
                     for(std::pair<const int,ShapeHistory::List> &histitem: history[iChild].shapeMap){ //loop over elements of history - that is - over faces of the child of source compound
                         int iFaceInChild = histitem.first;
                         ShapeHistory::List &iFacesInResult = histitem.second;
-                        TopoDS_Shape srcFace = facesOfChild(iFaceInChild + 1); //+1 to convert our 0-based to OCC 1-bsed conventions
+                        //+1 to convert our 0-based to OCC 1-bsed conventions
+                        TopoDS_Shape srcFace = facesOfChild(iFaceInChild + 1);
                         int iFaceInCompound = facesOfCompound.FindIndex(srcFace)-1;
-                        overallHist.shapeMap[iFaceInCompound] = iFacesInResult; //this may overwrite existing info if the same face is used in several children of compound. This shouldn't be a problem, because the histories should match anyway...
+                        //this may overwrite existing info if the same face is used in several children of compound. This shouldn't be a problem, because the histories should match anyway...
+                        overallHist.shapeMap[iFaceInCompound] = iFacesInResult;
                     }
                 }
                 history.clear();

--- a/src/Mod/Part/App/FeatureRevolution.cpp
+++ b/src/Mod/Part/App/FeatureRevolution.cpp
@@ -50,7 +50,8 @@ Revolution::Revolution()
     Angle.setConstraints(&angleRangeU);
     ADD_PROPERTY_TYPE(Symmetric,(false),"Revolve",App::Prop_None,"Extend revolution symmetrically from the profile.");
     ADD_PROPERTY_TYPE(Solid,(false),"Revolve",App::Prop_None,"Make revolution a solid if possible");
-    ADD_PROPERTY_TYPE(FaceMakerClass,(""),"Revolve",App::Prop_None,"Facemaker to use if Solid is true."); //default for old documents. For default for new objects, refer to setupObject().
+    //default for old documents. For default for new objects, refer to setupObject().
+    ADD_PROPERTY_TYPE(FaceMakerClass,(""),"Revolve",App::Prop_None,"Facemaker to use if Solid is true.");
 }
 
 short Revolution::mustExecute() const
@@ -179,7 +180,8 @@ App::DocumentObjectExecReturn *Revolution::execute()
             myShape = mkFace->Shape();
             sourceShape = TopoShape(myShape);
 
-            makeSolid = Standard_False;//don't ask TopoShape::revolve to make solid, as we've made faces...
+            //don't ask TopoShape::revolve to make solid, as we've made faces...
+            makeSolid = Standard_False;
         }
 
         // actual revolution!
@@ -200,5 +202,6 @@ App::DocumentObjectExecReturn *Revolution::execute()
 void Part::Revolution::setupObject()
 {
     Part::Feature::setupObject();
-    this->FaceMakerClass.setValue("Part::FaceMakerBullseye"); //default for newly created features
+    //default for newly created features
+    this->FaceMakerClass.setValue("Part::FaceMakerBullseye");
 }

--- a/src/Mod/Part/App/Geom2d/BSplineCurve2dPyImp.cpp
+++ b/src/Mod/Part/App/Geom2d/BSplineCurve2dPyImp.cpp
@@ -1146,7 +1146,8 @@ PyObject* BSplineCurve2dPy::buildFromPolesMultsKnots(PyObject *args, PyObject *k
             for (Py::Sequence::iterator it = multssq.begin(); it != multssq.end() && index <= occmults.Length(); ++it) {
                 Py::Long mult(*it);
                 if (index < occmults.Length() || !Base::asBoolean(periodic)) {
-                    sum_of_mults += (int)mult; //sum up the mults to compare them against the number of poles later
+                    //sum up the mults to compare them against the number of poles later
+                    sum_of_mults += (int)mult;
                 }
                 occmults(index++) = mult;
             }

--- a/src/Mod/Part/App/Geometry.cpp
+++ b/src/Mod/Part/App/Geometry.cpp
@@ -1835,7 +1835,8 @@ double GeomConic::getAngleXU() const
     gp_Dir xdir = conic->XAxis().Direction();
 
 
-    gp_Ax2 xdirref(center, normal); // this is a reference system, might be CCW or CW depending on the creation method
+    // this is a reference system, might be CCW or CW depending on the creation method
+    gp_Ax2 xdirref(center, normal);
 
     return -xdir.AngleWithRef(xdirref.XDirection(),normal);
 
@@ -2128,7 +2129,8 @@ double GeomArcOfConic::getAngleXU() const
     gp_Dir normal = conic->Axis().Direction();
     gp_Dir xdir = conic->XAxis().Direction();
 
-    gp_Ax2 xdirref(center, normal); // this is a reference system, might be CCW or CW depending on the creation method
+    // this is a reference system, might be CCW or CW depending on the creation method
+    gp_Ax2 xdirref(center, normal);
 
     return -xdir.AngleWithRef(xdirref.XDirection(),normal);
 }
@@ -2472,7 +2474,8 @@ void GeomArcOfCircle::getRange(double& u, double& v, bool emulateCCWXY) const
     if (emulateCCWXY){
         Handle(Geom_Conic) conic = Handle(Geom_Conic)::DownCast(curve->BasisCurve());
         double angleXU = -conic->Position().XDirection().AngleWithRef(gp_Dir(1.0,0.0,0.0), gp_Dir(0.0,0.0,1.0));
-        double u1 = u, v1 = v;//the true arc curve parameters, cached. u,v will contain the rotation-corrected and swapped angles.
+        //the true arc curve parameters, cached. u,v will contain the rotation-corrected and swapped angles.
+        double u1 = u, v1 = v;
         if (conic->Axis().Direction().Z() > 0.0){
             //normal CCW arc
             u = u1 + angleXU;
@@ -2507,7 +2510,8 @@ void GeomArcOfCircle::setRange(double u, double v, bool emulateCCWXY)
         if (emulateCCWXY){
             Handle(Geom_Conic) conic = Handle(Geom_Conic)::DownCast(curve->BasisCurve());
             double angleXU = -conic->Position().XDirection().AngleWithRef(gp_Dir(1.0,0.0,0.0), gp_Dir(0.0,0.0,1.0));
-            double u1 = u, v1 = v;//the values that were passed, ccw angles from X axis. u,v will contain the rotation-corrected and swapped angles.
+            //the values that were passed, ccw angles from X axis. u,v will contain the rotation-corrected and swapped angles.
+            double u1 = u, v1 = v;
             if (conic->Axis().Direction().Z() > 0.0){
                 //normal CCW arc
                 u = u1 - angleXU;
@@ -2776,7 +2780,8 @@ void GeomEllipse::setMajorAxisDir(Base::Vector3d newdir)
         return;//zero vector was passed. Keep the old orientation.
     try {
         gp_Ax2 pos = myCurve->Position();
-        pos.SetXDirection(gp_Dir(newdir.x, newdir.y, newdir.z));//OCC should keep the old main Direction (Z), and change YDirection to accommodate the new XDirection.
+        //OCC should keep the old main Direction (Z), and change YDirection to accommodate the new XDirection.
+        pos.SetXDirection(gp_Dir(newdir.x, newdir.y, newdir.z));
         myCurve->SetPosition(pos);
     }
     catch (Standard_Failure& e) {
@@ -2991,7 +2996,8 @@ void GeomArcOfEllipse::setMajorAxisDir(Base::Vector3d newdir)
         return;//zero vector was passed. Keep the old orientation.
     try {
         gp_Ax2 pos = c->Position();
-        pos.SetXDirection(gp_Dir(newdir.x, newdir.y, newdir.z));//OCC should keep the old main Direction (Z), and change YDirection to accommodate the new XDirection.
+        //OCC should keep the old main Direction (Z), and change YDirection to accommodate the new XDirection.
+        pos.SetXDirection(gp_Dir(newdir.x, newdir.y, newdir.z));
         c->SetPosition(pos);
     }
     catch (Standard_Failure& e) {
@@ -3426,7 +3432,8 @@ void GeomArcOfHyperbola::setMajorAxisDir(Base::Vector3d newdir)
 
     try {
         gp_Ax2 pos = c->Position();
-        pos.SetXDirection(gp_Dir(newdir.x, newdir.y, newdir.z));//OCC should keep the old main Direction (Z), and change YDirection to accommodate the new XDirection.
+        //OCC should keep the old main Direction (Z), and change YDirection to accommodate the new XDirection.
+        pos.SetXDirection(gp_Dir(newdir.x, newdir.y, newdir.z));
         c->SetPosition(pos);
     }
     catch (Standard_Failure& e) {

--- a/src/Mod/Part/App/GeometryDefaultExtension.cpp
+++ b/src/Mod/Part/App/GeometryDefaultExtension.cpp
@@ -77,7 +77,8 @@ std::unique_ptr<Part::GeometryExtension> GeometryDefaultExtension<T>::copy() con
 template <typename T>
 PyObject * GeometryDefaultExtension<T>::getPyObject()
 {
-    THROWM(Base::NotImplementedError,"Python object not implemented for default geometry extension template type. Template Specialisation missing."); // use template specialisation to provide the actual object
+    // use template specialisation to provide the actual object
+    THROWM(Base::NotImplementedError,"Python object not implemented for default geometry extension template type. Template Specialisation missing.");
 }
 
 namespace Part {

--- a/src/Mod/Part/App/Part2DObject.cpp
+++ b/src/Mod/Part/App/Part2DObject.cpp
@@ -202,7 +202,8 @@ bool Part2DObject::seekTrimPoints(const std::vector<Geometry *> &geomlist,
                             p1 = p;
                             geometryIndex1 = id;
                         }
-                        param -= period; // transfer param into the interval (pickedParam pickedParam+period]
+                        // transfer param into the interval (pickedParam pickedParam+period]
+                        param -= period;
                         if (param < param2) {
                             param2 = param;
                             p2 = p;

--- a/src/Mod/Part/App/TopoShape.cpp
+++ b/src/Mod/Part/App/TopoShape.cpp
@@ -2644,7 +2644,8 @@ TopoDS_Shape TopoShape::makeLoft(const TopTools_ListOfShape& profiles,
     }
 
     Standard_Boolean anIsCheck = Standard_True;
-    aGenerator.CheckCompatibility (anIsCheck);   // use BRepFill_CompatibleWires on profiles. force #edges, orientation, "origin" to match.
+    // use BRepFill_CompatibleWires on profiles. force #edges, orientation, "origin" to match.
+    aGenerator.CheckCompatibility (anIsCheck);
     aGenerator.Build();
     if (!aGenerator.IsDone())
         Standard_Failure::Raise("Failed to create loft face");

--- a/src/Mod/Part/Gui/DlgExtrusion.cpp
+++ b/src/Mod/Part/Gui/DlgExtrusion.cpp
@@ -642,7 +642,8 @@ bool DlgExtrusion::validate()
         errmsg.clear();
         try {
             App::PropertyLink lnk;
-            lnk.setValue(&this->getShapeToExtrude()); //simplified - check only for the first shape.
+            //simplified - check only for the first shape.
+            lnk.setValue(&this->getShapeToExtrude());
             Part::Extrusion::calculateShapeNormal(lnk);
         } catch(Base::Exception &err) {
             errmsg = QString::fromUtf8(err.what());

--- a/src/Mod/Part/Gui/TaskAttacher.cpp
+++ b/src/Mod/Part/Gui/TaskAttacher.cpp
@@ -401,7 +401,8 @@ void TaskAttacher::onSelectionChanged(const Gui::SelectionChanges& msg)
         try {
             pcAttach->Support.setValues(refs, refnames);
             updateListOfModes();
-            eMapMode mmode = getActiveMapMode();//will be mmDeactivated, if selected or if no modes are available
+            //will be mmDeactivated, if selected or if no modes are available
+            eMapMode mmode = getActiveMapMode();
             if(mmode == mmDeactivated){
                 //error = true;
                 this->completed = false;
@@ -793,7 +794,8 @@ void TaskAttacher::updateListOfModes()
     if (pcAttach->Support.getSize() > 0){
         pcAttach->attacher().suggestMapModes(this->lastSuggestResult);
         modesInList = this->lastSuggestResult.allApplicableModes;
-        modesInList.insert(modesInList.begin(), mmDeactivated); // always have the option to choose Deactivated mode
+        // always have the option to choose Deactivated mode
+        modesInList.insert(modesInList.begin(), mmDeactivated);
 
         //add reachable modes to the list, too, but gray them out (using lastValidModeItemIndex, later)
         lastValidModeItemIndex = modesInList.size()-1;

--- a/src/Mod/Part/Gui/TaskAttacher.h
+++ b/src/Mod/Part/Gui/TaskAttacher.h
@@ -134,9 +134,12 @@ private:
     VisibilityFunction visibilityFunc;
 
     // TODO fix documentation here (2015-11-10, Fat-Zer)
-    int iActiveRef; //what reference is being picked in 3d view now? -1 means no one, 0-3 means a reference is being picked.
-    bool autoNext;//if we should automatically switch to next reference (true after dialog launch, false afterwards)
-    std::vector<Attacher::eMapMode> modesInList; //this list is synchronous to what is populated into listOfModes widget.
+    //what reference is being picked in 3d view now? -1 means no one, 0-3 means a reference is being picked.
+    int iActiveRef;
+    //if we should automatically switch to next reference (true after dialog launch, false afterwards)
+    bool autoNext;
+    //this list is synchronous to what is populated into listOfModes widget.
+    std::vector<Attacher::eMapMode> modesInList;
     Attacher::SuggestResult lastSuggestResult;
     bool completed;
 

--- a/src/Mod/Part/Gui/TaskCheckGeometry.cpp
+++ b/src/Mod/Part/Gui/TaskCheckGeometry.cpp
@@ -97,40 +97,74 @@ QString shapeEnumToString(const int &index)
 QVector<QString> buildCheckStatusStringVector()
 {
     QVector<QString>names;
-    names.push_back(QObject::tr("No Error"));                           //    BRepCheck_NoError
-    names.push_back(QObject::tr("Invalid Point On Curve"));             //    BRepCheck_InvalidPointOnCurve
-    names.push_back(QObject::tr("Invalid Point On Curve On Surface"));  //    BRepCheck_InvalidPointOnCurveOnSurface
-    names.push_back(QObject::tr("Invalid Point On Surface"));           //    BRepCheck_InvalidPointOnSurface
-    names.push_back(QObject::tr("No 3D Curve"));                        //    BRepCheck_No3DCurve
-    names.push_back(QObject::tr("Multiple 3D Curve"));                  //    BRepCheck_Multiple3DCurve
-    names.push_back(QObject::tr("Invalid 3D Curve"));                   //    BRepCheck_Invalid3DCurve
-    names.push_back(QObject::tr("No Curve On Surface"));                //    BRepCheck_NoCurveOnSurface
-    names.push_back(QObject::tr("Invalid Curve On Surface"));           //    BRepCheck_InvalidCurveOnSurface
-    names.push_back(QObject::tr("Invalid Curve On Closed Surface"));    //    BRepCheck_InvalidCurveOnClosedSurface
-    names.push_back(QObject::tr("Invalid Same Range Flag"));            //    BRepCheck_InvalidSameRangeFlag
-    names.push_back(QObject::tr("Invalid Same Parameter Flag"));        //    BRepCheck_InvalidSameParameterFlag
-    names.push_back(QObject::tr("Invalid Degenerated Flag"));           //    BRepCheck_InvalidDegeneratedFlag
-    names.push_back(QObject::tr("Free Edge"));                          //    BRepCheck_FreeEdge
-    names.push_back(QObject::tr("Invalid MultiConnexity"));             //    BRepCheck_InvalidMultiConnexity
-    names.push_back(QObject::tr("Invalid Range"));                      //    BRepCheck_InvalidRange
-    names.push_back(QObject::tr("Empty Wire"));                         //    BRepCheck_EmptyWire
-    names.push_back(QObject::tr("Redundant Edge"));                     //    BRepCheck_RedundantEdge
-    names.push_back(QObject::tr("Self Intersecting Wire"));             //    BRepCheck_SelfIntersectingWire
-    names.push_back(QObject::tr("No Surface"));                         //    BRepCheck_NoSurface
-    names.push_back(QObject::tr("Invalid Wire"));                       //    BRepCheck_InvalidWire
-    names.push_back(QObject::tr("Redundant Wire"));                     //    BRepCheck_RedundantWire
-    names.push_back(QObject::tr("Intersecting Wires"));                 //    BRepCheck_IntersectingWires
-    names.push_back(QObject::tr("Invalid Imbrication Of Wires"));       //    BRepCheck_InvalidImbricationOfWires
-    names.push_back(QObject::tr("Empty Shell"));                        //    BRepCheck_EmptyShell
-    names.push_back(QObject::tr("Redundant Face"));                     //    BRepCheck_RedundantFace
-    names.push_back(QObject::tr("Unorientable Shape"));                 //    BRepCheck_UnorientableShape
-    names.push_back(QObject::tr("Not Closed"));                         //    BRepCheck_NotClosed
-    names.push_back(QObject::tr("Not Connected"));                      //    BRepCheck_NotConnected
-    names.push_back(QObject::tr("Sub Shape Not In Shape"));             //    BRepCheck_SubshapeNotInShape
-    names.push_back(QObject::tr("Bad Orientation"));                    //    BRepCheck_BadOrientation
-    names.push_back(QObject::tr("Bad Orientation Of Sub Shape"));       //    BRepCheck_BadOrientationOfSubshape
-    names.push_back(QObject::tr("Invalid Tolerance Value"));            //    BRepCheck_InvalidToleranceValue
-    names.push_back(QObject::tr("Check Failed"));                       //    BRepCheck_CheckFail
+    //    BRepCheck_NoError
+    names.push_back(QObject::tr("No Error"));
+    //    BRepCheck_InvalidPointOnCurve
+    names.push_back(QObject::tr("Invalid Point On Curve"));
+    //    BRepCheck_InvalidPointOnCurveOnSurface
+    names.push_back(QObject::tr("Invalid Point On Curve On Surface"));
+    //    BRepCheck_InvalidPointOnSurface
+    names.push_back(QObject::tr("Invalid Point On Surface"));
+    //    BRepCheck_No3DCurve
+    names.push_back(QObject::tr("No 3D Curve"));
+    //    BRepCheck_Multiple3DCurve
+    names.push_back(QObject::tr("Multiple 3D Curve"));
+    //    BRepCheck_Invalid3DCurve
+    names.push_back(QObject::tr("Invalid 3D Curve"));
+    //    BRepCheck_NoCurveOnSurface
+    names.push_back(QObject::tr("No Curve On Surface"));
+    //    BRepCheck_InvalidCurveOnSurface
+    names.push_back(QObject::tr("Invalid Curve On Surface"));
+    //    BRepCheck_InvalidCurveOnClosedSurface
+    names.push_back(QObject::tr("Invalid Curve On Closed Surface"));
+    //    BRepCheck_InvalidSameRangeFlag
+    names.push_back(QObject::tr("Invalid Same Range Flag"));
+    //    BRepCheck_InvalidSameParameterFlag
+    names.push_back(QObject::tr("Invalid Same Parameter Flag"));
+    //    BRepCheck_InvalidDegeneratedFlag
+    names.push_back(QObject::tr("Invalid Degenerated Flag"));
+    //    BRepCheck_FreeEdge
+    names.push_back(QObject::tr("Free Edge"));
+    //    BRepCheck_InvalidMultiConnexity
+    names.push_back(QObject::tr("Invalid MultiConnexity"));
+    //    BRepCheck_InvalidRange
+    names.push_back(QObject::tr("Invalid Range"));
+    //    BRepCheck_EmptyWire
+    names.push_back(QObject::tr("Empty Wire"));
+    //    BRepCheck_RedundantEdge
+    names.push_back(QObject::tr("Redundant Edge"));
+    //    BRepCheck_SelfIntersectingWire
+    names.push_back(QObject::tr("Self Intersecting Wire"));
+    //    BRepCheck_NoSurface
+    names.push_back(QObject::tr("No Surface"));
+    //    BRepCheck_InvalidWire
+    names.push_back(QObject::tr("Invalid Wire"));
+    //    BRepCheck_RedundantWire
+    names.push_back(QObject::tr("Redundant Wire"));
+    //    BRepCheck_IntersectingWires
+    names.push_back(QObject::tr("Intersecting Wires"));
+    //    BRepCheck_InvalidImbricationOfWires
+    names.push_back(QObject::tr("Invalid Imbrication Of Wires"));
+    //    BRepCheck_EmptyShell
+    names.push_back(QObject::tr("Empty Shell"));
+    //    BRepCheck_RedundantFace
+    names.push_back(QObject::tr("Redundant Face"));
+    //    BRepCheck_UnorientableShape
+    names.push_back(QObject::tr("Unorientable Shape"));
+    //    BRepCheck_NotClosed
+    names.push_back(QObject::tr("Not Closed"));
+    //    BRepCheck_NotConnected
+    names.push_back(QObject::tr("Not Connected"));
+    //    BRepCheck_SubshapeNotInShape
+    names.push_back(QObject::tr("Sub Shape Not In Shape"));
+    //    BRepCheck_BadOrientation
+    names.push_back(QObject::tr("Bad Orientation"));
+    //    BRepCheck_BadOrientationOfSubshape
+    names.push_back(QObject::tr("Bad Orientation Of Sub Shape"));
+    //    BRepCheck_InvalidToleranceValue
+    names.push_back(QObject::tr("Invalid Tolerance Value"));
+    //    BRepCheck_CheckFail
+    names.push_back(QObject::tr("Check Failed"));
 
     return names;
 }
@@ -156,17 +190,26 @@ QString checkStatusToString(const int &index)
 QVector<QString> buildBOPCheckResultVector()
 {
   QVector<QString> results;
-  results.push_back(QObject::tr("BOPAlgo CheckUnknown"));               //BOPAlgo_CheckUnknown
+  //BOPAlgo_CheckUnknown
+  results.push_back(QObject::tr("BOPAlgo CheckUnknown"));
   results.push_back(QObject::tr("BOPAlgo BadType"));                    //BOPAlgo_BadType
-  results.push_back(QObject::tr("BOPAlgo SelfIntersect"));              //BOPAlgo_SelfIntersect
-  results.push_back(QObject::tr("BOPAlgo TooSmallEdge"));               //BOPAlgo_TooSmallEdge
-  results.push_back(QObject::tr("BOPAlgo NonRecoverableFace"));         //BOPAlgo_NonRecoverableFace
-  results.push_back(QObject::tr("BOPAlgo IncompatibilityOfVertex"));    //BOPAlgo_IncompatibilityOfVertex
-  results.push_back(QObject::tr("BOPAlgo IncompatibilityOfEdge"));      //BOPAlgo_IncompatibilityOfEdge
-  results.push_back(QObject::tr("BOPAlgo IncompatibilityOfFace"));      //BOPAlgo_IncompatibilityOfFace
-  results.push_back(QObject::tr("BOPAlgo OperationAborted"));           //BOPAlgo_OperationAborted
+  //BOPAlgo_SelfIntersect
+  results.push_back(QObject::tr("BOPAlgo SelfIntersect"));
+  //BOPAlgo_TooSmallEdge
+  results.push_back(QObject::tr("BOPAlgo TooSmallEdge"));
+  //BOPAlgo_NonRecoverableFace
+  results.push_back(QObject::tr("BOPAlgo NonRecoverableFace"));
+  //BOPAlgo_IncompatibilityOfVertex
+  results.push_back(QObject::tr("BOPAlgo IncompatibilityOfVertex"));
+  //BOPAlgo_IncompatibilityOfEdge
+  results.push_back(QObject::tr("BOPAlgo IncompatibilityOfEdge"));
+  //BOPAlgo_IncompatibilityOfFace
+  results.push_back(QObject::tr("BOPAlgo IncompatibilityOfFace"));
+  //BOPAlgo_OperationAborted
+  results.push_back(QObject::tr("BOPAlgo OperationAborted"));
   results.push_back(QObject::tr("BOPAlgo GeomAbs_C0"));                 //BOPAlgo_GeomAbs_C0
-  results.push_back(QObject::tr("BOPAlgo_InvalidCurveOnSurface"));      //BOPAlgo_InvalidCurveOnSurface
+  //BOPAlgo_InvalidCurveOnSurface
+  results.push_back(QObject::tr("BOPAlgo_InvalidCurveOnSurface"));
   results.push_back(QObject::tr("BOPAlgo NotValid"));                   //BOPAlgo_NotValid
 
   return results;
@@ -667,7 +710,8 @@ int TaskCheckGeometryResults::goBOPSingleCheck(const TopoDS_Shape& shapeIn, Resu
   BOPCheck.RebuildFaceMode() = rebuildFaceMode;
   BOPCheck.ContinuityMode() = continuityMode;
 
-  BOPCheck.SetParallelMode(!runSingleThreaded); //this doesn't help for speed right now(occt 6.9.1).
+  //this doesn't help for speed right now(occt 6.9.1).
+  BOPCheck.SetParallelMode(!runSingleThreaded);
   BOPCheck.SetRunParallel(!runSingleThreaded); //performance boost, use all available cores
   BOPCheck.TangentMode() = tangentMode; //these 4 new tests add about 5% processing time.
   BOPCheck.MergeVertexMode() = mergeVertexMode;
@@ -762,7 +806,8 @@ void TaskCheckGeometryResults::dispatchError(ResultEntry *entry, const BRepCheck
     goSetupResultBoundingBox(entry);
     ParameterGrp::handle group = App::GetApplication().GetUserParameter().
     GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod")->GetGroup("Part")->GetGroup("CheckGeometry");
-    bool logErrors = group->GetBool("LogErrors", true); //log errors to report view
+    //log errors to report view
+    bool logErrors = group->GetBool("LogErrors", true);
 
     /*log BRepCheck errors to report view*/
     if (logErrors){

--- a/src/Mod/Part/Gui/TaskDimension.cpp
+++ b/src/Mod/Part/Gui/TaskDimension.cpp
@@ -371,7 +371,8 @@ void PartGui::ensureSomeDimensionVisible()
   bool visibilityDelta = group->GetBool("DimensionsDeltaVisible", true);
 
   if (!visibility3d && !visibilityDelta) //both turned off.
-    group->SetBool("Dimensions3dVisible", true); //turn on 3d, so something is visible.
+    //turn on 3d, so something is visible.
+    group->SetBool("Dimensions3dVisible", true);
 }
 
 void PartGui::ensure3dDimensionVisible()

--- a/src/Mod/Part/Gui/ViewProviderExt.cpp
+++ b/src/Mod/Part/Gui/ViewProviderExt.cpp
@@ -115,7 +115,8 @@ ViewProviderPartExt::ViewProviderPartExt()
     NormalsFromUV = true;
 
     // get default line color
-    unsigned long lcol = Gui::ViewParams::instance()->getDefaultShapeLineColor(); // dark grey (25,25,25)
+    // dark grey (25,25,25)
+    unsigned long lcol = Gui::ViewParams::instance()->getDefaultShapeLineColor();
     float lr,lg,lb;
     lr = ((lcol >> 24) & 0xff) / 255.0; lg = ((lcol >> 16) & 0xff) / 255.0; lb = ((lcol >> 8) & 0xff) / 255.0;
     // get default vertex color
@@ -1287,4 +1288,3 @@ void ViewProviderPartExt::forceUpdate(bool enable) {
     }else if(forceUpdateCount)
         --forceUpdateCount;
 }
-

--- a/src/Mod/Part/Gui/ViewProviderGridExtension.cpp
+++ b/src/Mod/Part/Gui/ViewProviderGridExtension.cpp
@@ -291,7 +291,8 @@ void GridExtensionP::createGridPart(int numberSubdiv, bool subDivLines, bool div
     grid->vertexProperty = vts;
 
     float gridDimension = 1.5 * camMaxDimension;
-    int vlines = static_cast<int>(gridDimension / computedGridValue); // total number of vertical lines
+    // total number of vertical lines
+    int vlines = static_cast<int>(gridDimension / computedGridValue);
     int nlines = 2 * vlines; // total number of lines
 
     if (nlines > 2000) {

--- a/src/Mod/PartDesign/App/FeatureExtrude.cpp
+++ b/src/Mod/PartDesign/App/FeatureExtrude.cpp
@@ -235,8 +235,10 @@ void FeatureExtrude::generateTaperedPrism(TopoDS_Shape& prism,
                                           const bool midplane)
 {
     std::list<TopoDS_Shape> drafts;
-    bool isSolid = true; // in PD we only generate solids, while Part Extrude can also create only shells
-    bool isPartDesign = true; // there is an OCC bug with single-edge wires (circles) we need to treat differently for PD and Part
+    // in PD we only generate solids, while Part Extrude can also create only shells
+    bool isSolid = true;
+    // there is an OCC bug with single-edge wires (circles) we need to treat differently for PD and Part
+    bool isPartDesign = true;
     if (method == "ThroughAll") {
         Part::ExtrusionHelper::makeDraft(sketchshape, direction, getThroughAllLength(),
             0.0, Base::toRadians(angle), 0.0, isSolid, drafts, isPartDesign);

--- a/src/Mod/PartDesign/App/FeatureHelix.cpp
+++ b/src/Mod/PartDesign/App/FeatureHelix.cpp
@@ -413,7 +413,8 @@ TopoDS_Shape Helix::generateHelixPath(double startOffset0)
     gp_Dir dir(axisVector.x, axisVector.y, axisVector.z);
 
     Base::Vector3d normal = getProfileNormal();
-    Base::Vector3d start = axisVector.Cross(normal);  // pointing towards the desired helix start point.
+    // pointing towards the desired helix start point.
+    Base::Vector3d start = axisVector.Cross(normal);
 
     // if our axis is (nearly) aligned with the profile's normal, we're only interested in the "twist"
     // of the helix. The actual starting point, and thus the radius, isn't important as long as it's
@@ -508,7 +509,8 @@ TopoDS_Shape Helix::generateHelixPath(double startOffset0)
 double Helix::safePitch()
 {
     Base::Vector3d axisVec = Axis.getValue();
-    Base::Vector3d startVec = axisVec.Cross(getProfileNormal()); // pointing towards the helix start point
+    // pointing towards the helix start point
+    Base::Vector3d startVec = axisVec.Cross(getProfileNormal());
     HelixMode mode = static_cast<HelixMode>(Mode.getValue());
     double growthValue = Growth.getValue();
     double turnsValue = Turns.getValue();

--- a/src/Mod/PartDesign/App/FeatureHole.cpp
+++ b/src/Mod/PartDesign/App/FeatureHole.cpp
@@ -707,7 +707,8 @@ Hole::Hole()
     ADD_PROPERTY_TYPE(ThreadDepthType, (0L), "Hole", App::Prop_None, "Thread depth type");
     ThreadDepthType.setEnums(ThreadDepthTypeEnums);
 
-    ADD_PROPERTY_TYPE(ThreadDepth, (23.5), "Hole", App::Prop_None, "Thread Length"); // default is assuming an M1
+    // default is assuming an M1
+    ADD_PROPERTY_TYPE(ThreadDepth, (23.5), "Hole", App::Prop_None, "Thread Length");
 
     ADD_PROPERTY_TYPE(UseCustomThreadClearance, (false), "Hole", App::Prop_None, "Use custom thread clearance");
 
@@ -2023,9 +2024,11 @@ TopoDS_Shape Hole::makeThread(const gp_Vec& xDir, const gp_Vec& zDir, double len
     // Note that in the ISO standard, Dmaj is called D, which has been followed here.
     double D = threadDescription[threadType][threadSize].diameter;  // Major diameter
     double P = getThreadPitch();
-    double H = sqrt(3) / 2 * P;                                                           // Height of fundamental triangle
+    // Height of fundamental triangle
+    double H = sqrt(3) / 2 * P;
 
-    double clearance;                                                                     // clearance to be added on the diameter
+    // clearance to be added on the diameter
+    double clearance;
     if (UseCustomThreadClearance.getValue())
         clearance = CustomThreadClearance.getValue();
     else

--- a/src/Mod/PartDesign/App/FeatureMultiTransform.cpp
+++ b/src/Mod/PartDesign/App/FeatureMultiTransform.cpp
@@ -142,7 +142,8 @@ const std::list<gp_Trsf> MultiTransform::getTransformations(const std::vector<Ap
                         double factor = nt->ScaleFactor(); // extract scale factor
 
                         if (factor > Precision::Confusion()) {
-                            trans.SetScale(*oc, factor); // recreate the scaled transformation to use the correct COG
+                            // recreate the scaled transformation to use the correct COG
+                            trans.SetScale(*oc, factor);
                             trans = trans * (*ot);
                             cogs.push_back(*oc); // Scaling does not affect the COG
                         } else {

--- a/src/Mod/PartDesign/App/FeaturePolarPattern.cpp
+++ b/src/Mod/PartDesign/App/FeaturePolarPattern.cpp
@@ -93,7 +93,8 @@ const std::list<gp_Trsf> PolarPattern::getTransformations(const std::vector<App:
     bool reversed = Reversed.getValue();
     double offset;
     if (std::fabs(angle - 360.0) < Precision::Confusion())
-        offset = radians / occurrences; // Because e.g. two occurrences in 360 degrees need to be 180 degrees apart
+        // Because e.g. two occurrences in 360 degrees need to be 180 degrees apart
+        offset = radians / occurrences;
     else
         offset = radians / (occurrences - 1);
 

--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -139,7 +139,8 @@ void UnifiedDatumCommand(Gui::Command &cmd, Base::Type type, std::string name)
                     QMessageBox::information(Gui::getMainWindow(),QObject::tr("Invalid selection"), QObject::tr("There are no attachment modes that fit selected objects. Select something else."));
                 }
             }
-            cmd.doCommand(Gui::Command::Doc,"App.activeDocument().recompute()");  // recompute the feature based on its references
+            // recompute the feature based on its references
+            cmd.doCommand(Gui::Command::Doc,"App.activeDocument().recompute()");
             PartDesignGui::setEdit(Feat,pcActiveBody);
         } else {
             QMessageBox::warning(Gui::getMainWindow(),QObject::tr("Error"), QObject::tr("There is no active body. Please make a body active before inserting a datum entity."));
@@ -1862,7 +1863,8 @@ void prepareTransformed(PartDesign::Body *pcActiveBody, Gui::Command* cmd, const
         FCMD_OBJ_CMD(pcActiveBody, "newObject('PartDesign::" << which << "','" << FeatName << "')");
         // FIXME: There seems to be kind of a race condition here, leading to sporadic errors like
         // Exception (Thu Sep  6 11:52:01 2012): 'App.Document' object has no attribute 'Mirrored'
-        Gui::Command::updateActive(); // Helps to ensure that the object already exists when the next command comes up
+        // Helps to ensure that the object already exists when the next command comes up
+        Gui::Command::updateActive();
         Gui::Command::doCommand(Gui::Command::Doc, str.str().c_str());
 
         auto Feat = pcActiveBody->getDocument()->getObject(FeatName.c_str());

--- a/src/Mod/PartDesign/Gui/TaskExtrudeParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskExtrudeParameters.cpp
@@ -447,7 +447,8 @@ void TaskExtrudeParameters::setCheckboxes(Modes mode, Type type)
     }
     else if (mode == Modes::ThroughAll && type == Type::Pocket) {
         isOffsetEditVisible = true;
-        isOffsetEditEnabled = false; // offset may have some meaning for through all but it doesn't work
+        // offset may have some meaning for through all but it doesn't work
+        isOffsetEditEnabled = false;
         isMidplaneEnabled = true;
         isMidplaneVisible = true;
         isReversedEnabled = !ui->checkBoxMidplane->isChecked();

--- a/src/Mod/PartDesign/Gui/TaskHelixParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskHelixParameters.cpp
@@ -354,7 +354,8 @@ void TaskHelixParameters::adaptVisibilityToMode()
 void TaskHelixParameters::assignToolTipsFromPropertyDocs()
 {
     auto pcHelix = static_cast<PartDesign::Helix*>(vp->getObject());
-    const char* propCategory = "App::Property"; // cf. https://tracker.freecadweb.org/view.php?id=0002524
+    // cf. https://tracker.freecadweb.org/view.php?id=0002524
+    const char* propCategory = "App::Property";
     QString toolTip;
 
     // Beware that "Axis" in the GUI actually represents the property "ReferenceAxis"!

--- a/src/Mod/PartDesign/Gui/TaskLinearPatternParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskLinearPatternParameters.cpp
@@ -69,7 +69,8 @@ TaskLinearPatternParameters::TaskLinearPatternParameters(ViewProviderTransformed
 
     selectionMode = none;
 
-    blockUpdate = false; // Hack, sometimes it is NOT false although set to false in Transformed::Transformed()!!
+    // Hack, sometimes it is NOT false although set to false in Transformed::Transformed()!!
+    blockUpdate = false;
     setupUI();
 }
 

--- a/src/Mod/PartDesign/Gui/TaskMirroredParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskMirroredParameters.cpp
@@ -65,7 +65,8 @@ TaskMirroredParameters::TaskMirroredParameters(ViewProviderTransformed *Transfor
 
     selectionMode = none;
 
-    blockUpdate = false; // Hack, sometimes it is NOT false although set to false in Transformed::Transformed()!!
+    // Hack, sometimes it is NOT false although set to false in Transformed::Transformed()!!
+    blockUpdate = false;
     setupUI();
 }
 
@@ -88,7 +89,8 @@ TaskMirroredParameters::TaskMirroredParameters(TaskMultiTransformParameters *par
 
     selectionMode = none;
 
-    blockUpdate = false; // Hack, sometimes it is NOT false although set to false in Transformed::Transformed()!!
+    // Hack, sometimes it is NOT false although set to false in Transformed::Transformed()!!
+    blockUpdate = false;
     setupUI();
 }
 

--- a/src/Mod/PartDesign/Gui/TaskMultiTransformParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskMultiTransformParameters.cpp
@@ -254,7 +254,8 @@ void TaskMultiTransformParameters::onTransformEdit()
 {
     if (editHint)
         return; // Can't edit the hint...
-    closeSubTask(); // For example if user is editing one subTask and then double-clicks on another without OK'ing first
+    // For example if user is editing one subTask and then double-clicks on another without OK'ing first
+    closeSubTask();
     ui->listTransformFeatures->currentItem()->setSelected(true);
     int row = ui->listTransformFeatures->currentIndex().row();
     PartDesign::MultiTransform* pcMultiTransform = static_cast<PartDesign::MultiTransform*>(TransformedView->getObject());

--- a/src/Mod/PartDesign/Gui/TaskPolarPatternParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPolarPatternParameters.cpp
@@ -99,7 +99,8 @@ TaskPolarPatternParameters::TaskPolarPatternParameters(TaskMultiTransformParamet
 
     selectionMode = none;
 
-    blockUpdate = false; // Hack, sometimes it is NOT false although set to false in Transformed::Transformed()!!
+    // Hack, sometimes it is NOT false although set to false in Transformed::Transformed()!!
+    blockUpdate = false;
     setupUI();
 }
 

--- a/src/Mod/PartDesign/Gui/TaskPrimitiveParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPrimitiveParameters.cpp
@@ -102,7 +102,8 @@ TaskBoxPrimitives::TaskBoxPrimitives(ViewProviderPrimitive* vp, QWidget* parent)
             ui->sphereAngle3->bind(static_cast<PartDesign::Sphere*>(vp->getObject())->Angle3);
             ui->sphereRadius->setValue(static_cast<PartDesign::Sphere*>(vp->getObject())->Radius.getValue());
             ui->sphereRadius->bind(static_cast<PartDesign::Sphere*>(vp->getObject())->Radius);
-            ui->sphereAngle1->setMaximum(ui->sphereAngle2->rawValue()); // must geometrically be <= than sphereAngle2
+            // must geometrically be <= than sphereAngle2
+            ui->sphereAngle1->setMaximum(ui->sphereAngle2->rawValue());
             ui->sphereAngle1->setMinimum(static_cast<PartDesign::Sphere*>(vp->getObject())->Angle1.getMinimum());
             ui->sphereAngle2->setMaximum(static_cast<PartDesign::Sphere*>(vp->getObject())->Angle2.getMaximum());
             ui->sphereAngle2->setMinimum(ui->sphereAngle1->rawValue());
@@ -144,7 +145,8 @@ TaskBoxPrimitives::TaskBoxPrimitives(ViewProviderPrimitive* vp, QWidget* parent)
             ui->ellipsoidRadius2->bind(static_cast<PartDesign::Ellipsoid*>(vp->getObject())->Radius2);
             ui->ellipsoidRadius3->setValue(static_cast<PartDesign::Ellipsoid*>(vp->getObject())->Radius3.getValue());
             ui->ellipsoidRadius3->bind(static_cast<PartDesign::Ellipsoid*>(vp->getObject())->Radius3);
-            ui->ellipsoidAngle1->setMaximum(ui->ellipsoidAngle2->rawValue()); // must geometrically be <= than sphereAngle2
+            // must geometrically be <= than sphereAngle2
+            ui->ellipsoidAngle1->setMaximum(ui->ellipsoidAngle2->rawValue());
             ui->ellipsoidAngle1->setMinimum(static_cast<PartDesign::Ellipsoid*>(vp->getObject())->Angle1.getMinimum());
             ui->ellipsoidAngle2->setMaximum(static_cast<PartDesign::Ellipsoid*>(vp->getObject())->Angle2.getMaximum());
             ui->ellipsoidAngle2->setMinimum(ui->ellipsoidAngle1->rawValue());
@@ -169,7 +171,8 @@ TaskBoxPrimitives::TaskBoxPrimitives(ViewProviderPrimitive* vp, QWidget* parent)
             ui->torusRadius1->bind(static_cast<PartDesign::Torus*>(vp->getObject())->Radius1);
             ui->torusRadius2->setValue(static_cast<PartDesign::Torus*>(vp->getObject())->Radius2.getValue());
             ui->torusRadius2->bind(static_cast<PartDesign::Torus*>(vp->getObject())->Radius2);
-            ui->torusAngle1->setMaximum(ui->torusAngle2->rawValue()); // must geometrically be <= than sphereAngle2
+            // must geometrically be <= than sphereAngle2
+            ui->torusAngle1->setMaximum(ui->torusAngle2->rawValue());
             ui->torusAngle1->setMinimum(static_cast<PartDesign::Torus*>(vp->getObject())->Angle1.getMinimum());
             ui->torusAngle2->setMaximum(static_cast<PartDesign::Torus*>(vp->getObject())->Angle2.getMaximum());
             ui->torusAngle2->setMinimum(ui->torusAngle1->rawValue());

--- a/src/Mod/PartDesign/Gui/TaskScaledParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskScaledParameters.cpp
@@ -79,7 +79,8 @@ TaskScaledParameters::TaskScaledParameters(TaskMultiTransformParameters *parentT
     ui->listWidgetFeatures->hide();
     ui->checkBoxUpdateView->hide();
 
-    blockUpdate = false; // Hack, sometimes it is NOT false although set to false in Transformed::Transformed()!!
+    // Hack, sometimes it is NOT false although set to false in Transformed::Transformed()!!
+    blockUpdate = false;
     setupUI();
 }
 

--- a/src/Mod/PartDesign/Gui/ViewProviderBody.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderBody.cpp
@@ -133,7 +133,8 @@ void ViewProviderBody::setupContextMenu(QMenu* menu, QObject* receiver, const ch
     QAction* act = menu->addAction(tr("Toggle active body"));
     func->trigger(act, std::bind(&ViewProviderBody::doubleClicked, this));
 
-    Gui::ViewProviderGeometryObject::setupContextMenu(menu, receiver, member); // clazy:exclude=skipped-base-method
+    // clazy:exclude=skipped-base-method
+    Gui::ViewProviderGeometryObject::setupContextMenu(menu, receiver, member);
 }
 
 bool ViewProviderBody::doubleClicked()

--- a/src/Mod/PartDesign/Gui/ViewProviderHole.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderHole.cpp
@@ -61,7 +61,8 @@ std::vector<App::DocumentObject*> ViewProviderHole::claimChildren()const
 void ViewProviderHole::setupContextMenu(QMenu* menu, QObject* receiver, const char* member)
 {
     addDefaultAction(menu, QObject::tr("Edit hole"));
-    PartGui::ViewProviderPart::setupContextMenu(menu, receiver, member); // clazy:exclude=skipped-base-method
+    // clazy:exclude=skipped-base-method
+    PartGui::ViewProviderPart::setupContextMenu(menu, receiver, member);
 }
 
 bool ViewProviderHole::setEdit(int ModNum)

--- a/src/Mod/PartDesign/Gui/ViewProviderMultiTransform.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderMultiTransform.cpp
@@ -40,7 +40,8 @@ TaskDlgFeatureParameters *ViewProviderMultiTransform::getEditDialog() {
 void ViewProviderMultiTransform::setupContextMenu(QMenu* menu, QObject* receiver, const char* member)
 {
     this->addDefaultAction(menu, QObject::tr("Edit %1").arg(QString::fromStdString(featureName)));
-    PartDesignGui::ViewProvider::setupContextMenu(menu, receiver, member); // clazy:exclude=skipped-base-method
+    // clazy:exclude=skipped-base-method
+    PartDesignGui::ViewProvider::setupContextMenu(menu, receiver, member);
 }
 
 std::vector<App::DocumentObject*> ViewProviderMultiTransform::claimChildren() const

--- a/src/Mod/PartDesign/Gui/ViewProviderTransformed.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderTransformed.cpp
@@ -116,7 +116,8 @@ bool ViewProviderTransformed::setEdit(int ModNum)
     pcRejectedRoot->addChild(rejectedMaterial);
     pcRejectedRoot->addChild(rejectedHints);
     pcRejectedRoot->addChild(rejectedFaceStyle);
-    pcRejectedRoot->addChild(rejectedNormb); // NOTE: The code relies on the last child added here being index 6
+    // NOTE: The code relies on the last child added here being index 6
+    pcRejectedRoot->addChild(rejectedNormb);
     pcRoot->addChild(pcRejectedRoot);
 
     recomputeFeature(false);

--- a/src/Mod/Path/App/Area.cpp
+++ b/src/Mod/Path/App/Area.cpp
@@ -903,7 +903,8 @@ struct WireJoiner {
 
         for (int iteration = 1; !edgesToVisit.empty(); ++iteration) {
             EdgeInfo* currentInfo = *edgesToVisit.begin();
-            int currentIdx = 1; // used to tell whether search connection from the start(0) or end(1)
+            // used to tell whether search connection from the start(0) or end(1)
+            int currentIdx = 1;
             TopoDS_Edge& e = currentInfo->edge;
             edgesToVisit.erase(edgesToVisit.begin());
             gp_Pnt pstart = currentInfo->p1;

--- a/src/Mod/Path/App/Command.h
+++ b/src/Mod/Path/App/Command.h
@@ -49,16 +49,26 @@ namespace Path
         virtual void Restore(Base::XMLReader &/*reader*/);
 
         // specific methods
-        Base::Placement getPlacement (const Base::Vector3d pos = Base::Vector3d()) const; // returns a placement from the x,y,z,a,b,c parameters
-        Base::Vector3d getCenter (void) const; // returns a 3d vector from the i,j,k parameters
-        void setCenter(const Base::Vector3d&, bool clockwise=true); // sets the center coordinates and the command name
-        std::string toGCode (int precision=6, bool padzero=true) const; // returns a GCode string representation of the command
-        void setFromGCode (const std::string&); // sets the parameters from the contents of the given GCode string
-        void setFromPlacement (const Base::Placement&); // sets the parameters from the contents of the given placement
-        bool has(const std::string&) const; // returns true if the given string exists in the parameters
-        Command transform(const Base::Placement&); // returns a transformed copy of this command
-        double getValue(const std::string &name) const; // returns the value of a given parameter
-        void scaleBy(double factor); // scales the receiver - use for imperial/metric conversions
+        // returns a placement from the x,y,z,a,b,c parameters
+        Base::Placement getPlacement (const Base::Vector3d pos = Base::Vector3d()) const;
+        // returns a 3d vector from the i,j,k parameters
+        Base::Vector3d getCenter (void) const;
+        // sets the center coordinates and the command name
+        void setCenter(const Base::Vector3d&, bool clockwise=true);
+        // returns a GCode string representation of the command
+        std::string toGCode (int precision=6, bool padzero=true) const;
+        // sets the parameters from the contents of the given GCode string
+        void setFromGCode (const std::string&);
+        // sets the parameters from the contents of the given placement
+        void setFromPlacement (const Base::Placement&);
+        // returns true if the given string exists in the parameters
+        bool has(const std::string&) const;
+        // returns a transformed copy of this command
+        Command transform(const Base::Placement&);
+        // returns the value of a given parameter
+        double getValue(const std::string &name) const;
+        // scales the receiver - use for imperial/metric conversions
+        void scaleBy(double factor);
 
         // this assumes the name is upper case
         inline double getParam(const std::string &name, double fallback = 0.0) const {

--- a/src/Mod/Path/App/Path.h
+++ b/src/Mod/Path/App/Path.h
@@ -59,9 +59,11 @@ namespace Path
             void insertCommand(const Command &Cmd, int); // inserts a command
             void deleteCommand(int); // deletes a command
             double getLength(void); // return the Length (mm) of the Path
-            double getCycleTime(double, double, double, double); // return the Cycle Time (s) of the Path
+            // return the Cycle Time (s) of the Path
+            double getCycleTime(double, double, double, double);
             void recalculate(void); // recalculates the points
-            void setFromGCode(const std::string); // sets the path from the contents of the given GCode string
+            // sets the path from the contents of the given GCode string
+            void setFromGCode(const std::string);
             std::string toGCode(void) const; // gets a gcode string representation from the Path
             Base::BoundBox3d getBoundBox(void) const;
 

--- a/src/Mod/Path/App/PathSegmentWalker.cpp
+++ b/src/Mod/Path/App/PathSegmentWalker.cpp
@@ -232,7 +232,8 @@ void PathSegmentWalker::walk(PathSegmentVisitor &cb, const Base::Vector3d &start
 
             double amax = std::max(fmod(fabs(a - A), 360), std::max(fmod(fabs(b - B), 360), fmod(fabs(c - C), 360)));
 
-            int segments = std::max(ARC_MIN_SEGMENTS, 3.0/(deviation/std::max(angle, amax))); //we use a rather simple rule here, provisorily
+            //we use a rather simple rule here, provisorily
+            int segments = std::max(ARC_MIN_SEGMENTS, 3.0/(deviation/std::max(angle, amax)));
             double dZ = (next.*pz - last.*pz)/segments; //How far each segment will helix in Z
 
             double dangle = angle/segments;

--- a/src/Mod/Path/Gui/ViewProviderPath.cpp
+++ b/src/Mod/Path/Gui/ViewProviderPath.cpp
@@ -136,10 +136,12 @@ ViewProviderPath::ViewProviderPath()
     :pt0Index(-1),blockPropertyChange(false),edgeStart(-1),coordStart(-1),coordEnd(-1)
 {
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Path");
-    unsigned long lcol = hGrp->GetUnsigned("DefaultNormalPathColor",11141375UL); // dark green (0,170,0)
+    // dark green (0,170,0)
+    unsigned long lcol = hGrp->GetUnsigned("DefaultNormalPathColor",11141375UL);
     float lr,lg,lb;
     lr = ((lcol >> 24) & 0xff) / 255.0; lg = ((lcol >> 16) & 0xff) / 255.0; lb = ((lcol >> 8) & 0xff) / 255.0;
-    unsigned long mcol = hGrp->GetUnsigned("DefaultPathMarkerColor",1442775295UL); // lime green (85,255,0)
+    // lime green (85,255,0)
+    unsigned long mcol = hGrp->GetUnsigned("DefaultPathMarkerColor",1442775295UL);
     float mr,mg,mb;
     mr = ((mcol >> 24) & 0xff) / 255.0; mg = ((mcol >> 16) & 0xff) / 255.0; mb = ((mcol >> 8) & 0xff) / 255.0;
     int lwidth = hGrp->GetInt("DefaultPathLineWidth",1);
@@ -403,7 +405,8 @@ void ViewProviderPath::showBoundingBox(bool show) {
 unsigned long ViewProviderPath::getBoundColor() const {
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Path");
     if(SelectionStyle.getValue() == 0 || !Selectable.getValue())
-        return hGrp->GetUnsigned("DefaultBBoxNormalColor",4294967295UL); // white (255,255,255)
+        // white (255,255,255)
+        return hGrp->GetUnsigned("DefaultBBoxNormalColor",4294967295UL);
     else
         return hGrp->GetUnsigned("DefaultBBoxSelectionColor",0xc8ffff00UL); // rgb(0,85,255)
 }

--- a/src/Mod/Path/libarea/AreaClipper.cpp
+++ b/src/Mod/Path/libarea/AreaClipper.cpp
@@ -317,7 +317,8 @@ static void MakePoly(const CCurve& curve, TPolygon &p, bool reverse = false)
 	p.resize(pts_for_AddVertex.size());
     if(reverse)
     {
-        std::size_t i = pts_for_AddVertex.size() - 1;// clipper wants them the opposite way to CArea
+        // clipper wants them the opposite way to CArea
+        std::size_t i = pts_for_AddVertex.size() - 1;
         for(std::list<DoubleAreaPoint>::iterator It = pts_for_AddVertex.begin(); It != pts_for_AddVertex.end(); It++, i--)
         {
             p[i] = It->int_point();
@@ -336,7 +337,7 @@ static void MakePoly(const CCurve& curve, TPolygon &p, bool reverse = false)
 static void MakePolyPoly( const CArea& area, TPolyPolygon &pp, bool reverse = true ){
 	pp.clear();
 
-	for(std::list<CCurve>::const_iterator It = area.m_curves.begin(); It != area.m_curves.end(); It++) 
+	for(std::list<CCurve>::const_iterator It = area.m_curves.begin(); It != area.m_curves.end(); It++)
     {
         pp.push_back(TPolygon());
         MakePoly(*It,pp.back(),reverse);
@@ -368,7 +369,7 @@ static void SetFromResult( CCurve& curve, TPolygon& p, bool reverse = true, bool
 static void SetFromResult( CArea& area, TPolyPolygon& pp, bool reverse=true, bool is_closed=true, bool clear=true)
 {
 	// delete existing geometry
-    if(clear) 
+    if(clear)
 	    area.m_curves.clear();
 
 	for(unsigned int i = 0; i < pp.size(); i++)
@@ -487,7 +488,7 @@ void CArea::PopulateClipper(Clipper &c, PolyType type) const
 		MakePoly(curve, p, false);
         c.AddPath(p, type, closed);
 	}
-    if(skipped) 
+    if(skipped)
         std::cout << "libarea: warning skipped " << skipped << " open wires" << std::endl;
 }
 
@@ -509,7 +510,7 @@ void CArea::Clip(ClipType op, const CArea *a,
 	SetFromResult(*this, solution, false, false, false);
 }
 
-void CArea::OffsetWithClipper(double offset, 
+void CArea::OffsetWithClipper(double offset,
                               JoinType joinType/* =jtRound */,
                               EndType endType/* =etOpenRound */,
                               double miterLimit/*  = 5.0 */,
@@ -533,7 +534,7 @@ void CArea::OffsetWithClipper(double offset,
 	TPolyPolygon pp, pp2;
 	MakePolyPoly(*this, pp, false);
     int i=0;
-    for(const CCurve &c : m_curves) 
+    for(const CCurve &c : m_curves)
         clipper.AddPath(pp[i++],joinType,c.IsClosed()?etClosedPolygon:endType);
     clipper.Execute(pp2,(long64)(offset));
 	SetFromResult(*this, pp2, false);

--- a/src/Mod/ReverseEngineering/App/ApproxSurface.h
+++ b/src/Mod/ReverseEngineering/App/ApproxSurface.h
@@ -173,7 +173,7 @@ public:
 
     /**
      * Calculates the function values of the basic functions that do not vanish at fParam.
-     * It must be ensured that the list for d (= degree of the B-spline) 
+     * It must be ensured that the list for d (= degree of the B-spline)
      * elements (0, ..., d-1) is sufficient (from: Piegl/Tiller 96 The NURBS-Book)
      * @param fParam Parameter
      * @param vFuncVals List of function values
@@ -258,7 +258,8 @@ public:
     explicit ParameterCorrection(unsigned usUOrder=4,               //Order in u-direction (order = degree + 1)
                         unsigned usVOrder=4,               //Order in v-direction
                         unsigned usUCtrlpoints=6,          //Qty. of the control points in the u-direction
-                        unsigned usVCtrlpoints=6);         //Qty. of the control points in the v-direction
+                        //Qty. of the control points in the v-direction
+                        unsigned usVCtrlpoints=6);
 
     virtual ~ParameterCorrection()
     {
@@ -346,12 +347,15 @@ protected:
     unsigned                _usVCtrlpoints;    //! Number of control points in the v-direction
     Base::Vector3d          _clU;              //! u-direction
     Base::Vector3d          _clV;              //! v-direction
-    Base::Vector3d          _clW;              //! w-direction (perpendicular to u & v directions)
+    //! w-direction (perpendicular to u & v directions)
+    Base::Vector3d          _clW;
     TColgp_Array1OfPnt*     _pvcPoints;        //! Raw data point list
     TColgp_Array1OfPnt2d*   _pvcUVParam;       //! Parameter value for the points in the list
     TColgp_Array2OfPnt      _vCtrlPntsOfSurf;  //! Array of control points
-    TColStd_Array1OfReal    _vUKnots;          //! Knot vector of the B-spline surface in the u-direction
-    TColStd_Array1OfReal    _vVKnots;          //! Knot vector of the B-spline surface in the v-direction
+    //! Knot vector of the B-spline surface in the u-direction
+    TColStd_Array1OfReal    _vUKnots;
+    //! Knot vector of the B-spline surface in the v-direction
+    TColStd_Array1OfReal    _vVKnots;
     TColStd_Array1OfInteger _vUMults;          //! Multiplicity of the knots in the knot vector
     TColStd_Array1OfInteger _vVMults;          //! Multiplicity of the knots in the knot vector
 };
@@ -373,7 +377,8 @@ public:
     explicit BSplineParameterCorrection(unsigned usUOrder=4,               //Order in u-direction (order = degree + 1)
                                unsigned usVOrder=4,               //Order in the v-direction
                                unsigned usUCtrlpoints=6,          //Qty. of the control points in u-direction
-                               unsigned usVCtrlpoints=6);         //Qty. of the control points in v-direction
+                               //Qty. of the control points in v-direction
+                               unsigned usVCtrlpoints=6);
 
     ~BSplineParameterCorrection() override{}
 

--- a/src/Mod/Robot/App/Robot6Axis.cpp
+++ b/src/Mod/Robot/App/Robot6Axis.cpp
@@ -51,7 +51,7 @@ using namespace KDL;
 // some default roboter
 
 AxisDefinition KukaIR500[6] = {
-//   a    ,alpha ,d    ,theta ,rotDir ,maxAngle ,minAngle ,AxisVelocity 
+//   a    ,alpha ,d    ,theta ,rotDir ,maxAngle ,minAngle ,AxisVelocity
     {500  ,-90   ,1045 ,0     , -1    ,+185     ,-185     ,156         }, // Axis 1
     {1300 ,0     ,0    ,0     , 1     ,+35      ,-155     ,156         }, // Axis 2
     {55   ,+90   ,0    ,-90   , 1     ,+154     ,-130     ,156         }, // Axis 3
@@ -171,7 +171,7 @@ void Robot6Axis::Save (Writer &writer) const
     for(unsigned int i=0;i<6;i++){
         Base::Placement Tip = toPlacement(Kinematic.getSegment(i).getFrameToTip());
         writer.Stream() << writer.ind() << "<Axis "
-                        << "Px=\""          <<  Tip.getPosition().x  << "\" " 
+                        << "Px=\""          <<  Tip.getPosition().x  << "\" "
                         << "Py=\""          <<  Tip.getPosition().y  << "\" "
                         << "Pz=\""          <<  Tip.getPosition().z  << "\" "
                         << "Q0=\""          <<  Tip.getRotation()[0] << "\" "
@@ -229,7 +229,8 @@ bool Robot6Axis::setTo(const Placement &To)
     //Creation of the solvers:
     ChainFkSolverPos_recursive fksolver1(Kinematic);//Forward position solver
     ChainIkSolverVel_pinv iksolver1v(Kinematic);//Inverse velocity solver
-    ChainIkSolverPos_NR_JL iksolver1(Kinematic,Min,Max,fksolver1,iksolver1v,100,1e-6);//Maximum 100 iterations, stop at accuracy 1e-6
+    //Maximum 100 iterations, stop at accuracy 1e-6
+    ChainIkSolverPos_NR_JL iksolver1(Kinematic,Min,Max,fksolver1,iksolver1v,100,1e-6);
 
     //Creation of jntarrays:
     JntArray result(Kinematic.getNrOfJoints());
@@ -261,8 +262,8 @@ bool Robot6Axis::calcTcp()
     ChainFkSolverPos_recursive fksolver = ChainFkSolverPos_recursive(Kinematic);
 
      // Create the frame that will contain the results
-    KDL::Frame cartpos;    
- 
+    KDL::Frame cartpos;
+
     // Calculate forward position kinematics
     int kinematics_status;
     kinematics_status = fksolver.JntToCart(Actual,cartpos);

--- a/src/Mod/Robot/App/kdl_cp/chainidsolver_vereshchagin.cpp
+++ b/src/Mod/Robot/App/kdl_cp/chainidsolver_vereshchagin.cpp
@@ -94,7 +94,8 @@ void ChainIdSolver_Vereshchagin::initial_upwards_sweep(const JntArray &q, const 
         //The total velocity of the segment expressed in the segments reference frame (tip)
         if (i != 0)
         {
-            s.v = s.F.Inverse(results[i].v) + vj; // recursive velocity of each link in segment frame
+            // recursive velocity of each link in segment frame
+            s.v = s.F.Inverse(results[i].v) + vj;
             //s.A=s.F.Inverse(results[i].A)+aj;
             s.A = s.F.M.Inverse(results[i].A);
         }
@@ -106,7 +107,8 @@ void ChainIdSolver_Vereshchagin::initial_upwards_sweep(const JntArray &q, const 
         //c[i] = cj + v[i]xvj (remark: cj=0, since our S is not time dependent in local coordinates)
         //The velocity product acceleration
         //std::cout << i << " Initial upward" << s.v << std::endl;
-        s.C = s.v*vj; //This is a cross product: cartesian space BIAS acceleration in local link coord.
+        //This is a cross product: cartesian space BIAS acceleration in local link coord.
+        s.C = s.v*vj;
         //Put C in the joint root reference frame
         s.C = s.F * s.C; //+F_total.M.Inverse(acc_root));
         //The rigid body inertia of the segment, expressed in the segments reference frame (tip)
@@ -316,7 +318,8 @@ void ChainIdSolver_Vereshchagin::final_upwards_sweep(JntArray &q_dotdot, JntArra
         //total joint space acceleration resulting from accelerations of parent joints, constraint forces and
         // nullspace forces.
         q_dotdot(j) = (s.nullspaceAccComp + parentAccComp + s.constAccComp);
-        s.acc = s.F.Inverse(a_p + s.Z * q_dotdot(j) + s.C);//returns acceleration in link distal tip coordinates. For use needs to be transformed
+        //returns acceleration in link distal tip coordinates. For use needs to be transformed
+        s.acc = s.F.Inverse(a_p + s.Z * q_dotdot(j) + s.C);
         if (chain.getSegment(i - 1).getJoint().getType() != Joint::None)
             j++;
     }

--- a/src/Mod/Sandbox/Gui/GLGraphicsView.cpp
+++ b/src/Mod/Sandbox/Gui/GLGraphicsView.cpp
@@ -818,7 +818,8 @@ void GraphicsView3D::OnChange(ParameterGrp::SubjectType &rCaller,ParameterGrp::M
     const ParameterGrp& rGrp = static_cast<ParameterGrp&>(rCaller);
 #if 0
     if (strcmp(Reason,"HeadlightColor") == 0) {
-        unsigned long headlight = rGrp.GetUnsigned("HeadlightColor",ULONG_MAX); // default color (white)
+        // default color (white)
+        unsigned long headlight = rGrp.GetUnsigned("HeadlightColor",ULONG_MAX);
         float transparency;
         SbColor headlightColor;
         headlightColor.setPackedValue((uint32_t)headlight, transparency);
@@ -843,7 +844,8 @@ void GraphicsView3D::OnChange(ParameterGrp::SubjectType &rCaller,ParameterGrp::M
         _viewer->setBacklight(rGrp.GetBool("EnableBacklight", false));
     }
     else if (strcmp(Reason,"BacklightColor") == 0) {
-        unsigned long backlight = rGrp.GetUnsigned("BacklightColor",ULONG_MAX); // default color (white)
+        // default color (white)
+        unsigned long backlight = rGrp.GetUnsigned("BacklightColor",ULONG_MAX);
         float transparency;
         SbColor backlightColor;
         backlightColor.setPackedValue((uint32_t)backlight, transparency);
@@ -972,9 +974,12 @@ void GraphicsView3D::OnChange(ParameterGrp::SubjectType &rCaller,ParameterGrp::M
     if (strcmp(Reason, "BackgroundColor") == 0)
     {
         unsigned long col1 = rGrp.GetUnsigned("BackgroundColor",3940932863UL);
-        //unsigned long col2 = rGrp.GetUnsigned("BackgroundColor2",859006463UL); // default color (dark blue)
-        //unsigned long col3 = rGrp.GetUnsigned("BackgroundColor3",2880160255UL); // default color (blue/grey)
-        //unsigned long col4 = rGrp.GetUnsigned("BackgroundColor4",1869583359UL); // default color (blue/grey)
+        // default color (dark blue)
+        //unsigned long col2 = rGrp.GetUnsigned("BackgroundColor2",859006463UL);
+        // default color (blue/grey)
+        //unsigned long col3 = rGrp.GetUnsigned("BackgroundColor3",2880160255UL);
+        // default color (blue/grey)
+        //unsigned long col4 = rGrp.GetUnsigned("BackgroundColor4",1869583359UL);
         float r1,g1,b1;
         //float r2,g2,b2;
         //float r3,g3,b3;

--- a/src/Mod/Sketcher/App/Constraint.h
+++ b/src/Mod/Sketcher/App/Constraint.h
@@ -98,7 +98,8 @@ public:
 
     ~Constraint() override = default;
 
-    Constraint *clone() const; // does copy the tag, it will be treated as a rename by the expression engine.
+    // does copy the tag, it will be treated as a rename by the expression engine.
+    Constraint *clone() const;
     Constraint *copy() const; // does not copy the tag, but generates a new one
 
     // from base class
@@ -161,7 +162,8 @@ public:
     float LabelDistance;
     float LabelPosition;
     bool isDriving;
-    int InternalAlignmentIndex; // Note: for InternalAlignment Type this index indexes equal internal geometry elements (e.g. index of pole in a bspline). It is not a GeoId!!
+    // Note: for InternalAlignment Type this index indexes equal internal geometry elements (e.g. index of pole in a bspline). It is not a GeoId!!
+    int InternalAlignmentIndex;
     bool isInVirtualSpace;
 
     bool isActive;

--- a/src/Mod/Sketcher/App/ConstraintPyImp.cpp
+++ b/src/Mod/Sketcher/App/ConstraintPyImp.cpp
@@ -407,7 +407,8 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
                 //valid = true;//non-standard assignment
                 this->getConstraintPtr()->First     = intArg1;
                 this->getConstraintPtr()->FirstPos  = Sketcher::PointPos::none;
-                this->getConstraintPtr()->Second    = intArg2; //let's goof up all the terminology =)
+                //let's goof up all the terminology =)
+                this->getConstraintPtr()->Second    = intArg2;
                 this->getConstraintPtr()->SecondPos = Sketcher::PointPos::none;
                 this->getConstraintPtr()->Third     = intArg3;
                 this->getConstraintPtr()->ThirdPos  = static_cast<Sketcher::PointPos>(intArg4);

--- a/src/Mod/Sketcher/App/ExternalGeometryFacade.cpp
+++ b/src/Mod/Sketcher/App/ExternalGeometryFacade.cpp
@@ -79,14 +79,16 @@ void ExternalGeometryFacade::initExtensions()
 {
     if(!Geo->hasExtension(SketchGeometryExtension::getClassTypeId())) {
 
-        getGeo()->setExtension(std::make_unique<SketchGeometryExtension>()); // Create getExtension
+        // Create getExtension
+        getGeo()->setExtension(std::make_unique<SketchGeometryExtension>());
 
         Base::Console().Warning("%s\nSketcher External Geometry without Geometry Extension: %s \n", boost::uuids::to_string(Geo->getTag()).c_str());
     }
 
     if(!Geo->hasExtension(ExternalGeometryExtension::getClassTypeId())) {
 
-        getGeo()->setExtension(std::make_unique<ExternalGeometryExtension>()); // Create getExtension
+        // Create getExtension
+        getGeo()->setExtension(std::make_unique<ExternalGeometryExtension>());
 
         Base::Console().Warning("%s\nSketcher External Geometry without ExternalGeometryExtension: %s \n", boost::uuids::to_string(Geo->getTag()).c_str());
     }
@@ -122,11 +124,13 @@ void ExternalGeometryFacade::initExtensions() const
 void ExternalGeometryFacade::ensureSketchGeometryExtensions(Part::Geometry * geometry)
 {
     if(!geometry->hasExtension(SketchGeometryExtension::getClassTypeId())) {
-        geometry->setExtension(std::make_unique<SketchGeometryExtension>()); // Create geoExtension
+        // Create geoExtension
+        geometry->setExtension(std::make_unique<SketchGeometryExtension>());
     }
 
     if(!geometry->hasExtension(ExternalGeometryExtension::getClassTypeId())) {
-        geometry->setExtension(std::make_unique<ExternalGeometryExtension>()); // Create external geoExtension
+        // Create external geoExtension
+        geometry->setExtension(std::make_unique<ExternalGeometryExtension>());
     }
 }
 

--- a/src/Mod/Sketcher/App/GeoList.h
+++ b/src/Mod/Sketcher/App/GeoList.h
@@ -221,7 +221,8 @@ private:
     int intGeoCount;
     bool OwnerT;
     mutable bool indexInit;
-    mutable std::vector<Sketcher::GeoElementId> VertexId2GeoElementId; // these maps a lazy initialised on first demand.
+    // these maps a lazy initialised on first demand.
+    mutable std::vector<Sketcher::GeoElementId> VertexId2GeoElementId;
     mutable std::map<Sketcher::GeoElementId, int> GeoElementId2VertexId;
 };
 
@@ -237,4 +238,3 @@ GeoListFacade getGeoListFacade(const GeoList & geolist);
 
 
 #endif // SKETCHER_GeoList_H
-

--- a/src/Mod/Sketcher/App/GeometryFacade.cpp
+++ b/src/Mod/Sketcher/App/GeometryFacade.cpp
@@ -58,7 +58,8 @@ std::unique_ptr<GeometryFacade> GeometryFacade::getFacade(Part::Geometry * geome
         return std::unique_ptr<GeometryFacade>(new GeometryFacade(geometry, owner));
     else
         return std::unique_ptr<GeometryFacade>(nullptr);
-    //return std::make_unique<GeometryFacade>(geometry); // make_unique has no access to private constructor
+    // make_unique has no access to private constructor
+    //return std::make_unique<GeometryFacade>(geometry);
 }
 
 std::unique_ptr<const GeometryFacade> GeometryFacade::getFacade(const Part::Geometry * geometry)
@@ -67,7 +68,8 @@ std::unique_ptr<const GeometryFacade> GeometryFacade::getFacade(const Part::Geom
         return std::unique_ptr<const GeometryFacade>(new GeometryFacade(geometry));
      else
         return std::unique_ptr<const GeometryFacade>(nullptr);
-    //return std::make_unique<const GeometryFacade>(geometry); // make_unique has no access to private constructor
+    // make_unique has no access to private constructor
+    //return std::make_unique<const GeometryFacade>(geometry);
 }
 
 void GeometryFacade::setGeometry(Part::Geometry *geometry)
@@ -84,7 +86,8 @@ void GeometryFacade::initExtension()
 {
     if(!Geo->hasExtension(SketchGeometryExtension::getClassTypeId())) {
 
-        getGeo()->setExtension(std::make_unique<SketchGeometryExtension>()); // Create getExtension
+        // Create getExtension
+        getGeo()->setExtension(std::make_unique<SketchGeometryExtension>());
 
         //Base::Console().Warning("%s\nSketcher Geometry without Extension: %s \n", boost::uuids::to_string(Geo->getTag()).c_str());
     }
@@ -117,7 +120,8 @@ void GeometryFacade::ensureSketchGeometryExtension(Part::Geometry * geometry)
     throwOnNullPtr(geometry);
 
     if(!geometry->hasExtension(SketchGeometryExtension::getClassTypeId())) {
-        geometry->setExtension(std::make_unique<SketchGeometryExtension>()); // Create getExtension
+        // Create getExtension
+        geometry->setExtension(std::make_unique<SketchGeometryExtension>());
     }
 }
 

--- a/src/Mod/Sketcher/App/Sketch.cpp
+++ b/src/Mod/Sketcher/App/Sketch.cpp
@@ -192,8 +192,10 @@ int Sketch::setUpSketch(const std::vector<Part::Geometry *> &GeoList,
     for (int i=int(GeoList.size())-extGeoCount; i < int(GeoList.size()); i++)
         extGeoList.push_back(GeoList[i]);
 
-    std::vector<bool> onlyBlockedGeometry(intGeoList.size(),false); // these geometries are blocked, frozen and sent as fixed parameters to the solver
-    std::vector<bool> unenforceableConstraints(ConstraintList.size(),false); // these constraints are unenforceable due to a Blocked constraint
+    // these geometries are blocked, frozen and sent as fixed parameters to the solver
+    std::vector<bool> onlyBlockedGeometry(intGeoList.size(),false);
+    // these constraints are unenforceable due to a Blocked constraint
+    std::vector<bool> unenforceableConstraints(ConstraintList.size(),false);
 
     /* This implements the old block constraint. I have decided not to remove it at this time while the new is tested, just in case the change
      * needs to be reverted */
@@ -1468,7 +1470,8 @@ GeoListFacade Sketch::extractGeoListFacade() const
     temp.reserve(Geoms.size());
     int internalGeometryCount = 0;
     for (std::vector<GeoDef>::const_iterator it=Geoms.begin(); it != Geoms.end(); ++it) {
-        auto gf = GeometryFacade::getFacade(it->geo->clone(), true); // GeometryFacade is the owner of this allocation
+        // GeometryFacade is the owner of this allocation
+        auto gf = GeometryFacade::getFacade(it->geo->clone(), true);
         if(!it->external)
             internalGeometryCount++;
 
@@ -2515,7 +2518,8 @@ int Sketch::addTangentLineAtBSplineKnotConstraint(int checkedlinegeoId, int chec
         }
     }
     else {
-        int tag = Sketch::addPointOnObjectConstraint(checkedknotgeoid, PointPos::start, checkedlinegeoId);//increases ConstraintsCounter
+        //increases ConstraintsCounter
+        int tag = Sketch::addPointOnObjectConstraint(checkedknotgeoid, PointPos::start, checkedlinegeoId);
         GCSsys.addConstraintTangentAtBSplineKnot(b, l, knotindex, tag);
         return ConstraintsCounter;
     }
@@ -2647,8 +2651,10 @@ int Sketch::addAngleAtPointConstraint(
     {
         //The same functionality is implemented in SketchObject.cpp, where
         // it is used to permanently lock down the autodecision.
-        double angleOffset = 0.0;//the difference between the datum value and the actual angle to apply. (datum=angle+offset)
-        double angleDesire = 0.0;//the desired angle value (and we are to decide if 180* should be added to it)
+        //the difference between the datum value and the actual angle to apply. (datum=angle+offset)
+        double angleOffset = 0.0;
+        //the desired angle value (and we are to decide if 180* should be added to it)
+        double angleDesire = 0.0;
         if (cTyp == Tangent) {angleOffset = -M_PI/2; angleDesire = 0.0;}
         if (cTyp == Perpendicular) {angleOffset = 0; angleDesire = M_PI/2;}
 
@@ -2670,7 +2676,8 @@ int Sketch::addAngleAtPointConstraint(
 
     int tag = -1;
     if(e2c)
-        tag = Sketch::addPointOnObjectConstraint(geoId1, pos1, geoId2, driving);//increases ConstraintsCounter
+        //increases ConstraintsCounter
+        tag = Sketch::addPointOnObjectConstraint(geoId1, pos1, geoId2, driving);
     if (e2e){
         tag = ++ConstraintsCounter;
         GCSsys.addConstraintP2PCoincident(p, *p2, tag, driving);
@@ -3144,7 +3151,8 @@ int Sketch::addSnellsLawConstraint(int geoIdRay1, PointPos posRay1,
     }
 
     int tag = -1;
-    //tag = Sketch::addPointOnObjectConstraint(geoIdRay1, posRay1, geoIdBnd);//increases ConstraintsCounter
+    //increases ConstraintsCounter
+    //tag = Sketch::addPointOnObjectConstraint(geoIdRay1, posRay1, geoIdBnd);
     tag = ++ConstraintsCounter;
     //GCSsys.addConstraintP2PCoincident(p1, p2, tag);
     GCSsys.addConstraintSnellsLaw(*ray1, *ray2,
@@ -4586,4 +4594,3 @@ void Sketch::Restore(XMLReader &)
 {
 
 }
-

--- a/src/Mod/Sketcher/App/Sketch.h
+++ b/src/Mod/Sketcher/App/Sketch.h
@@ -428,7 +428,8 @@ protected:
         Part::Geometry  * geo;             // pointer to the geometry
         GeoType           type;            // type of the geometry
         bool              external;        // flag for external geometries
-        int               index;           // index in the corresponding storage vector (Lines, Arcs, Circles, ...)
+        // index in the corresponding storage vector (Lines, Arcs, Circles, ...)
+        int               index;
         int               startPointId;    // index in Points of the start point of this geometry
         int               midPointId;      // index in Points of the start point of this geometry
         int               endPointId;      // index in Points of the end point of this geometry

--- a/src/Mod/Sketcher/App/SketchAnalysis.cpp
+++ b/src/Mod/Sketcher/App/SketchAnalysis.cpp
@@ -229,7 +229,8 @@ int SketchAnalysis::detectMissingPointOnPointConstraints(double precision, bool 
         // TODO take into account single vertices ?
     }
 
-    std::sort(vertexIds.begin(), vertexIds.end(), Vertex_Less(precision)); // Sort points in geographic order
+    // Sort points in geographic order
+    std::sort(vertexIds.begin(), vertexIds.end(), Vertex_Less(precision));
 
     // Build a list of all coincidence in the sketch
 
@@ -256,7 +257,8 @@ int SketchAnalysis::detectMissingPointOnPointConstraints(double precision, bool 
         vt = std::adjacent_find(vt, vertexIds.end(), pred);
         if (vt < vertexIds.end()) { // If one found
             std::vector<VertexIds>::iterator vn;
-            std::set<VertexIds, VertexID_Less> vertexGrp; // Holds a single group of adjacent vertices
+            // Holds a single group of adjacent vertices
+            std::set<VertexIds, VertexID_Less> vertexGrp;
             // Extract the group of adjacent vertices
             vertexGrp.insert(*vt);
             for (vn = vt+1; vn < vertexIds.end(); ++vn) {
@@ -268,7 +270,8 @@ int SketchAnalysis::detectMissingPointOnPointConstraints(double precision, bool 
                 }
             }
 
-            std::vector<std::set<VertexIds, VertexID_Less>> coincVertexGrps; // Holds groups of coincident vertices
+            // Holds groups of coincident vertices
+            std::vector<std::set<VertexIds, VertexID_Less>> coincVertexGrps;
 
             // Decompose the group of adjacent vertices into groups of coincident vertices
             for (auto &coincidence:coincidences) { // Going through existent coincidences

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -243,7 +243,8 @@ void SketchObject::retrieveSolverDiagnostics()
 
 int SketchObject::solve(bool updateGeoAfterSolving/*=true*/)
 {
-    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+    // no need to check input data validity as this is an sketchobject managed operation.
+    Base::StateLocker lock(managedoperation, true);
 
     // Reset the initial movement in case of a dragging operation was ongoing on the solver.
     solvedSketch.resetInitMove();
@@ -271,7 +272,8 @@ int SketchObject::solve(bool updateGeoAfterSolving/*=true*/)
 
     lastSolveTime=0.0;
 
-    lastSolverStatus=GCS::Failed; // Failure is default for notifying the user unless otherwise proven
+    // Failure is default for notifying the user unless otherwise proven
+    lastSolverStatus=GCS::Failed;
 
     int err=0;
 
@@ -314,7 +316,7 @@ int SketchObject::solve(bool updateGeoAfterSolving/*=true*/)
     if(err == 0) {
         FullyConstrained.setValue(lastDoF == 0);
     }
-    
+
     if (err == 0 && updateGeoAfterSolving) {
         // set the newly solved geometry
         std::vector<Part::Geometry *> geomlist = solvedSketch.extractGeometry();
@@ -333,7 +335,8 @@ int SketchObject::solve(bool updateGeoAfterSolving/*=true*/)
 
 int SketchObject::setDatum(int ConstrId, double Datum)
 {
-    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+    // no need to check input data validity as this is an sketchobject managed operation.
+    Base::StateLocker lock(managedoperation, true);
 
     // set the changed value for the constraint
     if (this->Constraints.hasInvalidGeometry())
@@ -368,7 +371,8 @@ int SketchObject::setDatum(int ConstrId, double Datum)
 
 int SketchObject::setDriving(int ConstrId, bool isdriving)
 {
-    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+    // no need to check input data validity as this is an sketchobject managed operation.
+    Base::StateLocker lock(managedoperation, true);
 
     const std::vector<Constraint *> &vals = this->Constraints.getValues();
 
@@ -425,7 +429,8 @@ int SketchObject::testDrivingChange(int ConstrId, bool isdriving)
 
 int SketchObject::setActive(int ConstrId, bool isactive)
 {
-    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+    // no need to check input data validity as this is an sketchobject managed operation.
+    Base::StateLocker lock(managedoperation, true);
 
     const std::vector<Constraint *> &vals = this->Constraints.getValues();
 
@@ -460,7 +465,8 @@ int SketchObject::getActive(int ConstrId, bool &isactive)
 
 int SketchObject::toggleActive(int ConstrId)
 {
-    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+    // no need to check input data validity as this is an sketchobject managed operation.
+    Base::StateLocker lock(managedoperation, true);
 
     const std::vector<Constraint *> &vals = this->Constraints.getValues();
 
@@ -485,7 +491,8 @@ int SketchObject::toggleActive(int ConstrId)
 /// Make all dimensionals Driving/non-Driving
 int SketchObject::setDatumsDriving(bool isdriving)
 {
-    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+    // no need to check input data validity as this is an sketchobject managed operation.
+    Base::StateLocker lock(managedoperation, true);
 
     const std::vector<Constraint *> &vals = this->Constraints.getValues();
     std::vector<Constraint *> newVals(vals);
@@ -499,7 +506,8 @@ int SketchObject::setDatumsDriving(bool isdriving)
 
     this->Constraints.setValues(std::move(newVals));
 
-    const std::vector<Constraint *> &uvals = this->Constraints.getValues(); // newVals is a shell now
+    // newVals is a shell now
+    const std::vector<Constraint *> &uvals = this->Constraints.getValues();
 
     for (size_t i = 0; i < uvals.size(); i++) {
         if (!isdriving && uvals[i]->isDimensional())
@@ -514,7 +522,8 @@ int SketchObject::setDatumsDriving(bool isdriving)
 
 int SketchObject::moveDatumsToEnd()
 {
-    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+    // no need to check input data validity as this is an sketchobject managed operation.
+    Base::StateLocker lock(managedoperation, true);
 
     const std::vector<Constraint *> &vals = this->Constraints.getValues();
 
@@ -549,7 +558,8 @@ int SketchObject::moveDatumsToEnd()
 
 int SketchObject::setVirtualSpace(int ConstrId, bool isinvirtualspace)
 {
-    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+    // no need to check input data validity as this is an sketchobject managed operation.
+    Base::StateLocker lock(managedoperation, true);
 
     const std::vector<Constraint *> &vals = this->Constraints.getValues();
 
@@ -571,7 +581,8 @@ int SketchObject::setVirtualSpace(int ConstrId, bool isinvirtualspace)
 
 int SketchObject::setVirtualSpace(std::vector<int> constrIds, bool isinvirtualspace)
 {
-    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+    // no need to check input data validity as this is an sketchobject managed operation.
+    Base::StateLocker lock(managedoperation, true);
 
     if (constrIds.empty())
         return 0;
@@ -614,7 +625,8 @@ int SketchObject::getVirtualSpace(int ConstrId, bool &isinvirtualspace) const
 
 int SketchObject::toggleVirtualSpace(int ConstrId)
 {
-    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+    // no need to check input data validity as this is an sketchobject managed operation.
+    Base::StateLocker lock(managedoperation, true);
 
     const std::vector<Constraint *> &vals = this->Constraints.getValues();
 
@@ -669,7 +681,8 @@ int SketchObject::diagnoseAdditionalConstraints(std::vector<Sketcher::Constraint
 
 int SketchObject::movePoint(int GeoId, PointPos PosId, const Base::Vector3d& toPoint, bool relative, bool updateGeoBeforeMoving)
 {
-    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+    // no need to check input data validity as this is an sketchobject managed operation.
+    Base::StateLocker lock(managedoperation, true);
 
     // if we are moving a point at SketchObject level, we need to start from a solved sketch
     // if we have conflicts we can forget about moving. However, there is the possibility that we
@@ -863,7 +876,8 @@ std::vector<Part::Geometry *> SketchObject::supportedGeometry(const std::vector<
 
 int SketchObject::addGeometry(const std::vector<Part::Geometry *> &geoList, bool construction/*=false*/)
 {
-    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+    // no need to check input data validity as this is an sketchobject managed operation.
+    Base::StateLocker lock(managedoperation, true);
 
     const std::vector< Part::Geometry * > &vals = getInternalGeometry();
 
@@ -900,7 +914,8 @@ int SketchObject::addGeometry(const Part::Geometry *geo, bool construction/*=fal
 
 int SketchObject::addGeometry(std::unique_ptr<Part::Geometry> newgeo, bool construction/*=false*/)
 {
-    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+    // no need to check input data validity as this is an sketchobject managed operation.
+    Base::StateLocker lock(managedoperation, true);
 
     const std::vector< Part::Geometry * > &vals = getInternalGeometry();
 
@@ -927,7 +942,8 @@ int SketchObject::addGeometry(std::unique_ptr<Part::Geometry> newgeo, bool const
 
 int SketchObject::delGeometry(int GeoId, bool deleteinternalgeo)
 {
-    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+    // no need to check input data validity as this is an sketchobject managed operation.
+    Base::StateLocker lock(managedoperation, true);
 
     const std::vector< Part::Geometry * > &vals = getInternalGeometry();
     if (GeoId < 0 || GeoId >= int(vals.size()))
@@ -960,7 +976,8 @@ int SketchObject::delGeometry(int GeoId, bool deleteinternalgeo)
             delConstraintOnPoint(GeoId, PosId, true /* only coincidence */);
             transferConstraints(GeoIdList[0], PosIdList[0], GeoIdList[1], PosIdList[1]);
         }
-        PosId = (PosId == PointPos::start) ? PointPos::end : PointPos::mid; // loop through [start, end, mid]
+        // loop through [start, end, mid]
+        PosId = (PosId == PointPos::start) ? PointPos::end : PointPos::mid;
     }
 
     const std::vector< Constraint * > &constraints = this->Constraints.getValues();
@@ -1029,7 +1046,8 @@ int SketchObject::delGeometriesExclusiveList(const std::vector<int>& GeoIds)
     if (sGeoIds.empty())
         return 0;
 
-    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+    // no need to check input data validity as this is an sketchobject managed operation.
+    Base::StateLocker lock(managedoperation, true);
 
     const std::vector< Part::Geometry * > &vals = getInternalGeometry();
     if (sGeoIds.front() < 0 || sGeoIds.back() >= int(vals.size()))
@@ -1050,7 +1068,8 @@ int SketchObject::delGeometriesExclusiveList(const std::vector<int>& GeoIds)
                 delConstraintOnPoint(GeoId, PosId, true /* only coincidence */);
                 transferConstraints(GeoIdList[0], PosIdList[0], GeoIdList[1], PosIdList[1]);
             }
-            PosId = (PosId == PointPos::start) ? PointPos::end : PointPos::mid; // loop through [start, end, mid]
+            // loop through [start, end, mid]
+            PosId = (PosId == PointPos::start) ? PointPos::end : PointPos::mid;
         }
     }
 
@@ -1100,7 +1119,8 @@ int SketchObject::delGeometriesExclusiveList(const std::vector<int>& GeoIds)
 
 int SketchObject::deleteAllGeometry()
 {
-    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+    // no need to check input data validity as this is an sketchobject managed operation.
+    Base::StateLocker lock(managedoperation, true);
 
     std::vector< Part::Geometry * > newVals(0);
     std::vector< Constraint * > newConstraints(0);
@@ -1122,7 +1142,8 @@ int SketchObject::deleteAllGeometry()
 
 int SketchObject::deleteAllConstraints()
 {
-    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+    // no need to check input data validity as this is an sketchobject managed operation.
+    Base::StateLocker lock(managedoperation, true);
 
     std::vector< Constraint * > newConstraints(0);
 
@@ -1136,7 +1157,8 @@ int SketchObject::deleteAllConstraints()
 
 int SketchObject::toggleConstruction(int GeoId)
 {
-    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+    // no need to check input data validity as this is an sketchobject managed operation.
+    Base::StateLocker lock(managedoperation, true);
 
     const std::vector< Part::Geometry * > &vals = getInternalGeometry();
     if (GeoId < 0 || GeoId >= int(vals.size()))
@@ -1160,7 +1182,8 @@ int SketchObject::toggleConstruction(int GeoId)
 
 int SketchObject::setConstruction(int GeoId, bool on)
 {
-    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+    // no need to check input data validity as this is an sketchobject managed operation.
+    Base::StateLocker lock(managedoperation, true);
 
     const std::vector< Part::Geometry * > &vals = getInternalGeometry();
     if (GeoId < 0 || GeoId >= int(vals.size()))
@@ -1218,7 +1241,8 @@ void SketchObject::removeGeometryState(const Constraint* cstr) const
 //ConstraintList is used only to make copies.
 int SketchObject::addConstraints(const std::vector<Constraint *> &ConstraintList)
 {
-    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+    // no need to check input data validity as this is an sketchobject managed operation.
+    Base::StateLocker lock(managedoperation, true);
 
     const std::vector< Constraint * > &vals = this->Constraints.getValues();
 
@@ -1242,7 +1266,8 @@ int SketchObject::addConstraints(const std::vector<Constraint *> &ConstraintList
 
 int SketchObject::addCopyOfConstraints(const SketchObject &orig)
 {
-    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+    // no need to check input data validity as this is an sketchobject managed operation.
+    Base::StateLocker lock(managedoperation, true);
 
     const std::vector< Constraint * > &vals = this->Constraints.getValues();
 
@@ -1287,7 +1312,8 @@ int SketchObject::addConstraint(const Constraint *constraint)
 
 int SketchObject::addConstraint(std::unique_ptr<Constraint> constraint)
 {
-    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+    // no need to check input data validity as this is an sketchobject managed operation.
+    Base::StateLocker lock(managedoperation, true);
 
     const std::vector< Constraint * > &vals = this->Constraints.getValues();
 
@@ -1309,7 +1335,8 @@ int SketchObject::addConstraint(std::unique_ptr<Constraint> constraint)
 
 int SketchObject::delConstraint(int ConstrId)
 {
-    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+    // no need to check input data validity as this is an sketchobject managed operation.
+    Base::StateLocker lock(managedoperation, true);
 
     const std::vector< Constraint * > &vals = this->Constraints.getValues();
     if (ConstrId < 0 || ConstrId >= int(vals.size()))
@@ -1329,7 +1356,8 @@ int SketchObject::delConstraint(int ConstrId)
 
 int SketchObject::delConstraints(std::vector<int> ConstrIds, bool updategeometry)
 {
-    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+    // no need to check input data validity as this is an sketchobject managed operation.
+    Base::StateLocker lock(managedoperation, true);
     if (ConstrIds.empty())
         return 0;
 
@@ -1371,7 +1399,8 @@ int SketchObject::delConstraintOnPoint(int VertexId, bool onlyCoincident)
 
 int SketchObject::delConstraintOnPoint(int GeoId, PointPos PosId, bool onlyCoincident)
 {
-    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+    // no need to check input data validity as this is an sketchobject managed operation.
+    Base::StateLocker lock(managedoperation, true);
 
     const std::vector<Constraint *> &vals = this->Constraints.getValues();
 
@@ -1654,7 +1683,8 @@ void SketchObject::transferFilletConstraints(int geoId1, PointPos posId1, int ge
 
 int SketchObject::transferConstraints(int fromGeoId, PointPos fromPosId, int toGeoId, PointPos toPosId, bool doNotTransformTangencies)
 {
-    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+    // no need to check input data validity as this is an sketchobject managed operation.
+    Base::StateLocker lock(managedoperation, true);
 
     const std::vector<Constraint *> &vals = this->Constraints.getValues();
     std::vector<Constraint *> newVals(vals);
@@ -2051,7 +2081,8 @@ int SketchObject::fillet(int GeoId1, int GeoId2,
                 double det = -dir1.x*dir2.y + dir2.x*dir1.y;
 
                 if (std::abs(det) < Precision::Confusion())
-                    throw Base::RuntimeError("No intersection of normals"); // no intersection of normals
+                    // no intersection of normals
+                    throw Base::RuntimeError("No intersection of normals");
 
                 Base::Vector3d refp1 = curve1->pointAtParameter(refparam1);
                 Base::Vector3d refp2 = curve2->pointAtParameter(refparam2);
@@ -2388,7 +2419,8 @@ bool SketchObject::seekTrimPoints(int GeoId, const Base::Vector3d &point,
     if(!Part2DObject::seekTrimPoints(geos, GeoId, point, localindex1, intersect1, localindex2, intersect2))
         return false;
 
-    GeoId1 = getGeoIdFromCompleteGeometryIndex(localindex1); // invalid complete geometry indices are mapped to GeoUndef
+    // invalid complete geometry indices are mapped to GeoUndef
+    GeoId1 = getGeoIdFromCompleteGeometryIndex(localindex1);
     GeoId2 = getGeoIdFromCompleteGeometryIndex(localindex2);
 
     return true;
@@ -2396,7 +2428,8 @@ bool SketchObject::seekTrimPoints(int GeoId, const Base::Vector3d &point,
 
 int SketchObject::trim(int GeoId, const Base::Vector3d& point)
 {
-    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+    // no need to check input data validity as this is an sketchobject managed operation.
+    Base::StateLocker lock(managedoperation, true);
 
     //******************* Basic checks rejecting the operation ****************************************//
     if (GeoId < 0 || GeoId > getHighestCurveIndex())
@@ -2632,7 +2665,8 @@ int SketchObject::trim(int GeoId, const Base::Vector3d& point)
         if(geo->isDerivedFrom(Part::GeomConic::getClassTypeId())) {
             auto *tc = static_cast<const Part::GeomConic*>(geo);
             if(tc->isReversed()) {
-                const_cast<Part::GeomConic *>(tc)->reverse(); // reversing does not change the curve as seen by the sketcher.
+                // reversing does not change the curve as seen by the sketcher.
+                const_cast<Part::GeomConic *>(tc)->reverse();
             }
         }
 
@@ -2842,7 +2876,8 @@ int SketchObject::trim(int GeoId, const Base::Vector3d& point)
             }
 
             //****** Step B.1 (4) => Constraint end points ******//
-            ConstraintType constrType = Sketcher::PointOnObject; // So this is the fallback constraint type here.
+            // So this is the fallback constraint type here.
+            ConstraintType constrType = Sketcher::PointOnObject;
             PointPos secondPos = Sketcher::PointPos::none;
 
             transformPreexistingConstraints (GeoId, op.intersectingGeoId, op.actingPoint, constrType, secondPos);
@@ -2904,7 +2939,8 @@ int SketchObject::trim(int GeoId, const Base::Vector3d& point)
             aoe->setMajorRadius(ellipse->getMajorRadius());
             aoe->setMinorRadius(ellipse->getMinorRadius());
             aoe->setMajorAxisDir(ellipse->getMajorAxisDir());
-            aoe->setRange(point2Param, point1Param,/*emulateCCW=*/false); // CCW curve goes from point2 (start) to point1 (end)
+            // CCW curve goes from point2 (start) to point1 (end)
+            aoe->setRange(point2Param, point1Param,/*emulateCCW=*/false);
             geoNew = std::move( aoe );
         }
         else if (isPeriodicBSpline) {
@@ -3647,7 +3683,8 @@ bool SketchObject::isCarbonCopyAllowed(App::Document *pDoc, App::DocumentObject 
 
 int SketchObject::addSymmetric(const std::vector<int> &geoIdList, int refGeoId, Sketcher::PointPos refPosId/*=Sketcher::PointPos::none*/)
 {
-    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+    // no need to check input data validity as this is an sketchobject managed operation.
+    Base::StateLocker lock(managedoperation, true);
 
     const std::vector< Part::Geometry * > &geovals = getInternalGeometry();
     std::vector< Part::Geometry * > newgeoVals(geovals);
@@ -4144,7 +4181,8 @@ int SketchObject::addSymmetric(const std::vector<int> &geoIdList, int refGeoId, 
 
         for (std::vector<Constraint *>::const_iterator it = constrvals.begin(); it != constrvals.end(); ++it) {
 
-            auto fit = geoIdMap.find((*it)->First); // we look in the map, because we might have skipped internal alignment geometry
+            // we look in the map, because we might have skipped internal alignment geometry
+            auto fit = geoIdMap.find((*it)->First);
 
             if(fit != geoIdMap.end()) { // if First of constraint is in geoIdList
 
@@ -4264,7 +4302,8 @@ int SketchObject::addCopy(const std::vector<int> &geoIdList, const Base::Vector3
                           bool clone /*=false*/, int csize/*=2*/, int rsize/*=1*/, bool constraindisplacement /*= false*/,
                           double perpscale /*= 1.0*/)
 {
-    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+    // no need to check input data validity as this is an sketchobject managed operation.
+    Base::StateLocker lock(managedoperation, true);
 
     const std::vector< Part::Geometry * > &geovals = getInternalGeometry();
     std::vector< Part::Geometry * > newgeoVals(geovals);
@@ -4511,7 +4550,8 @@ int SketchObject::addCopy(const std::vector<int> &geoIdList, const Base::Vector3
                                         Constraint *constNew = (*it)->copy();
                                         constNew->Type = Sketcher::Equal;
                                         constNew->isDriving = true;
-                                        constNew->Second = fit->second; // first is already (*it->First)
+                                        // first is already (*it->First)
+                                        constNew->Second = fit->second;
                                         newconstrVals.push_back(constNew);
                                     }
                                     else if ((*it)->Type == Sketcher::Angle && clone) {
@@ -4520,7 +4560,8 @@ int SketchObject::addCopy(const std::vector<int> &geoIdList, const Base::Vector3
                                             Constraint *constNew = (*it)->copy();
                                             constNew->Type = Sketcher::Parallel;
                                             constNew->isDriving = true;
-                                            constNew->Second = fit->second; // first is already (*it->First)
+                                            // first is already (*it->First)
+                                            constNew->Second = fit->second;
                                             newconstrVals.push_back(constNew);
                                         }
                                     }
@@ -4545,7 +4586,8 @@ int SketchObject::addCopy(const std::vector<int> &geoIdList, const Base::Vector3
                                         constNew->Type = Sketcher::Equal;
                                         constNew->isDriving = true;
                                         constNew->FirstPos = Sketcher::PointPos::none;
-                                        constNew->Second = fit->second; // first is already (*it->First)
+                                        // first is already (*it->First)
+                                        constNew->Second = fit->second;
                                         constNew->SecondPos = Sketcher::PointPos::none;
                                         newconstrVals.push_back(constNew);
                                     }
@@ -4581,8 +4623,10 @@ int SketchObject::addCopy(const std::vector<int> &geoIdList, const Base::Vector3
 
                     Base::Vector3d sp = getPoint(refgeoid,refposId)+ ( ( x == 0 )?
                                     (double(x)*displacement+double(y-1)*perpendicularDisplacement):
-                                    (double(x-1)*displacement+double(y)*perpendicularDisplacement)); // position of the reference point
-                    Base::Vector3d ep = iterfirstpoint; // position of the current instance corresponding point
+                                    // position of the reference point
+                                    (double(x-1)*displacement+double(y)*perpendicularDisplacement));
+                    // position of the current instance corresponding point
+                    Base::Vector3d ep = iterfirstpoint;
                     constrline->setPoints(sp,ep);
                     GeometryFacade::setConstruction(constrline,true);
 
@@ -4721,7 +4765,8 @@ int SketchObject::addCopy(const std::vector<int> &geoIdList, const Base::Vector3
                     }
                 }
 
-                geoIdMap.clear(); // after each creation reset map so that the key-value is univoque (only for operations other than move)
+                // after each creation reset map so that the key-value is univoque (only for operations other than move)
+                geoIdMap.clear();
             }
         }
     }
@@ -4746,7 +4791,8 @@ int SketchObject::addCopy(const std::vector<int> &geoIdList, const Base::Vector3
 
 int SketchObject::removeAxesAlignment(const std::vector<int> &geoIdList)
 {
-    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+    // no need to check input data validity as this is an sketchobject managed operation.
+    Base::StateLocker lock(managedoperation, true);
 
     const std::vector< Constraint * > &constrvals = this->Constraints.getValues();
 
@@ -4841,11 +4887,13 @@ int SketchObject::removeAxesAlignment(const std::vector<int> &geoIdList)
             }
             else if(changeConstraintIndices[cindex].second == Sketcher::Symmetric ||
                     changeConstraintIndices[cindex].second == Sketcher::PointOnObject) {
-                changed = true; // We remove symmetric on axes
+                // We remove symmetric on axes
+                changed = true;
             }
             else if(changeConstraintIndices[cindex].second == Sketcher::DistanceX ||
                     changeConstraintIndices[cindex].second == Sketcher::DistanceY) {
-                changed = true; // We remove symmetric on axes
+                // We remove symmetric on axes
+                changed = true;
                 newconstrVals.push_back(constrvals[i]->clone());
                 newconstrVals.back()->Type = Sketcher::Distance;
             }
@@ -5448,7 +5496,8 @@ int SketchObject::deleteUnusedInternalGeometry(int GeoId, bool delgeoid)
         }
 
         // Hide unused geometry here
-        int majorconstraints=0; // number of constraints associated to the geoid of the major axis
+        // number of constraints associated to the geoid of the major axis
+        int majorconstraints=0;
         int minorconstraints=0;
         int focus1constraints=0;
         int focus2constraints=0;
@@ -5484,7 +5533,8 @@ int SketchObject::deleteUnusedInternalGeometry(int GeoId, bool delgeoid)
         if(delgeoid)
             delgeometries.push_back(GeoId);
 
-        std::sort(delgeometries.begin(), delgeometries.end()); // indices over an erased element get automatically updated!!
+        // indices over an erased element get automatically updated!!
+        std::sort(delgeometries.begin(), delgeometries.end());
 
         if (!delgeometries.empty()) {
             for (std::vector<int>::reverse_iterator it=delgeometries.rbegin(); it!=delgeometries.rend(); ++it) {
@@ -5523,7 +5573,8 @@ int SketchObject::deleteUnusedInternalGeometry(int GeoId, bool delgeoid)
         }
 
         // Hide unused geometry here
-        int majorconstraints=0; // number of constraints associated to the geoid of the major axis other than the coincident ones
+        // number of constraints associated to the geoid of the major axis other than the coincident ones
+        int majorconstraints=0;
         int focus1constraints=0;
 
         for (std::vector< Sketcher::Constraint * >::const_iterator it= vals.begin(); it != vals.end(); ++it) {
@@ -5550,7 +5601,8 @@ int SketchObject::deleteUnusedInternalGeometry(int GeoId, bool delgeoid)
         if(delgeoid)
             delgeometries.push_back(GeoId);
 
-        std::sort(delgeometries.begin(), delgeometries.end()); // indices over an erased element get automatically updated!!
+        // indices over an erased element get automatically updated!!
+        std::sort(delgeometries.begin(), delgeometries.end());
 
         if (!delgeometries.empty()) {
             for (std::vector<int>::reverse_iterator it=delgeometries.rbegin(); it!=delgeometries.rend(); ++it) {
@@ -5673,7 +5725,8 @@ int SketchObject::deleteUnusedInternalGeometry(int GeoId, bool delgeoid)
 
 bool SketchObject::convertToNURBS(int GeoId)
 {
-    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+    // no need to check input data validity as this is an sketchobject managed operation.
+    Base::StateLocker lock(managedoperation, true);
 
     if (GeoId > getHighestCurveIndex() ||
         (GeoId < 0 && -GeoId > static_cast<int>(ExternalGeo.size())) ||
@@ -5756,7 +5809,8 @@ bool SketchObject::convertToNURBS(int GeoId)
 
 bool SketchObject::increaseBSplineDegree(int GeoId, int degreeincrement /*= 1*/)
 {
-    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+    // no need to check input data validity as this is an sketchobject managed operation.
+    Base::StateLocker lock(managedoperation, true);
 
     if (GeoId < 0 || GeoId > getHighestCurveIndex())
         return false;
@@ -5796,7 +5850,8 @@ bool SketchObject::increaseBSplineDegree(int GeoId, int degreeincrement /*= 1*/)
 
 bool SketchObject::decreaseBSplineDegree(int GeoId, int degreedecrement /*= 1*/)
 {
-    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+    // no need to check input data validity as this is an sketchobject managed operation.
+    Base::StateLocker lock(managedoperation, true);
 
     if (GeoId < 0 || GeoId > getHighestCurveIndex())
         return false;
@@ -5850,7 +5905,8 @@ bool SketchObject::decreaseBSplineDegree(int GeoId, int degreedecrement /*= 1*/)
 
 bool SketchObject::modifyBSplineKnotMultiplicity(int GeoId, int knotIndex, int multiplicityincr)
 {
-    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+    // no need to check input data validity as this is an sketchobject managed operation.
+    Base::StateLocker lock(managedoperation, true);
 
     if (GeoId < 0 || GeoId > getHighestCurveIndex())
         THROWMT(Base::ValueError,QT_TRANSLATE_NOOP("Exceptions", "BSpline Geometry Index (GeoID) is out of bounds."))
@@ -6023,7 +6079,8 @@ bool SketchObject::modifyBSplineKnotMultiplicity(int GeoId, int knotIndex, int m
 
 bool SketchObject::insertBSplineKnot(int GeoId, double param, int multiplicity)
 {
-    Base::StateLocker lock(managedoperation, true); // TODO: Check if this is still valid: no need to check input data validity as this is an sketchobject managed operation.
+    // TODO: Check if this is still valid: no need to check input data validity as this is an sketchobject managed operation.
+    Base::StateLocker lock(managedoperation, true);
 
     // handling unacceptable cases
     if (GeoId < 0 || GeoId > getHighestCurveIndex())
@@ -6177,7 +6234,8 @@ bool SketchObject::insertBSplineKnot(int GeoId, double param, int multiplicity)
 
 int SketchObject::carbonCopy(App::DocumentObject * pObj, bool construction)
 {
-    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+    // no need to check input data validity as this is an sketchobject managed operation.
+    Base::StateLocker lock(managedoperation, true);
 
     // so far only externals to the support of the sketch and datum features
     bool xinv = false, yinv = false;
@@ -6327,7 +6385,8 @@ int SketchObject::carbonCopy(App::DocumentObject * pObj, bool construction)
 
 int SketchObject::addExternal(App::DocumentObject *Obj, const char* SubName)
 {
-    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+    // no need to check input data validity as this is an sketchobject managed operation.
+    Base::StateLocker lock(managedoperation, true);
 
     // so far only externals to the support of the sketch and datum features
     if (!isExternalAllowed(Obj->getDocument(), Obj))
@@ -6377,7 +6436,8 @@ int SketchObject::addExternal(App::DocumentObject *Obj, const char* SubName)
 
 int SketchObject::delExternal(int ExtGeoId)
 {
-    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+    // no need to check input data validity as this is an sketchobject managed operation.
+    Base::StateLocker lock(managedoperation, true);
 
     // get the actual lists of the externals
     std::vector<DocumentObject*> Objects     = ExternalGeometry.getValues();
@@ -6445,7 +6505,8 @@ int SketchObject::delExternal(int ExtGeoId)
 
 int SketchObject::delAllExternal()
 {
-    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+    // no need to check input data validity as this is an sketchobject managed operation.
+    Base::StateLocker lock(managedoperation, true);
 
     // get the actual lists of the externals
     std::vector<DocumentObject*> Objects     = ExternalGeometry.getValues();
@@ -6492,7 +6553,8 @@ int SketchObject::delAllExternal()
 
 int SketchObject::delConstraintsToExternal()
 {
-    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+    // no need to check input data validity as this is an sketchobject managed operation.
+    Base::StateLocker lock(managedoperation, true);
 
     const std::vector< Constraint * > &constraints = Constraints.getValuesForce();
     std::vector< Constraint * > newConstraints(0);
@@ -6647,7 +6709,8 @@ bool SketchObject::evaluateSupport()
 
 void SketchObject::validateExternalLinks()
 {
-    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+    // no need to check input data validity as this is an sketchobject managed operation.
+    Base::StateLocker lock(managedoperation, true);
 
     std::vector<DocumentObject*> Objects     = ExternalGeometry.getValues();
     std::vector<std::string>     SubElements = ExternalGeometry.getSubValues();
@@ -6885,8 +6948,10 @@ void SketchObject::rebuildExternalGeometry()
 
                             if (!curve.IsClosed()) {  // arc of circle
 
-                                gp_Pnt pntF = curve.Value(curve.FirstParameter());  // start point of arc of circle
-                                gp_Pnt pntL = curve.Value(curve.LastParameter());  // end point of arc of circle
+                                // start point of arc of circle
+                                gp_Pnt pntF = curve.Value(curve.FirstParameter());
+                                // end point of arc of circle
+                                gp_Pnt pntL = curve.Value(curve.LastParameter());
 
                                 double alpha = dirOrientation.AngleWithRef(curve.Circle().XAxis().Direction(), curve.Circle().Axis().Direction());
 
@@ -6902,7 +6967,8 @@ void SketchObject::rebuildExternalGeometry()
                                     startAngle = baseAngle + --tours*2.0*M_PI + alpha;
                                 }
 
-                                double endAngle = curve.LastParameter() + startAngle - baseAngle;  // apply same offset to end angle
+                                // apply same offset to end angle
+                                double endAngle = curve.LastParameter() + startAngle - baseAngle;
 
                                 if (startAngle <= 0.0) {
                                     if (endAngle <= 0.0) {
@@ -6951,7 +7017,8 @@ void SketchObject::rebuildExternalGeometry()
                                 }
                             }
 
-                            Base::Vector3d p1(P1.X(),P1.Y(),P1.Z());  // ends of segment FCAD style
+                            // ends of segment FCAD style
+                            Base::Vector3d p1(P1.X(),P1.Y(),P1.Z());
                             Base::Vector3d p2(P2.X(),P2.Y(),P2.Z());
                             invPlm.multVec(p1,p1);
                             invPlm.multVec(p2,p2);
@@ -6963,23 +7030,30 @@ void SketchObject::rebuildExternalGeometry()
                         else {  // general case, full circle
                             gp_Pnt cnt = origCircle.Location();
                             GeomAPI_ProjectPointOnSurf proj(cnt,gPlane);
-                            cnt = proj.NearestPoint();  // projection of circle center on sketch plane, 3D space
-                            Base::Vector3d p(cnt.X(),cnt.Y(),cnt.Z());  // converting to FCAD style vector
-                            invPlm.multVec(p,p);  // transforming towards sketch's (x,y) coordinates
+                            // projection of circle center on sketch plane, 3D space
+                            cnt = proj.NearestPoint();
+                            // converting to FCAD style vector
+                            Base::Vector3d p(cnt.X(),cnt.Y(),cnt.Z());
+                            // transforming towards sketch's (x,y) coordinates
+                            invPlm.multVec(p,p);
 
 
                             gp_Vec vecMajorAxis = vec1 ^ vec2;  // major axis in 3D space
 
                             double minorRadius;  // TODO use data type of vectors around...
                             double cosTheta;
-                            cosTheta = fabs(vec1.Dot(vec2));  // cos of angle between the two planes, assuming vectirs are normalized to 1
+                            // cos of angle between the two planes, assuming vectirs are normalized to 1
+                            cosTheta = fabs(vec1.Dot(vec2));
                             minorRadius = origCircle.Radius() * cosTheta;
 
-                            Base::Vector3d vectorMajorAxis(vecMajorAxis.X(),vecMajorAxis.Y(),vecMajorAxis.Z());  // maj axis into FCAD style vector
-                            invRot.multVec(vectorMajorAxis, vectorMajorAxis);  // transforming to sketch's (x,y) coordinates
+                            // maj axis into FCAD style vector
+                            Base::Vector3d vectorMajorAxis(vecMajorAxis.X(),vecMajorAxis.Y(),vecMajorAxis.Z());
+                            // transforming to sketch's (x,y) coordinates
+                            invRot.multVec(vectorMajorAxis, vectorMajorAxis);
                             vecMajorAxis.SetXYZ(gp_XYZ(vectorMajorAxis[0], vectorMajorAxis[1], vectorMajorAxis[2]));  // back to OCC
 
-                            gp_Ax2 refFrameEllipse(gp_Pnt(gp_XYZ(p[0], p[1], p[2])), gp_Vec(0, 0, 1), vecMajorAxis);  // NB: force normal of ellipse to be normal of sketch's plane.
+                            // NB: force normal of ellipse to be normal of sketch's plane.
+                            gp_Ax2 refFrameEllipse(gp_Pnt(gp_XYZ(p[0], p[1], p[2])), gp_Vec(0, 0, 1), vecMajorAxis);
                             Handle(Geom_Ellipse) curve = new Geom_Ellipse(refFrameEllipse, origCircle.Radius(), minorRadius);
                             Part::GeomEllipse* ellipse = new Part::GeomEllipse();
                             ellipse->setHandle(curve);
@@ -7022,7 +7096,8 @@ void SketchObject::rebuildExternalGeometry()
                     gp_Vec2d PA = ProjVecOnPlane_UV(origAxisMajor, sketchPlane);
                     gp_Vec2d PB = ProjVecOnPlane_UV(origAxisMinor, sketchPlane);
                     double t_max = 2.0 * PA.Dot(PB) / (PA.SquareMagnitude() - PB.SquareMagnitude());
-                    t_max = 0.5 * atan(t_max);  // gives new major axis is most cases, but not all
+                    // gives new major axis is most cases, but not all
+                    t_max = 0.5 * atan(t_max);
                     double t_min = t_max + 0.5 * M_PI;
 
                     // ON_max = OM(t_max) gives the point, which projected on the sketch plane,
@@ -7744,7 +7819,8 @@ bool SketchObject::evaluateConstraints() const
 
 void SketchObject::validateConstraints()
 {
-    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+    // no need to check input data validity as this is an sketchobject managed operation.
+    Base::StateLocker lock(managedoperation, true);
 
     std::vector<Part::Geometry *> geometry = getCompleteGeometry();
     const std::vector<Sketcher::Constraint *>& constraints = Constraints.getValuesForce();
@@ -7943,7 +8019,8 @@ void SketchObject::onChanged(const App::Property* prop)
             if(!internaltransaction) { // internal sketchobject operations changing both geometry and constraints will explicitly perform an update
                 if(prop == &Geometry) {
                     if(managedoperation || isRestoring()) {
-                        acceptGeometry(); // if geometry changed, the constraint geometry indices must be updated
+                        // if geometry changed, the constraint geometry indices must be updated
+                        acceptGeometry();
                     }
                     else { // this change was not effect via SketchObject, but using direct access to properties, check input data
 
@@ -8017,7 +8094,8 @@ void SketchObject::onUndoRedoFinished()
     //
     // Historically this was "solved" by issuing a recompute, which is absolutely unnecessary and prevents solve() from working before
     // such a recompute
-    Constraints.checkConstraintIndices(getHighestCurveIndex(),-getExternalGeometryCount()); // in case it is redoing an operation with invalid data.
+    // in case it is redoing an operation with invalid data.
+    Constraints.checkConstraintIndices(getHighestCurveIndex(),-getExternalGeometryCount());
     acceptGeometry();
     synchroniseGeometryState();
     solve();
@@ -8189,7 +8267,8 @@ void SketchObject::migrateSketch()
 
                 if(ext->testMigrationType(Part::GeometryMigrationExtension::Construction))
                 {
-                    auto gf = GeometryFacade::getFacade(g); // at this point IA geometry is already migrated
+                    // at this point IA geometry is already migrated
+                    auto gf = GeometryFacade::getFacade(g);
 
                     bool oldconstr =  ext->getConstruction();
 
@@ -8353,7 +8432,8 @@ int SketchObject::getVertexIndexGeoPos(int GeoId, PointPos PosId) const
 /// unlocked.
 int SketchObject::changeConstraintsLocking(bool bLock)
 {
-    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+    // no need to check input data validity as this is an sketchobject managed operation.
+    Base::StateLocker lock(managedoperation, true);
 
     int cntSuccess = 0;
     int cntToBeAffected = 0;//==cntSuccess+cntFail
@@ -8403,7 +8483,8 @@ bool SketchObject::constraintHasExpression(int constrid) const
  */
 int SketchObject::port_reversedExternalArcs(bool justAnalyze)
 {
-    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+    // no need to check input data validity as this is an sketchobject managed operation.
+    Base::StateLocker lock(managedoperation, true);
 
     int cntToBeAffected = 0;//==cntSuccess+cntFail
     const std::vector< Constraint * > &vals = this->Constraints.getValues();
@@ -8526,8 +8607,10 @@ bool SketchObject::AutoLockTangencyAndPerpty(Constraint *cstr, bool bForce, bool
 
                 //this piece of code is also present in Sketch.cpp, correct for offset
                 //and to do the autodecision for old sketches.
-                double angleOffset = 0.0;//the difference between the datum value and the actual angle to apply. (datum=angle+offset)
-                double angleDesire = 0.0;//the desired angle value (and we are to decide if 180* should be added to it)
+                //the difference between the datum value and the actual angle to apply. (datum=angle+offset)
+                double angleOffset = 0.0;
+                //the desired angle value (and we are to decide if 180* should be added to it)
+                double angleDesire = 0.0;
                 if (cstr->Type == Tangent) {angleOffset = -M_PI/2; angleDesire = 0.0;}
                 if (cstr->Type == Perpendicular) {angleOffset = 0; angleDesire = M_PI/2;}
 
@@ -8541,7 +8624,8 @@ bool SketchObject::AutoLockTangencyAndPerpty(Constraint *cstr, bool bForce, bool
                 if(fabs(angleErr) > M_PI/2 )
                     angleDesire += M_PI;
 
-                cstr->setValue(angleDesire + angleOffset); //external tangency. The angle stored is offset by Pi/2 so that a value of 0.0 is invalid and treated as "undecided".
+                //external tangency. The angle stored is offset by Pi/2 so that a value of 0.0 is invalid and treated as "undecided".
+                cstr->setValue(angleDesire + angleOffset);
             }
         }
     }
@@ -8680,7 +8764,8 @@ int SketchObject::renameConstraint(int GeoId, std::string name)
     const Constraint* item = Constraints[GeoId];
 
     if (item->Name != name) {
-        Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+        // no need to check input data validity as this is an sketchobject managed operation.
+        Base::StateLocker lock(managedoperation, true);
 
         Constraint* copy = item->clone();
         copy->Name = name;
@@ -8688,7 +8773,8 @@ int SketchObject::renameConstraint(int GeoId, std::string name)
         Constraints.set1Value(GeoId, copy);
         delete copy;
 
-        solverNeedsUpdate = true; // make sure any prospective solver access updates the constraint pointer that just got invalidated
+        // make sure any prospective solver access updates the constraint pointer that just got invalidated
+        solverNeedsUpdate = true;
 
         return 0;
     }
@@ -8709,7 +8795,8 @@ std::vector<Base::Vector3d> SketchObject::getOpenVertices() const
 
 int SketchObject::setGeometryId(int GeoId, long id)
 {
-    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+    // no need to check input data validity as this is an sketchobject managed operation.
+    Base::StateLocker lock(managedoperation, true);
 
     if (GeoId < 0 || GeoId >= int(Geometry.getValues().size()))
         return -1;

--- a/src/Mod/Sketcher/App/SketchObject.h
+++ b/src/Mod/Sketcher/App/SketchObject.h
@@ -691,7 +691,8 @@ private:
 
     bool internaltransaction;
 
-    bool managedoperation; // indicates whether changes to properties are the deed of SketchObject or not (for input validation)
+    // indicates whether changes to properties are the deed of SketchObject or not (for input validation)
+    bool managedoperation;
 };
 
 inline int SketchObject::initTemporaryMove(int geoId, PointPos pos, bool fine/*=true*/)

--- a/src/Mod/Sketcher/App/planegcs/Constraints.cpp
+++ b/src/Mod/Sketcher/App/planegcs/Constraints.cpp
@@ -797,7 +797,8 @@ double ConstraintP2LDistance::error()
     double dx = x2-x1;
     double dy = y2-y1;
     double d = sqrt(dx*dx+dy*dy);
-    double area = std::abs(-x0*dy+y0*dx+x1*y2-x2*y1); // = x1y2 - x2y1 - x0y2 + x2y0 + x0y1 - x1y0 = 2*(triangle area)
+    // = x1y2 - x2y1 - x0y2 + x2y0 + x0y1 - x1y0 = 2*(triangle area)
+    double area = std::abs(-x0*dy+y0*dx+x1*y2-x2*y1);
     return scale * (area/d - dist);
 }
 
@@ -913,7 +914,8 @@ double ConstraintPointOnLine::error()
     double dx = x2-x1;
     double dy = y2-y1;
     double d = sqrt(dx*dx+dy*dy);
-    double area = -x0*dy+y0*dx+x1*y2-x2*y1; // = x1y2 - x2y1 - x0y2 + x2y0 + x0y1 - x1y0 = 2*(triangle area)
+    // = x1y2 - x2y1 - x0y2 + x2y0 + x0y1 - x1y0 = 2*(triangle area)
+    double area = -x0*dy+y0*dx+x1*y2-x2*y1;
     return scale * area/d;
 }
 
@@ -1295,7 +1297,8 @@ double ConstraintMidpointOnLine::error()
     double dx = x2-x1;
     double dy = y2-y1;
     double d = sqrt(dx*dx+dy*dy);
-    double area = -x0*dy+y0*dx+x1*y2-x2*y1; // = x1y2 - x2y1 - x0y2 + x2y0 + x0y1 - x1y0 = 2*(triangle area)
+    // = x1y2 - x2y1 - x0y2 + x2y0 + x0y1 - x1y0 = 2*(triangle area)
+    double area = -x0*dy+y0*dx+x1*y2-x2*y1;
     return scale * area/d;
 }
 
@@ -1631,7 +1634,8 @@ void ConstraintInternalAlignmentPoint2Ellipse::errorgrad(double *err, double *gr
     a = e.getRadMaj(c,f1,b,db,da);
 
     DeriVector2 poa;//point to align to
-    bool by_y_not_by_x = false;//a flag to indicate if the alignment error function is for y (false - x, true - y).
+    //a flag to indicate if the alignment error function is for y (false - x, true - y).
+    bool by_y_not_by_x = false;
 
     switch(AlignmentType){
         case EllipsePositiveMajorX:
@@ -1759,7 +1763,8 @@ void ConstraintInternalAlignmentPoint2Hyperbola::errorgrad(double *err, double *
     a = e.getRadMaj(c,f1,b,db,da);
 
     DeriVector2 poa;//point to align to
-    bool by_y_not_by_x = false;//a flag to indicate if the alignment error function is for y (false - x, true - y).
+    //a flag to indicate if the alignment error function is for y (false - x, true - y).
+    bool by_y_not_by_x = false;
 
     switch(AlignmentType){
         case HyperbolaPositiveMajorX:

--- a/src/Mod/Sketcher/App/planegcs/Constraints.h
+++ b/src/Mod/Sketcher/App/planegcs/Constraints.h
@@ -110,7 +110,8 @@ namespace GCS
         VEC_pD pvec;
         double scale;
         int tag;
-        bool pvecChangedFlag;  //indicates that pvec has changed and saved pointers must be reconstructed (currently used only in AngleViaPoint)
+        //indicates that pvec has changed and saved pointers must be reconstructed (currently used only in AngleViaPoint)
+        bool pvecChangedFlag;
         bool driving;
         Alignment internalAlignment;
 
@@ -533,8 +534,10 @@ namespace GCS
     private:
         Line l;
         Ellipse e;
-        void ReconstructGeomPointers(); //writes pointers in pvec to the parameters of crv1, crv2 and poa
-        void errorgrad(double* err, double* grad, double *param); //error and gradient combined. Values are returned through pointers.
+        //writes pointers in pvec to the parameters of crv1, crv2 and poa
+        void ReconstructGeomPointers();
+        //error and gradient combined. Values are returned through pointers.
+        void errorgrad(double* err, double* grad, double *param);
     public:
         ConstraintEllipseTangentLine(Line &l, Ellipse &e);
         ConstraintType getTypeId() override;
@@ -552,8 +555,10 @@ namespace GCS
         double error() override;
         double grad(double *) override;
     private:
-        void errorgrad(double* err, double* grad, double *param); //error and gradient combined. Values are returned through pointers.
-        void ReconstructGeomPointers(); //writes pointers in pvec to the parameters of crv1, crv2 and poa
+        //error and gradient combined. Values are returned through pointers.
+        void errorgrad(double* err, double* grad, double *param);
+        //writes pointers in pvec to the parameters of crv1, crv2 and poa
+        void ReconstructGeomPointers();
         Ellipse e;
         Point p;
         InternalAlignmentType AlignmentType;
@@ -568,8 +573,10 @@ namespace GCS
         double error() override;
         double grad(double *) override;
     private:
-        void errorgrad(double* err, double* grad, double *param); //error and gradient combined. Values are returned through pointers.
-        void ReconstructGeomPointers(); //writes pointers in pvec to the parameters of crv1, crv2 and poa
+        //error and gradient combined. Values are returned through pointers.
+        void errorgrad(double* err, double* grad, double *param);
+        //writes pointers in pvec to the parameters of crv1, crv2 and poa
+        void ReconstructGeomPointers();
         Hyperbola e;
         Point p;
         InternalAlignmentType AlignmentType;
@@ -580,8 +587,10 @@ namespace GCS
     private:
         MajorRadiusConic * e1;
         MajorRadiusConic * e2;
-        void ReconstructGeomPointers(); //writes pointers in pvec to the parameters of crv1, crv2 and poa
-        void errorgrad(double* err, double* grad, double *param); //error and gradient combined. Values are returned through pointers.
+        //writes pointers in pvec to the parameters of crv1, crv2 and poa
+        void ReconstructGeomPointers();
+        //error and gradient combined. Values are returned through pointers.
+        void errorgrad(double* err, double* grad, double *param);
     public:
         ConstraintEqualMajorAxesConic(MajorRadiusConic * a1, MajorRadiusConic * a2);
         ConstraintType getTypeId() override;
@@ -595,8 +604,10 @@ namespace GCS
     private:
         ArcOfParabola * e1;
         ArcOfParabola * e2;
-        void ReconstructGeomPointers(); //writes pointers in pvec to the parameters of crv1, crv2 and poa
-        void errorgrad(double* err, double* grad, double *param); //error and gradient combined. Values are returned through pointers.
+        //writes pointers in pvec to the parameters of crv1, crv2 and poa
+        void ReconstructGeomPointers();
+        //error and gradient combined. Values are returned through pointers.
+        void errorgrad(double* err, double* grad, double *param);
     public:
         ConstraintEqualFocalDistance(ArcOfParabola * a1, ArcOfParabola * a2);
         ConstraintType getTypeId() override;
@@ -610,8 +621,10 @@ namespace GCS
     private:
         inline double* pcoord() { return pvec[2]; } //defines, which coordinate of point is being constrained by this constraint
         inline double* u() { return pvec[3]; }
-        void errorgrad(double* err, double* grad, double *param); //error and gradient combined. Values are returned through pointers.
-        void ReconstructGeomPointers(); //writes pointers in pvec to the parameters of crv1, crv2 and poa
+        //error and gradient combined. Values are returned through pointers.
+        void errorgrad(double* err, double* grad, double *param);
+        //writes pointers in pvec to the parameters of crv1, crv2 and poa
+        void ReconstructGeomPointers();
         Curve* crv;
         Point p;
     public:
@@ -658,8 +671,10 @@ namespace GCS
     class ConstraintPointOnParabola : public Constraint
     {
     private:
-        void errorgrad(double* err, double* grad, double *param); //error and gradient combined. Values are returned through pointers.
-        void ReconstructGeomPointers(); //writes pointers in pvec to the parameters of crv1, crv2 and poa
+        //error and gradient combined. Values are returned through pointers.
+        void errorgrad(double* err, double* grad, double *param);
+        //writes pointers in pvec to the parameters of crv1, crv2 and poa
+        void ReconstructGeomPointers();
         Parabola* parab;
         Point p;
     public:
@@ -690,7 +705,8 @@ namespace GCS
         //The pointers in the curves need to be reconstructed if pvec was redirected
         // (test pvecChangedFlag variable before use!)
         Point poa;//poa=point of angle //needs to be reconstructed if pvec was redirected/reverted. The point is easily shallow-copied by C++, so no pointer type here and no delete is necessary.
-        void ReconstructGeomPointers(); //writes pointers in pvec to the parameters of crv1, crv2 and poa
+        //writes pointers in pvec to the parameters of crv1, crv2 and poa
+        void ReconstructGeomPointers();
     public:
         ConstraintAngleViaPoint(Curve &acrv1, Curve &acrv2, Point p, double* angle);
         ~ConstraintAngleViaPoint() override;
@@ -718,8 +734,10 @@ namespace GCS
         // (test pvecChangedFlag variable before use!)
         Point poa;//poa=point of refraction //needs to be reconstructed if pvec was redirected/reverted. The point is easily shallow-copied by C++, so no pointer type here and no delete is necessary.
         bool flipn1, flipn2;
-        void ReconstructGeomPointers(); //writes pointers in pvec to the parameters of crv1, crv2 and poa
-        void errorgrad(double* err, double* grad, double *param); //error and gradient combined. Values are returned through pointers.
+        //writes pointers in pvec to the parameters of crv1, crv2 and poa
+        void ReconstructGeomPointers();
+        //error and gradient combined. Values are returned through pointers.
+        void errorgrad(double* err, double* grad, double *param);
     public:
         //n1dn2 = n1 divided by n2. from n1 to n2. flipn1 = true instructs to flip ray1's tangent
         ConstraintSnell(Curve &ray1, Curve &ray2, Curve &boundary, Point p, double* n1, double* n2, bool flipn1, bool flipn2);
@@ -735,8 +753,10 @@ namespace GCS
     private:
         Line l1;
         Line l2;
-        void ReconstructGeomPointers(); //writes pointers in pvec to the parameters of line1, line2
-        void errorgrad(double* err, double* grad, double *param); //error and gradient combined. Values are returned through pointers.
+        //writes pointers in pvec to the parameters of line1, line2
+        void ReconstructGeomPointers();
+        //error and gradient combined. Values are returned through pointers.
+        void errorgrad(double* err, double* grad, double *param);
     public:
         ConstraintEqualLineLength(Line &l1, Line &l2);
         ConstraintType getTypeId() override;

--- a/src/Mod/Sketcher/App/planegcs/GCS.cpp
+++ b/src/Mod/Sketcher/App/planegcs/GCS.cpp
@@ -122,9 +122,11 @@ namespace Eigen {
         // can't accumulate on-the-fly because that will be done in reverse order for the rows.
         m_rowsTranspositions.resize(matrix.rows());
         m_colsTranspositions.resize(matrix.cols());
-        Index number_of_transpositions = 0; // number of NONTRIVIAL transpositions, i.e. m_rowsTranspositions[i]!=i
+        // number of NONTRIVIAL transpositions, i.e. m_rowsTranspositions[i]!=i
+        Index number_of_transpositions = 0;
 
-        m_nonzero_pivots = size; // the generic case is that in which all pivots are nonzero (invertible case)
+        // the generic case is that in which all pivots are nonzero (invertible case)
+        m_nonzero_pivots = size;
         m_maxpivot = RealScalar(0);
         RealScalar cutoff(0);
 
@@ -138,8 +140,10 @@ namespace Eigen {
             biggest_in_corner = m_lu.bottomRightCorner(rows-k, cols-k)
             .cwiseAbs()
             .maxCoeff(&row_of_biggest_in_corner, &col_of_biggest_in_corner);
-            row_of_biggest_in_corner += k; // correct the values! since they were computed in the corner,
-            col_of_biggest_in_corner += k; // need to add k to them.
+            // correct the values! since they were computed in the corner,
+            row_of_biggest_in_corner += k;
+            // need to add k to them.
+            col_of_biggest_in_corner += k;
 
             // when k==0, biggest_in_corner is the biggest coeff absolute value in the original matrix
             if(k == 0) cutoff = biggest_in_corner * NumTraits<Scalar>::epsilon();
@@ -300,7 +304,8 @@ void SolverReportingManager::LogToFile(const std::string& str)
 
     flushStream();
     #else
-    (void)(str); // silence unused parameter
+    // silence unused parameter
+    (void)(str);
     LogToConsole("Debugging to file not enabled!");
     #endif
 }
@@ -1450,9 +1455,12 @@ void System::calculateNormalAtPoint(const Curve &crv, const Point &p, double &rt
 
 double System::calculateConstraintErrorByTag(int tagId)
 {
-    int cnt = 0; //how many constraints have been accumulated
-    double sqErr = 0.0; //accumulator of squared errors
-    double err = 0.0;//last computed signed error value
+    //how many constraints have been accumulated
+    int cnt = 0;
+    //accumulator of squared errors
+    double sqErr = 0.0;
+    //last computed signed error value
+    double err = 0.0;
 
     for (std::vector<Constraint *>::const_iterator
          constr=clist.begin(); constr != clist.end(); ++constr) {
@@ -1556,9 +1564,11 @@ void System::initSolution(Algorithm alg)
         componentsSize = boost::connected_components(g, &components[0]);
 
     // identification of equality constraints and parameter reduction
-    std::set<Constraint *> reducedConstrs;  // constraints that will be eliminated through reduction
+    // constraints that will be eliminated through reduction
+    std::set<Constraint *> reducedConstrs;
     reductionmaps.clear(); // destroy any maps
-    reductionmaps.resize(componentsSize); // create empty maps to be filled in
+    // create empty maps to be filled in
+    reductionmaps.resize(componentsSize);
     {
         VEC_pD reducedParams=plist;
 
@@ -1587,7 +1597,8 @@ void System::initSolution(Algorithm alg)
     }
 
     clists.clear(); // destroy any lists
-    clists.resize(componentsSize); // create empty lists to be filled in
+    // create empty lists to be filled in
+    clists.resize(componentsSize);
     int i = int(plist.size());
     for (std::vector<Constraint *>::const_iterator constr=clistR.begin();
          constr != clistR.end(); ++constr, i++) {
@@ -1598,7 +1609,8 @@ void System::initSolution(Algorithm alg)
     }
 
     plists.clear(); // destroy any lists
-    plists.resize(componentsSize); // create empty lists to be filled in
+    // create empty lists to be filled in
+    plists.resize(componentsSize);
     for (int i=0; i < int(plist.size()); ++i) {
         int cid = components[i];
         plists[cid].push_back(plist[i]);
@@ -1837,8 +1849,10 @@ int System::solve_LM(SubSystem* subsys, bool isRedundantsolving)
     if (xsize == 0)
         return Success;
 
-    Eigen::VectorXd e(csize), e_new(csize); // vector of all function errors (every constraint is one function)
-    Eigen::MatrixXd J(csize, xsize);        // Jacobi of the subsystem
+    // vector of all function errors (every constraint is one function)
+    Eigen::VectorXd e(csize), e_new(csize);
+    // Jacobi of the subsystem
+    Eigen::MatrixXd J(csize, xsize);
     Eigen::MatrixXd A(xsize, xsize);
     Eigen::VectorXd x(xsize), h(xsize), x_new(xsize), g(xsize), diag_A(xsize);
 
@@ -1894,7 +1908,8 @@ int System::solve_LM(SubSystem* subsys, bool isRedundantsolving)
 
         // Compute ||J^T e||_inf
         double g_inf = g.lpNorm<Eigen::Infinity>();
-        diag_A = A.diagonal(); // save diagonal entries so that augmentation can be later canceled
+        // save diagonal entries so that augmentation can be later canceled
+        diag_A = A.diagonal();
 
         // check for convergence
         if (g_inf <= eps1) {
@@ -2205,7 +2220,8 @@ int System::solve_DL(SubSystem* subsys, bool isRedundantsolving)
 #ifdef _GCS_EXTRACT_SOLVER_SUBSYSTEM_
 void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
 {
-    VEC_pD plistout; //std::vector<double *>
+    //std::vector<double *>
+    VEC_pD plistout;
     std::vector<Constraint *> clist_;
     VEC_pD clist_params_;
 
@@ -2221,14 +2237,18 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
     int ip=0;
 
     subsystemfile << "GCS::VEC_pD plist_;" <<  std::endl; // all SYSTEM params
-    subsystemfile << "std::vector<GCS::Constraint *> clist_;" <<  std::endl; // SUBSYSTEM constraints
-    subsystemfile << "GCS::VEC_pD plistsub_;" <<  std::endl; // all SUBSYSTEM params
-    subsystemfile << "GCS::VEC_pD clist_params_;" <<  std::endl; // constraint params not within SYSTEM params
+    // SUBSYSTEM constraints
+    subsystemfile << "std::vector<GCS::Constraint *> clist_;" <<  std::endl;
+    // all SUBSYSTEM params
+    subsystemfile << "GCS::VEC_pD plistsub_;" <<  std::endl;
+    // constraint params not within SYSTEM params
+    subsystemfile << "GCS::VEC_pD clist_params_;" <<  std::endl;
 
     // these are all the parameters, including those not in the subsystem to
     // which constraints in the subsystem may make reference.
     for( VEC_pD::iterator it = plist.begin(); it != plist.end(); ++it, ++ip) {
-        subsystemfile << "plist_.push_back(new double("<< *(*it) <<")); // "<< ip <<" address: " << (void *)(*it) << std::endl;
+        // "<< ip <<" address: " << (void *)(*it) << std::endl;
+        subsystemfile << "plist_.push_back(new double("<< *(*it) <<"));
     }
 
     int ips=0;
@@ -2264,7 +2284,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni1 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[0]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[0]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[0] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[0] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[0]) <<"));
                         icp++;
                     }
                     npb1=true;
@@ -2278,14 +2299,16 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni2 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[1]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[1]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[1] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[1] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[1]) <<"));
                         icp++;
                     }
                     npb2=true;
                 }
 
                 subsystemfile << "clist_.push_back(new ConstraintEqual(" << (npb1?("clist_params_["):("plist_[")) << (npb1?ni1:i1) << "]," \
-                << (npb2?("clist_params_["):("plist_[")) << (npb2?ni2:i2) << "])); // addresses = "<< (*it)->pvec[0] << "," << (*it)->pvec[1] << std::endl;
+                // addresses = "<< (*it)->pvec[0] << "," << (*it)->pvec[1] << std::endl;
+                << (npb2?("clist_params_["):("plist_[")) << (npb2?ni2:i2) << "]));
                 break;
             }
             case Difference:
@@ -2305,7 +2328,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni1 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[0]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[0]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[0] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[0] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[0]) <<"));
                         icp++;
                     }
                     npb1=true;
@@ -2319,7 +2343,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni2 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[1]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[1]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[1] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[1] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[1]) <<"));
                         icp++;
                     }
                     npb2=true;
@@ -2333,7 +2358,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni3 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[2]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[2]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[2] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[2] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[2]) <<"));
                         icp++;
                     }
                     npb3=true;
@@ -2341,7 +2367,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
 
                 subsystemfile << "clist_.push_back(new ConstraintDifference(" << (npb1?("clist_params_["):("plist_[")) << (npb1?ni1:i1) << "]," \
                 << (npb2?("clist_params_["):("plist_[")) << (npb2?ni2:i2) << "]," \
-                << (npb3?("clist_params_["):("plist_[")) << (npb3?ni3:i3) << "])); // addresses = "<< (*it)->pvec[0] << "," << (*it)->pvec[1] << "," << (*it)->pvec[2] << std::endl;
+                // addresses = "<< (*it)->pvec[0] << "," << (*it)->pvec[1] << "," << (*it)->pvec[2] << std::endl;
+                << (npb3?("clist_params_["):("plist_[")) << (npb3?ni3:i3) << "]));
                 break;
             }
             case P2PDistance:
@@ -2365,7 +2392,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni1 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[0]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[0]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[0] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[0] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[0]) <<"));
                         icp++;
                     }
                     npb1=true;
@@ -2379,7 +2407,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni2 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[1]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[1]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[1] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[1] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[1]) <<"));
                         icp++;
                     }
                     npb2=true;
@@ -2393,7 +2422,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni3 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[2]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[2]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[2] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[2] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[2]) <<"));
                         icp++;
                     }
                     npb3=true;
@@ -2407,7 +2437,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni4 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[3]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[3]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[3] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[3] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[3]) <<"));
                         icp++;
                     }
                     npb4=true;
@@ -2421,7 +2452,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni5 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[4]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[4]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[4] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[4] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[4]) <<"));
                         icp++;
                     }
                     npb5=true;
@@ -2435,7 +2467,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                 subsystemfile << "c" << ic << "->pvec.push_back(" << (npb5?("clist_params_["):("plist_[")) << (npb5?ni5:i5) <<"]);" << std::endl;
                 subsystemfile << "c" << ic << "->origpvec=c" << ic << "->pvec;" << std::endl;
                 subsystemfile << "c" << ic << "->rescale();" << std::endl;
-                subsystemfile << "clist_.push_back(c" << ic << "); // addresses = "<< (*it)->pvec[0] << "," << (*it)->pvec[1] << "," << (*it)->pvec[2] << "," << (*it)->pvec[3] << "," << (*it)->pvec[4] << std::endl;
+                // addresses = "<< (*it)->pvec[0] << "," << (*it)->pvec[1] << "," << (*it)->pvec[2] << "," << (*it)->pvec[3] << "," << (*it)->pvec[4] << std::endl;
+                subsystemfile << "clist_.push_back(c" << ic << ");
                 break;
             }
             case P2PAngle:
@@ -2459,7 +2492,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni1 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[0]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[0]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[0] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[0] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[0]) <<"));
                         icp++;
                     }
                     npb1=true;
@@ -2473,7 +2507,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni2 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[1]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[1]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[1] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[1] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[1]) <<"));
                         icp++;
                     }
                     npb2=true;
@@ -2487,7 +2522,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni3 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[2]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[2]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[2] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[2] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[2]) <<"));
                         icp++;
                     }
                     npb3=true;
@@ -2501,7 +2537,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni4 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[3]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[3]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[3] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[3] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[3]) <<"));
                         icp++;
                     }
                     npb4=true;
@@ -2515,7 +2552,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni5 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[4]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[4]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[4] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[4] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[4]) <<"));
                         icp++;
                     }
                     npb5=true;
@@ -2529,7 +2567,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                 subsystemfile << "c" << ic << "->pvec.push_back(" << (npb5?("clist_params_["):("plist_[")) << (npb5?ni5:i5) <<"]);" << std::endl;
                 subsystemfile << "c" << ic << "->origpvec=c" << ic << "->pvec;" << std::endl;
                 subsystemfile << "c" << ic << "->rescale();" << std::endl;
-                subsystemfile << "clist_.push_back(c" << ic << "); // addresses = "<< (*it)->pvec[0] << "," << (*it)->pvec[1] << "," << (*it)->pvec[2] << "," << (*it)->pvec[3] << "," << (*it)->pvec[4] << std::endl;
+                // addresses = "<< (*it)->pvec[0] << "," << (*it)->pvec[1] << "," << (*it)->pvec[2] << "," << (*it)->pvec[3] << "," << (*it)->pvec[4] << std::endl;
+                subsystemfile << "clist_.push_back(c" << ic << ");
                 break;
             }
             case P2LDistance:
@@ -2557,7 +2596,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni1 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[0]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[0]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[0] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[0] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[0]) <<"));
                         icp++;
                     }
                     npb1=true;
@@ -2571,7 +2611,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni2 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[1]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[1]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[1] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[1] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[1]) <<"));
                         icp++;
                     }
                     npb2=true;
@@ -2585,7 +2626,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni3 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[2]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[2]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[2] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[2] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[2]) <<"));
                         icp++;
                     }
                     npb3=true;
@@ -2599,7 +2641,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni4 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[3]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[3]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[3] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[3] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[3]) <<"));
                         icp++;
                     }
                     npb4=true;
@@ -2613,7 +2656,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni5 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[4]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[4]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[4] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[4] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[4]) <<"));
                         icp++;
                     }
                     npb5=true;
@@ -2627,7 +2671,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni6 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[5]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[5]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[5] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[5] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[5]) <<"));
                         icp++;
                     }
                     npb6=true;
@@ -2641,7 +2686,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni7 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[6]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[6]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[6] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[6] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[6]) <<"));
                         icp++;
                     }
                     npb7=true;
@@ -2657,7 +2703,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                 subsystemfile << "c" << ic << "->pvec.push_back(" << (npb7?("clist_params_["):("plist_[")) << (npb7?ni7:i7) <<"]);" << std::endl;
                 subsystemfile << "c" << ic << "->origpvec=c" << ic << "->pvec;" << std::endl;
                 subsystemfile << "c" << ic << "->rescale();" << std::endl;
-                subsystemfile << "clist_.push_back(c" << ic << "); // addresses = "<< (*it)->pvec[0] << "," << (*it)->pvec[1] << "," << (*it)->pvec[2] << "," << (*it)->pvec[3] << "," << (*it)->pvec[4] << "," << (*it)->pvec[5] << "," << (*it)->pvec[6] << std::endl;
+                // addresses = "<< (*it)->pvec[0] << "," << (*it)->pvec[1] << "," << (*it)->pvec[2] << "," << (*it)->pvec[3] << "," << (*it)->pvec[4] << "," << (*it)->pvec[5] << "," << (*it)->pvec[6] << std::endl;
+                subsystemfile << "clist_.push_back(c" << ic << ");
                 break;
             }
             case PointOnLine:
@@ -2683,7 +2730,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni1 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[0]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[0]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[0] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[0] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[0]) <<"));
                         icp++;
                     }
                     npb1=true;
@@ -2697,7 +2745,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni2 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[1]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[1]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[1] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[1] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[1]) <<"));
                         icp++;
                     }
                     npb2=true;
@@ -2711,7 +2760,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni3 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[2]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[2]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[2] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[2] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[2]) <<"));
                         icp++;
                     }
                     npb3=true;
@@ -2725,7 +2775,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni4 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[3]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[3]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[3] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[3] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[3]) <<"));
                         icp++;
                     }
                     npb4=true;
@@ -2739,7 +2790,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni5 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[4]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[4]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[4] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[4] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[4]) <<"));
                         icp++;
                     }
                     npb5=true;
@@ -2753,7 +2805,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni6 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[5]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[5]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[5] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[5] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[5]) <<"));
                         icp++;
                     }
                     npb6=true;
@@ -2768,7 +2821,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                 subsystemfile << "c" << ic << "->pvec.push_back(" << (npb6?("clist_params_["):("plist_[")) << (npb6?ni6:i6) <<"]);" << std::endl;
                 subsystemfile << "c" << ic << "->origpvec=c" << ic << "->pvec;" << std::endl;
                 subsystemfile << "c" << ic << "->rescale();" << std::endl;
-                subsystemfile << "clist_.push_back(c" << ic << "); // addresses = "<< (*it)->pvec[0] << "," << (*it)->pvec[1] << "," << (*it)->pvec[2] << "," << (*it)->pvec[3] << "," << (*it)->pvec[4] << "," << (*it)->pvec[5] << std::endl;
+                // addresses = "<< (*it)->pvec[0] << "," << (*it)->pvec[1] << "," << (*it)->pvec[2] << "," << (*it)->pvec[3] << "," << (*it)->pvec[4] << "," << (*it)->pvec[5] << std::endl;
+                subsystemfile << "clist_.push_back(c" << ic << ");
                 break;
             }
             case PointOnPerpBisector:
@@ -2794,7 +2848,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni1 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[0]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[0]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[0] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[0] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[0]) <<"));
                         icp++;
                     }
                     npb1=true;
@@ -2808,7 +2863,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni2 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[1]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[1]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[1] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[1] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[1]) <<"));
                         icp++;
                     }
                     npb2=true;
@@ -2822,7 +2878,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni3 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[2]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[2]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[2] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[2] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[2]) <<"));
                         icp++;
                     }
                     npb3=true;
@@ -2836,7 +2893,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni4 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[3]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[3]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[3] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[3] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[3]) <<"));
                         icp++;
                     }
                     npb4=true;
@@ -2850,7 +2908,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni5 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[4]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[4]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[4] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[4] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[4]) <<"));
                         icp++;
                     }
                     npb5=true;
@@ -2864,7 +2923,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni6 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[5]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[5]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[5] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[5] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[5]) <<"));
                         icp++;
                     }
                     npb6=true;
@@ -2879,7 +2939,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                 subsystemfile << "c" << ic << "->pvec.push_back(" << (npb6?("clist_params_["):("plist_[")) << (npb6?ni6:i6) <<"]);" << std::endl;
                 subsystemfile << "c" << ic << "->origpvec=c" << ic << "->pvec;" << std::endl;
                 subsystemfile << "c" << ic << "->rescale();" << std::endl;
-                subsystemfile << "clist_.push_back(c" << ic << "); // addresses = "<< (*it)->pvec[0] << "," << (*it)->pvec[1] << "," << (*it)->pvec[2] << "," << (*it)->pvec[3] << "," << (*it)->pvec[4] << "," << (*it)->pvec[5] << std::endl;
+                // addresses = "<< (*it)->pvec[0] << "," << (*it)->pvec[1] << "," << (*it)->pvec[2] << "," << (*it)->pvec[3] << "," << (*it)->pvec[4] << "," << (*it)->pvec[5] << std::endl;
+                subsystemfile << "clist_.push_back(c" << ic << ");
                 break;
             }
             case Parallel:
@@ -2909,7 +2970,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni1 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[0]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[0]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[0] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[0] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[0]) <<"));
                         icp++;
                     }
                     npb1=true;
@@ -2923,7 +2985,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni2 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[1]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[1]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[1] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[1] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[1]) <<"));
                         icp++;
                     }
                     npb2=true;
@@ -2937,7 +3000,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni3 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[2]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[2]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[2] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[2] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[2]) <<"));
                         icp++;
                     }
                     npb3=true;
@@ -2951,7 +3015,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni4 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[3]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[3]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[3] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[3] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[3]) <<"));
                         icp++;
                     }
                     npb4=true;
@@ -2965,7 +3030,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni5 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[4]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[4]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[4] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[4] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[4]) <<"));
                         icp++;
                     }
                     npb5=true;
@@ -2979,7 +3045,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni6 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[5]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[5]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[5] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[5] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[5]) <<"));
                         icp++;
                     }
                     npb6=true;
@@ -2993,7 +3060,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni7 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[6]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[6]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[6] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[6] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[6]) <<"));
                         icp++;
                     }
                     npb7=true;
@@ -3007,7 +3075,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni8 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[7]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[7]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[7] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[7] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[7]) <<"));
                         icp++;
                     }
                     npb8=true;
@@ -3024,7 +3093,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                 subsystemfile << "c" << ic << "->pvec.push_back(" << (npb8?("clist_params_["):("plist_[")) << (npb8?ni8:i8) <<"]);" << std::endl;
                 subsystemfile << "c" << ic << "->origpvec=c" << ic << "->pvec;" << std::endl;
                 subsystemfile << "c" << ic << "->rescale();" << std::endl;
-                subsystemfile << "clist_.push_back(c" << ic << "); // addresses = "<< (*it)->pvec[0] << "," << (*it)->pvec[1] << "," << (*it)->pvec[2] << "," << (*it)->pvec[3] << "," << (*it)->pvec[4] << "," << (*it)->pvec[5] << "," << (*it)->pvec[6] << "," << (*it)->pvec[7] << std::endl;
+                // addresses = "<< (*it)->pvec[0] << "," << (*it)->pvec[1] << "," << (*it)->pvec[2] << "," << (*it)->pvec[3] << "," << (*it)->pvec[4] << "," << (*it)->pvec[5] << "," << (*it)->pvec[6] << "," << (*it)->pvec[7] << std::endl;
+                subsystemfile << "clist_.push_back(c" << ic << ");
                 break;
             }
             case Perpendicular:
@@ -3054,7 +3124,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni1 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[0]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[0]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[0] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[0] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[0]) <<"));
                         icp++;
                     }
                     npb1=true;
@@ -3068,7 +3139,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni2 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[1]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[1]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[1] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[1] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[1]) <<"));
                         icp++;
                     }
                     npb2=true;
@@ -3082,7 +3154,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni3 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[2]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[2]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[2] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[2] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[2]) <<"));
                         icp++;
                     }
                     npb3=true;
@@ -3096,7 +3169,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni4 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[3]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[3]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[3] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[3] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[3]) <<"));
                         icp++;
                     }
                     npb4=true;
@@ -3110,7 +3184,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni5 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[4]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[4]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[4] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[4] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[4]) <<"));
                         icp++;
                     }
                     npb5=true;
@@ -3124,7 +3199,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni6 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[5]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[5]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[5] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[5] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[5]) <<"));
                         icp++;
                     }
                     npb6=true;
@@ -3138,7 +3214,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni7 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[6]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[6]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[6] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[6] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[6]) <<"));
                         icp++;
                     }
                     npb7=true;
@@ -3152,7 +3229,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni8 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[7]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[7]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[7] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[7] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[7]) <<"));
                         icp++;
                     }
                     npb8=true;
@@ -3169,7 +3247,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                 subsystemfile << "c" << ic << "->pvec.push_back(" << (npb8?("clist_params_["):("plist_[")) << (npb8?ni8:i8) <<"]);" << std::endl;
                 subsystemfile << "c" << ic << "->origpvec=c" << ic << "->pvec;" << std::endl;
                 subsystemfile << "c" << ic << "->rescale();" << std::endl;
-                subsystemfile << "clist_.push_back(c" << ic << "); // addresses = "<< (*it)->pvec[0] << "," << (*it)->pvec[1] << "," << (*it)->pvec[2] << "," << (*it)->pvec[3] << "," << (*it)->pvec[4] << "," << (*it)->pvec[5] << "," << (*it)->pvec[6] << "," << (*it)->pvec[7] << std::endl;
+                // addresses = "<< (*it)->pvec[0] << "," << (*it)->pvec[1] << "," << (*it)->pvec[2] << "," << (*it)->pvec[3] << "," << (*it)->pvec[4] << "," << (*it)->pvec[5] << "," << (*it)->pvec[6] << "," << (*it)->pvec[7] << std::endl;
+                subsystemfile << "clist_.push_back(c" << ic << ");
                 break;
             }
             case L2LAngle:
@@ -3201,7 +3280,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni1 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[0]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[0]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[0] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[0] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[0]) <<"));
                         icp++;
                     }
                     npb1=true;
@@ -3215,7 +3295,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni2 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[1]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[1]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[1] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[1] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[1]) <<"));
                         icp++;
                     }
                     npb2=true;
@@ -3229,7 +3310,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni3 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[2]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[2]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[2] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[2] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[2]) <<"));
                         icp++;
                     }
                     npb3=true;
@@ -3243,7 +3325,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni4 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[3]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[3]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[3] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[3] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[3]) <<"));
                         icp++;
                     }
                     npb4=true;
@@ -3257,7 +3340,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni5 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[4]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[4]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[4] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[4] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[4]) <<"));
                         icp++;
                     }
                     npb5=true;
@@ -3271,7 +3355,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni6 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[5]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[5]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[5] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[5] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[5]) <<"));
                         icp++;
                     }
                     npb6=true;
@@ -3285,7 +3370,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni7 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[6]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[6]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[6] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[6] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[6]) <<"));
                         icp++;
                     }
                     npb7=true;
@@ -3299,7 +3385,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni8 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[7]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[7]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[7] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[7] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[7]) <<"));
                         icp++;
                     }
                     npb8=true;
@@ -3313,7 +3400,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni9 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[8]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[8]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[8] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[8] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[8]) <<"));
                         icp++;
                     }
                     npb9=true;
@@ -3331,7 +3419,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                 subsystemfile << "c" << ic << "->pvec.push_back(" << (npb9?("clist_params_["):("plist_[")) << (npb9?ni9:i9) <<"]);" << std::endl;
                 subsystemfile << "c" << ic << "->origpvec=c" << ic << "->pvec;" << std::endl;
                 subsystemfile << "c" << ic << "->rescale();" << std::endl;
-                subsystemfile << "clist_.push_back(c" << ic << "); // addresses = "<< (*it)->pvec[0] << "," << (*it)->pvec[1] << "," << (*it)->pvec[2] << "," << (*it)->pvec[3] << "," << (*it)->pvec[4] << "," << (*it)->pvec[5] << "," << (*it)->pvec[6] << "," << (*it)->pvec[7] << "," << (*it)->pvec[8] << std::endl;
+                // addresses = "<< (*it)->pvec[0] << "," << (*it)->pvec[1] << "," << (*it)->pvec[2] << "," << (*it)->pvec[3] << "," << (*it)->pvec[4] << "," << (*it)->pvec[5] << "," << (*it)->pvec[6] << "," << (*it)->pvec[7] << "," << (*it)->pvec[8] << std::endl;
+                subsystemfile << "clist_.push_back(c" << ic << ");
                 break;
             }
             case MidpointOnLine:
@@ -3361,7 +3450,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni1 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[0]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[0]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[0] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[0] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[0]) <<"));
                         icp++;
                     }
                     npb1=true;
@@ -3375,7 +3465,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni2 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[1]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[1]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[1] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[1] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[1]) <<"));
                         icp++;
                     }
                     npb2=true;
@@ -3389,7 +3480,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni3 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[2]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[2]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[2] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[2] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[2]) <<"));
                         icp++;
                     }
                     npb3=true;
@@ -3403,7 +3495,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni4 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[3]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[3]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[3] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[3] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[3]) <<"));
                         icp++;
                     }
                     npb4=true;
@@ -3417,7 +3510,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni5 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[4]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[4]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[4] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[4] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[4]) <<"));
                         icp++;
                     }
                     npb5=true;
@@ -3431,7 +3525,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni6 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[5]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[5]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[5] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[5] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[5]) <<"));
                         icp++;
                     }
                     npb6=true;
@@ -3445,7 +3540,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni7 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[6]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[6]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[6] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[6] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[6]) <<"));
                         icp++;
                     }
                     npb7=true;
@@ -3459,7 +3555,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni8 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[7]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[7]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[7] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[7] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[7]) <<"));
                         icp++;
                     }
                     npb8=true;
@@ -3476,7 +3573,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                 subsystemfile << "c" << ic << "->pvec.push_back(" << (npb8?("clist_params_["):("plist_[")) << (npb8?ni8:i8) <<"]);" << std::endl;
                 subsystemfile << "c" << ic << "->origpvec=c" << ic << "->pvec;" << std::endl;
                 subsystemfile << "c" << ic << "->rescale();" << std::endl;
-                subsystemfile << "clist_.push_back(c" << ic << "); // addresses = "<< (*it)->pvec[0] << "," << (*it)->pvec[1] << "," << (*it)->pvec[2] << "," << (*it)->pvec[3] << "," << (*it)->pvec[4] << "," << (*it)->pvec[5] << "," << (*it)->pvec[6] << "," << (*it)->pvec[7] << std::endl;
+                // addresses = "<< (*it)->pvec[0] << "," << (*it)->pvec[1] << "," << (*it)->pvec[2] << "," << (*it)->pvec[3] << "," << (*it)->pvec[4] << "," << (*it)->pvec[5] << "," << (*it)->pvec[6] << "," << (*it)->pvec[7] << std::endl;
+                subsystemfile << "clist_.push_back(c" << ic << ");
                 break;
             }
             case TangentCircumf:
@@ -3502,7 +3600,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni1 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[0]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[0]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[0] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[0] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[0]) <<"));
                         icp++;
                     }
                     npb1=true;
@@ -3516,7 +3615,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni2 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[1]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[1]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[1] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[1] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[1]) <<"));
                         icp++;
                     }
                     npb2=true;
@@ -3530,7 +3630,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni3 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[2]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[2]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[2] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[2] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[2]) <<"));
                         icp++;
                     }
                     npb3=true;
@@ -3544,7 +3645,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni4 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[3]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[3]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[3] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[3] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[3]) <<"));
                         icp++;
                     }
                     npb4=true;
@@ -3558,7 +3660,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni5 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[4]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[4]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[4] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[4] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[4]) <<"));
                         icp++;
                     }
                     npb5=true;
@@ -3572,7 +3675,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni6 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[5]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[5]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[5] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[5] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[5]) <<"));
                         icp++;
                     }
                     npb6=true;
@@ -3587,7 +3691,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                 subsystemfile << "c" << ic << "->pvec.push_back(" << (npb6?("clist_params_["):("plist_[")) << (npb6?ni6:i6) <<"]);" << std::endl;
                 subsystemfile << "c" << ic << "->origpvec=c" << ic << "->pvec;" << std::endl;
                 subsystemfile << "c" << ic << "->rescale();" << std::endl;
-                subsystemfile << "clist_.push_back(c" << ic << "); // addresses = "<< (*it)->pvec[0] << "," << (*it)->pvec[1] << "," << (*it)->pvec[2] << "," << (*it)->pvec[3] << "," << (*it)->pvec[4] << "," << (*it)->pvec[5] << std::endl;
+                // addresses = "<< (*it)->pvec[0] << "," << (*it)->pvec[1] << "," << (*it)->pvec[2] << "," << (*it)->pvec[3] << "," << (*it)->pvec[4] << "," << (*it)->pvec[5] << std::endl;
+                subsystemfile << "clist_.push_back(c" << ic << ");
                 break;
             }
             case PointOnEllipse:
@@ -3615,7 +3720,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni1 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[0]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[0]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[0] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[0] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[0]) <<"));
                         icp++;
                     }
                     npb1=true;
@@ -3629,7 +3735,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni2 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[1]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[1]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[1] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[1] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[1]) <<"));
                         icp++;
                     }
                     npb2=true;
@@ -3643,7 +3750,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni3 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[2]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[2]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[2] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[2] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[2]) <<"));
                         icp++;
                     }
                     npb3=true;
@@ -3657,7 +3765,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni4 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[3]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[3]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[3] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[3] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[3]) <<"));
                         icp++;
                     }
                     npb4=true;
@@ -3671,7 +3780,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni5 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[4]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[4]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[4] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[4] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[4]) <<"));
                         icp++;
                     }
                     npb5=true;
@@ -3685,7 +3795,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni6 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[5]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[5]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[5] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[5] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[5]) <<"));
                         icp++;
                     }
                     npb6=true;
@@ -3699,7 +3810,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                     if(ni7 == clist_params_.size()) {
                         subsystemfile << "// Address not in System params...rebuilding into clist_params_" << std::endl;
                         clist_params_.push_back((*it)->pvec[6]);
-                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[6]) <<")); // "<< icp <<" address: " << (void *)(*it)->pvec[6] << std::endl;
+                        // "<< icp <<" address: " << (void *)(*it)->pvec[6] << std::endl;
+                        subsystemfile << "clist_params_.push_back(new double("<< *((*it)->pvec[6]) <<"));
                         icp++;
                     }
                     npb7=true;
@@ -3715,7 +3827,8 @@ void System::extractSubsystem(SubSystem *subsys, bool isRedundantsolving)
                 subsystemfile << "c" << ic << "->pvec.push_back(" << (npb7?("clist_params_["):("plist_[")) << (npb7?ni7:i7) <<"]);" << std::endl;
                 subsystemfile << "c" << ic << "->origpvec=c" << ic << "->pvec;" << std::endl;
                 subsystemfile << "c" << ic << "->rescale();" << std::endl;
-                subsystemfile << "clist_.push_back(c" << ic << "); // addresses = "<< (*it)->pvec[0] << "," << (*it)->pvec[1] << "," << (*it)->pvec[2] << "," << (*it)->pvec[3] << "," << (*it)->pvec[4] << "," << (*it)->pvec[5] << "," << (*it)->pvec[6] << std::endl;
+                // addresses = "<< (*it)->pvec[0] << "," << (*it)->pvec[1] << "," << (*it)->pvec[2] << "," << (*it)->pvec[3] << "," << (*it)->pvec[4] << "," << (*it)->pvec[5] << "," << (*it)->pvec[6] << std::endl;
+                subsystemfile << "clist_.push_back(c" << ic << ");
                 break;
             }
             CASE_NOT_IMP(TangentEllipseLine)
@@ -3774,7 +3887,8 @@ int System::solve(SubSystem *subsysA, SubSystem *subsysB, bool /*isFine*/, bool 
 
     subsysB->getParams(plistAB,x);
     subsysA->getParams(plistAB,x);
-    subsysB->setParams(plistAB,x);  // just to ensure that A and B are synchronized
+    // just to ensure that A and B are synchronized
+    subsysB->setParams(plistAB,x);
 
     subsysB->calcGrad(plistAB,grad);
     subsysA->calcJacobi(plistAB,JA);
@@ -4081,7 +4195,8 @@ SolverReportingManager::Manager().LogToFile("GCS::System::diagnose()\n");
         Base::TimeInfo DenseQR_start_time;
     #endif
         if (J.rows() > 0) {
-            int rank = 0; // rank is not cheap to retrieve from qrJT in DenseQR
+            // rank is not cheap to retrieve from qrJT in DenseQR
+            int rank = 0;
             Eigen::MatrixXd R;
             Eigen::FullPivHouseholderQR<Eigen::MatrixXd> qrJT;
             // Here we give the system the possibility to run the two QR decompositions in parallel, depending on the load of the system
@@ -4107,7 +4222,8 @@ SolverReportingManager::Manager().LogToFile("GCS::System::diagnose()\n");
 
             fut.wait(); // wait for the execution of identifyDependentParametersSparseQR to finish
 
-            dofs = paramsNum - rank; // unless overconstraint, which will be overridden below
+            // unless overconstraint, which will be overridden below
+            dofs = paramsNum - rank;
 
             // Detecting conflicting or redundant constraints
             if (constrNum > rank) { // conflicting or redundant constraints
@@ -4160,7 +4276,8 @@ SolverReportingManager::Manager().LogToFile("GCS::System::diagnose()\n");
 
             fut.wait(); // wait for the execution of identifyDependentParametersSparseQR to finish
 
-            dofs = paramsNum - rank; // unless overconstraint, which will be overridden below
+            // unless overconstraint, which will be overridden below
+            dofs = paramsNum - rank;
 
             // Detecting conflicting or redundant constraints
             if (constrNum > rank) { // conflicting or redundant constraints
@@ -4200,8 +4317,10 @@ void System::makeDenseQRDecomposition(  const Eigen::MatrixXd &J,
 #endif
 
 #ifdef _GCS_DEBUG_SOLVER_JACOBIAN_QR_DECOMPOSITION_TRIANGULAR_MATRIX
-    Eigen::MatrixXd Q; // Obtaining the Q matrix with Sparse QR is buggy, see comments below
-    Eigen::MatrixXd R2; // Intended for a trapezoidal matrix, where R is the top triangular matrix of the R2 trapezoidal matrix
+    // Obtaining the Q matrix with Sparse QR is buggy, see comments below
+    Eigen::MatrixXd Q;
+    // Intended for a trapezoidal matrix, where R is the top triangular matrix of the R2 trapezoidal matrix
+    Eigen::MatrixXd R2;
 #endif
 
     // For a transposed J SJG rows are paramsNum and cols are constrNum
@@ -4279,8 +4398,10 @@ void System::makeSparseQRDecomposition( const Eigen::MatrixXd &J,
     #endif
 
     #ifdef _GCS_DEBUG_SOLVER_JACOBIAN_QR_DECOMPOSITION_TRIANGULAR_MATRIX
-    Eigen::MatrixXd Q; // Obtaining the Q matrix with Sparse QR is buggy, see comments below
-    Eigen::MatrixXd R2; // Intended for a trapezoidal matrix, where R is the top triangular matrix of the R2 trapezoidal matrix
+    // Obtaining the Q matrix with Sparse QR is buggy, see comments below
+    Eigen::MatrixXd Q;
+    // Intended for a trapezoidal matrix, where R is the top triangular matrix of the R2 trapezoidal matrix
+    Eigen::MatrixXd R2;
     #endif
 
     // For a transposed J SJG rows are paramsNum and cols are constrNum
@@ -4370,7 +4491,8 @@ void System::identifyDependentParametersSparseQR( const Eigen::MatrixXd &J,
 
     int nontransprank;
 
-    makeSparseQRDecomposition( J, jacobianconstraintmap, SqrJ, nontransprank, Rparams, false, true); // do not transpose allow to diagnose parameters
+    // do not transpose allow to diagnose parameters
+    makeSparseQRDecomposition( J, jacobianconstraintmap, SqrJ, nontransprank, Rparams, false, true);
 
     identifyDependentParameters(SqrJ, Rparams, nontransprank, pdiagnoselist, silent);
 }
@@ -4383,9 +4505,11 @@ void System::identifyDependentParameters(   T & qrJ,
                                             const GCS::VEC_pD &pdiagnoselist,
                                             bool silent)
 {
-    (void) silent; // silent is only used in debug code, but it is important as Base::Console is not thread-safe. Removes warning in non Debug mode.
+    // silent is only used in debug code, but it is important as Base::Console is not thread-safe. Removes warning in non Debug mode.
+    (void) silent;
 
-    //int constrNum = SqrJ.rows(); // this is the other way around than for the transposed J
+    // this is the other way around than for the transposed J
+    //int constrNum = SqrJ.rows();
     //int paramsNum = SqrJ.cols();
 
     eliminateNonZerosOverPivotInUpperTriangularMatrix(Rparams, rank);
@@ -4586,7 +4710,8 @@ void System::identifyConflictingRedundantConstraints(   Algorithm alg,
         for (std::map< Constraint *, SET_I >::const_iterator it=conflictingMap.begin();
                 it != conflictingMap.end(); ++it) {
 
-            int numberofsets =  static_cast<int>(it->second.size()); // number of sets in which the constraint appears
+            // number of sets in which the constraint appears
+            int numberofsets =  static_cast<int>(it->second.size());
 
             /* This is a heuristic algorithm to propose the user which constraints from a redundant/conflicting set should be removed. It is based on the following principles:
              * 1. if the current constraint is more popular than previous ones (appears in more sets), take it. This prioritises removal of constraints that cause several independent groups of constraints to be conflicting/redundant. It is based on the observation that the redundancy/conflict is caused by the lesser amount of constraints.

--- a/src/Mod/Sketcher/App/planegcs/GCS.h
+++ b/src/Mod/Sketcher/App/planegcs/GCS.h
@@ -119,9 +119,12 @@ namespace GCS
         void setReference();     // copies the current parameter values to reference
         void resetToReference(); // reverts all parameter values to the stored reference
 
-        std::vector< VEC_pD > plists;                    // partitioned plist except equality constraints
-        std::vector< std::vector<Constraint *> > clists; // partitioned clist except equality constraints
-        std::vector< MAP_pD_pD > reductionmaps;          // for simplification of equality constraints
+        // partitioned plist except equality constraints
+        std::vector< VEC_pD > plists;
+        // partitioned clist except equality constraints
+        std::vector< std::vector<Constraint *> > clists;
+        // for simplification of equality constraints
+        std::vector< MAP_pD_pD > reductionmaps;
 
         int dofs;
         std::set<Constraint *> redundant;
@@ -197,7 +200,8 @@ namespace GCS
     public:
         int maxIter;
         int maxIterRedundant;
-        bool sketchSizeMultiplier; // if true note that the total number of iterations allowed is MaxIterations *xLength
+        // if true note that the total number of iterations allowed is MaxIterations *xLength
+        bool sketchSizeMultiplier;
         bool sketchSizeMultiplierRedundant;
         double convergence;
         double convergenceRedundant;

--- a/src/Mod/Sketcher/App/planegcs/Geo.cpp
+++ b/src/Mod/Sketcher/App/planegcs/Geo.cpp
@@ -409,7 +409,8 @@ DeriVector2 Hyperbola::CalculateNormal(const Point &p, const double* derivparam)
     DeriVector2 f2v = cv.linCombi(2.0, f1v, -1.0); // 2*cv - f1v
 
     //pf1, pf2 = vectors from p to focus1,focus2
-    DeriVector2 pf1 = f1v.subtr(pv).mult(-1.0);  // <--- differs from ellipse normal calculation code by inverting this vector
+    // <--- differs from ellipse normal calculation code by inverting this vector
+    DeriVector2 pf1 = f1v.subtr(pv).mult(-1.0);
     DeriVector2 pf2 = f2v.subtr(pv);
     //return sum of normalized pf2, pf2
     DeriVector2 ret = pf1.getNormalized().sum(pf2.getNormalized());

--- a/src/Mod/Sketcher/App/planegcs/Geo.h
+++ b/src/Mod/Sketcher/App/planegcs/Geo.h
@@ -60,12 +60,14 @@ namespace GCS
         double y, dy;
 
         double length() const {return sqrt(x*x + y*y);}
-        double length(double &dlength) const; //returns length and writes length deriv into the dlength argument.
+        //returns length and writes length deriv into the dlength argument.
+        double length(double &dlength) const;
 
 
         //unlike other vectors in FreeCAD, this normalization creates a new vector instead of modifying existing one.
         DeriVector2 getNormalized() const; //returns zero vector if the original is zero.
-        double scalarProd(const DeriVector2 &v2, double* dprd=nullptr) const;//calculates scalar product of two vectors and returns the result. The derivative of the result is written into argument dprd.
+        //calculates scalar product of two vectors and returns the result. The derivative of the result is written into argument dprd.
+        double scalarProd(const DeriVector2 &v2, double* dprd=nullptr) const;
         DeriVector2 sum(const DeriVector2 &v2) const {//adds two vectors and returns result
             return DeriVector2(x + v2.x, y + v2.y,
                                dx + v2.dx, dy + v2.dy);}
@@ -76,7 +78,8 @@ namespace GCS
             return DeriVector2(x*val, y*val, dx*val, dy*val);}//multiplies the vector by a number. Derivatives are scaled.
         DeriVector2 multD(double val, double dval) const {//multiply vector by a variable with a derivative.
             return DeriVector2(x*val, y*val, dx*val+x*dval, dy*val+y*dval);}
-        DeriVector2 divD(double val, double dval) const;//divide vector by a variable with a derivative
+        //divide vector by a variable with a derivative
+        DeriVector2 divD(double val, double dval) const;
         DeriVector2 rotate90ccw() const {return DeriVector2(-y,x,-dy,dx);}
         DeriVector2 rotate90cw() const {return DeriVector2(y,-x,dy,-dx);}
         DeriVector2 linCombi(double m1, const DeriVector2 &v2, double m2) const {//linear combination of two vectors
@@ -116,7 +119,8 @@ namespace GCS
         //recunstruct curve's parameters reading them from pvec starting from index cnt.
         //cnt will be incremented by the same value as returned by PushOwnParams()
         virtual void ReconstructOnNewPvec (VEC_pD &pvec, int &cnt) = 0;
-        virtual Curve* Copy() = 0; //DeepSOIC: I haven't found a way to simply copy a curve object provided pointer to a curve object.
+        //DeepSOIC: I haven't found a way to simply copy a curve object provided pointer to a curve object.
+        virtual Curve* Copy() = 0;
     };
 
     class Line: public Curve
@@ -292,7 +296,8 @@ namespace GCS
         int degree;
         bool periodic;
         VEC_I knotpointGeoids; // geoids of knotpoints as to index Geom array
-        VEC_D flattenedknots; // knot vector with repetitions for multiplicity and "padding" for periodic spline
+        // knot vector with repetitions for multiplicity and "padding" for periodic spline
+        VEC_D flattenedknots;
         // interface helpers
         DeriVector2 CalculateNormal(const Point &p, const double* derivparam = nullptr) const override;
         DeriVector2 Value(double u, double du, const double* derivparam = nullptr) const override;

--- a/src/Mod/Sketcher/App/planegcs/SubSystem.cpp
+++ b/src/Mod/Sketcher/App/planegcs/SubSystem.cpp
@@ -58,7 +58,8 @@ void SubSystem::initialize(VEC_pD &params, MAP_pD_pD &reductionmap)
         SET_pD s2;
         for (std::vector<Constraint *>::iterator constr=clist.begin();
              constr != clist.end(); ++constr) {
-            (*constr)->revertParams(); // ensure that the constraint points to the original parameters
+            // ensure that the constraint points to the original parameters
+            (*constr)->revertParams();
             VEC_pD constr_params = (*constr)->params();
             s2.insert(constr_params.begin(), constr_params.end());
         }
@@ -109,7 +110,8 @@ void SubSystem::initialize(VEC_pD &params, MAP_pD_pD &reductionmap)
     p2c.clear();
     for (std::vector<Constraint *>::iterator constr=clist.begin();
          constr != clist.end(); ++constr) {
-        (*constr)->revertParams(); // ensure that the constraint points to the original parameters
+        // ensure that the constraint points to the original parameters
+        (*constr)->revertParams();
         VEC_pD constr_params_orig = (*constr)->params();
         SET_pD constr_params;
         for (VEC_pD::const_iterator p=constr_params_orig.begin();

--- a/src/Mod/Sketcher/App/planegcs/SubSystem.h
+++ b/src/Mod/Sketcher/App/planegcs/SubSystem.h
@@ -42,7 +42,8 @@ namespace GCS
         VEC_D pvals;       // current variables vector (psize)
 //        JacobianMatrix jacobi;  // jacobi matrix of the residuals
         std::map<Constraint *,VEC_pD > c2p; // constraint to parameter adjacency list
-        std::map<double *,std::vector<Constraint *> > p2c; // parameter to constraint adjacency list
+        // parameter to constraint adjacency list
+        std::map<double *,std::vector<Constraint *> > p2c;
         void initialize(VEC_pD &params, MAP_pD_pD &reductionmap); // called by the constructors
     public:
         SubSystem(std::vector<Constraint *> &clist_, VEC_pD &params);

--- a/src/Mod/Sketcher/Gui/Command.cpp
+++ b/src/Mod/Sketcher/Gui/Command.cpp
@@ -217,10 +217,12 @@ void CmdSketcherNewSketch::activated(int iMsg)
         else
             assert(0 /* mapmode index out of range */);
         doCommand(Gui,"App.activeDocument().%s.Support = %s", FeatName.c_str(), supportString.c_str());
-        doCommand(Gui,"App.activeDocument().recompute()");  // recompute the sketch placement based on its support
+        // recompute the sketch placement based on its support
+        doCommand(Gui,"App.activeDocument().recompute()");
         doCommand(Gui,"Gui.activeDocument().setEdit('%s')", FeatName.c_str());
 
-        Part::Feature *part = static_cast<Part::Feature*>(support.getValue());  // if multi-part support, this will return 0
+        // if multi-part support, this will return 0
+        Part::Feature *part = static_cast<Part::Feature*>(support.getValue());
         if (part){
             App::DocumentObjectGroup* grp = part->getGroup();
             if (grp) {

--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -100,7 +100,8 @@ void finishDatumConstraint (Gui::Command* cmd, Sketcher::SketchObject* sketch, b
     float labelPositionRandomness = 0.0;
 
     if (lastConstraintType == Radius || lastConstraintType == Diameter) {
-        labelPosition = hGrp->GetFloat("RadiusDiameterConstraintDisplayBaseAngle", 15.0) * (M_PI / 180); // Get radius/diameter constraint display angle
+        // Get radius/diameter constraint display angle
+        labelPosition = hGrp->GetFloat("RadiusDiameterConstraintDisplayBaseAngle", 15.0) * (M_PI / 180);
         labelPositionRandomness = hGrp->GetFloat("RadiusDiameterConstraintDisplayAngleRandomness", 0.0) * (M_PI / 180); // Get randomness
 
         // Adds a random value around the base angle, so that possibly overlapping labels get likely a different position.
@@ -200,7 +201,8 @@ void SketcherGui::makeTangentToEllipseviaNewPoint(Sketcher::SketchObject* Obj,
         center2= (static_cast<const Part::GeomArcOfCircle *>(geom2))->getCenter();
 
     Base::Vector3d direction=center2-center;
-    double tapprox=atan2(direction.y,direction.x)-phi; // we approximate the eccentric anomaly by the polar
+    // we approximate the eccentric anomaly by the polar
+    double tapprox=atan2(direction.y,direction.x)-phi;
 
     Base::Vector3d PoE = Base::Vector3d(center.x+majord*cos(tapprox)*cos(phi)-minord*sin(tapprox)*sin(phi),
                                         center.y+majord*cos(tapprox)*sin(phi)+minord*sin(tapprox)*cos(phi), 0);
@@ -213,10 +215,12 @@ void SketcherGui::makeTangentToEllipseviaNewPoint(Sketcher::SketchObject* Obj,
 
         // Point on first object
         Gui::cmdAppObjectArgs(Obj, "addConstraint(Sketcher.Constraint('PointOnObject',%d,%d,%d)) ",
-            GeoIdPoint,static_cast<int>(Sketcher::PointPos::start),geoId1); // constrain major axis
+            // constrain major axis
+            GeoIdPoint,static_cast<int>(Sketcher::PointPos::start),geoId1);
         // Point on second object
         Gui::cmdAppObjectArgs(Obj,"addConstraint(Sketcher.Constraint('PointOnObject',%d,%d,%d)) ",
-            GeoIdPoint,static_cast<int>(Sketcher::PointPos::start),geoId2); // constrain major axis
+            // constrain major axis
+            GeoIdPoint,static_cast<int>(Sketcher::PointPos::start),geoId2);
         // tangent via point
         Gui::cmdAppObjectArgs(Obj, "addConstraint(Sketcher.Constraint('TangentViaPoint',%d,%d,%d,%d))",
             geoId1, geoId2 ,GeoIdPoint, static_cast<int>(Sketcher::PointPos::start));
@@ -264,7 +268,8 @@ void SketcherGui::makeTangentToArcOfEllipseviaNewPoint(Sketcher::SketchObject* O
         center2= (static_cast<const Part::GeomArcOfCircle *>(geom2))->getCenter();
 
     Base::Vector3d direction=center2-center;
-    double tapprox=atan2(direction.y,direction.x)-phi; // we approximate the eccentric anomaly by the polar
+    // we approximate the eccentric anomaly by the polar
+    double tapprox=atan2(direction.y,direction.x)-phi;
 
     Base::Vector3d PoE = Base::Vector3d(center.x+majord*cos(tapprox)*cos(phi)-minord*sin(tapprox)*sin(phi),
                                         center.y+majord*cos(tapprox)*sin(phi)+minord*sin(tapprox)*cos(phi), 0);
@@ -277,10 +282,12 @@ void SketcherGui::makeTangentToArcOfEllipseviaNewPoint(Sketcher::SketchObject* O
 
         // Point on first object
         Gui::cmdAppObjectArgs(Obj,"addConstraint(Sketcher.Constraint('PointOnObject',%d,%d,%d)) ",
-            GeoIdPoint,static_cast<int>(Sketcher::PointPos::start),geoId1); // constrain major axis
+            // constrain major axis
+            GeoIdPoint,static_cast<int>(Sketcher::PointPos::start),geoId1);
         // Point on second object
         Gui::cmdAppObjectArgs(Obj,"addConstraint(Sketcher.Constraint('PointOnObject',%d,%d,%d)) ",
-            GeoIdPoint,static_cast<int>(Sketcher::PointPos::start),geoId2); // constrain major axis
+            // constrain major axis
+            GeoIdPoint,static_cast<int>(Sketcher::PointPos::start),geoId2);
         // tangent via point
         Gui::cmdAppObjectArgs(Obj, "addConstraint(Sketcher.Constraint('TangentViaPoint',%d,%d,%d,%d))",
             geoId1, geoId2 ,GeoIdPoint, static_cast<int>(Sketcher::PointPos::start));
@@ -358,10 +365,12 @@ void SketcherGui::makeTangentToArcOfHyperbolaviaNewPoint(Sketcher::SketchObject*
 
         // Point on first object
         Gui::cmdAppObjectArgs(Obj,"addConstraint(Sketcher.Constraint('PointOnObject',%d,%d,%d)) ",
-                              GeoIdPoint,static_cast<int>(Sketcher::PointPos::start),geoId1); // constrain major axis
+                              // constrain major axis
+                              GeoIdPoint,static_cast<int>(Sketcher::PointPos::start),geoId1);
         // Point on second object
         Gui::cmdAppObjectArgs(Obj,"addConstraint(Sketcher.Constraint('PointOnObject',%d,%d,%d)) ",
-                              GeoIdPoint,static_cast<int>(Sketcher::PointPos::start),geoId2); // constrain major axis
+                              // constrain major axis
+                              GeoIdPoint,static_cast<int>(Sketcher::PointPos::start),geoId2);
         // tangent via point
         Gui::cmdAppObjectArgs(Obj, "addConstraint(Sketcher.Constraint('TangentViaPoint',%d,%d,%d,%d))",
                               geoId1, geoId2 ,GeoIdPoint, static_cast<int>(Sketcher::PointPos::start));
@@ -434,10 +443,12 @@ void SketcherGui::makeTangentToArcOfParabolaviaNewPoint(Sketcher::SketchObject* 
 
         // Point on first object
         Gui::cmdAppObjectArgs(Obj,"addConstraint(Sketcher.Constraint('PointOnObject',%d,%d,%d)) ",
-                              GeoIdPoint,static_cast<int>(Sketcher::PointPos::start),geoId1); // constrain major axis
+                              // constrain major axis
+                              GeoIdPoint,static_cast<int>(Sketcher::PointPos::start),geoId1);
         // Point on second object
         Gui::cmdAppObjectArgs(Obj,"addConstraint(Sketcher.Constraint('PointOnObject',%d,%d,%d)) ",
-                              GeoIdPoint,static_cast<int>(Sketcher::PointPos::start),geoId2); // constrain major axis
+                              // constrain major axis
+                              GeoIdPoint,static_cast<int>(Sketcher::PointPos::start),geoId2);
         // tangent via point
         Gui::cmdAppObjectArgs(Obj, "addConstraint(Sketcher.Constraint('TangentViaPoint',%d,%d,%d,%d))",
                               geoId1, geoId2 ,GeoIdPoint, static_cast<int>(Sketcher::PointPos::start));
@@ -2001,7 +2012,8 @@ void CmdSketcherConstrainCoincident::activated(int iMsg)
         return;
     }
 
-    bool allConicsEdges = true; //If user selects only conics (circle, ellipse, arc, arcOfEllipse) then we make concentric constraint.
+    //If user selects only conics (circle, ellipse, arc, arcOfEllipse) then we make concentric constraint.
+    bool allConicsEdges = true;
     bool atLeastOneEdge = false;
     for (std::vector<std::string>::const_iterator it = SubNames.begin(); it != SubNames.end(); ++it) {
         int GeoId;
@@ -2013,7 +2025,8 @@ void CmdSketcherConstrainCoincident::activated(int iMsg)
                 allConicsEdges = false;
         }
         else
-            allConicsEdges = false; //at least one point is selected, so concentric can't be applied.
+            //at least one point is selected, so concentric can't be applied.
+            allConicsEdges = false;
 
         if (atLeastOneEdge && !allConicsEdges) {
             QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
@@ -3682,7 +3695,8 @@ void CmdSketcherConstrainPerpendicular::activated(int iMsg)
                 }
                 else {
                     Base::Vector3d direction=point1-center;
-                    double tapprox=atan2(direction.y,direction.x)-phi; // we approximate the eccentric anomaly by the polar
+                    // we approximate the eccentric anomaly by the polar
+                    double tapprox=atan2(direction.y,direction.x)-phi;
 
                     PoO = Base::Vector3d(center.x+majord*cos(tapprox)*cos(phi)-minord*sin(tapprox)*sin(phi),
                                                         center.y+majord*cos(tapprox)*sin(phi)+minord*sin(tapprox)*cos(phi), 0);
@@ -3863,7 +3877,8 @@ void CmdSketcherConstrainPerpendicular::applyConstraint(std::vector<SelIdPair> &
             }
             else {
                 Base::Vector3d direction=point1-center;
-                double tapprox=atan2(direction.y,direction.x)-phi; // we approximate the eccentric anomaly by the polar
+                // we approximate the eccentric anomaly by the polar
+                double tapprox=atan2(direction.y,direction.x)-phi;
 
                 PoO = Base::Vector3d(center.x+majord*cos(tapprox)*cos(phi)-minord*sin(tapprox)*sin(phi),
                                                     center.y+majord*cos(tapprox)*sin(phi)+minord*sin(tapprox)*cos(phi), 0);
@@ -4056,7 +4071,8 @@ bool CmdSketcherConstrainTangent::substituteConstraintCombinations(SketchObject 
             Gui::cmdAppObjectArgs(Obj, "delConstraintOnPoint(%i,%i)", first, firstpos);
 
             commitCommand();
-            Obj->solve(); // The substitution requires a solve() so that the autoremove redundants works when Autorecompute not active.
+            // The substitution requires a solve() so that the autoremove redundants works when Autorecompute not active.
+            Obj->solve();
             tryAutoRecomputeIfNotSolve(Obj);
 
             notifyConstraintSubstitutions(QObject::tr("Endpoint to endpoint tangency was applied. The coincident constraint was deleted."));
@@ -4072,7 +4088,8 @@ bool CmdSketcherConstrainTangent::substituteConstraintCombinations(SketchObject 
 
             doEndpointToEdgeTangency(Obj, (*it)->First, (*it)->FirstPos, (*it)->Second);
 
-            Gui::cmdAppObjectArgs(Obj, "delConstraint(%i)", cid); // remove the preexisting point on object constraint.
+            // remove the preexisting point on object constraint.
+            Gui::cmdAppObjectArgs(Obj, "delConstraint(%i)", cid);
 
             commitCommand();
 
@@ -4955,7 +4972,8 @@ void CmdSketcherConstrainRadius::activated(int iMsg)
         commitCommand();
 
     if(updateNeeded) {
-        tryAutoRecomputeIfNotSolve(Obj); // we have to update the solver after this aborted addition.
+        // we have to update the solver after this aborted addition.
+        tryAutoRecomputeIfNotSolve(Obj);
     }
 }
 
@@ -5007,7 +5025,8 @@ void CmdSketcherConstrainRadius::applyConstraint(std::vector<SelIdPair> &selSeq,
             Gui::cmdAppObjectArgs(Obj, "setDriving(%i,%s)",
                                   ConStr.size()-1, "False");
 
-            updateNeeded=true; // We do need to update the solver DoF after setting the constraint driving.
+            // We do need to update the solver DoF after setting the constraint driving.
+            updateNeeded=true;
         }
 
         finishDatumConstraint (this, Obj, constraintCreationMode==Driving && !fixed);
@@ -5018,7 +5037,8 @@ void CmdSketcherConstrainRadius::applyConstraint(std::vector<SelIdPair> &selSeq,
         commitCommand();
 
         if(updateNeeded) {
-            tryAutoRecomputeIfNotSolve(Obj); // we have to update the solver after this aborted addition.
+            // we have to update the solver after this aborted addition.
+            tryAutoRecomputeIfNotSolve(Obj);
         }
     }
     }
@@ -5232,7 +5252,8 @@ void CmdSketcherConstrainDiameter::activated(int iMsg)
         commitCommand();
 
     if(updateNeeded) {
-        tryAutoRecomputeIfNotSolve(Obj); // we have to update the solver after this aborted addition.
+        // we have to update the solver after this aborted addition.
+        tryAutoRecomputeIfNotSolve(Obj);
     }
 }
 
@@ -5281,7 +5302,8 @@ void CmdSketcherConstrainDiameter::applyConstraint(std::vector<SelIdPair> &selSe
             bool fixed = isPointOrSegmentFixed(Obj,GeoId);
             if(fixed || constraintCreationMode==Reference) {
                 Gui::cmdAppObjectArgs(Obj, "setDriving(%i,%s)", ConStr.size()-1, "False");
-                updateNeeded=true; // We do need to update the solver DoF after setting the constraint driving.
+                // We do need to update the solver DoF after setting the constraint driving.
+                updateNeeded=true;
             }
 
             finishDatumConstraint (this, Obj, constraintCreationMode==Driving && !fixed);
@@ -5292,7 +5314,8 @@ void CmdSketcherConstrainDiameter::applyConstraint(std::vector<SelIdPair> &selSe
             commitCommand();
 
             if(updateNeeded) {
-                tryAutoRecomputeIfNotSolve(Obj); // we have to update the solver after this aborted addition.
+                // we have to update the solver after this aborted addition.
+                tryAutoRecomputeIfNotSolve(Obj);
             }
         }
     }
@@ -5537,7 +5560,8 @@ void CmdSketcherConstrainRadiam::activated(int iMsg)
         commitCommand();
 
     if(updateNeeded) {
-        tryAutoRecomputeIfNotSolve(Obj); // we have to update the solver after this aborted addition.
+        // we have to update the solver after this aborted addition.
+        tryAutoRecomputeIfNotSolve(Obj);
     }
 }
 
@@ -5594,7 +5618,8 @@ void CmdSketcherConstrainRadiam::applyConstraint(std::vector<SelIdPair> &selSeq,
             bool fixed = isPointOrSegmentFixed(Obj,GeoId);
             if(fixed || constraintCreationMode==Reference) {
                 Gui::cmdAppObjectArgs(Obj, "setDriving(%i,%s)", ConStr.size()-1, "False");
-                updateNeeded=true; // We do need to update the solver DoF after setting the constraint driving.
+                // We do need to update the solver DoF after setting the constraint driving.
+                updateNeeded=true;
             }
 
             finishDatumConstraint (this, Obj, constraintCreationMode==Driving && !fixed);
@@ -5605,7 +5630,8 @@ void CmdSketcherConstrainRadiam::applyConstraint(std::vector<SelIdPair> &selSeq,
             commitCommand();
 
             if(updateNeeded) {
-                tryAutoRecomputeIfNotSolve(Obj); // we have to update the solver after this aborted addition.
+                // we have to update the solver after this aborted addition.
+                tryAutoRecomputeIfNotSolve(Obj);
             }
         }
     }
@@ -6314,7 +6340,8 @@ CmdSketcherConstrainEqual::CmdSketcherConstrainEqual()
     eType           = ForEdit;
 
     allowedSelSequences = {{SelEdge, SelEdge}, {SelEdge, SelExternalEdge},
-                           {SelExternalEdge, SelEdge}}; // Only option for equal constraint
+                           // Only option for equal constraint
+                           {SelExternalEdge, SelEdge}};
 }
 
 void CmdSketcherConstrainEqual::activated(int iMsg)

--- a/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp
+++ b/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp
@@ -1110,7 +1110,8 @@ public:
              * right button of the mouse */
         }
         else {
-            sketchgui->purgeHandler(); // no code after this line, Handler get deleted in ViewProvider
+            // no code after this line, Handler get deleted in ViewProvider
+            sketchgui->purgeHandler();
         }
 
         return true;

--- a/src/Mod/Sketcher/Gui/DrawSketchHandler.cpp
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandler.cpp
@@ -519,7 +519,8 @@ int DrawSketchHandler::seekAutoConstraint(std::vector<AutoConstraint> &suggested
     if (!sketchgui->Autoconstraints.getValue())
         return 0; // If Autoconstraints property is not set quit
 
-    Base::Vector3d hitShapeDir = Base::Vector3d(0,0,0); // direction of hit shape (if it is a line, the direction of the line)
+    // direction of hit shape (if it is a line, the direction of the line)
+    Base::Vector3d hitShapeDir = Base::Vector3d(0,0,0);
 
     // Get Preselection
     int preSelPnt = getPreselectPoint();
@@ -678,7 +679,8 @@ int DrawSketchHandler::seekAutoConstraint(std::vector<AutoConstraint> &suggested
 
             double distancetoline = norm*(tmpPos - focus1P); // distance focus1 to line
 
-            Base::Vector3d focus1PMirrored = focus1P + 2*distancetoline*norm; // mirror of focus1 with respect to the line
+            // mirror of focus1 with respect to the line
+            Base::Vector3d focus1PMirrored = focus1P + 2*distancetoline*norm;
 
             double error = fabs((focus1PMirrored-focus2P).Length() - 2*a);
 
@@ -733,7 +735,8 @@ int DrawSketchHandler::seekAutoConstraint(std::vector<AutoConstraint> &suggested
 
             double distancetoline = norm*(tmpPos - focus1P); // distance focus1 to line
 
-            Base::Vector3d focus1PMirrored = focus1P + 2*distancetoline*norm; // mirror of focus1 with respect to the line
+            // mirror of focus1 with respect to the line
+            Base::Vector3d focus1PMirrored = focus1P + 2*distancetoline*norm;
 
             double error = fabs((focus1PMirrored-focus2P).Length() - 2*a);
 
@@ -887,7 +890,8 @@ void DrawSketchHandler::createAutoConstraints(const std::vector<AutoConstraint> 
             if(createowncommand) {
                 Gui::Command::commitCommand();
             }
-            //Gui::Command::updateActive(); // There is already an recompute in each command creation, this is redundant.
+            // There is already an recompute in each command creation, this is redundant.
+            //Gui::Command::updateActive();
         }
     }
 }
@@ -991,4 +995,3 @@ Sketcher::SketchObject * DrawSketchHandler::getSketchObject()
 {
     return sketchgui->getSketchObject();
 }
-

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArc.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArc.h
@@ -177,7 +177,8 @@ public:
                     "(Part.Circle(App.Vector(%f,%f,0),App.Vector(0,0,1),%f),%f,%f),%s)",
                           CenterPoint.x, CenterPoint.y, sqrt(rx*rx + ry*ry),
                           startAngle, endAngle,
-                          geometryCreationMode==Construction?"True":"False"); //arcAngle > 0 ? 0 : 1);
+                          //arcAngle > 0 ? 0 : 1);
+                          geometryCreationMode==Construction?"True":"False");
 
                 Gui::Command::commitCommand();
             }
@@ -222,7 +223,8 @@ public:
                 * right button of the mouse */
             }
             else{
-                sketchgui->purgeHandler(); // no code after this line, Handler get deleted in ViewProvider
+                // no code after this line, Handler get deleted in ViewProvider
+                sketchgui->purgeHandler();
             }
         }
         return true;
@@ -279,7 +281,8 @@ public:
             // Build a 32 point circle ignoring already constructed points
             for (int i=1; i <= 32; i++) {
                 // Start at current angle
-                double angle = (i-1)*2*M_PI/32.0 + lineAngle; // N point closed circle has N segments
+                // N point closed circle has N segments
+                double angle = (i-1)*2*M_PI/32.0 + lineAngle;
                 if (i != 1 && i != 17 ) {
                     EditCurve[i] = Base::Vector2d(CenterPoint.x + radius*cos(angle),
                                                   CenterPoint.y + radius*sin(angle));
@@ -470,7 +473,8 @@ public:
                 * right button of the mouse */
             }
             else{
-                sketchgui->purgeHandler(); // no code after this line, Handler get deleted in ViewProvider
+                // no code after this line, Handler get deleted in ViewProvider
+                sketchgui->purgeHandler();
             }
         }
         return true;
@@ -495,4 +499,3 @@ protected:
 
 
 #endif // SKETCHERGUI_DrawSketchHandlerArc_H
-

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfEllipse.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfEllipse.h
@@ -132,7 +132,8 @@ public:
 
             double rxs = startingPoint.x - centerPoint.x;
             double rys = startingPoint.y - centerPoint.y;
-            startAngle = atan2(a*(rys*cos(phi)-rxs*sin(phi)), b*(rxs*cos(phi)+rys*sin(phi))); // eccentric anomaly angle
+            // eccentric anomaly angle
+            startAngle = atan2(a*(rys*cos(phi)-rxs*sin(phi)), b*(rxs*cos(phi)+rys*sin(phi)));
 
             double angle1 = atan2(a*((onSketchPos.y - centerPoint.y)*cos(phi)-(onSketchPos.x - centerPoint.x)*sin(phi)),
                                   b*((onSketchPos.x - centerPoint.x)*cos(phi)+(onSketchPos.y - centerPoint.y)*sin(phi)))- startAngle;
@@ -325,7 +326,8 @@ public:
                 * right button of the mouse */
             }
             else{
-                sketchgui->purgeHandler(); // no code after this line, Handler get deleted in ViewProvider
+                // no code after this line, Handler get deleted in ViewProvider
+                sketchgui->purgeHandler();
             }
         }
         return true;
@@ -348,4 +350,3 @@ protected:
 
 
 #endif // SKETCHERGUI_DrawSketchHandlerArcOfEllipse_H
-

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfHyperbola.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfHyperbola.h
@@ -339,7 +339,8 @@ public:
                  * right button of the mouse */
             }
             else{
-                sketchgui->purgeHandler(); // no code after this line, Handler get deleted in ViewProvider
+                // no code after this line, Handler get deleted in ViewProvider
+                sketchgui->purgeHandler();
             }
         }
         return true;
@@ -365,4 +366,3 @@ protected:
 
 
 #endif // SKETCHERGUI_DrawSketchHandlerArcOfHyperbola_H
-

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfParabola.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfParabola.h
@@ -292,7 +292,8 @@ public:
                  * right button of the mouse */
             }
             else {
-                sketchgui->purgeHandler(); // no code after this line, Handler get deleted in ViewProvider
+                // no code after this line, Handler get deleted in ViewProvider
+                sketchgui->purgeHandler();
             }
         }
         return true;
@@ -315,4 +316,3 @@ protected:
 
 
 #endif // SKETCHERGUI_DrawSketchHandlerArcOfParabola_H
-

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerBSpline.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerBSpline.h
@@ -111,7 +111,8 @@ public:
                 poleGeoIds.push_back(getHighestCurveIndex());
 
                 Gui::cmdAppObjectArgs(sketchgui->getObject(), "addConstraint(Sketcher.Constraint('Weight',%d,%f)) ",
-                                      poleGeoIds.back(), 1.0 ); // First pole defaults to 1.0 weight
+                                      // First pole defaults to 1.0 weight
+                                      poleGeoIds.back(), 1.0 );
             }
             catch (const Base::Exception& e) {
                 Base::Console().Error("%s\n", e.what());
@@ -480,7 +481,8 @@ private:
                  * right button of the mouse */
             }
             else{
-                sketchgui->purgeHandler(); // no code after this line, Handler get deleted in ViewProvider
+                // no code after this line, Handler get deleted in ViewProvider
+                sketchgui->purgeHandler();
             }
         }
         else {
@@ -513,4 +515,3 @@ protected:
 
 
 #endif // SKETCHERGUI_DrawSketchHandlerBSpline_H
-

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerCircle.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerCircle.h
@@ -147,7 +147,8 @@ public:
                 * right button of the mouse */
             }
             else{
-                sketchgui->purgeHandler(); // no code after this line, Handler get deleted in ViewProvider
+                // no code after this line, Handler get deleted in ViewProvider
+                sketchgui->purgeHandler();
             }
         }
         return true;
@@ -326,7 +327,8 @@ public:
                 * right button of the mouse */
             }
             else{
-                sketchgui->purgeHandler(); // no code after this line, Handler get deleted in ViewProvider
+                // no code after this line, Handler get deleted in ViewProvider
+                sketchgui->purgeHandler();
             }
         }
         return true;
@@ -351,4 +353,3 @@ protected:
 
 
 #endif // SKETCHERGUI_DrawSketchHandlerCircle_H
-

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerEllipse.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerEllipse.h
@@ -380,10 +380,12 @@ private:
             }
             else if (mode == STATUS_SEEK_B) {
                 // Get the closest distance from onSketchPos to apse line, as a 'requested' value for b
-                Base::Vector2d cursor = Base::Vector2d(onSketchPos - f); // vector from f to cursor pos
+                // vector from f to cursor pos
+                Base::Vector2d cursor = Base::Vector2d(onSketchPos - f);
                 // decompose cursor with a projection, then length of w_2 will give us b
                 Base::Vector2d w_1 = cursor;
-                w_1.ProjectToLine(cursor, (periapsis - apoapsis)); // projection of cursor line onto apse line
+                // projection of cursor line onto apse line
+                w_1.ProjectToLine(cursor, (periapsis - apoapsis));
                 Base::Vector2d w_2 = (cursor - w_1);
                 b = w_2.Length();
 
@@ -440,10 +442,12 @@ private:
                 // while looking for the last click, we may switch back and forth
                 // between looking for a b point and looking for periapsis, so ensure
                 // we are in the right mode
-                Base::Vector2d cursor = Base::Vector2d(onSketchPos - centroid); // vector from centroid to cursor pos
+                // vector from centroid to cursor pos
+                Base::Vector2d cursor = Base::Vector2d(onSketchPos - centroid);
                 // decompose cursor with a projection, then length of w_2 will give us b
                 Base::Vector2d w_1 = cursor;
-                w_1.ProjectToLine(cursor, (fixedAxis - centroid)); // projection of cursor line onto fixed axis line
+                // projection of cursor line onto fixed axis line
+                w_1.ProjectToLine(cursor, (fixedAxis - centroid));
                 Base::Vector2d w_2 = (cursor - w_1);
                 if (w_2.Length() > fixedAxisLength) {
                     // b is fixed, we are seeking a
@@ -810,7 +814,8 @@ private:
             * right button of the mouse */
         }
         else{
-            sketchgui->purgeHandler(); // no code after this line, Handler get deleted in ViewProvider
+            // no code after this line, Handler get deleted in ViewProvider
+            sketchgui->purgeHandler();
         }
 
     }
@@ -820,4 +825,3 @@ private:
 
 
 #endif // SKETCHERGUI_DrawSketchHandlerEllipse_H
-

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerExtend.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerExtend.h
@@ -120,7 +120,8 @@ public:
                  * expand.
                  */
                 bool inCurve = (projection.Length() < recenteredLine.Length()
-                    && projection.GetAngle(recenteredLine) < 0.1); // Two possible values here, M_PI and 0, but 0.1 is to avoid floating point problems.
+                    // Two possible values here, M_PI and 0, but 0.1 is to avoid floating point problems.
+                    && projection.GetAngle(recenteredLine) < 0.1);
                 if (inCurve) {
                     Increment = SavedExtendFromStart ? -1 * projection.Length() : projection.Length() - recenteredLine.Length();
                     ExtendFromStart = SavedExtendFromStart;
@@ -232,7 +233,8 @@ public:
                     Base::Vector2d angle = Base::Vector2d(onSketchPos.x - center.x, onSketchPos.y - center.y);
                     double angleToStart = angle.GetAngle(Base::Vector2d(cos(start), sin(start)));
                     double angleToEnd = angle.GetAngle(Base::Vector2d(cos(end), sin(end)));
-                    ExtendFromStart = (angleToStart < angleToEnd); // move start point if closer to angle than end point
+                    // move start point if closer to angle than end point
+                    ExtendFromStart = (angleToStart < angleToEnd);
                     EditCurve.resize(31);
                     Mode = STATUS_SEEK_Second;
                 }
@@ -270,7 +272,8 @@ public:
                     * handler is destroyed by the quit() method on pressing the
                     * right button of the mouse */
                 } else{
-                    sketchgui->purgeHandler(); // no code after this line, Handler get deleted in ViewProvider
+                    // no code after this line, Handler get deleted in ViewProvider
+                    sketchgui->purgeHandler();
                 }
             }
             catch (const Base::Exception& e) {
@@ -280,7 +283,8 @@ public:
 
         } else { // exit extension tool if user clicked on empty space
             BaseGeoId = -1;
-            sketchgui->purgeHandler(); // no code after this line, Handler get deleted in ViewProvider
+            // no code after this line, Handler get deleted in ViewProvider
+            sketchgui->purgeHandler();
         }
         return true;
     }
@@ -319,4 +323,3 @@ private:
 
 
 #endif // SKETCHERGUI_DrawSketchHandlerExtend_H
-

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerFillet.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerFillet.h
@@ -265,7 +265,8 @@ public:
         }
 
         if (VtId < 0 && GeoId < 0) // exit the fillet tool if the user clicked on empty space
-            sketchgui->purgeHandler(); // no code after this line, Handler get deleted in ViewProvider
+            // no code after this line, Handler get deleted in ViewProvider
+            sketchgui->purgeHandler();
 
         return true;
     }
@@ -289,4 +290,3 @@ protected:
 
 
 #endif // SKETCHERGUI_DrawSketchHandlerFillet_H
-

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerLine.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerLine.h
@@ -141,7 +141,8 @@ public:
                 * right button of the mouse */
             }
             else{
-                sketchgui->purgeHandler(); // no code after this line, Handler get deleted in ViewProvider
+                // no code after this line, Handler get deleted in ViewProvider
+                sketchgui->purgeHandler();
             }
         }
         return true;
@@ -164,4 +165,3 @@ protected:
 
 
 #endif // SKETCHERGUI_DrawSketchHandlerLine_H
-

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
@@ -314,12 +314,14 @@ public:
                          sugConstr1[i].PosId == Sketcher::PointPos::end)) {
                         previousCurve = sugConstr1[i].GeoId;
                         previousPosId = sugConstr1[i].PosId;
-                        updateTransitionData(previousCurve,previousPosId); // -> dirVec, EditCurve[0]
+                        // -> dirVec, EditCurve[0]
+                        updateTransitionData(previousCurve,previousPosId);
                         if (geom->getTypeId() == Part::GeomArcOfCircle::getClassTypeId()) {
                             TransitionMode = TRANSITION_MODE_Tangent;
                             SnapMode = SNAP_MODE_Free;
                         }
-                        sugConstr1.erase(sugConstr1.begin()+i); // actually we should clear the vector completely
+                        // actually we should clear the vector completely
+                        sugConstr1.erase(sugConstr1.begin()+i);
                         break;
                     }
                 }
@@ -367,7 +369,8 @@ public:
                     return true;
                 }
                 else{
-                    sketchgui->purgeHandler(); // no code after this line, Handler get deleted in ViewProvider
+                    // no code after this line, Handler get deleted in ViewProvider
+                    sketchgui->purgeHandler();
                     return true;
                 }
             }
@@ -530,7 +533,8 @@ public:
                     * right button of the mouse */
                 }
                 else{
-                    sketchgui->purgeHandler(); // no code after this line, Handler get deleted in ViewProvider
+                    // no code after this line, Handler get deleted in ViewProvider
+                    sketchgui->purgeHandler();
                 }
             }
             else {
@@ -552,7 +556,8 @@ public:
                     }
                 }
 
-                virtualsugConstr1 = sugConstr2; // these are the initial constraints for the next iteration.
+                // these are the initial constraints for the next iteration.
+                virtualsugConstr1 = sugConstr2;
 
                 if (!sugConstr2.empty()) {
                     createAutoConstraints(sugConstr2, getHighestCurveIndex(),
@@ -566,7 +571,8 @@ public:
                 // remember the vertex for the next rounds constraint..
                 previousCurve = getHighestCurveIndex();
                 previousPosId = (SegmentMode == SEGMENT_MODE_Arc && startAngle > endAngle) ?
-                                 Sketcher::PointPos::start : Sketcher::PointPos::end; // cw arcs are rendered in reverse
+                                 // cw arcs are rendered in reverse
+                                 Sketcher::PointPos::start : Sketcher::PointPos::end;
 
                 // setup for the next line segment
                 // calculate dirVec and EditCurve[0]
@@ -691,4 +697,3 @@ protected:
 
 
 #endif // SKETCHERGUI_DrawSketchHandlerLineSet_H
-

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerPoint.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerPoint.h
@@ -91,7 +91,8 @@ public:
                 * right button of the mouse */
             }
             else{
-                sketchgui->purgeHandler(); // no code after this line, Handler get deleted in ViewProvider
+                // no code after this line, Handler get deleted in ViewProvider
+                sketchgui->purgeHandler();
             }
         }
         return true;
@@ -114,4 +115,3 @@ protected:
 
 
 #endif // SKETCHERGUI_DrawSketchHandlerPoint_H
-

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerPolygon.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerPolygon.h
@@ -164,7 +164,8 @@ public:
                 * right button of the mouse */
             }
             else{
-                sketchgui->purgeHandler(); // no code after this line, Handler get deleted in ViewProvider
+                // no code after this line, Handler get deleted in ViewProvider
+                sketchgui->purgeHandler();
             }
         }
         return true;
@@ -190,4 +191,3 @@ protected:
 
 
 #endif // SKETCHERGUI_DrawSketchHandlerPolygon_H
-

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerRectangle.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerRectangle.h
@@ -281,7 +281,8 @@ public:
                 * right button of the mouse */
             }
             else{
-                sketchgui->purgeHandler(); // no code after this line, Handler get deleted in ViewProvider
+                // no code after this line, Handler get deleted in ViewProvider
+                sketchgui->purgeHandler();
             }
 
 
@@ -338,7 +339,8 @@ public:
             signX = Base::sgn(distanceX);
             signY = Base::sgn(distanceY);
             if (fabs(distanceX) > fabs(distanceY)) {
-                radius = fabs(distanceY) / 4; // we use a fourth of the smaller distance as default radius
+                // we use a fourth of the smaller distance as default radius
+                radius = fabs(distanceY) / 4;
             }
             else {
                 radius = fabs(distanceX) / 4;
@@ -571,7 +573,8 @@ public:
                 * right button of the mouse */
             }
             else {
-                sketchgui->purgeHandler(); // no code after this line, Handler get deleted in ViewProvider
+                // no code after this line, Handler get deleted in ViewProvider
+                sketchgui->purgeHandler();
             }
         }
         return true;
@@ -597,4 +600,3 @@ protected:
 
 
 #endif // SKETCHERGUI_DrawSketchHandlerRectangle_H
-

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerSlot.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerSlot.h
@@ -279,7 +279,8 @@ public:
                 * right button of the mouse */
             }
             else {
-                sketchgui->purgeHandler(); // no code after this line, Handler get deleted in ViewProvider
+                // no code after this line, Handler get deleted in ViewProvider
+                sketchgui->purgeHandler();
             }
             SnapMode = SNAP_MODE_Straight;
         }
@@ -306,4 +307,3 @@ protected:
 
 
 #endif // SKETCHERGUI_DrawSketchHandlerSlot_H
-

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerTrimming.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerTrimming.h
@@ -102,7 +102,8 @@ public:
                     EditMarkers.emplace_back( end.x, end.y);
                 }
 
-                drawEditMarkers(EditMarkers, 2); // maker augmented by two sizes (see supported marker sizes)
+                // maker augmented by two sizes (see supported marker sizes)
+                drawEditMarkers(EditMarkers, 2);
             }
         }
         else {
@@ -143,7 +144,8 @@ public:
             drawEditMarkers(EditMarkers);
         }
         else // exit the trimming tool if the user clicked on empty space
-            sketchgui->purgeHandler(); // no code after this line, Handler get deleted in ViewProvider
+            // no code after this line, Handler get deleted in ViewProvider
+            sketchgui->purgeHandler();
 
         return true;
     }
@@ -170,4 +172,3 @@ private:
 
 
 #endif // SKETCHERGUI_DrawSketchHandlerTrimming_H
-

--- a/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
@@ -222,14 +222,16 @@ void EditModeCoinManager::ParameterObserver::updateElementSizeParameters(const s
 
     int markersize = hGrp->GetInt("MarkerSize", 7);
 
-    int defaultFontSizePixels = Client.defaultApplicationFontSizePixels(); // returns height in pixels, not points
+    // returns height in pixels, not points
+    int defaultFontSizePixels = Client.defaultApplicationFontSizePixels();
 
     int sketcherfontSize = hGrp->GetInt("EditSketcherFontSize", defaultFontSizePixels);
 
     int dpi = Client.getApplicationLogicalDPIX();
 
     // simple scaling factor for hardcoded pixel values in the Sketcher
-    Client.drawingParameters.pixelScalingFactor = viewScalingFactor * dpi / 96; // 96 ppi is the standard pixel density for which pixel quantities were calculated
+    // 96 ppi is the standard pixel density for which pixel quantities were calculated
+    Client.drawingParameters.pixelScalingFactor = viewScalingFactor * dpi / 96;
 
     // About sizes:
     // SoDatumLabel takes the size in points, not in pixels. This is because it uses QFont internally.
@@ -249,7 +251,8 @@ void EditModeCoinManager::ParameterObserver::updateElementSizeParameters(const s
     // HDPI monitors.
 
     Client.drawingParameters.coinFontSize = std::lround(sketcherfontSize * 96.0f / dpi); // this is in pixels
-    Client.drawingParameters.labelFontSize = std::lround(sketcherfontSize * 72.0f / dpi); // this is in points, as SoDatumLabel uses points
+    // this is in points, as SoDatumLabel uses points
+    Client.drawingParameters.labelFontSize = std::lround(sketcherfontSize * 72.0f / dpi);
     Client.drawingParameters.constraintIconSize = std::lround(0.8 * sketcherfontSize);
 
     // For marker size the global default is used.
@@ -500,7 +503,8 @@ EditModeCoinManager::PreselectionResult EditModeCoinManager::detectPreselection(
             if (point_detail && point_detail->getTypeId() == SoPointDetail::getClassTypeId()) {
                 // get the index
                 int pindex = static_cast<const SoPointDetail *>(point_detail)->getCoordinateIndex();
-                result.PointIndex = coinMapping.getPointVertexId(pindex, l); // returns -1 for root, global VertexId for the rest of vertices.
+                // returns -1 for root, global VertexId for the rest of vertices.
+                result.PointIndex = coinMapping.getPointVertexId(pindex, l);
 
                 if (result.PointIndex == -1)
                     result.Cross = PreselectionResult::Axes::RootPoint;
@@ -648,7 +652,8 @@ void EditModeCoinManager::createEditModeInventorNodes()
 {
     // 1 - Create the edit root node
     editModeScenegraphNodes.EditRoot = new SoSeparator;
-    editModeScenegraphNodes.EditRoot->ref(); // Node is unref in the destructor of EditModeCoinManager
+    // Node is unref in the destructor of EditModeCoinManager
+    editModeScenegraphNodes.EditRoot->ref();
     editModeScenegraphNodes.EditRoot->setName("Sketch_EditRoot");
     ViewProviderSketchCoinAttorney::addNodeToRoot(viewProvider, editModeScenegraphNodes.EditRoot);
     editModeScenegraphNodes.EditRoot->renderCaching = SoSeparator::OFF ;

--- a/src/Mod/Sketcher/Gui/EditModeCoinManager.h
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManager.h
@@ -169,7 +169,8 @@ public:
         };
 
         int PointIndex = InvalidPoint;
-        int GeoIndex = InvalidCurve; // valid values are 0,1,2,... for normal geometry and -3,-4,-5,... for external geometry
+        // valid values are 0,1,2,... for normal geometry and -3,-4,-5,... for external geometry
+        int GeoIndex = InvalidCurve;
         Axes Cross = Axes::None;
         std::set<int> ConstrIndices;
 
@@ -225,7 +226,8 @@ public:
     /** @name update coin colors*/
     //@{
     void updateColor();
-    void updateColor(const GeoListFacade & geolistfacade); // overload to be used with temporal geometry.
+    // overload to be used with temporal geometry.
+    void updateColor(const GeoListFacade & geolistfacade);
     //@}
 
     /** @name change constraints selectability*/
@@ -292,4 +294,3 @@ private:
 
 
 #endif // SKETCHERGUI_EditModeCoinManager_H
-

--- a/src/Mod/Sketcher/Gui/EditModeCoinManagerParameters.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManagerParameters.cpp
@@ -27,30 +27,54 @@
 
 using namespace SketcherGui;
 
-SbColor DrawingParameters::InformationColor                         (0.0f,  1.0f,   0.0f);     // #00FF00 -> (  0,255,  0)
-SbColor DrawingParameters::CreateCurveColor                         (0.8f,  0.8f,   0.8f);     // #CCCCCC -> (204,204,204)
-SbColor DrawingParameters::CrossColorH                              (0.8f,  0.4f,   0.4f);     // #CC6666 -> (204,102,102)
-SbColor DrawingParameters::CrossColorV                              (0.47f, 1.0f,   0.51f);   // #83FF83 -> (120,255,131)
-SbColor DrawingParameters::InvalidSketchColor                       (1.0f,  0.42f,  0.0f);    // #FF6D00 -> (255,109,  0)
-SbColor DrawingParameters::FullyConstrainedColor                    (0.0f,  1.0f,   0.0f);     // #00FF00 -> (  0,255,  0)
-SbColor DrawingParameters::FullyConstraintInternalAlignmentColor    (0.87f, 0.87f,  0.78f);  // #DEDEC8 -> (222,222,200)
-SbColor DrawingParameters::InternalAlignedGeoColor                  (0.7f,  0.7f,   0.5f);     // #B2B27F -> (178,178,127)
-SbColor DrawingParameters::FullyConstraintConstructionPointColor    (1.0f,  0.58f,  0.50f);   // #FF9580 -> (255,149,128)
-SbColor DrawingParameters::VertexColor                              (1.0f,  0.149f, 0.0f);   // #FF2600 -> (255, 38,  0)
-SbColor DrawingParameters::FullyConstraintElementColor              (0.50f, 0.81f,  0.62f);  // #80D0A0 -> (128,208,160)
-SbColor DrawingParameters::CurveColor                               (1.0f,  1.0f,   1.0f);     // #FFFFFF -> (255,255,255)
-SbColor DrawingParameters::PreselectColor                           (0.88f, 0.88f,  0.0f);   // #E1E100 -> (225,225,  0)
-SbColor DrawingParameters::SelectColor                              (0.11f, 0.68f,  0.11f);  // #1CAD1C -> ( 28,173, 28)
-SbColor DrawingParameters::PreselectSelectedColor                   (0.36f, 0.48f,  0.11f);  // #5D7B1C -> ( 93,123, 28)
-SbColor DrawingParameters::CurveExternalColor                       (0.8f,  0.2f,   0.6f);     // #CC3399 -> (204, 51,153)
-SbColor DrawingParameters::CurveDraftColor                          (0.0f,  0.0f,   0.86f);    // #0000DC -> (  0,  0,220)
-SbColor DrawingParameters::FullyConstraintConstructionElementColor  (0.56f, 0.66f,  0.99f);  // #8FA9FD -> (143,169,253)
+// #00FF00 -> (  0,255,  0)
+SbColor DrawingParameters::InformationColor                         (0.0f,  1.0f,   0.0f);
+// #CCCCCC -> (204,204,204)
+SbColor DrawingParameters::CreateCurveColor                         (0.8f,  0.8f,   0.8f);
+// #CC6666 -> (204,102,102)
+SbColor DrawingParameters::CrossColorH                              (0.8f,  0.4f,   0.4f);
+// #83FF83 -> (120,255,131)
+SbColor DrawingParameters::CrossColorV                              (0.47f, 1.0f,   0.51f);
+// #FF6D00 -> (255,109,  0)
+SbColor DrawingParameters::InvalidSketchColor                       (1.0f,  0.42f,  0.0f);
+// #00FF00 -> (  0,255,  0)
+SbColor DrawingParameters::FullyConstrainedColor                    (0.0f,  1.0f,   0.0f);
+// #DEDEC8 -> (222,222,200)
+SbColor DrawingParameters::FullyConstraintInternalAlignmentColor    (0.87f, 0.87f,  0.78f);
+// #B2B27F -> (178,178,127)
+SbColor DrawingParameters::InternalAlignedGeoColor                  (0.7f,  0.7f,   0.5f);
+// #FF9580 -> (255,149,128)
+SbColor DrawingParameters::FullyConstraintConstructionPointColor    (1.0f,  0.58f,  0.50f);
+// #FF2600 -> (255, 38,  0)
+SbColor DrawingParameters::VertexColor                              (1.0f,  0.149f, 0.0f);
+// #80D0A0 -> (128,208,160)
+SbColor DrawingParameters::FullyConstraintElementColor              (0.50f, 0.81f,  0.62f);
+// #FFFFFF -> (255,255,255)
+SbColor DrawingParameters::CurveColor                               (1.0f,  1.0f,   1.0f);
+// #E1E100 -> (225,225,  0)
+SbColor DrawingParameters::PreselectColor                           (0.88f, 0.88f,  0.0f);
+// #1CAD1C -> ( 28,173, 28)
+SbColor DrawingParameters::SelectColor                              (0.11f, 0.68f,  0.11f);
+// #5D7B1C -> ( 93,123, 28)
+SbColor DrawingParameters::PreselectSelectedColor                   (0.36f, 0.48f,  0.11f);
+// #CC3399 -> (204, 51,153)
+SbColor DrawingParameters::CurveExternalColor                       (0.8f,  0.2f,   0.6f);
+// #0000DC -> (  0,  0,220)
+SbColor DrawingParameters::CurveDraftColor                          (0.0f,  0.0f,   0.86f);
+// #8FA9FD -> (143,169,253)
+SbColor DrawingParameters::FullyConstraintConstructionElementColor  (0.56f, 0.66f,  0.99f);
 
-SbColor DrawingParameters::ConstrDimColor                           (1.0f,  0.149f, 0.0f);   // #FF2600 -> (255, 38,  0)
-SbColor DrawingParameters::ConstrIcoColor                           (1.0f,  0.149f, 0.0f);   // #FF2600 -> (255, 38,  0)
-SbColor DrawingParameters::NonDrivingConstrDimColor                 (0.0f,  0.149f, 1.0f);   // #0026FF -> (  0, 38,255)
-SbColor DrawingParameters::ExprBasedConstrDimColor                  (1.0f,  0.5f,   0.149f);   // #FF7F26 -> (255, 127,38)
-SbColor DrawingParameters::DeactivatedConstrDimColor                (0.8f,  0.8f,   0.8f);     // #CCCCCC -> (204,204,204)
-SbColor DrawingParameters::CursorTextColor                          (0.0f,  0.0f,   1.0f);  // #0000FF -> (0,0,255)
+// #FF2600 -> (255, 38,  0)
+SbColor DrawingParameters::ConstrDimColor                           (1.0f,  0.149f, 0.0f);
+// #FF2600 -> (255, 38,  0)
+SbColor DrawingParameters::ConstrIcoColor                           (1.0f,  0.149f, 0.0f);
+// #0026FF -> (  0, 38,255)
+SbColor DrawingParameters::NonDrivingConstrDimColor                 (0.0f,  0.149f, 1.0f);
+// #FF7F26 -> (255, 127,38)
+SbColor DrawingParameters::ExprBasedConstrDimColor                  (1.0f,  0.5f,   0.149f);
+// #CCCCCC -> (204,204,204)
+SbColor DrawingParameters::DeactivatedConstrDimColor                (0.8f,  0.8f,   0.8f);
+// #0000FF -> (0,0,255)
+SbColor DrawingParameters::CursorTextColor                          (0.0f,  0.0f,   1.0f);
 
 const MultiFieldId MultiFieldId::Invalid = MultiFieldId();

--- a/src/Mod/Sketcher/Gui/EditModeCoinManagerParameters.h
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManagerParameters.h
@@ -93,39 +93,66 @@ struct DrawingParameters {
 
     /** @name Rendering Coin Colors **/
     //@{
-    static SbColor InformationColor;                            // Information Overlay Color
-    static SbColor CreateCurveColor;                            // Color for Edit Curves during creation
-    static SbColor CrossColorH;                                 // Color for the Horizontal Axis
-    static SbColor CrossColorV;                                 // Color for the Vertical Axis
-    static SbColor InvalidSketchColor;                          // Color for rendering an invalid sketch
-    static SbColor FullyConstrainedColor;                       // Color for a fully constrained sketch
-    static SbColor FullyConstraintInternalAlignmentColor;       // Color for fully constrained internal alignment geometry
-    static SbColor InternalAlignedGeoColor;                     // Color for non-fully constrained internal alignment geometry
-    static SbColor FullyConstraintConstructionPointColor;       // Color for fully constrained construction points
+    // Information Overlay Color
+    static SbColor InformationColor;
+    // Color for Edit Curves during creation
+    static SbColor CreateCurveColor;
+    // Color for the Horizontal Axis
+    static SbColor CrossColorH;
+    // Color for the Vertical Axis
+    static SbColor CrossColorV;
+    // Color for rendering an invalid sketch
+    static SbColor InvalidSketchColor;
+    // Color for a fully constrained sketch
+    static SbColor FullyConstrainedColor;
+    // Color for fully constrained internal alignment geometry
+    static SbColor FullyConstraintInternalAlignmentColor;
+    // Color for non-fully constrained internal alignment geometry
+    static SbColor InternalAlignedGeoColor;
+    // Color for fully constrained construction points
+    static SbColor FullyConstraintConstructionPointColor;
     static SbColor VertexColor;                                 // Color for vertices
-    static SbColor FullyConstraintElementColor;                 // Color for a fully constrained element
+    // Color for a fully constrained element
+    static SbColor FullyConstraintElementColor;
     static SbColor CurveColor;                                  // Color for curves
-    static SbColor PreselectColor;                              // Color used for pre-selection
-    static SbColor PreselectSelectedColor;                      // Color used for pre-selection when geometry is already selected
-    static SbColor SelectColor;                                 // Color used for selected geometry
-    static SbColor CurveExternalColor;                          // Color used for external geometry
-    static SbColor CurveDraftColor;                             // Color used for construction geometry
-    static SbColor FullyConstraintConstructionElementColor;     // Color used for a fully constrained construction element
-    static SbColor ConstrDimColor;                              // Color used for a dimensional constraints
-    static SbColor ConstrIcoColor;                              // Color used for constraint icons
-    static SbColor NonDrivingConstrDimColor;                    // Color used for non-driving (reference) dimensional constraints
-    static SbColor ExprBasedConstrDimColor;                     // Color used for expression based dimensional constraints
-    static SbColor DeactivatedConstrDimColor;                   // Color used for deactivated dimensional constraints
-    static SbColor CursorTextColor;                              // Color used by the edit mode cursor
+    // Color used for pre-selection
+    static SbColor PreselectColor;
+    // Color used for pre-selection when geometry is already selected
+    static SbColor PreselectSelectedColor;
+    // Color used for selected geometry
+    static SbColor SelectColor;
+    // Color used for external geometry
+    static SbColor CurveExternalColor;
+    // Color used for construction geometry
+    static SbColor CurveDraftColor;
+    // Color used for a fully constrained construction element
+    static SbColor FullyConstraintConstructionElementColor;
+    // Color used for a dimensional constraints
+    static SbColor ConstrDimColor;
+    // Color used for constraint icons
+    static SbColor ConstrIcoColor;
+    // Color used for non-driving (reference) dimensional constraints
+    static SbColor NonDrivingConstrDimColor;
+    // Color used for expression based dimensional constraints
+    static SbColor ExprBasedConstrDimColor;
+    // Color used for deactivated dimensional constraints
+    static SbColor DeactivatedConstrDimColor;
+    // Color used by the edit mode cursor
+    static SbColor CursorTextColor;
     //@}
 
     /** @name Rendering sizes (also to support HDPI monitors) **/
     //@{
-    double pixelScalingFactor = 1.0;    // Scaling factor to be used for pixels
-    int coinFontSize = 17;              // Font size to be used by coin
-    int labelFontSize = 17;             // Font size to be used by SoDatumLabel, which uses a QPainter and a QFont internally
-    int constraintIconSize = 15;        // Size of constraint icons
-    int markerSize = 7;                 // Size used for markers
+    // Scaling factor to be used for pixels
+    double pixelScalingFactor = 1.0;
+    // Font size to be used by coin
+    int coinFontSize = 17;
+    // Font size to be used by SoDatumLabel, which uses a QPainter and a QFont internally
+    int labelFontSize = 17;
+    // Size of constraint icons
+    int constraintIconSize = 15;
+    // Size used for markers
+    int markerSize = 7;
     //@}
 };
 
@@ -134,14 +161,18 @@ struct DrawingParameters {
 struct GeometryLayerNodes {
     /** @name Point nodes*/
     //@{
-    std::vector<SoMaterial *> &     PointsMaterials;    // The materials for the points/vertices
-    std::vector<SoCoordinate3 *>&   PointsCoordinate;   // The coordinates of the points/vertices
+    // The materials for the points/vertices
+    std::vector<SoMaterial *> &     PointsMaterials;
+    // The coordinates of the points/vertices
+    std::vector<SoCoordinate3 *>&   PointsCoordinate;
     //@}
 
     /** @name Curve nodes*/
     //@{
-    std::vector<SoMaterial *> &     CurvesMaterials;    // The materials for the curves
-    std::vector<SoCoordinate3 *> &  CurvesCoordinate;   // The coordinates of the segments of the curves
+    // The materials for the curves
+    std::vector<SoMaterial *> &     CurvesMaterials;
+    // The coordinates of the segments of the curves
+    std::vector<SoCoordinate3 *> &  CurvesCoordinate;
     std::vector<SoLineSet *> &      CurveSet;           // The set of curves
     //@}
 };
@@ -248,15 +279,19 @@ public:
     }
 
 private:
-    int CoinLayers = 1; // defaults to a single Coin Geometry Layer.
+    // defaults to a single Coin Geometry Layer.
+    int CoinLayers = 1;
 };
 
 /** @brief     Struct to hold the results of analysis performed on geometry
 */
 struct AnalysisResults { // TODO: This needs to be refactored
-    double combRepresentationScale = 0;     // used for information overlay (BSpline comb)
-    float boundingBoxMagnitudeOrder = 0;    // used for grid extension
-    std::vector<int> bsplineGeoIds;         // used for information overlay
+    // used for information overlay (BSpline comb)
+    double combRepresentationScale = 0;
+    // used for grid extension
+    float boundingBoxMagnitudeOrder = 0;
+    // used for information overlay
+    std::vector<int> bsplineGeoIds;
 };
 
 /** @brief      Struct adapted to store the parameters necessary to create and update
@@ -279,9 +314,12 @@ struct OverlayParameters {
  *  constraints.
  */
 struct ConstraintParameters {
-    bool bHideUnits;                    // whether units should be hidden or not
-    bool bShowDimensionalName;          // whether the name of dimensional constraints should be shown or not
-    QString sDimensionalStringFormat;   // how to code strings of dimensional constraints
+    // whether units should be hidden or not
+    bool bHideUnits;
+    // whether the name of dimensional constraints should be shown or not
+    bool bShowDimensionalName;
+    // how to code strings of dimensional constraints
+    QString sDimensionalStringFormat;
 };
 
 /** @brief      Helper struct adapted to store the pointer to edit mode scenegraph objects.
@@ -413,4 +451,3 @@ struct CoinMapping {
 } // namespace SketcherGui
 
 #endif // SKETCHERGUI_EditModeCoinManagerParameters_H
-

--- a/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
@@ -99,7 +99,8 @@ void EditModeConstraintCoinManager::updateVirtualSpace()
         SbBool *sws = editModeScenegraphNodes.constrGroup->enable.startEditing();
 
         for (size_t i = 0; i < constrlist.size(); i++)
-            sws[i] = !(constrlist[i]->isInVirtualSpace != isshownvirtualspace); // XOR of constraint mode and VP mode
+            // XOR of constraint mode and VP mode
+            sws[i] = !(constrlist[i]->isInVirtualSpace != isshownvirtualspace);
 
 
         editModeScenegraphNodes.constrGroup->enable.finishEditing();
@@ -228,7 +229,8 @@ Restart:
                             }
                             else {
                                 double ra=0,rb=0;
-                                double angle,angleplus=0.;//angle = rotation of object as a whole; angleplus = arc angle (t parameter for ellipses).
+                                //angle = rotation of object as a whole; angleplus = arc angle (t parameter for ellipses).
+                                double angle,angleplus=0.;
                                 if (geo->getTypeId() == Part::GeomCircle::getClassTypeId()) {
                                     const Part::GeomCircle *circle = static_cast<const Part::GeomCircle *>(geo);
                                     ra = circle->getRadius();
@@ -286,13 +288,16 @@ Restart:
                                     geo->getTypeId() == Part::GeomArcOfHyperbola::getClassTypeId()){
 
                                     Base::Vector3d majDir, minDir, rvec;
-                                    majDir = Base::Vector3d(cos(angle),sin(angle),0);//direction of major axis of ellipse
-                                    minDir = Base::Vector3d(-majDir.y,majDir.x,0);//direction of minor axis of ellipse
+                                    //direction of major axis of ellipse
+                                    majDir = Base::Vector3d(cos(angle),sin(angle),0);
+                                    //direction of minor axis of ellipse
+                                    minDir = Base::Vector3d(-majDir.y,majDir.x,0);
                                     rvec = (ra*cos(angleplus)) * majDir   +   (rb*sin(angleplus)) * minDir;
                                     midpos += rvec;
                                     rvec.Normalize();
                                     norm = rvec;
-                                    dir = Base::Vector3d(-rvec.y,rvec.x,0);//DeepSOIC: I'm not sure what dir is supposed to mean.
+                                    //DeepSOIC: I'm not sure what dir is supposed to mean.
+                                    dir = Base::Vector3d(-rvec.y,rvec.x,0);
                                 }
                                 else {
                                     norm = Base::Vector3d(cos(angle),sin(angle),0);
@@ -353,7 +358,8 @@ Restart:
 
                         Base::Vector3d midpos1, dir1, norm1;
                         Base::Vector3d midpos2, dir2, norm2;
-                        bool twoIcons = false;//a very local flag. It's set to true to indicate that the second dir+norm are valid and should be used
+                        //a very local flag. It's set to true to indicate that the second dir+norm are valid and should be used
+                        bool twoIcons = false;
 
 
                         if (Constr->Third != GeoEnum::GeoUndef || //perpty via point
@@ -463,7 +469,8 @@ Restart:
                             geo2->getTypeId() != Part::GeomLineSegment::getClassTypeId()) {
                             if (Constr->Type == Equal) {
                                 double r1a=0,r1b=0,r2a=0,r2b=0;
-                                double angle1,angle1plus=0.,  angle2, angle2plus=0.;//angle1 = rotation of object as a whole; angle1plus = arc angle (t parameter for ellipses).
+                                //angle1 = rotation of object as a whole; angle1plus = arc angle (t parameter for ellipses).
+                                double angle1,angle1plus=0.,  angle2, angle2plus=0.;
                                 if (geo1->getTypeId() == Part::GeomCircle::getClassTypeId()) {
                                     const Part::GeomCircle *circle = static_cast<const Part::GeomCircle *>(geo1);
                                     r1a = circle->getRadius();
@@ -573,13 +580,16 @@ Restart:
                                     geo1->getTypeId() == Part::GeomArcOfHyperbola::getClassTypeId() ){
 
                                     Base::Vector3d majDir, minDir, rvec;
-                                    majDir = Base::Vector3d(cos(angle1),sin(angle1),0);//direction of major axis of ellipse
-                                    minDir = Base::Vector3d(-majDir.y,majDir.x,0);//direction of minor axis of ellipse
+                                    //direction of major axis of ellipse
+                                    majDir = Base::Vector3d(cos(angle1),sin(angle1),0);
+                                    //direction of minor axis of ellipse
+                                    minDir = Base::Vector3d(-majDir.y,majDir.x,0);
                                     rvec = (r1a*cos(angle1plus)) * majDir   +   (r1b*sin(angle1plus)) * minDir;
                                     midpos1 += rvec;
                                     rvec.Normalize();
                                     norm1 = rvec;
-                                    dir1 = Base::Vector3d(-rvec.y,rvec.x,0);//DeepSOIC: I'm not sure what dir is supposed to mean.
+                                    //DeepSOIC: I'm not sure what dir is supposed to mean.
+                                    dir1 = Base::Vector3d(-rvec.y,rvec.x,0);
                                 }
                                 else {
                                     norm1 = Base::Vector3d(cos(angle1),sin(angle1),0);
@@ -593,8 +603,10 @@ Restart:
                                     geo2->getTypeId() == Part::GeomArcOfHyperbola::getClassTypeId()) {
 
                                     Base::Vector3d majDir, minDir, rvec;
-                                    majDir = Base::Vector3d(cos(angle2),sin(angle2),0);//direction of major axis of ellipse
-                                    minDir = Base::Vector3d(-majDir.y,majDir.x,0);//direction of minor axis of ellipse
+                                    //direction of major axis of ellipse
+                                    majDir = Base::Vector3d(cos(angle2),sin(angle2),0);
+                                    //direction of minor axis of ellipse
+                                    minDir = Base::Vector3d(-majDir.y,majDir.x,0);
                                     rvec = (r2a*cos(angle2plus)) * majDir   +   (r2b*sin(angle2plus)) * minDir;
                                     midpos2 += rvec;
                                     rvec.Normalize();
@@ -964,7 +976,8 @@ Restart:
                                 dir1 = getNormal(geolistfacade, Constr->First, p);
                                 // TODO: Check
                                 // dir1 = getSolvedSketch().calculateNormalAtPoint(Constr->First, p.x, p.y);
-                                dir1.RotateZ(-M_PI/2);//convert to vector of tangency by rotating
+                                //convert to vector of tangency by rotating
+                                dir1.RotateZ(-M_PI/2);
                                 dir2 = getNormal(geolistfacade, Constr->Second, p);
                                 // TODO: Check
                                 // dir2 = getSolvedSketch().calculateNormalAtPoint(Constr->Second, p.x, p.y);
@@ -1185,7 +1198,8 @@ Base::Vector3d EditModeConstraintCoinManager::seekConstraintPosition(const Base:
         rp->setPickAll(true);
         rp->setRay(SbVec3f(freePos.x, freePos.y, -1.f), SbVec3f(0, 0, 1) );
         //problem
-        rp->apply(editModeScenegraphNodes.constrGroup); // We could narrow it down to just the SoGroup containing the constraints
+        // We could narrow it down to just the SoGroup containing the constraints
+        rp->apply(editModeScenegraphNodes.constrGroup);
 
         // returns a copy of the point
         SoPickedPoint *pp = rp->getPickedPoint();
@@ -1635,8 +1649,10 @@ QString EditModeConstraintCoinManager::getPresentationString(const Constraint *c
             if (QString::compare(baseUnitStr, unitStr)==0)
             {
                 // Example code from: Mod/TechDraw/App/DrawViewDimension.cpp:372
-                QRegularExpression rxUnits(QString::fromUtf8(" \\D*$"));  //space + any non digits at end of string
-                valueStr.remove(rxUnits);                      //getUserString(defaultDecimals) without units
+                //space + any non digits at end of string
+                QRegularExpression rxUnits(QString::fromUtf8(" \\D*$"));
+                //getUserString(defaultDecimals) without units
+                valueStr.remove(rxUnits);
             }
         }
     }
@@ -2183,10 +2199,12 @@ QImage EditModeConstraintCoinManager::renderConstrIcon(const QString &type,
 
     QPixmap pxMap;
     std::stringstream constraintName;
-    constraintName << type.toLatin1().data() << drawingParameters.constraintIconSize; // allow resizing by embedding size
+    // allow resizing by embedding size
+    constraintName << type.toLatin1().data() << drawingParameters.constraintIconSize;
     if (! Gui::BitmapFactory().findPixmapInCache(constraintName.str().c_str(), pxMap)) {
         pxMap = Gui::BitmapFactory().pixmapFromSvg(type.toLatin1().data(),QSizeF(drawingParameters.constraintIconSize, drawingParameters.constraintIconSize));
-        Gui::BitmapFactory().addPixmapToCache(constraintName.str().c_str(), pxMap); // Cache for speed, avoiding pixmapFromSvg
+        // Cache for speed, avoiding pixmapFromSvg
+        Gui::BitmapFactory().addPixmapToCache(constraintName.str().c_str(), pxMap);
     }
     QImage icon = pxMap.toImage();
 
@@ -2383,7 +2401,8 @@ void EditModeConstraintCoinManager::createEditModeInventorNodes()
     editModeScenegraphNodes.EditRoot->addChild(editModeScenegraphNodes.ConstraintDrawStyle);
 
     // add the group where all the constraints has its SoSeparator
-    editModeScenegraphNodes.constrGrpSelect = new SoPickStyle(); // used to toggle constraints selectability
+    // used to toggle constraints selectability
+    editModeScenegraphNodes.constrGrpSelect = new SoPickStyle();
     editModeScenegraphNodes.constrGrpSelect->style.setValue(SoPickStyle::SHAPE);
     editModeScenegraphNodes.EditRoot->addChild(editModeScenegraphNodes.constrGrpSelect);
     setConstraintSelectability(); // Ensure default value;

--- a/src/Mod/Sketcher/Gui/EditModeGeometryCoinConverter.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeGeometryCoinConverter.cpp
@@ -81,7 +81,8 @@ void EditModeGeometryCoinConverter::convert(const Sketcher::GeoListFacade & geol
     // empty layer.
     Points[0].emplace_back(0.,0.,0.);
     coinMapping.PointIdToGeoId[0].push_back(-1); // root point
-    coinMapping.PointIdToVertexId[0].push_back(-1); // VertexId is the reference used for point selection/preselection
+    // VertexId is the reference used for point selection/preselection
+    coinMapping.PointIdToVertexId[0].push_back(-1);
 
     coinMapping.GeoElementId2SetId.emplace( std::piecewise_construct,
                                             std::forward_as_tuple(Sketcher::GeoElementId::RtPnt),
@@ -345,7 +346,8 @@ void EditModeGeometryCoinConverter::convert(const Sketcher::GeometryFacade * geo
                     // terminating here would mean that the other shapes would not be drawn.
                     // Solution: Report the issue and set dummy curvature to 0
                     e.ReportException();
-                    Base::Console().Error("Curvature graph for B-Spline with GeoId=%d could not be calculated.\n", geoid); // TODO: Fix identification of curve.
+                    // TODO: Fix identification of curve.
+                    Base::Console().Error("Curvature graph for B-Spline with GeoId=%d could not be calculated.\n", geoid);
                     curvaturelist[i] = 0;
                 }
 
@@ -361,7 +363,8 @@ void EditModeGeometryCoinConverter::convert(const Sketcher::GeometryFacade * geo
 
             double temprepscale = 0;
             if (maxcurv > 0)
-                temprepscale = (0.5 * maxdisttocenterofmass) / maxcurv; // just a factor to make a comb reasonably visible
+                // just a factor to make a comb reasonably visible
+                temprepscale = (0.5 * maxdisttocenterofmass) / maxcurv;
 
             if (temprepscale > combrepscale)
                 combrepscale = temprepscale;

--- a/src/Mod/Sketcher/Gui/EditModeGeometryCoinConverter.h
+++ b/src/Mod/Sketcher/Gui/EditModeGeometryCoinConverter.h
@@ -157,7 +157,8 @@ private:
 
     // measurements
     float boundingBoxMaxMagnitude = 100;
-    double combrepscale = 0; // the repscale that would correspond to this comb based only on this calculation.
+    // the repscale that would correspond to this comb based only on this calculation.
+    double combrepscale = 0;
     std::vector<int> bsplineGeoIds;
 
 };
@@ -167,4 +168,3 @@ private:
 
 
 #endif // SKETCHERGUI_GeometryCoinConverter_H
-

--- a/src/Mod/Sketcher/Gui/EditModeInformationOverlayCoinConverter.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeInformationOverlayCoinConverter.cpp
@@ -126,7 +126,8 @@ void EditModeInformationOverlayCoinConverter::calculate(const Part::Geometry * g
         if (spline->isPeriodic())
             controlPolygon.coordinates.emplace_back(poles[0]);
 
-        controlPolygon.indices.push_back(nvertices); // single continuous polygon starting at index 0
+        // single continuous polygon starting at index 0
+        controlPolygon.indices.push_back(nvertices);
     }
     else if constexpr (calculation == CalculationType::BSplineCurvatureComb ) {
 
@@ -195,8 +196,10 @@ void EditModeInformationOverlayCoinConverter::calculate(const Part::Geometry * g
             pointatcomblist.emplace_back(pointatcurvelist[i] - overlayParameters.currentBSplineCombRepresentationScale * curvaturelist[i] * normallist[i]);
         }
 
-        curvatureComb.coordinates.reserve(3*ndiv); // 2*ndiv +1 points of ndiv separate segments + ndiv points for last segment
-        curvatureComb.indices.reserve(ndiv+1); // ndiv separate segments of radials + 1 segment connecting at comb end
+        // 2*ndiv +1 points of ndiv separate segments + ndiv points for last segment
+        curvatureComb.coordinates.reserve(3*ndiv);
+        // ndiv separate segments of radials + 1 segment connecting at comb end
+        curvatureComb.indices.reserve(ndiv+1);
 
         auto zInfoH = ViewProviderSketchCoinAttorney::getViewOrientationFactor(viewProvider) * drawingParameters.zInfo;
 
@@ -209,7 +212,8 @@ void EditModeInformationOverlayCoinConverter::calculate(const Part::Geometry * g
         }
 
         for (int i = 0; i < ndiv; i++)
-            curvatureComb.coordinates.emplace_back(pointatcomblist[i].x, pointatcomblist[i].y, zInfoH); // // comb endpoint closing segment
+            // // comb endpoint closing segment
+            curvatureComb.coordinates.emplace_back(pointatcomblist[i].x, pointatcomblist[i].y, zInfoH);
 
         curvatureComb.indices.emplace_back(ndiv); // Comb line
     }

--- a/src/Mod/Sketcher/Gui/TaskDlgEditSketch.cpp
+++ b/src/Mod/Sketcher/Gui/TaskDlgEditSketch.cpp
@@ -101,7 +101,8 @@ bool TaskDlgEditSketch::reject()
     hGrp->SetBool("ExpandedConstraintsWidget",Constraints->isGroupVisible());
     hGrp->SetBool("ExpandedElementsWidget",Elements->isGroupVisible());
 
-    std::string document = getDocumentName(); // needed because resetEdit() deletes this instance
+    // needed because resetEdit() deletes this instance
+    std::string document = getDocumentName();
     Gui::Command::doCommand(Gui::Command::Gui,"Gui.getDocument('%s').resetEdit()", document.c_str());
     Gui::Command::doCommand(Gui::Command::Doc,"App.getDocument('%s').recompute()", document.c_str());
 

--- a/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
@@ -633,7 +633,8 @@ ConstraintFilterList::ConstraintFilterList(QWidget* parent)
     : QListWidget(parent)
 {
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher/General");
-    int filterState = hGrp->GetInt("ConstraintFilterState", INT_MAX); //INT_MAX = 1111111111111111111111111111111 in binary.
+    //INT_MAX = 1111111111111111111111111111111 in binary.
+    int filterState = hGrp->GetInt("ConstraintFilterState", INT_MAX);
 
     normalFilterCount = filterItems.size() - 2; //All filter but selected and associated
     selectedFilterIndex = normalFilterCount;
@@ -672,7 +673,7 @@ void ConstraintFilterList::languageChange()
     int i = 0;
     for (auto const& filterItem : filterItems) {
         auto text = QStringLiteral("  ").repeated(filterItem.second - 1) +
-            (filterItem.second > 0 ? QStringLiteral("- ") : QStringLiteral("")) + 
+            (filterItem.second > 0 ? QStringLiteral("- ") : QStringLiteral("")) +
             tr(filterItem.first);
         item(i++)->setText(text);
     }
@@ -1199,14 +1200,16 @@ void TaskSketcherConstraints::updateAssociatedConstraintsFilter()
 
 void TaskSketcherConstraints::updateList()
 {
-    multiFilterStatus = filterList->getMultiFilter(); //moved here in case the filter is changed programmatically.
+    //moved here in case the filter is changed programmatically.
+    multiFilterStatus = filterList->getMultiFilter();
 
     // enforce constraint visibility
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher");
     bool visibilityTracksFilter = hGrp->GetBool("VisualisationTrackingFilter",false);
 
     if(visibilityTracksFilter)
-        change3DViewVisibilityToTrackFilter(); // it will call slotConstraintChanged via update mechanism
+        // it will call slotConstraintChanged via update mechanism
+        change3DViewVisibilityToTrackFilter();
     else
         slotConstraintsChanged();
 }
@@ -1262,7 +1265,8 @@ void TaskSketcherConstraints::onSelectionChanged(const Gui::SelectionChanges& ms
 
                         if(specialFilterMode == SpecialFilterType::Selected) {
                             updateSelectionFilter();
-                            bool block = this->blockSelection(true); // avoid to be notified by itself
+                            // avoid to be notified by itself
+                            bool block = this->blockSelection(true);
                             updateList();
                             this->blockSelection(block);
                         }
@@ -1610,7 +1614,7 @@ void TaskSketcherConstraints::on_filterList_itemChanged(QListWidgetItem* item)
 
         auto itemAggregate = filterAggregates[filterindex];
 
-        /*First, if this is a group, we need to set the same state to all of its children. 
+        /*First, if this is a group, we need to set the same state to all of its children.
         ie any filter comprised on the filter of the activated item, gets the same check state.*/
         for (int i = 0; i < filterList->normalFilterCount; i++) {
             if (itemAggregate[i])
@@ -1623,7 +1627,8 @@ void TaskSketcherConstraints::on_filterList_itemChanged(QListWidgetItem* item)
     else if (filterindex == filterList->selectedFilterIndex) { //Selected constraints
         if (item->checkState() == Qt::Checked) {
             specialFilterMode = SpecialFilterType::Selected;
-            filterList->item(filterList->associatedFilterIndex)->setCheckState(Qt::Unchecked); //Disable 'associated'
+            //Disable 'associated'
+            filterList->item(filterList->associatedFilterIndex)->setCheckState(Qt::Unchecked);
             updateSelectionFilter();
         }
         else
@@ -1645,7 +1650,8 @@ void TaskSketcherConstraints::on_filterList_itemChanged(QListWidgetItem* item)
     int filterState = 0;
     for (int i = filterList->count() - 1; i >= 0; i--) {
         bool isChecked = filterList->item(i)->checkState() == Qt::Checked;
-        filterState = filterState << 1; //we shift left first, else the list is shifted at the end.
+        //we shift left first, else the list is shifted at the end.
+        filterState = filterState << 1;
         filterState = filterState | isChecked;
     }
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher/General");
@@ -1657,4 +1663,3 @@ void TaskSketcherConstraints::on_filterList_itemChanged(QListWidgetItem* item)
 
 
 #include "moc_TaskSketcherConstraints.cpp"
-

--- a/src/Mod/Sketcher/Gui/TaskSketcherConstraints.h
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstraints.h
@@ -100,7 +100,8 @@ protected:
     virtual void languageChange();
 
 private:
-    using filterItemRepr = std::pair<const char*, const int>; // {filter item text, filter item level}
+    // {filter item text, filter item level}
+    using filterItemRepr = std::pair<const char*, const int>;
     inline static const std::vector<filterItemRepr> filterItems = {
         {QT_TR_NOOP("All"),0},
         {QT_TR_NOOP("Geometric"),0},
@@ -201,9 +202,12 @@ private:
     QWidget* proxy;
     bool inEditMode;
     std::unique_ptr<Ui_TaskSketcherConstraints> ui;
-    ConstraintFilter::FilterValueBitset multiFilterStatus; // Stores the filters to be aggregated to form the multifilter.
-    std::vector<unsigned int> selectionFilter; // holds the constraint ids of the selected constraints
-    std::vector<unsigned int> associatedConstraintsFilter; // holds the constraint ids of the constraints associated with the selected geometry
+    // Stores the filters to be aggregated to form the multifilter.
+    ConstraintFilter::FilterValueBitset multiFilterStatus;
+    // holds the constraint ids of the selected constraints
+    std::vector<unsigned int> selectionFilter;
+    // holds the constraint ids of the constraints associated with the selected geometry
+    std::vector<unsigned int> associatedConstraintsFilter;
     ConstraintFilterList* filterList;
     boost::signals2::scoped_connection changedSketchView;
 

--- a/src/Mod/Sketcher/Gui/TaskSketcherElements.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherElements.cpp
@@ -552,7 +552,8 @@ void ElementItemDelegate::paint(QPainter* painter, const QStyleOptionViewItem& o
 
             QRect selection = QRect(customIconsMargin, option.rect.y(), option.rect.width()-customIconsMargin, option.rect.height());
 
-            painter->fillRect(selection, option.palette.highlight()); // paint the item as selected
+            // paint the item as selected
+            painter->fillRect(selection, option.palette.highlight());
 
             // Repaint individual icons
             if (!item->isLineSelected)
@@ -664,7 +665,8 @@ enum class GeoFilterType {
 ElementFilterList::ElementFilterList(QWidget* parent) : QListWidget(parent)
 {
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher/General");
-    int filterState = hGrp->GetInt("ElementFilterState", INT_MAX); //INT_MAX = 1111111111111111111111111111111 in binary.
+    //INT_MAX = 1111111111111111111111111111111 in binary.
+    int filterState = hGrp->GetInt("ElementFilterState", INT_MAX);
 
     for (auto const &filterItem:filterItems) {
         Q_UNUSED(filterItem);
@@ -864,7 +866,8 @@ void TaskSketcherElements::onListMultiFilterItemChanged(QListWidgetItem* item)
     int filterState = INT_MIN; //INT_MIN = 000000000000000000000000000000 in binary.
     for (int i = filterList->count() - 1; i >= 0 ; i--) {
         bool isChecked = filterList->item(i)->checkState() == Qt::Checked;
-        filterState = filterState << 1; //we shift left first, else the list is shifted at the end.
+        //we shift left first, else the list is shifted at the end.
+        filterState = filterState << 1;
         filterState = filterState | isChecked;
     }
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher/General");
@@ -989,7 +992,8 @@ void TaskSketcherElements::onSelectionChanged(const Gui::SelectionChanges& msg)
                     for (int i = 0; i < ui->listWidgetElements->count(); i++) {
                         ElementItem* item = static_cast<ElementItem*>(ui->listWidgetElements->item(i));
                         if(item->isSelected())
-                            item->setSelected(false); //if already selected, we need to reset setSelected or it won't draw subelements correctly if selecting several.
+                            //if already selected, we need to reset setSelected or it won't draw subelements correctly if selecting several.
+                            item->setSelected(false);
                         item->setSelected(item->isLineSelected || item->isStartingPointSelected || item->isEndPointSelected || item->isMidPointSelected);
                     }
                 }
@@ -1098,7 +1102,8 @@ void TaskSketcherElements::onListWidgetElementsItemPressed(QListWidgetItem* it) 
                 QSignalBlocker sigblk(ui->listWidgetElements);
 
                 if (item->isSelected() && selected) {
-                    item->setSelected(false);// if already selected and changing or adding subelement, ensure selection change is triggered, which ensures timely repaint
+                    // if already selected and changing or adding subelement, ensure selection change is triggered, which ensures timely repaint
+                    item->setSelected(false);
                     item->setSelected(selected);
                 }
                 else {

--- a/src/Mod/Sketcher/Gui/TaskSketcherElements.h
+++ b/src/Mod/Sketcher/Gui/TaskSketcherElements.h
@@ -144,7 +144,8 @@ protected:
     virtual void languageChange();
 
 private:
-    using filterItemRepr =  std::pair<const char *, const int>; // {filter item text, filter item level}
+    // {filter item text, filter item level}
+    using filterItemRepr =  std::pair<const char *, const int>;
     inline static const std::vector<filterItemRepr> filterItems = {
         {QT_TR_NOOP("Normal"),0},
         {QT_TR_NOOP("Construction"),0},

--- a/src/Mod/Sketcher/Gui/Utils.cpp
+++ b/src/Mod/Sketcher/Gui/Utils.cpp
@@ -557,7 +557,8 @@ std::string SketcherGui::lengthToDisplayFormat(double value, int digits)
 
     //get the numeric part of the user string
     QRegularExpression rxNoUnits(
-        QString::fromUtf8("(.*) \\D*$"));// text before space + any non digits at end of string
+        // text before space + any non digits at end of string
+        QString::fromUtf8("(.*) \\D*$"));
     QRegularExpressionMatch match = rxNoUnits.match(qUserString);
     if (!match.hasMatch()) {
         //no units in userString?
@@ -610,8 +611,10 @@ std::string SketcherGui::angleToDisplayFormat(double value, int digits)
         //Coin SbString doesn't handle utf8 well, so we convert to ascii
         QString schemeMinute = QString::fromUtf8("\xE2\x80\xB2");//prime symbol
         QString schemeSecond = QString::fromUtf8("\xE2\x80\xB3");//double prime symbol
-        QString escapeMinute = QString::fromLatin1("\'");        //substitute ascii single quote
-        QString escapeSecond = QString::fromLatin1("\"");        //substitute ascii double quote
+        //substitute ascii single quote
+        QString escapeMinute = QString::fromLatin1("\'");
+        //substitute ascii double quote
+        QString escapeSecond = QString::fromLatin1("\"");
         QString displayString = qUserString.replace(schemeMinute, escapeMinute);
         displayString = displayString.replace(schemeSecond, escapeSecond);
         return Base::Tools::toStdString(displayString);
@@ -624,7 +627,8 @@ std::string SketcherGui::angleToDisplayFormat(double value, int digits)
 
     //get the numeric part of the user string
     QRegularExpression rxNoUnits(
-        QString::fromUtf8("(\\d*\\%1?\\d*)(\\D*)$").arg(decimalSep));// number + non digits at end of string
+        // number + non digits at end of string
+        QString::fromUtf8("(\\d*\\%1?\\d*)(\\D*)$").arg(decimalSep));
     QRegularExpressionMatch match = rxNoUnits.match(qUserString);
     if (!match.hasMatch()) {
         //no units in userString?

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -445,7 +445,8 @@ void ViewProviderSketch::moveCursorToSketchPoint(Base::Vector2d point) {
 
     short x,y; screencoords.getValue(x,y);
 
-    short height = viewer->getGLWidget()->height(); // Coin3D origin bottom left, QT origin top left
+    // Coin3D origin bottom left, QT origin top left
+    short height = viewer->getGLWidget()->height();
 
     QPoint newPos = viewer->getGLWidget()->mapToGlobal(QPoint(x,height-y));
 
@@ -721,7 +722,8 @@ bool ViewProviderSketch::mouseButtonPressed(int Button, bool pressed, const SbVe
                         editDoubleClicked();
                         // Reset Double Click Static Variables
                         DoubleClick::prvClickTime = SbTime();
-                        DoubleClick::prvClickPos = SbVec2s(-16000,-16000); //certainly far away from any clickable place, to avoid re-trigger of double-click if next click happens fast.
+                        //certainly far away from any clickable place, to avoid re-trigger of double-click if next click happens fast.
+                        DoubleClick::prvClickPos = SbVec2s(-16000,-16000);
 
                         Mode = STATUS_NONE;
                     } else {
@@ -1957,12 +1959,14 @@ void ViewProviderSketch::doBoxSelection(const SbVec2s &startPos, const SbVec2s &
     int intGeoCount = sketchObject->getHighestCurveIndex() + 1;
     int extGeoCount = sketchObject->getExternalGeometryCount();
 
-    const std::vector<Part::Geometry *> geomlist = sketchObject->getCompleteGeometry(); // without memory allocation
+    // without memory allocation
+    const std::vector<Part::Geometry *> geomlist = sketchObject->getCompleteGeometry();
     assert(int(geomlist.size()) == extGeoCount + intGeoCount);
     assert(int(geomlist.size()) >= 2);
 
     Base::Vector3d pnt0, pnt1, pnt2, pnt;
-    int VertexId = -1; // the loop below should be in sync with the main loop in ViewProviderSketch::draw
+    // the loop below should be in sync with the main loop in ViewProviderSketch::draw
+    int VertexId = -1;
                        // so that the vertex indices are calculated correctly
     int GeoId = 0;
 
@@ -2624,7 +2628,8 @@ void ViewProviderSketch::scaleBSplinePoleCirclesAndUpdateSolverAndSketchObjectGe
                             else { // without memory allocation
                                 tmpcircle = static_cast<Part::GeomCircle *>(circle->clone());
                                 tmpcircle->setRadius(vradius);
-                                tempGeo[GeoId] = GeometryFacade::getFacade(tmpcircle, true); // this is the circle that will be drawn, with the updated vradius, the facade takes ownership and will deallocate.
+                                // this is the circle that will be drawn, with the updated vradius, the facade takes ownership and will deallocate.
+                                tempGeo[GeoId] = GeometryFacade::getFacade(tmpcircle, true);
                             }
 
                             if(!circle->hasExtension(SketcherGui::ViewProviderSketchGeometryExtension::getClassTypeId()))
@@ -2750,7 +2755,8 @@ void ViewProviderSketch::updateData(const App::Property *prop)
 
         // solver information is also updated when no matching geometry, so that if a solving fails
         // this failed solving info is presented to the user
-        UpdateSolverInformation(); // just update the solver window with the last SketchObject solving information
+        // just update the solver window with the last SketchObject solving information
+        UpdateSolverInformation();
 
         if(getSketchObject()->getExternalGeometryCount()+getSketchObject()->getHighestCurveIndex() + 1 ==
             getSolvedSketch().getGeometrySize()) {
@@ -3272,7 +3278,8 @@ void ViewProviderSketch::onCameraChanged(SoCamera* cam)
 {
     auto rotSk = Base::Rotation(getDocument()->getEditingTransform()); //sketch orientation
     auto rotc = cam->orientation.getValue().getValue();
-    auto rotCam = Base::Rotation(rotc[0], rotc[1], rotc[2], rotc[3]); // camera orientation (needed because float to double conversion)
+    // camera orientation (needed because float to double conversion)
+    auto rotCam = Base::Rotation(rotc[0], rotc[1], rotc[2], rotc[3]);
 
     // Is camera in the same hemisphere as positive sketch normal ?
     auto orientation = (rotCam.invert() * rotSk).multVec(Base::Vector3d(0, 0, 1));
@@ -3630,7 +3637,8 @@ const std::vector<Sketcher::Constraint *> ViewProviderSketch::getConstraints() c
 
 const GeoList ViewProviderSketch::getGeoList() const
 {
-    const std::vector<Part::Geometry *> tempGeo = getSketchObject()->getCompleteGeometry(); // without memory allocation
+    // without memory allocation
+    const std::vector<Part::Geometry *> tempGeo = getSketchObject()->getCompleteGeometry();
 
     int intGeoCount = getSketchObject()->getHighestCurveIndex() + 1;
 

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.h
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.h
@@ -274,11 +274,13 @@ private:
         bool isDragCurveValid() { return DragCurve > InvalidCurve;}
 
         double xInit, yInit;                // starting point of the dragging operation
-        bool relative;                      // whether the dragging move vector is relative or absolute
+        // whether the dragging move vector is relative or absolute
+        bool relative;
 
 
         int DragPoint;                      // dragged point id (only positive integers)
-        int DragCurve;                      // dragged curve id (only positive integers), negative external curves cannot be dragged.
+        // dragged curve id (only positive integers), negative external curves cannot be dragged.
+        int DragCurve;
         std::set<int> DragConstraintSet;    // dragged constraints ids
     };
 
@@ -337,8 +339,10 @@ private:
         int getPreselectionEdgeIndex() const { return PreselectCurve + 1;}
         int getPreselectionExternalEdgeIndex() const { return -PreselectCurve - 2;}
 
-        int PreselectPoint;                     // VertexN, with N = PreselectPoint + 1, same as DragPoint indexing (NOTE -1 is NOT the root point)
-        int PreselectCurve;                     // EdgeN, with N = PreselectCurve + 1 for positive values ; ExternalEdgeN, with N = -PreselectCurve - 2
+        // VertexN, with N = PreselectPoint + 1, same as DragPoint indexing (NOTE -1 is NOT the root point)
+        int PreselectPoint;
+        // EdgeN, with N = PreselectCurve + 1 for positive values ; ExternalEdgeN, with N = -PreselectCurve - 2
+        int PreselectCurve;
         Axes PreselectCross;                    // 0 => rootPoint, 1 => HAxis, 2 => VAxis
         std::set<int> PreselectConstraintSet;   // ConstraintN, N = index + 1
         bool blockedPreselection;
@@ -372,7 +376,8 @@ private:
             SelConstraintSet.clear();
         }
 
-        std::set<int> SelPointSet;              // Indices as PreselectPoint (and -1 for rootpoint)
+        // Indices as PreselectPoint (and -1 for rootpoint)
+        std::set<int> SelPointSet;
         std::set<int> SelCurvSet;               // also holds cross axes at -1 and -2
         std::set<int> SelConstraintSet;         // ConstraintN, N = index + 1.
     };
@@ -394,7 +399,8 @@ private:
         bool autoRecompute = false;
         bool recalculateInitialSolutionWhileDragging = false;
 
-        bool isShownVirtualSpace = false; // indicates whether the present virtual space view is the Real Space or the Virtual Space (virtual space 1 or 2)
+        // indicates whether the present virtual space view is the Real Space or the Virtual Space (virtual space 1 or 2)
+        bool isShownVirtualSpace = false;
         bool buttonPress = false;
     };
 
@@ -800,4 +806,3 @@ private:
 
 
 #endif // SKETCHERGUI_VIEWPROVIDERSKETCH_H
-

--- a/src/Mod/Spreadsheet/App/PropertySheet.cpp
+++ b/src/Mod/Spreadsheet/App/PropertySheet.cpp
@@ -320,7 +320,8 @@ void PropertySheet::Paste(const Property &from)
             *cell = *(ifrom->second); // Exists; assign cell directly
         }
         else {
-            cell = new Cell(this, *(ifrom->second)); // Doesn't exist, copy using Cell's copy constructor
+            // Doesn't exist, copy using Cell's copy constructor
+            cell = new Cell(this, *(ifrom->second));
             if (cell->getSpans(rows, cols))
                 spanChanges.push_back(ifrom->first);
         }

--- a/src/Mod/Spreadsheet/Gui/DlgBindSheet.cpp
+++ b/src/Mod/Spreadsheet/Gui/DlgBindSheet.cpp
@@ -142,7 +142,8 @@ void DlgBindSheet::accept()
 {
     bool commandActive = false;
     try {
-        const char *ref = ui->comboBox->itemData(ui->comboBox->currentIndex()).toByteArray().constData(); // clazy:exclude=returning-data-from-temporary
+        // clazy:exclude=returning-data-from-temporary
+        const char *ref = ui->comboBox->itemData(ui->comboBox->currentIndex()).toByteArray().constData();
         auto obj = sheet;
         if(ref[0]) {
             const char *sep = strchr(ref,'#');

--- a/src/Mod/Spreadsheet/Gui/LineEdit.cpp
+++ b/src/Mod/Spreadsheet/Gui/LineEdit.cpp
@@ -59,7 +59,8 @@ bool LineEdit::eventFilter(QObject* object, QEvent* event)
             }
         }
     }
-    return false; // We don't usually actually "handle" the tab event, we just keep track of it
+    // We don't usually actually "handle" the tab event, we just keep track of it
+    return false;
 }
 
 bool LineEdit::event(QEvent *event)

--- a/src/Mod/Spreadsheet/Gui/SheetTableView.cpp
+++ b/src/Mod/Spreadsheet/Gui/SheetTableView.cpp
@@ -849,7 +849,8 @@ void SheetTableView::finishEditWithMove(int keyPressed, Qt::KeyboardModifiers mo
                  modifiers == (Qt::ControlModifier | Qt::ShiftModifier))
             scanForRegionBoundary(targetRow, targetColumn, 0, -1);
         else
-            targetColumn--; //Unrecognized modifier combination: default to just moving one cell
+            //Unrecognized modifier combination: default to just moving one cell
+            targetColumn--;
         tabCounter = 0;
         break;
     case Qt::Key_Right:
@@ -861,7 +862,8 @@ void SheetTableView::finishEditWithMove(int keyPressed, Qt::KeyboardModifiers mo
                  modifiers == (Qt::ControlModifier | Qt::ShiftModifier))
             scanForRegionBoundary(targetRow, targetColumn, 0, 1);
         else
-            targetColumn += colSpan; //Unrecognized modifier combination: default to just moving one cell
+            //Unrecognized modifier combination: default to just moving one cell
+            targetColumn += colSpan;
         tabCounter = 0;
         break;
     case Qt::Key_Up:
@@ -873,7 +875,8 @@ void SheetTableView::finishEditWithMove(int keyPressed, Qt::KeyboardModifiers mo
                  modifiers == (Qt::ControlModifier | Qt::ShiftModifier))
             scanForRegionBoundary(targetRow, targetColumn, -1, 0);
         else
-            targetRow--; //Unrecognized modifier combination: default to just moving one cell
+            //Unrecognized modifier combination: default to just moving one cell
+            targetRow--;
         tabCounter = 0;
         break;
     case Qt::Key_Down:
@@ -885,7 +888,8 @@ void SheetTableView::finishEditWithMove(int keyPressed, Qt::KeyboardModifiers mo
                  modifiers == (Qt::ControlModifier | Qt::ShiftModifier))
             scanForRegionBoundary(targetRow, targetColumn, 1, 0);
         else
-            targetRow += rowSpan; //Unrecognized modifier combination: default to just moving one cell
+            //Unrecognized modifier combination: default to just moving one cell
+            targetRow += rowSpan;
         tabCounter = 0;
         break;
     case Qt::Key_Tab:

--- a/src/Mod/Surface/App/FeatureFilling.h
+++ b/src/Mod/Surface/App/FeatureFilling.h
@@ -41,11 +41,15 @@ public:
     Filling();
 
     //Properties of Curves
-    App::PropertyLinkSubList BoundaryEdges;         // Boundary Edges (C0 is required for edges without a corresponding face)
-    App::PropertyStringList  BoundaryFaces;         // Boundary Faces (C0, G1 and G2 are possible)
+    // Boundary Edges (C0 is required for edges without a corresponding face)
+    App::PropertyLinkSubList BoundaryEdges;
+    // Boundary Faces (C0, G1 and G2 are possible)
+    App::PropertyStringList  BoundaryFaces;
     App::PropertyIntegerList BoundaryOrder;         // Order of constraint on border faces
-    App::PropertyLinkSubList UnboundEdges;          // Unbound constraint edges (C0 is required for edges without a corresponding face)
-    App::PropertyStringList  UnboundFaces;          // Unbound constraint faces (C0, G1 and G2 are possible)
+    // Unbound constraint edges (C0 is required for edges without a corresponding face)
+    App::PropertyLinkSubList UnboundEdges;
+    // Unbound constraint faces (C0, G1 and G2 are possible)
+    App::PropertyStringList  UnboundFaces;
     App::PropertyIntegerList UnboundOrder;          // Order of constraint on curve faces
     App::PropertyLinkSubList FreeFaces;             // Free constraint faces
     App::PropertyIntegerList FreeOrder;             // Order of constraint on free faces

--- a/src/Mod/Surface/App/FeatureGeomFillSurface.cpp
+++ b/src/Mod/Surface/App/FeatureGeomFillSurface.cpp
@@ -276,7 +276,8 @@ void GeomFillSurface::createBezierSurface(TopoDS_Wire& aWire)
         const TopoDS_Edge hedge = TopoDS::Edge (anExp.Current());
         TopLoc_Location heloc; // this will be output
         Handle(Geom_Curve) c_geom = BRep_Tool::Curve(hedge, heloc, u1, u2); //The geometric curve
-        Handle(Geom_BezierCurve) bezier = Handle(Geom_BezierCurve)::DownCast(c_geom); //Try to get Bezier curve
+        //Try to get Bezier curve
+        Handle(Geom_BezierCurve) bezier = Handle(Geom_BezierCurve)::DownCast(c_geom);
 
         if (!bezier.IsNull()) {
             gp_Trsf transf = heloc.Transformation();
@@ -324,7 +325,8 @@ void GeomFillSurface::createBSplineSurface(TopoDS_Wire& aWire)
         const TopoDS_Edge& edge = TopoDS::Edge (anExp.Current());
         TopLoc_Location heloc; // this will be output
         Handle(Geom_Curve) c_geom = BRep_Tool::Curve(edge, heloc, u1, u2); //The geometric curve
-        Handle(Geom_BSplineCurve) bspline = Handle(Geom_BSplineCurve)::DownCast(c_geom); //Try to get BSpline curve
+        //Try to get BSpline curve
+        Handle(Geom_BSplineCurve) bspline = Handle(Geom_BSplineCurve)::DownCast(c_geom);
         gp_Trsf transf = heloc.Transformation();
         if (!bspline.IsNull()) {
             bspline->Transform(transf); // apply original transformation to control points
@@ -340,7 +342,8 @@ void GeomFillSurface::createBSplineSurface(TopoDS_Wire& aWire)
             Convert_ParameterisationType paratype = Convert_Polynomial;
             Handle(Geom_BSplineCurve) bspline2 = conv.CurveToBSplineCurve(trim, paratype);
             if (!bspline2.IsNull()) {
-                bspline2->Transform(transf); // apply original transformation to control points
+                // apply original transformation to control points
+                bspline2->Transform(transf);
                 curves.push_back(bspline2);
             }
             else {

--- a/src/Mod/Surface/App/FeatureGeomFillSurface.h
+++ b/src/Mod/Surface/App/FeatureGeomFillSurface.h
@@ -63,9 +63,12 @@ class GeomFillSurface : public Part::Spline
 
 public:
     GeomFillSurface();
-    App::PropertyLinkSubList BoundaryList;  // Curves to be turned into a face (2-4 curves allowed).
-    App::PropertyBoolList ReversedList;     // Booleans to handle orientation of the curves
-    App::PropertyEnumeration FillType;      // Fill method (1, 2, or 3 for Stretch, Coons, and Curved)
+    // Curves to be turned into a face (2-4 curves allowed).
+    App::PropertyLinkSubList BoundaryList;
+    // Booleans to handle orientation of the curves
+    App::PropertyBoolList ReversedList;
+    // Fill method (1, 2, or 3 for Stretch, Coons, and Curved)
+    App::PropertyEnumeration FillType;
 
     short mustExecute() const override;
     void onChanged(const App::Property*) override;

--- a/src/Mod/TechDraw/App/AppTechDrawPy.cpp
+++ b/src/Mod/TechDraw/App/AppTechDrawPy.cpp
@@ -715,7 +715,8 @@ private:
                             sDimText = dvd->getFormattedDimensionValue(1);
                         }
                         char* dimText = &sDimText[0u];                  //hack for const-ness
-                        float gap = 5.0;                                //hack. don't know font size here.
+                        //hack. don't know font size here.
+                        float gap = 5.0;
                         layerName = dvd->getNameInDocument();
                         writer.setLayerName(layerName);
                         int type = 0;                                   //Aligned/Distance

--- a/src/Mod/TechDraw/App/Cosmetic.h
+++ b/src/Mod/TechDraw/App/Cosmetic.h
@@ -93,12 +93,14 @@ public:
     CosmeticVertex* clone() const;
 
     Base::Vector3d permaPoint;           //permanent, unscaled value
-    int            linkGeom;             //connection to corresponding "geom" Vertex (fragile - index based!)
+    //connection to corresponding "geom" Vertex (fragile - index based!)
+    int            linkGeom;
                                          //better to do reverse search for CosmeticTag in vertex geometry
     App::Color     color;
     double         size;
     int            style;
-    bool           visible;              //base class vertex also has visible property
+    //base class vertex also has visible property
+    bool           visible;
 
     boost::uuids::uuid getTag() const;
     std::string getTagAsString() const override;
@@ -148,7 +150,8 @@ public:
     CosmeticEdge* copy() const;
     CosmeticEdge* clone() const;
 
-    Base::Vector3d permaStart;         //persistent unscaled start/end points in View coords
+    //persistent unscaled start/end points in View coords
+    Base::Vector3d permaStart;
     Base::Vector3d permaEnd;
     double permaRadius;
 //    void unscaleEnds(double scale);

--- a/src/Mod/TechDraw/App/DimensionFormatter.cpp
+++ b/src/Mod/TechDraw/App/DimensionFormatter.cpp
@@ -276,7 +276,8 @@ std::string DimensionFormatter::getFormattedDimensionValue(int partial)
         QString labelText = QString::fromUtf8(formatValue(m_dimension->getDimValue(),
                                                           qFormatSpec,
                                                           1,
-                                                          true).c_str()); //just the number pref/spec[unit]/suf
+                                                          //just the number pref/spec[unit]/suf
+                                                          true).c_str());
         QString unitText = QString::fromUtf8(formatValue(m_dimension->getDimValue(),
                                                          qFormatSpec,
                                                          2,
@@ -330,11 +331,13 @@ QStringList DimensionFormatter::getPrefixSuffixSpec(QString fSpec)
 {
     QStringList result;
     //find the %x.y tag in FormatSpec
-    QRegularExpression rxFormat(QStringLiteral("%[+-]?[0-9]*\\.*[0-9]*[aefgwAEFGW]")); //printf double format spec
+    //printf double format spec
+    QRegularExpression rxFormat(QStringLiteral("%[+-]?[0-9]*\\.*[0-9]*[aefgwAEFGW]"));
     QRegularExpressionMatch rxMatch;
     int pos = fSpec.indexOf(rxFormat, 0, &rxMatch);
     if (pos != -1)  {
-        QString match = rxMatch.captured(0);                                  //entire capture of rx
+        //entire capture of rx
+        QString match = rxMatch.captured(0);
         QString formatPrefix = fSpec.left(pos);
         result.append(formatPrefix);
         QString formatSuffix = fSpec.right(fSpec.size() - pos - match.size());
@@ -396,7 +399,8 @@ bool DimensionFormatter::isTooSmall(double value, QString formatSpec)
         return false;
     }
 
-    QRegularExpression rxFormat(QStringLiteral("%[+-]?[0-9]*\\.*([0-9]*)[aefgwAEFGW]")); //printf double format spec
+    //printf double format spec
+    QRegularExpression rxFormat(QStringLiteral("%[+-]?[0-9]*\\.*([0-9]*)[aefgwAEFGW]"));
     QRegularExpressionMatch rxMatch = rxFormat.match(formatSpec);
     if (rxMatch.hasMatch()) {
         QString decimalGroup = rxMatch.captured(1);

--- a/src/Mod/TechDraw/App/DrawGeomHatch.cpp
+++ b/src/Mod/TechDraw/App/DrawGeomHatch.cpp
@@ -320,7 +320,8 @@ std::vector<LineSet> DrawGeomHatch::getTrimmedLines(DrawViewPart* source,
 
     for (auto& ls: lineSets) {
         PATLineSpec hl = ls.getPATLineSpec();
-        std::vector<TopoDS_Edge> candidates = DrawGeomHatch::makeEdgeOverlay(hl, bBox, scale);   //completely cover face bbox with lines
+        //completely cover face bbox with lines
+        std::vector<TopoDS_Edge> candidates = DrawGeomHatch::makeEdgeOverlay(hl, bBox, scale);
 
         //make Compound for this linespec
         BRep_Builder builder;
@@ -453,7 +454,8 @@ std::vector<TopoDS_Edge> DrawGeomHatch::makeEdgeOverlay(PATLineSpec hl, Bnd_Box 
     } else if (angle > 0) {      //oblique  (bottom left -> top right)
         //ex: 60, 0,0, 0,4.0, 25, -25
 //        Base::Console().Message("TRACE - DGH-makeEdgeOverlay - making angle > 0\n");
-        double xLeftAtom = origin.x + (minY - origin.y)/slope;                  //the "atom" is the fill line that passes through the
+        //the "atom" is the fill line that passes through the
+        double xLeftAtom = origin.x + (minY - origin.y)/slope;
                                                                                 //pattern-origin (not necc. R2 origin)
         double xRightAtom = origin.x + (maxY - origin.y)/slope;
         int repeatRight = (int) fabs((maxX - xLeftAtom)/interval);
@@ -473,10 +475,14 @@ std::vector<TopoDS_Edge> DrawGeomHatch::makeEdgeOverlay(PATLineSpec hl, Bnd_Box 
     } else {    //oblique (bottom right -> top left)
         // ex: -60, 0,0, 0,4.0, 25.0, -12.5, 12.5, -6
 //        Base::Console().Message("TRACE - DGH-makeEdgeOverlay - making angle < 0\n");
-        double xRightAtom = origin.x + ((minY - origin.y)/slope);         //x-coord of left end of Atom line
-        double xLeftAtom = origin.x + ((maxY - origin.y)/slope);          //x-coord of right end of Atom line
-        int repeatRight = (int) fabs((maxX - xLeftAtom)/interval);        //number of lines to Right of Atom
-        int repeatLeft  = (int) fabs((xRightAtom - minX)/interval);       //number of lines to Left of Atom
+        //x-coord of left end of Atom line
+        double xRightAtom = origin.x + ((minY - origin.y)/slope);
+        //x-coord of right end of Atom line
+        double xLeftAtom = origin.x + ((maxY - origin.y)/slope);
+        //number of lines to Right of Atom
+        int repeatRight = (int) fabs((maxX - xLeftAtom)/interval);
+        //number of lines to Left of Atom
+        int repeatLeft  = (int) fabs((xRightAtom - minX)/interval);
         double leftEndX = xLeftAtom - (repeatLeft * interval);
         double leftStartX   = xRightAtom - (repeatLeft * interval);
         int repeatTotal = repeatRight + repeatLeft + 1;
@@ -563,7 +569,8 @@ TopoDS_Face DrawGeomHatch::extractFace(DrawViewPart* source, int iface )
     gp_Pln plane(gOrg, gDir);
 
     BRepBuilderAPI_MakeFace mkFace(plane, faceWires.front(), true);
-    std::vector<TopoDS_Wire>::iterator itWire = ++faceWires.begin();            //starting with second wire
+    //starting with second wire
+    std::vector<TopoDS_Wire>::iterator itWire = ++faceWires.begin();
     for (; itWire != faceWires.end(); itWire++) {
         mkFace.Add(*itWire);
     }

--- a/src/Mod/TechDraw/App/DrawGeomHatch.h
+++ b/src/Mod/TechDraw/App/DrawGeomHatch.h
@@ -56,7 +56,8 @@ public:
     DrawGeomHatch();
     ~DrawGeomHatch() = default;
 
-    App::PropertyLinkSub     Source;                                   //the dvX & face(s) this crosshatch belongs to
+    //the dvX & face(s) this crosshatch belongs to
+    App::PropertyLinkSub     Source;
     App::PropertyFile        FilePattern;
     App::PropertyFileIncluded PatIncluded;
     App::PropertyString      NamePattern;

--- a/src/Mod/TechDraw/App/DrawProjGroup.cpp
+++ b/src/Mod/TechDraw/App/DrawProjGroup.cpp
@@ -517,8 +517,10 @@ int DrawProjGroup::removeProjection(const char* viewProjType)
             auto projPtr(dynamic_cast<TechDraw::DrawProjGroupItem*>(it));
             if (projPtr) {
                 if (strcmp(viewProjType, projPtr->Type.getValueAsString()) == 0) {
-                    removeView(projPtr);                                 // Remove from collection
-                    getDocument()->removeObject(it->getNameInDocument());// Remove from the document
+                    // Remove from collection
+                    removeView(projPtr);
+                    // Remove from the document
+                    getDocument()->removeObject(it->getNameInDocument());
                     return Views.getValues().size();
                 }
             }
@@ -1011,7 +1013,8 @@ void DrawProjGroup::makeViewBbs(std::array<DrawProjGroupItem*, MAXPROJECTIONCOUN
             bboxes[i] = viewPtrs[i]->getBoundingBox();
             if (!scaled) {
                 double scale = 1.0 / viewPtrs[i]->getScale();//convert bbx to 1:1 scale
-                //                double scale = 1.0 / viewPtrs[i]->getLastScale();    //convert bbx to 1:1 scale
+                //convert bbx to 1:1 scale
+                //                double scale = 1.0 / viewPtrs[i]->getLastScale();
                 bboxes[i].ScaleX(scale);
                 bboxes[i].ScaleY(scale);
                 bboxes[i].ScaleZ(scale);

--- a/src/Mod/TechDraw/App/DrawProjGroupItem.cpp
+++ b/src/Mod/TechDraw/App/DrawProjGroupItem.cpp
@@ -325,7 +325,8 @@ double DrawProjGroupItem::getScale(void) const
     if (pgroup) {
         result = pgroup->getScale();
         if (!(result > 0.0)) {
-            result = 1.0;                                   //kludgy protective fix. autoscale sometimes serves up 0.0!
+            //kludgy protective fix. autoscale sometimes serves up 0.0!
+            result = 1.0;
         }
     }
     return result;
@@ -347,7 +348,8 @@ void DrawProjGroupItem::unsetupObject()
          !getPGroup()->isUnsetting() )         {
            Base::Console().Warning("Warning - DPG (%s/%s) may be corrupt - Anchor deleted\n",
                                    getPGroup()->getNameInDocument(), getPGroup()->Label.getValue());
-           getPGroup()->Anchor.setValue(nullptr);    //this catches situation where DPGI is deleted w/o DPG::removeProjection
+           //this catches situation where DPGI is deleted w/o DPG::removeProjection
+           getPGroup()->Anchor.setValue(nullptr);
     }
 
     DrawViewPart::unsetupObject();

--- a/src/Mod/TechDraw/App/DrawProjGroupItem.h
+++ b/src/Mod/TechDraw/App/DrawProjGroupItem.h
@@ -91,7 +91,8 @@ public:
 
     //DPGI always fits on page since DPG handles scaling
     bool checkFit() const override { return true; }
-    bool checkFit(DrawPage* page) const override { (void) page;         //avoid unused variable warning
+    //avoid unused variable warning
+    bool checkFit(DrawPage* page) const override { (void) page;
                                                    return true; }
 
     int countParentPages() const override;

--- a/src/Mod/TechDraw/App/DrawProjectSplit.cpp
+++ b/src/Mod/TechDraw/App/DrawProjectSplit.cpp
@@ -232,12 +232,15 @@ bool DrawProjectSplit::isOnEdge(TopoDS_Edge e, TopoDS_Vertex v, double& param, b
                 Base::Console().Error("DPS::isOnEdge - simpleMinDist failed: %.3f\n", dist);
                 result = false;
             } else if (dist < Precision::Confusion()) {
-                const gp_Pnt pt = BRep_Tool::Pnt(v);                         //have to duplicate method 3 to get param
+                //have to duplicate method 3 to get param
+                const gp_Pnt pt = BRep_Tool::Pnt(v);
                 BRepAdaptor_Curve adapt(e);
                 const Handle(Geom_Curve) c = adapt.Curve().Curve();
-                double maxDist = 0.000001;     //magic number.  less than this gives false positives.
+                //magic number.  less than this gives false positives.
+                double maxDist = 0.000001;
                 //bool found =
-                (void) GeomLib_Tool::Parameter(c, pt, maxDist, param);  //already know point it on curve
+                //already know point it on curve
+                (void) GeomLib_Tool::Parameter(c, pt, maxDist, param);
                 result = true;
             }
             if (result) {

--- a/src/Mod/TechDraw/App/DrawUtil.cpp
+++ b/src/Mod/TechDraw/App/DrawUtil.cpp
@@ -784,7 +784,8 @@ double DrawUtil::sensibleScale(double working_scale)
     //which gives the largest scale for which the min_space requirements can be met, but we want a 'sensible' scale, rather than 0.28457239...
     //eg if working_scale = 0.115, then we want to use 0.1, similarly 7.65 -> 5, and 76.5 -> 50
 
-    float exponent = std::floor(std::log10(working_scale));//if working_scale = a * 10^b, what is b?
+    //if working_scale = a * 10^b, what is b?
+    float exponent = std::floor(std::log10(working_scale));
     working_scale *= std::pow(10, -exponent);              //now find what 'a' is.
 
     //int choices = 10;

--- a/src/Mod/TechDraw/App/DrawViewClipPyImp.cpp
+++ b/src/Mod/TechDraw/App/DrawViewClipPyImp.cpp
@@ -48,9 +48,11 @@ PyObject* DrawViewClipPy::addView(PyObject* args)
         return nullptr;
     }
 
-    DrawViewClip* clip = getDrawViewClipPtr();                         //get DrawViewClip for pyClip
+    //get DrawViewClip for pyClip
+    DrawViewClip* clip = getDrawViewClipPtr();
     DrawViewPy* pyView = static_cast<TechDraw::DrawViewPy*>(pcDocObj);
-    DrawView* view = pyView->getDrawViewPtr();                 //get DrawView for pyView
+    //get DrawView for pyView
+    DrawView* view = pyView->getDrawViewPtr();
     clip->addView(view);
 
     Py_Return;
@@ -63,7 +65,8 @@ PyObject* DrawViewClipPy::removeView(PyObject* args)
         return nullptr;
     }
 
-    DrawViewClip* clip = getDrawViewClipPtr();                         //get DrawViewClip for pyClip
+    //get DrawViewClip for pyClip
+    DrawViewClip* clip = getDrawViewClipPtr();
     DrawViewPy* pyView = static_cast<TechDraw::DrawViewPy*>(pcDocObj);
     DrawView* view = pyView->getDrawViewPtr();                 //get DrawView for pyView
     clip->removeView(view);

--- a/src/Mod/TechDraw/App/DrawViewDetail.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDetail.cpp
@@ -225,7 +225,8 @@ void DrawViewDetail::makeDetailShape(TopoDS_Shape& shape, DrawViewPart* dvp, Dra
 
 
     m_viewAxis = dvp->getProjectionCS(shapeCenter);//save the CS for later
-    Base::Vector3d anchor = AnchorPoint.getValue();//this is a 2D point in base view local coords
+    //this is a 2D point in base view local coords
+    Base::Vector3d anchor = AnchorPoint.getValue();
     //    double baseRotationRad = dvp->Rotation.getValue() * M_PI / 180.0;
     //    anchor.RotateZ(baseRotationRad);
 
@@ -237,7 +238,8 @@ void DrawViewDetail::makeDetailShape(TopoDS_Shape& shape, DrawViewPart* dvp, Dra
     BRepBndLib::AddOptimal(copyShape, bbxSource);
     double diag = sqrt(bbxSource.SquareExtent());
 
-    Base::Vector3d toolPlaneOrigin = anchor + dirDetail * diag * -1.0;//center tool about anchor
+    //center tool about anchor
+    Base::Vector3d toolPlaneOrigin = anchor + dirDetail * diag * -1.0;
     double extrudeLength = 2.0 * toolPlaneOrigin.Length();
 
     gp_Pnt gpnt(toolPlaneOrigin.x, toolPlaneOrigin.y, toolPlaneOrigin.z);

--- a/src/Mod/TechDraw/App/DrawViewDimExtent.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDimExtent.cpp
@@ -46,8 +46,10 @@ PROPERTY_SOURCE(TechDraw::DrawViewDimExtent, TechDraw::DrawViewDimension)
 
 DrawViewDimExtent::DrawViewDimExtent(void)
 {
-    App::PropertyLinkSubList       Source;                       //DrawViewPart & SubElements(Edges)
-    App::PropertyLinkSubList       Source3d;                     //Part::Feature(s) & SubElements
+    //DrawViewPart & SubElements(Edges)
+    App::PropertyLinkSubList       Source;
+    //Part::Feature(s) & SubElements
+    App::PropertyLinkSubList       Source3d;
 
     ADD_PROPERTY_TYPE(Source, (nullptr, nullptr), "", (App::PropertyType)(App::Prop_Output), "View containing the  dimension");
     Source.setScope(App::LinkScope::Global);

--- a/src/Mod/TechDraw/App/DrawViewDimExtent.h
+++ b/src/Mod/TechDraw/App/DrawViewDimExtent.h
@@ -43,11 +43,15 @@ public:
     DrawViewDimExtent();
     ~DrawViewDimExtent() = default;
 
-    App::PropertyLinkSubList       Source;                       //DrawViewPart & SubElements(Edges)
+    //DrawViewPart & SubElements(Edges)
+    App::PropertyLinkSubList       Source;
                                                                  //Cosmetic End points are stored in DVD::References2d
-    App::PropertyLinkSubList       Source3d;                     //Part::Feature & SubElements  TBI
-    App::PropertyInteger           DirExtent;                    //Horizontal, Vertical, TBD
-    App::PropertyStringList        CosmeticTags;                 //id of cosmetic end points.  obsolete!
+    //Part::Feature & SubElements  TBI
+    App::PropertyLinkSubList       Source3d;
+    //Horizontal, Vertical, TBD
+    App::PropertyInteger           DirExtent;
+    //id of cosmetic end points.  obsolete!
+    App::PropertyStringList        CosmeticTags;
 
     App::DocumentObjectExecReturn *execute() override;
 

--- a/src/Mod/TechDraw/App/DrawViewDimension.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDimension.cpp
@@ -547,7 +547,8 @@ double DrawViewDimension::getDimValue()
         else if (Type.isValue("Radius")) {
             arcPoints pts = m_arcPoints;
             result =
-                pts.radius / getViewPart()->getScale();//Projected BaseGeom is scaled for drawing
+                //Projected BaseGeom is scaled for drawing
+                pts.radius / getViewPart()->getScale();
         }
         else if (Type.isValue("Diameter")) {
             arcPoints pts = m_arcPoints;
@@ -789,9 +790,11 @@ arcPoints DrawViewDimension::arcPointsFromBaseGeom(TechDraw::BaseGeomPtr base)
         else {
             pts.isArc = false;
             pts.onCurve.first(pts.center
-                              + Base::Vector3d(1, 0, 0) * circle->radius);//arbitrary point on edge
+                              //arbitrary point on edge
+                              + Base::Vector3d(1, 0, 0) * circle->radius);
             pts.onCurve.second(
-                pts.center + Base::Vector3d(-1, 0, 0) * circle->radius);//arbitrary point on edge
+                //arbitrary point on edge
+                pts.center + Base::Vector3d(-1, 0, 0) * circle->radius);
         }
     }
     else if ((base && base->getGeomType() == TechDraw::GeomType::ELLIPSE)
@@ -804,9 +807,11 @@ arcPoints DrawViewDimension::arcPointsFromBaseGeom(TechDraw::BaseGeomPtr base)
             pts.center = Base::Vector3d(ellipse->center.x, ellipse->center.y, 0.0);
             pts.radius = rAvg;
             pts.isArc = false;
-            pts.onCurve.first(pts.center + Base::Vector3d(1, 0, 0) * rAvg);//arbitrary point on edge
+            //arbitrary point on edge
+            pts.onCurve.first(pts.center + Base::Vector3d(1, 0, 0) * rAvg);
             pts.onCurve.second(pts.center
-                               + Base::Vector3d(-1, 0, 0) * rAvg);//arbitrary point on edge
+                               //arbitrary point on edge
+                               + Base::Vector3d(-1, 0, 0) * rAvg);
         }
         else {
             TechDraw::AOEPtr aoe = std::static_pointer_cast<TechDraw::AOE>(base);
@@ -823,7 +828,8 @@ arcPoints DrawViewDimension::arcPointsFromBaseGeom(TechDraw::BaseGeomPtr base)
             pts.onCurve.first(Base::Vector3d(aoe->midPnt.x, aoe->midPnt.y, 0.0));//for radius
             //            pts.onCurve.first(pts.center + Base::Vector3d(1, 0,0) * rAvg);   //for diameter
             pts.onCurve.second(pts.center
-                               + Base::Vector3d(-1, 0, 0) * rAvg);//arbitrary point on edge
+                               //arbitrary point on edge
+                               + Base::Vector3d(-1, 0, 0) * rAvg);
         }
     }
     else if (base && base->getGeomType() == TechDraw::GeomType::BSPLINE) {
@@ -846,9 +852,11 @@ arcPoints DrawViewDimension::arcPointsFromBaseGeom(TechDraw::BaseGeomPtr base)
             }
             else {
                 pts.onCurve.first(pts.center
-                                  + Base::Vector3d(1, 0, 0) * rad);//arbitrary point on edge
+                                  //arbitrary point on edge
+                                  + Base::Vector3d(1, 0, 0) * rad);
                 pts.onCurve.second(pts.center
-                                   + Base::Vector3d(-1, 0, 0) * rad);//arbitrary point on edge
+                                   //arbitrary point on edge
+                                   + Base::Vector3d(-1, 0, 0) * rad);
             }
         }
         else {
@@ -899,9 +907,11 @@ arcPoints DrawViewDimension::arcPointsFromEdge(TopoDS_Edge occEdge)
         else {
             //full circle
             pts.onCurve.first(pts.center
-                              + Base::Vector3d(1, 0, 0) * pts.radius);//arbitrary point on edge
+                              //arbitrary point on edge
+                              + Base::Vector3d(1, 0, 0) * pts.radius);
             pts.onCurve.second(pts.center
-                               + Base::Vector3d(-1, 0, 0) * pts.radius);//arbitrary point on edge
+                               //arbitrary point on edge
+                               + Base::Vector3d(-1, 0, 0) * pts.radius);
         }
     }
     else if (adapt.GetType() == GeomAbs_Ellipse) {
@@ -919,9 +929,11 @@ arcPoints DrawViewDimension::arcPointsFromEdge(TopoDS_Edge occEdge)
         else {
             //full ellipse
             pts.onCurve.first(pts.center
-                              + Base::Vector3d(1, 0, 0) * pts.radius);//arbitrary point on edge
+                              //arbitrary point on edge
+                              + Base::Vector3d(1, 0, 0) * pts.radius);
             pts.onCurve.second(pts.center
-                               + Base::Vector3d(-1, 0, 0) * pts.radius);//arbitrary point on edge
+                               //arbitrary point on edge
+                               + Base::Vector3d(-1, 0, 0) * pts.radius);
         }
     }
     else if (adapt.GetType() == GeomAbs_BSplineCurve) {
@@ -948,9 +960,11 @@ arcPoints DrawViewDimension::arcPointsFromEdge(TopoDS_Edge occEdge)
             else {
                 //full circle
                 pts.onCurve.first(pts.center
-                                  + Base::Vector3d(1, 0, 0) * pts.radius);//arbitrary point on edge
+                                  //arbitrary point on edge
+                                  + Base::Vector3d(1, 0, 0) * pts.radius);
                 pts.onCurve.second(
-                    pts.center + Base::Vector3d(-1, 0, 0) * pts.radius);//arbitrary point on edge
+                    //arbitrary point on edge
+                    pts.center + Base::Vector3d(-1, 0, 0) * pts.radius);
             }
         }
         else {

--- a/src/Mod/TechDraw/App/DrawViewDimension.h
+++ b/src/Mod/TechDraw/App/DrawViewDimension.h
@@ -71,7 +71,8 @@ enum DimensionType {
     App::PropertyEnumeration        MeasureType;           //True/Projected
     App::PropertyLinkSubList        References2D;          //Points to Projection SubFeatures
     App::PropertyLinkSubList        References3D;          //Points to 3D Geometry SubFeatures
-    App::PropertyEnumeration        Type;                  //DistanceX, DistanceY, Diameter, etc.
+    //DistanceX, DistanceY, Diameter, etc.
+    App::PropertyEnumeration        Type;
 
     App::PropertyBool               TheoreticalExact;
     App::PropertyBool               Inverted;
@@ -130,7 +131,8 @@ enum DimensionType {
     virtual DrawViewPart* getViewPart() const;
     QRectF getRect() const override { return {0, 0, 1, 1}; }          //pretend dimensions always fit!
     virtual int getRefType() const;             //Vertex-Vertex, Edge, Edge-Edge
-    static int getRefTypeSubElements(const std::vector<std::string> &);             //Vertex-Vertex, Edge, Edge-Edge
+    //Vertex-Vertex, Edge, Edge-Edge
+    static int getRefTypeSubElements(const std::vector<std::string> &);
 
     void setReferences2d(ReferenceVector refs);
     void setReferences3d(ReferenceVector refs);

--- a/src/Mod/TechDraw/App/DrawViewSection.cpp
+++ b/src/Mod/TechDraw/App/DrawViewSection.cpp
@@ -141,7 +141,8 @@ DrawViewSection::DrawViewSection() : m_waitingForCut(false), m_shapeSize(0.0)
                       "2D View source for this Section");
     BaseView.setScope(App::LinkScope::Global);
     ADD_PROPERTY_TYPE(SectionNormal, (0, 0, 1.0), sgroup, App::Prop_None,
-                      "Section Plane normal direction");//direction of extrusion of cutting prism
+                      //direction of extrusion of cutting prism
+                      "Section Plane normal direction");
     ADD_PROPERTY_TYPE(SectionOrigin, (0, 0, 0), sgroup, App::Prop_None, "Section Plane Origin");
 
     //TODO: SectionDirection is a legacy from when SectionViews were only available along
@@ -578,7 +579,8 @@ void DrawViewSection::postHlrTasks(void)
     if (dvp) {
         dvp->requestPaint();//to refresh section line
     }
-    requestPaint();//this will be a duplicate paint if we are making a standalone ComplexSection
+    //this will be a duplicate paint if we are making a standalone ComplexSection
+    requestPaint();
 }
 
 //activities that depend on a valid section cut

--- a/src/Mod/TechDraw/App/EdgeWalker.cpp
+++ b/src/Mod/TechDraw/App/EdgeWalker.cpp
@@ -206,7 +206,8 @@ std::vector<TopoDS_Wire> EdgeWalker::getResultWires()
             TopoDS_Edge e = m_saveInEdges.at((*iEdge).idx);
             topoEdges.push_back(e);
         }
-    TopoDS_Wire w = makeCleanWire(topoEdges, EWTOLERANCE);             //make 1 clean wire from its edges
+    //make 1 clean wire from its edges
+    TopoDS_Wire w = makeCleanWire(topoEdges, EWTOLERANCE);
     fw.push_back(w);
     }
     return fw;
@@ -231,7 +232,8 @@ std::vector<TopoDS_Wire> EdgeWalker::getResultNoDups()
             TopoDS_Edge e = m_saveInEdges.at((*iEdge).idx);
             topoEdges.push_back(e);
         }
-        TopoDS_Wire w = makeCleanWire(topoEdges, EWTOLERANCE);             //make 1 clean wire from its edges
+        //make 1 clean wire from its edges
+        TopoDS_Wire w = makeCleanWire(topoEdges, EWTOLERANCE);
         fw.push_back(w);
     }
     return fw;
@@ -349,7 +351,8 @@ size_t EdgeWalker::findUniqueVert(TopoDS_Vertex vx, std::vector<TopoDS_Vertex> &
 
 std::vector<TopoDS_Wire> EdgeWalker::sortStrip(std::vector<TopoDS_Wire> fw, bool includeBiggest)
 {
-    std::vector<TopoDS_Wire> closedWires;                  //all the wires should be closed, but anomalies happen
+    //all the wires should be closed, but anomalies happen
+    std::vector<TopoDS_Wire> closedWires;
     for (auto& w: fw) {
         if (!w.IsNull() && BRep_Tool::IsClosed(w)) {
             closedWires.push_back(w);
@@ -400,7 +403,8 @@ std::vector<embedItem> EdgeWalker::makeEmbedding(const std::vector<TopoDS_Edge> 
     //for each vertex v
     //  find all the edges that have v as first or last vertex
     for (auto& v: uniqueVList) {
-        TopoDS_Vertex cv = v;               //v is const but we need non-const for vertexEqual
+        //v is const but we need non-const for vertexEqual
+        TopoDS_Vertex cv = v;
         std::size_t iEdge = 0;
         std::vector<incidenceItem> iiList;
         for (auto& e: edges) {

--- a/src/Mod/TechDraw/App/Geometry.cpp
+++ b/src/Mod/TechDraw/App/Geometry.cpp
@@ -1206,11 +1206,13 @@ BSpline::BSpline(const TopoDS_Edge &e)
          endAngle += 2.0 * M_PI;
     }
 
-    Standard_Real tol3D = 0.001;                                   //1/1000 of a mm? screen can't resolve this
+    //1/1000 of a mm? screen can't resolve this
+    Standard_Real tol3D = 0.001;
     Standard_Integer maxDegree = 3, maxSegment = 200;
     Handle(BRepAdaptor_HCurve) hCurve = new BRepAdaptor_HCurve(c);
     // approximate the curve using a tolerance
-    //Approx_Curve3d approx(hCurve, tol3D, GeomAbs_C2, maxSegment, maxDegree);   //gives degree == 5  ==> too many poles ==> buffer overrun
+    //gives degree == 5  ==> too many poles ==> buffer overrun
+    //Approx_Curve3d approx(hCurve, tol3D, GeomAbs_C2, maxSegment, maxDegree);
     Approx_Curve3d approx(hCurve, tol3D, GeomAbs_C0, maxSegment, maxDegree);
     if (approx.IsDone() && approx.HasResult()) {
         spline = approx.Curve();

--- a/src/Mod/TechDraw/App/Geometry.h
+++ b/src/Mod/TechDraw/App/Geometry.h
@@ -213,7 +213,8 @@ class TechDrawExport AOE: public Ellipse
         ~AOE() override = default;
 
     public:
-        Base::Vector3d startPnt;  //TODO: The points are used for drawing, the angles for bounding box calcs - seems redundant
+        //TODO: The points are used for drawing, the angles for bounding box calcs - seems redundant
+        Base::Vector3d startPnt;
         Base::Vector3d endPnt;
         Base::Vector3d midPnt;
 

--- a/src/Mod/TechDraw/App/HatchLine.cpp
+++ b/src/Mod/TechDraw/App/HatchLine.cpp
@@ -163,11 +163,13 @@ Base::Vector3d LineSet::getPatternStartPoint(TechDraw::BaseGeomPtr g, double &of
 
 //figure out which line this is in the overlay
     if (angle == 0.0) {      //odd case - horizontal line
-        distY = (thisStart.y - atomStart.y);                                       //this is patternscaled
+        //this is patternscaled
+        distY = (thisStart.y - atomStart.y);
         overlayIndex = (int) round(distY/(scale * getIntervalY()));                //this is +/-
         lineOrigin = getOrigin() + distY * Base::Vector3d(0.0, 1.0, 0.0);                    //move u/d
     } else {
-        distX = (thisStart.x - atomStart.x);                                       //this is patternscaled
+        //this is patternscaled
+        distX = (thisStart.x - atomStart.x);
         overlayIndex = (int) round(distX/(scale * getIntervalX()));
         lineOrigin = getOrigin() + overlayIndex * (scale * getInterval()) * getUnitOrtho();
     }
@@ -190,7 +192,8 @@ Base::Vector3d LineSet::getPatternStartPoint(TechDraw::BaseGeomPtr g, double &of
         offset = 0.0;
     } else {
         //find a point where pattern repeats within g
-        double patsStartOrg = lenStartOrg/patternLength;                   //# pattern repeats from lineOrigin to start
+        //# pattern repeats from lineOrigin to start
+        double patsStartOrg = lenStartOrg/patternLength;
         double patsEndOrg = lenEndOrg/patternLength;
         if (lenStartOrg < lenEndOrg) {                                  //origin is before start
             double c = ceil(patsStartOrg);
@@ -200,7 +203,8 @@ Base::Vector3d LineSet::getPatternStartPoint(TechDraw::BaseGeomPtr g, double &of
             } else {
 //                //ugly case - partial pattern
                 result = gStart;
-                offset = patsStartOrg - (int)patsStartOrg;        //fraction of a patternLength
+                //fraction of a patternLength
+                offset = patsStartOrg - (int)patsStartOrg;
                 offset = offset * patternLength;
             }
         } else if (lenStartOrg > lenEndOrg) {                          //origin is after end
@@ -210,7 +214,8 @@ Base::Vector3d LineSet::getPatternStartPoint(TechDraw::BaseGeomPtr g, double &of
                 offset = 0.0;
             } else {
                 result = gStart;
-                offset = ceil(patsStartOrg) - patsStartOrg;      //fraction of a patternLength patstartorg to repeat point
+                //fraction of a patternLength patstartorg to repeat point
+                offset = ceil(patsStartOrg) - patsStartOrg;
                 offset = offset * patternLength;
             }
         }
@@ -483,8 +488,3 @@ void DashSpec::dump(const char* title)
     }
     Base::Console().Message("DUMP - DashSpec - %s\n", ss.str().c_str());
 }
-
-
-
-
-

--- a/src/Mod/TechDraw/App/HatchLine.h
+++ b/src/Mod/TechDraw/App/HatchLine.h
@@ -137,7 +137,8 @@ public:
     DashSpec          getDashSpec() { return m_hatchLine.getDashParms();}
     Base::Vector3d    calcApparentStart(TechDraw::BaseGeomPtr g);
     Base::Vector3d    findAtomStart();
-    Base::Vector3d    getLineOrigin();                              //point corresponding to pattern origin for this line (O + n*intervalX)
+    //point corresponding to pattern origin for this line (O + n*intervalX)
+    Base::Vector3d    getLineOrigin();
     Base::Vector3d    getPatternStartPoint(TechDraw::BaseGeomPtr g, double &offset, double scale = 1.0);
 
     Bnd_Box getBBox() {return m_box;}

--- a/src/Mod/TechDraw/App/ProjectionAlgos.h
+++ b/src/Mod/TechDraw/App/ProjectionAlgos.h
@@ -64,7 +64,8 @@ public:
                        XmlAttributes H_style=XmlAttributes(),
                        XmlAttributes H0_style=XmlAttributes(),
                        XmlAttributes H1_style=XmlAttributes());
-    std::string getDXF(ExtractionType type, double scale, double tolerance);//added by Dan Falck 2011/09/25
+    //added by Dan Falck 2011/09/25
+    std::string getDXF(ExtractionType type, double scale, double tolerance);
 
 
     const TopoDS_Shape &Input;

--- a/src/Mod/TechDraw/App/ShapeExtractor.cpp
+++ b/src/Mod/TechDraw/App/ShapeExtractor.cpp
@@ -156,12 +156,14 @@ std::vector<TopoDS_Shape> ShapeExtractor::getXShapes(const App::Link* xLink)
 
     bool needsTransform = false;
     std::vector<App::DocumentObject*> children = xLink->getLinkedChildren();
-    Base::Placement linkPlm;  // default constructor is an identity placement, i.e. no rotation nor translation
+    // default constructor is an identity placement, i.e. no rotation nor translation
+    Base::Placement linkPlm;
     if (xLink->hasPlacement()) {
         linkPlm = xLink->getLinkPlacementProperty()->getValue();
         needsTransform = true;
     }
-    Base::Matrix4D linkScale;  // default constructor is an identity matrix, possibly scale it with link's scale
+    // default constructor is an identity matrix, possibly scale it with link's scale
+    Base::Matrix4D linkScale;
     if(xLink->getScaleProperty() || xLink->getScaleVectorProperty()) {
         linkScale.scale(xLink->getScaleVector());
         needsTransform = true;
@@ -421,4 +423,3 @@ bool ShapeExtractor::prefAdd2d()
     bool result = hGrp->GetBool("ShowLoose2d", false);
     return result;
 }
-

--- a/src/Mod/TechDraw/App/TechDrawExport.cpp
+++ b/src/Mod/TechDraw/App/TechDrawExport.cpp
@@ -221,7 +221,8 @@ void SVGOutput::printCircle(const BRepAdaptor_Curve& c, std::ostream& out)
         // See also https://developer.mozilla.org/en/SVG/Tutorial/Paths
         char xar = '0'; // x-axis-rotation
         char las = (l-f > M_PI) ? '1' : '0'; // large-arc-flag
-        char swp = (a < 0) ? '1' : '0'; // sweep-flag, i.e. clockwise (0) or counter-clockwise (1)
+        // sweep-flag, i.e. clockwise (0) or counter-clockwise (1)
+        char swp = (a < 0) ? '1' : '0';
         out << "<path d=\"M" << s.X() <<  " " << s.Y()
             << " A" << r << " " << r << " "
             << xar << " " << las << " " << swp << " "
@@ -268,7 +269,8 @@ void SVGOutput::printEllipse(const BRepAdaptor_Curve& c, int id, std::ostream& o
     // arc of ellipse
     else {
         char las = (l-f > M_PI) ? '1' : '0'; // large-arc-flag
-        char swp = (a < 0) ? '1' : '0'; // sweep-flag, i.e. clockwise (0) or counter-clockwise (1)
+        // sweep-flag, i.e. clockwise (0) or counter-clockwise (1)
+        char swp = (a < 0) ? '1' : '0';
         out << "<path d=\"M" << s.X() <<  " " << s.Y()
             << " A" << r1 << " " << r2 << " "
             << angle << " " << las << " " << swp << " "
@@ -522,7 +524,8 @@ void DXFOutput::printCircle(const BRepAdaptor_Curve& c, std::ostream& out)
         // See also https://developer.mozilla.org/en/SVG/Tutorial/Paths
         /*char xar = '0'; // x-axis-rotation
         char las = (l-f > M_PI) ? '1' : '0'; // large-arc-flag
-        char swp = (a < 0) ? '1' : '0'; // sweep-flag, i.e. clockwise (0) or counter-clockwise (1)
+        // sweep-flag, i.e. clockwise (0) or counter-clockwise (1)
+        char swp = (a < 0) ? '1' : '0';
         out << "<path d=\"M" << s.X() <<  " " << s.Y()
             << " A" << r << " " << r << " "
             << xar << " " << las << " " << swp << " "
@@ -584,7 +587,8 @@ void DXFOutput::printEllipse(const BRepAdaptor_Curve& c, int /*id*/, std::ostrea
         Standard_Real angle = xaxis.Angle(gp_Dir(1, 0,0));
         angle = Base::toDegrees<double>(angle);
         char las = (l-f > D_PI) ? '1' : '0'; // large-arc-flag
-        char swp = (a < 0) ? '1' : '0'; // sweep-flag, i.e. clockwise (0) or counter-clockwise (1)
+        // sweep-flag, i.e. clockwise (0) or counter-clockwise (1)
+        char swp = (a < 0) ? '1' : '0';
         out << "<path d=\"M" << s.X() <<  " " << s.Y()
             << " A" << r1 << " " << r2 << " "
             << angle << " " << las << " " << swp << " "

--- a/src/Mod/TechDraw/Gui/DimensionValidators.h
+++ b/src/Mod/TechDraw/Gui/DimensionValidators.h
@@ -37,7 +37,8 @@ using StringVector = std::vector<std::string>;
 using GeomCount = std::pair<std::string, int>;           //geometry descriptor ("Edge") + counter pair
 using GeomCountVector = std::vector<GeomCount>;
 using GeomCountMap = std::map<std::string, int>;
-using GeometrySet = std::unordered_set<std::string>;    //queryable unique set of geometrty descriptors
+//queryable unique set of geometrty descriptors
+using GeometrySet = std::unordered_set<std::string>;
 
 using DimensionGeometryType = int;
 
@@ -68,12 +69,14 @@ DimensionGeometryType validateDimSelection(
     ReferenceVector references,
     StringVector acceptableGeometry,//"Edge", "Vertex", etc
     std::vector<int> minimumCounts, //how many of each geometry are needed for a good dimension
-    std::vector<DimensionGeometryType> acceptableDimensionGeometrys);//isVertical, isHorizontal, ...
+    //isVertical, isHorizontal, ...
+    std::vector<DimensionGeometryType> acceptableDimensionGeometrys);
 DimensionGeometryType validateDimSelection3d(
     DrawViewPart* dvp, ReferenceVector references,
     StringVector acceptableGeometry,//"Edge", "Vertex", etc
     std::vector<int> minimumCounts, //how many of each geometry are needed for a good dimension
-    std::vector<DimensionGeometryType> acceptableDimensionGeometrys);//isVertical, isHorizontal, ...
+    //isVertical, isHorizontal, ...
+    std::vector<DimensionGeometryType> acceptableDimensionGeometrys);
 
 bool validateSubnameList(StringVector subNames, GeometrySet acceptableGeometrySet);
 
@@ -99,4 +102,3 @@ long int mapGeometryTypeToDimType(long int dimType, DimensionGeometryType geomet
                                                  DimensionGeometryType geometry3d);
 }
 #endif //TECHDRAW_DIMENSIONVALIDATORS_H
-

--- a/src/Mod/TechDraw/Gui/MDIViewPage.cpp
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.cpp
@@ -797,7 +797,8 @@ void MDIViewPage::preSelectionChanged(const QPoint& pos)
     }
     else if (face) {
         ss << "Face"
-           << face->getProjIndex();//TODO: SectionFaces have ProjIndex = -1. (but aren't selectable?) Problem?
+           //TODO: SectionFaces have ProjIndex = -1. (but aren't selectable?) Problem?
+           << face->getProjIndex();
         //bool accepted =
         static_cast<void>(Gui::Selection().setPreselect(viewObj->getDocument()->getName(),
                                                         viewObj->getNameInDocument(),
@@ -901,7 +902,8 @@ void MDIViewPage::sceneSelectionManager()
     QList<QGraphicsItem*> sceneSel = m_scene->selectedItems();
 
     if (sceneSel.isEmpty()) {
-        m_qgSceneSelected.clear();//TODO: need to signal somebody?  Tree? handled elsewhere
+        //TODO: need to signal somebody?  Tree? handled elsewhere
+        m_qgSceneSelected.clear();
         //clearSelection
         return;
     }
@@ -965,7 +967,8 @@ void MDIViewPage::sceneSelectionChanged()
 void MDIViewPage::setTreeToSceneSelect()
 {
     //    Base::Console().Message("MDIVP::setTreeToSceneSelect()\n");
-    bool saveBlock = blockSelection(true);// block selectionChanged signal from Tree/Observer
+    // block selectionChanged signal from Tree/Observer
+    bool saveBlock = blockSelection(true);
     blockSceneSelection(true);
     Gui::Selection().clearSelection();
     QList<QGraphicsItem*> sceneSel = m_qgSceneSelected;

--- a/src/Mod/TechDraw/Gui/QGCustomClip.cpp
+++ b/src/Mod/TechDraw/Gui/QGCustomClip.cpp
@@ -37,7 +37,8 @@ using namespace TechDrawGui;
 
 QGCustomClip::QGCustomClip()
 {
-    setHandlesChildEvents(false);                //not sure if needs to handle events for Views in Group???
+    //not sure if needs to handle events for Views in Group???
+    setHandlesChildEvents(false);
     setCacheMode(QGraphicsItem::NoCache);
     setAcceptHoverEvents(false);
     setFlag(QGraphicsItem::ItemIsSelectable, false);
@@ -107,5 +108,3 @@ void QGCustomClip::makeMark(Base::Vector3d v)
 {
     makeMark(v.x, v.y);
 }
-
-

--- a/src/Mod/TechDraw/Gui/QGCustomText.h
+++ b/src/Mod/TechDraw/Gui/QGCustomText.h
@@ -86,7 +86,8 @@ protected:
     Base::Reference<ParameterGrp> getParmGroup(void);
 
     bool isHighlighted;
-    bool tightBounding;  // Option to use tighter boundingRect(), works only for plaintext QGCustomText
+    // Option to use tighter boundingRect(), works only for plaintext QGCustomText
+    bool tightBounding;
     QColor m_colCurrent;
     QColor m_colNormal;
 

--- a/src/Mod/TechDraw/Gui/QGIArrow.cpp
+++ b/src/Mod/TechDraw/Gui/QGIArrow.cpp
@@ -61,7 +61,8 @@ void QGIArrow::draw() {
         if (m_dirMode) {
             path = makeFilledTriangle(getDirection(), m_size, m_size/6.0);
         } else {
-            path = makeFilledTriangle(m_size, m_size/6.0, isFlipped());     //"arrow l/w sb 3/1" ??
+            //"arrow l/w sb 3/1" ??
+            path = makeFilledTriangle(m_size, m_size/6.0, isFlipped());
         }
     } else if (m_style == ArrowType::OPEN_ARROW) {
         if (m_dirMode) {
@@ -92,7 +93,8 @@ void QGIArrow::draw() {
             path = makePyramid(m_size, isFlipped());
         }
     }else {
-        path = makeFilledTriangle(m_size, m_size/6.0, isFlipped());     //sb a question mark or ???
+        //sb a question mark or ???
+        path = makeFilledTriangle(m_size, m_size/6.0, isFlipped());
     }
     setPath(path);
 }

--- a/src/Mod/TechDraw/Gui/QGIEdge.h
+++ b/src/Mod/TechDraw/Gui/QGIEdge.h
@@ -54,7 +54,8 @@ public:
     double getEdgeFuzz(void) const;
 
 protected:
-    int projIndex;                                                     //index of edge in Projection. must exist.
+    //index of edge in Projection. must exist.
+    int projIndex;
 
     bool isCosmetic;
     bool isHiddenEdge;

--- a/src/Mod/TechDraw/Gui/QGIFace.cpp
+++ b/src/Mod/TechDraw/Gui/QGIFace.cpp
@@ -653,9 +653,11 @@ QPixmap QGIFace::textureFromSvg(std::string fileSpec)
     if (ffi.isReadable()) {
         QSvgRenderer renderer(qs);
         QPixmap pixMap(renderer.defaultSize());
-        pixMap.fill(Qt::white);                                            //try  Qt::transparent?
+        //try  Qt::transparent?
+        pixMap.fill(Qt::white);
         QPainter painter(&pixMap);
-        renderer.render(&painter);                                         //svg texture -> bitmap
+        //svg texture -> bitmap
+        renderer.render(&painter);
         result = pixMap.scaled(m_fillScale, m_fillScale);
     }  //else return empty pixmap
     return result;

--- a/src/Mod/TechDraw/Gui/QGIFace.h
+++ b/src/Mod/TechDraw/Gui/QGIFace.h
@@ -39,7 +39,8 @@ class QGCustomSvg;
 class QGCustomRect;
 class QGCustomImage;
 
-    const double SVGSIZEW = 64.0;                     //width and height of standard FC SVG pattern
+    //width and height of standard FC SVG pattern
+    const double SVGSIZEW = 64.0;
     const double SVGSIZEH = 64.0;
     const std::string SVGCOLDEFAULT = "#000000";
 
@@ -127,7 +128,8 @@ protected:
     QPainterPath dashedPPath(const std::vector<double> dv, const Base::Vector3d start, const Base::Vector3d end);
     double dashRemain(const std::vector<double> dv, const double offset);
     double calcOffset(TechDraw::BaseGeomPtr g, TechDraw::LineSet ls);
-    int projIndex;                              //index of face in Projection. -1 for SectionFace.
+    //index of face in Projection. -1 for SectionFace.
+    int projIndex;
     QGCustomRect* m_svgHatchArea;
 
     QByteArray m_svgXML;

--- a/src/Mod/TechDraw/Gui/QGIPrimPath.cpp
+++ b/src/Mod/TechDraw/Gui/QGIPrimPath.cpp
@@ -255,7 +255,8 @@ Qt::PenCapStyle QGIPrimPath::prefCapStyle()
         .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/TechDraw/General");
     Qt::PenCapStyle result;
     int newStyle;
-    newStyle = hGrp->GetInt("EdgeCapStyle", 32);    //0x00 FlatCap, 0x10 SquareCap, 0x20 RoundCap
+    //0x00 FlatCap, 0x10 SquareCap, 0x20 RoundCap
+    newStyle = hGrp->GetInt("EdgeCapStyle", 32);
     switch (newStyle) {
         case 0:
             result = static_cast<Qt::PenCapStyle>(0x20);   //round;
@@ -334,4 +335,3 @@ void QGIPrimPath::paint ( QPainter * painter, const QStyleOptionGraphicsItem * o
 
     QGraphicsPathItem::paint (painter, &myOption, widget);
 }
-

--- a/src/Mod/TechDraw/Gui/QGIRichAnno.cpp
+++ b/src/Mod/TechDraw/Gui/QGIRichAnno.cpp
@@ -206,7 +206,8 @@ void QGIRichAnno::setTextItem()
 
         QString plainText = QTextDocumentFragment::fromHtml( inHtml ).toPlainText();
         m_text->setPlainText(plainText);
-        setLineSpacing(100);       //this doesn't appear in the generated Svg, but does space the lines!
+        //this doesn't appear in the generated Svg, but does space the lines!
+        setLineSpacing(100);
         m_rect->hide();
         m_rect->update();
     }

--- a/src/Mod/TechDraw/Gui/QGISectionLine.cpp
+++ b/src/Mod/TechDraw/Gui/QGISectionLine.cpp
@@ -56,7 +56,8 @@ QGISectionLine::QGISectionLine() :
     m_symbol = "";
     m_symSize = 0.0;
 
-    m_extLen = 1.5 * Rez::guiX(QGIArrow::getPrefArrowSize());   //is there a standard for this??
+    //is there a standard for this??
+    m_extLen = 1.5 * Rez::guiX(QGIArrow::getPrefArrowSize());
     m_arrowSize = QGIArrow::getPrefArrowSize();
 
     m_line = new QGraphicsPathItem();
@@ -148,7 +149,8 @@ void QGISectionLine::makeArrowsISO()
 
     if (m_arrowMode == SINGLEDIRECTIONMODE) {
         double arrowRotation = getArrowRotation(m_arrowDir);
-        m_arrow1->setRotation(arrowRotation);                   //rotation = 0  ==>  ->  horizontal, pointing right
+        //rotation = 0  ==>  ->  horizontal, pointing right
+        m_arrow1->setRotation(arrowRotation);
         m_arrow2->setRotation(arrowRotation);
     } else {
         double arrowRotation1 = getArrowRotation(m_arrowDir1);
@@ -170,7 +172,8 @@ void QGISectionLine::makeArrowsTrad()
 
     if (m_arrowMode == SINGLEDIRECTIONMODE) {
         double arrowRotation = getArrowRotation(m_arrowDir);
-        m_arrow1->setRotation(arrowRotation);                   //rotation = 0  ==>  ->  horizontal, pointing right
+        //rotation = 0  ==>  ->  horizontal, pointing right
+        m_arrow1->setRotation(arrowRotation);
         m_arrow2->setRotation(arrowRotation);
         m_arrowPos1 = getArrowPosition(m_arrowDir, m_start);
         m_arrow1->setPos(m_arrowPos1);
@@ -402,7 +405,8 @@ double QGISectionLine::getArrowRotation(Base::Vector3d arrowDir)
     if (angle < 0.0) {
         angle = 2 * M_PI + angle;
     }
-    double arrowRotation = 360.0 - angle * (180.0/M_PI);   //convert to Qt rotation (clockwise degrees)
+    //convert to Qt rotation (clockwise degrees)
+    double arrowRotation = 360.0 - angle * (180.0/M_PI);
     return arrowRotation;
 }
 

--- a/src/Mod/TechDraw/Gui/QGISectionLine.h
+++ b/src/Mod/TechDraw/Gui/QGISectionLine.h
@@ -115,7 +115,8 @@ private:
     QPointF            m_beginExt2;     //start of extension line 2
     QPointF            m_endExt2;       //end of extension line 1
     bool               m_pathMode;      //use external path for line
-    int                m_arrowMode;     //0 = 1 direction for both arrows, 1 = direction for each arrow
+    //0 = 1 direction for both arrows, 1 = direction for each arrow
+    int                m_arrowMode;
     Base::Vector3d     m_arrowDir1;
     Base::Vector3d     m_arrowDir2;
     QPointF            m_arrowPos1;

--- a/src/Mod/TechDraw/Gui/QGITile.cpp
+++ b/src/Mod/TechDraw/Gui/QGITile.cpp
@@ -115,11 +115,13 @@ void QGITile::draw()
     } else if (m_row == -1) {    //otherSide
         if (getAltWeld()) {
             if (isTailRight()) {
-                double x = m_origin.x() + (0.5 * totalWidth); //move to right 1/2 tile width
+                //move to right 1/2 tile width
+                double x = m_origin.x() + (0.5 * totalWidth);
                 double y = m_origin.y() +  (m_high * 0.5);    //inverted y!!
                 setPos(x, y);
             } else {
-                double x = m_origin.x() - (0.5 * totalWidth); //move to left 1/2 tile width
+                //move to left 1/2 tile width
+                double x = m_origin.x() - (0.5 * totalWidth);
                 double y = m_origin.y() +  (m_high * 0.5);    //inverted y!!
                 setPos(x, y);
             }
@@ -380,4 +382,3 @@ QRectF QGITile::boundingRect() const
 {
     return childrenBoundingRect();
 }
-

--- a/src/Mod/TechDraw/Gui/QGIView.cpp
+++ b/src/Mod/TechDraw/Gui/QGIView.cpp
@@ -536,7 +536,8 @@ void QGIView::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, Q
 QRectF QGIView::customChildrenBoundingRect() const
 {
     QList<QGraphicsItem*> children = childItems();
-    int dimItemType = QGraphicsItem::UserType + 106;  // TODO: Get magic number from include by name
+    // TODO: Get magic number from include by name
+    int dimItemType = QGraphicsItem::UserType + 106;
     int borderItemType = QGraphicsItem::UserType + 136;  // TODO: Magic number warning
     int labelItemType = QGraphicsItem::UserType + 135;  // TODO: Magic number warning
     int captionItemType = QGraphicsItem::UserType + 180;  // TODO: Magic number warning
@@ -569,7 +570,8 @@ QRectF QGIView::customChildrenBoundingRect() const
 
 QRectF QGIView::boundingRect() const
 {
-    return m_border->rect().adjusted(-2., -2., 2., 2.);     //allow for border line width  //TODO: fiddle brect if border off?
+    //allow for border line width  //TODO: fiddle brect if border off?
+    return m_border->rect().adjusted(-2., -2., 2., 2.);
 }
 
 QGIView* QGIView::getQGIVByName(std::string name)

--- a/src/Mod/TechDraw/Gui/QGIView.h
+++ b/src/Mod/TechDraw/Gui/QGIView.h
@@ -187,7 +187,8 @@ private:
 
     QHash<QString, QGraphicsItem*> alignHash;
     bool m_locked;
-    bool m_innerView;                                                  //View is inside another View
+    //View is inside another View
+    bool m_innerView;
 
     QPen m_pen;
     QBrush m_brush;

--- a/src/Mod/TechDraw/Gui/QGIViewClip.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewClip.cpp
@@ -136,7 +136,8 @@ void QGIViewClip::drawClip()
                 qgiv->show();
             }
         } else {
-            Base::Console().Warning("Logic error? - drawClip() - qgiv for %s not found\n", (*it).c_str());   //gview for feature !exist
+            //gview for feature !exist
+            Base::Console().Warning("Logic error? - drawClip() - qgiv for %s not found\n", (*it).c_str());
         }
     }
 

--- a/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
@@ -509,7 +509,8 @@ QGIViewDimension::QGIViewDimension() : dvDimension(nullptr), hasHover(false), m_
 
     QObject::connect(datumLabel, &QGIDatumLabel::setPretty, this, &QGIViewDimension::onPrettyChanged);
 
-    setZValue(ZVALUE::DIMENSION);//note: this won't paint dimensions over another View if it stacks
+    //note: this won't paint dimensions over another View if it stacks
+    setZValue(ZVALUE::DIMENSION);
                                  //above this Dimension's parent view.   need Layers?
     hideFrame();
 }
@@ -652,7 +653,8 @@ void QGIViewDimension::updateDim()
     }
 
     QString labelText =
-        QString::fromUtf8(dim->getFormattedDimensionValue(1).c_str());// pre value [unit] post
+        // pre value [unit] post
+        QString::fromUtf8(dim->getFormattedDimensionValue(1).c_str());
     if (dim->isMultiValueSchema()) {
         labelText =
             QString::fromUtf8(dim->getFormattedDimensionValue(0).c_str());//don't format multis

--- a/src/Mod/TechDraw/Gui/QGIViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewPart.cpp
@@ -275,7 +275,8 @@ QPainterPath QGIViewPart::geomToPainterPath(BaseGeomPtr baseGeom, double rot)
                         Base::Console().Error(
                             "Bad pole count (%d) for BezierSegment of B-spline geometry\n",
                             it->poles);
-                        path.lineTo(it->pnts[1].x, it->pnts[1].y);//show something for debugging
+                        //show something for debugging
+                        path.lineTo(it->pnts[1].x, it->pnts[1].y);
                     }
                 }
             }
@@ -304,7 +305,8 @@ QPainterPath QGIViewPart::geomToPainterPath(BaseGeomPtr baseGeom, double rot)
                         Base::Console().Error(
                             "Bad pole count (%d) for BezierSegment of B-spline geometry\n",
                             it->poles);
-                        path.lineTo(it->pnts[1].x, it->pnts[1].y);//show something for debugging
+                        //show something for debugging
+                        path.lineTo(it->pnts[1].x, it->pnts[1].y);
                     }
                 }
             }
@@ -818,7 +820,8 @@ void QGIViewPart::drawSectionLine(TechDraw::DrawViewSection* viewSection, bool b
 
         //which way do the arrows point?
         Base::Vector3d arrowDir = viewSection->SectionNormal.getValue();
-        arrowDir = -viewPart->projectPoint(arrowDir);      //arrows point reverse of sectionNormal
+        //arrows point reverse of sectionNormal
+        arrowDir = -viewPart->projectPoint(arrowDir);
         sectionLine->setDirection(arrowDir.x, -arrowDir.y);//3d direction needs Y inversion
 
         if (vp->SectionLineMarks.getValue()) {
@@ -1173,7 +1176,8 @@ void QGIViewPart::toggleCache(bool state)
 {
     QList<QGraphicsItem*> items = childItems();
     for (QList<QGraphicsItem*>::iterator it = items.begin(); it != items.end(); it++) {
-        //(*it)->setCacheMode((state)? DeviceCoordinateCache : NoCache);        //TODO: fiddle cache settings if req'd for performance
+        //TODO: fiddle cache settings if req'd for performance
+        //(*it)->setCacheMode((state)? DeviceCoordinateCache : NoCache);
         Q_UNUSED(state);
         (*it)->setCacheMode(NoCache);
         (*it)->update();
@@ -1300,6 +1304,7 @@ bool QGIViewPart::prefPrintCenters()
                                              .GetGroup("BaseApp")
                                              ->GetGroup("Preferences")
                                              ->GetGroup("Mod/TechDraw/Decorations");
-    bool printCenters = hGrp->GetBool("PrintCenterMarks", false);//true matches v0.18 behaviour
+    //true matches v0.18 behaviour
+    bool printCenters = hGrp->GetBool("PrintCenterMarks", false);
     return printCenters;
 }

--- a/src/Mod/TechDraw/Gui/QGVPage.cpp
+++ b/src/Mod/TechDraw/Gui/QGVPage.cpp
@@ -328,7 +328,8 @@ void QGVPage::drawBackground(QPainter* painter, const QRectF&)
 
     painter->setBrush(*bkgBrush);
     painter->drawRect(
-        viewport()->rect().adjusted(-2, -2, 2, 2));//just bigger than viewport to prevent artifacts
+        //just bigger than viewport to prevent artifacts
+        viewport()->rect().adjusted(-2, -2, 2, 2));
 
     // Default to A3 landscape, though this is currently relevant
     // only for opening corrupt docs, etc.
@@ -357,7 +358,8 @@ void QGVPage::setRenderer(RendererType type)
 
     if (m_renderer == OpenGL) {
 #ifndef QT_NO_OPENGL
-        //        setViewport(new QGLWidget(QGLFormat(QGL::SampleBuffers))); //QGLWidget is obsolete
+        //QGLWidget is obsolete
+        //        setViewport(new QGLWidget(QGLFormat(QGL::SampleBuffers)));
         setViewport(new QOpenGLWidget);
         setViewportUpdateMode(QGraphicsView::SmartViewportUpdate);
 #endif

--- a/src/Mod/TechDraw/Gui/TaskComplexSection.cpp
+++ b/src/Mod/TechDraw/Gui/TaskComplexSection.cpp
@@ -89,7 +89,8 @@ TaskComplexSection::TaskComplexSection(TechDraw::DrawPage* page, TechDraw::DrawV
     saveSectionState();
     setUiPrimary();
 
-    m_applyDeferred = 0;//setting the direction widgets causes an increment of the deferred count,
+    //setting the direction widgets causes an increment of the deferred count,
+    m_applyDeferred = 0;
                         //so we reset the counter and the message.
 }
 
@@ -126,7 +127,8 @@ TaskComplexSection::TaskComplexSection(TechDraw::DrawComplexSection* complexSect
     saveSectionState();
     setUiEdit();
 
-    m_applyDeferred = 0;//setting the direction widgets causes an increment of the deferred count,
+    //setting the direction widgets causes an increment of the deferred count,
+    m_applyDeferred = 0;
                         //so we reset the counter and the message.
     ui->lPendingUpdates->setText(QString());
 }
@@ -163,7 +165,8 @@ void TaskComplexSection::setUiPrimary()
         std::pair<Base::Vector3d, Base::Vector3d> dirs = DrawGuiUtil::get3DDirAndRot();
         m_saveNormal = dirs.first;
         m_saveXDir = dirs.second;
-        m_viewDirectionWidget->setValue(m_saveNormal * -1.0);//this will propagate to m_compass
+        //this will propagate to m_compass
+        m_viewDirectionWidget->setValue(m_saveNormal * -1.0);
     }
 
     //don't allow updates until a direction is picked

--- a/src/Mod/TechDraw/Gui/TaskHatch.cpp
+++ b/src/Mod/TechDraw/Gui/TaskHatch.cpp
@@ -198,7 +198,8 @@ void TaskHatch::createHatch()
     std::string FeatName = doc->getUniqueObjectName("Hatch");
     std::stringstream featLabel;
     featLabel << FeatName << "F" <<
-                    TechDraw::DrawUtil::getIndexFromName(m_subs.at(0)); //use 1st face# for label
+                    //use 1st face# for label
+                    TechDraw::DrawUtil::getIndexFromName(m_subs.at(0));
 
     Command::openCommand(QT_TRANSLATE_NOOP("Command", "Create Hatch"));
 

--- a/src/Mod/TechDraw/Gui/TaskLineDecor.cpp
+++ b/src/Mod/TechDraw/Gui/TaskLineDecor.cpp
@@ -86,7 +86,8 @@ void TaskLineDecor::initUi()
     }
     ui->le_Lines->setText(Base::Tools::fromStdString(temp));
 
-    ui->cb_Style->setCurrentIndex(m_style - 1);          //combobox does not have 0:NoLine choice
+    //combobox does not have 0:NoLine choice
+    ui->cb_Style->setCurrentIndex(m_style - 1);
     ui->cc_Color->setColor(m_color.asValue<QColor>());
     ui->dsb_Weight->setValue(m_weight);
     ui->dsb_Weight->setSingleStep(0.1);

--- a/src/Mod/TechDraw/Gui/TaskRichAnno.cpp
+++ b/src/Mod/TechDraw/Gui/TaskRichAnno.cpp
@@ -425,7 +425,8 @@ QPointF TaskRichAnno::calcTextStartPos(double scale)
             double h = Rez::guiX(m_basePage->getPageHeight() / 2.0);
             return QPointF(w, h);
         } else {
-            Base::Console().Message("TRA::calcStartPos - no m_basePage\n"); //shouldn't happen. caught elsewhere
+            //shouldn't happen. caught elsewhere
+            Base::Console().Message("TRA::calcStartPos - no m_basePage\n");
         }
     }
 

--- a/src/Mod/TechDraw/Gui/TaskSectionView.cpp
+++ b/src/Mod/TechDraw/Gui/TaskSectionView.cpp
@@ -78,7 +78,8 @@ TaskSectionView::TaskSectionView(TechDraw::DrawViewPart* base) :
     ui->setupUi(this);
     setUiPrimary();
 
-    m_applyDeferred = 0;//setting the direction widgets causes an increment of the deferred count,
+    //setting the direction widgets causes an increment of the deferred count,
+    m_applyDeferred = 0;
                         //so we reset the counter and the message.
 }
 
@@ -114,7 +115,8 @@ TaskSectionView::TaskSectionView(TechDraw::DrawViewSection* section) :
     saveSectionState();
     setUiEdit();
 
-    m_applyDeferred = 0;//setting the direction widgets causes an increment of the deferred count,
+    //setting the direction widgets causes an increment of the deferred count,
+    m_applyDeferred = 0;
                         //so we reset the counter and the message.
     ui->lPendingUpdates->setText(QString());
 }

--- a/src/Mod/TechDraw/Gui/ViewProviderPage.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderPage.cpp
@@ -348,7 +348,8 @@ void ViewProviderPage::removeMDIView(void)
             m_graphicsView = nullptr;//will take m_graphicsView with it
             Gui::MDIView* aw =
                 Gui::getMainWindow()
-                    ->activeWindow();//WF: this bit should be in the remove window logic, not here.
+                    //WF: this bit should be in the remove window logic, not here.
+                    ->activeWindow();
             if (aw)
                 aw->showMaximized();
         }

--- a/src/Mod/TechDraw/Gui/ZVALUE.h
+++ b/src/Mod/TechDraw/Gui/ZVALUE.h
@@ -14,7 +14,8 @@ namespace ZVALUE {
     const int VERTEX = 60;
     const int DIMENSION = 110;
     const int LABEL = 120;
-    const int SECTIONLINE = 80;    //TODO: change to "DECORATION"? section lines, symmetry lines, etc?
+    //TODO: change to "DECORATION"? section lines, symmetry lines, etc?
+    const int SECTIONLINE = 80;
     const int HIGHLIGHT = 80;
     const int MATTING = 100;
     const int TRACKER = 125;

--- a/src/Mod/TechDraw/Gui/mtextedit.cpp
+++ b/src/Mod/TechDraw/Gui/mtextedit.cpp
@@ -62,7 +62,8 @@ void MTextEdit::insertFromMimeData(const QMimeData *source) {
             }
         if (!format.isEmpty()) {
 //          dropImage(qvariant_cast<QImage>(source->imageData()), format);
-            dropImage(qvariant_cast<QImage>(source->imageData()), QString::fromLatin1("JPG")); // Sorry, ale cokoli jiného dlouho trvá
+            // Sorry, ale cokoli jiného dlouho trvá
+            dropImage(qvariant_cast<QImage>(source->imageData()), QString::fromLatin1("JPG"));
             return;
             }
         }
@@ -102,4 +103,3 @@ void MTextEdit::dropImage(const QImage& image, const QString& format) {
 }
 
 #include <Mod/TechDraw/Gui/moc_mtextedit.cpp>
-

--- a/src/Mod/Web/Gui/BrowserView.cpp
+++ b/src/Mod/Web/Gui/BrowserView.cpp
@@ -102,7 +102,8 @@ public:
         if (info.navigationType() == QWebEngineUrlRequestInfo::NavigationTypeLink) {
             // wash out windows file:///C:/something ->file://C:/something
             QUrl url = info.requestUrl();
-            QRegularExpression re(QLatin1String("^/([a-zA-Z]\\:.*)")); // match & catch drive letter forward
+            // match & catch drive letter forward
+            QRegularExpression re(QLatin1String("^/([a-zA-Z]\\:.*)"));
             QRegularExpressionMatch match = re.match(url.path());
 
             if (url.host().isEmpty() && url.isLocalFile() && match.hasMatch())
@@ -914,4 +915,3 @@ PyObject* BrowserView::getPyObject()
     return new BrowserViewPy(this);
 }
 #include "moc_BrowserView.cpp"
-

--- a/src/zipios++/zipfile.cpp
+++ b/src/zipios++/zipfile.cpp
@@ -26,16 +26,16 @@ ZipFile ZipFile::openEmbeddedZipFile( const string &name ) {
   ifs.seekg( -4, ios::end ) ;
   uint32 start_offset = readUint32( ifs ) ;
   ifs.close() ;
-  return ZipFile( name, start_offset, 4 ) ; 
+  return ZipFile( name, start_offset, 4 ) ;
 }
 
 
 ZipFile::ZipFile( const string &name , int s_off, int e_off
-		  /* , ios::open_mode mode */ ) 
+		  /* , ios::open_mode mode */ )
   : _vs( s_off, e_off ) {
 
   _filename = name ;
-  
+
 #if defined(_WIN32) && defined(ZIPIOS_UTF8)
   std::wstring wsname = Base::FileInfo(name).toStdWString();
   ifstream _zipfile( wsname.c_str(), ios::in | ios::binary ) ;
@@ -66,17 +66,17 @@ istream *ZipFile::getInputStream( const ConstEntryPointer &entry ) {
   return getInputStream( entry->getName() ) ;
 }
 
-istream *ZipFile::getInputStream( const string &entry_name, 
+istream *ZipFile::getInputStream( const string &entry_name,
 				  MatchPath matchpath ) {
   if ( ! _valid )
     throw InvalidStateException( "Attempt to use an invalid ZipFile" ) ;
 
   ConstEntryPointer ent = getEntry( entry_name, matchpath ) ;
-  
+
   if ( !ent )
     return nullptr ;
   else
-    return new ZipInputStream( _filename,	
+    return new ZipInputStream( _filename,
 			   static_cast< const ZipCDirEntry * >( ent.get() )->
 			   getLocalHeaderOffset() + _vs.startOffset() ) ;
 }
@@ -93,7 +93,7 @@ bool ZipFile::init( istream &_zipfile ) {
     setError ( "Error reading from file" ) ;
     return false ;
   }
-  
+
   _valid = readCentralDirectory( _zipfile ) ;
 
   return _valid ;
@@ -101,7 +101,7 @@ bool ZipFile::init( istream &_zipfile ) {
 
 
 bool ZipFile::readCentralDirectory ( istream &_zipfile ) {
-  // Find and read eocd. 
+  // Find and read eocd.
   if ( ! readEndOfCentralDirectory( _zipfile ) )
     throw FCollException( "Unable to find zip structure: End-of-central-directory" ) ;
 
@@ -112,11 +112,11 @@ bool ZipFile::readCentralDirectory ( istream &_zipfile ) {
   // Giving the default argument in the next line to keep Visual C++ quiet
   _entries.resize ( _eocd.totalCount(), nullptr ) ;
   while ( ( entry_num < _eocd.totalCount() ) ) {
-    ZipCDirEntry *ent = new ZipCDirEntry ; 
+    ZipCDirEntry *ent = new ZipCDirEntry ;
     _entries[ entry_num ] = ent ;
     _zipfile >>  *ent ;
     if ( ! _zipfile ) {
-      if ( _zipfile.bad()  ) 
+      if ( _zipfile.bad()  )
 	throw IOException( "Error reading zip file while reading zip file central directory" ) ;
       else if ( _zipfile.fail() )
 	throw FCollException( "Zip file consistency problem. Failure while reading zip file central directory" ) ;
@@ -127,7 +127,7 @@ bool ZipFile::readCentralDirectory ( istream &_zipfile ) {
   }
 
   // Consistency check. eocd should start here
-  
+
   int pos = _vs.vtellg( _zipfile ) ;
   _vs.vseekg( _zipfile, 0, ios::end ) ;
   int remaining = static_cast< int >( _vs.vtellg( _zipfile ) ) - pos ;
@@ -138,7 +138,7 @@ bool ZipFile::readCentralDirectory ( istream &_zipfile ) {
   // cd headers
   if ( ! confirmLocalHeaders( _zipfile ) )
     throw FCollException( "Zip file consistency problem. Zip file data fields are inconsistent with zip file layout" ) ;
-  
+
   return true ;
 }
 
@@ -185,7 +185,8 @@ void ZipFile::setError ( string error_str ) {
 #ifdef _USE_EXCEPTIONS
     throw  error_str ; // define exception class instead.
 #else
-    cerr << error_str << endl ; // define operator<< for exception class if such a class replaces string
+    // define operator<< for exception class if such a class replaces string
+    cerr << error_str << endl ;
 #endif
 }
 
@@ -199,17 +200,17 @@ void ZipFile::setError ( string error_str ) {
 /*
   Zipios++ - a small C++ library that provides easy access to .zip files.
   Copyright (C) 2000  Thomas Søndergaard
-  
+
   This library is free software; you can redistribute it and/or
   modify it under the terms of the GNU Lesser General Public
   License as published by the Free Software Foundation; either
   version 2 of the License, or (at your option) any later version.
-  
+
   This library is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
   Lesser General Public License for more details.
-  
+
   You should have received a copy of the GNU Lesser General Public
   License along with this library; if not, write to the Free Software
   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA

--- a/tests/src/Base/Unit.cpp
+++ b/tests/src/Base/Unit.cpp
@@ -55,7 +55,8 @@ TEST(Unit, TestTypeString)
     EXPECT_EQ(toString(Base::Unit::MagneticFieldStrength), "MagneticFieldStrength");
     EXPECT_EQ(toString(Base::Unit::MagneticFlux), "MagneticFlux");
     EXPECT_EQ(toString(Base::Unit::MagneticFluxDensity), "MagneticFluxDensity");
-    EXPECT_EQ(toString(Base::Unit::Magnetization), "MagneticFieldStrength"); // same as MagneticFieldStrength
+    // same as MagneticFieldStrength
+    EXPECT_EQ(toString(Base::Unit::Magnetization), "MagneticFieldStrength");
     EXPECT_EQ(toString(Base::Unit::Mass), "Mass");
     EXPECT_EQ(toString(Base::Unit::Pressure), "Pressure");
     EXPECT_EQ(toString(Base::Unit::Power), "Power");


### PR DESCRIPTION
https://forum.freecad.org/viewtopic.php?t=72183&start=60

An issue has been identified that long lines with trailing comments will get messed up with format. They still work ok - just look wrong.

This is an experiment to move comments that extend beyond 100 columns back to the previous line.