### PR TITLE
GUI: Don't have report view message tell users to see report view

### DIFF
--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -2828,7 +2828,7 @@ int Document::recompute(const std::vector<App::DocumentObject*> &objs, bool forc
     if (!d->_RecomputeLog.empty()) {
         d->pendingRemove.clear();
         if (!testStatus(Status::IgnoreErrorOnRecompute))
-            Base::Console().Error("Recompute failed! Please check report view.\n");
+            Base::Console().Error("Recompute failed!\n");
     }
     else {
         for(auto &o : d->pendingRemove) {


### PR DESCRIPTION
A message that is displayed in Report View telling users to check Report View is not terribly useful. Even when this displays in the new notifications system, it's probably not necessary.

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
