### PR TITLE
fix: use _WIN32 instead of WIN32

### DIFF
--- a/src/Mod/Mesh/App/WildMagic4/Wm4System.cpp
+++ b/src/Mod/Mesh/App/WildMagic4/Wm4System.cpp
@@ -22,7 +22,7 @@ using namespace Wm4;
 #include <sys/stat.h>
 
 // support for GetTime
-#if !defined(WIN32)
+#if !defined(_WIN32)
 #include <sys/time.h>
 static timeval gs_kInitial;
 static bool gs_bInitializedTime = false;
@@ -103,7 +103,7 @@ void System::EndianCopy (int iSize, int iQuantity, const void* pvSrc,
 //----------------------------------------------------------------------------
 double System::GetTime ()
 {
-#if !defined(WIN32)
+#if !defined(_WIN32)
     if (!gs_bInitializedTime)
     {
         gs_bInitializedTime = true;


### PR DESCRIPTION
macro WIN32 is deprecated, but it is implicit defined by some certain environment including visual studio

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
