### PR TITLE
FEM: Fix translation of long phrase

### DIFF
--- a/src/Mod/Fem/femguiutils/selection_widgets.py
+++ b/src/Mod/Fem/femguiutils/selection_widgets.py
@@ -273,12 +273,10 @@ class GeometryElementsSelection(QtGui.QWidget):
         self._helpTextLbl = QtGui.QLabel()
         self._helpTextLbl.setWordWrap(True)
         helpTextPart1 = self.tr(
-            'Click on "Add" and select geometric elements to add them to the list.{}'
-            "The following geometry elements are allowed to select: {}{}{}"
-            .format("<br>", "<b>", self.sel_elem_text, "</b>")
-        )
+            'Click on "Add" and select geometric elements to add them to the list.{}The following geometry elements can be selected: {}{}{}'
+        ).format("<br>", "<b>", self.sel_elem_text, "</b>")
         helpTextEmpty = self.tr(
-            "{}If no geometry is added to the list, all remaining ones are used.".format("<br>")
+            "{}If no geometry is added to the list, all remaining ones are used.").format("<br>"
         )
         if self.showHintEmptyList is True:
             self._helpTextLbl.setText(


### PR DESCRIPTION
Should fix https://github.com/FreeCAD/FreeCAD-translations/issues/191. The lupdate tool does not correctly parse Python string concatenation. Also, .format() calls should be made on the string returned from tr(), not on the string going into it.

---

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR