### PR TITLE
Gui: added semi transparent face to origin planes

### DIFF
--- a/src/Gui/ViewProviderOrigin.cpp
+++ b/src/Gui/ViewProviderOrigin.cpp
@@ -182,9 +182,9 @@ void ViewProviderOrigin::onChanged(const App::Property* prop) {
             if (vpPlaneXY) { vpPlaneXY->Size.setValue ( szXY ); }
             if (vpPlaneXZ) { vpPlaneXZ->Size.setValue ( szXZ ); }
             if (vpPlaneYZ) { vpPlaneYZ->Size.setValue ( szYZ ); }
-            if (vpLineX) { vpLineX->Size.setValue ( szX ); }
-            if (vpLineY) { vpLineY->Size.setValue ( szY ); }
-            if (vpLineZ) { vpLineZ->Size.setValue ( szZ ); }
+            if (vpLineX) { vpLineX->Size.setValue ( szX * axesScaling ); }
+            if (vpLineY) { vpLineY->Size.setValue ( szY * axesScaling ); }
+            if (vpLineZ) { vpLineZ->Size.setValue ( szZ * axesScaling ); }
 
         } catch (const Base::Exception &ex) {
             // While restoring a document don't report errors if one of the lines or planes

--- a/src/Gui/ViewProviderOrigin.h
+++ b/src/Gui/ViewProviderOrigin.h
@@ -76,6 +76,9 @@ public:
 
     /// Returns default size. Use this if it is not possible to determine appropriate size by other means
     static double defaultSize();
+
+    // default color for origini: light-blue (50, 150, 250, 255 stored as 0xRRGGBBAA)
+    static const uint32_t defaultColor = 0x3296faff;
 protected:
     void onChanged(const App::Property* prop) override;
     bool onDelete(const std::vector<std::string> &) override;

--- a/src/Gui/ViewProviderOrigin.h
+++ b/src/Gui/ViewProviderOrigin.h
@@ -77,6 +77,9 @@ public:
     /// Returns default size. Use this if it is not possible to determine appropriate size by other means
     static double defaultSize();
 
+    // the factor by which the axes are longer than the planes
+    static constexpr float axesScaling = 1.5f;
+
     // default color for origini: light-blue (50, 150, 250, 255 stored as 0xRRGGBBAA)
     static const uint32_t defaultColor = 0x3296faff;
 protected:

--- a/src/Gui/ViewProviderOriginFeature.cpp
+++ b/src/Gui/ViewProviderOriginFeature.cpp
@@ -35,6 +35,7 @@
 
 #include <App/Document.h>
 #include <App/OriginFeature.h>
+#include <App/Origin.h>
 
 #include "ViewProviderOriginFeature.h"
 #include "SoFCSelection.h"
@@ -98,7 +99,24 @@ void ViewProviderOriginFeature::attach(App::DocumentObject* pcObject)
 
     // Setup font size
     auto font = new SoFont ();
-    font->size.setValue ( defaultSz/10.);
+    float fontRatio = 10.0f;
+    if ( pcObject->getTypeId() == App::Line::getClassTypeId() ) {
+        // keep font size on axes equal to font size on planes
+        fontRatio *= ViewProviderOrigin::axesScaling;
+        const char* axisName = pcObject->getNameInDocument();
+        auto axisRoles = App::Origin::AxisRoles;
+        if ( strncmp(axisName, axisRoles[0], strlen(axisRoles[0]) ) == 0 ) {
+            // X-axis: red
+            ShapeColor.setValue ( 0xFF0000FF );
+        } else if ( strncmp(axisName, axisRoles[1], strlen(axisRoles[1]) ) == 0 ) {
+            // Y-axis: green
+            ShapeColor.setValue ( 0x00FF00FF );
+        } else if ( strncmp(axisName, axisRoles[2], strlen(axisRoles[2]) ) == 0 ) {
+            // Z-axis: blue
+            ShapeColor.setValue ( 0x0000FFFF );
+        }
+    }
+    font->size.setValue ( defaultSz / fontRatio );
     sep->addChild ( font );
 
     // Create the selection node

--- a/src/Gui/ViewProviderOriginFeature.cpp
+++ b/src/Gui/ViewProviderOriginFeature.cpp
@@ -49,7 +49,7 @@ ViewProviderOriginFeature::ViewProviderOriginFeature () {
     ADD_PROPERTY_TYPE ( Size, (ViewProviderOrigin::defaultSize()), 0, App::Prop_ReadOnly,
     QT_TRANSLATE_NOOP("App::Property", "Visual size of the feature"));
 
-    ShapeColor.setValue ( 50.f/255, 150.f/255, 250.f/255 ); // Set default color for origin (light-blue)
+    ShapeColor.setValue ( ViewProviderOrigin::defaultColor ); // Set default color for origin (light-blue)
     BoundingBox.setStatus(App::Property::Hidden, true); // Hide Boundingbox from the user due to it doesn't make sense
 
     // Create node for scaling the origin

--- a/src/Gui/ViewProviderPlane.cpp
+++ b/src/Gui/ViewProviderPlane.cpp
@@ -96,6 +96,11 @@ void ViewProviderPlane::attach ( App::DocumentObject *obj ) {
     shapeHints->shapeType = SoShapeHints::UNKNOWN_SHAPE_TYPE;
     faceSeparator->addChild(shapeHints);
 
+    // disable picking
+    auto pickStyle = new SoPickStyle();
+    pickStyle->style = SoPickStyle::UNPICKABLE;
+    faceSeparator->addChild(pickStyle);
+
     auto faceSet = new SoFaceSet();
     auto vertexProperty = new SoVertexProperty();
     vertexProperty->vertex.setValues(0, 4, verts);

--- a/src/Gui/ViewProviderPlane.cpp
+++ b/src/Gui/ViewProviderPlane.cpp
@@ -26,10 +26,14 @@
 #ifndef _PreComp_
 # include <Inventor/nodes/SoAsciiText.h>
 # include <Inventor/nodes/SoCoordinate3.h>
+# include <Inventor/nodes/SoFaceSet.h>
 # include <Inventor/nodes/SoIndexedLineSet.h>
+# include <Inventor/nodes/SoMaterial.h>
 # include <Inventor/nodes/SoPickStyle.h>
 # include <Inventor/nodes/SoSeparator.h>
+# include <Inventor/nodes/SoShapeHints.h>
 # include <Inventor/nodes/SoTranslation.h>
+# include <Inventor/SbColor.h>
 #endif
 
 #include "ViewProviderPlane.h"
@@ -72,6 +76,31 @@ void ViewProviderPlane::attach ( App::DocumentObject *obj ) {
     pLines->coordIndex.setNum(6);
     pLines->coordIndex.setValues(0, 6, lines);
     sep->addChild ( pLines );
+
+    // add semi transparent face
+    auto faceSeparator = new SoSeparator();
+    sep->addChild(faceSeparator);
+
+    auto material = new SoMaterial();
+    material->transparency.setValue(0.95f);
+    auto color = new SbColor();
+    float alpha = 0.0f;
+    color->setPackedValue(ViewProviderOrigin::defaultColor, alpha);
+    material->ambientColor.setValue(*color);
+    material->diffuseColor.setValue(*color);
+    faceSeparator->addChild(material);
+
+    // disable backface culling and render with two-sided lighting
+    auto shapeHints = new SoShapeHints();
+    shapeHints->vertexOrdering = SoShapeHints::COUNTERCLOCKWISE;
+    shapeHints->shapeType = SoShapeHints::UNKNOWN_SHAPE_TYPE;
+    faceSeparator->addChild(shapeHints);
+
+    auto faceSet = new SoFaceSet();
+    auto vertexProperty = new SoVertexProperty();
+    vertexProperty->vertex.setValues(0, 4, verts);
+    faceSet->vertexProperty.setValue(vertexProperty);
+    faceSeparator->addChild(faceSet);
 
     auto textTranslation = new SoTranslation ();
     textTranslation->translation.setValue ( SbVec3f ( -size * 49. / 50., size * 9./10., 0 ) );


### PR DESCRIPTION
The planes of the origin currently consist only of the surrounding lines, which are very difficult to distinguish visually, especially when rotating.

In this pull request I have added a semi transparent face to each plane, which improves their visibility.

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR
---
