### PR TITLE
Sketcher: Translate the menu entries in attach dialog

### DIFF
--- a/src/Mod/Sketcher/Gui/Command.cpp
+++ b/src/Mod/Sketcher/Gui/Command.cpp
@@ -178,7 +178,8 @@ void CmdSketcherNewSketch::activated(int iMsg)
             items.push_back(QObject::tr("Don't attach"));
             int iSugg = 0;//index of the auto-suggested mode in the list of valid modes
             for (size_t i = 0  ;  i < validModes.size()  ;  ++i){
-                items.push_back(QString::fromLatin1(AttachEngine::getModeName(validModes[i]).c_str()));
+                auto uiStrings = AttacherGui::getUIStrings(AttachEnginePlane::getClassTypeId(), validModes[i]);
+                items.push_back(uiStrings[0]);
                 if (validModes[i] == mapmode)
                     iSugg = items.size()-1;
             }


### PR DESCRIPTION
Should fix https://github.com/FreeCAD/FreeCAD-translations/issues/157 -- this dialog is created in two different places, this PR syncs them up (but does not eliminate the duplication).

---

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR
