### PR TITLE
Draft: fix props_changed_placement_only for attached clones and similar

### DIFF
--- a/src/Mod/Draft/draftobjects/array.py
+++ b/src/Mod/Draft/draftobjects/array.py
@@ -396,7 +396,7 @@ class Array(DraftLink):
 
     def execute(self, obj):
         """Execute when the object is created or recomputed."""
-        if self.props_changed_placement_only() \
+        if self.props_changed_placement_only(obj) \
                 or not obj.Base:
             self.props_changed_clear()
             return

--- a/src/Mod/Draft/draftobjects/block.py
+++ b/src/Mod/Draft/draftobjects/block.py
@@ -43,7 +43,7 @@ class Block(DraftObject):
         obj.addProperty("App::PropertyLinkList","Components", "Draft", _tip)
 
     def execute(self, obj):
-        if self.props_changed_placement_only():
+        if self.props_changed_placement_only(obj):
             obj.positionBySupport()
             self.props_changed_clear()
             return

--- a/src/Mod/Draft/draftobjects/clone.py
+++ b/src/Mod/Draft/draftobjects/clone.py
@@ -86,7 +86,7 @@ class Clone(DraftObject):
         return Part.makeCompound(shapes)
 
     def execute(self,obj):
-        if self.props_changed_placement_only():
+        if self.props_changed_placement_only(obj):
             if hasattr(obj,"positionBySupport"):
                 obj.positionBySupport()
             self.props_changed_clear()

--- a/src/Mod/Draft/draftobjects/facebinder.py
+++ b/src/Mod/Draft/draftobjects/facebinder.py
@@ -59,7 +59,7 @@ class Facebinder(DraftObject):
         obj.setEditorMode("Area",1)
 
     def execute(self,obj):
-        if self.props_changed_placement_only():
+        if self.props_changed_placement_only(obj):
             self.props_changed_clear()
             return
 

--- a/src/Mod/Draft/draftobjects/hatch.py
+++ b/src/Mod/Draft/draftobjects/hatch.py
@@ -77,7 +77,7 @@ class Hatch(DraftObject):
 
     def execute(self,obj):
 
-        if self.props_changed_placement_only() \
+        if self.props_changed_placement_only(obj) \
                 or not obj.Base \
                 or not obj.File \
                 or not obj.Pattern \

--- a/src/Mod/Draft/draftobjects/patharray.py
+++ b/src/Mod/Draft/draftobjects/patharray.py
@@ -296,7 +296,7 @@ class PathArray(DraftLink):
 
     def execute(self, obj):
         """Execute when the object is created or recomputed."""
-        if self.props_changed_placement_only() \
+        if self.props_changed_placement_only(obj) \
                 or not obj.Base \
                 or not obj.PathObject:
             self.props_changed_clear()

--- a/src/Mod/Draft/draftobjects/pathtwistedarray.py
+++ b/src/Mod/Draft/draftobjects/pathtwistedarray.py
@@ -130,7 +130,7 @@ class PathTwistedArray(DraftLink):
 
     def execute(self, obj):
         """Execute when the object is created or recomputed."""
-        if self.props_changed_placement_only() \
+        if self.props_changed_placement_only(obj) \
                 or not obj.Base \
                 or not obj.PathObject:
             self.props_changed_clear()

--- a/src/Mod/Draft/draftobjects/pointarray.py
+++ b/src/Mod/Draft/draftobjects/pointarray.py
@@ -105,7 +105,7 @@ class PointArray(DraftLink):
 
     def execute(self, obj):
         """Run when the object is created or recomputed."""
-        if self.props_changed_placement_only() \
+        if self.props_changed_placement_only(obj) \
                 or not obj.Base \
                 or not obj.PointObject:
             self.props_changed_clear()

--- a/src/Mod/Draft/draftobjects/shape2dview.py
+++ b/src/Mod/Draft/draftobjects/shape2dview.py
@@ -196,7 +196,7 @@ class Shape2DView(DraftObject):
             return objs
 
     def execute(self, obj):
-        if self.props_changed_placement_only() \
+        if self.props_changed_placement_only(obj) \
                 or not getattr(obj, "AutoUpdate", True):
             obj.positionBySupport()
             self.props_changed_clear()

--- a/src/Mod/Draft/draftobjects/wire.py
+++ b/src/Mod/Draft/draftobjects/wire.py
@@ -96,7 +96,7 @@ class Wire(DraftObject):
         obj.Closed = False
 
     def execute(self, obj):
-        if self.props_changed_placement_only():
+        if self.props_changed_placement_only(obj): # Supplying obj is required because of `Base` and `Tool`.
             obj.positionBySupport()
             self.update_start_end(obj)
             self.props_changed_clear()

--- a/src/Mod/Draft/drafttests/test_modification.py
+++ b/src/Mod/Draft/drafttests/test_modification.py
@@ -573,6 +573,29 @@ class DraftModification(unittest.TestCase):
         self.assertTrue(obj.hasExtension("Part::AttachExtension"),
                         "'{}' failed".format(operation))
 
+    def test_attached_clone_behavior(self):
+        """Check if an attached clone behaves correctly.
+
+        Test for https://github.com/FreeCAD/FreeCAD/issues/8771.
+        """
+        operation = "Check attached Draft Clone behavior"
+        _msg("  Test '{}'".format(operation))
+
+        box1 = App.ActiveDocument.addObject("Part::Box")
+        box1.Length = 10
+        box2 = App.ActiveDocument.addObject("Part::Box")
+        App.ActiveDocument.recompute()
+
+        obj = Draft.make_clone(box1)
+        obj.MapMode = "ObjectXY"
+        obj.Support = [(box2, ("",))]
+        App.ActiveDocument.recompute()
+
+        box1.Length = 1
+        App.ActiveDocument.recompute()
+
+        self.assertTrue(obj.Shape.BoundBox.XLength == 1, "'{}' failed".format(operation))
+
     def test_draft_to_techdraw(self):
         """Create a solid, and then a DraftView on a TechDraw page."""
         operation = "TechDraw DraftView (relies on Draft code)"


### PR DESCRIPTION
For an attached object whose Shape depends on one or more source objects `props_changed_placement_only` should always return `False`.

Arrays do not have attachment properties by default but these can be added with the Part_EditAttachment command. So arrays are also affected.

A test function `test_attached_clone_behavior` has been added to test_modification.py.

Fixes #8771.

- [x]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

---
