### PR TITLE
Addon Manager: Fixes #9001, icon was string

### DIFF
--- a/src/Mod/AddonManager/Addon.py
+++ b/src/Mod/AddonManager/Addon.py
@@ -188,7 +188,7 @@ class Addon:
         else:
             self.metadata_url = None
         self.metadata: Optional[Metadata] = None
-        self.icon = None  # Relative path to remote icon file
+        self.icon = None  # A QIcon version of this Addon's icon
         self.icon_file: str = ""  # Absolute local path to cached icon file
         self.best_icon_relative_path = ""
         self.macro = None  # Bridge to Gaël Écorchard's macro management class

--- a/src/Mod/AddonManager/addonmanager_workers_installation.py
+++ b/src/Mod/AddonManager/addonmanager_workers_installation.py
@@ -178,21 +178,7 @@ class UpdateMetadataCacheWorker(QtCore.QThread):
 
         # Grab a new copy of the icon as well: we couldn't enqueue this earlier because
         # we didn't know the path to it, which is stored in the package.xml file.
-        icon = metadata.icon
-        if not icon:
-            # If there is no icon set for the entire package, see if there are
-            # any workbenches, which are required to have icons, and grab the first
-            # one we find:
-            content = repo.metadata.content
-            if "workbench" in content:
-                wb = content["workbench"][0]
-                if wb.icon:
-                    if wb.subdirectory:
-                        subdir = wb.subdirectory
-                    else:
-                        subdir = wb.name
-                    repo.icon = subdir + wb.icon
-                    icon = repo.icon
+        icon = repo.get_best_icon_relative_path()
 
         icon_url = utils.construct_git_url(repo, icon)
         index = NetworkManager.AM_NETWORK_MANAGER.submit_unmonitored_get(icon_url)


### PR DESCRIPTION
Updates AddonManager to use the new `best_icon_relative_path` where it was missing. Fixes #9001.

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR