### PR TITLE
PD: Implement Profile Shift for InvoluteGear

### DIFF
--- a/src/Mod/PartDesign/InvoluteGearFeature.py
+++ b/src/Mod/PartDesign/InvoluteGearFeature.py
@@ -122,13 +122,17 @@ class _InvoluteGear:
             doc=QtCore.QT_TRANSLATE_NOOP("App::Property",
                 "The radius of the fillet at the root of the tooth, normalized by the module."),
             default=lambda: 0.375 if is_restore else 0.38)
+        ensure_property("App::PropertyFloat","ProfileShiftCoefficient",
+            doc=QtCore.QT_TRANSLATE_NOOP("App::Property",
+                "The distance by which the reference profile is shifted outwards, normalized by the module."),
+            default=0.0)
 
     def execute(self,obj):
         w = fcgear.FCWireBuilder()
         generator_func = involute.CreateExternalGear if obj.ExternalGear else involute.CreateInternalGear
         generator_func(w, obj.Modules.Value, obj.NumberOfTeeth, obj.PressureAngle.Value,
             split=obj.HighPrecision, addCoeff=obj.AddendumCoefficient, dedCoeff=obj.DedendumCoefficient,
-            filletCoeff=obj.RootFilletCoefficient)
+            filletCoeff=obj.RootFilletCoefficient, shiftCoeff=obj.ProfileShiftCoefficient)
         gearw = Part.Wire([o.toShape() for o in w.wire])
         obj.Shape = gearw
         obj.positionBySupport()
@@ -199,6 +203,7 @@ class _InvoluteGearTaskPanel:
         self.form.doubleSpinBox_Addendum.valueChanged.connect(assignValue("AddendumCoefficient"))
         self.form.doubleSpinBox_Dedendum.valueChanged.connect(assignValue("DedendumCoefficient"))
         self.form.doubleSpinBox_RootFillet.valueChanged.connect(assignValue("RootFilletCoefficient"))
+        self.form.doubleSpinBox_ProfileShift.valueChanged.connect(assignValue("ProfileShiftCoefficient"))
 
         self.update()
 
@@ -222,6 +227,7 @@ class _InvoluteGearTaskPanel:
         assign("AddendumCoefficient", self.form.doubleSpinBox_Addendum, self.form.label_Addendum)
         assign("DedendumCoefficient", self.form.doubleSpinBox_Dedendum, self.form.label_Dedendum)
         assign("RootFilletCoefficient", self.form.doubleSpinBox_RootFillet, self.form.label_RootFillet)
+        assign("ProfileShiftCoefficient", self.form.doubleSpinBox_ProfileShift, self.form.label_ProfileShift)
 
     def changeEvent(self, event):
         if event == QtCore.QEvent.LanguageChange:
@@ -237,6 +243,7 @@ class _InvoluteGearTaskPanel:
         self.obj.AddendumCoefficient = self.form.doubleSpinBox_Addendum.value()
         self.obj.DedendumCoefficient = self.form.doubleSpinBox_Dedendum.value()
         self.obj.RootFilletCoefficient = self.form.doubleSpinBox_RootFillet.value()
+        self.obj.ProfileShiftCoefficient = self.form.doubleSpinBox_ProfileShift.value()
 
     def transferFrom(self):
         "Transfer from the object to the dialog"
@@ -248,6 +255,7 @@ class _InvoluteGearTaskPanel:
         self.form.doubleSpinBox_Addendum.setValue(self.obj.AddendumCoefficient)
         self.form.doubleSpinBox_Dedendum.setValue(self.obj.DedendumCoefficient)
         self.form.doubleSpinBox_RootFillet.setValue(self.obj.RootFilletCoefficient)
+        self.form.doubleSpinBox_ProfileShift.setValue(self.obj.ProfileShiftCoefficient)
 
     def getStandardButtons(self):
         return int(QtGui.QDialogButtonBox.Ok) | int(QtGui.QDialogButtonBox.Cancel)| int(QtGui.QDialogButtonBox.Apply)

--- a/src/Mod/PartDesign/InvoluteGearFeature.ui
+++ b/src/Mod/PartDesign/InvoluteGearFeature.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>248</width>
-    <height>270</height>
+    <width>253</width>
+    <height>301</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -230,6 +230,29 @@
      </property>
      <property name="value">
       <double>0.380000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="0">
+    <widget class="QLabel" name="label_ProfileShift">
+     <property name="text">
+      <string>Profile Shift Coefficient</string>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="1">
+    <widget class="QDoubleSpinBox" name="doubleSpinBox_ProfileShift">
+     <property name="minimum">
+      <double>-3.000000000000000</double>
+     </property>
+     <property name="maximum">
+      <double>3.000000000000000</double>
+     </property>
+     <property name="singleStep">
+      <double>0.100000000000000</double>
+     </property>
+     <property name="value">
+      <double>0.000000000000000</double>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
This commit adds the ability to shift the involute profile inside or outside. Profile shift is implemented as coefficient, i.e. normalized by the module, so that the whole profile scales with the module without changing shape.
To verify the profile, the tests implement an "over pins measurement" using formulae found in literature.
Backward compatibility with FreeCAD-v0.20 is garanteed by already existing tests, not touched by this commit.

This addresses issue #5618.

----

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [x]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
