### PR TITLE
App: Fix missing python addProperty and removeProperty of Document object

### DIFF
--- a/src/App/DocumentPy.xml
+++ b/src/App/DocumentPy.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <GenerateModel xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="generateMetaModel_Module.xsd">
-  <PythonExport 
-    Father="PropertyContainerPy" 
-    Name="DocumentPy" 
-    Twin="Document" 
-    TwinPointer="Document" 
-    Include="App/Document.h" 
-    Namespace="App" 
-    FatherInclude="App/PropertyContainerPy.h" 
+  <PythonExport
+    Father="PropertyContainerPy"
+    Name="DocumentPy"
+    Twin="Document"
+    TwinPointer="Document"
+    Include="App/Document.h"
+    Namespace="App"
+    FatherInclude="App/PropertyContainerPy.h"
     FatherNamespace="App">
     <Documentation>
       <Author Licence="LGPL" Name="Juergen Riegel" EMail="FreeCAD@juergen-riegel.net" />
@@ -104,6 +104,23 @@ attach (Boolean): if True, then bind the document object first before adding to 
 viewType (String): override the view provider type directly, only effective when attach is False.</UserDocu>
       </Documentation>
     </Methode>
+    <Methode Name="addProperty">
+        <Documentation>
+            <UserDocu>
+                addProperty(string, string) -- Add a generic property.
+                The first argument specifies the type, the second the
+                name of the property.
+            </UserDocu>
+        </Documentation>
+    </Methode>
+    <Methode Name="removeProperty">
+        <Documentation>
+            <UserDocu>
+                removeProperty(string) -- Remove a generic property.
+                Note, you can only remove user-defined properties but not built-in ones.
+            </UserDocu>
+        </Documentation>
+    </Methode>
     <Methode Name="removeObject">
       <Documentation>
         <UserDocu>Remove an object from the document</UserDocu>
@@ -113,7 +130,7 @@ viewType (String): override the view provider type directly, only effective when
       <Documentation>
           <UserDocu>
 copyObject(object, with_dependencies=False, return_all=False)
-Copy an object or objects from another document to this document. 
+Copy an object or objects from another document to this document.
 
 object: can either a single object or sequence of objects
 with_dependencies: if True, all internal dependent objects are copied too.
@@ -127,7 +144,7 @@ return_all: if True, return all copied objects, or else return only the copied
         <UserDocu>
 moveObject(object, bool with_dependencies = False)
 Transfers an object from another document to this document.
-              
+
 object: can either a single object or sequence of objects
 with_dependencies: if True, all internal dependent objects are copied too.
         </UserDocu>

--- a/src/App/DocumentPyImp.cpp
+++ b/src/App/DocumentPyImp.cpp
@@ -40,6 +40,37 @@
 using namespace App;
 
 
+PyObject*  DocumentPy::addProperty(PyObject *args)
+{
+    char *sType,*sName=nullptr,*sGroup=nullptr,*sDoc=nullptr;
+    short attr=0;
+    std::string sDocStr;
+    PyObject *ro = Py_False, *hd = Py_False;
+    if (!PyArg_ParseTuple(args, "s|ssethO!O!", &sType,&sName,&sGroup,"utf-8",&sDoc,&attr,
+        &PyBool_Type, &ro, &PyBool_Type, &hd))
+        return nullptr;
+
+    if (sDoc) {
+        sDocStr = sDoc;
+        PyMem_Free(sDoc);
+    }
+
+    getDocumentPtr()->addDynamicProperty(sType,sName,sGroup,sDocStr.c_str(),attr,
+            Base::asBoolean(ro), Base::asBoolean(hd));
+
+    return Py::new_reference_to(this);
+}
+
+PyObject*  DocumentPy::removeProperty(PyObject *args)
+{
+    char *sName;
+    if (!PyArg_ParseTuple(args, "s", &sName))
+        return nullptr;
+
+    bool ok = getDocumentPtr()->removeDynamicProperty(sName);
+    return Py_BuildValue("O", (ok ? Py_True : Py_False));
+}
+
 // returns a string which represent the object e.g. when printed in python
 std::string DocumentPy::representation() const
 {


### PR DESCRIPTION
The python Document class didn't have addProperty nor removeProperty but such behavior was available throw GUI.

Forum discussion (french): https://forum.freecad.org/viewtopic.php?t=76855