### PR TITLE
PATH: Change GUI Op Base Geometry Import button to support multiple bases

### DIFF
--- a/src/Mod/Path/Path/Op/Gui/Base.py
+++ b/src/Mod/Path/Path/Op/Gui/Base.py
@@ -638,10 +638,10 @@ class TaskPanelBaseGeometryPage(TaskPanelPage):
             msg = translate("PathOp", "Multiple operations are labeled as")
             msg += " {}\n".format(opLabel)
             FreeCAD.Console.PrintWarning(msg)
-        (base, subList) = ops[0].Base[0]
-        FreeCADGui.Selection.clearSelection()
-        FreeCADGui.Selection.addSelection(base, subList)
-        self.addBase()
+        for base, subList in ops[0].Base:
+            FreeCADGui.Selection.clearSelection()
+            FreeCADGui.Selection.addSelection(base, subList)
+            self.addBase()
 
     def registerSignalHandlers(self, obj):
         self.form.baseList.itemSelectionChanged.connect(self.itemActivated)


### PR DESCRIPTION
This updates the GUI Base Geometry Import button to iterate through all bases of the source op and add each of them to the current op.

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [ ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
