### PR TITLE
GUI: Translate the tooltip for EditMode menu

### DIFF
--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -1312,14 +1312,14 @@ int Application::getUserEditMode(const std::string &mode) const
         return userEditMode;
     }
     for (auto const &uem : userEditModes) {
-        if (uem.second == mode) {
+        if (uem.second.first == mode) {
             return uem.first;
         }
     }
     return -1;
 }
 
-std::string Application::getUserEditModeName(int mode) const
+std::pair<std::string,std::string> Application::getUserEditModeUIStrings(int mode) const
 {
     if (mode == -1) {
         return userEditModes.at(userEditMode);
@@ -1327,7 +1327,7 @@ std::string Application::getUserEditModeName(int mode) const
     if (userEditModes.find(mode) != userEditModes.end()) {
         return userEditModes.at(mode);
     }
-    return "";
+    return std::make_pair(std::string(), std::string());
 }
 
 bool Application::setUserEditMode(int mode)
@@ -1343,7 +1343,7 @@ bool Application::setUserEditMode(int mode)
 bool Application::setUserEditMode(const std::string &mode)
 {
     for (auto const &uem : userEditModes) {
-        if (uem.second == mode) {
+        if (uem.second.first == mode) {
             return setUserEditMode(uem.first);
         }
     }

--- a/src/Gui/Application.h
+++ b/src/Gui/Application.h
@@ -248,18 +248,35 @@ protected:
     // the below std::map is a translation of 'EditMode' enum in ViewProvider.h
     // to add a new edit mode, it should first be added there
     // this is only used for GUI user interaction (menu, toolbar, Python API)
-    const std::map <int, std::string> userEditModes {
-        {0, QT_TRANSLATE_NOOP("EditMode", "Default")},
-        {1, QT_TRANSLATE_NOOP("EditMode", "Transform")},
-        {2, QT_TRANSLATE_NOOP("EditMode", "Cutting")},
-        {3, QT_TRANSLATE_NOOP("EditMode", "Color")}
+    const std::map<int, std::pair<std::string, std::string>> userEditModes {
+        {0,
+         std::make_pair(
+             QT_TRANSLATE_NOOP("EditMode", "Default"),
+             QT_TRANSLATE_NOOP("EditMode",
+                               "The object will be edited using the mode defined internally to be "
+                               "the most appropriate for the object type"))},
+        {1,
+         std::make_pair(QT_TRANSLATE_NOOP("EditMode", "Transform"),
+                        QT_TRANSLATE_NOOP("EditMode",
+                                          "The object will have its placement editable with the "
+                                          "Std TransformManip command"))},
+        {2,
+         std::make_pair(QT_TRANSLATE_NOOP("EditMode", "Cutting"),
+                        QT_TRANSLATE_NOOP("EditMode",
+                                          "This edit mode is implemented as available but "
+                                          "currently does not seem to be used by any object"))},
+        {3,
+         std::make_pair(QT_TRANSLATE_NOOP("EditMode", "Color"),
+                        QT_TRANSLATE_NOOP("EditMode",
+                                          "The object will have the color of its individual faces "
+                                          "editable with the Part FaceColors command"))},
     };
     int userEditMode = userEditModes.begin()->first;
 
 public:
-    std::map <int, std::string> listUserEditModes() const { return userEditModes; }
+    std::map <int, std::pair<std::string,std::string>> listUserEditModes() const { return userEditModes; }
     int getUserEditMode(const std::string &mode = "") const;
-    std::string getUserEditModeName(int mode = -1) const;
+    std::pair<std::string,std::string> getUserEditModeUIStrings(int mode = -1) const;
     bool setUserEditMode(int mode);
     bool setUserEditMode(const std::string &mode);
     //@}

--- a/src/Gui/ApplicationPy.cpp
+++ b/src/Gui/ApplicationPy.cpp
@@ -1552,7 +1552,7 @@ PyObject* Application::sListUserEditModes(PyObject * /*self*/, PyObject *args)
         return nullptr;
 
     for (auto const &uem : Instance->listUserEditModes()) {
-        ret.append(Py::String(uem.second));
+        ret.append(Py::String(uem.second.first));
     }
 
     return Py::new_reference_to(ret);
@@ -1563,7 +1563,7 @@ PyObject* Application::sGetUserEditMode(PyObject * /*self*/, PyObject *args)
     if (!PyArg_ParseTuple(args, ""))
         return nullptr;
 
-    return Py::new_reference_to(Py::String(Instance->getUserEditModeName()));
+    return Py::new_reference_to(Py::String(Instance->getUserEditModeUIStrings().first));
 }
 
 PyObject* Application::sSetUserEditMode(PyObject * /*self*/, PyObject *args)

--- a/src/Gui/CommandStd.cpp
+++ b/src/Gui/CommandStd.cpp
@@ -888,11 +888,12 @@ Gui::Action * StdCmdUserEditMode::createAction()
 
     for (auto const &uem : Gui::Application::Instance->listUserEditModes()) {
         QAction* act = pcAction->addAction(QString());
-        auto modeName = QString::fromStdString(uem.second);
+        auto modeName = QString::fromStdString(uem.second.first);
         act->setCheckable(true);
         act->setIcon(BitmapFactory().iconFromTheme(qPrintable(QString::fromLatin1("Std_UserEditMode")+modeName)));
         act->setObjectName(QString::fromLatin1("Std_UserEditMode")+modeName);
         act->setWhatsThis(QString::fromLatin1(getWhatsThis()));
+        act->setToolTip(QString::fromStdString(uem.second.second));
 
         if (uem.first == 0) {
             pcAction->setIcon(act->icon());
@@ -920,11 +921,11 @@ void StdCmdUserEditMode::languageChange()
     QList<QAction*> a = pcAction->actions();
 
     for (int i = 0 ; i < a.count() ; i++) {
-        auto modeName = QString::fromStdString(Gui::Application::Instance->getUserEditModeName(i));
+        auto modeName = Gui::Application::Instance->getUserEditModeUIStrings(i);
         a[i]->setText(QCoreApplication::translate(
-        "EditMode", qPrintable(modeName)));
+        "EditMode", modeName.first.c_str()));
         a[i]->setToolTip(QCoreApplication::translate(
-        "EditMode", qPrintable(modeName+QString::fromLatin1(" mode"))));
+        "EditMode", modeName.second.c_str()));
     }
 }
 


### PR DESCRIPTION
The tip text was extracted from the Wiki. Fixes https://github.com/FreeCAD/FreeCAD-translations/issues/102

This took more code than anticipated (considering that this button isn't even visible by default anymore). I'm not thrilled with the design, but it didn't seem worth putting in more time. If anyone objects I'll happily take suggestions.

---

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR