### PR TITLE
Origin plane: use shape color in translucent face and set label pick style to BOUNDING_BOX_ON_TOP

### DIFF
--- a/src/Gui/ViewProviderPlane.cpp
+++ b/src/Gui/ViewProviderPlane.cpp
@@ -127,7 +127,7 @@ void ViewProviderPlane::attach ( App::DocumentObject *obj ) {
 
     // pick label above all and by bounding box
     auto ps = new SoPickStyle();
-    ps->style.setValue(SoPickStyle::BOUNDING_BOX);
+    ps->style.setValue(SoPickStyle::BOUNDING_BOX_ON_TOP);
     sep->addChild(ps);
 
     sep->addChild ( getLabel () );

--- a/src/Gui/ViewProviderPlane.h
+++ b/src/Gui/ViewProviderPlane.h
@@ -39,6 +39,12 @@ public:
     ~ViewProviderPlane() override;
 
     void attach ( App::DocumentObject * ) override;
+ 
+protected: 
+    void onChanged(const App::Property* prop) override; 
+ 
+protected: 
+    SoMaterial * pPlaneFaceMaterial; 
 };
 
 } //namespace Gui


### PR DESCRIPTION
Follow up to #9361

in the rare case where someone changes the color of an origin plane the translucent face will update instead of remaining with hardcoded default color.

making the plane label always selectable even when it's behind other objects, makes it slightly easier to select the plane, since it's just for the label it's unlikely that I'll interfere often with selection of other objects.

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [ ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
