### PR TITLE
GUI: Transform sr-CS to sr_Latn in menu entry

### DIFF
--- a/src/Gui/DlgGeneralImp.cpp
+++ b/src/Gui/DlgGeneralImp.cpp
@@ -291,6 +291,12 @@ void DlgGeneralImp::loadSettings()
         QByteArray lang = it->first.c_str();
         QString langname = QString::fromLatin1(lang.constData());
 
+        if (it->second == "sr-CS") {
+            // Qt does not treat sr-CS (Serbian, Latin) as a Latin-script variant by default: this
+            // forces it to do so.
+            it->second = "sr_Latn";
+        }
+
         QLocale locale(QString::fromLatin1(it->second.c_str()));
         QString native = locale.nativeLanguageName();
         if (!native.isEmpty()) {


### PR DESCRIPTION
Fixes https://github.com/FreeCAD/FreeCAD-translations/issues/207

Qt's translation facilities render Serbian, Latin (which CrowdIn delivers as *_sr-CS.ts) in Cyrillic, which gives us two entries for Српски, rather than one for Српски (Serbian, Cyrillic) and one for Srpski (Serbian, Latin). This ugly hack simply replaces the country-coded BCP 47 value with the script-coded variant during construction of the menu. This doesn't affect anything else in FreeCAD, and all translations work as before.

---

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR