### PR TITLE
Sketcher: Fixes wrong redundancy reporting

### DIFF
--- a/src/Mod/Sketcher/App/planegcs/GCS.cpp
+++ b/src/Mod/Sketcher/App/planegcs/GCS.cpp
@@ -5371,11 +5371,21 @@ void System::identifyConflictingRedundantConstraints(
             }
         }
         if (maxPopularity > 0) {
-            skipped.insert(mostPopular);
-            for (SET_I::const_iterator it = conflictingMap[mostPopular].begin();
-                 it != conflictingMap[mostPopular].end();
-                 ++it)
-                satisfiedGroups.insert(*it);
+            // adding for skipping not only the mostPopular, but also any other constraint in the
+            // conflicting map associated with the same tag (namely any other solver
+            // constraint associated with the same sketcher constraint that is also conflicting)
+            auto maxPopularityTag = mostPopular->getTag();
+
+            for(const auto & c : conflictingMap) {
+                if(c.first->getTag() == maxPopularityTag) {
+                    skipped.insert(c.first);
+                    for (SET_I::const_iterator it = conflictingMap[c.first].begin();
+                        it != conflictingMap[c.first].end();
+                        ++it) {
+                        satisfiedGroups.insert(*it);
+                    }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
==========================================

fixes #6174

Problem
=======

The popularity contest heuristic was designed to assume that removing one solver constraint from a redundant group would potentially satisfy it.

This means that for sketcher constraints comprising several solver constraints, the sketcher constraint would never be notified as redundant, but always partially redundant (where the case may be that it is redundant or that it is partially redundant). This happens because after removing one solver constraint, it may happen:

(a) that no other solver constraint corresponding to the sketcher constraint remains in the redundant group (so it is indeed partially redundant) (b) that at least one other solver constraint corresponding to the sketcher constraint remains in the redundant group (so if all solver constraints remain in the redundant group, the sketcher constraint is actually redundant). This happens because solver constraints of a single sketcher constraint are orthogonal and consequently, a conflict (or redundancy) emanating from removing one of them cannot actually satisfy the group, as it has no effect on the other.

Solution
========

When popularity constraint decides on one solver constraint, remove any other solver constraint of the same tag (i.e. same sketcher constraint) that is present in the conflict group (case b). This does not affect case a, because the solver constraint that is not redundant is not present in the conflict (redundancy) group.