### PR TITLE
[Sketcher] Fix segmentation fault in ViewProviderSketch::setEdit

### DIFF
--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -2811,7 +2811,7 @@ bool ViewProviderSketch::setEdit(int ModNum)
         msgBox.setDefaultButton(QMessageBox::Yes);
         int ret = msgBox.exec();
         if (ret == QMessageBox::Yes)
-            Gui::Control().reject();
+            Gui::Control().closeDialog();
         else
             return false;
     }


### PR DESCRIPTION
If no one steps up to take on the challenge, then **xtemp09** will. This pull request closes #8979. The issue reported crash using _PartDesign_.

Turns out some dialogs use `Gui::Control().reject()` to close opened dialog while all other dialogs use `Gui::Control().closeDialog()`. Replacement the former with the latter prevents the segmentation fault caused by _Sketcher_. The crash does not occur with other workbenches.


---


**Note 1**. The crash occurs on all platforms, while the issue was reported on Linux Mint 20.3. I checked my patch on Ubuntu 22.04.

**Note 2**. Lurking for the culprit in the crash, I used valgrind. It reported 27 kB definitely lost, 30 kB indirectly lost and 608 kB possibly lost of memory leaks. Compilation with `-fvar-tracking -fsanitize=address,undefined` also reported some information.

---

<details><summary>Standard form</summary>





Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
</details>