### PR TITLE
[FEM] rewrite velocity constraint

### DIFF
--- a/src/Mod/Fem/Gui/Resources/ui/FlowVelocity.ui
+++ b/src/Mod/Fem/Gui/Resources/ui/FlowVelocity.ui
@@ -6,78 +6,27 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
-    <height>300</height>
+    <width>300</width>
+    <height>197</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Constraint Properties</string>
   </property>
-  <layout class="QFormLayout" name="formLayout">
-   <item row="1" column="0">
-    <widget class="QLabel" name="volocityXLbl">
-     <property name="text">
-      <string>Velocity x:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="velocityYLbl">
-     <property name="text">
-      <string>Velocity y:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="0">
-    <widget class="QLabel" name="velocityZLbl">
-     <property name="text">
-      <string>Velocity z:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="Gui::InputField" name="velocityZTxt">
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QGridLayout" name="gridLayout">
+     <item row="1" column="3">
+      <widget class="QCheckBox" name="formulaXCB">
        <property name="enabled">
         <bool>false</bool>
        </property>
-       <property name="singleStep">
-        <double>1.000000000000000</double>
-       </property>
-       <property name="unit" stdset="0">
-        <string>m/s</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QCheckBox" name="velocityZBox">
        <property name="text">
-        <string>unspecified</string>
-       </property>
-       <property name="checked">
-        <bool>true</bool>
+        <string>formula</string>
        </property>
       </widget>
      </item>
-    </layout>
-   </item>
-   <item row="1" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
-     <item>
-      <widget class="Gui::InputField" name="velocityXTxt">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="singleStep">
-        <double>1.000000000000000</double>
-       </property>
-       <property name="unit" stdset="0">
-        <string>m/s</string>
-       </property>
-      </widget>
-     </item>
-     <item>
+     <item row="0" column="3">
       <widget class="QCheckBox" name="velocityXBox">
        <property name="text">
         <string>unspecified</string>
@@ -87,24 +36,52 @@
        </property>
       </widget>
      </item>
-    </layout>
-   </item>
-   <item row="3" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_3">
-     <item>
-      <widget class="Gui::InputField" name="velocityYTxt">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="singleStep">
-        <double>1.000000000000000</double>
-       </property>
-       <property name="unit" stdset="0">
-        <string>m/s</string>
+     <item row="0" column="0">
+      <widget class="QLabel" name="volocityXLbl">
+       <property name="text">
+        <string>Velocity x:</string>
        </property>
       </widget>
      </item>
-     <item>
+     <item row="1" column="1">
+      <widget class="QLineEdit" name="formulaX">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="Gui::QuantitySpinBox" name="velocityX">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="unit" stdset="0">
+        <string notr="true"/>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QGridLayout" name="gridLayout_2">
+     <item row="1" column="3">
+      <widget class="QCheckBox" name="formulaYCB">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="text">
+        <string>formula</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="QLabel" name="velocityYLbl">
+       <property name="text">
+        <string>Velocity y:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="3">
       <widget class="QCheckBox" name="velocityYBox">
        <property name="text">
         <string>unspecified</string>
@@ -114,12 +91,77 @@
        </property>
       </widget>
      </item>
+     <item row="1" column="1">
+      <widget class="QLineEdit" name="formulaY">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="Gui::QuantitySpinBox" name="velocityY">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="unit" stdset="0">
+        <string notr="true"/>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
-   <item row="6" column="0" colspan="2">
+   <item>
+    <layout class="QGridLayout" name="gridLayout_3">
+     <item row="0" column="3">
+      <widget class="QCheckBox" name="velocityZBox">
+       <property name="text">
+        <string>unspecified</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="3">
+      <widget class="QCheckBox" name="formulaZCB">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="text">
+        <string>formula</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="QLabel" name="velocityZLbl">
+       <property name="text">
+        <string>Velocity z:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QLineEdit" name="formulaZ">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="Gui::QuantitySpinBox" name="velocityZ">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="unit" stdset="0">
+        <string notr="true"/>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
     <widget class="QCheckBox" name="normalBox">
      <property name="text">
-      <string>normal to boundary</string>
+      <string>Normal to boundary</string>
      </property>
     </widget>
    </item>
@@ -127,9 +169,9 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>Gui::InputField</class>
-   <extends>QLineEdit</extends>
-   <header>Gui/InputField.h</header>
+   <class>Gui::QuantitySpinBox</class>
+   <extends>QWidget</extends>
+   <header>Gui/QuantitySpinBox.h</header>
   </customwidget>
  </customwidgets>
  <resources/>
@@ -137,96 +179,48 @@
   <connection>
    <sender>velocityXBox</sender>
    <signal>toggled(bool)</signal>
-   <receiver>velocityXTxt</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>230</x>
-     <y>44</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>230</x>
-     <y>18</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>velocityXBox</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>velocityXTxt</receiver>
+   <receiver>formulaXCB</receiver>
    <slot>setDisabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>230</x>
-     <y>44</y>
+     <x>351</x>
+     <y>19</y>
     </hint>
     <hint type="destinationlabel">
-     <x>230</x>
-     <y>18</y>
+     <x>351</x>
+     <y>45</y>
     </hint>
    </hints>
   </connection>
   <connection>
    <sender>velocityYBox</sender>
    <signal>toggled(bool)</signal>
-   <receiver>velocityYTxt</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>347</x>
-     <y>53</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>184</x>
-     <y>53</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>velocityYBox</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>velocityYTxt</receiver>
+   <receiver>formulaYCB</receiver>
    <slot>setDisabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>347</x>
-     <y>53</y>
+     <x>351</x>
+     <y>73</y>
     </hint>
     <hint type="destinationlabel">
-     <x>184</x>
-     <y>53</y>
+     <x>351</x>
+     <y>99</y>
     </hint>
    </hints>
   </connection>
   <connection>
    <sender>velocityZBox</sender>
    <signal>toggled(bool)</signal>
-   <receiver>velocityZTxt</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>347</x>
-     <y>87</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>184</x>
-     <y>87</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>velocityZBox</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>velocityZTxt</receiver>
+   <receiver>formulaZCB</receiver>
    <slot>setDisabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>347</x>
-     <y>87</y>
+     <x>351</x>
+     <y>127</y>
     </hint>
     <hint type="destinationlabel">
-     <x>184</x>
-     <y>87</y>
+     <x>351</x>
+     <y>153</y>
     </hint>
    </hints>
   </connection>

--- a/src/Mod/Fem/femexamples/equation_flow_elmer_2D.py
+++ b/src/Mod/Fem/femexamples/equation_flow_elmer_2D.py
@@ -71,19 +71,19 @@ def setup(doc=None, solvertype="elmer"):
     # geometric objects
 
     # the wire defining the pipe volume in 2D
-    p1 = Vector(400, 0, -50.000)
-    p2 = Vector(400, 0, -150.000)
-    p3 = Vector(1200, 0, -150.000)
-    p4 = Vector(1200, 0, 50.000)
-    p5 = Vector(0, 0, 50.000)
-    p6 = Vector(0, 0, -50.000)
+    p1 = Vector(400, -50.000, 0)
+    p2 = Vector(400, -150.000, 0)
+    p3 = Vector(1200, -150.000, 0)
+    p4 = Vector(1200, 50.000, 0)
+    p5 = Vector(0, 50.000, 0)
+    p6 = Vector(0, -50.000, 0)
     wire = Draft.make_wire([p1, p2, p3, p4, p5, p6], closed=True)
     wire.Label = "Wire"
 
     # the circle defining the heating rod
     pCirc = Vector(160, 0, 0)
     axisCirc = Vector(1, 0, 0)
-    placementCircle = Placement(pCirc, Rotation(axisCirc, 90))
+    placementCircle = Placement(pCirc, Rotation(axisCirc, 0))
     circle = Draft.make_circle(10, placement=placementCircle)
     circle.Label = "HeatingRod"
     circle.ViewObject.Visibility = False
@@ -107,7 +107,6 @@ def setup(doc=None, solvertype="elmer"):
     doc.recompute()
     if FreeCAD.GuiUp:
         BooleanFragments.ViewObject.Transparency = 50
-        BooleanFragments.ViewObject.Document.activeView().viewFront()
         BooleanFragments.ViewObject.Document.activeView().fitAll()
 
     # analysis
@@ -119,6 +118,7 @@ def setup(doc=None, solvertype="elmer"):
     # solver
     if solvertype == "elmer":
         solver_obj = ObjectsFem.makeSolverElmer(doc, "SolverElmer")
+        solver_obj.CoordinateSystem = "Cartesian 2D"
         equation_flow = ObjectsFem.makeEquationFlow(doc, solver_obj)
         equation_heat = ObjectsFem.makeEquationHeat(doc, solver_obj)
     else:
@@ -133,6 +133,7 @@ def setup(doc=None, solvertype="elmer"):
     equation_flow.IdrsParameter = 3
     equation_flow.LinearIterativeMethod = "Idrs"
     equation_flow.LinearPreconditioning = "ILU1"
+    equation_flow.Variable = "Flow Solution[Velocity:2 Pressure:1]"
     equation_heat.Convection = "Computed"
     equation_heat.IdrsParameter = 3
     equation_heat.LinearIterativeMethod = "Idrs"
@@ -179,19 +180,10 @@ def setup(doc=None, solvertype="elmer"):
     FlowVelocity_Inlet = ObjectsFem.makeConstraintFlowVelocity(doc, "FlowVelocity_Inlet")
     FlowVelocity_Inlet.References = [(BooleanFragments, "Edge5")]
     FlowVelocity_Inlet.NormalDirection = Vector(-1, 0, 0)
-    FlowVelocity_Inlet.VelocityX = 0.020
-    FlowVelocity_Inlet.VelocityXEnabled = True
-    FlowVelocity_Inlet.VelocityYEnabled = True
-    FlowVelocity_Inlet.VelocityZEnabled = True
+    FlowVelocity_Inlet.VelocityXFormula = "Variable Coordinate 2; Real MATC \"-0.01*(tx-1)*(2-tx)\""
+    FlowVelocity_Inlet.VelocityXUnspecified = False
+    FlowVelocity_Inlet.VelocityXHasFormula = True
     analysis.addObject(FlowVelocity_Inlet)
-
-    # constraint outlet velocity
-    FlowVelocity_Outlet = ObjectsFem.makeConstraintFlowVelocity(doc, "FlowVelocity_Outlet")
-    FlowVelocity_Outlet.References = [(BooleanFragments, "Edge6")]
-    FlowVelocity_Outlet.NormalDirection = Vector(1, 0, 0)
-    FlowVelocity_Outlet.VelocityYEnabled = True
-    FlowVelocity_Outlet.VelocityZEnabled = True
-    analysis.addObject(FlowVelocity_Outlet)
 
     # constraint wall velocity
     FlowVelocity_Wall = ObjectsFem.makeConstraintFlowVelocity(doc, "FlowVelocity_Wall")
@@ -200,20 +192,10 @@ def setup(doc=None, solvertype="elmer"):
         (BooleanFragments, "Edge3"),
         (BooleanFragments, "Edge4"),
         (BooleanFragments, "Edge7")]
-    FlowVelocity_Wall.NormalDirection = Vector(0, 0, -1)
-    FlowVelocity_Wall.VelocityXEnabled = True
-    FlowVelocity_Wall.VelocityYEnabled = True
-    FlowVelocity_Wall.VelocityZEnabled = True
+    FlowVelocity_Wall.NormalDirection = Vector(0, -1, 0)
+    FlowVelocity_Wall.VelocityXUnspecified = False
+    FlowVelocity_Wall.VelocityYUnspecified = False
     analysis.addObject(FlowVelocity_Wall)
-
-    # constraint initial velocity
-    FlowVelocity_Initial = ObjectsFem.makeConstraintInitialFlowVelocity(doc, "FlowVelocity_Initial")
-    FlowVelocity_Initial.References = [(BooleanFragments, "Face2")]
-    FlowVelocity_Initial.NormalDirection = Vector(0, -1, 0)
-    FlowVelocity_Initial.VelocityXEnabled = True
-    FlowVelocity_Initial.VelocityYEnabled = True
-    FlowVelocity_Initial.VelocityZEnabled = True
-    analysis.addObject(FlowVelocity_Initial)
 
     # constraint initial temperature
     Temperature_Initial = ObjectsFem.makeConstraintInitialTemperature(doc, "Temperature_Initial")

--- a/src/Mod/Fem/femexamples/equation_flow_turbulent_elmer_2D.py
+++ b/src/Mod/Fem/femexamples/equation_flow_turbulent_elmer_2D.py
@@ -71,19 +71,19 @@ def setup(doc=None, solvertype="elmer"):
     # geometric objects
 
     # the wire defining the pipe volume in 2D
-    p1 = Vector(400, 0, -50.000)
-    p2 = Vector(400, 0, -150.000)
-    p3 = Vector(1200, 0, -150.000)
-    p4 = Vector(1200, 0, 50.000)
-    p5 = Vector(0, 0, 50.000)
-    p6 = Vector(0, 0, -50.000)
+    p1 = Vector(400, -50.000, 0)
+    p2 = Vector(400, -150.000, 0)
+    p3 = Vector(1200, -150.000, 0)
+    p4 = Vector(1200, 50.000, 0)
+    p5 = Vector(0, 50.000, 0)
+    p6 = Vector(0, -50.000, 0)
     wire = Draft.make_wire([p1, p2, p3, p4, p5, p6], closed=True)
     wire.Label = "Wire"
 
     # the circle defining the heating rod
     pCirc = Vector(160, 0, 0)
     axisCirc = Vector(1, 0, 0)
-    placementCircle = Placement(pCirc, Rotation(axisCirc, 90))
+    placementCircle = Placement(pCirc, Rotation(axisCirc, 0))
     circle = Draft.make_circle(10, placement=placementCircle)
     circle.Label = "HeatingRod"
     circle.ViewObject.Visibility = False
@@ -107,7 +107,6 @@ def setup(doc=None, solvertype="elmer"):
     doc.recompute()
     if FreeCAD.GuiUp:
         BooleanFragments.ViewObject.Transparency = 50
-        BooleanFragments.ViewObject.Document.activeView().viewFront()
         BooleanFragments.ViewObject.Document.activeView().fitAll()
 
     # analysis
@@ -119,6 +118,7 @@ def setup(doc=None, solvertype="elmer"):
     # solver
     if solvertype == "elmer":
         solver_obj = ObjectsFem.makeSolverElmer(doc, "SolverElmer")
+        solver_obj.CoordinateSystem = "Cartesian 2D"
         equation_flow = ObjectsFem.makeEquationFlow(doc, solver_obj)
         equation_heat = ObjectsFem.makeEquationHeat(doc, solver_obj)
     else:
@@ -131,7 +131,6 @@ def setup(doc=None, solvertype="elmer"):
 
     # solver settings
     equation_flow.IdrsParameter = 3
-    equation_flow.LinearIterations = 250
     equation_flow.LinearIterativeMethod = "Idrs"
     equation_flow.LinearPreconditioning = "ILU1"
     equation_flow.setExpression("LinearTolerance", "1e-6")
@@ -139,9 +138,9 @@ def setup(doc=None, solvertype="elmer"):
     equation_flow.NonlinearNewtonAfterIterations = 30
     equation_flow.setExpression("NonlinearTolerance", "1e-4")
     equation_flow.RelaxationFactor = 0.1
+    equation_flow.Variable = "Flow Solution[Velocity:2 Pressure:1]"
     equation_heat.Convection = "Computed"
     equation_heat.IdrsParameter = 3
-    equation_heat.LinearIterations = 250
     equation_heat.LinearIterativeMethod = "Idrs"
     equation_heat.LinearPreconditioning = "ILU1"
     equation_heat.setExpression("LinearTolerance", "1e-6")
@@ -187,19 +186,10 @@ def setup(doc=None, solvertype="elmer"):
     FlowVelocity_Inlet = ObjectsFem.makeConstraintFlowVelocity(doc, "FlowVelocity_Inlet")
     FlowVelocity_Inlet.References = [(BooleanFragments, "Edge5")]
     FlowVelocity_Inlet.NormalDirection = Vector(-1, 0, 0)
-    FlowVelocity_Inlet.VelocityX = 0.020
-    FlowVelocity_Inlet.VelocityXEnabled = True
-    FlowVelocity_Inlet.VelocityYEnabled = True
-    FlowVelocity_Inlet.VelocityZEnabled = True
+    FlowVelocity_Inlet.VelocityX = "20.0 mm/s"
+    FlowVelocity_Inlet.VelocityXUnspecified = False
+    FlowVelocity_Inlet.VelocityYUnspecified = False
     analysis.addObject(FlowVelocity_Inlet)
-
-    # constraint outlet velocity
-    FlowVelocity_Outlet = ObjectsFem.makeConstraintFlowVelocity(doc, "FlowVelocity_Outlet")
-    FlowVelocity_Outlet.References = [(BooleanFragments, "Edge6")]
-    FlowVelocity_Outlet.NormalDirection = Vector(1, 0, 0)
-    FlowVelocity_Outlet.VelocityYEnabled = True
-    FlowVelocity_Outlet.VelocityZEnabled = True
-    analysis.addObject(FlowVelocity_Outlet)
 
     # constraint wall velocity
     FlowVelocity_Wall = ObjectsFem.makeConstraintFlowVelocity(doc, "FlowVelocity_Wall")
@@ -209,19 +199,9 @@ def setup(doc=None, solvertype="elmer"):
         (BooleanFragments, "Edge4"),
         (BooleanFragments, "Edge7")]
     FlowVelocity_Wall.NormalDirection = Vector(0, 0, -1)
-    FlowVelocity_Wall.VelocityXEnabled = True
-    FlowVelocity_Wall.VelocityYEnabled = True
-    FlowVelocity_Wall.VelocityZEnabled = True
+    FlowVelocity_Wall.VelocityXUnspecified = False
+    FlowVelocity_Wall.VelocityYUnspecified = False
     analysis.addObject(FlowVelocity_Wall)
-
-    # constraint initial velocity
-    FlowVelocity_Initial = ObjectsFem.makeConstraintInitialFlowVelocity(doc, "FlowVelocity_Initial")
-    FlowVelocity_Initial.References = [(BooleanFragments, "Face2")]
-    FlowVelocity_Initial.NormalDirection = Vector(0, -1, 0)
-    FlowVelocity_Initial.VelocityXEnabled = True
-    FlowVelocity_Initial.VelocityYEnabled = True
-    FlowVelocity_Initial.VelocityZEnabled = True
-    analysis.addObject(FlowVelocity_Initial)
 
     # constraint initial temperature
     Temperature_Initial = ObjectsFem.makeConstraintInitialTemperature(doc, "Temperature_Initial")

--- a/src/Mod/Fem/femobjects/constraint_flowvelocity.py
+++ b/src/Mod/Fem/femobjects/constraint_flowvelocity.py
@@ -40,41 +40,83 @@ class ConstraintFlowVelocity(base_fempythonobject.BaseFemPythonObject):
     def __init__(self, obj):
         super(ConstraintFlowVelocity, self).__init__(obj)
         obj.addProperty(
-            "App::PropertyFloat",
+            "App::PropertyVelocity",
             "VelocityX",
             "Parameter",
             "Velocity in x-direction"
         )
         obj.addProperty(
+            "App::PropertyString",
+            "VelocityXFormula",
+            "Parameter",
+            "Velocity formula in x-direction"
+        )
+        obj.addProperty(
             "App::PropertyBool",
-            "VelocityXEnabled",
+            "VelocityXUnspecified",
             "Parameter",
             "Use velocity in x-direction"
         )
+        obj.VelocityXUnspecified = True
         obj.addProperty(
-            "App::PropertyFloat",
+            "App::PropertyBool",
+            "VelocityXHasFormula",
+            "Parameter",
+            "Use formula for velocity in x-direction"
+        )
+
+        obj.addProperty(
+            "App::PropertyVelocity",
             "VelocityY",
             "Parameter",
             "Velocity in y-direction"
         )
         obj.addProperty(
+            "App::PropertyString",
+            "VelocityYFormula",
+            "Parameter",
+            "Velocity formula in y-direction"
+        )
+        obj.addProperty(
             "App::PropertyBool",
-            "VelocityYEnabled",
+            "VelocityYUnspecified",
             "Parameter",
             "Use velocity in y-direction"
         )
+        obj.VelocityYUnspecified = True
         obj.addProperty(
-            "App::PropertyFloat",
+            "App::PropertyBool",
+            "VelocityYHasFormula",
+            "Parameter",
+            "Use formula for velocity in y-direction"
+        )
+
+        obj.addProperty(
+            "App::PropertyVelocity",
             "VelocityZ",
             "Parameter",
             "Velocity in z-direction"
         )
         obj.addProperty(
+            "App::PropertyString",
+            "VelocityZFormula",
+            "Parameter",
+            "Velocity formula in z-direction"
+        )
+        obj.addProperty(
             "App::PropertyBool",
-            "VelocityZEnabled",
+            "VelocityZUnspecified",
             "Parameter",
             "Use velocity in z-direction"
         )
+        obj.VelocityZUnspecified = True
+        obj.addProperty(
+            "App::PropertyBool",
+            "VelocityZHasFormula",
+            "Parameter",
+            "Use formula for velocity in z-direction"
+        )
+
         obj.addProperty(
             "App::PropertyBool",
             "NormalToBoundary",

--- a/src/Mod/Fem/femsolver/elmer/equations/flow_writer.py
+++ b/src/Mod/Fem/femsolver/elmer/equations/flow_writer.py
@@ -227,14 +227,23 @@ class Flowwriter:
         for obj in self.write.getMember("Fem::ConstraintFlowVelocity"):
             if obj.References:
                 for name in obj.References[0][1]:
-                    if obj.VelocityXEnabled:
-                        velocity = self.write.getFromUi(obj.VelocityX, "m/s", "L/T")
+                    if not obj.VelocityXUnspecified:
+                        if not obj.VelocityXHasFormula:
+                            velocity = float(obj.VelocityX.getValueAs("m/s"))
+                        else:
+                            velocity = obj.VelocityXFormula
                         self.write.boundary(name, "Velocity 1", velocity)
-                    if obj.VelocityYEnabled:
-                        velocity = self.write.getFromUi(obj.VelocityY, "m/s", "L/T")
+                    if not obj.VelocityYUnspecified:
+                        if not obj.VelocityYHasFormula:
+                            velocity = float(obj.VelocityY.getValueAs("m/s"))
+                        else:
+                            velocity = obj.VelocityYFormula
                         self.write.boundary(name, "Velocity 2", velocity)
-                    if obj.VelocityZEnabled:
-                        velocity = self.write.getFromUi(obj.VelocityZ, "m/s", "L/T")
+                    if not obj.VelocityZUnspecified:
+                        if not obj.VelocityZHasFormula:
+                            velocity = float(obj.VelocityZ.getValueAs("m/s"))
+                        else:
+                            velocity = obj.VelocityZFormula
                         self.write.boundary(name, "Velocity 3", velocity)
                     if obj.NormalToBoundary:
                         self.write.boundary(name, "Normal-Tangential Velocity", True)

--- a/src/Mod/Fem/femtaskpanels/task_constraint_flowvelocity.py
+++ b/src/Mod/Fem/femtaskpanels/task_constraint_flowvelocity.py
@@ -29,9 +29,10 @@ __url__ = "https://www.freecadweb.org"
 #  \ingroup FEM
 #  \brief task panel for constraint flow velocity object
 
+from PySide import QtCore
+
 import FreeCAD
 import FreeCADGui
-from FreeCAD import Units
 
 from femguiutils import selection_widgets
 from femtools import femutils
@@ -46,8 +47,7 @@ class _TaskPanel(object):
         self._paramWidget = FreeCADGui.PySideUic.loadUi(
             FreeCAD.getHomePath() + "Mod/Fem/Resources/ui/FlowVelocity.ui"
         )
-        self._initParamWidget()
-
+        
         # geometry selection widget
         # start with Solid in list!
         self._selectionWidget = selection_widgets.GeometryElementsSelection(
@@ -69,6 +69,96 @@ class _TaskPanel(object):
             self._part = femutils.get_part_to_mesh(self._mesh)
         self._partVisible = None
         self._meshVisible = None
+
+        # connect unspecified option
+        QtCore.QObject.connect(
+            self._paramWidget.velocityXBox,
+            QtCore.SIGNAL("toggled(bool)"),
+            self._velocityXEnable
+        )
+        QtCore.QObject.connect(
+            self._paramWidget.velocityYBox,
+            QtCore.SIGNAL("toggled(bool)"),
+            self._velocityYEnable
+        )
+        QtCore.QObject.connect(
+            self._paramWidget.velocityZBox,
+            QtCore.SIGNAL("toggled(bool)"),
+            self._velocityZEnable
+        )
+
+        # connect formula option
+        QtCore.QObject.connect(
+            self._paramWidget.formulaXCB,
+            QtCore.SIGNAL("toggled(bool)"),
+            self._formulaXEnable
+        )
+        QtCore.QObject.connect(
+            self._paramWidget.formulaYCB,
+            QtCore.SIGNAL("toggled(bool)"),
+            self._formulaYEnable
+        )
+        QtCore.QObject.connect(
+            self._paramWidget.formulaZCB,
+            QtCore.SIGNAL("toggled(bool)"),
+            self._formulaZEnable
+        )
+
+        self._initParamWidget()
+
+    def _velocityXEnable(self, toggled):
+        if toggled:
+            self._paramWidget.formulaX.setDisabled(toggled)
+            self._paramWidget.velocityX.setDisabled(toggled)
+        else:
+            if self._paramWidget.formulaXCB.isChecked():
+                self._paramWidget.formulaX.setDisabled(toggled)
+            else:
+                self._paramWidget.velocityX.setDisabled(toggled)
+
+    def _velocityYEnable(self, toggled):
+        if toggled:
+            self._paramWidget.formulaY.setDisabled(toggled)
+            self._paramWidget.velocityY.setDisabled(toggled)
+        else:
+            if self._paramWidget.formulaYCB.isChecked():
+                self._paramWidget.formulaY.setDisabled(toggled)
+            else:
+                self._paramWidget.velocityY.setDisabled(toggled)
+
+    def _velocityZEnable(self, toggled):
+        if toggled:
+            self._paramWidget.formulaZ.setDisabled(toggled)
+            self._paramWidget.velocityZ.setDisabled(toggled)
+        else:
+            if self._paramWidget.formulaZCB.isChecked():
+                self._paramWidget.formulaZ.setDisabled(toggled)
+            else:
+                self._paramWidget.velocityZ.setDisabled(toggled)
+
+    def _formulaXEnable(self, toggled):
+        FreeCAD.Console.PrintMessage("_formulaXEnable\n")
+        if self._paramWidget.velocityXBox.isChecked():
+            FreeCAD.Console.PrintMessage("velocityXBox isChecked\n")
+            return
+        else:
+            FreeCAD.Console.PrintMessage("velocityXBox not checked\n")
+            self._paramWidget.formulaX.setEnabled(toggled)
+            self._paramWidget.velocityX.setDisabled(toggled)
+
+    def _formulaYEnable(self, toggled):
+        if self._paramWidget.velocityYBox.isChecked():
+            return
+        else:
+            self._paramWidget.formulaY.setEnabled(toggled)
+            self._paramWidget.velocityY.setDisabled(toggled)
+
+    def _formulaZEnable(self, toggled):
+        if self._paramWidget.velocitZXBox.isChecked():
+            return
+        else:
+            self._paramWidget.formulaZ.setEnabled(toggled)
+            self._paramWidget.velocityZ.setDisabled(toggled)
 
     def open(self):
         if self._mesh is not None and self._part is not None:
@@ -104,36 +194,80 @@ class _TaskPanel(object):
 
     def _initParamWidget(self):
         unit = "m/s"
-        self._paramWidget.velocityXTxt.setText(
-            str(self._obj.VelocityX) + unit)
-        self._paramWidget.velocityYTxt.setText(
-            str(self._obj.VelocityY) + unit)
-        self._paramWidget.velocityZTxt.setText(
-            str(self._obj.VelocityZ) + unit)
+        self._paramWidget.velocityX.setProperty('unit', unit)
+        self._paramWidget.velocityY.setProperty('unit', unit)
+        self._paramWidget.velocityZ.setProperty('unit', unit)
+
+        self._paramWidget.velocityX.setProperty(
+            'value', self._obj.VelocityX)
+        FreeCADGui.ExpressionBinding(
+            self._paramWidget.velocityX).bind(self._obj, "VelocityX")
         self._paramWidget.velocityXBox.setChecked(
-            not self._obj.VelocityXEnabled)
+            self._obj.VelocityXUnspecified)
+        self._paramWidget.formulaX.setText(self._obj.VelocityXFormula)
+        self._paramWidget.formulaXCB.setChecked(
+            self._obj.VelocityXHasFormula)
+
+        self._paramWidget.velocityY.setProperty(
+            'value', self._obj.VelocityY)
+        FreeCADGui.ExpressionBinding(
+            self._paramWidget.velocityY).bind(self._obj, "VelocityY")
         self._paramWidget.velocityYBox.setChecked(
-            not self._obj.VelocityYEnabled)
+            self._obj.VelocityYUnspecified)
+        self._paramWidget.formulaY.setText(self._obj.VelocityYFormula)
+        self._paramWidget.formulaYCB.setChecked(
+            self._obj.VelocityYHasFormula)
+
+        self._paramWidget.velocityZ.setProperty(
+            'value', self._obj.VelocityZ)
+        FreeCADGui.ExpressionBinding(
+            self._paramWidget.velocityZ).bind(self._obj, "VelocityZ")
         self._paramWidget.velocityZBox.setChecked(
-            not self._obj.VelocityZEnabled)
+            self._obj.VelocityZUnspecified)
+        self._paramWidget.formulaZ.setText(self._obj.VelocityZFormula)
+        self._paramWidget.formulaZCB.setChecked(
+            self._obj.VelocityZHasFormula)
+
         self._paramWidget.normalBox.setChecked(
             self._obj.NormalToBoundary)
 
+    def _applyVelocityChanges(self, enabledBox, velocityQSB):
+        enabled = enabledBox.isChecked()
+        velocity = None
+        try:
+            velocity = velocityQSB.property('value')
+        except ValueError:
+            FreeCAD.Console.PrintMessage(
+                "Wrong input. Not recognised input: '{}' "
+                "Velocity has not been set.\n".format(velocityQSB.text())
+            )
+            velocity = '0.0 m/s'
+        return enabled, velocity
+
     def _applyWidgetChanges(self):
-        unit = "m/s"
-        self._obj.VelocityXEnabled = \
-            not self._paramWidget.velocityXBox.isChecked()
-        if self._obj.VelocityXEnabled:
-            quantity = Units.Quantity(self._paramWidget.velocityXTxt.text())
-            self._obj.VelocityX = quantity.getValueAs(unit).Value
-        self._obj.VelocityYEnabled = \
-            not self._paramWidget.velocityYBox.isChecked()
-        if self._obj.VelocityYEnabled:
-            quantity = Units.Quantity(self._paramWidget.velocityYTxt.text())
-            self._obj.VelocityY = quantity.getValueAs(unit).Value
-        self._obj.VelocityZEnabled = \
-            not self._paramWidget.velocityZBox.isChecked()
-        if self._obj.VelocityZEnabled:
-            quantity = Units.Quantity(self._paramWidget.velocityZTxt.text())
-            self._obj.VelocityZ = quantity.getValueAs(unit).Value
+        # apply the velocities and their enabled state
+        self._obj.VelocityXUnspecified, self._obj.VelocityX = \
+            self._applyVelocityChanges(
+                self._paramWidget.velocityXBox,
+                self._paramWidget.velocityX
+            )
+        self._obj.VelocityXHasFormula = self._paramWidget.formulaXCB.isChecked()
+        self._obj.VelocityXFormula = self._paramWidget.formulaX.text()
+
+        self._obj.VelocityYUnspecified, self._obj.VelocityY = \
+            self._applyVelocityChanges(
+                self._paramWidget.velocityYBox,
+                self._paramWidget.velocityY
+            )
+        self._obj.VelocityYHasFormula = self._paramWidget.formulaYCB.isChecked()
+        self._obj.VelocityYFormula = self._paramWidget.formulaY.text()
+
+        self._obj.VelocityZUnspecified, self._obj.VelocityZ = \
+            self._applyVelocityChanges(
+                self._paramWidget.velocityZBox,
+                self._paramWidget.velocityZ
+            )
+        self._obj.VelocityZHasFormula = self._paramWidget.formulaZCB.isChecked()
+        self._obj.VelocityZFormula = self._paramWidget.formulaZ.text()
+
         self._obj.NormalToBoundary = self._paramWidget.normalBox.isChecked()


### PR DESCRIPTION
- complete revision of the velocity constraint.

This is a breaking change, meaning existing constraints won't work.

This is possible because since 2 days ago the whole flow equation did not work at all. Also the existing constraint implementation if buggy and cannot be used to do the Elmer tutorials. Also, the constraint is only used by Elmer and only be the Flow equation.

Since nobody complained about the obvious wrong results, we can assume the flow equation was not yet in practical usage (and for FC 0.20 we known that it does not work at all, first with FC 0.20.1).

It is necessary since it must be possible to either input a velocity or an equation. With an equation, a velocity profile can be specified.

- update the flow examples accordingly:
-- simplify them since an initial and and output velocity is not necessary to specify
-- use a formula as input velocity for the non-turbulent example