### PR TITLE
[NotificationArea] Long message wrapping and preserve formatting

### DIFF
--- a/src/Gui/DlgSettingsNotificationArea.cpp
+++ b/src/Gui/DlgSettingsNotificationArea.cpp
@@ -78,6 +78,7 @@ void DlgSettingsNotificationArea::saveSettings()
     ui->maxNotifications->onSave();
     ui->maxWidgetMessages->onSave();
     ui->autoRemoveUserNotifications->onSave();
+    ui->notificationWidth->onSave();
 }
 
 void DlgSettingsNotificationArea::loadSettings()
@@ -89,6 +90,7 @@ void DlgSettingsNotificationArea::loadSettings()
     ui->maxNotifications->onRestore();
     ui->maxWidgetMessages->onRestore();
     ui->autoRemoveUserNotifications->onRestore();
+    ui->notificationWidth->onRestore();
 }
 
 void DlgSettingsNotificationArea::changeEvent(QEvent *e)

--- a/src/Gui/DlgSettingsNotificationArea.ui
+++ b/src/Gui/DlgSettingsNotificationArea.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>654</width>
-    <height>356</height>
+    <height>375</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -98,6 +98,35 @@
         </property>
         <property name="prefEntry" stdset="0">
          <cstring>MaxOpenNotifications</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>NotificationArea</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="label_width">
+        <property name="text">
+         <string>Notification width:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="Gui::PrefSpinBox" name="notificationWidth">
+        <property name="toolTip">
+         <string>Width of the notification in pixels</string>
+        </property>
+        <property name="minimum">
+         <number>300</number>
+        </property>
+        <property name="maximum">
+         <number>10000</number>
+        </property>
+        <property name="value">
+         <number>800</number>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>NotificiationWidth</cstring>
         </property>
         <property name="prefPath" stdset="0">
          <cstring>NotificationArea</cstring>

--- a/src/Gui/NotificationArea.cpp
+++ b/src/Gui/NotificationArea.cpp
@@ -32,6 +32,7 @@
 #include <QMenu>
 #include <QMessageBox>
 #include <QStringList>
+#include <QTextDocument>
 #include <QThread>
 #include <QTimer>
 #include <QTreeWidget>
@@ -938,6 +939,8 @@ void NotificationArea::showInNotificationArea()
                     iconstr = QStringLiteral(":/icons/info.svg");
                 }
 
+                QString tmpmessage = convertFromPlainText(item->msg, Qt::WhiteSpaceMode::WhiteSpaceNormal);
+
                 msgw +=
                     QString::fromLatin1(
                         "                                                                                   \
@@ -948,7 +951,7 @@ void NotificationArea::showInNotificationArea()
                 </tr>")
                         .arg(iconstr)
                         .arg(item->notifierName)
-                        .arg(item->msg);
+                        .arg(tmpmessage);
 
                 // start a timer for each of these notifications that was not previously shown
                 if (!item->shown) {

--- a/src/Gui/NotificationArea.cpp
+++ b/src/Gui/NotificationArea.cpp
@@ -79,6 +79,8 @@ struct NotificationAreaP
     bool notificationsDisabled = false;
     /// Control of confirmation mechanism (for Critical Messages)
     bool requireConfirmationCriticalMessageDuringRestoring = true;
+    /// Width of the non-intrusive notification
+    int notificationWidth = 800;
     //@}
 
     /** @name Widget parameters */
@@ -631,6 +633,13 @@ NotificationArea::ParameterObserver::ParameterObserver(NotificationArea* notific
              auto enabled = hGrp->GetBool(string.c_str(), true);
              notificationArea->pImp->autoRemoveUserNotifications = enabled;
          }},
+        {"NotificiationWidth",
+         [this](const std::string& string) {
+             auto width = hGrp->GetInt(string.c_str(), 800);
+             if (width < 300)
+                 width = 300;
+             notificationArea->pImp->notificationWidth = width;
+         }},
     };
 
     for (auto& val : parameterMap) {
@@ -982,7 +991,8 @@ void NotificationArea::showInNotificationArea()
         NotificationBox::showText(this->mapToGlobal(QPoint()),
                                   msgw,
                                   pImp->notificationExpirationTime,
-                                  pImp->minimumOnScreenTime);
+                                  pImp->minimumOnScreenTime,
+                                  pImp->notificationWidth);
     }
 }
 

--- a/src/Gui/NotificationArea.cpp
+++ b/src/Gui/NotificationArea.cpp
@@ -882,7 +882,7 @@ void NotificationArea::showInNotificationArea()
         QString msgw =
             QString::fromLatin1(
                 "<style>p { margin: 0 0 0 0 } td { padding: 0 15px }</style>                     \
-        <p style='white-space:nowrap'>                                                                                      \
+        <p style='white-space:normal'>                                                                                      \
         <table>                                                                                                             \
         <tr>                                                                                                               \
         <th><small>%1</small></th>                                                                                        \

--- a/src/Gui/NotificationBox.cpp
+++ b/src/Gui/NotificationBox.cpp
@@ -60,9 +60,9 @@ class NotificationLabel: public QLabel
 {
     Q_OBJECT
 public:
-    NotificationLabel(const QString& text, const QPoint& pos, int displayTime, int minShowTime = 0);
+    NotificationLabel(const QString& text, const QPoint& pos, int displayTime, int minShowTime = 0, int width = 0);
     /// Reuse existing notification to show a new notification (with a new text)
-    void reuseNotification(const QString& text, int displayTime, const QPoint& pos);
+    void reuseNotification(const QString& text, int displayTime, const QPoint& pos, int width);
     /// Hide notification after a hiding timer.
     void hideNotification();
     /// Update the size of the QLabel
@@ -96,7 +96,7 @@ private:
 qobject_delete_later_unique_ptr<NotificationLabel> NotificationLabel::instance = nullptr;
 
 NotificationLabel::NotificationLabel(const QString& text, const QPoint& pos, int displayTime,
-                                     int minShowTime)
+                                     int minShowTime, int width)
     : QLabel(nullptr, Qt::ToolTip | Qt::BypassGraphicsProxyWidget),
       minShowTime(minShowTime)
 {
@@ -125,7 +125,7 @@ NotificationLabel::NotificationLabel(const QString& text, const QPoint& pos, int
         hideNotificationImmediately();
     });
 
-    reuseNotification(text, displayTime, pos);
+    reuseNotification(text, displayTime, pos, width);
 }
 
 void NotificationLabel::restartExpireTimer(int displayTime)
@@ -143,8 +143,11 @@ void NotificationLabel::restartExpireTimer(int displayTime)
     hideTimer.stop();
 }
 
-void NotificationLabel::reuseNotification(const QString& text, int displayTime, const QPoint& pos)
+void NotificationLabel::reuseNotification(const QString& text, int displayTime, const QPoint& pos, int width)
 {
+    if(width > 0)
+        setFixedWidth(width);
+
     setText(text);
     updateSize(pos);
     restartExpireTimer(displayTime);
@@ -287,7 +290,7 @@ bool NotificationLabel::notificationLabelChanged(const QString& text)
 /***************************** NotificationBox **********************************/
 
 void NotificationBox::showText(const QPoint& pos, const QString& text, int displayTime,
-                               unsigned int minShowTime)
+                               unsigned int minShowTime, int width)
 {
     // a label does already exist
     if (NotificationLabel::instance && NotificationLabel::instance->isVisible()) {
@@ -298,7 +301,7 @@ void NotificationBox::showText(const QPoint& pos, const QString& text, int displ
         else {
             // If the label has changed, reuse the one that is showing (removes flickering)
             if (NotificationLabel::instance->notificationLabelChanged(text)) {
-                NotificationLabel::instance->reuseNotification(text, displayTime, pos);
+                NotificationLabel::instance->reuseNotification(text, displayTime, pos, width);
                 NotificationLabel::instance->placeNotificationLabel(pos);
             }
             return;
@@ -310,7 +313,8 @@ void NotificationBox::showText(const QPoint& pos, const QString& text, int displ
         new NotificationLabel(text,
                               pos,
                               displayTime,
-                              minShowTime);// sets NotificationLabel::instance to itself
+                              minShowTime,
+                              width);// sets NotificationLabel::instance to itself
 
         NotificationLabel::instance->placeNotificationLabel(pos);
         NotificationLabel::instance->setObjectName(QLatin1String("NotificationBox_label"));

--- a/src/Gui/NotificationBox.h
+++ b/src/Gui/NotificationBox.h
@@ -54,9 +54,11 @@ public:
      * an event, see class documentation above)
      * @param minShowTime  Time during which the notification can only be made disappear by popping
      * it out (clicking inside it).
+     * @param width Fixes the width of the notification. Default value makes the width to be system determined (dependent on
+     * the text).
      */
     static void showText(const QPoint& pos, const QString& text, int displayTime = -1,
-                         unsigned int minShowTime = 0);
+                         unsigned int minShowTime = 0, int width = 0);
     /// Hides a notification.
     static inline void hideText()
     {


### PR DESCRIPTION

It was reported that some non-intrusive notifications occupy the whole width of the screen and even then, they are so large that are not visible.

This PR:
- Enables normal wrapping of the notificationbox, so that text is automatically wrapped to fix the notification.
- Notification box are now provided of a fixed width. the width is configurable in preferences.
- Text is converted to HTML to properly preserve format as much as possible.

