### PR TITLE
Arch: endpoint after Wall length change was not in local sketch coords

### DIFF
--- a/src/Mod/Arch/ArchWall.py
+++ b/src/Mod/Arch/ArchWall.py
@@ -1054,8 +1054,9 @@ class _Wall(ArchComponent.Component):
                                     obj.Base.End = p2
                                 elif Draft.getType(obj.Base) == "Sketcher::SketchObject":
                                     try:
-                                        obj.Base.movePoint(0,2,p2,0)
-                                    except Exception:
+                                        obj.Base.recompute() # Fix for the 'GeoId index out range' error.
+                                        obj.Base.movePoint(0, 2, obj.Base.Placement.inverse().multVec(p2))
+                                    except Exception: # This 'GeoId index out range' error should no longer occur.
                                         print("Debug: The base sketch of this wall could not be changed, because the sketch has not been edited yet in this session (this is a bug in FreeCAD). Try entering and exiting edit mode in this sketch first, and then changing the wall length should work.")
                                 else:
                                     FreeCAD.Console.PrintError(translate("Arch","Error: Unable to modify the base object of this wall")+"\n")


### PR DESCRIPTION
If the length of a sketch based wall was changed the new point was not converted to the coordinate system of the sketch.

Additionally:
Added a recompute as a workaround for the 'GeoId index out range' error.

- [ ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
