### PR TITLE
Fem: fix warning field 'dimension' will be initialized after field 'u…

### DIFF
--- a/src/Mod/Fem/Gui/TaskFemConstraintFluidBoundary.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintFluidBoundary.cpp
@@ -128,8 +128,8 @@ void initComboBox(QComboBox* combo, const std::vector<std::string>& textItems,
 TaskFemConstraintFluidBoundary::TaskFemConstraintFluidBoundary(
     ViewProviderFemConstraintFluidBoundary* ConstraintView, QWidget* parent)
     : TaskFemConstraintOnBoundary(ConstraintView, parent, "FEM_ConstraintFluidBoundary"),
-      dimension(-1),
-      ui(new Ui_TaskFemConstraintFluidBoundary)
+      ui(new Ui_TaskFemConstraintFluidBoundary),
+      dimension(-1)
 {
     // we need a separate container widget to add all controls to
     proxy = new QWidget(this);


### PR DESCRIPTION
…i' [-Wreorder-ctor]

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [ ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
