### PR TITLE
CI: Run GTest suite

### DIFF
--- a/.github/workflows/actions/runCPPTests/action.yml
+++ b/.github/workflows/actions/runCPPTests/action.yml
@@ -1,0 +1,62 @@
+# ***************************************************************************
+# *   Copyright (c) 2023 0penBrain                                          *
+# *   Copyright (c) 2023 FreeCAD Project Association                        *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   This program is distributed in the hope that it will be useful,       *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with this program; if not, write to the Free Software   *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+
+name: runCPPTests
+description: "Run: C++ tests"
+
+inputs:
+  testCommand:
+    description: "Test command to be run"
+    required: true
+  testLogFile:
+    description: "Path for the command-line output of the tests"
+    required: true
+  reportFile:
+    description: "Report file"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Run GTest unit tests
+      id: runGoogleTests
+      shell: bash
+      run: stdbuf -oL -eL ${{ inputs.testCommand }} |& tee -a ${{ inputs.testLogFile }}
+    - name: Parse test results
+      if: always()
+      shell: bash
+      run:  |
+        result=$(sed -ne "/Global test environment tear-down/,/^$/{/^$/d;p}" ${{ inputs.testLogFile }})
+        if [ $(echo $result | grep -F "[  FAILED  ]") ]
+        then
+          echo "<details><summary>:fire: GTest C++ unit test suite failed</summary>" >> ${{ inputs.reportFile }}
+        else
+          echo "<details><summary>:heavy_check_mark: GTest C++ unit test suite succeeded</summary>" >> ${{ inputs.reportFile }}
+        fi
+        echo "" >> ${{ inputs.reportFile }}
+        echo "Results" >> ${{ inputs.reportFile }}
+        echo "" >> ${{ inputs.reportFile }}
+        echo '```' >> ${{ inputs.reportFile }}
+        echo "$result" >> ${{ inputs.reportFile }}
+        echo '```' >> ${{ inputs.reportFile }}
+        echo "</details>">> ${{ inputs.reportFile }}
+        echo "" >> ${{ inputs.reportFile }}

--- a/.github/workflows/actions/runPythonTests/action.yml
+++ b/.github/workflows/actions/runPythonTests/action.yml
@@ -1,5 +1,5 @@
 # ***************************************************************************
-# *   Copyright (c) 2023 0penBrain                               *
+# *   Copyright (c) 2023 0penBrain                                          *
 # *                                                                         *
 # *   This program is free software; you can redistribute it and/or modify  *
 # *   it under the terms of the GNU Lesser General Public License (LGPL)    *
@@ -19,15 +19,15 @@
 # *                                                                         *
 # ***************************************************************************
 
-name: runTests
-description: "Linux: run unit tests, generate log and report"
+name: runPythonTests
+description: "Linux: run Python tests, generate log and report"
 
 inputs:
   testDescription:
     description: "Test description text, will be used on report"
     required: true
   testCommand:
-    description: "Test command to be ran"
+    description: "Test command to be run"
     required: true
   logFile:
     description: "Path for log file"

--- a/.github/workflows/sub_buildUbuntu2004.yml
+++ b/.github/workflows/sub_buildUbuntu2004.yml
@@ -185,7 +185,7 @@ jobs:
       - name: FreeCAD CLI tests on build dir
         if: inputs.testOnBuildDir
         timeout-minutes: 10
-        uses: ./.github/workflows/actions/runTests
+        uses: ./.github/workflows/actions/runPythonTests
         with:
           testDescription: "CLI tests on build dir"
           testCommand: ${{ env.builddir }}bin/FreeCADCmd -t 0
@@ -194,11 +194,18 @@ jobs:
       - name: FreeCAD GUI tests on build dir
         if: inputs.testOnBuildDir
         timeout-minutes: 15
-        uses: ./.github/workflows/actions/runTests
+        uses: ./.github/workflows/actions/runPythonTests
         with:
           testDescription: "GUI tests on build dir"
           testCommand: xvfb-run ${{ env.builddir }}/bin/FreeCAD -t 0
           logFile: ${{ env.logdir }}TestGUIBuild.log
+          reportFile: ${{env.reportdir}}${{ env.reportfilename }}
+      - name: C++ unit tests
+        timeout-minutes: 1
+        uses: ./.github/workflows/actions/runCPPTests
+        with:
+          testCommand: ${{ env.builddir }}/tests/Tests_run --gtest_output=json:${{env.reportdir}}gtest_results.json
+          testLogFile: ${{env.reportdir}}gtest_test_log.txt
           reportFile: ${{env.reportdir}}${{ env.reportfilename }}
       - name: CMake Install
         uses: ./.github/workflows/actions/linux/install
@@ -209,7 +216,7 @@ jobs:
           reportFile: ${{env.reportdir}}${{ env.reportfilename }}
       - name: FreeCAD CLI tests on install
         timeout-minutes: 10
-        uses: ./.github/workflows/actions/runTests
+        uses: ./.github/workflows/actions/runPythonTests
         with:
           testDescription: "CLI tests on install"
           testCommand: FreeCADCmd -t 0
@@ -217,7 +224,7 @@ jobs:
           reportFile: ${{env.reportdir}}${{ env.reportfilename }}
       - name: FreeCAD GUI tests on install
         timeout-minutes: 15
-        uses: ./.github/workflows/actions/runTests
+        uses: ./.github/workflows/actions/runPythonTests
         with:
           testDescription: "GUI tests on install"
           testCommand: xvfb-run FreeCAD -t 0

--- a/.github/workflows/sub_buildUbuntu2204.yml
+++ b/.github/workflows/sub_buildUbuntu2204.yml
@@ -1,5 +1,5 @@
 # ***************************************************************************
-# *   Copyright (c) 2023 0penBrain                               *
+# *   Copyright (c) 2023 0penBrain                                          *
 # *                                                                         *
 # *   This program is free software; you can redistribute it and/or modify  *
 # *   it under the terms of the GNU Lesser General Public License (LGPL)    *
@@ -194,7 +194,7 @@ jobs:
       - name: FreeCAD CLI tests on build dir
         if: inputs.testOnBuildDir
         timeout-minutes: 10
-        uses: ./.github/workflows/actions/runTests
+        uses: ./.github/workflows/actions/runPythonTests
         with:
           testDescription: "CLI tests on build dir"
           testCommand: ${{ env.builddir }}bin/FreeCADCmd -t 0
@@ -203,11 +203,18 @@ jobs:
       - name: FreeCAD GUI tests on build dir
         if: inputs.testOnBuildDir
         timeout-minutes: 15
-        uses: ./.github/workflows/actions/runTests
+        uses: ./.github/workflows/actions/runPythonTests
         with:
           testDescription: "GUI tests on build dir"
           testCommand: xvfb-run ${{ env.builddir }}/bin/FreeCAD -t 0
           logFile: ${{ env.logdir }}TestGUIBuild.log
+          reportFile: ${{env.reportdir}}${{ env.reportfilename }}
+      - name: C++ unit tests
+        timeout-minutes: 1
+        uses: ./.github/workflows/actions/runCPPTests
+        with:
+          testCommand: ${{ env.builddir }}/tests/Tests_run --gtest_output=json:${{env.reportdir}}gtest_results.json
+          testLogFile: ${{env.reportdir}}gtest_test_log.txt
           reportFile: ${{env.reportdir}}${{ env.reportfilename }}
       - name: CMake Install
         uses: ./.github/workflows/actions/linux/install
@@ -218,7 +225,7 @@ jobs:
           reportFile: ${{env.reportdir}}${{ env.reportfilename }}
       - name: FreeCAD CLI tests on install
         timeout-minutes: 10
-        uses: ./.github/workflows/actions/runTests
+        uses: ./.github/workflows/actions/runPythonTests
         with:
           testDescription: "CLI tests on install"
           testCommand: FreeCADCmd -t 0
@@ -226,7 +233,7 @@ jobs:
           reportFile: ${{env.reportdir}}${{ env.reportfilename }}
       - name: FreeCAD GUI tests on install
         timeout-minutes: 15
-        uses: ./.github/workflows/actions/runTests
+        uses: ./.github/workflows/actions/runPythonTests
         with:
           testDescription: "GUI tests on install"
           testCommand: xvfb-run FreeCAD -t 0


### PR DESCRIPTION
Add running the C++ unit tests to the CI workflow. It generates a JSON output file that I don't do much with right now, but in the future we could get fancy with the parsing of the error results. Right now it just checks for errors or test failures and prints them in the summary.

Here's what it looks like when there are failing tests:
https://github.com/chennes/FreeCAD/actions/runs/4422559744

---

- [X]  This Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR