### PR TITLE
fix #8847 sketcher dialog tool buttons bad styling

### DIFF
--- a/src/Gui/Stylesheets/Behave-dark.qss
+++ b/src/Gui/Stylesheets/Behave-dark.qss
@@ -1648,6 +1648,33 @@ QSint--ActionGroup QFrame[class="content"] QToolButton:pressed {
     background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0 #65A2E5, stop:1 #65A2E5);
 }
 
+/* QToolButtons with a menu found in Sketcher task panel*/
+QSint--ActionGroup QToolButton::menu-button {
+    border: none;
+    border-top-right-radius: 4px;
+    border-bottom-right-radius: 4px;
+    padding: 2px;
+    width: 16px; /* 16px width + 4px for border = 20px allocated above */
+    outline: none;
+    background-color: transparent;
+}
+
+QSint--ActionGroup QToolButton#settingsButton,
+QSint--ActionGroup QToolButton#filterButton
+QSint--ActionGroup QToolButton#manualUpdate {
+    padding: 2px;
+    padding-right: 20px; /* make way for the popup button */
+    margin: 0px;
+}
+
+/* to give widget inside the menu same look as regular menu */
+QSint--ActionGroup QToolButton#filterButton QListWidget {
+    color: #D2D8E1;
+    background: #232932;
+    padding: 0px;
+    margin: 0px;
+}
+
 
 /*==================================================================================================
 Radio button

--- a/src/Gui/Stylesheets/Dark-blue.qss
+++ b/src/Gui/Stylesheets/Dark-blue.qss
@@ -1615,6 +1615,33 @@ QSint--ActionGroup QFrame[class="content"] QToolButton:pressed {
     background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0 #3874f2, stop:1 #5e90fa);
 }
 
+/* QToolButtons with a menu found in Sketcher task panel*/
+QSint--ActionGroup QToolButton::menu-button {
+    border: none;
+    border-top-right-radius: 4px;
+    border-bottom-right-radius: 4px;
+    padding: 2px;
+    width: 16px; /* 16px width + 4px for border = 20px allocated above */
+    outline: none;
+    background-color: transparent;
+}
+
+QSint--ActionGroup QToolButton#settingsButton,
+QSint--ActionGroup QToolButton#filterButton
+QSint--ActionGroup QToolButton#manualUpdate {
+    padding: 2px;
+    padding-right: 20px; /* make way for the popup button */
+    margin: 0px;
+}
+
+/* to give widget inside the menu same look as regular menu */
+QSint--ActionGroup QToolButton#filterButton QListWidget {
+    color: #e0e0e0;
+    background-color: #5a5a5a;
+    padding: 0px;
+    margin: 0px;
+}
+
 
 /*==================================================================================================
 Radio button

--- a/src/Gui/Stylesheets/Dark-contrast.qss
+++ b/src/Gui/Stylesheets/Dark-contrast.qss
@@ -1615,6 +1615,33 @@ QSint--ActionGroup QFrame[class="content"] QToolButton:pressed {
     background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0 #1b3774, stop:1 #2053c0);
 }
 
+/* QToolButtons with a menu found in Sketcher task panel*/
+QSint--ActionGroup QToolButton::menu-button {
+    border: none;
+    border-top-right-radius: 4px;
+    border-bottom-right-radius: 4px;
+    padding: 2px;
+    width: 16px; /* 16px width + 4px for border = 20px allocated above */
+    outline: none;
+    background-color: transparent;
+}
+
+QSint--ActionGroup QToolButton#settingsButton,
+QSint--ActionGroup QToolButton#filterButton
+QSint--ActionGroup QToolButton#manualUpdate {
+    padding: 2px;
+    padding-right: 20px; /* make way for the popup button */
+    margin: 0px;
+}
+
+/* to give widget inside the menu same look as regular menu */
+QSint--ActionGroup QToolButton#filterButton QListWidget {
+    color: #fefefe;
+    background-color: #111111;
+    padding: 0px;
+    margin: 0px;
+}
+
 
 /*==================================================================================================
 QComboBox inside Task Panel content

--- a/src/Gui/Stylesheets/Dark-green.qss
+++ b/src/Gui/Stylesheets/Dark-green.qss
@@ -1614,6 +1614,33 @@ QSint--ActionGroup QFrame[class="content"] QToolButton:pressed {
     background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0 #819c0c, stop:1 #94b30f);
 }
 
+/* QToolButtons with a menu found in Sketcher task panel*/
+QSint--ActionGroup QToolButton::menu-button {
+    border: none;
+    border-top-right-radius: 4px;
+    border-bottom-right-radius: 4px;
+    padding: 2px;
+    width: 16px; /* 16px width + 4px for border = 20px allocated above */
+    outline: none;
+    background-color: transparent;
+}
+
+QSint--ActionGroup QToolButton#settingsButton,
+QSint--ActionGroup QToolButton#filterButton
+QSint--ActionGroup QToolButton#manualUpdate {
+    padding: 2px;
+    padding-right: 20px; /* make way for the popup button */
+    margin: 0px;
+}
+
+/* to give widget inside the menu same look as regular menu */
+QSint--ActionGroup QToolButton#filterButton QListWidget {
+    color: #e0e0e0;
+    background-color: #5a5a5a;
+    padding: 0px;
+    margin: 0px;
+}
+
 
 /*==================================================================================================
 Radio button

--- a/src/Gui/Stylesheets/Dark-orange.qss
+++ b/src/Gui/Stylesheets/Dark-orange.qss
@@ -1615,6 +1615,33 @@ QSint--ActionGroup QFrame[class="content"] QToolButton:pressed {
     background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0 #d0970c, stop:1 #daa116);
 }
 
+/* QToolButtons with a menu found in Sketcher task panel*/
+QSint--ActionGroup QToolButton::menu-button {
+    border: none;
+    border-top-right-radius: 4px;
+    border-bottom-right-radius: 4px;
+    padding: 2px;
+    width: 16px; /* 16px width + 4px for border = 20px allocated above */
+    outline: none;
+    background-color: transparent;
+}
+
+QSint--ActionGroup QToolButton#settingsButton,
+QSint--ActionGroup QToolButton#filterButton
+QSint--ActionGroup QToolButton#manualUpdate {
+    padding: 2px;
+    padding-right: 20px; /* make way for the popup button */
+    margin: 0px;
+}
+
+/* to give widget inside the menu same look as regular menu */
+QSint--ActionGroup QToolButton#filterButton QListWidget {
+    color: #e0e0e0;
+    background-color: #5a5a5a;
+    padding: 0px;
+    margin: 0px;
+}
+
 
 /*==================================================================================================
 Radio button

--- a/src/Gui/Stylesheets/Darker-blue.qss
+++ b/src/Gui/Stylesheets/Darker-blue.qss
@@ -1615,6 +1615,33 @@ QSint--ActionGroup QFrame[class="content"] QToolButton:pressed {
     background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0 #1b3774, stop:1 #2053c0);
 }
 
+/* QToolButtons with a menu found in Sketcher task panel*/
+QSint--ActionGroup QToolButton::menu-button {
+    border: none;
+    border-top-right-radius: 4px;
+    border-bottom-right-radius: 4px;
+    padding: 2px;
+    width: 16px; /* 16px width + 4px for border = 20px allocated above */
+    outline: none;
+    background-color: transparent;
+}
+
+QSint--ActionGroup QToolButton#settingsButton,
+QSint--ActionGroup QToolButton#filterButton
+QSint--ActionGroup QToolButton#manualUpdate {
+    padding: 2px;
+    padding-right: 20px; /* make way for the popup button */
+    margin: 0px;
+}
+
+/* to give widget inside the menu same look as regular menu */
+QSint--ActionGroup QToolButton#filterButton QListWidget {
+    color: #f5f5f5;
+    background: #2a2a2a;
+    padding: 0px;
+    margin: 0px;
+}
+
 
 /*==================================================================================================
 QComboBox inside Task Panel content

--- a/src/Gui/Stylesheets/Darker-green.qss
+++ b/src/Gui/Stylesheets/Darker-green.qss
@@ -1615,6 +1615,33 @@ QSint--ActionGroup QFrame[class="content"] QToolButton:pressed {
     background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0 #566214, stop:1 #74831d);
 }
 
+/* QToolButtons with a menu found in Sketcher task panel*/
+QSint--ActionGroup QToolButton::menu-button {
+    border: none;
+    border-top-right-radius: 4px;
+    border-bottom-right-radius: 4px;
+    padding: 2px;
+    width: 16px; /* 16px width + 4px for border = 20px allocated above */
+    outline: none;
+    background-color: transparent;
+}
+
+QSint--ActionGroup QToolButton#settingsButton,
+QSint--ActionGroup QToolButton#filterButton
+QSint--ActionGroup QToolButton#manualUpdate {
+    padding: 2px;
+    padding-right: 20px; /* make way for the popup button */
+    margin: 0px;
+}
+
+/* to give widget inside the menu same look as regular menu */
+QSint--ActionGroup QToolButton#filterButton QListWidget {
+    color: #f5f5f5;
+    background: #2a2a2a;
+    padding: 0px;
+    margin: 0px;
+}
+
 
 /*==================================================================================================
 QComboBox inside Task Panel content

--- a/src/Gui/Stylesheets/Darker-orange.qss
+++ b/src/Gui/Stylesheets/Darker-orange.qss
@@ -1609,6 +1609,33 @@ QSint--ActionGroup QFrame[class="content"] QToolButton:pressed {
     background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0 #624b14, stop:1 #b28416);
 }
 
+/* QToolButtons with a menu found in Sketcher task panel*/
+QSint--ActionGroup QToolButton::menu-button {
+    border: none;
+    border-top-right-radius: 4px;
+    border-bottom-right-radius: 4px;
+    padding: 2px;
+    width: 16px; /* 16px width + 4px for border = 20px allocated above */
+    outline: none;
+    background-color: transparent;
+}
+
+QSint--ActionGroup QToolButton#settingsButton,
+QSint--ActionGroup QToolButton#filterButton
+QSint--ActionGroup QToolButton#manualUpdate {
+    padding: 2px;
+    padding-right: 20px; /* make way for the popup button */
+    margin: 0px;
+}
+
+/* to give widget inside the menu same look as regular menu */
+QSint--ActionGroup QToolButton#filterButton QListWidget {
+    color: #f5f5f5;
+    background-color: #2a2a2a;
+    padding: 0px;
+    margin: 0px;
+}
+
 
 /*==================================================================================================
 QComboBox inside Task Panel content

--- a/src/Gui/Stylesheets/Light-blue.qss
+++ b/src/Gui/Stylesheets/Light-blue.qss
@@ -1612,6 +1612,33 @@ QSint--ActionGroup QFrame[class="content"] QToolButton:pressed {
     background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0 #3874f2, stop:1 #5e90fa);
 }
 
+/* QToolButtons with a menu found in Sketcher task panel*/
+QSint--ActionGroup QToolButton::menu-button {
+    border: none;
+    border-top-right-radius: 4px;
+    border-bottom-right-radius: 4px;
+    padding: 2px;
+    width: 16px; /* 16px width + 4px for border = 20px allocated above */
+    outline: none;
+    background-color: transparent;
+}
+
+QSint--ActionGroup QToolButton#settingsButton,
+QSint--ActionGroup QToolButton#filterButton
+QSint--ActionGroup QToolButton#manualUpdate {
+    padding: 2px;
+    padding-right: 20px; /* make way for the popup button */
+    margin: 0px;
+}
+
+/* to give widget inside the menu same look as regular menu */
+QSint--ActionGroup QToolButton#filterButton QListWidget {
+    color: black;
+    background: #f5f5f5;
+    padding: 0px;
+    margin: 0px;
+}
+
 
 /*==================================================================================================
 Radio button

--- a/src/Gui/Stylesheets/Light-green.qss
+++ b/src/Gui/Stylesheets/Light-green.qss
@@ -1612,6 +1612,33 @@ QSint--ActionGroup QFrame[class="content"] QToolButton:pressed {
     background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0 #819c0c, stop:1 #94b30f);
 }
 
+/* QToolButtons with a menu found in Sketcher task panel*/
+QSint--ActionGroup QToolButton::menu-button {
+    border: none;
+    border-top-right-radius: 4px;
+    border-bottom-right-radius: 4px;
+    padding: 2px;
+    width: 16px; /* 16px width + 4px for border = 20px allocated above */
+    outline: none;
+    background-color: transparent;
+}
+
+QSint--ActionGroup QToolButton#settingsButton,
+QSint--ActionGroup QToolButton#filterButton
+QSint--ActionGroup QToolButton#manualUpdate {
+    padding: 2px;
+    padding-right: 20px; /* make way for the popup button */
+    margin: 0px;
+}
+
+/* to give widget inside the menu same look as regular menu */
+QSint--ActionGroup QToolButton#filterButton QListWidget {
+    color: black;
+    background: #f5f5f5;
+    padding: 0px;
+    margin: 0px;
+}
+
 
 /*==================================================================================================
 Radio button

--- a/src/Gui/Stylesheets/Light-orange.qss
+++ b/src/Gui/Stylesheets/Light-orange.qss
@@ -1612,6 +1612,33 @@ QSint--ActionGroup QFrame[class="content"] QToolButton:pressed {
     background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0 #d0970c, stop:1 #daa116);
 }
 
+/* QToolButtons with a menu found in Sketcher task panel*/
+QSint--ActionGroup QToolButton::menu-button {
+    border: none;
+    border-top-right-radius: 4px;
+    border-bottom-right-radius: 4px;
+    padding: 2px;
+    width: 16px; /* 16px width + 4px for border = 20px allocated above */
+    outline: none;
+    background-color: transparent;
+}
+
+QSint--ActionGroup QToolButton#settingsButton,
+QSint--ActionGroup QToolButton#filterButton
+QSint--ActionGroup QToolButton#manualUpdate {
+    padding: 2px;
+    padding-right: 20px; /* make way for the popup button */
+    margin: 0px;
+}
+
+/* to give widget inside the menu same look as regular menu */
+QSint--ActionGroup QToolButton#filterButton QListWidget {
+    color: black;
+    background: #f5f5f5;
+    padding: 0px;
+    margin: 0px;
+}
+
 
 /*==================================================================================================
 Radio button

--- a/src/Gui/Stylesheets/ProDark.qss
+++ b/src/Gui/Stylesheets/ProDark.qss
@@ -1815,6 +1815,32 @@ QSint--ActionGroup QFrame[class="content"] QToolButton:pressed {
     background-color: #557BB6;
 }
 
+/* QToolButtons with a menu found in Sketcher task panel*/
+QSint--ActionGroup QToolButton::menu-button {
+    border: none;
+    border-top-right-radius: 4px;
+    border-bottom-right-radius: 4px;
+    padding: 2px;
+    width: 16px; /* 16px width + 4px for border = 20px allocated above */
+    outline: none;
+    background-color: transparent;
+}
+
+QSint--ActionGroup QToolButton#settingsButton,
+QSint--ActionGroup QToolButton#filterButton
+QSint--ActionGroup QToolButton#manualUpdate {
+    padding: 2px;
+    padding-right: 20px; /* make way for the popup button */
+    margin: 0px;
+}
+
+/* to give widget inside the menu same look as regular menu */
+QSint--ActionGroup QToolButton#filterButton QListWidget {
+    color: #f5f5f5;
+    background: #2a2a2a;
+    padding: 0px;
+    margin: 0px;
+}
 
 /*==================================================================================================
 QComboBox inside Task Panel content
@@ -1824,7 +1850,7 @@ QComboBox inside Task Panel content
 /* TODO: external border not working, in the rest of GUI works setting up Qmenu background color but inside Task Panel it doesn't... */
 QSint--ActionGroup QFrame[class="content"] QMenu,
 QSint--ActionGroup QFrame[class="content"] QMenu::item {
-    background-color: #696969;
+    background-color: #2a2a2a;
 }
 
 QSint--ActionGroup QFrame[class="content"] QComboBox QAbstractItemView {


### PR DESCRIPTION
Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [x]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
Fixes #8847 
the buttons and filter menu now look like this:
![image](https://user-images.githubusercontent.com/36372335/224521192-4b1b8ccf-ac46-468c-9690-72f8ad74a63d.png)
instead of:
![image](https://user-images.githubusercontent.com/36372335/224521241-29276f94-9fbe-4aa9-8d69-bb5d94347984.png)

