### PR TITLE
Fix the typo in #9267

### DIFF
--- a/src/Mod/Part/App/FT2FC.cpp
+++ b/src/Mod/Part/App/FT2FC.cpp
@@ -142,7 +142,7 @@ PyObject* FT2FC(const Py_UNICODE *PyUString,
     int bytesNeeded = fontfile.tellg();
     fontfile.clear();
     fontfile.seekg (0, fontfile.beg);
-    auto buffer = std::unique_ptr <char> (new char[bytesNeeded]);
+    std::unique_ptr <char[]> buffer (new char[bytesNeeded]);
     fontfile.read(buffer.get(), bytesNeeded);
     if (!fontfile) {
         //get indignant


### PR DESCRIPTION
In my previous PR I replaced `char* buffer = new char[bytesNeeded];` with `auto buffer = std::unique_ptr <char> (new char[bytesNeeded]);`

The line should be `std::unique_ptr <char[]> buffer (new char[bytesNeeded]);`

I don't know the reasons why the leak disappeared, but I have two theories
-	it results from compilers optimizations
-	the leak became undetectable


Please, apply this patch.


---


<details><summary>Standard form</summary>

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

</details>


