### PR TITLE
removed Image workbench from directories list

### DIFF
--- a/src/Tools/updatets.py
+++ b/src/Tools/updatets.py
@@ -64,7 +64,6 @@ directories = [
         {"tsname":"Draft", "workingdir":"./src/Mod/Draft/", "tsdir":"Resources/translations"},
         {"tsname":"Drawing", "workingdir":"./src/Mod/Drawing/", "tsdir":"Gui/Resources/translations"},
         {"tsname":"Fem", "workingdir":"./src/Mod/Fem/", "tsdir":"Gui/Resources/translations"},
-        #{"tsname":"Image", "workingdir":"./src/Mod/Image/", "tsdir":"Gui/Resources/translations"},
         {"tsname":"Inspection", "workingdir":"./src/Mod/Inspection/", "tsdir":"Gui/Resources/translations"},
         {"tsname":"Material", "workingdir":"./src/Mod/Material/", "tsdir":"Resources/translations"},
         {"tsname":"Mesh", "workingdir":"./src/Mod/Mesh/", "tsdir":"Gui/Resources/translations"},

--- a/src/Tools/updatets.py
+++ b/src/Tools/updatets.py
@@ -64,7 +64,7 @@ directories = [
         {"tsname":"Draft", "workingdir":"./src/Mod/Draft/", "tsdir":"Resources/translations"},
         {"tsname":"Drawing", "workingdir":"./src/Mod/Drawing/", "tsdir":"Gui/Resources/translations"},
         {"tsname":"Fem", "workingdir":"./src/Mod/Fem/", "tsdir":"Gui/Resources/translations"},
-        {"tsname":"Image", "workingdir":"./src/Mod/Image/", "tsdir":"Gui/Resources/translations"},
+        #{"tsname":"Image", "workingdir":"./src/Mod/Image/", "tsdir":"Gui/Resources/translations"},
         {"tsname":"Inspection", "workingdir":"./src/Mod/Inspection/", "tsdir":"Gui/Resources/translations"},
         {"tsname":"Material", "workingdir":"./src/Mod/Material/", "tsdir":"Resources/translations"},
         {"tsname":"Mesh", "workingdir":"./src/Mod/Mesh/", "tsdir":"Gui/Resources/translations"},


### PR DESCRIPTION
The updatets.py script fails because the Image workbench is no longer there. This PR fixes this issue.

But this PR is still incomplete, there are some more fixes needed to improve i18n and L10n, but I need your help. Please allow me to elaborate:

I am working at a university in Switzerland, using the Swiss German locale. While general i18n and a German L10n of FreeCAD is there, me and my students always run into untranslated user visible strings that stick out like a sore thumb.

All I wanted to do yesterday was to fix the issue that new documents show up untranslated as "Unnamed" instead of "Unbenannt" in German.
The string "Unnamed" can be found at the Crowdin-Website:
https://crowdin.com/translate/freecad/549/en-de?filter=basic&value=0#6497188
... but it was already translated a long time ago. So what was the problem?

I found two already merged PRs regarding this issue:
https://github.com/FreeCAD/FreeCAD/pull/6825
https://github.com/FreeCAD/FreeCAD/pull/7119

This guided me to the src/Tools/updatets.py script and its sibling src/Tools/updatecrowdin.py. I noticed that the src/App directory was added to src/Tools/updatets.py but not to src/Tools/updatecrowdin.py, see:
https://github.com/FreeCAD/FreeCAD/commit/63174d487f3

I wanted to learn and understand how both scripts are supposed to be used and found this wiki page:
https://wiki.freecad.org/Crowdin_Scripts
Unfortunately, this page seems to be quite out of date (the updatefromcrowdin.py script doesn't exist anymore, the token file name is different from the one in the actual script, ...) and inconsistent (first stating that these scripts are run from the root of the FreeCAD/ directory and then running cd /path/to/freecad-source-code/src/Tools in the examples below).

So I wanted to find out more about how i18n/L10n is done in FreeCAD and found this page:
https://wiki.freecad.org/Localisation
There it reads "please subscribe to one of the Crowdin FreeCAD translation teams" but on Crowdin I only found (global?) managers and languages, no teams or anything I could subscribe to.

And besides all these little paper cuts I think the whole process needs a much shorter round trip time. If I update a string in the application I also want to be able to update its translation and check how it looks like right after a recompile. With the current system in place I need to create a branch, commit my changes, create a PR, wait for a merge, wait for someone who eventually uploads the new and updated strings to Crowdin, then I need to update the translations in Crowdin, wait again for someone who eventually downloads and merges the strings from Crowdin back into the sources where I can merge from and check the results. We are talking about a round trip time of weeks and months instead of mere minutes. Is there a shorter path for developers?

Sorry that this PR slightly degenerated into a rant. I am more than willing to include more fixes into this PR but I need your help.

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR
---
