### PR TITLE
added support for multi selection when toggling visibility in tree view

### DIFF
--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -409,10 +409,9 @@ TreeWidget::TreeWidget(const char* name, QWidget* parent)
     connect(this->showHiddenAction, &QAction::triggered,
             this, &TreeWidget::onShowHidden);
 
-    this->hideInTreeAction = new QAction(this);
-    this->hideInTreeAction->setCheckable(true);
-    connect(this->hideInTreeAction, &QAction::triggered,
-            this, &TreeWidget::onHideInTree);
+    this->toggleVisibilityInTreeAction = new QAction(this);
+    connect(this->toggleVisibilityInTreeAction, &QAction::triggered,
+            this, &TreeWidget::onToggleVisibilityInTree);
 
     this->createGroupAction = new QAction(this);
     connect(this->createGroupAction, &QAction::triggered,
@@ -843,9 +842,7 @@ void TreeWidget::contextMenuEvent(QContextMenuEvent* e)
 
         showHiddenAction->setChecked(doc->ShowHidden.getValue());
         contextMenu.addAction(this->showHiddenAction);
-
-        hideInTreeAction->setChecked(!objitem->object()->showInTree());
-        contextMenu.addAction(this->hideInTreeAction);
+        contextMenu.addAction(this->toggleVisibilityInTreeAction);
 
         if (!acrossDocuments) { // is only sensible for selections within one document
             if (objitem->object()->getObject()->isDerivedFrom(App::DocumentObjectGroup::getClassTypeId()))
@@ -2774,11 +2771,11 @@ void TreeWidget::setupText()
     this->headerItem()->setText(1, tr("Description"));
     this->rootItem->setText(0, tr("Application"));
 
-    this->showHiddenAction->setText(tr("Show hidden items"));
-    this->showHiddenAction->setStatusTip(tr("Show hidden tree view items"));
+    this->showHiddenAction->setText(tr("Show items hidden in tree view"));
+    this->showHiddenAction->setStatusTip(tr("Show items that are marked as 'hidden' in the tree view"));
 
-    this->hideInTreeAction->setText(tr("Hide item"));
-    this->hideInTreeAction->setStatusTip(tr("Hide the item in tree"));
+    this->toggleVisibilityInTreeAction->setText(tr("Toggle visibility in tree view"));
+    this->toggleVisibilityInTreeAction->setStatusTip(tr("Toggles the visibility of selected items in the tree view"));
 
     this->createGroupAction->setText(tr("Create group..."));
     this->createGroupAction->setStatusTip(tr("Create a group"));
@@ -2837,11 +2834,28 @@ void TreeWidget::onShowHidden()
         docItem->setShowHidden(showHiddenAction->isChecked());
 }
 
-void TreeWidget::onHideInTree()
+void TreeWidget::onToggleVisibilityInTree()
 {
-    if (this->contextItem && this->contextItem->type() == ObjectType) {
-        auto item = static_cast<DocumentObjectItem*>(contextItem);
-        item->object()->ShowInTree.setValue(!hideInTreeAction->isChecked());
+    const auto items = selectedItems();
+    for (auto item : items) {
+        if (item->type() == ObjectType) {
+            auto objectItem = static_cast<DocumentObjectItem*>(item);
+            auto object = objectItem->object();
+
+            // toggle value
+            bool showInTree = !object->showInTree();
+
+            // update object
+            object->ShowInTree.setValue(showInTree);
+
+            // update GUI
+            auto ownerDocument = objectItem->getOwnerDocument();
+            bool hidden = !ownerDocument->showHidden() && !showInTree;
+            objectItem->setHidden(hidden);
+            if (hidden) {
+                objectItem->setSelected(false);
+            }
+        }
     }
 }
 

--- a/src/Gui/Tree.h
+++ b/src/Gui/Tree.h
@@ -157,7 +157,7 @@ protected Q_SLOTS:
     void onPreSelectTimer();
     void onSelectTimer();
     void onShowHidden();
-    void onHideInTree();
+    void onToggleVisibilityInTree();
     void onSearchObjects();
 
 private Q_SLOTS:
@@ -205,7 +205,7 @@ private:
     QAction* markRecomputeAction;
     QAction* recomputeObjectAction;
     QAction* showHiddenAction;
-    QAction* hideInTreeAction;
+    QAction* toggleVisibilityInTreeAction;
     QAction* reloadDocAction;
     QAction* closeDocAction;
     QAction* searchObjectsAction;


### PR DESCRIPTION
The current implementation of hiding/showing objects in the tree view is cumbersome (only one single item can be toggled per execution) and inconsistent (hidden objects are still shown, even when the option to show them is disabled, only works after enabling and disabling the option again).

The patch in this pull request fixes these issues.

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR
---
