### PR TITLE
Expression: use a precision that ensures no floating point issue

### DIFF
--- a/src/App/Expression.cpp
+++ b/src/App/Expression.cpp
@@ -1320,7 +1320,7 @@ void NumberExpression::_toString(std::ostream &ss, bool,int) const
     // https://en.cppreference.com/w/cpp/types/numeric_limits/max_digits10
     // https://www.boost.org/doc/libs/1_63_0/libs/multiprecision/doc/html/boost_multiprecision/tut/limits/constants.html
     boost::io::ios_flags_saver ifs(ss);
-    ss << std::setprecision(std::numeric_limits<double>::digits10 + 1) << getValue();
+    ss << std::setprecision(std::numeric_limits<double>::digits10) << getValue();
 
     /* Trim of any extra spaces */
     //while (s.size() > 0 && s[s.size() - 1] == ' ')


### PR DESCRIPTION
https://forum.freecad.org/viewtopic.php?t=77287

I should say I didn't really understand current code.
`std::numeric_limits<double>::digits10` is exactly the maximum precision to ensure no floating point rounding issue.
So setting it to `+ 1` is just making a step to the world of problems. :smile: 