### PR TITLE
[FEM] Elmer: add new default coordinate system

### DIFF
--- a/src/Mod/Fem/femsolver/elmer/solver.py
+++ b/src/Mod/Fem/femsolver/elmer/solver.py
@@ -49,7 +49,7 @@ from femtools import femutils
 if FreeCAD.GuiUp:
     import FemGui
 
-COORDINATE_SYSTEM = ["Cartesian 1D", "Cartesian 2D", "Cartesian 3D",
+COORDINATE_SYSTEM = ["Cartesian", "Cartesian 1D", "Cartesian 2D", "Cartesian 3D",
                      "Polar 2D", "Polar 3D",
                      "Cylindric", "Cylindric Symmetric",
                      "Axi Symmetric"]
@@ -87,7 +87,7 @@ class Proxy(solverbase.Proxy):
             ""
         )
         obj.CoordinateSystem = COORDINATE_SYSTEM
-        obj.CoordinateSystem = "Cartesian 3D"
+        obj.CoordinateSystem = "Cartesian"
 
         obj.addProperty(
             "App::PropertyIntegerConstraint",

--- a/src/Mod/Fem/femsolver/elmer/writer.py
+++ b/src/Mod/Fem/femsolver/elmer/writer.py
@@ -364,7 +364,7 @@ class Writer(object):
                 ""
             )
             solver.CoordinateSystem = solverClass.COORDINATE_SYSTEM
-            solver.CoordinateSystem = "Cartesian 3D"
+            solver.CoordinateSystem = "Cartesian"
         if not hasattr(self.solver, "BDFOrder"):
             solver.addProperty(
                 "App::PropertyIntegerConstraint",

--- a/src/Mod/Fem/femtest/data/elmer/box_static_0_mm.sif
+++ b/src/Mod/Fem/femtest/data/elmer/box_static_0_mm.sif
@@ -26,7 +26,7 @@ End
 Simulation 
   Coordinate Mapping(3) = Integer 1 2 3
   Coordinate Scaling = Real 0.001
-  Coordinate System = String "Cartesian 3D"
+  Coordinate System = String "Cartesian"
   Output Intervals = Integer 1
   Simulation Type = String "Steady State"
   Steady State Max Iterations = Integer 1

--- a/src/Mod/Fem/femtest/data/elmer/ccxcantilever_faceload_0_mm.sif
+++ b/src/Mod/Fem/femtest/data/elmer/ccxcantilever_faceload_0_mm.sif
@@ -26,7 +26,7 @@ End
 Simulation 
   Coordinate Mapping(3) = Integer 1 2 3
   Coordinate Scaling = Real 0.001
-  Coordinate System = String "Cartesian 3D"
+  Coordinate System = String "Cartesian"
   Output Intervals = Integer 1
   Simulation Type = String "Steady State"
   Steady State Max Iterations = Integer 1

--- a/src/Mod/Fem/femtest/data/elmer/ccxcantilever_faceload_1_si.sif
+++ b/src/Mod/Fem/femtest/data/elmer/ccxcantilever_faceload_1_si.sif
@@ -26,7 +26,7 @@ End
 Simulation 
   Coordinate Mapping(3) = Integer 1 2 3
   Coordinate Scaling = Real 0.001
-  Coordinate System = String "Cartesian 3D"
+  Coordinate System = String "Cartesian"
   Output Intervals = Integer 1
   Simulation Type = String "Steady State"
   Steady State Max Iterations = Integer 1

--- a/src/Mod/Fem/femtest/data/elmer/ccxcantilever_nodeload_0_mm.sif
+++ b/src/Mod/Fem/femtest/data/elmer/ccxcantilever_nodeload_0_mm.sif
@@ -26,7 +26,7 @@ End
 Simulation 
   Coordinate Mapping(3) = Integer 1 2 3
   Coordinate Scaling = Real 0.001
-  Coordinate System = String "Cartesian 3D"
+  Coordinate System = String "Cartesian"
   Output Intervals = Integer 1
   Simulation Type = String "Steady State"
   Steady State Max Iterations = Integer 1

--- a/src/Mod/Fem/femtest/data/elmer/ccxcantilever_prescribeddisplacement_0_mm.sif
+++ b/src/Mod/Fem/femtest/data/elmer/ccxcantilever_prescribeddisplacement_0_mm.sif
@@ -26,7 +26,7 @@ End
 Simulation 
   Coordinate Mapping(3) = Integer 1 2 3
   Coordinate Scaling = Real 0.001
-  Coordinate System = String "Cartesian 3D"
+  Coordinate System = String "Cartesian"
   Output Intervals = Integer 1
   Simulation Type = String "Steady State"
   Steady State Max Iterations = Integer 1


### PR DESCRIPTION
- for new versions of Elmer the default coordinate system is "Cartesian". (if 2D or 3D is determined by the "Variable" setting for the equation)