### PR TITLE
[FEM] use unique result mesh name

### DIFF
--- a/src/Mod/Fem/feminout/importCcxFrdResults.py
+++ b/src/Mod/Fem/feminout/importCcxFrdResults.py
@@ -81,11 +81,6 @@ def importFrd(
 
     if len(m["Nodes"]) > 0:
         mesh = importToolsFem.make_femmesh(m)
-        result_mesh_object = ObjectsFem.makeMeshResult(
-            doc,
-            "ResultMesh"
-        )
-        result_mesh_object.FemMesh = mesh
         res_mesh_is_compacted = False
         nodenumbers_for_compacted_mesh = []
 
@@ -124,6 +119,9 @@ def importFrd(
                     )
 
                 res_obj = ObjectsFem.makeResultMechanical(doc, results_name)
+                # create result mesh
+                result_mesh_object = ObjectsFem.makeMeshResult(doc, results_name + "_Mesh")
+                result_mesh_object.FemMesh = mesh
                 res_obj.Mesh = result_mesh_object
                 res_obj = importToolsFem.fill_femresult_mechanical(res_obj, result_set)
                 if analysis:

--- a/src/Mod/Fem/femtaskpanels/task_solver_ccxtools.py
+++ b/src/Mod/Fem/femtaskpanels/task_solver_ccxtools.py
@@ -78,7 +78,7 @@ class _TaskPanel:
         self.CCX_mesh_visibility = False
 
         # store visibility of possibly existing mesh object
-        CCX_mesh = self.fea.analysis.Document.getObject("ResultMesh")
+        CCX_mesh = self.fea.analysis.Document.getObject("CCX_Results_Mesh")
         if CCX_mesh is not None:
             self.CCX_mesh_visibility = CCX_mesh.ViewObject.Visibility
 


### PR DESCRIPTION
- it is a long-standing bug that the name of the result mesh object is not unique. For example for a frequency analysis you get for every result the same object "ResultMesh". When now a "ResultMesh" object is deleted because one result mode object should be deleted, all result modes loose their mesh. To fix this, use a unique name for the mesh object.