### PR TITLE
Fix uninitialized member variable

### DIFF
--- a/src/Mod/Sketcher/Gui/Command.cpp
+++ b/src/Mod/Sketcher/Gui/Command.cpp
@@ -1327,7 +1327,7 @@ private:
     CmdSketcherSnap& operator= (const CmdSketcherSnap&) = delete;
     CmdSketcherSnap& operator= (CmdSketcherSnap&&) = delete;
 
-    bool snapEnabled;
+    bool snapEnabled = true;
 };
 
 CmdSketcherSnap::CmdSketcherSnap()


### PR DESCRIPTION
Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---

This specific boolean variable could be used uninitialized. Assigning it a default value is cheap and it avoids the issue.

I have been able to detect the issue thanks to UBSAN, which unfortunately _just_ detected an _invalid_ boolean value. Instead, MSAN would be able to actually detect the read from uninitialized memory, but it is very hard to use in projects like FreeCAD because every dependency should be recompiled with MSAN. It could be a helpful approach to discover hidden issues but it could take quite a lot of time to setup.
