### PR TITLE
Arch: Allow the IFC export recycler to work with other templates

### DIFF
--- a/src/Mod/Arch/exportIFCHelper.py
+++ b/src/Mod/Arch/exportIFCHelper.py
@@ -203,17 +203,21 @@ class recycler:
     # but it checks if a similar entity already exists before creating a new one
     # to compress a new type, just add the necessary method here
 
-    def __init__(self,ifcfile):
+    def __init__(self,ifcfile,template=True):
 
         self.ifcfile = ifcfile
         self.compress = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Arch").GetBool("ifcCompress",True)
         self.mergeProfiles = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Arch").GetBool("ifcMergeProfiles",False)
-        self.cartesianpoints = {(0,0,0):self.ifcfile[8]} # from template
-        self.directions = {(1,0,0):self.ifcfile[6],(0,0,1):self.ifcfile[7],(0,1,0):self.ifcfile[10]} # from template
+        self.cartesianpoints = {}
+        self.directions = {}
+        self.axis2placement3ds = {}
+        if template: # we are using the default template from exportIFC.py
+            self.cartesianpoints = {(0,0,0):self.ifcfile[8]} # from template
+            self.directions = {(1,0,0):self.ifcfile[6],(0,0,1):self.ifcfile[7],(0,1,0):self.ifcfile[10]} # from template
+            self.axis2placement3ds = {'(0.0, 0.0, 0.0)(0.0, 0.0, 1.0)(1.0, 0.0, 0.0)':self.ifcfile[9]} # from template
         self.polylines = {}
         self.polyloops = {}
         self.propertysinglevalues = {}
-        self.axis2placement3ds = {'(0.0, 0.0, 0.0)(0.0, 0.0, 1.0)(1.0, 0.0, 0.0)':self.ifcfile[9]} # from template
         self.axis2placement2ds = {}
         self.localplacements = {}
         self.rgbs = {}


### PR DESCRIPTION
The IFC export recycler always assumes to be used from the Arch builtin IFC exporter from exportIFC.py. This change allows it to be used with other templates/input files as well

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [x]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
