### PR TITLE
[NotificationArea] Preference based handling of non-intrusive notifications

### DIFF
--- a/src/Gui/DlgSettingsNotificationArea.cpp
+++ b/src/Gui/DlgSettingsNotificationArea.cpp
@@ -49,6 +49,8 @@ DlgSettingsNotificationArea::DlgSettingsNotificationArea(QWidget* parent)
             ui->maxNotifications->setEnabled(true);
             ui->maxWidgetMessages->setEnabled(true);
             ui->autoRemoveUserNotifications->setEnabled(true);
+            ui->hideNonIntrusiveNotificationsWhenWindowDeactivated->setEnabled(true);
+            ui->preventNonIntrusiveNotificationsWhenWindowNotActive->setEnabled(true);
             QMessageBox::information(this, tr("Notification Area"),
             tr("Activation of the Notification Area only takes effect after an application restart."));
         }
@@ -60,6 +62,8 @@ DlgSettingsNotificationArea::DlgSettingsNotificationArea(QWidget* parent)
             ui->maxNotifications->setEnabled(false);
             ui->maxWidgetMessages->setEnabled(false);
             ui->autoRemoveUserNotifications->setEnabled(false);
+            ui->hideNonIntrusiveNotificationsWhenWindowDeactivated->setEnabled(false);
+            ui->preventNonIntrusiveNotificationsWhenWindowNotActive->setEnabled(false);
         // N.B: Deactivation is handled by the Notification Area itself, as it listens to all its configuration parameters.
         }
     });
@@ -79,6 +83,8 @@ void DlgSettingsNotificationArea::saveSettings()
     ui->maxWidgetMessages->onSave();
     ui->autoRemoveUserNotifications->onSave();
     ui->notificationWidth->onSave();
+    ui->hideNonIntrusiveNotificationsWhenWindowDeactivated->onSave();
+    ui->preventNonIntrusiveNotificationsWhenWindowNotActive->onSave();
 }
 
 void DlgSettingsNotificationArea::loadSettings()
@@ -91,6 +97,9 @@ void DlgSettingsNotificationArea::loadSettings()
     ui->maxWidgetMessages->onRestore();
     ui->autoRemoveUserNotifications->onRestore();
     ui->notificationWidth->onRestore();
+    ui->hideNonIntrusiveNotificationsWhenWindowDeactivated->onRestore();
+    ui->preventNonIntrusiveNotificationsWhenWindowNotActive->onRestore();
+
 }
 
 void DlgSettingsNotificationArea::changeEvent(QEvent *e)

--- a/src/Gui/DlgSettingsNotificationArea.ui
+++ b/src/Gui/DlgSettingsNotificationArea.ui
@@ -133,6 +133,45 @@
         </property>
        </widget>
       </item>
+      <item row="4" column="0">
+       <widget class="Gui::PrefCheckBox" name="hideNonIntrusiveNotificationsWhenWindowDeactivated">
+        <property name="toolTip">
+         <string>Any open non-intrusive notifications will disappear when another window is activated</string>
+        </property>
+        <property name="text">
+         <string>Hide when other window is activated</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>HideNonIntrusiveNotificationsWhenWindowDeactivated</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>NotificationArea</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0">
+       <widget class="Gui::PrefCheckBox" name="preventNonIntrusiveNotificationsWhenWindowNotActive">
+        <property name="toolTip">
+         <string>Prevent non-intrusive notifications from appearing when the FreeCAD Window is not the active window</string>
+        </property>
+        <property name="text">
+         <string>Do not show when inactive</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>PreventNonIntrusiveNotificationsWhenWindowNotActive</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>NotificationArea</cstring>
+        </property>
+       </widget>
+      </item>
+
      </layout>
     </widget>
    </item>

--- a/src/Gui/Icons/InTray_missed_notifications.svg
+++ b/src/Gui/Icons/InTray_missed_notifications.svg
@@ -1,0 +1,501 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="64"
+   height="64"
+   id="svg11300"
+   version="1.1"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs3">
+    <linearGradient
+       id="linearGradient3822">
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1"
+         offset="0"
+         id="stop3824" />
+      <stop
+         style="stop-color:#204a87;stop-opacity:1"
+         offset="1"
+         id="stop3826" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient5060"
+       id="radialGradient5031"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-2.774389,0,0,1.969706,112.7623,-872.8854)"
+       cx="605.71429"
+       cy="486.64789"
+       fx="605.71429"
+       fy="486.64789"
+       r="117.14286" />
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         style="stop-color:black;stop-opacity:1;"
+         offset="0"
+         id="stop5062" />
+      <stop
+         style="stop-color:black;stop-opacity:0;"
+         offset="1"
+         id="stop5064" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient5060"
+       id="radialGradient5029"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.774389,0,0,1.969706,-1891.633,-872.8854)"
+       cx="605.71429"
+       cy="486.64789"
+       fx="605.71429"
+       fy="486.64789"
+       r="117.14286" />
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         style="stop-color:black;stop-opacity:0;"
+         offset="0"
+         id="stop5050" />
+      <stop
+         id="stop5056"
+         offset="0.5"
+         style="stop-color:black;stop-opacity:1;" />
+      <stop
+         style="stop-color:black;stop-opacity:0;"
+         offset="1"
+         id="stop5052" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient5048"
+       id="linearGradient5027"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.774389,0,0,1.969706,-1892.179,-872.8854)"
+       x1="302.85715"
+       y1="366.64789"
+       x2="302.85715"
+       y2="609.50507" />
+    <linearGradient
+       id="linearGradient3284">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3286" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3288" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3260">
+      <stop
+         style="stop-color:#204a87;stop-opacity:1;"
+         offset="0"
+         id="stop3262" />
+      <stop
+         style="stop-color:#204a87;stop-opacity:0;"
+         offset="1"
+         id="stop3264" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3239">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop3241" />
+      <stop
+         style="stop-color:#d3d7cf;stop-opacity:1"
+         offset="1"
+         id="stop3243" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11520">
+      <stop
+         id="stop11522"
+         offset="0.0000000"
+         style="stop-color:#ffffff;stop-opacity:1.0000000;" />
+      <stop
+         id="stop11524"
+         offset="1.0000000"
+         style="stop-color:#dcdcdc;stop-opacity:1.0000000;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11508">
+      <stop
+         id="stop11510"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop11512"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11494">
+      <stop
+         id="stop11496"
+         offset="0"
+         style="stop-color:#ef2929;stop-opacity:1;" />
+      <stop
+         id="stop11498"
+         offset="1"
+         style="stop-color:#ef2929;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11415">
+      <stop
+         id="stop11417"
+         offset="0.0000000"
+         style="stop-color:#204a87;stop-opacity:0.0000000;" />
+      <stop
+         style="stop-color:#204a87;stop-opacity:1.0000000;"
+         offset="0.50000000"
+         id="stop11423" />
+      <stop
+         id="stop11419"
+         offset="1"
+         style="stop-color:#204a87;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11399">
+      <stop
+         id="stop11401"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop11403"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-60.28571,-0.285714)"
+       y2="34.462429"
+       x2="43.615788"
+       y1="3.774456"
+       x1="15.82836"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11425"
+       xlink:href="#linearGradient11415" />
+    <linearGradient
+       gradientTransform="translate(-60.57143,0)"
+       y2="39.033859"
+       x2="35.679932"
+       y1="9.3458843"
+       x1="9.6957054"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11427"
+       xlink:href="#linearGradient11415" />
+    <linearGradient
+       y2="33.462429"
+       x2="26.758644"
+       y1="19.774456"
+       x1="13.267134"
+       gradientTransform="translate(-60.85714,0.428571)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11439"
+       xlink:href="#linearGradient11415" />
+    <radialGradient
+       r="8.5"
+       fy="39.142857"
+       fx="12.071428"
+       cy="39.142857"
+       cx="12.071428"
+       gradientTransform="matrix(1,0,0,0.487395,0,20.06483)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient11441"
+       xlink:href="#linearGradient11399" />
+    <radialGradient
+       gradientTransform="matrix(1.243453,0,0,1.243453,-6.713754,-3.742847)"
+       gradientUnits="userSpaceOnUse"
+       r="3.8335035"
+       fy="15.048258"
+       fx="27.577173"
+       cy="15.048258"
+       cx="27.577173"
+       id="radialGradient11500"
+       xlink:href="#linearGradient11494" />
+    <radialGradient
+       r="3.8335035"
+       fy="16.049133"
+       fx="27.577173"
+       cy="16.049133"
+       cx="27.577173"
+       gradientTransform="matrix(1.243453,0,0,1.243453,-6.713754,-3.742847)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient11504"
+       xlink:href="#linearGradient11494" />
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.338462,0,29.48178)"
+       r="6.5659914"
+       fy="44.565483"
+       fx="30.203562"
+       cy="44.565483"
+       cx="30.203562"
+       id="radialGradient11514"
+       xlink:href="#linearGradient11508" />
+    <radialGradient
+       gradientTransform="matrix(1.995058,0,0,1.995058,-24.32488,-35.70087)"
+       gradientUnits="userSpaceOnUse"
+       r="20.530962"
+       fy="35.87817"
+       fx="24.44569"
+       cy="35.87817"
+       cx="24.44569"
+       id="radialGradient11526"
+       xlink:href="#linearGradient11520" />
+    <radialGradient
+       r="6.5659914"
+       fy="44.565483"
+       fx="30.203562"
+       cy="44.565483"
+       cx="30.203562"
+       gradientTransform="matrix(1,0,0,0.338462,0,29.48178)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient11532"
+       xlink:href="#linearGradient11508" />
+    <radialGradient
+       xlink:href="#linearGradient11508"
+       id="radialGradient1348"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.338462,0,29.48178)"
+       cx="30.203562"
+       cy="44.565483"
+       fx="30.203562"
+       fy="44.565483"
+       r="6.5659914" />
+    <radialGradient
+       xlink:href="#linearGradient11520"
+       id="radialGradient1350"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.995058,0,0,1.995058,-24.32488,-35.70087)"
+       cx="24.44569"
+       cy="35.87817"
+       fx="24.44569"
+       fy="35.87817"
+       r="20.530962" />
+    <radialGradient
+       xlink:href="#linearGradient11494"
+       id="radialGradient1352"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.243453,0,0,1.243453,-6.713754,-3.742847)"
+       cx="27.577173"
+       cy="16.049133"
+       fx="27.577173"
+       fy="16.049133"
+       r="3.8335035" />
+    <radialGradient
+       xlink:href="#linearGradient11494"
+       id="radialGradient1354"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.243453,0,0,1.243453,-6.713754,-3.742847)"
+       cx="27.577173"
+       cy="15.048258"
+       fx="27.577173"
+       fy="15.048258"
+       r="3.8335035" />
+    <radialGradient
+       xlink:href="#linearGradient11508"
+       id="radialGradient1356"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.338462,0,29.48178)"
+       cx="30.203562"
+       cy="44.565483"
+       fx="30.203562"
+       fy="44.565483"
+       r="6.5659914" />
+    <radialGradient
+       xlink:href="#linearGradient11520"
+       id="radialGradient1366"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.049266,0,0,2.049266,-25.65002,-37.31089)"
+       cx="24.44569"
+       cy="35.87817"
+       fx="24.44569"
+       fy="35.87817"
+       r="20.530962" />
+    <linearGradient
+       xlink:href="#linearGradient3239"
+       id="linearGradient3249"
+       gradientUnits="userSpaceOnUse"
+       x1="15.663794"
+       y1="5.1465507"
+       x2="27.11207"
+       y2="42.353451"
+       gradientTransform="matrix(1.3975903,0,0,1.3975902,-1.8915666,-1.192769)" />
+    <linearGradient
+       xlink:href="#linearGradient3260"
+       id="linearGradient3266"
+       x1="12.363961"
+       y1="11.394304"
+       x2="18.22703"
+       y2="17.58149"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3813389,0,0,1.3813389,-1.8428134,-16.461473)" />
+    <linearGradient
+       xlink:href="#linearGradient3260"
+       id="linearGradient3270"
+       gradientUnits="userSpaceOnUse"
+       x1="12.363961"
+       y1="11.394304"
+       x2="18.22703"
+       y2="17.58149"
+       gradientTransform="matrix(-1.3813389,0,0,1.3813389,65.842795,-16.461473)" />
+    <linearGradient
+       xlink:href="#linearGradient3260"
+       id="linearGradient3278"
+       gradientUnits="userSpaceOnUse"
+       x1="12.363961"
+       y1="11.394304"
+       x2="18.22703"
+       y2="17.58149"
+       gradientTransform="matrix(1.3813389,0,0,-1.3813389,-1.8428134,48.504624)" />
+    <linearGradient
+       xlink:href="#linearGradient3260"
+       id="linearGradient3280"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.3813389,0,0,-1.3813389,65.842795,48.504624)"
+       x1="12.363961"
+       y1="11.394304"
+       x2="18.22703"
+       y2="17.58149" />
+    <radialGradient
+       xlink:href="#linearGradient3284"
+       id="radialGradient3290"
+       cx="25.455845"
+       cy="43.403805"
+       fx="25.455845"
+       fy="43.403805"
+       r="20.682873"
+       gradientTransform="matrix(1,0,0,0.205128,0,34.50046)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       xlink:href="#linearGradient3822"
+       id="linearGradient3828"
+       x1="44"
+       y1="41"
+       x2="53"
+       y2="56"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       xlink:href="#linearGradient11494"
+       id="linearGradient3834-3-0"
+       gradientUnits="userSpaceOnUse"
+       x1="48"
+       y1="54"
+       x2="25.519545"
+       y2="28.740286"
+       gradientTransform="rotate(180,34.5,37.5)" />
+    <linearGradient
+       id="linearGradient3822-6-2">
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1"
+         offset="0"
+         id="stop3824-7-3" />
+      <stop
+         style="stop-color:#204a87;stop-opacity:1"
+         offset="1"
+         id="stop3826-5-7" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3774"
+       id="linearGradient3780-9"
+       x1="30"
+       y1="-2"
+       x2="26"
+       y2="-26"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3774">
+      <stop
+         style="stop-color:#d3d7cf;stop-opacity:1"
+         offset="0"
+         id="stop3776" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="1"
+         id="stop3778" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata4">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>Jakub Steiner</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:source>http://jimmac.musichall.cz</dc:source>
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/by-sa/2.0/" />
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by-sa/2.0/">
+        <cc:permits
+           rdf:resource="http://web.resource.org/cc/Reproduction" />
+        <cc:permits
+           rdf:resource="http://web.resource.org/cc/Distribution" />
+        <cc:requires
+           rdf:resource="http://web.resource.org/cc/Notice" />
+        <cc:requires
+           rdf:resource="http://web.resource.org/cc/Attribution" />
+        <cc:permits
+           rdf:resource="http://web.resource.org/cc/DerivativeWorks" />
+        <cc:requires
+           rdf:resource="http://web.resource.org/cc/ShareAlike" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     style="display:inline"
+     id="g5022"
+     transform="matrix(0.03152036,0,0,0.03344397,60.035325,53.041739)">
+    <rect
+       y="-150.69685"
+       x="-1559.2523"
+       height="478.35718"
+       width="1339.6335"
+       id="rect4173"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.402062;fill:url(#linearGradient5027);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+    <path
+       id="path5058"
+       d="m -219.61876,-150.68038 c 0,0 0,478.33079 0,478.33079 142.874166,0.90045 345.40022,-107.16966 345.40014,-239.196175 0,-132.026537 -159.436816,-239.134595 -345.40014,-239.134615 z"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.402062;fill:url(#radialGradient5029);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+    <path
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.402062;fill:url(#radialGradient5031);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+       d="m -1559.2523,-150.68038 c 0,0 0,478.33079 0,478.33079 -142.8742,0.90045 -345.4002,-107.16966 -345.4002,-239.196175 0,-132.026537 159.4368,-239.134595 345.4002,-239.134615 z"
+       id="path5018" />
+  </g>
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3249);fill-opacity:1;fill-rule:evenodd;stroke:#888a85;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     id="rect2354"
+     width="58"
+     height="57.999996"
+     x="3"
+     y="3.000001"
+     rx="2.5900114"
+     ry="2.5900111" />
+  <path
+     xlink:href="#rect2354"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     id="path3247"
+     d="m 6.50838,5.0000002 c -0.8476842,0 -1.5083799,0.6606954 -1.5083799,1.5083798 V 57.49162 C 5.0000001,58.339304 5.6606958,59 6.50838,59 H 57.49162 C 58.339304,59 59,58.339303 59,57.49162 V 6.50838 C 59,5.6606966 58.339304,5.0000002 57.49162,5.0000002 Z" />
+  <path
+     id="path3050-5-8"
+     d="M 12,18 V 55 H 52 V 18 c -13.333333,0 -26.666667,0 -40,0 z"
+     style="fill:url(#linearGradient3834-3-0);fill-opacity:1;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
+  <path
+     id="path3820-6-9"
+     d="M 50,21 32,36 14,21 14.15625,53 H 50 Z"
+     style="fill:none;stroke:#cc0000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+</svg>

--- a/src/Gui/Icons/resource.qrc
+++ b/src/Gui/Icons/resource.qrc
@@ -101,6 +101,7 @@
         <file>accessories-calculator.svg</file>
         <file>internet-web-browser.svg</file>
         <file>InTray.svg</file>
+        <file>InTray_missed_notifications.svg</file>
         <file>view-select.svg</file>
         <file>view-unselectable.svg</file>
         <file>view-refresh.svg</file>

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -314,7 +314,6 @@ MainWindow::MainWindow(QWidget * parent, Qt::WindowFlags f)
     if(notificationAreaEnabled) {
         NotificationArea* notificationArea = new NotificationArea(statusBar());
         notificationArea->setObjectName(QString::fromLatin1("notificationArea"));
-        notificationArea->setIcon(QIcon(QString::fromLatin1(":/icons/InTray.svg")));
         notificationArea->setStyleSheet(QStringLiteral("text-align:left;"));
         statusBar()->addPermanentWidget(notificationArea);
     }

--- a/src/Gui/NotificationArea.cpp
+++ b/src/Gui/NotificationArea.cpp
@@ -997,7 +997,8 @@ void NotificationArea::showInNotificationArea()
                                   pImp->notificationExpirationTime,
                                   pImp->minimumOnScreenTime,
                                   NotificationBox::OnlyIfReferenceActive |
-                                  NotificationBox::RestrictAreaToReference,
+                                  NotificationBox::RestrictAreaToReference |
+                                  NotificationBox::HideIfReferenceWidgetDeactivated,
                                   pImp->notificationWidth);
     }
 }

--- a/src/Gui/NotificationArea.cpp
+++ b/src/Gui/NotificationArea.cpp
@@ -84,7 +84,8 @@ struct NotificationAreaP
     int notificationWidth = 800;
     /// Any open non-intrusive notifications will disappear when another window is activated
     bool hideNonIntrusiveNotificationsWhenWindowDeactivated = true;
-    /// Prevent non-intrusive notifications from appearing when the FreeCAD Window is not the active window
+    /// Prevent non-intrusive notifications from appearing when the FreeCAD Window is not the active
+    /// window
     bool preventNonIntrusiveNotificationsWhenWindowNotActive = true;
     //@}
 
@@ -144,7 +145,8 @@ private:
         critical = BitmapFactory().pixmapFromSvg(":/icons/critical-info.svg", QSize(16, 16));
         info = BitmapFactory().pixmapFromSvg(":/icons/info.svg", QSize(16, 16));
         notificationArea = QIcon(QStringLiteral(":/icons/InTray.svg"));
-        notificationAreaMissedNotifications = QIcon(QStringLiteral(":/icons/InTray_missed_notifications.svg"));
+        notificationAreaMissedNotifications =
+            QIcon(QStringLiteral(":/icons/InTray_missed_notifications.svg"));
     }
 
     inline static const auto& getResourceManager()
@@ -741,7 +743,7 @@ NotificationArea::NotificationArea(QWidget* parent)
             pImp->mutexNotification);// guard to avoid modifying the notification list and indices
                                      // while creating the tooltip
         setText(QString::number(0)); // no unread notifications
-        if(pImp->missedNotifications) {
+        if (pImp->missedNotifications) {
             setIcon(TrayIcon::Normal);
             pImp->missedNotifications = false;
         }
@@ -1031,23 +1033,23 @@ void NotificationArea::showInNotificationArea()
 
         NotificationBox::Options options = NotificationBox::Options::RestrictAreaToReference;
 
-        if(pImp->preventNonIntrusiveNotificationsWhenWindowNotActive) {
+        if (pImp->preventNonIntrusiveNotificationsWhenWindowNotActive) {
             options = options | NotificationBox::Options::OnlyIfReferenceActive;
         }
 
-        if(pImp->hideNonIntrusiveNotificationsWhenWindowDeactivated) {
+        if (pImp->hideNonIntrusiveNotificationsWhenWindowDeactivated) {
             options = options | NotificationBox::Options::HideIfReferenceWidgetDeactivated;
         }
 
         bool isshown = NotificationBox::showText(this->mapToGlobal(QPoint()),
-                                  msgw,
-                                  getMainWindow(),
-                                  pImp->notificationExpirationTime,
-                                  pImp->minimumOnScreenTime,
-                                  options,
-                                  pImp->notificationWidth);
+                                                 msgw,
+                                                 getMainWindow(),
+                                                 pImp->notificationExpirationTime,
+                                                 pImp->minimumOnScreenTime,
+                                                 options,
+                                                 pImp->notificationWidth);
 
-        if(!isshown && !pImp->missedNotifications) {
+        if (!isshown && !pImp->missedNotifications) {
             pImp->missedNotifications = true;
             setIcon(TrayIcon::MissedNotifications);
         }
@@ -1062,10 +1064,10 @@ void NotificationArea::slotRestoreFinished(const App::Document&)
 
 void NotificationArea::setIcon(TrayIcon trayIcon)
 {
-    if(trayIcon == TrayIcon::Normal) {
+    if (trayIcon == TrayIcon::Normal) {
         QPushButton::setIcon(ResourceManager::NotificationAreaIcon());
     }
-    else if(trayIcon == TrayIcon::MissedNotifications) {
+    else if (trayIcon == TrayIcon::MissedNotifications) {
         QPushButton::setIcon(ResourceManager::notificationAreaMissedNotificationsIcon());
     }
 }

--- a/src/Gui/NotificationArea.cpp
+++ b/src/Gui/NotificationArea.cpp
@@ -991,17 +991,13 @@ void NotificationArea::showInNotificationArea()
 
         msgw += QString::fromLatin1("</table></p>");
 
-        // Calculate the main window QRect in global screen coordinates.
-        auto mainwindow = getMainWindow();
-        auto mainwindowrect = mainwindow->rect();
-        auto globalmainwindowrect =
-            QRect(mainwindow->mapToGlobal(mainwindowrect.topLeft()), mainwindowrect.size());
-
         NotificationBox::showText(this->mapToGlobal(QPoint()),
                                   msgw,
+                                  getMainWindow(),
                                   pImp->notificationExpirationTime,
                                   pImp->minimumOnScreenTime,
-                                  globalmainwindowrect,
+                                  NotificationBox::OnlyIfReferenceActive |
+                                  NotificationBox::RestrictAreaToReference,
                                   pImp->notificationWidth);
     }
 }

--- a/src/Gui/NotificationArea.cpp
+++ b/src/Gui/NotificationArea.cpp
@@ -996,9 +996,9 @@ void NotificationArea::showInNotificationArea()
                                   getMainWindow(),
                                   pImp->notificationExpirationTime,
                                   pImp->minimumOnScreenTime,
-                                  NotificationBox::OnlyIfReferenceActive |
-                                  NotificationBox::RestrictAreaToReference |
-                                  NotificationBox::HideIfReferenceWidgetDeactivated,
+                                  NotificationBox::Options::OnlyIfReferenceActive |
+                                  NotificationBox::Options::RestrictAreaToReference |
+                                  NotificationBox::Options::HideIfReferenceWidgetDeactivated,
                                   pImp->notificationWidth);
     }
 }

--- a/src/Gui/NotificationArea.h
+++ b/src/Gui/NotificationArea.h
@@ -39,7 +39,8 @@ struct NotificationAreaP;
 
 class NotificationArea: public QPushButton
 {
-    enum class TrayIcon {
+    enum class TrayIcon
+    {
         Normal,
         MissedNotifications,
     };

--- a/src/Gui/NotificationArea.h
+++ b/src/Gui/NotificationArea.h
@@ -39,6 +39,11 @@ struct NotificationAreaP;
 
 class NotificationArea: public QPushButton
 {
+    enum class TrayIcon {
+        Normal,
+        MissedNotifications,
+    };
+
 public:
     class ParameterObserver: public ParameterGrp::ObserverType
     {
@@ -67,6 +72,8 @@ private:
     void slotRestoreFinished(const App::Document&);
 
     void mousePressEvent(QMouseEvent* e) override;
+
+    void setIcon(TrayIcon trayIcon);
 
 private:
     std::unique_ptr<NotificationAreaP> pImp;

--- a/src/Gui/NotificationBox.cpp
+++ b/src/Gui/NotificationBox.cpp
@@ -76,6 +76,8 @@ public:
     /// Set the windowrect defining an area to which the label should be constrained
     void setTipRect(const QRect &restrictionarea);
 
+    void setHideIfReferenceWidgetDeactivated(bool on);
+
     /// The instance
     static qobject_delete_later_unique_ptr<NotificationLabel> instance;
 
@@ -95,6 +97,7 @@ private:
     QTimer expireTimer;
 
     QRect restrictionArea;
+    bool hideIfReferenceWidgetDeactivated;
 };
 
 qobject_delete_later_unique_ptr<NotificationLabel> NotificationLabel::instance = nullptr;
@@ -248,7 +251,8 @@ bool NotificationLabel::eventFilter(QObject* o, QEvent* e)
         }
         break;
         case QEvent::WindowDeactivate:
-            hideNotificationImmediately();
+            if(hideIfReferenceWidgetDeactivated)
+                hideNotificationImmediately();
             break;
 
         default:
@@ -302,6 +306,11 @@ void NotificationLabel::setTipRect(const QRect &restrictionarea)
     restrictionArea = restrictionarea;
 }
 
+void NotificationLabel::setHideIfReferenceWidgetDeactivated(bool on)
+{
+    hideIfReferenceWidgetDeactivated = on;
+}
+
 bool NotificationLabel::notificationLabelChanged(const QString& text)
 {
     return NotificationLabel::instance->text() != text;
@@ -341,6 +350,8 @@ void NotificationBox::showText(const QPoint& pos, const QString& text, QWidget *
             // If the label has changed, reuse the one that is showing (removes flickering)
             if (NotificationLabel::instance->notificationLabelChanged(text)) {
                 NotificationLabel::instance->setTipRect(restrictionarea);
+                NotificationLabel::instance->setHideIfReferenceWidgetDeactivated(options &
+                    Options::HideIfReferenceWidgetDeactivated);
                 NotificationLabel::instance->reuseNotification(text, displayTime, pos, width);
                 NotificationLabel::instance->placeNotificationLabel(pos);
             }
@@ -360,6 +371,8 @@ void NotificationBox::showText(const QPoint& pos, const QString& text, QWidget *
                               width);// sets NotificationLabel::instance to itself
 
         NotificationLabel::instance->setTipRect(restrictionarea);
+        NotificationLabel::instance->setHideIfReferenceWidgetDeactivated(options &
+            Options::HideIfReferenceWidgetDeactivated);
         NotificationLabel::instance->placeNotificationLabel(pos);
         NotificationLabel::instance->setObjectName(QLatin1String("NotificationBox_label"));
 

--- a/src/Gui/NotificationBox.cpp
+++ b/src/Gui/NotificationBox.cpp
@@ -309,9 +309,28 @@ bool NotificationLabel::notificationLabelChanged(const QString& text)
 
 /***************************** NotificationBox **********************************/
 
-void NotificationBox::showText(const QPoint& pos, const QString& text, int displayTime,
-                               unsigned int minShowTime, const QRect &restrictionarea, int width)
+void NotificationBox::showText(const QPoint& pos, const QString& text, QWidget * referenceWidget, int displayTime,
+                         unsigned int minShowTime, Options options,
+                         int width)
 {
+    QRect restrictionarea = {};
+
+    if(referenceWidget) {
+        if(options & Options::OnlyIfReferenceActive) {
+            if (!referenceWidget->isActiveWindow()) {
+                return;
+            }
+        }
+
+        if(options & Options::RestrictAreaToReference) {
+            // Calculate the main window QRect in global screen coordinates.
+            auto mainwindowrect = referenceWidget->rect();
+
+            restrictionarea =
+                QRect(referenceWidget->mapToGlobal(mainwindowrect.topLeft()), mainwindowrect.size());
+        }
+    }
+
     // a label does already exist
     if (NotificationLabel::instance && NotificationLabel::instance->isVisible()) {
         if (text.isEmpty()) {// empty text means hide current label

--- a/src/Gui/NotificationBox.cpp
+++ b/src/Gui/NotificationBox.cpp
@@ -246,6 +246,11 @@ bool NotificationLabel::eventFilter(QObject* o, QEvent* e)
                 return insideclick;
             }
         }
+        break;
+        case QEvent::WindowDeactivate:
+            hideNotificationImmediately();
+            break;
+
         default:
             break;
     }

--- a/src/Gui/NotificationBox.cpp
+++ b/src/Gui/NotificationBox.cpp
@@ -318,7 +318,7 @@ bool NotificationLabel::notificationLabelChanged(const QString& text)
 
 /***************************** NotificationBox **********************************/
 
-void NotificationBox::showText(const QPoint& pos, const QString& text, QWidget * referenceWidget, int displayTime,
+bool NotificationBox::showText(const QPoint& pos, const QString& text, QWidget * referenceWidget, int displayTime,
                          unsigned int minShowTime, Options options,
                          int width)
 {
@@ -327,7 +327,7 @@ void NotificationBox::showText(const QPoint& pos, const QString& text, QWidget *
     if(referenceWidget) {
         if(options & Options::OnlyIfReferenceActive) {
             if (!referenceWidget->isActiveWindow()) {
-                return;
+                return false;
             }
         }
 
@@ -344,7 +344,7 @@ void NotificationBox::showText(const QPoint& pos, const QString& text, QWidget *
     if (NotificationLabel::instance && NotificationLabel::instance->isVisible()) {
         if (text.isEmpty()) {// empty text means hide current label
             NotificationLabel::instance->hideNotification();
-            return;
+            return false;
         }
         else {
             // If the label has changed, reuse the one that is showing (removes flickering)
@@ -355,7 +355,7 @@ void NotificationBox::showText(const QPoint& pos, const QString& text, QWidget *
                 NotificationLabel::instance->reuseNotification(text, displayTime, pos, width);
                 NotificationLabel::instance->placeNotificationLabel(pos);
             }
-            return;
+            return true;
         }
     }
 
@@ -378,6 +378,8 @@ void NotificationBox::showText(const QPoint& pos, const QString& text, QWidget *
 
         NotificationLabel::instance->showNormal();
     }
+
+    return true;
 }
 
 bool NotificationBox::isVisible()

--- a/src/Gui/NotificationBox.cpp
+++ b/src/Gui/NotificationBox.cpp
@@ -60,7 +60,8 @@ class NotificationLabel: public QLabel
 {
     Q_OBJECT
 public:
-    NotificationLabel(const QString& text, const QPoint& pos, int displayTime, int minShowTime = 0, int width = 0);
+    NotificationLabel(const QString& text, const QPoint& pos, int displayTime, int minShowTime = 0,
+                      int width = 0);
     /// Reuse existing notification to show a new notification (with a new text)
     void reuseNotification(const QString& text, int displayTime, const QPoint& pos, int width);
     /// Hide notification after a hiding timer.
@@ -74,7 +75,7 @@ public:
     /// Place the notification at the given position
     void placeNotificationLabel(const QPoint& pos);
     /// Set the windowrect defining an area to which the label should be constrained
-    void setTipRect(const QRect &restrictionarea);
+    void setTipRect(const QRect& restrictionarea);
 
     void setHideIfReferenceWidgetDeactivated(bool on);
 
@@ -150,9 +151,10 @@ void NotificationLabel::restartExpireTimer(int displayTime)
     hideTimer.stop();
 }
 
-void NotificationLabel::reuseNotification(const QString& text, int displayTime, const QPoint& pos, int width)
+void NotificationLabel::reuseNotification(const QString& text, int displayTime, const QPoint& pos,
+                                          int width)
 {
-    if(width > 0)
+    if (width > 0)
         setFixedWidth(width);
 
     setText(text);
@@ -248,10 +250,9 @@ bool NotificationLabel::eventFilter(QObject* o, QEvent* e)
 
                 return insideclick;
             }
-        }
-        break;
+        } break;
         case QEvent::WindowDeactivate:
-            if(hideIfReferenceWidgetDeactivated)
+            if (hideIfReferenceWidgetDeactivated)
                 hideNotificationImmediately();
             break;
 
@@ -278,7 +279,7 @@ void NotificationLabel::placeNotificationLabel(const QPoint& pos)
 
         QRect actinglimit = screen->geometry();
 
-        if(!restrictionArea.isNull())
+        if (!restrictionArea.isNull())
             actinglimit = restrictionArea;
 
         const int standard_x_padding = 4;
@@ -301,7 +302,7 @@ void NotificationLabel::placeNotificationLabel(const QPoint& pos)
     this->move(p);
 }
 
-void NotificationLabel::setTipRect(const QRect &restrictionarea)
+void NotificationLabel::setTipRect(const QRect& restrictionarea)
 {
     restrictionArea = restrictionarea;
 }
@@ -318,25 +319,25 @@ bool NotificationLabel::notificationLabelChanged(const QString& text)
 
 /***************************** NotificationBox **********************************/
 
-bool NotificationBox::showText(const QPoint& pos, const QString& text, QWidget * referenceWidget, int displayTime,
-                         unsigned int minShowTime, Options options,
-                         int width)
+bool NotificationBox::showText(const QPoint& pos, const QString& text, QWidget* referenceWidget,
+                               int displayTime, unsigned int minShowTime, Options options,
+                               int width)
 {
     QRect restrictionarea = {};
 
-    if(referenceWidget) {
-        if(options & Options::OnlyIfReferenceActive) {
+    if (referenceWidget) {
+        if (options & Options::OnlyIfReferenceActive) {
             if (!referenceWidget->isActiveWindow()) {
                 return false;
             }
         }
 
-        if(options & Options::RestrictAreaToReference) {
+        if (options & Options::RestrictAreaToReference) {
             // Calculate the main window QRect in global screen coordinates.
             auto mainwindowrect = referenceWidget->rect();
 
-            restrictionarea =
-                QRect(referenceWidget->mapToGlobal(mainwindowrect.topLeft()), mainwindowrect.size());
+            restrictionarea = QRect(referenceWidget->mapToGlobal(mainwindowrect.topLeft()),
+                                    mainwindowrect.size());
         }
     }
 
@@ -350,8 +351,8 @@ bool NotificationBox::showText(const QPoint& pos, const QString& text, QWidget *
             // If the label has changed, reuse the one that is showing (removes flickering)
             if (NotificationLabel::instance->notificationLabelChanged(text)) {
                 NotificationLabel::instance->setTipRect(restrictionarea);
-                NotificationLabel::instance->setHideIfReferenceWidgetDeactivated(options &
-                    Options::HideIfReferenceWidgetDeactivated);
+                NotificationLabel::instance->setHideIfReferenceWidgetDeactivated(
+                    options & Options::HideIfReferenceWidgetDeactivated);
                 NotificationLabel::instance->reuseNotification(text, displayTime, pos, width);
                 NotificationLabel::instance->placeNotificationLabel(pos);
             }
@@ -371,8 +372,8 @@ bool NotificationBox::showText(const QPoint& pos, const QString& text, QWidget *
                               width);// sets NotificationLabel::instance to itself
 
         NotificationLabel::instance->setTipRect(restrictionarea);
-        NotificationLabel::instance->setHideIfReferenceWidgetDeactivated(options &
-            Options::HideIfReferenceWidgetDeactivated);
+        NotificationLabel::instance->setHideIfReferenceWidgetDeactivated(
+            options & Options::HideIfReferenceWidgetDeactivated);
         NotificationLabel::instance->placeNotificationLabel(pos);
         NotificationLabel::instance->setObjectName(QLatin1String("NotificationBox_label"));
 

--- a/src/Gui/NotificationBox.h
+++ b/src/Gui/NotificationBox.h
@@ -23,6 +23,7 @@
 #ifndef GUI_NOTIFICATIONBOX_H
 #define GUI_NOTIFICATIONBOX_H
 
+#include <type_traits>
 
 namespace Gui
 {
@@ -48,21 +49,30 @@ class NotificationBox
     NotificationBox() = delete;
 
 public:
+     enum Options {
+         None = 0x0,
+         RestrictAreaToReference = 0x1,
+         OnlyIfReferenceActive = 0x2,
+    };
+
     /** Shows a non-intrusive notification.
      * @param pos Position at which the notification will be shown
+     * @param text Message to be shown
+     * @param referenceWidget If provided, will set the reference to calculate a restrictionarea (see below restrictAreaToReference) and
+     * to prevent notifications for being shown if not active.
      * @param displayTime Time after which the notification will auto-close (unless it is closed by
      * an event, see class documentation above)
      * @param minShowTime  Time during which the notification can only be made disappear by popping
      * it out (clicking inside it).
-     * @param restrictionarea Try to keep the NotificationBox within this area. If this area is not
-     * provided, the whole screen is used as restriction area. This are must be provided in global
-     * screen coordinates.
+     * @param restrictAreaToReference Try to keep the NotificationBox within the QRect of the referenceWidget. if false or referenceWidget is
+     * nullptr, the whole screen is used as restriction area.
+     * @param onlyIfReferenceActive Show only if the reference window is active.
      * @param width Fixes the width of the notification. Default value makes the width to be system
      * determined (dependent on the text). If a fixed width is provided it is enforced over the
      * restrictionarea.
      */
-    static void showText(const QPoint& pos, const QString& text, int displayTime = -1,
-                         unsigned int minShowTime = 0, const QRect& restrictionarea = {},
+    static void showText(const QPoint& pos, const QString& text, QWidget * referenceWidget = nullptr, int displayTime = -1,
+                         unsigned int minShowTime = 0, Options options = Options::None,
                          int width = 0);
     /// Hides a notification.
     static inline void hideText()
@@ -83,6 +93,11 @@ public:
     static void setFont(const QFont&);
 };
 
+inline NotificationBox::Options operator|(NotificationBox::Options lhs, NotificationBox::Options rhs) {
+    return static_cast<NotificationBox::Options>(
+        static_cast<std::underlying_type<NotificationBox::Options>::type>(lhs) |
+        static_cast<std::underlying_type<NotificationBox::Options>::type>(rhs));
+}
 
 }// namespace Gui
 

--- a/src/Gui/NotificationBox.h
+++ b/src/Gui/NotificationBox.h
@@ -49,34 +49,40 @@ class NotificationBox
     NotificationBox() = delete;
 
 public:
-     enum class Options {
-         None = 0x0,
-         RestrictAreaToReference = 0x1,
-         OnlyIfReferenceActive = 0x2,
-         HideIfReferenceWidgetDeactivated = 0x4,
+    enum class Options
+    {
+        None = 0x0,
+        RestrictAreaToReference = 0x1,
+        OnlyIfReferenceActive = 0x2,
+        HideIfReferenceWidgetDeactivated = 0x4,
     };
 
     /** Shows a non-intrusive notification.
      * @param pos Position at which the notification will be shown
      * @param text Message to be shown
-     * @param referenceWidget If provided, will set the reference to calculate a restrictionarea (see below restrictAreaToReference) and
-     * to prevent notifications for being shown if not active.
+     * @param referenceWidget If provided, will set the reference to calculate a restrictionarea
+     * (see below options) and to prevent notifications for being shown if not active.
      * @param displayTime Time after which the notification will auto-close (unless it is closed by
      * an event, see class documentation above)
      * @param minShowTime  Time during which the notification can only be made disappear by popping
      * it out (clicking inside it).
-     * @param restrictAreaToReference Try to keep the NotificationBox within the QRect of the referenceWidget. if false or referenceWidget is
-     * nullptr, the whole screen is used as restriction area.
-     * @param onlyIfReferenceActive Show only if the reference window is active.
+     * @param options Different flag options:
+     *  - HideIfReferenceWidgetDeactivated - Hides a notification if the main window becomes
+     * inactive.
+     *  - RestrictAreaToReference - Try to keep the NotificationBox within the QRect of the
+     *  referenceWidget. if false or referenceWidget is nullptr, the whole screen is used as
+     *  restriction area.
+     *  - OnlyIfReferenceActive - Show only if the reference window is active.
+     *
      * @param width Fixes the width of the notification. Default value makes the width to be system
      * determined (dependent on the text). If a fixed width is provided it is enforced over the
      * restrictionarea.
      *
      * @return returns whether the notification was shown or not
      */
-    static bool showText(const QPoint& pos, const QString& text, QWidget * referenceWidget = nullptr, int displayTime = -1,
-                         unsigned int minShowTime = 0, Options options = Options::None,
-                         int width = 0);
+    static bool showText(const QPoint& pos, const QString& text, QWidget* referenceWidget = nullptr,
+                         int displayTime = -1, unsigned int minShowTime = 0,
+                         Options options = Options::None, int width = 0);
     /// Hides a notification.
     static inline void hideText()
     {
@@ -96,16 +102,18 @@ public:
     static void setFont(const QFont&);
 };
 
-inline NotificationBox::Options operator|(NotificationBox::Options lhs, NotificationBox::Options rhs) {
+inline NotificationBox::Options operator|(NotificationBox::Options lhs,
+                                          NotificationBox::Options rhs)
+{
     return static_cast<NotificationBox::Options>(
-        static_cast<std::underlying_type<NotificationBox::Options>::type>(lhs) |
-        static_cast<std::underlying_type<NotificationBox::Options>::type>(rhs));
+        static_cast<std::underlying_type<NotificationBox::Options>::type>(lhs)
+        | static_cast<std::underlying_type<NotificationBox::Options>::type>(rhs));
 }
 
-inline bool operator&(NotificationBox::Options lhs, NotificationBox::Options rhs) {
-    return (
-        static_cast<std::underlying_type<NotificationBox::Options>::type>(lhs) &
-        static_cast<std::underlying_type<NotificationBox::Options>::type>(rhs));
+inline bool operator&(NotificationBox::Options lhs, NotificationBox::Options rhs)
+{
+    return (static_cast<std::underlying_type<NotificationBox::Options>::type>(lhs)
+            & static_cast<std::underlying_type<NotificationBox::Options>::type>(rhs));
 }
 
 }// namespace Gui

--- a/src/Gui/NotificationBox.h
+++ b/src/Gui/NotificationBox.h
@@ -53,6 +53,7 @@ public:
          None = 0x0,
          RestrictAreaToReference = 0x1,
          OnlyIfReferenceActive = 0x2,
+         HideIfReferenceWidgetDeactivated = 0x4,
     };
 
     /** Shows a non-intrusive notification.

--- a/src/Gui/NotificationBox.h
+++ b/src/Gui/NotificationBox.h
@@ -71,8 +71,10 @@ public:
      * @param width Fixes the width of the notification. Default value makes the width to be system
      * determined (dependent on the text). If a fixed width is provided it is enforced over the
      * restrictionarea.
+     *
+     * @return returns whether the notification was shown or not
      */
-    static void showText(const QPoint& pos, const QString& text, QWidget * referenceWidget = nullptr, int displayTime = -1,
+    static bool showText(const QPoint& pos, const QString& text, QWidget * referenceWidget = nullptr, int displayTime = -1,
                          unsigned int minShowTime = 0, Options options = Options::None,
                          int width = 0);
     /// Hides a notification.

--- a/src/Gui/NotificationBox.h
+++ b/src/Gui/NotificationBox.h
@@ -49,7 +49,7 @@ class NotificationBox
     NotificationBox() = delete;
 
 public:
-     enum Options {
+     enum class Options {
          None = 0x0,
          RestrictAreaToReference = 0x1,
          OnlyIfReferenceActive = 0x2,
@@ -97,6 +97,12 @@ public:
 inline NotificationBox::Options operator|(NotificationBox::Options lhs, NotificationBox::Options rhs) {
     return static_cast<NotificationBox::Options>(
         static_cast<std::underlying_type<NotificationBox::Options>::type>(lhs) |
+        static_cast<std::underlying_type<NotificationBox::Options>::type>(rhs));
+}
+
+inline bool operator&(NotificationBox::Options lhs, NotificationBox::Options rhs) {
+    return (
+        static_cast<std::underlying_type<NotificationBox::Options>::type>(lhs) &
         static_cast<std::underlying_type<NotificationBox::Options>::type>(rhs));
 }
 


### PR DESCRIPTION

This PR addresses that non-intrusive notifications where shown when the FreeCAD window was not active (e.g. the browser or okular was active) and this was unwelcome for some use cases (as when running simulations).

Based on preferences, it can now be selected that any existing notification disappears when the FreeCAD window becomes inactive, and that notifications raised while FreeCAD is inactive are inhibited.

To compensate, when a notification was inhibited, the notification area button changes color, so that when the user comes back to FreeCAD he can access any missed notification via the widget.