### PR TITLE
Fix crash ElementsWidget

### DIFF
--- a/src/Mod/Sketcher/Gui/TaskSketcherElements.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherElements.cpp
@@ -168,6 +168,39 @@ class ElementItem : public QListWidgetItem
 
     const Part::Geometry * geo;
 };
+
+class ElementFilterList : public QListWidget
+{
+    Q_OBJECT
+
+public:
+    explicit ElementFilterList(QWidget* parent = nullptr);
+    ~ElementFilterList() override;
+
+protected:
+    void changeEvent(QEvent* e) override;
+    virtual void languageChange();
+
+private:
+    using filterItemRepr =  std::pair<const char *, const int>; // {filter item text, filter item level}
+    inline static const std::vector<filterItemRepr> filterItems = {
+        {QT_TR_NOOP("Normal"),0},
+        {QT_TR_NOOP("Construction"),0},
+        {QT_TR_NOOP("Internal"),0},
+        {QT_TR_NOOP("External"),0},
+        {QT_TR_NOOP("All types"),0},
+        {QT_TR_NOOP("Point"),1},
+        {QT_TR_NOOP("Line"),1},
+        {QT_TR_NOOP("Circle"),1},
+        {QT_TR_NOOP("Ellipse"),1},
+        {QT_TR_NOOP("Arc of circle"),1},
+        {QT_TR_NOOP("Arc of ellipse"),1},
+        {QT_TR_NOOP("Arc of hyperbola"),1},
+        {QT_TR_NOOP("Arc of parabola"),1},
+        {QT_TR_NOOP("B-Spline"),1}
+    };
+
+};
 } // SketcherGui
 
 class ElementWidgetIcons {
@@ -675,40 +708,6 @@ ElementItem* ElementItemDelegate::getElementtItem(const QModelIndex& index) cons
 }
 
 /* Filter element list widget ------------------------------------------------------ */
-namespace SketcherGui {
-class ElementFilterList : public QListWidget
-{
-    Q_OBJECT
-
-public:
-    explicit ElementFilterList(QWidget* parent = nullptr);
-    ~ElementFilterList() override;
-
-protected:
-    void changeEvent(QEvent* e) override;
-    virtual void languageChange();
-
-private:
-    using filterItemRepr =  std::pair<const char *, const int>; // {filter item text, filter item level}
-    inline static const std::vector<filterItemRepr> filterItems = {
-        {QT_TR_NOOP("Normal"),0},
-        {QT_TR_NOOP("Construction"),0},
-        {QT_TR_NOOP("Internal"),0},
-        {QT_TR_NOOP("External"),0},
-        {QT_TR_NOOP("All types"),0},
-        {QT_TR_NOOP("Point"),1},
-        {QT_TR_NOOP("Line"),1},
-        {QT_TR_NOOP("Circle"),1},
-        {QT_TR_NOOP("Ellipse"),1},
-        {QT_TR_NOOP("Arc of circle"),1},
-        {QT_TR_NOOP("Arc of ellipse"),1},
-        {QT_TR_NOOP("Arc of hyperbola"),1},
-        {QT_TR_NOOP("Arc of parabola"),1},
-        {QT_TR_NOOP("B-Spline"),1}
-    };
-
-};
-}
 
 enum class GeoFilterType {
     NormalGeos,


### PR DESCRIPTION
This should fix this (I cannot reproduce it):
https://forum.freecad.org/viewtopic.php?p=667579#p667579

Lately I added the geometry pointer to the item. This has indeed
the potential for an already deleted pointer being accessed.

This PR removes the geometry pointer from the item and relies on the
ViewProvider to indirectly access an updated pointer.