### PR TITLE
[FEM] several Elmer fixes

### DIFF
--- a/src/Mod/Fem/femobjects/constraint_flowvelocity.py
+++ b/src/Mod/Fem/femobjects/constraint_flowvelocity.py
@@ -1,6 +1,7 @@
 # ***************************************************************************
 # *   Copyright (c) 2017 Markus Hovorka <m.hovorka@live.de>                 *
 # *   Copyright (c) 2020 Bernd Hahnebach <bernd@bimstatik.org>              *
+# *   Copyright (c) 2023 Uwe Stöhr <uwestoehr@lyx.org>                      *
 # *                                                                         *
 # *   This file is part of the FreeCAD CAx development system.              *
 # *                                                                         *
@@ -23,7 +24,7 @@
 # ***************************************************************************
 
 __title__ = "FreeCAD FEM constraint flow velocity document object"
-__author__ = "Markus Hovorka, Bernd Hahnebach"
+__author__ = "Markus Hovorka, Bernd Hahnebach, Uwe Stöhr"
 __url__ = "https://www.freecadweb.org"
 
 ## @package constraint_flowvelocity

--- a/src/Mod/Fem/femsolver/elmer/equations/nonlinear.py
+++ b/src/Mod/Fem/femsolver/elmer/equations/nonlinear.py
@@ -76,8 +76,8 @@ class Proxy(linear.Proxy):
             )
         )
 
-        obj.NonlinearIterations = (500, 1, int(1e6), 10)
-        obj.NonlinearNewtonAfterIterations = (3, 1, 100, 1)
+        obj.NonlinearIterations = (20, 1, int(1e6), 10)
+        obj.NonlinearNewtonAfterIterations = (3, 1, 500, 1)
         # for small numbers we must set an expression because we don't have a UI,
         # the user has to view and edit the tolerance via the property editor and
         # this does not yet allow to view and edit small numbers in scientific notation

--- a/src/Mod/Fem/femsolver/elmer/sifio.py
+++ b/src/Mod/Fem/femsolver/elmer/sifio.py
@@ -364,7 +364,7 @@ class _Writer(object):
                 attrType = _TYPE_VARIABLE
         if attrType is not _TYPE_VARIABLE:
             self._stream.write(attrType)
-        self._stream.write(_WHITESPACE)
+            self._stream.write(_WHITESPACE)
         output = self._preprocess(data, type(data))
         # in case of a variable the output must be without the quatoation marks
         if attrType is _TYPE_VARIABLE:

--- a/src/Mod/Fem/femtaskpanels/task_constraint_flowvelocity.py
+++ b/src/Mod/Fem/femtaskpanels/task_constraint_flowvelocity.py
@@ -1,5 +1,6 @@
 # ***************************************************************************
 # *   Copyright (c) 2017 Markus Hovorka <m.hovorka@live.de>                 *
+# *   Copyright (c) 2023 Uwe Stöhr <uwestoehr@lyx.org>                      *
 # *                                                                         *
 # *   This file is part of the FreeCAD CAx development system.              *
 # *                                                                         *
@@ -22,7 +23,7 @@
 # ***************************************************************************
 
 __title__ = "FreeCAD FEM constraint flow velocity task panel for the document object"
-__author__ = "Markus Hovorka, Bernd Hahnebach"
+__author__ = "Markus Hovorka, Bernd Hahnebach, Uwe Stöhr"
 __url__ = "https://www.freecadweb.org"
 
 ## @package task_constraint_flowvelocity


### PR DESCRIPTION
- fix whitespace in the SIF writer
- Elmer GUI uses only 20 nonlinear iterations, so we should do the same (500 were also not sensible)
- don't restrict nonlinear-Newton iterations to 100, 500 might be necessary for turbulent flow
- update author