### PR TITLE
Clang-Tidy: Allow pointer-to-bool conversion

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -205,6 +205,8 @@ CheckOptions:
     value:           '0.200000'
   - key:             readability-implicit-bool-conversion.AllowIntegerConditions
     value:           'false'
+  - key:             readability-implicit-bool-conversion.AllowPointerConditions
+    value:           'true'
   - key:             readability-identifier-length.IgnoredParameterNames
     value:           '^[n]$'
   - key:             readability-function-size.StatementThreshold


### PR DESCRIPTION
Allow code like:
```
if (myPointer && myPointer->doTheThing())
```
(that is, allow pointers to be implicitly converted to booleans, instead of requiring explicit comparison to `nullptr`).

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR