### PR TITLE
changed Z-axis rotation so that it is readable by default

### DIFF
--- a/src/App/Origin.cpp
+++ b/src/App/Origin.cpp
@@ -139,7 +139,7 @@ void Origin::setupObject () {
     } setupData [] = {
         {App::Line::getClassTypeId(),  AxisRoles[0],  tr("X-axis"),   Base::Rotation()},
         {App::Line::getClassTypeId(),  AxisRoles[1],  tr("Y-axis"),   Base::Rotation(Base::Vector3d(1,1,1), M_PI*2/3)},
-        {App::Line::getClassTypeId(),  AxisRoles[2],  tr("Z-axis"),   Base::Rotation(Base::Vector3d(1,1,1), M_PI*4/3)},
+        {App::Line::getClassTypeId(),  AxisRoles[2],  tr("Z-axis"),   Base::Rotation(Base::Vector3d(1,-1,1), M_PI*2/3)},
         {App::Plane::getClassTypeId(), PlaneRoles[0], tr("XY-plane"), Base::Rotation()},
         {App::Plane::getClassTypeId(), PlaneRoles[1], tr("XZ-plane"), Base::Rotation(1.0, 0.0, 0.0, 1.0 )},
         {App::Plane::getClassTypeId(), PlaneRoles[2], tr("YZ-plane"), Base::Rotation(Base::Vector3d(1,1,1), M_PI*2/3)}


### PR DESCRIPTION
I think it is very unkind of the Z-axis to turn its back on us by default. Therefore, I propose the following change, so that the labels of all axes and planes are readable by default:
![Change](https://user-images.githubusercontent.com/1651625/233789758-c5739123-5497-4961-9502-82f97b8b5737.png)


- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR
---
