### PR TITLE
[TD]fix unwanted inversion in edge scrubbing

### DIFF
--- a/src/Mod/TechDraw/App/DrawProjectSplit.cpp
+++ b/src/Mod/TechDraw/App/DrawProjectSplit.cpp
@@ -486,7 +486,7 @@ std::string edgeSortItem::dump()
 std::vector<TopoDS_Edge> DrawProjectSplit::scrubEdges(const std::vector<TechDraw::BaseGeomPtr>& origEdges,
                                                       std::vector<TopoDS_Edge> &closedEdges)
 {
-//    Base::Console().Message("DPS::scrubEdges() - edges in: %d\n", origEdges.size());
+//    Base::Console().Message("DPS::scrubEdges() - BaseGeom in: %d\n", origEdges.size());
     //make a copy of the input edges so the loose tolerances of face finding are
     //not applied to the real edge geometry.  See TopoDS_Shape::TShape().
     std::vector<TopoDS_Edge> copyEdges;
@@ -505,6 +505,8 @@ std::vector<TopoDS_Edge> DrawProjectSplit::scrubEdges(const std::vector<TechDraw
 std::vector<TopoDS_Edge> DrawProjectSplit::scrubEdges(std::vector<TopoDS_Edge>& origEdges,
                                                       std::vector<TopoDS_Edge> &closedEdges)
 {
+//    Base::Console().Message("DPS::scrubEdges() - TopoDS_Edges in: %d\n", origEdges.size());
+
     if (origEdges.empty()) {
         //how did this happen? if Scale is zero, all the edges will be zero length,
         //but Scale property has constraint, so this shouldn't happen!
@@ -605,7 +607,7 @@ std::vector<TopoDS_Edge> DrawProjectSplit::pruneUnconnected(vertexMap verts,
     return newPile;
 }
 
-bool DrawProjectSplit::sameEndPoints(TopoDS_Edge& e1, TopoDS_Edge& e2)
+bool DrawProjectSplit::sameEndPoints(const TopoDS_Edge &e1, const TopoDS_Edge &e2)
 {
     TopoDS_Vertex first1 = TopExp::FirstVertex(e1);
     TopoDS_Vertex last1 = TopExp::LastVertex(e1);
@@ -630,7 +632,7 @@ bool DrawProjectSplit::sameEndPoints(TopoDS_Edge& e1, TopoDS_Edge& e2)
 #define NOTASUBSET 3
 
 //eliminate edges that overlap another edge
-std::vector<TopoDS_Edge> DrawProjectSplit::removeOverlapEdges(std::vector<TopoDS_Edge> inEdges)
+std::vector<TopoDS_Edge> DrawProjectSplit::removeOverlapEdges(const std::vector<TopoDS_Edge> &inEdges)
 {
 //    Base::Console().Message("DPS::removeOverlapEdges() - %d edges in\n", inEdges.size());
     std::vector<TopoDS_Edge> outEdges;
@@ -676,11 +678,14 @@ std::vector<TopoDS_Edge> DrawProjectSplit::removeOverlapEdges(std::vector<TopoDS
     if (!overlapEdges.empty()) {
         outEdges.insert(outEdges.end(), overlapEdges.begin(), overlapEdges.end());
     }
+
+//    Base::Console().Message("DPS::removeOverlapEdges() - %d edges out\n", outEdges.size());
+
     return outEdges;
 }
 
 //determine if edge0 & edge1 are superimposed, and classify the type of overlap
-int DrawProjectSplit::isSubset(TopoDS_Edge& edge0, TopoDS_Edge& edge1)
+int DrawProjectSplit::isSubset(const TopoDS_Edge &edge0, const TopoDS_Edge &edge1)
 {
     if (!boxesIntersect(edge0, edge1)) {
         return NOTASUBSET;      //boxes don't intersect, so edges do not overlap
@@ -722,7 +727,7 @@ int DrawProjectSplit::isSubset(TopoDS_Edge& edge0, TopoDS_Edge& edge1)
 }
 
 //edge0 and edge1 overlap, so we need to make 3 edges - part of edge0, common segment, part of edge1
-std::vector<TopoDS_Edge> DrawProjectSplit::fuseEdges(TopoDS_Edge &edge0, TopoDS_Edge &edge1)
+std::vector<TopoDS_Edge> DrawProjectSplit::fuseEdges(const TopoDS_Edge &edge0, const TopoDS_Edge &edge1)
 {
     std::vector<TopoDS_Edge> edgeList;
     BRepAlgoAPI_Fuse anOp;
@@ -864,7 +869,7 @@ std::vector<TopoDS_Edge> DrawProjectSplit::splitIntersectingEdges(std::vector<To
     return outEdges;
 }
 
-bool DrawProjectSplit::boxesIntersect(TopoDS_Edge& edge0, TopoDS_Edge& edge1)
+bool DrawProjectSplit::boxesIntersect(const TopoDS_Edge &edge0, const TopoDS_Edge &edge1)
 {
     Bnd_Box box0, box1;
     BRepBndLib::Add(edge0, box0);

--- a/src/Mod/TechDraw/App/DrawProjectSplit.h
+++ b/src/Mod/TechDraw/App/DrawProjectSplit.h
@@ -120,17 +120,17 @@ public:
     static vertexMap                getUniqueVertexes(std::vector<TopoDS_Edge> inEdges);
     static std::vector<TopoDS_Edge> pruneUnconnected(vertexMap verts,
                                                      std::vector<TopoDS_Edge> edges);
-    static std::vector<TopoDS_Edge> removeOverlapEdges(std::vector<TopoDS_Edge> inEdges);
+    static std::vector<TopoDS_Edge> removeOverlapEdges(const std::vector<TopoDS_Edge>& inEdges);
     static std::vector<TopoDS_Edge> splitIntersectingEdges(std::vector<TopoDS_Edge>& inEdges);
 
-    static bool                     sameEndPoints(TopoDS_Edge& e1,
-                                                  TopoDS_Edge& e2);
-    static int                      isSubset(TopoDS_Edge &e0,
-                                             TopoDS_Edge &e1);
-    static std::vector<TopoDS_Edge> fuseEdges(TopoDS_Edge& e0,
-                                              TopoDS_Edge& e1);
-    static bool                     boxesIntersect(TopoDS_Edge& e0,
-                                                   TopoDS_Edge& e1);
+    static bool                     sameEndPoints(const TopoDS_Edge& e1,
+                                                  const TopoDS_Edge& e2);
+    static int                      isSubset(const TopoDS_Edge &e0,
+                                             const TopoDS_Edge &e1);
+    static std::vector<TopoDS_Edge> fuseEdges(const TopoDS_Edge& e0,
+                                              const TopoDS_Edge& e1);
+    static bool                     boxesIntersect(const TopoDS_Edge& e0,
+                                                   const TopoDS_Edge& e1);
     static void dumpVertexMap(vertexMap verts);
 
 protected:

--- a/src/Mod/TechDraw/App/DrawUtil.cpp
+++ b/src/Mod/TechDraw/App/DrawUtil.cpp
@@ -536,7 +536,7 @@ bool DrawUtil::vectorEqual(Base::Vector3d& v1, Base::Vector3d& v2)
 
 //TODO: the next 2 could be templated
 //construct a compound shape from a list of edges
-TopoDS_Shape DrawUtil::vectorToCompound(std::vector<TopoDS_Edge> vecIn)
+TopoDS_Shape DrawUtil::vectorToCompound(std::vector<TopoDS_Edge> vecIn, bool invert)
 {
     BRep_Builder builder;
     TopoDS_Compound compOut;
@@ -544,11 +544,14 @@ TopoDS_Shape DrawUtil::vectorToCompound(std::vector<TopoDS_Edge> vecIn)
     for (auto& v : vecIn) {
         builder.Add(compOut, v);
     }
-    return TechDraw::mirrorShape(compOut);
+    if (invert) {
+        return TechDraw::mirrorShape(compOut);
+    }
+    return compOut;
 }
 
 //construct a compound shape from a list of wires
-TopoDS_Shape DrawUtil::vectorToCompound(std::vector<TopoDS_Wire> vecIn)
+TopoDS_Shape DrawUtil::vectorToCompound(std::vector<TopoDS_Wire> vecIn, bool invert)
 {
     BRep_Builder builder;
     TopoDS_Compound compOut;
@@ -556,7 +559,10 @@ TopoDS_Shape DrawUtil::vectorToCompound(std::vector<TopoDS_Wire> vecIn)
     for (auto& v : vecIn) {
         builder.Add(compOut, v);
     }
-    return TechDraw::mirrorShape(compOut);
+    if (invert) {
+        return TechDraw::mirrorShape(compOut);
+    }
+    return compOut;
 }
 
 //constructs a list of edges from a shape

--- a/src/Mod/TechDraw/App/DrawUtil.h
+++ b/src/Mod/TechDraw/App/DrawUtil.h
@@ -128,8 +128,8 @@ public:
     static bool vertexEqual(TopoDS_Vertex& v1, TopoDS_Vertex& v2);
     static bool vectorEqual(Base::Vector3d& v1, Base::Vector3d& v2);
 
-    static TopoDS_Shape vectorToCompound(std::vector<TopoDS_Edge> vecIn);
-    static TopoDS_Shape vectorToCompound(std::vector<TopoDS_Wire> vecIn);
+    static TopoDS_Shape vectorToCompound(std::vector<TopoDS_Edge> vecIn, bool invert = true);
+    static TopoDS_Shape vectorToCompound(std::vector<TopoDS_Wire> vecIn, bool invert = true);
     static std::vector<TopoDS_Edge> shapeToVector(TopoDS_Shape shapeIn);
 
     static Base::Vector3d toR3(const gp_Ax2& fromSystem, const Base::Vector3d& fromPoint);

--- a/src/Mod/TechDraw/App/GeometryObject.cpp
+++ b/src/Mod/TechDraw/App/GeometryObject.cpp
@@ -545,7 +545,9 @@ void GeometryObject::addGeomFromCompound(TopoDS_Shape edgeCompound, edgeClass ca
         for (int iPass = 0; iPass < passes; iPass++)  {
             edgeVector = DrawProjectSplit::removeOverlapEdges(edgeVector);
         }
-        cleanShape = DU::vectorToCompound(edgeVector);
+        bool invertResult = false;
+        cleanShape = DU::vectorToCompound(edgeVector, invertResult);
+
     } else {
         cleanShape = edgeCompound;
     }


### PR DESCRIPTION
This PR corrects an unwanted Y coordinate inversion when cleaning edges from HLR.

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [x ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
