### PR TITLE
Gui: Refactor NaviCube camera orientation handling

### DIFF
--- a/src/Gui/NaviCube.cpp
+++ b/src/Gui/NaviCube.cpp
@@ -974,357 +974,40 @@ bool NaviCubeImplementation::mouseReleased(short x, short y) {
     setHilite(PickId::None);
     m_MouseDown = false;
 
-    // get the current view
-    SbMatrix ViewRotMatrix;
-    SbRotation CurrentViewRot = m_View3DInventorViewer->getCameraOrientation();
-    CurrentViewRot.getValue(ViewRotMatrix);
+    SbRotation currentOrientation = m_View3DInventorViewer->getCameraOrientation();
 
     if (m_Dragging) {
         m_Dragging = false;
     } else {
-        float rot = 45;
-        float tilt = 90 - Base::toDegrees(atan(sqrt(2.0)));
         PickId pick = pickFace(x, y);
         long step = Base::clamp(long(m_NaviStepByTurn), 4L, 36L);
-        float rotStepAngle = 360.0f / step;
-        bool applyRotation = true;
+        float rotStepAngle = (2 * M_PI) / step;
 
-        SbRotation viewRot = CurrentViewRot;
-
-        switch (pick) {
-        default:
-            return false;
-            break;
-        case PickId::Front:
-            viewRot = setView(0, 90);
-            // we don't want to dumb rotate to the same view since depending on from where the user clicked on Front
-            // we have one of four suitable end positions.
-            // we use here the same rotation logic used by other programs using OCC like "CAD Assistant"
-            // when current matrix's 0,0 entry is larger than its |1,0| entry, we already have the final result
-            // otherwise rotate around y
-            if (m_RotateToNearest) {
-                if (ViewRotMatrix[0][0] < 0 && abs(ViewRotMatrix[0][0]) >= abs(ViewRotMatrix[1][0]))
-                    viewRot = rotateView(viewRot, DirId::Out, 180);
-                else if (ViewRotMatrix[1][0] > 0 && abs(ViewRotMatrix[1][0]) > abs(ViewRotMatrix[0][0]))
-                    viewRot = rotateView(viewRot, DirId::Out, 90);
-                else if (ViewRotMatrix[1][0] < 0 && abs(ViewRotMatrix[1][0]) > abs(ViewRotMatrix[0][0]))
-                    viewRot = rotateView(viewRot, DirId::Out, -90);
-            }
-            break;
-        case PickId::Rear:
-            viewRot = setView(180, 90);
-            if (m_RotateToNearest) {
-                if (ViewRotMatrix[0][0] > 0 && abs(ViewRotMatrix[0][0]) >= abs(ViewRotMatrix[1][0]))
-                    viewRot = rotateView(viewRot, DirId::Out, 180);
-                else if (ViewRotMatrix[1][0] > 0 && abs(ViewRotMatrix[1][0]) > abs(ViewRotMatrix[0][0]))
-                    viewRot = rotateView(viewRot, DirId::Out, -90);
-                else if (ViewRotMatrix[1][0] < 0 && abs(ViewRotMatrix[1][0]) > abs(ViewRotMatrix[0][0]))
-                    viewRot = rotateView(viewRot, DirId::Out, 90);
-            }
-            break;
-        case PickId::Left:
-            viewRot = setView(270, 90);
-            if (m_RotateToNearest) {
-                if (ViewRotMatrix[0][1] > 0 && abs(ViewRotMatrix[0][1]) >= abs(ViewRotMatrix[1][1]))
-                    viewRot = rotateView(viewRot, DirId::Out, 180);
-                else if (ViewRotMatrix[1][1] > 0 && abs(ViewRotMatrix[1][1]) > abs(ViewRotMatrix[0][1]))
-                    viewRot = rotateView(viewRot, DirId::Out, -90);
-                else if (ViewRotMatrix[1][1] < 0 && abs(ViewRotMatrix[1][1]) > abs(ViewRotMatrix[0][1]))
-                    viewRot = rotateView(viewRot, DirId::Out, 90);
-            }
-            break;
-        case PickId::Right:
-            viewRot = setView(90, 90);
-            if (m_RotateToNearest) {
-                if (ViewRotMatrix[0][1] < 0 && abs(ViewRotMatrix[0][1]) >= abs(ViewRotMatrix[1][1]))
-                    viewRot = rotateView(viewRot, DirId::Out, 180);
-                else if (ViewRotMatrix[1][1] > 0 && abs(ViewRotMatrix[1][1]) > abs(ViewRotMatrix[0][1]))
-                    viewRot = rotateView(viewRot, DirId::Out, 90);
-                else if (ViewRotMatrix[1][1] < 0 && abs(ViewRotMatrix[1][1]) > abs(ViewRotMatrix[0][1]))
-                    viewRot = rotateView(viewRot, DirId::Out, -90);
-            }
-            break;
-        case PickId::Top:
-            viewRot = setView(0, 0);
-            if (m_RotateToNearest) {
-                if (ViewRotMatrix[0][0] < 0 && abs(ViewRotMatrix[0][0]) >= abs(ViewRotMatrix[1][0]))
-                    viewRot = rotateView(viewRot, DirId::Out, 180);
-                else if (ViewRotMatrix[1][0] > 0 && abs(ViewRotMatrix[1][0]) > abs(ViewRotMatrix[0][0]))
-                    viewRot = rotateView(viewRot, DirId::Out, 90);
-                else if (ViewRotMatrix[1][0] < 0 && abs(ViewRotMatrix[1][0]) > abs(ViewRotMatrix[0][0]))
-                    viewRot = rotateView(viewRot, DirId::Out, -90);
-            }
-            break;
-        case PickId::Bottom:
-            viewRot = setView(0, 180);
-            if (m_RotateToNearest) {
-                if (ViewRotMatrix[0][0] < 0 && abs(ViewRotMatrix[0][0]) >= abs(ViewRotMatrix[1][0]))
-                    viewRot = rotateView(viewRot, DirId::Out, 180);
-                else if (ViewRotMatrix[1][0] > 0 && abs(ViewRotMatrix[1][0]) > abs(ViewRotMatrix[0][0]))
-                    viewRot = rotateView(viewRot, DirId::Out, 90);
-                else if (ViewRotMatrix[1][0] < 0 && abs(ViewRotMatrix[1][0]) > abs(ViewRotMatrix[0][0]))
-                    viewRot = rotateView(viewRot, DirId::Out, -90);
-            }
-            break;
-        case PickId::FrontTop:
-            // set to Front then rotate
-            viewRot = setView(0, 90);
-            viewRot = rotateView(viewRot, DirId::Right, 45);
-            if (m_RotateToNearest) {
-                if (ViewRotMatrix[0][0] < 0 && abs(ViewRotMatrix[0][0]) >= abs(ViewRotMatrix[1][0]))
-                    viewRot = rotateView(viewRot, DirId::Out, 180);
-                else if (ViewRotMatrix[1][0] > 0 && abs(ViewRotMatrix[1][0]) > abs(ViewRotMatrix[0][0]))
-                    viewRot = rotateView(viewRot, DirId::Out, 90);
-                else if (ViewRotMatrix[1][0] < 0 && abs(ViewRotMatrix[1][0]) > abs(ViewRotMatrix[0][0]))
-                    viewRot = rotateView(viewRot, DirId::Out, -90);
-            }
-            break;
-        case PickId::FrontBottom:
-            // set to Front then rotate
-            viewRot = setView(0, 90);
-            viewRot = rotateView(viewRot, DirId::Right, -45);
-            if (m_RotateToNearest) {
-                if (ViewRotMatrix[0][0] < 0 && abs(ViewRotMatrix[0][0]) >= abs(ViewRotMatrix[1][0]))
-                    viewRot = rotateView(viewRot, DirId::Out, 180);
-                else if (ViewRotMatrix[1][0] > 0 && abs(ViewRotMatrix[1][0]) > abs(ViewRotMatrix[0][0]))
-                    viewRot = rotateView(viewRot, DirId::Out, 90);
-                else if (ViewRotMatrix[1][0] < 0 && abs(ViewRotMatrix[1][0]) > abs(ViewRotMatrix[0][0]))
-                    viewRot = rotateView(viewRot, DirId::Out, -90);
-            }
-            break;
-        case PickId::RearBottom:
-            // set to Rear then rotate
-            viewRot = setView(180, 90);
-            viewRot = rotateView(viewRot, DirId::Right, -45);
-            if (m_RotateToNearest) {
-                if (ViewRotMatrix[0][0] > 0 && abs(ViewRotMatrix[0][0]) >= abs(ViewRotMatrix[1][0]))
-                    viewRot = rotateView(viewRot, DirId::Out, 180);
-                else if (ViewRotMatrix[1][0] > 0 && abs(ViewRotMatrix[1][0]) > abs(ViewRotMatrix[0][0]))
-                    viewRot = rotateView(viewRot, DirId::Out, -90);
-                else if (ViewRotMatrix[1][0] < 0 && abs(ViewRotMatrix[1][0]) > abs(ViewRotMatrix[0][0]))
-                    viewRot = rotateView(viewRot, DirId::Out, 90);
-            }
-            break;
-        case PickId::RearTop:
-            // set to Rear then rotate
-            viewRot = setView(180, 90);
-            viewRot = rotateView(viewRot, DirId::Right, 45);
-            if (m_RotateToNearest) {
-                if (ViewRotMatrix[0][0] > 0 && abs(ViewRotMatrix[0][0]) >= abs(ViewRotMatrix[1][0]))
-                    viewRot = rotateView(viewRot, DirId::Out, 180);
-                else if (ViewRotMatrix[1][0] > 0 && abs(ViewRotMatrix[1][0]) > abs(ViewRotMatrix[0][0]))
-                    viewRot = rotateView(viewRot, DirId::Out, -90);
-                else if (ViewRotMatrix[1][0] < 0 && abs(ViewRotMatrix[1][0]) > abs(ViewRotMatrix[0][0]))
-                    viewRot = rotateView(viewRot, DirId::Out, 90);
-            }
-            break;
-        case PickId::FrontLeft:
-            // set to Front then rotate
-            viewRot = setView(0, 90);
-            viewRot = rotateView(viewRot, DirId::Up, 45);
-            if (m_RotateToNearest) {
-                if (ViewRotMatrix[1][2] < 0 && abs(ViewRotMatrix[1][2]) >= abs(ViewRotMatrix[0][2]))
-                    viewRot = rotateView(viewRot, DirId::Out, 180);
-                else if (ViewRotMatrix[0][2] > 0 && abs(ViewRotMatrix[0][2]) > abs(ViewRotMatrix[1][2]))
-                    viewRot = rotateView(viewRot, DirId::Out, -90);
-                else if (ViewRotMatrix[0][2] < 0 && abs(ViewRotMatrix[0][2]) > abs(ViewRotMatrix[1][2]))
-                    viewRot = rotateView(viewRot, DirId::Out, 90);
-            }
-            break;
-        case PickId::FrontRight:
-            // set to Front then rotate
-            viewRot = setView(0, 90);
-            viewRot = rotateView(viewRot, DirId::Up, -45);
-            if (m_RotateToNearest) {
-                if (ViewRotMatrix[1][2] < 0 && abs(ViewRotMatrix[1][2]) >= abs(ViewRotMatrix[0][2]))
-                    viewRot = rotateView(viewRot, DirId::Out, 180);
-                else if (ViewRotMatrix[0][2] > 0 && abs(ViewRotMatrix[0][2]) > abs(ViewRotMatrix[1][2]))
-                    viewRot = rotateView(viewRot, DirId::Out, -90);
-                else if (ViewRotMatrix[0][2] < 0 && abs(ViewRotMatrix[0][2]) > abs(ViewRotMatrix[1][2]))
-                    viewRot = rotateView(viewRot, DirId::Out, 90);
-            }
-            break;
-        case PickId::RearRight:
-            // set to Rear then rotate
-            viewRot = setView(180, 90);
-            viewRot = rotateView(viewRot, DirId::Up, 45);
-            if (m_RotateToNearest) {
-                if (ViewRotMatrix[1][2] < 0 && abs(ViewRotMatrix[1][2]) >= abs(ViewRotMatrix[0][2]))
-                    viewRot = rotateView(viewRot, DirId::Out, 180);
-                else if (ViewRotMatrix[0][2] > 0 && abs(ViewRotMatrix[0][2]) > abs(ViewRotMatrix[1][2]))
-                    viewRot = rotateView(viewRot, DirId::Out, -90);
-                else if (ViewRotMatrix[0][2] < 0 && abs(ViewRotMatrix[0][2]) > abs(ViewRotMatrix[1][2]))
-                    viewRot = rotateView(viewRot, DirId::Out, 90);
-            }
-            break;
-        case PickId::RearLeft:
-            // set to Rear then rotate
-            viewRot = setView(180, 90);
-            viewRot = rotateView(viewRot, DirId::Up, -45);
-            if (ViewRotMatrix[1][2] < 0 && abs(ViewRotMatrix[1][2]) >= abs(ViewRotMatrix[0][2]))
-                viewRot = rotateView(viewRot, DirId::Out, 180);
-            else if (ViewRotMatrix[0][2] > 0 && abs(ViewRotMatrix[0][2]) > abs(ViewRotMatrix[1][2]))
-                viewRot = rotateView(viewRot, DirId::Out, -90);
-            else if (ViewRotMatrix[0][2] < 0 && abs(ViewRotMatrix[0][2]) > abs(ViewRotMatrix[1][2]))
-                viewRot = rotateView(viewRot, DirId::Out, 90);
-            break;
-        case PickId::TopLeft:
-            // set to Left then rotate
-            viewRot = setView(270, 90);
-            viewRot = rotateView(viewRot, DirId::Right, 45);
-            if (m_RotateToNearest) {
-                if (ViewRotMatrix[0][1] > 0 && abs(ViewRotMatrix[0][1]) >= abs(ViewRotMatrix[1][1]))
-                    viewRot = rotateView(viewRot, DirId::Out, 180);
-                else if (ViewRotMatrix[1][1] > 0 && abs(ViewRotMatrix[1][1]) > abs(ViewRotMatrix[0][1]))
-                    viewRot = rotateView(viewRot, DirId::Out, -90);
-                else if (ViewRotMatrix[1][1] < 0 && abs(ViewRotMatrix[1][1]) > abs(ViewRotMatrix[0][1]))
-                    viewRot = rotateView(viewRot, DirId::Out, 90);
-            }
-            break;
-        case PickId::TopRight:
-            // set to Right then rotate
-            viewRot = setView(90, 90);
-            viewRot = rotateView(viewRot, DirId::Right, 45);
-            if (m_RotateToNearest) {
-                if (ViewRotMatrix[0][1] < 0 && abs(ViewRotMatrix[0][1]) >= abs(ViewRotMatrix[1][1]))
-                    viewRot = rotateView(viewRot, DirId::Out, 180);
-                else if (ViewRotMatrix[1][1] > 0 && abs(ViewRotMatrix[1][1]) > abs(ViewRotMatrix[0][1]))
-                    viewRot = rotateView(viewRot, DirId::Out, 90);
-                else if (ViewRotMatrix[1][1] < 0 && abs(ViewRotMatrix[1][1]) > abs(ViewRotMatrix[0][1]))
-                    viewRot = rotateView(viewRot, DirId::Out, -90);
-            }
-            break;
-        case PickId::BottomRight:
-            // set to Right then rotate
-            viewRot = setView(90, 90);
-            viewRot = rotateView(viewRot, DirId::Right, -45);
-            if (m_RotateToNearest) {
-                if (ViewRotMatrix[0][1] < 0 && abs(ViewRotMatrix[0][1]) >= abs(ViewRotMatrix[1][1]))
-                    viewRot = rotateView(viewRot, DirId::Out, 180);
-                else if (ViewRotMatrix[1][1] > 0 && abs(ViewRotMatrix[1][1]) > abs(ViewRotMatrix[0][1]))
-                    viewRot = rotateView(viewRot, DirId::Out, 90);
-                else if (ViewRotMatrix[1][1] < 0 && abs(ViewRotMatrix[1][1]) > abs(ViewRotMatrix[0][1]))
-                    viewRot = rotateView(viewRot, DirId::Out, -90);
-            }
-            break;
-        case PickId::BottomLeft:
-            // set to Left then rotate
-            viewRot = setView(270, 90);
-            viewRot = rotateView(viewRot, DirId::Right, -45);
-            if (m_RotateToNearest) {
-                if (ViewRotMatrix[0][1] > 0 && abs(ViewRotMatrix[0][1]) >= abs(ViewRotMatrix[1][1]))
-                    viewRot = rotateView(viewRot, DirId::Out, 180);
-                else if (ViewRotMatrix[1][1] > 0 && abs(ViewRotMatrix[1][1]) > abs(ViewRotMatrix[0][1]))
-                    viewRot = rotateView(viewRot, DirId::Out, -90);
-                else if (ViewRotMatrix[1][1] < 0 && abs(ViewRotMatrix[1][1]) > abs(ViewRotMatrix[0][1]))
-                    viewRot = rotateView(viewRot, DirId::Out, 90);
-            }
-            break;
-        case PickId::FrontBottomLeft:
-            viewRot = setView(rot - 90, 90 + tilt);
-            // we have 3 possible end states:
-            // - z-axis is not rotated larger than 120 deg from (0, 1, 0) -> we are already there
-            // - y-axis is not rotated larger than 120 deg from (0, 1, 0)
-            // - x-axis is not rotated larger than 120 deg from (0, 1, 0)
-            if (m_RotateToNearest) {
-                if (ViewRotMatrix[1][0] > 0.4823)
-                    viewRot = rotateView(viewRot, DirId::Custom, -120, SbVec3f(1, 1, 1));
-                else if (ViewRotMatrix[1][1] > 0.4823)
-                    viewRot = rotateView(viewRot, DirId::Custom, 120, SbVec3f(1, 1, 1));
-            }
-            break;
-        case PickId::FrontBottomRight:
-            viewRot = setView(90 + rot - 90, 90 + tilt);
-            if (m_RotateToNearest) {
-                if (ViewRotMatrix[1][0] < -0.4823)
-                    viewRot = rotateView(viewRot, DirId::Custom, 120, SbVec3f(-1, 1, 1));
-                else if (ViewRotMatrix[1][1] > 0.4823)
-                    viewRot = rotateView(viewRot, DirId::Custom, -120, SbVec3f(-1, 1, 1));
-            }
-            break;
-        case PickId::RearBottomRight:
-            viewRot = setView(180 + rot - 90, 90 + tilt);
-            if (m_RotateToNearest) {
-                if (ViewRotMatrix[1][0] < -0.4823)
-                    viewRot = rotateView(viewRot, DirId::Custom, -120, SbVec3f(-1, -1, 1));
-                else if (ViewRotMatrix[1][1] < -0.4823)
-                    viewRot = rotateView(viewRot, DirId::Custom, 120, SbVec3f(-1, -1, 1));
-            }
-            break;
-        case PickId::RearBottomLeft:
-            viewRot = setView(270 + rot - 90, 90 + tilt);
-            if (m_RotateToNearest) {
-                if (ViewRotMatrix[1][0] > 0.4823)
-                    viewRot = rotateView(viewRot, DirId::Custom, 120, SbVec3f(1, -1, 1));
-                else if (ViewRotMatrix[1][1] < -0.4823)
-                    viewRot = rotateView(viewRot, DirId::Custom, -120, SbVec3f(1, -1, 1));
-            }
-            break;
-        case PickId::FrontTopRight:
-            viewRot = setView(rot, 90 - tilt);
-            if (m_RotateToNearest) {
-                if (ViewRotMatrix[1][0] > 0.4823)
-                    viewRot = rotateView(viewRot, DirId::Custom, -120, SbVec3f(-1, 1, -1));
-                else if (ViewRotMatrix[1][1] < -0.4823)
-                    viewRot = rotateView(viewRot, DirId::Custom, 120, SbVec3f(-1, 1, -1));
-            }
-            break;
-        case PickId::FrontTopLeft:
-            viewRot = setView(rot - 90, 90 - tilt);
-            if (m_RotateToNearest) {
-                if (ViewRotMatrix[1][0] < -0.4823)
-                    viewRot = rotateView(viewRot, DirId::Custom, 120, SbVec3f(1, 1, -1));
-                else if (ViewRotMatrix[1][1] < -0.4823)
-                    viewRot = rotateView(viewRot, DirId::Custom, -120, SbVec3f(1, 1, -1));
-            }
-            break;
-        case PickId::RearTopLeft:
-            viewRot = setView(rot - 180, 90 - tilt);
-            if (m_RotateToNearest) {
-                if (ViewRotMatrix[1][0] < -0.4823)
-                    viewRot = rotateView(viewRot, DirId::Custom, -120, SbVec3f(1, -1, -1));
-                else if (ViewRotMatrix[1][1] > 0.4823)
-                    viewRot = rotateView(viewRot, DirId::Custom, 120, SbVec3f(1, -1, -1));
-            }
-            break;
-        case PickId::RearTopRight:
-            viewRot = setView(rot - 270, 90 - tilt);
-            if (m_RotateToNearest) {
-                if (ViewRotMatrix[1][0] > 0.4823)
-                    viewRot = rotateView(viewRot, DirId::Custom, 120, SbVec3f(-1, -1, -1));
-                else if (ViewRotMatrix[1][1] > 0.4823)
-                    viewRot = rotateView(viewRot, DirId::Custom, -120, SbVec3f(-1, -1, -1));
-            }
-            break;
-        case PickId::ArrowLeft:
-            viewRot = rotateView(viewRot, DirId::Out, rotStepAngle);
-            break;
-        case PickId::ArrowRight:
-            viewRot = rotateView(viewRot, DirId::Out, -rotStepAngle);
-            break;
-        case PickId::ArrowWest:
-            viewRot = rotateView(viewRot, DirId::Up, -rotStepAngle);
-            break;
-        case PickId::ArrowEast:
-            viewRot = rotateView(viewRot, DirId::Up, rotStepAngle);
-            break;
-        case PickId::ArrowNorth:
-            viewRot = rotateView(viewRot, DirId::Right, -rotStepAngle);
-            break;
-        case PickId::ArrowSouth:
-            viewRot = rotateView(viewRot, DirId::Right, rotStepAngle);
-            break;
-        case PickId::DotBackside:
-            viewRot = rotateView(viewRot, DirId::Up, 180);
-            break;
-        case PickId::ViewMenu:
-            handleMenu();
-            applyRotation = false;
-            break;
+        if (m_Faces[pick].type == ShapeId::Main || m_Faces[pick].type == ShapeId::Edge || m_Faces[pick].type == ShapeId::Corner) {
+            // Handle the cube faces
+            m_View3DInventorViewer->setCameraOrientation(m_Faces[pick].rotation);
         }
+        else if (m_Faces[pick].type == ShapeId::Button) {
 
-        if (applyRotation)
-            rotateView(viewRot);
+            // Handle the menu
+            if (pick == PickId::ViewMenu) {
+                handleMenu();
+                return true;
+            }
+
+            // Handle the flat buttons
+            SbRotation orientation = m_Faces[pick].rotation;
+            if (pick == PickId::DotBackside) {
+                orientation.scaleAngle(M_PI);
+            }
+            else {
+                orientation.scaleAngle(rotStepAngle);
+            }
+            m_View3DInventorViewer->setCameraOrientation(orientation * currentOrientation);
+        }
+        else {
+            return false;
+        }
     }
     return true;
 }

--- a/src/Gui/NaviCube.cpp
+++ b/src/Gui/NaviCube.cpp
@@ -151,10 +151,6 @@ private:
     void addCubeFace(const Vector3f&, const Vector3f&, ShapeId, PickId, float rotZ = 0.0);
     void addButtonFace(PickId, const SbVec3f& direction = SbVec3f(0, 0, 0));
 
-    SbRotation setView(float, float) const;
-    SbRotation rotateView(SbRotation, DirId, float, SbVec3f customAxis = SbVec3f(0, 0, 0)) const;
-    void rotateView(const SbRotation&);
-
     QString str(const char* str);
     QMenu* createNaviCubeMenu();
     void drawNaviCube(bool picking);
@@ -920,50 +916,6 @@ bool NaviCubeImplementation::mousePressed(short x, short y) {
     PickId pick = pickFace(x, y);
     setHilite(pick);
     return pick != PickId::None;
-}
-
-SbRotation NaviCubeImplementation::setView(float rotZ, float rotX) const {
-    SbRotation rz, rx, t;
-    rz.setValue(SbVec3f(0, 0, 1), rotZ * M_PI / 180);
-    rx.setValue(SbVec3f(1, 0, 0), rotX * M_PI / 180);
-    return rx * rz;
-}
-
-SbRotation NaviCubeImplementation::rotateView(SbRotation viewRot, DirId axis, float rotAngle, SbVec3f customAxis) const {
-    SbVec3f up;
-    viewRot.multVec(SbVec3f(0, 1, 0), up);
-
-    SbVec3f out;
-    viewRot.multVec(SbVec3f(0, 0, 1), out);
-
-    SbVec3f right;
-    viewRot.multVec(SbVec3f(1, 0, 0), right);
-
-    SbVec3f direction;
-    switch (axis) {
-    default:
-        return viewRot;
-    case DirId::Up:
-        direction = up;
-        break;
-    case DirId::Out:
-        direction = out;
-        break;
-    case DirId::Right:
-        direction = right;
-        break;
-    case DirId::Custom:
-        direction = customAxis;
-        break;
-    }
-
-    SbRotation rot(direction, -rotAngle * M_PI / 180.0);
-    SbRotation newViewRot = viewRot * rot;
-    return newViewRot;
-}
-
-void NaviCubeImplementation::rotateView(const SbRotation& rot) {
-    m_View3DInventorViewer->setCameraOrientation(rot);
 }
 
 void NaviCubeImplementation::handleMenu() {

--- a/src/Gui/NaviCube.cpp
+++ b/src/Gui/NaviCube.cpp
@@ -944,7 +944,7 @@ SbRotation NaviCubeImplementation::getNearestOrientation(PickId pickId) {
     SbRotation rotation = intermediateOrientation.inverse() * standardOrientation;
     rotation.getValue(axis, angle);
 
-    // f is a small value used to control orientation priority when the camera is almost excactly between two
+    // f is a small value used to control orientation priority when the camera is almost exactly between two
     // orientations (e.g. +45 and -45 degrees). The standard orientation is preferred compared to
     // +90 and -90 degree orientations and the +90 and -90 degree orientations are preferred compared to an
     // upside down standard orientation

--- a/src/Gui/NaviCube.cpp
+++ b/src/Gui/NaviCube.cpp
@@ -126,6 +126,8 @@ private:
     struct Face {
         ShapeId type;
         vector<Vector3f> vertexArray;
+        // The rotation is the standard orientation for the faces of the cube
+        // For the flat buttons it is the direction of the rotation
         SbRotation rotation;
     };
     struct LabelTexture {
@@ -147,7 +149,7 @@ private:
     void setHilite(PickId);
 
     void addCubeFace(const Vector3f&, const Vector3f&, ShapeId, PickId, float rotZ = 0.0);
-    void addButtonFace(PickId);
+    void addButtonFace(PickId, const SbVec3f& direction = SbVec3f(0, 0, 0));
 
     SbRotation setView(float, float) const;
     SbRotation rotateView(SbRotation, DirId, float, SbVec3f customAxis = SbVec3f(0, 0, 0)) const;
@@ -450,7 +452,7 @@ void NaviCubeImplementation::createCubeFaceTextures() {
     }
 }
 
-void NaviCubeImplementation::addButtonFace(PickId pickId)
+void NaviCubeImplementation::addButtonFace(PickId pickId, const SbVec3f& direction)
 {
     if (m_Faces[pickId].vertexArray.size())
         m_Faces[pickId].vertexArray.clear();
@@ -535,6 +537,7 @@ void NaviCubeImplementation::addButtonFace(PickId pickId)
             m_Faces[pickId].vertexArray.emplace_back(Vector3f(x, y, 0.0));
     }
     m_Faces[pickId].type = ShapeId::Button;
+    m_Faces[pickId].rotation = SbRotation(direction, 1).inverse();
 }
 
 void NaviCubeImplementation::addCubeFace(const Vector3f& x, const Vector3f& z, ShapeId shapeType, PickId pickId, float rotZ) {
@@ -657,13 +660,13 @@ void NaviCubeImplementation::prepare() {
     addCubeFace(y,-z-x, ShapeId::Edge, PickId::BottomLeft, M_PI);
 
     // create the flat buttons
-    addButtonFace(PickId::ArrowNorth);
-    addButtonFace(PickId::ArrowSouth);
-    addButtonFace(PickId::ArrowEast);
-    addButtonFace(PickId::ArrowWest);
-    addButtonFace(PickId::ArrowLeft);
-    addButtonFace(PickId::ArrowRight);
-    addButtonFace(PickId::DotBackside);
+    addButtonFace(PickId::ArrowNorth, SbVec3f(1, 0, 0));
+    addButtonFace(PickId::ArrowSouth, SbVec3f(-1, 0, 0));
+    addButtonFace(PickId::ArrowEast, SbVec3f(0, 1, 0));
+    addButtonFace(PickId::ArrowWest, SbVec3f(0, -1, 0));
+    addButtonFace(PickId::ArrowLeft, SbVec3f(0, 0, 1));
+    addButtonFace(PickId::ArrowRight, SbVec3f(0, 0, -1));
+    addButtonFace(PickId::DotBackside, SbVec3f(0, 1, 0));
     addButtonFace(PickId::ViewMenu);
 
     if (m_PickingFramebuffer)


### PR DESCRIPTION
Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---

This PR replaces the huge switch that determined the camera orientation after clicking on a NaviCube face. The standard orientation is now stored in the face when it is created and a method is added to find the nearest orientation if rotate to nearest is enabled. A small change is that the corner faces now have 6 possible orientations when rotate to nearest is enabled instead of 3.
