### PR TITLE
Sketcher: Constraint Widget: Change showHideButton from QPushButton ...

### DIFF
--- a/src/Gui/Stylesheets/Behave-dark.qss
+++ b/src/Gui/Stylesheets/Behave-dark.qss
@@ -1662,9 +1662,7 @@ QSint--ActionGroup QToolButton::menu-button {
 QSint--ActionGroup QToolButton#settingsButton,
 QSint--ActionGroup QToolButton#filterButton,
 QSint--ActionGroup QToolButton#manualUpdate {
-    padding: 2px;
     padding-right: 20px; /* make way for the popup button */
-    margin: 0px;
 }
 
 /* to give widget inside the menu same look as regular menu */

--- a/src/Gui/Stylesheets/Dark-blue.qss
+++ b/src/Gui/Stylesheets/Dark-blue.qss
@@ -1629,9 +1629,7 @@ QSint--ActionGroup QToolButton::menu-button {
 QSint--ActionGroup QToolButton#settingsButton,
 QSint--ActionGroup QToolButton#filterButton,
 QSint--ActionGroup QToolButton#manualUpdate {
-    padding: 2px;
     padding-right: 20px; /* make way for the popup button */
-    margin: 0px;
 }
 
 /* to give widget inside the menu same look as regular menu */

--- a/src/Gui/Stylesheets/Dark-contrast.qss
+++ b/src/Gui/Stylesheets/Dark-contrast.qss
@@ -1629,9 +1629,7 @@ QSint--ActionGroup QToolButton::menu-button {
 QSint--ActionGroup QToolButton#settingsButton,
 QSint--ActionGroup QToolButton#filterButton,
 QSint--ActionGroup QToolButton#manualUpdate {
-    padding: 2px;
     padding-right: 20px; /* make way for the popup button */
-    margin: 0px;
 }
 
 /* to give widget inside the menu same look as regular menu */

--- a/src/Gui/Stylesheets/Dark-green.qss
+++ b/src/Gui/Stylesheets/Dark-green.qss
@@ -1628,9 +1628,7 @@ QSint--ActionGroup QToolButton::menu-button {
 QSint--ActionGroup QToolButton#settingsButton,
 QSint--ActionGroup QToolButton#filterButton,
 QSint--ActionGroup QToolButton#manualUpdate {
-    padding: 2px;
     padding-right: 20px; /* make way for the popup button */
-    margin: 0px;
 }
 
 /* to give widget inside the menu same look as regular menu */

--- a/src/Gui/Stylesheets/Dark-orange.qss
+++ b/src/Gui/Stylesheets/Dark-orange.qss
@@ -1629,9 +1629,7 @@ QSint--ActionGroup QToolButton::menu-button {
 QSint--ActionGroup QToolButton#settingsButton,
 QSint--ActionGroup QToolButton#filterButton,
 QSint--ActionGroup QToolButton#manualUpdate {
-    padding: 2px;
     padding-right: 20px; /* make way for the popup button */
-    margin: 0px;
 }
 
 /* to give widget inside the menu same look as regular menu */

--- a/src/Gui/Stylesheets/Darker-blue.qss
+++ b/src/Gui/Stylesheets/Darker-blue.qss
@@ -1629,9 +1629,7 @@ QSint--ActionGroup QToolButton::menu-button {
 QSint--ActionGroup QToolButton#settingsButton,
 QSint--ActionGroup QToolButton#filterButton,
 QSint--ActionGroup QToolButton#manualUpdate {
-    padding: 2px;
     padding-right: 20px; /* make way for the popup button */
-    margin: 0px;
 }
 
 /* to give widget inside the menu same look as regular menu */

--- a/src/Gui/Stylesheets/Darker-green.qss
+++ b/src/Gui/Stylesheets/Darker-green.qss
@@ -1629,9 +1629,7 @@ QSint--ActionGroup QToolButton::menu-button {
 QSint--ActionGroup QToolButton#settingsButton,
 QSint--ActionGroup QToolButton#filterButton,
 QSint--ActionGroup QToolButton#manualUpdate {
-    padding: 2px;
     padding-right: 20px; /* make way for the popup button */
-    margin: 0px;
 }
 
 /* to give widget inside the menu same look as regular menu */

--- a/src/Gui/Stylesheets/Darker-orange.qss
+++ b/src/Gui/Stylesheets/Darker-orange.qss
@@ -1623,9 +1623,7 @@ QSint--ActionGroup QToolButton::menu-button {
 QSint--ActionGroup QToolButton#settingsButton,
 QSint--ActionGroup QToolButton#filterButton,
 QSint--ActionGroup QToolButton#manualUpdate {
-    padding: 2px;
     padding-right: 20px; /* make way for the popup button */
-    margin: 0px;
 }
 
 /* to give widget inside the menu same look as regular menu */

--- a/src/Gui/Stylesheets/Light-blue.qss
+++ b/src/Gui/Stylesheets/Light-blue.qss
@@ -1626,9 +1626,7 @@ QSint--ActionGroup QToolButton::menu-button {
 QSint--ActionGroup QToolButton#settingsButton,
 QSint--ActionGroup QToolButton#filterButton,
 QSint--ActionGroup QToolButton#manualUpdate {
-    padding: 2px;
     padding-right: 20px; /* make way for the popup button */
-    margin: 0px;
 }
 
 /* to give widget inside the menu same look as regular menu */

--- a/src/Gui/Stylesheets/Light-green.qss
+++ b/src/Gui/Stylesheets/Light-green.qss
@@ -1626,9 +1626,7 @@ QSint--ActionGroup QToolButton::menu-button {
 QSint--ActionGroup QToolButton#settingsButton,
 QSint--ActionGroup QToolButton#filterButton,
 QSint--ActionGroup QToolButton#manualUpdate {
-    padding: 2px;
     padding-right: 20px; /* make way for the popup button */
-    margin: 0px;
 }
 
 /* to give widget inside the menu same look as regular menu */

--- a/src/Gui/Stylesheets/Light-orange.qss
+++ b/src/Gui/Stylesheets/Light-orange.qss
@@ -1626,9 +1626,7 @@ QSint--ActionGroup QToolButton::menu-button {
 QSint--ActionGroup QToolButton#settingsButton,
 QSint--ActionGroup QToolButton#filterButton,
 QSint--ActionGroup QToolButton#manualUpdate {
-    padding: 2px;
     padding-right: 20px; /* make way for the popup button */
-    margin: 0px;
 }
 
 /* to give widget inside the menu same look as regular menu */

--- a/src/Gui/Stylesheets/ProDark.qss
+++ b/src/Gui/Stylesheets/ProDark.qss
@@ -1815,9 +1815,7 @@ QSint--ActionGroup QToolButton::menu-button {
 QSint--ActionGroup QToolButton#settingsButton,
 QSint--ActionGroup QToolButton#filterButton,
 QSint--ActionGroup QToolButton#manualUpdate {
-    padding: 2px;
     padding-right: 20px; /* make way for the popup button */
-    margin: 0px;
 }
 
 /* to give widget inside the menu same look as regular menu */

--- a/src/Mod/Sketcher/Gui/TaskSketcherConstraints.ui
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstraints.ui
@@ -70,7 +70,7 @@
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="showHideButton">
+      <widget class="QToolButton" name="showHideButton">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
          <horstretch>0</horstretch>


### PR DESCRIPTION
This is just so that both 'eye' and 'settings' buttons have the same style all the time. Adrianpreviously fixed it in stylesheet but by changing the qtoolbutton margin/padding. The issue was that on windows his fixes did not apply correctly.

So here we do : 
- Change showHideButton from QPushButton to QToolButton.
- Reverse the stylesheet changes for padding and margin.

![image](https://user-images.githubusercontent.com/19984177/225026268-511ee0a5-d851-4d01-a961-d30f750ff2a9.png)


Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [ ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
