### PR TITLE
PartDesign: (extrude) Pad inward taper angle orientation

### DIFF
--- a/src/Mod/Part/App/ExtrusionHelper.cpp
+++ b/src/Mod/Part/App/ExtrusionHelper.cpp
@@ -58,6 +58,7 @@ void ExtrusionHelper::makeDraft(const TopoDS_Shape& shape,
                                 const double LengthRev,
                                 const double AngleFwd,
                                 const double AngleRev,
+                                bool taperParallel,
                                 bool isSolid,
                                 std::list<TopoDS_Shape>& drafts,
                                 bool isPartDesign)
@@ -156,13 +157,10 @@ void ExtrusionHelper::makeDraft(const TopoDS_Shape& shape,
                     createTaperedPrismOffset(TopoDS::Wire(singleWire), vecRev, distanceRev, true, offsetWire);
                 }
                 else {
-                    // there is an OCC bug with single-edge wires (circles), see inside createTaperedPrismOffset
-                    if (numEdges > 1 || !isPartDesign)
-                        // inner wires must get the negated offset
-                        createTaperedPrismOffset(TopoDS::Wire(singleWire), vecRev, -distanceRev, true, offsetWire);
-                    else
-                        // circles in PartDesign must not get the negated offset
+                    if (taperParallel)
                         createTaperedPrismOffset(TopoDS::Wire(singleWire), vecRev, distanceRev, true, offsetWire);
+                    else
+                        createTaperedPrismOffset(TopoDS::Wire(singleWire), vecRev, -distanceRev, true, offsetWire);
                 }
                 if (offsetWire.IsNull())
                     return;
@@ -204,13 +202,10 @@ void ExtrusionHelper::makeDraft(const TopoDS_Shape& shape,
                     createTaperedPrismOffset(TopoDS::Wire(singleWire), vecFwd, distanceFwd, false, offsetWire);
                 }
                 else {
-                    // there is an OCC bug with single-edge wires (circles), see inside createTaperedPrismOffset
-                    if (numEdges > 1 || !isPartDesign)
-                        // inner wires must get the negated offset
-                        createTaperedPrismOffset(TopoDS::Wire(singleWire), vecFwd, -distanceFwd, false, offsetWire);
-                    else
-                        // circles in PartDesign must not get the negated offset
+                    if (taperParallel)
                         createTaperedPrismOffset(TopoDS::Wire(singleWire), vecFwd, distanceFwd, false, offsetWire);
+                    else
+                        createTaperedPrismOffset(TopoDS::Wire(singleWire), vecFwd, -distanceFwd, false, offsetWire);
                 }
                 if (offsetWire.IsNull())
                     return;

--- a/src/Mod/Part/App/ExtrusionHelper.h
+++ b/src/Mod/Part/App/ExtrusionHelper.h
@@ -47,7 +47,8 @@ public:
                           const double LengthFwd,
                           const double LengthRev,
                           const double AngleFwd,
-                          const double AngleRev,
+                          const double AngleRev, 
+                          bool taperParallel,
                           bool isSolid,
                           std::list<TopoDS_Shape>& drafts,
                           bool isPartDesign);

--- a/src/Mod/Part/App/FeatureExtrusion.cpp
+++ b/src/Mod/Part/App/FeatureExtrusion.cpp
@@ -65,6 +65,7 @@ Extrusion::Extrusion()
     ADD_PROPERTY_TYPE(LengthRev, (0.0), "Extrude", App::Prop_None, "Length of additional extrusion, against direction.");
     ADD_PROPERTY_TYPE(Solid, (false), "Extrude", App::Prop_None, "If true, extruding a wire yields a solid. If false, a shell.");
     ADD_PROPERTY_TYPE(Reversed, (false), "Extrude", App::Prop_None, "Set to true to swap the direction of extrusion.");
+    ADD_PROPERTY_TYPE(InwardTaperParallel, (false), "Pad", App::Prop_None, "Make inward and outward taper parallel");
     ADD_PROPERTY_TYPE(Symmetric, (false), "Extrude", App::Prop_None, "If true, extrusion is done in both directions to a total of LengthFwd. LengthRev is ignored.");
     ADD_PROPERTY_TYPE(TaperAngle, (0.0), "Extrude", App::Prop_None, "Sets the angle of slope (draft) to apply to the sides. The angle is for outward taper; negative value yields inward tapering.");
     ADD_PROPERTY_TYPE(TaperAngleRev, (0.0), "Extrude", App::Prop_None, "Taper angle of reverse part of extrusion.");
@@ -83,6 +84,7 @@ short Extrusion::mustExecute() const
         Reversed.isTouched() ||
         Symmetric.isTouched() ||
         TaperAngle.isTouched() ||
+        InwardTaperParallel.isTouched() ||
         TaperAngleRev.isTouched() ||
         FaceMakerClass.isTouched())
         return 1;
@@ -249,7 +251,7 @@ TopoShape Extrusion::extrudeShape(const TopoShape& source, const Extrusion::Extr
         std::list<TopoDS_Shape> drafts;
         bool isPartDesign = false; // there is an OCC bug with single-edge wires (circles) we need to treat differently for PD and Part
         ExtrusionHelper::makeDraft(myShape, params.dir, params.lengthFwd, params.lengthRev,
-                                   params.taperAngleFwd, params.taperAngleRev, params.solid, drafts, isPartDesign);
+                                   params.taperAngleFwd, params.taperAngleRev, params.inwardTaperParallel, params.solid, drafts, isPartDesign);
         if (drafts.empty()) {
             Standard_Failure::Raise("Drafting shape failed");
         }

--- a/src/Mod/Part/App/FeatureExtrusion.h
+++ b/src/Mod/Part/App/FeatureExtrusion.h
@@ -49,6 +49,7 @@ public:
     App::PropertyBool Solid;
     App::PropertyBool Reversed;
     App::PropertyBool Symmetric;
+    App::PropertyBool InwardTaperParallel;
     App::PropertyAngle TaperAngle;
     App::PropertyAngle TaperAngleRev;
     App::PropertyString FaceMakerClass;
@@ -64,10 +65,11 @@ public:
         double lengthFwd;
         double lengthRev;
         bool solid;
+        bool inwardTaperParallel;
         double taperAngleFwd; //in radians
         double taperAngleRev;
         std::string faceMakerClass;
-        ExtrusionParameters(): lengthFwd(0), lengthRev(0), solid(false), taperAngleFwd(0), taperAngleRev(0) {}// constructor to keep garbage out
+        ExtrusionParameters(): lengthFwd(0), lengthRev(0), solid(false), inwardTaperParallel(false), taperAngleFwd(0), taperAngleRev(0) {}// constructor to keep garbage out
     };
 
     /** @name methods override feature */

--- a/src/Mod/PartDesign/App/FeatureExtrude.h
+++ b/src/Mod/PartDesign/App/FeatureExtrude.h
@@ -52,6 +52,7 @@ public:
     App::PropertyBool        AlongSketchNormal;
     App::PropertyLength      Offset;
     App::PropertyLinkSub     ReferenceAxis;
+    App::PropertyBool        InwardTaperParallel;
 
     static App::PropertyQuantityConstraint::Constraints signedLengthConstraint;
     static double maxAngle;
@@ -110,7 +111,8 @@ protected:
                               const double L2,
                               const double angle,
                               const double angle2,
-                              const bool midplane);
+                              const bool midplane, 
+                              const bool taperParallel);
 
     /**
       * Disables settings that are not valid for the current method

--- a/src/Mod/PartDesign/App/FeaturePad.cpp
+++ b/src/Mod/PartDesign/App/FeaturePad.cpp
@@ -56,6 +56,7 @@ Pad::Pad()
     ADD_PROPERTY_TYPE(AlongSketchNormal, (true), "Pad", App::Prop_None, "Measure pad length along the sketch normal direction");
     ADD_PROPERTY_TYPE(UpToFace, (nullptr), "Pad", App::Prop_None, "Face where pad will end");
     ADD_PROPERTY_TYPE(Offset, (0.0), "Pad", App::Prop_None, "Offset from face in which pad will end");
+    ADD_PROPERTY_TYPE(InwardTaperParallel, (false), "Pad", App::Prop_None, "Make inward and outward taper parallel");
     Offset.setConstraints(&signedLengthConstraint);
     ADD_PROPERTY_TYPE(TaperAngle, (0.0), "Pad", App::Prop_None, "Taper angle");
     TaperAngle.setConstraints(&floatAngle);
@@ -194,7 +195,7 @@ App::DocumentObjectExecReturn *Pad::execute()
             if (hasTaperedAngle()) {
                 if (hasReversed)
                     dir.Reverse();
-                generateTaperedPrism(prism, sketchshape, method, dir, L, L2, TaperAngle.getValue(), TaperAngle2.getValue(), hasMidplane);
+                generateTaperedPrism(prism, sketchshape, method, dir, L, L2, TaperAngle.getValue(), TaperAngle2.getValue(), hasMidplane, InwardTaperParallel.getValue());
             }
             else {
                 generatePrism(prism, sketchshape, method, dir, L, L2, hasMidplane, hasReversed);

--- a/src/Mod/PartDesign/App/FeaturePocket.cpp
+++ b/src/Mod/PartDesign/App/FeaturePocket.cpp
@@ -58,6 +58,7 @@ Pocket::Pocket()
     ADD_PROPERTY_TYPE(UpToFace, (nullptr), "Pocket", App::Prop_None, "Face where pocket will end");
     ADD_PROPERTY_TYPE(Offset, (0.0), "Pocket", App::Prop_None, "Offset from face in which pocket will end");
     Offset.setConstraints(&signedLengthConstraint);
+    ADD_PROPERTY_TYPE(InwardTaperParallel, (false), "Pad", App::Prop_None, "Make inward and outward taper parallel");
     ADD_PROPERTY_TYPE(TaperAngle, (0.0), "Pocket", App::Prop_None, "Taper angle");
     TaperAngle.setConstraints(&floatAngle);
     ADD_PROPERTY_TYPE(TaperAngle2, (0.0), "Pocket", App::Prop_None, "Taper angle for 2nd direction");
@@ -204,7 +205,7 @@ App::DocumentObjectExecReturn *Pocket::execute()
             if (hasTaperedAngle()) {
                 if (Reversed.getValue())
                     dir.Reverse();
-                generateTaperedPrism(prism, profileshape, method, dir, L, L2, TaperAngle.getValue(), TaperAngle2.getValue(), Midplane.getValue());
+                generateTaperedPrism(prism, profileshape, method, dir, L, L2, TaperAngle.getValue(), TaperAngle2.getValue(), Midplane.getValue(), InwardTaperParallel.getValue());
             }
             else {
                 generatePrism(prism, profileshape, method, dir, L, L2, Midplane.getValue(), Reversed.getValue());

--- a/src/Mod/PartDesign/Gui/TaskExtrudeParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskExtrudeParameters.h
@@ -90,6 +90,7 @@ protected Q_SLOTS:
     void onZDirectionEditChanged(double);
     void onMidplaneChanged(bool);
     void onReversedChanged(bool);
+    void onTaperParallelChanged(bool);
     void onButtonFace(const bool checked = true);
     void onFaceName(const QString& text);
     virtual void onModeChanged(int);
@@ -111,6 +112,7 @@ protected:
     double getZDirection(void) const;
     bool   getReversed(void) const;
     bool   getMidplane(void) const;
+    bool   getTaperParallel(void) const;
     int    getMode(void) const;
     QString getFaceName(void) const;
     void onSelectionChanged(const Gui::SelectionChanges& msg) override;

--- a/src/Mod/PartDesign/Gui/TaskPadPocketParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskPadPocketParameters.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>300</width>
-    <height>490</height>
+    <height>523</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -40,14 +40,14 @@
       </widget>
      </item>
      <item row="1" column="1">
-      <widget class="Gui::PrefQuantitySpinBox" name="lengthEdit">
-       <property name="keyboardTracking">
+      <widget class="Gui::PrefQuantitySpinBox" name="lengthEdit" native="true">
+       <property name="keyboardTracking" stdset="0">
         <bool>false</bool>
        </property>
        <property name="unit" stdset="0">
         <string notr="true">mm</string>
        </property>
-       <property name="minimum">
+       <property name="minimum" stdset="0">
         <double>0.000000000000000</double>
        </property>
       </widget>
@@ -60,8 +60,8 @@
       </widget>
      </item>
      <item row="2" column="1">
-      <widget class="Gui::PrefQuantitySpinBox" name="offsetEdit">
-       <property name="keyboardTracking">
+      <widget class="Gui::PrefQuantitySpinBox" name="offsetEdit" native="true">
+       <property name="keyboardTracking" stdset="0">
         <bool>false</bool>
        </property>
        <property name="unit" stdset="0">
@@ -277,8 +277,8 @@ measured along the specified direction</string>
       </widget>
      </item>
      <item>
-      <widget class="Gui::PrefQuantitySpinBox" name="taperEdit">
-       <property name="keyboardTracking">
+      <widget class="Gui::PrefQuantitySpinBox" name="taperEdit" native="true">
+       <property name="keyboardTracking" stdset="0">
         <bool>false</bool>
        </property>
        <property name="unit" stdset="0">
@@ -287,6 +287,13 @@ measured along the specified direction</string>
       </widget>
      </item>
     </layout>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="checkBoxTaperParallel">
+     <property name="text">
+      <string>Inward/outward taper parallel</string>
+     </property>
+    </widget>
    </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_4">
@@ -298,8 +305,8 @@ measured along the specified direction</string>
       </widget>
      </item>
      <item>
-      <widget class="Gui::PrefQuantitySpinBox" name="lengthEdit2">
-       <property name="keyboardTracking">
+      <widget class="Gui::PrefQuantitySpinBox" name="lengthEdit2" native="true">
+       <property name="keyboardTracking" stdset="0">
         <bool>false</bool>
        </property>
        <property name="unit" stdset="0">
@@ -322,8 +329,8 @@ measured along the specified direction</string>
       </widget>
      </item>
      <item>
-      <widget class="Gui::PrefQuantitySpinBox" name="taperEdit2">
-       <property name="keyboardTracking">
+      <widget class="Gui::PrefQuantitySpinBox" name="taperEdit2" native="true">
+       <property name="keyboardTracking" stdset="0">
         <bool>false</bool>
        </property>
        <property name="unit" stdset="0">


### PR DESCRIPTION
This PR corrects the discrepency of taper angle in the PD extrude function. (issue: #8949)

The single edge and multi-edge inner sketch had opposite direction taper angles. It adds a checkbox to enable to select if the inward and outward taper angles are opposite or parallel.

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [ x]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
![TaperAngle](https://user-images.githubusercontent.com/128159531/226116294-015a4f45-82e7-4c2b-9626-dab1a906248d.png)

![TaperAngleCorrected](https://user-images.githubusercontent.com/128159531/226116287-7edc9eef-af11-45be-b965-8f92b663c2b3.png)

![CheckBox](https://user-images.githubusercontent.com/128159531/226116469-c1c70974-1839-4ad4-8533-16bde063d6a3.png)
