### PR TITLE
[TD]Correct default extension line gaps

### DIFF
--- a/src/Mod/TechDraw/App/Preferences.cpp
+++ b/src/Mod/TechDraw/App/Preferences.cpp
@@ -283,16 +283,17 @@ std::string Preferences::bitmapFill()
     return prefBitmapFile;
 }
 
+//! Returns the factor for calculating the ISO extension line gap, not the actual distance.
 double Preferences::GapISO()
 {
-    double factor = getPreferenceGroup("Dimensions")->GetFloat("GapISO", 8.0);
+    double factor = getPreferenceGroup("Dimensions")->GetFloat("GapISO", 0.0);
     return factor;
 }
 
-//! Returns the factor for calculating the ISO gap, not the actual distance.
+//! Returns the factor for calculating the ASME extension line gap, not the actual distance.
 double Preferences::GapASME()
 {
-    double factor = getPreferenceGroup("Dimensions")->GetFloat("GapASME", 6.0);
+    double factor = getPreferenceGroup("Dimensions")->GetFloat("GapASME", 0.0);
     return factor;
 }
 

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawDimensions.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawDimensions.ui
@@ -524,13 +524,13 @@ Multiplier of 'Font Size'</string>
         <item row="9" column="2">
          <widget class="Gui::PrefDoubleSpinBox" name="pdsbGapISO">
           <property name="toolTip">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Controls the size of gap between dimension point and start of extension line for ISO dimensions. Value * linewidth is the gap.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Controls the size of gap between dimension point and start of extension line for ISO dimensions. Value * linewidth is the gap.  Normally, no gap is used.  If using a gap, the recommended value 8.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
           <property name="alignment">
            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
           </property>
           <property name="value">
-           <double>8.000000000000000</double>
+           <double>0.000000000000000</double>
           </property>
           <property name="prefEntry" stdset="0">
            <cstring>GapISO</cstring>
@@ -543,13 +543,13 @@ Multiplier of 'Font Size'</string>
         <item row="10" column="2">
          <widget class="Gui::PrefDoubleSpinBox" name="pdsbGapASME">
           <property name="toolTip">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Controls the size of gap between dimension point and start of extension line for ASME dimensions. Value * linewidth is the gap.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Controls the size of gap between dimension point and start of extension line for ASME dimensions. Value * linewidth is the gap.  Normally, no gap is used.  If a gap is used, the recommended value is 6.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
           <property name="alignment">
            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
           </property>
           <property name="value">
-           <double>6.000000000000000</double>
+           <double>0.000000000000000</double>
           </property>
           <property name="prefEntry" stdset="0">
            <cstring>GapASME</cstring>


### PR DESCRIPTION
This PR corrects the default values for extension line gaps.  The default should be zero for both ISO and ASME.

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [x ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
