### PR TITLE
[GUI] Setting initial color of QColorDialog

### DIFF
--- a/src/Gui/Widgets.cpp
+++ b/src/Gui/Widgets.cpp
@@ -804,6 +804,7 @@ void ColorButton::showModeless()
         if (DialogOptions::dontUseNativeColorDialog())
             dlg->setOptions(QColorDialog::DontUseNativeDialog);
         dlg->setOption(QColorDialog::ColorDialogOption::ShowAlphaChannel, d->allowTransparency);
+        dlg->setCurrentColor(d->old);
         connect(dlg, &QColorDialog::rejected, this, &ColorButton::onRejected);
         connect(dlg, &QColorDialog::currentColorChanged, this, &ColorButton::onColorChosen);
         d->cd = dlg;


### PR DESCRIPTION
This commit fixes issue #7322. When setting option the initial color is discarded. It needs to be reset, like it's done in `void ColorButton::showModal()`.

<details><summary>Before</summary>


https://user-images.githubusercontent.com/9303235/232278731-bcfd38b8-0655-4fc2-a5ab-1b8d9bd00d0d.mp4



</details>

<details><summary>After</summary>


https://user-images.githubusercontent.com/9303235/232278734-5d32ccf1-4ab9-4961-901a-73e2be9eb0b4.mp4



</details>


---

<details><summary>Standard form</summary>

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

</details>


