### PR TITLE
PartDesign: Fillet, Chamfer, Draft, Thickness rework.

### DIFF
--- a/src/Mod/PartDesign/App/FeatureChamfer.cpp
+++ b/src/Mod/PartDesign/App/FeatureChamfer.cpp
@@ -109,7 +109,8 @@ App::DocumentObjectExecReturn *Chamfer::execute()
     Part::TopoShape TopShape;
     try {
         TopShape = getBaseShape();
-    } catch (Base::Exception& e) {
+    }
+    catch (Base::Exception& e) {
         return new App::DocumentObjectExecReturn(e.what());
     }
 
@@ -130,9 +131,6 @@ App::DocumentObjectExecReturn *Chamfer::execute()
 
     getContinuousEdges(TopShape, SubNames, FaceNames);
 
-    if (SubNames.empty())
-        return new App::DocumentObjectExecReturn("No edges specified");
-
     const int chamferType = ChamferType.getValue();
     const double size = Size.getValue();
     const double size2 = Size2.getValue();
@@ -145,6 +143,13 @@ App::DocumentObjectExecReturn *Chamfer::execute()
     }
 
     this->positionByBaseFeature();
+
+    //If no element is selected, then we use a copy of previous feature.
+    if (SubNames.empty()) {
+        this->Shape.setValue(TopShape);
+        return App::DocumentObject::StdReturn;
+    }
+
     // create an untransformed copy of the basefeature shape
     Part::TopoShape baseShape(TopShape);
     baseShape.setTransform(Base::Matrix4D());

--- a/src/Mod/PartDesign/App/FeatureDraft.cpp
+++ b/src/Mod/PartDesign/App/FeatureDraft.cpp
@@ -102,15 +102,21 @@ App::DocumentObjectExecReturn *Draft::execute()
     Part::TopoShape TopShape;
     try {
         TopShape = getBaseShape();
-    } catch (Base::Exception& e) {
+    }
+    catch (Base::Exception& e) {
         return new App::DocumentObjectExecReturn(e.what());
     }
 
     // Faces where draft should be applied
     // Note: Cannot be const reference currently because of BRepOffsetAPI_DraftAngle::Remove() bug, see below
     std::vector<std::string> SubVals = Base.getSubValuesStartsWith("Face");
-    if (SubVals.empty())
-        return new App::DocumentObjectExecReturn("No faces specified");
+
+    //If no element is selected, then we use a copy of previous feature.
+    if (SubVals.empty()) {
+        this->positionByBaseFeature();
+        this->Shape.setValue(TopShape);
+        return App::DocumentObject::StdReturn;
+    }
 
     // Draft angle
     double angle = Base::toRadians(Angle.getValue());

--- a/src/Mod/PartDesign/App/FeatureFillet.cpp
+++ b/src/Mod/PartDesign/App/FeatureFillet.cpp
@@ -68,7 +68,8 @@ App::DocumentObjectExecReturn *Fillet::execute()
     Part::TopoShape TopShape;
     try {
         TopShape = getBaseShape();
-    } catch (Base::Exception& e) {
+    }
+    catch (Base::Exception& e) {
         return new App::DocumentObjectExecReturn(e.what());
     }
     std::vector<std::string> SubNames = std::vector<std::string>(Base.getSubValues());
@@ -86,15 +87,18 @@ App::DocumentObjectExecReturn *Fillet::execute()
 
     getContinuousEdges(TopShape, SubNames);
 
-    if (SubNames.empty())
-        return new App::DocumentObjectExecReturn("Fillet not possible on selected shapes");
-
     double radius = Radius.getValue();
 
     if(radius <= 0)
         return new App::DocumentObjectExecReturn("Fillet radius must be greater than zero");
 
     this->positionByBaseFeature();
+
+    //If no element is selected, then we use a copy of previous feature.
+    if (SubNames.empty()) {
+        this->Shape.setValue(TopShape);
+        return App::DocumentObject::StdReturn;
+    }
 
     // create an untransformed copy of the base shape
     Part::TopoShape baseShape(TopShape);

--- a/src/Mod/PartDesign/App/FeatureThickness.cpp
+++ b/src/Mod/PartDesign/App/FeatureThickness.cpp
@@ -76,9 +76,15 @@ App::DocumentObjectExecReturn *Thickness::execute()
 
     //If no element is selected, then we use a copy of previous feature.
     if (subStrings.empty()) {
+        //We must set the placement of the feature in case it's empty.
+        this->positionByBaseFeature();
         this->Shape.setValue(TopShape);
         return App::DocumentObject::StdReturn;
     }
+
+    /* If the feature was empty at some point, then Placement was set by positionByBaseFeature.
+    *  However makeThickSolid apparantly requires the placement to be empty, so we have to clear it*/
+    this->Placement.setValue(Base::Placement());
 
     TopTools_ListOfShape closingFaces;
 

--- a/src/Mod/PartDesign/App/FeatureThickness.cpp
+++ b/src/Mod/PartDesign/App/FeatureThickness.cpp
@@ -72,8 +72,16 @@ App::DocumentObjectExecReturn *Thickness::execute()
         return new App::DocumentObjectExecReturn(e.what());
     }
 
-    TopTools_ListOfShape closingFaces;
     const std::vector<std::string>& subStrings = Base.getSubValues();
+
+    //If no element is selected, then we use a copy of previous feature.
+    if (subStrings.empty()) {
+        this->Shape.setValue(TopShape);
+        return App::DocumentObject::StdReturn;
+    }
+
+    TopTools_ListOfShape closingFaces;
+
     for (std::vector<std::string>::const_iterator it = subStrings.begin(); it != subStrings.end(); ++it) {
         TopoDS_Face face = TopoDS::Face(TopShape.getSubShape(it->c_str()));
         closingFaces.Append(face);

--- a/src/Mod/PartDesign/App/FeatureThickness.cpp
+++ b/src/Mod/PartDesign/App/FeatureThickness.cpp
@@ -83,7 +83,7 @@ App::DocumentObjectExecReturn *Thickness::execute()
     }
 
     /* If the feature was empty at some point, then Placement was set by positionByBaseFeature.
-    *  However makeThickSolid apparantly requires the placement to be empty, so we have to clear it*/
+    *  However makeThickSolid apparently requires the placement to be empty, so we have to clear it*/
     this->Placement.setValue(Base::Placement());
 
     TopTools_ListOfShape closingFaces;

--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -1766,7 +1766,7 @@ void CmdPartDesignDraft::activated(int iMsg)
         size_t i = 0;
         while (i < SubNames.size())
         {
-            std::string aSubName = static_cast<std::string>(SubNames.at(i));
+            std::string aSubName = SubNames.at(i);
 
             if (aSubName.compare(0, 4, "Face") == 0) {
                 // Check for valid face types
@@ -1833,7 +1833,7 @@ void CmdPartDesignThickness::activated(int iMsg)
         size_t i = 0;
         while (i < SubNames.size())
         {
-            std::string aSubName = static_cast<std::string>(SubNames.at(i));
+            std::string aSubName = SubNames.at(i);
 
             if (aSubName.compare(0, 4, "Face") != 0) {
                 // empty name or any other sub-element

--- a/src/Mod/PartDesign/Gui/TaskChamferParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskChamferParameters.cpp
@@ -175,7 +175,7 @@ void TaskChamferParameters::onCheckBoxUseAllEdgesToggled(bool checked)
 void TaskChamferParameters::setButtons(const selectionModes mode)
 {
     ui->buttonRefSel->setChecked(mode == refSel);
-    ui->buttonRefSel->setText(mode == refSel ? tr("End selection") : tr("Start selection"));
+    ui->buttonRefSel->setText(mode == refSel ? btnPreviewStr : btnSelectStr);
 }
 
 void TaskChamferParameters::onRefDeleted()

--- a/src/Mod/PartDesign/Gui/TaskChamferParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskChamferParameters.cpp
@@ -318,6 +318,10 @@ void TaskChamferParameters::apply()
             ui->chamferAngle->apply();
             break;
     }
+
+    //Alert user if he created an empty feature
+    if (ui->listWidgetReferences->count() == 0)
+        Base::Console().Warning(tr("Empty chamfer created !\n").toStdString().c_str());
 }
 
 //**************************************************************************

--- a/src/Mod/PartDesign/Gui/TaskChamferParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskChamferParameters.h
@@ -55,7 +55,7 @@ private Q_SLOTS:
     void onCheckBoxUseAllEdgesToggled(bool checked);
 
 protected:
-    void clearButtons(const selectionModes notThis) override;
+    void setButtons(const selectionModes mode) override;
     bool event(QEvent *e) override;
     void changeEvent(QEvent *e) override;
     void onSelectionChanged(const Gui::SelectionChanges& msg) override;

--- a/src/Mod/PartDesign/Gui/TaskChamferParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskChamferParameters.ui
@@ -21,7 +21,7 @@
 click again to end selection</string>
      </property>
      <property name="text">
-      <string>Select</string>
+      <string>Enter selection</string>
      </property>
      <property name="checkable">
       <bool>true</bool>

--- a/src/Mod/PartDesign/Gui/TaskChamferParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskChamferParameters.ui
@@ -21,7 +21,7 @@
 click again to end selection</string>
      </property>
      <property name="text">
-      <string>Enter selection</string>
+      <string>Select</string>
      </property>
      <property name="checkable">
       <bool>true</bool>

--- a/src/Mod/PartDesign/Gui/TaskChamferParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskChamferParameters.ui
@@ -15,36 +15,18 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QToolButton" name="buttonRefAdd">
-       <property name="toolTip">
-        <string>Click button to enter selection mode,
+    <widget class="QToolButton" name="buttonRefSel">
+     <property name="toolTip">
+      <string>Click button to enter selection mode,
 click again to end selection</string>
-       </property>
-       <property name="text">
-        <string>Add</string>
-       </property>
-       <property name="checkable">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QToolButton" name="buttonRefRemove">
-       <property name="toolTip">
-        <string>Click button to enter selection mode,
-click again to end selection</string>
-       </property>
-       <property name="text">
-        <string>Remove</string>
-       </property>
-       <property name="checkable">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-    </layout>
+     </property>
+     <property name="text">
+      <string>Select</string>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+    </widget>
    </item>
    <item>
     <widget class="QListWidget" name="listWidgetReferences">

--- a/src/Mod/PartDesign/Gui/TaskDraftParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskDraftParameters.cpp
@@ -165,7 +165,7 @@ void TaskDraftParameters::onSelectionChanged(const Gui::SelectionChanges& msg)
 
 void TaskDraftParameters::setButtons(const selectionModes mode)
 {
-    ui->buttonRefSel->setText(mode == refSel ? tr("End selection") : tr("Start selection"));
+    ui->buttonRefSel->setText(mode == refSel ? btnPreviewStr : btnSelectStr);
     ui->buttonRefSel->setChecked(mode == refSel);
     ui->buttonLine->setChecked(mode == line);
     ui->buttonPlane->setChecked(mode == plane);

--- a/src/Mod/PartDesign/Gui/TaskDraftParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskDraftParameters.cpp
@@ -275,6 +275,14 @@ void TaskDraftParameters::changeEvent(QEvent *e)
     }
 }
 
+void TaskDraftParameters::apply()
+{
+    //Alert user if he created an empty feature
+    if (ui->listWidgetReferences->count() == 0)
+        Base::Console().Warning(tr("Empty draft created !\n").toStdString().c_str());
+
+    TaskDressUpParameters::apply();
+}
 
 //**************************************************************************
 //**************************************************************************
@@ -311,6 +319,8 @@ bool TaskDlgDraftParameters::accept()
     auto tobj = vp->getObject();
     if (!tobj->isError())
         parameter->showObject();
+
+    parameter->apply();
 
     std::vector<std::string> strings;
     App::DocumentObject* obj;

--- a/src/Mod/PartDesign/Gui/TaskDraftParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskDraftParameters.h
@@ -40,6 +40,8 @@ public:
     explicit TaskDraftParameters(ViewProviderDressUp *DressUpView, QWidget *parent=nullptr);
     ~TaskDraftParameters() override;
 
+    void apply() override;
+
     double getAngle() const;
     bool getReversed() const;
     const std::vector<std::string> getFaces() const;

--- a/src/Mod/PartDesign/Gui/TaskDraftParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskDraftParameters.h
@@ -54,7 +54,7 @@ private Q_SLOTS:
     void onRefDeleted() override;
 
 protected:
-    void clearButtons(const selectionModes notThis) override;
+    void setButtons(const selectionModes mode) override;
     bool event(QEvent *e) override;
     void changeEvent(QEvent *e) override;
     void onSelectionChanged(const Gui::SelectionChanges& msg) override;

--- a/src/Mod/PartDesign/Gui/TaskDraftParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskDraftParameters.ui
@@ -15,36 +15,19 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QToolButton" name="buttonRefAdd">
-       <property name="toolTip">
-        <string>Click button to enter selection mode,
+
+    <widget class="QToolButton" name="buttonRefSel">
+     <property name="toolTip">
+      <string>Click button to enter selection mode,
 click again to end selection</string>
-       </property>
-       <property name="text">
-        <string>Add face</string>
-       </property>
-       <property name="checkable">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QToolButton" name="buttonRefRemove">
-       <property name="toolTip">
-        <string>Click button to enter selection mode,
-click again to end selection</string>
-       </property>
-       <property name="text">
-        <string>Remove face</string>
-       </property>
-       <property name="checkable">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-    </layout>
+     </property>
+     <property name="text">
+      <string>Select face</string>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+    </widget>
    </item>
    <item>
     <widget class="QListWidget" name="listWidgetReferences">

--- a/src/Mod/PartDesign/Gui/TaskDraftParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskDraftParameters.ui
@@ -22,7 +22,7 @@
 click again to end selection</string>
      </property>
      <property name="text">
-      <string>Enter selection</string>
+      <string>Select</string>
      </property>
      <property name="checkable">
       <bool>true</bool>

--- a/src/Mod/PartDesign/Gui/TaskDraftParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskDraftParameters.ui
@@ -22,7 +22,7 @@
 click again to end selection</string>
      </property>
      <property name="text">
-      <string>Select face</string>
+      <string>Enter selection</string>
      </property>
      <property name="checkable">
       <bool>true</bool>

--- a/src/Mod/PartDesign/Gui/TaskDressUpParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskDressUpParameters.cpp
@@ -51,6 +51,9 @@ FC_LOG_LEVEL_INIT("PartDesign",true,true)
 using namespace PartDesignGui;
 using namespace Gui;
 
+const QString TaskDressUpParameters::btnPreviewStr = tr("Preview");
+const QString TaskDressUpParameters::btnSelectStr = tr("Select");
+
 /* TRANSLATOR PartDesignGui::TaskDressUpParameters */
 
 TaskDressUpParameters::TaskDressUpParameters(ViewProviderDressUp *DressUpView, bool selectEdges, bool selectFaces, QWidget *parent)

--- a/src/Mod/PartDesign/Gui/TaskDressUpParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskDressUpParameters.h
@@ -25,6 +25,7 @@
 #define GUI_TASKVIEW_TaskDressUpParameters_H
 
 #include <Gui/TaskView/TaskView.h>
+#include <Mod/PartDesign/App/FeatureDressUp.h>
 
 #include "TaskFeatureParameters.h"
 #include "ViewProviderDressUp.h"
@@ -72,17 +73,19 @@ protected Q_SLOTS:
     void createAddAllEdgesAction(QListWidget* parentList);
 
 protected:
-    void exitSelectionMode();
-    bool referenceSelected(const Gui::SelectionChanges& msg);
+    void referenceSelected(const Gui::SelectionChanges& msg, QListWidget* widget);
     bool wasDoubleClicked = false;
     bool KeyEvent(QEvent *e);
     void hideOnError();
     void addAllEdges(QListWidget* listWidget);
+    void deleteRef(QListWidget* listWidget);
+    void updateFeature(PartDesign::DressUp* pcDressUp, const std::vector<std::string>& refs);
 
 protected:
     enum selectionModes { none, refSel, plane, line };
-    virtual void clearButtons(const selectionModes notThis) = 0;
-    static bool removeItemFromListWidget(QListWidget* widget, const char* itemstr);
+    void setSelectionMode(selectionModes mode);
+    virtual void setButtons(const selectionModes mode) = 0;
+    static void removeItemFromListWidget(QListWidget* widget, const char* itemstr);
 
     ViewProviderDressUp* getDressUpView() const
     { return DressUpView; }

--- a/src/Mod/PartDesign/Gui/TaskDressUpParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskDressUpParameters.h
@@ -99,6 +99,9 @@ protected:
     bool allowFaces, allowEdges;
     selectionModes selectionMode;
     int transactionID;
+
+    static const QString btnPreviewStr;
+    static const QString btnSelectStr;
 };
 
 /// simulation dialog for the TaskView

--- a/src/Mod/PartDesign/Gui/TaskDressUpParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskDressUpParameters.h
@@ -63,13 +63,12 @@ public:
     }
 
 protected Q_SLOTS:
-    void onButtonRefAdd(const bool checked);
-    void onButtonRefRemove(const bool checked);
+    void onButtonRefSel(const bool checked);
     void doubleClicked(QListWidgetItem* item);
     void setSelection(QListWidgetItem* current);
     void itemClickedTimeout();
     virtual void onRefDeleted(void) = 0;
-    void createDeleteAction(QListWidget* parentList, QWidget* parentButton);
+    void createDeleteAction(QListWidget* parentList);
     void createAddAllEdgesAction(QListWidget* parentList);
 
 protected:
@@ -81,9 +80,9 @@ protected:
     void addAllEdges(QListWidget* listWidget);
 
 protected:
-    enum selectionModes { none, refAdd, refRemove, plane, line };
+    enum selectionModes { none, refSel, plane, line };
     virtual void clearButtons(const selectionModes notThis) = 0;
-    static void removeItemFromListWidget(QListWidget* widget, const char* itemstr);
+    static bool removeItemFromListWidget(QListWidget* widget, const char* itemstr);
 
     ViewProviderDressUp* getDressUpView() const
     { return DressUpView; }

--- a/src/Mod/PartDesign/Gui/TaskFilletParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskFilletParameters.cpp
@@ -128,7 +128,7 @@ void TaskFilletParameters::onCheckBoxUseAllEdgesToggled(bool checked)
 void TaskFilletParameters::setButtons(const selectionModes mode)
 {
     ui->buttonRefSel->setChecked(mode == refSel);
-    ui->buttonRefSel->setText(mode == refSel ? tr("End selection") : tr("Start selection"));
+    ui->buttonRefSel->setText(mode == refSel ? btnPreviewStr : btnSelectStr);
 }
 
 void TaskFilletParameters::onRefDeleted()

--- a/src/Mod/PartDesign/Gui/TaskFilletParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskFilletParameters.cpp
@@ -52,7 +52,6 @@ TaskFilletParameters::TaskFilletParameters(ViewProviderDressUp *DressUpView, QWi
     // we need a separate container widget to add all controls to
     proxy = new QWidget(this);
     ui->setupUi(proxy);
-
     this->groupLayout()->addWidget(proxy);
 
     PartDesign::Fillet* pcFillet = static_cast<PartDesign::Fillet*>(DressUpView->getObject());
@@ -97,8 +96,10 @@ TaskFilletParameters::TaskFilletParameters(ViewProviderDressUp *DressUpView, QWi
     connect(ui->listWidgetReferences, &QListWidget::itemDoubleClicked,
         this, &TaskFilletParameters::doubleClicked);
 
-    // the dialog can be called on a broken fillet, then hide the fillet
-    hideOnError();
+    if (strings.size() == 0)
+        setSelectionMode(refSel);
+    else
+        hideOnError();
 }
 
 void TaskFilletParameters::onSelectionChanged(const Gui::SelectionChanges& msg)
@@ -106,40 +107,17 @@ void TaskFilletParameters::onSelectionChanged(const Gui::SelectionChanges& msg)
     // executed when the user selected something in the CAD object
     // adds/deletes the selection accordingly
 
-    if (selectionMode == none)
-        return;
-
     if (msg.Type == Gui::SelectionChanges::AddSelection) {
-        if (referenceSelected(msg)) {
-            // Clear selection.
-            Gui::Selection().clearSelection();
-
-            if (removeItemFromListWidget(ui->listWidgetReferences, msg.pSubName)) {
-                // if there is only one item left, it cannot be deleted
-                if (ui->listWidgetReferences->count() == 1) {
-                    deleteAction->setEnabled(false);
-                    deleteAction->setStatusTip(tr("There must be at least one item"));
-                    // we must also end the selection mode
-                    exitSelectionMode();
-                    clearButtons(none);
-                }
-            }
-            else {
-                ui->listWidgetReferences->addItem(QString::fromStdString(msg.pSubName));
-                // it might be the second one so we can enable the context menu
-                if (ui->listWidgetReferences->count() > 1) {
-                    deleteAction->setEnabled(true);
-                    deleteAction->setStatusTip(QString());
-                }
-            }
-            // highlight existing references for possible further selections
-            DressUpView->highlightReferences(true);
+        if (selectionMode == refSel) {
+            referenceSelected(msg, ui->listWidgetReferences);
         }
     }
 }
 
 void TaskFilletParameters::onCheckBoxUseAllEdgesToggled(bool checked)
 {
+    if (checked)
+        setSelectionMode(none);
     PartDesign::Fillet* pcFillet = static_cast<PartDesign::Fillet*>(DressUpView->getObject());
     ui->buttonRefSel->setEnabled(!checked);
     ui->listWidgetReferences->setEnabled(!checked);
@@ -147,60 +125,15 @@ void TaskFilletParameters::onCheckBoxUseAllEdgesToggled(bool checked)
     pcFillet->getDocument()->recomputeFeature(pcFillet);
 }
 
-void TaskFilletParameters::clearButtons(const selectionModes notThis)
+void TaskFilletParameters::setButtons(const selectionModes mode)
 {
-    if (notThis != refSel) ui->buttonRefSel->setChecked(false);
-    DressUpView->highlightReferences(false);
+    ui->buttonRefSel->setChecked(mode == refSel);
+    ui->buttonRefSel->setText(mode == refSel ? tr("End selection") : tr("Start selection"));
 }
 
 void TaskFilletParameters::onRefDeleted()
 {
-    // assure we we are not in selection mode
-    exitSelectionMode();
-    clearButtons(none);
-    // delete any selections since the reference(s) might be highlighted
-    Gui::Selection().clearSelection();
-    DressUpView->highlightReferences(false);
-
-    // get the list of items to be deleted
-    QList<QListWidgetItem*> selectedList = ui->listWidgetReferences->selectedItems();
-
-    // if all items are selected, we must stop because one must be kept to avoid that the feature gets broken
-    if (selectedList.count() == ui->listWidgetReferences->model()->rowCount()){
-        QMessageBox::warning(this, tr("Selection error"), tr("At least one item must be kept."));
-        return;
-    }
-
-    // get the fillet object
-    PartDesign::Fillet* pcFillet = static_cast<PartDesign::Fillet*>(DressUpView->getObject());
-    App::DocumentObject* base = pcFillet->Base.getValue();
-    // get all fillet references
-    std::vector<std::string> refs = pcFillet->Base.getSubValues();
-    setupTransaction();
-
-    // delete the selection backwards to assure the list index keeps valid for the deletion
-    for (int i = selectedList.count()-1; i > -1; i--) {
-        // the ref index is the same as the listWidgetReferences index
-        // so we can erase using the row number of the element to be deleted
-        int rowNumber = ui->listWidgetReferences->row(selectedList.at(i));
-        // erase the reference
-        refs.erase(refs.begin() + rowNumber);
-        // remove from the list
-        ui->listWidgetReferences->model()->removeRow(rowNumber);
-    }
-
-    // update the object
-    pcFillet->Base.setValue(base, refs);
-    // recompute the feature
-    pcFillet->recomputeFeature();
-    // hide the fillet if there was a computation error
-    hideOnError();
-
-    // if there is only one item left, it cannot be deleted
-    if (ui->listWidgetReferences->count() == 1) {
-        deleteAction->setEnabled(false);
-        deleteAction->setStatusTip(tr("There must be at least one item"));
-    }
+    TaskDressUpParameters::deleteRef(ui->listWidgetReferences);
 }
 
 void TaskFilletParameters::onAddAllEdges()
@@ -210,7 +143,7 @@ void TaskFilletParameters::onAddAllEdges()
 
 void TaskFilletParameters::onLengthChanged(double len)
 {
-    clearButtons(none);
+    setSelectionMode(none);
     PartDesign::Fillet* pcFillet = static_cast<PartDesign::Fillet*>(DressUpView->getObject());
     setupTransaction();
     pcFillet->Radius.setValue(len);

--- a/src/Mod/PartDesign/Gui/TaskFilletParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskFilletParameters.cpp
@@ -188,6 +188,10 @@ void TaskFilletParameters::apply()
 
     //Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Fillet changed"));
     ui->filletRadius->apply();
+
+    //Alert user if he created an empty feature
+    if(ui->listWidgetReferences->count() == 0)
+        Base::Console().Warning(tr("Empty fillet created !\n").toStdString().c_str());
 }
 
 //**************************************************************************

--- a/src/Mod/PartDesign/Gui/TaskFilletParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskFilletParameters.h
@@ -49,7 +49,7 @@ private Q_SLOTS:
 
 protected:
     double getLength() const;
-    void clearButtons(const selectionModes notThis) override;
+    void setButtons(const selectionModes mode) override;
     bool event(QEvent *e) override;
     void changeEvent(QEvent *e) override;
     void onSelectionChanged(const Gui::SelectionChanges& msg) override;

--- a/src/Mod/PartDesign/Gui/TaskFilletParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskFilletParameters.ui
@@ -21,7 +21,7 @@
 click again to end selection</string>
      </property>
      <property name="text">
-      <string>Select</string>
+      <string>Enter selection</string>
      </property>
      <property name="checkable">
       <bool>true</bool>

--- a/src/Mod/PartDesign/Gui/TaskFilletParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskFilletParameters.ui
@@ -21,7 +21,7 @@
 click again to end selection</string>
      </property>
      <property name="text">
-      <string>Enter selection</string>
+      <string>Select</string>
      </property>
      <property name="checkable">
       <bool>true</bool>

--- a/src/Mod/PartDesign/Gui/TaskFilletParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskFilletParameters.ui
@@ -15,36 +15,18 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QToolButton" name="buttonRefAdd">
-       <property name="toolTip">
-        <string>Click button to enter selection mode,
+    <widget class="QToolButton" name="buttonRefSel">
+     <property name="toolTip">
+      <string>Click button to enter selection mode,
 click again to end selection</string>
-       </property>
-       <property name="text">
-        <string>Add</string>
-       </property>
-       <property name="checkable">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QToolButton" name="buttonRefRemove">
-       <property name="toolTip">
-        <string>Click button to enter selection mode,
-click again to end selection</string>
-       </property>
-       <property name="text">
-        <string>Remove</string>
-       </property>
-       <property name="checkable">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-    </layout>
+     </property>
+     <property name="text">
+      <string>Select</string>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+    </widget>
    </item>
    <item>
     <widget class="QListWidget" name="listWidgetReferences">

--- a/src/Mod/PartDesign/Gui/TaskThicknessParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskThicknessParameters.cpp
@@ -131,7 +131,7 @@ void TaskThicknessParameters::onSelectionChanged(const Gui::SelectionChanges& ms
 void TaskThicknessParameters::setButtons(const selectionModes mode)
 {
     ui->buttonRefSel->setChecked(mode == refSel);
-    ui->buttonRefSel->setText(mode == refSel ? tr("End selection") : tr("Start selection"));
+    ui->buttonRefSel->setText(mode == refSel ? btnPreviewStr : btnSelectStr);
 }
 
 void TaskThicknessParameters::onRefDeleted(void)

--- a/src/Mod/PartDesign/Gui/TaskThicknessParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskThicknessParameters.cpp
@@ -110,8 +110,10 @@ TaskThicknessParameters::TaskThicknessParameters(ViewProviderDressUp *DressUpVie
     int join = pcThickness->Join.getValue();
     ui->joinComboBox->setCurrentIndex(join);
 
-    // the dialog can be called on a broken thickness, then hide the thickness
-    hideOnError();
+    if (strings.size() == 0)
+        setSelectionMode(refSel);
+    else
+        hideOnError();
 }
 
 void TaskThicknessParameters::onSelectionChanged(const Gui::SelectionChanges& msg)
@@ -119,97 +121,27 @@ void TaskThicknessParameters::onSelectionChanged(const Gui::SelectionChanges& ms
     // executed when the user selected something in the CAD object
     // adds/deletes the selection accordingly
 
-    if (selectionMode == none)
-        return;
-
     if (msg.Type == Gui::SelectionChanges::AddSelection) {
-        if (referenceSelected(msg)) {
-            // Clear selection.
-            Gui::Selection().clearSelection();
-
-            if (removeItemFromListWidget(ui->listWidgetReferences, msg.pSubName)) {
-                // if there is only one item left, it cannot be deleted
-                if (ui->listWidgetReferences->count() == 1) {
-                    deleteAction->setEnabled(false);
-                    deleteAction->setStatusTip(tr("There must be at least one item"));
-                    // we must also end the selection mode
-                    exitSelectionMode();
-                    clearButtons(none);
-                }
-            }
-            else {
-                ui->listWidgetReferences->addItem(QString::fromStdString(msg.pSubName));
-                // it might be the second one so we can enable the context menu
-                if (ui->listWidgetReferences->count() > 1) {
-                    deleteAction->setEnabled(true);
-                    deleteAction->setStatusTip(QString());
-                }
-            }
-            // highlight existing references for possible further selections
-            DressUpView->highlightReferences(true);
+        if (selectionMode == refSel) {
+            referenceSelected(msg, ui->listWidgetReferences);
         }
     }
 }
 
-void TaskThicknessParameters::clearButtons(const selectionModes notThis)
+void TaskThicknessParameters::setButtons(const selectionModes mode)
 {
-    if (notThis != refSel) ui->buttonRefSel->setChecked(false);
-    DressUpView->highlightReferences(false);
+    ui->buttonRefSel->setChecked(mode == refSel);
+    ui->buttonRefSel->setText(mode == refSel ? tr("End selection") : tr("Start selection"));
 }
 
 void TaskThicknessParameters::onRefDeleted(void)
 {
-    // assure we we are not in selection mode
-    exitSelectionMode();
-    clearButtons(none);
-    // delete any selections since the reference(s) might be highlighted
-    Gui::Selection().clearSelection();
-    DressUpView->highlightReferences(false);
-
-    // get the list of items to be deleted
-    QList<QListWidgetItem*> selectedList = ui->listWidgetReferences->selectedItems();
-
-    // if all items are selected, we must stop because one must be kept to avoid that the feature gets broken
-    if (selectedList.count() == ui->listWidgetReferences->model()->rowCount()) {
-        QMessageBox::warning(this, tr("Selection error"), tr("At least one item must be kept."));
-        return;
-    }
-
-    // get the thickness object
-    PartDesign::Thickness* pcThickness = static_cast<PartDesign::Thickness*>(DressUpView->getObject());
-    App::DocumentObject* base = pcThickness->Base.getValue();
-    // get all thickness references
-    std::vector<std::string> refs = pcThickness->Base.getSubValues();
-    setupTransaction();
-
-    // delete the selection backwards to assure the list index keeps valid for the deletion
-    for (int i = selectedList.count() - 1; i > -1; i--) {
-        // the ref index is the same as the listWidgetReferences index
-        // so we can erase using the row number of the element to be deleted
-        int rowNumber = ui->listWidgetReferences->row(selectedList.at(i));
-        // erase the reference
-        refs.erase(refs.begin() + rowNumber);
-        // remove from the list
-        ui->listWidgetReferences->model()->removeRow(rowNumber);
-    }
-
-    // update the object
-    pcThickness->Base.setValue(base, refs);
-    // recompute the feature
-    pcThickness->recomputeFeature();
-    // hide the thickness if there was a computation error
-    hideOnError();
-
-    // if there is only one item left, it cannot be deleted
-    if (ui->listWidgetReferences->count() == 1) {
-        deleteAction->setEnabled(false);
-        deleteAction->setStatusTip(tr("There must be at least one item"));
-    }
+    TaskDressUpParameters::deleteRef(ui->listWidgetReferences);
 }
 
 void TaskThicknessParameters::onValueChanged(double angle)
 {
-    clearButtons(none);
+    setButtons(none);
     PartDesign::Thickness* pcThickness = static_cast<PartDesign::Thickness*>(DressUpView->getObject());
     setupTransaction();
     pcThickness->Value.setValue(angle);
@@ -220,7 +152,7 @@ void TaskThicknessParameters::onValueChanged(double angle)
 
 void TaskThicknessParameters::onJoinTypeChanged(int join) {
 
-    clearButtons(none);
+    setButtons(none);
     PartDesign::Thickness* pcThickness = static_cast<PartDesign::Thickness*>(DressUpView->getObject());
     setupTransaction();
     pcThickness->Join.setValue(join);
@@ -231,7 +163,7 @@ void TaskThicknessParameters::onJoinTypeChanged(int join) {
 
 void TaskThicknessParameters::onModeChanged(int mode) {
 
-    clearButtons(none);
+    setButtons(none);
     PartDesign::Thickness* pcThickness = static_cast<PartDesign::Thickness*>(DressUpView->getObject());
     setupTransaction();
     pcThickness->Mode.setValue(mode);
@@ -246,7 +178,7 @@ double TaskThicknessParameters::getValue(void) const
 }
 
 void TaskThicknessParameters::onReversedChanged(const bool on) {
-    clearButtons(none);
+    setButtons(none);
     PartDesign::Thickness* pcThickness = static_cast<PartDesign::Thickness*>(DressUpView->getObject());
     setupTransaction();
     pcThickness->Reversed.setValue(on);
@@ -261,7 +193,7 @@ bool TaskThicknessParameters::getReversed(void) const
 }
 
 void TaskThicknessParameters::onIntersectionChanged(const bool on) {
-    clearButtons(none);
+    setButtons(none);
     PartDesign::Thickness* pcThickness = static_cast<PartDesign::Thickness*>(DressUpView->getObject());
     pcThickness->Intersection.setValue(on);
     pcThickness->getDocument()->recomputeFeature(pcThickness);

--- a/src/Mod/PartDesign/Gui/TaskThicknessParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskThicknessParameters.cpp
@@ -241,6 +241,12 @@ void TaskThicknessParameters::changeEvent(QEvent *e)
     }
 }
 
+void TaskThicknessParameters::apply()
+{
+    //Alert user if he created an empty feature
+    if (ui->listWidgetReferences->count() == 0)
+        Base::Console().Warning(tr("Empty thickness created !\n").toStdString().c_str());
+}
 
 //**************************************************************************
 //**************************************************************************
@@ -282,6 +288,8 @@ bool TaskDlgThicknessParameters::accept()
     auto obj = vp->getObject();
     if (!obj->isError())
         parameter->showObject();
+
+    parameter->apply();
 
     TaskThicknessParameters* draftparameter = static_cast<TaskThicknessParameters*>(parameter);
 

--- a/src/Mod/PartDesign/Gui/TaskThicknessParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskThicknessParameters.h
@@ -39,6 +39,8 @@ public:
     explicit TaskThicknessParameters(ViewProviderDressUp *DressUpView, QWidget *parent=nullptr);
     ~TaskThicknessParameters() override;
 
+    void apply() override;
+
     double getValue(void) const;
     bool getReversed(void) const;
     bool getIntersection(void) const;

--- a/src/Mod/PartDesign/Gui/TaskThicknessParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskThicknessParameters.h
@@ -54,7 +54,7 @@ private Q_SLOTS:
     void onRefDeleted(void) override;
 
 protected:
-    void clearButtons(const selectionModes notThis) override;
+    void setButtons(const selectionModes mode) override;
     bool event(QEvent *e) override;
     void changeEvent(QEvent *e) override;
     void onSelectionChanged(const Gui::SelectionChanges& msg) override;

--- a/src/Mod/PartDesign/Gui/TaskThicknessParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskThicknessParameters.ui
@@ -21,7 +21,7 @@
 click again to end selection</string>
      </property>
      <property name="text">
-      <string>Start selection</string>
+      <string>Select</string>
      </property>
      <property name="checkable">
       <bool>true</bool>

--- a/src/Mod/PartDesign/Gui/TaskThicknessParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskThicknessParameters.ui
@@ -15,36 +15,18 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QToolButton" name="buttonRefAdd">
-       <property name="toolTip">
-        <string>Click button to enter selection mode,
+    <widget class="QToolButton" name="buttonRefSel">
+     <property name="toolTip">
+      <string>Click button to enter selection mode,
 click again to end selection</string>
-       </property>
-       <property name="text">
-        <string>Add face</string>
-       </property>
-       <property name="checkable">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QToolButton" name="buttonRefRemove">
-       <property name="toolTip">
-        <string>Click button to enter selection mode,
-click again to end selection</string>
-       </property>
-       <property name="text">
-        <string>Remove face</string>
-       </property>
-       <property name="checkable">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-    </layout>
+     </property>
+     <property name="text">
+      <string>Select face</string>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+    </widget>
    </item>
    <item>
     <widget class="QListWidget" name="listWidgetReferences">

--- a/src/Mod/PartDesign/Gui/TaskThicknessParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskThicknessParameters.ui
@@ -21,7 +21,7 @@
 click again to end selection</string>
      </property>
      <property name="text">
-      <string>Select face</string>
+      <string>Start selection</string>
      </property>
      <property name="checkable">
       <bool>true</bool>


### PR DESCRIPTION
For the tools Fillet, Chamfer, Draft, Thickness in PartDesign : 
- Merge Add and Remove in one button.
- Enable those features to be empty. This let us start the tool before selection.
- Refactor the code that had needless duplicates.
- Fix bug (fillet, click addAllEdges after having a face in the list. Then the list has more entries than the feature has references. So if you delete the last element of the list, crash.)

Issue : https://github.com/FreeCAD/FreeCAD/issues/8909

Forum Dicussion :
https://forum.freecad.org/viewtopic.php?t=76989&start=10

Video explanation : 
https://youtu.be/3mHUwT8-pwQ

Testers and reviewers welcome !


Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [x]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
