### PR TITLE
Sketcher: Remove "Show Edit Section" from preferences

### DIFF
--- a/src/Mod/Sketcher/Gui/SketcherSettings.cpp
+++ b/src/Mod/Sketcher/Gui/SketcherSettings.cpp
@@ -62,7 +62,6 @@ void SketcherSettings::saveSettings()
 {
     // Sketch editing
     ui->checkBoxAdvancedSolverTaskBox->onSave();
-    ui->checkBoxSettingsTaskBox->onSave();
     ui->checkBoxRecalculateInitialSolutionWhileDragging->onSave();
     ui->checkBoxEnableEscape->onSave();
     ui->checkBoxNotifyConstraintSubstitutions->onSave();
@@ -73,7 +72,6 @@ void SketcherSettings::loadSettings()
 {
     // Sketch editing
     ui->checkBoxAdvancedSolverTaskBox->onRestore();
-    ui->checkBoxSettingsTaskBox->onRestore();
     ui->checkBoxRecalculateInitialSolutionWhileDragging->onRestore();
     ui->checkBoxEnableEscape->onRestore();
     ui->checkBoxNotifyConstraintSubstitutions->onRestore();

--- a/src/Mod/Sketcher/Gui/SketcherSettings.ui
+++ b/src/Mod/Sketcher/Gui/SketcherSettings.ui
@@ -37,26 +37,6 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="0">
-       <widget class="Gui::PrefCheckBox" name="checkBoxSettingsTaskBox">
-        <property name="toolTip">
-         <string>Sketcher dialog will have additional section
-'Edit controls' to easily access basic settings.</string>
-        </property>
-        <property name="text">
-         <string>Show section 'Edit controls'</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>ShowSettingsWidget</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Sketcher</cstring>
-        </property>
-       </widget>
-      </item>
      </layout>
     </widget>
    </item>


### PR DESCRIPTION
=====================================================

In a previous commit the Edit Section and its preferences where removed, however Adrián Insaurralde realised that the setting for showing or not this section had been left behind: https://github.com/FreeCAD/FreeCAD/pull/8716#issuecomment-1462364487

This commit just removes that settings.

