### PR TITLE
Draft: Indicate which DXF pref option is for legacy importer/exporter only

### DIFF
--- a/src/Mod/Draft/Resources/ui/preferences-dxf.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-dxf.ui
@@ -94,7 +94,7 @@ Note: C++ exporter is faster, but is not as featureful yet</string>
          <widget class="Gui::PrefCheckBox" name="checkBox_3">
           <property name="toolTip">
            <string>Allow FreeCAD to download the Python converter for DXF import and export.
-You can also do this manually by installing the "dxf_library" workbench
+You can also do this manually by installing the &quot;dxf_library&quot; workbench
 from the Addon Manager.</string>
           </property>
           <property name="text">
@@ -339,7 +339,7 @@ Example: for files in millimeters: 1, in centimeters: 10,
 Otherwise default colors will be applied. </string>
           </property>
           <property name="text">
-           <string>Get original colors from the DXF file</string>
+           <string>Get original colors from the DXF file (legacy importer only)</string>
           </property>
           <property name="prefEntry" stdset="0">
            <cstring>dxfGetOriginalColors</cstring>
@@ -445,7 +445,7 @@ instead of the size they have in the DXF document</string>
            <string>Hatches will be converted into simple wires</string>
           </property>
           <property name="text">
-           <string>Import hatch boundaries as wires</string>
+           <string>Import hatch boundaries as wires (legacy importer only)</string>
           </property>
           <property name="prefEntry" stdset="0">
            <cstring>importDxfHatches</cstring>
@@ -466,7 +466,7 @@ instead of the size they have in the DXF document</string>
 as closed wires with correct width</string>
           </property>
           <property name="text">
-           <string>Render polylines with width</string>
+           <string>Render polylines with width (legacy importer only)</string>
           </property>
           <property name="prefEntry" stdset="0">
            <cstring>renderPolylineWidth</cstring>
@@ -567,7 +567,7 @@ If it is set to '0' the whole spline is treated as a straight segment.</string>
            <string>All objects containing faces will be exported as 3D polyfaces</string>
           </property>
           <property name="text">
-           <string>Export 3D objects as polyface meshes</string>
+           <string>Export 3D objects as polyface meshes (legacy exporter only)</string>
           </property>
           <property name="prefEntry" stdset="0">
            <cstring>dxfmesh</cstring>
@@ -611,7 +611,7 @@ This might fail for post DXF R12 templates.</string>
            <string>Exported objects will be projected to reflect the current view direction</string>
           </property>
           <property name="text">
-           <string>Project exported objects along current view direction</string>
+           <string>Project exported objects along current view direction (legacy exporter only)</string>
           </property>
           <property name="prefEntry" stdset="0">
            <cstring>dxfproject</cstring>


### PR DESCRIPTION
On the Import/Export -> DXF preferences page, user has the option to use the legacy py importer or exporter, instead of the newer C++ ones. But not all options apply to both importers/exporters. This PR indicates next to the different options which is used by the legacy scripts only.

fixes #6001

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [ ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
