### PR TITLE
[TD] Extend command CmdExtensionPositionSectionView to manage rotated section views

### DIFF
--- a/src/Mod/TechDraw/App/DrawUtil.cpp
+++ b/src/Mod/TechDraw/App/DrawUtil.cpp
@@ -1050,6 +1050,21 @@ bool DrawUtil::circulation(Base::Vector3d A, Base::Vector3d B, Base::Vector3d C)
     }
 }
 
+Base::Vector3d DrawUtil::getTrianglePoint(Base::Vector3d p1, Base::Vector3d dir, Base::Vector3d p2)
+{
+    // get third point of a perpendicular triangle
+    // p1, p2 ...vertexes of hypothenusis, dir ...direction of one kathete, p3 ...3rd vertex
+    float a = -dir.y;
+    float b = dir.x;
+    float c1 = p1.x * a + p1.y * b;
+    float c2 = -p2.x * b + p2.y * a;
+    float ab = a * a + b * b;
+    float x = (c1 * a - c2 * b) / ab;
+    float y = (c2 * a + c1 * b) / ab;
+    Base::Vector3d p3(x,y,0.0);
+    return p3;
+}
+
 int DrawUtil::countSubShapes(TopoDS_Shape shape, TopAbs_ShapeEnum subShape)
 {
     int count = 0;

--- a/src/Mod/TechDraw/App/DrawUtil.h
+++ b/src/Mod/TechDraw/App/DrawUtil.h
@@ -202,6 +202,7 @@ public:
     static bool isCrazy(TopoDS_Edge e);
     static Base::Vector3d getFaceCenter(TopoDS_Face f);
     static bool circulation(Base::Vector3d A, Base::Vector3d B, Base::Vector3d C);
+    static Base::Vector3d getTrianglePoint(Base::Vector3d p1, Base::Vector3d d, Base::Vector3d p2);
     static int countSubShapes(TopoDS_Shape shape, TopAbs_ShapeEnum subShape);
     static void encodeXmlSpecialChars(std::string& inoutText);
     static std::list<TopoDS_Edge> sort_Edges(double tol3d, std::list<TopoDS_Edge>& edges);

--- a/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp
+++ b/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp
@@ -75,7 +75,6 @@ namespace TechDrawGui {
     //internal helper functions
     void _selectDimensionAttributes(Gui::Command* cmd);
     std::vector<TechDraw::DrawViewDimension*>_getDimensions(std::vector<Gui::SelectionObject> selection, std::string needDimType);
-    Base::Vector3d _getTrianglePoint(Base::Vector3d p1, Base::Vector3d d, Base::Vector3d p2);
     std::vector<dimVertex> _getVertexInfo(TechDraw::DrawViewPart* objFeat,
         std::vector<std::string> subNames);
     TechDraw::DrawViewDimension* _createLinDimension(Gui::Command* cmd,
@@ -698,7 +697,7 @@ void execPosObliqueChainDimension(Gui::Command* cmd) {
         float xDim = dim->X.getValue();
         float yDim = dim->Y.getValue();
         Base::Vector3d pDim(xDim, yDim, 0.0);
-        Base::Vector3d p3 = _getTrianglePoint(pMaster, dirMaster, pDim);
+        Base::Vector3d p3 = DrawUtil::getTrianglePoint(pMaster, dirMaster, pDim);
         dim->X.setValue(p3.x);
         dim->Y.setValue(p3.y);
     }
@@ -1014,7 +1013,7 @@ void execCascadeObliqueDimension(Gui::Command* cmd) {
     Base::Vector3d dirMaster = pp.second() - pp.first();
     dirMaster.y = -dirMaster.y;
     Base::Vector3d origin(0.0, 0.0, 0.0);
-    Base::Vector3d ipDelta = _getTrianglePoint(pMaster, dirMaster, origin);
+    Base::Vector3d ipDelta = DrawUtil::getTrianglePoint(pMaster, dirMaster, origin);
     float dimDistance = activeDimAttributes.getCascadeSpacing();
     Base::Vector3d delta = ipDelta.Normalize() * dimDistance;
     int i = 0;
@@ -1022,7 +1021,7 @@ void execCascadeObliqueDimension(Gui::Command* cmd) {
         float xDim = dim->X.getValue();
         float yDim = dim->Y.getValue();
         Base::Vector3d pDim(xDim, yDim, 0.0);
-        Base::Vector3d p3 = _getTrianglePoint(pMaster, dirMaster, pDim);
+        Base::Vector3d p3 = DrawUtil::getTrianglePoint(pMaster, dirMaster, pDim);
         p3 = p3 + delta * i;
         dim->X.setValue(p3.x);
         dim->Y.setValue(p3.y);
@@ -1331,12 +1330,12 @@ void execCreateObliqueChainDimension(Gui::Command* cmd) {
         Base::Vector3d pMaster = allVertexes[0].point;
         Base::Vector3d dirMaster = pMaster - allVertexes[1].point;
         Base::Vector3d origin(0.0, 0.0, 0.0);
-        Base::Vector3d delta = _getTrianglePoint(pMaster, dirMaster, origin);
+        Base::Vector3d delta = DrawUtil::getTrianglePoint(pMaster, dirMaster, origin);
         float dimDistance = activeDimAttributes.getCascadeSpacing();
         delta = delta.Normalize() * dimDistance;
         double scale = objFeat->getScale();
         for (dimVertex oldVertex : allVertexes) {
-            Base::Vector3d nextPoint = _getTrianglePoint(pMaster, dirMaster, oldVertex.point);
+            Base::Vector3d nextPoint = DrawUtil::getTrianglePoint(pMaster, dirMaster, oldVertex.point);
             nextPoint.y = -nextPoint.y;
             oldVertex.point.y = -oldVertex.point.y;
             if ((oldVertex.point - nextPoint).Length() > 0.01) {
@@ -1680,12 +1679,12 @@ void execCreateObliqueCoordDimension(Gui::Command* cmd) {
         Base::Vector3d pMaster = allVertexes[0].point;
         Base::Vector3d dirMaster = pMaster - allVertexes[1].point;
         Base::Vector3d origin(0.0, 0.0, 0.0);
-        Base::Vector3d delta = _getTrianglePoint(pMaster, dirMaster, origin);
+        Base::Vector3d delta = DrawUtil::getTrianglePoint(pMaster, dirMaster, origin);
         float dimDistance = activeDimAttributes.getCascadeSpacing();
         delta = delta.Normalize() * dimDistance;
         double scale = objFeat->getScale();
         for (dimVertex oldVertex : allVertexes) {
-            Base::Vector3d nextPoint = _getTrianglePoint(pMaster, dirMaster, oldVertex.point);
+            Base::Vector3d nextPoint = DrawUtil::getTrianglePoint(pMaster, dirMaster, oldVertex.point);
             nextPoint.y = -nextPoint.y;
             oldVertex.point.y = -oldVertex.point.y;
             if ((oldVertex.point - nextPoint).Length() > 0.01) {
@@ -2317,20 +2316,6 @@ namespace TechDrawGui {
             }
         }
         return vertexes;
-    }
-
-    Base::Vector3d _getTrianglePoint(Base::Vector3d p1, Base::Vector3d dir, Base::Vector3d p2) {
-        // get third point of a perpendicular triangle
-        // p1, p2 ...vertexes of hypothenusis, dir ...direction of one kathete, p3 ...3rd vertex
-        float a = -dir.y;
-        float b = dir.x;
-        float c1 = p1.x * a + p1.y * b;
-        float c2 = -p2.x * b + p2.y * a;
-        float ab = a * a + b * b;
-        float x = (c1 * a - c2 * b) / ab;
-        float y = (c2 * a + c1 * b) / ab;
-        Base::Vector3d p3(x, y, 0.0);
-        return p3;
     }
 
     std::vector<TechDraw::DrawViewDimension*>_getDimensions(std::vector<Gui::SelectionObject> selection, std::string needDimType) {

--- a/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp
+++ b/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp
@@ -1495,6 +1495,15 @@ void CmdTechDrawExtensionPositionSectionView::activated(int iMsg)
             sectionView->Y.setValue(yPos);
         else if ((direction == "Up") || (direction == "Down"))
             sectionView->X.setValue(xPos);
+        else if (direction == "Aligned")
+        {
+            Base::Vector3d pBase(xPos,yPos,0.0);
+            Base::Vector3d dirView(sectionView->Direction.getValue());
+            Base::Vector3d pSection(sectionView->X.getValue(),sectionView->Y.getValue(),0.0);
+            Base::Vector3d newPos = DrawUtil::getTrianglePoint(pBase, dirView, pSection);
+            sectionView->X.setValue(newPos.x);
+            sectionView->Y.setValue(newPos.y);
+        }
     }
 }
 


### PR DESCRIPTION
This PR does the following:
1) Move the helper function **getTrianglePoint** to the file DrawUtil.
2) Extend the command **CmdExtensionPositionSectionView** to manage rotated section views.

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
