### PR TITLE
Fix wrong downcasting of QEvent

### DIFF
--- a/src/Gui/Quarter/QuarterWidget.cpp
+++ b/src/Gui/Quarter/QuarterWidget.cpp
@@ -936,8 +936,7 @@ bool QuarterWidget::viewportEvent(QEvent* event)
     // additionally handle it by this viewer. This is e.g. needed when
     // resizing a widget item because the cursor may already be outside
     // this widget.
-    if (event->type() == QEvent::Wheel ||
-        event->type() == QEvent::MouseButtonDblClick ||
+    if (event->type() == QEvent::MouseButtonDblClick ||
         event->type() == QEvent::MouseButtonPress) {
         QMouseEvent* mouse = static_cast<QMouseEvent*>(event);
         QGraphicsItem *item = itemAt(mouse->pos());
@@ -950,6 +949,19 @@ bool QuarterWidget::viewportEvent(QEvent* event)
              event->type() == QEvent::MouseButtonRelease) {
         QGraphicsScene* glScene = this->scene();
         if (!(glScene && glScene->mouseGrabberItem())) {
+            QGraphicsView::viewportEvent(event);
+            return false;
+        }
+    }
+    else if (event->type() == QEvent::Wheel) {
+        auto wheel = static_cast<QWheelEvent*>(event);
+#if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
+        QPoint pos = wheel->pos();
+#else
+        QPoint pos = wheel->position().toPoint();
+#endif
+        QGraphicsItem* item = itemAt(pos);
+        if (!item) {
             QGraphicsView::viewportEvent(event);
             return false;
         }


### PR DESCRIPTION
Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---

When an event type is `QEvent::Wheel`, the event type is `QWheelEvent`, which is not a `QMouseEvent`. This caused a undefined behavior that can be cached by ubsan.
