### PR TITLE
Sketcher: Tweak wording as suggested by translators

### DIFF
--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -1350,8 +1350,7 @@ CmdSketcherConstrainLock::CmdSketcherConstrainLock()
     sAppModule      = "Sketcher";
     sGroup          = "Sketcher";
     sMenuText       = QT_TR_NOOP("Constrain lock");
-    sToolTipText    = QT_TR_NOOP("Lock constraint: "
-                                 "create both a horizontal "
+    sToolTipText    = QT_TR_NOOP("Create both a horizontal "
                                  "and a vertical distance constraint\n"
                                  "on the selected vertex");
     sWhatsThis      = "Sketcher_ConstrainLock";
@@ -1578,8 +1577,7 @@ CmdSketcherConstrainBlock::CmdSketcherConstrainBlock()
     sAppModule      = "Sketcher";
     sGroup          = "Sketcher";
     sMenuText       = QT_TR_NOOP("Constrain block");
-    sToolTipText    = QT_TR_NOOP("Block constraint: "
-                                 "block the selected edge from moving");
+    sToolTipText    = QT_TR_NOOP("Block the selected edge from moving");
     sWhatsThis      = "Sketcher_ConstrainBlock";
     sStatusTip      = sToolTipText;
     sPixmap         = "Constraint_Block";

--- a/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
+++ b/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
@@ -1568,7 +1568,7 @@ CmdSketcherCarbonCopy::CmdSketcherCarbonCopy()
     sAppModule      = "Sketcher";
     sGroup          = "Sketcher";
     sMenuText       = QT_TR_NOOP("Carbon copy");
-    sToolTipText    = QT_TR_NOOP("Copies the geometry of another sketch");
+    sToolTipText    = QT_TR_NOOP("Copy the geometry of another sketch");
     sWhatsThis      = "Sketcher_CarbonCopy";
     sStatusTip      = sToolTipText;
     sPixmap         = "Sketcher_CarbonCopy";


### PR DESCRIPTION
Suggested for consistency by david69 on CrowdIn.

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR