### PR TITLE
CI: remove trailing whitespace checks in Pylint

### DIFF
--- a/.github/workflows/sub_lint.yml
+++ b/.github/workflows/sub_lint.yml
@@ -93,7 +93,7 @@ on:
         type: boolean
         required: false
       pylintDisable:
-        default: disable=C0302
+        default: C0302,C0303 # Trailing whitespaces (C0303) are already checked
         type: string
         required: false
       pylintFailSilent:


### PR DESCRIPTION
 As they are already checked globally before