### PR TITLE
[TD]display escaped unicode annotations

### DIFF
--- a/src/Mod/TechDraw/Gui/QGIViewAnnotation.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewAnnotation.cpp
@@ -133,7 +133,21 @@ void QGIViewAnnotation::drawAnnotation()
         return;
     }
 
-    const std::vector<std::string>& annoText = viewAnno->Text.getValues();
+    const std::vector<std::string>& annoRawText = viewAnno->Text.getValues();
+    std::vector<std::string> annoText;
+    // v0.19- stored text as escapedUnicode
+    // v0.20+ stores text as utf8
+    for (auto& line : annoRawText) {
+        if (line.find("\\x") == std::string::npos) {
+            // not escaped
+            annoText.push_back(line);
+        } else {
+            // is escaped
+            std::string newLine = Base::Tools::escapedUnicodeToUtf8(line);
+            annoText.push_back(newLine);
+        }
+    }
+
     int fontSize = calculateFontPixelSize(viewAnno->TextSize.getValue());
 
     //build HTML/CSS formatting around Text lines


### PR DESCRIPTION
Version 0.19 stored annotations as escaped unicode, but v0.20 expects utf8.  This PR implements a check for "\x" in the text, and, if present, treats the text as escaped unicode, otherwise it treats the text as utf8.  This change affects display only, it does not change how text is stored.

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [x ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
