### PR TITLE
Path: set enumeration default properties after `.initOperation`

### DIFF
--- a/src/Mod/Path/Path/Op/Base.py
+++ b/src/Mod/Path/Path/Op/Base.py
@@ -332,12 +332,6 @@ class ObjectOp(object):
                 ),
             )
 
-        for n in self.opPropertyEnumerations():
-            Path.Log.debug("n: {}".format(n))
-            Path.Log.debug("n[0]: {}  n[1]: {}".format(n[0], n[1]))
-            if hasattr(obj, n[0]):
-                setattr(obj, n[0], n[1])
-
         # members being set later
         self.commandlist = None
         self.horizFeed = None
@@ -352,6 +346,12 @@ class ObjectOp(object):
         self.addNewProps = None
 
         self.initOperation(obj)
+
+        for n in self.opPropertyEnumerations():
+            Path.Log.debug("n: {}".format(n))
+            Path.Log.debug("n[0]: {}  n[1]: {}".format(n[0], n[1]))
+            if hasattr(obj, n[0]):
+                setattr(obj, n[0], n[1])
 
         if not hasattr(obj, "DoNotSetDefaultValues") or not obj.DoNotSetDefaultValues:
             if parentJob:


### PR DESCRIPTION
This allows subclasses to override opPropertyEnumerations and have their defaults set by ObjectOp.__init__

Started a conversation here. https://forum.freecad.org/viewtopic.php?t=77274

The Path unit tests run as expected with this change in place, so I believe this should have no side effects.