### PR TITLE
libE57Format: fix compile using gcc13

### DIFF
--- a/src/3rdParty/libE57Format/include/E57Format.h
+++ b/src/3rdParty/libE57Format/include/E57Format.h
@@ -33,6 +33,7 @@
 
 #include <cfloat>
 #include <memory>
+#include <cstdint>
 #include <vector>
 
 #include "E57Exception.h"


### PR DESCRIPTION
Adding missing header file. Also submitted this upstream here:

https://github.com/asmaloney/libE57Format/pull/243
