### PR TITLE
[FEM] output less messages

### DIFF
--- a/src/Mod/Fem/femguiutils/selection_widgets.py
+++ b/src/Mod/Fem/femguiutils/selection_widgets.py
@@ -599,7 +599,7 @@ class FemSelectionObserver:
     def __init__(self, parseSelectionFunction, print_message=""):
         self.parseSelectionFunction = parseSelectionFunction
         FreeCADGui.Selection.addObserver(self)
-        FreeCAD.Console.PrintMessage(print_message + "!\n")
+        #FreeCAD.Console.PrintMessage(print_message + "!\n")
 
     def addSelection(self, docName, objName, sub, pos):
         selected_object = FreeCAD.getDocument(docName).getObject(objName)  # get the obj objName


### PR DESCRIPTION
- the console message how to use the feature is not useful since it is triggered by the GUI selection and in the GUI has already the info in form of tooltips how to use