### PR TITLE
TD: First step to port to Qt6

### DIFF
--- a/src/Mod/TechDraw/App/DimensionFormatter.cpp
+++ b/src/Mod/TechDraw/App/DimensionFormatter.cpp
@@ -22,6 +22,7 @@
 
 #include "PreCompiled.h"
 #ifndef _PreComp_
+# include <QLocale>
 # include <QRegularExpression>
 #endif
 

--- a/src/Mod/TechDraw/App/DrawComplexSection.cpp
+++ b/src/Mod/TechDraw/App/DrawComplexSection.cpp
@@ -282,7 +282,7 @@ TopoDS_Shape DrawComplexSection::prepareShape(const TopoDS_Shape& cutShape, doub
 }
 
 
-void DrawComplexSection::makeSectionCut(TopoDS_Shape& baseShape)
+void DrawComplexSection::makeSectionCut(const TopoDS_Shape& baseShape)
 {
     //    Base::Console().Message("DCS::makeSectionCut() - %s - baseShape.IsNull: %d\n",
     //                            getNameInDocument(), baseShape.IsNull());
@@ -295,7 +295,11 @@ void DrawComplexSection::makeSectionCut(TopoDS_Shape& baseShape)
         connectAlignWatcher =
             QObject::connect(&m_alignWatcher, &QFutureWatcherBase::finished, &m_alignWatcher,
                              [this] { this->onSectionCutFinished(); });
+#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
         m_alignFuture = QtConcurrent::run(this, &DrawComplexSection::makeAlignedPieces, baseShape);
+#else
+        m_alignFuture = QtConcurrent::run(&DrawComplexSection::makeAlignedPieces, this, baseShape);
+#endif
         m_alignWatcher.setFuture(m_alignFuture);
         waitingForAlign(true);
     }

--- a/src/Mod/TechDraw/App/DrawComplexSection.h
+++ b/src/Mod/TechDraw/App/DrawComplexSection.h
@@ -58,7 +58,7 @@ public:
     TopoDS_Compound alignSectionFaces(TopoDS_Shape faceIntersections) override;
     std::pair<Base::Vector3d, Base::Vector3d> sectionLineEnds() override;
 
-    void makeSectionCut(TopoDS_Shape& baseShape) override;
+    void makeSectionCut(const TopoDS_Shape& baseShape) override;
 
     void waitingForAlign(bool s) { m_waitingForAlign = s; }
     bool waitingForAlign(void) const { return m_waitingForAlign; }

--- a/src/Mod/TechDraw/App/DrawViewDetail.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDetail.cpp
@@ -186,7 +186,11 @@ void DrawViewDetail::detailExec(TopoDS_Shape& shape, DrawViewPart* dvp, DrawView
     connectDetailWatcher =
         QObject::connect(&m_detailWatcher, &QFutureWatcherBase::finished, &m_detailWatcher,
                          [this] { this->onMakeDetailFinished(); });
+#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
     m_detailFuture = QtConcurrent::run(this, &DrawViewDetail::makeDetailShape, shape, dvp, dvs);
+#else
+    m_detailFuture = QtConcurrent::run(&DrawViewDetail::makeDetailShape, this, shape, dvp, dvs);
+#endif
     m_detailWatcher.setFuture(m_detailFuture);
     waitingForDetail(true);
 }
@@ -194,7 +198,7 @@ void DrawViewDetail::detailExec(TopoDS_Shape& shape, DrawViewPart* dvp, DrawView
 //this runs in a separate thread since it can sometimes take a long time
 //make a common of the input shape and a cylinder (or prism depending on
 //the matting style)
-void DrawViewDetail::makeDetailShape(TopoDS_Shape& shape, DrawViewPart* dvp, DrawViewSection* dvs)
+void DrawViewDetail::makeDetailShape(const TopoDS_Shape& shape, DrawViewPart* dvp, DrawViewSection* dvs)
 {
     showProgressMessage(getNameInDocument(), "is making detail shape");
 

--- a/src/Mod/TechDraw/App/DrawViewDetail.h
+++ b/src/Mod/TechDraw/App/DrawViewDetail.h
@@ -73,7 +73,7 @@ public:
     void detailExec(TopoDS_Shape& s,
                     DrawViewPart* baseView,
                     DrawViewSection* sectionAlias);
-    void makeDetailShape(TopoDS_Shape& shape,
+    void makeDetailShape(const TopoDS_Shape& shape,
                          DrawViewPart* dvp,
                          DrawViewSection* dvs);
     void postHlrTasks(void) override;

--- a/src/Mod/TechDraw/App/DrawViewPart.cpp
+++ b/src/Mod/TechDraw/App/DrawViewPart.cpp
@@ -390,7 +390,11 @@ TechDraw::GeometryObjectPtr DrawViewPart::buildGeometryObject(TopoDS_Shape& shap
         //https://github.com/KDE/clazy/blob/1.11/docs/checks/README-connect-3arg-lambda.md
         connectHlrWatcher = QObject::connect(&m_hlrWatcher, &QFutureWatcherBase::finished,
                                              &m_hlrWatcher, [this] { this->onHlrFinished(); });
+#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
         m_hlrFuture = QtConcurrent::run(go.get(), &GeometryObject::projectShape, shape, viewAxis);
+#else
+        m_hlrFuture = QtConcurrent::run(&GeometryObject::projectShape, go.get(), shape, viewAxis);
+#endif
         m_hlrWatcher.setFuture(m_hlrFuture);
         waitingForHlr(true);
     }
@@ -430,7 +434,11 @@ void DrawViewPart::onHlrFinished(void)
             connectFaceWatcher =
                 QObject::connect(&m_faceWatcher, &QFutureWatcherBase::finished, &m_faceWatcher,
                                  [this] { this->onFacesFinished(); });
+#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
             m_faceFuture = QtConcurrent::run(this, &DrawViewPart::extractFaces);
+#else
+            m_faceFuture = QtConcurrent::run(&DrawViewPart::extractFaces, this);
+#endif
             m_faceWatcher.setFuture(m_faceFuture);
             waitingForFaces(true);
         }

--- a/src/Mod/TechDraw/App/DrawViewSection.cpp
+++ b/src/Mod/TechDraw/App/DrawViewSection.cpp
@@ -380,7 +380,11 @@ void DrawViewSection::sectionExec(TopoDS_Shape& baseShape)
         connectCutWatcher =
             QObject::connect(&m_cutWatcher, &QFutureWatcherBase::finished, &m_cutWatcher,
                              [this] { this->onSectionCutFinished(); });
+#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
         m_cutFuture = QtConcurrent::run(this, &DrawViewSection::makeSectionCut, baseShape);
+#else
+        m_cutFuture = QtConcurrent::run(&DrawViewSection::makeSectionCut, this, baseShape);
+#endif
         m_cutWatcher.setFuture(m_cutFuture);
         waitingForCut(true);
     }
@@ -390,7 +394,7 @@ void DrawViewSection::sectionExec(TopoDS_Shape& baseShape)
     }
 }
 
-void DrawViewSection::makeSectionCut(TopoDS_Shape& baseShape)
+void DrawViewSection::makeSectionCut(const TopoDS_Shape& baseShape)
 {
     //    Base::Console().Message("DVS::makeSectionCut() - %s - baseShape.IsNull: %d\n",
     //                            getNameInDocument(), baseShape.IsNull());

--- a/src/Mod/TechDraw/App/DrawViewSection.h
+++ b/src/Mod/TechDraw/App/DrawViewSection.h
@@ -116,7 +116,7 @@ public:
     short mustExecute() const override;
 
     void sectionExec(TopoDS_Shape& s);
-    virtual void makeSectionCut(TopoDS_Shape& baseShape);
+    virtual void makeSectionCut(const TopoDS_Shape& baseShape);
     void postHlrTasks(void) override;
     virtual void postSectionCutTasks();
     void waitingForCut(bool s) { m_waitingForCut = s; }

--- a/src/Mod/TechDraw/Gui/AppTechDrawGui.cpp
+++ b/src/Mod/TechDraw/Gui/AppTechDrawGui.cpp
@@ -84,14 +84,13 @@ void loadTechDrawResource()
 
     // add fonts
     std::string fontDir = App::Application::getResourceDir() + "Mod/TechDraw/Resources/fonts/";
-    QFontDatabase fontDB;
 
     std::vector<std::string> fontsAll(
         {"osifont-lgpl3fe.ttf", "osifont-italic.ttf", "Y14.5-2018.ttf", "Y14.5-FreeCAD.ttf"});
 
     for (auto& font : fontsAll) {
         QString fontFile = Base::Tools::fromStdString(fontDir + font);
-        int rc = fontDB.addApplicationFont(fontFile);
+        int rc = QFontDatabase::addApplicationFont(fontFile);
         if (rc < 0) {
             Base::Console().Warning(
                 "TechDraw failed to load font file: %d from: %s\n", rc, qPrintable(fontFile));

--- a/src/Mod/TechDraw/Gui/QGSPage.cpp
+++ b/src/Mod/TechDraw/Gui/QGSPage.cpp
@@ -1259,7 +1259,9 @@ void QGSPage::postProcessXml(QTemporaryFile& temporaryFile, QString fileName, QS
 
     QTextStream stream(&outFile);
     stream.setGenerateByteOrderMark(false);
+#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
     stream.setCodec("UTF-8");
+#endif
 
     stream << exportDoc.toByteArray();
     outFile.close();

--- a/src/Mod/TechDraw/Gui/QGVPage.cpp
+++ b/src/Mod/TechDraw/Gui/QGVPage.cpp
@@ -27,7 +27,6 @@
 #include <QApplication>
 #include <QBitmap>
 #include <QContextMenuEvent>
-#include <QGLWidget>
 #include <QLabel>
 #include <QMouseEvent>
 #include <QPaintEvent>
@@ -357,7 +356,6 @@ void QGVPage::setRenderer(RendererType type)
 
     if (m_renderer == OpenGL) {
 #ifndef QT_NO_OPENGL
-        //        setViewport(new QGLWidget(QGLFormat(QGL::SampleBuffers))); //QGLWidget is obsolete
         setViewport(new QOpenGLWidget);
         setViewportUpdateMode(QGraphicsView::SmartViewportUpdate);
 #endif
@@ -466,7 +464,11 @@ void QGVPage::kbPanScroll(int xMove, int yMove)
     }
 }
 
+#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
 void QGVPage::enterEvent(QEvent* event)
+#else
+void QGVPage::enterEvent(QEnterEvent* event)
+#endif
 {
     QGraphicsView::enterEvent(event);
     m_navStyle->handleEnterEvent(event);

--- a/src/Mod/TechDraw/Gui/QGVPage.h
+++ b/src/Mod/TechDraw/Gui/QGVPage.h
@@ -130,7 +130,11 @@ public Q_SLOTS:
 protected:
     void wheelEvent(QWheelEvent* event) override;
     void paintEvent(QPaintEvent* event) override;
+#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
     void enterEvent(QEvent* event) override;
+#else
+    void enterEvent(QEnterEvent* event) override;
+#endif
     void leaveEvent(QEvent* event) override;
     void mousePressEvent(QMouseEvent* event) override;
     void mouseMoveEvent(QMouseEvent* event) override;

--- a/src/Mod/TechDraw/Gui/mrichtextedit.cpp
+++ b/src/Mod/TechDraw/Gui/mrichtextedit.cpp
@@ -201,8 +201,7 @@ MRichTextEdit::MRichTextEdit(QWidget *parent, QString textIn) : QWidget(parent) 
 
     // font size
 
-    QFontDatabase db;
-    const auto sizes = db.standardSizes();
+    const auto sizes = QFontDatabase::standardSizes();
     for(int size: sizes) {
         f_fontsize->addItem(QString::number(size));
     }
@@ -430,7 +429,11 @@ void MRichTextEdit::textStyle(int index) {
         }
     if (index == ParagraphMonospace) {
         fmt = cursor.charFormat();
+#if QT_VERSION < QT_VERSION_CHECK(5,13,0)
         fmt.setFontFamily(QString::fromUtf8("Monospace"));
+#else
+        fmt.setFontFamilies(QStringList() << QString::fromUtf8("Monospace"));
+#endif
         fmt.setFontStyleHint(QFont::Monospace);
         fmt.setFontFixedPitch(true);
         }


### PR DESCRIPTION
* in QtConcurrent::run the order of 1st and 2nd argument are swapped
* QtConcurrent::run asserts that the argument of the passed function pointer is not non-const
* Used methods of QFontDatabase are static in Qt5 and Qt6
* QTextStream::setCodec() has been removed in Qt6
* Argument of enterEvent() has changed from QEvent to QEnterEvent
* QTextCharFormat::setFamily() is deprecated

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [ ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
