### PR TITLE
[Gui]overload toQGraphicsItem, toQGraphicsObject for PyObject

### DIFF
--- a/src/Gui/PythonWrapper.cpp
+++ b/src/Gui/PythonWrapper.cpp
@@ -563,6 +563,11 @@ QGraphicsItem* PythonWrapper::toQGraphicsItem(PyObject* pyPtr)
     return nullptr;
 }
 
+QGraphicsItem* PythonWrapper::toQGraphicsItem(const Py::Object& pyobject)
+{
+    return toQGraphicsItem(pyobject.ptr());
+}
+
 QGraphicsObject* PythonWrapper::toQGraphicsObject(PyObject* pyPtr)
 {
 #if defined (HAVE_SHIBOKEN) && defined(HAVE_PYSIDE)
@@ -575,6 +580,12 @@ QGraphicsObject* PythonWrapper::toQGraphicsObject(PyObject* pyPtr)
 #endif
     return nullptr;
 }
+
+QGraphicsObject* PythonWrapper::toQGraphicsObject(const Py::Object& pyobject)
+{
+return toQGraphicsObject(pyobject.ptr());
+}
+
 
 Py::Object PythonWrapper::fromQIcon(const QIcon* icon)
 {

--- a/src/Gui/PythonWrapper.h
+++ b/src/Gui/PythonWrapper.h
@@ -53,10 +53,11 @@ public:
     bool toCString(const Py::Object&, std::string&);
     QObject* toQObject(const Py::Object&);
     QGraphicsItem* toQGraphicsItem(PyObject* ptr);
+    QGraphicsItem* toQGraphicsItem(const Py::Object& pyObject);
     QGraphicsObject* toQGraphicsObject(PyObject* pyPtr);
+    QGraphicsObject* toQGraphicsObject(const Py::Object& pyObject);
 
     Py::Object fromQPrinter(QPrinter*);
-
     Py::Object fromQObject(QObject*, const char* className=nullptr);
     Py::Object fromQWidget(QWidget*, const char* className=nullptr);
     const char* getWrapperName(QObject*) const;


### PR DESCRIPTION
This PR overloads the existing toQGraphicswItem and toQGraphicsObject methods in PythonWrapper to accept a reference.

This PR is a prerequisite for future PRs which will add functions for adding graphics to TechDraw Pages from Python.

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [ ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
