### PR TITLE
TechDraw: Translate leader line arrow shapes

### DIFF
--- a/src/Mod/TechDraw/App/ArrowPropEnum.cpp
+++ b/src/Mod/TechDraw/App/ArrowPropEnum.cpp
@@ -28,15 +28,16 @@
 namespace TechDraw {
 
 const int   ArrowPropEnum::ArrowCount = 8;
-const char* ArrowPropEnum::ArrowTypeEnums[]= { "Filled Arrow",
-                               "Open Arrow",
-                               "Tick",
-                               "Dot",
-                               "Open Circle",
-                               "Fork",
-                               "Filled Triangle",
-                               "None",
-                               nullptr};
+const char* ArrowPropEnum::ArrowTypeEnums[]= {
+    QT_TRANSLATE_NOOP("ArrowPropEnum", "Filled Arrow"),
+    QT_TRANSLATE_NOOP("ArrowPropEnum", "Open Arrow"),
+    QT_TRANSLATE_NOOP("ArrowPropEnum", "Tick"),
+    QT_TRANSLATE_NOOP("ArrowPropEnum", "Dot"),
+    QT_TRANSLATE_NOOP("ArrowPropEnum", "Open Circle"),
+    QT_TRANSLATE_NOOP("ArrowPropEnum", "Fork"),
+    QT_TRANSLATE_NOOP("ArrowPropEnum", "Filled Triangle"),
+    QT_TRANSLATE_NOOP("ArrowPropEnum", "None"),
+    nullptr};
 
 const std::vector<std::string> ArrowPropEnum::ArrowTypeIcons = { ":icons/arrowfilled.svg",
                                             ":icons/arrowopen.svg",

--- a/src/Mod/TechDraw/Gui/DrawGuiUtil.cpp
+++ b/src/Mod/TechDraw/Gui/DrawGuiUtil.cpp
@@ -73,7 +73,7 @@ void DrawGuiUtil::loadArrowBox(QComboBox* qcb)
     qcb->clear();
     int i = 0;
     for (; i < ArrowPropEnum::ArrowCount; i++) {
-        qcb->addItem(tr(ArrowPropEnum::ArrowTypeEnums[i]));
+        qcb->addItem(QCoreApplication::translate("ArrowPropEnum", ArrowPropEnum::ArrowTypeEnums[i]));
         QIcon itemIcon(QString::fromUtf8(ArrowPropEnum::ArrowTypeIcons[i].c_str()));
         qcb->setItemIcon(i, itemIcon);
     }


### PR DESCRIPTION
Fixes https://github.com/FreeCAD/FreeCAD-translations/issues/46. The base enum is unchanged by this operation (which uses NOOP to ensure the char * is unchanged). Only on actual display in the user interface is the translated value used. It appears that this was actually the original intent, but it didn't work because the translatable strings were never added to the database. Internally, only the numeric index of the current entry is used, so the actual displayed text can be anything.

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR