### PR TITLE
[Lint] remove checks for line endings

### DIFF
--- a/.github/workflows/sub_lint.yml
+++ b/.github/workflows/sub_lint.yml
@@ -39,7 +39,7 @@ on:
         type: string
         required: true
       checkLineendings:
-        default: true
+        default: false
         type: boolean
         required: false
       lineendingsFailSilent:


### PR DESCRIPTION
- there is no need to check for certain OS line endings, git handles them well apparently