### PR TITLE
[TD]Handle escaped unicode from old versions (partial fix for 9365)

### DIFF
--- a/src/Mod/TechDraw/App/DrawViewAnnotation.h
+++ b/src/Mod/TechDraw/App/DrawViewAnnotation.h
@@ -48,9 +48,9 @@ public:
     App::PropertyFont         Font;
     App::PropertyColor        TextColor;
     App::PropertyLength       TextSize;
-    App::PropertyPercent      LineSpace;
+    App::PropertyInteger      LineSpace;
     App::PropertyEnumeration  TextStyle; // Plain, Bold, Italic, Bold-Italic
-    App::PropertyLength       MaxWidth;
+    App::PropertyFloat        MaxWidth;
 
     QRectF getRect() const override;
 

--- a/src/Mod/TechDraw/Gui/QGIViewAnnotation.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewAnnotation.cpp
@@ -39,6 +39,7 @@
 
 #include <App/Application.h>
 #include <Base/Console.h>
+#include <Base/Tools.h>
 #include <Gui/MainWindow.h>
 #include <Gui/Widgets.h>
 #include <Mod/TechDraw/App/DrawViewAnnotation.h>
@@ -111,7 +112,21 @@ void QGIViewAnnotation::drawAnnotation()
         return;
     }
 
-    const std::vector<std::string>& annoText = viewAnno->Text.getValues();
+    const std::vector<std::string>& annoRawText = viewAnno->Text.getValues();
+    std::vector<std::string> annoText;
+    // v0.19- stored text as escapedUnicode
+    // v0.20+ stores text as utf8
+    for (auto& line : annoRawText) {
+        if (line.find("\\x") == std::string::npos) {
+            // not escaped
+            annoText.push_back(line);
+        } else {
+            // is escaped
+            std::string newLine = Base::Tools::escapedUnicodeToUtf8(line);
+            annoText.push_back(newLine);
+        }
+    }
+
     int scaledSize = exactFontSize(viewAnno->Font.getValue(), viewAnno->TextSize.getValue());
 
     //build HTML/CSS formatting around Text lines


### PR DESCRIPTION
This PR implements a partial fix for issue 9365.  It is the v021 equivalent of PR #9389 which applied to v0.20.
From PR9389:
Version 0.19 stored annotations as escaped unicode, but v0.20 expects utf8. This PR implements a check for "\x" in the text, and, if present, treats the text as escaped unicode, otherwise it treats the text as utf8. This change affects display only, it does not change how text is stored.

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [ x]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
