### PR TITLE
PartDesign: Patterns, return directly if occurrences is 1

### DIFF
--- a/src/Mod/PartDesign/App/FeatureLinearPattern.cpp
+++ b/src/Mod/PartDesign/App/FeatureLinearPattern.cpp
@@ -72,12 +72,16 @@ short LinearPattern::mustExecute() const
 
 const std::list<gp_Trsf> LinearPattern::getTransformations(const std::vector<App::DocumentObject*>)
 {
-    double distance = Length.getValue();
-    if (distance < Precision::Confusion())
-        throw Base::ValueError("Pattern length too small");
     int occurrences = Occurrences.getValue();
     if (occurrences < 1)
         throw Base::ValueError("At least one occurrence required");
+
+    if (occurrences == 1)
+        return {gp_Trsf()};
+
+    double distance = Length.getValue();
+    if (distance < Precision::Confusion())
+        throw Base::ValueError("Pattern length too small");
     bool reversed = Reversed.getValue();
 
     App::DocumentObject* refObject = Direction.getValue();
@@ -168,23 +172,20 @@ const std::list<gp_Trsf> LinearPattern::getTransformations(const std::vector<App
     TopLoc_Location invObjLoc = this->getLocation().Inverted();
     dir.Transform(invObjLoc.Transformation());
 
-    gp_Vec direction(dir.X(), dir.Y(), dir.Z());
-
+    gp_Vec offset(dir.X(), dir.Y(), dir.Z());
+    offset *= distance / (occurrences - 1);
     if (reversed)
-        direction.Reverse();
+        offset.Reverse();
 
-    // Note: The original feature is NOT included in the list of transformations! Therefore
-    // we start with occurrence number 1, not number 0
     std::list<gp_Trsf> transformations;
     gp_Trsf trans;
-    transformations.push_back(trans); // identity transformation
+    transformations.push_back(trans);
 
-    if (occurrences > 1) {
-        double offset = distance / (occurrences - 1);
-        for (int i = 1; i < occurrences; i++) {
-            trans.SetTranslation(direction * i * offset);
-            transformations.push_back(trans);
-        }
+    // Note: The original feature is already included in the list of transformations!
+    // Therefore we start with occurrence number 1
+    for (int i = 1; i < occurrences; i++) {
+        trans.SetTranslation(offset * i);
+        transformations.push_back(trans);
     }
 
     return transformations;

--- a/src/Mod/PartDesign/App/FeaturePolarPattern.cpp
+++ b/src/Mod/PartDesign/App/FeaturePolarPattern.cpp
@@ -73,22 +73,17 @@ short PolarPattern::mustExecute() const
 
 const std::list<gp_Trsf> PolarPattern::getTransformations(const std::vector<App::DocumentObject*>)
 {
-    double angle = Angle.getValue();
-    double radians = Base::toRadians<double>(angle);
-    if (radians < Precision::Angular())
-        throw Base::ValueError("Pattern angle too small");
     int occurrences = Occurrences.getValue();
     if (occurrences < 1)
         throw Base::ValueError("At least one occurrence required");
 
-    // Note: The original feature is NOT included in the list of transformations! Therefore
-    // we start with occurrence number 1, not number 0
-    std::list<gp_Trsf> transformations;
-    gp_Trsf trans;
-    transformations.push_back(trans); // identity transformation
+    if (occurrences == 1)
+        return {gp_Trsf()};
 
-    if (occurrences < 2)
-        return transformations;
+    double angle = Angle.getValue();
+    double radians = Base::toRadians<double>(angle);
+    if (radians < Precision::Angular())
+        throw Base::ValueError("Pattern angle too small");
 
     bool reversed = Reversed.getValue();
     double offset;
@@ -171,6 +166,12 @@ const std::list<gp_Trsf> PolarPattern::getTransformations(const std::vector<App:
     if (reversed)
         axis.SetDirection(axis.Direction().Reversed());
 
+    std::list<gp_Trsf> transformations;
+    gp_Trsf trans;
+    transformations.push_back(trans);
+
+    // Note: The original feature is already included in the list of transformations!
+    // Therefore we start with occurrence number 1
     for (int i = 1; i < occurrences; i++) {
         trans.SetRotation(axis.Axis(), i * offset);
         transformations.push_back(trans);


### PR DESCRIPTION
In LinearPattern and PolarPattern. Skip all checks if occurrences is 1. Allows Expressions on Length/Angle that evaluates to 0 if Occurrences is 1.

This PR fixes issue #8935