### PR TITLE
Fixed segmentation fault in PartDesign workbench

### DIFF
--- a/src/Mod/PartDesign/Gui/Utils.cpp
+++ b/src/Mod/PartDesign/Gui/Utils.cpp
@@ -438,6 +438,9 @@ void relinkToBody (PartDesign::Feature *feature) {
 
 bool isFeatureMovable(App::DocumentObject* const feat)
 {
+    if (!feat)
+        return false;
+
     if (feat->getTypeId().isDerivedFrom(PartDesign::Feature::getClassTypeId())) {
         auto prim = static_cast<PartDesign::Feature*>(feat);
         App::DocumentObject* bf = prim->BaseFeature.getValue();


### PR DESCRIPTION
Closes #9382. [usakhelo](https://github.com/usakhelo), the original author of the function `isFeatureMovable`, politely [refused](https://github.com/FreeCAD/FreeCAD/issues/9382#issuecomment-1522224360) to contribute to FreeCAD.

The cause of segmentation fault was attempted access to nonexistent `App::DocumentObject* const feat` (it was `nullptr`).

I concluded that if there is no object, so it cannot be moved. I can be wrong.



---


<details><summary>Standard form</summary>

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

</details>



