### PR TITLE
[FEM] [skip ci] BoxWidget.ui fix

### DIFF
--- a/src/Mod/Fem/Gui/BoxWidget.ui
+++ b/src/Mod/Fem/Gui/BoxWidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>280</width>
-    <height>85</height>
+    <width>500</width>
+    <height>137</height>
    </rect>
   </property>
   <property name="windowTitle">


### PR DESCRIPTION
- was reported and automatically fixed by Qt's Designer that the size in the file is incorrect, (the sum of the widget's widths is wider than the main widget's specified size)