### PR TITLE
Gui: Adjust tooltips for improved translation

### DIFF
--- a/src/Gui/CommandDoc.cpp
+++ b/src/Gui/CommandDoc.cpp
@@ -1688,9 +1688,9 @@ public:
     {
         sGroup        = "Edit";
         sMenuText     = QT_TR_NOOP("Expression actions");
-        sToolTipText  = QT_TR_NOOP("Expression actions");
+        sToolTipText  = QT_TR_NOOP("Actions that apply to expressions");
         sWhatsThis    = "Std_Expressions";
-        sStatusTip    = QT_TR_NOOP("Expression actions");
+        sStatusTip    = QT_TR_NOOP("Actions that apply to expressions");
         eType         = ForEdit;
     }
 

--- a/src/Gui/CommandFeat.cpp
+++ b/src/Gui/CommandFeat.cpp
@@ -76,9 +76,9 @@ StdCmdRandomColor::StdCmdRandomColor()
 {
     sGroup        = "File";
     sMenuText     = QT_TR_NOOP("Random color");
-    sToolTipText  = QT_TR_NOOP("Random color");
+    sToolTipText  = QT_TR_NOOP("Set each selected object to a randomly-selected color");
     sWhatsThis    = "Std_RandomColor";
-    sStatusTip    = QT_TR_NOOP("Random color");
+    sStatusTip    = QT_TR_NOOP("Set each selected object to a randomly-selected color");
     sPixmap       = "Std_RandomColor";
 }
 

--- a/src/Gui/CommandLink.cpp
+++ b/src/Gui/CommandLink.cpp
@@ -872,9 +872,9 @@ public:
     {
         sGroup        = "View";
         sMenuText     = QT_TR_NOOP("Link actions");
-        sToolTipText  = QT_TR_NOOP("Link actions");
+        sToolTipText  = QT_TR_NOOP("Actions that apply to link objects");
         sWhatsThis    = "Std_LinkMakeRelative";
-        sStatusTip    = QT_TR_NOOP("Link actions");
+        sStatusTip    = QT_TR_NOOP("Actions that apply to link objects");
         eType         = AlterDoc;
         bCanLog       = false;
 

--- a/src/Gui/CommandMacro.cpp
+++ b/src/Gui/CommandMacro.cpp
@@ -238,9 +238,9 @@ StdCmdMacroStepOver::StdCmdMacroStepOver()
 {
     sGroup        = "Macro";
     sMenuText     = QT_TR_NOOP("Step over");
-    sToolTipText  = QT_TR_NOOP("Step over");
+    sToolTipText  = QT_TR_NOOP("Step to the next line in this file");
     sWhatsThis    = "Std_MacroStepOver";
-    sStatusTip    = QT_TR_NOOP("Step over");
+    sStatusTip    = QT_TR_NOOP("Step to the next line in this file");
     sPixmap       = nullptr;
     sAccel        = "F10";
     eType         = 0;
@@ -265,9 +265,9 @@ StdCmdMacroStepInto::StdCmdMacroStepInto()
 {
     sGroup        = "Macro";
     sMenuText     = QT_TR_NOOP("Step into");
-    sToolTipText  = QT_TR_NOOP("Step into");
+    sToolTipText  = QT_TR_NOOP("Step to the next line executed");
     //sWhatsThis    = "Std_MacroStepOver";
-    sStatusTip    = QT_TR_NOOP("Step into");
+    sStatusTip    = QT_TR_NOOP("Step to the next line executed");
     sPixmap       = nullptr;
     sAccel        = "F11";
     eType         = 0;
@@ -292,9 +292,9 @@ StdCmdToggleBreakpoint::StdCmdToggleBreakpoint()
 {
     sGroup        = "Macro";
     sMenuText     = QT_TR_NOOP("Toggle breakpoint");
-    sToolTipText  = QT_TR_NOOP("Toggle breakpoint");
+    sToolTipText  = QT_TR_NOOP("Add or remove a breakpoint at this position");
     sWhatsThis    = "Std_ToggleBreakpoint";
-    sStatusTip    = QT_TR_NOOP("Toggle breakpoint");
+    sStatusTip    = QT_TR_NOOP("Add or remove a breakpoint at this position");
     sPixmap       = nullptr;
     sAccel        = "F9";
     eType         = 0;

--- a/src/Gui/CommandTest.cpp
+++ b/src/Gui/CommandTest.cpp
@@ -715,8 +715,8 @@ CmdTestConsoleOutput::CmdTestConsoleOutput()
 {
     sGroup      = "Standard-Test";
     sMenuText   = QT_TR_NOOP("Test console output");
-    sToolTipText= QT_TR_NOOP("Test console output");
-    sStatusTip  = QT_TR_NOOP("Test console output");
+    sToolTipText= QT_TR_NOOP("Run test cases to verify console messages");
+    sStatusTip  = QT_TR_NOOP("Run test cases to verify console messages");
 }
 
 namespace Gui {

--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -2105,8 +2105,8 @@ StdCmdAxisCross::StdCmdAxisCross()
 {
         sGroup        = "Standard-View";
         sMenuText     = QT_TR_NOOP("Toggle axis cross");
-        sToolTipText  = QT_TR_NOOP("Toggle axis cross");
-        sStatusTip    = QT_TR_NOOP("Toggle axis cross");
+        sToolTipText  = QT_TR_NOOP("Turns on or off the axis cross at the origin");
+        sStatusTip    = QT_TR_NOOP("Turns on or off the axis cross at the origin");
         sWhatsThis    = "Std_AxisCross";
         sPixmap       = "Std_AxisCross";
         sAccel        = "A,C";
@@ -2428,9 +2428,9 @@ StdViewZoomIn::StdViewZoomIn()
 {
     sGroup        = "Standard-View";
     sMenuText     = QT_TR_NOOP("Zoom In");
-    sToolTipText  = QT_TR_NOOP("Zoom In");
+    sToolTipText  = QT_TR_NOOP("Increase the zoom factor by a fixed amount");
     sWhatsThis    = "Std_ViewZoomIn";
-    sStatusTip    = QT_TR_NOOP("Zoom In");
+    sStatusTip    = QT_TR_NOOP("Increase the zoom factor by a fixed amount");
     sPixmap       = "zoom-in";
     sAccel        = keySequenceToAccel(QKeySequence::ZoomIn);
     eType         = Alter3DView;
@@ -2457,9 +2457,9 @@ StdViewZoomOut::StdViewZoomOut()
 {
     sGroup        = "Standard-View";
     sMenuText     = QT_TR_NOOP("Zoom Out");
-    sToolTipText  = QT_TR_NOOP("Zoom Out");
+    sToolTipText  = QT_TR_NOOP("Decrease the zoom factor by a fixed amount");
     sWhatsThis    = "Std_ViewZoomOut";
-    sStatusTip    = QT_TR_NOOP("Zoom Out");
+    sStatusTip    = QT_TR_NOOP("Decrease the zoom factor by a fixed amount");
     sPixmap       = "zoom-out";
     sAccel        = keySequenceToAccel(QKeySequence::ZoomOut);
     eType         = Alter3DView;
@@ -2623,9 +2623,9 @@ StdViewBoxZoom::StdViewBoxZoom()
 {
     sGroup        = "Standard-View";
     sMenuText     = QT_TR_NOOP("Box zoom");
-    sToolTipText  = QT_TR_NOOP("Box zoom");
+    sToolTipText  = QT_TR_NOOP("Activate the box zoom tool");
     sWhatsThis    = "Std_ViewBoxZoom";
-    sStatusTip    = QT_TR_NOOP("Box zoom");
+    sStatusTip    = QT_TR_NOOP("Activate the box zoom tool");
     sPixmap       = "zoom-border";
     sAccel        = "Ctrl+B";
     eType         = Alter3DView;
@@ -2693,9 +2693,9 @@ StdBoxSelection::StdBoxSelection()
 {
     sGroup        = "Standard-View";
     sMenuText     = QT_TR_NOOP("Box selection");
-    sToolTipText  = QT_TR_NOOP("Box selection");
+    sToolTipText  = QT_TR_NOOP("Activate the box selection tool");
     sWhatsThis    = "Std_BoxSelection";
-    sStatusTip    = QT_TR_NOOP("Box selection");
+    sStatusTip    = QT_TR_NOOP("Activate the box selection tool");
     sPixmap       = "edit-select-box";
     sAccel        = "Shift+B";
     eType         = AlterSelection;
@@ -3123,9 +3123,9 @@ StdCmdMeasureDistance::StdCmdMeasureDistance()
 {
     sGroup        = "View";
     sMenuText     = QT_TR_NOOP("Measure distance");
-    sToolTipText  = QT_TR_NOOP("Measure distance");
+    sToolTipText  = QT_TR_NOOP("Activate the distance measurement tool");
     sWhatsThis    = "Std_MeasureDistance";
-    sStatusTip    = QT_TR_NOOP("Measure distance");
+    sStatusTip    = QT_TR_NOOP("Activate the distance measurement tool");
     sPixmap       = "view-measurement";
     eType         = Alter3DView;
 }
@@ -3302,7 +3302,7 @@ CmdViewMeasureClearAll::CmdViewMeasureClearAll()
 {
     sGroup        = "Measure";
     sMenuText     = QT_TR_NOOP("Clear measurement");
-    sToolTipText  = QT_TR_NOOP("Clear measurement");
+    sToolTipText  = QT_TR_NOOP("Clear all visible measurements");
     sWhatsThis    = "View_Measure_Clear_All";
     sStatusTip    = sToolTipText;
     sPixmap       = "Part_Measure_Clear_All";
@@ -3332,7 +3332,7 @@ CmdViewMeasureToggleAll::CmdViewMeasureToggleAll()
 {
     sGroup        = "Measure";
     sMenuText     = QT_TR_NOOP("Toggle measurement");
-    sToolTipText  = QT_TR_NOOP("Toggle measurement");
+    sToolTipText  = QT_TR_NOOP("Turn on or off the display of all measurements");
     sWhatsThis    = "View_Measure_Toggle_All";
     sStatusTip    = sToolTipText;
     sPixmap       = "Part_Measure_Toggle_All";

--- a/src/Gui/CommandWindow.cpp
+++ b/src/Gui/CommandWindow.cpp
@@ -414,7 +414,7 @@ StdCmdWindowsMenu::StdCmdWindowsMenu()
   : Command("Std_WindowsMenu")
 {
     sGroup        = "Window";
-    sMenuText     = QT_TR_NOOP("Activates this window");
+    sMenuText     = QT_TR_NOOP("Activate window"); // Replaced with the name of the window
     sToolTipText  = QT_TR_NOOP("Activates this window");
     sWhatsThis    = "Std_WindowsMenu";
     sStatusTip    = QT_TR_NOOP("Activates this window");


### PR DESCRIPTION
Tooltips should not be identical to the command menu entry, it prevents translators from translating them separately. The alternative solution, using `QT_TRANSLATE_NOOP3`, is awkward because of the need to hand-code the context, and to extract the first item from the anonymous struct that gets created. Since there is no point to a tooltip that exactly duplicates the menu text, this solution seemed reasonable.

The first of several PRs that will eventually resolve https://github.com/FreeCAD/FreeCAD-translations/issues/167

---

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR