### PR TITLE
CI: remove pivy patching on Ubuntu 22.04 workflow

### DIFF
--- a/.github/workflows/sub_buildUbuntu2204.yml
+++ b/.github/workflows/sub_buildUbuntu2204.yml
@@ -138,17 +138,6 @@ jobs:
                             swig                                        \
                             ccache                                      \
                             xvfb
-      - name: Install Pivy version compatible with Python 3.10
-        run: |
-          sudo apt-get purge python3-pivy
-          cd /tmp/
-          git clone --depth 1 --branch 0.6.8 https://github.com/coin3d/pivy.git
-          cd pivy
-          mkdir build
-          cd build
-          cmake ..
-          make -j$(nproc)
-          sudo make install
       - name: Make needed directories, files and initializations
         id: Init
         run: |


### PR DESCRIPTION
 Problems have been fixed upstream