### PR TITLE
NotificationBox/NotificationArea: Restrict rendering area to main frame

### DIFF
--- a/src/Gui/NotificationArea.cpp
+++ b/src/Gui/NotificationArea.cpp
@@ -234,7 +234,7 @@ void NotificationAreaObserver::SendLog(const std::string& notifiername, const st
             .trimmed();// remove any leading and trailing whitespace character ('\n')
 
     // avoid processing empty strings
-    if(simplifiedstring.isEmpty())
+    if (simplifiedstring.isEmpty())
         return;
 
     if (level == Base::LogStyle::TranslatedNotification) {
@@ -827,7 +827,7 @@ void NotificationArea::pushNotification(const QString& notifiername, const QStri
     auto timer_thread = pImp->inhibitTimer.thread();
     auto current_thread = QThread::currentThread();
 
-    if(timer_thread == current_thread)
+    if (timer_thread == current_thread)
         pImp->inhibitTimer.start(pImp->inhibitNotificationTime);
 }
 
@@ -939,7 +939,8 @@ void NotificationArea::showInNotificationArea()
                     iconstr = QStringLiteral(":/icons/info.svg");
                 }
 
-                QString tmpmessage = convertFromPlainText(item->msg, Qt::WhiteSpaceMode::WhiteSpaceNormal);
+                QString tmpmessage =
+                    convertFromPlainText(item->msg, Qt::WhiteSpaceMode::WhiteSpaceNormal);
 
                 msgw +=
                     QString::fromLatin1(
@@ -990,11 +991,17 @@ void NotificationArea::showInNotificationArea()
 
         msgw += QString::fromLatin1("</table></p>");
 
+        // Calculate the main window QRect in global screen coordinates.
+        auto mainwindow = getMainWindow();
+        auto mainwindowrect = mainwindow->rect();
+        auto globalmainwindowrect =
+            QRect(mainwindow->mapToGlobal(mainwindowrect.topLeft()), mainwindowrect.size());
 
         NotificationBox::showText(this->mapToGlobal(QPoint()),
                                   msgw,
                                   pImp->notificationExpirationTime,
                                   pImp->minimumOnScreenTime,
+                                  globalmainwindowrect,
                                   pImp->notificationWidth);
     }
 }

--- a/src/Gui/NotificationBox.h
+++ b/src/Gui/NotificationBox.h
@@ -54,11 +54,16 @@ public:
      * an event, see class documentation above)
      * @param minShowTime  Time during which the notification can only be made disappear by popping
      * it out (clicking inside it).
-     * @param width Fixes the width of the notification. Default value makes the width to be system determined (dependent on
-     * the text).
+     * @param restrictionarea Try to keep the NotificationBox within this area. If this area is not
+     * provided, the whole screen is used as restriction area. This are must be provided in global
+     * screen coordinates.
+     * @param width Fixes the width of the notification. Default value makes the width to be system
+     * determined (dependent on the text). If a fixed width is provided it is enforced over the
+     * restrictionarea.
      */
     static void showText(const QPoint& pos, const QString& text, int displayTime = -1,
-                         unsigned int minShowTime = 0, int width = 0);
+                         unsigned int minShowTime = 0, const QRect& restrictionarea = {},
+                         int width = 0);
     /// Hides a notification.
     static inline void hideText()
     {


### PR DESCRIPTION
========================================================================

The NotificationBox is extended to take the QRect in global coordinates. Then it will try to dimension the label within this area. If a fixed width is provided, that is enforced (take precedence).

The NotificationArea passes the QRect of the main window to the NotificationBox.

This is intended to fix:
https://github.com/FreeCAD/FreeCAD/issues/8940
