### PR TITLE
Tests: Add Sketcher tests to CI

### DIFF
--- a/.github/workflows/actions/runCPPTests/runAllTests/action.yml
+++ b/.github/workflows/actions/runCPPTests/runAllTests/action.yml
@@ -1,8 +1,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 # ***************************************************************************
 # *                                                                         *
-# *   Copyright (c) 2023 0penBrain.                                         *
-# *   Copyright (c) 2023 FreeCAD Project Association                        *
+# *   Copyright (c) 2023 The FreeCAD Project Association                    *
 # *                                                                         *
 # *   This file is part of FreeCAD.                                         *
 # *                                                                         *
@@ -22,42 +21,34 @@
 # *                                                                         *
 # ***************************************************************************
 
-name: runCPPTests
-description: "Run C++ tests, generate log and report"
+name: Run all C++ Tests
+description: "Run all C++ tests, generating logs and reports for each"
 
 inputs:
-  testCommand:
-    description: "Test command to be run"
+  reportdir:
+    description: "Report directory"
     required: true
-  testLogFile:
-    description: "Path for the command-line output of the tests"
+  builddir:
+    description: "Build directory"
     required: true
-  reportFile:
-    description: "Report file"
+  reportfilename:
+    description: "Report filename"
     required: true
 
 runs:
   using: "composite"
   steps:
-    - name: Run C++ unit tests
-      shell: bash
-      run: stdbuf -oL -eL ${{ inputs.testCommand }} |& tee -a ${{ inputs.testLogFile }}
-    - name: Parse test results
-      if: always()
-      shell: bash
-      run:  |
-        result=$(sed -ne "/Global test environment tear-down/,/^$/{/^$/d;p}" ${{ inputs.testLogFile }})
-        if grep -qF "[  FAILED  ]" <<< $result
-        then
-          echo "<details><summary>:fire: GTest C++ unit test suite failed</summary>" >> ${{ inputs.reportFile }}
-        else
-          echo "<details><summary>:heavy_check_mark: GTest C++ unit test suite succeeded</summary>" >> ${{ inputs.reportFile }}
-        fi
-        echo "" >> ${{ inputs.reportFile }}
-        echo "Results" >> ${{ inputs.reportFile }}
-        echo "" >> ${{ inputs.reportFile }}
-        echo '```' >> ${{ inputs.reportFile }}
-        echo "$result" >> ${{ inputs.reportFile }}
-        echo '```' >> ${{ inputs.reportFile }}
-        echo "</details>">> ${{ inputs.reportFile }}
-        echo "" >> ${{ inputs.reportFile }}
+      - name: C++ core tests
+        uses: ./.github/workflows/actions/runCPPTests/runSingleTest
+        with:
+          testCommand: ${{ inputs.builddir }}/tests/Tests_run --gtest_output=json:${{ inputs.reportdir }}core_gtest_results.json
+          testLogFile: ${{ inputs.reportdir }}core_gtest_test_log.txt
+          reportFile: ${{ inputs.reportdir }}${{ inputs.reportfilename }}
+          testName: Core
+      - name: C++ Sketcher tests
+        uses: ./.github/workflows/actions/runCPPTests/runSingleTest
+        with:
+          testCommand: ${{ inputs.builddir }}/tests/Sketcher_tests_run --gtest_output=json:${{ inputs.reportdir }}sketcher_gtest_results.json
+          testLogFile: ${{ inputs.reportdir }}sketcher_gtest_test_log.txt
+          reportFile: ${{ inputs.reportdir }}${{ inputs.reportfilename }}
+          testName: Sketcher

--- a/.github/workflows/actions/runCPPTests/runAllTests/action.yml
+++ b/.github/workflows/actions/runCPPTests/runAllTests/action.yml
@@ -21,34 +21,59 @@
 # *                                                                         *
 # ***************************************************************************
 
+# !!! Each step running a single test shall have an'id' defined so its report will be output
+
 name: Run all C++ Tests
 description: "Run all C++ tests, generating logs and reports for each"
 
 inputs:
   reportdir:
-    description: "Report directory"
+    description: "Report directory where logs will be stored"
     required: true
   builddir:
-    description: "Build directory"
+    description: "Build directory where tests are located"
     required: true
-  reportfilename:
-    description: "Report filename"
+  reportFile:
+    description: "Path for report file"
     required: true
 
 runs:
   using: "composite"
   steps:
       - name: C++ core tests
+        id: core
         uses: ./.github/workflows/actions/runCPPTests/runSingleTest
         with:
           testCommand: ${{ inputs.builddir }}/tests/Tests_run --gtest_output=json:${{ inputs.reportdir }}core_gtest_results.json
           testLogFile: ${{ inputs.reportdir }}core_gtest_test_log.txt
-          reportFile: ${{ inputs.reportdir }}${{ inputs.reportfilename }}
           testName: Core
       - name: C++ Sketcher tests
+        id: sketcher
         uses: ./.github/workflows/actions/runCPPTests/runSingleTest
         with:
           testCommand: ${{ inputs.builddir }}/tests/Sketcher_tests_run --gtest_output=json:${{ inputs.reportdir }}sketcher_gtest_results.json
           testLogFile: ${{ inputs.reportdir }}sketcher_gtest_test_log.txt
-          reportFile: ${{ inputs.reportdir }}${{ inputs.reportfilename }}
           testName: Sketcher
+      - name: Compose summary report based on test results
+        if: always()
+        shell: bash
+        run: |
+          # Printing global result
+          if [ ${{ job.status }} != "success" ]
+          then
+            echo "<details><summary>:fire: C++ tests failed</summary>" >> ${{ inputs.reportFile }}
+          else
+            echo "<details><summary>:heavy_check_mark: C++ tests succeeded</summary>" >> ${{ inputs.reportFile }}
+          fi
+          echo "" >> ${{ inputs.reportFile }}
+          echo "<blockquote>" >> ${{ inputs.reportFile }}
+          #Extract individual results
+          cat > /tmp/data << "EOD"
+          ${{ toJSON(steps) }}
+          EOD
+          echo "$(jq -r ".[].outputs.reportText" /tmp/data)" >> ${{ inputs.reportFile }}
+          # Close report
+          echo "</blockquote>" >> ${{ inputs.reportFile }}
+          echo "</details>" >> ${{ inputs.reportFile }}
+          echo "" >> ${{ inputs.reportFile }}
+

--- a/.github/workflows/actions/runCPPTests/runSingleTest/action.yml
+++ b/.github/workflows/actions/runCPPTests/runSingleTest/action.yml
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# ***************************************************************************
+# *                                                                         *
+# *   Copyright (c) 2023 0penBrain.                                         *
+# *   Copyright (c) 2023 FreeCAD Project Association                        *
+# *                                                                         *
+# *   This file is part of FreeCAD.                                         *
+# *                                                                         *
+# *   FreeCAD is free software: you can redistribute it and/or modify it    *
+# *   under the terms of the GNU Lesser General Public License as           *
+# *   published by the Free Software Foundation, either version 2.1 of the  *
+# *   License, or (at your option) any later version.                       *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful, but        *
+# *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+# *   Lesser General Public License for more details.                       *
+# *                                                                         *
+# *   You should have received a copy of the GNU Lesser General Public      *
+# *   License along with FreeCAD. If not, see                               *
+# *   <https://www.gnu.org/licenses/>.                                      *
+# *                                                                         *
+# ***************************************************************************
+
+name: runCPPTests
+description: "Run C++ tests, generate log and report"
+
+inputs:
+  testCommand:
+    description: "Test command to be run"
+    required: true
+  testLogFile:
+    description: "Path for the command-line output of the tests"
+    required: true
+  reportFile:
+    description: "Report file"
+    required: true
+  testName:
+    description: "A descriptive name for the test suite"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Run C++ tests
+      shell: bash
+      run: stdbuf -oL -eL ${{ inputs.testCommand }} |& tee -a ${{ inputs.testLogFile }}
+    - name: Parse test results
+      if: always()
+      shell: bash
+      run:  |
+        result=$(sed -ne "/Global test environment tear-down/,/^$/{/^$/d;p}" ${{ inputs.testLogFile }})
+        if grep -qF "[  FAILED  ]" <<< $result
+        then
+          echo "<details><summary>:fire: GTest C++ test suite '${{ inputs.testName }}' failed</summary>" >> ${{ inputs.reportFile }}
+        else
+          echo "<details><summary>:heavy_check_mark: GTest C++ test suite '${{ inputs.testName }}' succeeded</summary>" >> ${{ inputs.reportFile }}
+        fi
+        echo "" >> ${{ inputs.reportFile }}
+        echo "Results" >> ${{ inputs.reportFile }}
+        echo "" >> ${{ inputs.reportFile }}
+        echo '```' >> ${{ inputs.reportFile }}
+        echo "$result" >> ${{ inputs.reportFile }}
+        echo '```' >> ${{ inputs.reportFile }}
+        echo "</details>">> ${{ inputs.reportFile }}
+        echo "" >> ${{ inputs.reportFile }}

--- a/.github/workflows/actions/runCPPTests/runSingleTest/action.yml
+++ b/.github/workflows/actions/runCPPTests/runSingleTest/action.yml
@@ -32,12 +32,13 @@ inputs:
   testLogFile:
     description: "Path for the command-line output of the tests"
     required: true
-  reportFile:
-    description: "Report file"
-    required: true
   testName:
     description: "A descriptive name for the test suite"
     required: true
+outputs:
+  reportText:
+    description: "Report text"
+    value: ${{ steps.report.outputs.reportText }}
 
 runs:
   using: "composite"
@@ -47,20 +48,25 @@ runs:
       run: stdbuf -oL -eL ${{ inputs.testCommand }} |& tee -a ${{ inputs.testLogFile }}
     - name: Parse test results
       if: always()
+      id: report
       shell: bash
       run:  |
         result=$(sed -ne "/Global test environment tear-down/,/^$/{/^$/d;p}" ${{ inputs.testLogFile }})
         if grep -qF "[  FAILED  ]" <<< $result
         then
-          echo "<details><summary>:fire: GTest C++ test suite '${{ inputs.testName }}' failed</summary>" >> ${{ inputs.reportFile }}
+          reportText="<details><summary>:fire: GTest C++ test suite '${{ inputs.testName }}' failed</summary>\n"
         else
-          echo "<details><summary>:heavy_check_mark: GTest C++ test suite '${{ inputs.testName }}' succeeded</summary>" >> ${{ inputs.reportFile }}
+          reportText="<details><summary>:heavy_check_mark: GTest C++ test suite '${{ inputs.testName }}' succeeded</summary>\n"
         fi
-        echo "" >> ${{ inputs.reportFile }}
-        echo "Results" >> ${{ inputs.reportFile }}
-        echo "" >> ${{ inputs.reportFile }}
-        echo '```' >> ${{ inputs.reportFile }}
-        echo "$result" >> ${{ inputs.reportFile }}
-        echo '```' >> ${{ inputs.reportFile }}
-        echo "</details>">> ${{ inputs.reportFile }}
-        echo "" >> ${{ inputs.reportFile }}
+        reportText+="\n"
+        reportText+="Results\n"
+        reportText+="\n"
+        reportText+='```\n'
+        reportText+="$result\n"
+        reportText+='```\n'
+        reportText+="</details>\n"
+        reportText+="\n"
+        echo "reportText<<EOD" >> $GITHUB_OUTPUT
+        echo -e "$reportText" >> $GITHUB_OUTPUT
+        echo "EOD" >> $GITHUB_OUTPUT
+        echo -e "$reportText"

--- a/.github/workflows/sub_buildUbuntu2004.yml
+++ b/.github/workflows/sub_buildUbuntu2004.yml
@@ -202,13 +202,13 @@ jobs:
           testCommand: xvfb-run ${{ env.builddir }}/bin/FreeCAD -t 0
           logFile: ${{ env.logdir }}TestGUIBuild.log
           reportFile: ${{env.reportdir}}${{ env.reportfilename }}
-      - name: C++ unit tests
+      - name: C++ tests
         timeout-minutes: 1
-        uses: ./.github/workflows/actions/runCPPTests
+        uses: ./.github/workflows/actions/runCPPTests/runAllTests
         with:
-          testCommand: ${{ env.builddir }}/tests/Tests_run --gtest_output=json:${{env.reportdir}}gtest_results.json
-          testLogFile: ${{env.reportdir}}gtest_test_log.txt
-          reportFile: ${{env.reportdir}}${{ env.reportfilename }}
+          reportdir: ${{ env.reportdir }}
+          builddir: ${{ env.builddir }}
+          reportfilename: ${{ env.reportfilename }}
       - name: CMake Install
         uses: ./.github/workflows/actions/linux/install
         with:

--- a/.github/workflows/sub_buildUbuntu2004.yml
+++ b/.github/workflows/sub_buildUbuntu2004.yml
@@ -208,7 +208,7 @@ jobs:
         with:
           reportdir: ${{ env.reportdir }}
           builddir: ${{ env.builddir }}
-          reportfilename: ${{ env.reportfilename }}
+          reportFile: ${{ env.reportdir }}${{ env.reportfilename }}
       - name: CMake Install
         uses: ./.github/workflows/actions/linux/install
         with:

--- a/.github/workflows/sub_buildUbuntu2204.yml
+++ b/.github/workflows/sub_buildUbuntu2204.yml
@@ -206,7 +206,7 @@ jobs:
         with:
           reportdir: ${{ env.reportdir }}
           builddir: ${{ env.builddir }}
-          reportfilename: ${{ env.reportfilename }}
+          reportFile: ${{ env.reportdir }}${{ env.reportfilename }}
       - name: CMake Install
         uses: ./.github/workflows/actions/linux/install
         with:

--- a/.github/workflows/sub_buildUbuntu2204.yml
+++ b/.github/workflows/sub_buildUbuntu2204.yml
@@ -200,13 +200,13 @@ jobs:
           testCommand: xvfb-run ${{ env.builddir }}/bin/FreeCAD -t 0
           logFile: ${{ env.logdir }}TestGUIBuild.log
           reportFile: ${{env.reportdir}}${{ env.reportfilename }}
-      - name: C++ unit tests
+      - name: C++ tests
         timeout-minutes: 1
-        uses: ./.github/workflows/actions/runCPPTests
+        uses: ./.github/workflows/actions/runCPPTests/runAllTests
         with:
-          testCommand: ${{ env.builddir }}/tests/Tests_run --gtest_output=json:${{env.reportdir}}gtest_results.json
-          testLogFile: ${{env.reportdir}}gtest_test_log.txt
-          reportFile: ${{env.reportdir}}${{ env.reportfilename }}
+          reportdir: ${{ env.reportdir }}
+          builddir: ${{ env.builddir }}
+          reportfilename: ${{ env.reportfilename }}
       - name: CMake Install
         uses: ./.github/workflows/actions/linux/install
         with:


### PR DESCRIPTION
Now that Sketcher has independent C++ tests, it needs to be explicitly added to the CI. 