### PR TITLE
[MeshPart] fix unwrap feature

### DIFF
--- a/src/Mod/MeshPart/App/MeshFlatteningPy.cpp
+++ b/src/Mod/MeshPart/App/MeshFlatteningPy.cpp
@@ -34,9 +34,15 @@
 # include <TopoDS_Face.hxx>
 #endif
 
+// neccessary for the feature despite not all are necessary for compilation
+#include <pybind11/eigen.h>
+#include <pybind11/numpy.h>
+#include <pybind11/operators.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
 #include <Mod/Part/App/TopoShapeFacePy.h>
 #include <Mod/Part/App/TopoShapeEdgePy.h>
-#include <pybind11/eigen.h>
 
 #include "MeshFlattening.h"
 #include "MeshFlatteningLscmRelax.h"


### PR DESCRIPTION
- fixes #8741
- in commit d62d41a53b66af1e824e the pybind headers were accidentally removed