### PR TITLE
Gui: fix failure of QMetaObject::connectSlotsByName

### DIFF
--- a/src/Gui/DlgEditorImp.cpp
+++ b/src/Gui/DlgEditorImp.cpp
@@ -88,6 +88,8 @@ DlgSettingsEditorImp::DlgSettingsEditorImp( QWidget* parent )
     ui->setupUi(this);
     ui->EnableFolding->hide(); // Switch off until we have an editor with folding
 
+    setupConnections();
+
 #if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
     ui->textEdit1->setTabStopWidth(40);
 #else
@@ -176,11 +178,30 @@ DlgSettingsEditorImp::~DlgSettingsEditorImp()
     delete d;
 }
 
+void DlgSettingsEditorImp::setupConnections()
+{
+    connect(ui->displayItems, &QTreeWidget::currentItemChanged,
+            this, &DlgSettingsEditorImp::onDisplayItemsCurrentItemChanged);
+    connect(ui->colorButton, &ColorButton::changed,
+            this, &DlgSettingsEditorImp::onColorButtonChanged);
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
+    connect(ui->fontFamily, qOverload<const QString&>(&QComboBox::activated),
+            this, &DlgSettingsEditorImp::onFontFamilyActivated);
+    connect(ui->fontSize, qOverload<const QString&>(&PrefSpinBox::valueChanged),
+            this, &DlgSettingsEditorImp::onFontSizeValueChanged);
+#else
+    connect(ui->fontFamily, &QComboBox::textActivated,
+            this, &DlgSettingsEditorImp::onFontFamilyActivated);
+    connect(ui->fontSize, &PrefSpinBox::textChanged,
+            this, &DlgSettingsEditorImp::onFontSizeValueChanged);
+#endif
+}
+
 /** Searches for the color value corresponding to \e name in current editor
  *   settings ColorMap and assigns it to the color button
  *  @see Gui::ColorButton
  */
-void DlgSettingsEditorImp::on_displayItems_currentItemChanged(QTreeWidgetItem *item)
+void DlgSettingsEditorImp::onDisplayItemsCurrentItemChanged(QTreeWidgetItem *item)
 {
     int index = ui->displayItems->indexOfTopLevelItem(item);
     unsigned int col = d->colormap[index].second;
@@ -188,7 +209,7 @@ void DlgSettingsEditorImp::on_displayItems_currentItemChanged(QTreeWidgetItem *i
 }
 
 /** Updates the color map if a color was changed */
-void DlgSettingsEditorImp::on_colorButton_changed()
+void DlgSettingsEditorImp::onColorButtonChanged()
 {
     QColor col = ui->colorButton->color();
     unsigned int lcol = App::Color::asPackedRGB<QColor>(col);
@@ -297,7 +318,7 @@ void DlgSettingsEditorImp::loadSettings()
     if (index < 0)
         index = 0;
     ui->fontFamily->setCurrentIndex(index);
-    on_fontFamily_activated(ui->fontFamily->currentText());
+    onFontFamilyActivated(ui->fontFamily->currentText());
     ui->displayItems->setCurrentItem(ui->displayItems->topLevelItem(0));
 }
 
@@ -316,16 +337,16 @@ void DlgSettingsEditorImp::changeEvent(QEvent *e)
     }
 }
 
-void DlgSettingsEditorImp::on_fontFamily_activated(const QString& fontFamily)
+void DlgSettingsEditorImp::onFontFamilyActivated(const QString& fontFamily)
 {
     int fontSize = ui->fontSize->value();
     QFont ft(fontFamily, fontSize);
     ui->textEdit1->setFont(ft);
 }
 
-void DlgSettingsEditorImp::on_fontSize_valueChanged(const QString&)
+void DlgSettingsEditorImp::onFontSizeValueChanged(const QString&)
 {
-    on_fontFamily_activated(ui->fontFamily->currentText());
+    onFontFamilyActivated(ui->fontFamily->currentText());
 }
 
 #include "moc_DlgEditorImp.cpp"

--- a/src/Gui/DlgEditorImp.h
+++ b/src/Gui/DlgEditorImp.h
@@ -52,11 +52,12 @@ public:
     void saveSettings() override;
     void loadSettings() override;
 
-protected Q_SLOTS:
-    void on_displayItems_currentItemChanged(QTreeWidgetItem *i);
-    void on_colorButton_changed();
-    void on_fontFamily_activated(const QString&);
-    void on_fontSize_valueChanged(const QString&);
+private:
+    void setupConnections();
+    void onDisplayItemsCurrentItemChanged(QTreeWidgetItem *i);
+    void onColorButtonChanged();
+    void onFontFamilyActivated(const QString&);
+    void onFontSizeValueChanged(const QString&);
 
 protected:
     void changeEvent(QEvent *e) override;


### PR DESCRIPTION
because in Qt6 QSpinBox::valueChanged(QString) and QComboBox::activated(QString) have been removed

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [ ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
