### PR TITLE
OpenSCAD: Minor wording tweak in preferences

### DIFF
--- a/src/Mod/OpenSCAD/Resources/ui/openscadprefs-base.ui
+++ b/src/Mod/OpenSCAD/Resources/ui/openscadprefs-base.ui
@@ -286,7 +286,7 @@
            <string>Minimum angle for a fragment</string>
           </property>
           <property name="text">
-           <string>angular (fa)</string>
+           <string>angle (fa)</string>
           </property>
          </widget>
         </item>


### PR DESCRIPTION
- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR