### PR TITLE
Draft: Added dim overshoot parameters to Style task dialog

### DIFF
--- a/src/Mod/Draft/Resources/ui/TaskPanel_SetStyle.ui
+++ b/src/Mod/Draft/Resources/ui/TaskPanel_SetStyle.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>246</width>
-    <height>573</height>
+    <width>287</width>
+    <height>827</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -44,8 +44,7 @@
        </property>
        <property name="icon">
         <iconset theme="gtk-save">
-         <normaloff/>
-        </iconset>
+         <normaloff>.</normaloff>.</iconset>
        </property>
       </widget>
      </item>
@@ -199,10 +198,65 @@
       <string>Annotations</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_3" columnstretch="1,0" columnminimumwidth="0,120">
+      <item row="1" column="1">
+       <widget class="Gui::InputField" name="TextSize">
+        <property name="toolTip">
+         <string>The size of texts and dimension texts</string>
+        </property>
+        <property name="unit" stdset="0">
+         <string notr="true"/>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="Gui::ColorButton" name="TextColor">
+        <property name="toolTip">
+         <string>The color of texts and dimension texts</string>
+        </property>
+       </widget>
+      </item>
       <item row="0" column="0">
        <widget class="QLabel" name="label_4">
         <property name="text">
          <string>Text font</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_9">
+        <property name="text">
+         <string>Text spacing</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_5">
+        <property name="text">
+         <string>Text size</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="Gui::InputField" name="TextSpacing">
+        <property name="toolTip">
+         <string>The space between the text and the dimension line</string>
+        </property>
+        <property name="unit" stdset="0">
+         <string notr="true"/>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0">
+       <widget class="QLabel" name="label_15">
+        <property name="text">
+         <string>Line spacing</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="label_7">
+        <property name="text">
+         <string>Text color</string>
         </property>
        </widget>
       </item>
@@ -219,61 +273,6 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_5">
-        <property name="text">
-         <string>Text size</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="Gui::InputField" name="TextSize">
-        <property name="toolTip">
-         <string>The size of texts and dimension texts</string>
-        </property>
-        <property name="unit" stdset="0">
-         <string notr="true"/>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_9">
-        <property name="text">
-         <string>Text spacing</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="Gui::InputField" name="TextSpacing">
-        <property name="toolTip">
-         <string>The space between the text and the dimension line</string>
-        </property>
-        <property name="unit" stdset="0">
-         <string notr="true"/>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0">
-       <widget class="QLabel" name="label_7">
-        <property name="text">
-         <string>Text color</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="1">
-       <widget class="Gui::ColorButton" name="TextColor">
-        <property name="toolTip">
-         <string>The color of texts and dimension texts</string>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="0">
-       <widget class="QLabel" name="label_15">
-        <property name="text">
-         <string>Line spacing</string>
-        </property>
-       </widget>
-      </item>
       <item row="5" column="1">
        <widget class="QDoubleSpinBox" name="LineSpacing">
         <property name="toolTip">
@@ -281,14 +280,36 @@
         </property>
        </widget>
       </item>
-      <item row="6" column="0">
-       <widget class="QLabel" name="label_6">
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="groupBox_3">
+     <property name="title">
+      <string>Dimensins</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_2" columnstretch="1,0" columnminimumwidth="0,120">
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_8">
         <property name="text">
-         <string>Arrow style</string>
+         <string>Arrow size</string>
         </property>
        </widget>
       </item>
-      <item row="6" column="1">
+      <item row="2" column="1">
+       <widget class="QCheckBox" name="ShowUnit">
+        <property name="toolTip">
+         <string>If the unit suffix is shown on dimension texts or not</string>
+        </property>
+        <property name="layoutDirection">
+         <enum>Qt::RightToLeft</enum>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
        <widget class="QComboBox" name="ArrowStyle">
         <property name="toolTip">
          <string>The type of dimension arrows</string>
@@ -320,14 +341,7 @@
         </item>
        </widget>
       </item>
-      <item row="7" column="0">
-       <widget class="QLabel" name="label_8">
-        <property name="text">
-         <string>Arrow size</string>
-        </property>
-       </widget>
-      </item>
-      <item row="7" column="1">
+      <item row="1" column="1">
        <widget class="Gui::InputField" name="ArrowSize">
         <property name="toolTip">
          <string>The size of dimension arrows</string>
@@ -337,41 +351,86 @@
         </property>
        </widget>
       </item>
-      <item row="8" column="0">
-       <widget class="QLabel" name="label_13">
+      <item row="4" column="0">
+       <widget class="QLabel" name="label_16">
         <property name="text">
-         <string>Show unit</string>
+         <string>Dim Overshoot</string>
         </property>
        </widget>
       </item>
-      <item row="8" column="1">
-       <widget class="QCheckBox" name="ShowUnit">
-        <property name="toolTip">
-         <string>If the unit suffix is shown on dimension texts or not</string>
-        </property>
-        <property name="layoutDirection">
-         <enum>Qt::RightToLeft</enum>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
-      <item row="9" column="0">
+      <item row="3" column="0">
        <widget class="QLabel" name="label_14">
         <property name="text">
          <string>Unit override</string>
         </property>
        </widget>
       </item>
-      <item row="9" column="1">
+      <item row="3" column="1">
        <widget class="QLineEdit" name="UnitOverride">
         <property name="toolTip">
          <string>The unit to use for dimensions. Leave blank to use current FreeCAD unit</string>
         </property>
        </widget>
       </item>
-      </layout>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_13">
+        <property name="text">
+         <string>Show unit</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_6">
+        <property name="text">
+         <string>Arrow style</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0">
+       <widget class="QLabel" name="label_17">
+        <property name="text">
+         <string>Ext Lines</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="0">
+       <widget class="QLabel" name="label_18">
+        <property name="text">
+         <string>Ext Overshoot</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="Gui::InputField" name="DimOvershoot">
+        <property name="toolTip">
+         <string>The distance the dimension line is extended past the extension lines</string>
+        </property>
+        <property name="unit" stdset="0">
+         <string notr="true"/>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="1">
+       <widget class="Gui::InputField" name="ExtLines">
+        <property name="toolTip">
+         <string>Length of the extension lines</string>
+        </property>
+        <property name="unit" stdset="0">
+         <string notr="true"/>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="1">
+       <widget class="Gui::InputField" name="ExtOvershoot">
+        <property name="toolTip">
+         <string>Length of the extension lines beyond the dimension line</string>
+        </property>
+        <property name="unit" stdset="0">
+         <string notr="true"/>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
    <item>
@@ -386,8 +445,7 @@
        </property>
        <property name="icon">
         <iconset theme="gtk-apply">
-         <normaloff/>
-        </iconset>
+         <normaloff>.</normaloff>.</iconset>
        </property>
       </widget>
      </item>

--- a/src/Mod/Draft/Resources/ui/TaskPanel_SetStyle.ui
+++ b/src/Mod/Draft/Resources/ui/TaskPanel_SetStyle.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>287</width>
-    <height>827</height>
+    <height>945</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -222,27 +222,10 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_9">
-        <property name="text">
-         <string>Text spacing</string>
-        </property>
-       </widget>
-      </item>
       <item row="1" column="0">
        <widget class="QLabel" name="label_5">
         <property name="text">
          <string>Text size</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="Gui::InputField" name="TextSpacing">
-        <property name="toolTip">
-         <string>The space between the text and the dimension line</string>
-        </property>
-        <property name="unit" stdset="0">
-         <string notr="true"/>
         </property>
        </widget>
       </item>
@@ -286,26 +269,23 @@
    <item>
     <widget class="QGroupBox" name="groupBox_3">
      <property name="title">
-      <string>Dimensins</string>
+      <string>Dimensions</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_2" columnstretch="1,0" columnminimumwidth="0,120">
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_8">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_6">
         <property name="text">
-         <string>Arrow size</string>
+         <string>Arrow style</string>
         </property>
        </widget>
       </item>
-      <item row="2" column="1">
-       <widget class="QCheckBox" name="ShowUnit">
+      <item row="8" column="1">
+       <widget class="Gui::InputField" name="TextSpacing">
         <property name="toolTip">
-         <string>If the unit suffix is shown on dimension texts or not</string>
+         <string>The space between the text and the dimension line</string>
         </property>
-        <property name="layoutDirection">
-         <enum>Qt::RightToLeft</enum>
-        </property>
-        <property name="text">
-         <string/>
+        <property name="unit" stdset="0">
+         <string notr="true"/>
         </property>
        </widget>
       </item>
@@ -341,6 +321,13 @@
         </item>
        </widget>
       </item>
+      <item row="6" column="0">
+       <widget class="QLabel" name="label_17">
+        <property name="text">
+         <string>Ext lines</string>
+        </property>
+       </widget>
+      </item>
       <item row="1" column="1">
        <widget class="Gui::InputField" name="ArrowSize">
         <property name="toolTip">
@@ -351,56 +338,27 @@
         </property>
        </widget>
       </item>
-      <item row="4" column="0">
-       <widget class="QLabel" name="label_16">
-        <property name="text">
-         <string>Dim Overshoot</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="label_14">
-        <property name="text">
-         <string>Unit override</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
-       <widget class="QLineEdit" name="UnitOverride">
+      <item row="9" column="1">
+       <widget class="QCheckBox" name="ShowUnit">
         <property name="toolTip">
-         <string>The unit to use for dimensions. Leave blank to use current FreeCAD unit</string>
+         <string>If the unit suffix is shown on dimension texts or not</string>
         </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_13">
+        <property name="layoutDirection">
+         <enum>Qt::RightToLeft</enum>
+        </property>
         <property name="text">
-         <string>Show unit</string>
+         <string/>
         </property>
        </widget>
       </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_6">
+      <item row="8" column="0">
+       <widget class="QLabel" name="label_9">
         <property name="text">
-         <string>Arrow style</string>
+         <string>Text spacing</string>
         </property>
        </widget>
       </item>
-      <item row="5" column="0">
-       <widget class="QLabel" name="label_17">
-        <property name="text">
-         <string>Ext Lines</string>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="0">
-       <widget class="QLabel" name="label_18">
-        <property name="text">
-         <string>Ext Overshoot</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="1">
+      <item row="5" column="1">
        <widget class="Gui::InputField" name="DimOvershoot">
         <property name="toolTip">
          <string>The distance the dimension line is extended past the extension lines</string>
@@ -410,7 +368,31 @@
         </property>
        </widget>
       </item>
-      <item row="5" column="1">
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_8">
+        <property name="text">
+         <string>Arrow size</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0">
+       <widget class="QLabel" name="label_16">
+        <property name="text">
+         <string>Dim overshoot</string>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="1">
+       <widget class="Gui::InputField" name="ExtOvershoot">
+        <property name="toolTip">
+         <string>Length of the extension lines beyond the dimension line</string>
+        </property>
+        <property name="unit" stdset="0">
+         <string notr="true"/>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="1">
        <widget class="Gui::InputField" name="ExtLines">
         <property name="toolTip">
          <string>Length of the extension lines</string>
@@ -420,13 +402,31 @@
         </property>
        </widget>
       </item>
-      <item row="6" column="1">
-       <widget class="Gui::InputField" name="ExtOvershoot">
-        <property name="toolTip">
-         <string>Length of the extension lines beyond the dimension line</string>
+      <item row="9" column="0">
+       <widget class="QLabel" name="label_13">
+        <property name="text">
+         <string>Show unit</string>
         </property>
-        <property name="unit" stdset="0">
-         <string notr="true"/>
+       </widget>
+      </item>
+      <item row="7" column="0">
+       <widget class="QLabel" name="label_18">
+        <property name="text">
+         <string>Ext overshoot</string>
+        </property>
+       </widget>
+      </item>
+      <item row="10" column="0">
+       <widget class="QLabel" name="label_14">
+        <property name="text">
+         <string>Unit override</string>
+        </property>
+       </widget>
+      </item>
+      <item row="10" column="1">
+       <widget class="QLineEdit" name="UnitOverride">
+        <property name="toolTip">
+         <string>The unit to use for dimensions. Leave blank to use current FreeCAD unit</string>
         </property>
        </widget>
       </item>
@@ -451,6 +451,9 @@
      </item>
      <item>
       <widget class="QPushButton" name="annotButton">
+       <property name="toolTip">
+        <string>Apply above style to all annotations (texts and dimensions)</string>
+       </property>
        <property name="text">
         <string>Annotations</string>
        </property>

--- a/src/Mod/Draft/draftguitools/gui_setstyle.py
+++ b/src/Mod/Draft/draftguitools/gui_setstyle.py
@@ -92,6 +92,9 @@ class Draft_SetStyle_TaskPanel:
         self.form.saveButton.setIcon(QtGui.QIcon.fromTheme("gtk-save", QtGui.QIcon(":/icons/document-save.svg")))
         self.form.TextSpacing.setText(FreeCAD.Units.Quantity(FreeCAD.ParamGet(self.p+"Mod/Draft").GetFloat("dimspacing",1),FreeCAD.Units.Length).UserString)
         self.form.LineSpacing.setValue(FreeCAD.ParamGet(self.p+"Mod/Draft").GetFloat("LineSpacing",1))
+        self.form.DimOvershoot.setText(FreeCAD.Units.Quantity(FreeCAD.ParamGet(self.p+"Mod/Draft").GetFloat("dimovershoot",0),FreeCAD.Units.Length).UserString)
+        self.form.ExtLines.setText(FreeCAD.Units.Quantity(FreeCAD.ParamGet(self.p+"Mod/Draft").GetFloat("extlines",0),FreeCAD.Units.Length).UserString)
+        self.form.ExtOvershoot.setText(FreeCAD.Units.Quantity(FreeCAD.ParamGet(self.p+"Mod/Draft").GetFloat("extovershoot",0),FreeCAD.Units.Length).UserString)
         self.form.saveButton.clicked.connect(self.onSaveStyle)
         self.form.applyButton.clicked.connect(self.onApplyStyle)
         self.form.annotButton.clicked.connect(self.onApplyAnnot)
@@ -139,6 +142,9 @@ class Draft_SetStyle_TaskPanel:
         preset["UnitOverride"] = self.form.UnitOverride.text()
         preset["TextSpacing"] = FreeCAD.Units.Quantity(self.form.TextSpacing.text()).Value
         preset["LineSpacing"] = self.form.LineSpacing.value()
+        preset["DimOvershoot"] = FreeCAD.Units.Quantity(self.form.DimOvershoot.text()).Value
+        preset["ExtLines"] = FreeCAD.Units.Quantity(self.form.ExtLines.text()).Value
+        preset["ExtOvershoot"] = FreeCAD.Units.Quantity(self.form.ExtOvershoot.text()).Value
         return preset
 
     def setValues(self,preset):
@@ -159,6 +165,9 @@ class Draft_SetStyle_TaskPanel:
         self.form.ArrowSize.setText(FreeCAD.Units.Quantity(preset.get("ArrowSize",5),FreeCAD.Units.Length).UserString)
         self.form.TextSpacing.setText(FreeCAD.Units.Quantity(preset.get("TextSpacing",25),FreeCAD.Units.Length).UserString)
         self.form.LineSpacing.setValue(preset.get("LineSpacing",3))
+        self.form.DimOvershoot.setText(FreeCAD.Units.Quantity(preset.get("DimOvershoot",0),FreeCAD.Units.Length).UserString)
+        self.form.ExtLines.setText(FreeCAD.Units.Quantity(preset.get("ExtLines",0),FreeCAD.Units.Length).UserString)
+        self.form.ExtOvershoot.setText(FreeCAD.Units.Quantity(preset.get("ExtOvershoot",0),FreeCAD.Units.Length).UserString)
 
     def reject(self):
 
@@ -186,6 +195,9 @@ class Draft_SetStyle_TaskPanel:
         param_draft.SetString("overrideUnit",self.form.UnitOverride.text())
         param_draft.SetFloat("dimspacing",FreeCAD.Units.Quantity(self.form.TextSpacing.text()).Value)
         param_draft.SetFloat("LineSpacing",self.form.LineSpacing.value())
+        param_draft.SetFloat("dimovershoot",FreeCAD.Units.Quantity(self.form.DimOvershoot.text()).Value)
+        param_draft.SetFloat("extlines",FreeCAD.Units.Quantity(self.form.ExtLines.text()).Value)
+        param_draft.SetFloat("extovershoot",FreeCAD.Units.Quantity(self.form.ExtOvershoot.text()).Value)
         if hasattr(FreeCADGui,"draftToolBar"):
             FreeCADGui.draftToolBar.setStyleButton()
         self.reject()
@@ -250,6 +262,12 @@ class Draft_SetStyle_TaskPanel:
             vobj.TextSpacing = FreeCAD.Units.Quantity(self.form.TextSpacing.text()).Value
         if "LineSpacing" in properties:
             vobj.LineSpacing = self.form.LineSpacing.value()
+        if "DimOvershoot" in properties:
+            vobj.DimOvershoot = FreeCAD.Units.Quantity(self.form.DimOvershoot.text()).Value
+        if "ExtLines" in properties:
+            vobj.ExtLines = FreeCAD.Units.Quantity(self.form.ExtLines.text()).Value
+        if "ExtOvershoot" in properties:
+            vobj.ExtOvershoot = FreeCAD.Units.Quantity(self.form.ExtOvershoot.text()).Value
 
     def onLoadStyle(self,index):
 
@@ -291,6 +309,7 @@ class Draft_SetStyle_TaskPanel:
             import json
             from json.decoder import JSONDecodeError
         except Exception:
+            FreeCAD.Console.PrintError(translate("Draft","Error: json module not found. Unable to load style")+"\n")
             return
         if os.path.exists(PRESETPATH):
             with open(PRESETPATH,"r") as f:


### PR DESCRIPTION
Dim Overshoot, Ext Lines and Ext Overshoot parameters were missing from the Draft "Set Style" button task dialog

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [x]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
