### PR TITLE
[Sketcher] [DO NOT MERGE] General Tangency with B-splines

### DIFF
--- a/src/Mod/Sketcher/App/Sketch.cpp
+++ b/src/Mod/Sketcher/App/Sketch.cpp
@@ -3041,7 +3041,6 @@ int Sketch::addAngleAtPointConstraint(int geoId1,
                                       ConstraintType cTyp,
                                       bool driving)
 {
-
     if (!(cTyp == Angle || cTyp == Tangent || cTyp == Perpendicular)) {
         // assert(0);//none of the three types. Why are we here??
         return -1;
@@ -3158,7 +3157,68 @@ int Sketch::addAngleAtPointConstraint(int geoId1,
         tag = ++ConstraintsCounter;
     }
 
-    GCSsys.addConstraintAngleViaPoint(*crv1, *crv2, p, angle, tag, driving);
+    if (Geoms[geoId1].type == BSpline || Geoms[geoId2].type == BSpline) {
+        if (Geoms[geoId1].type == BSpline && Geoms[geoId2].type == BSpline) {
+            GCS::Point& p3 = Points[getPointId(geoId3, pos3)];
+            auto* partBsp = static_cast<GeomBSplineCurve*>(Geoms[geoId1].geo);
+            double uNear;
+            partBsp->closestParameter(Base::Vector3d(*p3.x, *p3.y, 0.0), uNear);
+            double* pointparam1 = new double(uNear);
+            Parameters.push_back(pointparam1);
+            addPointOnObjectConstraint(geoId3,
+                                       pos3,
+                                       geoId1,
+                                       pointparam1,
+                                       driving);  // increases ConstraintsCounter
+            --ConstraintsCounter;
+            partBsp = static_cast<GeomBSplineCurve*>(Geoms[geoId2].geo);
+            partBsp->closestParameter(Base::Vector3d(*p3.x, *p3.y, 0.0), uNear);
+            double* pointparam2 = new double(uNear);
+            addPointOnObjectConstraint(geoId3,
+                                       pos3,
+                                       geoId2,
+                                       pointparam2,
+                                       driving);  // increases ConstraintsCounter
+            Parameters.push_back(pointparam2);
+            --ConstraintsCounter;
+            GCSsys.addConstraintAngleViaPointAndTwoParams(*crv1,
+                                                          *crv2,
+                                                          p,
+                                                          pointparam1,
+                                                          pointparam2,
+                                                          angle,
+                                                          tag,
+                                                          driving);
+        }
+        else {
+            if (Geoms[geoId1].type != BSpline) {
+                std::swap(geoId1, geoId2);
+                std::swap(pos1, pos2);
+            }
+            GCS::Point& p3 = Points[getPointId(geoId3, pos3)];
+            auto* partBsp = static_cast<GeomBSplineCurve*>(Geoms[geoId1].geo);
+            double uNear;
+            partBsp->closestParameter(Base::Vector3d(*p3.x, *p3.y, 0.0), uNear);
+            double* pointparam = new double(uNear);
+            Parameters.push_back(pointparam);
+            int tag = addPointOnObjectConstraint(geoId3,
+                                                 pos3,
+                                                 geoId1,
+                                                 pointparam,
+                                                 driving);  // increases ConstraintsCounter
+            --ConstraintsCounter;
+            GCSsys.addConstraintAngleViaPointAndParam(*crv1,
+                                                      *crv2,
+                                                      p,
+                                                      pointparam,
+                                                      angle,
+                                                      tag,
+                                                      driving);
+        }
+    }
+    else {
+        GCSsys.addConstraintAngleViaPoint(*crv1, *crv2, p, angle, tag, driving);
+    }
     return ConstraintsCounter;
 }
 

--- a/src/Mod/Sketcher/App/Sketch.cpp
+++ b/src/Mod/Sketcher/App/Sketch.cpp
@@ -3148,19 +3148,32 @@ int Sketch::addAngleAtPointConstraint(int geoId1,
     // FIXME: Perform construction of any parameters where this method is called instead of here
     if (e2c) {
         if (Geoms[geoId2].type == BSpline) {
-            GCS::Point &p1 = Points[getPointId(geoId1, pos1)];
+            GCS::Point& p1 = Points[getPointId(geoId1, pos1)];
             auto* partBsp = static_cast<GeomBSplineCurve*>(Geoms[geoId2].geo);
             double uNear;
             partBsp->closestParameter(Base::Vector3d(*p1.x, *p1.y, 0.0), uNear);
             double* pointparam = new double(uNear);
             Parameters.push_back(pointparam);
-            tag = addPointOnObjectConstraint(geoId1, pos1, geoId2, pointparam, driving); //increases ConstraintsCounter
+            tag = addPointOnObjectConstraint(geoId1,
+                                             pos1,
+                                             geoId2,
+                                             pointparam,
+                                             driving);  // increases ConstraintsCounter
             --ConstraintsCounter;
-            GCSsys.addConstraintAngleViaPointAndParam(*crv2, *crv1, p, pointparam, angle, tag, driving);
+            GCSsys.addConstraintAngleViaPointAndParam(*crv2,
+                                                      *crv1,
+                                                      p,
+                                                      pointparam,
+                                                      angle,
+                                                      tag,
+                                                      driving);
         }
         else {
             // increases ConstraintsCounter
-            tag = Sketch::addPointOnObjectConstraint(geoId1, pos1, geoId2, driving);//increases ConstraintsCounter
+            tag = Sketch::addPointOnObjectConstraint(geoId1,
+                                                     pos1,
+                                                     geoId2,
+                                                     driving);  // increases ConstraintsCounter
             GCSsys.addConstraintAngleViaPoint(*crv1, *crv2, p, angle, tag, driving);
         }
     }
@@ -3173,40 +3186,66 @@ int Sketch::addAngleAtPointConstraint(int geoId1,
         tag = ++ConstraintsCounter;
         if (Geoms[geoId1].type == BSpline || Geoms[geoId2].type == BSpline) {
             if (Geoms[geoId1].type == BSpline && Geoms[geoId2].type == BSpline) {
-                GCS::Point &p3 = Points[getPointId(geoId3, pos3)];
+                GCS::Point& p3 = Points[getPointId(geoId3, pos3)];
                 auto* partBsp = static_cast<GeomBSplineCurve*>(Geoms[geoId1].geo);
                 double uNear;
                 partBsp->closestParameter(Base::Vector3d(*p3.x, *p3.y, 0.0), uNear);
                 double* pointparam1 = new double(uNear);
                 Parameters.push_back(pointparam1);
-                addPointOnObjectConstraint(geoId3, pos3, geoId1, pointparam1, driving); //increases ConstraintsCounter
+                addPointOnObjectConstraint(geoId3,
+                                           pos3,
+                                           geoId1,
+                                           pointparam1,
+                                           driving);  // increases ConstraintsCounter
                 --ConstraintsCounter;
                 partBsp = static_cast<GeomBSplineCurve*>(Geoms[geoId2].geo);
                 partBsp->closestParameter(Base::Vector3d(*p3.x, *p3.y, 0.0), uNear);
                 double* pointparam2 = new double(uNear);
-                addPointOnObjectConstraint(geoId3, pos3, geoId2, pointparam2, driving); //increases ConstraintsCounter
+                addPointOnObjectConstraint(geoId3,
+                                           pos3,
+                                           geoId2,
+                                           pointparam2,
+                                           driving);  // increases ConstraintsCounter
                 Parameters.push_back(pointparam2);
                 --ConstraintsCounter;
-                GCSsys.addConstraintAngleViaPointAndTwoParams(*crv1, *crv2, p, pointparam1, pointparam2, angle, tag, driving);
+                GCSsys.addConstraintAngleViaPointAndTwoParams(*crv1,
+                                                              *crv2,
+                                                              p,
+                                                              pointparam1,
+                                                              pointparam2,
+                                                              angle,
+                                                              tag,
+                                                              driving);
             }
             else {
                 if (Geoms[geoId1].type != BSpline) {
                     std::swap(geoId1, geoId2);
                     std::swap(pos1, pos2);
                 }
-                GCS::Point &p3 = Points[getPointId(geoId3, pos3)];
+                GCS::Point& p3 = Points[getPointId(geoId3, pos3)];
                 auto* partBsp = static_cast<GeomBSplineCurve*>(Geoms[geoId1].geo);
                 double uNear;
                 partBsp->closestParameter(Base::Vector3d(*p3.x, *p3.y, 0.0), uNear);
                 double* pointparam = new double(uNear);
                 Parameters.push_back(pointparam);
-                addPointOnObjectConstraint(geoId3, pos3, geoId1, pointparam, driving); //increases ConstraintsCounter
+                addPointOnObjectConstraint(geoId3,
+                                           pos3,
+                                           geoId1,
+                                           pointparam,
+                                           driving);  // increases ConstraintsCounter
                 --ConstraintsCounter;
-                GCSsys.addConstraintAngleViaPointAndParam(*crv1, *crv2, p, pointparam, angle, tag, driving);
+                GCSsys.addConstraintAngleViaPointAndParam(*crv1,
+                                                          *crv2,
+                                                          p,
+                                                          pointparam,
+                                                          angle,
+                                                          tag,
+                                                          driving);
             }
         }
-        else
+        else {
             GCSsys.addConstraintAngleViaPoint(*crv1, *crv2, p, angle, tag, driving);
+        }
     }
 
     return ConstraintsCounter;

--- a/src/Mod/Sketcher/App/planegcs/Constraints.h
+++ b/src/Mod/Sketcher/App/planegcs/Constraints.h
@@ -78,7 +78,9 @@ enum ConstraintType
     PointOnBSpline = 29,
     C2CDistance = 30,
     C2LDistance = 31,
-    P2CDistance = 32
+    P2CDistance = 32,
+    AngleViaPointAndParam = 33,
+    AngleViaPointAndTwoParams = 34
 };
 
 enum InternalAlignmentType
@@ -1167,6 +1169,91 @@ public:
                     bool flipn1,
                     bool flipn2);
     ~ConstraintSnell() override;
+    ConstraintType getTypeId() override;
+    void rescale(double coef = 1.) override;
+    double error() override;
+    double grad(double*) override;
+};
+
+class ConstraintAngleViaPointAndParam: public Constraint
+{
+private:
+    inline double* angle()
+    {
+        return pvec[0];
+    };
+    inline double* cparam()
+    {
+        return pvec[3];
+    };
+    Curve* crv1;
+    Curve* crv2;
+    // These two pointers hold copies of the curves that were passed on
+    //  constraint creation. The curves must be deleted upon destruction of
+    //  the constraint. It is necessary to have copies, since messing with
+    //  original objects that were passed is a very bad idea (but messing is
+    //  necessary, because we need to support redirectParams()/revertParams
+    //  functions.
+    // The pointers in the curves need to be reconstructed if pvec was redirected
+    //  (test pvecChangedFlag variable before use!)
+    Point poa;  // poa=point of angle //needs to be reconstructed if pvec was redirected/reverted.
+                // The point is easily shallow-copied by C++, so no pointer type here and no delete
+                // is necessary.
+    void
+    ReconstructGeomPointers();  // writes pointers in pvec to the parameters of crv1, crv2 and poa
+public:
+    // We assume first curve needs param1
+    ConstraintAngleViaPointAndParam(Curve& acrv1,
+                                    Curve& acrv2,
+                                    Point p,
+                                    double* param1,
+                                    double* angle);
+    ~ConstraintAngleViaPointAndParam() override;
+    ConstraintType getTypeId() override;
+    void rescale(double coef = 1.) override;
+    double error() override;
+    double grad(double*) override;
+};
+
+// TODO: Do we need point here at all?
+class ConstraintAngleViaPointAndTwoParams: public Constraint
+{
+private:
+    inline double* angle()
+    {
+        return pvec[0];
+    };
+    inline double* cparam1()
+    {
+        return pvec[3];
+    };
+    inline double* cparam2()
+    {
+        return pvec[4];
+    };
+    Curve* crv1;
+    Curve* crv2;
+    // These two pointers hold copies of the curves that were passed on
+    //  constraint creation. The curves must be deleted upon destruction of
+    //  the constraint. It is necessary to have copies, since messing with
+    //  original objects that were passed is a very bad idea (but messing is
+    //  necessary, because we need to support redirectParams()/revertParams
+    //  functions.
+    // The pointers in the curves need to be reconstructed if pvec was redirected
+    //  (test pvecChangedFlag variable before use!)
+    Point poa;  // poa=point of angle //needs to be reconstructed if pvec was redirected/reverted.
+                // The point is easily shallow-copied by C++, so no pointer type here and no delete
+                // is necessary.
+    void
+    ReconstructGeomPointers();  // writes pointers in pvec to the parameters of crv1, crv2 and poa
+public:
+    ConstraintAngleViaPointAndTwoParams(Curve& acrv1,
+                                        Curve& acrv2,
+                                        Point p,
+                                        double* param1,
+                                        double* param2,
+                                        double* angle);
+    ~ConstraintAngleViaPointAndTwoParams() override;
     ConstraintType getTypeId() override;
     void rescale(double coef = 1.) override;
     double error() override;

--- a/src/Mod/Sketcher/App/planegcs/GCS.cpp
+++ b/src/Mod/Sketcher/App/planegcs/GCS.cpp
@@ -774,6 +774,36 @@ int System::addConstraintAngleViaPoint(Curve& crv1,
     return addConstraint(constr);
 }
 
+int System::addConstraintAngleViaPointAndParam(Curve& crv1,
+                                               Curve& crv2,
+                                               Point& p,
+                                               double* cparam,
+                                               double* angle,
+                                               int tagId,
+                                               bool driving)
+{
+    Constraint* constr = new ConstraintAngleViaPointAndParam(crv1, crv2, p, cparam, angle);
+    constr->setTag(tagId);
+    constr->setDriving(driving);
+    return addConstraint(constr);
+}
+
+int System::addConstraintAngleViaPointAndTwoParams(Curve& crv1,
+                                                   Curve& crv2,
+                                                   Point& p,
+                                                   double* cparam1,
+                                                   double* cparam2,
+                                                   double* angle,
+                                                   int tagId,
+                                                   bool driving)
+{
+    Constraint* constr =
+        new ConstraintAngleViaPointAndTwoParams(crv1, crv2, p, cparam1, cparam2, angle);
+    constr->setTag(tagId);
+    constr->setDriving(driving);
+    return addConstraint(constr);
+}
+
 int System::addConstraintMidpointOnLine(Line& l1, Line& l2, int tagId, bool driving)
 {
     Constraint* constr = new ConstraintMidpointOnLine(l1, l2);

--- a/src/Mod/Sketcher/App/planegcs/GCS.h
+++ b/src/Mod/Sketcher/App/planegcs/GCS.h
@@ -317,6 +317,21 @@ public:
                                    double* angle,
                                    int tagId = 0,
                                    bool driving = true);
+    int addConstraintAngleViaPointAndParam(Curve& crv1,
+                                           Curve& crv2,
+                                           Point& p,
+                                           double* cparam,
+                                           double* angle,
+                                           int tagId = 0,
+                                           bool driving = true);
+    int addConstraintAngleViaPointAndTwoParams(Curve& crv1,
+                                               Curve& crv2,
+                                               Point& p,
+                                               double* cparam1,
+                                               double* cparam2,
+                                               double* angle,
+                                               int tagId = 0,
+                                               bool driving = true);
     int addConstraintMidpointOnLine(Line& l1, Line& l2, int tagId = 0, bool driving = true);
     int addConstraintMidpointOnLine(Point& l1p1,
                                     Point& l1p2,

--- a/src/Mod/Sketcher/App/planegcs/Geo.cpp
+++ b/src/Mod/Sketcher/App/planegcs/Geo.cpp
@@ -777,31 +777,43 @@ DeriVector2 BSpline::CalculateNormal(const double* param, const double* derivpar
 {
     // TODO: is there any advantage in making this a `static`?
     size_t startpole = 0;
-    for (size_t j = 1; j < mult.size() && *(knots[j]) <= *param; ++j)
+    for (size_t j = 1; j < mult.size() && *(knots[j]) <= *param; ++j) {
         startpole += mult[j];
-    if (!periodic && startpole >= poles.size())
+    }
+    if (!periodic && startpole >= poles.size()) {
         startpole = poles.size() - degree - 1;
+    }
 
     // double xsum = 0., xslopesum = 0.;
     // double ysum = 0., yslopesum = 0.;
     // double wsum = 0., wslopesum = 0.;
 
-    auto polexat = [&](size_t i) { return poles[(startpole + i) % poles.size()].x; };
-    auto poleyat = [&](size_t i) { return poles[(startpole + i) % poles.size()].y; };
-    auto weightat = [&](size_t i) { return weights[(startpole + i) % weights.size()]; };
+    auto polexat = [&](size_t i) {
+        return poles[(startpole + i) % poles.size()].x;
+    };
+    auto poleyat = [&](size_t i) {
+        return poles[(startpole + i) % poles.size()].y;
+    };
+    auto weightat = [&](size_t i) {
+        return weights[(startpole + i) % weights.size()];
+    };
 
     size_t numpoints = degree + 1;
     // Tangent vector
-    // This should in principle be identical to error gradient wrt curve parameter in point-on-object
+    // This should in principle be identical to error gradient wrt curve parameter in
+    // point-on-object
     VEC_D d(numpoints);
-    for (size_t i = 0; i < numpoints; ++i)
+    for (size_t i = 0; i < numpoints; ++i) {
         d[i] = *polexat(i) * *weightat(i);
+    }
     double xsum = BSpline::splineValue(*param, startpole + degree, degree, d, flattenedknots);
-    for (size_t i = 0; i < numpoints; ++i)
+    for (size_t i = 0; i < numpoints; ++i) {
         d[i] = *poleyat(i) * *weightat(i);
+    }
     double ysum = BSpline::splineValue(*param, startpole + degree, degree, d, flattenedknots);
-    for (size_t i = 0; i < numpoints; ++i)
+    for (size_t i = 0; i < numpoints; ++i) {
         d[i] = *weightat(i);
+    }
     double wsum = BSpline::splineValue(*param, startpole + degree, degree, d, flattenedknots);
 
     d.resize(numpoints - 1);
@@ -809,22 +821,22 @@ DeriVector2 BSpline::CalculateNormal(const double* param, const double* derivpar
         d[i - 1] = (*polexat(i) * *weightat(i) - *polexat(i - 1) * *weightat(i - 1))
             / (flattenedknots[startpole + i + degree] - flattenedknots[startpole + i]);
     }
-    double xslopesum = degree * BSpline::splineValue(
-        *param, startpole + degree, degree - 1, d, flattenedknots);
+    double xslopesum =
+        degree * BSpline::splineValue(*param, startpole + degree, degree - 1, d, flattenedknots);
     for (size_t i = 1; i < numpoints; ++i) {
         d[i - 1] = (*poleyat(i) * *weightat(i) - *poleyat(i - 1) * *weightat(i - 1))
             / (flattenedknots[startpole + i + degree] - flattenedknots[startpole + i]);
     }
-    double yslopesum = degree * BSpline::splineValue(
-        *param, startpole + degree, degree - 1, d, flattenedknots);
+    double yslopesum =
+        degree * BSpline::splineValue(*param, startpole + degree, degree - 1, d, flattenedknots);
     for (size_t i = 1; i < numpoints; ++i) {
         d[i - 1] = (*weightat(i) - *weightat(i - 1))
             / (flattenedknots[startpole + i + degree] - flattenedknots[startpole + i]);
     }
-    double wslopesum = degree * BSpline::splineValue(
-        *param, startpole + degree, degree - 1, d, flattenedknots);
+    double wslopesum =
+        degree * BSpline::splineValue(*param, startpole + degree, degree - 1, d, flattenedknots);
 
-    DeriVector2 result(wsum*xslopesum - wslopesum*xsum, wsum*yslopesum - wslopesum*ysum);
+    DeriVector2 result(wsum * xslopesum - wslopesum * xsum, wsum * yslopesum - wslopesum * ysum);
 
     // get dx, dy of the normal as well
     bool dpfound = false;
@@ -832,95 +844,113 @@ DeriVector2 BSpline::CalculateNormal(const double* param, const double* derivpar
         if (derivparam == polexat(i)) {
             VEC_D d(numpoints);
             d[i] = 1;
-            double factor = BSpline::splineValue(*param, startpole + degree, degree, d, flattenedknots);
-            VEC_D sd(numpoints-1);
-            if (i > 0)
-                sd[i-1] = 1.0 / (flattenedknots[startpole+i+degree] - flattenedknots[startpole+i]);
-            if (i < numpoints - 1)
-                sd[i] = -1.0 / (flattenedknots[startpole+i+1+degree] - flattenedknots[startpole+i+1]);
-            double slopefactor = BSpline::splineValue(*param, startpole + degree, degree-1, sd, flattenedknots);
-            result.dx = *weightat(i) * (wsum*slopefactor - wslopesum*factor);
+            double factor =
+                BSpline::splineValue(*param, startpole + degree, degree, d, flattenedknots);
+            VEC_D sd(numpoints - 1);
+            if (i > 0) {
+                sd[i - 1] =
+                    1.0 / (flattenedknots[startpole + i + degree] - flattenedknots[startpole + i]);
+            }
+            if (i < numpoints - 1) {
+                sd[i] = -1.0
+                    / (flattenedknots[startpole + i + 1 + degree]
+                       - flattenedknots[startpole + i + 1]);
+            }
+            double slopefactor =
+                BSpline::splineValue(*param, startpole + degree, degree - 1, sd, flattenedknots);
+            result.dx = *weightat(i) * (wsum * slopefactor - wslopesum * factor);
             dpfound = true;
             break;
         }
         if (derivparam == poleyat(i)) {
             VEC_D d(numpoints);
             d[i] = 1;
-            double factor = BSpline::splineValue(*param, startpole + degree, degree, d, flattenedknots);
-            VEC_D sd(numpoints-1);
-            if (i > 0)
-                sd[i-1] = 1.0 / (flattenedknots[startpole+i+degree] - flattenedknots[startpole+i]);
-            if (i < numpoints - 1)
-                sd[i] = -1.0 / (flattenedknots[startpole+i+1+degree] - flattenedknots[startpole+i+1]);
-            double slopefactor = BSpline::splineValue(*param, startpole + degree, degree-1, sd, flattenedknots);
-            result.dy = *weightat(i) * (wsum*slopefactor - wslopesum*factor);
+            double factor =
+                BSpline::splineValue(*param, startpole + degree, degree, d, flattenedknots);
+            VEC_D sd(numpoints - 1);
+            if (i > 0) {
+                sd[i - 1] =
+                    1.0 / (flattenedknots[startpole + i + degree] - flattenedknots[startpole + i]);
+            }
+            if (i < numpoints - 1) {
+                sd[i] = -1.0
+                    / (flattenedknots[startpole + i + 1 + degree]
+                       - flattenedknots[startpole + i + 1]);
+            }
+            double slopefactor =
+                BSpline::splineValue(*param, startpole + degree, degree - 1, sd, flattenedknots);
+            result.dy = *weightat(i) * (wsum * slopefactor - wslopesum * factor);
             dpfound = true;
             break;
         }
         if (derivparam == weightat(i)) {
             VEC_D d(numpoints);
             d[i] = 1;
-            double factor = BSpline::splineValue(*param, startpole + degree, degree, d, flattenedknots);
-            VEC_D sd(numpoints-1);
-            if (i > 0)
-                sd[i-1] = 1.0 / (flattenedknots[startpole+i+degree] - flattenedknots[startpole+i]);
-            if (i < numpoints - 1)
-                sd[i] = -1.0 / (flattenedknots[startpole+i+1+degree] - flattenedknots[startpole+i+1]);
-            double slopefactor = BSpline::splineValue(*param, startpole + degree, degree-1, sd, flattenedknots);
-            result.dx = degree *
-                (factor * (xslopesum - wslopesum*(*polexat(i))) - slopefactor * (xsum - wsum*(*polexat(i))));
-            result.dy = degree *
-                (factor * (yslopesum - wslopesum*(*poleyat(i))) - slopefactor * (ysum - wsum*(*poleyat(i))));
+            double factor =
+                BSpline::splineValue(*param, startpole + degree, degree, d, flattenedknots);
+            VEC_D sd(numpoints - 1);
+            if (i > 0) {
+                sd[i - 1] =
+                    1.0 / (flattenedknots[startpole + i + degree] - flattenedknots[startpole + i]);
+            }
+            if (i < numpoints - 1) {
+                sd[i] = -1.0
+                    / (flattenedknots[startpole + i + 1 + degree]
+                       - flattenedknots[startpole + i + 1]);
+            }
+            double slopefactor =
+                BSpline::splineValue(*param, startpole + degree, degree - 1, sd, flattenedknots);
+            result.dx = degree
+                * (factor * (xslopesum - wslopesum * (*polexat(i)))
+                   - slopefactor * (xsum - wsum * (*polexat(i))));
+            result.dy = degree
+                * (factor * (yslopesum - wslopesum * (*poleyat(i)))
+                   - slopefactor * (ysum - wsum * (*poleyat(i))));
             dpfound = true;
             break;
         }
     }
 
     // the curve parameter being used by the constraint is not known to the geometry (there can be
-    // many tangent constraints on the same curve after all). Assume that this is the param provided.
+    // many tangent constraints on the same curve after all). Assume that this is the param
+    // provided.
     if (derivparam == param) {
-        VEC_D sd(numpoints-1), ssd(numpoints-2);
+        VEC_D sd(numpoints - 1), ssd(numpoints - 2);
         for (size_t i = 1; i < numpoints; ++i) {
-            sd[i-1] =
-                (*weightat(i) - *weightat(i-1)) /
-                (flattenedknots[startpole+i+degree] - flattenedknots[startpole+i]);
+            sd[i - 1] = (*weightat(i) - *weightat(i - 1))
+                / (flattenedknots[startpole + i + degree] - flattenedknots[startpole + i]);
         }
-        for (size_t i = 1; i < numpoints-1; ++i) {
-            ssd[i-1] =
-                (sd[i] - sd[i-1]) /
-                (flattenedknots[startpole+i+degree] - flattenedknots[startpole+i]);
+        for (size_t i = 1; i < numpoints - 1; ++i) {
+            ssd[i - 1] = (sd[i] - sd[i - 1])
+                / (flattenedknots[startpole + i + degree] - flattenedknots[startpole + i]);
         }
-        double wslopeslopesum = degree * (degree - 1) *
-            BSpline::splineValue(*param, startpole + degree, degree-2, ssd, flattenedknots);
+        double wslopeslopesum = degree * (degree - 1)
+            * BSpline::splineValue(*param, startpole + degree, degree - 2, ssd, flattenedknots);
 
         for (size_t i = 1; i < numpoints; ++i) {
-            sd[i-1] =
-                (*polexat(i) * *weightat(i) - *polexat(i-1) * *weightat(i-1)) /
-                (flattenedknots[startpole+i+degree] - flattenedknots[startpole+i]);
+            sd[i - 1] = (*polexat(i) * *weightat(i) - *polexat(i - 1) * *weightat(i - 1))
+                / (flattenedknots[startpole + i + degree] - flattenedknots[startpole + i]);
         }
-        for (size_t i = 1; i < numpoints-1; ++i) {
-            ssd[i-1] =
-                (sd[i] - sd[i-1]) /
-                (flattenedknots[startpole+i+degree] - flattenedknots[startpole+i]);
+        for (size_t i = 1; i < numpoints - 1; ++i) {
+            ssd[i - 1] = (sd[i] - sd[i - 1])
+                / (flattenedknots[startpole + i + degree] - flattenedknots[startpole + i]);
         }
-        double xslopeslopesum = degree * (degree - 1) *
-            BSpline::splineValue(*param, startpole + degree, degree-2, ssd, flattenedknots);
+        double xslopeslopesum = degree * (degree - 1)
+            * BSpline::splineValue(*param, startpole + degree, degree - 2, ssd, flattenedknots);
 
         for (size_t i = 1; i < numpoints; ++i) {
-            sd[i-1] =
-                (*poleyat(i) * *weightat(i) - *poleyat(i-1) * *weightat(i-1)) /
-                (flattenedknots[startpole+i+degree] - flattenedknots[startpole+i]);
+            sd[i - 1] = (*poleyat(i) * *weightat(i) - *poleyat(i - 1) * *weightat(i - 1))
+                / (flattenedknots[startpole + i + degree] - flattenedknots[startpole + i]);
         }
-        for (size_t i = 1; i < numpoints-1; ++i) {
-            ssd[i-1] =
-                (sd[i] - sd[i-1]) /
-                (flattenedknots[startpole+i+degree] - flattenedknots[startpole+i]);
+        for (size_t i = 1; i < numpoints - 1; ++i) {
+            ssd[i - 1] = (sd[i] - sd[i - 1])
+                / (flattenedknots[startpole + i + degree] - flattenedknots[startpole + i]);
         }
-        double yslopeslopesum = degree * (degree - 1) *
-            BSpline::splineValue(*param, startpole + degree, degree-2, ssd, flattenedknots);
+        double yslopeslopesum = degree * (degree - 1)
+            * BSpline::splineValue(*param, startpole + degree, degree - 2, ssd, flattenedknots);
 
-        result.dx = wsum*xslopeslopesum - wslopeslopesum*xsum;
-        result.dy = wsum*yslopeslopesum - wslopeslopesum*ysum;
+        result.dx = wsum * xslopeslopesum - wslopeslopesum * xsum;
+        result.dy = wsum * yslopeslopesum - wslopeslopesum * ysum;
     }
 
     return result.rotate90ccw();

--- a/src/Mod/Sketcher/App/planegcs/Geo.cpp
+++ b/src/Mod/Sketcher/App/planegcs/Geo.cpp
@@ -773,6 +773,159 @@ DeriVector2 BSpline::CalculateNormal(const Point& p, const double* derivparam) c
     return ret;
 }
 
+DeriVector2 BSpline::CalculateNormal(const double* param, const double* derivparam) const
+{
+    // TODO: is there any advantage in making this a `static`?
+    size_t startpole = 0;
+    for (size_t j = 1; j < mult.size() && *(knots[j]) <= *param; ++j)
+        startpole += mult[j];
+    if (!periodic && startpole >= poles.size())
+        startpole = poles.size() - degree - 1;
+
+    // double xsum = 0., xslopesum = 0.;
+    // double ysum = 0., yslopesum = 0.;
+    // double wsum = 0., wslopesum = 0.;
+
+    auto polexat = [&](size_t i) { return poles[(startpole + i) % poles.size()].x; };
+    auto poleyat = [&](size_t i) { return poles[(startpole + i) % poles.size()].y; };
+    auto weightat = [&](size_t i) { return weights[(startpole + i) % weights.size()]; };
+
+    size_t numpoints = degree + 1;
+    // Tangent vector
+    // This should in principle be identical to error gradient wrt curve parameter in point-on-object
+    VEC_D d(numpoints);
+    for (size_t i = 0; i < numpoints; ++i)
+        d[i] = *polexat(i) * *weightat(i);
+    double xsum = BSpline::splineValue(*param, startpole + degree, degree, d, flattenedknots);
+    for (size_t i = 0; i < numpoints; ++i)
+        d[i] = *poleyat(i) * *weightat(i);
+    double ysum = BSpline::splineValue(*param, startpole + degree, degree, d, flattenedknots);
+    for (size_t i = 0; i < numpoints; ++i)
+        d[i] = *weightat(i);
+    double wsum = BSpline::splineValue(*param, startpole + degree, degree, d, flattenedknots);
+
+    d.resize(numpoints - 1);
+    for (size_t i = 1; i < numpoints; ++i) {
+        d[i - 1] = (*polexat(i) * *weightat(i) - *polexat(i - 1) * *weightat(i - 1))
+            / (flattenedknots[startpole + i + degree] - flattenedknots[startpole + i]);
+    }
+    double xslopesum = degree * BSpline::splineValue(
+        *param, startpole + degree, degree - 1, d, flattenedknots);
+    for (size_t i = 1; i < numpoints; ++i) {
+        d[i - 1] = (*poleyat(i) * *weightat(i) - *poleyat(i - 1) * *weightat(i - 1))
+            / (flattenedknots[startpole + i + degree] - flattenedknots[startpole + i]);
+    }
+    double yslopesum = degree * BSpline::splineValue(
+        *param, startpole + degree, degree - 1, d, flattenedknots);
+    for (size_t i = 1; i < numpoints; ++i) {
+        d[i - 1] = (*weightat(i) - *weightat(i - 1))
+            / (flattenedknots[startpole + i + degree] - flattenedknots[startpole + i]);
+    }
+    double wslopesum = degree * BSpline::splineValue(
+        *param, startpole + degree, degree - 1, d, flattenedknots);
+
+    DeriVector2 result(wsum*xslopesum - wslopesum*xsum, wsum*yslopesum - wslopesum*ysum);
+
+    // get dx, dy of the normal as well
+    bool dpfound = false;
+    for (size_t i = 0; i < numpoints; ++i) {
+        if (derivparam == polexat(i)) {
+            VEC_D d(numpoints);
+            d[i] = 1;
+            double factor = BSpline::splineValue(*param, startpole + degree, degree, d, flattenedknots);
+            VEC_D sd(numpoints-1);
+            if (i > 0)
+                sd[i-1] = 1.0 / (flattenedknots[startpole+i+degree] - flattenedknots[startpole+i]);
+            if (i < numpoints - 1)
+                sd[i] = -1.0 / (flattenedknots[startpole+i+1+degree] - flattenedknots[startpole+i+1]);
+            double slopefactor = BSpline::splineValue(*param, startpole + degree, degree-1, sd, flattenedknots);
+            result.dx = *weightat(i) * (wsum*slopefactor - wslopesum*factor);
+            dpfound = true;
+            break;
+        }
+        if (derivparam == poleyat(i)) {
+            VEC_D d(numpoints);
+            d[i] = 1;
+            double factor = BSpline::splineValue(*param, startpole + degree, degree, d, flattenedknots);
+            VEC_D sd(numpoints-1);
+            if (i > 0)
+                sd[i-1] = 1.0 / (flattenedknots[startpole+i+degree] - flattenedknots[startpole+i]);
+            if (i < numpoints - 1)
+                sd[i] = -1.0 / (flattenedknots[startpole+i+1+degree] - flattenedknots[startpole+i+1]);
+            double slopefactor = BSpline::splineValue(*param, startpole + degree, degree-1, sd, flattenedknots);
+            result.dy = *weightat(i) * (wsum*slopefactor - wslopesum*factor);
+            dpfound = true;
+            break;
+        }
+        if (derivparam == weightat(i)) {
+            VEC_D d(numpoints);
+            d[i] = 1;
+            double factor = BSpline::splineValue(*param, startpole + degree, degree, d, flattenedknots);
+            VEC_D sd(numpoints-1);
+            if (i > 0)
+                sd[i-1] = 1.0 / (flattenedknots[startpole+i+degree] - flattenedknots[startpole+i]);
+            if (i < numpoints - 1)
+                sd[i] = -1.0 / (flattenedknots[startpole+i+1+degree] - flattenedknots[startpole+i+1]);
+            double slopefactor = BSpline::splineValue(*param, startpole + degree, degree-1, sd, flattenedknots);
+            result.dx = degree *
+                (factor * (xslopesum - wslopesum*(*polexat(i))) - slopefactor * (xsum - wsum*(*polexat(i))));
+            result.dy = degree *
+                (factor * (yslopesum - wslopesum*(*poleyat(i))) - slopefactor * (ysum - wsum*(*poleyat(i))));
+            dpfound = true;
+            break;
+        }
+    }
+
+    // the curve parameter being used by the constraint is not known to the geometry (there can be
+    // many tangent constraints on the same curve after all). Assume that this is the param provided.
+    if (derivparam == param) {
+        VEC_D sd(numpoints-1), ssd(numpoints-2);
+        for (size_t i = 1; i < numpoints; ++i) {
+            sd[i-1] =
+                (*weightat(i) - *weightat(i-1)) /
+                (flattenedknots[startpole+i+degree] - flattenedknots[startpole+i]);
+        }
+        for (size_t i = 1; i < numpoints-1; ++i) {
+            ssd[i-1] =
+                (sd[i] - sd[i-1]) /
+                (flattenedknots[startpole+i+degree] - flattenedknots[startpole+i]);
+        }
+        double wslopeslopesum = degree * (degree - 1) *
+            BSpline::splineValue(*param, startpole + degree, degree-2, ssd, flattenedknots);
+
+        for (size_t i = 1; i < numpoints; ++i) {
+            sd[i-1] =
+                (*polexat(i) * *weightat(i) - *polexat(i-1) * *weightat(i-1)) /
+                (flattenedknots[startpole+i+degree] - flattenedknots[startpole+i]);
+        }
+        for (size_t i = 1; i < numpoints-1; ++i) {
+            ssd[i-1] =
+                (sd[i] - sd[i-1]) /
+                (flattenedknots[startpole+i+degree] - flattenedknots[startpole+i]);
+        }
+        double xslopeslopesum = degree * (degree - 1) *
+            BSpline::splineValue(*param, startpole + degree, degree-2, ssd, flattenedknots);
+
+        for (size_t i = 1; i < numpoints; ++i) {
+            sd[i-1] =
+                (*poleyat(i) * *weightat(i) - *poleyat(i-1) * *weightat(i-1)) /
+                (flattenedknots[startpole+i+degree] - flattenedknots[startpole+i]);
+        }
+        for (size_t i = 1; i < numpoints-1; ++i) {
+            ssd[i-1] =
+                (sd[i] - sd[i-1]) /
+                (flattenedknots[startpole+i+degree] - flattenedknots[startpole+i]);
+        }
+        double yslopeslopesum = degree * (degree - 1) *
+            BSpline::splineValue(*param, startpole + degree, degree-2, ssd, flattenedknots);
+
+        result.dx = wsum*xslopeslopesum - wslopeslopesum*xsum;
+        result.dy = wsum*yslopeslopesum - wslopeslopesum*ysum;
+    }
+
+    return result.rotate90ccw();
+}
+
 DeriVector2 BSpline::Value(double /*u*/, double /*du*/, const double* /*derivparam*/) const
 {
     // place holder

--- a/src/Mod/Sketcher/App/planegcs/Geo.h
+++ b/src/Mod/Sketcher/App/planegcs/Geo.h
@@ -162,7 +162,8 @@ public:
                                         const double* derivparam = nullptr) const = 0;
 
     // returns normal vector at parameter instead of at the given point.
-    virtual DeriVector2 CalculateNormal(const double* param, const double* derivparam = nullptr)
+    virtual DeriVector2 CalculateNormal(const double* param,
+                                        const double* derivparam = nullptr) const
     {
         DeriVector2 pointDV = Value(*param, 0.0);
         Point p(&pointDV.x, &pointDV.y);
@@ -423,8 +424,8 @@ public:
     VEC_D flattenedknots;
     DeriVector2 CalculateNormal(const Point& p, const double* derivparam = nullptr) const override;
     // TODO: override parametric version
-    // DeriVector2 CalculateNormal(const double* param, const double* derivparam = nullptr) const
-    // override;
+    DeriVector2 CalculateNormal(const double* param,
+                                const double* derivparam = nullptr) const override;
     DeriVector2 Value(double u, double du, const double* derivparam = nullptr) const override;
     int PushOwnParams(VEC_pD& pvec) override;
     void ReconstructOnNewPvec(VEC_pD& pvec, int& cnt) override;

--- a/src/Mod/Sketcher/App/planegcs/Geo.h
+++ b/src/Mod/Sketcher/App/planegcs/Geo.h
@@ -161,6 +161,14 @@ public:
     virtual DeriVector2 CalculateNormal(const Point& p,
                                         const double* derivparam = nullptr) const = 0;
 
+    // returns normal vector at parameter instead of at the given point.
+    virtual DeriVector2 CalculateNormal(const double* param, const double* derivparam = nullptr)
+    {
+        DeriVector2 pointDV = Value(*param, 0.0);
+        Point p(&pointDV.x, &pointDV.y);
+        return CalculateNormal(p, derivparam);
+    }
+
     /**
      * @brief Value: returns point (vector) given the value of parameter
      * @param u: value of parameter
@@ -414,6 +422,9 @@ public:
     // interface helpers
     VEC_D flattenedknots;
     DeriVector2 CalculateNormal(const Point& p, const double* derivparam = nullptr) const override;
+    // TODO: override parametric version
+    // DeriVector2 CalculateNormal(const double* param, const double* derivparam = nullptr) const
+    // override;
     DeriVector2 Value(double u, double du, const double* derivparam = nullptr) const override;
     int PushOwnParams(VEC_pD& pvec) override;
     void ReconstructOnNewPvec(VEC_pD& pvec, int& cnt) override;
@@ -433,7 +444,7 @@ public:
     /// x is the point at which combination is needed
     /// k is the range in `flattenedknots` that contains x
     /// p is the degree
-    /// d is the vector of (relevant) poles (this will be changed)
+    /// d is the vector of (relevant) poles (note that this is not const and will be changed)
     /// flatknots is the vector of knots
     static double splineValue(double x, size_t k, unsigned int p, VEC_D& d, const VEC_D& flatknots);
 };

--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -5854,14 +5854,14 @@ void CmdSketcherConstrainPerpendicular::activated(int iMsg)
 
             const Part::Geometry* geom2 = Obj->getGeometry(GeoId2);
 
-            if (geom2 && isBSplineCurve(*geom2)) {
-                // unsupported until normal to B-spline at any point implemented.
-                Gui::TranslatedUserWarning(
-                    Obj,
-                    QObject::tr("Wrong selection"),
-                    QObject::tr("Perpendicular to B-spline edge currently unsupported."));
-                return;
-            }
+            // if (geom2 && isBSplineCurve(*geom2)) {
+            //     // unsupported until normal to B-spline at any point implemented.
+            //     Gui::TranslatedUserWarning(
+            //         Obj,
+            //         QObject::tr("Wrong selection"),
+            //         QObject::tr("Perpendicular to B-spline edge currently unsupported."));
+            //     return;
+            // }
 
             if (isBsplinePole(geom2)) {
                 Gui::TranslatedUserWarning(
@@ -5900,14 +5900,14 @@ void CmdSketcherConstrainPerpendicular::activated(int iMsg)
                 return;
             }
 
-            if (isBSplineCurve(*geo1) || isBSplineCurve(*geo2)) {
-                // unsupported until tangent to B-spline at any point implemented.
-                Gui::TranslatedUserWarning(
-                    Obj,
-                    QObject::tr("Wrong selection"),
-                    QObject::tr("Perpendicular to B-spline edge currently unsupported."));
-                return;
-            }
+            // if (isBSplineCurve(*geo1) || isBSplineCurve(*geo2)) {
+            //     // unsupported until tangent to B-spline at any point implemented.
+            //     Gui::TranslatedUserWarning(
+            //         Obj,
+            //         QObject::tr("Wrong selection"),
+            //         QObject::tr("Perpendicular to B-spline edge currently unsupported."));
+            //     return;
+            // }
 
             if (isLineSegment(*geo1)) {
                 std::swap(GeoId1, GeoId2);
@@ -6101,14 +6101,14 @@ void CmdSketcherConstrainPerpendicular::applyConstraint(std::vector<SelIdPair>& 
                 return;
             }
 
-            if (isBSplineCurve(*geo1) || isBSplineCurve(*geo2)) {
-                // unsupported until tangent to B-spline at any point implemented.
-                Gui::TranslatedUserWarning(
-                    Obj,
-                    QObject::tr("Wrong selection"),
-                    QObject::tr("Perpendicular to B-spline edge currently unsupported."));
-                return;
-            }
+            // if (isBSplineCurve(*geo1) || isBSplineCurve(*geo2)) {
+            //     // unsupported until tangent to B-spline at any point implemented.
+            //     Gui::TranslatedUserWarning(
+            //         Obj,
+            //         QObject::tr("Wrong selection"),
+            //         QObject::tr("Perpendicular to B-spline edge currently unsupported."));
+            //     return;
+            // }
 
             if (isLineSegment(*geo1)) {
                 std::swap(GeoId1, GeoId2);
@@ -6690,14 +6690,14 @@ void CmdSketcherConstrainTangent::activated(int iMsg)
 
             const Part::Geometry* geom2 = Obj->getGeometry(GeoId2);
 
-            if (geom2 && isBSplineCurve(*geom2)) {
-                // unsupported until tangent to B-spline at any point implemented.
-                Gui::TranslatedUserWarning(
-                    Obj,
-                    QObject::tr("Wrong selection"),
-                    QObject::tr("Tangency to B-spline edge currently unsupported."));
-                return;
-            }
+            // if (geom2 && isBSplineCurve(*geom2)) {
+            //     // unsupported until tangent to B-spline at any point implemented.
+            //     Gui::TranslatedUserWarning(
+            //         Obj,
+            //         QObject::tr("Wrong selection"),
+            //         QObject::tr("Tangency to B-spline edge currently unsupported."));
+            //     return;
+            // }
 
             if (isBsplinePole(geom2)) {
                 Gui::TranslatedUserWarning(
@@ -6725,14 +6725,14 @@ void CmdSketcherConstrainTangent::activated(int iMsg)
             const Part::Geometry* geom1 = Obj->getGeometry(GeoId1);
             const Part::Geometry* geom2 = Obj->getGeometry(GeoId2);
 
-            if (geom1 && geom2 && (isBSplineCurve(*geom1) || isBSplineCurve(*geom2))) {
-                // unsupported until tangent to B-spline at any point implemented.
-                Gui::TranslatedUserWarning(
-                    Obj,
-                    QObject::tr("Wrong selection"),
-                    QObject::tr("Tangency to B-spline edge currently unsupported."));
-                return;
-            }
+            // if (geom1 && geom2 && (isBSplineCurve(*geom1) || isBSplineCurve(*geom2))) {
+            //     // unsupported until tangent to B-spline at any point implemented.
+            //     Gui::TranslatedUserWarning(
+            //         Obj,
+            //         QObject::tr("Wrong selection"),
+            //         QObject::tr("Tangency to B-spline edge currently unsupported."));
+            //     return;
+            // }
 
             if (isBsplinePole(geom1) || isBsplinePole(geom2)) {
                 Gui::TranslatedUserWarning(
@@ -6938,14 +6938,14 @@ void CmdSketcherConstrainTangent::applyConstraint(std::vector<SelIdPair>& selSeq
             const Part::Geometry* geom1 = Obj->getGeometry(GeoId1);
             const Part::Geometry* geom2 = Obj->getGeometry(GeoId2);
 
-            if (geom1 && geom2 && (isBSplineCurve(*geom1) || isBSplineCurve(*geom2))) {
-                // unsupported until tangent to B-spline at any point implemented.
-                Gui::TranslatedUserWarning(
-                    Obj,
-                    QObject::tr("Wrong selection"),
-                    QObject::tr("Tangency to B-spline edge currently unsupported."));
-                return;
-            }
+            // if (geom1 && geom2 && (isBSplineCurve(*geom1) || isBSplineCurve(*geom2))) {
+            //     // unsupported until tangent to B-spline at any point implemented.
+            //     Gui::TranslatedUserWarning(
+            //         Obj,
+            //         QObject::tr("Wrong selection"),
+            //         QObject::tr("Tangency to B-spline edge currently unsupported."));
+            //     return;
+            // }
 
             if (isBsplinePole(geom1) || isBsplinePole(geom2)) {
                 Gui::TranslatedUserWarning(
@@ -9591,14 +9591,14 @@ void CmdSketcherConstrainSnellsLaw::activated(int iMsg)
 
     const Part::Geometry* geo = Obj->getGeometry(GeoId3);
 
-    if (geo && isBSplineCurve(*geo)) {
-        // unsupported until normal to B-spline at any point implemented.
-        Gui::TranslatedUserWarning(
-            Obj,
-            QObject::tr("Wrong selection"),
-            QObject::tr("SnellsLaw on B-spline edge is currently unsupported."));
-        return;
-    }
+    // if (geo && isBSplineCurve(*geo)) {
+    //     // unsupported until normal to B-spline at any point implemented.
+    //     Gui::TranslatedUserWarning(
+    //         Obj,
+    //         QObject::tr("Wrong selection"),
+    //         QObject::tr("SnellsLaw on B-spline edge is currently unsupported."));
+    //     return;
+    // }
 
     if (isBsplinePole(geo)) {
         Gui::TranslatedUserWarning(Obj,

--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -5720,11 +5720,11 @@ void CmdSketcherConstrainPerpendicular::activated(int iMsg)
         if (isVertex(GeoId1, PosId1)) {
             std::swap(GeoId1, GeoId2);
             std::swap(PosId1, PosId2);
-        };
+        }
         if (isVertex(GeoId2, PosId2)) {
             std::swap(GeoId2, GeoId3);
             std::swap(PosId2, PosId3);
-        };
+        }
 
         if (isEdge(GeoId1, PosId1) && isEdge(GeoId2, PosId2) && isVertex(GeoId3, PosId3)) {
 
@@ -5741,35 +5741,45 @@ void CmdSketcherConstrainPerpendicular::activated(int iMsg)
             bool safe = addConstraintSafely(Obj, [&]() {
                 // add missing point-on-object constraints
                 if (!IsPointAlreadyOnCurve(GeoId1, GeoId3, PosId3, Obj)) {
-                    Gui::cmdAppObjectArgs(
-                        selection[0].getObject(),
-                        "addConstraint(Sketcher.Constraint('PointOnObject',%d,%d,%d))",
-                        GeoId3,
-                        static_cast<int>(PosId3),
-                        GeoId1);
-                };
+                    const Part::Geometry *geom1 = Obj->getGeometry(GeoId1);
+                    if (!(geom1 && isBSplineCurve(*geom1))) {
+                        Gui::cmdAppObjectArgs(
+                            selection[0].getObject(),
+                            "addConstraint(Sketcher.Constraint('PointOnObject',%d,%d,%d))",
+                            GeoId3,
+                            static_cast<int>(PosId3),
+                            GeoId1);
+                    }
+                }
 
                 if (!IsPointAlreadyOnCurve(GeoId2, GeoId3, PosId3, Obj)) {
-                    Gui::cmdAppObjectArgs(
-                        selection[0].getObject(),
-                        "addConstraint(Sketcher.Constraint('PointOnObject',%d,%d,%d))",
-                        GeoId3,
-                        static_cast<int>(PosId3),
-                        GeoId2);
-                };
+                    const Part::Geometry *geom2 = Obj->getGeometry(GeoId2);
+                    if (!(geom2 && isBSplineCurve(*geom2))) {
+                        Gui::cmdAppObjectArgs(
+                            selection[0].getObject(),
+                            "addConstraint(Sketcher.Constraint('PointOnObject',%d,%d,%d))",
+                            GeoId3,
+                            static_cast<int>(PosId3),
+                            GeoId2);
+                    }
+                }
 
                 if (!IsPointAlreadyOnCurve(
                         GeoId1,
                         GeoId3,
                         PosId3,
-                        Obj)) {// FIXME: it's a good idea to add a check if the sketch is solved
-                    Gui::cmdAppObjectArgs(
-                        selection[0].getObject(),
-                        "addConstraint(Sketcher.Constraint('PointOnObject',%d,%d,%d))",
-                        GeoId3,
-                        static_cast<int>(PosId3),
-                        GeoId1);
-                };
+                        Obj)) {
+                    // FIXME: it's a good idea to add a check if the sketch is solved
+                    const Part::Geometry *geom1 = Obj->getGeometry(GeoId1);
+                    if (!(geom1 && isBSplineCurve(*geom1))) {
+                        Gui::cmdAppObjectArgs(
+                            selection[0].getObject(),
+                            "addConstraint(Sketcher.Constraint('PointOnObject',%d,%d,%d))",
+                            GeoId3,
+                            static_cast<int>(PosId3),
+                            GeoId1);
+                    }
+                }
 
                 Gui::cmdAppObjectArgs(
                     selection[0].getObject(),
@@ -5791,7 +5801,7 @@ void CmdSketcherConstrainPerpendicular::activated(int iMsg)
             getSelection().clearSelection();
 
             return;
-        };
+        }
 
         Gui::TranslatedUserWarning(
             Obj,
@@ -6306,35 +6316,41 @@ void CmdSketcherConstrainPerpendicular::applyConstraint(std::vector<SelIdPair>& 
         bool safe = addConstraintSafely(Obj, [&]() {
             // add missing point-on-object constraints
             if (!IsPointAlreadyOnCurve(GeoId1, GeoId3, PosId3, Obj)) {
-                Gui::cmdAppObjectArgs(
-                    Obj,
-                    "addConstraint(Sketcher.Constraint('PointOnObject',%d,%d,%d))",
-                    GeoId3,
-                    static_cast<int>(PosId3),
-                    GeoId1);
-            };
+                const Part::Geometry *geom1 = Obj->getGeometry(GeoId1);
+                if (!(geom1 && isBSplineCurve(*geom1))) {
+                    Gui::cmdAppObjectArgs(
+                        Obj,
+                        "addConstraint(Sketcher.Constraint('PointOnObject',%d,%d,%d))",
+                        GeoId3,
+                        static_cast<int>(PosId3),
+                        GeoId1);
+                }
+            }
 
             if (!IsPointAlreadyOnCurve(GeoId2, GeoId3, PosId3, Obj)) {
-                Gui::cmdAppObjectArgs(
-                    Obj,
-                    "addConstraint(Sketcher.Constraint('PointOnObject',%d,%d,%d))",
-                    GeoId3,
-                    static_cast<int>(PosId3),
-                    GeoId2);
-            };
+                const Part::Geometry *geom2 = Obj->getGeometry(GeoId2);
+                if (!(geom2 && isBSplineCurve(*geom2))) {
+                    Gui::cmdAppObjectArgs(
+                        Obj,
+                        "addConstraint(Sketcher.Constraint('PointOnObject',%d,%d,%d))",
+                        GeoId3,
+                        static_cast<int>(PosId3),
+                        GeoId2);
+                }
+            }
 
-            if (!IsPointAlreadyOnCurve(
-                    GeoId1,
-                    GeoId3,
-                    PosId3,
-                    Obj)) {// FIXME: it's a good idea to add a check if the sketch is solved
-                Gui::cmdAppObjectArgs(
-                    Obj,
-                    "addConstraint(Sketcher.Constraint('PointOnObject',%d,%d,%d))",
-                    GeoId3,
-                    static_cast<int>(PosId3),
-                    GeoId1);
-            };
+            if (!IsPointAlreadyOnCurve(GeoId1, GeoId3, PosId3, Obj)) {
+                // FIXME: it's a good idea to add a check if the sketch is solved
+                const Part::Geometry *geom1 = Obj->getGeometry(GeoId1);
+                if (!(geom1 && isBSplineCurve(*geom1))) {
+                    Gui::cmdAppObjectArgs(
+                        Obj,
+                        "addConstraint(Sketcher.Constraint('PointOnObject',%d,%d,%d))",
+                        GeoId3,
+                        static_cast<int>(PosId3),
+                        GeoId1);
+                }
+            }
 
             Gui::cmdAppObjectArgs(
                 Obj,
@@ -6356,7 +6372,7 @@ void CmdSketcherConstrainPerpendicular::applyConstraint(std::vector<SelIdPair>& 
         getSelection().clearSelection();
 
         return;
-    };
+    }
 }
 
 // ======================================================================================
@@ -6540,11 +6556,11 @@ void CmdSketcherConstrainTangent::activated(int iMsg)
         if (isVertex(GeoId1, PosId1)) {
             std::swap(GeoId1, GeoId2);
             std::swap(PosId1, PosId2);
-        };
+        }
         if (isVertex(GeoId2, PosId2)) {
             std::swap(GeoId2, GeoId3);
             std::swap(PosId2, PosId3);
-        };
+        }
 
         if (isEdge(GeoId1, PosId1) && isEdge(GeoId2, PosId2) && isVertex(GeoId3, PosId3)) {
 
@@ -6561,35 +6577,41 @@ void CmdSketcherConstrainTangent::activated(int iMsg)
             bool safe = addConstraintSafely(Obj, [&]() {
                 // add missing point-on-object constraints
                 if (!IsPointAlreadyOnCurve(GeoId1, GeoId3, PosId3, Obj)) {
-                    Gui::cmdAppObjectArgs(
-                        selection[0].getObject(),
-                        "addConstraint(Sketcher.Constraint('PointOnObject',%d,%d,%d))",
-                        GeoId3,
-                        static_cast<int>(PosId3),
-                        GeoId1);
-                };
+                    const Part::Geometry *geom1 = Obj->getGeometry(GeoId1);
+                    if (!(geom1 && isBSplineCurve(*geom1))) {
+                        Gui::cmdAppObjectArgs(
+                            selection[0].getObject(),
+                            "addConstraint(Sketcher.Constraint('PointOnObject',%d,%d,%d))",
+                            GeoId3,
+                            static_cast<int>(PosId3),
+                            GeoId1);
+                    }
+                }
 
                 if (!IsPointAlreadyOnCurve(GeoId2, GeoId3, PosId3, Obj)) {
-                    Gui::cmdAppObjectArgs(
-                        selection[0].getObject(),
-                        "addConstraint(Sketcher.Constraint('PointOnObject',%d,%d,%d))",
-                        GeoId3,
-                        static_cast<int>(PosId3),
-                        GeoId2);
-                };
+                    const Part::Geometry *geom2 = Obj->getGeometry(GeoId2);
+                    if (!(geom2 && isBSplineCurve(*geom2))) {
+                        Gui::cmdAppObjectArgs(
+                            selection[0].getObject(),
+                            "addConstraint(Sketcher.Constraint('PointOnObject',%d,%d,%d))",
+                            GeoId3,
+                            static_cast<int>(PosId3),
+                            GeoId2);
+                    }
+                }
 
-                if (!IsPointAlreadyOnCurve(
-                        GeoId1,
-                        GeoId3,
-                        PosId3,
-                        Obj)) {// FIXME: it's a good idea to add a check if the sketch is solved
-                    Gui::cmdAppObjectArgs(
-                        selection[0].getObject(),
-                        "addConstraint(Sketcher.Constraint('PointOnObject',%d,%d,%d))",
-                        GeoId3,
-                        static_cast<int>(PosId3),
-                        GeoId1);
-                };
+                if (!IsPointAlreadyOnCurve(GeoId1, GeoId3, PosId3, Obj)) {
+                    // FIXME: it's a good idea to add a check if the sketch is solved
+                    const Part::Geometry *geom1 = Obj->getGeometry(GeoId1);
+                    if (!(geom1 && isBSplineCurve(*geom1))) {
+                        Gui::cmdAppObjectArgs(
+                            selection[0].getObject(),
+                            "addConstraint(Sketcher.Constraint('PointOnObject',%d,%d,%d))",
+                            GeoId3,
+                            static_cast<int>(PosId3),
+                            GeoId1);
+                    }
+                }
 
                 Gui::cmdAppObjectArgs(
                     selection[0].getObject(),
@@ -6611,7 +6633,7 @@ void CmdSketcherConstrainTangent::activated(int iMsg)
             getSelection().clearSelection();
 
             return;
-        };
+        }
 
         Gui::TranslatedUserWarning(
             Obj,
@@ -7179,35 +7201,41 @@ void CmdSketcherConstrainTangent::applyConstraint(std::vector<SelIdPair>& selSeq
         bool safe = addConstraintSafely(Obj, [&]() {
             // add missing point-on-object constraints
             if (!IsPointAlreadyOnCurve(GeoId1, GeoId3, PosId3, Obj)) {
-                Gui::cmdAppObjectArgs(
-                    Obj,
-                    "addConstraint(Sketcher.Constraint('PointOnObject',%d,%d,%d))",
-                    GeoId3,
-                    static_cast<int>(PosId3),
-                    GeoId1);
-            };
+                const Part::Geometry *geom1 = Obj->getGeometry(GeoId1);
+                if (!(geom1 && isBSplineCurve(*geom1))) {
+                    Gui::cmdAppObjectArgs(
+                        Obj,
+                        "addConstraint(Sketcher.Constraint('PointOnObject',%d,%d,%d))",
+                        GeoId3,
+                        static_cast<int>(PosId3),
+                        GeoId1);
+                }
+            }
 
             if (!IsPointAlreadyOnCurve(GeoId2, GeoId3, PosId3, Obj)) {
-                Gui::cmdAppObjectArgs(
-                    Obj,
-                    "addConstraint(Sketcher.Constraint('PointOnObject',%d,%d,%d))",
-                    GeoId3,
-                    static_cast<int>(PosId3),
-                    GeoId2);
-            };
+                const Part::Geometry *geom2 = Obj->getGeometry(GeoId2);
+                if (!(geom2 && isBSplineCurve(*geom2))) {
+                    Gui::cmdAppObjectArgs(
+                        Obj,
+                        "addConstraint(Sketcher.Constraint('PointOnObject',%d,%d,%d))",
+                        GeoId3,
+                        static_cast<int>(PosId3),
+                        GeoId2);
+                }
+            }
 
-            if (!IsPointAlreadyOnCurve(
-                    GeoId1,
-                    GeoId3,
-                    PosId3,
-                    Obj)) {// FIXME: it's a good idea to add a check if the sketch is solved
-                Gui::cmdAppObjectArgs(
-                    Obj,
-                    "addConstraint(Sketcher.Constraint('PointOnObject',%d,%d,%d))",
-                    GeoId3,
-                    static_cast<int>(PosId3),
-                    GeoId1);
-            };
+            if (!IsPointAlreadyOnCurve(GeoId1, GeoId3, PosId3, Obj)) {
+                // FIXME: it's a good idea to add a check if the sketch is solved
+                const Part::Geometry *geom1 = Obj->getGeometry(GeoId1);
+                if (!(geom1 && isBSplineCurve(*geom1))) {
+                    Gui::cmdAppObjectArgs(
+                        Obj,
+                        "addConstraint(Sketcher.Constraint('PointOnObject',%d,%d,%d))",
+                        GeoId3,
+                        static_cast<int>(PosId3),
+                        GeoId1);
+                }
+            }
 
             Gui::cmdAppObjectArgs(
                 Obj,
@@ -7229,7 +7257,7 @@ void CmdSketcherConstrainTangent::applyConstraint(std::vector<SelIdPair>& selSeq
         getSelection().clearSelection();
 
         return;
-    };
+    }
 }
 
 // ======================================================================================
@@ -8551,11 +8579,11 @@ void CmdSketcherConstrainAngle::activated(int iMsg)
         if (isVertex(GeoId1, PosId1)) {
             std::swap(GeoId1, GeoId2);
             std::swap(PosId1, PosId2);
-        };
+        }
         if (isVertex(GeoId2, PosId2)) {
             std::swap(GeoId2, GeoId3);
             std::swap(PosId2, PosId3);
-        };
+        }
 
         bool bothexternal = areBothPointsOrSegmentsFixed(Obj, GeoId1, GeoId2);
 
@@ -8575,32 +8603,38 @@ void CmdSketcherConstrainAngle::activated(int iMsg)
 
             // add missing point-on-object constraints
             if (!IsPointAlreadyOnCurve(GeoId1, GeoId3, PosId3, Obj)) {
-                Gui::cmdAppObjectArgs(
-                    selection[0].getObject(),
-                    "addConstraint(Sketcher.Constraint('PointOnObject',%d,%d,%d))",
-                    GeoId3,
-                    static_cast<int>(PosId3),
-                    GeoId1);
+                const Part::Geometry *geom1 = Obj->getGeometry(GeoId1);
+                if (!(geom1 && isBSplineCurve(*geom1))) {
+                    Gui::cmdAppObjectArgs(
+                        selection[0].getObject(),
+                        "addConstraint(Sketcher.Constraint('PointOnObject',%d,%d,%d))",
+                        GeoId3,
+                        static_cast<int>(PosId3),
+                        GeoId1);
+                }
             }
             if (!IsPointAlreadyOnCurve(GeoId2, GeoId3, PosId3, Obj)) {
-                Gui::cmdAppObjectArgs(
-                    selection[0].getObject(),
-                    "addConstraint(Sketcher.Constraint('PointOnObject',%d,%d,%d))",
-                    GeoId3,
-                    static_cast<int>(PosId3),
-                    GeoId2);
+                const Part::Geometry *geom2 = Obj->getGeometry(GeoId2);
+                if (!(geom2 && isBSplineCurve(*geom2))) {
+                    Gui::cmdAppObjectArgs(
+                        selection[0].getObject(),
+                        "addConstraint(Sketcher.Constraint('PointOnObject',%d,%d,%d))",
+                        GeoId3,
+                        static_cast<int>(PosId3),
+                        GeoId2);
+                }
             }
-            if (!IsPointAlreadyOnCurve(
-                    GeoId1,
-                    GeoId3,
-                    PosId3,
-                    Obj)) {// FIXME: it's a good idea to add a check if the sketch is solved
-                Gui::cmdAppObjectArgs(
-                    selection[0].getObject(),
-                    "addConstraint(Sketcher.Constraint('PointOnObject',%d,%d,%d))",
-                    GeoId3,
-                    static_cast<int>(PosId3),
-                    GeoId1);
+            if (!IsPointAlreadyOnCurve(GeoId1, GeoId3, PosId3, Obj)) {
+                // FIXME: it's a good idea to add a check if the sketch is solved
+                const Part::Geometry *geom1 = Obj->getGeometry(GeoId1);
+                if (!(geom1 && isBSplineCurve(*geom1))) {
+                    Gui::cmdAppObjectArgs(
+                        selection[0].getObject(),
+                        "addConstraint(Sketcher.Constraint('PointOnObject',%d,%d,%d))",
+                        GeoId3,
+                        static_cast<int>(PosId3),
+                        GeoId1);
+                }
             }
 
             // assuming point-on-curves have been solved, calculate the angle.
@@ -8641,7 +8675,7 @@ void CmdSketcherConstrainAngle::activated(int iMsg)
             }
 
             return;
-        };
+        }
     }
     else if (SubNames.size() < 3) {
 
@@ -8728,7 +8762,7 @@ void CmdSketcherConstrainAngle::activated(int iMsg)
                 return;
             }
         }
-    };
+    }
 
     Gui::TranslatedUserWarning(
         Obj,
@@ -8804,26 +8838,35 @@ void CmdSketcherConstrainAngle::applyConstraint(std::vector<SelIdPair>& selSeq, 
 
         // add missing point-on-object constraints
         if (!IsPointAlreadyOnCurve(GeoId1, GeoId3, PosId3, Obj)) {
-            Gui::cmdAppObjectArgs(Obj,
-                                  "addConstraint(Sketcher.Constraint('PointOnObject',%d,%d,%d))",
-                                  GeoId3,
-                                  static_cast<int>(PosId3),
-                                  GeoId1);
+            const Part::Geometry *geom1 = Obj->getGeometry(GeoId1);
+            if (!(geom1 && isBSplineCurve(*geom1))) {
+                Gui::cmdAppObjectArgs(Obj,
+                                      "addConstraint(Sketcher.Constraint('PointOnObject',%d,%d,%d))",
+                                      GeoId3,
+                                      static_cast<int>(PosId3),
+                                      GeoId1);
+            }
         }
         if (!IsPointAlreadyOnCurve(GeoId2, GeoId3, PosId3, Obj)) {
-            Gui::cmdAppObjectArgs(Obj,
-                                  "addConstraint(Sketcher.Constraint('PointOnObject',%d,%d,%d))",
-                                  GeoId3,
-                                  static_cast<int>(PosId3),
-                                  GeoId2);
+            const Part::Geometry *geom2 = Obj->getGeometry(GeoId2);
+            if (!(geom2 && isBSplineCurve(*geom2))) {
+                Gui::cmdAppObjectArgs(Obj,
+                                      "addConstraint(Sketcher.Constraint('PointOnObject',%d,%d,%d))",
+                                      GeoId3,
+                                      static_cast<int>(PosId3),
+                                      GeoId2);
+            }
         }
         if (!IsPointAlreadyOnCurve(GeoId1, GeoId3, PosId3, Obj)) {
             // FIXME: it's a good idea to add a check if the sketch is solved
-            Gui::cmdAppObjectArgs(Obj,
-                                  "addConstraint(Sketcher.Constraint('PointOnObject',%d,%d,%d))",
-                                  GeoId3,
-                                  static_cast<int>(PosId3),
-                                  GeoId1);
+            const Part::Geometry *geom1 = Obj->getGeometry(GeoId1);
+            if (!(geom1 && isBSplineCurve(*geom1))) {
+                Gui::cmdAppObjectArgs(Obj,
+                                      "addConstraint(Sketcher.Constraint('PointOnObject',%d,%d,%d))",
+                                      GeoId3,
+                                      static_cast<int>(PosId3),
+                                      GeoId1);
+            }
         }
 
         // assuming point-on-curves have been solved, calculate the angle.
@@ -8859,7 +8902,7 @@ void CmdSketcherConstrainAngle::applyConstraint(std::vector<SelIdPair>& selSeq, 
         }
 
         return;
-    };
+    }
 }
 
 void CmdSketcherConstrainAngle::updateAction(int mode)
@@ -9587,7 +9630,7 @@ void CmdSketcherConstrainSnellsLaw::activated(int iMsg)
                                    QObject::tr("Wrong selection"),
                                    QObject::tr("Incompatible geometry is selected."));
         return;
-    };
+    }
 
     const Part::Geometry* geo = Obj->getGeometry(GeoId3);
 


### PR DESCRIPTION
Generalizing `AngleViaPoint` to allow working with B-splines without nearest point. Instead this will take the same parameter as `PointOnObject`.

This would need one or two extra param to be stored ([depending] on whether one or both curves are B-splines or need this param otherwise).

@abdullahtahiriyo opinions?