### PR TITLE
Issues 8884, 8806. Change readDXF settings handling

### DIFF
--- a/src/Mod/Import/App/AppImportPy.cpp
+++ b/src/Mod/Import/App/AppImportPy.cpp
@@ -108,7 +108,7 @@ public:
             "export(list,string) -- Export a list of objects into a single file."
         );
          add_varargs_method("readDXF",&Module::readDXF,
-            "readDXF(filename,[document,ignore_errors]): Imports a DXF file into the given document. ignore_errors is True by default."
+            "readDXF(filename,[document,ignore_errors,option_source]): Imports a DXF file into the given document. ignore_errors is True by default."
         );
         add_varargs_method("writeDXFShape",&Module::writeDXFShape,
             "writeDXFShape([shape],filename [version,usePolyline,optionSource]): Exports Shape(s) to a DXF file."


### PR DESCRIPTION
This PR is offered as a correction for issues #8884 and #8806

The change leaves loading the regular import options to the `ImpExpDXFRead` class object's ctor (where the code already existed). If the caller to `readDXF` passes a fourth argument specifying another options location, this will be given to the `ImpExpDXFRead` object to load from, but otherwise `readDXF` does not initiate any options loading.

The documentation string for readDXF has been updated to include the options_source argument, which was already in the code.

Because the removed code was causing the `ImpExpDXFRead` to load settings from a location where no settings had been stored, the settings from the dialog were being ignored, so no text was being imported, layers were never grouped into blocks, and the scaling factor was always 1.

- [X ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR