### PR TITLE
Path: move trailing whitespace out of l10n string

### DIFF
--- a/src/Mod/Path/Path/Main/Gui/Job.py
+++ b/src/Mod/Path/Path/Main/Gui/Job.py
@@ -630,16 +630,16 @@ class TaskPanel:
             0, QtGui.QHeaderView.Stretch
         )
         self.form.toolControllerList.horizontalHeaderItem(1).setToolTip(
-            translate("Path", "tool number ")
+            translate("Path", "Tool number") + ' '
         )
         self.form.toolControllerList.horizontalHeaderItem(2).setToolTip(
-            translate("Path", "horizontal feedrate ")+vUnit
+            translate("Path", "Horizontal feedrate")+ ' ' + vUnit
         )
         self.form.toolControllerList.horizontalHeaderItem(3).setToolTip(
-            translate("Path", "vertical feedrate ")+vUnit
+            translate("Path", "Vertical feedrate")+ ' ' + vUnit
         )
         self.form.toolControllerList.horizontalHeaderItem(4).setToolTip(
-            translate("Path", "spindle RPM ")
+            translate("Path", "Spindle RPM")+ ' '
         )
 
         # ensure correct ellisis behaviour on tool controller names.


### PR DESCRIPTION
Removes trailing whitespace from `src/Mod/Path/Path/Main/Gui/Job.py` and adds capitalization.  
Closes #9383

---

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR