### PR TITLE
Surface: allow instant update of BlendCurve properties

### DIFF
--- a/src/Mod/Surface/App/Blending/FeatureBlendCurve.cpp
+++ b/src/Mod/Surface/App/Blending/FeatureBlendCurve.cpp
@@ -48,19 +48,19 @@ PROPERTY_SOURCE(Surface::FeatureBlendCurve, Part::Spline)
 
 FeatureBlendCurve::FeatureBlendCurve()
 {
-    ADD_PROPERTY_TYPE(StartEdge, (nullptr), "FirstEdge", App::Prop_None, "");
-    ADD_PROPERTY_TYPE(StartContinuity, (2), "FirstEdge", App::Prop_None, "");
+    ADD_PROPERTY_TYPE(StartEdge, (nullptr), "FirstEdge", App::Prop_None, "Edge support of the start point");
+    ADD_PROPERTY_TYPE(StartContinuity, (2), "FirstEdge", App::Prop_None, "Geometric continuity at start point");
     StartContinuity.setConstraints(&StartContinuityConstraint);
-    ADD_PROPERTY_TYPE(StartParameter, (0.0f), "FirstEdge", App::Prop_None, "");
+    ADD_PROPERTY_TYPE(StartParameter, (0.0f), "FirstEdge", App::Prop_None, "Parameter of start point along edge");
     StartParameter.setConstraints(&StartParameterConstraint);
-    ADD_PROPERTY_TYPE(StartSize, (1.0f), "FirstEdge", App::Prop_None, "");
+    ADD_PROPERTY_TYPE(StartSize, (1.0f), "FirstEdge", App::Prop_None, "Size of derivatives at start point");
 
-    ADD_PROPERTY_TYPE(EndEdge, (nullptr), "SecondEdge", App::Prop_None, "");
-    ADD_PROPERTY_TYPE(EndContinuity, (2), "SecondEdge", App::Prop_None, "");
+    ADD_PROPERTY_TYPE(EndEdge, (nullptr), "SecondEdge", App::Prop_None, "Edge support of the end point");
+    ADD_PROPERTY_TYPE(EndContinuity, (2), "SecondEdge", App::Prop_None, "Geometric continuity at end point");
     EndContinuity.setConstraints(&EndContinuityConstraint);
-    ADD_PROPERTY_TYPE(EndParameter, (0.0f), "SecondEdge", App::Prop_None, "");
+    ADD_PROPERTY_TYPE(EndParameter, (0.0f), "SecondEdge", App::Prop_None, "Parameter of end point along edge");
     EndParameter.setConstraints(&EndParameterConstraint);
-    ADD_PROPERTY_TYPE(EndSize, (1.0f), "SecondEdge", App::Prop_None, "");
+    ADD_PROPERTY_TYPE(EndSize, (1.0f), "SecondEdge", App::Prop_None, "Size of derivatives at end point");
     Handle(Geom_BezierCurve) maxDegreeCurve;
     maxDegree = maxDegreeCurve->MaxDegree();
 }

--- a/src/Mod/Surface/App/Blending/FeatureBlendCurve.cpp
+++ b/src/Mod/Surface/App/Blending/FeatureBlendCurve.cpp
@@ -39,10 +39,9 @@
 
 using namespace Surface;
 
-const App::PropertyFloatConstraint::Constraints StartParameterConstraint = {0.0, 1.0, 0.05};
-const App::PropertyFloatConstraint::Constraints EndParameterConstraint = {0.0, 1.0, 0.05};
-const App::PropertyIntegerConstraint::Constraints StartContinuityConstraint = {0, 25, 1};
-const App::PropertyIntegerConstraint::Constraints EndContinuityConstraint = {0, 25, 1};
+const App::PropertyFloatConstraint::Constraints ParameterConstraint = {0.0, 1.0, 0.05};
+const App::PropertyIntegerConstraint::Constraints ContinuityConstraint = {0, 25, 1};
+const App::PropertyFloatConstraint::Constraints SizeConstraint = {-100.0, 100.0, 0.1};
 
 PROPERTY_SOURCE(Surface::FeatureBlendCurve, Part::Spline)
 
@@ -50,17 +49,20 @@ FeatureBlendCurve::FeatureBlendCurve()
 {
     ADD_PROPERTY_TYPE(StartEdge, (nullptr), "FirstEdge", App::Prop_None, "Edge support of the start point");
     ADD_PROPERTY_TYPE(StartContinuity, (2), "FirstEdge", App::Prop_None, "Geometric continuity at start point");
-    StartContinuity.setConstraints(&StartContinuityConstraint);
+    StartContinuity.setConstraints(&ContinuityConstraint);
     ADD_PROPERTY_TYPE(StartParameter, (0.0f), "FirstEdge", App::Prop_None, "Parameter of start point along edge");
-    StartParameter.setConstraints(&StartParameterConstraint);
+    StartParameter.setConstraints(&ParameterConstraint);
     ADD_PROPERTY_TYPE(StartSize, (1.0f), "FirstEdge", App::Prop_None, "Size of derivatives at start point");
+    StartSize.setConstraints(&SizeConstraint);
 
     ADD_PROPERTY_TYPE(EndEdge, (nullptr), "SecondEdge", App::Prop_None, "Edge support of the end point");
     ADD_PROPERTY_TYPE(EndContinuity, (2), "SecondEdge", App::Prop_None, "Geometric continuity at end point");
-    EndContinuity.setConstraints(&EndContinuityConstraint);
+    EndContinuity.setConstraints(&ContinuityConstraint);
     ADD_PROPERTY_TYPE(EndParameter, (0.0f), "SecondEdge", App::Prop_None, "Parameter of end point along edge");
-    EndParameter.setConstraints(&EndParameterConstraint);
+    EndParameter.setConstraints(&ParameterConstraint);
     ADD_PROPERTY_TYPE(EndSize, (1.0f), "SecondEdge", App::Prop_None, "Size of derivatives at end point");
+    EndSize.setConstraints(&SizeConstraint);
+
     Handle(Geom_BezierCurve) maxDegreeCurve;
     maxDegree = maxDegreeCurve->MaxDegree();
 }

--- a/src/Mod/Surface/App/Blending/FeatureBlendCurve.cpp
+++ b/src/Mod/Surface/App/Blending/FeatureBlendCurve.cpp
@@ -157,11 +157,6 @@ double FeatureBlendCurve::RelativeToRealParameters(double relativeValue, double 
 
 void FeatureBlendCurve::onChanged(const App::Property *prop)
 {
-    // using a mutex and lock to protect a recursive calling when setting the new values
-    if (lockOnChangeMutex)
-        return;
-    Base::StateLocker lock(lockOnChangeMutex);
-
     if (prop == &StartContinuity) {
         auto changedStartProp = dynamic_cast<const App::PropertyInteger *>(prop);
 
@@ -175,6 +170,12 @@ void FeatureBlendCurve::onChanged(const App::Property *prop)
 
         if (changedEndProp->getValue() > (maxDegree - 2 - StartContinuity.getValue())) {
             EndContinuity.setValue(maxDegree - 2 - StartContinuity.getValue());
+        }
+    }
+    if (prop == &StartContinuity || prop == &StartParameter || prop == &StartSize || prop == &EndContinuity || prop == &EndParameter || prop == &EndSize) {
+        if (!isRestoring()) {
+            App::DocumentObjectExecReturn *ret = recompute();
+            delete ret;
         }
     }
     Part::Spline::onChanged(prop);

--- a/src/Mod/Surface/App/Blending/FeatureBlendCurve.cpp
+++ b/src/Mod/Surface/App/Blending/FeatureBlendCurve.cpp
@@ -158,18 +158,15 @@ double FeatureBlendCurve::RelativeToRealParameters(double relativeValue, double 
 void FeatureBlendCurve::onChanged(const App::Property *prop)
 {
     if (prop == &StartContinuity) {
-        auto changedStartProp = dynamic_cast<const App::PropertyInteger *>(prop);
-
-        if (changedStartProp->getValue() > (maxDegree - 2 - EndContinuity.getValue())) {
-
-            StartContinuity.setValue(maxDegree - 2 - EndContinuity.getValue());
+        long maxValue = maxDegree - 2 - EndContinuity.getValue();
+        if (StartContinuity.getValue() > maxValue) {
+            StartContinuity.setValue(maxValue);
         }
     }
     else if (prop == &EndContinuity) {
-        auto changedEndProp = dynamic_cast<const App::PropertyInteger *>(prop);
-
-        if (changedEndProp->getValue() > (maxDegree - 2 - StartContinuity.getValue())) {
-            EndContinuity.setValue(maxDegree - 2 - StartContinuity.getValue());
+        long maxValue = maxDegree - 2 - StartContinuity.getValue();
+        if (EndContinuity.getValue() > maxValue) {
+            EndContinuity.setValue(maxValue);
         }
     }
     if (prop == &StartContinuity || prop == &StartParameter || prop == &StartSize || prop == &EndContinuity || prop == &EndParameter || prop == &EndSize) {

--- a/src/Mod/Surface/App/Blending/FeatureBlendCurve.h
+++ b/src/Mod/Surface/App/Blending/FeatureBlendCurve.h
@@ -63,7 +63,6 @@ public:
 private:
     BlendPoint GetBlendPoint(App::PropertyLinkSub &link, App::PropertyFloatConstraint &param, App::PropertyIntegerConstraint &Continuity);
     double RelativeToRealParameters(double, double, double);
-    bool lockOnChangeMutex{false};
 
 protected:
     void onChanged(const App::Property *prop) override;

--- a/src/Mod/Surface/App/Blending/FeatureBlendCurve.h
+++ b/src/Mod/Surface/App/Blending/FeatureBlendCurve.h
@@ -44,12 +44,12 @@ public:
     App::PropertyLinkSub StartEdge;
     App::PropertyFloatConstraint StartParameter;
     App::PropertyIntegerConstraint StartContinuity;
-    App::PropertyFloat StartSize;
+    App::PropertyFloatConstraint StartSize;
 
     App::PropertyLinkSub EndEdge;
     App::PropertyFloatConstraint EndParameter;
     App::PropertyIntegerConstraint EndContinuity;
-    App::PropertyFloat EndSize;
+    App::PropertyFloatConstraint EndSize;
 
     Standard_Integer maxDegree;
 


### PR DESCRIPTION
Hello,
Since Surface::BlendCurve feature doesn't compute any automatic initial property values, I think it is better to allow live update of properties, for easier tweaking.
Thanks

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [ ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
