### PR TITLE
Clang-Tidy: Remove readability-qualified-auto

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,7 +2,7 @@
 Checks:          'clang-diagnostic-*,clang-analyzer-*,boost-*,bugprone-*,
 performance-*,readability-*,portability-*,modernize-*,cppcoreguidelines-*,
 concurrency-*,-modernize-use-trailing-return-type, -modernize-use-nodiscard,
--readability-redundant-access-specifiers'
+-readability-redundant-access-specifiers,-readability-qualified-auto'
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false


### PR DESCRIPTION
Get rid of `readability-qualified-auto` (which enforces the LLVM coding standard of qualifying pointer-typed auto variables with a *, e.g. `auto *myPointer` instead of `auto myPointer`). IMO the last thing C++ needs is more punctuation marks 😄 .

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR