### PR TITLE
[TD]Handle BSpline Straight Lines

### DIFF
--- a/src/Mod/TechDraw/App/DrawViewDimension.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDimension.cpp
@@ -1479,7 +1479,7 @@ bool DrawViewDimension::fixExactMatch()
 void DrawViewDimension::handleNoExactMatch()
 {
 //    Base::Console().Message("DVD::handleNoExactMatch()\n");
-    Base::Console().Message("%s - trying to match changed geometry - stage 2\n", getNameInDocument());
+//    Base::Console().Message("%s - trying to match changed geometry - stage 2\n", getNameInDocument());
     // this is where we insert the clever logic to determine that the changed geometry
     // actually still represents the "front top left" edge.
     updateSavedGeometry();

--- a/src/Mod/TechDraw/App/Geometry.cpp
+++ b/src/Mod/TechDraw/App/Geometry.cpp
@@ -1266,39 +1266,7 @@ BSpline::BSpline(const TopoDS_Edge &e)
 // if len(first-last) == sum(len(pi - pi+1)) then it is a line
 bool BSpline::isLine()
 {
-    BRepAdaptor_Curve c(occEdge);
-
-    Handle(Geom_BSplineCurve) spline = c.BSpline();
-    double f = c.FirstParameter();
-    double l = c.LastParameter();
-    gp_Pnt s = c.Value(f);
-    gp_Pnt e = c.Value(l);
-
-    bool samePnt = s.IsEqual(e, FLT_EPSILON);
-    if (samePnt) {
-        return false;
-    }
-
-    Base::Vector3d vs = DrawUtil::toVector3d(s);
-    Base::Vector3d ve = DrawUtil::toVector3d(e);
-    double endLength = (vs - ve).Length();
-    int low = 0;
-    int high = spline->NbPoles() - 1;
-    TColgp_Array1OfPnt poles(low, high);
-    spline->Poles(poles);
-    double lenTotal = 0.0;
-    for (int i = 0; i < high; i++) {
-        gp_Pnt p1 = poles(i);
-        Base::Vector3d v1 = DrawUtil::toVector3d(p1);
-        gp_Pnt p2 = poles(i+1);
-        Base::Vector3d v2 = DrawUtil::toVector3d(p2);
-        lenTotal += (v2-v1).Length();
-    }
-
-    if (DrawUtil::fpCompare(lenTotal, endLength)) {
-        return true;
-    }
-    return false;
+    return GeometryUtils::isLine(occEdge);
 }
 
 //used by DVDim for approximate dims
@@ -1801,4 +1769,41 @@ TopoDS_Edge GeometryUtils::asCircle(TopoDS_Edge occEdge, bool& arc)
         return TopoDS_Edge();
     }
     return result;
+}
+
+bool GeometryUtils::isLine(TopoDS_Edge occEdge)
+{
+    BRepAdaptor_Curve c(occEdge);
+
+    Handle(Geom_BSplineCurve) spline = c.BSpline();
+    double f = c.FirstParameter();
+    double l = c.LastParameter();
+    gp_Pnt s = c.Value(f);
+    gp_Pnt e = c.Value(l);
+
+    bool samePnt = s.IsEqual(e, FLT_EPSILON);
+    if (samePnt) {
+        return false;
+    }
+
+    Base::Vector3d vs = DrawUtil::toVector3d(s);
+    Base::Vector3d ve = DrawUtil::toVector3d(e);
+    double endLength = (vs - ve).Length();
+    int low = 0;
+    int high = spline->NbPoles() - 1;
+    TColgp_Array1OfPnt poles(low, high);
+    spline->Poles(poles);
+    double lenTotal = 0.0;
+    for (int i = 0; i < high; i++) {
+        gp_Pnt p1 = poles(i);
+        Base::Vector3d v1 = DrawUtil::toVector3d(p1);
+        gp_Pnt p2 = poles(i+1);
+        Base::Vector3d v2 = DrawUtil::toVector3d(p2);
+        lenTotal += (v2-v1).Length();
+    }
+
+    if (DrawUtil::fpCompare(lenTotal, endLength)) {
+        return true;
+    }
+    return false;
 }

--- a/src/Mod/TechDraw/App/Geometry.h
+++ b/src/Mod/TechDraw/App/Geometry.h
@@ -435,6 +435,7 @@ class TechDrawExport GeometryUtils
         static bool isCircle(TopoDS_Edge occEdge);
         static bool getCircleParms(TopoDS_Edge occEdge, double& radius, Base::Vector3d& center, bool& isArc);
         static TopoDS_Edge asCircle(TopoDS_Edge occEdge, bool& arc);
+        static bool isLine(TopoDS_Edge occEdge);
 };
 
 } //end namespace TechDraw

--- a/src/Mod/TechDraw/App/GeometryMatcher.cpp
+++ b/src/Mod/TechDraw/App/GeometryMatcher.cpp
@@ -55,12 +55,14 @@ bool GeometryMatcher::compareGeometry(Part::TopoShape shape1,  Part::TopoShape s
 {
 //    Base::Console().Message("GM::compareGeometry()\n");
     if (shape1.isNull() || shape2.isNull()) {
-        Base::Console().Message("GM::compareGeometry - one or more TopoShapes are null\n");
+//        Base::Console().Message("GM::compareGeometry - one or more TopoShapes are null\n");
+        return false;
     }
     TopoDS_Shape geom1 = shape1.getShape();
     TopoDS_Shape geom2 = shape2.getShape();
     if (geom1.IsNull() || geom2.IsNull()) {
-        Base::Console().Message("GM::compareGeometry - one or more TopoDS_Shapes are null\n");
+//        Base::Console().Message("GM::compareGeometry - one or more TopoDS_Shapes are null\n");
+        return false;
     }
 
     if (geom1.ShapeType() == TopAbs_VERTEX) {
@@ -102,7 +104,8 @@ bool GeometryMatcher::compareEdges(TopoDS_Shape &shape1,  TopoDS_Shape &shape2)
     TopoDS_Edge edge1 = TopoDS::Edge(shape1);
     TopoDS_Edge edge2 = TopoDS::Edge(shape2);
    if (edge1.IsNull() || edge2.IsNull()) {
-        Base::Console().Message("GM::compareEdges - an input edge is null\n");
+//        Base::Console().Message("GM::compareEdges - an input edge is null\n");
+        return false;
     }
 
     BRepAdaptor_Curve adapt1(edge1);
@@ -144,6 +147,7 @@ bool GeometryMatcher::compareLines(TopoDS_Edge &edge1, TopoDS_Edge &edge2)
 {
 //    Base::Console().Message("GM::compareLines()\n");
     // how does the edge that was NOT null in compareEdges become null here?
+    // should not happen, but does!
     if (edge1.IsNull() || edge2.IsNull()) {
 //        Base::Console().Message("GM::compareLine - an input edge is null\n");
         return false;
@@ -212,14 +216,21 @@ bool GeometryMatcher::compareEllipses(TopoDS_Edge &edge1, TopoDS_Edge &edge2)
     return false;
  }
 
-// for our purposes, only circles masquerading as bsplines are of interest
+// for our purposes, only lines or circles masquerading as bsplines are of interest
 bool GeometryMatcher::compareBSplines(TopoDS_Edge &edge1, TopoDS_Edge &edge2)
 {
+//    Base::Console().Message("GM::compareBSplines()\n");
     // how does the edge that was NOT null in compareEdges become null here?
     if (edge1.IsNull() || edge2.IsNull()) {
-//        Base::Console().Message("GM::compareBSplines - an input edge is null\n");
+        Base::Console().Message("GM::compareBSplines - an input edge is null\n");
         return false;
     }
+
+    if (GeometryUtils::isLine(edge1) && GeometryUtils::isLine(edge2)) {
+        return compareEndPoints(edge1, edge2);
+    }
+
+    // deal with bsplines as circles
     BRepAdaptor_Curve adapt1(edge1);
     BRepAdaptor_Curve adapt2(edge2);
     bool isArc1(false);
@@ -261,6 +272,7 @@ bool GeometryMatcher::compareEllipseArcs(TopoDS_Edge &edge1, TopoDS_Edge &edge2)
 // not sure how successful this would be.  For now, we just say it doesn't match
 bool GeometryMatcher::compareDifferent(TopoDS_Edge &edge1, TopoDS_Edge &edge2)
 {
+    Base::Console().Message("GM::compareDifferent()\n");
     BRepAdaptor_Curve adapt1(edge1);
     BRepAdaptor_Curve adapt2(edge2);
     return false;


### PR DESCRIPTION
This PR corrects a situation where straight lines which are actually BSplines were not being handled correctly in the GeometryMatcher.

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [ x]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
