### PR TITLE
Gui: Hack to get Windows 11 version

### DIFF
--- a/src/Gui/Splashscreen.cpp
+++ b/src/Gui/Splashscreen.cpp
@@ -34,6 +34,7 @@
 # include <QRegularExpression>
 # include <QRegularExpressionMatch>
 # include <QScreen>
+# include <QSettings>
 # include <QSysInfo>
 # include <QTextBrowser>
 # include <QTextStream>
@@ -64,7 +65,7 @@ namespace Gui {
 QString prettyProductInfoWrapper()
 {
     auto productName = QSysInfo::prettyProductName();
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#if QT_VERSION < QT_VERSION_CHECK(6, 5, 0)
 #ifdef FC_OS_MACOSX
     auto macosVersionFile = QString::fromUtf8("/System/Library/CoreServices/.SystemVersionPlatform.plist");
     auto fi = QFileInfo (macosVersionFile);
@@ -87,6 +88,26 @@ QString prettyProductInfoWrapper()
         }
     }
 #endif
+#endif
+#ifdef FC_OS_WIN64
+    QSettings regKey {QString::fromUtf8("HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion"), QSettings::NativeFormat};
+    if (regKey.contains(QString::fromUtf8("CurrentBuildNumber"))) {
+        auto buildNumber = regKey.value(QString::fromUtf8("CurrentBuildNumber")).toInt();
+        if (buildNumber > 0) {
+            if (buildNumber < 9200) {
+                productName = QString::fromUtf8("Windows 7 build %1").arg(buildNumber);
+            }
+            else if (buildNumber < 10240) {
+                productName = QString::fromUtf8("Windows 8 build %1").arg(buildNumber);
+            }
+            else if (buildNumber < 22000) {
+                productName = QString::fromUtf8("Windows 10 build %1").arg(buildNumber);
+            }
+            else {
+                productName = QString::fromUtf8("Windows 11 build %1").arg(buildNumber);
+            }
+        }
+    }
 #endif
     return productName;
 }


### PR DESCRIPTION
As promised in #9596, here's the equivalent hack to get the proper Windows 11 version based on the current build number.

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR