### PR TITLE
Fix circles distance constraint for concentrics

### DIFF
--- a/src/Mod/Sketcher/App/planegcs/Constraints.cpp
+++ b/src/Mod/Sketcher/App/planegcs/Constraints.cpp
@@ -2666,8 +2666,11 @@ void ConstraintC2CDistance::errorgrad(double *err, double *grad, double *param)
             else if(param == distance()) {
                 drad = (*distance()<0.)?1.0:-1.0;
             }
-
-            *grad = -dlength_ct12 + drad;
+            if (length_ct12>1e-13) {
+                *grad = -dlength_ct12 + drad;
+            } else { // concentric case
+                *grad = drad;
+            }
         }
     }
 }


### PR DESCRIPTION
This small circle won't be fully constrained anymore:
![image](https://user-images.githubusercontent.com/10371513/226205503-50e50561-1e66-458f-9ec0-6a21c0617da3.png)
