### PR TITLE
PD/ShaftWizard: Correct some translation issues

### DIFF
--- a/src/Mod/PartDesign/WizardShaft/WizardShaft.py
+++ b/src/Mod/PartDesign/WizardShaft/WizardShaft.py
@@ -27,6 +27,8 @@ from PySide import QtCore, QtGui
 from .WizardShaftTable import WizardShaftTable
 from .Shaft import Shaft
 
+translate = FreeCAD.Qt.translate
+
 class TaskWizardShaft:
     "Shaft Wizard"
     App = FreeCAD
@@ -51,7 +53,8 @@ class TaskWizardShaft:
 
         # Buttons for diagram display
         buttonLayout = QtGui.QGridLayout()
-        bnames = [["All [x]", "All [y]", "All [z]" ],
+        all = translate("TaskWizardShaft", "All")
+        bnames = [[f"{all} [x]", f"{all} [y]", f"{all} [z]" ],
                            ["N [x]", "Q [y]", "Q [z]"],
                            ["Mt [x]",  "Mb [z]", "Mb [y]"],
                            ["",  "w [y]",  "w [z]"],
@@ -98,8 +101,8 @@ class TaskWizardShaft:
         except ImportError as e:
             msgBox = QtGui.QMessageBox()
             msgBox.setIcon(msgBox.Information)
-            msgBox.setWindowTitle("Missing module")
-            msgBox.setText("You may have to install the Plot add-on")
+            msgBox.setWindowTitle(translate("TaskWizardShaft", "Missing module"))
+            msgBox.setText(translate("TaskWizardShaft", "You may have to install the Plot add-on"))
             msgBox.setDetailedText(traceback.format_exc())
             msgBox.exec_()
     def slotAllx(self):
@@ -182,8 +185,8 @@ class WizardShaftGui:
 
     def GetResources(self):
         IconPath = FreeCAD.ConfigGet("AppHomePath") + "Mod/PartDesign/WizardShaft/WizardShaft.svg"
-        MenuText = QtCore.QT_TRANSLATE_NOOP("WizardShaft", "Shaft design wizard...")
-        ToolTip  = QtCore.QT_TRANSLATE_NOOP("WizardShaft", "Start the shaft design wizard")
+        MenuText = QtCore.QT_TRANSLATE_NOOP("PartDesign_WizardShaft", "Shaft design wizard...")
+        ToolTip  = QtCore.QT_TRANSLATE_NOOP("PartDesign_WizardShaft", "Start the shaft design wizard")
         return {'Pixmap': IconPath,
                 'MenuText': MenuText,
                 'ToolTip': ToolTip}
@@ -207,8 +210,8 @@ class WizardShaftGuiCallback:
 
     def GetResources(self):
         IconPath = FreeCAD.ConfigGet("AppHomePath") + "Mod/PartDesign/WizardShaft/WizardShaft.svg"
-        MenuText = QtCore.QT_TRANSLATE_NOOP("WizardShaft", "Shaft design wizard...")
-        ToolTip  = QtCore.QT_TRANSLATE_NOOP("WizardShaft", "Start the shaft design wizard")
+        MenuText = QtCore.QT_TRANSLATE_NOOP("PartDesign_WizardShaftCallBack", "Shaft design wizard...")
+        ToolTip  = QtCore.QT_TRANSLATE_NOOP("PartDesign_WizardShaftCallBack", "Start the shaft design wizard")
         return {'Pixmap': IconPath,
                 'MenuText': MenuText,
                 'ToolTip': ToolTip}

--- a/src/Mod/PartDesign/WizardShaft/WizardShaftTable.py
+++ b/src/Mod/PartDesign/WizardShaft/WizardShaftTable.py
@@ -22,7 +22,9 @@
 # ******************************************************************************/
 
 from PySide import QtCore, QtGui
-import FreeCAD # Just for debug printing...
+import FreeCAD
+
+translate = FreeCAD.Qt.translate
 
 class WizardShaftTable:
     "The table widget that contains all the data of the shaft"
@@ -40,14 +42,14 @@ class WizardShaftTable:
     }
     rowDictReverse = {}
     headers = [
-               QtCore.QT_TRANSLATE_NOOP("WizardShaftTable", "Length [mm]"),
-               QtCore.QT_TRANSLATE_NOOP("WizardShaftTable", "Diameter [mm]"),
-               QtCore.QT_TRANSLATE_NOOP("WizardShaftTable", "Inner diameter [mm]"),
-               QtCore.QT_TRANSLATE_NOOP("WizardShaftTable", "Constraint type"),
-               QtCore.QT_TRANSLATE_NOOP("WizardShaftTable", "Start edge type"),
-               QtCore.QT_TRANSLATE_NOOP("WizardShaftTable", "Start edge size"),
-               QtCore.QT_TRANSLATE_NOOP("WizardShaftTable", "End edge type"),
-               QtCore.QT_TRANSLATE_NOOP("WizardShaftTable", "End edge size")
+        translate("WizardShaftTable", "Length [mm]"),
+        translate("WizardShaftTable", "Diameter [mm]"),
+        translate("WizardShaftTable", "Inner diameter [mm]"),
+        translate("WizardShaftTable", "Constraint type"),
+        translate("WizardShaftTable", "Start edge type"),
+        translate("WizardShaftTable", "Start edge size"),
+        translate("WizardShaftTable", "End edge type"),
+        translate("WizardShaftTable", "End edge size")
               ]
 
     def __init__(self, w, s):
@@ -59,18 +61,19 @@ class WizardShaftTable:
         # Create table widget
         self.widget = QtGui.QTableWidget(len(self.rowDict), 0)
         self.widget.setObjectName("ShaftWizardTable") # Do not change or translate: Used in ViewProviderFemConstraintXXX
-        self.widget.setWindowTitle("Shaft wizard")
+        self.widget.setWindowTitle(translate("WizardShaftTable", "Shaft wizard"))
         self.widget.resize(QtCore.QSize(300,200))
         self.editedRow = None
         self.editedColumn = None
 
         # Label rows and columns
         self.widget.setVerticalHeaderLabels(self.headers)
-        self.widget.setHorizontalHeaderLabels(["Section 1", "Section 2"])
+        self.widget.setHorizontalHeaderLabels([
+            translate("WizardShaftTable", "Section 1"), translate("WizardShaftTable", "Section 2")])
         #self.widget.columnMoved.connect(column, oldIndex, newIndex)
 
         # Create context menu
-        action = QtGui.QAction("Add column", self.widget)
+        action = QtGui.QAction(translate("WizardShaftTable", "Add column"), self.widget)
         action.triggered.connect(self.slotInsertColumn)
         self.widget.addAction(action)
         self.widget.setContextMenuPolicy(QtCore.Qt.ActionsContextMenu)
@@ -116,7 +119,7 @@ class WizardShaftTable:
         self.shaft.addSegment(length, diameter, innerdiameter)
 
         self.widget.insertColumn(index)
-        self.widget.setHorizontalHeaderItem(index + 1, QtGui.QTableWidgetItem("Section %s" % (index + 1)))
+        self.widget.setHorizontalHeaderItem(index + 1, QtGui.QTableWidgetItem(translate("WizardShaftTable", "Section %s") % (index + 1)))
 
         # Length
         widget = QtGui.QDoubleSpinBox(self.widget)


### PR DESCRIPTION
This addresses some of the translation problems with the Part Design shaft wizard. Many of the combobox entries are directly used as the name of constraints in FEM, however, so in the current implementation cannot be translated without breaking the Wizard. This design should be changed. Addresses some of the issues in https://github.com/FreeCAD/FreeCAD-translations/issues/4

---

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR