### PR TITLE
Points: `show` now returns an `GeoFeature` object

### DIFF
--- a/src/Mod/Points/App/AppPointsPy.cpp
+++ b/src/Mod/Points/App/AppPointsPy.cpp
@@ -398,6 +398,7 @@ private:
             Points::Feature* pcFeature = static_cast<Points::Feature*>(pcDoc->addObject("Points::Feature", name));
             // copy the data
             pcFeature->Points.setValue(*(pPoints->getPointKernelPtr()));
+	    return Py::asObject(pcFeature->getPyObject());
         }
         catch (const Base::Exception& e) {
             throw Py::RuntimeError(e.what());


### PR DESCRIPTION
* Added one return statement into try-catch block which returns the appropriate object (instead of `None`).
* Behaviour now in line with `Part.show`.

Example:

```Python
>>> import Points
>>> pp = Points.Points()
>>> pp.addPoints([(1,2,3),(4,5,6)])
>>> go = Points.show(pp)
>>> go  # Former behaviour was to return None
<GeoFeature object>
>>> go.ViewObject.ShapeColor = (1.,0.,0.)
>>> go.ViewObject.PointSize = 20
```

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
