### PR TITLE
Draft: use convert_draft_texts in importDXF.py

### DIFF
--- a/src/Mod/Draft/importDXF.py
+++ b/src/Mod/Draft/importDXF.py
@@ -2729,7 +2729,7 @@ def open(filename):
         FreeCAD.setActiveDocument(doc.Name)
         import Import
         Import.readDXF(filename)
-        Draft.convertDraftTexts() # convert annotations to Draft texts
+        Draft.convert_draft_texts() # convert annotations to Draft texts
         doc.recompute()
 
 
@@ -2771,7 +2771,7 @@ def insert(filename, docname):
     else:
         import Import
         Import.readDXF(filename)
-        Draft.convertDraftTexts() # convert annotations to Draft texts
+        Draft.convert_draft_texts() # convert annotations to Draft texts
         doc.recompute()
 
 def getShapes(filename):


### PR DESCRIPTION
Replace `convertDraftTexts` with `convert_draft_texts` to prevent a warning.
