### PR TITLE
[Gui] work around for NaviCube button color bug

### DIFF
--- a/src/Gui/DlgSettingsNavigation.cpp
+++ b/src/Gui/DlgSettingsNavigation.cpp
@@ -94,7 +94,6 @@ void DlgSettingsNavigation::saveSettings()
     ui->naviCubeToNearest->onSave();
     ui->prefCubeSize->onSave();
     ui->naviCubeFontSize->onSave();
-    ui->naviCubeButtonColor->onSave();
 
     bool showNaviCube = ui->groupBoxNaviCube->isChecked();
     hGrp->SetBool("ShowNaviCube", showNaviCube);
@@ -113,6 +112,9 @@ void DlgSettingsNavigation::saveSettings()
     hGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/NaviCube");
     hGrp->SetASCII("FontString", ui->naviCubeFontName->currentText().toLatin1());
+
+    hGrp->SetUnsigned("ButtonColor",
+                      App::Color::asPackedRGBA<QColor>(ui->naviCubeButtonColor->color()));
 
     recreateNaviCubes();
 }
@@ -143,7 +145,6 @@ void DlgSettingsNavigation::loadSettings()
     ui->naviCubeToNearest->onRestore();
     ui->prefCubeSize->onRestore();
     ui->naviCubeFontSize->onRestore();
-    ui->naviCubeButtonColor->onRestore();
 
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath
         ("User parameter:BaseApp/Preferences/View");
@@ -215,6 +216,11 @@ void DlgSettingsNavigation::loadSettings()
         // we purposely don't write to the parameters because the writing would
         // also be done when the user cancels the preferences dialog
     }
+
+    // we cannot just  use ui->naviCubeButtonColor->onRestore(); because this would not read the
+    // transparency
+    unsigned long buttonColor = hGrp->GetUnsigned("ButtonColor", 3806916480);
+    ui->naviCubeButtonColor->setColor(App::Color::fromPackedRGBA<QColor>(buttonColor));
 }
 
 void DlgSettingsNavigation::onMouseButtonClicked()


### PR DESCRIPTION
- onRestore() does not read in transparencies, always assumes the transparency is 255

This is PR is not the optimal solution just a workaround.

Therefore it does not fix the following issue:
- set in the parameters the parameter "ButtonColor" to "3806916480"
- open the preferences
- do nothing else than pressing the Apply button twice

result: the transparency of the NaviCube buttons is lost.

@wwmayer , you recently changes the color handling. I assume there is a bug in the reading of colors using onRestore ()