### PR TITLE
Fix encoding error for import from older DXF files

### DIFF
--- a/src/Mod/Import/App/dxf/dxf.cpp
+++ b/src/Mod/Import/App/dxf/dxf.cpp
@@ -3304,7 +3304,7 @@ bool CDxfRead::ReadVersion()
     if (found == last)
         m_version = RNewer;
     else if (*found == m_str)
-        m_version = (eAutoCADVersion_t)(std::distance(first, found) + (ROlder + 1));
+        m_version = (eDXFVersion_t)(std::distance(first, found) + (ROlder + 1));
     else if (found == first)
         m_version = ROlder;
     else

--- a/src/Mod/Import/App/dxf/dxf.h
+++ b/src/Mod/Import/App/dxf/dxf.h
@@ -118,6 +118,22 @@ struct LWPolyDataOut
     std::vector<double> Bulge;
     point3D Extr;
 };
+typedef enum
+{
+    RUnknown,
+    ROlder,
+    R10,
+    R11_12,
+    R13,
+    R14,
+    R2000,
+    R2004,
+    R2007,
+    R2010,
+    R2013,
+    R2018,
+    RNewer,
+} eAutoCADVersion_t;
 //********************
 
 class CDxfWrite{
@@ -277,6 +293,9 @@ private:
     bool ReadInsert();
     bool ReadDimension();
     bool ReadBlockInfo();
+    bool ReadVersion();
+    bool ReadDWGCodePage();
+    bool ResolveEncoding();
 
     void get_line();
     void put_line(const char *value);
@@ -284,6 +303,15 @@ private:
 
 protected:
     Aci_t m_aci; // manifest color name or 256 for layer color
+    eAutoCADVersion_t m_version;// Version from $ACADVER variable in DXF
+    const char* (CDxfRead::*stringToUTF8)(const char*) const;
+
+private:
+    const std::string* m_CodePage;     // Code Page name from $DWGCODEPAGE or null if none/not read yet
+    // The following was going to be python's canonical name for the encoding, but this is (a) not easily found and (b) does not speed up finding the encoding object.
+    const std::string* m_encoding;// A name for the encoding implied by m_version and m_CodePage
+    const char* UTF8ToUTF8(const char* encoded) const;
+    const char* GeneralToUTF8(const char* encoded) const;
 
 public:
     ImportExport CDxfRead(const char* filepath); // this opens the file

--- a/src/Mod/Import/App/dxf/dxf.h
+++ b/src/Mod/Import/App/dxf/dxf.h
@@ -133,7 +133,7 @@ typedef enum
     R2013,
     R2018,
     RNewer,
-} eAutoCADVersion_t;
+} eDXFVersion_t;
 //********************
 
 class CDxfWrite{
@@ -303,7 +303,7 @@ private:
 
 protected:
     Aci_t m_aci; // manifest color name or 256 for layer color
-    eAutoCADVersion_t m_version;// Version from $ACADVER variable in DXF
+    eDXFVersion_t m_version;// Version from $ACADVER variable in DXF
     const char* (CDxfRead::*stringToUTF8)(const char*) const;
 
 private:

--- a/src/Mod/Import/App/dxf/dxf.h
+++ b/src/Mod/Import/App/dxf/dxf.h
@@ -26,7 +26,7 @@
 #define HAVE_IOSTREAM
 #endif
 
-typedef int Aci_t; // AutoCAD color index
+typedef int ColorIndex_t; // DXF color index
 
 typedef enum
 {
@@ -272,8 +272,9 @@ private:
     bool m_ignore_errors;
 
 
-    typedef std::map< std::string,Aci_t > LayerAciMap_t;
-    LayerAciMap_t m_layer_aci;  // layer names -> layer color aci map
+    std::map<std::string,ColorIndex_t> m_layer_ColorIndex_map;  // Mapping from layer name -> layer color index
+    const ColorIndex_t ColorBylayer = 256;
+    const ColorIndex_t ColorByBlock = 0;
 
     bool ReadUnits();
     bool ReadLayer();
@@ -299,10 +300,10 @@ private:
 
     void get_line();
     void put_line(const char *value);
-    void DerefACI();
+    void ResolveColorIndex();
 
 protected:
-    Aci_t m_aci; // manifest color name or 256 for layer color
+    ColorIndex_t m_ColorIndex;
     eDXFVersion_t m_version;// Version from $ACADVER variable in DXF
     const char* (CDxfRead::*stringToUTF8)(const char*) const;
 


### PR DESCRIPTION
This addresses #8704 and replaces #8862 which I accidentally closed while trying to clean up.

The C++ importer incorrectly treated the contents of all TEXT and MTEXT objects as beind encoded as UTF-8, but this is not true for DXF files before AutoCAD 2007, where the encoding is "plain ASCII" plus some in-band \U+dddd encoding. This would cause errors if the text contained non-ASCII characters such as the Degree Sign.

This change causes the correct encoding to be used.

- [X ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR
