### PR TITLE
fix incorrect docstring for Part.Shape.extrude method

### DIFF
--- a/src/Mod/Part/App/TopoShapePy.xml
+++ b/src/Mod/Part/App/TopoShapePy.xml
@@ -118,7 +118,7 @@ importBrepFromString(str,False) to not display a progress bar.
         <UserDocu>Extrude the shape along a vector.
 extrude(vector) -> Shape
 --
-Shp2 = Shp1.extrude(Vector(0,0,10)) - extrude the shape 10 mm in the +Z direction.</UserDocu>
+Shp2 = Shp1.extrude(App.Vector(0,0,10)) - extrude the shape 10 mm in the +Z direction.</UserDocu>
       </Documentation>
     </Methode>
     <Methode Name="revolve" Const="true">
@@ -126,7 +126,7 @@ Shp2 = Shp1.extrude(Vector(0,0,10)) - extrude the shape 10 mm in the +Z directio
         <UserDocu>Revolve the shape around an Axis to a given degree.
 revolve(base, direction, angle)
 --
-Part.revolve(Vector(0,0,0),Vector(0,0,1),360) - revolves the shape around the Z Axis 360 degree.
+Part.revolve(App.Vector(0,0,0),App.Vector(0,0,1),360) - revolves the shape around the Z Axis 360 degree.
 
 Hints: Sometimes you want to create a rotation body out of a closed edge or wire.
 Example:
@@ -400,7 +400,7 @@ translated(vector) -> shape
         <UserDocu>Apply the rotation (base,dir,degree) to the current location of this shape
 rotate(base,dir,degree)
 --
-Shp.rotate(Vector(0,0,0),Vector(0,0,1),180) - rotate the shape around the Z Axis 180 degrees.
+Shp.rotate(App.Vector(0,0,0),App.Vector(0,0,1),180) - rotate the shape around the Z Axis 180 degrees.
         </UserDocu>
       </Documentation>
     </Methode>
@@ -414,14 +414,14 @@ rotated(base,dir,degree) -> shape
     <Methode Name="scale">
       <Documentation>
         <UserDocu>Apply scaling with point and factor to this shape.
-scale(factor,[base=Vector(0,0,0)])
+scale(factor,[base=App.Vector(0,0,0)])
         </UserDocu>
       </Documentation>
     </Methode>
     <Methode Name="scaled" Const="true">
       <Documentation>
           <UserDocu>Create a new shape with scale.
-scaled(factor,[base=Vector(0,0,0)]) -> shape
+scaled(factor,[base=App.Vector(0,0,0)]) -> shape
           </UserDocu>
       </Documentation>
     </Methode>
@@ -789,9 +789,9 @@ distToShape(shape) -> (dist, vectors, infos)
 dist is the minimum distance, in mm (float value).
 
 vectors is a list of pairs of App.Vector. Each pair corresponds to solution.
-Example: [(Vector (2.0, -1.0, 2.0), Vector (2.0, 0.0, 2.0)), (Vector (2.0,
--1.0, 2.0), Vector (2.0, -1.0, 3.0))] First vector is a point on self, second
-vector is a point on s.
+Example: [(App.Vector(2.0, -1.0, 2.0), App.Vector(2.0, 0.0, 2.0)),
+(App.Vector(2.0, -1.0, 2.0), App.Vector(2.0, -1.0, 3.0))]
+First vector is a point on self, second vector is a point on s.
 
 infos contains additional info on the solutions. It is a list of tuples:
 (topo1, index1, params1, topo2, index2, params2)

--- a/src/Mod/Part/App/TopoShapePy.xml
+++ b/src/Mod/Part/App/TopoShapePy.xml
@@ -115,8 +115,10 @@ importBrepFromString(str,False) to not display a progress bar.
     </Methode>
     <Methode Name="extrude" Const="true">
       <Documentation>
-        <UserDocu>Extrude the shape along a direction.
-extrude(direction, length)</UserDocu>
+        <UserDocu>Extrude the shape along a vector.
+extrude(vector) -> Shape
+--
+Shp2 = Shp1.extrude(Vector(0,0,10)) - extrude the shape 10 mm in the +Z direction.</UserDocu>
       </Documentation>
     </Methode>
     <Methode Name="revolve" Const="true">


### PR DESCRIPTION
Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [x]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
[https://wiki.freecad.org/TopoShape_API](https://wiki.freecad.org/TopoShape_API) correctly describes this method, but the console tool-tip currently suggests using an incorrect extra argument.