### PR TITLE
Sketcher: Remove references to non-existing icons

### DIFF
--- a/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp
+++ b/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp
@@ -346,8 +346,6 @@ CmdSketcherSelectMalformedConstraints::CmdSketcherSelectMalformedConstraints()
     sToolTipText = QT_TR_NOOP("Select malformed constraints");
     sWhatsThis = "Sketcher_SelectMalformedConstraints";
     sStatusTip = sToolTipText;
-    sPixmap = "Sketcher_SelectMalformedConstraints";
-    sAccel = "Z, P, M";
     eType = ForEdit;
 }
 
@@ -407,8 +405,6 @@ CmdSketcherSelectPartiallyRedundantConstraints::CmdSketcherSelectPartiallyRedund
     sToolTipText = QT_TR_NOOP("Select partially redundant constraints");
     sWhatsThis = "Sketcher_SelectPartiallyRedundantConstraints";
     sStatusTip = sToolTipText;
-    sPixmap = "Sketcher_SelectPartiallyRedundantConstraints";
-    sAccel = "Z, P, P";
     eType = ForEdit;
 }
 


### PR DESCRIPTION
=================================================

User Syres realised that some commands that are in use by the solver messages url referenced non-existing icons, which triggers errors in the report view while customising: https://forum.freecad.org/viewtopic.php?p=666167&sid=16ac6777c440d632e5f60083fb4327ca#p666167

This commit removes them.