### PR TITLE
Addon Manager: Handle icons with query strings

### DIFF
--- a/src/Mod/AddonManager/addonmanager_macro.py
+++ b/src/Mod/AddonManager/addonmanager_macro.py
@@ -31,6 +31,7 @@ import codecs
 import shutil
 from html import unescape
 from typing import Dict, Tuple, List, Union, Optional
+import urllib.parse
 
 from addonmanager_macro_parser import MacroParser
 import addonmanager_utilities as utils
@@ -231,12 +232,13 @@ class Macro:
         copy, potentially updating the internal icon location to that local storage."""
         if self.icon.startswith("http://") or self.icon.startswith("https://"):
             self._console.PrintLog(f"Attempting to fetch macro icon from {self.icon}\n")
+            parsed_url = urllib.parse.urlparse(self.icon)
             p = Macro.blocking_get(self.icon)
             if p:
                 cache_path = fci.DataPaths().cache_dir
                 am_path = os.path.join(cache_path, "AddonManager", "MacroIcons")
                 os.makedirs(am_path, exist_ok=True)
-                _, _, filename = self.icon.rpartition("/")
+                _, _, filename = parsed_url.path.rpartition("/")
                 base, _, extension = filename.rpartition(".")
                 if base.lower().startswith("file:"):
                     self._console.PrintMessage(

--- a/src/Mod/AddonManager/package_list.py
+++ b/src/Mod/AddonManager/package_list.py
@@ -36,7 +36,7 @@ from compact_view import Ui_CompactView
 from expanded_view import Ui_ExpandedView
 
 import addonmanager_utilities as utils
-from addonmanager_metadata import get_first_supported_freecad_version
+from addonmanager_metadata import get_first_supported_freecad_version, Version
 
 translate = FreeCAD.Qt.translate
 
@@ -650,15 +650,9 @@ class PackageListFilter(QtCore.QSortFilterProxyModel):
 
             first_supported_version = get_first_supported_freecad_version(data.metadata)
             if first_supported_version is not None:
-                required_version = first_supported_version.split(".")
-                fc_major = int(FreeCAD.Version()[0])
-                fc_minor = int(FreeCAD.Version()[1])
-
-                if int(required_version[0]) > fc_major:
+                current_fc_version = Version(from_list=FreeCAD.Version())
+                if first_supported_version > current_fc_version:
                     return False
-                if int(required_version[0]) == fc_major and len(required_version) > 1:
-                    if int(required_version[1]) > fc_minor:
-                        return False
 
         name = data.display_name
         desc = data.description


### PR DESCRIPTION
Icons that had query strings after their filename broke the Macro parser, and they are appearing with increasing frequency on the Wiki (possibly due to a configuration change?). This fixes that bug, as well as a couple of small issues from the last refactoring PR.

- [X]  This Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR