### PR TITLE
Translate import export names

### DIFF
--- a/src/App/FreeCADInit.py
+++ b/src/App/FreeCADInit.py
@@ -30,6 +30,10 @@
 # imports the one and only
 import FreeCAD
 
+
+def QT_TRANSLATE_NOOP(_, txt):
+    return txt
+
 def removeFromPath(module_name):
     """removes the module from the sys.path. The entry point for imports
         will therefore always be FreeCAD.
@@ -690,7 +694,7 @@ except Exception as e:
     Err(traceback.format_exc())
     Err('-'*80+'\n')
 
-FreeCAD.addImportType("FreeCAD document (*.FCStd)","FreeCAD")
+FreeCAD.addImportType(QT_TRANSLATE_NOOP("FileFormat","FreeCAD document (*.FCStd)"), "FreeCAD")
 
 # set to no gui, is overwritten by InitGui
 App.GuiUp = 0

--- a/src/Gui/FileDialog.cpp
+++ b/src/Gui/FileDialog.cpp
@@ -882,7 +882,9 @@ SelectModule::SelectModule (const QString& type, const SelectModule::Dict& types
             module = module.left(match.capturedStart());
         }
 
-        button->setText(QString::fromLatin1("%1 (%2)").arg(filter, module));
+        auto filterText = QObject::tr(filter); // Filter should be in the QObject context
+        auto providerText = translate("Workbench", module); // Provider is usually a Workbench
+        button->setText(QString::fromLatin1("%1 (%2)").arg(filterText, providerText));
         button->setObjectName(it.value());
         gridLayout1->addWidget(button, index, 0, 1, 1);
         group->addButton(button, index);

--- a/src/Gui/FileDialog.cpp
+++ b/src/Gui/FileDialog.cpp
@@ -882,8 +882,12 @@ SelectModule::SelectModule (const QString& type, const SelectModule::Dict& types
             module = module.left(match.capturedStart());
         }
 
-        auto filterText = QObject::tr(filter); // Filter should be in the QObject context
-        auto providerText = translate("Workbench", module); // Provider is usually a Workbench
+        // Filter should be in the FileFormat context
+        auto filterText = QCoreApplication::translate("FileFormat", filter.toStdString().c_str());
+
+        // Provider is often a Workbench, so try to translate it
+        auto providerText = QCoreApplication::translate("Workbench", module.toStdString().c_str());
+
         button->setText(QString::fromLatin1("%1 (%2)").arg(filterText, providerText));
         button->setObjectName(it.value());
         gridLayout1->addWidget(button, index, 0, 1, 1);

--- a/src/Gui/FreeCADGuiInit.py
+++ b/src/Gui/FreeCADGuiInit.py
@@ -304,7 +304,11 @@ FreeCAD.addExportType("X3D Extensible 3D (*.x3d *.x3dz)","FreeCADGui")
 FreeCAD.addExportType("WebGL/X3D (*.xhtml)","FreeCADGui")
 #FreeCAD.addExportType("IDTF (for 3D PDF) (*.idtf)","FreeCADGui")
 #FreeCAD.addExportType("3D View (*.svg)","FreeCADGui")
-FreeCAD.addExportType("Portable Document Format (*.pdf)","FreeCADGui")
+
+def QT_TRANSLATE_NOOP(_, txt):
+    return txt
+
+FreeCAD.addExportType(QT_TRANSLATE_NOOP("FileFormat", "Portable Document Format (*.pdf)"), "FreeCADGui")
 
 del InitApplications
 del NoneWorkbench

--- a/src/Mod/Arch/Init.py
+++ b/src/Mod/Arch/Init.py
@@ -19,16 +19,21 @@
 #*                                                                         *
 #***************************************************************************
 
+
+def QT_TRANSLATE_NOOP(_1, txt):
+    return txt
+
+
 # add import/export types
-FreeCAD.addImportType("Industry Foundation Classes (*.ifc)","importIFC")
-FreeCAD.addExportType("Industry Foundation Classes (*.ifc)","exportIFC")
-FreeCAD.addExportType("Industry Foundation Classes - IFCJSON (*.ifcJSON)","exportIFC")
-FreeCAD.addImportType("Wavefront OBJ - Arch module (*.obj)","importOBJ")
-FreeCAD.addExportType("Wavefront OBJ - Arch module (*.obj)","importOBJ")
-FreeCAD.addExportType("WebGL file (*.html)","importWebGL")
-FreeCAD.addExportType("JavaScript Object Notation (*.json)","importJSON")
-FreeCAD.addImportType("Collada (*.dae)","importDAE")
-FreeCAD.addExportType("Collada (*.dae)","importDAE")
-FreeCAD.addImportType("3D Studio mesh (*.3ds)","import3DS")
-FreeCAD.addImportType("SweetHome3D XML export (*.zip)","importSH3D")
-FreeCAD.addImportType("Shapefile (*.shp)","importSHP")
+FreeCAD.addImportType(QT_TRANSLATE_NOOP("FileFormat", "Industry Foundation Classes (*.ifc)"), "importIFC")
+FreeCAD.addExportType(QT_TRANSLATE_NOOP("FileFormat", "Industry Foundation Classes (*.ifc)"), "exportIFC")
+FreeCAD.addExportType(QT_TRANSLATE_NOOP("FileFormat", "Industry Foundation Classes - IFCJSON (*.ifcJSON)"), "exportIFC")
+FreeCAD.addImportType(QT_TRANSLATE_NOOP("FileFormat", "Wavefront OBJ - Arch module (*.obj)"), "importOBJ")
+FreeCAD.addExportType(QT_TRANSLATE_NOOP("FileFormat", "Wavefront OBJ - Arch module (*.obj)"), "importOBJ")
+FreeCAD.addExportType(QT_TRANSLATE_NOOP("FileFormat", "WebGL file (*.html)"),"importWebGL")
+FreeCAD.addExportType(QT_TRANSLATE_NOOP("FileFormat", "JavaScript Object Notation (*.json)"), "importJSON")
+FreeCAD.addImportType("Collada (*.dae)", "importDAE")
+FreeCAD.addExportType("Collada (*.dae)", "importDAE")
+FreeCAD.addImportType(QT_TRANSLATE_NOOP("FileFormat", "3D Studio mesh (*.3ds)"), "import3DS")
+FreeCAD.addImportType(QT_TRANSLATE_NOOP("FileFormat", "SweetHome3D XML export (*.zip)"), "importSH3D")
+FreeCAD.addImportType("Shapefile (*.shp)", "importSHP")

--- a/src/Mod/Draft/Init.py
+++ b/src/Mod/Draft/Init.py
@@ -22,15 +22,20 @@
 
 import FreeCAD as App
 
+
+def QT_TRANSLATE_NOOP(_1, txt):
+    return txt
+
+
 # add Import/Export types
-App.addImportType("Autodesk DXF 2D (*.dxf)", "importDXF")
-App.addImportType("SVG as geometry (*.svg)", "importSVG")
-App.addImportType("Open CAD Format (*.oca *.gcad)", "importOCA")
-App.addImportType("Common airfoil data (*.dat)", "importAirfoilDAT")
-App.addExportType("Autodesk DXF 2D (*.dxf)", "importDXF")
-App.addExportType("Flattened SVG (*.svg)", "importSVG")
-App.addExportType("Open CAD Format (*.oca)", "importOCA")
-App.addImportType("Autodesk DWG 2D (*.dwg)", "importDWG")
-App.addExportType("Autodesk DWG 2D (*.dwg)", "importDWG")
+App.addImportType(QT_TRANSLATE_NOOP("FileFormat", "Autodesk DXF 2D (*.dxf)"), "importDXF")
+App.addImportType(QT_TRANSLATE_NOOP("FileFormat", "SVG as geometry (*.svg)"), "importSVG")
+App.addImportType(QT_TRANSLATE_NOOP("FileFormat", "Open CAD Format (*.oca *.gcad)"), "importOCA")
+App.addImportType(QT_TRANSLATE_NOOP("FileFormat", "Common airfoil data (*.dat)"), "importAirfoilDAT")
+App.addExportType(QT_TRANSLATE_NOOP("FileFormat", "Autodesk DXF 2D (*.dxf)"), "importDXF")
+App.addExportType(QT_TRANSLATE_NOOP("FileFormat", "Flattened SVG (*.svg)"), "importSVG")
+App.addExportType(QT_TRANSLATE_NOOP("FileFormat", "Open CAD Format (*.oca)"), "importOCA")
+App.addImportType(QT_TRANSLATE_NOOP("FileFormat", "Autodesk DWG 2D (*.dwg)"), "importDWG")
+App.addExportType(QT_TRANSLATE_NOOP("FileFormat", "Autodesk DWG 2D (*.dwg)"), "importDWG")
 
 App.__unit_test__ += ["TestDraft"]

--- a/src/Mod/Fem/Init.py
+++ b/src/Mod/Fem/Init.py
@@ -48,6 +48,10 @@ import FreeCAD
 from femtools.migrate_app import FemMigrateApp
 
 
+def QT_TRANSLATE_NOOP(_1, txt):
+    return txt
+
+
 # migrate old FEM App objects
 sys.meta_path.append(FemMigrateApp())
 
@@ -57,37 +61,37 @@ FreeCAD.__unit_test__ += ["TestFemApp"]
 
 
 # add import and export file types
-FreeCAD.addExportType("FEM mesh Python (*.meshpy)", "feminout.importPyMesh")
+FreeCAD.addExportType(QT_TRANSLATE_NOOP("FileFormat", "FEM mesh Python (*.meshpy)"), "feminout.importPyMesh")
 
-FreeCAD.addExportType("FEM mesh TetGen (*.poly)", "feminout.convert2TetGen")
+FreeCAD.addExportType(QT_TRANSLATE_NOOP("FileFormat", "FEM mesh TetGen (*.poly)"), "feminout.convert2TetGen")
 
 # see FemMesh::read() and FemMesh::write() methods in src/Mod/Fem/App/FemMesh.cpp
 FreeCAD.addImportType(
-    "FEM mesh formats (*.bdf *.dat *.inp *.med *.unv *.vtk *.vtu *.pvtu *.z88)", "Fem"
+    QT_TRANSLATE_NOOP("FileFormat", "FEM mesh formats (*.bdf *.dat *.inp *.med *.unv *.vtk *.vtu *.pvtu *.z88)"), "Fem"
 )
 FreeCAD.addExportType(
-    "FEM mesh formats (*.dat *.inp *.med *.stl *.unv *.vtk *.vtu *.z88)", "Fem"
+    QT_TRANSLATE_NOOP("FileFormat", "FEM mesh formats (*.dat *.inp *.med *.stl *.unv *.vtk *.vtu *.z88)"), "Fem"
 )
 
-FreeCAD.addExportType("FEM mesh Nastran (*.bdf)", "feminout.exportNastranMesh")
+FreeCAD.addExportType(QT_TRANSLATE_NOOP("FileFormat", "FEM mesh Nastran (*.bdf)"), "feminout.exportNastranMesh")
 
-FreeCAD.addImportType("FEM result CalculiX (*.frd)", "feminout.importCcxFrdResults")
+FreeCAD.addImportType(QT_TRANSLATE_NOOP("FileFormat", "FEM result CalculiX (*.frd)"), "feminout.importCcxFrdResults")
 
-FreeCAD.addImportType("FEM mesh Fenics (*.xml *.xdmf)", "feminout.importFenicsMesh")
-FreeCAD.addExportType("FEM mesh Fenics (*.xml *.xdmf)", "feminout.importFenicsMesh")
+FreeCAD.addImportType(QT_TRANSLATE_NOOP("FileFormat", "FEM mesh Fenics (*.xml *.xdmf)"), "feminout.importFenicsMesh")
+FreeCAD.addExportType(QT_TRANSLATE_NOOP("FileFormat", "FEM mesh Fenics (*.xml *.xdmf)"), "feminout.importFenicsMesh")
 
 FreeCAD.addImportType(
-    "FEM mesh YAML/JSON (*.meshyaml *.meshjson *.yaml *.json)", "feminout.importYamlJsonMesh"
+    QT_TRANSLATE_NOOP("FileFormat", "FEM mesh YAML/JSON (*.meshyaml *.meshjson *.yaml *.json)"), "feminout.importYamlJsonMesh"
 )
 FreeCAD.addExportType(
-    "FEM mesh YAML/JSON (*.meshyaml *.meshjson *.yaml *.json)", "feminout.importYamlJsonMesh"
+    QT_TRANSLATE_NOOP("FileFormat", "FEM mesh YAML/JSON (*.meshyaml *.meshjson *.yaml *.json)"), "feminout.importYamlJsonMesh"
 )
 
-FreeCAD.addImportType("FEM mesh Z88 (*i1.txt)", "feminout.importZ88Mesh")
-FreeCAD.addExportType("FEM mesh Z88 (*i1.txt)", "feminout.importZ88Mesh")
+FreeCAD.addImportType(QT_TRANSLATE_NOOP("FileFormat", "FEM mesh Z88 (*i1.txt)"), "feminout.importZ88Mesh")
+FreeCAD.addExportType(QT_TRANSLATE_NOOP("FileFormat", "FEM mesh Z88 (*i1.txt)"), "feminout.importZ88Mesh")
 
-FreeCAD.addImportType("FEM result Z88 displacements (*o2.txt)", "feminout.importZ88O2Results")
+FreeCAD.addImportType(QT_TRANSLATE_NOOP("FileFormat", "FEM result Z88 displacements (*o2.txt)"), "feminout.importZ88O2Results")
 
 if "BUILD_FEM_VTK" in FreeCAD.__cmake__:
-    FreeCAD.addImportType("FEM result VTK (*.vtk *.vtu *.pvtu)", "feminout.importVTKResults")
-    FreeCAD.addExportType("FEM result VTK (*.vtk *.vtu)", "feminout.importVTKResults")
+    FreeCAD.addImportType(QT_TRANSLATE_NOOP("FileFormat", "FEM result VTK (*.vtk *.vtu *.pvtu)"), "feminout.importVTKResults")
+    FreeCAD.addExportType(QT_TRANSLATE_NOOP("FileFormat", "FEM result VTK (*.vtk *.vtu)"), "feminout.importVTKResults")

--- a/src/Mod/Idf/Init.py
+++ b/src/Mod/Idf/Init.py
@@ -27,6 +27,11 @@
 # This is the second one of three init scripts, the third one
 # runs when the gui is up
 
+
+def QT_TRANSLATE_NOOP(_1, txt):
+    return txt
+
+
 # two options for IDF added by Milos Koutny (12-Feb-2010)
-FreeCAD.addImportType("IDF emn file File Type (*.emn)","Idf")
+FreeCAD.addImportType(QT_TRANSLATE_NOOP("FileFormat", "IDF emn file File Type (*.emn)"),"Idf")
 #FreeCAD.addImportType("IDF emp File Type (*.emp)","Import_Emp")

--- a/src/Mod/Import/Init.py
+++ b/src/Mod/Import/Init.py
@@ -25,12 +25,15 @@
 #***************************************************************************/
 
 
+def QT_TRANSLATE_NOOP(_1, txt):
+    return txt
+
 
 # Append the open handler
 #FreeCAD.addImportType("STEP 214 (*.step *.stp)","ImportGui")
 #FreeCAD.addExportType("STEP 214 (*.step *.stp)","ImportGui")
 #FreeCAD.addExportType("IGES files (*.iges *.igs)","ImportGui")
-FreeCAD.addImportType("PLMXML files (*.plmxml)","PlmXmlParser")
-FreeCAD.addImportType("STEPZ Zip File Type (*.stpZ *.stpz)","stepZ")
-FreeCAD.addExportType("STEPZ zip File Type (*.stpZ *.stpz)","stepZ")
+FreeCAD.addImportType(QT_TRANSLATE_NOOP("FileFormat", "PLMXML files (*.plmxml)"),"PlmXmlParser")
+FreeCAD.addImportType(QT_TRANSLATE_NOOP("FileFormat", "STEPZ Zip File Type (*.stpZ *.stpz)"),"stepZ")
+FreeCAD.addExportType(QT_TRANSLATE_NOOP("FileFormat", "STEPZ zip File Type (*.stpZ *.stpz)"),"stepZ")
 FreeCAD.addExportType("glTF (*.gltf *.glb)","ImportGui")

--- a/src/Mod/Material/Init.py
+++ b/src/Mod/Material/Init.py
@@ -21,5 +21,10 @@
 
 import FreeCAD
 
+
+def QT_TRANSLATE_NOOP(_1, txt):
+    return txt
+
+
 # import for the FreeCAD Material card
-FreeCAD.addImportType("FreeCAD Material Card (*.FCMat)", "importFCMat")
+FreeCAD.addImportType(QT_TRANSLATE_NOOP("FileFormat", "FreeCAD Material Card (*.FCMat)"), "importFCMat")

--- a/src/Mod/Mesh/Init.py
+++ b/src/Mod/Mesh/Init.py
@@ -3,22 +3,27 @@
 
 import FreeCAD
 
-# Append the open handler
-FreeCAD.addImportType("STL Mesh (*.stl *.ast)", "Mesh")
-FreeCAD.addImportType("Binary Mesh (*.bms)", "Mesh")
-FreeCAD.addImportType("Alias Mesh (*.obj)", "Mesh")
-FreeCAD.addImportType("Object File Format Mesh (*.off)", "Mesh")
-FreeCAD.addImportType("Stanford Triangle Mesh (*.ply)", "Mesh")
-FreeCAD.addImportType("Simple Model Format (*.smf)", "Mesh")
-FreeCAD.addImportType("3D Manufacturing Format (*.3mf)", "Mesh")
 
-FreeCAD.addExportType("STL Mesh (*.stl *.ast)", "Mesh")
-FreeCAD.addExportType("Binary Mesh (*.bms)", "Mesh")
-FreeCAD.addExportType("Alias Mesh (*.obj)", "Mesh")
-FreeCAD.addExportType("Object File Format Mesh (*.off)", "Mesh")
-FreeCAD.addExportType("Stanford Triangle Mesh (*.ply)", "Mesh")
-FreeCAD.addExportType("Additive Manufacturing Format (*.amf)", "Mesh")
-FreeCAD.addExportType("Simple Model Format (*.smf)", "Mesh")
-FreeCAD.addExportType("3D Manufacturing Format (*.3mf)", "Mesh")
+def QT_TRANSLATE_NOOP(_1, txt):
+    return txt
+
+
+# Append the open handler
+FreeCAD.addImportType(QT_TRANSLATE_NOOP("FileFormat", "STL Mesh (*.stl *.ast)"), "Mesh")
+FreeCAD.addImportType(QT_TRANSLATE_NOOP("FileFormat", "Binary Mesh (*.bms)"), "Mesh")
+FreeCAD.addImportType(QT_TRANSLATE_NOOP("FileFormat", "Alias Mesh (*.obj)"), "Mesh")
+FreeCAD.addImportType(QT_TRANSLATE_NOOP("FileFormat", "Object File Format Mesh (*.off)"), "Mesh")
+FreeCAD.addImportType(QT_TRANSLATE_NOOP("FileFormat", "Stanford Triangle Mesh (*.ply)"), "Mesh")
+FreeCAD.addImportType(QT_TRANSLATE_NOOP("FileFormat", "Simple Model Format (*.smf)"), "Mesh")
+FreeCAD.addImportType(QT_TRANSLATE_NOOP("FileFormat", "3D Manufacturing Format (*.3mf)"), "Mesh")
+
+FreeCAD.addExportType(QT_TRANSLATE_NOOP("FileFormat", "STL Mesh (*.stl *.ast)"), "Mesh")
+FreeCAD.addExportType(QT_TRANSLATE_NOOP("FileFormat", "Binary Mesh (*.bms)"), "Mesh")
+FreeCAD.addExportType(QT_TRANSLATE_NOOP("FileFormat", "Alias Mesh (*.obj)"), "Mesh")
+FreeCAD.addExportType(QT_TRANSLATE_NOOP("FileFormat", "Object File Format Mesh (*.off)"), "Mesh")
+FreeCAD.addExportType(QT_TRANSLATE_NOOP("FileFormat", "Stanford Triangle Mesh (*.ply)"), "Mesh")
+FreeCAD.addExportType(QT_TRANSLATE_NOOP("FileFormat", "Additive Manufacturing Format (*.amf)"), "Mesh")
+FreeCAD.addExportType(QT_TRANSLATE_NOOP("FileFormat", "Simple Model Format (*.smf)"), "Mesh")
+FreeCAD.addExportType(QT_TRANSLATE_NOOP("FileFormat", "3D Manufacturing Format (*.3mf)"), "Mesh")
 
 FreeCAD.__unit_test__ += [ "MeshTestsApp" ]

--- a/src/Mod/OpenSCAD/Init.py
+++ b/src/Mod/OpenSCAD/Init.py
@@ -26,7 +26,12 @@
 import os
 import FreeCAD
 
-FreeCAD.addImportType("OpenSCAD CSG Format (*.csg)", "importCSG")
+
+def QT_TRANSLATE_NOOP(_1, txt):
+    return txt
+
+
+FreeCAD.addImportType(QT_TRANSLATE_NOOP("FileFormat", "OpenSCAD CSG Format (*.csg)"), "importCSG")
 
 param = FreeCAD.ParamGet(\
         "User parameter:BaseApp/Preferences/Mod/OpenSCAD")
@@ -34,8 +39,8 @@ openscadfilename = param.GetString('openscadexecutable')
 openscadbin = openscadfilename and os.path.isfile(openscadfilename)
 
 if openscadbin:
-    FreeCAD.addImportType("OpenSCAD Format (*.scad)", "importCSG")
+    FreeCAD.addImportType(QT_TRANSLATE_NOOP("FileFormat", "OpenSCAD Format (*.scad)"), "importCSG")
     FreeCAD.__unit_test__ += ["TestOpenSCADApp"]
 
-FreeCAD.addExportType("OpenSCAD CSG Format (*.csg)", "exportCSG")
-FreeCAD.addExportType("OpenSCAD Format (*.scad)", "exportCSG")
+FreeCAD.addExportType(QT_TRANSLATE_NOOP("FileFormat", "OpenSCAD CSG Format (*.csg)"), "exportCSG")
+FreeCAD.addExportType(QT_TRANSLATE_NOOP("FileFormat", "OpenSCAD Format (*.scad)"), "exportCSG")

--- a/src/Mod/Part/Init.py
+++ b/src/Mod/Part/Init.py
@@ -23,13 +23,18 @@
 
 # FreeCAD init script of the part module
 
+
+def QT_TRANSLATE_NOOP(_1, txt):
+    return txt
+
+
 #FreeCAD.addImportType("CAD formats (*.igs *.iges *.step *.stp *.brep *.brp)","Part")
 #FreeCAD.addExportType("CAD formats (*.igs *.iges *.step *.stp *.brep *.brp)","Part")
-FreeCAD.addImportType("BREP format (*.brep *.brp)","Part")
-FreeCAD.addExportType("BREP format (*.brep *.brp)","Part")
-FreeCAD.addImportType("IGES format (*.iges *.igs)","Part")
-FreeCAD.addExportType("IGES format (*.iges *.igs)","Part")
-FreeCAD.addImportType("STEP with colors (*.step *.stp)","Import")
-FreeCAD.addExportType("STEP with colors (*.step *.stp)","Import")
+FreeCAD.addImportType(QT_TRANSLATE_NOOP("FileFormat", "BREP format (*.brep *.brp)"),"Part")
+FreeCAD.addExportType(QT_TRANSLATE_NOOP("FileFormat", "BREP format (*.brep *.brp)"),"Part")
+FreeCAD.addImportType(QT_TRANSLATE_NOOP("FileFormat", "IGES format (*.iges *.igs)"),"Part")
+FreeCAD.addExportType(QT_TRANSLATE_NOOP("FileFormat", "IGES format (*.iges *.igs)"),"Part")
+FreeCAD.addImportType(QT_TRANSLATE_NOOP("FileFormat", "STEP with colors (*.step *.stp)"),"Import")
+FreeCAD.addExportType(QT_TRANSLATE_NOOP("FileFormat", "STEP with colors (*.step *.stp)"),"Import")
 
 FreeCAD.__unit_test__ += [ "TestPartApp" ]

--- a/src/Mod/Points/Init.py
+++ b/src/Mod/Points/Init.py
@@ -23,6 +23,11 @@
 
 # FreeCAD init script of the Points module
 
+
+def QT_TRANSLATE_NOOP(_1, txt):
+    return txt
+
+
 # Append the open handler
-FreeCAD.addImportType("Point formats (*.asc *.pcd *.ply *.e57)","Points")
-FreeCAD.addExportType("Point formats (*.asc *.pcd *.ply)","Points")
+FreeCAD.addImportType(QT_TRANSLATE_NOOP("FileFormat", "Point formats (*.asc *.pcd *.ply *.e57)"),"Points")
+FreeCAD.addExportType(QT_TRANSLATE_NOOP("FileFormat", "Point formats (*.asc *.pcd *.ply)"),"Points")

--- a/src/Mod/Sandbox/Init.py
+++ b/src/Mod/Sandbox/Init.py
@@ -24,5 +24,10 @@
 # FreeCAD init script of the Sandbox module
 
 import FreeCAD
-FreeCAD.addExportType("DRAWEXE script (*.tcl)","exportDRAWEXE")
 
+
+def QT_TRANSLATE_NOOP(_1, txt):
+    return txt
+
+
+FreeCAD.addExportType(QT_TRANSLATE_NOOP("FileFormat", "DRAWEXE script (*.tcl)"),"exportDRAWEXE")

--- a/src/Mod/Sandbox/exportDRAWEXE.py
+++ b/src/Mod/Sandbox/exportDRAWEXE.py
@@ -25,6 +25,11 @@ __author__ = "Sebastian Hoogen <github@sebastianhoogen.de>"
 
 import FreeCAD, Part
 
+
+def QT_TRANSLATE_NOOP(_1, txt):
+    return txt
+
+
 if open.__module__ == '__builtin__':
         pythonopen = open
 
@@ -850,4 +855,4 @@ def export(exportList,filename):
         exporter.export_objects(exportList)
 
 if 'tcl' not in FreeCAD.getExportType():
-    FreeCAD.addExportType("DRAWEXE script (*.tcl)","exportDRAWEXE")
+    FreeCAD.addExportType(QT_TRANSLATE_NOOP("FileFormat", "DRAWEXE script (*.tcl)"),"exportDRAWEXE")

--- a/src/Mod/Spreadsheet/Init.py
+++ b/src/Mod/Spreadsheet/Init.py
@@ -25,6 +25,9 @@
 
 # FreeCAD init script of the Spreadsheet module
 
+def QT_TRANSLATE_NOOP(_1, txt):
+    return txt
+
 
 # Get the Parameter Group of this module
 ParGrp = App.ParamGet("System parameter:Modules").GetGroup("Spreadsheet")
@@ -35,7 +38,7 @@ ParGrp.SetString("WorkBenchName",    "Spreadsheet")
 ParGrp.SetString("WorkBenchModule",  "SpreadsheetWorkbench.py")
 
 # add Import/Export types
-App.addImportType("Excel spreadsheet (*.xlsx)","importXLSX")
+App.addImportType(QT_TRANSLATE_NOOP("FileFormat", "Excel spreadsheet (*.xlsx)"),"importXLSX")
 
 App.__unit_test__ += [ "TestSpreadsheet" ]
 

--- a/src/Mod/Spreadsheet/InitGui.py
+++ b/src/Mod/Spreadsheet/InitGui.py
@@ -27,6 +27,9 @@
 # This is the second one of three init scripts, the third one
 # runs when the gui is up
 
+def QT_TRANSLATE_NOOP(_1, txt):
+    return txt
+
 
 class SpreadsheetWorkbench ( Workbench ):
     "Spreadsheet workbench object"
@@ -45,4 +48,4 @@ class SpreadsheetWorkbench ( Workbench ):
 Gui.addWorkbench(SpreadsheetWorkbench())
 
 # Append the open handler
-FreeCAD.addImportType("Spreadsheet formats (*.csv)","SpreadsheetGui")
+FreeCAD.addImportType(QT_TRANSLATE_NOOP("FileFormat", "Spreadsheet formats (*.csv)"),"SpreadsheetGui")

--- a/src/Mod/TechDraw/InitGui.py
+++ b/src/Mod/TechDraw/InitGui.py
@@ -28,6 +28,10 @@
 # runs when the gui is up
 
 
+def QT_TRANSLATE_NOOP(_1, txt):
+    return txt
+
+
 class TechDrawWorkbench(Workbench):
     "Technical Drawing workbench object"
 
@@ -60,7 +64,7 @@ class TechDrawWorkbench(Workbench):
 Gui.addWorkbench(TechDrawWorkbench())
 
 # Append the export handler
-FreeCAD.addExportType("Technical Drawing (*.svg *.dxf *.pdf)", "TechDrawGui")
+FreeCAD.addExportType(QT_TRANSLATE_NOOP("FileFormat", "Technical Drawing (*.svg *.dxf *.pdf)"), "TechDrawGui")
 
 FreeCAD.__unit_test__ += ["TestTechDrawGui"]
 

--- a/src/Mod/Web/InitGui.py
+++ b/src/Mod/Web/InitGui.py
@@ -26,6 +26,9 @@
 # This is the second one of three init scripts, the third one
 # runs when the gui is up
 
+def QT_TRANSLATE_NOOP(_1, txt):
+    return txt
+
 
 class WebWorkbench ( Workbench ):
     "Web workbench object"
@@ -44,6 +47,6 @@ class WebWorkbench ( Workbench ):
 Gui.addWorkbench(WebWorkbench())
 
 # Append the open handler
-FreeCAD.addImportType("Web Page (*.html *.xhtml)", "WebGui")
+FreeCAD.addImportType(QT_TRANSLATE_NOOP("FileFormat", "Web Page (*.html *.xhtml)"), "WebGui")
 
 FreeCAD.__unit_test__ += [ "TestWebGui" ]


### PR DESCRIPTION
Many of the importer/exporter strings that we display to users contain translatable elements ("STEP with colors", "Point formats", etc.). This PR exposes any importer/exporter text strings that contain potentially-translatable elements to translation, adding them to the "FileFormat" context. They are translated at point-of-use in the GUI when the dialog is presented. This fixes https://github.com/FreeCAD/FreeCAD-translations/issues/217

---

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR