### PR TITLE
Notifications: Extend translated notification to include caption

### DIFF
--- a/src/Gui/Notifications.h
+++ b/src/Gui/Notifications.h
@@ -153,7 +153,7 @@ inline void Gui::Notify(TNotifier && notifier, TCaption && caption, TMessage && 
 
         if constexpr( type == Base::LogStyle::TranslatedNotification) {
             // trailing newline is necessary as this may be shown too in a console requiring them (depending on the configuration).
-            auto msg = message.append(QStringLiteral("\n")); // QString
+            auto msg = QStringLiteral("%1. %2\n").arg(caption).arg(message); // QString
 
             if constexpr( std::is_base_of_v<App::DocumentObject, std::remove_pointer_t<typename std::decay<TNotifier>::type>> ) {
                 Base::Console().Send<type>(notifier->getFullLabel(), msg.toUtf8());


### PR DESCRIPTION
===============================================================

For translated notifications now the caption is included in the message, as the translation is already done, and this improves the semantics of existing messages.

See:
https://forum.freecad.org/viewtopic.php?p=668333#p668333