### PR TITLE
Deletes GCS::Constraint directly instead of calling GCS::free().

### DIFF
--- a/src/Mod/Sketcher/App/planegcs/GCS.cpp
+++ b/src/Mod/Sketcher/App/planegcs/GCS.cpp
@@ -651,9 +651,7 @@ void System::removeConstraint(Constraint *constr)
     }
     c2p.erase(constr);
 
-    std::vector<Constraint *> constrvec;
-    constrvec.push_back(constr);
-    free(constrvec);
+    delete(constr);
 }
 
 // basic constraints


### PR DESCRIPTION
As requested by @abdullahtahiriyo. See https://forum.freecad.org/viewtopic.php?t=76724#p673116.

Still needs to eliminate the switch/case from `GCS::free(std::vector<Constraint*>)`, to simply [delete the constraint instead of `static_casting` the many possible derived classes](https://github.com/FreeCAD/FreeCAD/blob/84808ef7bd0752e60e8050b3f8e5edef2afa5e29/src/Mod/Sketcher/App/planegcs/GCS.cpp#L5590).

---

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [ ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

It does not. Sorry!
Tests did not pass clean, but they did not pass clean using the code form FreeCAD/master, either. I get:
```
Activate workbench 'ImageWorkbench'
Program received signal SIGSEGV, Segmentation fault.
#0  /lib/x86_64-linux-gnu/libc.so.6(+0x3bf90) [0x7f6cba45af90]
#1  0x7f6cbc853820 in typeinfo for Base::ConsoleOutput from /home/andre/repositorios/FreeCAD_stable/build/build-FreeCAD_stable-Imported_Kit_temporary-Debug/lib/libFreeCADBase.so+0
Abortado
```

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
