### PR TITLE
Mesh: Eliminate Alt+O as a shortcut for close

### DIFF
--- a/src/Mod/Mesh/Gui/DlgRegularSolid.ui
+++ b/src/Mod/Mesh/Gui/DlgRegularSolid.ui
@@ -822,10 +822,7 @@
      <item>
       <widget class="QPushButton" name="buttonClose">
        <property name="text">
-        <string>Cl&amp;ose</string>
-       </property>
-       <property name="shortcut">
-        <string>Alt+O</string>
+        <string>Close</string>
        </property>
        <property name="autoDefault">
         <bool>true</bool>


### PR DESCRIPTION
We got a question on CrowdIn about this one. I don't think there's any reason to maintain this shortcut, it's totally unintuitive, and Esc closes the dialog just fine. Fixes https://github.com/FreeCAD/FreeCAD-translations/issues/129

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR