### PR TITLE
[Base] US Building Schema correct sign on fraction

### DIFF
--- a/src/Base/UnitsSchemaImperial1.cpp
+++ b/src/Base/UnitsSchemaImperial1.cpp
@@ -274,35 +274,32 @@ QString UnitsSchemaImperialBuilding::schemaTranslate(const Quantity &quant, doub
 
         // Process into string. Start with negative sign if quantity is less
         // than zero
+        char plusOrMinus;
         if( quant.getValue() < 0 )
+        {
             output << "-";
+            plusOrMinus = '-';
+        }
+        else plusOrMinus = '+';
 
+        bool trailingNumber = false;
         // Print feet if we have any
         if( feet!=0 )
         {
             output << feet << "'";
-
-            // if there is to be trailing numbers, add space
-            if( inches!=0 || num!=0 )
-            {
-                output << " ";
-            }
+            trailingNumber = true;
         }
-
-        // Three cases:
-        //   1. Whole inches, no fraction
-        //   2. Whole inches, fraction
-        //   3. Fraction only
-        if( inches>0 && num==0 ) // case 1.
+        // Print whole inches if we have any
+        if( inches!=0 )
         {
+            if (trailingNumber) output << " ";
             output << inches << "\"";
+            trailingNumber = true;
         }
-        else if( inches>0 && num!=0 ) // case 2
+        // Print fractional inches if we have any
+        if( num!=0 )
         {
-            output << inches << "+" << num << "/" << den << "\"";
-        }
-        else if( inches==0 && num!=0 ) // case 3
-        {
+            if (trailingNumber) output << " " << plusOrMinus << " ";
             output << num << "/" << den << "\"";
         }
 


### PR DESCRIPTION
Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [x]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---

This makes a few changes to how US Building Scheme displays/calculates units:
1. Sign is carried through multiple units: -1'2.5" -> -1'2" - 1/2" https://github.com/FreeCAD/FreeCAD/issues/8426
2. Inches is notated with a quote to play better with the expression parser/spinbox 1'2 -> 1'2" and 2 -> 2"
3. A fraction is always preceded by a plus or minus to play better with the expression parser 1'1/2" -> 1'+1/2"

This relies on this PR to handle the #'#" format units US Building creates. https://github.com/FreeCAD/FreeCAD/pull/9397