### PR TITLE
Fix memory leak when loading a font file

### DIFF
--- a/src/Mod/Part/App/FT2FC.cpp
+++ b/src/Mod/Part/App/FT2FC.cpp
@@ -32,8 +32,6 @@
 #ifndef _PreComp_
 # include <iostream>
 # include <fstream>
-# include <string>
-# include <sstream>
 # include <cstdio>
 # include <cstdlib>
 # include <stdexcept>
@@ -144,8 +142,8 @@ PyObject* FT2FC(const Py_UNICODE *PyUString,
     int bytesNeeded = fontfile.tellg();
     fontfile.clear();
     fontfile.seekg (0, fontfile.beg);
-    char* buffer = new char[bytesNeeded];
-    fontfile.read(buffer, bytesNeeded);
+    auto buffer = std::unique_ptr <char> (new char[bytesNeeded]);
+    fontfile.read(buffer.get(), bytesNeeded);
     if (!fontfile) {
         //get indignant
         ErrorMsg << "Can not read font file: " << FontSpec;
@@ -153,7 +151,7 @@ PyObject* FT2FC(const Py_UNICODE *PyUString,
     }
     fontfile.close();
 
-    const FT_Byte* ftBuffer = reinterpret_cast<FT_Byte*>(buffer);
+    const FT_Byte* ftBuffer = reinterpret_cast<FT_Byte*>(buffer.get());
     error = FT_New_Memory_Face(FTLib, ftBuffer, bytesNeeded, FaceIndex, &FTFace);
     if (error) {
         ErrorMsg << "FT_New_Face failed: " << error;


### PR DESCRIPTION
I compiled FreeCAD with leak sanitizer, did some things in Draft. When I closed the program, it reported enormous memory leak. Staring into the code, I found out that FreeCAD allocates memory to load font file, however, nowhere deallocates.

The quick one-line patch with automatic memory management fixed it.

I also deleted unnecessary includes.

---
<details><summary>Standard form</summary>





Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

</details>


