### PR TITLE
Git: Add pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+files: ^src/Mod/AddonManager
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-yaml
+    -   id: check-added-large-files
+-   repo: https://github.com/psf/black
+    rev: 22.10.0
+    hooks:
+        -   id: black
+-   repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v15.0.7
+    hooks:
+        -   id: clang-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,8 @@ repos:
     -   id: end-of-file-fixer
     -   id: check-yaml
     -   id: check-added-large-files
+    -   id: mixed-line-ending
+        args: [--fix=lf]
 -   repo: https://github.com/psf/black
     rev: 22.10.0
     hooks:


### PR DESCRIPTION
This is the first step towards resolving #8232 (and towards unifying our formatting so that we can eliminate superfluous formatting changes from PRs, speeding up the review process).

As [discussed in the forums](https://forum.freecad.org/viewtopic.php?t=77205), this is the first step in a multi-step process of unifying our code formatting. The overall idea is to use [pre-commit hooks](https://pre-commit.com) to auto format the code, _prior to the creation of the commit_. This all happens locally, and depends on developers installing the "pre-commit" Python package (e.g. `pip install pre-commit` and then `pre-commit install`). If a file in a proposed commit fails the checks, the hook automatically modifies the file in questions, and the developer must `git add` the modified file again to continue with the commit.

For testing purposes, the configuration in this PR *only* runs on commits made to the Addon Manager. As the "captain" of each Workbench in FreeCAD unifies that WB's formatting (and commits the results, adding the commit in question to the .git-blame-ignore-revs file), those captains can then add their Mod to the hook's `file:` regex, activating the hook for that code.

The hooks included here are:
* [trailing-whitespace](https://github.com/pre-commit/pre-commit-hooks#trailing-whitespace) (Deletes trailing whitespace)
* [end-of-file-fixer](https://github.com/pre-commit/pre-commit-hooks#end-of-file-fixer) (Ensures a single newline ends a non-empty file)
* [mixed-line-ending](https://github.com/pre-commit/pre-commit-hooks#mixed-line-ending) (Ensures Unix-style line endings)
* [check-yaml](https://github.com/pre-commit/pre-commit-hooks#check-yaml) (Sanitizes YAML)
* [check-added-large-files](https://github.com/pre-commit/pre-commit-hooks#check-added-large-files) (Prevents addition of large files)
* [black v22.10.0](https://github.com/psf/black) (Black code formatter for Python)
* [clang-format v15.0.7](https://github.com/pre-commit/mirrors-clang-format) (Clang-format code formatter for C++)

---

- [X]  This Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR