### PR TITLE
Tools: switch to subprocess

### DIFF
--- a/src/Tools/updatecrowdin.py
+++ b/src/Tools/updatecrowdin.py
@@ -72,6 +72,7 @@ import json
 import os
 import sys
 import shutil
+import subprocess
 import tempfile
 import zipfile
 import re
@@ -428,7 +429,16 @@ def doFile(tsfilepath, targetpath, lncode, qrcpath):
     newname = basename + "_" + lncode + ".ts"
     newpath = targetpath + os.sep + newname
     shutil.copyfile(tsfilepath, newpath)
-    os.system("lrelease " + newpath + " >/dev/null 2>&1")
+    try:
+        subprocess.run(
+            [
+                "lrelease",
+                newpath,
+            ],
+            timeout=5,
+        )
+    except Exception as e:
+        print(e)
     newqm = targetpath + os.sep + basename + "_" + lncode + ".qm"
     if not os.path.exists(newqm):
         print("ERROR: impossible to create " + newqm + ", aborting")


### PR DESCRIPTION
Using `system` to execute `lrelease` causes problems with Windows paths when run from within MinGW (and is discouraged for a host of other reasons). This PR migrates to an identical call that uses subprocess instead.

---

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR