### PR TITLE
TechDraw: Fix Windows compilation

### DIFF
--- a/src/Mod/TechDraw/App/CosmeticVertex.cpp
+++ b/src/Mod/TechDraw/App/CosmeticVertex.cpp
@@ -21,8 +21,11 @@
  *                                                                         *
  ***************************************************************************/
 
-#include <boost/uuid/uuid_generators.hpp>
-#include <boost/uuid/uuid_io.hpp>
+#include "PreCompiled.h"
+#ifndef _PreComp_
+    #include <boost/uuid/uuid_generators.hpp>
+    #include <boost/uuid/uuid_io.hpp>
+#endif // _PreComp_
 
 #include <App/Application.h>
 #include <Base/Persistence.h>

--- a/src/Mod/TechDraw/App/CosmeticVertex.h
+++ b/src/Mod/TechDraw/App/CosmeticVertex.h
@@ -24,11 +24,10 @@
 #define TECHDRAW_COSMETIC_VERTEX_H
 
 #include "PreCompiled.h"
-#ifndef _PreComp_
-    #include <App/FeaturePython.h>
-    #include <Base/Persistence.h>
-    #include <Base/Vector3D.h>
-#endif
+
+#include <App/FeaturePython.h>
+#include <Base/Persistence.h>
+#include <Base/Vector3D.h>
 
 #include "Geometry.h"
 


### PR DESCRIPTION
A clean recompile on Windows was failing because of a couple of precompiled header issues.

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR