### PR TITLE
Precommit: Enable in tests/src

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,11 @@
 
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
-files: ^src/Mod/AddonManager
+files: |
+    (?x)^(
+        src/Mod/AddonManager|
+        tests/src
+    )
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.2.0


### PR DESCRIPTION
The enables pre-commit for the `test/src` subdirectory (and shows how to add additional paths using the verbose regex syntax).

- [X]  This Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR