### PR TITLE
[FEM] Elmer: fix transient analyses

### DIFF
--- a/src/Mod/Fem/femsolver/elmer/solver.py
+++ b/src/Mod/Fem/femsolver/elmer/solver.py
@@ -101,10 +101,18 @@ class Proxy(solverbase.Proxy):
 
         obj.addProperty(
             "App::PropertyIntegerList",
+            "OutputIntervals",
+            "Timestepping",
+            "After how many time steps a result file is output"
+        )
+        obj.OutputIntervals = [1]
+
+        obj.addProperty(
+            "App::PropertyIntegerList",
             "TimestepIntervals",
             "Timestepping",
             (
-                "List of maximum optimization rounds if 'Simulation Type'\n"
+                "List of times if 'Simulation Type'\n"
                 "is either 'Scanning' or 'Transient'"
             )
         )
@@ -113,7 +121,7 @@ class Proxy(solverbase.Proxy):
             "TimestepSizes",
             "Timestepping",
             (
-                "List of time steps of optimization if 'Simulation Type'\n"
+                "List of time steps sizes if 'Simulation Type'\n"
                 "is either 'Scanning' or 'Transient'"
             )
         )

--- a/src/Mod/Fem/femsolver/elmer/writer.py
+++ b/src/Mod/Fem/femsolver/elmer/writer.py
@@ -326,8 +326,6 @@ class Writer(object):
         for equation in self.solver.Group:
             if femutils.is_of_type(equation, "Fem::EquationElmerHeat"):
                 hasHeat = True
-        if hasHeat:
-            self._simulation("BDF Order", self.solver.BDFOrder)
         self._simulation("Coordinate System", self.solver.CoordinateSystem)
         self._simulation("Coordinate Mapping", (1, 2, 3))
         # Elmer uses SI base units, but our mesh is in mm, therefore we must tell
@@ -348,11 +346,10 @@ class Writer(object):
             self.solver.SimulationType == "Scanning"
             or self.solver.SimulationType == "Transient"
         ):
+            self._simulation("BDF Order", self.solver.BDFOrder)
+            self._simulation("Output Intervals", self.solver.OutputIntervals)
             self._simulation("Timestep Intervals", self.solver.TimestepIntervals)
-            self._simulation("Timestep Sizes", self.solver.TimestepSizes)
-            # Output Intervals must be equal to Timestep Intervals
-            self._simulation("Output Intervals", self.solver.TimestepIntervals)
-        if hasHeat:
+            self._simulation("Timestep Sizes", self.solver.TimestepSizes) 
             self._simulation("Timestepping Method", "BDF")
         self._simulation("Use Mesh Names", True)
 
@@ -375,6 +372,14 @@ class Writer(object):
                 "Order of time stepping method 'BDF'"
             )
             solver.BDFOrder = (2, 1, 5, 1)
+        if not hasattr(self.solver, "OutputIntervals"):
+            solver.addProperty(
+                "App::PropertyIntegerList",
+                "OutputIntervals",
+                "Timestepping",
+                "After how many time steps a result file is output"
+            )
+            solver.OutputIntervals = [1]
         if not hasattr(self.solver, "SimulationType"):
             solver.addProperty(
                 "App::PropertyEnumeration",
@@ -809,9 +814,16 @@ class Writer(object):
         # To get it back in the original size we let Elmer scale it back
         s["Coordinate Scaling Revert"] = True
         s["Equation"] = "ResultOutput"
-        s["Exec Solver"] = "After simulation"
+        if (
+            self.solver.SimulationType == "Scanning"
+            or self.solver.SimulationType == "Transient"
+        ):
+            # we must execute the post solver every time we output a result
+            # therefore we must use the same as self.solver.OutputIntervals
+            s["Exec Intervals"] = self.solver.OutputIntervals
+        else:
+            s["Exec Solver"] = "After simulation"
         s["Procedure"] = sifio.FileAttr("ResultOutputSolve/ResultOutputSolver")
-        s["Output File Name"] = sifio.FileAttr("case")
         s["Vtu Format"] = True
         if self.unit_schema == Units.Scheme.SI2:
             s["Coordinate Scaling Revert"] = True


### PR DESCRIPTION
- different time results were never output, only the final one the reason is that the Output Intervals intervals property was missing
- a second reason was that the result scaling solver must be executed every time an output should be generated
- the BDF Order property is a transient-only property