### PR TITLE
Sketcher: improve context menu text for Sketcher_ToggleConstruction

### DIFF
--- a/src/Mod/Sketcher/Gui/TaskSketcherElements.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherElements.cpp
@@ -484,7 +484,7 @@ void ElementView::contextMenuEvent (QContextMenuEvent* event)
 
     menu.addSeparator();
 
-    CONTEXT_ITEM("Sketcher_ToggleConstruction","Toggle construction line","Sketcher_ToggleConstruction",doToggleConstruction,true)
+    CONTEXT_ITEM("Sketcher_ToggleConstruction","Toggle construction geometry","Sketcher_ToggleConstruction",doToggleConstruction,true)
 
     menu.addSeparator();
 


### PR DESCRIPTION
In the Elements context menu (Sketcher task panel) the menu text for Sketcher_ToggleConstruction is "Toggle construction line", this should be "Toggle construction geometry". It is not just lines that can be toggled, and this is also the menu text in the main Sketcher menu.

- [ ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

---
