### PR TITLE
Start: Fixed loading from custom folder

### DIFF
--- a/src/Mod/Start/StartPage/LoadCustom.py
+++ b/src/Mod/Start/StartPage/LoadCustom.py
@@ -37,7 +37,7 @@ if cfolders:
     f = unquote(filename).replace("+", " ")
     ext = os.path.splitext(filename)[1].lower().strip(".")
     mod = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Start").GetString("DefaultImport"+ext,"")
-    FreeCAD.loadFile(os.path.join(cfolder, f),mod)
+    FreeCADGui.loadFile(os.path.join(cfolder, f),mod)
     FreeCADGui.activeDocument().sendMsgToViews("ViewFit")
 
     from StartPage import StartPage


### PR DESCRIPTION
Clicking a file in a custom folder did not call the correct module because of a difference between FreeCAD.loadFile() and FreeCADGui.loadFile()

- [x]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR