### PR TITLE
[NotificationArea] Sketcher: Constraint - notification and internal geometry command clean up

### DIFF
--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -38,6 +38,7 @@
 #include <Gui/DlgCheckableMessageBox.h>
 #include <Gui/Document.h>
 #include <Gui/MainWindow.h>
+#include <Gui/Notifications.h>
 #include <Gui/Selection.h>
 #include <Gui/SelectionFilter.h>
 #include <Gui/SelectionObject.h>
@@ -142,19 +143,22 @@ void finishDatumConstraint (Gui::Command* cmd, Sketcher::SketchObject* sketch, b
     cmd->getSelection().clearSelection();
 }
 
-void showNoConstraintBetweenExternal()
+void showNoConstraintBetweenExternal(const App::DocumentObject * obj)
 {
-    QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                         QObject::tr("Cannot add a constraint between two external geometries."));
+    Gui::TranslatedNotification(obj,
+                  QObject::tr("Wrong selection"),
+                  QObject::tr("Cannot add a constraint between two external geometries."));
 }
 
-void showNoConstraintBetweenFixedGeometry()
+void showNoConstraintBetweenFixedGeometry(const App::DocumentObject * obj)
 {
-    QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                         QObject::tr("Cannot add a constraint between two fixed geometries. "
-                                     "Fixed geometries include external geometry, "
-                                     "blocked geometry, and special points "
-                                     "such as B-spline knot points."));
+    Gui::TranslatedNotification(obj,
+                  QObject::tr("Wrong selection"),
+                  QObject::tr("Cannot add a constraint between two fixed geometries. "
+                                                     "Fixed geometries include external geometry, "
+                                                     "blocked geometry, and special points "
+                                                     "such as B-spline knot points."));
+
 }
 
 bool isGeoConcentricCompatible(const Part::Geometry* geo) {
@@ -909,7 +913,7 @@ void CmdSketcherConstrainHorizontal::activated(int iMsg)
                     new DrawSketchHandlerGenConstraint(this));
             getSelection().clearSelection();
         } else {
-            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
+            Gui::TranslatedNotification("Sketcher", QObject::tr("Wrong selection"),
                                  QObject::tr("Select an edge from the sketch."));
         }
         return;
@@ -935,8 +939,7 @@ void CmdSketcherConstrainHorizontal::activated(int iMsg)
         if (isEdge(GeoId,PosId)) {// it is an edge
             const Part::Geometry *geo = Obj->getGeometry(GeoId);
             if (geo->getTypeId() != Part::GeomLineSegment::getClassTypeId()) {
-                QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Impossible constraint"),
-                                     QObject::tr("The selected edge is not a line segment."));
+                Gui::TranslatedNotification(Obj, QObject::tr("Impossible constraint"), QObject::tr("The selected edge is not a line segment."));
                 return;
             }
 
@@ -944,19 +947,16 @@ void CmdSketcherConstrainHorizontal::activated(int iMsg)
             for (std::vector< Sketcher::Constraint * >::const_iterator it= vals.begin();
                  it != vals.end(); ++it) {
                 if ((*it)->Type == Sketcher::Horizontal && (*it)->First == GeoId && (*it)->FirstPos == Sketcher::PointPos::none){
-                    QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Double constraint"),
-                        QObject::tr("The selected edge already has a horizontal constraint!"));
+                    Gui::TranslatedNotification(Obj, QObject::tr("Double constraint"), QObject::tr("The selected edge already has a horizontal constraint!"));
                     return;
                 }
                 if ((*it)->Type == Sketcher::Vertical && (*it)->First == GeoId && (*it)->FirstPos == Sketcher::PointPos::none) {
-                    QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Impossible constraint"),
-                                         QObject::tr("The selected edge already has a vertical constraint!"));
+                    Gui::TranslatedNotification(Obj, QObject::tr("Impossible constraint"), QObject::tr("The selected edge already has a vertical constraint!"));
                     return;
                 }
                 // check if the edge already has a Block constraint
                 if ((*it)->Type == Sketcher::Block && (*it)->First == GeoId && (*it)->FirstPos == Sketcher::PointPos::none) {
-                    QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Impossible constraint"),
-                                         QObject::tr("The selected edge already has a Block constraint!"));
+                    Gui::TranslatedNotification(Obj, QObject::tr("Impossible constraint"), QObject::tr("The selected edge already has a Block constraint!"));
                     return;
                 }
             }
@@ -974,8 +974,7 @@ void CmdSketcherConstrainHorizontal::activated(int iMsg)
     }
 
     if (edgegeoids.empty() && pointgeoids.empty()) {
-        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Impossible constraint"),
-                             QObject::tr("The selected item(s) can't accept a horizontal constraint!"));
+        Gui::TranslatedNotification(Obj, QObject::tr("Impossible constraint"), QObject::tr("The selected item(s) can't accept a horizontal constraint!"));
         return;
     }
 
@@ -1002,8 +1001,7 @@ void CmdSketcherConstrainHorizontal::activated(int iMsg)
         }
     }
     else { // vertex mode, fixedpoints > 1
-        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Impossible constraint"),
-                             QObject::tr("There are more than one fixed points selected. Select a maximum of one fixed point!"));
+        Gui::TranslatedNotification(Obj, QObject::tr("Impossible constraint"), QObject::tr("There are more than one fixed points selected. Select a maximum of one fixed point!"));
         return;
     }
     // finish the transaction and update
@@ -1030,8 +1028,7 @@ void CmdSketcherConstrainHorizontal::applyConstraint(std::vector<SelIdPair> &sel
             if (CrvId != -1) {
                 const Part::Geometry *geo = Obj->getGeometry(CrvId);
                 if (geo->getTypeId() != Part::GeomLineSegment::getClassTypeId()) {
-                    QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Impossible constraint"),
-                                        QObject::tr("The selected edge is not a line segment."));
+                    Gui::TranslatedNotification(Obj, QObject::tr("Impossible constraint"), QObject::tr("The selected edge is not a line segment."));
                     return;
                 }
 
@@ -1039,19 +1036,16 @@ void CmdSketcherConstrainHorizontal::applyConstraint(std::vector<SelIdPair> &sel
                 for (std::vector< Sketcher::Constraint * >::const_iterator it= vals.begin();
                     it != vals.end(); ++it) {
                     if ((*it)->Type == Sketcher::Horizontal && (*it)->First == CrvId && (*it)->FirstPos == Sketcher::PointPos::none){
-                        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Double constraint"),
-                            QObject::tr("The selected edge already has a horizontal constraint!"));
+                        Gui::TranslatedNotification(Obj, QObject::tr("Double constraint"), QObject::tr("The selected edge already has a horizontal constraint!"));
                         return;
                     }
                     if ((*it)->Type == Sketcher::Vertical && (*it)->First == CrvId && (*it)->FirstPos == Sketcher::PointPos::none) {
-                        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Impossible constraint"),
-                                            QObject::tr("The selected edge already has a vertical constraint!"));
+                        Gui::TranslatedNotification(Obj, QObject::tr("Impossible constraint"), QObject::tr("The selected edge already has a vertical constraint!"));
                         return;
                     }
                     // check if the edge already has a Block constraint
                     if ((*it)->Type == Sketcher::Block && (*it)->First == CrvId && (*it)->FirstPos == Sketcher::PointPos::none) {
-                        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Impossible constraint"),
-                                            QObject::tr("The selected edge already has a Block constraint!"));
+                        Gui::TranslatedNotification(Obj, QObject::tr("Impossible constraint"), QObject::tr("The selected edge already has a Block constraint!"));
                         return;
                     }
                 }
@@ -1078,7 +1072,7 @@ void CmdSketcherConstrainHorizontal::applyConstraint(std::vector<SelIdPair> &sel
             PosId1 = selSeq.at(0).PosId;  PosId2 = selSeq.at(1).PosId;
 
             if ( areBothPointsOrSegmentsFixed(Obj, GeoId1, GeoId2) ) {
-                showNoConstraintBetweenFixedGeometry();
+                showNoConstraintBetweenFixedGeometry(Obj);
                 return;
             }
 
@@ -1147,7 +1141,7 @@ void CmdSketcherConstrainVertical::activated(int iMsg)
                 new DrawSketchHandlerGenConstraint(this));
             getSelection().clearSelection();
         } else {
-            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
+            Gui::TranslatedNotification("Sketcher", QObject::tr("Wrong selection"),
                                  QObject::tr("Select an edge from the sketch."));
         }
         return;
@@ -1173,8 +1167,9 @@ void CmdSketcherConstrainVertical::activated(int iMsg)
         if (isEdge(GeoId,PosId)) {// it is an edge
             const Part::Geometry *geo = Obj->getGeometry(GeoId);
             if (geo->getTypeId() != Part::GeomLineSegment::getClassTypeId()) {
-                QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Impossible constraint"),
-                                     QObject::tr("The selected edge is not a line segment."));
+                Gui::TranslatedNotification(Obj,
+                              QObject::tr("Impossible constraint"),
+                              QObject::tr("The selected edge is not a line segment."));
                 return;
             }
 
@@ -1182,19 +1177,22 @@ void CmdSketcherConstrainVertical::activated(int iMsg)
             for (std::vector< Sketcher::Constraint * >::const_iterator it= vals.begin();
                  it != vals.end(); ++it) {
                 if ((*it)->Type == Sketcher::Vertical && (*it)->First == GeoId && (*it)->FirstPos == Sketcher::PointPos::none){
-                    QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Double constraint"),
-                                         QObject::tr("The selected edge already has a vertical constraint!"));
+                    Gui::TranslatedNotification(Obj,
+                                  QObject::tr("Double constraint"),
+                                  QObject::tr("The selected edge already has a horizontal constraint!"));
                     return;
                 }
                 if ((*it)->Type == Sketcher::Horizontal && (*it)->First == GeoId && (*it)->FirstPos == Sketcher::PointPos::none) {
-                    QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Impossible constraint"),
-                                         QObject::tr("The selected edge already has a horizontal constraint!"));
+                    Gui::TranslatedNotification(Obj,
+                                  QObject::tr("Impossible constraint"),
+                                  QObject::tr("The selected edge already has a horizontal constraint!"));
                     return;
                 }
                 // check if the edge already has a Block constraint
                 if ((*it)->Type == Sketcher::Block && (*it)->First == GeoId && (*it)->FirstPos == Sketcher::PointPos::none) {
-                    QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Impossible constraint"),
-                                         QObject::tr("The selected edge already has a Block constraint!"));
+                    Gui::TranslatedNotification(Obj,
+                                  QObject::tr("Impossible constraint"),
+                                  QObject::tr("The selected edge already has a Block constraint!"));
                     return;
                 }
             }
@@ -1211,8 +1209,9 @@ void CmdSketcherConstrainVertical::activated(int iMsg)
     }
 
     if (edgegeoids.empty() && pointgeoids.empty()) {
-        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Impossible constraint"),
-                             QObject::tr("The selected item(s) can't accept a vertical constraint!"));
+        Gui::TranslatedNotification(Obj,
+                      QObject::tr("Impossible constraint"),
+                      QObject::tr("The selected item(s) can't accept a vertical constraint!"));
         return;
     }
 
@@ -1237,8 +1236,9 @@ void CmdSketcherConstrainVertical::activated(int iMsg)
         }
     }
     else { // vertex mode, fixedpoints > 1
-        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Impossible constraint"),
-                             QObject::tr("There are more than one fixed points selected. Select a maximum of one fixed point!"));
+        Gui::TranslatedNotification(Obj,
+                      QObject::tr("Impossible constraint"),
+                      QObject::tr("There are more than one fixed points selected. Select a maximum of one fixed point!"));
         return;
     }
 
@@ -1266,8 +1266,7 @@ void CmdSketcherConstrainVertical::applyConstraint(std::vector<SelIdPair> &selSe
         if (CrvId != -1) {
             const Part::Geometry *geo = Obj->getGeometry(CrvId);
             if (geo->getTypeId() != Part::GeomLineSegment::getClassTypeId()) {
-                QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Impossible constraint"),
-                                     QObject::tr("The selected edge is not a line segment."));
+                Gui::TranslatedNotification(Obj, QObject::tr("Impossible constraint"), QObject::tr("The selected edge is not a line segment."));
                 return;
             }
 
@@ -1275,19 +1274,16 @@ void CmdSketcherConstrainVertical::applyConstraint(std::vector<SelIdPair> &selSe
             for (std::vector< Sketcher::Constraint * >::const_iterator it= vals.begin();
                  it != vals.end(); ++it) {
                 if ((*it)->Type == Sketcher::Horizontal && (*it)->First == CrvId && (*it)->FirstPos == Sketcher::PointPos::none){
-                    QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Impossible constraint"),
-                                         QObject::tr("The selected edge already has a horizontal constraint!"));
+                    Gui::TranslatedNotification(Obj, QObject::tr("Impossible constraint"), QObject::tr("The selected edge already has a horizontal constraint!"));
                     return;
                 }
                 if ((*it)->Type == Sketcher::Vertical && (*it)->First == CrvId && (*it)->FirstPos == Sketcher::PointPos::none) {
-                    QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Double constraint"),
-                                         QObject::tr("The selected edge already has a vertical constraint!"));
+                    Gui::TranslatedNotification(Obj, QObject::tr("Double constraint"), QObject::tr("The selected edge already has a vertical constraint!"));
                     return;
                 }
                 // check if the edge already has a Block constraint
                 if ((*it)->Type == Sketcher::Block && (*it)->First == CrvId && (*it)->FirstPos == Sketcher::PointPos::none) {
-                    QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Impossible constraint"),
-                                         QObject::tr("The selected edge already has a Block constraint!"));
+                    Gui::TranslatedNotification(Obj, QObject::tr("Impossible constraint"), QObject::tr("The selected edge already has a Block constraint!"));
                     return;
                 }
             }
@@ -1313,7 +1309,7 @@ void CmdSketcherConstrainVertical::applyConstraint(std::vector<SelIdPair> &selSe
         PosId1 = selSeq.at(0).PosId;  PosId2 = selSeq.at(1).PosId;
 
         if ( areBothPointsOrSegmentsFixed(Obj, GeoId1, GeoId2) ) {
-            showNoConstraintBetweenFixedGeometry();
+            showNoConstraintBetweenFixedGeometry(Obj);
             return;
         }
 
@@ -1384,7 +1380,7 @@ void CmdSketcherConstrainLock::activated(int iMsg)
                 new DrawSketchHandlerGenConstraint(this));
             getSelection().clearSelection();
         } else {
-            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
+            Gui::TranslatedNotification("Sketcher", QObject::tr("Wrong selection"),
                                  QObject::tr("Select vertices from the sketch."));
         }
         return;
@@ -1407,12 +1403,14 @@ void CmdSketcherConstrainLock::activated(int iMsg)
         if ((it != std::prev(SubNames.end()) && (isEdge(GeoIdt,PosIdt) || (GeoIdt < 0 && GeoIdt >= Sketcher::GeoEnum::VAxis))) ||
             (it == std::prev(SubNames.end()) && isEdge(GeoIdt,PosIdt)) ) {
             if(selection.size() == 1) {
-                QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                                     QObject::tr("Select one vertex from the sketch other than the origin."));
+                Gui::TranslatedNotification(Obj,
+                              QObject::tr("Wrong selection"),
+                              QObject::tr("Select one vertex from the sketch other than the origin."));
             }
             else {
-                QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                                     QObject::tr("Select only vertices from the sketch. The last selected vertex may be the origin."));
+                Gui::TranslatedNotification(Obj,
+                              QObject::tr("Wrong selection"),
+                              QObject::tr("Select only vertices from the sketch. The last selected vertex may be the origin."));
             }
             // clear the selection (convenience)
             getSelection().clearSelection();
@@ -1608,7 +1606,7 @@ void CmdSketcherConstrainBlock::activated(int iMsg)
                             new DrawSketchHandlerGenConstraint(this));
             getSelection().clearSelection();
         } else {
-            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
+            Gui::TranslatedNotification("Sketcher", QObject::tr("Wrong selection"),
                                     QObject::tr("Select vertices from the sketch."));
         }
         return;
@@ -1620,11 +1618,12 @@ void CmdSketcherConstrainBlock::activated(int iMsg)
 
     // Check that the solver does not report redundant/conflicting constraints
     if(Obj->getLastSolverStatus()!=GCS::Success || Obj->getLastHasConflicts() || Obj->getLastHasRedundancies()) {
-      QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong solver status"),
-                           QObject::tr("A Block constraint cannot be added "
-                                       "if the sketch is unsolved "
-                                       "or there are redundant and "
-                                       "conflicting constraints."));
+        Gui::TranslatedNotification(Obj,
+                      QObject::tr("Wrong solver status"),
+                      QObject::tr("A Block constraint cannot be added "
+                                                         "if the sketch is unsolved "
+                                                         "or there are redundant and "
+                                                         "conflicting constraints."));
       return;
     }
 
@@ -1638,12 +1637,14 @@ void CmdSketcherConstrainBlock::activated(int iMsg)
 
         if ( isVertex(GeoIdt,PosIdt) || GeoIdt < 0 ) {
             if(selection.size() == 1) {
-                QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                                        QObject::tr("Select one edge from the sketch."));
+                Gui::TranslatedNotification(Obj,
+                              QObject::tr("Wrong selection"),
+                              QObject::tr("Select one edge from the sketch."));
             }
             else {
-                QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                                        QObject::tr("Select only edges from the sketch."));
+                Gui::TranslatedNotification(Obj,
+                              QObject::tr("Wrong selection"),
+                              QObject::tr("Select only edges from the sketch."));
             }
             // clear the selection
             getSelection().clearSelection();
@@ -1652,8 +1653,9 @@ void CmdSketcherConstrainBlock::activated(int iMsg)
 
         // check if the edge already has a Block constraint
         if ( checkConstraint(vals, Sketcher::Block, GeoIdt, Sketcher::PointPos::none)) {
-            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Double constraint"),
-                                 QObject::tr("The selected edge already has a Block constraint!"));
+            Gui::TranslatedNotification(Obj,
+                          QObject::tr("Double constraint"),
+                          QObject::tr("The selected edge already has a Block constraint!"));
             return;
         }
 
@@ -1669,10 +1671,9 @@ void CmdSketcherConstrainBlock::activated(int iMsg)
             Gui::cmdAppObjectArgs(Obj, "addConstraint(Sketcher.Constraint('Block',%d)) ", (*itg));
 
         } catch (const Base::Exception& e) {
-            Base::Console().Error("%s\n", e.what());
-            QMessageBox::warning(Gui::getMainWindow(),
-                                 QObject::tr("Error"),
-                                 QString::fromLatin1(e.what()));
+            Gui::NotifyError(Obj,
+                        QT_TRANSLATE_NOOP("Notifications", "Error"),
+                        e.what());
 
             Gui::Command::abortCommand();
 
@@ -1696,12 +1697,13 @@ void CmdSketcherConstrainBlock::applyConstraint(std::vector<SelIdPair> &selSeq, 
             // Create the constraints
             SketcherGui::ViewProviderSketch* sketchgui = static_cast<SketcherGui::ViewProviderSketch*>(getActiveGuiDocument()->getInEdit());
 
+            auto Obj = static_cast<Sketcher::SketchObject *>(sketchgui->getObject());
+
             // check if the edge already has a Block constraint
-            const std::vector< Sketcher::Constraint * > &vals = static_cast<Sketcher::SketchObject *>(sketchgui->getObject())->Constraints.getValues();
+            const std::vector< Sketcher::Constraint * > &vals = Obj->Constraints.getValues();
 
             if ( checkConstraint(vals, Sketcher::Block, selSeq.front().GeoId, Sketcher::PointPos::none)) {
-                QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Double constraint"),
-                                     QObject::tr("The selected edge already has a Block constraint!"));
+                Gui::TranslatedNotification(Obj, QObject::tr("Double constraint"), QObject::tr("The selected edge already has a Block constraint!"));
                 return;
             }
 
@@ -1714,10 +1716,9 @@ void CmdSketcherConstrainBlock::applyConstraint(std::vector<SelIdPair> &selSeq, 
                                       selSeq.front().GeoId);
 
             } catch (const Base::Exception& e) {
-                Base::Console().Error("%s\n", e.what());
-                QMessageBox::warning(Gui::getMainWindow(),
-                                     QObject::tr("Error"),
-                                     QString::fromLatin1(e.what()));
+                Gui::NotifyError(Obj,
+                            QT_TRANSLATE_NOOP("Notifications", "Error"),
+                            e.what());
 
                 Gui::Command::abortCommand();
 
@@ -1985,7 +1986,7 @@ void CmdSketcherConstrainCoincident::activated(int iMsg)
             getSelection().clearSelection();
         } else {
             // TODO: Get the exact message from git history and put it here
-            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
+            Gui::TranslatedNotification("Sketcher", QObject::tr("Wrong selection"),
                                  QObject::tr("Select two or more points from the sketch."));
         }
         return;
@@ -1996,8 +1997,9 @@ void CmdSketcherConstrainCoincident::activated(int iMsg)
     Sketcher::SketchObject* Obj = static_cast<Sketcher::SketchObject*>(selection[0].getObject());
 
     if (SubNames.size() < 2) {
-        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-            QObject::tr("Select two or more vertices from the sketch."));
+        Gui::TranslatedNotification(Obj,
+                      QObject::tr("Wrong selection"),
+                      QObject::tr("Select two or more vertices from the sketch."));
         return;
     }
 
@@ -2016,8 +2018,9 @@ void CmdSketcherConstrainCoincident::activated(int iMsg)
             allConicsEdges = false; //at least one point is selected, so concentric can't be applied.
 
         if (atLeastOneEdge && !allConicsEdges) {
-            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                QObject::tr("Select two or more vertices from the sketch for a coincident constraint, or two or more circles, ellipses, arcs or arcs of ellipse for a concentric constraint."));
+            Gui::TranslatedNotification(Obj,
+                          QObject::tr("Wrong selection"),
+                          QObject::tr("Select two or more vertices from the sketch for a coincident constraint, or two or more circles, ellipses, arcs or arcs of ellipse for a concentric constraint."));
             return;
         }
     }
@@ -2038,7 +2041,7 @@ void CmdSketcherConstrainCoincident::activated(int iMsg)
 
         // check if the edge already has a Block constraint
         if (areBothPointsOrSegmentsFixed(Obj,GeoId1,GeoId2)) {
-            showNoConstraintBetweenFixedGeometry();
+            showNoConstraintBetweenFixedGeometry(Obj);
             return;
         }
 
@@ -2091,8 +2094,9 @@ void CmdSketcherConstrainCoincident::applyConstraint(std::vector<SelIdPair> &sel
     case 4: // {SelExternalEdge, SelEdge}
         //Concentric for circles, ellipse, arc, arcofEllipse only.
         if (!isGeoConcentricCompatible(Obj->getGeometry(GeoId1)) || !isGeoConcentricCompatible(Obj->getGeometry(GeoId2))) {
-            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                QObject::tr("Select two vertices from the sketch for a coincident constraint, or two circles, ellipses, arcs or arcs of ellipse for a concentric constraint."));
+            Gui::TranslatedNotification(Obj,
+                          QObject::tr("Wrong selection"),
+                          QObject::tr("Select two vertices from the sketch for a coincident constraint, or two circles, ellipses, arcs or arcs of ellipse for a concentric constraint."));
             return;
         }
         PosId1 = Sketcher::PointPos::mid;
@@ -2102,7 +2106,7 @@ void CmdSketcherConstrainCoincident::applyConstraint(std::vector<SelIdPair> &sel
 
     // check if the edge already has a Block constraint
     if (areBothPointsOrSegmentsFixed(Obj, GeoId1, GeoId2)) {
-        showNoConstraintBetweenFixedGeometry();
+        showNoConstraintBetweenFixedGeometry(Obj);
         return;
     }
 
@@ -2177,7 +2181,7 @@ void CmdSketcherConstrainDistance::activated(int iMsg)
             getSelection().clearSelection();
         }
         else {
-            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
+            Gui::TranslatedNotification("Sketcher", QObject::tr("Wrong selection"),
                                  QObject::tr("Select vertices from the sketch."));
         }
         return;
@@ -2188,8 +2192,9 @@ void CmdSketcherConstrainDistance::activated(int iMsg)
     Sketcher::SketchObject* Obj = static_cast<Sketcher::SketchObject*>(selection[0].getObject());
 
     if (SubNames.empty() || SubNames.size() > 2) {
-        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-            QObject::tr("Select exactly one line or one point and one line or two points from the sketch."));
+        Gui::TranslatedNotification(Obj,
+                      QObject::tr("Wrong selection"),
+                      QObject::tr("Select exactly one line or one point and one line or two points from the sketch."));
         return;
     }
 
@@ -2286,8 +2291,9 @@ void CmdSketcherConstrainDistance::activated(int iMsg)
     }
     else if (isEdge(GeoId1,PosId1)) { // line length
         if (GeoId1 < 0 && GeoId1 >= Sketcher::GeoEnum::VAxis) {
-            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                                 QObject::tr("Cannot add a length constraint on an axis!"));
+            Gui::TranslatedNotification(Obj,
+                          QObject::tr("Wrong selection"),
+                          QObject::tr("Cannot add a length constraint on an axis!"));
             return;
         }
 
@@ -2319,8 +2325,9 @@ void CmdSketcherConstrainDistance::activated(int iMsg)
         }
     }
 
-    QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-        QObject::tr("Select exactly one line or one point and one line or two points from the sketch."));
+    Gui::TranslatedNotification(Obj,
+                  QObject::tr("Wrong selection"),
+                  QObject::tr("Select exactly one line or one point and one line or two points from the sketch."));
     return;
 }
 
@@ -2410,8 +2417,9 @@ void CmdSketcherConstrainDistance::applyConstraint(std::vector<SelIdPair> &selSe
                 finishDatumConstraint (this, Obj, true);
         }
         else {
-            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                QObject::tr("This constraint does not make sense for non-linear curves."));
+            Gui::TranslatedNotification(Obj,
+                          QObject::tr("Wrong selection"),
+                          QObject::tr("This constraint does not make sense for non-linear curves."));
         }
 
         return;
@@ -2555,7 +2563,7 @@ void CmdSketcherConstrainPointOnObject::activated(int iMsg)
             getSelection().clearSelection();
         } else {
             // TODO: Get the exact message from git history and put it here
-            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
+            Gui::TranslatedNotification("Sketcher", QObject::tr("Wrong selection"),
                                  QObject::tr("Select the right things from the sketch."));
         }
         return;
@@ -2585,7 +2593,7 @@ void CmdSketcherConstrainPointOnObject::activated(int iMsg)
         for (std::size_t iPnt = 0;  iPnt < points.size();  iPnt++) {
             for (std::size_t iCrv = 0;  iCrv < curves.size();  iCrv++) {
                 if (areBothPointsOrSegmentsFixed(Obj, points[iPnt].GeoId, curves[iCrv].GeoId)){
-                    showNoConstraintBetweenFixedGeometry();
+                    showNoConstraintBetweenFixedGeometry(Obj);
                     continue;
                 }
                 if (points[iPnt].GeoId == curves[iCrv].GeoId)
@@ -2594,8 +2602,9 @@ void CmdSketcherConstrainPointOnObject::activated(int iMsg)
                 const Part::Geometry *geom = Obj->getGeometry(curves[iCrv].GeoId);
 
                 if( geom && isBsplinePole(geom)) {
-                    QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                                        QObject::tr("Select an edge that is not a B-spline weight."));
+                    Gui::TranslatedNotification(Obj,
+                                  QObject::tr("Wrong selection"),
+                                  QObject::tr("Select an edge that is not a B-spline weight."));
                     abortCommand();
 
                     continue;
@@ -2616,21 +2625,22 @@ void CmdSketcherConstrainPointOnObject::activated(int iMsg)
             getSelection().clearSelection();
         } else {
             abortCommand();
-            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                QObject::tr("None of the selected points were constrained "
-                            "onto the respective curves, "
-                            "because they are parts "
-                            "of the same element, "
-                            "because they are both external geometry, "
-                            "or because the edge is not eligible."));
+            Gui::TranslatedNotification(Obj,
+                          QObject::tr("Wrong selection"),
+                          QObject::tr("None of the selected points were constrained "
+                                                             "onto the respective curves, "
+                                                             "because they are parts "
+                                                             "of the same element, "
+                                                             "because they are both external geometry, "
+                                                             "or because the edge is not eligible."));
         }
         return;
     }
 
-    QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-        QObject::tr("Select either one point and several curves, "
-                    "or one curve and several points. "
-                    "You have selected %1 curves and %2 points.").arg(curves.size()).arg(points.size()));
+    Gui::TranslatedNotification(Obj,
+                  QObject::tr("Wrong selection"),
+                  QObject::tr("Select either one point and several curves, "
+                                                     "or one curve and several points."));
     return;
 }
 
@@ -2665,7 +2675,7 @@ void CmdSketcherConstrainPointOnObject::applyConstraint(std::vector<SelIdPair> &
     bool allOK = true;
 
     if (areBothPointsOrSegmentsFixed(Obj, GeoIdVt, GeoIdCrv)){
-        showNoConstraintBetweenFixedGeometry();
+        showNoConstraintBetweenFixedGeometry(Obj);
         allOK = false;
     }
     if (GeoIdVt == GeoIdCrv)
@@ -2674,8 +2684,9 @@ void CmdSketcherConstrainPointOnObject::applyConstraint(std::vector<SelIdPair> &
     const Part::Geometry *geom = Obj->getGeometry(GeoIdCrv);
 
     if( geom && isBsplinePole(geom)) {
-        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                             QObject::tr("Select an edge that is not a B-spline weight."));
+        Gui::TranslatedNotification(Obj,
+                      QObject::tr("Wrong selection"),
+                      QObject::tr("Select an edge that is not a B-spline weight."));
         abortCommand();
 
         return;
@@ -2691,11 +2702,12 @@ void CmdSketcherConstrainPointOnObject::applyConstraint(std::vector<SelIdPair> &
     }
     else {
         abortCommand();
-        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-            QObject::tr("None of the selected points "
-                        "were constrained onto the respective curves, "
-                        "either because they are parts of the same element, "
-                        "or because they are both external geometry."));
+        Gui::TranslatedNotification(Obj,
+                      QObject::tr("Wrong selection"),
+                      QObject::tr("None of the selected points "
+                                                         "were constrained onto the respective curves, "
+                                                         "either because they are parts of the same element, "
+                                                         "or because they are both external geometry."));
     }
     return;
 }
@@ -2752,7 +2764,7 @@ void CmdSketcherConstrainDistanceX::activated(int iMsg)
         }
         else {
             // TODO: Get the exact message from git history and put it here
-            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
+            Gui::TranslatedNotification("Sketcher", QObject::tr("Wrong selection"),
                                  QObject::tr("Select the right things from the sketch."));
         }
         return;
@@ -2763,8 +2775,9 @@ void CmdSketcherConstrainDistanceX::activated(int iMsg)
     Sketcher::SketchObject* Obj = static_cast<Sketcher::SketchObject*>(selection[0].getObject());
 
     if (SubNames.empty() || SubNames.size() > 2) {
-        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-            QObject::tr("Select exactly one line or up to two points from the sketch."));
+        Gui::TranslatedNotification(Obj,
+                      QObject::tr("Wrong selection"),
+                      QObject::tr("Select exactly one line or up to two points from the sketch."));
         return;
     }
 
@@ -2792,8 +2805,9 @@ void CmdSketcherConstrainDistanceX::activated(int iMsg)
     if (isEdge(GeoId1,PosId1) && GeoId2 == GeoEnum::GeoUndef)  {
         // horizontal length of a line
         if (GeoId1 < 0 && GeoId1 >= Sketcher::GeoEnum::VAxis) {
-            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                                 QObject::tr("Cannot add a horizontal length constraint on an axis!"));
+            Gui::TranslatedNotification(Obj,
+                          QObject::tr("Wrong selection"),
+                          QObject::tr("Cannot add a horizontal length constraint on an axis!"));
             return;
         }
 
@@ -2842,8 +2856,9 @@ void CmdSketcherConstrainDistanceX::activated(int iMsg)
         // point on fixed x-coordinate
 
         if (GeoId1 < 0 && GeoId1 >= Sketcher::GeoEnum::VAxis) {
-            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                    QObject::tr("Cannot add a fixed x-coordinate constraint on the origin point!"));
+            Gui::TranslatedNotification(Obj,
+                          QObject::tr("Wrong selection"),
+                          QObject::tr("Cannot add a fixed x-coordinate constraint on the origin point!"));
             return;
         }
 
@@ -2871,8 +2886,10 @@ void CmdSketcherConstrainDistanceX::activated(int iMsg)
         return;
     }
 
-    QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-        QObject::tr("Select exactly one line or up to two points from the sketch."));
+    Gui::TranslatedNotification(Obj,
+                  QObject::tr("Wrong selection"),
+                  QObject::tr("Select exactly one line or up to two points from the sketch."));
+
     return;
 }
 
@@ -2900,8 +2917,9 @@ void CmdSketcherConstrainDistanceX::applyConstraint(std::vector<SelIdPair> &selS
 
         const Part::Geometry *geom = Obj->getGeometry(GeoId1);
         if (geom->getTypeId() != Part::GeomLineSegment::getClassTypeId()) {
-            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                QObject::tr("This constraint only makes sense on a line segment or a pair of points."));
+            Gui::TranslatedNotification(Obj,
+                          QObject::tr("Wrong selection"),
+                          QObject::tr("This constraint only makes sense on a line segment or a pair of points."));
             return;
         }
 
@@ -3004,7 +3022,7 @@ void CmdSketcherConstrainDistanceY::activated(int iMsg)
             getSelection().clearSelection();
         } else {
             // TODO: Get the exact message from git history and put it here
-            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
+            Gui::TranslatedNotification("Sketcher", QObject::tr("Wrong selection"),
                                  QObject::tr("Select the right things from the sketch."));
         }
         return;
@@ -3015,8 +3033,9 @@ void CmdSketcherConstrainDistanceY::activated(int iMsg)
     Sketcher::SketchObject* Obj = static_cast<Sketcher::SketchObject*>(selection[0].getObject());
 
     if (SubNames.empty() || SubNames.size() > 2) {
-        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-            QObject::tr("Select exactly one line or up to two points from the sketch."));
+        Gui::TranslatedNotification(Obj,
+                      QObject::tr("Wrong selection"),
+                      QObject::tr("Select exactly one line or up to two points from the sketch."));
         return;
     }
 
@@ -3040,8 +3059,9 @@ void CmdSketcherConstrainDistanceY::activated(int iMsg)
 
     if (isEdge(GeoId1,PosId1) && GeoId2 == GeoEnum::GeoUndef)  { // vertical length of a line
         if (GeoId1 < 0 && GeoId1 >= Sketcher::GeoEnum::VAxis) {
-            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                        QObject::tr("Cannot add a vertical length constraint on an axis!"));
+            Gui::TranslatedNotification(Obj,
+                          QObject::tr("Wrong selection"),
+                          QObject::tr("Cannot add a vertical length constraint on an axis!"));
             return;
         }
 
@@ -3090,8 +3110,9 @@ void CmdSketcherConstrainDistanceY::activated(int iMsg)
     else if (isVertex(GeoId1,PosId1) && GeoId2 == GeoEnum::GeoUndef) {
         // point on fixed y-coordinate
         if (GeoId1 < 0 && GeoId1 >= Sketcher::GeoEnum::VAxis) {
-            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                QObject::tr("Cannot add a fixed y-coordinate constraint on the origin point!"));
+            Gui::TranslatedNotification(Obj,
+                          QObject::tr("Wrong selection"),
+                          QObject::tr("Cannot add a fixed y-coordinate constraint on the origin point!"));
             return;
         }
 
@@ -3119,8 +3140,10 @@ void CmdSketcherConstrainDistanceY::activated(int iMsg)
         return;
     }
 
-    QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-        QObject::tr("Select exactly one line or up to two points from the sketch."));
+    Gui::TranslatedNotification(Obj,
+                  QObject::tr("Wrong selection"),
+                  QObject::tr("Select exactly one line or up to two points from the sketch."));
+
     return;
 }
 
@@ -3148,8 +3171,9 @@ void CmdSketcherConstrainDistanceY::applyConstraint(std::vector<SelIdPair> &selS
 
         const Part::Geometry *geom = Obj->getGeometry(GeoId1);
         if (geom->getTypeId() != Part::GeomLineSegment::getClassTypeId()) {
-            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                QObject::tr("This constraint only makes sense on a line segment or a pair of points."));
+            Gui::TranslatedNotification(Obj,
+                          QObject::tr("Wrong selection"),
+                          QObject::tr("This constraint only makes sense on a line segment or a pair of points."));
             return;
         }
 
@@ -3249,7 +3273,7 @@ void CmdSketcherConstrainParallel::activated(int iMsg)
             getSelection().clearSelection();
         } else {
             // TODO: Get the exact message from git history and put it here
-            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
+            Gui::TranslatedNotification("Sketcher", QObject::tr("Wrong selection"),
                                  QObject::tr("Select two or more lines from the sketch."));
         }
         return;
@@ -3262,8 +3286,9 @@ void CmdSketcherConstrainParallel::activated(int iMsg)
     // go through the selected subelements
 
     if (SubNames.size() < 2) {
-        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-            QObject::tr("Select at least two lines from the sketch."));
+        Gui::TranslatedNotification(Obj,
+                      QObject::tr("Wrong selection"),
+                      QObject::tr("Select at least two lines from the sketch."));
         return;
     }
 
@@ -3276,13 +3301,14 @@ void CmdSketcherConstrainParallel::activated(int iMsg)
         getIdsFromName(*it, Obj, GeoId, PosId);
 
         if (!isEdge(GeoId,PosId)) {
-            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                                 QObject::tr("Select a valid line."));
+            Gui::TranslatedNotification(Obj,
+                          QObject::tr("Wrong selection"),
+                          QObject::tr("Select a valid line."));
             return;
         }
         else if (isPointOrSegmentFixed(Obj,GeoId)) {
             if (hasAlreadyExternal) {
-                showNoConstraintBetweenFixedGeometry();
+                showNoConstraintBetweenFixedGeometry(Obj);
                 return;
             }
             else
@@ -3292,8 +3318,10 @@ void CmdSketcherConstrainParallel::activated(int iMsg)
         // Check that the curve is a line segment
         const Part::Geometry *geo = Obj->getGeometry(GeoId);
         if (geo->getTypeId() != Part::GeomLineSegment::getClassTypeId()) {
-            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                                QObject::tr("The selected edge is not a valid line."));
+            Gui::TranslatedNotification(Obj,
+                          QObject::tr("Wrong selection"),
+                          QObject::tr("The selected edge is not a valid line."));
+
             return;
         }
         ids.push_back(GeoId);
@@ -3330,13 +3358,14 @@ void CmdSketcherConstrainParallel::applyConstraint(std::vector<SelIdPair> &selSe
         // Check that the curves are line segments
         if (    Obj->getGeometry(GeoId1)->getTypeId() != Part::GeomLineSegment::getClassTypeId() ||
                 Obj->getGeometry(GeoId2)->getTypeId() != Part::GeomLineSegment::getClassTypeId()) {
-            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                                QObject::tr("The selected edge is not a valid line."));
+            Gui::TranslatedNotification(Obj,
+                          QObject::tr("Wrong selection"),
+                          QObject::tr("The selected edge is not a valid line."));
             return;
         }
 
         if( areBothPointsOrSegmentsFixed(Obj,GeoId1, GeoId2)) {
-            showNoConstraintBetweenFixedGeometry();
+            showNoConstraintBetweenFixedGeometry(Obj);
             return;
         }
 
@@ -3394,12 +3423,6 @@ CmdSketcherConstrainPerpendicular::CmdSketcherConstrainPerpendicular()
 void CmdSketcherConstrainPerpendicular::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-    QString strBasicHelp =
-            QObject::tr(
-             "There is a number of ways this constraint can be applied.\n\n"
-             "Accepted combinations: two curves; an endpoint and a curve; two endpoints; two curves and a point.",
-             /*disambig.:*/ "perpendicular constraint");
-    QString strError;
 
     // get the selection
     std::vector<Gui::SelectionObject> selection = getSelection().getSelectionEx();
@@ -3415,10 +3438,16 @@ void CmdSketcherConstrainPerpendicular::activated(int iMsg)
             getSelection().clearSelection();
         } else {
             // TODO: Get the exact message from git history and put it here
-            strError = QObject::tr("Select some geometry from the sketch.", "perpendicular constraint");
-            if (!strError.isEmpty()) strError.append(QString::fromLatin1("\n\n"));
-            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                                 strError+strBasicHelp);
+            QString strBasicHelp =
+            QObject::tr(
+                "There is a number of ways this constraint can be applied.\n\n"
+                "Accepted combinations: two curves; an endpoint and a curve; two endpoints; two curves and a point.",
+                /*disambig.:*/ "perpendicular constraint");
+            QString strError = QObject::tr("Select some geometry from the sketch.", "perpendicular constraint");
+            strError.append(QString::fromLatin1("\n\n"));
+            strError.append(strBasicHelp);
+            Gui::TranslatedNotification("Sketcher", QObject::tr("Wrong selection"),
+                                 std::move(strError));
         }
         return;
     }
@@ -3428,10 +3457,9 @@ void CmdSketcherConstrainPerpendicular::activated(int iMsg)
     Sketcher::SketchObject* Obj = dynamic_cast<Sketcher::SketchObject*>(selection[0].getObject());
 
     if (!Obj || (SubNames.size() != 2 && SubNames.size() != 3)) {
-        strError = QObject::tr("Wrong number of selected objects!","perpendicular constraint.");
-        if (!strError.isEmpty()) strError.append(QString::fromLatin1("\n\n"));
-        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-            strError+strBasicHelp);
+        Gui::TranslatedNotification(Obj,
+                      QObject::tr("Wrong selection"),
+                      QObject::tr("Wrong number of selected objects!"));
         return;
     }
 
@@ -3441,7 +3469,7 @@ void CmdSketcherConstrainPerpendicular::activated(int iMsg)
     getIdsFromName(SubNames[1], Obj, GeoId2, PosId2);
 
     if (areBothPointsOrSegmentsFixed(Obj, GeoId1, GeoId2)) { //checkBothExternal displays error message
-        showNoConstraintBetweenFixedGeometry();
+        showNoConstraintBetweenFixedGeometry(Obj);
         return;
     }
 
@@ -3460,8 +3488,9 @@ void CmdSketcherConstrainPerpendicular::activated(int iMsg)
         if (isEdge(GeoId1, PosId1) && isEdge(GeoId2, PosId2) && isVertex(GeoId3, PosId3)) {
 
             if(isBsplinePole(Obj, GeoId1) || isBsplinePole(Obj, GeoId2)) {
-                QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                             QObject::tr("Select an edge that is not a B-spline weight."));
+                Gui::TranslatedNotification(Obj,
+                              QObject::tr("Wrong selection"),
+                              QObject::tr("Select an edge that is not a B-spline weight."));
                 return;
             }
 
@@ -3487,10 +3516,10 @@ void CmdSketcherConstrainPerpendicular::activated(int iMsg)
                 Gui::cmdAppObjectArgs(selection[0].getObject(), "addConstraint(Sketcher.Constraint('PerpendicularViaPoint',%d,%d,%d,%d)) ",
                     GeoId1,GeoId2,GeoId3,static_cast<int>(PosId3));
             } catch (const Base::Exception& e) {
-                Base::Console().Error("%s\n", e.what());
-                QMessageBox::warning(Gui::getMainWindow(),
-                                     QObject::tr("Error"),
-                                     QString::fromLatin1(e.what()));
+                Gui::NotifyError(Obj,
+                            QT_TRANSLATE_NOOP("Notifications", "Error"),
+                            e.what());
+
                 Gui::Command::abortCommand();
 
                 tryAutoRecompute(Obj);
@@ -3505,7 +3534,11 @@ void CmdSketcherConstrainPerpendicular::activated(int iMsg)
             return;
 
         };
-        strError = QObject::tr("With 3 objects, there must be 2 curves and 1 point.", "tangent constraint");
+
+        Gui::TranslatedNotification(Obj,
+                      QObject::tr("Wrong selection"),
+                      QObject::tr("With 3 objects, there must be 2 curves and 1 point."));
+
 
     } else if (SubNames.size() == 2) {
 
@@ -3513,8 +3546,9 @@ void CmdSketcherConstrainPerpendicular::activated(int iMsg)
 
             if (isSimpleVertex(Obj, GeoId1, PosId1) ||
                 isSimpleVertex(Obj, GeoId2, PosId2)) {
-                QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                    QObject::tr("Cannot add a perpendicularity constraint at an unconnected point!"));
+                Gui::TranslatedNotification(Obj,
+                              QObject::tr("Wrong selection"),
+                              QObject::tr("Cannot add a perpendicularity constraint at an unconnected point!"));
                 return;
             }
 
@@ -3550,8 +3584,9 @@ void CmdSketcherConstrainPerpendicular::activated(int iMsg)
             }
 
             if (isSimpleVertex(Obj, GeoId1, PosId1)) {
-                QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                    QObject::tr("Cannot add a perpendicularity constraint at an unconnected point!"));
+                Gui::TranslatedNotification(Obj,
+                              QObject::tr("Wrong selection"),
+                              QObject::tr("Cannot add a perpendicularity constraint at an unconnected point!"));
                 return;
             }
 
@@ -3559,14 +3594,16 @@ void CmdSketcherConstrainPerpendicular::activated(int iMsg)
 
             if( geom2 && geom2->getTypeId() == Part::GeomBSplineCurve::getClassTypeId() ){
                 // unsupported until normal to B-spline at any point implemented.
-                QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                                     QObject::tr("Perpendicular to B-spline edge currently unsupported."));
+                Gui::TranslatedNotification(Obj,
+                              QObject::tr("Wrong selection"),
+                              QObject::tr("Perpendicular to B-spline edge currently unsupported."));
                 return;
             }
 
             if(isBsplinePole(geom2)) {
-                QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                             QObject::tr("Select an edge that is not a B-spline weight."));
+                Gui::TranslatedNotification(Obj,
+                              QObject::tr("Wrong selection"),
+                              QObject::tr("Select an edge that is not a B-spline weight."));
                 return;
             }
 
@@ -3589,8 +3626,9 @@ void CmdSketcherConstrainPerpendicular::activated(int iMsg)
 
             if (geo1->getTypeId() != Part::GeomLineSegment::getClassTypeId() &&
                 geo2->getTypeId() != Part::GeomLineSegment::getClassTypeId()) {
-                QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                    QObject::tr("One of the selected edges should be a line."));
+                Gui::TranslatedNotification(Obj,
+                              QObject::tr("Wrong selection"),
+                              QObject::tr("One of the selected edges should be a line."));
                 return;
             }
 
@@ -3598,8 +3636,9 @@ void CmdSketcherConstrainPerpendicular::activated(int iMsg)
                 geo2->getTypeId() == Part::GeomBSplineCurve::getClassTypeId()){
 
                 // unsupported until tangent to B-spline at any point implemented.
-                QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                                     QObject::tr("Perpendicular to B-spline edge currently unsupported."));
+                Gui::TranslatedNotification(Obj,
+                              QObject::tr("Wrong selection"),
+                              QObject::tr("Perpendicular to B-spline edge currently unsupported."));
                 return;
             }
 
@@ -3607,8 +3646,9 @@ void CmdSketcherConstrainPerpendicular::activated(int iMsg)
                 std::swap(GeoId1,GeoId2);
 
             if(isBsplinePole(Obj, GeoId1)) {
-                QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                             QObject::tr("Select an edge that is not a B-spline weight."));
+                Gui::TranslatedNotification(Obj,
+                              QObject::tr("Wrong selection"),
+                              QObject::tr("Select an edge that is not a B-spline weight."));
                 return;
             }
 
@@ -3734,9 +3774,6 @@ void CmdSketcherConstrainPerpendicular::activated(int iMsg)
         }
     }
 
-    if (!strError.isEmpty()) strError.append(QString::fromLatin1("\n\n"));
-    QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-        strError+strBasicHelp);
     return;
 }
 
@@ -3758,7 +3795,7 @@ void CmdSketcherConstrainPerpendicular::applyConstraint(std::vector<SelIdPair> &
 
         // check if the edge already has a Block constraint
         if ( areBothPointsOrSegmentsFixed(Obj,GeoId1,GeoId2) ) {
-            showNoConstraintBetweenFixedGeometry();
+            showNoConstraintBetweenFixedGeometry(Obj);
             return;
         }
 
@@ -3770,8 +3807,9 @@ void CmdSketcherConstrainPerpendicular::applyConstraint(std::vector<SelIdPair> &
 
         if (geo1->getTypeId() != Part::GeomLineSegment::getClassTypeId() &&
             geo2->getTypeId() != Part::GeomLineSegment::getClassTypeId()) {
-            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                QObject::tr("One of the selected edges should be a line."));
+            Gui::TranslatedNotification(Obj,
+                          QObject::tr("Wrong selection"),
+                          QObject::tr("One of the selected edges should be a line."));
             return;
         }
 
@@ -3779,8 +3817,10 @@ void CmdSketcherConstrainPerpendicular::applyConstraint(std::vector<SelIdPair> &
             geo2->getTypeId() == Part::GeomBSplineCurve::getClassTypeId()){
 
             // unsupported until tangent to B-spline at any point implemented.
-            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                                 QObject::tr("Perpendicular to B-spline edge currently unsupported."));
+            Gui::TranslatedNotification(Obj,
+                          QObject::tr("Wrong selection"),
+                          QObject::tr("Perpendicular to B-spline edge currently unsupported."));
+
             return;
         }
 
@@ -3788,8 +3828,9 @@ void CmdSketcherConstrainPerpendicular::applyConstraint(std::vector<SelIdPair> &
             std::swap(GeoId1,GeoId2);
 
         if(isBsplinePole(Obj, GeoId1)) {
-            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                            QObject::tr("Select an edge that is not a B-spline weight."));
+            Gui::TranslatedNotification(Obj,
+                          QObject::tr("Wrong selection"),
+                          QObject::tr("Select an edge that is not a B-spline weight."));
             return;
         }
 
@@ -3940,14 +3981,16 @@ void CmdSketcherConstrainPerpendicular::applyConstraint(std::vector<SelIdPair> &
 
         // check if the edge already has a Block constraint
         if ( areBothPointsOrSegmentsFixed(Obj,GeoId1,GeoId2) ) {
-            showNoConstraintBetweenFixedGeometry();
+            showNoConstraintBetweenFixedGeometry(Obj);
             return;
         }
 
         if(isBsplinePole(Obj, GeoId1) || isBsplinePole(Obj, GeoId2)) {
-                QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                             QObject::tr("Select an edge that is not a B-spline weight."));
-                return;
+            Gui::TranslatedNotification(Obj,
+                          QObject::tr("Wrong selection"),
+                          QObject::tr("Select an edge that is not a B-spline weight."));
+
+            return;
         }
 
         openCommand(QT_TRANSLATE_NOOP("Command", "Add perpendicular constraint"));
@@ -3972,10 +4015,10 @@ void CmdSketcherConstrainPerpendicular::applyConstraint(std::vector<SelIdPair> &
             Gui::cmdAppObjectArgs(Obj, "addConstraint(Sketcher.Constraint('PerpendicularViaPoint',%d,%d,%d,%d)) ",
                 GeoId1,GeoId2,GeoId3,static_cast<int>(PosId3));
         } catch (const Base::Exception& e) {
-            Base::Console().Error("%s\n", e.what());
-            QMessageBox::warning(Gui::getMainWindow(),
-                                 QObject::tr("Error"),
-                                 QString::fromLatin1(e.what()));
+            Gui::NotifyError(Obj,
+                        QT_TRANSLATE_NOOP("Notifications", "Error"),
+                        e.what());
+
             Gui::Command::abortCommand();
 
             tryAutoRecompute(Obj);
@@ -4093,13 +4136,7 @@ bool CmdSketcherConstrainTangent::substituteConstraintCombinations(SketchObject 
 void CmdSketcherConstrainTangent::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-    QString strBasicHelp =
-            QObject::tr(
-             "There are a number of ways this constraint can be applied.\n\n"
-             "Accepted combinations: two curves; an endpoint and a curve; two endpoints; two curves and a point.",
-             /*disambig.:*/ "tangent constraint");
 
-    QString strError;
     // get the selection
     std::vector<Gui::SelectionObject> selection = getSelection().getSelectionEx();
 
@@ -4113,10 +4150,16 @@ void CmdSketcherConstrainTangent::activated(int iMsg)
                     new DrawSketchHandlerGenConstraint(this));
             getSelection().clearSelection();
         } else {
-            strError = QObject::tr("Select some geometry from the sketch.", "tangent constraint");
-            if (!strError.isEmpty()) strError.append(QString::fromLatin1("\n\n"));
-            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                                 strError+strBasicHelp);
+            QString strBasicHelp =
+            QObject::tr(
+                "There are a number of ways this constraint can be applied.\n\n"
+                "Accepted combinations: two curves; an endpoint and a curve; two endpoints; two curves and a point.",
+                /*disambig.:*/ "tangent constraint");
+            QString strError = QObject::tr("Select some geometry from the sketch.", "tangent constraint");
+            strError.append(QString::fromLatin1("\n\n"));
+            strError.append(strBasicHelp);
+            Gui::TranslatedNotification("Sketcher", QObject::tr("Wrong selection"),
+                                 std::move(strError));
         }
         return;
     }
@@ -4126,10 +4169,10 @@ void CmdSketcherConstrainTangent::activated(int iMsg)
     Sketcher::SketchObject* Obj = static_cast<Sketcher::SketchObject*>(selection[0].getObject());
 
     if (SubNames.size() != 2 && SubNames.size() != 3){
-        strError = QObject::tr("Wrong number of selected objects!","tangent constraint");
-        if (!strError.isEmpty()) strError.append(QString::fromLatin1("\n\n"));
-        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-            strError+strBasicHelp);
+        Gui::TranslatedNotification(Obj,
+                      QObject::tr("Wrong selection"),
+                      QObject::tr("Wrong number of selected objects!"));
+
         return;
 
     }
@@ -4140,7 +4183,7 @@ void CmdSketcherConstrainTangent::activated(int iMsg)
     getIdsFromName(SubNames[1], Obj, GeoId2, PosId2);
 
     if (areBothPointsOrSegmentsFixed(Obj, GeoId1, GeoId2)){ //checkBothExternal displays error message
-        showNoConstraintBetweenFixedGeometry();
+        showNoConstraintBetweenFixedGeometry(Obj);
         return;
     }
     if (SubNames.size() == 3) { //tangent via point
@@ -4158,8 +4201,10 @@ void CmdSketcherConstrainTangent::activated(int iMsg)
         if (isEdge(GeoId1, PosId1) && isEdge(GeoId2, PosId2) && isVertex(GeoId3, PosId3)) {
 
             if(isBsplinePole(Obj, GeoId1) || isBsplinePole(Obj, GeoId2)) {
-                QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                             QObject::tr("Select an edge that is not a B-spline weight."));
+                Gui::TranslatedNotification(Obj,
+                              QObject::tr("Wrong selection"),
+                              QObject::tr("Select an edge that is not a B-spline weight."));
+
                 return;
             }
 
@@ -4185,10 +4230,9 @@ void CmdSketcherConstrainTangent::activated(int iMsg)
                 Gui::cmdAppObjectArgs(selection[0].getObject(), "addConstraint(Sketcher.Constraint('TangentViaPoint',%d,%d,%d,%d)) ",
                     GeoId1,GeoId2,GeoId3,static_cast<int>(PosId3));
             } catch (const Base::Exception& e) {
-                Base::Console().Error("%s\n", e.what());
-                QMessageBox::warning(Gui::getMainWindow(),
-                                     QObject::tr("Error"),
-                                     QString::fromLatin1(e.what()));
+                Gui::NotifyError(Obj,
+                            QT_TRANSLATE_NOOP("Notifications", "Error"),
+                            e.what());
                 Gui::Command::abortCommand();
                 tryAutoRecompute(Obj);
                 return;
@@ -4202,7 +4246,10 @@ void CmdSketcherConstrainTangent::activated(int iMsg)
             return;
 
         };
-        strError = QObject::tr("With 3 objects, there must be 2 curves and 1 point.", "tangent constraint");
+
+        Gui::TranslatedNotification(Obj,
+                      QObject::tr("Wrong selection"),
+                      QObject::tr("With 3 objects, there must be 2 curves and 1 point."));
 
     }
     else if (SubNames.size() == 2) {
@@ -4216,17 +4263,22 @@ void CmdSketcherConstrainTangent::activated(int iMsg)
 
             if (isSimpleVertex(Obj, GeoId1, PosId1) ||
                 isSimpleVertex(Obj, GeoId2, PosId2)) {
+
                 if (isBsplineKnot(Obj, GeoId1)) {
                     const Part::Geometry *geom2 = Obj->getGeometry(GeoId2);
                     if (!geom2 || geom2->getTypeId() !=Part::GeomLineSegment::getClassTypeId()) {
-                        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                                             QObject::tr("Tangent constraint at B-spline knot is only supported with lines!"));
+                        Gui::TranslatedNotification(Obj,
+                              QObject::tr("Wrong selection"),
+                              QObject::tr("Tangent constraint at B-spline knot is only supported with lines!"));
+
                         return;
                     }
                 }
                 else {
-                    QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                                         QObject::tr("Cannot add a tangency constraint at an unconnected point!"));
+                    Gui::TranslatedNotification(Obj,
+                              QObject::tr("Wrong selection"),
+                              QObject::tr("Cannot add a tangency constraint at an unconnected point!"));
+
                     return;
                 }
             }
@@ -4250,14 +4302,17 @@ void CmdSketcherConstrainTangent::activated(int iMsg)
                 if (isBsplineKnot(Obj, GeoId1)) {
                     const Part::Geometry *geom2 = Obj->getGeometry(GeoId2);
                     if (!geom2 || geom2->getTypeId() !=Part::GeomLineSegment::getClassTypeId()) {
-                        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                                             QObject::tr("Tangent constraint at B-spline knot is only supported with lines!"));
+                        Gui::TranslatedNotification(Obj,
+                                      QObject::tr("Wrong selection"),
+                                      QObject::tr("Tangent constraint at B-spline knot is only supported with lines!"));
                         return;
                     }
                 }
                 else {
-                    QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                                         QObject::tr("Cannot add a tangency constraint at an unconnected point!"));
+                    Gui::TranslatedNotification(Obj,
+                                  QObject::tr("Wrong selection"),
+                                  QObject::tr("Cannot add a tangency constraint at an unconnected point!"));
+
                     return;
                 }
             }
@@ -4266,14 +4321,18 @@ void CmdSketcherConstrainTangent::activated(int iMsg)
 
             if( geom2 && geom2->getTypeId() == Part::GeomBSplineCurve::getClassTypeId() ){
                 // unsupported until tangent to B-spline at any point implemented.
-                QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                                     QObject::tr("Tangency to B-spline edge currently unsupported."));
+                Gui::TranslatedNotification(Obj,
+                              QObject::tr("Wrong selection"),
+                              QObject::tr("Tangency to B-spline edge currently unsupported."));
+
                 return;
             }
 
             if(isBsplinePole(geom2)) {
-                QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                             QObject::tr("Select an edge that is not a B-spline weight."));
+                Gui::TranslatedNotification(Obj,
+                              QObject::tr("Wrong selection"),
+                              QObject::tr("Select an edge that is not a B-spline weight."));
+
                 return;
             }
 
@@ -4296,14 +4355,18 @@ void CmdSketcherConstrainTangent::activated(int iMsg)
                 geom2->getTypeId() == Part::GeomBSplineCurve::getClassTypeId() )){
 
                 // unsupported until tangent to B-spline at any point implemented.
-                QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                                     QObject::tr("Tangency to B-spline edge currently unsupported."));
+                Gui::TranslatedNotification(Obj,
+                              QObject::tr("Wrong selection"),
+                              QObject::tr("Tangency to B-spline edge currently unsupported."));
+
                 return;
             }
 
             if(isBsplinePole(geom1) || isBsplinePole(geom2)) {
-                QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                             QObject::tr("Select an edge that is not a B-spline weight."));
+                Gui::TranslatedNotification(Obj,
+                              QObject::tr("Wrong selection"),
+                              QObject::tr("Select an edge that is not a B-spline weight."));
+
                 return;
             }
 
@@ -4457,9 +4520,6 @@ void CmdSketcherConstrainTangent::activated(int iMsg)
 
     }
 
-    if (!strError.isEmpty()) strError.append(QString::fromLatin1("\n\n"));
-    QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-        strError+strBasicHelp);
     return;
 }
 
@@ -4481,7 +4541,7 @@ void CmdSketcherConstrainTangent::applyConstraint(std::vector<SelIdPair> &selSeq
 
         // check if the edge already has a Block constraint
         if ( areBothPointsOrSegmentsFixed(Obj,GeoId1,GeoId2) ) {
-            showNoConstraintBetweenFixedGeometry();
+            showNoConstraintBetweenFixedGeometry(Obj);
             return;
         }
 
@@ -4493,15 +4553,19 @@ void CmdSketcherConstrainTangent::applyConstraint(std::vector<SelIdPair> &selSeq
             geom2->getTypeId() == Part::GeomBSplineCurve::getClassTypeId() )){
 
             // unsupported until tangent to B-spline at any point implemented.
-            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                                 QObject::tr("Tangency to B-spline edge currently unsupported."));
+            Gui::TranslatedNotification(Obj,
+                          QObject::tr("Wrong selection"),
+                          QObject::tr("Tangency to B-spline edge currently unsupported."));
+
             return;
         }
 
         if(isBsplinePole(geom1) || isBsplinePole(geom2)) {
-                QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                             QObject::tr("Select an edge that is not a B-spline weight."));
-                return;
+            Gui::TranslatedNotification(Obj,
+                          QObject::tr("Wrong selection"),
+                          QObject::tr("Select an edge that is not a B-spline weight."));
+
+            return;
         }
 
         // check if as a consequence of this command undesirable combinations of constraints would
@@ -4644,14 +4708,16 @@ void CmdSketcherConstrainTangent::applyConstraint(std::vector<SelIdPair> &selSeq
 
         // check if the edge already has a Block constraint
         if ( areBothPointsOrSegmentsFixed(Obj,GeoId1,GeoId2) ) {
-            showNoConstraintBetweenFixedGeometry();
+            showNoConstraintBetweenFixedGeometry(Obj);
             return;
         }
 
         if (isSimpleVertex(Obj, GeoId1, PosId1) ||
             isSimpleVertex(Obj, GeoId2, PosId2)) {
-            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                QObject::tr("Cannot add a tangency constraint at an unconnected point!"));
+            Gui::TranslatedNotification(Obj,
+                          QObject::tr("Wrong selection"),
+                          QObject::tr("Cannot add a tangency constraint at an unconnected point!"));
+
             return;
         }
 
@@ -4687,14 +4753,16 @@ void CmdSketcherConstrainTangent::applyConstraint(std::vector<SelIdPair> &selSeq
 
         // check if the edge already has a Block constraint
         if ( areBothPointsOrSegmentsFixed(Obj,GeoId1,GeoId2) ) {
-            showNoConstraintBetweenFixedGeometry();
+            showNoConstraintBetweenFixedGeometry(Obj);
             return;
         }
 
         if(isBsplinePole(Obj, GeoId1) || isBsplinePole(Obj, GeoId2)) {
-                QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                             QObject::tr("Select an edge that is not a B-spline weight."));
-                return;
+            Gui::TranslatedNotification(Obj,
+                          QObject::tr("Wrong selection"),
+                          QObject::tr("Select an edge that is not a B-spline weight."));
+
+            return;
         }
 
         openCommand(QT_TRANSLATE_NOOP("Command", "Add tangent constraint"));
@@ -4719,10 +4787,10 @@ void CmdSketcherConstrainTangent::applyConstraint(std::vector<SelIdPair> &selSeq
             Gui::cmdAppObjectArgs(Obj, "addConstraint(Sketcher.Constraint('TangentViaPoint',%d,%d,%d,%d)) ",
                 GeoId1,GeoId2,GeoId3,static_cast<int>(PosId3));
         } catch (const Base::Exception& e) {
-            Base::Console().Error("%s\n", e.what());
-            QMessageBox::warning(Gui::getMainWindow(),
-                                 QObject::tr("Error"),
-                                 QString::fromLatin1(e.what()));
+            Gui::NotifyError(Obj,
+                        QT_TRANSLATE_NOOP("Notifications", "Error"),
+                        e.what());
+
             Gui::Command::abortCommand();
 
             tryAutoRecompute(Obj);
@@ -4786,7 +4854,7 @@ void CmdSketcherConstrainRadius::activated(int iMsg)
             getSelection().clearSelection();
         } else {
             // TODO: Get the exact message from git history and put it here
-            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
+            Gui::TranslatedNotification("Sketcher", QObject::tr("Wrong selection"),
                                  QObject::tr("Select the right things from the sketch."));
         }
         return;
@@ -4797,8 +4865,9 @@ void CmdSketcherConstrainRadius::activated(int iMsg)
     Sketcher::SketchObject* Obj = static_cast<Sketcher::SketchObject*>(selection[0].getObject());
 
     if (SubNames.empty()) {
-        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-            QObject::tr("Select one or more arcs or circles from the sketch."));
+        Gui::TranslatedNotification(Obj,
+                      QObject::tr("Wrong selection"),
+                      QObject::tr("Select one or more arcs or circles from the sketch."));
         return;
     }
 
@@ -4858,14 +4927,18 @@ void CmdSketcherConstrainRadius::activated(int iMsg)
     }
 
     if (geoIdRadiusMap.empty() && externalGeoIdRadiusMap.empty()) {
-        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-            QObject::tr("Select one or more arcs or circles from the sketch."));
+        Gui::TranslatedNotification(Obj,
+                      QObject::tr("Wrong selection"),
+                      QObject::tr("Select one or more arcs or circles from the sketch."));
+
         return;
     }
 
     if(poles && nonpoles) {
-        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-            QObject::tr("Select either only one or more B-Spline poles or only one or more arcs or circles from the sketch, but not mixed."));
+        Gui::TranslatedNotification(Obj,
+                      QObject::tr("Wrong selection"),
+                      QObject::tr("Select either only one or more B-Spline poles or only one or more arcs or circles from the sketch, but not mixed."));
+
         return;
     }
 
@@ -4983,8 +5056,10 @@ void CmdSketcherConstrainRadius::applyConstraint(std::vector<SelIdPair> &selSeq,
             radius = circle->getRadius();
         }
         else {
-            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                QObject::tr("Constraint only applies to arcs or circles."));
+            Gui::TranslatedNotification(Obj,
+                          QObject::tr("Wrong selection"),
+                          QObject::tr("Constraint only applies to arcs or circles."));
+
             return;
         }
 
@@ -5086,7 +5161,7 @@ void CmdSketcherConstrainDiameter::activated(int iMsg)
             getSelection().clearSelection();
         } else {
             // TODO: Get the exact message from git history and put it here
-            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
+            Gui::TranslatedNotification("Sketcher", QObject::tr("Wrong selection"),
                                  QObject::tr("Select the right things from the sketch."));
         }
         return;
@@ -5097,8 +5172,10 @@ void CmdSketcherConstrainDiameter::activated(int iMsg)
     Sketcher::SketchObject* Obj = static_cast<Sketcher::SketchObject*>(selection[0].getObject());
 
     if (SubNames.empty()) {
-        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                             QObject::tr("Select one or more arcs or circles from the sketch."));
+        Gui::TranslatedNotification(Obj,
+                      QObject::tr("Wrong selection"),
+                      QObject::tr("Select one or more arcs or circles from the sketch."));
+
         return;
     }
 
@@ -5139,8 +5216,10 @@ void CmdSketcherConstrainDiameter::activated(int iMsg)
             double radius = circle->getRadius();
 
             if(isBsplinePole(geom)) {
-                QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                             QObject::tr("Select an edge that is not a B-spline weight."));
+                Gui::TranslatedNotification(Obj,
+                              QObject::tr("Wrong selection"),
+                              QObject::tr("Select an edge that is not a B-spline weight."));
+
                 continue;
             }
 
@@ -5154,8 +5233,10 @@ void CmdSketcherConstrainDiameter::activated(int iMsg)
     }
 
     if (geoIdDiameterMap.empty() && externalGeoIdDiameterMap.empty()) {
-        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                             QObject::tr("Select one or more arcs or circles from the sketch."));
+        Gui::TranslatedNotification(Obj,
+                      QObject::tr("Wrong selection"),
+                      QObject::tr("Select one or more arcs or circles from the sketch."));
+
         return;
     }
 
@@ -5260,14 +5341,18 @@ void CmdSketcherConstrainDiameter::applyConstraint(std::vector<SelIdPair> &selSe
                 diameter = 2*circle->getRadius();
             }
             else {
-                QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                                     QObject::tr("Constraint only applies to arcs or circles."));
+                Gui::TranslatedNotification(Obj,
+                              QObject::tr("Wrong selection"),
+                              QObject::tr("Constraint only applies to arcs or circles."));
+
                 return;
             }
 
             if(isBsplinePole(geom)) {
-                QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                             QObject::tr("Select an edge that is not a B-spline weight"));
+                Gui::TranslatedNotification(Obj,
+                              QObject::tr("Wrong selection"),
+                              QObject::tr("Select an edge that is not a B-spline weight."));
+
                 return;
             }
 
@@ -5360,7 +5445,7 @@ void CmdSketcherConstrainRadiam::activated(int iMsg)
             getSelection().clearSelection();
         } else {
             // TODO: Get the exact message from git history and put it here
-            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
+            Gui::TranslatedNotification("Sketcher", QObject::tr("Wrong selection"),
                                  QObject::tr("Select the right things from the sketch."));
         }
         return;
@@ -5371,8 +5456,10 @@ void CmdSketcherConstrainRadiam::activated(int iMsg)
     Sketcher::SketchObject* Obj = static_cast<Sketcher::SketchObject*>(selection[0].getObject());
 
     if (SubNames.empty()) {
-        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                             QObject::tr("Select one or more arcs or circles from the sketch."));
+        Gui::TranslatedNotification(Obj,
+                      QObject::tr("Wrong selection"),
+                      QObject::tr("Select one or more arcs or circles from the sketch."));
+
         return;
     }
 
@@ -5426,14 +5513,18 @@ void CmdSketcherConstrainRadiam::activated(int iMsg)
     }
 
     if (geoIdRadiamMap.empty() && externalGeoIdRadiamMap.empty()) {
-        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                             QObject::tr("Select one or more arcs or circles from the sketch."));
+        Gui::TranslatedNotification(Obj,
+                      QObject::tr("Wrong selection"),
+                      QObject::tr("Select one or more arcs or circles from the sketch."));
+
         return;
     }
 
     if(poles && nonpoles) {
-        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-            QObject::tr("Select either only one or more B-Spline poles or only one or more arcs or circles from the sketch, but not mixed."));
+        Gui::TranslatedNotification(Obj,
+                      QObject::tr("Wrong selection"),
+                      QObject::tr("Select either only one or more B-Spline poles or only one or more arcs or circles from the sketch, but not mixed."));
+
         return;
     }
 
@@ -5571,8 +5662,10 @@ void CmdSketcherConstrainRadiam::applyConstraint(std::vector<SelIdPair> &selSeq,
                     isPole = true;
             }
             else {
-                QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                                     QObject::tr("Constraint only applies to arcs or circles."));
+                Gui::TranslatedNotification(Obj,
+                              QObject::tr("Wrong selection"),
+                              QObject::tr("Constraint only applies to arcs or circles."));
+
                 return;
             }
 
@@ -5819,7 +5912,7 @@ void CmdSketcherConstrainAngle::activated(int iMsg)
             getSelection().clearSelection();
         } else {
             // TODO: Get the exact message from git history and put it here
-            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
+            Gui::TranslatedNotification("Sketcher", QObject::tr("Wrong selection"),
                                  QObject::tr("Select the right things from the sketch."));
         }
         return;
@@ -5830,10 +5923,11 @@ void CmdSketcherConstrainAngle::activated(int iMsg)
     Sketcher::SketchObject* Obj = static_cast<Sketcher::SketchObject*>(selection[0].getObject());
 
     if (SubNames.empty() || SubNames.size() > 3) {
-        //goto ExitWithMessage;
-        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-            QObject::tr("Select one or two lines from the sketch. Or select two edges and a point."));
+        Gui::TranslatedNotification(Obj,
+                      QObject::tr("Wrong selection"),
+                      QObject::tr("Select one or two lines from the sketch. Or select two edges and a point."));
 
+        return;
     }
 
 
@@ -5862,8 +5956,9 @@ void CmdSketcherConstrainAngle::activated(int iMsg)
         if (isEdge(GeoId1, PosId1) && isEdge(GeoId2, PosId2) && isVertex(GeoId3, PosId3)) {
 
             if(isBsplinePole(Obj, GeoId1) || isBsplinePole(Obj, GeoId2)) {
-                QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                             QObject::tr("Select an edge that is not a B-spline weight."));
+                Gui::TranslatedNotification(Obj,
+                              QObject::tr("Wrong selection"),
+                              QObject::tr("Select an edge that is not a B-spline weight."));
                 return;
             }
 
@@ -5924,8 +6019,10 @@ void CmdSketcherConstrainAngle::activated(int iMsg)
         }
 
         if(isBsplinePole(Obj, GeoId1) || (GeoId2 != GeoEnum::GeoUndef && isBsplinePole(Obj, GeoId2))) {
-            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                            QObject::tr("Select an edge that is not a B-spline weight."));
+            Gui::TranslatedNotification(Obj,
+                          QObject::tr("Wrong selection"),
+                          QObject::tr("Select an edge that is not a B-spline weight."));
+
             return;
         }
 
@@ -5988,8 +6085,10 @@ void CmdSketcherConstrainAngle::activated(int iMsg)
                 if (dir3.Length() < Precision::Intersection()) {
                     Base::Vector3d dist = (p1[0] - p2[0]) % dir1;
                     if (dist.Sqr() > Precision::Intersection()) {
-                        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Parallel lines"),
-                            QObject::tr("An angle constraint cannot be set for two parallel lines."));
+                        Gui::TranslatedNotification(Obj,
+                                      QObject::tr("Parallel lines"),
+                                      QObject::tr("An angle constraint cannot be set for two parallel lines."));
+
                         return;
                     }
                 }
@@ -6020,8 +6119,10 @@ void CmdSketcherConstrainAngle::activated(int iMsg)
             }
         } else if (isEdge(GeoId1,PosId1)) { // line angle
             if (GeoId1 < 0 && GeoId1 >= Sketcher::GeoEnum::VAxis) {
-                QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                    QObject::tr("Cannot add an angle constraint on an axis!"));
+                Gui::TranslatedNotification(Obj,
+                              QObject::tr("Wrong selection"),
+                              QObject::tr("Cannot add an angle constraint on an axis!"));
+
                 return;
             }
 
@@ -6076,8 +6177,10 @@ void CmdSketcherConstrainAngle::activated(int iMsg)
         }
     };
 
-    QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-        QObject::tr("Select one or two lines from the sketch. Or select two edges and a point."));
+    Gui::TranslatedNotification(Obj,
+                  QObject::tr("Wrong selection"),
+                  QObject::tr("Select one or two lines from the sketch. Or select two edges and a point."));
+
     return;
 }
 
@@ -6155,8 +6258,10 @@ void CmdSketcherConstrainAngle::applyConstraint(std::vector<SelIdPair> &selSeq, 
             if (dir3.Length() < Precision::Intersection()) {
                 Base::Vector3d dist = (p1[0] - p2[0]) % dir1;
                 if (dist.Sqr() > Precision::Intersection()) {
-                    QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Parallel lines"),
-                        QObject::tr("An angle constraint cannot be set for two parallel lines."));
+                    Gui::TranslatedNotification(Obj,
+                                  QObject::tr("Parallel lines"),
+                                  QObject::tr("An angle constraint cannot be set for two parallel lines."));
+
                     return;
                 }
             }
@@ -6216,9 +6321,11 @@ void CmdSketcherConstrainAngle::applyConstraint(std::vector<SelIdPair> &selSeq, 
     if (isEdge(GeoId1, PosId1) && isEdge(GeoId2, PosId2) && isVertex(GeoId3, PosId3)) {
 
         if(isBsplinePole(Obj, GeoId1) || isBsplinePole(Obj, GeoId2)) {
-                QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                             QObject::tr("Select an edge that is not a B-spline weight."));
-                return;
+            Gui::TranslatedNotification(Obj,
+                          QObject::tr("Wrong selection"),
+                          QObject::tr("Select an edge that is not a B-spline weight."));
+
+            return;
         }
 
         double ActAngle = 0.0;
@@ -6333,7 +6440,7 @@ void CmdSketcherConstrainEqual::activated(int iMsg)
                             new DrawSketchHandlerGenConstraint(this));
             getSelection().clearSelection();
         } else {
-            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
+            Gui::TranslatedNotification("Sketcher", QObject::tr("Wrong selection"),
                                  QObject::tr("Select two edges from the sketch."));
         }
         return;
@@ -6346,8 +6453,10 @@ void CmdSketcherConstrainEqual::activated(int iMsg)
     // go through the selected subelements
 
     if (SubNames.size() < 2) {
-        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-            QObject::tr("Select at least two lines from the sketch."));
+        Gui::TranslatedNotification(Obj,
+                      QObject::tr("Wrong selection"),
+                      QObject::tr("Select at least two lines from the sketch."));
+
         return;
     }
 
@@ -6362,19 +6471,23 @@ void CmdSketcherConstrainEqual::activated(int iMsg)
         getIdsFromName(*it, Obj, GeoId, PosId);
 
         if (!isEdge(GeoId,PosId)) {
-            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                                 QObject::tr("Select two or more compatible edges."));
+            Gui::TranslatedNotification(Obj,
+                          QObject::tr("Wrong selection"),
+                          QObject::tr("Select two or more compatible edges."));
+
             return;
         }
         else if (GeoId == Sketcher::GeoEnum::HAxis || GeoId == Sketcher::GeoEnum::VAxis) {
-                QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                                     QObject::tr("Sketch axes cannot be used in equality constraints."));
-                return;
+            Gui::TranslatedNotification(Obj,
+                          QObject::tr("Wrong selection"),
+                          QObject::tr("Sketch axes cannot be used in equality constraints."));
+
+            return;
         }
         else if (isPointOrSegmentFixed(Obj,GeoId)) {
 
             if (hasAlreadyExternal) {
-                showNoConstraintBetweenFixedGeometry();
+                showNoConstraintBetweenFixedGeometry(Obj);
                 return;
             }
             else {
@@ -6386,8 +6499,10 @@ void CmdSketcherConstrainEqual::activated(int iMsg)
 
         if(geo->getTypeId() == Part::GeomBSplineCurve::getClassTypeId()) {
             // unsupported as they are generally hereogeneus shapes
-            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                                 QObject::tr("Equality for B-spline edge currently unsupported."));
+            Gui::TranslatedNotification(Obj,
+                          QObject::tr("Wrong selection"),
+                          QObject::tr("Equality for B-spline edge currently unsupported."));
+
             return;
         }
 
@@ -6416,8 +6531,10 @@ void CmdSketcherConstrainEqual::activated(int iMsg)
             parabSel = true;
         }
         else {
-            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                QObject::tr("Select two or more edges of similar type."));
+            Gui::TranslatedNotification(Obj,
+                          QObject::tr("Wrong selection"),
+                          QObject::tr("Select two or more edges of similar type."));
+
             return;
         }
 
@@ -6431,8 +6548,10 @@ void CmdSketcherConstrainEqual::activated(int iMsg)
          ( hyperbSel && (parabSel || weightSel)) ||
          ( parabSel && weightSel)) {
 
-        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-            QObject::tr("Select two or more edges of similar type."));
+        Gui::TranslatedNotification(Obj,
+                      QObject::tr("Wrong selection"),
+                      QObject::tr("Select two or more edges of similar type."));
+
         return;
     }
 
@@ -6466,7 +6585,7 @@ void CmdSketcherConstrainEqual::applyConstraint(std::vector<SelIdPair> &selSeq, 
 
         // check if the edge already has a Block constraint
         if ( areBothPointsOrSegmentsFixed(Obj, GeoId1, GeoId2) ) {
-            showNoConstraintBetweenFixedGeometry();
+            showNoConstraintBetweenFixedGeometry(Obj);
             return;
         }
 
@@ -6482,8 +6601,10 @@ void CmdSketcherConstrainEqual::applyConstraint(std::vector<SelIdPair> &selSeq, 
              ( (geo1->getTypeId() == Part::GeomEllipse::getClassTypeId() || geo1->getTypeId() == Part::GeomArcOfEllipse::getClassTypeId()) &&
                !(geo2->getTypeId() == Part::GeomEllipse::getClassTypeId() || geo2->getTypeId() == Part::GeomArcOfEllipse::getClassTypeId())) ){
 
-            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                QObject::tr("Select two or more edges of similar type."));
+            Gui::TranslatedNotification(Obj,
+                          QObject::tr("Wrong selection"),
+                          QObject::tr("Select two or more edges of similar type."));
+
             return;
         }
 
@@ -6564,7 +6685,7 @@ void CmdSketcherConstrainSymmetric::activated(int iMsg)
                             new DrawSketchHandlerGenConstraint(this));
             getSelection().clearSelection();
         } else {
-            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
+            Gui::TranslatedNotification("Sketcher", QObject::tr("Wrong selection"),
                                  QObject::tr("Select two points and a symmetry line, "
                                              "two points and a symmetry point "
                                              "or a line and a symmetry point from the sketch."));
@@ -6577,10 +6698,12 @@ void CmdSketcherConstrainSymmetric::activated(int iMsg)
     Sketcher::SketchObject* Obj = static_cast<Sketcher::SketchObject*>(selection[0].getObject());
 
     if (SubNames.size() != 3 && SubNames.size() != 2) {
-        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-            QObject::tr("Select two points and a symmetry line, "
-                        "two points and a symmetry point "
-                        "or a line and a symmetry point from the sketch."));
+        Gui::TranslatedNotification(Obj,
+                      QObject::tr("Wrong selection"),
+                      QObject::tr("Select two points and a symmetry line, "
+                                                         "two points and a symmetry point "
+                                                         "or a line and a symmetry point from the sketch."));
+
         return;
     }
 
@@ -6591,7 +6714,7 @@ void CmdSketcherConstrainSymmetric::activated(int iMsg)
 
     if (SubNames.size() == 2) {
         if ( areBothPointsOrSegmentsFixed(Obj, GeoId1, GeoId2) ) {
-            showNoConstraintBetweenFixedGeometry();
+            showNoConstraintBetweenFixedGeometry(Obj);
             return;
         }
         if (isVertex(GeoId1,PosId1) && isEdge(GeoId2,PosId2)) {
@@ -6602,9 +6725,11 @@ void CmdSketcherConstrainSymmetric::activated(int iMsg)
             const Part::Geometry *geom = Obj->getGeometry(GeoId1);
             if (geom->getTypeId() == Part::GeomLineSegment::getClassTypeId()) {
                 if (GeoId1 == GeoId2) {
-                    QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                        QObject::tr("Cannot add a symmetry constraint "
-                                    "between a line and its end points."));
+                    Gui::TranslatedNotification(Obj,
+                                  QObject::tr("Wrong selection"),
+                                  QObject::tr("Cannot add a symmetry constraint "
+                                                                     "between a line and its end points."));
+
                     return;
                 }
 
@@ -6624,10 +6749,12 @@ void CmdSketcherConstrainSymmetric::activated(int iMsg)
             }
         }
 
-        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-            QObject::tr("Select two points and a symmetry line, "
-                        "two points and a symmetry point "
-                        "or a line and a symmetry point from the sketch."));
+        Gui::TranslatedNotification(Obj,
+                      QObject::tr("Wrong selection"),
+                      QObject::tr("Select two points and a symmetry line, "
+                                                         "two points and a symmetry point "
+                                                         "or a line and a symmetry point from the sketch."));
+
         return;
     }
 
@@ -6643,7 +6770,7 @@ void CmdSketcherConstrainSymmetric::activated(int iMsg)
     }
 
     if ( areAllPointsOrSegmentsFixed(Obj, GeoId1, GeoId2, GeoId3) ) {
-      showNoConstraintBetweenFixedGeometry();
+      showNoConstraintBetweenFixedGeometry(Obj);
       return;
     }
 
@@ -6654,9 +6781,11 @@ void CmdSketcherConstrainSymmetric::activated(int iMsg)
             const Part::Geometry *geom = Obj->getGeometry(GeoId3);
             if (geom->getTypeId() == Part::GeomLineSegment::getClassTypeId()) {
                 if (GeoId1 == GeoId2 && GeoId2 == GeoId3) {
-                    QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                        QObject::tr("Cannot add a symmetry constraint "
-                                    "between a line and its end points!"));
+                    Gui::TranslatedNotification(Obj,
+                                  QObject::tr("Wrong selection"),
+                                  QObject::tr("Cannot add a symmetry constraint "
+                                                                     "between a line and its end points!"));
+
                     return;
                 }
 
@@ -6691,10 +6820,13 @@ void CmdSketcherConstrainSymmetric::activated(int iMsg)
             return;
         }
     }
-    QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-        QObject::tr("Select two points and a symmetry line, "
-                    "two points and a symmetry point "
-                    "or a line and a symmetry point from the sketch."));
+
+    Gui::TranslatedNotification(Obj,
+                  QObject::tr("Wrong selection"),
+                  QObject::tr("Select two points and a symmetry line, "
+                                                     "two points and a symmetry point "
+                                                     "or a line and a symmetry point from the sketch."));
+
 }
 
 void CmdSketcherConstrainSymmetric::applyConstraint(std::vector<SelIdPair> &selSeq, int seqIndex)
@@ -6713,13 +6845,15 @@ void CmdSketcherConstrainSymmetric::applyConstraint(std::vector<SelIdPair> &selS
         PosId1 = Sketcher::PointPos::start; PosId2 = Sketcher::PointPos::end; PosId3 = selSeq.at(1).PosId;
 
         if (GeoId1 == GeoId3) {
-            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                QObject::tr("Cannot add a symmetry constraint between a line and its end points!"));
+            Gui::TranslatedNotification(Obj,
+                          QObject::tr("Wrong selection"),
+                          QObject::tr("Cannot add a symmetry constraint between a line and its end points!"));
+
             return;
         }
 
         if ( areBothPointsOrSegmentsFixed(Obj, GeoId1, GeoId2) ) {
-            showNoConstraintBetweenFixedGeometry();
+            showNoConstraintBetweenFixedGeometry(Obj);
             return;
         }
         break;
@@ -6748,16 +6882,18 @@ void CmdSketcherConstrainSymmetric::applyConstraint(std::vector<SelIdPair> &selS
         }
 
         if ( areAllPointsOrSegmentsFixed(Obj, GeoId1, GeoId2, GeoId3) ) {
-            showNoConstraintBetweenFixedGeometry();
+            showNoConstraintBetweenFixedGeometry(Obj);
             return;
         }
 
         const Part::Geometry *geom = Obj->getGeometry(GeoId3);
         if (geom->getTypeId() == Part::GeomLineSegment::getClassTypeId()) {
             if (GeoId1 == GeoId2 && GeoId2 == GeoId3) {
-                QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                    QObject::tr("Cannot add a symmetry constraint "
-                                "between a line and its end points."));
+                Gui::TranslatedNotification(Obj,
+                              QObject::tr("Wrong selection"),
+                              QObject::tr("Cannot add a symmetry constraint "
+                                                                 "between a line and its end points."));
+
                 return;
             }
 
@@ -6771,10 +6907,12 @@ void CmdSketcherConstrainSymmetric::applyConstraint(std::vector<SelIdPair> &selS
             tryAutoRecompute(Obj);
         }
         else {
-            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                QObject::tr("Select two points and a symmetry line, "
-                            "two points and a symmetry point "
-                            "or a line and a symmetry point from the sketch."));
+            Gui::TranslatedNotification(Obj,
+                          QObject::tr("Wrong selection"),
+                          QObject::tr("Select two points and a symmetry line, "
+                                                             "two points and a symmetry point "
+                                                             "or a line and a symmetry point from the sketch."));
+
         }
 
         return;
@@ -6787,7 +6925,7 @@ void CmdSketcherConstrainSymmetric::applyConstraint(std::vector<SelIdPair> &selS
         PosId1 = selSeq.at(0).PosId;  PosId2 = selSeq.at(1).PosId; PosId3 = selSeq.at(2).PosId;
 
         if ( areAllPointsOrSegmentsFixed(Obj, GeoId1, GeoId2, GeoId3) ) {
-            showNoConstraintBetweenFixedGeometry();
+            showNoConstraintBetweenFixedGeometry(Obj);
             return;
         }
         break;
@@ -6834,112 +6972,129 @@ CmdSketcherConstrainSnellsLaw::CmdSketcherConstrainSnellsLaw()
 void CmdSketcherConstrainSnellsLaw::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-    QString strHelp = QObject::tr("Select two endpoints of lines to act as rays, "
-                                  "and an edge representing a boundary. "
-                                  "The first selected point corresponds "
-                                  "to index n1, second to n2, "
-                                  "and datum value sets the ratio n2/n1.",
-                                  "Constraint_SnellsLaw");
-    QString strError;
 
-    const char dmbg[] = "Constraint_SnellsLaw";
 
-    try{
-        // get the selection
-        std::vector<Gui::SelectionObject> selection = getSelection().getSelectionEx();
+    // get the selection
+    std::vector<Gui::SelectionObject> selection = getSelection().getSelectionEx();
 
-        // only one sketch with its subelements are allowed to be selected
-        if (selection.size() != 1 || !selection[0].isObjectTypeOf(Sketcher::SketchObject::getClassTypeId())) {
-            strError = QObject::tr("Selected objects are not just geometry "
-                                   "from one sketch.", dmbg);
-            throw Base::ValueError("");
-        }
+    // only one sketch with its subelements are allowed to be selected
+    if (selection.size() != 1 || !selection[0].isObjectTypeOf(Sketcher::SketchObject::getClassTypeId())) {
+        QString strHelp = QObject::tr("Select two endpoints of lines to act as rays, "
+        "and an edge representing a boundary. "
+        "The first selected point corresponds "
+        "to index n1, second to n2, "
+        "and datum value sets the ratio n2/n1.",
+        "Constraint_SnellsLaw");
 
-        // get the needed lists and objects
-        Sketcher::SketchObject* Obj = static_cast<Sketcher::SketchObject*>(selection[0].getObject());
-        const std::vector<std::string> &SubNames = selection[0].getSubNames();
+        const char dmbg[] = "Constraint_SnellsLaw";
 
-        if (SubNames.size() != 3) {
-            strError = QObject::tr("Number of selected objects is not 3 (is %1).", dmbg).arg(SubNames.size());
-            throw Base::ValueError("");
-        }
+        QString strError = QObject::tr("Selected objects are not just geometry "
+                                "from one sketch.", dmbg);
 
-        int GeoId1, GeoId2, GeoId3;
-        Sketcher::PointPos PosId1, PosId2, PosId3;
-        getIdsFromName(SubNames[0], Obj, GeoId1, PosId1);
-        getIdsFromName(SubNames[1], Obj, GeoId2, PosId2);
-        getIdsFromName(SubNames[2], Obj, GeoId3, PosId3);
+        strError.append(strHelp);
+        Gui::TranslatedNotification("Sketcher", QObject::tr("Wrong selection"),
+                                std::move(strError));
+    }
 
-        //sink the edge to be the last item
-        if (isEdge(GeoId1,PosId1) ) {
-            std::swap(GeoId1,GeoId2);
-            std::swap(PosId1,PosId2);
-        }
-        if (isEdge(GeoId2,PosId2) ) {
-            std::swap(GeoId2,GeoId3);
-            std::swap(PosId2,PosId3);
-        }
+    // get the needed lists and objects
+    Sketcher::SketchObject* Obj = static_cast<Sketcher::SketchObject*>(selection[0].getObject());
+    const std::vector<std::string> &SubNames = selection[0].getSubNames();
 
-        //a bunch of validity checks
-        if (areAllPointsOrSegmentsFixed(Obj, GeoId1, GeoId2, GeoId3) ) {
-            strError = QObject::tr("Cannot create constraint with external geometry only.", dmbg);
-            throw Base::ValueError("");
-        }
+    if (SubNames.size() != 3) {
+        Gui::TranslatedNotification(Obj,
+                        QObject::tr("Wrong selection"),
+                        QObject::tr("Number of selected objects is not 3"));
 
-        if (!(isVertex(GeoId1,PosId1) && !isSimpleVertex(Obj, GeoId1, PosId1) &&
-              isVertex(GeoId2,PosId2) && !isSimpleVertex(Obj, GeoId2, PosId2) &&
-              isEdge(GeoId3,PosId3)   )) {
-            strError = QObject::tr("Incompatible geometry is selected.", dmbg);
-            throw Base::ValueError("");
-        };
+        return;
+    }
 
-        const Part::Geometry *geo = Obj->getGeometry(GeoId3);
+    int GeoId1, GeoId2, GeoId3;
+    Sketcher::PointPos PosId1, PosId2, PosId3;
+    getIdsFromName(SubNames[0], Obj, GeoId1, PosId1);
+    getIdsFromName(SubNames[1], Obj, GeoId2, PosId2);
+    getIdsFromName(SubNames[2], Obj, GeoId3, PosId3);
 
-        if( geo && geo->getTypeId() == Part::GeomBSplineCurve::getClassTypeId() ){
-            // unsupported until normal to B-spline at any point implemented.
-            QMessageBox::warning(Gui::getMainWindow(),
-                                 QObject::tr("Wrong selection"),
-                                 QObject::tr("SnellsLaw on B-spline edge is currently unsupported."));
-            return;
-        }
+    //sink the edge to be the last item
+    if (isEdge(GeoId1,PosId1) ) {
+        std::swap(GeoId1,GeoId2);
+        std::swap(PosId1,PosId2);
+    }
+    if (isEdge(GeoId2,PosId2) ) {
+        std::swap(GeoId2,GeoId3);
+        std::swap(PosId2,PosId3);
+    }
 
-        if(isBsplinePole(geo)) {
-            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                            QObject::tr("Select an edge that is not a B-spline weight."));
-            return;
-        }
+    //a bunch of validity checks
+    if (areAllPointsOrSegmentsFixed(Obj, GeoId1, GeoId2, GeoId3) ) {
+        Gui::TranslatedNotification(Obj,
+                        QObject::tr("Wrong selection"),
+                        QObject::tr("Cannot create constraint with external geometry only."));
 
-        double n2divn1=0;
+        return;
+    }
 
-        //the essence.
-        //Unlike other constraints, we'll ask for a value immediately.
-        QDialog dlg(Gui::getMainWindow());
-        Ui::InsertDatum ui_Datum;
-        ui_Datum.setupUi(&dlg);
-        dlg.setWindowTitle(EditDatumDialog::tr("Refractive index ratio", dmbg));
-        ui_Datum.label->setText(EditDatumDialog::tr("Ratio n2/n1:", dmbg));
-        Base::Quantity init_val;
-        init_val.setUnit(Base::Unit());
-        init_val.setValue(0.0);
+    if (!(isVertex(GeoId1,PosId1) && !isSimpleVertex(Obj, GeoId1, PosId1) &&
+            isVertex(GeoId2,PosId2) && !isSimpleVertex(Obj, GeoId2, PosId2) &&
+            isEdge(GeoId3,PosId3)   )) {
 
-        ui_Datum.labelEdit->setValue(init_val);
-        ui_Datum.labelEdit->setParamGrpPath(QByteArray("User parameter:BaseApp/History/SketcherRefrIndexRatio"));
-        ui_Datum.labelEdit->setEntryName(QByteArray("DatumValue"));
-        ui_Datum.labelEdit->setToLastUsedValue();
-        ui_Datum.labelEdit->selectNumber();
-        ui_Datum.labelEdit->setSingleStep(0.05);
-        // Unable to bind, because the constraint does not yet exist
+        Gui::TranslatedNotification(Obj,
+                        QObject::tr("Wrong selection"),
+                        QObject::tr("Incompatible geometry is selected."));
 
-        if (dlg.exec() != QDialog::Accepted)
-            return;
-        ui_Datum.labelEdit->pushToHistory();
+        return;
+    };
 
-        Base::Quantity newQuant = ui_Datum.labelEdit->value();
-        n2divn1 = newQuant.getValue();
+    const Part::Geometry *geo = Obj->getGeometry(GeoId3);
 
-        //add constraint
-        openCommand(QT_TRANSLATE_NOOP("Command", "Add Snell's law constraint"));
+    if( geo && geo->getTypeId() == Part::GeomBSplineCurve::getClassTypeId() ){
+        // unsupported until normal to B-spline at any point implemented.
+        Gui::TranslatedNotification(Obj,
+                        QObject::tr("Wrong selection"),
+                        QObject::tr("SnellsLaw on B-spline edge is currently unsupported."));
 
+        return;
+    }
+
+    if(isBsplinePole(geo)) {
+        Gui::TranslatedNotification(Obj,
+                        QObject::tr("Wrong selection"),
+                        QObject::tr("Select an edge that is not a B-spline weight."));
+
+        return;
+    }
+
+    double n2divn1=0;
+
+    //the essence.
+    //Unlike other constraints, we'll ask for a value immediately.
+    QDialog dlg(Gui::getMainWindow());
+    Ui::InsertDatum ui_Datum;
+    ui_Datum.setupUi(&dlg);
+    dlg.setWindowTitle(EditDatumDialog::tr("Refractive index ratio"));
+    ui_Datum.label->setText(EditDatumDialog::tr("Ratio n2/n1:"));
+    Base::Quantity init_val;
+    init_val.setUnit(Base::Unit());
+    init_val.setValue(0.0);
+
+    ui_Datum.labelEdit->setValue(init_val);
+    ui_Datum.labelEdit->setParamGrpPath(QByteArray("User parameter:BaseApp/History/SketcherRefrIndexRatio"));
+    ui_Datum.labelEdit->setEntryName(QByteArray("DatumValue"));
+    ui_Datum.labelEdit->setToLastUsedValue();
+    ui_Datum.labelEdit->selectNumber();
+    ui_Datum.labelEdit->setSingleStep(0.05);
+    // Unable to bind, because the constraint does not yet exist
+
+    if (dlg.exec() != QDialog::Accepted)
+        return;
+    ui_Datum.labelEdit->pushToHistory();
+
+    Base::Quantity newQuant = ui_Datum.labelEdit->value();
+    n2divn1 = newQuant.getValue();
+
+    //add constraint
+    openCommand(QT_TRANSLATE_NOOP("Command", "Add Snell's law constraint"));
+
+    try {
         if (! IsPointAlreadyOnCurve(GeoId2,GeoId1,PosId1,Obj))
             Gui::cmdAppObjectArgs(selection[0].getObject(),
                 "addConstraint(Sketcher.Constraint('Coincident',%d,%d,%d,%d)) ",
@@ -6959,17 +7114,20 @@ void CmdSketcherConstrainSnellsLaw::activated(int iMsg)
             Gui::cmdAppObjectArgs(selection[0].getObject(),"setDriving(%i,%s)",
                 ConStr.size()-1,"False");
         }*/
-
-        commitCommand();
-        tryAutoRecompute(Obj);
-
-        // clear the selection (convenience)
-        getSelection().clearSelection();
     } catch (Base::Exception &e) {
-        if (strError.isEmpty()) strError = QString::fromLatin1(e.what());
-        if (!strError.isEmpty()) strError.append(QString::fromLatin1("\n\n"));
-        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Error"), strError + strHelp);
+        abortCommand();
+        Gui::NotifyError(Obj,
+                    QT_TRANSLATE_NOOP("Notifications", "Error"),
+                    e.what());
+        return;
     }
+
+    commitCommand();
+    tryAutoRecompute(Obj);
+
+    // clear the selection (convenience)
+    getSelection().clearSelection();
+
 }
 
 bool CmdSketcherConstrainSnellsLaw::isActive()
@@ -6977,467 +7135,6 @@ bool CmdSketcherConstrainSnellsLaw::isActive()
     return isCreateConstraintActive( getActiveGuiDocument() );
 }
 
-// ======================================================================================
-
-DEF_STD_CMD_A(CmdSketcherConstrainInternalAlignment)
-
-// NOTE: This command is deprecated. Nobody seriously uses today manual creation of an internal alignment constraint
-// The only reason this code remains is the extremely unlikely scenario that some user macro may rely on it.
-CmdSketcherConstrainInternalAlignment::CmdSketcherConstrainInternalAlignment()
-    :Command("Sketcher_ConstrainInternalAlignment")
-{
-    sAppModule      = "Sketcher";
-    sGroup          = "Sketcher";
-    sMenuText       = QT_TR_NOOP("Constrain internal alignment");
-    sToolTipText    = QT_TR_NOOP("Constrains an element to be aligned "
-                                 "with the internal geometry of another element");
-    sWhatsThis      = "Sketcher_ConstrainInternalAlignment";
-    sStatusTip      = sToolTipText;
-    sPixmap         = "Constraint_InternalAlignment";
-    eType           = ForEdit;
-}
-
-void CmdSketcherConstrainInternalAlignment::activated(int iMsg)
-{
-    Q_UNUSED(iMsg);
-    // get the selection
-    std::vector<Gui::SelectionObject> selection = getSelection().getSelectionEx();
-
-    // only one sketch with its subelements are allowed to be selected
-    if (selection.size() != 1 || !selection[0].isObjectTypeOf(Sketcher::SketchObject::getClassTypeId())) {
-        QMessageBox::warning(Gui::getMainWindow(),
-                             QObject::tr("Wrong selection"),
-                             QObject::tr("Select at least one ellipse "
-                                         "and one edge from the sketch."));
-        return;
-    }
-
-    // get the needed lists and objects
-    const std::vector<std::string> &SubNames = selection[0].getSubNames();
-    Sketcher::SketchObject* Obj = static_cast<Sketcher::SketchObject*>(selection[0].getObject());
-
-    // go through the selected subelements
-    if (SubNames.size() < 2) {
-        QMessageBox::warning(Gui::getMainWindow(),
-                             QObject::tr("Wrong selection"),
-                             QObject::tr("Select at least one ellipse "
-                                         "and one edge from the sketch."));
-        return;
-    }
-
-    std::vector<int> pointids;
-    std::vector<int> lineids;
-    std::vector<int> ellipseids;
-    std::vector<int> arcsofellipseids;
-
-    bool hasAlreadyExternal = false;
-
-    for (std::vector<std::string>::const_iterator it=SubNames.begin(); it != SubNames.end(); ++it) {
-
-        int GeoId;
-        Sketcher::PointPos PosId;
-        getIdsFromName(*it, Obj, GeoId, PosId);
-
-        if (isPointOrSegmentFixed(Obj,GeoId)) {
-            if (GeoId == Sketcher::GeoEnum::HAxis || GeoId == Sketcher::GeoEnum::VAxis) {
-                QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                                     QObject::tr("Sketch axes cannot be used in internal alignment constraint."));
-                return;
-            }
-            else if (hasAlreadyExternal) {
-                showNoConstraintBetweenExternal();
-                return;
-            }
-            else
-                hasAlreadyExternal = true;
-        }
-
-        const Part::Geometry *geo = Obj->getGeometry(GeoId);
-
-        if (geo && geo->getTypeId() == Part::GeomPoint::getClassTypeId())
-            pointids.push_back(GeoId);
-        else if (geo && geo->getTypeId() == Part::GeomLineSegment::getClassTypeId())
-            lineids.push_back(GeoId);
-        else if (geo && geo->getTypeId() == Part::GeomEllipse::getClassTypeId())
-            ellipseids.push_back(GeoId);
-        else if (geo && geo->getTypeId() == Part::GeomArcOfEllipse::getClassTypeId())
-            arcsofellipseids.push_back(GeoId);
-        else {
-            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                QObject::tr("Select two or more compatible edges."));
-            return;
-        }
-    }
-
-    int GeoId;
-    Sketcher::PointPos PosId;
-    getIdsFromName(SubNames[SubNames.size()-1], Obj, GeoId, PosId); // last selected element
-
-    const Part::Geometry *geo = Obj->getGeometry(GeoId);
-
-    // Currently it is only supported for ellipses
-    if(geo->getTypeId() == Part::GeomEllipse::getClassTypeId()) {
-
-        // Priority list
-        // EllipseMajorDiameter    = 1,
-        // EllipseMinorDiameter    = 2,
-        // EllipseFocus1           = 3,
-        // EllipseFocus2           = 4
-
-        if(ellipseids.size()>1){
-            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                QObject::tr("You cannot internally constrain an ellipse "
-                            "on another ellipse. "
-                            "Select only one ellipse."));
-            return;
-        }
-
-        if (pointids.size()>2) {
-            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                QObject::tr("Maximum 2 points are supported."));
-            return;
-        }
-
-        if (lineids.size()>2) {
-            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                QObject::tr("Maximum 2 lines are supported."));
-            return;
-        }
-
-        // look for which internal constraints are already applied
-        bool major=false;
-        bool minor=false;
-        bool focus1=false;
-        bool focus2=false;
-        bool extra_elements=false;
-
-        const std::vector< Sketcher::Constraint * > &vals = Obj->Constraints.getValues();
-
-        for (std::vector< Sketcher::Constraint * >::const_iterator it= vals.begin();
-                it != vals.end(); ++it) {
-            if((*it)->Type == Sketcher::InternalAlignment && (*it)->Second == GeoId)
-            {
-                switch((*it)->AlignmentType){
-                    case Sketcher::EllipseMajorDiameter:
-                        major=true;
-                        break;
-                    case Sketcher::EllipseMinorDiameter:
-                        minor=true;
-                        break;
-                    case Sketcher::EllipseFocus1:
-                        focus1=true;
-                        break;
-                    case Sketcher::EllipseFocus2:
-                        focus2=true;
-                        break;
-                    default:
-                        break;
-                }
-            }
-        }
-
-        if(major && minor && focus1 && focus2) {
-            QMessageBox::warning(Gui::getMainWindow(),
-                                 QObject::tr("Nothing to constrain"),
-                                 QObject::tr("Currently all internal geometrical elements "
-                                             "of the ellipse are already exposed."));
-            return;
-        }
-
-        // if some element is missing and we are adding an element of that type
-        if((!(focus1 && focus2) && !pointids.empty()) ||
-           (!(major && minor) && !lineids.empty()) ){
-
-            openCommand(QT_TRANSLATE_NOOP("Command", "Add internal alignment constraint"));
-
-            if(!pointids.empty())
-            {
-                if(!focus1) {
-                    Gui::cmdAppObjectArgs(selection[0].getObject(),
-                        "addConstraint(Sketcher.Constraint('InternalAlignment:EllipseFocus1',%d,%d,%d)) ",
-                        pointids[0],static_cast<int>(Sketcher::PointPos::start),ellipseids[0]);
-                }
-                else if(!focus2) {
-                    Gui::cmdAppObjectArgs(selection[0].getObject(),
-                        "addConstraint(Sketcher.Constraint('InternalAlignment:EllipseFocus2',%d,%d,%d)) ",
-                        pointids[0],static_cast<int>(Sketcher::PointPos::start),ellipseids[0]);
-                    focus2=true;
-                }
-                else
-                    extra_elements=true;
-            }
-
-            if(pointids.size()==2)
-            {
-                if(!focus2) {
-                    Gui::cmdAppObjectArgs(selection[0].getObject(),
-                        "addConstraint(Sketcher.Constraint('InternalAlignment:EllipseFocus2',%d,%d,%d)) ",
-                        pointids[1],static_cast<int>(Sketcher::PointPos::start),ellipseids[0]);
-                }
-                else
-                    extra_elements=true;
-            }
-
-            if(!lineids.empty())
-            {
-                if(!major) {
-                    Gui::cmdAppObjectArgs(selection[0].getObject(),
-                        "addConstraint(Sketcher.Constraint('InternalAlignment:EllipseMajorDiameter',%d,%d)) ",
-                        lineids[0],ellipseids[0]);
-
-                    const Part::GeomLineSegment *geo = static_cast<const Part::GeomLineSegment *>(Obj->getGeometry(lineids[0]));
-
-                    if(!Sketcher::GeometryFacade::getConstruction(geo))
-                        Gui::cmdAppObjectArgs(selection[0].getObject(),"toggleConstruction(%d) ",lineids[0]);
-
-                }
-                else if(!minor) {
-                    Gui::cmdAppObjectArgs(selection[0].getObject(),
-                            "addConstraint(Sketcher.Constraint('InternalAlignment:EllipseMinorDiameter',%d,%d)) ",
-                            lineids[0],ellipseids[0]);
-
-                    const Part::GeomLineSegment *geo = static_cast<const Part::GeomLineSegment *>(Obj->getGeometry(lineids[0]));
-
-                    if(!Sketcher::GeometryFacade::getConstruction(geo))
-                        Gui::cmdAppObjectArgs(selection[0].getObject(),"toggleConstruction(%d) ",lineids[0]);
-
-                    minor=true;
-                }
-                else
-                    extra_elements=true;
-            }
-            if(lineids.size()==2)
-            {
-                if(!minor){
-                    Gui::cmdAppObjectArgs(selection[0].getObject(),
-                        "addConstraint(Sketcher.Constraint('InternalAlignment:EllipseMinorDiameter',%d,%d)) ",
-                        lineids[1],ellipseids[0]);
-
-                    const Part::GeomLineSegment *geo = static_cast<const Part::GeomLineSegment *>(Obj->getGeometry(lineids[1]));
-
-                    if(!Sketcher::GeometryFacade::getConstruction(geo))
-                        Gui::cmdAppObjectArgs(selection[0].getObject(),"toggleConstruction(%d) ",lineids[1]);
-                }
-                else
-                    extra_elements=true;
-            }
-
-            // finish the transaction and update
-            commitCommand();
-
-            tryAutoRecompute(Obj);
-
-            if(extra_elements){
-                QMessageBox::warning(Gui::getMainWindow(),
-                                     QObject::tr("Extra elements"),
-                                     QObject::tr("More elements than possible "
-                                                 "for the given ellipse were provided. "
-                                                 "These were ignored."));
-            }
-
-            // clear the selection (convenience)
-            getSelection().clearSelection();
-        }
-        else {
-            QMessageBox::warning(Gui::getMainWindow(),
-                                 QObject::tr("Extra elements"),
-                                 QObject::tr("More elements than possible "
-                                             "for the given ellipse were provided. "
-                                             "These were ignored."));
-        }
-    }
-    else if(geo->getTypeId() == Part::GeomArcOfEllipse::getClassTypeId()) {
-
-        // Priority list
-        // EllipseMajorDiameter    = 1,
-        // EllipseMinorDiameter    = 2,
-        // EllipseFocus1           = 3,
-        // EllipseFocus2           = 4
-
-        if(arcsofellipseids.size()>1){
-            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                QObject::tr("You cannot internally constrain an arc of ellipse "
-                            "on another arc of ellipse. "
-                            "Select only one arc of ellipse."));
-            return;
-        }
-
-        if(!ellipseids.empty()){
-            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                QObject::tr("You cannot internally constrain an ellipse "
-                            "on an arc of ellipse. "
-                            "Select only one ellipse or arc of ellipse."));
-            return;
-        }
-
-        if (pointids.size()>2) {
-            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                QObject::tr("Maximum 2 points are supported."));
-            return;
-        }
-
-        if (lineids.size()>2) {
-            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                QObject::tr("Maximum 2 lines are supported."));
-            return;
-        }
-
-        // look for which internal constraints are already applied
-        bool major=false;
-        bool minor=false;
-        bool focus1=false;
-        bool focus2=false;
-        bool extra_elements=false;
-
-        const std::vector< Sketcher::Constraint * > &vals = Obj->Constraints.getValues();
-
-        for (std::vector< Sketcher::Constraint * >::const_iterator it= vals.begin();
-                it != vals.end(); ++it) {
-            if((*it)->Type == Sketcher::InternalAlignment && (*it)->First == GeoId)
-            {
-                switch((*it)->AlignmentType){
-                    case Sketcher::EllipseMajorDiameter:
-                        major=true;
-                        break;
-                    case Sketcher::EllipseMinorDiameter:
-                        minor=true;
-                        break;
-                    case Sketcher::EllipseFocus1:
-                        focus1=true;
-                        break;
-                    case Sketcher::EllipseFocus2:
-                        focus2=true;
-                        break;
-                    default:
-                        break;
-                }
-            }
-        }
-
-        if(major && minor && focus1 && focus2) {
-            QMessageBox::warning(Gui::getMainWindow(),
-                                 QObject::tr("Nothing to constrain"),
-                                 QObject::tr("Currently all internal geometrical elements "
-                                             "of the ellipse are already exposed."));
-            return;
-        }
-
-        // if some element is missing and we are adding an element of that type
-        if((!(focus1 && focus2) && !pointids.empty()) ||
-           (!(major && minor) && !lineids.empty()) ){
-
-            openCommand(QT_TRANSLATE_NOOP("Command", "Add internal alignment constraint"));
-
-            if(!pointids.empty())
-            {
-                if(!focus1) {
-                    Gui::cmdAppObjectArgs(selection[0].getObject(),
-                        "addConstraint(Sketcher.Constraint('InternalAlignment:EllipseFocus1',%d,%d,%d)) ",
-                        pointids[0],static_cast<int>(Sketcher::PointPos::start),arcsofellipseids[0]);
-                }
-                else if(!focus2) {
-                    Gui::cmdAppObjectArgs(selection[0].getObject(),
-                        "addConstraint(Sketcher.Constraint('InternalAlignment:EllipseFocus2',%d,%d,%d)) ",
-                        pointids[0],static_cast<int>(Sketcher::PointPos::start),arcsofellipseids[0]);
-                    focus2=true;
-                }
-                else
-                    extra_elements=true;
-            }
-
-            if(pointids.size()==2)
-            {
-                if(!focus2) {
-                    Gui::cmdAppObjectArgs(selection[0].getObject(),
-                        "addConstraint(Sketcher.Constraint('InternalAlignment:EllipseFocus2',%d,%d,%d)) ",
-                        pointids[1],static_cast<int>(Sketcher::PointPos::start),arcsofellipseids[0]);
-                }
-                else
-                    extra_elements=true;
-            }
-
-            if(!lineids.empty())
-            {
-                if(!major) {
-                    Gui::cmdAppObjectArgs(selection[0].getObject(),
-                        "addConstraint(Sketcher.Constraint('InternalAlignment:EllipseMajorDiameter',%d,%d)) ",
-                        lineids[0],arcsofellipseids[0]);
-
-                    const Part::GeomLineSegment *geo = static_cast<const Part::GeomLineSegment *>(Obj->getGeometry(lineids[0]));
-
-                    if(!Sketcher::GeometryFacade::getConstruction(geo))
-                        Gui::cmdAppObjectArgs(selection[0].getObject(),"toggleConstruction(%d) ",lineids[0]);
-
-                }
-                else if(!minor) {
-                    Gui::cmdAppObjectArgs(selection[0].getObject(),
-                            "addConstraint(Sketcher.Constraint('InternalAlignment:EllipseMinorDiameter',%d,%d)) ",
-                            lineids[0],arcsofellipseids[0]);
-
-                    const Part::GeomLineSegment *geo = static_cast<const Part::GeomLineSegment *>(Obj->getGeometry(lineids[0]));
-
-                    if(!Sketcher::GeometryFacade::getConstruction(geo))
-                        Gui::cmdAppObjectArgs(selection[0].getObject(),"toggleConstruction(%d) ",lineids[0]);
-
-                    minor=true;
-                }
-                else
-                    extra_elements=true;
-            }
-
-            if(lineids.size()==2) {
-                if (!minor) {
-                    Gui::cmdAppObjectArgs(selection[0].getObject(),
-                        "addConstraint(Sketcher.Constraint('InternalAlignment:EllipseMinorDiameter',%d,%d)) ",
-                        lineids[1],arcsofellipseids[0]);
-
-                    const Part::GeomLineSegment *geo = static_cast<const Part::GeomLineSegment *>(Obj->getGeometry(lineids[1]));
-
-                    if (!Sketcher::GeometryFacade::getConstruction(geo))
-                        Gui::cmdAppObjectArgs(selection[0].getObject(),"toggleConstruction(%d) ",lineids[1]);
-                }
-                else
-                    extra_elements=true;
-            }
-
-            // finish the transaction and update
-            commitCommand();
-
-            tryAutoRecompute(Obj);
-
-            if(extra_elements){
-                QMessageBox::warning(Gui::getMainWindow(),
-                                     QObject::tr("Extra elements"),
-                                     QObject::tr("More elements than possible "
-                                                 "for the given ellipse were provided. "
-                                                 "These were ignored."));
-            }
-
-            // clear the selection (convenience)
-            getSelection().clearSelection();
-        }
-        else {
-            QMessageBox::warning(Gui::getMainWindow(),
-                                 QObject::tr("Extra elements"),
-                                 QObject::tr("More elements than possible "
-                                             "for the given arc of ellipse were provided. "
-                                             "These were ignored."));
-        }
-    }
-    else {
-        QMessageBox::warning(Gui::getMainWindow(),
-                             QObject::tr("Wrong selection"),
-                             QObject::tr("Currently internal geometry "
-                                         "is only supported for ellipse or arc of ellipse. "
-                                         "The last selected element must be an ellipse "
-                                         "or an arc of ellipse."));
-    }
-}
-
-bool CmdSketcherConstrainInternalAlignment::isActive()
-{
-    return isCreateConstraintActive(getActiveGuiDocument());
-}
 
 // ======================================================================================
 /*** Creation Mode / Toggle to or from Reference ***/
@@ -7487,16 +7184,20 @@ void CmdSketcherToggleDrivingConstraint::activated(int iMsg)
 
         // only one sketch with its subelements are allowed to be selected
         if (selection.size() != 1 || !selection[0].isObjectTypeOf(Sketcher::SketchObject::getClassTypeId())) {
-            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
+            Gui::TranslatedNotification("Sketcher", QObject::tr("Wrong selection"),
                 QObject::tr("Select constraints from the sketch."));
             return;
         }
 
+        Sketcher::SketchObject* Obj = static_cast<Sketcher::SketchObject*>(selection[0].getObject());
+
         // get the needed lists and objects
         const std::vector<std::string> &SubNames = selection[0].getSubNames();
         if (SubNames.empty()) {
-            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                QObject::tr("Select constraints from the sketch."));
+            Gui::TranslatedNotification(Obj,
+                          QObject::tr("Wrong selection"),
+                          QObject::tr("Select constraints from the sketch."));
+
             return;
         }
 
@@ -7527,8 +7228,10 @@ void CmdSketcherToggleDrivingConstraint::activated(int iMsg)
         // get the needed lists and objects
         const std::vector<std::string> &SubNames = selection[0].getSubNames();
         if (SubNames.empty()) {
-            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                QObject::tr("Select constraints from the sketch."));
+            Gui::TranslatedNotification(Obj,
+                          QObject::tr("Wrong selection"),
+                          QObject::tr("Select constraints from the sketch."));
+
             return;
         }
 
@@ -7599,7 +7302,7 @@ void CmdSketcherToggleActiveConstraint::activated(int iMsg)
 
         // only one sketch with its subelements are allowed to be selected
         if (selection.size() != 1 || !selection[0].isObjectTypeOf(Sketcher::SketchObject::getClassTypeId())) {
-            QMessageBox::warning(Gui::getMainWindow(),
+            Gui::TranslatedNotification("Sketcher",
                                  QObject::tr("Wrong selection"),
                                  QObject::tr("Select constraints from the sketch."));
             return;
@@ -7610,9 +7313,10 @@ void CmdSketcherToggleActiveConstraint::activated(int iMsg)
         // get the needed lists and objects
         const std::vector<std::string> &SubNames = selection[0].getSubNames();
         if (SubNames.empty()) {
-            QMessageBox::warning(Gui::getMainWindow(),
-                                 QObject::tr("Wrong selection"),
-                                 QObject::tr("Select constraints from the sketch."));
+            Gui::TranslatedNotification( Obj,
+                                    QObject::tr("Wrong selection"),
+                                    QObject::tr("Select constraints from the sketch."));
+
             return;
         }
 
@@ -7677,7 +7381,6 @@ void CreateSketcherCommandsConstraints()
     rcCmdMgr.addCommand(new CmdSketcherConstrainPointOnObject());
     rcCmdMgr.addCommand(new CmdSketcherConstrainSymmetric());
     rcCmdMgr.addCommand(new CmdSketcherConstrainSnellsLaw());
-    rcCmdMgr.addCommand(new CmdSketcherConstrainInternalAlignment());
     rcCmdMgr.addCommand(new CmdSketcherToggleDrivingConstraint());
     rcCmdMgr.addCommand(new CmdSketcherToggleActiveConstraint());
 }

--- a/src/Mod/Sketcher/Gui/Workbench.cpp
+++ b/src/Mod/Sketcher/Gui/Workbench.cpp
@@ -325,7 +325,6 @@ inline void SketcherAddWorkbenchConstraints<Gui::MenuItem>(Gui::MenuItem& cons)
             << "Sketcher_ConstrainRadiam"
             << "Sketcher_ConstrainAngle"
             << "Sketcher_ConstrainSnellsLaw"
-            << "Sketcher_ConstrainInternalAlignment"
             << "Separator"
             << "Sketcher_ToggleDrivingConstraint"
             << "Sketcher_ToggleActiveConstraint";
@@ -352,7 +351,6 @@ inline void SketcherAddWorkbenchConstraints<Gui::ToolBarItem>(Gui::ToolBarItem& 
             << "Sketcher_CompConstrainRadDia"
             << "Sketcher_ConstrainAngle"
             // << "Sketcher_ConstrainSnellsLaw" // Rarely used, show only in menu
-            // << "Sketcher_ConstrainInternalAlignment" // This constrain is never used by the user - Do not use precious toolbar space
             << "Separator"
             << "Sketcher_ToggleDrivingConstraint"
             << "Sketcher_ToggleActiveConstraint";


### PR DESCRIPTION

This is the first Sketcher package of conversion of intrusive notifications into the new framework, which provides intrusive or non-intrusive notifications depending on user preferences.

So far only for constraints.

In the same PR it also removes the deprecated framework of manual addition of internal geometries.