### PR TITLE
Consistency of task button positions

### DIFF
--- a/src/Gui/DlgDisplayProperties.ui
+++ b/src/Gui/DlgDisplayProperties.ui
@@ -434,13 +434,6 @@
      </layout>
     </widget>
    </item>
-   <item row="3" column="0">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Close</set>
-     </property>
-    </widget>
-   </item>
   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
@@ -528,22 +521,6 @@
     <hint type="destinationlabel">
      <x>98</x>
      <y>404</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>rejected()</signal>
-   <receiver>Gui::Dialog::DlgDisplayProperties</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>150</x>
-     <y>461</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>144</x>
-     <y>243</y>
     </hint>
    </hints>
   </connection>

--- a/src/Gui/DlgDisplayPropertiesImp.cpp
+++ b/src/Gui/DlgDisplayPropertiesImp.cpp
@@ -192,11 +192,6 @@ void DlgDisplayPropertiesImp::setupConnections()
     connect(d->ui.buttonColorPlot, &ColorButton::clicked, this, &DlgDisplayPropertiesImp::onButtonColorPlotClicked);
 }
 
-void DlgDisplayPropertiesImp::showDefaultButtons(bool ok)
-{
-    d->ui.buttonBox->setVisible(ok);
-}
-
 void DlgDisplayPropertiesImp::changeEvent(QEvent *e)
 {
     if (e->type() == QEvent::LanguageChange) {
@@ -630,7 +625,6 @@ TaskDisplayProperties::TaskDisplayProperties()
 {
     this->setButtonPosition(TaskDisplayProperties::North);
     widget = new DlgDisplayPropertiesImp(false);
-    widget->showDefaultButtons(false);
     taskbox = new Gui::TaskView::TaskBox(QPixmap(), widget->windowTitle(),true, nullptr);
     taskbox->groupLayout()->addWidget(widget);
     Content.push_back(taskbox);

--- a/src/Mod/Part/Gui/TaskDimension.cpp
+++ b/src/Mod/Part/Gui/TaskDimension.cpp
@@ -1804,7 +1804,7 @@ void PartGui::TaskMeasureAngular::setUpGui()
   controlTaskBox->groupLayout()->addLayout(controlLayout);
   QObject::connect(control->resetButton, &QPushButton::clicked, this, &TaskMeasureAngular::resetDialogSlot);
 
-  this->setButtonPosition(TaskDialog::South);
+  this->setButtonPosition(TaskDialog::North);
   Content.push_back(selectionTaskBox);
   Content.push_back(controlTaskBox);
 


### PR DESCRIPTION
I noticed that most task dialogs have their buttons north. I also noticed that the angular measure task had its buttons south despite the linear measure task was already changed to have them north. This is now fixed.

I also removed a redundant implementation of the close button in the display properties task (View -> Appearance...). This way it now also has its close button north per default.

The "Edit -> Placement" task still has the buttons at the south position but I am not sure if it is by design because of the additional reset button...

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR