### PR TITLE
Gui: disable lighting for the label of an axis

### DIFF
--- a/src/Gui/ViewProviderOrigin.cpp
+++ b/src/Gui/ViewProviderOrigin.cpp
@@ -24,7 +24,8 @@
 #include "PreCompiled.h"
 
 #ifndef _PreComp_
-# include <Inventor/nodes/SoGroup.h>
+# include <Inventor/nodes/SoLightModel.h>
+# include <Inventor/nodes/SoSeparator.h>
 #endif
 
 #include <App/Document.h>
@@ -59,6 +60,10 @@ ViewProviderOrigin::ViewProviderOrigin()
 
     pcGroupChildren = new SoGroup();
     pcGroupChildren->ref();
+
+    auto lm = new SoLightModel();
+    lm->model = SoLightModel::BASE_COLOR;
+    pcRoot->insertChild(lm, 0);
 }
 
 ViewProviderOrigin::~ViewProviderOrigin() {


### PR DESCRIPTION
This way the backside of the label is displayed with the same color as the front side. Otherwise it may be black.

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [x]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
