### PR TITLE
Gui: fix NaviCube in split views:

### DIFF
--- a/src/Gui/NaviCube.cpp
+++ b/src/Gui/NaviCube.cpp
@@ -241,11 +241,13 @@ void NaviCube::setSize(int size)
 {
     m_NaviCubeImplementation->setSize(size);
 }
+
 void NaviCube::setChamfer(float chamfer)
 {
     m_NaviCubeImplementation->m_Chamfer = min(max(0.05f, chamfer), 0.18f);
     m_NaviCubeImplementation->m_Prepared = false;
 }
+
 void NaviCube::setNaviRotateToNearest(bool toNearest)
 {
     m_NaviCubeImplementation->m_RotateToNearest = toNearest;
@@ -301,7 +303,6 @@ void NaviCube::setBorderWidth(double BorderWidth)
     m_NaviCubeImplementation->m_BorderWidth = BorderWidth;
 }
 
-
 void NaviCube::setShowCS(bool showCS)
 {
     m_NaviCubeImplementation->m_ShowCS = showCS;
@@ -311,6 +312,7 @@ void NaviCube::setNaviCubeLabels(const std::vector<std::string>& labels)
 {
     m_NaviCubeImplementation->setLabels(labels);
 }
+
 void NaviCubeImplementation::setLabels(const std::vector<std::string>& labels)
 {
     m_LabelTextures[PickId::Front].label  = labels[0];
@@ -322,8 +324,9 @@ void NaviCubeImplementation::setLabels(const std::vector<std::string>& labels)
     m_Prepared = false;
 }
 
-
 NaviCubeImplementation::NaviCubeImplementation(Gui::View3DInventorViewer* viewer)
+    : m_BaseColor{226, 232, 239}
+    , m_HiliteColor{170, 226, 255}
 {
     m_View3DInventorViewer = viewer;
     m_PickingFramebuffer = nullptr;
@@ -368,6 +371,10 @@ auto convertWeights = [](int weight) -> QFont::Weight {
 };
 
 int imageVerticalBalance(QImage p, int sizeHint) {
+    if (sizeHint < 0) {
+        return 0;
+    }
+
     int h = p.height();
     int startRow = (h - sizeHint) / 2;
     bool done = false;
@@ -394,8 +401,10 @@ void NaviCubeImplementation::createCubeFaceTextures() {
     int texSize = 192; // Works well for the max cube size 1024
     // find font sizes
     QFont font;
-    QString fontString = QString::fromStdString(m_TextFont);
-    font.fromString(fontString);
+    if (!m_TextFont.empty()) {
+        QString fontString = QString::fromStdString(m_TextFont);
+        font.fromString(fontString);
+    }
     if (m_FontWeight > 0) {
         font.setWeight(convertWeights(m_FontWeight));
     }

--- a/src/Gui/SplitView3DInventor.cpp
+++ b/src/Gui/SplitView3DInventor.cpp
@@ -110,6 +110,12 @@ void AbstractSplitView::setupSettings()
     viewSettings->ignoreRenderCache = true;
     viewSettings->ignoreDimensions = true;
     viewSettings->applySettings();
+
+    for (auto view : _viewer) {
+        NaviCubeSettings naviSettings(App::GetApplication().GetParameterGroupByPath
+                                     ("User parameter:BaseApp/Preferences/NaviCube"), view);
+        naviSettings.applySettings();
+    }
 }
 
 View3DInventorViewer* AbstractSplitView::getViewer(unsigned int n) const

--- a/src/Gui/View3DSettings.cpp
+++ b/src/Gui/View3DSettings.cpp
@@ -449,6 +449,7 @@ NaviCubeSettings::~NaviCubeSettings()
 {
     connectParameterChanged.disconnect();
 }
+
 QString NaviCubeSettings::getDefaultSansserifFont()
 {
     // "FreeCAD NaviCube" family susbtitutions are set in MainWindow::MainWindow
@@ -458,6 +459,7 @@ QString NaviCubeSettings::getDefaultSansserifFont()
     return QFontInfo(font).family();
     // return QStringLiteral("FreeCAD NaviCube");
 }
+
 void NaviCubeSettings::applySettings()
 {
     parameterChanged("BaseColor");
@@ -519,7 +521,7 @@ void NaviCubeSettings::parameterChanged(const char* Name)
         nc->setBaseColor(App::Color::fromPackedRGBA<QColor>(col));
         // update default contrast colors
         parameterChanged("EmphaseColor");
-   }
+    }
     else if (strcmp(Name, "EmphaseColor") == 0) {
         App::Color bc((uint32_t)hGrp->GetUnsigned("BaseColor", 3806916544));
         unsigned long d = bc.r + bc.g + bc.b >= 1.5f ? 255 : 4294967295;


### PR DESCRIPTION
* initialize base and hilite color with more snesible default values
* handle case if no font name is set
* apply user preferences to NaviCube

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [x]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
