### PR TITLE
Draft: Std_TransformManip should not be called from setEdit

### DIFF
--- a/src/Mod/Arch/ArchPanel.py
+++ b/src/Mod/Arch/ArchPanel.py
@@ -1081,6 +1081,11 @@ class ViewProviderPanelCut(Draft.ViewProviderDraft):
             self.onChanged(obj.ViewObject,"Margin")
         Draft.ViewProviderDraft.updateData(self,obj,prop)
 
+    def doubleClicked(self,vobj):
+
+        # See setEdit in ViewProviderDraft.
+        FreeCADGui.runCommand("Std_TransformManip")
+        return True
 
 class PanelSheet(Draft.DraftObject):
 

--- a/src/Mod/Draft/draftviewproviders/view_base.py
+++ b/src/Mod/Draft/draftviewproviders/view_base.py
@@ -388,18 +388,21 @@ class ViewProviderDraft(object):
         if mode == 1 or mode == 2:
             return None
 
-        tp = utils.get_type(vobj.Object)
+        # Fillet, Point, Shape2DView and PanelCut objects rely on a doubleClicked
+        # function which takes precedence over all double-click edit modes. This
+        # is a workaround as calling Gui.runCommand("Std_TransformManip") from
+        # setEdit does not work properly. The object then seems to be put into
+        # edit mode twice (?) and Esc will not cancel the command.
 
-        if tp in ("Wire", "Circle", "Ellipse", "Rectangle", "Polygon",
-                  "BSpline", "BezCurve"): # Facebinder, ShapeString, PanelSheet and Profile objects have their own setEdit.
+        # Facebinder, ShapeString, PanelSheet and Profile objects have their own
+        # setEdit and unsetEdit.
+
+        if utils.get_type(vobj.Object) in ("Wire", "Circle", "Ellipse", "Rectangle", "Polygon",
+                                           "BSpline", "BezCurve"):
             if not "Draft_Edit" in Gui.listCommands():
                 self.wb_before_edit = Gui.activeWorkbench()
                 Gui.activateWorkbench("DraftWorkbench")
             Gui.runCommand("Draft_Edit")
-            return True
-
-        if tp in ("Fillet", "Point", "Shape2DView", "PanelCut"):
-            Gui.runCommand("Std_TransformManip")
             return True
 
         return None
@@ -412,19 +415,14 @@ class ViewProviderDraft(object):
         if mode == 1 or mode == 2:
             return None
 
-        tp = utils.get_type(vobj.Object)
-
-        if tp in ("Wire", "Circle", "Ellipse", "Rectangle", "Polygon",
-                  "BSpline", "BezCurve"): # Facebinder, ShapeString, PanelSheet and Profile objects have their own unsetEdit.
+        if utils.get_type(vobj.Object) in ("Wire", "Circle", "Ellipse", "Rectangle", "Polygon",
+                                           "BSpline", "BezCurve"):
             if hasattr(App, "activeDraftCommand") and App.activeDraftCommand:
                 App.activeDraftCommand.finish()
             Gui.Control.closeDialog()
             if hasattr(self, "wb_before_edit"):
                 Gui.activateWorkbench(self.wb_before_edit.name())
                 delattr(self, "wb_before_edit")
-            return True
-
-        if tp in ("Fillet", "Point", "Shape2DView", "PanelCut"):
             return True
 
         return None
@@ -542,15 +540,21 @@ class ViewProviderDraftAlt(ViewProviderDraft):
 
     The `claimChildren` method is overridden to return an empty list.
 
+    The `doubleClicked` method is defined.
+
     Only used by the `Shape2DView` object.
     """
 
     def __init__(self, vobj):
         super(ViewProviderDraftAlt, self).__init__(vobj)
 
+    def doubleClicked(self, vobj):
+        # See setEdit in ViewProviderDraft.
+        Gui.runCommand("Std_TransformManip")
+        return True
+
     def claimChildren(self):
-        objs = []
-        return objs
+        return []
 
 
 # Alias for compatibility with v0.18 and earlier

--- a/src/Mod/Draft/draftviewproviders/view_fillet.py
+++ b/src/Mod/Draft/draftviewproviders/view_fillet.py
@@ -39,5 +39,11 @@ class ViewProviderFillet(ViewProviderWire):
     def __init__(self, vobj):
         super(ViewProviderFillet, self).__init__(vobj)
 
+    def doubleClicked(self, vobj):
+        # See setEdit in ViewProviderDraft.
+        import FreeCADGui as Gui
+        Gui.runCommand("Std_TransformManip")
+        return True
+
 
 ## @}

--- a/src/Mod/Draft/draftviewproviders/view_point.py
+++ b/src/Mod/Draft/draftviewproviders/view_point.py
@@ -52,6 +52,12 @@ class ViewProviderPoint(ViewProviderDraft):
     def getIcon(self):
         return ":/icons/Draft_Dot.svg"
 
+    def doubleClicked(self, vobj):
+        # See setEdit in ViewProviderDraft.
+        import FreeCADGui as Gui
+        Gui.runCommand("Std_TransformManip")
+        return True
+
 
 # Alias for compatibility with v0.18 and earlier
 _ViewProviderPoint = ViewProviderPoint


### PR DESCRIPTION
The object then seems to be put into edit mode twice (?) and Esc will not cancel the command.

Forum post:
https://forum.freecad.org/viewtopic.php?p=677099#p677099

As a workaround `doubleClicked` is used. This function takes precedence over all double-click edit modes. It can be used here because the affected objects (Fillet, Point, Shape2DView and PanelCut) currently only support a single edit mode.

- [x]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

---
