### PR TITLE
Draft: Fixes grid on/off behaviour - fixes #5878

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_base_original.py
+++ b/src/Mod/Draft/draftguitools/gui_base_original.py
@@ -148,7 +148,7 @@ class DraftTool:
         if utils.get_param("showPlaneTracker", False):
             self.planetrack = trackers.PlaneTracker()
         if hasattr(Gui, "Snapper"):
-            Gui.Snapper.setTrackers()
+            Gui.Snapper.setTrackers(tool=True)
 
         _msg("{}".format(16*"-"))
         _msg("GuiCommand: {}".format(self.featureName))

--- a/src/Mod/Draft/draftguitools/gui_grid.py
+++ b/src/Mod/Draft/draftguitools/gui_grid.py
@@ -66,7 +66,7 @@ class ToggleGrid(gui_base.GuiCommandSimplest):
         super(ToggleGrid, self).Activated()
 
         if hasattr(Gui, "Snapper"):
-            Gui.Snapper.setTrackers()
+            Gui.Snapper.setTrackers(tool=True)
             if Gui.Snapper.grid:
                 if Gui.Snapper.grid.Visible:
                     Gui.Snapper.grid.off()

--- a/src/Mod/Draft/draftguitools/gui_lines.py
+++ b/src/Mod/Draft/draftguitools/gui_lines.py
@@ -139,7 +139,7 @@ class Line(gui_base_original.Creator):
         if self.oldWP:
             App.DraftWorkingPlane.setFromParameters(self.oldWP)
             if hasattr(Gui, "Snapper"):
-                Gui.Snapper.setGrid()
+                Gui.Snapper.setGrid(tool=True)
                 Gui.Snapper.restack()
         self.oldWP = None
 

--- a/src/Mod/Draft/draftguitools/gui_snapper.py
+++ b/src/Mod/Draft/draftguitools/gui_snapper.py
@@ -1594,15 +1594,15 @@ class Snapper:
             self.toolbar.toggleViewAction().setVisible(False)
 
 
-    def setGrid(self):
+    def setGrid(self, tool=False):
         """Set the grid, if visible."""
         self.setTrackers()
         if self.grid and (not self.forceGridOff):
             if self.grid.Visible:
-                self.grid.set()
+                self.grid.set(tool)
 
 
-    def setTrackers(self):
+    def setTrackers(self, tool=False):
         """Set the trackers."""
         v = Draft.get3DView()
         if v and (v != self.activeview):
@@ -1620,7 +1620,10 @@ class Snapper:
             else:
                 if Draft.getParam("grid", True):
                     self.grid = trackers.gridTracker()
-                    self.grid.on()
+                    if Draft.getParam("alwaysShowGrid", True) or tool:
+                        self.grid.on()
+                    else:
+                        self.grid.off()
                 else:
                     self.grid = None
                 self.tracker = trackers.snapTracker()
@@ -1651,7 +1654,7 @@ class Snapper:
             self.activeview = v
 
         if self.grid and (not self.forceGridOff):
-            self.grid.set()
+            self.grid.set(tool)
 
 
     def addHoldPoint(self):

--- a/src/Mod/Draft/draftguitools/gui_trackers.py
+++ b/src/Mod/Draft/draftguitools/gui_trackers.py
@@ -1216,7 +1216,7 @@ class gridTracker(Tracker):
         self.numlines = Draft.getParam("gridSize", 100)
         self.update()
 
-    def set(self):
+    def set(self,tool=False):
         """Move and rotate the grid according to the current working plane."""
         self.reset()
         Q = FreeCAD.DraftWorkingPlane.getRotation().Rotation.Q
@@ -1225,7 +1225,8 @@ class gridTracker(Tracker):
         self.trans.translation.setValue([P.x, P.y, P.z])
         self.displayHumanFigure()
         self.setAxesColor()
-        self.on()
+        if tool:
+            self.on()
 
     def getClosestNode(self, point):
         """Return the closest node from the given point."""


### PR DESCRIPTION
Fixes faultly Draft grid behaviour. Now:

- If grid is on and auto grid on: Grid always appears
- If grid is on and auto grid off: Grid off at start, on when using a tool, off afterwards
- If grid is off: Grid never appears

- [x]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR
---
