### PR TITLE
Begin translating user-visible exception strings

### DIFF
--- a/src/Mod/Part/Gui/DlgExtrusion.cpp
+++ b/src/Mod/Part/Gui/DlgExtrusion.cpp
@@ -495,8 +495,10 @@ void DlgExtrusion::apply()
         throw;
     }
     catch (Base::Exception &err){
-        QMessageBox::critical(this, windowTitle(),
-            tr("Creating Extrusion failed.\n%1").arg(QString::fromUtf8(err.what())));
+        QMessageBox::critical(this,
+                              windowTitle(),
+                              tr("Creating Extrusion failed.\n%1")
+                                  .arg(QCoreApplication::translate("Exception", err.what())));
         return;
     }
     catch(...) {
@@ -643,11 +645,11 @@ bool DlgExtrusion::validate()
         Base::Vector3d dir, base;
         hasValidAxisLink = Part::Extrusion::fetchAxisLink(lnk, base, dir);
     } catch(Base::Exception &err) {
-        errmsg = QString::fromUtf8(err.what());
+        errmsg = QCoreApplication::translate("Exception", err.what());
     } catch(Standard_Failure &err) {
         errmsg = QString::fromLocal8Bit(err.GetMessageString());
     } catch(...) {
-        errmsg = QString::fromUtf8("Unknown error");
+        errmsg = tr("Unknown error");
     }
     if (this->getDirMode() == Part::Extrusion::dmEdge && !hasValidAxisLink){
         if (errmsg.length() > 0)
@@ -669,7 +671,7 @@ bool DlgExtrusion::validate()
             lnk.setValue(&this->getShapeToExtrude()); //simplified - check only for the first shape.
             Part::Extrusion::calculateShapeNormal(lnk);
         } catch(Base::Exception &err) {
-            errmsg = QString::fromUtf8(err.what());
+            errmsg = QCoreApplication::translate("Exception", err.what());
         } catch(Standard_Failure &err) {
             errmsg = QString::fromLocal8Bit(err.GetMessageString());
         } catch(...) {

--- a/src/Mod/Part/Gui/DlgPrimitives.cpp
+++ b/src/Mod/Part/Gui/DlgPrimitives.cpp
@@ -125,7 +125,7 @@ void Picker::createPrimitive(QWidget* widget, const QString& descr, Gui::Documen
         Gui::Command::runCommand(Gui::Command::Gui, "Gui.SendMsgToActiveView(\"ViewFit\")");
     }
     catch (const Base::Exception& e) {
-        QMessageBox::warning(widget, descr, QString::fromLatin1(e.what()));
+        QMessageBox::warning(widget, descr, QCoreApplication::translate("Exception", e.what()));
     }
 }
 
@@ -1935,11 +1935,11 @@ void DlgPrimitives::createPrimitive(const QString& placement)
     }
     catch (const std::exception& e) {
         QMessageBox::warning(this, tr("Create %1")
-            .arg(ui->PrimitiveTypeCB->currentText()), QString::fromLatin1(e.what()));
+            .arg(ui->PrimitiveTypeCB->currentText()), QCoreApplication::translate("Exception", e.what()));
     }
     catch (const Base::PyException& e) {
         QMessageBox::warning(this, tr("Create %1")
-            .arg(ui->PrimitiveTypeCB->currentText()), QString::fromLatin1(e.what()));
+            .arg(ui->PrimitiveTypeCB->currentText()), QCoreApplication::translate("Exception", e.what()));
     }
 }
 

--- a/src/Mod/Part/Gui/DlgRevolution.cpp
+++ b/src/Mod/Part/Gui/DlgRevolution.cpp
@@ -277,7 +277,7 @@ bool DlgRevolution::validate()
         axisLinkHasAngle = angle_edge != 1e100;
     } catch(Base::Exception &err) {
         QMessageBox::critical(this, windowTitle(),
-            tr("Revolution axis link is invalid.\n\n%1").arg(QString::fromUtf8(err.what())));
+            tr("Revolution axis link is invalid.\n\n%1").arg(QCoreApplication::translate("Exception", err.what())));
         ui->txtAxisLink->setFocus();
         return false;
     } catch(Standard_Failure &err) {
@@ -287,7 +287,7 @@ bool DlgRevolution::validate()
         return false;
     } catch(...) {
         QMessageBox::critical(this, windowTitle(),
-            tr("Revolution axis link is invalid.\n\n%1").arg(QString::fromUtf8("Unknown error")));
+            tr("Revolution axis link is invalid.\n\n%1").arg(tr("Unknown error")));
         ui->txtAxisLink->setFocus();
         return false;
     }
@@ -440,7 +440,7 @@ void DlgRevolution::accept()
         activeDoc->recompute();
     } catch (Base::Exception &err) {
         QMessageBox::critical(this, windowTitle(),
-            tr("Creating Revolve failed.\n\n%1").arg(QString::fromUtf8(err.what())));
+            tr("Creating Revolve failed.\n\n%1").arg(QCoreApplication::translate("Exception", err.what())));
         return;
     } catch (...){
         QMessageBox::critical(this, windowTitle(),

--- a/src/Mod/Part/Gui/TaskAttacher.cpp
+++ b/src/Mod/Part/Gui/TaskAttacher.cpp
@@ -313,7 +313,7 @@ bool TaskAttacher::updatePreview()
     try{
         attached = pcAttach->positionBySupport();
     } catch (Base::Exception &err){
-        errMessage = QString::fromLatin1(err.what());
+        errMessage = QCoreApplication::translate("Exception", err.what());
     } catch (Standard_Failure &err){
         errMessage = tr("OCC error: %1").arg(QString::fromLatin1(err.GetMessageString()));
     } catch (...) {
@@ -414,7 +414,7 @@ void TaskAttacher::onSelectionChanged(const Gui::SelectionChanges& msg)
         }
         catch(Base::Exception& e) {
             //error = true;
-            ui->message->setText(QString::fromLatin1(e.what()));
+            ui->message->setText(QCoreApplication::translate("Exception", e.what()));
             ui->message->setStyleSheet(QString::fromLatin1("QLabel{color: red;}"));
         }
 
@@ -1115,7 +1115,7 @@ bool TaskDlgAttacher::accept()
         document->commitCommand();
     }
     catch (const Base::Exception& e) {
-        QMessageBox::warning(parameter, tr("Datum dialog: Input error"), QString::fromLatin1(e.what()));
+        QMessageBox::warning(parameter, tr("Datum dialog: Input error"), QCoreApplication::translate("Exception", e.what()));
         return false;
     }
 

--- a/src/Mod/Part/Gui/TaskLoft.cpp
+++ b/src/Mod/Part/Gui/TaskLoft.cpp
@@ -212,7 +212,7 @@ bool LoftWidget::accept()
         doc->commitCommand();
     }
     catch (const Base::Exception& e) {
-        QMessageBox::warning(this, tr("Input error"), QString::fromLatin1(e.what()));
+        QMessageBox::warning(this, tr("Input error"), QCoreApplication::translate("Exception", e.what()));
         return false;
     }
 

--- a/src/Mod/Part/Gui/TaskOffset.cpp
+++ b/src/Mod/Part/Gui/TaskOffset.cpp
@@ -207,7 +207,7 @@ bool OffsetWidget::accept()
         Gui::Command::commitCommand();
     }
     catch (const Base::Exception& e) {
-        QMessageBox::warning(this, tr("Input error"), QString::fromLatin1(e.what()));
+        QMessageBox::warning(this, tr("Input error"), QCoreApplication::translate("Exception", e.what()));
         return false;
     }
 

--- a/src/Mod/Part/Gui/TaskSweep.cpp
+++ b/src/Mod/Part/Gui/TaskSweep.cpp
@@ -378,7 +378,7 @@ bool SweepWidget::accept()
         doc->commitCommand();
     }
     catch (const Base::Exception& e) {
-        QMessageBox::warning(this, tr("Input error"), QString::fromLatin1(e.what()));
+        QMessageBox::warning(this, tr("Input error"), QCoreApplication::translate("Exception", e.what()));
         return false;
     }
 

--- a/src/Mod/Part/Gui/TaskThickness.cpp
+++ b/src/Mod/Part/Gui/TaskThickness.cpp
@@ -255,7 +255,8 @@ bool ThicknessWidget::accept()
         Gui::Command::commitCommand();
     }
     catch (const Base::Exception& e) {
-        QMessageBox::warning(this, tr("Input error"), QString::fromLatin1(e.what()));
+        QMessageBox::warning(
+            this, tr("Input error"), QCoreApplication::translate("Exception", e.what()));
         return false;
     }
 

--- a/src/Mod/PartDesign/App/Body.cpp
+++ b/src/Mod/PartDesign/App/Body.cpp
@@ -398,14 +398,14 @@ App::DocumentObjectExecReturn *Body::execute()
     Part::TopoShape tipShape;
     if ( tip ) {
         if ( !tip->getTypeId().isDerivedFrom ( PartDesign::Feature::getClassTypeId() ) ) {
-            return new App::DocumentObjectExecReturn ( "Linked object is not a PartDesign feature" );
+            return new App::DocumentObjectExecReturn (QT_TRANSLATE_NOOP("Exception", "Linked object is not a PartDesign feature" ));
         }
 
         // get the shape of the tip
         tipShape = static_cast<Part::Feature *>(tip)->Shape.getShape();
 
         if ( tipShape.getShape().IsNull () ) {
-            return new App::DocumentObjectExecReturn ( "Tip shape is empty" );
+            return new App::DocumentObjectExecReturn (QT_TRANSLATE_NOOP("Exception", "Tip shape is empty" ));
         }
 
         // We should hide here the transformation of the baseFeature

--- a/src/Mod/PartDesign/App/FeatureBase.cpp
+++ b/src/Mod/PartDesign/App/FeatureBase.cpp
@@ -59,14 +59,14 @@ short int FeatureBase::mustExecute() const {
 App::DocumentObjectExecReturn* FeatureBase::execute() {
 
     if(!BaseFeature.getValue())
-        return new App::DocumentObjectExecReturn("BaseFeature link is not set");
+        return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "BaseFeature link is not set"));
 
     if(!BaseFeature.getValue()->isDerivedFrom(Part::Feature::getClassTypeId()))
-        return new App::DocumentObjectExecReturn("BaseFeature must be a Part::Feature");
+        return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "BaseFeature must be a Part::Feature"));
 
     auto shape = static_cast<Part::Feature*>(BaseFeature.getValue())->Shape.getValue();
     if (shape.IsNull())
-        return new App::DocumentObjectExecReturn("BaseFeature has an empty shape");
+        return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "BaseFeature has an empty shape"));
 
     Shape.setValue(shape);
 

--- a/src/Mod/PartDesign/App/FeatureBoolean.cpp
+++ b/src/Mod/PartDesign/App/FeatureBoolean.cpp
@@ -75,7 +75,7 @@ App::DocumentObjectExecReturn *Boolean::execute()
     const Part::Feature* baseFeature = this->getBaseObject(/* silent = */ true);
 
     if (!baseFeature && type == "Cut") {
-        return new App::DocumentObjectExecReturn("Cannot do boolean cut without BaseFeature");
+        return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Cannot do boolean cut without BaseFeature"));
     }
 
     std::vector<App::DocumentObject*> tools = Group.getValues();
@@ -89,56 +89,56 @@ App::DocumentObjectExecReturn *Boolean::execute()
     else {
         auto feature = tools.back();
         if(!feature->isDerivedFrom(Part::Feature::getClassTypeId()))
-            return new App::DocumentObjectExecReturn("Cannot do boolean with anything but Part::Feature and its derivatives");
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Cannot do boolean with anything but Part::Feature and its derivatives"));
 
         baseTopShape = static_cast<Part::Feature*>(feature)->Shape.getShape();
         tools.pop_back();
     }
 
     if (baseTopShape.getShape().IsNull())
-        return new App::DocumentObjectExecReturn("Cannot do boolean operation with invalid base shape");
+        return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Cannot do boolean operation with invalid base shape"));
 
     //get the body this boolean feature belongs to
     Part::BodyBase* baseBody = Part::BodyBase::findBodyOf(this);
 
     if(!baseBody)
-         return new App::DocumentObjectExecReturn("Cannot do boolean on feature which is not in a body");
+         return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Cannot do boolean on feature which is not in a body"));
 
     TopoDS_Shape result = baseTopShape.getShape();
 
     for (auto tool : tools)
     {
         if(!tool->isDerivedFrom(Part::Feature::getClassTypeId()))
-            return new App::DocumentObjectExecReturn("Cannot do boolean with anything but Part::Feature and its derivatives");
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Cannot do boolean with anything but Part::Feature and its derivatives"));
 
         TopoDS_Shape shape = static_cast<Part::Feature*>(tool)->Shape.getValue();
         TopoDS_Shape boolOp;
 
         // Must not pass null shapes to the boolean operations
         if (result.IsNull())
-            return new App::DocumentObjectExecReturn("Base shape is null");
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Base shape is null"));
 
         if (shape.IsNull())
-            return new App::DocumentObjectExecReturn("Tool shape is null");
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Tool shape is null"));
 
         if (type == "Fuse") {
             BRepAlgoAPI_Fuse mkFuse(result, shape);
             if (!mkFuse.IsDone())
-                return new App::DocumentObjectExecReturn("Fusion of tools failed");
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Fusion of tools failed"));
             // we have to get the solids (fuse sometimes creates compounds)
             boolOp = this->getSolid(mkFuse.Shape());
             // lets check if the result is a solid
             if (boolOp.IsNull())
-                return new App::DocumentObjectExecReturn("Resulting shape is not a solid");
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Resulting shape is not a solid"));
         } else if (type == "Cut") {
             BRepAlgoAPI_Cut mkCut(result, shape);
             if (!mkCut.IsDone())
-                return new App::DocumentObjectExecReturn("Cut out failed");
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Cut out failed"));
             boolOp = mkCut.Shape();
         } else if (type == "Common") {
             BRepAlgoAPI_Common mkCommon(result, shape);
             if (!mkCommon.IsDone())
-                return new App::DocumentObjectExecReturn("Common operation failed");
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Common operation failed"));
             boolOp = mkCommon.Shape();
         }
 
@@ -149,7 +149,7 @@ App::DocumentObjectExecReturn *Boolean::execute()
 
     int solidCount = countSolids(result);
     if (solidCount > 1) {
-        return new App::DocumentObjectExecReturn("Boolean: Result has multiple solids. This is not supported at this time.");
+        return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Boolean: Result has multiple solids. This is not supported at this time."));
     }
 
     this->Shape.setValue(getSolid(result));

--- a/src/Mod/PartDesign/App/FeatureChamfer.cpp
+++ b/src/Mod/PartDesign/App/FeatureChamfer.cpp
@@ -200,11 +200,11 @@ App::DocumentObjectExecReturn *Chamfer::execute()
 
         mkChamfer.Build();
         if (!mkChamfer.IsDone())
-            return new App::DocumentObjectExecReturn("Failed to create chamfer");
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Failed to create chamfer"));
 
         TopoDS_Shape shape = mkChamfer.Shape();
         if (shape.IsNull())
-            return new App::DocumentObjectExecReturn("Resulting shape is null");
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Resulting shape is null"));
 
         TopTools_ListOfShape aLarg;
         aLarg.Append(baseShape.getShape());
@@ -215,12 +215,12 @@ App::DocumentObjectExecReturn *Chamfer::execute()
             aSfs->Perform();
             shape = aSfs->Shape();
             if (!BRepAlgo::IsValid(aLarg, shape, Standard_False, Standard_False)) {
-                return new App::DocumentObjectExecReturn("Resulting shape is invalid");
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Resulting shape is invalid"));
             }
         }
         int solidCount = countSolids(shape);
         if (solidCount > 1) {
-            return new App::DocumentObjectExecReturn("Chamfer: Result has multiple solids. This is not supported at this time.");
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Chamfer: Result has multiple solids. This is not supported at this time."));
         }
         shape = refineShapeIfActive(shape);
         this->Shape.setValue(getSolid(shape));
@@ -286,7 +286,7 @@ static App::DocumentObjectExecReturn *validateParameters(int chamferType, double
 {
     // Size is common to all chamfer types.
     if (size <= 0) {
-        return new App::DocumentObjectExecReturn("Size must be greater than zero");
+        return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Size must be greater than zero"));
     }
 
     switch (chamferType) {
@@ -295,12 +295,12 @@ static App::DocumentObjectExecReturn *validateParameters(int chamferType, double
             break;
         case 1: // Two distances
             if (size2 <= 0) {
-                return new App::DocumentObjectExecReturn("Size2 must be greater than zero");
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Size2 must be greater than zero"));
             }
             break;
         case 2: // Distance and angle
             if (angle <= 0 || angle >= 180.0) {
-                return new App::DocumentObjectExecReturn("Angle must be greater than 0 and less than 180");
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Angle must be greater than 0 and less than 180"));
             }
             break;
     }

--- a/src/Mod/PartDesign/App/FeatureDraft.cpp
+++ b/src/Mod/PartDesign/App/FeatureDraft.cpp
@@ -312,15 +312,15 @@ App::DocumentObjectExecReturn *Draft::execute()
 
         mkDraft.Build();
         if (!mkDraft.IsDone())
-            return new App::DocumentObjectExecReturn("Failed to create draft");
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Failed to create draft"));
 
         TopoDS_Shape shape = mkDraft.Shape();
         if (shape.IsNull())
-            return new App::DocumentObjectExecReturn("Resulting shape is null");
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Resulting shape is null"));
 
         int solidCount = countSolids(shape);
         if (solidCount > 1) {
-            return new App::DocumentObjectExecReturn("Fuse: Result has multiple solids. This is not supported at this time.");
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Fuse: Result has multiple solids. This is not supported at this time."));
         }
 
         this->Shape.setValue(getSolid(shape));

--- a/src/Mod/PartDesign/App/FeatureFillet.cpp
+++ b/src/Mod/PartDesign/App/FeatureFillet.cpp
@@ -90,7 +90,7 @@ App::DocumentObjectExecReturn *Fillet::execute()
     double radius = Radius.getValue();
 
     if(radius <= 0)
-        return new App::DocumentObjectExecReturn("Fillet radius must be greater than zero");
+        return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Fillet radius must be greater than zero"));
 
     this->positionByBaseFeature();
 
@@ -113,11 +113,11 @@ App::DocumentObjectExecReturn *Fillet::execute()
 
         mkFillet.Build();
         if (!mkFillet.IsDone())
-            return new App::DocumentObjectExecReturn("Failed to create fillet");
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Failed to create fillet"));
 
         TopoDS_Shape shape = mkFillet.Shape();
         if (shape.IsNull())
-            return new App::DocumentObjectExecReturn("Resulting shape is null");
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Resulting shape is null"));
 
         TopTools_ListOfShape aLarg;
         aLarg.Append(baseShape.getShape());
@@ -128,13 +128,13 @@ App::DocumentObjectExecReturn *Fillet::execute()
             aSfs->Perform();
             shape = aSfs->Shape();
             if (!BRepAlgo::IsValid(aLarg, shape, Standard_False, Standard_False)) {
-                return new App::DocumentObjectExecReturn("Resulting shape is invalid");
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Resulting shape is invalid"));
             }
         }
 
         int solidCount = countSolids(shape);
         if (solidCount > 1) {
-            return new App::DocumentObjectExecReturn("Fillet: Result has multiple solids. This is not supported at this time.");
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Fillet: Result has multiple solids. This is not supported at this time."));
         }
 
         shape = refineShapeIfActive(shape);

--- a/src/Mod/PartDesign/App/FeatureGroove.cpp
+++ b/src/Mod/PartDesign/App/FeatureGroove.cpp
@@ -75,11 +75,11 @@ App::DocumentObjectExecReturn *Groove::execute()
     // Validate parameters
     double angle = Angle.getValue();
     if (angle > 360.0)
-        return new App::DocumentObjectExecReturn("Angle of groove too large");
+        return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Angle of groove too large"));
 
     angle = Base::toRadians<double>(angle);
     if (angle < Precision::Angular())
-        return new App::DocumentObjectExecReturn("Angle of groove too small");
+        return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Angle of groove too small"));
 
     // Reverse angle if selected
     if (Reversed.getValue() && !Midplane.getValue())
@@ -98,7 +98,7 @@ App::DocumentObjectExecReturn *Groove::execute()
         base = getBaseShape();
     }
     catch (const Base::Exception&) {
-        std::string text(QT_TR_NOOP("The requested feature cannot be created. The reason may be that:\n"
+        std::string text(QT_TRANSLATE_NOOP("Exception", "The requested feature cannot be created. The reason may be that:\n"
                                     "  - the active Body does not contain a base shape, so there is no\n"
                                     "  material to be removed;\n"
                                     "  - the selected sketch does not belong to the active Body."));
@@ -115,7 +115,7 @@ App::DocumentObjectExecReturn *Groove::execute()
 
     try {
         if (sketchshape.IsNull())
-            return new App::DocumentObjectExecReturn("Creating a face from sketch failed");
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Creating a face from sketch failed"));
 
         // Rotate the face by half the angle to get Groove symmetric to sketch plane
         if (Midplane.getValue()) {
@@ -137,7 +137,7 @@ App::DocumentObjectExecReturn *Groove::execute()
         xp.Init(sketchshape, TopAbs_FACE);
         for (;xp.More(); xp.Next()) {
             if (checkLineCrossesFace(gp_Lin(pnt, dir), TopoDS::Face(xp.Current())))
-                return new App::DocumentObjectExecReturn("Revolve axis intersects the sketch");
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Revolve axis intersects the sketch"));
         }
 
         // revolve the face to a solid
@@ -153,32 +153,32 @@ App::DocumentObjectExecReturn *Groove::execute()
             BRepAlgoAPI_Cut mkCut(base, result);
             // Let's check if the fusion has been successful
             if (!mkCut.IsDone())
-                throw Base::CADKernelError("Cut out of base feature failed");
+                throw Base::CADKernelError(QT_TRANSLATE_NOOP("Exception", "Cut out of base feature failed"));
 
             // we have to get the solids (fuse sometimes creates compounds)
             TopoDS_Shape solRes = this->getSolid(mkCut.Shape());
             if (solRes.IsNull())
-                return new App::DocumentObjectExecReturn("Resulting shape is not a solid");
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Resulting shape is not a solid"));
 
             solRes = refineShapeIfActive(solRes);
             this->Shape.setValue(getSolid(solRes));
 
             int solidCount = countSolids(solRes);
             if (solidCount > 1) {
-                return new App::DocumentObjectExecReturn("Groove: Result has multiple solids. This is not supported at this time.");
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Groove: Result has multiple solids. This is not supported at this time."));
             }
 
         }
         else
-            return new App::DocumentObjectExecReturn("Could not revolve the sketch!");
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Could not revolve the sketch!"));
 
         return App::DocumentObject::StdReturn;
     }
     catch (Standard_Failure& e) {
 
         if (std::string(e.GetMessageString()) == "TopoDS::Face")
-            return new App::DocumentObjectExecReturn("Could not create face from sketch.\n"
-                "Intersecting sketch entities in a sketch are not allowed.");
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Could not create face from sketch.\n"
+                "Intersecting sketch entities in a sketch are not allowed."));
         else
             return new App::DocumentObjectExecReturn(e.GetMessageString());
     }

--- a/src/Mod/PartDesign/App/FeatureHelix.cpp
+++ b/src/Mod/PartDesign/App/FeatureHelix.cpp
@@ -124,35 +124,35 @@ App::DocumentObjectExecReturn* Helix::execute()
     HelixMode mode = static_cast<HelixMode>(Mode.getValue());
     if (mode == HelixMode::pitch_height_angle) {
         if (Pitch.getValue() < Precision::Confusion())
-            return new App::DocumentObjectExecReturn("Error: Pitch too small");
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Error: Pitch too small"));
         if (Height.getValue() < Precision::Confusion())
-            return new App::DocumentObjectExecReturn("Error: height too small!");
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Error: height too small!"));
         Turns.setValue(Height.getValue() / Pitch.getValue());
         Growth.setValue(Pitch.getValue() * tan(Base::toRadians(Angle.getValue())));
     }
     else if (mode == HelixMode::pitch_turns_angle) {
         if (Pitch.getValue() < Precision::Confusion())
-            return new App::DocumentObjectExecReturn("Error: pitch too small!");
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Error: pitch too small!"));
         if (Turns.getValue() < Precision::Confusion())
-            return new App::DocumentObjectExecReturn("Error: turns too small!");
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Error: turns too small!"));
         Height.setValue(Turns.getValue() * Pitch.getValue());
         Growth.setValue(Pitch.getValue() * tan(Base::toRadians(Angle.getValue())));
     }
     else if (mode == HelixMode::height_turns_angle) {
         if (Height.getValue() < Precision::Confusion())
-            return new App::DocumentObjectExecReturn("Error: height too small!");
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Error: height too small!"));
         if (Turns.getValue() < Precision::Confusion())
-            return new App::DocumentObjectExecReturn("Error: turns too small!");
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Error: turns too small!"));
         Pitch.setValue(Height.getValue() / Turns.getValue());
         Growth.setValue(Pitch.getValue() * tan(Base::toRadians(Angle.getValue())));
     }
     else if (mode == HelixMode::height_turns_growth) {
         if (Turns.getValue() < Precision::Confusion())
-            return new App::DocumentObjectExecReturn("Error: turns too small!");
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Error: turns too small!"));
         if ((Height.getValue() < Precision::Confusion())
             && (abs(Growth.getValue()) < Precision::Confusion())
             && Turns.getValue() > 1.0)
-            return new App::DocumentObjectExecReturn("Error: either height or growth must not be zero!");
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Error: either height or growth must not be zero!"));
         Pitch.setValue(Height.getValue() / Turns.getValue());
         if (Height.getValue() > 0) {
             Angle.setValue(Base::toDegrees(atan(
@@ -166,7 +166,7 @@ App::DocumentObjectExecReturn* Helix::execute()
         }
     }
     else {
-        return new App::DocumentObjectExecReturn("Error: unsupported mode");
+        return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Error: unsupported mode"));
     }
 
     TopoDS_Shape sketchshape;
@@ -178,7 +178,7 @@ App::DocumentObjectExecReturn* Helix::execute()
     }
 
     if (sketchshape.IsNull())
-        return new App::DocumentObjectExecReturn("Error: No valid sketch or face");
+        return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Error: No valid sketch or face"));
     else {
         //TODO: currently we only allow planar faces. the reason for this is that with other faces in front, we could
         //not use the current simulate approach and build the start and end face from the wires. As the shell
@@ -187,7 +187,7 @@ App::DocumentObjectExecReturn* Helix::execute()
         TopoDS_Face face = TopoDS::Face(sketchshape);
         BRepAdaptor_Surface adapt(face);
         if (adapt.GetType() != GeomAbs_Plane)
-            return new App::DocumentObjectExecReturn("Error: Face must be planar");
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Error: Face must be planar"));
     }
 
     // if the Base property has a valid shape, fuse the AddShape into it
@@ -253,7 +253,7 @@ App::DocumentObjectExecReturn* Helix::execute()
             }
 
             if (!mkPS.IsReady())
-                return new App::DocumentObjectExecReturn("Error: Could not build");
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Error: Could not build"));
 
             shells.push_back(mkPS.Shape());
 
@@ -293,7 +293,7 @@ App::DocumentObjectExecReturn* Helix::execute()
         }
 
         if (!mkSolid.IsDone())
-            return new App::DocumentObjectExecReturn("Error: Result is not a solid");
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Error: Result is not a solid"));
 
         TopoDS_Shape result = mkSolid.Shape();
 
@@ -307,11 +307,11 @@ App::DocumentObjectExecReturn* Helix::execute()
         if (base.IsNull()) {
 
             if (getAddSubType() == FeatureAddSub::Subtractive)
-                return new App::DocumentObjectExecReturn("Error: There is nothing to subtract\n");
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Error: There is nothing to subtract"));
 
             int solidCount = countSolids(result);
             if (solidCount > 1) {
-                return new App::DocumentObjectExecReturn("Error: Result has multiple solids");
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Error: Result has multiple solids"));
             }
             Shape.setValue(getSolid(result));
             return App::DocumentObject::StdReturn;
@@ -321,17 +321,17 @@ App::DocumentObjectExecReturn* Helix::execute()
 
             BRepAlgoAPI_Fuse mkFuse(base, result);
             if (!mkFuse.IsDone())
-                return new App::DocumentObjectExecReturn("Error: Adding the helix failed");
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Error: Adding the helix failed"));
             // we have to get the solids (fuse sometimes creates compounds)
             TopoDS_Shape boolOp = this->getSolid(mkFuse.Shape());
 
             // lets check if the result is a solid
             if (boolOp.IsNull())
-                return new App::DocumentObjectExecReturn("Error: Result is not a solid");
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Error: Result is not a solid"));
 
             int solidCount = countSolids(boolOp);
             if (solidCount > 1) {
-                return new App::DocumentObjectExecReturn("Error: Result has multiple solids");
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Error: Result has multiple solids"));
             }
 
             boolOp = refineShapeIfActive(boolOp);
@@ -344,24 +344,24 @@ App::DocumentObjectExecReturn* Helix::execute()
             if (Outside.getValue()) {  // are we subtracting the inside or the outside of the profile.
                 BRepAlgoAPI_Common mkCom(result, base);
                 if (!mkCom.IsDone())
-                    return new App::DocumentObjectExecReturn("Error: Intersecting the helix failed");
+                    return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Error: Intersecting the helix failed"));
                 boolOp = this->getSolid(mkCom.Shape());
 
             }
             else {
                 BRepAlgoAPI_Cut mkCut(base, result);
                 if (!mkCut.IsDone())
-                    return new App::DocumentObjectExecReturn("Error: Subtracting the helix failed");
+                    return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Error: Subtracting the helix failed"));
                 boolOp = this->getSolid(mkCut.Shape());
             }
 
             // lets check if the result is a solid
             if (boolOp.IsNull())
-                return new App::DocumentObjectExecReturn("Error: Result is not a solid");
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Error: Result is not a solid"));
 
             int solidCount = countSolids(boolOp);
             if (solidCount > 1) {
-                return new App::DocumentObjectExecReturn("Error: Result has multiple solids");
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Error: Result has multiple solids"));
             }
 
             boolOp = refineShapeIfActive(boolOp);
@@ -373,7 +373,7 @@ App::DocumentObjectExecReturn* Helix::execute()
     catch (Standard_Failure& e) {
 
         if (std::string(e.GetMessageString()) == "TopoDS::Face")
-            return new App::DocumentObjectExecReturn("Error: Could not create face from sketch");
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Error: Could not create face from sketch"));
         else
             return new App::DocumentObjectExecReturn(e.GetMessageString());
     }

--- a/src/Mod/PartDesign/App/FeatureHole.cpp
+++ b/src/Mod/PartDesign/App/FeatureHole.cpp
@@ -1666,7 +1666,7 @@ App::DocumentObjectExecReturn* Hole::execute()
         base = getBaseShape();
     }
     catch (const Base::Exception&) {
-        std::string text(QT_TR_NOOP("The requested feature cannot be created. The reason may be that:\n"
+        std::string text(QT_TRANSLATE_NOOP("Exception", "The requested feature cannot be created. The reason may be that:\n"
             "  - the active Body does not contain a base shape, so there is no\n"
             "  material to be removed;\n"
             "  - the selected sketch does not belong to the active Body."));
@@ -1684,7 +1684,7 @@ App::DocumentObjectExecReturn* Hole::execute()
 
         if (profileshape.IsNull())
             return new App::DocumentObjectExecReturn(
-                "Hole error: Creating a face from sketch failed");
+                QT_TRANSLATE_NOOP("Exception", "Hole error: Creating a face from sketch failed"));
         profileshape.Move(invObjLoc);
 
         /* Build the prototype hole */
@@ -1709,10 +1709,10 @@ App::DocumentObjectExecReturn* Hole::execute()
         }
         else
             return new App::DocumentObjectExecReturn(
-                "Hole error: Unsupported length specification");
+                QT_TRANSLATE_NOOP("Exception", "Hole error: Unsupported length specification"));
 
         if (length <= 0.0)
-            return new App::DocumentObjectExecReturn("Hole error: Invalid hole depth");
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Hole error: Invalid hole depth"));
 
         BRepBuilderAPI_MakeWire mkWire;
         const std::string holeCutType = HoleCutType.getValueAsString();
@@ -1735,7 +1735,7 @@ App::DocumentObjectExecReturn* Hole::execute()
         double zPosCounter = 0.0;
 
         if (TaperedAngleVal <= 0.0 || TaperedAngleVal > Base::toRadians(180.0))
-            return new App::DocumentObjectExecReturn("Hole error: Invalid taper angle");
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Hole error: Invalid taper angle"));
 
         if (isCountersink || isCounterbore || isCounterdrill) {
             double holeCutRadius = HoleCutDiameter.getValue() / 2.0;
@@ -1756,15 +1756,15 @@ App::DocumentObjectExecReturn* Hole::execute()
             }
 
             if (holeCutRadius < radius)
-                return new App::DocumentObjectExecReturn("Hole error: Hole cut diameter too small");
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Hole error: Hole cut diameter too small"));
 
             if (holeCutDepth > length)
                 return new App::DocumentObjectExecReturn(
-                    "Hole error: Hole cut depth must be less than hole depth");
+                    QT_TRANSLATE_NOOP("Exception", "Hole error: Hole cut depth must be less than hole depth"));
 
             if (holeCutDepth < 0.0)
                 return new App::DocumentObjectExecReturn(
-                    "Hole error: Hole cut depth must be greater or equal to zero");
+                    QT_TRANSLATE_NOOP("Exception", "Hole error: Hole cut depth must be greater or equal to zero"));
 
             // Top point
             gp_Pnt newPoint = toPnt(holeCutRadius * xDir);
@@ -1786,7 +1786,7 @@ App::DocumentObjectExecReturn* Hole::execute()
                                 gp_Pnt(radiusBottom, -length, 0), xPosCounter, zPosCounter);
 
             if (-length > zPosCounter)
-                return new App::DocumentObjectExecReturn("Hole error: Invalid countersink");
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Hole error: Invalid countersink"));
 
             lengthCounter = zPosCounter;
             newPoint = toPnt(xPosCounter * xDir + zPosCounter * zDir);
@@ -1819,7 +1819,7 @@ App::DocumentObjectExecReturn* Hole::execute()
 
             // the angle is in any case > 0 and < 90 but nevertheless this safeguard:
             if (drillPointAngle <= 0.0 || drillPointAngle >= Base::toRadians(180.0))
-                return new App::DocumentObjectExecReturn("Hole error: Invalid drill point angle");
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Hole error: Invalid drill point angle"));
 
             // if option to take drill point size into account
             // the next wire point is the intersection of the drill edge and the hole edge
@@ -1829,7 +1829,7 @@ App::DocumentObjectExecReturn* Hole::execute()
                     gp_Pnt(radius, 0, 0),
                     gp_Pnt(radiusBottom, -length, 0), xPosDrill, zPosDrill);
                 if (zPosDrill > 0 || zPosDrill >= lengthCounter)
-                    return new App::DocumentObjectExecReturn("Hole error: Invalid drill point");
+                    return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Hole error: Invalid drill point"));
 
                 newPoint = toPnt(xPosDrill * xDir + zPosDrill * zDir);
                 mkWire.Add(BRepBuilderAPI_MakeEdge(lastPoint, newPoint));
@@ -1863,11 +1863,11 @@ App::DocumentObjectExecReturn* Hole::execute()
         double angle = Base::toRadians<double>(360.0);
         BRepPrimAPI_MakeRevol RevolMaker(face, gp_Ax1(firstPoint, zDir), angle);
         if (!RevolMaker.IsDone())
-            return new App::DocumentObjectExecReturn("Hole error: Could not revolve sketch");
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Hole error: Could not revolve sketch"));
 
         TopoDS_Shape protoHole = RevolMaker.Shape();
         if (protoHole.IsNull())
-            return new App::DocumentObjectExecReturn("Hole error: Resulting shape is empty");
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Hole error: Resulting shape is empty"));
 
 
         // Make thread
@@ -1877,7 +1877,7 @@ App::DocumentObjectExecReturn* Hole::execute()
             // fuse the thread to the hole
             BRepAlgoAPI_Fuse mkFuse(protoHole, protoThread);
             if (!mkFuse.IsDone())
-                return new App::DocumentObjectExecReturn("Error: Adding the thread failed");
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Error: Adding the thread failed"));
 
             // we reuse the name protoHole (only now it is threaded)
             protoHole = mkFuse.Shape();
@@ -1889,9 +1889,7 @@ App::DocumentObjectExecReturn* Hole::execute()
         // For some reason it is faster to do the cut through a BooleanOperation.
         BRepAlgoAPI_Cut mkBool(base, holes);
         if (!mkBool.IsDone()) {
-            std::stringstream error;
-            error << "Boolean operation failed";
-            return new App::DocumentObjectExecReturn(error.str());
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Boolean operation failed"));
         }
         TopoDS_Shape result = mkBool.Shape();
 
@@ -1899,7 +1897,7 @@ App::DocumentObjectExecReturn* Hole::execute()
         // We have to get the solids (fuse sometimes creates compounds)
         base = getSolid(result);
         if (base.IsNull())
-            return new App::DocumentObjectExecReturn("Hole: Resulting shape is not a solid");
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Hole: Resulting shape is not a solid"));
         base = refineShapeIfActive(base);
 
 
@@ -1907,7 +1905,7 @@ App::DocumentObjectExecReturn* Hole::execute()
         int solidCount = countSolids(base);
         if (solidCount > 1) {
             return new App::DocumentObjectExecReturn(
-                "Hole: Result has multiple solids. This is not supported at this time.");
+                QT_TRANSLATE_NOOP("Exception", "Hole: Result has multiple solids. This is not supported at this time."));
         }
 
         this->Shape.setValue(base);
@@ -1918,10 +1916,10 @@ App::DocumentObjectExecReturn* Hole::execute()
         if (std::string(e.GetMessageString()) == "TopoDS::Face"
             && (std::string(DepthType.getValueAsString()) == "UpToFirst"
                 || std::string(DepthType.getValueAsString()) == "UpToFace"))
-            return new App::DocumentObjectExecReturn(
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception",
                 "Could not create face from sketch.\n"
                 "Intersecting sketch entities or multiple faces in a sketch are not allowed "
-                "for making a pocket up to a face.");
+                "for making a pocket up to a face."));
         else
             return new App::DocumentObjectExecReturn(e.GetMessageString());
     }
@@ -2024,10 +2022,10 @@ TopoDS_Shape Hole::makeThread(const gp_Vec& xDir, const gp_Vec& zDir, double len
     int threadType = ThreadType.getValue();
     int threadSize = ThreadSize.getValue();
     if (threadType < 0) {
-        throw Base::IndexError("Thread type out of range");
+        throw Base::IndexError(QT_TRANSLATE_NOOP("Exception", "Thread type out of range"));
     }
     if (threadSize < 0) {
-        throw Base::IndexError("Thread size out of range");
+        throw Base::IndexError(QT_TRANSLATE_NOOP("Exception", "Thread size out of range"));
     }
 
     bool leftHanded = (bool)ThreadDirection.getValue();
@@ -2119,7 +2117,7 @@ TopoDS_Shape Hole::makeThread(const gp_Vec& xDir, const gp_Vec& zDir, double len
     mkPS.SetMode(true);  //This is for frenet
     mkPS.Add(threadWire);
     if (!mkPS.IsReady())
-        throw Base::CADKernelError("Error: Thread could not be built");
+        throw Base::CADKernelError(QT_TRANSLATE_NOOP("Exception", "Error: Thread could not be built"));
     TopoDS_Shape shell = mkPS.Shape();
 
     // create faces at the ends of the pipe shell
@@ -2144,7 +2142,7 @@ TopoDS_Shape Hole::makeThread(const gp_Vec& xDir, const gp_Vec& zDir, double len
     BRepBuilderAPI_MakeSolid mkSolid;
     mkSolid.Add(TopoDS::Shell(sewer.SewedShape()));
     if (!mkSolid.IsDone())
-        throw Base::CADKernelError("Error: Result is not a solid");
+        throw Base::CADKernelError(QT_TRANSLATE_NOOP("Exception", "Error: Result is not a solid"));
     TopoDS_Shape result = mkSolid.Shape();
 
     // check if the algorithm has confused the inside and outside of the solid

--- a/src/Mod/PartDesign/App/FeatureLoft.cpp
+++ b/src/Mod/PartDesign/App/FeatureLoft.cpp
@@ -132,12 +132,12 @@ App::DocumentObjectExecReturn *Loft::execute()
         // build up multisections
         auto multisections = Sections.getSubListValues();
         if (multisections.empty())
-            return new App::DocumentObjectExecReturn("Loft: At least one section is needed");
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Loft: At least one section is needed"));
 
         TopoDS_Shape profileShape = getSectionShape(Profile.getValue(),
                                                     Profile.getSubValues());
         if (profileShape.IsNull())
-            return new App::DocumentObjectExecReturn("Loft: Could not obtain profile shape");
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Loft: Could not obtain profile shape"));
 
         std::vector<std::vector<TopoDS_Shape>> wiresections;
 
@@ -150,7 +150,7 @@ App::DocumentObjectExecReturn *Loft::execute()
                 profilePoint = ex.Current();
             }
             if (i > 1)
-                return new App::DocumentObjectExecReturn("Loft: When using points for profile/sections, the sketch should have a single point");
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Loft: When using points for profile/sections, the sketch should have a single point"));
         }
 
         bool isLastSectionVertex = false;
@@ -158,12 +158,12 @@ App::DocumentObjectExecReturn *Loft::execute()
         size_t subSetCnt=0;
         for (const auto & subSet : multisections) {
             if (!subSet.first->isDerivedFrom(Part::Feature::getClassTypeId()))
-                return new App::DocumentObjectExecReturn("Loft: All sections need to be part features");
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Loft: All sections need to be part features"));
 
             // if the selected subvalue is a point, pick that even if we have a sketch
             TopoDS_Shape shape = getSectionShape(subSet.first, subSet.second);
             if (shape.IsNull())
-                return new App::DocumentObjectExecReturn("Loft: Could not obtain section shape");
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Loft: Could not obtain section shape"));
 
             size_t numWiresAdded = addWiresToWireSections(shape, wiresections);
             if (numWiresAdded == 0) {
@@ -179,18 +179,18 @@ App::DocumentObjectExecReturn *Loft::execute()
                 }
 
                 if (vertexShape.IsNull())
-                    return new App::DocumentObjectExecReturn("Loft: A section doesn't contain any wires nor is a single vertex");
+                    return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Loft: A section doesn't contain any wires nor is a single vertex"));
                 if (subSetCnt != multisections.size()-1)
-                    return new App::DocumentObjectExecReturn("Loft: Only the profile and the last section can be vertices");
+                    return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Loft: Only the profile and the last section can be vertices"));
                 if (Closed.getValue())
-                    return new App::DocumentObjectExecReturn("Loft: For closed lofts only the profile can be a vertex");
+                    return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Loft: For closed lofts only the profile can be a vertex"));
 
                 // all good; push vertex to all wiresection list
                 for (auto &wires : wiresections)
                     wires.push_back(vertexShape);
                 isLastSectionVertex = true;
             } else if (numWiresAdded != wiresections.size())
-                return new App::DocumentObjectExecReturn("Loft: all loft sections need to have the same amount of inner wires");
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Loft: all loft sections need to have the same amount of inner wires"));
             subSetCnt++;
         }
 
@@ -229,7 +229,7 @@ App::DocumentObjectExecReturn *Loft::execute()
 
             mkTS.Build();
             if (!mkTS.IsDone())
-                return new App::DocumentObjectExecReturn("Loft could not be built");
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Loft could not be built"));
 
             // build the shell use simulate to get the top and bottom wires in an easy way
             shells.push_back(mkTS.Shape());
@@ -262,7 +262,7 @@ App::DocumentObjectExecReturn *Loft::execute()
         BRepBuilderAPI_MakeSolid mkSolid;
         mkSolid.Add(TopoDS::Shell(sewer.SewedShape()));
         if (!mkSolid.IsDone())
-            return new App::DocumentObjectExecReturn("Loft: Result is not a solid");
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Loft: Result is not a solid"));
 
         TopoDS_Shape result = mkSolid.Shape();
         BRepClass3d_SolidClassifier SC(result);
@@ -275,7 +275,7 @@ App::DocumentObjectExecReturn *Loft::execute()
 
         if (base.IsNull()) {
             if (getAddSubType() == FeatureAddSub::Subtractive)
-                return new App::DocumentObjectExecReturn("Loft: There is nothing to subtract from\n");
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Loft: There is nothing to subtract from"));
 
             Shape.setValue(getSolid(result));
             return App::DocumentObject::StdReturn;
@@ -285,15 +285,15 @@ App::DocumentObjectExecReturn *Loft::execute()
 
             BRepAlgoAPI_Fuse mkFuse(base, result);
             if (!mkFuse.IsDone())
-                return new App::DocumentObjectExecReturn("Loft: Adding the loft failed");
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Loft: Adding the loft failed"));
             // we have to get the solids (fuse sometimes creates compounds)
             TopoDS_Shape boolOp = this->getSolid(mkFuse.Shape());
             // lets check if the result is a solid
             if (boolOp.IsNull())
-                return new App::DocumentObjectExecReturn("Loft: Resulting shape is not a solid");
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Loft: Resulting shape is not a solid"));
             int solidCount = countSolids(boolOp);
             if (solidCount > 1) {
-                return new App::DocumentObjectExecReturn("Loft: Result has multiple solids. This is not supported at this time.");
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Loft: Result has multiple solids. This is not supported at this time."));
             }
 
             boolOp = refineShapeIfActive(boolOp);
@@ -303,15 +303,15 @@ App::DocumentObjectExecReturn *Loft::execute()
 
             BRepAlgoAPI_Cut mkCut(base, result);
             if (!mkCut.IsDone())
-                return new App::DocumentObjectExecReturn("Loft: Subtracting the loft failed");
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Loft: Subtracting the loft failed"));
             // we have to get the solids (fuse sometimes creates compounds)
             TopoDS_Shape boolOp = this->getSolid(mkCut.Shape());
             // lets check if the result is a solid
             if (boolOp.IsNull())
-                return new App::DocumentObjectExecReturn("Loft: Resulting shape is not a solid");
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Loft: Resulting shape is not a solid"));
             int solidCount = countSolids(boolOp);
             if (solidCount > 1) {
-                return new App::DocumentObjectExecReturn("Loft: Result has multiple solids. This is not supported at this time.");
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Loft: Result has multiple solids. This is not supported at this time."));
             }
 
             boolOp = refineShapeIfActive(boolOp);
@@ -327,7 +327,7 @@ App::DocumentObjectExecReturn *Loft::execute()
         return new App::DocumentObjectExecReturn(e.what());
     }
     catch (...) {
-        return new App::DocumentObjectExecReturn("Loft: A fatal error occurred when making the loft");
+        return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Loft: A fatal error occurred when making the loft"));
     }
 }
 

--- a/src/Mod/PartDesign/App/FeaturePad.cpp
+++ b/src/Mod/PartDesign/App/FeaturePad.cpp
@@ -72,10 +72,10 @@ App::DocumentObjectExecReturn *Pad::execute()
     // Validate parameters
     double L = Length.getValue();
     if ((std::string(Type.getValueAsString()) == "Length") && (L < Precision::Confusion()))
-        return new App::DocumentObjectExecReturn("Length of pad too small");
+        return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Length of pad too small"));
     double L2 = Length2.getValue();
     if ((std::string(Type.getValueAsString()) == "TwoLengths") && (L < Precision::Confusion()))
-        return new App::DocumentObjectExecReturn("Second length of pad too small");
+        return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Second length of pad too small"));
 
     // if midplane is true, disable reversed and vice versa
     bool hasMidplane = Midplane.getValue();
@@ -127,7 +127,7 @@ App::DocumentObjectExecReturn *Pad::execute()
 
         // factor would be zero if vectors are orthogonal
         if (factor < Precision::Confusion())
-            return new App::DocumentObjectExecReturn("Pad: Creation failed because direction is orthogonal to sketch's normal vector");
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Pad: Creation failed because direction is orthogonal to sketch's normal vector"));
 
         // perform the length correction if not along custom vector
         if (AlongSketchNormal.getValue()) {
@@ -138,7 +138,7 @@ App::DocumentObjectExecReturn *Pad::execute()
         dir.Transform(invObjLoc.Transformation());
 
         if (sketchshape.IsNull())
-            return new App::DocumentObjectExecReturn("Pad: Creating a face from sketch failed");
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Pad: Creating a face from sketch failed"));
         sketchshape.Move(invObjLoc);
 
         TopoDS_Shape prism;
@@ -202,7 +202,7 @@ App::DocumentObjectExecReturn *Pad::execute()
         }
 
         if (prism.IsNull())
-            return new App::DocumentObjectExecReturn("Pad: Resulting shape is empty");
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Pad: Resulting shape is empty"));
 
         // set the additive shape property for later usage in e.g. pattern
         prism = refineShapeIfActive(prism);
@@ -213,17 +213,17 @@ App::DocumentObjectExecReturn *Pad::execute()
             BRepAlgoAPI_Fuse mkFuse(base, prism);
             // Let's check if the fusion has been successful
             if (!mkFuse.IsDone())
-                return new App::DocumentObjectExecReturn("Pad: Fusion with base feature failed");
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Pad: Fusion with base feature failed"));
             TopoDS_Shape result = mkFuse.Shape();
             // we have to get the solids (fuse sometimes creates compounds)
             TopoDS_Shape solRes = this->getSolid(result);
             // lets check if the result is a solid
             if (solRes.IsNull())
-                return new App::DocumentObjectExecReturn("Pad: Resulting shape is not a solid");
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Pad: Resulting shape is not a solid"));
 
             int solidCount = countSolids(result);
             if (solidCount > 1) {
-                return new App::DocumentObjectExecReturn("Pad: Result has multiple solids. This is not supported at this time.");
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Pad: Result has multiple solids. This is not supported at this time."));
             }
 
             solRes = refineShapeIfActive(solRes);
@@ -232,7 +232,7 @@ App::DocumentObjectExecReturn *Pad::execute()
         else {
             int solidCount = countSolids(prism);
             if (solidCount > 1) {
-                return new App::DocumentObjectExecReturn("Pad: Result has multiple solids. This is not supported at this time.");
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Pad: Result has multiple solids. This is not supported at this time."));
             }
 
            this->Shape.setValue(getSolid(prism));
@@ -245,8 +245,8 @@ App::DocumentObjectExecReturn *Pad::execute()
     }
     catch (Standard_Failure& e) {
         if (std::string(e.GetMessageString()) == "TopoDS::Face")
-            return new App::DocumentObjectExecReturn("Could not create face from sketch.\n"
-                "Intersecting sketch entities or multiple faces in a sketch are not allowed.");
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Could not create face from sketch.\n"
+                "Intersecting sketch entities or multiple faces in a sketch are not allowed."));
         else
             return new App::DocumentObjectExecReturn(e.GetMessageString());
     }

--- a/src/Mod/PartDesign/App/FeaturePipe.cpp
+++ b/src/Mod/PartDesign/App/FeaturePipe.cpp
@@ -169,12 +169,12 @@ App::DocumentObjectExecReturn *Pipe::execute()
         TopoDS_Shape profileShape = getSectionShape(Profile.getValue(),
                                                     Profile.getSubValues());
         if (profileShape.IsNull())
-            return new App::DocumentObjectExecReturn("Pipe: Could not obtain profile shape");
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Pipe: Could not obtain profile shape"));
 
         // build the paths
         App::DocumentObject* spine = Spine.getValue();
         if (!(spine && spine->getTypeId().isDerivedFrom(Part::Feature::getClassTypeId())))
-            return new App::DocumentObjectExecReturn("No spine linked");
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "No spine linked"));
 
         std::vector<std::string> subedge = Spine.getSubValues();
         TopoDS_Shape path;
@@ -187,7 +187,7 @@ App::DocumentObjectExecReturn *Pipe::execute()
         if (Mode.getValue() == 3) {
             App::DocumentObject* auxspine = AuxillerySpine.getValue();
             if (!(auxspine && auxspine->getTypeId().isDerivedFrom(Part::Feature::getClassTypeId())))
-                return new App::DocumentObjectExecReturn("No auxiliary spine linked.");
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "No auxiliary spine linked."));
             std::vector<std::string> auxsubedge = AuxillerySpine.getSubValues();
 
             const Part::TopoShape& auxshape =
@@ -208,14 +208,14 @@ App::DocumentObjectExecReturn *Pipe::execute()
             for (ex.Init(profileShape, TopAbs_VERTEX); ex.More(); ex.Next(), ++i)
                 profilePoint = ex.Current();
             if (i > 1)
-                return new App::DocumentObjectExecReturn(
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception",
                     "Pipe: Only one isolated point is needed if using a sketch with isolated "
-                    "points for section");
+                    "points for section"));
         }
 
         if (!profilePoint.IsNull() && (Transformation.getValue() != 1 || multisections.empty()))
-            return new App::DocumentObjectExecReturn(
-                "Pipe: At least one section is needed when using a single point for profile");
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception",
+                "Pipe: At least one section is needed when using a single point for profile"));
 
         // maybe we need a scaling law
         Handle(Law_Function) scalinglaw;
@@ -228,14 +228,14 @@ App::DocumentObjectExecReturn *Pipe::execute()
             // as makepipeshell connects the sections in the order of adding
             for (auto& subSet : multisections) {
                 if (!subSet.first->isDerivedFrom(Part::Feature::getClassTypeId()))
-                    return new App::DocumentObjectExecReturn(
-                        "Pipe: All sections need to be part features");
+                    return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception",
+                        "Pipe: All sections need to be part features"));
 
                 // if the section is an object's face then take just the face
                 TopoDS_Shape shape = getSectionShape(subSet.first, subSet.second);
                 if (shape.IsNull())
-                    return new App::DocumentObjectExecReturn(
-                        "Pipe: Could not obtain section shape");
+                    return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception",
+                        "Pipe: Could not obtain section shape"));
 
                 size_t nWiresAdded = addWiresToWireSections(shape, wiresections);
                 if (nWiresAdded == 0) {
@@ -243,8 +243,8 @@ App::DocumentObjectExecReturn *Pipe::execute()
                     size_t i = 0;
                     for (ex.Init(shape, TopAbs_VERTEX); ex.More(); ex.Next(), ++i) {
                         if (isLastSectionVertex)
-                            return new App::DocumentObjectExecReturn(
-                                "Pipe: Only the profile and last section can be vertices");
+                            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception",
+                                "Pipe: Only the profile and last section can be vertices"));
                         isLastSectionVertex = true;
                         for (auto& wires : wiresections)
                             wires.push_back(ex.Current());
@@ -252,9 +252,9 @@ App::DocumentObjectExecReturn *Pipe::execute()
                 }
 
                 if (!isLastSectionVertex && nWiresAdded < wiresections.size())
-                    return new App::DocumentObjectExecReturn(
+                    return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception",
                         "Multisections need to have the same amount of inner wires as the base "
-                        "section");
+                        "section"));
             }
         }
         /*//build the law functions instead
@@ -279,7 +279,8 @@ App::DocumentObjectExecReturn *Pipe::execute()
 
         // Verify that path is not a null shape
         if (path.IsNull())
-            return new App::DocumentObjectExecReturn("Path must not be a null shape");
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP(
+                "Exception", "Path must not be a null shape"));
 
         // build all shells
         std::vector<TopoDS_Shape> shells;
@@ -313,7 +314,7 @@ App::DocumentObjectExecReturn *Pipe::execute()
             }
 
             if (!mkPS.IsReady())
-                return new App::DocumentObjectExecReturn("Pipe could not be built");
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Pipe could not be built"));
 
             shells.push_back(mkPS.Shape());
 
@@ -359,7 +360,7 @@ App::DocumentObjectExecReturn *Pipe::execute()
         }
 
         if (!mkSolid.IsDone())
-            return new App::DocumentObjectExecReturn("Result is not a solid");
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Result is not a solid"));
 
         TopoDS_Shape result = mkSolid.Shape();
         BRepClass3d_SolidClassifier SC(result);
@@ -374,7 +375,7 @@ App::DocumentObjectExecReturn *Pipe::execute()
         if (base.IsNull()) {
             if (getAddSubType() == FeatureAddSub::Subtractive)
                 return new App::DocumentObjectExecReturn(
-                    "Pipe: There is nothing to subtract from\n");
+                    QT_TRANSLATE_NOOP("Exception", "Pipe: There is nothing to subtract from"));
 
             result = refineShapeIfActive(result);
             Shape.setValue(getSolid(result));
@@ -385,17 +386,17 @@ App::DocumentObjectExecReturn *Pipe::execute()
 
             BRepAlgoAPI_Fuse mkFuse(base, result);
             if (!mkFuse.IsDone())
-                return new App::DocumentObjectExecReturn("Adding the pipe failed");
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Adding the pipe failed"));
             // we have to get the solids (fuse sometimes creates compounds)
             TopoDS_Shape boolOp = this->getSolid(mkFuse.Shape());
             // lets check if the result is a solid
             if (boolOp.IsNull())
-                return new App::DocumentObjectExecReturn("Resulting shape is not a solid");
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Resulting shape is not a solid"));
 
             int solidCount = countSolids(boolOp);
             if (solidCount > 1) {
-                return new App::DocumentObjectExecReturn(
-                    "Pipe: Result has multiple solids. This is not supported at this time.");
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception",
+                    "Pipe: Result has multiple solids. This is not supported at this time."));
             }
 
             boolOp = refineShapeIfActive(boolOp);
@@ -405,17 +406,17 @@ App::DocumentObjectExecReturn *Pipe::execute()
 
             BRepAlgoAPI_Cut mkCut(base, result);
             if (!mkCut.IsDone())
-                return new App::DocumentObjectExecReturn("Subtracting the pipe failed");
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Subtracting the pipe failed"));
             // we have to get the solids (fuse sometimes creates compounds)
             TopoDS_Shape boolOp = this->getSolid(mkCut.Shape());
             // lets check if the result is a solid
             if (boolOp.IsNull())
-                return new App::DocumentObjectExecReturn("Resulting shape is not a solid");
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Resulting shape is not a solid"));
 
             int solidCount = countSolids(boolOp);
             if (solidCount > 1) {
-                return new App::DocumentObjectExecReturn(
-                    "Pipe: Result has multiple solids. This is not supported at this time.");
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception",
+                    "Pipe: Result has multiple solids. This is not supported at this time."));
             }
 
             boolOp = refineShapeIfActive(boolOp);
@@ -429,7 +430,7 @@ App::DocumentObjectExecReturn *Pipe::execute()
         return new App::DocumentObjectExecReturn(e.GetMessageString());
     }
     catch (...) {
-        return new App::DocumentObjectExecReturn("A fatal error occurred when making the pipe");
+        return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "A fatal error occurred when making the pipe"));
     }
 }
 
@@ -554,10 +555,10 @@ void Pipe::buildPipePath(const Part::TopoShape& shape, const std::vector<std::st
                 TopoDS_Iterator it(shape.getShape());
                 for (; it.More(); it.Next()) {
                     if (it.Value().IsNull())
-                        throw Base::ValueError("In valid element in spine.");
+                        throw Base::ValueError(QT_TRANSLATE_NOOP("Exception", "Invalid element in spine."));
                     if ((it.Value().ShapeType() != TopAbs_EDGE) &&
                         (it.Value().ShapeType() != TopAbs_WIRE)) {
-                        throw Base::TypeError("Element in spine is neither an edge nor a wire.");
+                        throw Base::TypeError(QT_TRANSLATE_NOOP("Exception", "Element in spine is neither an edge nor a wire."));
                     }
                 }
 
@@ -570,15 +571,15 @@ void Pipe::buildPipePath(const Part::TopoShape& shape, const std::vector<std::st
                     hEdges, Precision::Confusion(), Standard_True, hWires);
                 int len = hWires->Length();
                 if (len != 1)
-                    throw Base::ValueError("Spine is not connected.");
+                    throw Base::ValueError(QT_TRANSLATE_NOOP("Exception", "Spine is not connected."));
                 path = hWires->Value(1);
             }
             else {
-                throw Base::TypeError("Spine is neither an edge nor a wire.");
+                throw Base::TypeError(QT_TRANSLATE_NOOP("Exception", "Spine is neither an edge nor a wire."));
             }
         }
         catch (Standard_Failure&) {
-            throw Base::CADKernelError("Invalid spine.");
+            throw Base::CADKernelError(QT_TRANSLATE_NOOP("Exception", "Invalid spine."));
         }
     }
 }

--- a/src/Mod/PartDesign/App/FeaturePocket.cpp
+++ b/src/Mod/PartDesign/App/FeaturePocket.cpp
@@ -79,11 +79,11 @@ App::DocumentObjectExecReturn *Pocket::execute()
     // Validate parameters
     double L = Length.getValue();
     if ((std::string(Type.getValueAsString()) == "Length") && (L < Precision::Confusion()))
-        return new App::DocumentObjectExecReturn("Pocket: Length of pocket too small");
+        return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Pocket: Length of pocket too small"));
 
     double L2 = Length2.getValue();
     if ((std::string(Type.getValueAsString()) == "TwoLengths") && (L < Precision::Confusion()))
-        return new App::DocumentObjectExecReturn("Pocket: Second length of pocket too small");
+        return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Pocket: Second length of pocket too small"));
 
     TopoDS_Shape profileshape;
     try {
@@ -98,10 +98,10 @@ App::DocumentObjectExecReturn *Pocket::execute()
         base = getBaseShape();
     }
     catch (const Base::Exception&) {
-        std::string text(QT_TR_NOOP("The requested feature cannot be created. The reason may be that:\n"
+        std::string text(QT_TRANSLATE_NOOP("Exception", ("The requested feature cannot be created. The reason may be that:\n"
                                     "  - the active Body does not contain a base shape, so there is no\n"
                                     "  material to be removed;\n"
-                                    "  - the selected sketch does not belong to the active Body."));
+                                    "  - the selected sketch does not belong to the active Body.")));
         return new App::DocumentObjectExecReturn(text);
     }
 
@@ -135,7 +135,7 @@ App::DocumentObjectExecReturn *Pocket::execute()
 
         // factor would be zero if vectors are orthogonal
         if (factor < Precision::Confusion())
-            return new App::DocumentObjectExecReturn("Pocket: Creation failed because direction is orthogonal to sketch's normal vector");
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Pocket: Creation failed because direction is orthogonal to sketch's normal vector"));
 
         // perform the length correction if not along custom vector
         if (AlongSketchNormal.getValue()) {
@@ -146,13 +146,13 @@ App::DocumentObjectExecReturn *Pocket::execute()
         dir.Transform(invObjLoc.Transformation());
 
         if (profileshape.IsNull())
-            return new App::DocumentObjectExecReturn("Pocket: Creating a face from sketch failed");
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Pocket: Creating a face from sketch failed"));
         profileshape.Move(invObjLoc);
 
         std::string method(Type.getValueAsString());
         if (method == "UpToFirst" || method == "UpToFace") {
             if (base.IsNull())
-                return new App::DocumentObjectExecReturn("Pocket: Extruding up to a face is only possible if the sketch is located on a face");
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Pocket: Extruding up to a face is only possible if the sketch is located on a face"));
 
             // Note: This will return an unlimited planar face if support is a datum plane
             TopoDS_Face supportface = getSupportFace();
@@ -187,14 +187,14 @@ App::DocumentObjectExecReturn *Pocket::execute()
             // And the really expensive way to get the SubShape...
             BRepAlgoAPI_Cut mkCut(base, prism);
             if (!mkCut.IsDone())
-                return new App::DocumentObjectExecReturn("Pocket: Up to face: Could not get SubShape!");
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Pocket: Up to face: Could not get SubShape!"));
             // FIXME: In some cases this affects the Shape property: It is set to the same shape as the SubShape!!!!
             TopoDS_Shape result = refineShapeIfActive(mkCut.Shape());
             this->AddSubShape.setValue(result);
 
             int prismCount = countSolids(prism);
             if (prismCount > 1) {
-                return new App::DocumentObjectExecReturn("Pocket: Result has multiple solids. This is not supported at this time.");
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Pocket: Result has multiple solids. This is not supported at this time."));
             }
 
             this->Shape.setValue(getSolid(prism));
@@ -211,7 +211,7 @@ App::DocumentObjectExecReturn *Pocket::execute()
             }
 
             if (prism.IsNull())
-                return new App::DocumentObjectExecReturn("Pocket: Resulting shape is empty");
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Pocket: Resulting shape is empty"));
 
             // set the subtractive shape property for later usage in e.g. pattern
             prism = refineShapeIfActive(prism);
@@ -220,16 +220,16 @@ App::DocumentObjectExecReturn *Pocket::execute()
             // Cut the SubShape out of the base feature
             BRepAlgoAPI_Cut mkCut(base, prism);
             if (!mkCut.IsDone())
-                return new App::DocumentObjectExecReturn("Pocket: Cut out of base feature failed");
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Pocket: Cut out of base feature failed"));
             TopoDS_Shape result = mkCut.Shape();
             // we have to get the solids (fuse sometimes creates compounds)
             TopoDS_Shape solRes = this->getSolid(result);
             if (solRes.IsNull())
-                return new App::DocumentObjectExecReturn("Pocket: Resulting shape is not a solid");
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Pocket: Resulting shape is not a solid"));
 
             int solidCount = countSolids(result);
             if (solidCount > 1) {
-                return new App::DocumentObjectExecReturn("Pocket: Result has multiple solids. This is not supported at this time.");
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Pocket: Result has multiple solids. This is not supported at this time."));
 
             }
             solRes = refineShapeIfActive(solRes);
@@ -245,9 +245,9 @@ App::DocumentObjectExecReturn *Pocket::execute()
     catch (Standard_Failure& e) {
         if (std::string(e.GetMessageString()) == "TopoDS::Face" &&
             (std::string(Type.getValueAsString()) == "UpToFirst" || std::string(Type.getValueAsString()) == "UpToFace"))
-            return new App::DocumentObjectExecReturn("Could not create face from sketch.\n"
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Could not create face from sketch.\n"
                 "Intersecting sketch entities or multiple faces in a sketch are not allowed "
-                "for making a pocket up to a face.");
+                "for making a pocket up to a face."));
         else
             return new App::DocumentObjectExecReturn(e.GetMessageString());
     }

--- a/src/Mod/PartDesign/App/FeaturePrimitive.cpp
+++ b/src/Mod/PartDesign/App/FeaturePrimitive.cpp
@@ -87,7 +87,7 @@ App::DocumentObjectExecReturn* FeaturePrimitive::execute(const TopoDS_Shape& pri
              if(getAddSubType() == FeatureAddSub::Additive)
                  Shape.setValue(getSolid(primitiveShape));
              else
-                 return new App::DocumentObjectExecReturn("Cannot subtract primitive feature without base feature");
+                 return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Cannot subtract primitive feature without base feature"));
 
              return  App::DocumentObject::StdReturn;
         }
@@ -96,16 +96,16 @@ App::DocumentObjectExecReturn* FeaturePrimitive::execute(const TopoDS_Shape& pri
 
             BRepAlgoAPI_Fuse mkFuse(base, primitiveShape);
             if (!mkFuse.IsDone())
-                return new App::DocumentObjectExecReturn("Adding the primitive failed");
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Adding the primitive failed"));
             // we have to get the solids (fuse sometimes creates compounds)
             TopoDS_Shape boolOp = this->getSolid(mkFuse.Shape());
             // lets check if the result is a solid
             if (boolOp.IsNull())
-                return new App::DocumentObjectExecReturn("Resulting shape is not a solid");
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Resulting shape is not a solid"));
 
             int solidCount = countSolids(boolOp);
             if (solidCount > 1) {
-                return new App::DocumentObjectExecReturn("Additive: Result has multiple solids. This is not supported at this time.");
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Additive: Result has multiple solids. This is not supported at this time."));
             }
 
             boolOp = refineShapeIfActive(boolOp);
@@ -116,16 +116,16 @@ App::DocumentObjectExecReturn* FeaturePrimitive::execute(const TopoDS_Shape& pri
 
             BRepAlgoAPI_Cut mkCut(base, primitiveShape);
             if (!mkCut.IsDone())
-                return new App::DocumentObjectExecReturn("Subtracting the primitive failed");
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Subtracting the primitive failed"));
             // we have to get the solids (fuse sometimes creates compounds)
             TopoDS_Shape boolOp = this->getSolid(mkCut.Shape());
             // lets check if the result is a solid
             if (boolOp.IsNull())
-                return new App::DocumentObjectExecReturn("Resulting shape is not a solid");
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Resulting shape is not a solid"));
 
             int solidCount = countSolids(boolOp);
             if (solidCount > 1) {
-                return new App::DocumentObjectExecReturn("Subtractive: Result has multiple solids. This is not supported at this time.");
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Subtractive: Result has multiple solids. This is not supported at this time."));
             }
 
             boolOp = refineShapeIfActive(boolOp);
@@ -196,11 +196,11 @@ App::DocumentObjectExecReturn* Box::execute()
     double H = Height.getValue();
 
     if (L < Precision::Confusion())
-        return new App::DocumentObjectExecReturn("Length of box too small");
+        return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Length of box too small"));
     if (W < Precision::Confusion())
-        return new App::DocumentObjectExecReturn("Width of box too small");
+        return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Width of box too small"));
     if (H < Precision::Confusion())
-        return new App::DocumentObjectExecReturn("Height of box too small");
+        return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Height of box too small"));
 
     try {
         // Build a box using the dimension attributes
@@ -246,11 +246,11 @@ App::DocumentObjectExecReturn* Cylinder::execute()
 {
     // Build a cylinder
     if (Radius.getValue() < Precision::Confusion())
-        return new App::DocumentObjectExecReturn("Radius of cylinder too small");
+        return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Radius of cylinder too small"));
     if (Height.getValue() < Precision::Confusion())
-        return new App::DocumentObjectExecReturn("Height of cylinder too small");
+        return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Height of cylinder too small"));
     if (Angle.getValue() < Precision::Confusion())
-        return new App::DocumentObjectExecReturn("Rotation angle of cylinder too small");
+        return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Rotation angle of cylinder too small"));
     try {
         BRepPrimAPI_MakeCylinder mkCylr(Radius.getValue(),
                                         Height.getValue(),
@@ -303,7 +303,7 @@ App::DocumentObjectExecReturn* Sphere::execute()
 {
    // Build a sphere
     if (Radius.getValue() < Precision::Confusion())
-        return new App::DocumentObjectExecReturn("Radius of sphere too small");
+        return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Radius of sphere too small"));
     try {
         BRepPrimAPI_MakeSphere mkSphere(Radius.getValue(),
                                         Base::toRadians<double>(Angle1.getValue()),
@@ -352,13 +352,13 @@ Cone::Cone()
 App::DocumentObjectExecReturn* Cone::execute()
 {
     if (Radius1.getValue() < 0.0)
-        return new App::DocumentObjectExecReturn("Radius of cone cannot be negative");
+        return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Radius of cone cannot be negative"));
     if (Radius2.getValue() < 0.0)
-        return new App::DocumentObjectExecReturn("Radius of cone cannot be negative");
+        return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Radius of cone cannot be negative"));
     if (Radius1.getValue() == Radius2.getValue())
-        return new App::DocumentObjectExecReturn("The radii for cones must not be equal");
+        return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "The radii for cones must not be equal"));
     if (Height.getValue() < Precision::Confusion())
-        return new App::DocumentObjectExecReturn("Height of cone too small");
+        return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Height of cone too small"));
     try {
         // Build a cone
         BRepPrimAPI_MakeCone mkCone(Radius1.getValue(),
@@ -415,9 +415,9 @@ App::DocumentObjectExecReturn* Ellipsoid::execute()
 {
     // Build a sphere
     if (Radius1.getValue() < Precision::Confusion())
-        return new App::DocumentObjectExecReturn("Radius of ellipsoid too small");
+        return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Radius of ellipsoid too small"));
     if (Radius2.getValue() < Precision::Confusion())
-        return new App::DocumentObjectExecReturn("Radius of ellipsoid too small");
+        return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Radius of ellipsoid too small"));
 
     try {
         gp_Pnt pnt(0.0,0.0,0.0);
@@ -499,9 +499,9 @@ Torus::Torus()
 App::DocumentObjectExecReturn* Torus::execute()
 {
     if (Radius1.getValue() < Precision::Confusion())
-        return new App::DocumentObjectExecReturn("Radius of torus too small");
+        return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Radius of torus too small"));
     if (Radius2.getValue() < Precision::Confusion())
-        return new App::DocumentObjectExecReturn("Radius of torus too small");
+        return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Radius of torus too small"));
     try {
         // https://forum.freecad.org/viewtopic.php?f=3&t=52719
 #if 0
@@ -564,11 +564,11 @@ App::DocumentObjectExecReturn* Prism::execute()
 {
     // Build a prism
     if (Polygon.getValue() < 3)
-        return new App::DocumentObjectExecReturn("Polygon of prism is invalid, must have 3 or more sides");
+        return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Polygon of prism is invalid, must have 3 or more sides"));
     if (Circumradius.getValue() < Precision::Confusion())
-        return new App::DocumentObjectExecReturn("Circumradius of the polygon, of the prism, is too small");
+        return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Circumradius of the polygon, of the prism, is too small"));
     if (Height.getValue() < Precision::Confusion())
-        return new App::DocumentObjectExecReturn("Height of prism is too small");
+        return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Height of prism is too small"));
     try {
         long nodes = Polygon.getValue();
 
@@ -649,19 +649,19 @@ App::DocumentObjectExecReturn* Wedge::execute()
     double dx2 = x2max-x2min;
 
     if (dx < Precision::Confusion())
-        return new App::DocumentObjectExecReturn("delta x of wedge too small");
+        return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "delta x of wedge too small"));
 
     if (dy < Precision::Confusion())
-        return new App::DocumentObjectExecReturn("delta y of wedge too small");
+        return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "delta y of wedge too small"));
 
     if (dz < Precision::Confusion())
-        return new App::DocumentObjectExecReturn("delta z of wedge too small");
+        return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "delta z of wedge too small"));
 
     if (dz2 < 0)
-        return new App::DocumentObjectExecReturn("delta z2 of wedge is negative");
+        return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "delta z2 of wedge is negative"));
 
     if (dx2 < 0)
-        return new App::DocumentObjectExecReturn("delta x2 of wedge is negative");
+        return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "delta x2 of wedge is negative"));
 
     try {
         gp_Pnt pnt(0.0,0.0,0.0);

--- a/src/Mod/PartDesign/App/FeatureRevolution.cpp
+++ b/src/Mod/PartDesign/App/FeatureRevolution.cpp
@@ -74,11 +74,11 @@ App::DocumentObjectExecReturn *Revolution::execute()
     // Validate parameters
     double angle = Angle.getValue();
     if (angle > 360.0)
-        return new App::DocumentObjectExecReturn("Angle of revolution too large");
+        return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Angle of revolution too large"));
 
     angle = Base::toRadians<double>(angle);
     if (angle < Precision::Angular())
-        return new App::DocumentObjectExecReturn("Angle of revolution too small");
+        return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Angle of revolution too small"));
 
     // Reverse angle if selected
     if (Reversed.getValue() && !Midplane.getValue())
@@ -115,7 +115,7 @@ App::DocumentObjectExecReturn *Revolution::execute()
 
     try {
         if (sketchshape.IsNull())
-            return new App::DocumentObjectExecReturn("Creating a face from sketch failed");
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Creating a face from sketch failed"));
 
         // Rotate the face by half the angle to get Revolution symmetric to sketch plane
         if (Midplane.getValue()) {
@@ -137,7 +137,7 @@ App::DocumentObjectExecReturn *Revolution::execute()
         xp.Init(sketchshape, TopAbs_FACE);
         for (;xp.More(); xp.Next()) {
             if (checkLineCrossesFace(gp_Lin(pnt, dir), TopoDS::Face(xp.Current())))
-                return new App::DocumentObjectExecReturn("Revolve axis intersects the sketch");
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Revolve axis intersects the sketch"));
         }
 
         // revolve the face to a solid
@@ -154,7 +154,7 @@ App::DocumentObjectExecReturn *Revolution::execute()
                 BRepAlgoAPI_Fuse mkFuse(base, result);
                 // Let's check if the fusion has been successful
                 if (!mkFuse.IsDone())
-                    throw Part::BooleanException("Fusion with base feature failed");
+                    throw Part::BooleanException(QT_TRANSLATE_NOOP("Exception", "Fusion with base feature failed"));
                 result = mkFuse.Shape();
                 result = refineShapeIfActive(result);
             }
@@ -162,15 +162,15 @@ App::DocumentObjectExecReturn *Revolution::execute()
             this->Shape.setValue(getSolid(result));
         }
         else
-            return new App::DocumentObjectExecReturn("Could not revolve the sketch!");
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Could not revolve the sketch!"));
 
         return App::DocumentObject::StdReturn;
     }
     catch (Standard_Failure& e) {
 
         if (std::string(e.GetMessageString()) == "TopoDS::Face")
-            return new App::DocumentObjectExecReturn("Could not create face from sketch.\n"
-                "Intersecting sketch entities in a sketch are not allowed.");
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Could not create face from sketch.\n"
+                "Intersecting sketch entities in a sketch are not allowed."));
         else
             return new App::DocumentObjectExecReturn(e.GetMessageString());
     }

--- a/src/Mod/PartDesign/App/FeatureTransformed.cpp
+++ b/src/Mod/PartDesign/App/FeatureTransformed.cpp
@@ -91,10 +91,10 @@ Part::Feature* Transformed::getBaseObject(bool silent) const {
         if(firstOriginal->isDerivedFrom(Part::Feature::getClassTypeId())) {
             rv = static_cast<Part::Feature*>(firstOriginal);
         } else {
-            err = "Transformation feature Linked object is not a Part object";
+            err = QT_TRANSLATE_NOOP("Exception", "Transformation feature Linked object is not a Part object");
         }
     } else {
-        err = "No originals linked to the transformed feature.";
+        err = QT_TRANSLATE_NOOP("Exception", "No originals linked to the transformed feature.");
     }
 
     if (!silent && err) {
@@ -201,7 +201,7 @@ App::DocumentObjectExecReturn *Transformed::execute()
 
     const Part::TopoShape& supportTopShape = supportFeature->Shape.getShape();
     if (supportTopShape.getShape().IsNull())
-        return new App::DocumentObjectExecReturn("Cannot transform invalid support shape");
+        return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Cannot transform invalid support shape"));
 
     // create an untransformed copy of the support shape
     Part::TopoShape supportShape(supportTopShape);
@@ -230,7 +230,7 @@ App::DocumentObjectExecReturn *Transformed::execute()
 
             BRepBuilderAPI_Transform mkTrf(shape, *transformIter, false); // No need to copy, now
             if (!mkTrf.IsDone()) {
-                throw Base::CADKernelError("Transformation failed");
+                throw Base::CADKernelError(QT_TRANSLATE_NOOP("Exception", "Transformation failed"));
             }
             shape = mkTrf.Shape();
 
@@ -258,7 +258,7 @@ App::DocumentObjectExecReturn *Transformed::execute()
             PartDesign::FeatureAddSub* feature = static_cast<PartDesign::FeatureAddSub*>(*o);
             feature->getAddSubShape(fuseShape, cutShape);
             if (fuseShape.isNull() && cutShape.isNull())
-                return new App::DocumentObjectExecReturn("Shape of addsub feature is empty");
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Shape of addsub feature is empty"));
             gp_Trsf trsf = feature->getLocation().Transformation().Multiplied(trsfInv);
             if (!fuseShape.isNull())
                 fuseShape = fuseShape.makeTransform(trsf);
@@ -266,7 +266,7 @@ App::DocumentObjectExecReturn *Transformed::execute()
                 cutShape = cutShape.makeTransform(trsf);
         }
         else {
-            return new App::DocumentObjectExecReturn("Only additive and subtractive features can be transformed");
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Only additive and subtractive features can be transformed"));
         }
 
         TopoDS_Shape current = support;
@@ -280,9 +280,7 @@ App::DocumentObjectExecReturn *Transformed::execute()
                 mkBool->SetTools(shapeTools);
                 mkBool->Build();
                 if (!mkBool->IsDone()) {
-                    std::stringstream error;
-                    error << "Boolean operation failed";
-                    return new App::DocumentObjectExecReturn(error.str());
+                    return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Boolean operation failed"));
                 }
                 current = mkBool->Shape();
             }
@@ -297,9 +295,7 @@ App::DocumentObjectExecReturn *Transformed::execute()
                 mkBool->SetTools(shapeTools);
                 mkBool->Build();
                 if (!mkBool->IsDone()) {
-                    std::stringstream error;
-                    error << "Boolean operation failed";
-                    return new App::DocumentObjectExecReturn(error.str());
+                    return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Boolean operation failed"));
                 }
                 current = mkBool->Shape();
             }

--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -145,7 +145,7 @@ void UnifiedDatumCommand(Gui::Command &cmd, Base::Type type, std::string name)
             QMessageBox::warning(Gui::getMainWindow(),QObject::tr("Error"), QObject::tr("There is no active body. Please make a body active before inserting a datum entity."));
         }
     } catch (Base::Exception &e) {
-        QMessageBox::warning(Gui::getMainWindow(),QObject::tr("Error"),QString::fromLatin1(e.what()));
+        QMessageBox::warning(Gui::getMainWindow(),QObject::tr("Error"),QApplication::translate("Exception", e.what()));
     } catch (Standard_Failure &e) {
         QMessageBox::warning(Gui::getMainWindow(),QObject::tr("Error"),QString::fromLatin1(e.GetMessageString()));
     }
@@ -406,7 +406,7 @@ void CmdPartDesignSubShapeBinder::activated(int iMsg)
     } catch (Base::Exception &e) {
         e.ReportException();
         QMessageBox::critical(Gui::getMainWindow(),
-                QObject::tr("Sub-Shape Binder"), QString::fromUtf8(e.what()));
+                QObject::tr("Sub-Shape Binder"), QApplication::translate("Exception", e.what()));
         abortCommand();
     }
 }

--- a/src/Mod/PartDesign/Gui/TaskBooleanParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskBooleanParameters.cpp
@@ -361,7 +361,7 @@ bool TaskDlgBooleanParameters::accept()
         Gui::Command::runCommand(Gui::Command::Doc,str.str().c_str());
     }
     catch (const Base::Exception& e) {
-        QMessageBox::warning(parameter, tr("Boolean: Accept: Input error"), QString::fromLatin1(e.what()));
+        QMessageBox::warning(parameter, tr("Boolean: Accept: Input error"), QCoreApplication::translate("Exception", e.what()));
         return false;
     }
 

--- a/src/Mod/PartDesign/Gui/TaskLinearPatternParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskLinearPatternParameters.cpp
@@ -333,7 +333,7 @@ void TaskLinearPatternParameters::onDirectionChanged(int /*num*/)
             pcLinearPattern->Direction.Paste(dirLinks.getCurrentLink());
         }
     } catch (Base::Exception &e) {
-        QMessageBox::warning(nullptr,tr("Error"),QString::fromLatin1(e.what()));
+        QMessageBox::warning(nullptr,tr("Error"),QApplication::translate("Exception", e.what()));
     }
 
     kickUpdateViewTimer();

--- a/src/Mod/PartDesign/Gui/TaskMirroredParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskMirroredParameters.cpp
@@ -242,7 +242,7 @@ void TaskMirroredParameters::onPlaneChanged(int /*num*/)
             pcMirrored->MirrorPlane.Paste(planeLinks.getCurrentLink());
         }
     } catch (Base::Exception &e) {
-        QMessageBox::warning(nullptr,tr("Error"),QString::fromLatin1(e.what()));
+        QMessageBox::warning(nullptr,tr("Error"),QApplication::translate("Exception", e.what()));
     }
 
     recomputeFeature();

--- a/src/Mod/PartDesign/Gui/TaskPipeParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPipeParameters.cpp
@@ -518,7 +518,7 @@ bool TaskPipeParameters::accept()
         }
     }
     catch (const Base::Exception& e) {
-        QMessageBox::warning(this, tr("Input error"), QString::fromUtf8(e.what()));
+        QMessageBox::warning(this, tr("Input error"), QApplication::translate("Exception", e.what()));
         return false;
     }
 

--- a/src/Mod/PartDesign/Gui/TaskPolarPatternParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPolarPatternParameters.cpp
@@ -332,7 +332,7 @@ void TaskPolarPatternParameters::onAxisChanged(int /*num*/)
             pcPolarPattern->Axis.Paste(axesLinks.getCurrentLink());
         }
     } catch (Base::Exception &e) {
-        QMessageBox::warning(nullptr,tr("Error"),QString::fromLatin1(e.what()));
+        QMessageBox::warning(nullptr,tr("Error"),QApplication::translate("Exception", e.what()));
     }
 
     kickUpdateViewTimer();

--- a/src/Mod/PartDesign/Gui/TaskPrimitiveParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPrimitiveParameters.cpp
@@ -882,7 +882,7 @@ bool TaskBoxPrimitives::setPrimitive(App::DocumentObject *obj)
         Gui::Command::runCommand(Gui::Command::Doc, "App.ActiveDocument.recompute()");
     }
     catch (const Base::PyException& e) {
-        QMessageBox::warning(this, tr("Create primitive"), QString::fromLatin1(e.what()));
+        QMessageBox::warning(this, tr("Create primitive"), QApplication::translate("Exception", e.what()));
         return false;
     }
     return true;

--- a/src/Mod/PartDesign/Gui/TaskShapeBinder.cpp
+++ b/src/Mod/PartDesign/Gui/TaskShapeBinder.cpp
@@ -410,7 +410,7 @@ bool TaskDlgShapeBinder::accept()
         }
     }
     catch (const Base::Exception& e) {
-        QMessageBox::warning(parameter, tr("Input error"), QString::fromUtf8(e.what()));
+        QMessageBox::warning(parameter, tr("Input error"), QApplication::translate("Exception", e.what()));
         return false;
     }
 


### PR DESCRIPTION
In many cases we directly display exception strings to users in dialog boxes explaining the cause of a failure. This PR begins the process of allowing translating those strings. This is a two-step process: when displaying the exception text in the dialog box, the code that displays that dialog must ask Qt to attempt to translate that string using `QApplication::translate` with the context "Exception". Second, when creating the text for those exceptions, developers must use the `QT_TRANSLATE_NOOP()` macro with the "Exception" context to ensure the text is added to the TS file for translation.

Fixes https://github.com/FreeCAD/FreeCAD-translations/issues/203 (though there are certainly many more exceptions that must be tagged -- these will be addressed in follow-on PRs).

---

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR