### PR TITLE
Addon Manager: Fix tests breaking on second run

### DIFF
--- a/src/Mod/AddonManager/AddonManagerTest/app/test_metadata.py
+++ b/src/Mod/AddonManager/AddonManagerTest/app/test_metadata.py
@@ -249,14 +249,14 @@ class TestMetadataReader(unittest.TestCase):
     def setUp(self) -> None:
         if "xml.etree.ElementTree" in sys.modules:
             sys.modules.pop("xml.etree.ElementTree")
-        if "MetadataReader" in sys.modules:
-            sys.modules.pop("MetadataReader")
+        if "addonmanager_metadata" in sys.modules:
+            sys.modules.pop("addonmanager_metadata")
 
     def tearDown(self) -> None:
         if "xml.etree.ElementTree" in sys.modules:
             sys.modules.pop("xml.etree.ElementTree")
-        if "MetadataReader" in sys.modules:
-            sys.modules.pop("MetadataReader")
+        if "addonmanager_metadata" in sys.modules:
+            sys.modules.pop("addonmanager_metadata")
 
     def test_from_file(self):
         from addonmanager_metadata import MetadataReader


### PR DESCRIPTION
Correct the cleanup post-test.

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR