### PR TITLE
Gui: Add function in WindowParameter class to connect slot to ParameterManager signal

### DIFF
--- a/src/Gui/Window.cpp
+++ b/src/Gui/Window.cpp
@@ -23,11 +23,13 @@
 
 #include "PreCompiled.h"
 
+#include <boost/algorithm/string.hpp>
 #include <qglobal.h>
-#include "Window.h"
 
 #include <App/Application.h>
-#include <Base/Console.h>
+
+#include "Window.h"
+
 
 using namespace Gui;
 
@@ -53,29 +55,40 @@ WindowParameter::WindowParameter(const char *name)
 
 WindowParameter::~WindowParameter()
 {
+    connParamChanged.disconnect();
 }
 
 /** Sets the group of the window to \a name */
 bool WindowParameter::setGroupName(const char* name)
 {
-  if (_handle.isValid())
-    return false; // cannot change parameter group
+    // cannot change parameter group
+    if (_handle.isValid()) {
+        return false;
+    }
 
-  assert(name);
-  std::string prefGroup = name;
-  if (prefGroup.compare(0,15,"User parameter:") == 0 ||
-      prefGroup.compare(0,17,"System parameter:") == 0)
-    _handle = App::GetApplication().GetParameterGroupByPath( name );
-  else
-    _handle = getDefaultParameter()->GetGroup( name );
-  return true;
+    assert(name);
+
+    std::string prefGroup = name;
+    const auto& list = App::GetApplication().GetParameterSetList();
+
+    auto found = std::find_if(list.begin(), list.end(), [prefGroup](auto item) {
+        return boost::starts_with(prefGroup, item.first);
+    });
+
+    if (found != list.end()) {
+        _handle = App::GetApplication().GetParameterGroupByPath(name);
+    }
+    else {
+        _handle = getDefaultParameter()->GetGroup(name);
+    }
+
+    return true;
 }
 
 void WindowParameter::OnChange(Base::Subject<const char*> &rCaller, const char * sReason)
 {
   Q_UNUSED(rCaller);
   Q_UNUSED(sReason);
-  Base::Console().Log("Parameter has changed and window (%s) has not overridden this function!",_handle->GetGroupName());
 }
 
 ParameterGrp::handle  WindowParameter::getWindowParameter()

--- a/src/Gui/Window.cpp
+++ b/src/Gui/Window.cpp
@@ -44,13 +44,13 @@ using namespace Gui;
 
 WindowParameter::WindowParameter(const char *name)
 {
-  // not allowed to use a Window without a name, see the constructor of a DockWindow or a other QT Widget
-  assert(name);
-  //printf("Instanceate:%s\n",name);
+    // not allowed to use a Window without a name, see the constructor
+    // of a DockWindow or a other QT Widget
+    assert(name);
 
-  // if string is empty do not create group
-  if ( strcmp(name, "") != 0 )
-    _handle = getDefaultParameter()->GetGroup( name );
+    // if string is empty do not create group
+    if ( strcmp(name, "") != 0 )
+      _handle = getDefaultParameter()->GetGroup( name );
 }
 
 WindowParameter::~WindowParameter()
@@ -87,13 +87,13 @@ bool WindowParameter::setGroupName(const char* name)
 
 void WindowParameter::OnChange(Base::Subject<const char*> &rCaller, const char * sReason)
 {
-  Q_UNUSED(rCaller);
-  Q_UNUSED(sReason);
+    Q_UNUSED(rCaller);
+    Q_UNUSED(sReason);
 }
 
 ParameterGrp::handle  WindowParameter::getWindowParameter()
 {
-  return _handle;
+    return _handle;
 }
 
 /**
@@ -102,5 +102,5 @@ ParameterGrp::handle  WindowParameter::getWindowParameter()
  */
 ParameterGrp::handle  WindowParameter::getDefaultParameter()
 {
-  return App::GetApplication().GetUserParameter().GetGroup("BaseApp")->GetGroup("Preferences");
+    return App::GetApplication().GetUserParameter().GetGroup("BaseApp")->GetGroup("Preferences");
 }

--- a/src/Gui/Window.h
+++ b/src/Gui/Window.h
@@ -38,7 +38,6 @@ public:
   WindowParameter(const char *name);
   ~WindowParameter() override;
 
-  bool setGroupName( const char* name );
   void OnChange(Base::Subject<const char*> &rCaller, const char * sReason) override;
 
   /// get the parameters
@@ -46,9 +45,27 @@ public:
   /// return the parameter group of this window
   ParameterGrp::handle getWindowParameter();
 
+protected:
+  bool setGroupName( const char* name );
+  /// connect slot to ParameterManager signal
+  template<typename S, typename T>
+  void setSlotParamChanged(S slot, T* obsPtr);
+
 private:
   ParameterGrp::handle _handle;
+  boost::signals2::connection connParamChanged;
 };
+
+
+template<typename S, typename T>
+inline void WindowParameter::setSlotParamChanged(S slot, T* obsPtr)
+{
+  namespace bp = std::placeholders;
+  if (_handle->Manager()) {
+      connParamChanged = _handle->Manager()->signalParamChanged.connect(
+          std::bind(slot, obsPtr, bp::_1, bp::_2, bp::_3, bp::_4));
+  }
+}
 
 } // namespace Gui
 

--- a/src/Gui/Window.h
+++ b/src/Gui/Window.h
@@ -35,36 +35,36 @@ namespace Gui {
 class GuiExport WindowParameter : public ParameterGrp::ObserverType
 {
 public:
-  WindowParameter(const char *name);
-  ~WindowParameter() override;
+    WindowParameter(const char *name);
+    ~WindowParameter() override;
 
-  void OnChange(Base::Subject<const char*> &rCaller, const char * sReason) override;
+    void OnChange(Base::Subject<const char*> &rCaller, const char * sReason) override;
 
-  /// get the parameters
-  static ParameterGrp::handle getDefaultParameter();
-  /// return the parameter group of this window
-  ParameterGrp::handle getWindowParameter();
+    /// get the parameters
+    static ParameterGrp::handle getDefaultParameter();
+    /// return the parameter group of this window
+    ParameterGrp::handle getWindowParameter();
 
 protected:
-  bool setGroupName( const char* name );
-  /// connect slot to ParameterManager signal
-  template<typename S, typename T>
-  void setSlotParamChanged(S slot, T* obsPtr);
+    bool setGroupName( const char* name );
+    /// connect slot to ParameterManager signal
+    template<typename S, typename T>
+    void setSlotParamChanged(S slot, T* obsPtr);
 
 private:
-  ParameterGrp::handle _handle;
-  boost::signals2::connection connParamChanged;
+    ParameterGrp::handle _handle;
+    boost::signals2::connection connParamChanged;
 };
 
 
 template<typename S, typename T>
 inline void WindowParameter::setSlotParamChanged(S slot, T* obsPtr)
 {
-  namespace bp = std::placeholders;
-  if (_handle->Manager()) {
-      connParamChanged = _handle->Manager()->signalParamChanged.connect(
-          std::bind(slot, obsPtr, bp::_1, bp::_2, bp::_3, bp::_4));
-  }
+    namespace bp = std::placeholders;
+    if (_handle->Manager()) {
+        connParamChanged = _handle->Manager()->signalParamChanged.connect(
+            std::bind(slot, obsPtr, bp::_1, bp::_2, bp::_3, bp::_4));
+    }
 }
 
 } // namespace Gui


### PR DESCRIPTION
If a observer is connected directly to the signal of the ParameterManager, the observer is only notifed when a parameter value changes. So if is necessary to avoid recomputations, this strategy can by used instead the traditional `OnChange` function.

Sub-classes  of `WindowParameter` class can define a slot function with the appropiate signature:
`void MyClass::slot(ParameterGrp*, ParameterGrp::ParamType, const char*, const char*)`
and then connect using `setSlotParamChanged(&MyClass::slot, this)`

In `setGroupName` the group path is now checked using a regular expression.

 
Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [ ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
