### PR TITLE
Sketcher: Tooltips for solver message hyperlinks

### DIFF
--- a/src/Mod/Sketcher/Gui/TaskSketcherMessages.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherMessages.cpp
@@ -105,6 +105,25 @@ void TaskSketcherMessages::slotSetUp(const QString& state, const QString& msg, c
     ui->labelConstrainStatus->setText(msg);
     ui->labelConstrainStatusLink->setUrl(link);
     ui->labelConstrainStatusLink->setText(linkText);
+    updateToolTip(link);
+}
+
+void TaskSketcherMessages::updateToolTip(const QString& link)
+{
+    if( link == QString::fromLatin1("#conflicting"))
+        ui->labelConstrainStatusLink->setToolTip(tr("Click to select the conflicting constraints."));
+    else
+    if( link == QString::fromLatin1("#redundant"))
+        ui->labelConstrainStatusLink->setToolTip(tr("Click to select the redundant constraints."));
+    else
+    if( link == QString::fromLatin1("#dofs"))
+        ui->labelConstrainStatusLink->setToolTip(tr("The sketch has unconstrained elements giving raise to those Degrees Of Freedom. Click to select the unconstrained elements."));
+    else
+    if( link == QString::fromLatin1("#malformed"))
+        ui->labelConstrainStatusLink->setToolTip(tr("Click to select the malformed constraints."));
+    else
+    if( link == QString::fromLatin1("#partiallyredundant"))
+        ui->labelConstrainStatusLink->setToolTip(tr("Some constraints in combination are partially redundant. Click to select the partially redundant constraints."));
 }
 
 void TaskSketcherMessages::onLabelConstrainStatusLinkClicked(const QString &str)

--- a/src/Mod/Sketcher/Gui/TaskSketcherMessages.h
+++ b/src/Mod/Sketcher/Gui/TaskSketcherMessages.h
@@ -54,6 +54,8 @@ private:
     void onLabelConstrainStatusLinkClicked(const QString &);
     void onAutoUpdateStateChanged();
     void onManualUpdateClicked(bool checked);
+
+    void updateToolTip(const QString& link);
     
 protected:
     ViewProviderSketch *sketchView;


### PR DESCRIPTION
================================================

I promised Uwe I would look into improving the information of the solver messages, including the abbreviation DoF.

I wanted to keep the effort by Paddle to reduce the width of the taskbar.

This commit introduces new explanatory tooltips for the hyperlinks, a different tooltip per type of information.

UrlLabel sets the tooltips automatically to the url text on change. This commit modifies the tooltip just after the change, so that the meaningful tooltip is shown.
