### PR TITLE
CI: initial release of Windows build workflow

### DIFF
--- a/.github/workflows/CI_master.yml
+++ b/.github/workflows/CI_master.yml
@@ -43,13 +43,19 @@ jobs:
     needs: [Prepare]
     uses: ./.github/workflows/sub_buildUbuntu2004.yml
     with:
-      artifactBasename: Build2004-${{ github.run_id }}
+      artifactBasename: Ubuntu_20-04-${{ github.run_id }}
 
   Ubuntu_22-04:
     needs: [Prepare]
     uses: ./.github/workflows/sub_buildUbuntu2204.yml
     with:
-      artifactBasename: Build2204-${{ github.run_id }}
+      artifactBasename: Ubuntu_22-04-${{ github.run_id }}
+
+  Windows:
+    needs: [Prepare]
+    uses: ./.github/workflows/sub_buildWindows.yml
+    with:
+      artifactBasename: Windows-${{ github.run_id }}
 
   Lint:
     needs: [Prepare]
@@ -61,7 +67,7 @@ jobs:
       changedPythonFiles: ${{ needs.Prepare.outputs.changedPythonFiles }}
 
   WrapUp:
-    needs: [Prepare, Ubuntu_20-04, Ubuntu_22-04, Lint]
+    needs: [Prepare, Ubuntu_20-04, Ubuntu_22-04, Windows, Lint]
     if: always()
     uses: ./.github/workflows/sub_wrapup.yml
     with:

--- a/.github/workflows/actions/windows/getCcache/action.yml
+++ b/.github/workflows/actions/windows/getCcache/action.yml
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# ***************************************************************************
+# *                                                                         *
+# *   Copyright (c) 2023 0penBrain.                                         *
+# *                                                                         *
+# *   This file is part of FreeCAD.                                         *
+# *                                                                         *
+# *   FreeCAD is free software: you can redistribute it and/or modify it    *
+# *   under the terms of the GNU Lesser General Public License as           *
+# *   published by the Free Software Foundation, either version 2.1 of the  *
+# *   License, or (at your option) any later version.                       *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful, but        *
+# *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+# *   Lesser General Public License for more details.                       *
+# *                                                                         *
+# *   You should have received a copy of the GNU Lesser General Public      *
+# *   License along with FreeCAD. If not, see                               *
+# *   <https://www.gnu.org/licenses/>.                                      *
+# *                                                                         *
+# ***************************************************************************
+
+# This action aims at speeding up CI and reduce dependency to external resources
+# by creating a cache of Ccache needed binaries then using it for CI runs rather
+# than downloading every time.
+#
+# If it needs to be updated to another version, the process it to change
+# 'downloadpath' and 'version' inputs below then delete the existing cache
+# from Github interface so a new one is generated using new values.
+
+name: getCcache
+description: "Windows: tries to get a cached version of Ccache and create one if fails"
+
+inputs:
+  ccachebindir:
+    description: "Directory where ccache binaries shall be stored"
+    required: true
+# Below inputs shall generally not be provided as they won't be used if a cached version exists
+# They are mainly used because Github do not support adding env variables in a composite action
+  ccachedownloadpath:
+    description: "Path where to download ccache"
+    required: false
+    default: https://github.com/ccache/ccache/releases/download/v4.7.4/
+  ccacheversion:
+    description: "Ccache version to be downloaded"
+    required: false
+    default: ccache-4.7.4-windows-x86_64
+
+runs:
+  using: "composite"
+  steps:
+    - name: Create destination directory
+      shell: bash
+      run: |
+        mkdir -p ${{ inputs.ccachebindir }}
+    - name: Get cached version
+      uses: actions/cache/restore@v3
+      id: getCached
+      with:
+        path: ${{ inputs.ccachebindir }}
+        key: ccacheforwin
+    - name: Download ccache
+      shell: bash
+      if: steps.getCached.outputs.cache-hit != 'true'
+      run: |
+        curl -L -o ccache.zip ${{ inputs.ccachedownloadpath }}${{ inputs.ccacheversion }}.zip
+        7z x ccache.zip -o"ccachetemp" -r -y
+        cp -a ccachetemp/${{ inputs.ccacheversion }}/ccache.exe ${{ inputs.ccachebindir }}
+        cp -a ccachetemp/${{ inputs.ccacheversion }}/ccache.exe ${{ inputs.ccachebindir }}/cl.exe
+        rm ccache.zip
+        rm -rf ccachetemp
+    - name: Save version to cache
+      if: steps.getCached.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v3
+      with:
+        path: ${{ inputs.ccachebindir }}
+        key: ${{ steps.getCached.outputs.cache-primary-key }}

--- a/.github/workflows/actions/windows/getLibpack/action.yml
+++ b/.github/workflows/actions/windows/getLibpack/action.yml
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# ***************************************************************************
+# *                                                                         *
+# *   Copyright (c) 2023 0penBrain.                                         *
+# *                                                                         *
+# *   This file is part of FreeCAD.                                         *
+# *                                                                         *
+# *   FreeCAD is free software: you can redistribute it and/or modify it    *
+# *   under the terms of the GNU Lesser General Public License as           *
+# *   published by the Free Software Foundation, either version 2.1 of the  *
+# *   License, or (at your option) any later version.                       *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful, but        *
+# *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+# *   Lesser General Public License for more details.                       *
+# *                                                                         *
+# *   You should have received a copy of the GNU Lesser General Public      *
+# *   License along with FreeCAD. If not, see                               *
+# *   <https://www.gnu.org/licenses/>.                                      *
+# *                                                                         *
+# ***************************************************************************
+
+# This action aims at speeding up CI and reduce dependency to external resources
+# by creating a cache of Libpack needed files then using it for CI runs rather
+# than downloading every time.
+#
+# If it needs to be updated to another version, the process it to change
+# 'downloadpath' and 'version' inputs below then delete the existing cache
+# from Github interface so a new one is generated using new values.
+
+name: getLibpack
+description: "Windows: tries to get a cached version of Libpack and create one if fails"
+
+inputs:
+  libpackdir:
+    description: "Directory where libpack files shall be stored"
+    required: true
+# Below inputs shall generally not be provided as they won't be used if a cached version exists
+# They are mainly used because Github do not support adding env variables in a composite action
+  libpackdownloadurl:
+    description: "URL where to download libpack"
+    required: false
+    default: https://github.com/FreeCAD/FreeCAD-LibPack/releases/download/2.8.2/LibPack-OCC76-V2-8.7z
+  libpackname:
+    description: "Libpack name (once downloaded)"
+    required: false
+    default: LibPack-OCC76-V2
+
+runs:
+  using: "composite"
+  steps:
+    - name: Create destination directory
+      shell: bash
+      run: |
+        mkdir -p ${{ inputs.libpackdir }}
+    - name: Get cached version
+      uses: actions/cache/restore@v3
+      id: getCached
+      with:
+        path: ${{ inputs.libpackdir }}
+        key: libpackforwin
+    - name: Download libpack
+      shell: bash
+      if: steps.getCached.outputs.cache-hit != 'true'
+      run: |
+        curl -L -o libpack.7z ${{ inputs.libpackdownloadurl }}
+        7z x libpack.7z -o"libpacktemp" -r -y
+        mv libpacktemp/${{ inputs.libpackname }}/* ${{ inputs.libpackdir }}
+        rm -rf libpacktemp
+    - name: Save version to cache
+      if: steps.getCached.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v3
+      with:
+        path: ${{ inputs.libpackdir }}
+        key: ${{ steps.getCached.outputs.cache-primary-key }}

--- a/.github/workflows/sub_buildWindows.yml
+++ b/.github/workflows/sub_buildWindows.yml
@@ -1,0 +1,143 @@
+# ***************************************************************************
+# *   Copyright (c) 2023 0penBrain                               *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   This program is distributed in the hope that it will be useful,       *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with this program; if not, write to the Free Software   *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+
+# This is a build and test workflow for CI of FreeCAD.
+# This workflow aims at building and testing FreeCAD on Windows using MSVC.
+
+name: Build Windows
+on:
+  workflow_call:
+    inputs:
+      artifactBasename:
+        type: string
+        required: true
+      allowedToFail:
+        default: false
+        type: boolean
+        required: false
+    outputs:
+      reportFile:
+        value: ${{ jobs.Build.outputs.reportFile }}
+
+jobs:
+  Build:
+    runs-on: windows-latest
+    continue-on-error: ${{ inputs.allowedToFail }}
+    env:
+      CCACHE_DIR: C:/FC/cache/
+      CCACHE_COMPILERCHECK: "%compiler%" # default:mtime
+      CCACHE_MAXSIZE: 1G
+      CCACHE_COMPRESS: true
+      CCACHE_COMPRESSLEVEL: 1
+      CCACHE_NOHASHDIR: true
+      CCACHE_DIRECT: true
+      #CCACHE_SLOPPINESS: "pch_defines,time_macros" # Can't get PCH to work on Windows
+      CCACHE_LOGFILE: C:/logs/ccache.log
+      ## Have to use C:\ because not enough space on workspace drive
+      builddir: C:/FC/build/
+      libpackdir: C:/FC/libpack/
+      ccachebindir: C:/FC/ccache/
+      logdir: C:/logs/
+      reportdir: C:/report/
+      reportfilename: ${{ inputs.artifactBasename }}-report.md
+    outputs:
+      reportFile: ${{ steps.Init.outputs.reportFile }}
+
+    steps:
+      - name: Checking out source code
+        uses: actions/checkout@v3
+      - name: Make needed directories, files and initializations
+        id: Init
+        run: |
+          mkdir ${{ env.CCACHE_DIR }}
+          mkdir ${{ env.ccachebindir }}
+          mkdir ${{ env.libpackdir }}
+          mkdir ${{ env.builddir }}
+          mkdir ${{ env.logdir }}
+          mkdir ${{ env.reportdir }}
+          echo "reportFile=${{ env.reportfilename }}" >> $GITHUB_OUTPUT
+      - name: Get Ccache
+        uses: ./.github/workflows/actions/windows/getCcache
+        with:
+          ccachebindir: ${{ env.ccachebindir }}
+      - name: Get Libpack
+        uses: ./.github/workflows/actions/windows/getLibpack
+        with:
+          libpackdir: ${{ env.libpackdir }}
+      - name: Restore compiler cache
+        uses: pat-s/always-upload-cache@v3
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: FC-Windows-${{ github.ref }}-${{ github.run_id }}
+          restore-keys: |
+            FC-Windows-${{ github.ref }}-
+            FC-Windows-
+      - name: Print Ccache statistics before build, reset stats and print config
+        run: |
+          . $env:ccachebindir\ccache -s
+          . $env:ccachebindir\ccache -z
+          . $env:ccachebindir\ccache -p
+      - name: Append Libpack bin directory to Path
+        if: false # Disabled because not enough to set FREECAD_COPY_LIBPACK_BIN_TO_BUILD=OFF
+        run: |
+          echo "${{ env.libpackdir }}/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      - name: Configuring CMake
+        run: >
+          cmake -B"${{ env.builddir }}" .
+          -DCMAKE_VS_NO_COMPILE_BATCHING=ON
+          -DCMAKE_BUILD_TYPE=Release
+          -DFREECAD_USE_PCH=OFF
+          -DFREECAD_RELEASE_PDB=OFF
+          -DFREECAD_LIBPACK_DIR="${{ env.libpackdir }}"
+          -DPYTHON_DEBUG_LIBRARY="${{ env.libpackdir }}bin/libs/python38_d.lib"
+          -DPYTHON_EXECUTABLE="${{ env.libpackdir }}bin/python.exe"
+          -DPYTHON_INCLUDE_DIR="${{ env.libpackdir }}bin/include"
+          -DPYTHON_LIBRARY="${{ env.libpackdir }}bin/libs/python38.lib"
+          -DXercesC_INCLUDE_DIR="${{ env.libpackdir }}include"
+          -DXercesC_LIBRARY_RELEASE="${{ env.libpackdir }}lib/xerces-c_3.lib"
+          -DXercesC_LIBRARY_DEBUG="${{ env.libpackdir }}lib/xerces-c_3D.lib"
+          -DFREECAD_COPY_DEPEND_DIRS_TO_BUILD=ON
+          -DFREECAD_COPY_LIBPACK_BIN_TO_BUILD=ON
+          -DFREECAD_COPY_PLUGINS_BIN_TO_BUILD=ON
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v1.1
+      - name: Compiling sources
+        run: |
+          cd $env:builddir
+          msbuild ALL_BUILD.vcxproj /m /p:Configuration=Release /p:TrackFileAccess=false /p:CLToolPath=${{ env.ccachebindir }}
+      - name: Print Ccache statistics after build
+        run: |
+          . $env:ccachebindir\ccache -s
+      - name: C++ unit tests
+        if: false # Disabled because seems to not exist on Windows build
+        timeout-minutes: 1
+        run: |
+          . ${{ env.builddir }}\test\Tests_run --gtest_output=json:${{ env.reportdir }}gtest_results.json # 2>&1 | tee -filepath ${{ env.logdir }}\unitTests.log
+      - name: FreeCAD CLI tests
+        run: |
+          . ${{ env.builddir }}\bin\FreeCADCmd -t 0 # 2>&1 | tee -filepath ${{ env.logdir }}\integrationTests.log
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ inputs.artifactBasename }}-Logs
+          path: |
+            ${{ env.logdir }}


### PR DESCRIPTION
Well, this is what I ended up as an initial Windows workflow.
It has following structure :
* Uses ccache as a caching program
* Builds with MSVC
* 2 actions are created so we can use a GH cached version of LibPack and CCache to reduce compilation time
* Only CLI tests (unit tests seems to not be here -- didn't investigate much -- and I didn't looked at GUI tests yet)
* No report is generated yet, just the status is reported in the summary (PowerShell isn't my friend actually)

I tried to optimize running delay but still it's generally longer than the Ubuntu builds (from about 5 to 15 min) and so will be the bottleneck of the CI.

One of things that takes some minutes is copying the libpack bin folder to build directory.
I tried to instead add the folder to PATH but tests fail. So it looks like it's not enough and actually there are some dependencies in it that aren't handled by the "COPY_DEPENDS" flag.