### PR TITLE
fix G98 retract height bug

### DIFF
--- a/src/Mod/Path/Path/Post/scripts/grbl_post.py
+++ b/src/Mod/Path/Path/Post/scripts/grbl_post.py
@@ -602,8 +602,10 @@ def drill_translate(outstring, cmd, params):
     global UNITS
     global UNIT_FORMAT
     global UNIT_SPEED_FORMAT
+    
 
     strFormat = "." + str(PRECISION) + "f"
+    strG0_Initial_Z=("G0 Z" + format(float(CURRENT_Z.getValueAs(UNIT_FORMAT)), strFormat) + "\n")
 
     trBuff = ""
 
@@ -630,8 +632,8 @@ def drill_translate(outstring, cmd, params):
         drill_Z += CURRENT_Z
         RETRACT_Z += CURRENT_Z
 
-    if DRILL_RETRACT_MODE == "G98" and CURRENT_Z >= RETRACT_Z:
-        RETRACT_Z = CURRENT_Z
+#    if DRILL_RETRACT_MODE == "G98" and CURRENT_Z >= RETRACT_Z:
+#        RETRACT_Z = CURRENT_Z
 
     # get the other parameters
     drill_feedrate = Units.Quantity(params["F"], FreeCAD.Units.Velocity)
@@ -726,7 +728,11 @@ def drill_translate(outstring, cmd, params):
                             + format(float(drill_Z.getValueAs(UNIT_FORMAT)), strFormat)
                             + strF_Feedrate
                         )
-                        trBuff += linenumber() + strG0_RETRACT_Z
+                        
+                        if DRILL_RETRACT_MODE == "G98" : 
+                            trBuff += (linenumber() + strG0_Initial_Z)
+                        else: 
+                            trBuff += (linenumber() + strG0_RETRACT_Z)
                         break
 
     except Exception as e:


### PR DESCRIPTION
grbl-post was not using the R value as retract height when expanding drilling cycles, instead always using CURRENT_Z on entry.  This is corrected and only sets the final pull  out to either CURRENT_Z or Z_retract according to G98 status.

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [x]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
