### PR TITLE
Pin conda package libcxx<16 to build with boost 1.78.0.

### DIFF
--- a/conda/environment.devenv.yml
+++ b/conda/environment.devenv.yml
@@ -70,6 +70,7 @@ dependencies:
 - gmsh
 - graphviz
 - hdf5
+- libcxx<16
 - matplotlib
 - ninja
 - numpy


### PR DESCRIPTION
Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [x]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---

Upstream conda-forge moved their pinning from `libcxx==15` to `libcxx==16` which led to build failures for projects that include boost.  Boost utilizes `std::unary_function` which has been removed in C++17 and is not present in `libcxx==16`.

This PR pins `libcxx<16` so that the project may build until a better fix is in place.

References:
* Upstream conda-forge `libcxx-feedstock` [Issue 114](https://github.com/conda-forge/libcxx-feedstock/issues/114)
* conda-forge `boost-cpp-feedstock` fix in review [PR#135](https://github.com/conda-forge/boost-cpp-feedstock/pull/135)