### PR TITLE
[TD]trap bad format spec - fix #8897 in master branch

### DIFF
--- a/src/Mod/TechDraw/App/DimensionFormatter.cpp
+++ b/src/Mod/TechDraw/App/DimensionFormatter.cpp
@@ -320,12 +320,26 @@ QString DimensionFormatter::formatValueToSpec(double value, QString formatSpecif
         formattedValue.replace(QRegularExpression(QStringLiteral("([0-9][0-9]*\\.[0-9]*[1-9])00*$")), QStringLiteral("\\1"));
         formattedValue.replace(QRegularExpression(QStringLiteral("([0-9][0-9]*)\\.0*$")), QStringLiteral("\\1"));
     } else {
-        formattedValue = QString::asprintf(Base::Tools::toStdString(formatSpecifier).c_str(), value);
+        if (isNumericFormat(formatSpecifier)) {
+            formattedValue = QString::asprintf(Base::Tools::toStdString(formatSpecifier).c_str(), value);
+        }
     }
 
     return formattedValue;
 }
 
+bool DimensionFormatter::isNumericFormat(QString formatSpecifier)
+{
+    QRegularExpression rxFormat(QStringLiteral("%[+-]?[0-9]*\\.*[0-9]*[aefgwAEFGW]")); //printf double format spec
+    QRegularExpressionMatch rxMatch;
+    int pos = formatSpecifier.indexOf(rxFormat, 0, &rxMatch);
+    if (pos != -1)  {
+        return true;
+    }
+    return false;
+}
+
+//TODO: similiar code here and above
 QStringList DimensionFormatter::getPrefixSuffixSpec(QString fSpec)
 {
     QStringList result;

--- a/src/Mod/TechDraw/App/DimensionFormatter.h
+++ b/src/Mod/TechDraw/App/DimensionFormatter.h
@@ -49,6 +49,7 @@ public:
     std::string getDefaultFormatSpec(bool isToleranceFormat) const;
     bool isTooSmall(double value, QString formatSpec);
     QString formatValueToSpec(double value, QString formatSpecifier);
+    bool isNumericFormat(QString formatSpecifier);
 
 private:
     DrawViewDimension* m_dimension;


### PR DESCRIPTION
- bad format spec can break QString::asprintf

- this can probably be backported to v20, but it will have to be cut and paste, not cherry-pick.

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [ x]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
