### PR TITLE
Gui: Translate unit system UI

### DIFF
--- a/src/Base/UnitsApi.cpp
+++ b/src/Base/UnitsApi.cpp
@@ -61,29 +61,29 @@ UnitSystem    UnitsApi::currentSystem = UnitSystem::SI1;
 
 int UnitsApi::UserPrefDecimals = 2;
 
-const char* UnitsApi::getDescription(UnitSystem system)
+QString UnitsApi::getDescription(UnitSystem system)
 {
     switch (system) {
     case UnitSystem::SI1:
-        return "Standard (mm/kg/s/degree)";
+        return tr("Standard (mm, kg, s, degree)");
     case UnitSystem::SI2:
-        return "MKS (m/kg/s/degree)";
+        return tr("MKS (m, kg, s, degree)");
     case UnitSystem::Imperial1:
-        return "US customary (in/lb)";
+        return tr("US customary (in, lb)");
     case UnitSystem::ImperialDecimal:
-        return "Imperial decimal (in/lb)";
+        return tr("Imperial decimal (in, lb)");
     case UnitSystem::Centimeters:
-        return "Building Euro (cm/m²/m³)";
+        return tr("Building Euro (cm, m², m³)");
     case UnitSystem::ImperialBuilding:
-        return "Building US (ft-in/sqft/cft)";
+        return tr("Building US (ft-in, sqft, cft)");
     case UnitSystem::MmMin:
-        return "Metric small parts & CNC(mm, mm/min)";
+        return tr("Metric small parts & CNC(mm, mm/min)");
     case UnitSystem::ImperialCivil:
-        return "Imperial for Civil Eng (ft, ft/sec)";
+        return tr("Imperial for Civil Eng (ft, ft/sec)");
     case UnitSystem::FemMilliMeterNewton:
-        return "FEM (mm, N, s)";
+        return tr("FEM (mm, N, s)");
     default:
-        return "Unknown schema";
+        return tr("Unknown schema");
     }
 }
 

--- a/src/Base/UnitsApi.h
+++ b/src/Base/UnitsApi.h
@@ -26,6 +26,7 @@
 
 #include <memory>
 #include <QString>
+#include <QCoreApplication>
 #include "UnitsSchema.h"
 #include "Quantity.h"
 
@@ -40,6 +41,7 @@ using UnitsSchemaPtr = std::unique_ptr<UnitsSchema>;
  */
 class BaseExport UnitsApi
 {
+    Q_DECLARE_TR_FUNCTIONS(UnitsApi)
 
 public:
     /** set Schema
@@ -54,7 +56,7 @@ public:
         return currentSystem;
     }
     /// Returns a brief description of a schema
-    static const char* getDescription(UnitSystem);
+    static QString getDescription(UnitSystem);
 
     static QString schemaTranslate(const Base::Quantity& quant, double &factor, QString &unitString);
     static QString schemaTranslate(const Base::Quantity& quant) { // to satisfy GCC

--- a/src/Base/UnitsApiPy.cpp
+++ b/src/Base/UnitsApiPy.cpp
@@ -100,7 +100,8 @@ PyObject* UnitsApi::sListSchemas(PyObject * /*self*/, PyObject *args)
         int num = static_cast<int>(UnitSystem::NumUnitSystemTypes);
         Py::Tuple tuple(num);
         for (int i=0; i<num; i++) {
-            tuple.setItem(i, Py::String(UnitsApi::getDescription(static_cast<UnitSystem>(i))));
+            const auto description {UnitsApi::getDescription(static_cast<UnitSystem>(i)).toStdString()};
+            tuple.setItem(i, Py::String(description.c_str()));
         }
 
         return Py::new_reference_to(tuple);
@@ -115,7 +116,8 @@ PyObject* UnitsApi::sListSchemas(PyObject * /*self*/, PyObject *args)
             return nullptr;
         }
 
-        return Py_BuildValue("s", UnitsApi::getDescription(static_cast<UnitSystem>(index)));
+        const auto description {UnitsApi::getDescription(static_cast<UnitSystem>(index)).toStdString()};
+        return Py_BuildValue("s", description.c_str());
     }
 
     PyErr_SetString(PyExc_TypeError, "int or empty argument list expected");

--- a/src/Gui/DlgGeneralImp.cpp
+++ b/src/Gui/DlgGeneralImp.cpp
@@ -88,7 +88,7 @@ DlgGeneralImp::DlgGeneralImp( QWidget* parent )
 
     int num = static_cast<int>(Base::UnitSystem::NumUnitSystemTypes);
     for (int i = 0; i < num; i++) {
-        QString item = qApp->translate("Gui::Dialog::DlgGeneralImp", Base::UnitsApi::getDescription(static_cast<Base::UnitSystem>(i)));
+        QString item = Base::UnitsApi::getDescription(static_cast<Base::UnitSystem>(i));
         ui->comboBox_UnitSystem->addItem(item, i);
     }
 

--- a/src/Gui/DlgUnitsCalculatorImp.cpp
+++ b/src/Gui/DlgUnitsCalculatorImp.cpp
@@ -53,7 +53,7 @@ DlgUnitsCalculator::DlgUnitsCalculator( QWidget* parent, Qt::WindowFlags fl )
     ui->comboBoxScheme->addItem(QString::fromLatin1("Preference system"), static_cast<int>(-1));
     int num = static_cast<int>(Base::UnitSystem::NumUnitSystemTypes);
     for (int i=0; i<num; i++) {
-        QString item = qApp->translate("Gui::Dialog::DlgGeneralImp", Base::UnitsApi::getDescription(static_cast<Base::UnitSystem>(i)));
+        QString item = Base::UnitsApi::getDescription(static_cast<Base::UnitSystem>(i));
         ui->comboBoxScheme->addItem(item, i);
     }
 

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -230,8 +230,7 @@ private:
         assert(actions.size() <= maxSchema);
         for(int i = 0; i < maxSchema ; i++)
         {
-            actions[i]->setText(qApp->translate("Gui::Dialog::DlgGeneralImp",
-                    Base::UnitsApi::getDescription(static_cast<Base::UnitSystem>(i))));
+            actions[i]->setText(Base::UnitsApi::getDescription(static_cast<Base::UnitSystem>(i)));
         }
     }
 };


### PR DESCRIPTION
When we modified the preferences dialogs we lost the translation of the unit system text. This restores it, and attempts to ensure that the translated text is *always* used. There shouldn't be any reason to use the untranslated base strings, so they are no longer available to calling code, which always gets the translated strings now. Closes https://github.com/FreeCAD/FreeCAD-translations/issues/220

---

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR