### PR TITLE
src: Add descriptor protocol support for Python C++ extension modules

### DIFF
--- a/src/Base/CMakeLists.txt
+++ b/src/Base/CMakeLists.txt
@@ -243,6 +243,7 @@ SET(FreeCADBase_CPP_SRCS
     ProgressIndicatorPy.cpp
     PyExport.cpp
     PyObjectBase.cpp
+    PythonTypeExt.cpp
     QtTools.cpp
     Reader.cpp
     Rotation.cpp
@@ -308,6 +309,7 @@ SET(FreeCADBase_HPP_SRCS
     ProgressIndicatorPy.h
     PyExport.h
     PyObjectBase.h
+    PythonTypeExt.h
     QtTools.h
     Reader.h
     Rotation.h

--- a/src/Base/PythonTypeExt.cpp
+++ b/src/Base/PythonTypeExt.cpp
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+/***************************************************************************
+ *   Copyright (c) 2023 Werner Mayer <wmayer[at]users.sourceforge.net>     *
+ *   Copyright (c) 2023 Mario Passaglia <mpassaglia[at]cbc.uba.ar>         *
+ *                                                                         *
+ *   This file is part of FreeCAD.                                         *
+ *                                                                         *
+ *   FreeCAD is free software: you can redistribute it and/or modify it    *
+ *   under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1 of the  *
+ *   License, or (at your option) any later version.                       *
+ *                                                                         *
+ *   FreeCAD is distributed in the hope that it will be useful, but        *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public      *
+ *   License along with FreeCAD. If not, see                               *
+ *   <https://www.gnu.org/licenses/>.                                      *
+ *                                                                         *
+ **************************************************************************/
+
+#include <CXX/Extensions.hxx>
+
+#include <Base/PythonTypeExt.h>
+
+
+using namespace Base;
+
+PythonTypeExt::PythonTypeExt(Py::PythonType& type)
+    : pytype(type)
+{
+}
+
+Py::PythonType& PythonTypeExt::set_tp_descr_get(PyObject* (*tp_descr_get)(PyObject* self, PyObject* obj, PyObject* type))
+{
+    pytype.type_object()->tp_descr_get = tp_descr_get;
+
+    return pytype;
+}
+
+Py::PythonType& PythonTypeExt::set_tp_descr_set(int (*tp_descr_set)(PyObject* self, PyObject* obj, PyObject* value))
+{
+    pytype.type_object()->tp_descr_set = tp_descr_set;
+
+    return pytype;
+}

--- a/src/Base/PythonTypeExt.h
+++ b/src/Base/PythonTypeExt.h
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+/***************************************************************************
+ *   Copyright (c) 2023 Werner Mayer <wmayer[at]users.sourceforge.net>     *
+ *   Copyright (c) 2023 Mario Passaglia <mpassaglia[at]cbc.uba.ar>         *
+ *                                                                         *
+ *   This file is part of FreeCAD.                                         *
+ *                                                                         *
+ *   FreeCAD is free software: you can redistribute it and/or modify it    *
+ *   under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1 of the  *
+ *   License, or (at your option) any later version.                       *
+ *                                                                         *
+ *   FreeCAD is distributed in the hope that it will be useful, but        *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public      *
+ *   License along with FreeCAD. If not, see                               *
+ *   <https://www.gnu.org/licenses/>.                                      *
+ *                                                                         *
+ **************************************************************************/
+
+#ifndef BASE_PYTHONTYPEEXT_H
+#define BASE_PYTHONTYPEEXT_H
+
+#include <FCGlobal.h>
+
+namespace Py
+{
+    class PythonType;
+}
+
+using PyObject = struct _object;
+
+namespace Base
+{
+
+/// class to extend PyCXX PythonType class
+class BaseExport PythonTypeExt
+{
+public:
+    PythonTypeExt(Py::PythonType& type);
+
+    Py::PythonType& set_tp_descr_get(PyObject* (*tp_descr_get)(PyObject* self, PyObject* obj, PyObject* type));
+    Py::PythonType& set_tp_descr_set(int (*tp_descr_set)(PyObject* self, PyObject* obj, PyObject* value));
+
+private:
+    Py::PythonType& pytype;
+};
+
+} // namespace Base
+
+#endif // BASE_PYTHONTYPEEXT_H

--- a/src/CXX/Python3/ExtensionType.hxx
+++ b/src/CXX/Python3/ExtensionType.hxx
@@ -96,7 +96,7 @@
 // need to support METH_STATIC and METH_CLASS
 
 #define PYCXX_ADD_NOARGS_METHOD( PYNAME, NAME, docs ) \
-    add_method( #PYNAME, (PyCFunction)PYCXX_NOARGS_METHOD_NAME( NAME ), METH_NOARGS, docs )
+    add_method( #PYNAME, (PyCFunction)(void (*) (void))PYCXX_NOARGS_METHOD_NAME( NAME ), METH_NOARGS, docs )
 #define PYCXX_ADD_VARARGS_METHOD( PYNAME, NAME, docs ) \
     add_method( #PYNAME, (PyCFunction)(void (*) (void))PYCXX_VARARGS_METHOD_NAME( NAME ), METH_VARARGS, docs )
 #define PYCXX_ADD_KEYWORDS_METHOD( PYNAME, NAME, docs ) \

--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -62,6 +62,7 @@
 #include "AxisOriginPy.h"
 #include "BitmapFactory.h"
 #include "Command.h"
+#include "CommandActionPy.h"
 #include "CommandPy.h"
 #include "Control.h"
 #include "DlgSettingsCacheDirectory.h"
@@ -468,6 +469,10 @@ Application::Application(bool GUIenabled)
         Py::Module(module).setAttr(std::string("Control"),
             Py::Object(Gui::TaskView::ControlPy::getInstance(), true));
         Gui::TaskView::TaskDialogPy::init_type();
+
+        CommandActionPy::init_type();
+        Base::Interpreter().addType(CommandActionPy::type_object(),
+            module, "CommandAction");
 
         Base::Interpreter().addType(&LinkViewPy::Type, module, "LinkView");
         Base::Interpreter().addType(&AxisOriginPy::Type, module, "AxisOrigin");

--- a/src/Gui/CMakeLists.txt
+++ b/src/Gui/CMakeLists.txt
@@ -378,6 +378,7 @@ SET(Command_CPP_SRCS
     CommandPyImp.cpp
     ShortcutManager.cpp
     CommandCompleter.cpp
+    CommandActionPy.cpp
 )
 SET(Command_SRCS
     ${Command_CPP_SRCS}
@@ -387,6 +388,7 @@ SET(Command_SRCS
     CommandT.h
     ShortcutManager.h
     CommandCompleter.h
+    CommandActionPy.h
 )
 SOURCE_GROUP("Command" FILES ${Command_SRCS})
 

--- a/src/Gui/Command.cpp
+++ b/src/Gui/Command.cpp
@@ -1259,6 +1259,11 @@ PythonCommand::PythonCommand(const char* name, PyObject * pcPyCommand, const cha
             type += int(NoTransaction);
         eType = type;
     }
+
+    auto& rcCmdMgr = Gui::Application::Instance->commandManager();
+
+    connPyCmdInitialized = rcCmdMgr.signalPyCmdInitialized.connect(
+        boost::bind(&PythonCommand::onActionInit, this));
 }
 
 PythonCommand::~PythonCommand()
@@ -1432,6 +1437,25 @@ bool PythonCommand::isChecked() const
     }
 }
 
+void PythonCommand::onActionInit() const
+{
+    try {
+        Base::PyGILStateLocker lock;
+        Py::Object cmd(_pcPyCommand);
+        if (cmd.hasAttr("OnActionInit")) {
+            Py::Callable call(cmd.getAttr("OnActionInit"));
+            Py::Tuple args;
+            Py::Object ret = call.apply(args);
+        }
+    }
+    catch(Py::Exception& e) {
+        Base::PyGILStateLocker lock;
+        e.clear();
+    }
+
+    connPyCmdInitialized.disconnect();
+}
+
 //===========================================================================
 // PythonGroupCommand
 //===========================================================================
@@ -1466,6 +1490,11 @@ PythonGroupCommand::PythonGroupCommand(const char* name, PyObject * pcPyCommand)
             type += int(ForEdit);
         eType = type;
     }
+
+    auto& rcCmdMgr = Gui::Application::Instance->commandManager();
+
+    connPyCmdInitialized = rcCmdMgr.signalPyCmdInitialized.connect(
+        boost::bind(&PythonGroupCommand::onActionInit, this));
 }
 
 PythonGroupCommand::~PythonGroupCommand()
@@ -1730,6 +1759,25 @@ bool PythonGroupCommand::hasDropDownMenu() const
         throw Base::TypeError("PythonGroupCommand::hasDropDownMenu(): Method GetResources() of the Python "
                               "command object contains the key 'DropDownMenu' which is not a boolean");
     }
+}
+
+void PythonGroupCommand::onActionInit() const
+{
+    try {
+        Base::PyGILStateLocker lock;
+        Py::Object cmd(_pcPyCommand);
+        if (cmd.hasAttr("OnActionInit")) {
+            Py::Callable call(cmd.getAttr("OnActionInit"));
+            Py::Tuple args;
+            Py::Object ret = call.apply(args);
+        }
+    }
+    catch(Py::Exception& e) {
+        Base::PyGILStateLocker lock;
+        e.clear();
+    }
+
+    connPyCmdInitialized.disconnect();
 }
 
 //===========================================================================

--- a/src/Gui/Command.h
+++ b/src/Gui/Command.h
@@ -686,8 +686,6 @@ protected:
     bool isActive() override;
     /// Get the help URL
     const char* getHelpUrl() const override;
-    /// Creates the used Action
-    Action * createAction() override;
     //@}
 
 public:
@@ -710,12 +708,18 @@ public:
 protected:
     /// Returns the resource values
     const char* getResource(const char* sName) const;
+    /// Creates the used Action
+    Action * createAction() override;
     /// a pointer to the Python command object
     PyObject * _pcPyCommand;
     /// the command object resource dictionary
     PyObject * _pcPyResourceDict;
     /// the activation sequence
     std::string Activation;
+    //// set the parameters on action creation
+    void onActionInit() const;
+
+    boost::signals2::connection connPyCmdInitialized;
 };
 
 /** The Python group command class
@@ -761,10 +765,14 @@ public:
 protected:
     /// Returns the resource values
     const char* getResource(const char* sName) const;
+    //// set the parameters on action creation
+    void onActionInit() const;
     /// a pointer to the Python command object
     PyObject * _pcPyCommand;
     /// the command object resources
     PyObject * _pcPyResource;
+
+    boost::signals2::connection connPyCmdInitialized;
 };
 
 
@@ -886,6 +894,9 @@ public:
 
     /// Signal on any addition or removal of command
     boost::signals2::signal<void ()> signalChanged;
+
+    /// Signal to Python command on first workbench activation
+    boost::signals2::signal<void ()> signalPyCmdInitialized;
 
     /** 
      * Returns a pointer to a conflicting command, or nullptr if there is no conflict.

--- a/src/Gui/CommandActionPy.cpp
+++ b/src/Gui/CommandActionPy.cpp
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+/***************************************************************************
+ *   Copyright (c) 2023 Mario Passaglia <mpassaglia[at]cbc.uba.ar>         *
+ *                                                                         *
+ *   This file is part of FreeCAD.                                         *
+ *                                                                         *
+ *   FreeCAD is free software: you can redistribute it and/or modify it    *
+ *   under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1 of the  *
+ *   License, or (at your option) any later version.                       *
+ *                                                                         *
+ *   FreeCAD is distributed in the hope that it will be useful, but        *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public      *
+ *   License along with FreeCAD. If not, see                               *
+ *   <https://www.gnu.org/licenses/>.                                      *
+ *                                                                         *
+ **************************************************************************/
+
+#include <Base/PythonTypeExt.h>
+
+#include "Command.h"
+#include "Action.h"
+#include "PythonWrapper.h"
+
+#include "CommandActionPy.h"
+#include "CommandPy.h"
+
+
+using namespace Gui;
+
+CommandActionPy::CommandActionPy(Py::PythonClassInstance* self, Py::Tuple& args, Py::Dict& kwds)
+    : Py::PythonClass<CommandActionPy>::PythonClass(self, args, kwds)
+{
+    const char* name;
+    if (!PyArg_ParseTuple(args.ptr(), "s", &name)) {
+        throw Py::Exception();
+    }
+
+    cmdName = name;
+    cmd = Application::Instance->commandManager().getCommandByName(name);
+}
+
+CommandActionPy::~CommandActionPy()
+{
+}
+
+Py::Object CommandActionPy::getAction()
+{
+    if (!cmd) {
+        cmd = Application::Instance->commandManager().getCommandByName(cmdName.c_str());
+    }
+
+    if (cmd) {
+        Action* action = cmd->getAction();
+        PythonWrapper wrap;
+        wrap.loadWidgetsModule();
+
+        return wrap.fromQObject(action->action());
+    }
+    else {
+        return Py::None();
+    }
+}
+
+Py::Object CommandActionPy::getCommand()
+{
+    if (!cmd) {
+        cmd = Application::Instance->commandManager().getCommandByName(cmdName.c_str());
+    }
+
+    if (cmd) {
+        auto cmdPy = new CommandPy(cmd);
+        return Py::asObject(cmdPy);
+    }
+
+    return Py::None();
+}
+PYCXX_NOARGS_METHOD_DECL(CommandActionPy, getCommand)
+
+void CommandActionPy::init_type()
+{
+    Base::PythonTypeExt ext(behaviors());
+
+    behaviors().name("Gui.CommandAction");
+    behaviors().doc("Descriptor to access the action of the commands");
+    behaviors().supportRepr();
+    behaviors().supportGetattro();
+    behaviors().supportSetattro();
+    ext.set_tp_descr_get(&CommandActionPy::descriptorGetter);
+    ext.set_tp_descr_set(&CommandActionPy::descriptorSetter);
+    PYCXX_ADD_NOARGS_METHOD(getCommand, getCommand, "Descriptor associated command");
+
+    behaviors().readyType();
+}
+
+PyObject* CommandActionPy::descriptorGetter(PyObject* self, PyObject* /*obj*/, PyObject* /*type*/)
+{
+    auto cmdAction = Py::PythonClassObject<CommandActionPy>(self).getCxxObject();
+
+    return Py::new_reference_to(cmdAction->getAction());
+}
+
+int CommandActionPy::descriptorSetter(PyObject* /*self*/, PyObject* /*obj*/, PyObject* value)
+{
+    if (value) {
+        PyErr_SetString(PyExc_AttributeError, "Can't overwrite command action");
+    }
+    else {
+        PyErr_SetString(PyExc_AttributeError, "Can't delete command action");
+    }
+
+    return -1;
+}
+
+Py::Object CommandActionPy::repr()
+{
+    std::stringstream s;
+    s << this->cmdName << " command action descriptor";
+
+    return Py::String(s.str());
+}
+
+Py::Object CommandActionPy::getattro(const Py::String& attr_)
+{
+    std::string attr = static_cast<std::string>(attr_);
+    Py::Dict d;
+    d["name"] = Py::String(this->cmdName);
+    if (attr == "__dict__") {
+        return d;
+    }
+    else if (attr == "name") {
+        return d["name"];
+    }
+    else {
+        return genericGetAttro(attr_);
+    }
+}
+
+int CommandActionPy::setattro(const Py::String& attr_, const Py::Object& value)
+{
+    std::string attr = static_cast<std::string>(attr_);
+    if (attr == "name" && value.isString()) {
+        cmdName = static_cast<std::string>(Py::String(value));
+        cmd = Application::Instance->commandManager().getCommandByName(cmdName.c_str());
+    }
+    else {
+        return genericSetAttro(attr_, value);
+    }
+
+    return 0;
+}

--- a/src/Gui/CommandActionPy.h
+++ b/src/Gui/CommandActionPy.h
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+/***************************************************************************
+ *   Copyright (c) 2023 Mario Passaglia <mpassaglia[at]cbc.uba.ar>         *
+ *                                                                         *
+ *   This file is part of FreeCAD.                                         *
+ *                                                                         *
+ *   FreeCAD is free software: you can redistribute it and/or modify it    *
+ *   under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1 of the  *
+ *   License, or (at your option) any later version.                       *
+ *                                                                         *
+ *   FreeCAD is distributed in the hope that it will be useful, but        *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public      *
+ *   License along with FreeCAD. If not, see                               *
+ *   <https://www.gnu.org/licenses/>.                                      *
+ *                                                                         *
+ **************************************************************************/
+
+#ifndef GUI_COMMANDACTIONPY_H
+#define GUI_COMMANDACTIONPY_H
+
+#include <CXX/Extensions.hxx>
+
+
+namespace Gui
+{
+
+class CommandActionPy : public Py::PythonClass<CommandActionPy>
+{
+public:
+    static void init_type();
+
+    CommandActionPy(Py::PythonClassInstance* self, Py::Tuple& args, Py::Dict& kdws);
+    ~CommandActionPy() override;
+
+    Py::Object getCommand();
+
+protected:
+    static PyObject* descriptorGetter(PyObject* self, PyObject* obj, PyObject* type);
+    static int descriptorSetter(PyObject* self, PyObject* obj, PyObject* value);
+    Py::Object repr() override;
+    Py::Object getattro(const Py::String& attr) override;
+    int setattro(const Py::String& attr_, const Py::Object& value) override;
+
+    Py::Object getAction();
+
+private:
+    std::string cmdName;
+    Command* cmd = nullptr;
+};
+
+} // namespace Gui
+
+#endif // GUI_COMMANDACTIONPY_H

--- a/src/Gui/Workbench.cpp
+++ b/src/Gui/Workbench.cpp
@@ -393,6 +393,7 @@ void  Workbench::addPermanentMenuItems(MenuItem* mb) const
 
 void Workbench::activated()
 {
+    Application::Instance->commandManager().signalPyCmdInitialized();
 }
 
 void Workbench::deactivated()

--- a/src/Tools/generateBase/generateMetaModel_Module.xsd
+++ b/src/Tools/generateBase/generateMetaModel_Module.xsd
@@ -66,6 +66,8 @@
 						<xs:attribute name="Reference" type="xs:boolean" use="optional"/>
 						<xs:attribute name="Initialization" type="xs:boolean" use="optional" default="false"/>
 						<xs:attribute name="DisableNotify" type="xs:boolean" use="optional" default="false"/>
+						<xs:attribute name="DescriptorGetter" type="xs:boolean" use="optional" default="false"/>
+						<xs:attribute name="DescriptorSetter" type="xs:boolean" use="optional" default="false"/>
 					</xs:complexType>
 				</xs:element>
 			</xs:sequence>

--- a/src/Tools/generateBase/generateModel_Module.py
+++ b/src/Tools/generateBase/generateModel_Module.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# Generated Mon Mar  6 17:37:05 2023 by generateDS.py.
+# Generated Fri Mar 31 16:59:53 2023 by generateDS.py.
 # Update it with: python generateDS.py -o generateModel_Module.py generateMetaModel_Module.xsd
 #
 # WARNING! All changes made in this file will be lost!
@@ -220,7 +220,7 @@ class GenerateModel:
 
 class PythonExport:
     subclass = None
-    def __init__(self, Name='', PythonName='', Include='', Father='', Twin='', Namespace='', FatherInclude='', FatherNamespace='', Constructor=0, NumberProtocol=0, RichCompare=0, TwinPointer='', Delete=0, Reference=0, Initialization=0, DisableNotify=0, Documentation=None, Methode=None, Attribute=None, Sequence=None, CustomAttributes='', ClassDeclarations='', ForwardDeclarations=''):
+    def __init__(self, Name='', PythonName='', Include='', Father='', Twin='', Namespace='', FatherInclude='', FatherNamespace='', Constructor=0, NumberProtocol=0, RichCompare=0, TwinPointer='', Delete=0, Reference=0, Initialization=0, DisableNotify=0, DescriptorGetter=0, DescriptorSetter=0, Documentation=None, Methode=None, Attribute=None, Sequence=None, CustomAttributes='', ClassDeclarations='', ForwardDeclarations=''):
         self.Name = Name
         self.PythonName = PythonName
         self.Include = Include
@@ -237,6 +237,8 @@ class PythonExport:
         self.Reference = Reference
         self.Initialization = Initialization
         self.DisableNotify = DisableNotify
+        self.DescriptorGetter = DescriptorGetter
+        self.DescriptorSetter = DescriptorSetter
         self.Documentation = Documentation
         if Methode is None:
             self.Methode = []
@@ -306,6 +308,10 @@ class PythonExport:
     def setInitialization(self, Initialization): self.Initialization = Initialization
     def getDisablenotify(self): return self.DisableNotify
     def setDisablenotify(self, DisableNotify): self.DisableNotify = DisableNotify
+    def getDescriptorgetter(self): return self.DescriptorGetter
+    def setDescriptorgetter(self, DescriptorGetter): self.DescriptorGetter = DescriptorGetter
+    def getDescriptorsetter(self): return self.DescriptorSetter
+    def setDescriptorsetter(self, DescriptorSetter): self.DescriptorSetter = DescriptorSetter
     def export(self, outfile, level, name_='PythonExport'):
         showIndent(outfile, level)
         outfile.write('<%s' % (name_, ))
@@ -339,6 +345,10 @@ class PythonExport:
             outfile.write(' Initialization="%s"' % (self.getInitialization(), ))
         if self.getDisablenotify() is not None:
             outfile.write(' DisableNotify="%s"' % (self.getDisablenotify(), ))
+        if self.getDescriptorgetter() is not None:
+            outfile.write(' DescriptorGetter="%s"' % (self.getDescriptorgetter(), ))
+        if self.getDescriptorsetter() is not None:
+            outfile.write(' DescriptorSetter="%s"' % (self.getDescriptorsetter(), ))
     def exportChildren(self, outfile, level, name_='PythonExport'):
         if self.Documentation:
             self.Documentation.export(outfile, level)
@@ -391,6 +401,10 @@ class PythonExport:
         outfile.write('Initialization = "%s",\n' % (self.getInitialization(),))
         showIndent(outfile, level)
         outfile.write('DisableNotify = "%s",\n' % (self.getDisablenotify(),))
+        showIndent(outfile, level)
+        outfile.write('DescriptorGetter = "%s",\n' % (self.getDescriptorgetter(),))
+        showIndent(outfile, level)
+        outfile.write('DescriptorSetter = "%s",\n' % (self.getDescriptorsetter(),))
     def exportLiteralChildren(self, outfile, level, name_):
         if self.Documentation:
             showIndent(outfile, level)
@@ -508,6 +522,20 @@ class PythonExport:
                 self.DisableNotify = 0
             else:
                 raise ValueError('Bad boolean attribute (DisableNotify)')
+        if attrs.get('DescriptorGetter'):
+            if attrs.get('DescriptorGetter').value in ('true', '1'):
+                self.DescriptorGetter = 1
+            elif attrs.get('DescriptorGetter').value in ('false', '0'):
+                self.DescriptorGetter = 0
+            else:
+                raise ValueError('Bad boolean attribute (DescriptorGetter)')
+        if attrs.get('DescriptorSetter'):
+            if attrs.get('DescriptorSetter').value in ('true', '1'):
+                self.DescriptorSetter = 1
+            elif attrs.get('DescriptorSetter').value in ('false', '0'):
+                self.DescriptorSetter = 0
+            else:
+                raise ValueError('Bad boolean attribute (DescriptorSetter)')
     def buildChildren(self, child_, nodeName_):
         if child_.nodeType == Node.ELEMENT_NODE and \
             nodeName_ == 'Documentation':
@@ -1950,6 +1978,22 @@ class SaxGeneratemodelHandler(handler.ContentHandler):
                     obj.setDisablenotify(0)
                 else:
                     self.reportError('"DisableNotify" attribute must be boolean ("true", "1", "false", "0")')
+            val = attrs.get('DescriptorGetter', None)
+            if val is not None:
+                if val in ('true', '1'):
+                    obj.setDescriptorgetter(1)
+                elif val in ('false', '0'):
+                    obj.setDescriptorgetter(0)
+                else:
+                    self.reportError('"DescriptorGetter" attribute must be boolean ("true", "1", "false", "0")')
+            val = attrs.get('DescriptorSetter', None)
+            if val is not None:
+                if val in ('true', '1'):
+                    obj.setDescriptorsetter(1)
+                elif val in ('false', '0'):
+                    obj.setDescriptorsetter(0)
+                else:
+                    self.reportError('"DescriptorSetter" attribute must be boolean ("true", "1", "false", "0")')
             stackObj = SaxStackElement('PythonExport', obj)
             self.stack.append(stackObj)
             done = 1

--- a/src/Tools/generateTemplates/templateClassPyExport.py
+++ b/src/Tools/generateTemplates/templateClassPyExport.py
@@ -71,6 +71,12 @@ public:
 + if (self.export.RichCompare):
     static PyObject * richCompare(PyObject *v, PyObject *w, int op);
 -
++ if (self.export.DescriptorGetter):
+    static PyObject* descriptorGetter(PyObject* self, PyObject* obj, PyObject* type);
+-
++ if (self.export.DescriptorSetter):
+    static int descriptorSetter(PyObject* self, PyObject* obj, PyObject* value);
+-
     static PyGetSetDef    GetterSetter[];
     virtual PyTypeObject *GetType() {return &Type;}
 
@@ -325,8 +331,16 @@ PyTypeObject @self.export.Name@::Type = {
     @self.export.Namespace@::@self.export.Name@::GetterSetter,                     /*tp_getset */
     &@self.export.FatherNamespace@::@self.export.Father@::Type,                        /*tp_base */
     nullptr,                                          /*tp_dict */
++ if (self.export.DescriptorGetter):
+    @self.export.Namespace@::@self.export.Name@::descriptorGetter,                       /*tp_descr_get */
+= else:
     nullptr,                                          /*tp_descr_get */
+-
++ if (self.export.DescriptorSetter):
+    @self.export.Namespace@::@self.export.Name@::descriptorSetter,                       /*tp_descr_set */
+= else:
     nullptr,                                          /*tp_descr_set */
+-
     0,                                                /*tp_dictoffset */
     __PyInit,                                         /*tp_init */
     nullptr,                                          /*tp_alloc */
@@ -1125,6 +1139,22 @@ int @self.export.Name@::setCustomAttributes(const char* /*attr*/, PyObject* /*ob
     return 0; 
 }
 -
+
++ if (self.export.DescriptorGetter):
+PyObject* @self.export.Name@::descriptorGetter(PyObject* self, PyObject* obj, PyObject* type)
+{
+    PyErr_SetString(PyExc_NotImplementedError, "Not yet implemented");
+    return nullptr;
+}
+-
+
++ if (self.export.DescriptorSetter):
+int @self.export.Name@::descriptorSetter(PyObject* self, PyObject* obj, PyObject* value)
+{
+    PyErr_SetString(PyExc_NotImplementedError, "Not yet implemented");
+    return -1;
+}
+-
 #endif
 
 
@@ -1450,6 +1480,22 @@ PyObject *@self.export.Name@::getCustomAttributes(const char* /*attr*/) const
 int @self.export.Name@::setCustomAttributes(const char* /*attr*/, PyObject* /*obj*/)
 {
     return 0; 
+}
+-
+
++ if (self.export.DescriptorGetter):
+PyObject* @self.export.Name@::descriptorGetter(PyObject* self, PyObject* obj, PyObject* type)
+{
+    PyErr_SetString(PyExc_NotImplementedError, "Not yet implemented");
+    return nullptr;
+}
+-
+
++ if (self.export.DescriptorSetter):
+int @self.export.Name@::descriptorSetter(PyObject* self, PyObject* obj, PyObject* value)
+{
+    PyErr_SetString(PyExc_NotImplementedError, "Not yet implemented");
+    return -1;
 }
 -
 


### PR DESCRIPTION
This PR contains two commits:

The first  add support for descriptor objects.

On the PyCXX side, the `set_tp_descr_get` and `set_tp_descr_set` functions are added to the `Py::PythonType` class.

For C++ extensions generated via xml files, the boolean attributes `DescriptorSetter` and `DescriptorGetter` are added to the initial tag of the `PythonExport` element.
then in the file `MyClassPyImp.cpp` you must add the definition of the functions:

`PyObject* MyClassPy::descriptorGetter(PyObject* self, PyObject* obj, PyObject* type)`
`int MyClassPy::descriptorSetter(PyObject* self, PyObject* obj, PyObject* value)`
\
\
In the second commit  the `CommandActionPy` class is added (as an example of the use of descriptors) which allows full access to the action of the commands from Python code through a class attribute previously defined at the initialization of the command itself and therefore to the existence of the action.

The `onActionInit` function is also added to the `PythonCommand` and `PythonGroupCommand` classes to control the initialization state of the action when loading the workbench for the first time.
The idea is that the classes of the commands written in python can define a function `OnActionInit` where the initial parameters of the action are set.

For example, in Python can do the following to access the action of the command `"MyMod_MyCommand"`:
```
class MyCommand:
         action = Gui.CommandAction("MyMod_MyCommand") # here the action does not exist in the system yet
        def __init__(self):
        .....
       def some_method(self):
       # use self.action here
       ......
       def OnActionInit(self)
              self.action.setVisible(False) # some initial state for the action
       ........

Gui.addCommand("MyMod_MyCommand", MyCommand())
```

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [ ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
