### PR TITLE
Path: 'ToolController' -> 'Tool Controller' in UI panels

### DIFF
--- a/src/Mod/Path/Gui/Resources/panels/PageOpCustomEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PageOpCustomEdit.ui
@@ -32,7 +32,7 @@
       <item row="0" column="0">
        <widget class="QLabel" name="label">
         <property name="text">
-         <string>ToolController</string>
+         <string>Tool Controller</string>
         </property>
        </widget>
       </item>

--- a/src/Mod/Path/Gui/Resources/panels/PageOpDrillingEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PageOpDrillingEdit.ui
@@ -32,7 +32,7 @@
       <item row="0" column="0">
        <widget class="QLabel" name="label_2">
         <property name="text">
-         <string>ToolController</string>
+         <string>Tool Controller</string>
         </property>
        </widget>
       </item>

--- a/src/Mod/Path/Gui/Resources/panels/PageOpEngraveEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PageOpEngraveEdit.ui
@@ -26,7 +26,7 @@
       <item row="0" column="0">
        <widget class="QLabel" name="label">
         <property name="text">
-         <string>ToolController</string>
+         <string>Tool Controller</string>
         </property>
        </widget>
       </item>

--- a/src/Mod/Path/Gui/Resources/panels/PageOpProbeEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PageOpProbeEdit.ui
@@ -32,7 +32,7 @@
       <item row="0" column="0">
        <widget class="QLabel" name="label">
         <property name="text">
-         <string>ToolController</string>
+         <string>Tool Controller</string>
         </property>
        </widget>
       </item>

--- a/src/Mod/Path/Gui/Resources/panels/PageOpSlotEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PageOpSlotEdit.ui
@@ -32,7 +32,7 @@
       <item row="0" column="0">
        <widget class="QLabel" name="toolController_label">
         <property name="text">
-         <string>ToolController</string>
+         <string>Tool Controller</string>
         </property>
        </widget>
       </item>

--- a/src/Mod/Path/Gui/Resources/panels/PageOpSurfaceEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PageOpSurfaceEdit.ui
@@ -26,7 +26,7 @@
       <item row="0" column="0">
        <widget class="QLabel" name="toolController_label">
         <property name="text">
-         <string>ToolController</string>
+         <string>Tool Controller</string>
         </property>
        </widget>
       </item>

--- a/src/Mod/Path/Gui/Resources/panels/PageOpVcarveEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PageOpVcarveEdit.ui
@@ -26,7 +26,7 @@
       <item row="0" column="0">
        <widget class="QLabel" name="label">
         <property name="text">
-         <string>ToolController</string>
+         <string>Tool Controller</string>
         </property>
        </widget>
       </item>

--- a/src/Mod/Path/Gui/Resources/panels/PageOpWaterlineEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PageOpWaterlineEdit.ui
@@ -26,7 +26,7 @@
       <item row="0" column="0">
        <widget class="QLabel" name="toolController_label">
         <property name="text">
-         <string>ToolController</string>
+         <string>Tool Controller</string>
         </property>
        </widget>
       </item>

--- a/src/Mod/Path/Gui/Resources/panels/SurfaceEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/SurfaceEdit.ui
@@ -260,7 +260,7 @@
           <item row="0" column="0">
            <widget class="QLabel" name="label_8">
             <property name="text">
-             <string>ToolController</string>
+             <string>Tool Controller</string>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
In cases where this isn't being used specifically to access the property in code (e.g. it's just a UI label), put a space between the terms.

---

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR