### PR TITLE
[Part]handle unicode filename on win

### DIFF
--- a/src/Mod/Part/App/FT2FC.cpp
+++ b/src/Mod/Part/App/FT2FC.cpp
@@ -60,6 +60,7 @@
 #endif // _PreComp
 
 #include <Base/Console.h>
+#include <Base/FileInfo.h>
 
 #include "TopoShapeWirePy.h"
 
@@ -126,8 +127,14 @@ PyObject* FT2FC(const Py_UNICODE *PyUString,
         throw std::runtime_error(ErrorMsg.str());
     }
 
+
     std::ifstream fontfile;
-    fontfile.open(FontSpec, std::ios::binary|std::ios::in);
+#ifdef FC_OS_WIN32
+    Base::FileInfo winFI(FontSpec);
+    fontfile.open(winFI.toStdWString().c_str(), std::ios::binary | std::ios::in);
+#else
+    fontfile.open(FontSpec, std::ios::binary | std::ios::in);
+#endif
     if (!fontfile.is_open()) {
         //get indignant
         ErrorMsg << "Can not open font file: " << FontSpec;


### PR DESCRIPTION
This PR addresses an issue with non-ascii filename on the windows platform as reported here: https://forum.freecad.org/viewtopic.php?t=77191

hank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [ ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
