### PR TITLE
[TD]remove Qt5 Svg handling code

### DIFF
--- a/src/Mod/TechDraw/App/CMakeLists.txt
+++ b/src/Mod/TechDraw/App/CMakeLists.txt
@@ -136,8 +136,6 @@ SET(Draw_SRCS
     DrawLeaderLine.h
     DrawRichAnno.cpp
     DrawRichAnno.h
-    QDomNodeModel.cpp
-    QDomNodeModel.h
     DrawTile.cpp
     DrawTile.h
     DrawTileWeld.cpp

--- a/src/Mod/TechDraw/App/XMLQuery.cpp
+++ b/src/Mod/TechDraw/App/XMLQuery.cpp
@@ -24,12 +24,7 @@
 #include "PreCompiled.h"
 
 #ifndef _PreComp_
-# include <QDomDocument>
-#if 0 && QT_VERSION < QT_VERSION_CHECK(6,0,0)
-# include "QDomNodeModel.h"
-# include <QXmlQuery>
-# include <QXmlResultItems>
-#endif
+#include <QDomDocument>
 #endif
 
 #include "XMLQuery.h"
@@ -43,29 +38,6 @@ XMLQuery::XMLQuery(QDomDocument& dom)
 
 }
 
-#if 0 && QT_VERSION < QT_VERSION_CHECK(6,0,0)
-bool XMLQuery::processItems(const QString& queryStr, const std::function<bool(QDomElement&)>& process)
-{
-    QXmlQuery query(QXmlQuery::XQuery10);
-    QDomNodeModel model(query.namePool(), domDocument);
-    QDomElement symbolDocElem = domDocument.documentElement();
-    query.setFocus(QXmlItem(model.fromDomNode(symbolDocElem)));
-
-    query.setQuery(queryStr);
-    QXmlResultItems queryResult;
-    query.evaluateTo(&queryResult);
-
-    while (!queryResult.next().isNull()) {
-        QDomElement tspanElement =
-            model.toDomNode(queryResult.current().toNodeModelIndex()).toElement();
-        if (!process(tspanElement)) {
-            return false;
-        }
-    }
-
-    return true;
-}
-#else
 // A helper function that traverses all child elements recursively and check for
 // elements of name "text" with an attribute "freecad:editable"
 // If the query string contains "tspan" the first sub-element is used or the
@@ -115,4 +87,3 @@ bool XMLQuery::processItems(const QString& queryStr, const std::function<bool(QD
 
     return true;
 }
-#endif


### PR DESCRIPTION
This PR removes code based on the Qt5 Svg handling classes that are no longer available in Qt6. Code using a replacement was implemented by #9421 and #9104.

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [ ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
